### PR TITLE
[Prim][PIR] fix one_hot op forward in prim pir

### DIFF
--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -225,7 +225,12 @@ Tensor one_hot_decomp(const Tensor& x, const Tensor& num_classes) {
       backend::full_with_tensor<T>(num_classes, 0, x.dtype());
 
   std::vector<int64_t> input_dim;
-  input_dim.push_back(x.shape()[0]);
+  int x_dims = 1;
+  for (size_t i = 0; i < x.shape().size(); i++) {
+    x_dims *= x.shape()[i];
+  }
+
+  input_dim.push_back(x_dims);
   input_dim.push_back(num_classes_tensor.shape()[0]);
   auto input_tensor = full<T>(input_dim, 0, x.dtype());
 
@@ -235,13 +240,13 @@ Tensor one_hot_decomp(const Tensor& x, const Tensor& num_classes) {
   }
   output_dim.push_back(num_classes_tensor.shape()[0]);
 
-  auto end = full<T>({1}, x.shape()[0], x.dtype());
+  auto end = full<T>({1}, x_dims, x.dtype());
   auto start = full<T>({1}, 0, x.dtype());
   auto step = full<T>({1}, 1, x.dtype());
   auto arange_tensor =
       backend::arange_with_tensor<T>(start, end, step, x.dtype());
 
-  std::vector<int64_t> reshape_dim{x.shape()[0], 1};
+  std::vector<int64_t> reshape_dim{x_dims, 1};
   auto x_reshape = reshape<T>(x, reshape_dim);
   auto arange_tensor_reshape = reshape<T>(arange_tensor, reshape_dim);
 
@@ -250,7 +255,7 @@ Tensor one_hot_decomp(const Tensor& x, const Tensor& num_classes) {
   index_concat.push_back(x_reshape);
   auto index_tensor = concat<T>(index_concat, 1);
 
-  auto update_tensor = full<T>({x.shape()[0]}, 1, x.dtype());
+  auto update_tensor = full<T>({x_dims}, 1, x.dtype());
 
   auto ans = reshape<T>(
       cast<T>(scatter_nd_add<T>(input_tensor, index_tensor, update_tensor),

--- a/test/deprecated/legacy_test/test_one_hot_v2_op.py
+++ b/test/deprecated/legacy_test/test_one_hot_v2_op.py
@@ -54,6 +54,37 @@ class TestOneHotOp(OpTest):
         self.check_output(check_cinn=True, check_prim_pir=True)
 
 
+class TestOneHotOp_dims(OpTest):
+    def setUp(self):
+        self.op_type = 'one_hot_v2'
+        self.prim_op_type = "comp"
+        self.python_api = one_hot_wrapper
+        self.public_python_api = one_hot_wrapper
+        self.python_out_sig = ['Out']
+        depth = 10
+        depth_np = np.array(10).astype('int32')
+        x_shape = [4, 1, 3, 3]
+        x = [np.random.randint(0, depth - 1) for i in range(np.prod(x_shape))]
+        x = np.array(x).astype('int32').reshape(x_shape)
+
+        out = np.zeros(shape=(np.prod(x.shape), depth)).astype('float32')
+
+        r_x = np.reshape(x, np.prod(x.shape))
+        for i in range(np.prod(x.shape)):
+            out[i, r_x[i]] = 1.0
+
+        shape_np = list(x.shape)
+        shape_np.append(depth)
+        out = np.reshape(out, shape_np)
+
+        self.inputs = {'X': x, 'depth_tensor': depth_np}
+        self.attrs = {'dtype': int(core.VarDesc.VarType.FP32)}
+        self.outputs = {'Out': out}
+
+    def test_check_output(self):
+        self.check_output(check_cinn=True, check_prim_pir=True)
+
+
 class TestOneHotOp_attr(OpTest):
     def setUp(self):
         self.op_type = 'one_hot_v2'

--- a/test/deprecated/legacy_test/test_one_hot_v2_op.py
+++ b/test/deprecated/legacy_test/test_one_hot_v2_op.py
@@ -63,7 +63,7 @@ class TestOneHotOp_dims(OpTest):
         self.python_out_sig = ['Out']
         depth = 10
         depth_np = np.array(10).astype('int32')
-        x_shape = [4, 1, 3, 3]
+        x_shape = [5, 10, 7, 3]
         x = [np.random.randint(0, depth - 1) for i in range(np.prod(x_shape))]
         x = np.array(x).astype('int32').reshape(x_shape)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
[Prim][PIR] fix one_hot op forward in prim pir
