### PR TITLE
[Typing] type checking with apis

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -146,7 +146,7 @@ def _get_reduce_axis_with_tensor(axis, x):
     return reduce_all, axis
 
 
-def log(x, name=None):
+def log(x: paddle.Tensor, name: str | None = None) -> paddle.Tensor:
     r"""
     Calculates the natural log of the given input Tensor, element-wise.
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 """
 math functions
 """

--- a/tools/sampcd_processor_utils.py
+++ b/tools/sampcd_processor_utils.py
@@ -598,6 +598,7 @@ def get_test_capacity(run_on_device="cpu"):
 def get_docstring(
     full_test: bool = False,
     filter_api: typing.Callable[[str], bool] | None = None,
+    apis: tuple[tuple[str, str], ...] | None = None,
 ):
     '''
     this function will get the docstring for test.
@@ -605,34 +606,40 @@ def get_docstring(
     Args:
         full_test, get all api
         filter_api, a function that filter api, if `True` then skip add to `docstrings_to_test`.
+        apis, checking apis with ((line, api), (line, api), ...) like (("paddle.abs", "paddle.abs"), ("paddle.sin", "paddle.sin"), ...).
+            Do NOT use `full_test` and `apis` at the same time.
     '''
     import paddle
     import paddle.static.quantization  # noqa: F401
 
-    if full_test:
-        get_full_api_from_pr_spec()
-    else:
-        get_incrementapi()
-
     docstrings_to_test = {}
     whl_error = []
-    with open(API_DIFF_SPEC_FN) as f:
-        for line in f.readlines():
-            api = line.replace('\n', '')
-            if filter_api is not None and filter_api(api.strip()):
-                continue
 
-            try:
-                api_obj = eval(api)
-            except AttributeError:
-                whl_error.append(api)
-                continue
-            except SyntaxError:
-                logger.warning('line:%s, api:%s', line, api)
-                # paddle.Tensor.<lambda>
-                continue
-            if hasattr(api_obj, '__doc__') and api_obj.__doc__:
-                docstrings_to_test[api] = api_obj.__doc__
+    if apis is None or not apis:
+        # get api from spec
+        if full_test:
+            get_full_api_from_pr_spec()
+        else:
+            get_incrementapi()
+
+        with open(API_DIFF_SPEC_FN) as f:
+            apis = ((line, line.replace('\n', '')) for line in f.readlines())
+
+    for line, api in apis:
+        if filter_api is not None and filter_api(api.strip()):
+            continue
+
+        try:
+            api_obj = eval(api)
+        except AttributeError:
+            whl_error.append(api)
+            continue
+        except SyntaxError:
+            logger.warning('line:%s, api:%s', line, api)
+            # paddle.Tensor.<lambda>
+            continue
+        if hasattr(api_obj, '__doc__') and api_obj.__doc__:
+            docstrings_to_test[api] = api_obj.__doc__
 
     if len(docstrings_to_test) == 0 and len(whl_error) == 0:
         logger.warning("-----API_PR.spec is the same as API_DEV.spec-----")

--- a/tools/sampcd_processor_utils.py
+++ b/tools/sampcd_processor_utils.py
@@ -598,7 +598,7 @@ def get_test_capacity(run_on_device="cpu"):
 def get_docstring(
     full_test: bool = False,
     filter_api: typing.Callable[[str], bool] | None = None,
-    apis: tuple[tuple[str, str], ...] | None = None,
+    apis: list[tuple[str, str]] | None = None,
 ):
     '''
     this function will get the docstring for test.

--- a/tools/type_checking.py
+++ b/tools/type_checking.py
@@ -159,7 +159,7 @@ class MypyChecker(TypeChecker):
                         test_result.api_name,
                     )
                     logger.error(test_result.msg)
-                    failed_apis.append(test_result.api_name)
+                    failed_apis.append(test_result.api_name.split(':')[0])
 
             is_fail = True
 
@@ -169,7 +169,7 @@ class MypyChecker(TypeChecker):
                     is_fail = True
                     logger.error(test_result.api_name)
                     logger.error(test_result.msg)
-                    failed_apis.append(test_result.api_name)
+                    failed_apis.append(test_result.api_name.split(':')[0])
 
                 else:
                     logger.debug(test_result.api_name)

--- a/tools/type_checking.py
+++ b/tools/type_checking.py
@@ -262,7 +262,7 @@ def run_type_checker(
     docstrings_to_test, whl_error = get_docstring(
         full_test=args.full_test,
         filter_api=filter_api,
-        apis=tuple((api, api) for api in args.apis),
+        apis=[(api, api) for api in args.apis],
     )
 
     logger.info(">>> Running type checker ...")

--- a/tools/type_checking.py
+++ b/tools/type_checking.py
@@ -227,6 +227,13 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
+# https://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool
+# ctrl+c interrupt handler
+# this should be a global function, a local function makes `pickle` fail on MacOS.
+def init_worker():
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
 def get_test_results(
     type_checker: TypeChecker, docstrings_to_test: dict[str, str]
 ) -> list[TestResult]:
@@ -252,11 +259,6 @@ def get_test_results(
                     codeblock['codes'],
                 )
             )
-
-    # https://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool
-    # ctrl+c interrupt handler
-    def init_worker():
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
 
     test_results = []
     pool = multiprocessing.Pool(initializer=init_worker)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
修改 `tools/type_checking.py` ，使其可以单独检查指定的 api，具体用法为：

1. checking from input `apis`
``` shell
> python type_checking.py paddle.abs paddle.abs_ paddle.sin
```

2. checking from spec, with increment api
``` shell
> python type_checking.py
```

3. checking from spec, with full apis
``` shell
> python type_checking.py --full-test
```

`--full-test` and `apis` should not be set at the same time.

@SigureMo 
