### PR TITLE
[XPU] force use calc stream for xpu

### DIFF
--- a/paddle/fluid/distributed/collective/process_group_bkcl.cc
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.cc
@@ -206,7 +206,7 @@ void ProcessGroupBKCL::CreateBKCLEnvCache(const Place& place,
   auto* calc_ctx = static_cast<phi::XPUContext*>(
       platform::DeviceContextPool::Instance().Get(place));
   // must use XPUDeviceContext here to make sure XPUContext::Init() is called
-  auto comm_ctx = std::make_unique<XPUDeviceContext>(place);
+  auto comm_ctx = std::make_unique<XPUDeviceContext>(place, true);
   // comm_ctx does not require a pre-allocated GM buffer
   comm_ctx->x_context()->set_option("XPUAPI_DEFAULT_SIZE", "1");
   auto bkcl_comm_ctx = this->GetCommContext();
@@ -217,8 +217,7 @@ void ProcessGroupBKCL::CreateBKCLEnvCache(const Place& place,
                              .GetAllocator(place)
                              .get());
   // Note(lijin23): XPU use calc stream for communication now, so we disable the
-  // creation of comm stream to reduce the total number of streams used. comm
-  // context creates a separate XPU stream for communication
+  // creation of comm stream to reduce the total number of streams used.
   // comm_ctx->CreateStream();
 
   place_to_calc_ctx_[place_key] = calc_ctx;

--- a/paddle/fluid/distributed/collective/process_group_bkcl.cc
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.cc
@@ -237,6 +237,12 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Collective(
     CommType op_type,
     bool sync_op,
     bool use_calc_stream) {
+  if (!use_calc_stream) {
+    VLOG(3) << "For XPU, Communication on non-calc stream has minor effect on "
+               "performance and might be conflict with streams in calc_ctx, so "
+               "we disable it currently.";
+    use_calc_stream = true;
+  }
   const auto& place = tensor.place();
   const auto& key = GetKeyFromPlace(place);
 
@@ -281,6 +287,12 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Point2Point(
     CommType comm_type,
     bool sync_op,
     bool use_calc_stream) {
+  if (!use_calc_stream) {
+    VLOG(3) << "For XPU, Communication on non-calc stream has minor effect on "
+               "performance and might be conflict with streams in calc_ctx, so "
+               "we disable it currently.";
+    use_calc_stream = true;
+  }
   auto tensor_tmp =
       paddle::experimental::CheckAndTrans2NewContiguousTensor(tensor);
   const auto& place = tensor_tmp.place();

--- a/paddle/phi/core/distributed/comm_context_manager.cc
+++ b/paddle/phi/core/distributed/comm_context_manager.cc
@@ -210,9 +210,8 @@ void CommContextManager::CreateBKCLCommContext(
       std::make_unique<BKCLCommContext>(rank, size, bkcl_id);
 
   if (CommContextManager::device_id != -1) {
-    bool is_comm_context = 1;
     std::unique_ptr<phi::XPUContext> dev_ctx(new phi::XPUContext(
-        phi::XPUPlace(CommContextManager::device_id), is_comm_context));
+        phi::XPUPlace(CommContextManager::device_id), true));
     dev_ctx->SetAllocator(phi::memory_utils::GetAllocator(
         CommContextManager::device_id, dev_ctx->stream()));
     dev_ctx->SetHostAllocator(phi::memory_utils::GetHostAllocator());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
1. Force `use_calc_stream = True`. 
The python code in Paddle set `use_calc_stream = False` and `sync_op=True` by default. However, the performance improvement of dispatching communication kernels on another stream is minor for XPU and would cause additional `xpu_wait` that hinder the end-to-end performance of models.
2. Do not create stream for comm `XPUContext` to reduce stream creation in `ProcessGroupBKCL`.
The hardware channels for XPU are limited. If the number of streams created exceeds the max channels available, there might be calc streams that are projected onto the same channel which disables the CDNN_CLUSTER parallel essentially. Because we force `use_calc_stream=True` for communication, We can avoid the stream creation in `XPUContext` when `is_comm_context=True`.
