### PR TITLE
[CINN] Normalize cinn reduce ops attribute names

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
+++ b/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
@@ -58,14 +58,14 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : reduce_prod
-  args : (Tensor x, int64_t[] dims, bool keep_dim, bool reduce_all)
+  args : (Tensor x, int64_t[] axis, bool keepdim, bool reduce_all)
   output : Tensor(out)
   infer_meta :
     func : ReduceInferMeta
-    param : [x, dims, keep_dim]
+    param : [x, axis, keepdim]
   kernel :
     func : frobenius_norm
-    param : [x, dims, keep_dim]
+    param : [x, axis, keepdim]
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : reduce_sum

--- a/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
+++ b/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
@@ -69,7 +69,7 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : reduce_sum
-  args : (Tensor x, int64_t[] axis, bool keepdim=false, DataType dtype=DataType::UNDEFINED)
+  args : (Tensor x, int64_t[] axis, bool keepdim, DataType dtype=DataType::UNDEFINED)
   output : Tensor(out)
   infer_meta :
     func : ReduceInferMeta

--- a/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
+++ b/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
@@ -40,7 +40,7 @@
     param : [x, kernel_size, stride_size, padding_size, ceil_mode, exclusive, data_format, pooling_type, global_pooling, adaptive, padding_algorithm]
 
 - op : reduce_max
-  args : (Tensor x, int64_t[] dim,  bool keep_dim)
+  args : (Tensor x, int64_t[] axis, bool keepdim)
   output : Tensor(out)
   infer_meta :
     func : ReduceInferMeta
@@ -49,7 +49,7 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : reduce_min
-  args : (Tensor x, int64_t[] dim,  bool keep_dim)
+  args : (Tensor x, int64_t[] axis, bool keepdim)
   output : Tensor(out)
   infer_meta :
     func : ReduceInferMeta
@@ -58,25 +58,25 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : reduce_prod
-  args : (Tensor x, int64_t[] dim,  bool keep_dim, bool reduce_all)
+  args : (Tensor x, int64_t[] dims, bool keep_dim, bool reduce_all)
   output : Tensor(out)
   infer_meta :
     func : ReduceInferMeta
-    param : [x, dim, keep_dim]
+    param : [x, dims, keep_dim]
   kernel :
     func : frobenius_norm
-    param : [x, dim, keep_dim]
+    param : [x, dims, keep_dim]
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : reduce_sum
-  args : (Tensor x, int64_t[] dim,  bool keep_dim, DataType dtype=DataType::UNDEFINED)
+  args : (Tensor x, int64_t[] axis, DataType dtype=DataType::UNDEFINED, bool keepdim=false)
   output : Tensor(out)
   infer_meta :
     func : ReduceInferMeta
-    param : [x, dim, keep_dim]
+    param : [x, axis, keepdim]
   kernel :
     func : frobenius_norm
-    param : [x, dim, keep_dim]
+    param : [x, axis, keepdim]
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : reshape

--- a/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
+++ b/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
@@ -69,7 +69,7 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : reduce_sum
-  args : (Tensor x, int64_t[] axis, DataType dtype=DataType::UNDEFINED, bool keepdim=false)
+  args : (Tensor x, int64_t[] axis, bool keepdim=false, DataType dtype=DataType::UNDEFINED)
   output : Tensor(out)
   infer_meta :
     func : ReduceInferMeta

--- a/paddle/cinn/hlir/dialect/operator/transforms/cinn_to_pd_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/cinn_to_pd_util.cc
@@ -53,12 +53,8 @@ const auto& handler_reduce_sum_op =
   auto attrs = op->attributes();
 
   ::pir::Attribute attr_axis = ArrayAttributeToIntArrayAttribute(
-      attrs.at("dim").dyn_cast<::pir::ArrayAttribute>());
-  attrs.insert({"axis", attr_axis});
-  attrs.insert({"dtype", attrs["dtype"]});
-  attrs.insert({"keepdim", attrs["keep_dim"]});
-  attrs.erase("dim");
-  attrs.erase("keep_dim");
+      attrs.at("axis").dyn_cast<::pir::ArrayAttribute>());
+  attrs["axis"] = attr_axis;
 
   auto pd_op = rewriter.Build<paddle::dialect::SumOp>(
       ir_mapping.Lookup(op->operand_source(0)), attrs);
@@ -78,11 +74,8 @@ const auto& handler_reduce_max_op =
   // TODO(chenxi67): 1. CINN op Dialect Normalization；2.AST Op compute
   // Normalization
   ::pir::Attribute attr_axis = ArrayAttributeToIntArrayAttribute(
-      attrs.at("dim").dyn_cast<::pir::ArrayAttribute>());
-  attrs.insert({"axis", attr_axis});
-  attrs.insert({"keepdim", attrs["keep_dim"]});
-  attrs.erase("dim");
-  attrs.erase("keep_dim");
+      attrs.at("axis").dyn_cast<::pir::ArrayAttribute>());
+  attrs["axis"] = attr_axis;
 
   auto pd_op = rewriter.Build<paddle::dialect::MaxOp>(
       ir_mapping.Lookup(op->operand_source(0)), attrs);
@@ -100,11 +93,8 @@ const auto& handler_reduce_min_op =
   auto attrs = op->attributes();
 
   ::pir::Attribute attr_axis = ArrayAttributeToIntArrayAttribute(
-      attrs.at("dim").dyn_cast<::pir::ArrayAttribute>());
-  attrs.insert({"axis", attr_axis});
-  attrs.insert({"keepdim", attrs["keep_dim"]});
-  attrs.erase("dim");
-  attrs.erase("keep_dim");
+      attrs.at("axis").dyn_cast<::pir::ArrayAttribute>());
+  attrs["axis"] = attr_axis;
 
   auto pd_op = rewriter.Build<paddle::dialect::MinOp>(
       ir_mapping.Lookup(op->operand_source(0)), attrs);
@@ -122,9 +112,8 @@ const auto& handler_reduce_prod_op =
   auto attrs = op->attributes();
 
   ::pir::Attribute attr_axis = ArrayAttributeToIntArrayAttribute(
-      attrs.at("dim").dyn_cast<::pir::ArrayAttribute>());
-  attrs.insert({"dims", attr_axis});
-  attrs.erase("dim");
+      attrs.at("dims").dyn_cast<::pir::ArrayAttribute>());
+  attrs["dims"] = attr_axis;
 
   auto pd_op = rewriter.Build<paddle::dialect::ProdOp>(
       ir_mapping.Lookup(op->operand_source(0)), attrs);

--- a/paddle/cinn/hlir/dialect/operator/transforms/cinn_to_pd_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/cinn_to_pd_util.cc
@@ -113,7 +113,10 @@ const auto& handler_reduce_prod_op =
 
   ::pir::Attribute attr_axis = ArrayAttributeToIntArrayAttribute(
       attrs.at("dims").dyn_cast<::pir::ArrayAttribute>());
-  attrs["dims"] = attr_axis;
+  attrs.insert({"axis", attr_axis});
+  attrs.insert({"keepdim", attrs["keep_dim"]});
+  attrs.erase("dims");
+  attrs.erase("keep_dim");
 
   auto pd_op = rewriter.Build<paddle::dialect::ProdOp>(
       ir_mapping.Lookup(op->operand_source(0)), attrs);

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/group_with_group_merge_pass_utils.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/group_with_group_merge_pass_utils.h
@@ -132,7 +132,7 @@ bool WithoutLastDimInReduce(const phi::DDim& inshape,
 
 static int GetSharedSize(const cinn::dialect::ir::OpNode& op_node) {
   const auto& inshape = op_node.inputs()[0].shape();
-  const auto& axes = op_node.GetAttr<std::vector<int64_t>>("dim");
+  const auto& axes = op_node.GetAttr<std::vector<int64_t>>("axis");
 
   if (WithoutLastDimInReduce(inshape, axes)) {
     int lane = 1;
@@ -211,27 +211,27 @@ static bool ReduceFuseReduce1(const OpGroupPtr& first,
   const auto& reducer_1_input_shape = reducer_1->inputs()[0].shape();
   const auto& reducer_1_output_shape = reducer_1->outputs()[0].shape();
 
-  auto reducer_0_reduce_dim = reducer_0->GetAttr<std::vector<int64_t>>("dim");
-  auto reducer_1_reduce_dim = reducer_1->GetAttr<std::vector<int64_t>>("dim");
+  auto reducer_0_reduce_axes = reducer_0->GetAttr<std::vector<int64_t>>("axis");
+  auto reducer_1_reduce_axes = reducer_1->GetAttr<std::vector<int64_t>>("axis");
 
-  for (auto& dim : reducer_0_reduce_dim) {
+  for (auto& dim : reducer_0_reduce_axes) {
     // if dim = -1, set as shape.size() - 1
     if (dim == -1) {
-      dim = reducer_0_reduce_dim.size() - 1;
+      dim = reducer_0_reduce_axes.size() - 1;
     }
   }
 
-  for (auto& dim : reducer_1_reduce_dim) {
+  for (auto& dim : reducer_1_reduce_axes) {
     // if dim = -1,  set as shape.size() - 1
     if (dim == -1) {
-      dim = reducer_1_reduce_dim.size() - 1;
+      dim = reducer_1_reduce_axes.size() - 1;
     }
   }
 
   // check shape is same
   if (reducer_0_input_shape == reducer_1_input_shape &&
       reducer_0_output_shape == reducer_1_output_shape &&
-      reducer_0_reduce_dim == reducer_1_reduce_dim) {
+      reducer_0_reduce_axes == reducer_1_reduce_axes) {
     auto shared_size = 0;
     for (auto& fusion_group : {first, second}) {
       fusion_group.WalkOpNodes([&](const cinn::dialect::ir::OpNode& op) {
@@ -249,10 +249,10 @@ static bool ReduceFuseReduce1(const OpGroupPtr& first,
     return true;
   }
 
-  if (WithoutLastDimInReduce(reducer_0_input_shape, reducer_0_reduce_dim) &&
-      WithoutLastDimInReduce(reducer_1_input_shape, reducer_1_reduce_dim) &&
+  if (WithoutLastDimInReduce(reducer_0_input_shape, reducer_0_reduce_axes) &&
+      WithoutLastDimInReduce(reducer_1_input_shape, reducer_1_reduce_axes) &&
       reducer_0_output_shape == reducer_1_output_shape &&
-      reducer_0_reduce_dim == reducer_1_reduce_dim) {
+      reducer_0_reduce_axes == reducer_1_reduce_axes) {
     auto shared_size = 0;
     for (auto& fusion_group : {first, second}) {
       fusion_group.WalkOpNodes([&](const cinn::dialect::ir::OpNode& op) {

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/group_with_group_merge_util.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/group_with_group_merge_util.h
@@ -242,7 +242,7 @@ inline bool elementwise_fuse_reduce(const std::shared_ptr<ir::Group>& first,
   // }
 
   auto input_shape = GetValueShape(reducer->operand_source(0));
-  auto reduce_axes = GetVectorAttr(reducer, "dim");
+  auto reduce_axes = GetVectorAttr(reducer, "axis");
 
   // int max_num_threads = helper->target_.max_num_threads();
   int max_num_threads = 1000;
@@ -437,10 +437,10 @@ inline bool reduce_fuse_broadcast(const std::shared_ptr<ir::Group>& first,
         ::common::vectorize(GetValueShape(reducer->operand_source(0)));
     auto reducer_output_shape =
         ::common::vectorize(GetValueShape(reducer->result(0)));
-    std::vector<int64_t> reduce_axes = GetVectorAttr(reducer, "dim");
+    std::vector<int64_t> reduce_axes = GetVectorAttr(reducer, "axis");
 
-    auto keep_dim =
-        reducer->attribute("keep_dim").dyn_cast<pir::BoolAttribute>().data();
+    auto keepdim =
+        reducer->attribute("keepdim").dyn_cast<pir::BoolAttribute>().data();
     for (auto& axis : reduce_axes) {
       if (axis == -1) {
         axis = reducer_input_shape.size() - 1;
@@ -525,7 +525,7 @@ inline bool reduce_fuse_broadcast(const std::shared_ptr<ir::Group>& first,
         return false;
       }
 
-      if (keep_dim) {
+      if (keepdim) {
         continue;
       } else {
         // if reducer_output_shape = [1]
@@ -579,27 +579,27 @@ inline bool reduce_fuse_reduce(const std::shared_ptr<ir::Group>& first,
   auto reducer_1_input_shape = GetValueShape(reducer_1->operand_source(0));
   auto reducer_1_output_shape = GetValueShape(reducer_1->result(0));
 
-  auto reducer_0_reduce_dim = GetVectorAttr(reducer_0, "dim");
-  auto reducer_1_reduce_dim = GetVectorAttr(reducer_1, "dim");
+  auto reducer_0_reduce_axes = GetVectorAttr(reducer_0, "axis");
+  auto reducer_1_reduce_axes = GetVectorAttr(reducer_1, "axis");
 
-  for (auto& dim : reducer_0_reduce_dim) {
+  for (auto& dim : reducer_0_reduce_axes) {
     // if dim = -1, set as shape.size() - 1
     if (dim == -1) {
-      dim = reducer_0_reduce_dim.size() - 1;
+      dim = reducer_0_reduce_axes.size() - 1;
     }
   }
 
-  for (auto& dim : reducer_1_reduce_dim) {
+  for (auto& dim : reducer_1_reduce_axes) {
     // if dim = -1,  set as shape.size() - 1
     if (dim == -1) {
-      dim = reducer_1_reduce_dim.size() - 1;
+      dim = reducer_1_reduce_axes.size() - 1;
     }
   }
 
   // check shape is same
   if (reducer_0_input_shape == reducer_1_input_shape &&
       reducer_0_output_shape == reducer_1_output_shape &&
-      reducer_0_reduce_dim == reducer_1_reduce_dim) {
+      reducer_0_reduce_axes == reducer_1_reduce_axes) {
     auto shared_size = 0;
     for (auto& fusion_group : {first, second}) {
       for (auto* master : fusion_group->master_ops) {
@@ -618,10 +618,10 @@ inline bool reduce_fuse_reduce(const std::shared_ptr<ir::Group>& first,
     return true;
   }
 
-  if (WithoutLastDimInReduce(reducer_0_input_shape, reducer_0_reduce_dim) &&
-      WithoutLastDimInReduce(reducer_1_input_shape, reducer_1_reduce_dim) &&
+  if (WithoutLastDimInReduce(reducer_0_input_shape, reducer_0_reduce_axes) &&
+      WithoutLastDimInReduce(reducer_1_input_shape, reducer_1_reduce_axes) &&
       reducer_0_output_shape == reducer_1_output_shape &&
-      reducer_0_reduce_dim == reducer_1_reduce_dim) {
+      reducer_0_reduce_axes == reducer_1_reduce_axes) {
     auto shared_size = 0;
     for (auto& fusion_group : {first, second}) {
       for (auto* master : fusion_group->master_ops) {

--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -143,13 +143,13 @@ class ProdOpPattern : public pir::OpRewritePattern<paddle::dialect::ProdOp> {
     // get attribute value from full_int_array op
     const std::vector<int64_t> axis = GetVectorFromIntArrayAttribute<int64_t>(
         full_int_array_op.attribute("value").dyn_cast<pir::ArrayAttribute>());
-    const bool keep_dim =
-        op.attribute("keep_dim").dyn_cast<::pir::BoolAttribute>().data();
+    const bool keepdim =
+        op.attribute("keepdim").dyn_cast<::pir::BoolAttribute>().data();
     const bool reduce_all =
         op.attribute("reduce_all").dyn_cast<::pir::BoolAttribute>().data();
 
     auto cinn_reduce = rewriter.Build<cinn::dialect::ReduceProdOp>(
-        op->operand_source(0), axis, keep_dim, reduce_all);
+        op->operand_source(0), axis, keepdim, reduce_all);
     rewriter.ReplaceAllUsesWith(op.result(0), cinn_reduce.result(0));
     rewriter.EraseOp(op);
     if (full_int_array_op->use_empty()) {

--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -74,14 +74,14 @@ class SumOpPattern : public pir::OpRewritePattern<paddle::dialect::SumOp> {
     // get attribute value from full_int_array op
     const std::vector<int64_t> axis = GetVectorFromIntArrayAttribute<int64_t>(
         full_int_array_op.attribute("value").dyn_cast<pir::ArrayAttribute>());
-    const bool keep_dim =
-        op.attribute("keepdim").dyn_cast<::pir::BoolAttribute>().data();
     const auto &dtype = op.attribute("dtype")
                             .dyn_cast<paddle::dialect::DataTypeAttribute>()
                             .data();
+    const bool keepdim =
+        op.attribute("keepdim").dyn_cast<::pir::BoolAttribute>().data();
 
     auto cinn_reduce = rewriter.Build<cinn::dialect::ReduceSumOp>(
-        op->operand_source(0), axis, keep_dim, dtype);
+        op->operand_source(0), axis, dtype, keepdim);
     rewriter.ReplaceAllUsesWith(op.result(0), cinn_reduce.result(0));
     rewriter.EraseOp(op);
     if (full_int_array_op->use_empty()) {
@@ -110,12 +110,12 @@ class ReduceMinMaxOpPattern : public pir::OpRewritePattern<SOURCE_OP> {
     const std::vector<int64_t> axis = GetVectorFromIntArrayAttribute<int64_t>(
         full_int_array_op.attribute("value")
             .template dyn_cast<pir::ArrayAttribute>());
-    const bool keep_dim = op.attribute("keepdim")
-                              .template dyn_cast<::pir::BoolAttribute>()
-                              .data();
+    const bool keepdim = op.attribute("keepdim")
+                             .template dyn_cast<::pir::BoolAttribute>()
+                             .data();
 
     auto cinn_reduce =
-        rewriter.Build<TARGET_OP>(op->operand_source(0), axis, keep_dim);
+        rewriter.Build<TARGET_OP>(op->operand_source(0), axis, keepdim);
     rewriter.ReplaceAllUsesWith(op.result(0), cinn_reduce.result(0));
     rewriter.EraseOp(op);
     if (full_int_array_op->use_empty()) {

--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -74,14 +74,14 @@ class SumOpPattern : public pir::OpRewritePattern<paddle::dialect::SumOp> {
     // get attribute value from full_int_array op
     const std::vector<int64_t> axis = GetVectorFromIntArrayAttribute<int64_t>(
         full_int_array_op.attribute("value").dyn_cast<pir::ArrayAttribute>());
+    const bool keepdim =
+        op.attribute("keepdim").dyn_cast<::pir::BoolAttribute>().data();
     const auto &dtype = op.attribute("dtype")
                             .dyn_cast<paddle::dialect::DataTypeAttribute>()
                             .data();
-    const bool keepdim =
-        op.attribute("keepdim").dyn_cast<::pir::BoolAttribute>().data();
 
     auto cinn_reduce = rewriter.Build<cinn::dialect::ReduceSumOp>(
-        op->operand_source(0), axis, dtype, keepdim);
+        op->operand_source(0), axis, keepdim, dtype);
     rewriter.ReplaceAllUsesWith(op.result(0), cinn_reduce.result(0));
     rewriter.EraseOp(op);
     if (full_int_array_op->use_empty()) {

--- a/paddle/cinn/hlir/framework/op_lowering_util.cc
+++ b/paddle/cinn/hlir/framework/op_lowering_util.cc
@@ -1015,7 +1015,7 @@ void LoopAssignReduce(
   // shape and axis.
   CHECK(shape_dict.count(reducer->inlinks_in_order()[0]->source()->id()));
   auto shape = shape_dict.at(reducer->inlinks_in_order()[0]->source()->id());
-  auto axes = absl::get<std::vector<int>>(reducer->attrs.attr_store.at("dim"));
+  auto axes = absl::get<std::vector<int>>(reducer->attrs.attr_store.at("axis"));
   if (axes.empty()) {
     for (int idx = 0; idx < shape.size(); idx++) {
       axes.push_back(idx);
@@ -1277,7 +1277,7 @@ void InsertSyncThread(
     const std::unordered_map<std::string, ir::Tensor>& tensor_map) {
   CHECK(shape_dict.count(node->inlinks_in_order()[0]->source()->id()));
   auto shape = shape_dict.at(node->inlinks_in_order()[0]->source()->id());
-  auto axes = absl::get<std::vector<int>>(node->attrs.attr_store.at("dim"));
+  auto axes = absl::get<std::vector<int>>(node->attrs.attr_store.at("axis"));
   if (axes.empty()) {
     for (int idx = 0; idx < shape.size(); idx++) {
       axes.push_back(idx);
@@ -1352,7 +1352,7 @@ void MergeReduceToReduce(
 
   CHECK(shape_dict.count(node->inlinks_in_order()[0]->source()->id()));
   auto shape = shape_dict.at(node->inlinks_in_order()[0]->source()->id());
-  auto axes = absl::get<std::vector<int>>(node->attrs.attr_store.at("dim"));
+  auto axes = absl::get<std::vector<int>>(node->attrs.attr_store.at("axis"));
   if (axes.empty()) {
     for (int idx = 0; idx < shape.size(); idx++) {
       axes.push_back(idx);

--- a/paddle/cinn/hlir/framework/pir/op_lowering_util.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_util.cc
@@ -827,7 +827,7 @@ std::vector<int> GetReducerDimAttr(::pir::Operation* reduce_op) {
                  .dims()
                  .size();
 
-  auto attr = reduce_op->attributes().at("dim");
+  auto attr = reduce_op->attributes().at("axis");
   auto attr_vec = attr.dyn_cast<::pir::ArrayAttribute>().AsVector();
 
   std::vector<int> dim;

--- a/paddle/cinn/hlir/framework/pir/op_mapper.cc
+++ b/paddle/cinn/hlir/framework/pir/op_mapper.cc
@@ -38,8 +38,8 @@ std::vector<int> GetVec32FromVec64Attr(::pir::Attribute attr) {
 
 void AppendAttrForReduceOp(const ::pir::Operation& op,
                            utils::AttributeMap& attrs) {  // NOLINT
-  auto attr = op.attributes().at("dim");
-  attrs["dim"] = GetVec32FromVec64Attr(attr);
+  auto attr = op.attributes().at("axis");
+  attrs["axis"] = GetVec32FromVec64Attr(attr);
 }
 
 void AppendAttrForTransposeOp(const ::pir::Operation& op,

--- a/paddle/cinn/hlir/op/op_broadcast_test.cc
+++ b/paddle/cinn/hlir/op/op_broadcast_test.cc
@@ -275,6 +275,7 @@ TEST(Operator, Operator_BroadcastTo_0) {
   auto tensor_4 = out_4.as_tensor_ref();
   poly::StageMap stages_4 = rets_4.back();
 
+  attrs.attr_store.erase("axis");
   auto impl_3 = OpStrategy::SelectImpl(strategy[elementwise_add](
       attrs, {tensor_1, tensor_2}, type, {out_shape}, target));
   std::vector<cinn::common::CINNValue> cinn_inputs_3 = {

--- a/paddle/cinn/hlir/op/op_broadcast_test.cc
+++ b/paddle/cinn/hlir/op/op_broadcast_test.cc
@@ -230,8 +230,8 @@ TEST(Operator, Operator_BroadcastTo_0) {
   std::vector<int> broadcast_axes = {0};
   attrs.attr_store["broadcast_axes"] = broadcast_axes;
 
-  std::vector<int> dim = {0, 2, 3};
-  attrs.attr_store["dim"] = dim;
+  std::vector<int> axis = {0, 2, 3};
+  attrs.attr_store["axis"] = axis;
 
   std::vector<Type> type{Float(32)};
   cinn::common::Target target = cinn::common::DefaultHostTarget();

--- a/paddle/cinn/hlir/op/reduction.cc
+++ b/paddle/cinn/hlir/op/reduction.cc
@@ -69,17 +69,17 @@ std::shared_ptr<OpStrategy> StrategyForReduce(
     ReduceFunc common_reduce_func) {
   std::vector<int> reduce_axes;
   auto ndim = inputs[0]->shape.size();
-  if (attrs.attr_store.count("dim")) {
+  if (attrs.attr_store.count("axis")) {
     reduce_axes = [&] {
       if (absl::holds_alternative<std::vector<int64_t>>(
-              attrs.attr_store.at("dim"))) {
+              attrs.attr_store.at("axis"))) {
         const auto &dim_attr =
-            absl::get<std::vector<int64_t>>(attrs.attr_store.at("dim"));
+            absl::get<std::vector<int64_t>>(attrs.attr_store.at("axis"));
         return std::vector<int>(dim_attr.begin(), dim_attr.end());
       } else if (absl::holds_alternative<std::vector<int>>(
-                     attrs.attr_store.at("dim"))) {
-        return absl::get<std::vector<int>>(attrs.attr_store.at("dim"));
-      } else if (absl::holds_alternative<bool>(attrs.attr_store.at("dim"))) {
+                     attrs.attr_store.at("axis"))) {
+        return absl::get<std::vector<int>>(attrs.attr_store.at("axis"));
+      } else if (absl::holds_alternative<bool>(attrs.attr_store.at("axis"))) {
         return std::vector<int>{};
       } else {
         PADDLE_THROW(phi::errors::InvalidArgument(
@@ -106,9 +106,9 @@ std::shared_ptr<OpStrategy> StrategyForReduce(
     PADDLE_THROW(phi::errors::InvalidArgument("reduce dimension is not set!"));
   }
 
-  bool keep_dim = false;
-  if (attrs.attr_store.count("keep_dim")) {
-    keep_dim = absl::get<bool>(attrs.attr_store.at("keep_dim"));
+  bool keepdim = false;
+  if (attrs.attr_store.count("keepdim")) {
+    keepdim = absl::get<bool>(attrs.attr_store.at("keepdim"));
   }
 
   auto WithoutLastDimInReduce = [](const std::vector<ir::Expr> &inshape,
@@ -152,7 +152,7 @@ std::shared_ptr<OpStrategy> StrategyForReduce(
 
     const auto &NaiveCompute = [&]() {
       VLOG(3) << "Do Reduce Compute!";
-      auto out = common_reduce_func(x, reduce_axes, keep_dim, tensor_name);
+      auto out = common_reduce_func(x, reduce_axes, keepdim, tensor_name);
       auto stages = CreateStages({out});
 
       std::vector<CINNValue> cinn_values{CINNValue(out), CINNValue(stages)};
@@ -164,7 +164,7 @@ std::shared_ptr<OpStrategy> StrategyForReduce(
             if (!WithoutLastDimInReduce(inputs[0]->shape, reduce_axes)) {
               VLOG(3) << "Do Two Step Block Reduce Compute!";
               auto res = gpu_reduce_with_last_axis_func(
-                  x, reduce_axes, keep_dim, tensor_name);
+                  x, reduce_axes, keepdim, tensor_name);
               auto stages = CreateStages(res);
 
               std::vector<CINNValue> cinn_values;
@@ -176,7 +176,7 @@ std::shared_ptr<OpStrategy> StrategyForReduce(
             } else {
               VLOG(3) << "Do Block Shuffle Reduce Compute!";
               auto res = gpu_reduce_without_last_axis_func(
-                  x, reduce_axes, keep_dim, tensor_name);
+                  x, reduce_axes, keepdim, tensor_name);
               auto stages = CreateStages(res);
 
               std::vector<CINNValue> cinn_values;
@@ -369,17 +369,17 @@ std::shared_ptr<OpStrategy> StrategyForReduceSymbolic(
     ReduceFunc common_reduce_func) {
   std::vector<int> reduce_axes;
   auto ndim = inputs[0]->shape.size();
-  if (attrs.attr_store.count("dim")) {
+  if (attrs.attr_store.count("axis")) {
     reduce_axes = [&] {
       if (absl::holds_alternative<std::vector<int64_t>>(
-              attrs.attr_store.at("dim"))) {
+              attrs.attr_store.at("axis"))) {
         const auto &dim_attr =
-            absl::get<std::vector<int64_t>>(attrs.attr_store.at("dim"));
+            absl::get<std::vector<int64_t>>(attrs.attr_store.at("axis"));
         return std::vector<int>(dim_attr.begin(), dim_attr.end());
       } else if (absl::holds_alternative<std::vector<int>>(
-                     attrs.attr_store.at("dim"))) {
-        return absl::get<std::vector<int>>(attrs.attr_store.at("dim"));
-      } else if (absl::holds_alternative<bool>(attrs.attr_store.at("dim"))) {
+                     attrs.attr_store.at("axis"))) {
+        return absl::get<std::vector<int>>(attrs.attr_store.at("axis"));
+      } else if (absl::holds_alternative<bool>(attrs.attr_store.at("axis"))) {
         return std::vector<int>{};
       } else {
         PADDLE_THROW(phi::errors::InvalidArgument(
@@ -405,9 +405,9 @@ std::shared_ptr<OpStrategy> StrategyForReduceSymbolic(
     PADDLE_THROW(phi::errors::InvalidArgument("reduce dimension is not set!"));
   }
 
-  bool keep_dim = false;
-  if (attrs.attr_store.count("keep_dim")) {
-    keep_dim = absl::get<bool>(attrs.attr_store.at("keep_dim"));
+  bool keepdim = false;
+  if (attrs.attr_store.count("keepdim")) {
+    keepdim = absl::get<bool>(attrs.attr_store.at("keepdim"));
   }
 
   framework::CINNCompute reduction_compute(
@@ -430,7 +430,7 @@ std::shared_ptr<OpStrategy> StrategyForReduceSymbolic(
             << " should be bool, but get " << x->type() << "! Please check.";
 
         VLOG(3) << "Do Reduce Compute!";
-        auto out = common_reduce_func(x, reduce_axes, keep_dim, tensor_name);
+        auto out = common_reduce_func(x, reduce_axes, keepdim, tensor_name);
         auto stages = CreateStages({out});
 
         std::vector<CINNValue> cinn_values{CINNValue(out), CINNValue(stages)};
@@ -557,33 +557,34 @@ std::vector<shape_t> InferShapeForReduction(
     const std::vector<shape_t> &inputs_shape,
     const framework::AttrMapType &attrs) {
   CHECK(inputs_shape.size() == 1UL || inputs_shape.size() == 3UL);
-  std::vector<int> dim;
-  bool keep_dim = false;
-  if (attrs.find("dim") != attrs.end()) {
-    dim = absl::get<std::vector<int>>(attrs.at("dim"));
+  std::vector<int> axis;
+  bool keepdim = false;
+  if (attrs.find("axis") != attrs.end()) {
+    axis = absl::get<std::vector<int>>(attrs.at("axis"));
   }
 
-  if (attrs.find("keep_dim") != attrs.end()) {
-    keep_dim = absl::get<bool>(attrs.at("keep_dim"));
+  if (attrs.find("keepdim") != attrs.end()) {
+    keepdim = absl::get<bool>(attrs.at("keepdim"));
   }
 
   auto ndim = inputs_shape[0].size();
-  CHECK_LE(dim.size(), ndim) << "reduce dim should no more than the input size";
+  CHECK_LE(axis.size(), ndim)
+      << "reduce dim should no more than the input size";
 
-  if (dim.empty()) {
+  if (axis.empty()) {
     for (int i = 0; i < ndim; ++i) {
-      dim.emplace_back(i);
+      axis.emplace_back(i);
     }
   } else {
-    std::for_each(dim.begin(), dim.end(), [&ndim](int &x) {
+    std::for_each(axis.begin(), axis.end(), [&ndim](int &x) {
       if (x < 0) x += ndim;
     });
   }
 
   std::vector<int> out_shapes;
   for (size_t i = 0; i < ndim; ++i) {
-    if (std::find(dim.begin(), dim.end(), i) != dim.end()) {
-      if (keep_dim) {
+    if (std::find(axis.begin(), axis.end(), i) != axis.end()) {
+      if (keepdim) {
         out_shapes.push_back(1);
       }
     } else {
@@ -597,8 +598,8 @@ std::vector<shape_t> InferShapeForReduction(
 
   VLOG(4) << "Reduce from input shape ["
           << cinn::utils::Join(inputs_shape[0], ",") << "] to output shape ["
-          << cinn::utils::Join(out_shapes, ",") << "] with reduce dim ["
-          << cinn::utils::Join(dim, ",") << "] and keep_dim is " << keep_dim;
+          << cinn::utils::Join(out_shapes, ",") << "] with reduce axis ["
+          << cinn::utils::Join(axis, ",") << "] and keepdim is " << keepdim;
 
   return {out_shapes};
 }
@@ -606,10 +607,10 @@ std::vector<shape_t> InferShapeForReduction(
 void GenerateEquationsForReduction(cinn::adt::config::OpEquationContext *ctx) {
   CHECK(ctx->GetInTensorsRanks().size() != 0)
       << "The inputs is empty! Please check again.";
-  const bool keep_dim = ctx->Attr<bool>("keep_dim");
-  const auto &dim = ctx->Attr<std::vector<int>>("dim");
+  const bool keepdim = ctx->Attr<bool>("keepdim");
+  const auto &axis = ctx->Attr<std::vector<int>>("axis");
   std::vector<int> aligned_dim{};
-  for (int d : dim) {
+  for (int d : axis) {
     aligned_dim.push_back((d + ctx->GetInTensorsRanks().at(0)) %
                           ctx->GetInTensorsRanks().at(0));
   }
@@ -623,7 +624,7 @@ void GenerateEquationsForReduction(cinn::adt::config::OpEquationContext *ctx) {
   for (std::size_t in_axis = 0; in_axis < ctx->GetInTensorsRanks().at(0);
        ++in_axis) {
     if (IsReduceAxis(in_axis)) {
-      if (keep_dim) {
+      if (keepdim) {
         ctx->Equal(ctx->GetOutIteratorTuple(0)->at(in_axis),
                    ctx->GetConstantIterator(ctx->GetInIndex(0), 0));
         out_axis += 1;

--- a/paddle/cinn/hlir/op/reduction_test.cc
+++ b/paddle/cinn/hlir/op/reduction_test.cc
@@ -56,9 +56,9 @@ using runtime::cuda::CUDAModule;
 
 std::pair<ir::Module, std::string> GenReduceCode(
     const std::vector<int>& shape,
-    const std::vector<int>& dim,
+    const std::vector<int>& axis,
     const std::string& func_name,
-    bool keep_dim = false,
+    bool keepdim = false,
     const std::string& op_name = "reduce_sum") {
   // code gen
   Context::Global().ResetNameId();
@@ -75,15 +75,15 @@ std::pair<ir::Module, std::string> GenReduceCode(
 
   // set attrs
   NodeAttr attrs;
-  attrs.attr_store["dim"] = dim;
-  attrs.attr_store["keep_dim"] = keep_dim;
+  attrs.attr_store["axis"] = axis;
+  attrs.attr_store["keepdim"] = keepdim;
   std::vector<ir::Tensor> inputs{X.tensor()};
   std::vector<Type> out_type{Float(32)};
 
   std::vector<int> output_shape;
   for (int idx = 0; idx < shape.size(); ++idx) {
-    if (std::find(dim.begin(), dim.end(), idx) != dim.end()) {
-      if (keep_dim) {
+    if (std::find(axis.begin(), axis.end(), idx) != axis.end()) {
+      if (keepdim) {
         output_shape.push_back(1);
       }
     } else {
@@ -131,150 +131,150 @@ std::pair<ir::Module, std::string> GenReduceCode(
 // last dimension not in reduce
 TEST(Operator, Operator_Reduce_Without_Last_Channel_Case_5) {
   std::vector<int> shape = {128, 112, 112, 128};
-  std::vector<int> dim = {0, 1, 2};
+  std::vector<int> axis = {0, 1, 2};
 
-  GenReduceCode(shape, dim, "Reduce_Without_Last_Channel_Case_5");
+  GenReduceCode(shape, axis, "Reduce_Without_Last_Channel_Case_5");
 }
 
 // last dimension not in reduce
 TEST(Operator, Operator_Reduce_Without_Last_Channel_Case_4) {
   std::vector<int> shape = {16, 16, 8, 8, 16, 16};
-  std::vector<int> dim = {0, 2, 3};
+  std::vector<int> axis = {0, 2, 3};
 
-  GenReduceCode(shape, dim, "Reduce_Without_Last_Channel_Case_4");
+  GenReduceCode(shape, axis, "Reduce_Without_Last_Channel_Case_4");
 }
 // case 3
 TEST(Operator, Operator_Reduce_Without_Last_Channel_Case_3) {
   std::vector<int> shape = {16, 16, 16, 16, 16};
-  std::vector<int> dim = {0, 2};
+  std::vector<int> axis = {0, 2};
 
-  GenReduceCode(shape, dim, "Reduce_Without_Last_Channel_Case_3");
+  GenReduceCode(shape, axis, "Reduce_Without_Last_Channel_Case_3");
 }
 // case 2
 TEST(Operator, Operator_Reduce_Without_Last_Channel_Case_2) {
   std::vector<int> shape = {16, 16, 16, 16};
-  std::vector<int> dim = {0, 1};
+  std::vector<int> axis = {0, 1};
 
-  GenReduceCode(shape, dim, "Reduce_Without_Last_Channel_Case_2");
+  GenReduceCode(shape, axis, "Reduce_Without_Last_Channel_Case_2");
 }
 // case 1
 TEST(Operator, Operator_Reduce_Without_Last_Channel_Case_1) {
   std::vector<int> shape = {16, 16, 16, 16};
-  std::vector<int> dim = {1};
+  std::vector<int> axis = {1};
 
-  GenReduceCode(shape, dim, "Reduce_Without_Last_Channel_Case_1");
+  GenReduceCode(shape, axis, "Reduce_Without_Last_Channel_Case_1");
 }
 // case 0
 TEST(Operator, Operator_Reduce_Without_Last_Channel_Case_0) {
   std::vector<int> shape = {16, 16, 32};
-  std::vector<int> dim = {1};
+  std::vector<int> axis = {1};
 
-  GenReduceCode(shape, dim, "Reduce_Without_Last_Channel_Case_0");
+  GenReduceCode(shape, axis, "Reduce_Without_Last_Channel_Case_0");
 }
 
 TEST(Operator, Operator_Reduction_Case_Last_Dim_1) {
   std::vector<int> shape = {10, 100, 1};
-  std::vector<int> dim = {0, 2};
+  std::vector<int> axis = {0, 2};
 
-  GenReduceCode(shape, dim, "reduce_cast_with_last_dim_1");
+  GenReduceCode(shape, axis, "reduce_cast_with_last_dim_1");
 }
 
 TEST(Operator, Operator_Reduction_Case_0) {
   std::vector<int> shape = {16, 16, 8, 16};
-  std::vector<int> dim = {2, 3};
+  std::vector<int> axis = {2, 3};
 
-  GenReduceCode(shape, dim, "reduce_cast_0");
+  GenReduceCode(shape, axis, "reduce_cast_0");
 }
 
 TEST(Operator, Operator_Reduction_Case_0_0) {
   std::vector<int> shape = {16, 16, 8, 16};
-  std::vector<int> dim = {2, 3};
+  std::vector<int> axis = {2, 3};
 
-  GenReduceCode(shape, dim, "reduce_cast_0_0", true);
+  GenReduceCode(shape, axis, "reduce_cast_0_0", true);
 }
 
 TEST(Operator, Operator_Reduction_Case_1) {
   std::vector<int> shape = {16, 16, 32, 32};
-  std::vector<int> dim = {2, 3};
+  std::vector<int> axis = {2, 3};
 
-  GenReduceCode(shape, dim, "reduce_cast_1");
+  GenReduceCode(shape, axis, "reduce_cast_1");
 }
 
 TEST(Operator, Operator_Reduction_Case_1_1) {
   std::vector<int> shape = {16, 16, 32, 32};
-  std::vector<int> dim = {2, 3};
+  std::vector<int> axis = {2, 3};
 
-  GenReduceCode(shape, dim, "reduce_cast_1_1", true);
+  GenReduceCode(shape, axis, "reduce_cast_1_1", true);
 }
 
 TEST(Operator, Operator_Reduction_Case_2) {
   std::vector<int> shape = {16, 16, 32, 32};
-  std::vector<int> dim = {1};
+  std::vector<int> axis = {1};
 
-  GenReduceCode(shape, dim, "reduce_cast_2", true);
+  GenReduceCode(shape, axis, "reduce_cast_2", true);
 }
 
 TEST(Operator, Operator_Reduction_Case_2_1) {
   std::vector<int> shape = {16, 16, 32, 32};
-  std::vector<int> dim = {-1};
+  std::vector<int> axis = {-1};
 
-  GenReduceCode(shape, dim, "reduce_cast_2_1", true);
+  GenReduceCode(shape, axis, "reduce_cast_2_1", true);
 }
 
 TEST(Operator, Operator_Reduction_Case_3) {
   std::vector<int> shape = {16, 16, 64, 64};
-  std::vector<int> dim = {1};
+  std::vector<int> axis = {1};
 
-  GenReduceCode(shape, dim, "reduce_cast_3");
+  GenReduceCode(shape, axis, "reduce_cast_3");
 }
 
 TEST(Operator, Operator_Reduction_Case_4) {
   std::vector<int> shape = {16, 16, 16, 16};
-  std::vector<int> dim = {0, 2, 3};
+  std::vector<int> axis = {0, 2, 3};
 
-  GenReduceCode(shape, dim, "reduce_cast_4");
+  GenReduceCode(shape, axis, "reduce_cast_4");
 }
 
 TEST(Operator, Operator_Reduction_Case_4_4) {
   std::vector<int> shape = {16, 16, 16, 16};
-  std::vector<int> dim = {0, 2, 3};
+  std::vector<int> axis = {0, 2, 3};
 
-  GenReduceCode(shape, dim, "reduce_cast_4_4", true);
+  GenReduceCode(shape, axis, "reduce_cast_4_4", true);
 }
 
 TEST(Operator, Operator_Reduction_Case_5) {
   std::vector<int> shape = {16, 16, 16, 16, 16, 32};
-  std::vector<int> dim = {1, 3, 5};
+  std::vector<int> axis = {1, 3, 5};
 
-  GenReduceCode(shape, dim, "reduce_cast_5");
+  GenReduceCode(shape, axis, "reduce_cast_5");
 }
 
 TEST(Operator, Operator_Reduction_Case_5_5) {
   std::vector<int> shape = {16, 16, 16, 16, 16, 32};
-  std::vector<int> dim = {1, 3, 5};
+  std::vector<int> axis = {1, 3, 5};
 
-  GenReduceCode(shape, dim, "reduce_cast_5_5", true);
+  GenReduceCode(shape, axis, "reduce_cast_5_5", true);
 }
 
 TEST(Operator, Operator_Reduction_Case_6_0) {
   std::vector<int> shape = {32, 32, 32};
-  std::vector<int> dim = {0, 1, 2};
+  std::vector<int> axis = {0, 1, 2};
 
-  GenReduceCode(shape, dim, "reduce_cast_6_0", false);
+  GenReduceCode(shape, axis, "reduce_cast_6_0", false);
 }
 
 TEST(Operator, Operator_Reduction_Case_6_00) {
   std::vector<int> shape = {32, 32, 32, 32};
-  std::vector<int> dim = {0, 1, 2};
+  std::vector<int> axis = {0, 1, 2};
 
-  GenReduceCode(shape, dim, "reduce_cast_6_00", false);
+  GenReduceCode(shape, axis, "reduce_cast_6_00", false);
 }
 
 TEST(Operator, Operator_Reduction_Case_6_10) {
   std::vector<int> shape = {32, 32, 32};
-  std::vector<int> dim = {-2, -1, 0};
+  std::vector<int> axis = {-2, -1, 0};
 
-  GenReduceCode(shape, dim, "reduce_cast_6_10", true);
+  GenReduceCode(shape, axis, "reduce_cast_6_10", true);
 }
 
 struct SumOp {
@@ -334,11 +334,11 @@ void TestCaseForReduce(const float init_val,
                        const std::string& test_name,
                        const std::string& op_name) {
   std::vector<int> shape = {n, c, h, w};
-  std::vector<int> dim = {0, 2, 3};
+  std::vector<int> axis = {0, 2, 3};
 
   // get source code
   auto source_code =
-      GenReduceCode(shape, dim, test_name, false, op_name).second;
+      GenReduceCode(shape, axis, test_name, false, op_name).second;
 
   // nv jit compile to ptx
   backends::nvrtc::Compiler compiler;
@@ -420,11 +420,11 @@ TEST(Operator, Operator_Reduction_Case_6_4) {
 TEST(Operator, Operator_Reduction_Case_7) {
   int n = 32, c = 32, h = 16, w = 16;
   std::vector<int> shape = {n, c, h, w};
-  std::vector<int> dim = {0, 1};
+  std::vector<int> axis = {0, 1};
 
   std::string func_name = "reduce_cast_7";
   // get source code
-  auto host_source = GenReduceCode(shape, dim, func_name);
+  auto host_source = GenReduceCode(shape, axis, func_name);
 
   // compile to ptx
   backends::nvrtc::Compiler compiler;
@@ -490,44 +490,44 @@ TEST(Operator, Operator_Reduction_Case_7) {
 
 TEST(Operator, Operator_Reduction_Case_8) {
   std::vector<int> shape = {128, 1};
-  std::vector<int> dim = {0};
+  std::vector<int> axis = {0};
 
-  GenReduceCode(shape, dim, "Operator_Reduction_Case_8");
+  GenReduceCode(shape, axis, "Operator_Reduction_Case_8");
 }
 
 TEST(Operator, Operator_Reduction_Case_88) {
   std::vector<int> shape = {128, 1};
-  std::vector<int> dim = {0};
+  std::vector<int> axis = {0};
 
-  GenReduceCode(shape, dim, "Operator_Reduction_Case_88", true);
+  GenReduceCode(shape, axis, "Operator_Reduction_Case_88", true);
 }
 
 TEST(Operator, Operator_Reduction_Case_9) {
   std::vector<int> shape = {2560, 1};
-  std::vector<int> dim = {0};
+  std::vector<int> axis = {0};
 
-  GenReduceCode(shape, dim, "Operator_Reduction_Case_9");
+  GenReduceCode(shape, axis, "Operator_Reduction_Case_9");
 }
 
 TEST(Operator, Operator_Reduction_Case_99) {
   std::vector<int> shape = {2560, 1};
-  std::vector<int> dim = {0};
+  std::vector<int> axis = {0};
 
-  GenReduceCode(shape, dim, "Operator_Reduction_Case_99", true);
+  GenReduceCode(shape, axis, "Operator_Reduction_Case_99", true);
 }
 
 TEST(Operator, Operator_Reduction_Case_10) {
   std::vector<int> shape = {16, 2560, 1};
-  std::vector<int> dim = {1};
+  std::vector<int> axis = {1};
 
-  GenReduceCode(shape, dim, "Operator_Reduction_Case_10");
+  GenReduceCode(shape, axis, "Operator_Reduction_Case_10");
 }
 
 TEST(Operator, Operator_Reduction_Case_11) {
   std::vector<int> shape = {16, 128, 128, 1};
-  std::vector<int> dim = {1, 2};
+  std::vector<int> axis = {1, 2};
 
-  GenReduceCode(shape, dim, "Operator_Reduction_Case_11");
+  GenReduceCode(shape, axis, "Operator_Reduction_Case_11");
 }
 
 TEST(Operator, Operator_Reduction_Case_Warp_Reduce) {
@@ -537,9 +537,9 @@ TEST(Operator, Operator_Reduction_Case_Warp_Reduce) {
   int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
 
   std::vector<int> shape = {warp_reduce_threshold + 10, 256};
-  std::vector<int> dim = {1};
+  std::vector<int> axis = {1};
 
-  auto res = GenReduceCode(shape, dim, "Operator_Reduction_Case_Warp_Reduce");
+  auto res = GenReduceCode(shape, axis, "Operator_Reduction_Case_Warp_Reduce");
   if (!FLAGS_cinn_new_group_scheduler)
     CHECK(res.second.find("threadIdx.x < 32") != std::string::npos);
 }
@@ -551,9 +551,9 @@ TEST(Operator, Operator_Reduction_Case_Block_Reduce) {
   int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
 
   std::vector<int> shape = {warp_reduce_threshold - 10, 33};
-  std::vector<int> dim = {1};
+  std::vector<int> axis = {1};
 
-  auto res = GenReduceCode(shape, dim, "Operator_Reduction_Case_Block_Reduce");
+  auto res = GenReduceCode(shape, axis, "Operator_Reduction_Case_Block_Reduce");
   if (!FLAGS_cinn_new_group_scheduler)
     CHECK(res.second.find("threadIdx.x < 32") == std::string::npos);
 }
@@ -565,10 +565,10 @@ TEST(Operator, Operator_Reduction_Case_Warp_Reduce_Case_1) {
   int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
 
   std::vector<int> shape = {(warp_reduce_threshold + 32) / 2, 2, 10, 256};
-  std::vector<int> dim = {2, 3};
+  std::vector<int> axis = {2, 3};
 
   auto res =
-      GenReduceCode(shape, dim, "Operator_Reduction_Case_Warp_Reduce_Case_1");
+      GenReduceCode(shape, axis, "Operator_Reduction_Case_Warp_Reduce_Case_1");
   if (!FLAGS_cinn_new_group_scheduler)
     CHECK(res.second.find("threadIdx.x < 32") != std::string::npos);
 }
@@ -580,10 +580,10 @@ TEST(Operator, Operator_Reduction_Case_Block_Reduce_Case_1) {
   int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
 
   std::vector<int> shape = {(warp_reduce_threshold - 32) / 2, 2, 10, 33};
-  std::vector<int> dim = {2, 3};
+  std::vector<int> axis = {2, 3};
 
   auto res =
-      GenReduceCode(shape, dim, "Operator_Reduction_Case_Block_Reduce_Case_2");
+      GenReduceCode(shape, axis, "Operator_Reduction_Case_Block_Reduce_Case_2");
   if (!FLAGS_cinn_new_group_scheduler)
     CHECK(res.second.find("threadIdx.x < 32") == std::string::npos);
 }

--- a/paddle/cinn/hlir/pass/check_fusion_accuracy_pass.cc
+++ b/paddle/cinn/hlir/pass/check_fusion_accuracy_pass.cc
@@ -347,8 +347,8 @@ std::pair<NodePtr, NodeData*> CheckFusionAccuracyPass::CreateAllNode(
   for (int i = 0; i < shape_size; ++i) {
     axes[i] = i;
   }
-  all_node->attrs.attr_store["dim"] = axes;
-  all_node->attrs.attr_store["keep_dim"] = false;
+  all_node->attrs.attr_store["axis"] = axes;
+  all_node->attrs.attr_store["keepdim"] = false;
 
   graph_->RegisterNode(all_node_id, all_node.get());
 

--- a/paddle/cinn/hlir/pass/fusion_helper_base.h
+++ b/paddle/cinn/hlir/pass/fusion_helper_base.h
@@ -176,7 +176,7 @@ class FusionHelperBase {
         0,
         phi::errors::InvalidArgument("The input node should not be empty!"));
     auto inshape = shape_dict_.at(producers[0]->id());
-    auto axes = absl::get<std::vector<int>>(node->attrs.attr_store.at("dim"));
+    auto axes = absl::get<std::vector<int>>(node->attrs.attr_store.at("axis"));
     if (WithoutLastDimInReduce(inshape, axes)) {
       int lane = 1;
       for (int idx = axes.back() + 1; idx < inshape.size(); ++idx) {

--- a/paddle/cinn/hlir/pass/fusion_merge_pass_util.h
+++ b/paddle/cinn/hlir/pass/fusion_merge_pass_util.h
@@ -221,7 +221,7 @@ CONDITION_FUNC(elementwise_fuse_reduce) {
   auto input_shape =
       helper->shape_dict_.at(reducer->inlinks_in_order()[0]->source()->id());
   auto reduce_axes =
-      absl::get<std::vector<int>>(reducer->attrs.attr_store.at("dim"));
+      absl::get<std::vector<int>>(reducer->attrs.attr_store.at("axis"));
 
   int max_num_threads = helper->target_.max_num_threads();
   // if without last dimension in reduce.
@@ -411,8 +411,8 @@ CONDITION_FUNC(reduce_fuse_broadcast) {
     auto reducer_input_shape = helper->GetNodeInputShape(reducer);
     auto reducer_output_shape = helper->GetNodeDataShape(reducer);
     auto reduce_axes =
-        absl::get<std::vector<int>>(reducer->attrs.attr_store.at("dim"));
-    auto keep_dim = absl::get<bool>(reducer->attrs.attr_store.at("keep_dim"));
+        absl::get<std::vector<int>>(reducer->attrs.attr_store.at("axis"));
+    auto keepdim = absl::get<bool>(reducer->attrs.attr_store.at("keepdim"));
     for (auto& axis : reduce_axes) {
       if (axis == -1) {
         axis = reducer_input_shape.size() - 1;
@@ -479,7 +479,7 @@ CONDITION_FUNC(reduce_fuse_broadcast) {
         return false;
       }
 
-      if (keep_dim) {
+      if (keepdim) {
         continue;
       } else {
         // if reducer_output_shape = [1]
@@ -535,29 +535,29 @@ CONDITION_FUNC(reduce_fuse_reduce) {
   auto reducer_1_output_shape =
       helper->shape_dict_.at(reducer_1->outlinks_in_order()[0]->sink()->id());
 
-  auto reducer_0_reduce_dim =
-      absl::get<std::vector<int>>(reducer_0->attrs.attr_store.at("dim"));
-  auto reducer_1_reduce_dim =
-      absl::get<std::vector<int>>(reducer_1->attrs.attr_store.at("dim"));
+  auto reducer_0_reduce_axis =
+      absl::get<std::vector<int>>(reducer_0->attrs.attr_store.at("axis"));
+  auto reducer_1_reduce_axis =
+      absl::get<std::vector<int>>(reducer_1->attrs.attr_store.at("axis"));
 
-  for (auto& dim : reducer_0_reduce_dim) {
+  for (auto& dim : reducer_0_reduce_axis) {
     // if dim = -1, set as shape.size() - 1
     if (dim == -1) {
-      dim = reducer_0_reduce_dim.size() - 1;
+      dim = reducer_0_reduce_axis.size() - 1;
     }
   }
 
-  for (auto& dim : reducer_1_reduce_dim) {
+  for (auto& dim : reducer_1_reduce_axis) {
     // if dim = -1,  set as shape.size() - 1
     if (dim == -1) {
-      dim = reducer_1_reduce_dim.size() - 1;
+      dim = reducer_1_reduce_axis.size() - 1;
     }
   }
 
   // check shape is same
   if (reducer_0_input_shape == reducer_1_input_shape &&
       reducer_0_output_shape == reducer_1_output_shape &&
-      reducer_0_reduce_dim == reducer_1_reduce_dim) {
+      reducer_0_reduce_axis == reducer_1_reduce_axis) {
     auto shared_size = 0;
     for (auto& fusion_group : {first, second}) {
       for (auto* master : fusion_group->master_nodes) {
@@ -576,11 +576,11 @@ CONDITION_FUNC(reduce_fuse_reduce) {
   }
 
   if (helper->WithoutLastDimInReduce(reducer_0_input_shape,
-                                     reducer_0_reduce_dim) &&
+                                     reducer_0_reduce_axis) &&
       helper->WithoutLastDimInReduce(reducer_1_input_shape,
-                                     reducer_1_reduce_dim) &&
+                                     reducer_1_reduce_axis) &&
       reducer_0_output_shape == reducer_1_output_shape &&
-      reducer_0_reduce_dim == reducer_1_reduce_dim) {
+      reducer_0_reduce_axis == reducer_1_reduce_axis) {
     auto shared_size = 0;
     for (auto& fusion_group : {first, second}) {
       for (auto* master : fusion_group->master_nodes) {

--- a/paddle/cinn/hlir/pass/general_fusion_merge_pass_utils.h
+++ b/paddle/cinn/hlir/pass/general_fusion_merge_pass_utils.h
@@ -140,7 +140,7 @@ static int GetSharedSize(const api::OpNode& op_node) {
                     phi::errors::InvalidArgument(
                         "The producer size should be greater than 0."));
   const auto& inshape = producers[0].shape();
-  const auto& axes = op_node.GetAttr<std::vector<int>>("dim");
+  const auto& axes = op_node.GetAttr<std::vector<int>>("axis");
   if (WithoutLastDimInReduce(inshape, axes)) {
     int lane = 1;
     for (int idx = axes.back() + 1; idx < inshape.size(); ++idx) {
@@ -211,27 +211,27 @@ static bool ReduceFuseReduce(const OpGroupPtr& first,
   const auto& reducer_1_input_shape = reducer_1->inputs()[0].shape();
   const auto& reducer_1_output_shape = reducer_1->outputs()[0].shape();
 
-  auto reducer_0_reduce_dim = reducer_0->GetAttr<std::vector<int>>("dim");
-  auto reducer_1_reduce_dim = reducer_1->GetAttr<std::vector<int>>("dim");
+  auto reducer_0_reduce_axes = reducer_0->GetAttr<std::vector<int>>("axis");
+  auto reducer_1_reduce_axes = reducer_1->GetAttr<std::vector<int>>("axis");
 
-  for (auto& dim : reducer_0_reduce_dim) {
+  for (auto& dim : reducer_0_reduce_axes) {
     // if dim = -1, set as shape.size() - 1
     if (dim == -1) {
-      dim = reducer_0_reduce_dim.size() - 1;
+      dim = reducer_0_reduce_axes.size() - 1;
     }
   }
 
-  for (auto& dim : reducer_1_reduce_dim) {
+  for (auto& dim : reducer_1_reduce_axes) {
     // if dim = -1,  set as shape.size() - 1
     if (dim == -1) {
-      dim = reducer_1_reduce_dim.size() - 1;
+      dim = reducer_1_reduce_axes.size() - 1;
     }
   }
 
   // check shape is same
   if (reducer_0_input_shape == reducer_1_input_shape &&
       reducer_0_output_shape == reducer_1_output_shape &&
-      reducer_0_reduce_dim == reducer_1_reduce_dim) {
+      reducer_0_reduce_axes == reducer_1_reduce_axes) {
     auto shared_size = 0;
     for (auto& fusion_group : {first, second}) {
       fusion_group.WalkOpNodes([&](const api::OpNode& op) {
@@ -249,10 +249,10 @@ static bool ReduceFuseReduce(const OpGroupPtr& first,
     return true;
   }
 
-  if (WithoutLastDimInReduce(reducer_0_input_shape, reducer_0_reduce_dim) &&
-      WithoutLastDimInReduce(reducer_1_input_shape, reducer_1_reduce_dim) &&
+  if (WithoutLastDimInReduce(reducer_0_input_shape, reducer_0_reduce_axes) &&
+      WithoutLastDimInReduce(reducer_1_input_shape, reducer_1_reduce_axes) &&
       reducer_0_output_shape == reducer_1_output_shape &&
-      reducer_0_reduce_dim == reducer_1_reduce_dim) {
+      reducer_0_reduce_axes == reducer_1_reduce_axes) {
     auto shared_size = 0;
     for (auto& fusion_group : {first, second}) {
       fusion_group.WalkOpNodes([&](const api::OpNode& op) {

--- a/paddle/cinn/hlir/pass/op_fusion_pass_util.h
+++ b/paddle/cinn/hlir/pass/op_fusion_pass_util.h
@@ -54,7 +54,7 @@ CONDITION_FUNC(without_last_dimension_in_reduce) {
   auto in_shape =
       helper->shape_dict_.at(producer->inlinks_in_order()[0]->source()->id());
   auto reduce_axes =
-      absl::get<std::vector<int>>(producer->attrs.attr_store.at("dim"));
+      absl::get<std::vector<int>>(producer->attrs.attr_store.at("axis"));
   return helper->WithoutLastDimInReduce(in_shape, reduce_axes);
 }
 
@@ -77,19 +77,19 @@ CONDITION_FUNC(reduce_fuse_reduce) {
   auto reducer_output_shape =
       helper->shape_dict_.at(reducer->outlinks_in_order()[0]->sink()->id());
 
-  auto producer_reduce_dim =
-      absl::get<std::vector<int>>(producer->attrs.attr_store.at("dim"));
-  auto reducer_reduce_dim =
-      absl::get<std::vector<int>>(reducer->attrs.attr_store.at("dim"));
+  auto producer_reduce_axes =
+      absl::get<std::vector<int>>(producer->attrs.attr_store.at("axis"));
+  auto reducer_reduce_axes =
+      absl::get<std::vector<int>>(reducer->attrs.attr_store.at("axis"));
 
-  for (auto& dim : producer_reduce_dim) {
+  for (auto& dim : producer_reduce_axes) {
     // if dim = -1, set as shape.size() - 1
     if (dim < 0) {
       dim += producer_input_shape.size();
     }
   }
 
-  for (auto& dim : reducer_reduce_dim) {
+  for (auto& dim : reducer_reduce_axes) {
     // if dim = -1,  set as shape.size() - 1
     if (dim < 0) {
       dim += reducer_input_shape.size();
@@ -97,12 +97,12 @@ CONDITION_FUNC(reduce_fuse_reduce) {
   }
 
   if (producer_output_shape == reducer_output_shape &&
-      producer_reduce_dim == reducer_reduce_dim) {
+      producer_reduce_axes == reducer_reduce_axes) {
     bool input_shape_same = producer_input_shape == reducer_input_shape;
-    bool without_last_dim =
-        helper->WithoutLastDimInReduce(producer_input_shape,
-                                       producer_reduce_dim) &&
-        helper->WithoutLastDimInReduce(reducer_input_shape, reducer_reduce_dim);
+    bool without_last_dim = helper->WithoutLastDimInReduce(
+                                producer_input_shape, producer_reduce_axes) &&
+                            helper->WithoutLastDimInReduce(reducer_input_shape,
+                                                           reducer_reduce_axes);
     // check shape is same
     if (input_shape_same || without_last_dim) {
       auto shared_size = helper->GetSharedSize(producer);
@@ -184,7 +184,7 @@ CONDITION_FUNC(horizontal_or_vertical_reduce_relation) {
   auto reduce_shape =
       helper->shape_dict_.at(helper->GetProducerNodeData(reducer)[0]->id());
   auto reduce_axes =
-      absl::get<std::vector<int>>(reducer->attrs.attr_store.at("dim"));
+      absl::get<std::vector<int>>(reducer->attrs.attr_store.at("axis"));
   for (auto& axis : reduce_axes) {
     // if axis = -1, set as shape.size() - 1
     if (axis < 0) {
@@ -269,8 +269,8 @@ CONDITION_FUNC(reduce_fuse_broadcast) {
 
   auto rinput_shape = helper->GetNodeInputShape(producer);
   auto reduce_axes =
-      absl::get<std::vector<int>>(producer->attrs.attr_store.at("dim"));
-  auto keep_dim = absl::get<bool>(producer->attrs.attr_store.at("keep_dim"));
+      absl::get<std::vector<int>>(producer->attrs.attr_store.at("axis"));
+  auto keepdim = absl::get<bool>(producer->attrs.attr_store.at("keepdim"));
   for (auto& axis : reduce_axes) {
     if (axis < 0) {
       axis += rinput_shape.size();
@@ -337,7 +337,7 @@ CONDITION_FUNC(reduce_fuse_broadcast) {
       return false;
     }
     // if keep dim = true.
-    if (keep_dim) {
+    if (keepdim) {
       continue;
     } else {
       // if routput_shape = [1]

--- a/paddle/cinn/operator_fusion/utils.h
+++ b/paddle/cinn/operator_fusion/utils.h
@@ -53,7 +53,7 @@ static size_t GetCompitableRank(pir::Value value) {
 
 static std::vector<int64_t> GetReduceAxisIdx(pir::Operation* reduce_op) {
   const size_t input_rank = GetCompitableRank(reduce_op->operand_source(0));
-  const auto& attr_val = reduce_op->attributes().at("dim");
+  const auto& attr_val = reduce_op->attributes().at("axis");
   CHECK(attr_val.isa<::pir::ArrayAttribute>());
   const auto& axis_attr = attr_val.dyn_cast<::pir::ArrayAttribute>();
   if (axis_attr.empty()) {
@@ -79,7 +79,7 @@ static std::vector<int64_t> GetReduceAxisIdx(pir::Operation* reduce_op) {
 }
 
 static bool GetReduceOpKeepDims(pir::Operation* reduce_op) {
-  const auto& attr_val = reduce_op->attributes().at("keep_dim");
+  const auto& attr_val = reduce_op->attributes().at("keepdim");
   CHECK(attr_val.isa<::pir::BoolAttribute>());
   return attr_val.dyn_cast<::pir::BoolAttribute>().data();
 }

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
@@ -95,11 +95,11 @@ bool ConcatOpInferSymbolicShape(pir::Operation *op,
 
 bool ReduceInferSymbolicShape(pir::Operation *op,
                               pir::InferSymbolicShapeContext *infer_context) {
-  bool keep_dim = GetBoolAttr(op, "keep_dim");
-  auto axis = paddle::dialect::details::GetVectorAttr(op, "dim");
+  bool keepdim = GetBoolAttr(op, "keepdim");
+  auto axis = paddle::dialect::details::GetVectorAttr(op, "axis");
   bool reduce_all = axis.size() == 0 ? true : false;
   return paddle::dialect::details::ReduceInferDim(
-      op, infer_context, axis, keep_dim, reduce_all);
+      op, infer_context, axis, keepdim, reduce_all);
 }
 
 bool ReduceMaxOpInferSymbolicShape(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
#### 背景
规范 CINN 算子跨 Dialect 转换的一致性，避免手写转换规则

#### Done
将 cinn reduce ops 的属性名称与 pd ops 对齐
- `dim` -> `axis`
- `keep_dim` -> `keepdim`
- 因为 cinn reduce ops 需要有一致的 axis 和 keepdim 属性名称（一些地方 reduce op 是统一处理的），因此 cinn_op.reduce_prod 暂时无法与 pd_op.prod 对齐（可能需要修改 pd_op.prod）

#### Todo
1. 处理 cinn_op.reduce_prod 的属性名不一致问题
2. 规范 Scalar 属性的转换
3. 规范 IntArray 属性的转换
