### PR TITLE
fix PGLBOX training bug

### DIFF
--- a/paddle/fluid/framework/device_worker.cc
+++ b/paddle/fluid/framework/device_worker.cc
@@ -93,8 +93,7 @@ void PrintLodTensorType<float>(phi::DenseTensor* tensor,
                                char separator,
                                bool need_leading_separator,
                                int num_decimals) {
-  std::string buf;
-  buf.resize(MAX_FLOAT_BUFF_SIZE);
+  char buf[MAX_FLOAT_BUFF_SIZE];  // NOLINT
   auto count = tensor->numel();
   if (start < 0 || end > count) {
     VLOG(3) << "access violation";
@@ -109,7 +108,7 @@ void PrintLodTensorType<float>(phi::DenseTensor* tensor,
       out_val += "0";
     } else {
       std::string format = "%." + std::to_string(num_decimals) + "f";
-      sprintf(&buf[0], &format[0], tensor->data<float>()[i]);  // NOLINT
+      sprintf(buf, &format[0], tensor->data<float>()[i]);  // NOLINT
       out_val += buf;
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Parameter Server

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
fix PGLBOX training bug `ValueError: invalid literal for float()` when infer dump embedding

related error PR: https://github.com/PaddlePaddle/Paddle/pull/64511

Pcard-84360