### PR TITLE
[Prim] Modify the reduce_as op

### DIFF
--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -383,8 +383,11 @@ void reduce_as_grad(const Tensor& x,
         axis_[i] += x_dim_size;
       }
     }
-    auto out_grad_shape = get_unsqueeze_dims(out_grad, axis_);
-    auto out_grad_ = reshape<T>(out_grad, out_grad_shape);
+    Tensor out_grad_ = out_grad;
+    if (out_grad.shape().size() != x.shape().size()) {
+      auto out_grad_shape = get_unsqueeze_dims(out_grad, axis_);
+      out_grad_ = reshape<T>(out_grad, out_grad_shape);
+    }
     x_grad_tmp = expand<T>(out_grad_, IntArray(x_dim));
   }
 

--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -366,28 +366,21 @@ void reduce_as_grad(const Tensor& x,
   std::vector<int64_t> axis = common::vectorize<int64_t>(
       get_reduce_dims_from_out(x.dims(), target.dims()));
   int64_t axis_size = axis.size();
-  int64_t x_dim_size = x_dim.size();
-  bool reduce_all = false;
-  if (reduce_all || axis_size == 0 || axis_size == x_dim_size) {
-    reduce_all = true;
-  } else {
-    reduce_all = false;
+  if (axis_size == 0) {
+    by_pass<T>(out_grad, x_grad);
+    return;
   }
+  int64_t x_dim_size = x_dim.size();
+
   auto x_grad_tmp = Tensor();
   if (x_dim_size == 1) {
     x_grad_tmp = expand<T>(out_grad, IntArray(x_dim));
   } else {
     auto axis_ = std::vector<int64_t>();
-    if (reduce_all) {
-      for (int64_t i = 0; i < x_dim_size; i++) {
-        axis_.push_back(i);
-      }
-    } else {
-      for (int64_t i = 0; i < axis_size; i++) {
-        axis_.push_back(axis[i]);
-        if (axis[i] < 0) {
-          axis_[i] += x_dim_size;
-        }
+    for (int64_t i = 0; i < axis_size; i++) {
+      axis_.push_back(axis[i]);
+      if (axis[i] < 0) {
+        axis_[i] += x_dim_size;
       }
     }
     auto out_grad_shape = get_unsqueeze_dims(out_grad, axis_);

--- a/paddle/phi/kernels/cpu/reduce_as_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_as_grad_kernel.cc
@@ -33,6 +33,7 @@ void ReduceAsGradKernel(const Context& dev_ctx,
     ReduceGradKernel<Context, T, funcs::SumGradFunctor, true>(
         dev_ctx, x, paddle::none, out_grad, reduce_dim, false, false, x_grad);
   } else {
+    dev_ctx.template Alloc<T>(x_grad);
     phi::Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
   }
 }

--- a/paddle/phi/kernels/cpu/reduce_as_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_as_grad_kernel.cc
@@ -29,15 +29,12 @@ void ReduceAsGradKernel(const Context& dev_ctx,
                         const DenseTensor& out_grad,
                         DenseTensor* x_grad) {
   auto reduce_dim = phi::funcs::GetReduceDims(x, target);
-  bool reduce_all = recompute_reduce_all(x, reduce_dim);
-  ReduceGradKernel<Context, T, funcs::SumGradFunctor, true>(dev_ctx,
-                                                            x,
-                                                            paddle::none,
-                                                            out_grad,
-                                                            reduce_dim,
-                                                            false,
-                                                            reduce_all,
-                                                            x_grad);
+  if (reduce_dim.size() != 0) {
+    ReduceGradKernel<Context, T, funcs::SumGradFunctor, true>(
+        dev_ctx, x, paddle::none, out_grad, reduce_dim, false, false, x_grad);
+  } else {
+    phi::Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
+  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/reduce_as_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_as_kernel.cc
@@ -28,9 +28,12 @@ void ReduceAsKernel(const Context& dev_ctx,
                     const DenseTensor& target,
                     DenseTensor* out) {
   auto reduce_dim = phi::funcs::GetReduceDims(x, target);
-  bool reduce_all = recompute_reduce_all(x, reduce_dim);
-  phi::Reduce<CPUContext, T, phi::funcs::SumFunctor>(
-      dev_ctx, x, reduce_all, reduce_dim, false, out->type(), out);
+  if (reduce_dim.size() != 0) {
+    phi::Reduce<CPUContext, T, phi::funcs::SumFunctor>(
+        dev_ctx, x, false, reduce_dim, false, out->type(), out);
+  } else {
+    phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/reduce_as_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_as_kernel.cc
@@ -32,6 +32,7 @@ void ReduceAsKernel(const Context& dev_ctx,
     phi::Reduce<CPUContext, T, phi::funcs::SumFunctor>(
         dev_ctx, x, false, reduce_dim, false, out->type(), out);
   } else {
+    dev_ctx.template Alloc<T>(out);
     phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
   }
 }

--- a/paddle/phi/kernels/gpu/reduce_as_kernel.cu
+++ b/paddle/phi/kernels/gpu/reduce_as_kernel.cu
@@ -28,7 +28,11 @@ void ReduceAsKernel(const Context& dev_ctx,
                     DenseTensor* out) {
   auto reduce_dim = phi::funcs::GetReduceDims(x, target);
   dev_ctx.template Alloc<T>(out);
-  phi::SumKernel<T, Context>(dev_ctx, x, reduce_dim, out->type(), false, out);
+  if (reduce_dim.size() != 0) {
+    phi::SumKernel<T, Context>(dev_ctx, x, reduce_dim, out->type(), false, out);
+  } else {
+    phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+  }
 }
 
 }  // namespace phi

--- a/test/deprecated/legacy_test/test_reduce_as_op.py
+++ b/test/deprecated/legacy_test/test_reduce_as_op.py
@@ -154,6 +154,15 @@ class TestReduceAsOp13(TestReduceAsOp):
         self.attrs = {'dim': [0, 1]}
 
 
+class TestReduceAsOp14(TestReduceAsOp):
+    def init_shape(self):
+        self.shape_x = [10, 10, 6]
+        self.shape_y = [10, 10, 6]
+
+    def init_attrs(self):
+        self.attrs = {'dim': []}
+
+
 class TestReduceAsDynamicShape(unittest.TestCase):
     def setUp(self):
         np.random.seed(2023)

--- a/test/deprecated/legacy_test/test_reduce_as_op.py
+++ b/test/deprecated/legacy_test/test_reduce_as_op.py
@@ -78,7 +78,10 @@ class TestReduceAsOp(OpTest):
         pass
 
     def calc_output(self):
-        self.out = self.x.sum(axis=tuple(self.attrs['dim']))
+        if len(self.attrs['dim']) != 0:
+            self.out = self.x.sum(axis=tuple(self.attrs['dim']))
+        else:
+            self.out = self.x
 
     def test_check_output(self):
         self.check_output(check_pir=True)

--- a/test/deprecated/legacy_test/test_reduce_as_op.py
+++ b/test/deprecated/legacy_test/test_reduce_as_op.py
@@ -79,7 +79,10 @@ class TestReduceAsOp(OpTest):
 
     def calc_output(self):
         if len(self.attrs['dim']) != 0:
-            self.out = self.x.sum(axis=tuple(self.attrs['dim']))
+            if 1 in self.shape_y:
+                self.out = self.x.sum(axis=tuple(self.attrs['dim']), keepdims=True)
+            else:
+                self.out = self.x.sum(axis=tuple(self.attrs['dim']))
         else:
             self.out = self.x
 
@@ -161,6 +164,14 @@ class TestReduceAsOp14(TestReduceAsOp):
 
     def init_attrs(self):
         self.attrs = {'dim': []}
+
+class TestReduceAsOp15(TestReduceAsOp):
+    def init_shape(self):
+        self.shape_x = [10, 10, 6, 6]
+        self.shape_y = [1, 10, 1, 1]
+
+    def init_attrs(self):
+        self.attrs = {'dim': [0, 2, 3]}
 
 
 class TestReduceAsDynamicShape(unittest.TestCase):

--- a/test/deprecated/legacy_test/test_reduce_as_op.py
+++ b/test/deprecated/legacy_test/test_reduce_as_op.py
@@ -80,7 +80,9 @@ class TestReduceAsOp(OpTest):
     def calc_output(self):
         if len(self.attrs['dim']) != 0:
             if 1 in self.shape_y:
-                self.out = self.x.sum(axis=tuple(self.attrs['dim']), keepdims=True)
+                self.out = self.x.sum(
+                    axis=tuple(self.attrs['dim']), keepdims=True
+                )
             else:
                 self.out = self.x.sum(axis=tuple(self.attrs['dim']))
         else:
@@ -164,6 +166,7 @@ class TestReduceAsOp14(TestReduceAsOp):
 
     def init_attrs(self):
         self.attrs = {'dim': []}
+
 
 class TestReduceAsOp15(TestReduceAsOp):
     def init_shape(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

现在reduce_as op的实现是在计算好reduce_dim之后将reduce_dim作为输入传给reduce_sum kernel。当reduce_dim为空数组时，reduce_sum会默认执行reduce_all的计算，但是在reduce_as op中，当reduce_dim为空时，期望是不对输入做任何操作。该PR就是修复reduce_as op在reduce_dim为空时的情况。