### PR TITLE
fix spmd rule of flatten_grad, add xshape dist_attr in result

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/flatten.cc
+++ b/paddle/phi/infermeta/spmd_rules/flatten.cc
@@ -191,7 +191,13 @@ SpmdInfo FlattenInferSpmdReverse(const DistMetaTensor& x,
 
 SpmdInfo FlattenGradInferSpmd(const DistMetaTensor& xshape,
                               const DistMetaTensor& out_grad) {
-  return ReshapeGradInferSpmd(xshape, out_grad);
+  // TODO(jeff41404): when ReshapeInferSpmd and ReshapeGradInferSpmd can deliver
+  // distributed attribute of xshape, we will use ReshapeGradInferSpmd directly
+  // in future return ReshapeGradInferSpmd(xshape, out_grad);
+  auto shape = phi::vectorize(xshape.dims());
+  shape = std::vector<int64_t>(shape.begin() + 1, shape.end());
+  const auto& spmd = ReshapeInferSpmd(out_grad, shape);
+  return {{xshape.dist_attr(), spmd.first[0]}, {spmd.second[0]}};
 }
 
 }  // namespace distributed

--- a/test/cpp/auto_parallel/spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/spmd_rule_test.cc
@@ -1908,13 +1908,14 @@ TEST(Flatten, Ctor) {
   check_dim_mapping(spmd4.second[0], {-1, -1});
   check_dim_mapping(spmd4.second[1], {-1, -1, -1, -1, -1, -1});  // x_shape
 
-  auto out_grad = build_input({2, 1024, 1024}, {-1, -1, -1});
-  auto xshape = build_input({0, 2, 1024, 4, 1024 / 4}, {-1, 0, 1, -1, -1});
+  auto out_grad = build_input({2, 1024, 1024}, {0, -1, 1});
+  auto xshape = build_input({0, 2, 1024, 4, 1024 / 4}, {-1, 0, -1, 1, -1});
   auto spmd_grad = FlattenGradInferSpmd(xshape, out_grad);
-  EXPECT_EQ(spmd_grad.first.size(), static_cast<size_t>(1));
+  EXPECT_EQ(spmd_grad.first.size(), static_cast<size_t>(2));
   EXPECT_EQ(spmd_grad.second.size(), static_cast<size_t>(1));
-  check_dim_mapping(spmd_grad.first[0], {0, 1, -1});
-  check_dim_mapping(spmd_grad.second[0], {0, 1, -1, -1});
+  check_dim_mapping(spmd_grad.first[0], {-1, 0, -1, 1, -1});
+  check_dim_mapping(spmd_grad.first[1], {0, -1, 1});
+  check_dim_mapping(spmd_grad.second[0], {0, -1, 1, -1});
 }
 
 }  // namespace auto_parallel


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel

### PR Types
Bug fixes

### Description
pcard-84490
- when #64723 add flatten_grad spmd rule, which directly use ReshapeGradInferSpmd, but ReshapeGradInferSpmd do not return distributed attribute of xshape in result which will cause error in running flatten_grad.
- when ReshapeInferSpmd and ReshapeGradInferSpmd can deliver distributed attribute of xshape, we will use ReshapeGradInferSpmd directly in future.
