### PR TITLE
[Typing][A-34] Add type annotations for `paddle/nn/initializer/orthogonal.py	`

### DIFF
--- a/python/paddle/nn/initializer/orthogonal.py
+++ b/python/paddle/nn/initializer/orthogonal.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import paddle
 from paddle import _C_ops, pir

--- a/python/paddle/nn/initializer/orthogonal.py
+++ b/python/paddle/nn/initializer/orthogonal.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import paddle
 from paddle import _C_ops, pir
 from paddle.utils import unique_name
 
@@ -47,7 +48,7 @@ class Orthogonal(Initializer):
 
     Args:
         gain(float, optional): The multiplication coefficient for initialized tensor. Default: 1.0.
-        name(str, optional): The default value is None. Normally there is no need for user to set this
+        name(str|None, optional): The default value is None. Normally there is no need for user to set this
             property. For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
@@ -65,17 +66,17 @@ class Orthogonal(Initializer):
             >>> # linear.weight: X' * X = I
     """
 
-    def __init__(self, gain=1.0, name=None):
+    def __init__(self, gain: float = 1.0, name: str | None = None) -> None:
         assert gain is not None, 'gain should not be None'
         super().__init__()
         self._gain = gain
 
-    def __call__(self, var, block=None):
+    def __call__(self, var: paddle.Tensor, block: pir.Block | None = None):
         """Initialize the input tensor with orthogonal initializer.
 
         Args:
             var(Tensor): Tensor that needs to be initialized.
-            block(Block, optional): The block in which initialization ops
+            block(Block|None, optional): The block in which initialization ops
                    should be added. Used in static graph only, default None.
 
         Returns:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

类型标注：

- paddle/nn/initializer/orthogonal.py

### Related links
 
- https://github.com/PaddlePaddle/Paddle/issues/65008

@SigureMo @megemini 
