### PR TITLE
[CodeStyle] Clean trailing whitespace in tool shell scripts (part4)

### DIFF
--- a/tools/check_added_ut.sh
+++ b/tools/check_added_ut.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,7 +32,7 @@ if [[ "$SYSTEM" == "Linux" ]] || [[ "$SYSTEM" == "Darwin" ]];then
     cp $PADDLE_ROOT/paddle/scripts/paddle_build.sh $PADDLE_ROOT/paddle/scripts/paddle_build_pre.sh
 elif [[ "$SYSTEM" == "Windows_NT" ]];then
     git remote | grep upstream
-    if [ $? != 0 ]; then 
+    if [ $? != 0 ]; then
         git remote add upstream https://github.com/PaddlePaddle/Paddle.git
     fi
     git fetch upstream ${BRANCH}

--- a/tools/check_sequence_op.sh
+++ b/tools/check_sequence_op.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tools/ci_op_benchmark.sh
+++ b/tools/ci_op_benchmark.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -333,6 +333,6 @@ fi
 case $1 in
   run_op_benchmark)
     prepare_env
-    gpu_op_benchmark 
+    gpu_op_benchmark
   ;;
 esac

--- a/tools/document_preview.sh
+++ b/tools/document_preview.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -45,7 +45,7 @@ function get_docs_pr_num_from_paddle_pr_info(){
 }
 
 # Attention:
-# 1. /FluidDoc will be used as the workspace of PaddlePaddle/docs. 
+# 1. /FluidDoc will be used as the workspace of PaddlePaddle/docs.
 # 2. And /docs is used as the output of doc-build process.
 # 3. If conflicted with yours, please modify the definition of FLUIDDOCDIR and
 #    OUTPUTDIR in the subsequent codes.

--- a/tools/enforce/count_enforce_by_dir.sh
+++ b/tools/enforce/count_enforce_by_dir.sh
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 # This script is used to count detail PADDLE checks in the paddle/fluid directory,
-#   contains the number of PADDLE checks under each folder, the statistical data 
+#   contains the number of PADDLE checks under each folder, the statistical data
 #   does not include subdirectories, only covers all files under the current directory.
-#   
-#   The three columns of data are: total number, valid number, invalid number. 
+#
+#   The three columns of data are: total number, valid number, invalid number.
 #   The output format is easy to display as a markdown table.
 
 # Usage: bash count_enforce_by_dir.sh (run in tools directory)
@@ -70,8 +70,8 @@ function count_dir_independently(){
             enforce_count $1"/"$file dir_total_check_cnt dir_valid_check_cnt
             sub_dir_total_check_cnt=$(($sub_dir_total_check_cnt+$dir_total_check_cnt))
             sub_dir_valid_check_cnt=$(($sub_dir_valid_check_cnt+$dir_valid_check_cnt))
-            
-            count_dir_independently $1"/"$file $dir_total_check_cnt $dir_valid_check_cnt 
+
+            count_dir_independently $1"/"$file $dir_total_check_cnt $dir_valid_check_cnt
         fi
     done
     total_check_cnt=$(($2-$sub_dir_total_check_cnt))

--- a/tools/enforce/count_enforce_by_file.sh
+++ b/tools/enforce/count_enforce_by_file.sh
@@ -16,8 +16,8 @@
 
 # This script is used to count PADDLE checks by files in the paddle/fluid/operators directory,
 #   contains the number of PADDLE checks under each file.
-#   
-#   The three columns of data are: total number, valid number, invalid number. 
+#
+#   The three columns of data are: total number, valid number, invalid number.
 #   The output format is easy to display as a markdown table.
 
 # Usage: bash count_enforce_by_file.sh  [target directory or file] (run in tools directory)

--- a/tools/enforce/grep_invalid_enforce.sh
+++ b/tools/enforce/grep_invalid_enforce.sh
@@ -17,14 +17,14 @@
 # This script is used to grep invalid PADDLE checks by directory or file in the paddle/fluid/,
 #   the result show all invalid PADDLE checks in specified directory or file.
 
-# Usage: 
+# Usage:
 #   - bash grep_invalid_enforce.sh [target directory or file] (run in tools directory)
 #       - The default check path is paddle/fluid/operators
 
 # Result Examples:
 # 1. grep invalid PADDLE checks in directory
 
-#     - Command: /work/paddle/tools {develop} bash grep_invalid_enforce.sh ../paddle/fluid/imperative 
+#     - Command: /work/paddle/tools {develop} bash grep_invalid_enforce.sh ../paddle/fluid/imperative
 #     - Results:
 #         - paddle/fluid/imperative/gradient_accumulator.cc
 #         PADDLE_ENFORCE_EQ(dst_tensor->numel() == numel, true,
@@ -60,7 +60,7 @@
 #                     "Place cannot be CUDAPlace when use_double_buffer is False");
 #         PADDLE_ENFORCE_NOT_NULL(exceptions_[i]);
 #         PADDLE_ENFORCE_EQ(status, Status::kException);
-#         PADDLE_ENFORCE_EQ(status, Status::kSuccess);    
+#         PADDLE_ENFORCE_EQ(status, Status::kSuccess);
 
 . ./count_enforce_by_file.sh --source-only
 

--- a/tools/enforce/grep_invalid_enforce.sh
+++ b/tools/enforce/grep_invalid_enforce.sh
@@ -17,14 +17,14 @@
 # This script is used to grep invalid PADDLE checks by directory or file in the paddle/fluid/,
 #   the result show all invalid PADDLE checks in specified directory or file.
 
-# Usage:
+# Usage: 
 #   - bash grep_invalid_enforce.sh [target directory or file] (run in tools directory)
 #       - The default check path is paddle/fluid/operators
 
 # Result Examples:
 # 1. grep invalid PADDLE checks in directory
 
-#     - Command: /work/paddle/tools {develop} bash grep_invalid_enforce.sh ../paddle/fluid/imperative
+#     - Command: /work/paddle/tools {develop} bash grep_invalid_enforce.sh ../paddle/fluid/imperative 
 #     - Results:
 #         - paddle/fluid/imperative/gradient_accumulator.cc
 #         PADDLE_ENFORCE_EQ(dst_tensor->numel() == numel, true,
@@ -60,7 +60,7 @@
 #                     "Place cannot be CUDAPlace when use_double_buffer is False");
 #         PADDLE_ENFORCE_NOT_NULL(exceptions_[i]);
 #         PADDLE_ENFORCE_EQ(status, Status::kException);
-#         PADDLE_ENFORCE_EQ(status, Status::kSuccess);
+#         PADDLE_ENFORCE_EQ(status, Status::kSuccess);    
 
 . ./count_enforce_by_file.sh --source-only
 

--- a/tools/externalError/start.sh
+++ b/tools/externalError/start.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tools/gen_alias_mapping.sh
+++ b/tools/gen_alias_mapping.sh
@@ -17,16 +17,16 @@
 # Brief:
 #     This code is used for generating the mapping list of Paddle API alias.
 #     Only the APIs set with the `DEFINE_ALIAS` flag is enable.
-# 
+#
 # Arguments:
 #     None
-# 
+#
 # Usage:
-#     Go into the `Paddle` folder and just run `./tools/gen_alias_mapping.sh`     
+#     Go into the `Paddle` folder and just run `./tools/gen_alias_mapping.sh`
 #
 # Returns:
 #     succ: 0
-# 
+#
 #     Will also print the mapping list to stdout. The format of each line is as below:
 #         <real API implement>\t<API recommend>,<API other alias name1>,<API other alias name2>,...
 
@@ -38,7 +38,7 @@ find ${PADDLE_ROOT}/python/ -name '*.py' \
     | grep 'DEFINE_ALIAS' \
     | perl -ne '
         if (/\/python\/(.*):from (\.*)(\w.*) import (.*?)\s+#DEFINE_ALIAS\s+$/) {
-            my @arr = split(", ", $4); 
+            my @arr = split(", ", $4);
             foreach $i (@arr) {
                 printf "%s|%s|%s|%d\n", $3, $i, substr($1, 0, -3), length($2);
             }
@@ -66,7 +66,7 @@ find ${PADDLE_ROOT}/python/ -name '*.py' \
             }
             key = key""new;
             n2o[key] = val;
-        } 
+        }
         END {
             for (new in n2o) {
                 old = n2o[new] in n2o ? n2o[n2o[new]] : n2o[new];
@@ -78,7 +78,7 @@ find ${PADDLE_ROOT}/python/ -name '*.py' \
         {
             o2n[$1] = o2n[$1] ? o2n[$1]","$3 : $3;
         }
-        END { 
+        END {
             for (i in o2n) {
                 print i"\t"o2n[i];
             }

--- a/tools/get_build_time.sh
+++ b/tools/get_build_time.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tools/get_cpu_info.sh
+++ b/tools/get_cpu_info.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -54,7 +54,7 @@ echo "OS Version             : `uname -o`"
 echo "Kernel Release Version : `uname -r`"
 echo "Kernel Patch Version   : `uname -v`"
 echo "GCC Version            :`gcc --version | head -n 1|awk -F '\\\(GCC\\\)' '{print $2}'`"
-if command -v cmake >/dev/null 2>&1; then 
+if command -v cmake >/dev/null 2>&1; then
   cmake_ver=`cmake --version | head -n 1 | awk -F 'version' '{print $2}'`
 else
   cmake_ver=" Not installed"

--- a/tools/get_op_list.sh
+++ b/tools/get_op_list.sh
@@ -1,11 +1,11 @@
 # Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tools/gpups_test.sh
+++ b/tools/gpups_test.sh
@@ -1,11 +1,11 @@
 # Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,7 +40,7 @@ function get_quickly_disable_ut() {
     fi
 }
 
-# disable test: 
+# disable test:
 # test_dygraph_dataparallel_bf16
 # test_dygraph_sharding_stage2_bf16
 # test_dygraph_sharding_stage3_bf16

--- a/tools/nvcc_lazy.sh
+++ b/tools/nvcc_lazy.sh
@@ -17,7 +17,7 @@
 echo "#!/usr/bin/env bash" >> $1
 echo "unset GREP_OPTIONS" >> $1
 echo "set -e" >> $1
-echo -e >> $1 
+echo -e >> $1
 echo "# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved." >> $1
 echo "#" >> $1
 echo "# Licensed under the Apache License, Version 2.0 (the \"License\");" >> $1
@@ -25,7 +25,7 @@ echo "# you may not use this file except in compliance with the License." >> $1
 echo "# You may obtain a copy of the License at" >> $1
 echo "#" >> $1
 echo "#     http://www.apache.org/licenses/LICENSE-2.0" >> $1
-echo "#" >> $1 
+echo "#" >> $1
 echo "# Unless required by applicable law or agreed to in writing, software" >> $1
 echo "# distributed under the License is distributed on an \"AS IS\" BASIS," >> $1
 echo "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied." >> $1

--- a/tools/statistics_UT_resource.sh
+++ b/tools/statistics_UT_resource.sh
@@ -1,11 +1,11 @@
 # Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tools/timeout_debug_help.sh
+++ b/tools/timeout_debug_help.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,7 @@ set +e
 failed_uts=$1
 need_debug_ut_re='test_dist_fleet'
 cat_log_judge=$(echo "${failed_uts}" | grep 'Timeout' |  grep -oEi "$need_debug_ut_re" )
-if [[ "$cat_log_judge" != "" ]];then 
+if [[ "$cat_log_judge" != "" ]];then
     echo "=============================================="
     echo "show timeout ut logs"
     echo "=============================================="

--- a/tools/windows/check_change_of_unittest.sh
+++ b/tools/windows/check_change_of_unittest.sh
@@ -19,7 +19,7 @@ GITHUB_API_TOKEN=$GITHUB_API_TOKEN
 GIT_PR_ID=$AGILE_PULL_ID
 BRANCH=$BRANCH
 if [ "${GITHUB_API_TOKEN}" == "" ] || [ "${GIT_PR_ID}" == "" ];then
-    exit 0 
+    exit 0
 fi
 
 unittest_spec_diff=$(cat $PADDLE_ROOT/deleted_ut | sed 's/^/ - /g')

--- a/tools/xpu/get_xpti_dependence.sh
+++ b/tools/xpu/get_xpti_dependence.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

清理 trailing whitespace part4，为全文件启用 trailing whitespace 自动修复做准备

PCard-66972