### PR TITLE
[CINN]Fix DataOp and ConcatOp infer symbolic shape problem

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
@@ -43,9 +43,16 @@ bool ConcatOpInferSymbolicShape(pir::Operation *op,
   const auto input_values = op->operands_source();
   const auto input_size = input_values.size();
 
-  if (infer_context->GetShapeOrDataForValue(input_values[0])
-          .data()
-          .has_value()) {
+  const auto IsAllDataValue = [&]() -> bool {
+    for (const auto &value : input_values) {
+      if (!infer_context->GetShapeOrDataForValue(value).data().has_value()) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  if (IsAllDataValue()) {
     std::vector<symbol::DimExpr> out_data;
     for (const auto &value : input_values) {
       const auto &shape_or_data = infer_context->GetShapeOrDataForValue(value);

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
@@ -136,7 +136,7 @@ bool DataOpInferSymbolicShape(pir::Operation *op,
     const auto &dims = value.type().dyn_cast<pir::DenseTensorType>().dims();
     const int64_t numel = ::common::product(dims);
     std::vector<symbol::DimExpr> data;
-    for (size_t i = 0; i < numel; ++i) {
+    for (int64_t i = 0; i < numel; ++i) {
       data.push_back(symbol::DimExpr(infer_context->GetNextSymName()));
     }
     return data;

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
@@ -117,9 +117,11 @@ bool DataOpInferSymbolicShape(pir::Operation *op,
     return sym_dims;
   }();
 
-  auto IsOneNumel = [&](pir::Value value) {
+  auto IsNumelLEKMaxRank = [](pir::Value value) {
     const auto &dims = value.type().dyn_cast<pir::DenseTensorType>().dims();
-    if (dims.size() == 1 && dims[0] == 1) {
+    if (dims.size() == 0) return true;
+    if (dims.size() != 1) return false;
+    if (dims[0] >= 1 && dims[0] <= ::common::DDim::kMaxRank) {
       return true;
     }
     return false;
@@ -130,12 +132,20 @@ bool DataOpInferSymbolicShape(pir::Operation *op,
     return dtype.isa<pir::Int32Type>() || dtype.isa<pir::Int64Type>();
   };
 
+  auto CreateSymForEachNumel = [&](pir::Value value) -> decltype(auto) {
+    const auto &dims = value.type().dyn_cast<pir::DenseTensorType>().dims();
+    const int64_t numel = ::common::product(dims);
+    std::vector<symbol::DimExpr> data;
+    for (size_t i = 0; i < numel; ++i) {
+      data.push_back(symbol::DimExpr(infer_context->GetNextSymName()));
+    }
+    return data;
+  };
+
   const auto &shape_or_data = [&]() {
-    if (IsOneNumel(op->result(0)) && IsIntType(op->result(0))) {
-      std::vector<symbol::DimExpr> data{
-          symbol::DimExpr(infer_context->GetNextSymName())};
-      return symbol::ShapeOrDataDimExprs{
-          symbol::TensorShapeOrDataDimExprs(sym_dims, data)};
+    if (IsNumelLEKMaxRank(op->result(0)) && IsIntType(op->result(0))) {
+      return symbol::ShapeOrDataDimExprs{symbol::TensorShapeOrDataDimExprs(
+          sym_dims, CreateSymForEachNumel(op->result(0)))};
     } else {
       return symbol::ShapeOrDataDimExprs{
           symbol::TensorShapeOrDataDimExprs(sym_dims)};


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复了2个算子对于符号data 区域的问题：
+ ConcatOp：之前实现中如果第一个value有data区域，则认为所有的input values都有data区域，此假设不成立
+ DataOp: 扩展支持了 0D Tensor 和 1D Tensor 在shape value <= 9 的新符号创建的逻辑

![image](https://github.com/PaddlePaddle/Paddle/assets/9301846/f1e3a575-4efb-4683-ad3b-e028a155a415)
