### PR TITLE
[Prim]Fix amp cast conflict with prim decomp/vjp rules

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/api_gen.py
@@ -101,7 +101,7 @@ API_INNER_CODE_TEMPLATE = """
 
 AMP_LOGIC_TEMPLATE = """
     if (egr::Controller::Instance().GetCurrentAmpAttrs()->GetAmpLevel() != paddle::imperative::AmpLevel::O0){{
-        VLOG(5) << "Check and Prepare For AMP";
+        VLOG(5) << "Check and Prepare For AMP: {op_name}";
         auto op_name = phi::TransToFluidOpName("{op_name}");
         paddle::small_vector<std::vector<pir::Value>, egr::kSlotSmallVectorSize> amp_values_vector = {{ {no_optional_inputs} }};
         {optional_inputs}

--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -14,6 +14,8 @@
 
 #include "paddle/fluid/primitive/base/decomp_trans.h"
 #include <regex>
+#include "paddle/fluid/eager/api/utils/global_utils.h"
+#include "paddle/fluid/imperative/amp_auto_cast.h"
 #include "paddle/fluid/pir/dialect/operator/ir/api_builder.h"
 #include "paddle/fluid/pir/dialect/operator/ir/control_flow_op.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_dialect.h"
@@ -424,7 +426,15 @@ void DecompProgram::decomp_program() {
   }
   std::vector<pir::Value> tar_vars(src_vars_.size());
   pir::Block* block = program_->block();
-  decomp_block(block, orig_vars_dict, tar_vars);
+  {
+    // NOTE(dev): Prim decomposed rules will call paddle::dialect::xx
+    // api, which has amp strategy. But Prim already process cast operation
+    // and we need to disable amp strategy here.
+    paddle::imperative::AutoCastGuard guard(
+        egr::Controller::Instance().GetCurrentAmpAttrs(),
+        paddle::imperative::AmpLevel::O0);
+    decomp_block(block, orig_vars_dict, tar_vars);
+  }
   std::ostringstream decomp_prog_stream;
   program_->Print(decomp_prog_stream);
   if (VLOG_IS_ON(4)) {

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -857,6 +857,13 @@ void BindVjp(pybind11::module *m) {
          const std::vector<std::vector<pir::Value>> &outputs,
          const std::vector<std::vector<pir::Value>> &out_grads,
          const std::vector<std::vector<bool>> &stop_gradients) {
+        // NOTE(dev): Prim decomposed rules will call paddle::dialect::xx
+        // api, which has amp strategy. But Prim already process cast operation
+        // and we need to disable amp strategy here.
+        paddle::imperative::AutoCastGuard guard(
+            egr::Controller::Instance().GetCurrentAmpAttrs(),
+            paddle::imperative::AmpLevel::O0);
+
         py::list res;
         std::vector<std::vector<pir::Value>> vjp_res;
 

--- a/test/ir/pir/cinn/test_cinn_amp.py
+++ b/test/ir/pir/cinn/test_cinn_amp.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class BatchNormNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.batch_norm = paddle.nn.layer.norm.BatchNorm2D(10, 10)
+
+    def forward(self, x):
+        y = paddle.nn.functional.relu(x)
+        z = self.batch_norm(y)
+        return paddle.mean(z)
+
+
+class TestBNAMP(unittest.TestCase):
+    def train(self, use_cinn):
+        paddle.seed(2024)
+        net = BatchNormNet()
+        optimizer = paddle.optimizer.SGD(
+            learning_rate=0.0001, parameters=net.parameters()
+        )
+        scaler = paddle.amp.GradScaler(init_loss_scaling=1024)
+        if use_cinn:
+            net = paddle.jit.to_static(net, backend='CINN', full_graph=True)
+
+        x = paddle.randn([4, 10, 10, 10], dtype='float16')
+        x.stop_gradient = False
+        with paddle.amp.auto_cast(level='O2'):
+            loss = net(x)
+        scaled = scaler.scale(loss)
+        scaled.backward()
+        scaler.step(optimizer)
+        scaler.update()
+        optimizer.clear_grad(set_to_zero=False)
+
+        return x.grad.numpy()
+
+    def test_amp_train(self):
+        dy_x_grad = self.train(use_cinn=False)
+        cinn_x_grad = self.train(use_cinn=True)
+        np.testing.assert_allclose(dy_x_grad, cinn_x_grad, atol=1e-6, rtol=1e-6)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Bug fixes

Pcard-67164

修复了paddle::dialect::xx 内含的amp 策略与组合算子前、反向拆分规则交互逻辑上有潜在重复的问题。

#### 问题
在 `addleClas_PPHGNet_small_ampo2_ultra_bs128_fp16_DP_dynamicTostatic_N1C1` 中，开启Prim+CINN后会报错。从最初的日志可以看出，在经历过BatchNorm_算子的拆解规则后，run_mean的dtype确实变化了，意味着是拆解过程中引入的问题：
![image](https://github.com/PaddlePaddle/Paddle/assets/9301846/ec7d2e64-a8d7-4f24-854b-4673d63583a7)

经过进一步的分析，发现run_mean的计算依赖batch_mean这个变量，而batch_mean_new = sum(x)，x是float32的，但算完mean出来变成了float16

![image](https://github.com/PaddlePaddle/Paddle/assets/9301846/7b028d4c-11a2-4dd5-9a9f-f6f0b9a45187)
更近一步分析，发现是因为在组合算子拆解过程中，AMP策略是默认生效的，因为此时模型就是AMP训练，全局的AMPGuard是O1。在组合算子拆分时，应该局部切换到O0才对。在decomp_block前切换AMPGuard后，行为符合预期了

![image](https://github.com/PaddlePaddle/Paddle/assets/9301846/1f6a8f73-e9db-45fd-b2f5-c1782f8c32b3)
