### PR TITLE
[CINN][ROCM] fix compilation error when -DWITH_ROCM=ON -DWITH_CINN=ON

### DIFF
--- a/cmake/cinn/external/absl.cmake
+++ b/cmake/cinn/external/absl.cmake
@@ -63,6 +63,10 @@ set(ABSL_LIB_NAMES
     raw_hash_set)
 set(ABSL_LIBS "")
 
+if(WITH_ROCM)
+  list(APPEND ABSL_LIB_NAMES strings_internal raw_logging_internal)
+endif()
+
 add_library(absl STATIC IMPORTED GLOBAL)
 set_property(TARGET absl PROPERTY IMPORTED_LOCATION
                                   ${ABSL_INSTALL_DIR}/lib/libabsl_base.a)

--- a/cmake/hip.cmake
+++ b/cmake/hip.cmake
@@ -136,11 +136,7 @@ list(APPEND HIP_CXX_FLAGS -Wno-unused-local-typedef)
 list(APPEND HIP_CXX_FLAGS -Wno-missing-braces)
 list(APPEND HIP_CXX_FLAGS -Wno-sometimes-uninitialized)
 
-if(WITH_CINN)
-  list(APPEND HIP_CXX_FLAGS -std=c++14)
-else()
-  list(APPEND HIP_CXX_FLAGS -std=c++17)
-endif()
+list(APPEND HIP_CXX_FLAGS -std=c++17)
 list(APPEND HIP_CXX_FLAGS --gpu-max-threads-per-block=1024)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)


### PR DESCRIPTION
### PR Category
CINN


### PR Types
Bug fixes

### Description
修复-DWITH_ROCM=ON -DWITH_CINN=ON时的编译错误https://github.com/PaddlePaddle/Paddle/issues/64785

- 修改WITH_CINN时的HIP_CXX_FLAGS 为c++17，因为GPU kernel中使用了c++17。
- 增加WITH_ROCM时的absl链接库API。

pcard-79890
