### PR TITLE
Multiple Invocations of AllocAndCopy in ArraySetterBase

### DIFF
--- a/paddle/phi/kernels/funcs/segmented_array.h
+++ b/paddle/phi/kernels/funcs/segmented_array.h
@@ -112,7 +112,7 @@ struct ArraySetterBase {
                      void* src,
                      size_t num_bytes,
                      bool use_cuda_graph = false) {
-    allocation = phi::memory_utils::Alloc(
+    auto allocation = phi::memory_utils::Alloc(
         ctx.GetPlace(),
         num_bytes,
         phi::Stream(reinterpret_cast<phi::StreamId>(ctx.stream())));
@@ -129,10 +129,13 @@ struct ArraySetterBase {
                                        num_bytes,
                                        phi::gpuMemcpyHostToDevice,
                                        ctx.stream());
-    return allocation->ptr();
+
+    auto ptr = allocation->ptr();
+    allocations.emplace_back(std::move(allocation));
+    return ptr;
   }
 
-  phi::Allocator::AllocationPtr allocation{nullptr};
+  std::vector<phi::Allocator::AllocationPtr> allocations;
 };
 
 template <typename Context, typename T, SegmentedArraySize Size>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description


The `AllocAndCopy` function in `ArraySetterBase` may be invoked multiple times. For instance, it is called in both the `PointerArraySetter` class (see [here](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/kernels/funcs/segmented_array.h#L197)) and its derived class, `PointerAndColArray` (see [here](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/kernels/funcs/concat_and_split_functor.cu#L640)).

Each invocation of `AllocAndCopy` replaces the current `allocation`, causing the previous pointer to be released. To prevent this unintended deallocation and potential loss of data, the pointers should be stored in a vector, ensuring that all allocations remain accessible and valid.
