### PR TITLE
[Prim] add builtin.slice case

### DIFF
--- a/test/deprecated/prim/pir_prim/CMakeLists.txt
+++ b/test/deprecated/prim/pir_prim/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(TEST_PRIM_TRANS_PIR_CASES
     test_custom_vjp_trait test_decomp_op test_decompose_op test_vjp_prim
-    test_batch_norm_shape_check)
+    test_batch_norm_shape_check test_builtin_slice)
 
 foreach(target ${TEST_PRIM_TRANS_PIR_CASES})
   py_test_modules(${target} MODULES ${target} ENVS GLOG_v=1

--- a/test/deprecated/prim/pir_prim/test_builtin_slice.py
+++ b/test/deprecated/prim/pir_prim/test_builtin_slice.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle import pir
+from paddle.decomposition import decompose
+from paddle.framework import core
+
+paddle.enable_static()
+
+
+def meshgrid_net(x1, x2, x3, x4):
+    return paddle.meshgrid(x1, x2, x3, x4)
+
+
+class TestBuildOp(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.c_shape = [64]
+        self.init_x_shape = [1, 64, 512, 1024]
+        self.x1 = np.random.random(self.c_shape).astype(self.dtype)
+        self.x2 = np.random.random(self.c_shape).astype(self.dtype)
+        self.x3 = np.random.random(self.c_shape).astype(self.dtype)
+        self.x4 = np.random.random(self.c_shape).astype(self.dtype)
+        self.net = meshgrid_net
+
+    def get_ir_program(self):
+        paddle.enable_static()
+        main_program, start_program = (
+            paddle.static.Program(),
+            paddle.static.Program(),
+        )
+        with paddle.static.program_guard(main_program, start_program):
+            x1 = paddle.static.data('x1', self.c_shape, self.dtype)
+            x2 = paddle.static.data('x2', self.c_shape, self.dtype)
+            x3 = paddle.static.data('x3', self.c_shape, self.dtype)
+            x4 = paddle.static.data('x4', self.c_shape, self.dtype)
+            y = meshgrid_net(x1, x2, x3, x4)
+            res1 = paddle.tanh(y[0])
+            res2 = paddle.sin(y[1])
+            res3 = paddle.cos(y[2])
+        pir_program = pir.translate_to_pir(main_program.desc)
+        return pir_program
+
+    def test_build_op(self):
+        pir_program = self.get_ir_program()
+        y = pir_program.global_block().ops[-1].results()
+        orig_shape = y[0].shape
+        with paddle.pir_utils.IrGuard():
+            core._set_prim_forward_enabled(True)
+            y_new = decompose(pir_program, y)
+            core._set_prim_forward_enabled(False)
+            new_shape = y_new[0].shape
+            assert (
+                orig_shape == new_shape
+            ), f"Original shape {orig_shape} is not equal to new shape {new_shape}"
+            op_name_list = [op.name() for op in pir_program.global_block().ops]
+            assert "pd_op.meshgrid" not in op_name_list
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others


### Description
<!-- Describe what you’ve done -->
Pcard-66975
When come to op whose output is tensor[] type, this op will be followed by builtin.split or builtin.slice.
