### PR TITLE
[PIR][oneDNN] set is_test attribute for onednn ops

### DIFF
--- a/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
@@ -51,7 +51,12 @@ class OneDNNPlacementPattern : public pir::OpRewritePattern<OpType> {
       paddle::dialect::OpRunTimeInfo runtime_info =
           std::get<3>(yaml_interface->get_op_info_(target_op_name));
       for (auto &attr : runtime_info.extra_args_default_value) {
-        attributes[attr.first] = attr.second;
+        if (attributes.find(attr.first) == attributes.end()) {
+          attributes[attr.first] = attr.second;
+        }
+        if (attr.first == "is_test") {
+          attributes[attr.first] = rewriter.bool_attr(true);
+        }
       }
 
       pir::Operation *op_item_inner = rewriter.Build(op->operands_source(),

--- a/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
@@ -51,12 +51,10 @@ class OneDNNPlacementPattern : public pir::OpRewritePattern<OpType> {
       paddle::dialect::OpRunTimeInfo runtime_info =
           std::get<3>(yaml_interface->get_op_info_(target_op_name));
       for (auto &attr : runtime_info.extra_args_default_value) {
-        if (attributes.find(attr.first) == attributes.end()) {
-          attributes[attr.first] = attr.second;
-        }
-        if (attr.first == "is_test") {
-          attributes[attr.first] = rewriter.bool_attr(true);
-        }
+        attributes[attr.first] = attr.second;
+      }
+      if (attributes.find("is_test") != attributes.end()) {
+        attributes["is_test"] = rewriter.bool_attr(true);
       }
 
       pir::Operation *op_item_inner = rewriter.Build(op->operands_source(),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
In former fluid mechanism, there was a pass called "is_test_pass" to set "is_test" as true for all ops. While in PIR, there is no such pass. To avoid failure on some ops, we revise the pass to support setting true for this attribute.
