### PR TITLE
[CINN] Support spatial loop pattern

### DIFF
--- a/paddle/cinn/ir/group_schedule/tactic/tile_first_general_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_first_general_tactic.cc
@@ -47,11 +47,11 @@ bool IsWarpReduce(const ScheduleConfig& config) {
   return std::visit(MatchWarpReduce, config.tile_config.reduce_method);
 }
 
-bool UseReduceTile(const ScheduleConfig& config) {
+bool UseContinuousDataTile(const ScheduleConfig& config) {
   const auto& raw_reduce_axis = config.base_info->raw_reduce_axis;
   const auto raw_data_rank = config.base_info->raw_data_rank;
   if (raw_reduce_axis.empty()) {
-    return false;
+    return true;
   }
   for (size_t i = 1; i < raw_reduce_axis.size(); i++) {
     if (raw_reduce_axis[i] != raw_reduce_axis[i - 1] + 1) {
@@ -66,7 +66,8 @@ class TileFirstGeneralTactic final : public ScheduleTactic {
   void Init(ScheduleContext* context) override;
 
   void Apply(ir::IRSchedule* sch, const std::string& block_id) override;
-  void ApplyReduceTile(ir::IRSchedule* sch, const std::string& block_id);
+  void ApplyContinuousDataTile(ir::IRSchedule* sch,
+                               const std::string& block_id);
 
   std::string TacticName() const override { return "TileFirstGeneralTactic"; }
 
@@ -113,9 +114,9 @@ void TileFirstGeneralTactic::Init(ScheduleContext* context) {
 
 void TileFirstGeneralTactic::Apply(ir::IRSchedule* sch,
                                    const std::string& block_id) {
-  if (UseReduceTile(context_->config)) {
-    VLOG(4) << "Using ApplyReduceTile";
-    ApplyReduceTile(sch, block_id);
+  if (UseContinuousDataTile(context_->config)) {
+    VLOG(4) << "Using ApplyContinuousDataTile";
+    ApplyContinuousDataTile(sch, block_id);
     return;
   }
   if (ir::IsReduceInitTensorName(block_id)) return;
@@ -156,20 +157,20 @@ void TileFirstGeneralTactic::Apply(ir::IRSchedule* sch,
   SetReduceType(sch, block_id);
 }
 
-void TileFirstGeneralTactic::ApplyReduceTile(ir::IRSchedule* sch,
-                                             const std::string& block_id) {
+void TileFirstGeneralTactic::ApplyContinuousDataTile(
+    ir::IRSchedule* sch, const std::string& block_id) {
   if (ir::IsReduceInitTensorName(block_id)) return;
 
   const auto sp_thread = context_->config.tile_config.warp_num * 32 /
                          context_->config.tile_config.tree_reduce_num;
   const auto sp_loop = context_->config.tile_config.spatial_inner_num;
   const auto rd_thread = context_->config.tile_config.tree_reduce_num;
-  VLOG(4) << "ApplyReduceTile sp_thread=" << sp_thread;
-  VLOG(4) << "ApplyReduceTile sp_loop=" << sp_loop;
-  VLOG(4) << "ApplyReduceTile rd_thread=" << rd_thread;
-  VLOG(4) << "ApplyReduceTile vec_flatten_axis: "
+  VLOG(4) << "ApplyContinuousDataTile sp_thread=" << sp_thread;
+  VLOG(4) << "ApplyContinuousDataTile sp_loop=" << sp_loop;
+  VLOG(4) << "ApplyContinuousDataTile rd_thread=" << rd_thread;
+  VLOG(4) << "ApplyContinuousDataTile vec_flatten_axis: "
           << utils::Join(vec_flatten_axis_, ", ");
-  VLOG(4) << "ApplyReduceTile vec_reduce_axis: "
+  VLOG(4) << "ApplyContinuousDataTile vec_reduce_axis: "
           << utils::Join(vec_reduce_axis_, ", ");
 
   // Merge reduce axes


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Performance


### Description
<!-- Describe what you’ve done -->
pcard-76996

主要改动：
1. 将 S pattern 接入默认的 Tile 流程中，从而获得更好的性能。
2. 将默认的 Tile 流程更名为 ContinuousDataTile，默认的 Tile 流程可以处理 S 和 SR 两种 pattern，从 Warp 的角度出发，这两种 pattern 的数据是**连续**的，支持在 Warp 内进行同步操作；后续 RS pattern 将起名 DiscreteDataTile，表示 warp 内的数据离散，不支持同步。

Main Change:
1. Integrate the S pattern into the default tiling process for better performance.
2. Rename the default tiling process to ContinuousDataTile, which can handle both S and SR patterns. From the perspective of a warp, these two patterns deal with continuous data, allowing for intra-warp synchronization. Subsequently, the RS pattern will be named DiscreteDataTile, indicating that the data within a warp is discrete and does not support intra-warp synchronization.
