### PR TITLE
[CINN]ignore null type GetShapeOrDataForValue

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/simplify_dim_expr_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/simplify_dim_expr_pass.cc
@@ -101,6 +101,9 @@ void SimplifyDimExpr(pir::Operation* module_op) {
 
   VisitEachOp(module_op, [&](pir::Operation& op) {
     VisitEachValue(op, [&](pir::Value value) {
+      if (!value || !value.type()) {
+        return;
+      }
       const symbol::ShapeOrDataDimExprs& shape_or_data =
           shape_analysis->GetShapeOrDataForValue(value);
       VLOG(8) << op.name() << "     origin_shape_or_data: " << shape_or_data;

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -60,7 +60,6 @@ InferSymbolicShapeContext::GetShapeOrDataForValue(Value val) const {
     return empty;
   }
   if (!HasShapeOrDataForValue(val)) {
-    VLOG(3) << "fail value defining op: " << val.defining_op()->name();
     PADDLE_THROW(phi::errors::Fatal(
         "Fail to GetShapeOrDataForValue on InferSymbolicShape!"));
   }

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -60,6 +60,7 @@ InferSymbolicShapeContext::GetShapeOrDataForValue(Value val) const {
     return empty;
   }
   if (!HasShapeOrDataForValue(val)) {
+    VLOG(3) << "fail value defining op: " << val.defining_op()->name();
     PADDLE_THROW(phi::errors::Fatal(
         "Fail to GetShapeOrDataForValue on InferSymbolicShape!"));
   }
@@ -380,21 +381,22 @@ void ShapeConstraintIRAnalysis::InferShapeOrDataForValue(Value val) {
     if (infer_symbolic_shape_interface) {
       infer_symbolic_shape_interface.InferSymbolicShape(&context_);
       for (auto& result_value : op->results()) {
-        if (result_value && (!context_.HasShapeOrDataForValue(result_value))) {
+        if (!result_value || !result_value.type()) {
+          continue;
+        }
+        if (!context_.HasShapeOrDataForValue(result_value)) {
           PADDLE_THROW(phi::errors::Fatal(op->name() +
                                           " HAS ERROR on InferSymbolicShape!"));
         }
       }
     } else {
-      // TODO(Hongqing-work): throw it after the shape analysis reconstruct
-      // is done.
-      // PADDLE_THROW(phi::errors::Unimplemented(
-      //     val.defining_op()->name() +
-      //     " DOES NOT have InferSymbolicShapeInterface!"));
       LOG(WARNING) << op->name()
                    << " DOES NOT have InferSymbolicShapeInterface!";
       for (auto& result_value : op->results()) {
-        if (result_value && (!context_.HasShapeOrDataForValue(result_value))) {
+        if (!result_value || !result_value.type()) {
+          continue;
+        }
+        if (!context_.HasShapeOrDataForValue(result_value)) {
           SetSymbolForValueByStaticShape(result_value);
         }
       }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR ignores GetShapeOrDataForValue for  null type in simplify_dim_expr_pass and lazy infer check.