### PR TITLE
[Serde][Typing] Ensure Tensor contiguous before serialize and improve `jit.save` typing

### DIFF
--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -903,6 +903,12 @@ def _save_property(filename: str, property_vals: list[tuple[Any, str]]):
         f.write(meta.serialize_to_string())
 
 
+def ensure_tensor_contiguous(tensor):
+    if not tensor.is_contiguous():
+        return tensor.contiguous()
+    return tensor
+
+
 @_run_save_pre_hooks
 @switch_to_static_graph
 def save(
@@ -1257,7 +1263,7 @@ def save(
             state_var_dict = {}
             for structured_name, var in dygraph_state_dict.items():
                 state_names_dict[var.name] = structured_name
-                state_var_dict[var.name] = var
+                state_var_dict[var.name] = ensure_tensor_contiguous(var)
         # 3. share parameters from Layer to scope & record var info
         with dygraph.guard():
             if use_pir_api():

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -910,12 +910,6 @@ def _save_property(filename: str, property_vals: list[tuple[Any, str]]):
         f.write(meta.serialize_to_string())
 
 
-def ensure_tensor_contiguous(tensor):
-    if not tensor.is_contiguous():
-        return tensor.contiguous()
-    return tensor
-
-
 @_run_save_pre_hooks
 @switch_to_static_graph
 def save(
@@ -1270,7 +1264,7 @@ def save(
             state_var_dict = {}
             for structured_name, var in dygraph_state_dict.items():
                 state_names_dict[var.name] = structured_name
-                state_var_dict[var.name] = ensure_tensor_contiguous(var)
+                state_var_dict[var.name] = var
         # 3. share parameters from Layer to scope & record var info
         with dygraph.guard():
             if use_pir_api():

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -23,16 +23,10 @@ import threading
 import types
 import warnings
 from collections import OrderedDict
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from contextlib import contextmanager
 from types import ModuleType
-from typing import (
-    Any,
-    Protocol,
-    TypedDict,
-    TypeVar,
-    overload,
-)
+from typing import Any, Callable, Protocol, TypedDict, TypeVar, overload
 
 from typing_extensions import (
     Literal,

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -34,7 +34,13 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Literal, NotRequired, ParamSpec, TypeAlias, Unpack
+from typing_extensions import (
+    Literal,
+    NotRequired,
+    ParamSpec,
+    TypeAlias,
+    Unpack,
+)
 
 import paddle
 from paddle._typing import NestedSequence
@@ -83,6 +89,8 @@ from .translated_layer import (
 
 ENV_ENABLE_SOT = BooleanEnvironmentVariable("ENABLE_FALL_BACK", True)
 
+
+_F = TypeVar('_F', bound=Callable[..., Any])
 _LayerT = TypeVar("_LayerT", bound=Layer)
 _RetT = TypeVar("_RetT")
 _InputT = ParamSpec("_InputT")
@@ -860,14 +868,19 @@ def _remove_save_pre_hook(hook):
 
 
 @wrap_decorator
-def _run_save_pre_hooks(func):
-    def wrapper(layer, path, input_spec=None, **configs):
+def _run_save_pre_hooks(func: _F) -> _F:
+    def wrapper(
+        layer: Layer | Callable[..., Any],
+        path: str,
+        input_spec: Sequence[InputSpec | paddle.Tensor | object] | None = None,
+        **configs: Unpack[_SaveLoadOptions],
+    ) -> None:
         global _save_pre_hooks
         for hook in _save_pre_hooks:
             hook(layer, input_spec, configs)
         func(layer, path, input_spec, **configs)
 
-    return wrapper
+    return wrapper  # type: ignore
 
 
 def _save_property(filename: str, property_vals: list[tuple[Any, str]]):
@@ -912,9 +925,9 @@ def ensure_tensor_contiguous(tensor):
 @_run_save_pre_hooks
 @switch_to_static_graph
 def save(
-    layer: Callable[_InputT, _RetT],
+    layer: Layer | Callable[..., Any],
     path: str,
-    input_spec: InputSpec | None = None,
+    input_spec: Sequence[InputSpec | paddle.Tensor | object] | None = None,
     **configs: Unpack[_SaveLoadOptions],
 ) -> None:
     """


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 SwinT（<https://github.com/PaddlePaddle/PaddleClas/blob/release/2.5/ppcls/arch/backbone/legendary_models/swin_transformer.py>）在 2.6 下 save 后推理精度出现 diff 的问题

一些前期实验和表现：

- 2.6 save + 2.6 load 有 diff
- 2.6 save + 2.5 load 有 diff
- 2.5 save + 2.6 load 无 diff

这里可确认是动转静 + save 流程的问题，基本确认与 load 没关系

之后通过 pickle dump 的方式将动转静直接跑的 paramerter+buffer、save 前的 parameter+buffer、load 回来的 parameter+buffer 进行对比：

- 对于 parameter 全能对齐
- 对于 buffer，动转静直接跑的 parameter 和 save 前的能对齐，load 回来的就对不齐了

这里能确认是 save 的问题，基本确认与动转静和 load 没关系

经排查发现是 stride 机制导致部分 buffer 的 `Tensor` 表现和底层 `holder`（实际内存）数据排布不一致，我们在序列化的那一刻会直接对 `holder` 数据区进行序列化，在这一刻丢失了 stride 信息，但是我们需要 save 的是我们「实际看到的」Tensor 表现的数据，因此对于 stride 的 `Tensor`，我们需要转为连续，确保实际表现和底层 `holder` 数据排布一致，这样 save 结果才是对的

<p align="center">
   <img width="578" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/38436475/8b49a6ae-7299-4002-bc72-fa28b0a89ba2" width="400px">
</p>

上图中 `eager_tmp_1` 是存在问题的 buffer，为经过 stride 计算得到，经测试发现 `Tensor` 表现的数据第 0 个位置和底层 `holder` 是可以对应上的（`_show_head` 是为了 debug 加的 pybind 接口，用于直接显示 `holder` 数据区前 5 个元素），但之后会呈现某种周期性，比如实际的第 1 个位置在底层 `holder` 的第 4 个位置（间隔为 4），便可猜想到是某种机制导致 `Tensor` 数据表现和 `holder` 底层数据不一致，进而根据周期性可基本确定是 stride 机制导致的

`linear_27.b_0` 是随便找的另一个没有问题的 parameter，`Tensor` 的表现和底层 `holder` 一致

<p align="center">
   <img width="378" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/38436475/70d2d689-1f6c-49c2-a2de-8051b2a0e512" width="400px">
</p>

之后测试也确实如此，而且 stride 机制也是 2.6 引入的，一切就说得通了

PCard-66972