### PR TITLE
【Hackathon 6th No.5】Add chi2/LKJCholesky API to Paddle

### DIFF
--- a/python/paddle/distribution/chi2.py
+++ b/python/paddle/distribution/chi2.py
@@ -26,7 +26,7 @@ class Chi2(Gamma):
     This is exactly equivalent to Gamma(concentration=0.5*df, rate=0.5), :ref:`api_paddle_distribution_Gamma`.
 
     Args:
-        df (float or Tensor): shape parameter of the distribution
+        df (float or Tensor): The degree of freedom of the distribution, which should be non-negative. If the input data type is Tensor, it indicates the batch creation of distributions with multiple different parameters, and the `batch_shape` (refer to the :ref:`api_paddle_distribution_Distribution` base class) is the parameter.
 
     Example:
         .. code-block:: python


### PR DESCRIPTION
### PR Category
Others


### PR Types
Others

### Description
需要为飞桨扩充 API paddle.distribution.chi2 和 paddle.distribution.LKJCholesky
相关PR：https://github.com/PaddlePaddle/Paddle/pull/63883
RFC-link: [RFC-link:【Hackathon 6th No.5】为 Paddle 新增 chi2/LKJCholesky API #872](https://github.com/PaddlePaddle/community/pull/872)
1.本次PR更新chi2部分英文文档，与中文文档同步