### PR TITLE
[Infra] Add upper bound for numpy version to avoid use 2.0 in CI

### DIFF
--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -11,7 +11,7 @@ paddle2onnx>=0.9.6
 scipy>=1.6, !=1.7.2, !=1.7.3
 prettytable
 distro
-numpy>=1.20
+numpy>=1.20, <2.0
 autograd==1.4
 librosa==0.8.1 ; python_version<"3.12"
 parameterized


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#64937 去掉了 NumPy 依赖的上界，使用户可以在使用 Paddle 的同时使用 NumPy 2.0，但 CI 中 NumPy 2.0 的存量问题尚未修复完成（#64905），而 NumPy 几小时前发布了 [2.0.0 正式版](https://github.com/numpy/numpy/releases/tag/v2.0.0)，CI 中默认安装了最新版本，导致 CI 挂掉

因此本 PR 修改 CI 中使用的 `unittest_py/requirements.txt`，添加上界，运行单测时避免使用 NumPy 2.0

PCard-66972