### PR TITLE
Wrong parameter order in `all_to_all`

### DIFF
--- a/python/paddle/distributed/communication/stream/all_to_all.py
+++ b/python/paddle/distributed/communication/stream/all_to_all.py
@@ -27,10 +27,10 @@ def _all_to_all_tensor_in_dygraph(
 ):
     if use_calc_stream:
         return group.process_group.all_to_all_tensor_on_calc_stream(
-            in_tensor, out_tensor
+            out_tensor, in_tensor
         )
 
-    task = group.process_group.all_to_all_tensor(in_tensor, out_tensor, sync_op)
+    task = group.process_group.all_to_all_tensor(out_tensor, in_tensor, sync_op)
     if sync_op:
         task.wait()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Distributed Strategy

### PR Types
Bug fixes


### Description

The parameter order in PyBind differs from that in Python, causing a bug. By swapping the parameter order, this issue can be resolved.

Please refer to the PyBind C++ Interface ([all_to_all_tensor_on_calc_stream](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/pybind/distributed_py.cc#L916) and [all_to_all_tensor](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/pybind/distributed_py.cc#L916).), where `out_tensor` should be the first parameter. 

However, in the `_all_to_all_tensor_in_dygraph`, `in_tensor` is the first parameter.

Additionally, the parameter order in PaddlePaddle is not standardized, even in the highest-level APIs, which lack a consistent parameter sequence. Please check [alltoall (stream)](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/distributed/stream/alltoall_cn.html) and [alltoall (distributed)](https://www.paddlepaddle.org.cn/documentation/docs/zh/2.5/api/paddle/distributed/alltoall_cn.html)
