### PR TITLE
[Typing][Fix] Ensure all workers are running complete before pool terminate

### DIFF
--- a/tools/type_checking.py
+++ b/tools/type_checking.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import argparse
 import doctest
 import multiprocessing
+import os
 import pathlib
 import re
 import signal
@@ -33,6 +34,7 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+import psutil
 from mypy import api as mypy_api
 from sampcd_processor_utils import (
     extract_code_blocks_from_docstr,
@@ -229,10 +231,26 @@ def parse_args() -> argparse.Namespace:
 
 
 # https://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool
+# https://stackoverflow.com/questions/32160054/keyboard-interrupts-with-pythons-multiprocessing-pool-and-map-function/45259908#45259908
 # ctrl+c interrupt handler
 # this should be a global function, a local function makes `pickle` fail on MacOS.
+parent_id = os.getpid()
+
+
 def init_worker():
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    def sig_int(signal_num, frame):
+        logger.debug(f"signal: {signal_num}")
+        parent = psutil.Process(parent_id)
+        for child in parent.children():
+            if child.pid != os.getpid():
+                logger.debug(f"killing child: {child.pid}")
+                child.kill()
+        logger.debug(f"killing parent: {parent_id}")
+        parent.kill()
+        logger.debug(f"suicide: {os.getpid()}")
+        psutil.Process(os.getpid()).kill()
+
+    signal.signal(signal.SIGINT, sig_int)
 
 
 def get_test_results(
@@ -262,12 +280,16 @@ def get_test_results(
             )
 
     test_results = []
-    pool = multiprocessing.Pool(initializer=init_worker)
     try:
+        pool = multiprocessing.Pool(initializer=init_worker)
         test_results = pool.starmap(type_checker.run, codeblocks)
 
     except KeyboardInterrupt:
         pool.terminate()
+        pool.join()
+
+    else:
+        pool.close()
         pool.join()
 
     return list(test_results)

--- a/tools/type_checking.py
+++ b/tools/type_checking.py
@@ -229,7 +229,6 @@ def parse_args() -> argparse.Namespace:
 
 
 # https://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool
-# https://stackoverflow.com/questions/32160054/keyboard-interrupts-with-pythons-multiprocessing-pool-and-map-function/45259908#45259908
 # ctrl+c interrupt handler
 # this should be a global function, a local function makes `pickle` fail on MacOS.
 def init_worker():

--- a/tools/type_checking.py
+++ b/tools/type_checking.py
@@ -286,10 +286,9 @@ def get_test_results(
 
     except KeyboardInterrupt:
         pool.terminate()
-        pool.join()
-
     else:
         pool.close()
+    finally:
         pool.join()
 
     return list(test_results)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
参考 https://stackoverflow.com/questions/32160054/keyboard-interrupts-with-pythons-multiprocessing-pool-and-map-function/45259908 中的办法，子进程强行关闭所有相关进程 ～