### PR TITLE
[PaddleInference]Support fused_embedding_eltwise_layernorm max sequence lengths is 512 for VarSeqlen

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/many_emb_layernorm_varseqlen_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/many_emb_layernorm_varseqlen_plugin.cu
@@ -354,13 +354,21 @@ int32_t EmbLayerNormVarSeqlenPluginHFace::enqueue(
   int32_t batchSize = inputDesc[0].dims.d[0] - 1;
   // read out the maximum sequence length from the dummy input
   int32_t const maxSeqlen = inputDesc[nbLookupTables_].dims.d[1];
-  int32_t S = 384;
+  int32_t S = 512;
   if (maxSeqlen <= 128) {
     S = 128;
   } else if (maxSeqlen <= 192) {
     S = 192;
   } else if (maxSeqlen <= 256) {
     S = 256;
+  } else if (maxSeqlen <= 384) {
+    S = 384;
+  } else if (maxSeqlen <= 512) {
+    S = 512;
+  } else {
+    std::cerr << "fused_embedding_eltwise_layernorm'max sequence lengths is "
+                 "512 for VarSeqlen"
+              << std::endl;
   }
   const float* beta = mBetaDev.get();
   const float* gamma = mGammaDev.get();

--- a/paddle/fluid/inference/tensorrt/plugin/many_emb_layernorm_varseqlen_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/many_emb_layernorm_varseqlen_plugin.cu
@@ -507,13 +507,21 @@ int32_t EmbLayerNormVarSeqlenPluginMTron::enqueue(
   int32_t batchSize = inputDesc[0].dims.d[0] - 1;
   // read out the maximum sequence length from the dummy input
   int32_t const maxSeqlen = inputDesc[nbLookupTables_].dims.d[1];
-  int32_t S = 384;
+  int32_t S = 512;
   if (maxSeqlen <= 128) {
     S = 128;
   } else if (maxSeqlen <= 192) {
     S = 192;
   } else if (maxSeqlen <= 256) {
     S = 256;
+  } else if (maxSeqlen <= 384) {
+    S = 384;
+  } else if (maxSeqlen <= 512) {
+    S = 512;
+  } else {
+    std::cerr << "fused_embedding_eltwise_layernorm'max sequence lengths is "
+                 "512 for VarSeqlen"
+              << std::endl;
   }
   const float* beta = mBetaDev.get();
   const float* gamma = mGammaDev.get();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

pcard-71500

add fused_embedding_eltwise_layernorm max sequence lengths is 512 for VarSeqlen