### PR TITLE
[CINN]Call GetKernelInfo in thread to speed up compile

### DIFF
--- a/paddle/cinn/hlir/framework/pir_compiler.cc
+++ b/paddle/cinn/hlir/framework/pir_compiler.cc
@@ -77,6 +77,7 @@ std::vector<pir::CINNKernelInfo> PirCompiler::Build(
     auto worker_fn = [&](int index) {
       CompilationTask task(&group_compilation_contexts[index]);
       compilation_results[index] = task();
+      compilation_results[index]->GetKernelInfo();
     };
     utils::parallel_run(worker_fn,
                         utils::SequenceDispatcher(0, task_size),

--- a/paddle/cinn/hlir/framework/pir_compiler.cc
+++ b/paddle/cinn/hlir/framework/pir_compiler.cc
@@ -77,6 +77,7 @@ std::vector<pir::CINNKernelInfo> PirCompiler::Build(
     auto worker_fn = [&](int index) {
       CompilationTask task(&group_compilation_contexts[index]);
       compilation_results[index] = task();
+      // Triggering llvm compilation in thread
       compilation_results[index]->GetKernelInfo();
     };
     utils::parallel_run(worker_fn,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-72718
本pr的修改在cuda11.2环境下大概可以减少5%的编译时间
- 修改之前
![image](https://github.com/PaddlePaddle/Paddle/assets/23097963/24fdf1c2-31a6-4fdb-8f9a-6ec0f32b0682)
- 修改之后
![image](https://github.com/PaddlePaddle/Paddle/assets/23097963/cdfa90a0-de3c-481b-8ef2-750b738ae055)
