### PR TITLE
fix replicated dist_out_attr for view op

### DIFF
--- a/paddle/phi/api/generator/dist_api_gen.py
+++ b/paddle/phi/api/generator/dist_api_gen.py
@@ -1106,9 +1106,7 @@ class DistForwardAPI(ForwardAPI):
                         )
                     else:
                         if (
-                            self.need_to_generate_code_for_inplace_or_view_impl(
-                                i
-                            )
+                            self.need_to_generate_code_for_inplace_impl(i)
                             and self.generate_general_infer_spmd
                         ):
                             output_creation_code += (


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
ATT
The original implementation may generate the follow code for view op,
```
std::tuple<Tensor, Tensor> api_output;
auto dist_out_attr_0 = static_cast<phi::distributed::DistTensor*>((std::get<1>(api_output)).impl().get())->dist_attr();
```
However, api_output is uninitialized and its impl is NULL, SO it may result in segment fault.

Pcard-76459
