### PR TITLE
[Inference] fix max workspace setting in fused_conv2d_add_act kernel

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/fused_conv2d_add_act_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_conv2d_add_act_kernel.cu
@@ -385,7 +385,7 @@ void FusedConv2dAddActKernel(const Context& ctx,
   size_t workspace_size_limit = 0;
   if (FLAGS_conv_workspace_size_limit > 0 || workspace_size_MB > 0) {
     int64_t max_user_size =
-        std::min(static_cast<int64_t>(FLAGS_conv_workspace_size_limit),
+        std::max(static_cast<int64_t>(FLAGS_conv_workspace_size_limit),
                  static_cast<int64_t>(workspace_size_MB));
     workspace_size_limit = max_user_size * 1024 * 1024;
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
fix max workspace setting in fused_conv2d_add_act kernel

#### Others
Pcard-71500