### PR TITLE
[Serde] Keep alphabet order when save dictionary output

### DIFF
--- a/python/paddle/utils/layers_utils.py
+++ b/python/paddle/utils/layers_utils.py
@@ -149,10 +149,19 @@ def _hash_with_id(*args):
     return hash(info)
 
 
+def _sorted(dict_):
+    """
+    Returns a sorted list of the dict keys, with error if keys not sortable.
+    """
+    try:
+        return sorted(dict_.keys())
+    except TypeError:
+        raise TypeError("nest only supports dicts with sortable keys.")
+
+
 def _yield_value(iterable):
     if isinstance(iterable, dict):
-        # NOTE: Keep order unchanged as python dict is ordered since python3.6
-        for key in iterable:
+        for key in _sorted(iterable):
             yield iterable[key]
     else:
         yield from iterable
@@ -192,7 +201,7 @@ def _sequence_like(instance, args):
     Convert the sequence `args` to the same type as `instance`.
     """
     if isinstance(instance, dict):
-        result = dict(zip(instance, args))
+        result = dict(zip(_sorted(instance), args))
         return type(instance)((key, result[key]) for key in instance.keys())
     elif (
         isinstance(instance, tuple)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

Revert 掉 #63791 的修改，保持 `jit.save` 时模型输出为 dict 时按照 keys 字母序，避免不兼容变动

PCard-66972