### PR TITLE
remove runtime checks for distribution

### DIFF
--- a/python/paddle/distribution/bernoulli.py
+++ b/python/paddle/distribution/bernoulli.py
@@ -109,16 +109,6 @@ class Bernoulli(exponential_family.ExponentialFamily):
             [self.probs] = self._to_tensor(probs)
             self.dtype = paddle.get_default_dtype()
 
-        # Check probs range [0, 1].
-        if in_dynamic_mode():
-            """Not use `paddle.any` in static mode, which always be `True`."""
-            if (
-                paddle.any(self.probs < 0)
-                or paddle.any(self.probs > 1)
-                or paddle.any(paddle.isnan(self.probs))
-            ):
-                raise ValueError("The arg of `probs` must be in range [0, 1].")
-
         # Clip probs from [0, 1] to (0, 1) with smallest representable number `eps`.
         self.probs = _clip_probs(self.probs, self.dtype)
         self.logits = self._probs_to_logits(self.probs, is_binary=True)

--- a/python/paddle/distribution/binomial.py
+++ b/python/paddle/distribution/binomial.py
@@ -71,10 +71,6 @@ class Binomial(distribution.Distribution):
         self.dtype = paddle.get_default_dtype()
         self.total_count, self.probs = self._to_tensor(total_count, probs)
 
-        if not self._check_constraint(self.total_count, self.probs):
-            raise ValueError(
-                'Every element of input parameter `total_count` should be grater than or equal to one, and `probs` should be grater than or equal to zero and less than or equal to one.'
-            )
         if self.total_count.shape == []:
             batch_shape = (1,)
         else:
@@ -99,20 +95,6 @@ class Binomial(distribution.Distribution):
 
         # broadcast tensor
         return paddle.broadcast_tensors([total_count, probs])
-
-    def _check_constraint(self, total_count, probs):
-        """Check the constraints for input parameters
-
-        Args:
-            total_count (Tensor)
-            probs (Tensor)
-
-        Returns:
-            bool: pass or not.
-        """
-        total_count_check = (total_count >= 1).all()
-        probability_check = (probs >= 0).all() * (probs <= 1).all()
-        return total_count_check and probability_check
 
     @property
     def mean(self):

--- a/python/paddle/distribution/continuous_bernoulli.py
+++ b/python/paddle/distribution/continuous_bernoulli.py
@@ -101,10 +101,6 @@ class ContinuousBernoulli(distribution.Distribution):
         self.dtype = paddle.get_default_dtype()
         self.probs = self._to_tensor(probs)
         self.lims = paddle.to_tensor(lims, dtype=self.dtype)
-        if not self._check_constraint(self.probs):
-            raise ValueError(
-                'Every element of input parameter `probs` should be nonnegative.'
-            )
 
         # eps_prob is used to clip the input `probs` in the range of [eps_prob, 1-eps_prob]
         eps_prob = paddle.finfo(self.probs.dtype).eps
@@ -128,17 +124,6 @@ class ContinuousBernoulli(distribution.Distribution):
         else:
             self.dtype = probs.dtype
         return probs
-
-    def _check_constraint(self, value):
-        """Check the constraint for input parameters
-
-        Args:
-            value (Tensor)
-
-        Returns:
-            bool: pass or not.
-        """
-        return (value >= 0).all() and (value <= 1).all()
 
     def _cut_support_region(self):
         """Generate stable support region indicator (prob < self.lims[0] && prob >= self.lims[1] )
@@ -290,10 +275,6 @@ class ContinuousBernoulli(distribution.Distribution):
           Tensor: log probability. The data type is the same as `self.probs`.
         """
         value = paddle.cast(value, dtype=self.dtype)
-        if not self._check_constraint(value):
-            raise ValueError(
-                'Every element of input parameter `value` should be >= 0.0 and <= 1.0.'
-            )
         eps = paddle.finfo(self.probs.dtype).eps
         cross_entropy = paddle.nan_to_num(
             value * paddle.log(self.probs)
@@ -363,10 +344,6 @@ class ContinuousBernoulli(distribution.Distribution):
             Tensor: quantile of :attr:`value`. The data type is the same as `self.probs`.
         """
         value = paddle.cast(value, dtype=self.dtype)
-        if not self._check_constraint(value):
-            raise ValueError(
-                'Every element of input parameter `value` should be >= 0.0 and <= 1.0.'
-            )
         cut_probs = self._cut_probs()
         cdfs = (
             paddle.pow(cut_probs, value)
@@ -407,10 +384,6 @@ class ContinuousBernoulli(distribution.Distribution):
             Tensor: the value of the r.v. corresponding to the quantile. The data type is the same as `self.probs`.
         """
         value = paddle.cast(value, dtype=self.dtype)
-        if not self._check_constraint(value):
-            raise ValueError(
-                'Every element of input parameter `value` should be >= 0.0 and <= 1.0.'
-            )
         cut_probs = self._cut_probs()
         return paddle.where(
             self._cut_support_region(),

--- a/python/paddle/distribution/exponential.py
+++ b/python/paddle/distribution/exponential.py
@@ -76,9 +76,6 @@ class Exponential(exponential_family.ExponentialFamily):
             [self.rate] = self._to_tensor(rate)
             self.dtype = paddle.get_default_dtype()
 
-        if not paddle.all(self.rate > 0):
-            raise ValueError("The arg of `rate` must be positive.")
-
         super().__init__(self.rate.shape)
 
     @property

--- a/python/paddle/distribution/gamma.py
+++ b/python/paddle/distribution/gamma.py
@@ -103,12 +103,6 @@ class Gamma(exponential_family.ExponentialFamily):
             )
             self.dtype = paddle.get_default_dtype()
 
-        if not paddle.all(self.concentration > 0):
-            raise ValueError("The arg of `concentration` must be positive.")
-
-        if not paddle.all(self.rate > 0):
-            raise ValueError("The arg of `rate` must be positive.")
-
         super().__init__(self.concentration.shape)
 
     @property

--- a/python/paddle/distribution/geometric.py
+++ b/python/paddle/distribution/geometric.py
@@ -92,15 +92,7 @@ class Geometric(distribution.Distribution):
                 f"Expected type of probs is Number.Real|Tensor|framework.Variable, but got {type(probs)}"
             )
 
-        if paddle.equal_all(lessthen_0, all_false) and paddle.equal_all(
-            morethen_1, all_false
-        ):
-            batch_shape = tuple(probs.shape)
-        else:
-            raise ValueError(
-                "Expected parameter probs of distribution Geometric to satisfy the"
-                "constraint Interval(lower_bound=0.0, upper_bound=1.0)"
-            )
+        batch_shape = tuple(probs.shape)
 
         self.probs = probs
         super().__init__(batch_shape)

--- a/python/paddle/distribution/multivariate_normal.py
+++ b/python/paddle/distribution/multivariate_normal.py
@@ -150,7 +150,6 @@ class MultivariateNormal(distribution.Distribution):
                 batch_shape
                 + [precision_matrix.shape[-2], precision_matrix.shape[-1]]
             )
-        self._check_constraints()
         self.loc = loc.expand(
             batch_shape
             + [
@@ -171,91 +170,6 @@ class MultivariateNormal(distribution.Distribution):
             )
 
         super().__init__(batch_shape, event_shape)
-
-    def _check_lower_triangular(self, value):
-        """Check whether the input is a lower triangular matrix
-
-        Args:
-            value (Tensor): input matrix
-
-        Return:
-            Tensor: indicator for lower triangular matrix
-        """
-        tril = paddle.tril(value)
-        is_lower_triangular = paddle.cast(
-            (tril == value).reshape(
-                value.shape[:-2]
-                + [
-                    -1,
-                ]
-            ),
-            dtype=self.dtype,
-        ).min(-1, keepdim=True)[0]
-        is_positive_diag = paddle.cast(
-            (value.diagonal(axis1=-2, axis2=-1) > 0), dtype=self.dtype
-        ).min(-1, keepdim=True)[0]
-        return is_lower_triangular and is_positive_diag
-
-    def _check_positive_definite(self, value):
-        """Check whether the input is a positive definite matrix
-
-        Args:
-            value (Tensor): input matrix
-
-        Return:
-            Tensor: indicator for positive definite matrix
-        """
-        is_square = paddle.full(
-            shape=value.shape[:-2],
-            fill_value=(value.shape[-2] == value.shape[-1]),
-            dtype="bool",
-        ).all()
-        if not is_square:
-            raise ValueError(
-                "covariance_matrix or precision_matrix must be a square matrix"
-            )
-        new_perm = list(range(len(value.shape)))
-        new_perm[-1], new_perm[-2] = new_perm[-2], new_perm[-1]
-        is_symmetric = paddle.isclose(
-            value, value.transpose(new_perm), atol=1e-6
-        ).all()
-        if not is_symmetric:
-            raise ValueError(
-                "covariance_matrix or precision_matrix must be a symmetric matrix"
-            )
-        is_positive_definite = (
-            paddle.cast(paddle.linalg.eigvalsh(value), dtype=self.dtype) > 0
-        ).all()
-        return is_positive_definite
-
-    def _check_constraints(self):
-        """Check whether the matrix satisfy corresponding constraint
-
-        Return:
-            Tensor: indicator for the pass of constraints check
-        """
-        if self.scale_tril is not None:
-            check = self._check_lower_triangular(self.scale_tril)
-            if not check:
-                raise ValueError(
-                    "scale_tril matrix must be a lower triangular matrix with positive diagonals"
-                )
-        elif self.covariance_matrix is not None:
-            is_positive_definite = self._check_positive_definite(
-                self.covariance_matrix
-            )
-            if not is_positive_definite:
-                raise ValueError(
-                    "covariance_matrix must be a symmetric positive definite matrix"
-                )
-        else:
-            is_positive_definite = self._check_positive_definite(
-                self.precision_matrix
-            )
-            if not is_positive_definite:
-                raise ValueError(
-                    "precision_matrix must be a symmetric positive definite matrix"
-                )
 
     @property
     def mean(self):

--- a/python/paddle/distribution/poisson.py
+++ b/python/paddle/distribution/poisson.py
@@ -76,10 +76,6 @@ class Poisson(distribution.Distribution):
         self.dtype = paddle.get_default_dtype()
         self.rate = self._to_tensor(rate)
 
-        if not self._check_constraint(self.rate):
-            raise ValueError(
-                'Every element of input parameter `rate` should be nonnegative.'
-            )
         if self.rate.shape == []:
             batch_shape = (1,)
         else:
@@ -98,17 +94,6 @@ class Poisson(distribution.Distribution):
         else:
             self.dtype = rate.dtype
         return rate
-
-    def _check_constraint(self, value):
-        """Check the constraint for input parameters
-
-        Args:
-            value (Tensor)
-
-        Returns:
-            bool: pass or not.
-        """
-        return (value >= 0).all()
 
     @property
     def mean(self):
@@ -209,10 +194,6 @@ class Poisson(distribution.Distribution):
           Tensor: log probability. The data type is the same as `rate`.
         """
         value = paddle.cast(value, dtype=self.dtype)
-        if not self._check_constraint(value):
-            raise ValueError(
-                'Every element of input parameter `value` should be nonnegative.'
-            )
         eps = paddle.finfo(self.rate.dtype).eps
         return paddle.nan_to_num(
             (

--- a/test/distribution/test_distribution_bernoulli.py
+++ b/test/distribution/test_distribution_bernoulli.py
@@ -566,18 +566,6 @@ class BernoulliTestError(unittest.TestCase):
 
     @parameterize_func(
         [
-            (-0.1, ValueError),
-            (1.1, ValueError),
-            (np.nan, ValueError),
-            (-1j + 1, TypeError),
-        ]
-    )
-    def test_bad_init(self, probs, error):
-        with paddle.base.dygraph.guard(self.place):
-            self.assertRaises(error, Bernoulli, probs)
-
-    @parameterize_func(
-        [
             (
                 [0.3, 0.5],
                 paddle.to_tensor([0.1, 0.2, 0.3]),

--- a/test/distribution/test_distribution_cauchy.py
+++ b/test/distribution/test_distribution_cauchy.py
@@ -625,22 +625,6 @@ class CauchyTestError(unittest.TestCase):
     def setUp(self):
         paddle.disable_static(self.place)
 
-    @parameterize_func(
-        [
-            (-1j + 1, 0.0, TypeError),  # complex
-            (np.array(0.0), 0.0, TypeError),  # ndarray
-            ([0.0, 0.0], 0.0, TypeError),  # list
-            ((0.0, 0.0), 0.0, TypeError),  # tuple
-            (0.0, -1j + 1, TypeError),  # complex
-            (0.0, np.array(0.0), TypeError),  # ndarray
-            (0.0, [0.0, 0.0], TypeError),  # list
-            (0.0, (0.0, 0.0), TypeError),  # tuple
-        ]
-    )
-    def test_bad_init(self, loc, scale, error):
-        with paddle.base.dygraph.guard(self.place):
-            self.assertRaises(error, Cauchy, loc, scale)
-
     def test_bad_property(self):
         """For property like mean/variance/stddev which is undefined in math,
         we should raise `ValueError` instead of `NotImplementedError`.

--- a/test/distribution/test_distribution_continuous_bernoulli.py
+++ b/test/distribution/test_distribution_continuous_bernoulli.py
@@ -343,31 +343,6 @@ class ContinuousBernoulliTestError(unittest.TestCase):
 
     @parameterize_func(
         [
-            (-0.1, ValueError),
-            (1.1, ValueError),
-        ]
-    )
-    def test_bad_init(self, probs, error):
-        with paddle.base.dygraph.guard(self.place):
-            self.assertRaises(error, ContinuousBernoulli, probs)
-
-    @parameterize_func(
-        [
-            (
-                paddle.to_tensor([0.3, 0.5]),
-                paddle.to_tensor([-0.1, 1.2]),
-            ),
-        ]
-    )
-    def test_bad_log_prob_value(self, probs, value):
-        with paddle.base.dygraph.guard(self.place):
-            rv = ContinuousBernoulli(probs)
-            self.assertRaises(ValueError, rv.cdf, value)
-            self.assertRaises(ValueError, rv.log_prob, value)
-            self.assertRaises(ValueError, rv.icdf, value)
-
-    @parameterize_func(
-        [
             (
                 paddle.to_tensor([0.3, 0.5]),
                 paddle.to_tensor([0.2, 0.8, 0.6]),

--- a/test/distribution/test_distribution_geometric.py
+++ b/test/distribution/test_distribution_geometric.py
@@ -94,10 +94,6 @@ class TestGeometric(unittest.TestCase):
                 atol=ATOL.get(str(self._paddle_geom.probs.numpy().dtype)),
             )
 
-    def test_init_prob_value_error(self):
-        with self.assertRaises(ValueError):
-            paddle.distribution.geometric.Geometric(2)
-
     def test_init_prob_type_error(self):
         with self.assertRaises(TypeError):
             paddle.distribution.geometric.Geometric([2])

--- a/test/distribution/test_distribution_multivariate_normal.py
+++ b/test/distribution/test_distribution_multivariate_normal.py
@@ -21,7 +21,6 @@ from distribution import config
 from parameterize import (
     TEST_CASE_NAME,
     parameterize_cls,
-    parameterize_func,
 )
 
 import paddle
@@ -259,51 +258,6 @@ class TestMVNKL(unittest.TestCase):
 class MVNTestError(unittest.TestCase):
     def setUp(self):
         paddle.disable_static(self.place)
-
-    @parameterize_func(
-        [
-            (5, None, ValueError),  # no matrix input
-            (
-                5,
-                paddle.to_tensor([2.0, 3.0]),
-                ValueError,
-            ),  # wrong input matrix dim
-            (
-                5,
-                paddle.to_tensor([[2.0, 3.0, 4.0], [2.0, 3.0, 4.0]]),
-                ValueError,
-            ),  # non-sqaure input matrix
-            (
-                5,
-                paddle.to_tensor([[2.0, 3.0], [2.0, 3.0]]),
-                ValueError,
-            ),  # non-symmetric input matrix
-            (
-                5,
-                paddle.to_tensor([[-2.0, 3.0], [3.0, -1.0]]),
-                ValueError,
-            ),  # non-psd input matrix
-        ]
-    )
-    def test_bad_cov_matrix(self, loc, matrix, error):
-        with paddle.base.dygraph.guard(self.place):
-            self.assertRaises(error, MultivariateNormal, loc, matrix)
-
-    @parameterize_func(
-        [
-            (
-                1.0,
-                2.0,
-                paddle.to_tensor([[3.0, 2.0], [2.0, 3.0]]),
-                paddle.to_tensor([[2.0, 1.0], [1.0, 2.0]]),
-            ),
-        ]
-    )
-    def test_bad_kl_div(self, loc1, loc2, matrix1, matrix2):
-        with paddle.base.dygraph.guard(self.place):
-            rv = MultivariateNormal(loc1, covariance_matrix=matrix1)
-            rv_other = MultivariateNormal(loc2, covariance_matrix=matrix2)
-            self.assertRaises(ValueError, rv.kl_divergence, rv_other)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-66975

概率分布一些参数，如概率probs，通常需要满足一定范围，如大于等于0，小于等于1，这需要运行时值检查。

当前Distribution目录下运行检查有三个问题 1）部分文件有检查逻辑、部分文件缺少检查逻辑 2）运行时检查存在性能开销，竞品通过参数中额外引入一个flag控制，让用户自行选择是否开启检查  3）PIR体系对检查逻辑和异常逻辑支持不友好。

该PR统一移除运行时检查逻辑，避免不必要的性能开销，以及支持PIR推全项目
后续运行检查逻辑通过flag控制，并对所有distribution一次性补全。