### PR TITLE
[pybind11] fix deprecated `T(handle, bool)`

### DIFF
--- a/paddle/fluid/pybind/eager.cc
+++ b/paddle/fluid/pybind/eager.cc
@@ -376,11 +376,13 @@ py::object ParsePyArray(
   py::object numpy_value = py::object();
 
   if (kw_order_map["value"] <= args_num) {
-    numpy_value = py::object(
-        py::handle(PyTuple_GET_ITEM(args, kw_order_map["value"] - 1)), true);
+    numpy_value = py::reinterpret_borrow<py::object>(
+        py::handle(PyTuple_GET_ITEM(args, kw_order_map["value"] - 1)));
   } else {
     if (flag_kwargs && kws_map["value"] != nullptr) {
-      numpy_value = py::object(py::handle(kws_map["value"]), true);
+      numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(kws_map["value"]));
+
     } else {
       PADDLE_THROW(platform::errors::InvalidArgument(
           "The first expected arguments is {value: PyArray}, "

--- a/paddle/fluid/pybind/eager_math_op_patch.cc
+++ b/paddle/fluid/pybind/eager_math_op_patch.cc
@@ -293,7 +293,8 @@ static PyObject* tensor__add__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -397,7 +398,8 @@ static PyObject* tensor__sub__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -499,7 +501,8 @@ static PyObject* tensor__rsub__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -605,7 +608,8 @@ static PyObject* tensor__mul__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -708,7 +712,8 @@ static PyObject* tensor__div__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -814,7 +819,8 @@ static PyObject* tensor__rdiv__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -924,7 +930,8 @@ static PyObject* tensor__gt__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -1024,7 +1031,8 @@ static PyObject* tensor__ge__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -1125,7 +1133,8 @@ static PyObject* tensor__mod__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -1222,7 +1231,8 @@ static PyObject* tensor__matmul__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -1350,7 +1360,8 @@ static PyObject* tensor__lt__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -1450,7 +1461,8 @@ static PyObject* tensor__le__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -1551,7 +1563,8 @@ static PyObject* tensor__floordiv__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -1655,7 +1668,8 @@ static PyObject* tensor__pow__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -1755,7 +1769,8 @@ static PyObject* tensor__rpow__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -1855,7 +1870,8 @@ static PyObject* tensor__ne__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
@@ -1954,7 +1970,8 @@ static PyObject* tensor__eq__method(TensorObject* self,
     other_tensor = other_tensor_ref;
   } else {
     if (IsNumpyArray(other_obj)) {
-      py::object numpy_value = py::object(py::handle(other_obj), true);
+      py::object numpy_value =
+          py::reinterpret_borrow<py::object>(py::handle(other_obj));
       other_tensor = paddle::Tensor(place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1113,7 +1113,8 @@ pir::Value apply(Value self, py::object func) {
           return py::cast<py::none>(Py_None);                                \
         }                                                                    \
         auto py_data = reinterpret_cast<PyObject *>(prop_ptr);               \
-        py::object obj = py::object(py::handle(py_data), true);              \
+        py::object obj =                                                     \
+            py::reinterpret_borrow<py::object>(py::handle(py_data));         \
         return obj;                                                          \
       },                                                                     \
       [](Value self, py::object obj) {                                       \

--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -549,7 +549,7 @@ static paddle::Tensor dealWithValues(const paddle::Tensor& tensor,
     paddle::Tensor value_tensor_tmp(
         std::make_shared<phi::DenseTensor>(),
         egr::Controller::Instance().GenerateUniqueName());
-    py::object value_obj_tmp(py::handle(value_obj), true);
+    py::object value_obj_tmp = py::reinterpret_borrow<py::object>(value_obj);
     py::object value = value_obj_tmp;
     if (tensor.dtype() == phi::DataType::FLOAT32) {
       if (!py::isinstance<py::array_t<float>>(value_obj_tmp)) {
@@ -595,7 +595,7 @@ static paddle::Tensor dealWithValues(const paddle::Tensor& tensor,
         false);
     value_tensor = value_tensor_tmp;
   } else {
-    py::object value_obj_tmp(py::handle(value_obj), true);
+    py::object value_obj_tmp = py::reinterpret_borrow<py::object>(value_obj);
     // convert the value to self data type
     if (py::isinstance<py::float_>(value_obj_tmp) ||
         py::isinstance<py::int_>(value_obj_tmp) ||


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

移除 pybind11 弃用方法

参考 pybind/pybind11#464 修改
