### PR TITLE
【Inference PIR】add fused_rotary_position_embedding_pass

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -611,6 +611,7 @@ const std::vector<std::string> kPirGpuPasses{
     "conv2d_add_act_fuse_pass",
     "conv2d_add_fuse_pass",
     "embedding_eltwise_layernorm_fuse_pass",
+    "fused_rotary_position_embedding_pass",
     "fused_flash_attn_pass",
     "multihead_matmul_fuse_pass",
     "fused_weight_only_linear_pass",
@@ -623,7 +624,6 @@ const std::vector<std::string> kPirGpuPasses{
     "transpose_flatten_concat_fuse_pass",
     "remove_redundant_transpose_pass",
     "transfer_layout_pass",
-    "fused_rotary_position_embedding_pass",
 };
 
 const std::vector<std::string> kPirXpuPasses{

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -623,6 +623,7 @@ const std::vector<std::string> kPirGpuPasses{
     "transpose_flatten_concat_fuse_pass",
     "remove_redundant_transpose_pass",
     "transfer_layout_pass",
+    "fused_rotary_position_embedding_pass",
 };
 
 const std::vector<std::string> kPirXpuPasses{

--- a/paddle/fluid/pir/transforms/gpu/fused_rotary_position_embedding.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_rotary_position_embedding.cc
@@ -209,9 +209,12 @@ class FusedRotaryPositionEmbeddingPattern : public paddle::drr::DrrPatternBase {
         return true;
       };
 
+      bool all_checkes_passed = true;
+
       auto axis = match_ctx.Attr<std::vector<int64_t>>("full_13_value");
       auto axis_2 = match_ctx.Attr<std::vector<int64_t>>("full_12_value");
-      return check_axes(axis) && check_axes(axis_2);
+      all_checks_passed = all_checks_passed && check_axes(axis, {0, 2}) &&
+                          check_axes(axis_2, {0, 2});
 
       auto check_unsqueeze_axes = [&](const std::vector<int64_t> &axes) {
         std::vector<int64_t> expected_axes = {0};
@@ -234,10 +237,11 @@ class FusedRotaryPositionEmbeddingPattern : public paddle::drr::DrrPatternBase {
       auto unsqueeze_axis_3 =
           match_ctx.Attr<std::vector<int64_t>>("full_9_value");
 
-      return check_unsqueeze_axes(unsqueeze_axis) &&
-             check_unsqueeze_axes(unsqueeze_axis_1) &&
-             check_unsqueeze_axes(unsqueeze_axis_2) &&
-             check_unsqueeze_axes(unsqueeze_axis_3);
+      all_checks_passed = all_checks_passed &&
+                          check_axes(unsqueeze_axis, {0}) &&
+                          check_axes(unsqueeze_axis_1, {0}) &&
+                          check_axes(unsqueeze_axis_2, {0}) &&
+                          check_axes(unsqueeze_axis_3, {0});
 
       auto check_concat_axes = [&](const std::vector<int64_t> &axes) {
         std::vector<int64_t> expected_axes = {-1};
@@ -253,7 +257,9 @@ class FusedRotaryPositionEmbeddingPattern : public paddle::drr::DrrPatternBase {
       };
       auto concat_axis = match_ctx.Attr<std::vector<int64_t>>("full_op_3");
       auto concat_axis_1 = match_ctx.Attr<std::vector<int64_t>>("full_op_2");
-      return check_concat_axes(concat_axis) && check_concat_axes(concat_axis_1);
+      all_checks_passed = all_checks_passed && check_axes(concat_axis, {-1}) &&
+                          check_axes(concat_axis_1, {-1});
+      return all_checks_passed;
     });
 
     paddle::drr::ResultPattern res = pat.ResultPattern();

--- a/paddle/fluid/pir/transforms/gpu/fused_rotary_position_embedding.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_rotary_position_embedding.cc
@@ -1,0 +1,305 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/pir/transforms/gpu/fused_rotary_position_embedding.h"
+
+#include <string>
+
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
+
+#include "paddle/fluid/pir/utils/general_functions.h"
+#include "paddle/pir/include/core/builtin_op.h"
+#include "paddle/pir/include/core/value.h"
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pass/pass_registry.h"
+
+namespace {
+
+class FusedRotaryPositionEmbeddingPattern : public paddle::drr::DrrPatternBase {
+ private:
+  bool with_transpose_;
+
+ public:
+  explicit FusedRotaryPositionEmbeddingPattern(bool with_transpose)
+      : with_transpose_(with_transpose) {}
+
+  std::string name() const override { return "RotaryPositionEmbeddingPattern"; }
+
+  uint32_t benefit() const override { return 2; }
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+    const auto &squeeze = pat.Op(paddle::dialect::SqueezeOp::name());
+    const auto &squeeze_1 = pat.Op(paddle::dialect::SqueezeOp::name());
+
+    const auto &gather_nd = pat.Op(paddle::dialect::GatherNdOp::name());
+    const auto &gather_nd_1 = pat.Op(paddle::dialect::GatherNdOp::name());
+    const auto &unsqueeze = pat.Op(paddle::dialect::UnsqueezeOp::name());
+    const auto &unsqueeze_1 = pat.Op(paddle::dialect::UnsqueezeOp::name());
+    const auto &unsqueeze_2 = pat.Op(paddle::dialect::UnsqueezeOp::name());
+    const auto &unsqueeze_4 = pat.Op(paddle::dialect::UnsqueezeOp::name());
+
+    const auto &add = pat.Op(paddle::dialect::AddOp::name());
+    const auto &add_1 = pat.Op(paddle::dialect::AddOp::name());
+    const auto &multiply1 = pat.Op(paddle::dialect::MultiplyOp::name());
+    const auto &multiply2 = pat.Op(paddle::dialect::MultiplyOp::name());
+    const auto &multiply3 = pat.Op(paddle::dialect::MultiplyOp::name());
+    const auto &multiply4 = pat.Op(paddle::dialect::MultiplyOp::name());
+
+    const auto &slice_q = pat.Op(paddle::dialect::SliceOp::name());
+    const auto &slice_q_1 = pat.Op(paddle::dialect::SliceOp::name());
+
+    const auto &slice_k = pat.Op(paddle::dialect::SliceOp::name());
+
+    const auto &slice_k_1 = pat.Op(paddle::dialect::SliceOp::name());
+
+    const auto &full_op = pat.Op(paddle::dialect::FullOp::name(),
+                                 {{"shape", pat.Attr("shape")},
+                                  {"value", pat.Attr("value")},
+                                  {"dtype", pat.Attr("dtype")},
+                                  {"place", pat.Attr("place")}});
+    const auto &full_op_1 = pat.Op(paddle::dialect::FullOp::name(),
+                                   {{"value", pat.Attr("full_op_1")}});
+    const auto &full_op_2 = pat.Op(paddle::dialect::FullOp::name(),
+                                   {{"value", pat.Attr("full_op_2")}});
+    const auto &full_op_3 = pat.Op(paddle::dialect::FullOp::name(),
+                                   {{"value", pat.Attr("full_op_3")}});
+    // const auto &shape = pat.Op(paddle::dialect::ShapeOp::name());
+
+    const auto &scale_op = pat.Op(paddle::dialect::ScaleOp::name());
+
+    const auto &scale_op_k = pat.Op(paddle::dialect::ScaleOp::name());
+
+    const auto &full_1 = pat.Op(paddle::dialect::FullIntArrayOp::name());
+    const auto &full_2 = pat.Op(paddle::dialect::FullIntArrayOp::name());
+    const auto &full_3 = pat.Op(paddle::dialect::FullIntArrayOp::name());
+    const auto &full_4 = pat.Op(paddle::dialect::FullIntArrayOp::name());
+    const auto &full_5 = pat.Op(paddle::dialect::FullIntArrayOp::name());
+    const auto &full_6 = pat.Op(paddle::dialect::FullIntArrayOp::name());
+    const auto &full_7 = pat.Op(paddle::dialect::FullIntArrayOp::name());
+    const auto &full_8 = pat.Op(paddle::dialect::FullIntArrayOp::name(),
+                                {{"value", pat.Attr("full_8_value")}});
+    const auto &full_9 = pat.Op(paddle::dialect::FullIntArrayOp::name(),
+                                {{"value", pat.Attr("full_9_value")}});
+    const auto &full_10 = pat.Op(paddle::dialect::FullIntArrayOp::name(),
+                                 {{"value", pat.Attr("full_10_value")}});
+    const auto &full_11 = pat.Op(paddle::dialect::FullIntArrayOp::name(),
+                                 {{"value", pat.Attr("full_11_value")}});
+    const auto &full_12 = pat.Op(paddle::dialect::FullIntArrayOp::name(),
+                                 {{"value", pat.Attr("full_12_value")}});
+    const auto &full_13 = pat.Op(paddle::dialect::FullIntArrayOp::name(),
+                                 {{"value", pat.Attr("full_13_value")}});
+    const auto &full_14 = pat.Op(paddle::dialect::FullIntArrayOp::name());
+
+    const auto &concat_op = pat.Op(paddle::dialect::ConcatOp::name());
+    const auto &combine = pat.Op(pir::CombineOp::name());
+    const auto &concat_op_k = pat.Op(paddle::dialect::ConcatOp::name());
+    const auto &combine_k = pat.Op(pir::CombineOp::name());
+
+    squeeze({&pat.Tensor("cos"), &full_13()},
+            {&pat.Tensor("squeeze_out_cos"), &pat.Tensor("xshape")});
+
+    squeeze_1({&pat.Tensor("sin"), &full_12()},
+              {&pat.Tensor("squeeze_out_sin"), &pat.Tensor("xshape")});
+
+    unsqueeze({&pat.Tensor("position_ids"), &full_11()},
+              {&pat.Tensor("unsqueeze_s_out_cos"), &pat.Tensor("xshape")});
+
+    if (with_transpose_) {
+      const auto &transpose_1 = pat.Op(paddle::dialect::TransposeOp::name(),
+                                       {{"perm", pat.Attr("perm_1")}});
+      pat.Tensor("transpose_1_cos") =
+          transpose_1(pat.Tensor("squeeze_out_cos"));
+
+      const auto &transpose_2 = pat.Op(paddle::dialect::TransposeOp::name(),
+                                       {{"perm", pat.Attr("perm_2")}});
+      pat.Tensor("transpose_2_sin") =
+          transpose_2(pat.Tensor("squeeze_out_sin"));
+
+      pat.Tensor("gather_nd_out_cos") = gather_nd(
+          pat.Tensor("transpose_1_cos"), pat.Tensor("unsqueeze_s_out_cos"));
+
+      pat.Tensor("gather_nd_out_sin") = gather_nd_1(
+          pat.Tensor("transpose_2_sin"), pat.Tensor("unsqueeze_s_out_sin"));
+    } else {
+      pat.Tensor("gather_nd_out_cos") = gather_nd(
+          pat.Tensor("squeeze_out_cos"), pat.Tensor("unsqueeze_s_out_cos"));
+      pat.Tensor("gather_nd_out_sin") = gather_nd_1(
+          pat.Tensor("squeeze_out_sin"), pat.Tensor("unsqueeze_s_out_sin"));
+    }
+
+    unsqueeze_1({&pat.Tensor("gather_nd_out_cos"), &full_10()},
+                {&pat.Tensor("unsqueeze_out_cos"), &pat.Tensor("xshape")});
+
+    unsqueeze_4({&pat.Tensor("position_ids"), &full_8()},
+                {&pat.Tensor("unsqueeze_s_out_sin"), &pat.Tensor("xshape")});
+
+    unsqueeze_2({&pat.Tensor("gather_nd_out_sin"), &full_9()},
+                {&pat.Tensor("unsqueeze_out_sin"), &pat.Tensor("xshape")});
+
+    pat.Tensor("tmp_25") =
+        multiply1(pat.Tensor("q"), pat.Tensor("unsqueeze_out_cos"));
+
+    pat.Tensor("q_slice_out1") = slice_q(pat.Tensor("q"), full_1(), full_2());
+
+    pat.Tensor("q_slice_out2") = slice_q_1(pat.Tensor("q"), full_3(), full_4());
+
+    scale_op({&pat.Tensor("q_slice_out2"), &full_op()},
+             {&pat.Tensor("scale_out")});
+
+    std::vector<const paddle::drr::Tensor *> combine_in;
+    combine_in.push_back(&pat.Tensor("scale_out"));
+    combine_in.push_back(&pat.Tensor("q_slice_out1"));
+    combine(combine_in, {&pat.Tensor("combine_out")});
+
+    concat_op({&pat.Tensor("combine_out"), &full_op_3()},
+              {&pat.Tensor("concat_out")});
+
+    pat.Tensor("tmp_27") =
+        multiply3(pat.Tensor("concat_out"), pat.Tensor("unsqueeze_out_sin"));
+
+    pat.Tensor("out_q") = add(pat.Tensor("tmp_25"), pat.Tensor("tmp_27"));
+
+    pat.Tensor("tmp_29") =
+        multiply2(pat.Tensor("k"), pat.Tensor("unsqueeze_out_cos"));
+
+    pat.Tensor("k_slice_out1") = slice_k(pat.Tensor("k"), full_5(), full_6());
+
+    pat.Tensor("k_slice_out2") =
+        slice_k_1(pat.Tensor("k"), full_7(), full_14());
+
+    scale_op_k({&pat.Tensor("k_slice_out2"), &full_op_1()},
+               {&pat.Tensor("scale_out_k")});
+
+    std::vector<const paddle::drr::Tensor *> combine_in_k;
+    combine_in_k.push_back(&pat.Tensor("scale_out_k"));
+    combine_in_k.push_back(&pat.Tensor("k_slice_out1"));
+    combine_k(combine_in_k, {&pat.Tensor("combine_out_k")});
+
+    concat_op_k({&pat.Tensor("combine_out_k"), &full_op_2()},
+                {&pat.Tensor("concat_out_k")});
+
+    pat.Tensor("tmp_31") =
+        multiply4(pat.Tensor("concat_out_k"), pat.Tensor("unsqueeze_out_sin"));
+
+    pat.Tensor("out_k") = add_1(pat.Tensor("tmp_29"), pat.Tensor("tmp_31"));
+
+    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+      auto check_axes = [&](const std::vector<int64_t> &axes) {
+        std::vector<int64_t> expected_axes = {0, 2};
+        if (axes.size() != expected_axes.size()) {
+          return false;
+        }
+        for (size_t i = 0; i < axes.size(); ++i) {
+          if (axes[i] != expected_axes[i]) {
+            return false;
+          }
+        }
+        return true;
+      };
+
+      auto axis = match_ctx.Attr<std::vector<int64_t>>("full_13_value");
+      auto axis_2 = match_ctx.Attr<std::vector<int64_t>>("full_12_value");
+      return check_axes(axis) && check_axes(axis_2);
+
+      auto check_unsqueeze_axes = [&](const std::vector<int64_t> &axes) {
+        std::vector<int64_t> expected_axes = {0};
+        if (axes.size() != expected_axes.size()) {
+          return false;
+        }
+        for (size_t i = 0; i < axes.size(); ++i) {
+          if (axes[i] != expected_axes[i]) {
+            return false;
+          }
+        }
+        return true;
+      };
+      auto unsqueeze_axis =
+          match_ctx.Attr<std::vector<int64_t>>("full_11_value");
+      auto unsqueeze_axis_1 =
+          match_ctx.Attr<std::vector<int64_t>>("full_10_value");
+      auto unsqueeze_axis_2 =
+          match_ctx.Attr<std::vector<int64_t>>("full_8_value");
+      auto unsqueeze_axis_3 =
+          match_ctx.Attr<std::vector<int64_t>>("full_9_value");
+
+      return check_unsqueeze_axes(unsqueeze_axis) &&
+             check_unsqueeze_axes(unsqueeze_axis_1) &&
+             check_unsqueeze_axes(unsqueeze_axis_2) &&
+             check_unsqueeze_axes(unsqueeze_axis_3);
+
+      auto check_concat_axes = [&](const std::vector<int64_t> &axes) {
+        std::vector<int64_t> expected_axes = {-1};
+        if (axes.size() != expected_axes.size()) {
+          return false;
+        }
+        for (size_t i = 0; i < axes.size(); ++i) {
+          if (axes[i] != expected_axes[i]) {
+            return false;
+          }
+        }
+        return true;
+      };
+      auto concat_axis = match_ctx.Attr<std::vector<int64_t>>("full_op_3");
+      auto concat_axis_1 = match_ctx.Attr<std::vector<int64_t>>("full_op_2");
+      return check_concat_axes(concat_axis) && check_concat_axes(concat_axis_1);
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    const auto &fused_rotary_position_embedding = res.Op(
+        paddle::dialect::FusedRotaryPositionEmbeddingOp::name(),
+        {
+            // TODO(lizexu123): This pass only supports the case where
+            // use_neox_rotary_style is false. When use_neox_rotary_style is
+            // true, the source pattern needs to be modified accordingly.
+            {"use_neox_rotary_style", res.BoolAttr(false)},
+            {"time_major", res.BoolAttr(false)},
+            {"rotary_emb_base", res.Float32Attr(10000.0)},
+        });
+
+    fused_rotary_position_embedding(
+        {&res.Tensor("q"),
+         &res.Tensor("k"),
+         &res.InputNoneTensor(),
+         &res.Tensor("sin"),
+         &res.Tensor("cos"),
+         &res.Tensor("position_ids")},
+        {&res.Tensor("out_q"), &res.Tensor("out_k"), &res.OutputNoneTensor()});
+  }
+};
+class FusedRotaryPositionEmbeddingPass : public pir::PatternRewritePass {
+ public:
+  FusedRotaryPositionEmbeddingPass()
+      : pir::PatternRewritePass("fused_rotary_position_embedding_pass", 2) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
+    pir::RewritePatternSet ps(context);
+    ps.Add(paddle::drr::Create<FusedRotaryPositionEmbeddingPattern>(context,
+                                                                    true));
+    ps.Add(paddle::drr::Create<FusedRotaryPositionEmbeddingPattern>(context,
+                                                                    false));
+    return ps;
+  }
+};
+}  // namespace
+
+namespace pir {
+
+std::unique_ptr<Pass> CreateFusedRotaryPositionEmbeddingPass() {
+  return std::make_unique<FusedRotaryPositionEmbeddingPass>();
+}
+}  // namespace pir
+REGISTER_IR_PASS(fused_rotary_position_embedding_pass,
+                 FusedRotaryPositionEmbeddingPass);

--- a/paddle/fluid/pir/transforms/gpu/fused_rotary_position_embedding.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_rotary_position_embedding.cc
@@ -71,11 +71,8 @@ class FusedRotaryPositionEmbeddingPattern : public paddle::drr::DrrPatternBase {
                                   {"place", pat.Attr("place")}});
     const auto &full_op_1 = pat.Op(paddle::dialect::FullOp::name(),
                                    {{"value", pat.Attr("full_op_1")}});
-    const auto &full_op_2 = pat.Op(paddle::dialect::FullOp::name(),
-                                   {{"value", pat.Attr("full_op_2")}});
-    const auto &full_op_3 = pat.Op(paddle::dialect::FullOp::name(),
-                                   {{"value", pat.Attr("full_op_3")}});
-    // const auto &shape = pat.Op(paddle::dialect::ShapeOp::name());
+    const auto &full_op_2 = pat.Op(paddle::dialect::FullOp::name());
+    const auto &full_op_3 = pat.Op(paddle::dialect::FullOp::name());
 
     const auto &scale_op = pat.Op(paddle::dialect::ScaleOp::name());
 

--- a/paddle/fluid/pir/transforms/gpu/fused_rotary_position_embedding.h
+++ b/paddle/fluid/pir/transforms/gpu/fused_rotary_position_embedding.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/core/dll_decl.h"
+
+namespace pir {
+
+class Pass;
+
+IR_API std::unique_ptr<Pass> CreateFusedRotaryPositionEmbeddingPass();
+
+}  // namespace pir

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -45,6 +45,7 @@ USE_PIR_PASS(remove_redundant_transpose_pass);
 USE_PIR_PASS(delete_weight_dequant_linear_op_pass);
 USE_PIR_PASS(delete_quant_dequant_linear_op_pass);
 USE_PIR_PASS(transfer_layout_pass);
+USE_PIR_PASS(fused_rotary_position_embedding_pass);
 
 #ifdef PADDLE_WITH_DNNL
 USE_PIR_PASS(depthwise_conv_onednn_pass);

--- a/test/ir/pir/fused_pass/test_pir_fused_rotary_position_embedding_pass.py
+++ b/test/ir/pir/fused_pass/test_pir_fused_rotary_position_embedding_pass.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from pass_test import PassTest
+
+import paddle
+from paddle.base import core
+
+paddle.enable_static()
+
+
+class TestFusedRotaryPositionEmbeddingPass(PassTest):
+    r"""
+    k                        k                       cos       position_ids               sin        position_ids                   q             q
+   /  \                       \                         |             |                      |              |                      /             / \
+slice slice                    \                   squeeze       unsqueeze              squeeze       unsqueeze                   /          slice slice
+  |     |                       \                      \             /                      \             /                      /             |     |
+  |   scale                      \                        gather_nd                            gather_nd                        /              |   scale
+   \     /                        \                           |                                    |                           /               \     /
+   concat                          \                      unsqueeze                            unsqueeze                      /                 concat
+      \                              \                        / \                                  /\                         /                   /
+       \                              \                      /   \                                /  \                       /                   /
+        \                              \                    /     \                              /    \                    /                    /
+         \                              \                  /       \                            /      \                   /                   /
+          \                              \                /         \                          /        \                 /                   /
+           \                              \              /           \                        /          \               /                   /
+            \                                 multiply                \                      /            \             /                   /
+             \                                     \                   \                    /              \           /                   /
+              \                                     \                   \                  /                \         /                   /
+               \                                     \                   \                /                  \       /                   /
+                \                                     \                   \              /                    \     /                   /
+                 \                                     \                   \            /                      \   /                   /
+                  \                                     \                   \          /                        \ /                   /
+                   \                                     \                   \        /                         /\                   /
+                    \                                     \                   \      /                         /  \                 /
+                     \                                     \                   \    /                         /    \               /
+                      \                                     \                   \  /                         /      \             /
+                       \                                     \                   \/                         /          multiply
+                        \                                     \                  /\                        /              /
+                         \                                     \                /  \                      /              /
+                          \                                     \              /    \                    /              /
+                           \                                     \            /      \                  /              /
+                            \                                     \          /        \                /              /
+                             \                                     \        /          \              /              /
+                              \                                     \      /              multiply                  /
+                               \                                     \    /                    \                   /
+                                \                                     \  /                      \                 /
+                                 \                                     \/                        \               /
+                                  \                                    /\                         \             /
+                                   \                                  /  \                         \           /
+                                    \                                /    \                            add
+                                     \                              /      \
+                                      \                            /        \
+                                       \                          /          \
+                                        \                        /            /
+                                         \                      /            /
+                                          \                    /            /
+                                           \                 /             /
+                                                multiply                  /
+                                                       \                 /
+                                                        \               /
+                                                         \             /
+                                                          \           /
+                                                           \         /
+                                                               add
+  """
+
+    def is_program_valid(self, program=None):
+        return True
+
+    def rotate_half(self, x):
+        """Rotates half the hidden dims of the input."""
+        x1 = x[..., : x.shape[-1] // 2]
+        x2 = x[..., x.shape[-1] // 2 :]
+        x3 = paddle.concat([-x2, x1], axis=-1)
+        return x3
+
+    def sample_program(self):
+        for q_shape in [[2, 8, 2, 16]]:
+            for k_shape in [[2, 8, 2, 16]]:
+                for cos_shape in [[1, 8, 1, 16]]:
+                    for sin_shape in [[1, 8, 1, 16]]:
+                        for position_ids_shape in [[2, 8]]:
+                            with paddle.pir_utils.IrGuard():
+                                start_prog = paddle.static.Program()
+                                main_prog = paddle.static.Program()
+                                with paddle.pir.core.program_guard(
+                                    main_prog, start_prog
+                                ):
+                                    q = paddle.static.data(
+                                        name="q",
+                                        shape=q_shape,
+                                        dtype='float32',
+                                    )
+                                    k = paddle.static.data(
+                                        name="k",
+                                        shape=k_shape,
+                                        dtype='float32',
+                                    )
+                                    cos = paddle.static.data(
+                                        name="cos",
+                                        shape=cos_shape,
+                                        dtype='float32',
+                                    )
+                                    sin = paddle.static.data(
+                                        name="sin",
+                                        shape=sin_shape,
+                                        dtype='float32',
+                                    )
+                                    position_ids = paddle.static.data(
+                                        name="position_ids",
+                                        shape=position_ids_shape,
+                                        dtype='int64',
+                                    )
+
+                                    cos = cos.squeeze(axis=[0, 2])
+                                    sin = sin.squeeze(axis=[0, 2])
+                                    cos = cos[position_ids].unsqueeze(2)
+                                    sin = sin[position_ids].unsqueeze(2)
+
+                                    q_embed = (q * cos) + (
+                                        self.rotate_half(q) * sin
+                                    )
+                                    k_embed = (k * cos) + (
+                                        self.rotate_half(k) * sin
+                                    )
+
+                                    out1 = paddle.assign(q_embed)
+                                    out2 = paddle.assign(k_embed)
+
+                                    position_ids_values = np.array(
+                                        [
+                                            [7, 5, 4, 6, 3, 1, 2, 0],
+                                            [3, 1, 4, 0, 7, 6, 5, 2],
+                                        ],
+                                        dtype='int64',
+                                    )
+
+                                    self.pass_attr_list = [
+                                        {
+                                            'fused_rotary_position_embedding_pass': {}
+                                        }
+                                    ]
+
+                                    self.feeds = {
+                                        "q": np.random.random(q_shape).astype(
+                                            "float32"
+                                        ),
+                                        "k": np.random.random(k_shape).astype(
+                                            "float32"
+                                        ),
+                                        "cos": np.random.random(
+                                            cos_shape
+                                        ).astype("float32"),
+                                        "sin": np.random.random(
+                                            sin_shape
+                                        ).astype("float32"),
+                                        "position_ids": np.broadcast_to(
+                                            np.arange(8, dtype='int64'), (2, 8)
+                                        ),
+                                    }
+                                    self.fetch_list = [out1, out2]
+                                    self.valid_op_map = {
+                                        "pd_op.squeeze": 0,
+                                        "pd_op.unsqueeze": 0,
+                                        "pd_op.concat": 0,
+                                        "pd_op.multiply": 0,
+                                        "pd_op.add": 0,
+                                        "pd_op.slice": 0,
+                                        "pd_op.scale": 0,
+                                        "builtin.combine": 0,
+                                        "pd_op.gather_nd": 0,
+                                        "pd_op.fused_rotary_position_embedding": 1,
+                                    }
+                                    yield [main_prog, start_prog], False
+
+    def setUp(self):
+        if core.is_compiled_with_cuda():
+            self.places.append(paddle.CUDAPlace(0))
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-71500
增加fused_rotary_position_embedding_pass

A30测试结果:
Llama-7b   batch-size:1 no fused_rotary_position_embedding_pass:32857.339ms
Llama-7b  batch-size:1 have fused_rotary_position_embedding_pass:31191.201ms
Llama-7b batch-size:4 no fused_rotary_position_embedding_pass:52057.086ms
Llama-7b batch-size:4 have fused_rotary_position_embedding_pass:50541.888ms
在pir 下，llama-7b 模型在 batch_size=1 与batch_size=4 的平均时延方面分别有 5.071% 与 2.911% 的性能提升，其余模型无明显影响；显存方面基本持平