### PR TITLE
[Prim] decomp fix batch_norm infer in eval mode

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_op_decomp.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op_decomp.cc
@@ -98,12 +98,22 @@ std::vector<std::vector<pir::Value>> BatchNormOp::Decomp(pir::Operation* op) {
   res[2].push_back(std::static_pointer_cast<primitive::LazyTensor>(
                        std::get<2>(op_res).impl())
                        ->value());
-  res[3].push_back(std::static_pointer_cast<primitive::LazyTensor>(
-                       std::get<3>(op_res).impl())
-                       ->value());
-  res[4].push_back(std::static_pointer_cast<primitive::LazyTensor>(
-                       std::get<4>(op_res).impl())
-                       ->value());
+  if (std::get<3>(op_res).initialized()) {
+    res[3].push_back(std::static_pointer_cast<primitive::LazyTensor>(
+                         std::get<3>(op_res).impl())
+                         ->value());
+  } else {
+    pir::Value saved_mean;
+    res[3].push_back(saved_mean);
+  }
+  if (std::get<4>(op_res).initialized()) {
+    res[4].push_back(std::static_pointer_cast<primitive::LazyTensor>(
+                         std::get<4>(op_res).impl())
+                         ->value());
+  } else {
+    pir::Value saved_var;
+    res[4].push_back(saved_var);
+  }
   pir::Value reserve_space;
   res[5].push_back(reserve_space);
 
@@ -180,12 +190,23 @@ std::vector<std::vector<pir::Value>> BatchNorm_Op::Decomp(pir::Operation* op) {
   res[2].push_back(std::static_pointer_cast<primitive::LazyTensor>(
                        std::get<2>(op_res).impl())
                        ->value());
-  res[3].push_back(std::static_pointer_cast<primitive::LazyTensor>(
-                       std::get<3>(op_res).impl())
-                       ->value());
-  res[4].push_back(std::static_pointer_cast<primitive::LazyTensor>(
-                       std::get<4>(op_res).impl())
-                       ->value());
+  if (std::get<3>(op_res).initialized()) {
+    res[3].push_back(std::static_pointer_cast<primitive::LazyTensor>(
+                         std::get<3>(op_res).impl())
+                         ->value());
+  } else {
+    pir::Value saved_mean;
+    res[3].push_back(saved_mean);
+  }
+  if (std::get<4>(op_res).initialized()) {
+    res[4].push_back(std::static_pointer_cast<primitive::LazyTensor>(
+                         std::get<4>(op_res).impl())
+                         ->value());
+  } else {
+    pir::Value saved_var;
+    res[4].push_back(saved_var);
+  }
+
   pir::Value reserve_space;
   res[5].push_back(reserve_space);
 

--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -41,7 +41,8 @@ std::unordered_set<std::string> decomp_op_contain_none = {"pd_op.squeeze",
                                                           "pd_op.unsqueeze",
                                                           "pd_op.flatten",
                                                           "pd_op.batch_norm",
-                                                          "pd_op.batch_norm_"};
+                                                          "pd_op.batch_norm_",
+                                                          "pd_op.dropout"};
 //
 std::unordered_set<std::string> dynamic_shape_blacklist = {
     "pd_op.squeeze",

--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -441,8 +441,10 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
     return std::make_tuple(
         y, run_mean_, run_var_, batch_mean_, inv_std_, reserve_space);
   } else {
+    Tensor batch_mean_none;
+    Tensor inv_std_none;
     return std::make_tuple(
-        y, run_mean_, run_var_, batch_mean_, inv_std_, reserve_space);
+        y, run_mean_, run_var_, batch_mean_none, inv_std_none, reserve_space);
   }
 }
 

--- a/test/deprecated/prim/pir_prim/CMakeLists.txt
+++ b/test/deprecated/prim/pir_prim/CMakeLists.txt
@@ -1,5 +1,6 @@
-set(TEST_PRIM_TRANS_PIR_CASES test_custom_vjp_trait test_decomp_op
-                              test_decompose_op test_vjp_prim)
+set(TEST_PRIM_TRANS_PIR_CASES
+    test_custom_vjp_trait test_decomp_op test_decompose_op test_vjp_prim
+    test_batch_norm_shape_check)
 
 foreach(target ${TEST_PRIM_TRANS_PIR_CASES})
   py_test_modules(${target} MODULES ${target} ENVS GLOG_v=1

--- a/test/deprecated/prim/pir_prim/test_batch_norm_shape_check.py
+++ b/test/deprecated/prim/pir_prim/test_batch_norm_shape_check.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle import pir
+from paddle.decomposition import decompose
+from paddle.framework import core
+
+paddle.enable_static()
+
+
+def batch_norm_net1(x, r_m, r_v, w, b):
+    return paddle.nn.functional.batch_norm(x, r_m, r_v, w, b, training=False)
+
+
+class TestBuildOp(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [1, 64, 512, 1024]
+        self.c_shape = [64]
+        self.dtype_x = "float32"
+        self.init_x_shape = [1, 64, 512, 1024]
+        self.x = np.random.random(self.x_shape).astype(self.dtype_x)
+        self.r_m = np.random.random(self.x_shape[1]).astype(self.dtype)
+        self.r_v = np.random.random(self.x_shape[1]).astype(self.dtype)
+        self.w = np.random.random(self.x_shape[1]).astype(self.dtype)
+        self.b = np.random.random(self.x_shape[1]).astype(self.dtype)
+        self.net = batch_norm_net1
+        self.necessary_ops = "pd_op.batch_norm"
+        self.enable_cinn = False
+        self.tol = 5e-6
+
+    def get_ir_program(self):
+        paddle.enable_static()
+        x = paddle.randn([4, 4])
+        main_program, start_program = (
+            paddle.static.Program(),
+            paddle.static.Program(),
+        )
+        with paddle.static.program_guard(main_program, start_program):
+            x = paddle.static.data('x', self.x_shape, x.dtype)
+            x.stop_gradients = False
+            r_m = paddle.static.data('r_m', self.c_shape, x.dtype)
+            r_v = paddle.static.data('r_v', self.c_shape, x.dtype)
+            w = paddle.static.data('w', self.c_shape, x.dtype)
+            b = paddle.static.data('b', self.c_shape, x.dtype)
+            y = batch_norm_net1(x, r_m, r_v, w, b)
+            res = paddle.tanh(y)
+        pir_program = pir.translate_to_pir(main_program.desc)
+        return pir_program
+
+    def test_build_op(self):
+        pir_program = self.get_ir_program()
+        y = pir_program.global_block().ops[-2].results()
+        orig_shape = y[0].shape
+        with paddle.pir_utils.IrGuard():
+            core._set_prim_forward_enabled(True)
+            y_new = decompose(pir_program, y)
+            core._set_prim_forward_enabled(False)
+            new_shape = y_new[0].shape
+            assert (
+                orig_shape == new_shape
+            ), f"Original shape {orig_shape} is not equal to new shape {new_shape}"
+            op_name_list = [op.name() for op in pir_program.global_block().ops]
+            assert "pd_op.batch_norm_" not in op_name_list
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes


### Description
<!-- Describe what you’ve done -->
Pcard-66975
Decomp process batch_norm infershape in eval mode.
