### PR TITLE
[CINN]Fix cuLaunchKernel invalid handle error while Data-Parallel train with CINN

### DIFF
--- a/paddle/cinn/backends/compiler.cc
+++ b/paddle/cinn/backends/compiler.cc
@@ -336,7 +336,7 @@ void Compiler::CompileCudaModule(const Module& module,
   RuntimeSymbols symbols;
   for (auto& fn : device_module.functions()) {
     std::string kernel_fn_name = fn->name;
-    auto fn_kernel = cuda_module_->GetFunction(0, kernel_fn_name);
+    auto fn_kernel = cuda_module_->GetFunction(kernel_fn_name);
     CHECK(fn_kernel);
 
     fn_ptr_.push_back(reinterpret_cast<void*>(fn_kernel));

--- a/paddle/cinn/hlir/framework/pir_compiler.cc
+++ b/paddle/cinn/hlir/framework/pir_compiler.cc
@@ -77,9 +77,11 @@ std::vector<pir::CINNKernelInfo> PirCompiler::Build(
     // See
     // https://developer.nvidia.com/blog/cuda-pro-tip-always-set-current-device-avoid-multithreading-bugs/
     // for details.
-    const int device_id = runtime::GetArchDevice(target_);
+    const auto device_id = runtime::GetArchDevice(target_);
     auto worker_fn = [&](int index) {
-      runtime::SetArchDevice(target_, device_id);
+      if (device_id.has_value()) {
+        runtime::SetArchDevice(target_, device_id.value());
+      }
       CompilationTask task(&group_compilation_contexts[index]);
       compilation_results[index] = task();
       // Triggering llvm compilation in thread

--- a/paddle/cinn/hlir/framework/pir_compiler.cc
+++ b/paddle/cinn/hlir/framework/pir_compiler.cc
@@ -79,9 +79,7 @@ std::vector<pir::CINNKernelInfo> PirCompiler::Build(
     // for details.
     const auto device_id = runtime::GetArchDevice(target_);
     auto worker_fn = [&](int index) {
-      if (device_id.has_value()) {
-        runtime::SetArchDevice(target_, device_id.value());
-      }
+      runtime::SetArchDevice(target_, device_id);
       CompilationTask task(&group_compilation_contexts[index]);
       compilation_results[index] = task();
       // Triggering llvm compilation in thread

--- a/paddle/cinn/hlir/framework/pir_compiler.cc
+++ b/paddle/cinn/hlir/framework/pir_compiler.cc
@@ -15,37 +15,15 @@
 #include "paddle/cinn/hlir/framework/pir_compiler.h"
 
 #include "paddle/cinn/hlir/framework/pir/utils.h"
+#include "paddle/cinn/runtime/arch_device.h"
 #include "paddle/cinn/utils/multi_threading.h"
 #include "paddle/common/enforce.h"
 #include "paddle/common/flags.h"
-#ifdef PADDLE_WITH_CUDA
-#include <cuda_runtime.h>
-#endif
 
 PD_DECLARE_bool(enable_cinn_compile_cache);
 PD_DECLARE_int64(cinn_compile_thread_num);
 
 namespace cinn::hlir::framework {
-namespace {
-
-std::optional<int> GetCudaDevice() {
-#ifdef PADDLE_WITH_CUDA
-  int device_id;
-  cudaGetDevice(&device_id);
-  return std::optional<int>{device_id};
-#else
-  return std::nullopt;
-#endif
-}
-
-void SetCudaDevice(const std::optional<int>& device_id) {
-#ifdef PADDLE_WITH_CUDA
-  if (device_id.has_value()) cudaSetDevice(device_id.value());
-#endif
-}
-
-}  // namespace
-
 class CompilationContextMapper {
  public:
   CompilationContextMapper(const Target& target,
@@ -99,9 +77,9 @@ std::vector<pir::CINNKernelInfo> PirCompiler::Build(
     // See
     // https://developer.nvidia.com/blog/cuda-pro-tip-always-set-current-device-avoid-multithreading-bugs/
     // for details.
-    const std::optional<int> device_id = GetCudaDevice();
+    const int device_id = runtime::GetArchDevice(target_);
     auto worker_fn = [&](int index) {
-      SetCudaDevice(device_id);
+      runtime::SetArchDevice(target_, device_id);
       CompilationTask task(&group_compilation_contexts[index]);
       compilation_results[index] = task();
       // Triggering llvm compilation in thread

--- a/paddle/cinn/runtime/arch_device.h
+++ b/paddle/cinn/runtime/arch_device.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#ifdef PADDLE_WITH_CUDA
+#include <cuda_runtime.h>
+#endif
+
+#include "paddle/cinn/adt/adt.h"
+#include "paddle/cinn/common/macros.h"
+#include "paddle/cinn/common/target.h"
+
+namespace cinn::runtime {
+
+int GetArchDevice(const common::Target& target) {
+  return target.arch.Visit(
+      adt::match{[&](common::UnknownArch) -> int { CINN_NOT_IMPLEMENTED; },
+                 [&](common::X86Arch) -> int { CINN_NOT_IMPLEMENTED; },
+                 [&](common::ARMArch) -> int { CINN_NOT_IMPLEMENTED; },
+                 [&](common::NVGPUArch) -> int {
+#ifdef CINN_WITH_CUDA
+                   int device_id;
+                   cudaGetDevice(&device_id);
+                   return device_id;
+#else
+                   CINN_NOT_IMPLEMENTED
+#endif
+                 }});
+}
+
+void SetArchDevice(const common::Target& target, int device_id) {
+  target.arch.Visit(
+      adt::match{[&](common::UnknownArch) -> void { CINN_NOT_IMPLEMENTED; },
+                 [&](common::X86Arch) -> void { CINN_NOT_IMPLEMENTED; },
+                 [&](common::ARMArch) -> void { CINN_NOT_IMPLEMENTED; },
+                 [&](common::NVGPUArch) -> void {
+#ifdef CINN_WITH_CUDA
+                   cudaSetDevice(device_id);
+#else
+                   CINN_NOT_IMPLEMENTED
+#endif
+                 }});
+}
+
+}  // namespace cinn::runtime

--- a/paddle/cinn/runtime/arch_device.h
+++ b/paddle/cinn/runtime/arch_device.h
@@ -35,7 +35,7 @@ std::optional<int> GetArchDevice(const common::Target& target) {
         PADDLE_ENFORCE_EQ(
             cudaGetDevice(&device_id),
             cudaSuccess,
-            ::common::errors::InvalidArgument("cudaGetDeviceCount failed!"));
+            ::common::errors::InvalidArgument("cudaGetDevice failed!"));
         return std::optional<int>{device_id};
 #else
         return std::nullopt;

--- a/paddle/cinn/runtime/cuda/cuda_module.cc
+++ b/paddle/cinn/runtime/cuda/cuda_module.cc
@@ -49,6 +49,8 @@ CUDAModule::CUDAModule(const std::string& data, Kind kind)
   cuDeviceGet(&device_, current_device_id);
   cuCtxGetCurrent(&context_);
   cuDevicePrimaryCtxRetain(&context_, device_);
+  VLOG(5) << "Construct CUDAModule " << this
+          << " in device: " << current_device_id;
 }
 
 void CUDAModule::LaunchKernel(int device_id,
@@ -81,6 +83,12 @@ void CUDAModule::LaunchKernel(int device_id,
                                   stream,
                                   args,
                                   nullptr));
+}
+
+CUfunction CUDAModule::GetFunction(const std::string& func_name) {
+  int device_id;
+  cudaGetDevice(&device_id);
+  return this->GetFunction(device_id, func_name);
 }
 
 CUfunction CUDAModule::GetFunction(int device_id,

--- a/paddle/cinn/runtime/cuda/cuda_module.h
+++ b/paddle/cinn/runtime/cuda/cuda_module.h
@@ -53,6 +53,9 @@ class CUDAModule {
   //! Get a function.
   CUfunction GetFunction(int device_id, const std::string& func_name);
 
+  //! Get a function by CudaGetDevice
+  CUfunction GetFunction(const std::string& func_name);
+
   //! Get a global variable.
   CUdeviceptr GetGlobal(int device_id, const std::string& name, size_t nbytes);
 

--- a/paddle/cinn/runtime/cuda/cuda_util.cc
+++ b/paddle/cinn/runtime/cuda/cuda_util.cc
@@ -99,7 +99,7 @@ void cinn_call_cuda_kernel(void *kernel_fn,
           << ", " << grid_z << "}, block_dim={" << block_x << ", " << block_y
           << ", " << block_z << "}, num_args=" << num_args
           << ", shared_memory_bytes=" << shared_memory_bytes
-          << ", stream=" << stream;
+          << ", stream=" << stream << ", kernel_fn=" << kernel_fn;
 
   std::vector<void *> kernel_args;
   {

--- a/test/ir/pir/cinn/CMakeLists.txt
+++ b/test/ir/pir/cinn/CMakeLists.txt
@@ -32,7 +32,7 @@ if(WITH_GPU)
     COMMAND
       ${CMAKE_COMMAND} -E env
       PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
-      FLAGS_enable_pir_api=1 FLAGS_prim_all=True
+      CUDA_VISIBLE_DEVICES=0,1 FLAGS_enable_pir_api=1 FLAGS_prim_all=True
       FLAGS_cinn_new_group_scheduler=1 FLAGS_cinn_bucket_compile=1
       FLAGS_group_schedule_tiling_first=1 ${PYTHON_EXECUTABLE}
       ${CMAKE_CURRENT_SOURCE_DIR}/test_cinn_multi_device.py

--- a/test/ir/pir/cinn/CMakeLists.txt
+++ b/test/ir/pir/cinn/CMakeLists.txt
@@ -11,7 +11,7 @@ if(WITH_GPU)
     "test_*.py")
   string(REPLACE ".py" "" CINN_PIR_TEST "${CINN_PIR_TEST}")
 
-  list(REMOVE_ITEM CINN_PIR_TEST test_subgraph_checker)
+  list(REMOVE_ITEM CINN_PIR_TEST test_subgraph_checker test_cinn_multi_device)
   foreach(cinn_pir_test_name ${CINN_PIR_TEST})
     add_test(
       NAME ${cinn_pir_test_name}
@@ -26,6 +26,18 @@ if(WITH_GPU)
     set_tests_properties(${cinn_pir_test_name} PROPERTIES LABELS
                                                           "RUN_TYPE=CINN")
   endforeach()
+
+  add_test(
+    NAME test_cinn_multi_device
+    COMMAND
+      ${CMAKE_COMMAND} -E env
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+      FLAGS_enable_pir_api=1 FLAGS_prim_all=True
+      FLAGS_cinn_new_group_scheduler=1 FLAGS_cinn_bucket_compile=1
+      FLAGS_group_schedule_tiling_first=1 ${PYTHON_EXECUTABLE}
+      ${CMAKE_CURRENT_SOURCE_DIR}/test_cinn_multi_device.py
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  set_tests_properties(test_cinn_multi_device PROPERTIES LABELS "RUN_TYPE=CINN")
 
   add_test(
     NAME test_cinn_sub_graph_stride_read

--- a/test/ir/pir/cinn/test_cinn_multi_device.py
+++ b/test/ir/pir/cinn/test_cinn_multi_device.py
@@ -30,7 +30,7 @@ class LinearNet(nn.Layer):
 
 def train():
     dist.init_parallel_env()
-    layer = paddle.jit.to_static(LinearNet(), full_graph=True)
+    layer = paddle.jit.to_static(LinearNet(), full_graph=True, backend='CINN')
     dp_layer = paddle.DataParallel(layer)
     inputs = paddle.randn([10, 10], 'float32')
     # NOTE(dev): Spawn will launch multi-process to run this file in

--- a/test/ir/pir/cinn/test_cinn_multi_device.py
+++ b/test/ir/pir/cinn/test_cinn_multi_device.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import paddle
+import paddle.distributed as dist
+from paddle import nn
+
+
+class LinearNet(nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self._linear1 = nn.Linear(10, 10)
+        self._linear2 = nn.Linear(10, 1)
+
+    def forward(self, x):
+        return self._linear2(self._linear1(x))
+
+
+def train():
+    dist.init_parallel_env()
+    layer = paddle.jit.to_static(LinearNet(), full_graph=True)
+    dp_layer = paddle.DataParallel(layer)
+    inputs = paddle.randn([10, 10], 'float32')
+    # NOTE(dev): Spawn will launch multi-process to run this file in
+    # gpu:0 and gpu:1, it's not easy to apply np.testing.allclose
+    # between @to_static and dynamic mode.
+    dp_layer(inputs)
+
+
+if __name__ == "__main__":
+    dist.spawn(train, nprocs=2)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164 
修复了模型上开启CINN的8卡数据并行训练报`CUDA Driver Error: cuLaunchKernel(static_cast<CUfunction>(kernel_fn)`的问题。

原因：在CINN的底层Cuda Compiler组件里，固定是使用的`CUDAModule->GetFunction(/*device_id*/=0, func_name)`，在多卡场景下，需要根据不同的设备自适应去获取函数指针。

修复前：
<img width="1058" alt="3a9d1b103dba50b8e838c1682e63ef1d" src="https://github.com/PaddlePaddle/Paddle/assets/9301846/c1fed0f4-e8d4-4504-b8c5-e06874245af1">



修复后：

<img width="967" alt="2619772e67e4fb11252898a1b1a55bc4" src="https://github.com/PaddlePaddle/Paddle/assets/9301846/1cb474d2-d3ad-4130-8cbf-090ad834a0de">
