### PR TITLE
[Infra]Update Numpy Version to Support v2.0+

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 httpx
-numpy>=1.13, <2.0
+numpy>=1.13
 protobuf>=3.20.2 
 Pillow
 decorator


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
去掉numpy上限，paddle可以在numpy2.x下编译，并且是前向兼容的，numpy下2.x下编译的paddle可以在1.x下使用

To do：

CI升级对Numpy2.x的支持，暂时单测阶段使用的numpy1.x

Pcard-67174