### PR TITLE
[Typing] Skip coverage check if title has `typing`

### DIFF
--- a/tools/get_pr_title.py
+++ b/tools/get_pr_title.py
@@ -14,9 +14,21 @@
 
 import json
 import os
+import re
 import sys
 
 import requests
+
+SKIP_COVERAGE_CHECKING_LABELS = [
+    "cinn",
+    "typing",
+]
+
+SKIP_COVERAGE_CHECKING_REGEX = re.compile(
+    rf"[\[【]({'|'.join(SKIP_COVERAGE_CHECKING_LABELS)})[\]】]",
+    re.IGNORECASE,
+)
+
 
 pr_id = os.getenv('GIT_PR_ID')
 if not pr_id:
@@ -32,9 +44,10 @@ data = json.loads(response.text)
 
 title = data['title']
 
-prefixes = ['【CINN】', '[CINN]', '[cinn]', '【cinn】']
-if any(title.startswith(prefix) for prefix in prefixes):
-    print('The title starts with cinn')
+if match_obj := SKIP_COVERAGE_CHECKING_REGEX.search(title):
+    print(f'The title starts with {match_obj.group(0)}')
 else:
-    print('The title does not start with cinn')
+    print(
+        f'The title does not start with {" or ".join(SKIP_COVERAGE_CHECKING_LABELS)}'
+    )
     sys.exit(1)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

同 #64452，支持跳过标题中包含 `[Typing]` PR 的 coverage 检查，因此类型提示相关 PR 不会影响运行时，而且运行时也测不到，Coverage 检查没有意义

比如下面的流水线

https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/10862939/job/26496476

PCard-66972