### PR TITLE
[Typing][A-70,A-71] Add type annotations for hub and sysconfig

### DIFF
--- a/python/paddle/hapi/hub.py
+++ b/python/paddle/hapi/hub.py
@@ -12,19 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import shutil
 import sys
 import zipfile
+from typing import Any, List, Literal
 
+from typing_extensions import TypeAlias
+
+import paddle
 from paddle.utils.download import get_path_from_url
 
 __all__ = []
 
-DEFAULT_CACHE_DIR = '~/.cache'
-VAR_DEPENDENCY = 'dependencies'
-MODULE_HUBCONF = 'hubconf.py'
-HUB_DIR = os.path.expanduser(os.path.join('~', '.cache', 'paddle', 'hub'))
+_Source: TypeAlias = Literal["github", "gitee", "local"]
+
+DEFAULT_CACHE_DIR: str = '~/.cache'
+VAR_DEPENDENCY: str = 'dependencies'
+MODULE_HUBCONF: str = 'hubconf.py'
+HUB_DIR: str = os.path.expanduser(os.path.join('~', '.cache', 'paddle', 'hub'))
 
 
 def _remove_if_exists(path):
@@ -169,7 +177,11 @@ def _check_dependencies(m):
             )
 
 
-def list(repo_dir, source='github', force_reload=False):
+def list(
+    repo_dir: str,
+    source: _Source = 'github',
+    force_reload: bool = False,
+) -> List[str]:  # noqa: UP006
     r"""
     List all entrypoints available in `github` hubconf.
 
@@ -215,7 +227,12 @@ def list(repo_dir, source='github', force_reload=False):
     return entrypoints
 
 
-def help(repo_dir, model, source='github', force_reload=False):
+def help(
+    repo_dir: str,
+    model,
+    source: _Source = 'github',
+    force_reload: bool = False,
+) -> str:
     """
     Show help information of model
 
@@ -258,7 +275,13 @@ def help(repo_dir, model, source='github', force_reload=False):
     return entry.__doc__
 
 
-def load(repo_dir, model, source='github', force_reload=False, **kwargs):
+def load(
+    repo_dir: str,
+    model: str,
+    source: _Source = 'github',
+    force_reload: bool = False,
+    **kwargs: Any,
+) -> paddle.nn.Layer:
     """
     Load model
 

--- a/python/paddle/sysconfig.py
+++ b/python/paddle/sysconfig.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 
 __all__ = ['get_include', 'get_lib']
 
 
-def get_include():
+def get_include() -> str:
     """
     Get the directory containing the PaddlePaddle C++ header files.
 
@@ -36,7 +38,7 @@ def get_include():
     return os.path.join(os.path.dirname(paddle.__file__), 'include')
 
 
-def get_lib():
+def get_lib() -> str:
     """
     Get the directory containing the libpaddle_framework.
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

为 hub & sysconfig 添加类型提示

### Related links

- #65008

PCard-66972