### PR TITLE
[CINN]add limit for broadcast tree

### DIFF
--- a/paddle/cinn/common/broadcast_tree.h
+++ b/paddle/cinn/common/broadcast_tree.h
@@ -29,7 +29,8 @@ using BroadcastLeaf = adt::List<std::vector<symbol::DimExpr>>;
 
 using BroadcastTree = adt::Tree<BroadcastBranch, BroadcastLeaf>;
 
-BroadcastTree ConstructBroadcastTree(const BroadcastLeaf& leaves);
+BroadcastTree ConstructBroadcastTree(const BroadcastLeaf& leaves,
+                                     int* num_of_leaves);
 
 std::string ToTxtString(const BroadcastTree&);
 

--- a/paddle/cinn/common/broadcast_tree_test.cc
+++ b/paddle/cinn/common/broadcast_tree_test.cc
@@ -66,7 +66,8 @@ TEST(BroadcastTree, Naive) {
                                     MakeBroadcastDimExpr(expr1, expr2),
                                     MakeBroadcastDimExpr(expr3, expr4)};
   BroadcastLeaf leaf = adt::List<std::vector<DimExpr>>{tensor_shape};
-  BroadcastTree tree = ConstructBroadcastTree(leaf);
+  int num_of_leaves = 0;
+  BroadcastTree tree = ConstructBroadcastTree(leaf, &num_of_leaves);
   ASSERT_TRUE(tree.Has<BroadcastBranch<BroadcastTree>>());
   const auto& branch = tree.Get<BroadcastBranch<BroadcastTree>>();
   const auto& [cstr_broadcastable,
@@ -96,7 +97,8 @@ TEST(BroadcastTree, SimplifyConstantBroadcast) {
                                     MakeBroadcastDimExpr(expr1, expr2),
                                     MakeBroadcastDimExpr(expr3, expr4)};
   BroadcastLeaf leaf = adt::List<std::vector<DimExpr>>{tensor_shape};
-  BroadcastTree tree = ConstructBroadcastTree(leaf);
+  int num_of_leaves = 0;
+  BroadcastTree tree = ConstructBroadcastTree(leaf, &num_of_leaves);
   ASSERT_TRUE(tree.Has<BroadcastBranch<BroadcastTree>>());
   const auto& branch = tree.Get<BroadcastBranch<BroadcastTree>>();
   const auto& [cstr_broadcastable,

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/broadcast_with_cf.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/broadcast_with_cf.cc
@@ -442,9 +442,11 @@ std::shared_ptr<BroadcastTree> ConstructBroadcastTree(
     const cinn::common::BroadcastLeaf& leaves) {
   VLOG(6) << "before constructed. broadcast-leaf: \n"
           << ToTxtString(cinn::common::BroadcastTree(leaves));
+  int num_of_leaves = 0;
   auto broadcast_tree = std::make_shared<cinn::common::BroadcastTree>(
-      cinn::common::ConstructBroadcastTree(
-          cinn::common::BroadcastLeaf(leaves)));
+      cinn::common::ConstructBroadcastTree(cinn::common::BroadcastLeaf(leaves),
+                                           &num_of_leaves));
+  VLOG(4) << "num of broadcast tree leaves:" << num_of_leaves;
   VLOG(4) << "broadcast-tree: \n" << ToTxtString(*broadcast_tree);
   return broadcast_tree;
 }

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1612,6 +1612,11 @@ PHI_DEFINE_EXPORTED_bool(pir_apply_shape_optimization_pass,
                          "Whether to apply shape_optimization pass "
                          "to infer symbolic shape");
 
+PHI_DEFINE_EXPORTED_int64(
+    pir_broadcast_tree_limit,
+    32,
+    "Maximum number of broadcast nodes allowed in a tree");
+
 PHI_DEFINE_EXPORTED_string(
     nvidia_package_dir,  // NOLINT
     "",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR adds limit for broadcast tree. When the number of single Broadcast Expr items is larger than 3 or the number of broadcast leaves is greater than FLAGS_pir_broadcast_tree_limit(default is 32), CINN will throw phi::errors::Fatal("Too many broadcast leaves to compile!".