### PR TITLE
refine pir dist to_static to support master weight

### DIFF
--- a/paddle/fluid/pybind/auto_parallel_py.cc
+++ b/paddle/fluid/pybind/auto_parallel_py.cc
@@ -490,9 +490,10 @@ void BindAutoParallel(py::module *m) {
                        .def(py::self == py::self)   // NOLINT
                        .def(py::self != py::self);  // NOLINT
 
-  auto Partial = py::class_<phi::distributed::Partial,
-                            std::shared_ptr<phi::distributed::Partial>>(
-                     *m, "Partial", Placement, R"DOC(
+  auto Partial =
+      py::class_<phi::distributed::Partial,
+                 std::shared_ptr<phi::distributed::Partial>>(
+          *m, "Partial", Placement, R"DOC(
                  The `Partial` describes `Tensor` across multiple devices, this type of tensor has the same shape but only a fraction of the value, which can be further reduce (e.g. sum/min/max) to obtain dist_tensor, often used as an intermediate representation.
 
                  Parameters:
@@ -510,12 +511,13 @@ void BindAutoParallel(py::module *m) {
                          >>> d_tensor = dist.shard_tensor(a, mesh, [dist.Partial()])
 
                  )DOC")
-                     .def(py::init<phi::ReduceType>(),
-                          py::arg("reduce_type") = phi::ReduceType::kRedSum)
-                     .def("__hash__", &phi::distributed::Partial::hash)
-                     .def("__str__", &phi::distributed::Partial::to_string)
-                     .def(py::self == py::self)   // NOLINT
-                     .def(py::self != py::self);  // NOLINT
+          .def(py::init<phi::ReduceType>(),
+               py::arg("reduce_type") = phi::ReduceType::kRedSum)
+          .def("reduce_type", &phi::distributed::Partial::get_reduce_type)
+          .def("__hash__", &phi::distributed::Partial::hash)
+          .def("__str__", &phi::distributed::Partial::to_string)
+          .def(py::self == py::self)   // NOLINT
+          .def(py::self != py::self);  // NOLINT
 
   g_placement_shard_pytype = reinterpret_cast<PyTypeObject *>(Shard.ptr());
   g_placement_replicated_pytype =

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -2867,4 +2867,37 @@ void BindEagerUtils(PyObject* module) {
   }
 }
 
+std::tuple<std::vector<int64_t>,
+           paddle::flat_hash_map<int64_t, phi::ReduceType>>
+CvtPlacements(Placements placements, int ndim) {
+  std::vector<int64_t> dim_map(ndim, -1);
+  for (size_t i = 0; i < placements.size(); i++) {
+    auto& placement = placements[i];
+    if (placement->is_shard()) {
+      auto shard_dim =
+          dynamic_cast<const phi::distributed::Shard&>(*placement).get_dim();
+      PADDLE_ENFORCE_EQ(
+          dim_map[shard_dim],
+          -1,
+          common::errors::InvalidArgument(
+              "Tensor dim %lld is already sharded on mesh dim %lld,"
+              " DistTensor operator implementation does not support things "
+              "like hybrid"
+              " sharding strategies yet (i.e. [Shard(0), Shard(0)])",
+              shard_dim,
+              dim_map[shard_dim]));
+      dim_map[shard_dim] = i;
+    }
+  }
+  paddle::flat_hash_map<int64_t, phi::ReduceType> partial_status;
+  for (size_t i = 0; i < placements.size(); ++i) {
+    auto& p = placements[i];
+    if (p->is_partial()) {
+      partial_status.insert(
+          {i, dynamic_cast<phi::distributed::Partial&>(*p).get_reduce_type()});
+    }
+  }
+  return {dim_map, partial_status};
+}
+
 }  // namespace paddle::pybind

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -507,5 +507,9 @@ void ConvertAllInputsToDistTensor(const phi::distributed::ProcessMesh* mesh,
 void ConvertToDistTensor(Tensor* x, const phi::distributed::ProcessMesh* mesh);
 void BindEagerUtils(PyObject* module);
 
+std::tuple<std::vector<int64_t>,
+           paddle::flat_hash_map<int64_t, phi::ReduceType>>
+CvtPlacements(phi::distributed::Placements placements, int ndim);
+
 }  // namespace pybind
 }  // namespace paddle

--- a/paddle/phi/core/distributed/auto_parallel/dist_meta_tensor.cc
+++ b/paddle/phi/core/distributed/auto_parallel/dist_meta_tensor.cc
@@ -47,5 +47,9 @@ const distributed::TensorDistAttr& DistMetaTensor::dist_attr() const {
   }
 }
 
+bool DistMetaTensor::initialized() const {
+  return tensor_ != nullptr || dist_attr_ != TensorDistAttr();
+}
+
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/core/distributed/auto_parallel/dist_meta_tensor.h
+++ b/paddle/phi/core/distributed/auto_parallel/dist_meta_tensor.h
@@ -48,6 +48,8 @@ class DistMetaTensor : public MetaTensor {
 
   const distributed::TensorDistAttr& dist_attr() const;
 
+  bool initialized() const override;
+
  private:
   /**
    * Note: When using the semi-automatic parallel segmentation derivation rules

--- a/python/paddle/distributed/auto_parallel/placement_type.py
+++ b/python/paddle/distributed/auto_parallel/placement_type.py
@@ -87,7 +87,7 @@ def to_dim_map(placements, tensor_dims):
 
             dim_map[shard_dim] = i
         if placement.is_partial():
-            partial_status.append[i] = cast(Partial, placement).reduce_type()
+            partial_status[i] = cast(Partial, placement).reduce_type()
 
     return dim_map, partial_status
 

--- a/python/paddle/distributed/auto_parallel/placement_type.py
+++ b/python/paddle/distributed/auto_parallel/placement_type.py
@@ -76,6 +76,7 @@ def to_dim_map(placements, tensor_dims):
         List[int]: a list of integer that represents sharding on each tensor dimension.
     """
     dim_map = [-1] * tensor_dims
+    partial_status = {}
     for i, placement in enumerate(placements):
         if placement.is_shard():
             shard_dim = cast(Shard, placement).get_dim()
@@ -85,13 +86,15 @@ def to_dim_map(placements, tensor_dims):
                 )
 
             dim_map[shard_dim] = i
+        if placement.is_partial():
+            partial_status.append[i] = cast(Partial, placement).reduce_type()
 
-    return dim_map
+    return dim_map, partial_status
 
 
 def get_shard_spec(mesh, placements, tensor_dims):
     """to get shard_spec for construct DistAttr for static API."""
-    dim_map = to_dim_map(placements, tensor_dims)
+    dim_map, _ = to_dim_map(placements, tensor_dims)
     mesh_dim_names = mesh.dim_names
     shard_spec = [None] * len(dim_map)
     for i, d in enumerate(dim_map):

--- a/python/paddle/jit/pir_dy2static/parameter_recorder.py
+++ b/python/paddle/jit/pir_dy2static/parameter_recorder.py
@@ -48,22 +48,9 @@ class ParametersRecorder:
                 name=tensor.name,
                 initializer=non_used_initializer,
                 trainable=(not tensor.stop_gradient),
+                placements=tensor.placements,
+                process_mesh=tensor.process_mesh,
             )
-
-            if tensor.placements is not None:  # import for shard tensor api
-                import paddle.distributed as dist
-
-                dist_value = dist.shard_tensor(
-                    value,
-                    tensor.process_mesh,
-                    tensor.placements,
-                    stop_gradient=value.stop_gradient,
-                )
-                value.set_type(dist_value.type())
-                value.get_defining_op().dist_attr = (
-                    dist_value.get_defining_op().dist_attr
-                )
-                dist_value.block.remove_op(dist_value.get_defining_op())
 
             if isinstance(tensor, paddle.Tensor):
                 params.add(tensor)

--- a/python/paddle/pir/core.py
+++ b/python/paddle/pir/core.py
@@ -317,6 +317,15 @@ def create_parameter(
     main_program = default_main_program()
     parameter_meta = ParameterMeta(shape, dtype)
 
+    is_dist = False
+    if (
+        'placements' in kwargs
+        and kwargs['placements']
+        and 'process_mesh' in kwargs
+        and kwargs['process_mesh']
+    ):
+        is_dist = True
+
     def to_dist(value):
         import paddle
         import paddle.distributed as dist
@@ -343,7 +352,7 @@ def create_parameter(
             parameter_meta, startup_program.global_block()
         )
         init_result.persistable = True
-        if kwargs['placements'] is not None:
+        if is_dist:
             to_dist(init_result)
 
         set_parameter(init_result, value_name)
@@ -354,7 +363,7 @@ def create_parameter(
         param = parameter(value_name)
         param.persistable = True
 
-        if kwargs['placements'] is not None:
+        if is_dist:
             to_dist(param)
 
     param.trainable = kwargs.get('trainable', True)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
ATT
- unify the function of  `convert placements to dim_map and partial_status`
- fix `distMetaTensor.initialzed()` to support calling spmd from static graph 
- make parameter in startup program as distTensor, to be consistent with main program
- make master weight as distTensor if needed

Pcard-76459