### PR TITLE
[CINN] Add reduce_sum unittest

### DIFF
--- a/test/ir/pir/cinn/test_cinn_reduce_sum.py
+++ b/test/ir/pir/cinn/test_cinn_reduce_sum.py
@@ -27,30 +27,83 @@ class ReduceSumSubGraph(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
 
-    def forward(self, x):
-        return paddle.max(x * 2, axis=[-1], keepdim=True)
+    def forward(self, x, axis):
+        return paddle.sum(x, axis=axis, keepdim=True)
 
 
-class TestReduceSumSubGraph(unittest.TestCase):
+class TestReduceSumBase(unittest.TestCase):
     def setUp(self):
         paddle.seed(2024)
         self.prepare_data()
+        self.prepare_atol()
+        self.x = paddle.randn(self.shape, dtype="float32")
 
     def prepare_data(self):
-        self.x = paddle.randn([8, 4], dtype="float32")
+        self.shape = [8, 4]
+        self.axis = [-1]
+
+    def prepare_atol(self):
+        self.atol = 1e-5
 
     def eval(self, use_cinn):
         net = ReduceSumSubGraph()
         net.eval()
         net = utils.apply_to_static(net, use_cinn)
-        out = net(self.x)
+        out = net(self.x, self.axis)
         return out
 
     def test_eval(self):
         cinn_out = self.eval(use_cinn=True)
         dy_out = self.eval(use_cinn=False)
 
-        np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-6)
+        np.testing.assert_allclose(
+            cinn_out.numpy(), dy_out.numpy(), atol=self.atol
+        )
+
+
+class TestReduceLastAxis1(TestReduceSumBase):
+    def prepare_data(self):
+        self.shape = [512, 64]
+        self.axis = -1
+
+
+class TestReduceLastAxis2(TestReduceSumBase):
+    def prepare_data(self):
+        self.shape = [512, 1024]
+        self.axis = -1
+
+
+class TestReduceLastDim3(TestReduceSumBase):
+    def prepare_data(self):
+        self.shape = [512, 2048]
+        self.axis = -1
+
+    def prepare_atol(self):
+        self.atol = 1e-4
+
+
+class TestReduceFirstAxis1(TestReduceSumBase):
+    def prepare_data(self):
+        self.shape = [512, 8]
+        self.axis = 0
+
+
+class TestReduceFirstAxis2(TestReduceSumBase):
+    def prepare_data(self):
+        self.shape = [512, 64]
+        self.axis = 0
+
+
+class TestReduceFirstAxis3(TestReduceSumBase):
+    def prepare_data(self):
+        self.shape = [512, 128]
+        self.axis = 0
+
+
+class TestReduceFirstAxis4(TestReduceSumBase):
+    def prepare_data(self):
+        self.shape = [4, 8]
+        self.axis = 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Not User Facing


### Description
<!-- Describe what you’ve done -->
pcard-76996

添加 reduce 相关单测，覆盖 warp_reduce, block_reduce 和 discrete_reduce 模版

Add multiple reduce_sum unit tests, which cover warp_reduce, block_reduce and discrete_reduce.
