### PR TITLE
[Dy2St][NumPy2] Replace deprecated `gym` with `gymnasium`

### DIFF
--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -2,7 +2,7 @@ PyGithub
 coverage==5.5
 pycrypto ; platform_system != "Windows"
 mock
-gym==0.26.2
+gymnasium==0.29.1
 pygame==2.5.2
 hypothesis
 opencv-python<=4.2.0.32

--- a/test/dygraph_to_static/test_reinforcement_learning.py
+++ b/test/dygraph_to_static/test_reinforcement_learning.py
@@ -16,7 +16,7 @@ import itertools
 import math
 import unittest
 
-import gym
+import gymnasium as gym
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#64905 暴露问题

使用 `gym` 的 fork `gymnasium` 替换 `gym`，`gym` 已经弃用，不再维护，其中有用法与 NumPy2.0 不兼容

为免阻塞 NumPy2.0 升级，替换 `gym` 为 `gymnasium`

see also: https://github.com/openai/gym/pull/3258

PCard-66972