### PR TITLE
[PIR] fix codegen full zero dim

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -262,7 +262,7 @@ def GenBuildInsertFullForMutableAttribute(
   pir::Value {attr_name}_ = full_{attr_name}_op->result(0);
     """
     BUILD_SCALAR_ATTRIBUTE_TEMPLATE = """  // Generate scalar mutable attribute: {attr_name}
-  paddle::dialect::FullOp full_{attr_name}_op = builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{{1}}, {attr_name}, {phi_dtype}, phi::CPUPlace());
+  paddle::dialect::FullOp full_{attr_name}_op = builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{{}}, {attr_name}, {phi_dtype}, phi::CPUPlace());
   pir::Value {attr_name}_ = full_{attr_name}_op->result(0);
     """
     for idx in range(len(op_mutable_attribute_name_list)):

--- a/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
@@ -174,7 +174,7 @@ MUTABLE_ATTR_CAST_TEMPLATE = """
             {type} {name_} = {cast_func}({name}_obj, "{api_name}", {index});"""
 
 FULL_OP_TEMPLATE = """
-            {name} = paddle::dialect::full(std::vector<int64_t>{{1}}, {name}_tmp, phi::DataType::{phi_datatype}, phi::CPUPlace());
+            {name} = paddle::dialect::full(std::vector<int64_t>{{}}, {name}_tmp, phi::DataType::{phi_datatype}, phi::CPUPlace());
 """
 
 FULL_INT_ARRAY_OP_TEMPLATE = """

--- a/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
@@ -286,6 +286,19 @@ class TestPrimClip(TestPrimBase):
         self.tol = 1e-6
 
 
+class TestPrimClip2(TestPrimBase):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = []
+        self.init_x_shape = []
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = clip_net
+        self.necessary_ops = "pd_op.clip"
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
 class TestPrimSquaredL2Norm(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes


### Description
<!-- Describe what you’ve done -->
Pcard-66975
Ops like clip(x,min,max), current min and max will be assigned with shape [1]. When x is assigned with shape [], the result.shape is [1], instead of [].
