### PR TITLE
Prevent Early Release of AllocationPtr in `test_from_blob`

### DIFF
--- a/test/cpp/phi/api/test_from_blob.cc
+++ b/test/cpp/phi/api/test_from_blob.cc
@@ -89,12 +89,13 @@ TEST(GetPlaceFromPtr, GPU) {
   ASSERT_EQ(cpu_data_place, phi::CPUPlace());
   std::cout << "cpu_data_place: " << cpu_data_place << std::endl;
 
-  float* gpu0_data = static_cast<float*>(paddle::GetAllocator(phi::GPUPlace(0))
-                                             ->Allocate(sizeof(cpu_data))
-                                             ->ptr());
+  auto alloc_ptr =
+      paddle::GetAllocator(phi::GPUPlace(0))->Allocate(sizeof(cpu_data));
+  float* gpu0_data = static_cast<float*>(alloc_ptr->ptr());
   auto gpu0_data_place = GetPlaceFromPtr(gpu0_data);
   ASSERT_EQ(gpu0_data_place, phi::GPUPlace(0));
   std::cout << "gpu0_data_place: " << gpu0_data_place << std::endl;
+  alloc_ptr.release();
 
   if (phi::backends::gpu::GetGPUDeviceCount() > 1) {
     float* gpu1_data =


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Others

### PR Types
Bug fixes

### Description

The `Allocate()` function returns a `unique_ptr`. When we chain the functions and call `ptr()`, the original `unique_ptr` is released, making the accessed memory invalid.

To address this issue, we must retain the `unique_ptr` until the memory is no longer in use.

With a stream-safe allocator, this bug is not immediately apparent because the allocator does not trigger cudaFree immediately. However, with an async allocator, the bug is detected due to stricter memory management.