### PR TITLE
[AutoParallel] Refine some pass and spmd rules

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
@@ -184,6 +184,14 @@ IfInstruction::IfInstruction(size_t id,
   false_branch_inter_->SetSkipGcVars(false_skip_gc_names_set);
 
   VLOG(6) << "finish process false branch interpreter";
+
+  if (op_->HasAttribute("fake_false_branch") &&
+      op_->attributes()
+          .at("fake_false_branch")
+          .dyn_cast<pir::BoolAttribute>()
+          .data()) {
+    has_fake_false_branch_ = true;
+  }
 }
 
 IfInstruction::~IfInstruction() {
@@ -240,6 +248,7 @@ void IfInstruction::Run() {
 #endif
     true_branch_inter_->Run({}, false);
   } else {
+    if (has_fake_false_branch_) return;
 #ifdef PADDLE_WITH_DNNL
     // Executor on being destroyed clears oneDNN cache and resets
     // registered model data layout. This is unwanted for nested

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
@@ -104,6 +104,7 @@ IfInstruction::IfInstruction(size_t id,
   SetInputs(inputs);
 
   std::unordered_map<pir::Value, std::vector<int>> outputs;
+  bool is_last_op = true;
   for (size_t i = 0; i < op->num_results(); i++) {
     pir::Value value = op->result(i);
     if (value && value.type()) {
@@ -115,6 +116,10 @@ IfInstruction::IfInstruction(size_t id,
               i,
               "if op"));
       outputs.emplace(value, GetValueIds(value, *value_exec_info));
+    }
+    if (value.use_count() > 0) {
+      VLOG(0) << "value " << i << " use conutn != 0";
+      is_last_op = false;
     }
   }
   InsertTuplePushContinerToOuts(&true_branch_block, *value_exec_info, &outputs);
@@ -189,7 +194,8 @@ IfInstruction::IfInstruction(size_t id,
       op_->attributes()
           .at("fake_false_branch")
           .dyn_cast<pir::BoolAttribute>()
-          .data()) {
+          .data() &&
+      is_last_op) {
     has_fake_false_branch_ = true;
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.h
@@ -70,6 +70,8 @@ class IfInstruction : public InstructionBase {
   std::vector<std::string> true_skip_gc_names_;
 
   std::vector<std::string> false_skip_gc_names_;
+
+  bool has_fake_false_branch_{false};
 };
 
 }  // namespace framework

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.h
@@ -71,6 +71,9 @@ class IfInstruction : public InstructionBase {
 
   std::vector<std::string> false_skip_gc_names_;
 
+  // NOTE(zhangbo): The fake_false_branch indicates that the false branch is an
+  // artificially constructed block, which will be directly skipped during the
+  // execution phase.
   bool has_fake_false_branch_{false};
 };
 

--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -464,6 +464,8 @@ void ProgramTranslator::TranslateIfOperation(
     }
     false_region.front().push_back(
         pir::Operation::Create(false_yield_inputs, {}, {}, yield_info));
+    if_op->set_attribute("fake_false_branch",
+                         pir::BoolAttribute::get(ctx_, true));
   }
   VLOG(4) << "[general op][conditional_block] IfOp true block translate end.";
 

--- a/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
@@ -132,8 +132,8 @@ class FusedAllReduceSplitPattern2 : public paddle::drr::DrrPatternBase {
 
     c_reducescatter({&res.Tensor("a")}, {&res.Tensor("b")});
     add1({&res.Tensor("b"), &res.Tensor("c")}, {&res.Tensor("h")});
-    add_grad1({&pat.Tensor("b"), &pat.Tensor("c"), &pat.Tensor("grad")},
-              {&pat.Tensor("b_g"), &pat.Tensor("c_g")});
+    add_grad1({&res.Tensor("b"), &res.Tensor("c"), &res.Tensor("grad")},
+              {&res.Tensor("b_g"), &res.Tensor("c_g")});
   }
 };
 

--- a/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
@@ -89,51 +89,108 @@ class FusedAllReduceSplitPattern2 : public paddle::drr::DrrPatternBase {
 
   void operator()(paddle::drr::DrrPatternContext *ctx) const override {
     paddle::drr::SourcePattern pat = ctx->SourcePattern();
-
+    // forward
+    // out1 = matmul(input, weight)
+    const auto &matmul = pat.Op(paddle::dialect::MatmulOp::name(),
+                                {{"transpose_x", pat.Attr("trans_x")},
+                                 {"transpose_y", pat.Attr("trans_y")}});
+    // out2 = c_allreduce_sum_(out1)
     const auto &c_allreduce_sum_ =
         pat.Op(paddle::dialect::CAllreduceSum_Op::name(),
                {{"ring_id", pat.Attr("ring_id")},
                 {"use_calc_stream", pat.Attr("use_calc_stream")},
-                {"execution_stream", pat.Attr("execution_stream")},
                 {"force_record_event", pat.Attr("force_record_event")},
                 {"event_to_record", pat.Attr("event_to_record")},
                 {"events_to_wait", pat.Attr("events_to_wait")}});
+    // out3 = add(out2, bias)
     const auto &add = pat.Op(paddle::dialect::AddOp::name());
+    // out4 = split_with_num(out3, index)
     const auto &full = pat.Op(paddle::dialect::FullOp::name());
     const auto &split_with_num = pat.Op(paddle::dialect::SplitWithNumOp::name(),
                                         {{"num", pat.Attr("num")}});
     const auto &builtin_slice =
         pat.Op(pir::SliceOp::name(), {{"index", pat.Attr("index")}});
     const auto &assign = pat.Op(paddle::dialect::AssignOp::name());
-    // const auto &add_grad = pat.Op(paddle::dialect::AddGradOp::name());
+    // backward
+    // out_g_assign = assign(out_g)
+    const auto &assign1 = pat.Op(paddle::dialect::AssignOp::name());
+    // out_g_all = c_allgather(out_g_assign)
+    const auto &c_allgather =
+        pat.Op(paddle::dialect::CAllgatherOp::name(),
+               {{"ring_id", pat.Attr("gather_ring_id")},
+                {"use_calc_stream", pat.Attr("gather_use_calc_stream")},
+                {"nranks", pat.Attr("gather_nranks")}});
+    //
+    const auto &add_grad = pat.Op(paddle::dialect::AddGradOp::name(),
+                                  {{"axis", pat.Attr("axis")}});
+    //
+    const auto &add_ = pat.Op(paddle::dialect::Add_Op::name());
+    //
+    const auto &matmul_grad =
+        pat.Op(paddle::dialect::MatmulGradOp::name(),
+               {{"transpose_x", pat.Attr("mm_g_trans_x")},
+                {"transpose_y", pat.Attr("mm_g_trans_y")}});
 
-    pat.Tensor("b") = c_allreduce_sum_(pat.Tensor("a"));
-    pat.Tensor("d") = add(pat.Tensor("b"), pat.Tensor("c"));
-    pat.Tensor("e") = full();
-    pat.Tensor("f") = split_with_num(pat.Tensor("d"), pat.Tensor("e"));
-    pat.Tensor("g") = builtin_slice(pat.Tensor("f"));
-    pat.Tensor("h") = assign(pat.Tensor("g"));
-    // add_grad({&pat.Tensor("b"), &pat.Tensor("c"), &pat.Tensor("grad")},
-    //          {&pat.Tensor("b_g"), &pat.Tensor("c_g")});
+    pat.Tensor("out1") = matmul(pat.Tensor("input"), pat.Tensor("weight"));
+    pat.Tensor("out2") = c_allreduce_sum_(pat.Tensor("out1"));
+    pat.Tensor("out3") = add(pat.Tensor("out2"), pat.Tensor("bias"));
+    pat.Tensor("index") = full();
+    pat.Tensor("out4") =
+        split_with_num(pat.Tensor("out3"), pat.Tensor("index"));
+    pat.Tensor("out5") = builtin_slice(pat.Tensor("out4"));
+    pat.Tensor("out6") = assign(pat.Tensor("out5"));
 
+    pat.Tensor("out_g_assign") = assign1(pat.Tensor("out_g"));
+    pat.Tensor("out_g_all") = c_allgather(pat.Tensor("out_g_assign"));
+    add_grad(
+        {&pat.Tensor("out2"), &pat.Tensor("bias"), &pat.Tensor("out_g_all")},
+        {&pat.Tensor("out2_g"), &pat.Tensor("bias_g")});
+    pat.Tensor("bias_g_m2") =
+        add_(pat.Tensor("bias_g_m1"), pat.Tensor("bias_g"));
+    matmul_grad(
+        {&pat.Tensor("input"), &pat.Tensor("weight"), &pat.Tensor("out2_g")},
+        {&pat.Tensor("input_g"), &pat.Tensor("weight_g")});
+
+    //////////////////////////////////////////////////////
     paddle::drr::ResultPattern res = pat.ResultPattern();
-
-    const auto &c_reducescatter =
+    const auto &res_matmul = res.Op(paddle::dialect::MatmulOp::name(),
+                                    {{"transpose_x", pat.Attr("trans_x")},
+                                     {"transpose_y", pat.Attr("trans_y")}});
+    const auto &res_c_reducescatter =
         res.Op(paddle::dialect::CReducescatterOp::name(),
                {{"ring_id", pat.Attr("ring_id")},
                 {"nranks", pat.Attr("num")},
                 {"use_calc_stream", pat.Attr("use_calc_stream")}},
-               {{"execution_stream", pat.Attr("execution_stream")},
-                {"force_record_event", pat.Attr("force_record_event")},
+               {{"force_record_event", pat.Attr("force_record_event")},
                 {"event_to_record", pat.Attr("event_to_record")},
                 {"events_to_wait", pat.Attr("events_to_wait")}});
-    const auto &add1 = res.Op(paddle::dialect::AddOp::name());
-    // const auto &add_grad1 = res.Op(paddle::dialect::AddGradOp::name());
+    const auto &res_add = res.Op(paddle::dialect::AddOp::name());
+    const auto &res_add_grad = res.Op(paddle::dialect::AddGradOp::name(),
+                                      {{"axis", pat.Attr("axis")}});
+    const auto &res_add_ = res.Op(paddle::dialect::Add_Op::name());
+    const auto &res_c_allgather =
+        res.Op(paddle::dialect::CAllgatherOp::name(),
+               {{"ring_id", pat.Attr("gather_ring_id")},
+                {"use_calc_stream", pat.Attr("gather_use_calc_stream")},
+                {"nranks", pat.Attr("gather_nranks")}});
+    const auto &res_matmul_grad =
+        res.Op(paddle::dialect::MatmulGradOp::name(),
+               {{"transpose_x", pat.Attr("mm_g_trans_x")},
+                {"transpose_y", pat.Attr("mm_g_trans_y")}});
 
-    c_reducescatter({&res.Tensor("a")}, {&res.Tensor("b")});
-    add1({&res.Tensor("b"), &res.Tensor("c")}, {&res.Tensor("h")});
-    // add_grad1({&res.Tensor("b"), &res.Tensor("c"), &res.Tensor("grad")},
-    //           {&res.Tensor("b_g"), &res.Tensor("c_g")});
+    res.Tensor("out1") = res_matmul(res.Tensor("input"), res.Tensor("weight"));
+    res.Tensor("out2") = res_c_reducescatter(res.Tensor("out1"));
+    res.Tensor("out6") = res_add(res.Tensor("out2"), res.Tensor("bias"));
+
+    res_add_grad(
+        {&res.Tensor("out2"), &res.Tensor("bias"), &res.Tensor("out_g")},
+        {&res.Tensor("out_g_assign"), &res.Tensor("bias_g")});
+    res.Tensor("bias_g_m2") =
+        res_add_(res.Tensor("bias_g_m1"), res.Tensor("bias_g"));
+    res.Tensor("out_g_all") = res_c_allgather(res.Tensor("out_g_assign"));
+    res_matmul_grad(
+        {&res.Tensor("input"), &res.Tensor("weight"), &res.Tensor("out_g_all")},
+        {&res.Tensor("input_g"), &res.Tensor("weight_g")});
   }
 };
 
@@ -145,7 +202,7 @@ class FuseAllreduceSplitToReducescatterPass : public pir::PatternRewritePass {
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
-    // ps.Add(paddle::drr::Create<FusedAllReduceSplitPattern1>(context));
+    ps.Add(paddle::drr::Create<FusedAllReduceSplitPattern1>(context));
     ps.Add(paddle::drr::Create<FusedAllReduceSplitPattern2>(context));
 
     return ps;

--- a/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
@@ -105,7 +105,7 @@ class FusedAllReduceSplitPattern2 : public paddle::drr::DrrPatternBase {
     const auto &builtin_slice =
         pat.Op(pir::SliceOp::name(), {{"index", pat.Attr("index")}});
     const auto &assign = pat.Op(paddle::dialect::AssignOp::name());
-    const auto &add_grad = pat.Op(paddle::dialect::AddGradOp::name());
+    // const auto &add_grad = pat.Op(paddle::dialect::AddGradOp::name());
 
     pat.Tensor("b") = c_allreduce_sum_(pat.Tensor("a"));
     pat.Tensor("d") = add(pat.Tensor("b"), pat.Tensor("c"));
@@ -128,7 +128,7 @@ class FusedAllReduceSplitPattern2 : public paddle::drr::DrrPatternBase {
                 {"event_to_record", pat.Attr("event_to_record")},
                 {"events_to_wait", pat.Attr("events_to_wait")}});
     const auto &add1 = res.Op(paddle::dialect::AddOp::name());
-    const auto &add_grad1 = res.Op(paddle::dialect::AddGradOp::name());
+    // const auto &add_grad1 = res.Op(paddle::dialect::AddGradOp::name());
 
     c_reducescatter({&res.Tensor("a")}, {&res.Tensor("b")});
     add1({&res.Tensor("b"), &res.Tensor("c")}, {&res.Tensor("h")});

--- a/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
@@ -113,8 +113,8 @@ class FusedAllReduceSplitPattern2 : public paddle::drr::DrrPatternBase {
     pat.Tensor("f") = split_with_num(pat.Tensor("d"), pat.Tensor("e"));
     pat.Tensor("g") = builtin_slice(pat.Tensor("f"));
     pat.Tensor("h") = assign(pat.Tensor("g"));
-    add_grad({&pat.Tensor("b"), &pat.Tensor("c"), &pat.Tensor("grad")},
-             {&pat.Tensor("b_g"), &pat.Tensor("c_g")});
+    // add_grad({&pat.Tensor("b"), &pat.Tensor("c"), &pat.Tensor("grad")},
+    //          {&pat.Tensor("b_g"), &pat.Tensor("c_g")});
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
 
@@ -132,8 +132,8 @@ class FusedAllReduceSplitPattern2 : public paddle::drr::DrrPatternBase {
 
     c_reducescatter({&res.Tensor("a")}, {&res.Tensor("b")});
     add1({&res.Tensor("b"), &res.Tensor("c")}, {&res.Tensor("h")});
-    add_grad1({&res.Tensor("b"), &res.Tensor("c"), &res.Tensor("grad")},
-              {&res.Tensor("b_g"), &res.Tensor("c_g")});
+    // add_grad1({&res.Tensor("b"), &res.Tensor("c"), &res.Tensor("grad")},
+    //           {&res.Tensor("b_g"), &res.Tensor("c_g")});
   }
 };
 

--- a/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
@@ -128,7 +128,7 @@ class FusedAllReduceSplitPattern2 : public paddle::drr::DrrPatternBase {
                 {"event_to_record", pat.Attr("event_to_record")},
                 {"events_to_wait", pat.Attr("events_to_wait")}});
     const auto &add1 = res.Op(paddle::dialect::AddOp::name());
-    const auto &add_grad1 = pat.Op(paddle::dialect::AddGradOp::name());
+    const auto &add_grad1 = res.Op(paddle::dialect::AddGradOp::name());
 
     c_reducescatter({&res.Tensor("a")}, {&res.Tensor("b")});
     add1({&res.Tensor("b"), &res.Tensor("c")}, {&res.Tensor("h")});

--- a/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
@@ -124,10 +124,10 @@ class FusedAllReduceSplitPattern2 : public paddle::drr::DrrPatternBase {
                 {"force_record_event", pat.Attr("force_record_event")},
                 {"event_to_record", pat.Attr("event_to_record")},
                 {"events_to_wait", pat.Attr("events_to_wait")}});
-    const auto &add = res.Op(paddle::dialect::AddOp::name());
+    const auto &add1 = res.Op(paddle::dialect::AddOp::name());
 
     c_reducescatter({&res.Tensor("a")}, {&res.Tensor("b")});
-    add({&res.Tensor("b"), &res.Tensor("c")}, {&res.Tensor("h")});
+    add1({&res.Tensor("b"), &res.Tensor("c")}, {&res.Tensor("h")});
   }
 };
 

--- a/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
@@ -113,9 +113,6 @@ class FusedAllReduceSplitPattern2 : public paddle::drr::DrrPatternBase {
     pat.Tensor("f") = split_with_num(pat.Tensor("d"), pat.Tensor("e"));
     pat.Tensor("g") = builtin_slice(pat.Tensor("f"));
     pat.Tensor("h") = assign(pat.Tensor("g"));
-    pat.Tensor("b_g"),
-        pat.Tensor("c_g") =
-            add_grad(pat.Tensor("b"), pat.Tensor("c"), pat.Tensor("grad"));
     add_grad({&pat.Tensor("b"), &pat.Tensor("c"), &pat.Tensor("grad")},
              {&pat.Tensor("b_g"), &pat.Tensor("c_g")});
 
@@ -148,7 +145,7 @@ class FuseAllreduceSplitToReducescatterPass : public pir::PatternRewritePass {
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
-    ps.Add(paddle::drr::Create<FusedAllReduceSplitPattern1>(context));
+    // ps.Add(paddle::drr::Create<FusedAllReduceSplitPattern1>(context));
     ps.Add(paddle::drr::Create<FusedAllReduceSplitPattern2>(context));
 
     return ps;

--- a/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
@@ -22,16 +22,14 @@
 #include "paddle/pir/include/pass/pass_registry.h"
 
 namespace {
-class FusedAllReduceSplitPattern : public paddle::drr::DrrPatternBase {
+// c_allreduce_sum_+assign+full+split_with_num+builtin_slice -> c_reducescatter
+class FusedAllReduceSplitPattern1 : public paddle::drr::DrrPatternBase {
  public:
-  std::string name() const override { return "FusedAllReduceSplitPattern"; }
+  std::string name() const override { return "FusedAllReduceSplitPattern1"; }
 
   void operator()(paddle::drr::DrrPatternContext *ctx) const override {
     paddle::drr::SourcePattern pat = ctx->SourcePattern();
 
-    const auto &matmul = pat.Op(paddle::dialect::MatmulOp::name(),
-                                {{"transpose_x", pat.Attr("trans_x")},
-                                 {"transpose_y", pat.Attr("trans_y")}});
     const auto &c_allreduce_sum_ =
         pat.Op(paddle::dialect::CAllreduceSum_Op::name(),
                {{"ring_id", pat.Attr("ring_id")},
@@ -47,8 +45,6 @@ class FusedAllReduceSplitPattern : public paddle::drr::DrrPatternBase {
     const auto &builtin_slice =
         pat.Op(pir::SliceOp::name(), {{"index", pat.Attr("index")}});
 
-    pat.Tensor("input_grad_partial") =
-        matmul(pat.Tensor("out_grad"), pat.Tensor("weight"));
     pat.Tensor("input_grad") =
         c_allreduce_sum_(pat.Tensor("input_grad_partial"));
     pat.Tensor("input_grad_tmp") = assign(pat.Tensor("input_grad"));
@@ -58,8 +54,6 @@ class FusedAllReduceSplitPattern : public paddle::drr::DrrPatternBase {
     pat.Tensor("out") = builtin_slice(pat.Tensor("input_grad_group"));
 
     pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
-      const auto &x_trans = match_ctx.Attr<bool>("trans_x");
-      const auto &y_trans = match_ctx.Attr<bool>("trans_y");
       auto input_grad_partial_count =
           match_ctx.Tensor("input_grad_partial").use_count();
       auto input_grad_count = match_ctx.Tensor("input_grad").use_count();
@@ -67,8 +61,7 @@ class FusedAllReduceSplitPattern : public paddle::drr::DrrPatternBase {
           match_ctx.Tensor("input_grad_tmp").use_count();
       auto input_grad_group_count =
           match_ctx.Tensor("input_grad_group").use_count();
-      return (x_trans == false && y_trans == true &&
-              input_grad_partial_count == 1 && input_grad_count == 1 &&
+      return (input_grad_partial_count == 1 && input_grad_count == 1 &&
               input_grad_tmp_count == 1 && input_grad_group_count == 1);
     });
 
@@ -88,6 +81,56 @@ class FusedAllReduceSplitPattern : public paddle::drr::DrrPatternBase {
   }
 };
 
+// c_allreduce_sum_+add+full+split_with_num+builtin_slice+assign ->
+// c_reducescatter+add
+class FusedAllReduceSplitPattern2 : public paddle::drr::DrrPatternBase {
+ public:
+  std::string name() const override { return "FusedAllReduceSplitPattern2"; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+
+    const auto &c_allreduce_sum_ =
+        pat.Op(paddle::dialect::CAllreduceSum_Op::name(),
+               {{"ring_id", pat.Attr("ring_id")},
+                {"use_calc_stream", pat.Attr("use_calc_stream")},
+                {"execution_stream", pat.Attr("execution_stream")},
+                {"force_record_event", pat.Attr("force_record_event")},
+                {"event_to_record", pat.Attr("event_to_record")},
+                {"events_to_wait", pat.Attr("events_to_wait")}});
+    const auto &add = pat.Op(paddle::dialect::AddOp::name());
+    const auto &full = pat.Op(paddle::dialect::FullOp::name());
+    const auto &split_with_num = pat.Op(paddle::dialect::SplitWithNumOp::name(),
+                                        {{"num", pat.Attr("num")}});
+    const auto &builtin_slice =
+        pat.Op(pir::SliceOp::name(), {{"index", pat.Attr("index")}});
+    const auto &assign = pat.Op(paddle::dialect::AssignOp::name());
+
+    pat.Tensor("b") = c_allreduce_sum_(pat.Tensor("a"));
+    pat.Tensor("d") = add(pat.Tensor("b"), pat.Tensor("c"));
+    pat.Tensor("e") = full();
+    pat.Tensor("f") = split_with_num(pat.Tensor("d"), pat.Tensor("e"));
+    pat.Tensor("g") = builtin_slice(pat.Tensor("f"));
+    pat.Tensor("h") = assign(pat.Tensor("g"));
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    const auto &c_reducescatter =
+        res.Op(paddle::dialect::CReducescatterOp::name(),
+               {{"ring_id", pat.Attr("ring_id")},
+                {"nranks", pat.Attr("num")},
+                {"use_calc_stream", pat.Attr("use_calc_stream")}},
+               {{"execution_stream", pat.Attr("execution_stream")},
+                {"force_record_event", pat.Attr("force_record_event")},
+                {"event_to_record", pat.Attr("event_to_record")},
+                {"events_to_wait", pat.Attr("events_to_wait")}});
+    const auto &add = res.Op(paddle::dialect::AddOp::name());
+
+    c_reducescatter({&res.Tensor("a")}, {&res.Tensor("b")});
+    add({&res.Tensor("b"), &res.Tensor("c")}, {&res.Tensor("h")});
+  }
+};
+
 class FuseAllreduceSplitToReducescatterPass : public pir::PatternRewritePass {
  public:
   FuseAllreduceSplitToReducescatterPass()
@@ -96,7 +139,8 @@ class FuseAllreduceSplitToReducescatterPass : public pir::PatternRewritePass {
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
-    ps.Add(paddle::drr::Create<FusedAllReduceSplitPattern>(context));
+    ps.Add(paddle::drr::Create<FusedAllReduceSplitPattern1>(context));
+    ps.Add(paddle::drr::Create<FusedAllReduceSplitPattern2>(context));
 
     return ps;
   }

--- a/paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.cc
@@ -112,6 +112,81 @@ class FusedLinearGradPattern : public paddle::drr::DrrPatternBase {
   }
 };
 
+class FusedLinearGradSplitPattern : public paddle::drr::DrrPatternBase {
+ public:
+  std::string name() const override { return "FusedLinearGradSplitPattern"; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+    const auto &matmul = pat.Op(paddle::dialect::MatmulOp::name(),
+                                {{"transpose_x", pat.Attr("trans_x")},
+                                 {"transpose_y", pat.Attr("trans_y")}});
+    const auto &add = pat.Op(paddle::dialect::AddOp::name());
+    pat.Tensor("tmp") = matmul(pat.Tensor("x"), pat.Tensor("w"));
+    pat.Tensor("out") = add(pat.Tensor("tmp"), pat.Tensor("bias"));
+
+    const auto &add_grad = pat.Op(paddle::dialect::AddGradOp::name());
+    const auto &matmul_x_grad = pat.Op(paddle::dialect::MatmulOp::name());
+    const auto &full_int_array1 =
+        pat.Op(paddle::dialect::FullIntArrayOp::name());
+    const auto &reshape_x = pat.Op(paddle::dialect::ReshapeOp::name());
+    const auto &full_int_array2 =
+        pat.Op(paddle::dialect::FullIntArrayOp::name());
+    const auto &reshape_tmp_grad = pat.Op(paddle::dialect::ReshapeOp::name());
+    const auto &matmul_w_grad_reshaped =
+        pat.Op(paddle::dialect::MatmulOp::name());
+    const auto &full_int_array3 =
+        pat.Op(paddle::dialect::FullIntArrayOp::name());
+    const auto &matmul_w_grad = pat.Op(paddle::dialect::ReshapeOp::name());
+
+    add_grad({&pat.Tensor("tmp"), &pat.Tensor("bias"), &pat.Tensor("out_grad")},
+             {&pat.Tensor("tmp_grad"), &pat.Tensor("bias_grad")});
+    matmul_x_grad({&pat.Tensor("tmp_grad"), &pat.Tensor("w")},
+                  {&pat.Tensor("x_grad")});
+    reshape_x({&pat.Tensor("x"), &full_int_array1()},
+              {&pat.Tensor("x_reshape"), &pat.Tensor("x_reshape_xshape")});
+    reshape_tmp_grad({&pat.Tensor("tmp_grad"), &full_int_array2()},
+                     {&pat.Tensor("tmp_grad_reshaped"),
+                      &pat.Tensor("tmp_grad_reshaped_xshape")});
+    matmul_w_grad_reshaped(
+        {&pat.Tensor("x_reshape"), &pat.Tensor("tmp_grad_reshaped")},
+        {&pat.Tensor("w_grad_reshaped")});
+    matmul_w_grad({&pat.Tensor("w_grad_reshaped"), &full_int_array3()},
+                  {&pat.Tensor("w_grad"), &pat.Tensor("w_grad_xshape")});
+
+    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+      auto w_dims = pir::GetShapeFromValue(match_ctx.Tensor("w"));
+      auto x_dims = pir::GetShapeFromValue(match_ctx.Tensor("x"));
+      auto bias_dims = pir::GetShapeFromValue(match_ctx.Tensor("bias"));
+      return (w_dims.size() == 2 && x_dims.size() >= 2 &&
+              bias_dims.size() == 1);
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    const auto &fused_gemm_epilogue =
+        res.Op(paddle::dialect::FusedGemmEpilogueOp::name(),
+               {{{"trans_x", pat.Attr("trans_x")},
+                 {"trans_y", pat.Attr("trans_y")},
+                 {"activation", res.StrAttr("none")}}});
+    const auto &fused_gemm_epilogue_grad =
+        res.Op(paddle::dialect::FusedGemmEpilogueGradOp::name(),
+               {{{"trans_x", pat.Attr("trans_x")},
+                 {"trans_y", pat.Attr("trans_y")},
+                 {"activation_grad", res.StrAttr("none")}}});
+    fused_gemm_epilogue(
+        {&res.Tensor("x"), &res.Tensor("w"), &res.Tensor("bias")},
+        {&res.Tensor("out")});
+    fused_gemm_epilogue_grad({&res.Tensor("x"),
+                              &res.Tensor("w"),
+                              &res.InputNoneTensor(),
+                              &res.Tensor("out_grad")},
+                             {&res.Tensor("x_grad"),
+                              &res.Tensor("w_grad"),
+                              &res.Tensor("bias_grad")});
+  }
+};
+
 class FusedLinearGeluPattern : public paddle::drr::DrrPatternBase {
  public:
   std::string name() const override { return "FusedLinearGeluPattern"; }
@@ -317,8 +392,9 @@ class FusedGemmEpiloguePass : public pir::PatternRewritePass {
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
-    ps.Add(paddle::drr::Create<FusedLinearGradPattern>(context));
     ps.Add(paddle::drr::Create<FusedLinearPattern>(context));
+    ps.Add(paddle::drr::Create<FusedLinearGradPattern>(context));
+    ps.Add(paddle::drr::Create<FusedLinearGradSplitPattern>(context));
     ps.Add(paddle::drr::Create<FusedLinearGeluPattern>(context));
     ps.Add(paddle::drr::Create<FusedLinearReluPattern>(context));
     ps.Add(paddle::drr::Create<FusedLinearGeluGradPattern>(context));

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -1407,6 +1407,15 @@ void HandleForIfOp(
   }
   auto new_ifop = builder.Build<IfOp>(new_cond, std::move(new_ifop_outputs));
 
+  if (op_item->HasAttribute("fake_false_branch") &&
+      op_item->attributes()
+          .at("fake_false_branch")
+          .dyn_cast<pir::BoolAttribute>()
+          .data()) {
+    new_ifop->set_attribute("fake_false_branch",
+                            op_item->attribute("fake_false_branch"));
+  }
+
   // process true block
   auto& true_block = new_ifop.true_block();
   ProcessBlock(place,

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -563,6 +563,11 @@ PD_REGISTER_SPMD_RULE(slice,
                       PD_INFER_SPMD(phi::distributed::SliceInferSpmd),
                       PD_INFER_SPMD(phi::distributed::SliceInferSpmdReverse));
 
+PD_REGISTER_SPMD_RULE(
+    strided_slice,
+    PD_INFER_SPMD(phi::distributed::StridedSliceInferSpmd),
+    PD_INFER_SPMD(phi::distributed::StridedSliceGradInferSpmd));
+
 PD_REGISTER_SPMD_RULE(concat,
                       PD_INFER_SPMD(phi::distributed::ConcatInferSpmd),
                       PD_INFER_SPMD(phi::distributed::ConcatInferSpmdReverse));

--- a/paddle/phi/infermeta/spmd_rules/slice.cc
+++ b/paddle/phi/infermeta/spmd_rules/slice.cc
@@ -42,7 +42,10 @@ std::vector<int64_t> BuildOutputAxisToInputAxisMap(
 
 SpmdInfo SliceInferSpmdBase(const DistMetaTensor& input,
                             const std::vector<int64_t>& axes,
-                            const std::vector<int64_t>& decrease_axis) {
+                            const std::vector<int64_t>& decrease_axis,
+                            const std::vector<int>& starts,
+                            const std::vector<int>& ends,
+                            const std::vector<int>& strides) {
   // Step0: Verify input args based on slice logic
   auto input_shape = common::vectorize(input.dims());
   int input_ndim = static_cast<int>(input_shape.size());
@@ -74,11 +77,18 @@ SpmdInfo SliceInferSpmdBase(const DistMetaTensor& input,
 
   // Step2.3 get new dist attribute for input. the sliced
   // cannot be sharded, if it is sharded, set it to replicated.
+  std::vector<int64_t> input_process_mesh =
+      input_dist_attr_src.process_mesh().shape();
   TensorDistAttr input_dist_attr_dst =
       CopyTensorDistAttrForOutput(input_dist_attr_src);
   for (auto axe : axes) {
     int axis = axe < 0 ? axe + input_ndim : axe;
-    input_dims_mapping[axis] = -1;
+    if (!(axis == (input_ndim - 1) && strides.size() == 1 &&
+          (input_shape[axis] / input_process_mesh[input_dims_mapping[axis]]) %
+                  strides[0] ==
+              0)) {
+      input_dims_mapping[axis] = -1;
+    }
   }
   input_dist_attr_dst.set_dims_mapping(input_dims_mapping);
 
@@ -113,13 +123,16 @@ SpmdInfo SliceInferSpmd(const DistMetaTensor& input,
                         const std::vector<int64_t>& decrease_axis) {
   // starts, ends, infer_flags and decrease_axis have no impact on the
   // derivation, only to align with the definition in phi api
-  return SliceInferSpmdBase(input, axes, {});
+  return SliceInferSpmdBase(input, axes, {}, starts, ends, {});
 }
 
 SpmdInfo SliceInferSpmdReverseBase(const DistMetaTensor& input,
                                    const DistMetaTensor& output,
                                    const std::vector<int64_t>& axes,
-                                   const std::vector<int64_t>& decrease_axis) {
+                                   const std::vector<int64_t>& decrease_axis,
+                                   const std::vector<int>& starts,
+                                   const std::vector<int>& ends,
+                                   const std::vector<int>& strides) {
   auto output_shape = common::vectorize(output.dims());
   int out_ndim = output_shape.size();
   auto out_dist_attr = output.dist_attr();
@@ -163,11 +176,18 @@ SpmdInfo SliceInferSpmdReverseBase(const DistMetaTensor& input,
     out_axes[i] = input_axes[input_axis];
   }
 
+  std::vector<int64_t> input_process_mesh =
+      input_dist_attr.process_mesh().shape();
   for (auto axe : axes) {
     int axis = axe < 0 ? axe + input_ndim : axe;
     // the sliced axis cannot be sharded, set its notation
     // with the special '1' to set its dim mapping to -1.
-    input_axes[axis] = '1';
+    if (!(axis == (input_ndim - 1) && strides.size() == 1 &&
+          (input_shape[axis] / input_process_mesh[input_dims_mapping[axis]]) %
+                  strides[0] ==
+              0)) {
+      input_axes[axis] = '1';
+    }
   }
 
   // Step2: Sharding Propagation
@@ -189,9 +209,16 @@ SpmdInfo SliceInferSpmdReverseBase(const DistMetaTensor& input,
   // step2.3 get new dist attribute for output. the sliced
   // cannot be sharded, if it is sharded, set it to replicated.
   out_dims_mapping = GetDimsMappingForAxes(out_axes, axis_to_dim_map, true);
+  std::vector<int64_t> output_process_mesh =
+      out_dist_attr.process_mesh().shape();
   for (auto axe : axes) {
     int axis = axe < 0 ? axe + input_ndim : axe;
-    out_dims_mapping[axis] = -1;
+    if (!(axis == (out_ndim - 1) && strides.size() == 1 &&
+          (output_shape[axis] / output_process_mesh[out_dims_mapping[axis]]) %
+                  strides[0] ==
+              0)) {
+      out_dims_mapping[axis] = -1;
+    }
   }
   auto out_dist_attr_dst = CopyTensorDistAttrForOutput(out_dist_attr);
   out_dist_attr_dst.set_dims_mapping(out_dims_mapping);
@@ -220,7 +247,7 @@ SpmdInfo SliceInferSpmdReverse(const DistMetaTensor& input,
                                const std::vector<int64_t>& decrease_axis) {
   // starts, ends, infer_flags and decrease_axis have no impact on the
   // derivation, only to align with the definition in phi api
-  return SliceInferSpmdReverseBase(input, output, axes, {});
+  return SliceInferSpmdReverseBase(input, output, axes, {}, starts, ends, {});
 }
 
 SpmdInfo SliceInferSpmdDynamic(const DistMetaTensor& input,
@@ -234,7 +261,7 @@ SpmdInfo SliceInferSpmdDynamic(const DistMetaTensor& input,
   std::vector<int> start_indexes(starts.GetData().begin(),
                                  starts.GetData().end());
   std::vector<int> end_indexes(ends.GetData().begin(), ends.GetData().end());
-  return SliceInferSpmdBase(input, axes, decrease_axis);
+  return SliceInferSpmdBase(input, axes, decrease_axis, {}, {}, {});
 }
 
 SpmdInfo SliceGradInferBase(const DistMetaTensor& input,
@@ -363,7 +390,7 @@ SpmdInfo StridedSliceInferSpmd(const DistMetaTensor& input,
   // starts, ends and strides have no impact on the derivation,
   // only to align with the definition in phi api
   std::vector<int64_t> axes_bridge(axes.begin(), axes.end());
-  return SliceInferSpmdBase(input, axes_bridge, {});
+  return SliceInferSpmdBase(input, axes_bridge, {}, starts, ends, strides);
 }
 
 SpmdInfo StridedSliceGradInferSpmd(const DistMetaTensor& input,
@@ -386,7 +413,7 @@ SpmdInfo StridedSliceInferSpmdDynamic(const DistMetaTensor& input,
   // starts, ends and strides have no impact on the derivation,
   // only to align with the definition in phi api
   std::vector<int64_t> axes_bridge(axes.begin(), axes.end());
-  return SliceInferSpmdBase(input, axes_bridge, {});
+  return SliceInferSpmdBase(input, axes_bridge, {}, {}, {}, {});
 }
 
 SpmdInfo StridedSliceGradInferSpmdDynamic(const DistMetaTensor& input,

--- a/paddle/phi/infermeta/spmd_rules/slice.cc
+++ b/paddle/phi/infermeta/spmd_rules/slice.cc
@@ -355,6 +355,29 @@ SpmdInfo SliceGradInferSpmdDynamic(const DistMetaTensor& input,
   return SliceGradInferBase(input, out_grad, axes, decrease_axis);
 }
 
+SpmdInfo StridedSliceInferSpmd(const DistMetaTensor& input,
+                               const std::vector<int>& axes,
+                               const std::vector<int>& starts,
+                               const std::vector<int>& ends,
+                               const std::vector<int>& strides) {
+  // starts, ends and strides have no impact on the derivation,
+  // only to align with the definition in phi api
+  std::vector<int64_t> axes_bridge(axes.begin(), axes.end());
+  return SliceInferSpmdBase(input, axes_bridge, {});
+}
+
+SpmdInfo StridedSliceGradInferSpmd(const DistMetaTensor& input,
+                                   const DistMetaTensor& out_grad,
+                                   const std::vector<int>& axes,
+                                   const std::vector<int>& starts,
+                                   const std::vector<int>& ends,
+                                   const std::vector<int>& strides) {
+  // starts, ends and strides have no impact on the derivation,
+  // only to align with the definition in phi api
+  std::vector<int64_t> axes_bridge(axes.begin(), axes.end());
+  return SliceGradInferBase(input, out_grad, axes_bridge, {});
+}
+
 SpmdInfo StridedSliceInferSpmdDynamic(const DistMetaTensor& input,
                                       const std::vector<int>& axes,
                                       const IntArray& starts,

--- a/paddle/phi/infermeta/spmd_rules/slice.h
+++ b/paddle/phi/infermeta/spmd_rules/slice.h
@@ -56,6 +56,19 @@ SpmdInfo SliceGradInferSpmdDynamic(const DistMetaTensor& input,
                                    const std::vector<int64_t>& infer_flags,
                                    const std::vector<int64_t>& decrease_axis);
 
+SpmdInfo StridedSliceInferSpmd(const DistMetaTensor& input,
+                               const std::vector<int>& axes,
+                               const std::vector<int>& starts,
+                               const std::vector<int>& ends,
+                               const std::vector<int>& strides);
+
+SpmdInfo StridedSliceGradInferSpmd(const DistMetaTensor& input,
+                                   const DistMetaTensor& out_grad,
+                                   const std::vector<int>& axes,
+                                   const std::vector<int>& starts,
+                                   const std::vector<int>& ends,
+                                   const std::vector<int>& strides);
+
 SpmdInfo StridedSliceInferSpmdDynamic(const DistMetaTensor& input,
                                       const std::vector<int>& axes,
                                       const IntArray& starts,

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -944,7 +944,8 @@ class _ExecutorCache:
         )
 
     def _get_program_and_executor(self, cached_data):
-        program = cached_data.program
+        # do type promotion if necessary
+        program = process_type_promotion(cached_data.program)
         inner_program = (
             program._program
             if isinstance(program, compiler.CompiledProgram)
@@ -1802,8 +1803,6 @@ class Executor:
                 return_numpy=return_numpy,
             )
         else:
-            # do type promotion if necessary
-            program = process_type_promotion(program)
             res = self._run_impl(
                 program=program,
                 feed=feed,

--- a/python/paddle/distributed/auto_parallel/static/completion.py
+++ b/python/paddle/distributed/auto_parallel/static/completion.py
@@ -186,6 +186,7 @@ def _can_apply_infer_spmd_rule(dist_op):
         "swiglu",
         "tile",
         "fused_rms_norm",
+        "strided_slice",
     ]
     parallel_ce = os.getenv("PARALLEL_CROSS_ENTROPY")
     if parallel_ce == "true":

--- a/python/paddle/distributed/auto_parallel/static/operators/__init__.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/__init__.py
@@ -39,6 +39,7 @@ from . import (  # noqa: F401
     dist_slice,
     dist_softmax,
     dist_split,
+    dist_strided_slice,
     dist_tile,
     dist_transpose,
     dist_unsqueeze2,

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_strided_slice.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_strided_slice.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..completion import get_phi_spmd_rule
+from ..utils import get_dist_tensor_spec
+from .common import (
+    DistributedOperatorImplContainer,
+    get_default_distributed_operator_impl,
+    register_distributed_operator_impl_container,
+    update_op_dims_mapping,
+)
+
+
+class DistributedStridedSlice(DistributedOperatorImplContainer):
+    def __init__(self, op_type):
+        super().__init__(op_type)
+
+    @staticmethod
+    def update_dims_mapping(dist_op):
+        # step1: prepare inputs need for rule (order args as PHI definition and filter out unnecessary args)
+        op_desc = dist_op.serial_op.desc
+
+        x_name = op_desc.input('Input')[0]
+        y_name = op_desc.output('Out')[0]
+        axes = op_desc.attr('axes')
+        starts = op_desc.attr('starts')
+        ends = op_desc.attr('ends')
+        strides = op_desc.attr('strides')
+
+        x_spec = get_dist_tensor_spec(dist_op, x_name)
+        y_spec = get_dist_tensor_spec(dist_op, y_name, False)
+
+        # step2: infer spmd
+        print("infer spmd by strided_slice", flush=1)
+        rule = get_phi_spmd_rule("strided_slice")
+        # tensor order following order in PHI definition
+        fw_results = rule.infer_forward(x_spec, axes, starts, ends, strides)
+        bw_results = rule.infer_backward(
+            x_spec,
+            y_spec,
+            axes,
+            starts,
+            ends,
+            strides,
+        )
+
+        # step3: update dist_attr
+        # tensor order following order in PHI definition
+        changed = update_op_dims_mapping(
+            dist_op,
+            [x_name],
+            [y_name],
+            fw_results,
+            bw_results,
+        )
+
+        return changed
+
+    @staticmethod
+    def mapping_to_dist_operator_impl(dist_op, original_op_dist_attr):
+        op_dist_attr = dist_op.dist_attr
+        default_impl = get_default_distributed_operator_impl()
+        op_dist_attr.impl_type = default_impl.type
+        op_dist_attr.impl_idx = default_impl.idx
+
+        return False
+
+
+register_distributed_operator_impl_container(
+    DistributedStridedSlice("strided_slice")
+)

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_strided_slice.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_strided_slice.py
@@ -42,7 +42,6 @@ class DistributedStridedSlice(DistributedOperatorImplContainer):
         y_spec = get_dist_tensor_spec(dist_op, y_name, False)
 
         # step2: infer spmd
-        print("infer spmd by strided_slice", flush=1)
         rule = get_phi_spmd_rule("strided_slice")
         # tensor order following order in PHI definition
         fw_results = rule.infer_forward(x_spec, axes, starts, ends, strides)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
This PR includes the following work：
- register strided_slice inferspmd rule
- refine fuse_allreduce_split_to_reducescatter_pass, add mm+allreduce+add pattern
- fix the performance degradation problem caused by type promotion logic
- fix the problem that in the program translator, there is a fake false block in the if op, resulting in reduced execution performance.

Pcard-73145
