### PR TITLE
[CINN] Unify pd_op.prod attributes with cinn_op.reduce_prod

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/cinn_to_pd_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/cinn_to_pd_util.cc
@@ -112,11 +112,8 @@ const auto& handler_reduce_prod_op =
   auto attrs = op->attributes();
 
   ::pir::Attribute attr_axis = ArrayAttributeToIntArrayAttribute(
-      attrs.at("dims").dyn_cast<::pir::ArrayAttribute>());
-  attrs.insert({"axis", attr_axis});
-  attrs.insert({"keepdim", attrs["keep_dim"]});
-  attrs.erase("dims");
-  attrs.erase("keep_dim");
+      attrs.at("axis").dyn_cast<::pir::ArrayAttribute>());
+  attrs["axis"] = attr_axis;
 
   auto pd_op = rewriter.Build<paddle::dialect::ProdOp>(
       ir_mapping.Lookup(op->operand_source(0)), attrs);

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2306,15 +2306,15 @@
     data_type : x
 
 - backward_op : prod_grad
-  forward : prod (Tensor x, IntArray dims, bool keep_dim, bool reduce_all) -> Tensor(out)
-  args : (Tensor x, Tensor out, Tensor out_grad, IntArray dims,  bool keep_dim, bool reduce_all)
+  forward : prod (Tensor x, IntArray axis, bool keepdim, bool reduce_all) -> Tensor(out)
+  args : (Tensor x, Tensor out, Tensor out_grad, IntArray axis, bool keepdim, bool reduce_all)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta
     param : [x]
   kernel :
     func : prod_grad
-  composite: prod_grad(x, out, out_grad, dims, keep_dim, reduce_all, x_grad)
+  composite: prod_grad(x, out, out_grad, axis, keepdim, reduce_all, x_grad)
 
 - backward_op : psroi_pool_grad
   forward : psroi_pool (Tensor x, Tensor boxes, Tensor boxes_num, int pooled_height=1, int pooled_width=1, int output_channels=1, float spatial_scale=1.0) -> Tensor(out)

--- a/paddle/phi/ops/yaml/legacy/static_backward.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_backward.yaml
@@ -290,15 +290,15 @@
     param : [x, out, out_grad, kernel_size, strides, paddings, ceil_mode, exclusive, data_format, pooling_type, global_pooling, adaptive, padding_algorithm]
 
 - backward_op : prod_grad
-  forward : prod (Tensor x, IntArray dims={0}, bool keep_dim=false, bool reduce_all=false, int in_dtype=-1, DataType out_dtype=DataType::UNDEFINED) -> Tensor(out)
-  args : (Tensor x, Tensor out, Tensor out_grad, IntArray dims={0},  bool keep_dim=false, bool reduce_all=false)
+  forward : prod (Tensor x, IntArray axis={0}, bool keepdim=false, bool reduce_all=false, int in_dtype=-1, DataType out_dtype=DataType::UNDEFINED) -> Tensor(out)
+  args : (Tensor x, Tensor out, Tensor out_grad, IntArray axis={0},  bool keepdim=false, bool reduce_all=false)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta
     param : [x]
   kernel :
     func : prod_grad
-  composite: prod_grad(x, out, out_grad, dims, keep_dim, reduce_all, x_grad)
+  composite: prod_grad(x, out, out_grad, axis, keepdim, reduce_all, x_grad)
 
 - backward_op : rnn_grad
   forward : rnn (Tensor x, Tensor[] pre_state, Tensor[] weight_list, Tensor sequence_length, float dropout_prob=0.0, bool is_bidirec=false, int input_size=10, int hidden_size=100, int num_layers=1, str mode="RNN_TANH", int seed=0, bool is_test=false) -> Tensor(out), Tensor(dropout_state_out), Tensor[](state), Tensor(reserve)

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -564,14 +564,14 @@
   backward : pool3d_grad
 
 - op : prod
-  args : (Tensor x, IntArray dims={0}, bool keep_dim=false, bool reduce_all=false, int in_dtype=-1, DataType out_dtype=DataType::UNDEFINED)
+  args : (Tensor x, IntArray axis={0}, bool keepdim=false, bool reduce_all=false, int in_dtype=-1, DataType out_dtype=DataType::UNDEFINED)
   output : Tensor(out)
   infer_meta :
     func : ReduceIntArrayAxisInferMetaBase
-    param : [x, dims, keep_dim, reduce_all, out_dtype]
+    param : [x, axis, keepdim, reduce_all, out_dtype]
   kernel :
     func : prod
-    param : [x, dims, keep_dim, reduce_all, out_dtype]
+    param : [x, axis, keepdim, reduce_all, out_dtype]
     data_type : x
   backward : prod_grad
 

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -2730,9 +2730,9 @@
   outputs:
     out : Out
   attrs:
-    { dims : dim,  keep_dim : keep_dim}
+    { axis : dim,  keepdim : keep_dim}
   int_array:
-    dims :
+    axis :
       data_type : int
       support_tensor : true
   extra :

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -3301,7 +3301,7 @@
     data_type : input
 
 - op : prod
-  args : (Tensor x, IntArray dims, bool keep_dim, bool reduce_all)
+  args : (Tensor x, IntArray axis, bool keepdim, bool reduce_all)
   output : Tensor
   infer_meta :
     func : ReduceIntArrayAxisInferMetaBase


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- #65224
- Unify pd_op.prod attributes with cinn_op.prod