### PR TITLE
[CINN]Fix ReshapeOpInferSymbolicShape while target_shape contains 0

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
@@ -151,14 +151,6 @@ bool ReshapeOpInferSymbolicShape(
     return false;
   };
 
-  const auto &target_shape = [&] {
-    std::vector<symbol::DimExpr> target_shape;
-    for (int dim : shape) {
-      target_shape.emplace_back(static_cast<std::int64_t>(dim));
-    }
-    return target_shape;
-  }();
-
   const symbol::ShapeOrDataDimExprs &x_dim_expr =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
 
@@ -167,6 +159,17 @@ bool ReshapeOpInferSymbolicShape(
   const auto &out_dims = [&] {
     const auto &numel =
         GetProduct(original_shape, [](const auto &) { return true; });
+    const auto &target_shape = [&] {
+      std::vector<symbol::DimExpr> target_shape;
+      for (size_t i = 0; i < shape.size(); ++i) {
+        if (shape[i] == 0) {
+          target_shape.emplace_back(original_shape[i]);
+        } else {
+          target_shape.emplace_back(static_cast<std::int64_t>(shape[i]));
+        }
+      }
+      return target_shape;
+    }();
 
     const auto &product_exclude_minus_one =
         GetProduct(target_shape, IsNotMinusOne);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164