### PR TITLE
修改get_logger使用的默认name为paddle

### DIFF
--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -246,7 +246,7 @@ class Pod:
         return r
 
 
-def get_logger(log_level=20, name="root"):
+def get_logger(log_level=20, name="pproot"):
     logger = logging.getLogger(name)
     logger.setLevel(log_level)
 

--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -246,7 +246,7 @@ class Pod:
         return r
 
 
-def get_logger(log_level=20, name="pproot"):
+def get_logger(log_level=20, name="paddle"):
     logger = logging.getLogger(name)
     logger.setLevel(log_level)
 

--- a/python/paddle/distributed/utils/log_utils.py
+++ b/python/paddle/distributed/utils/log_utils.py
@@ -15,7 +15,7 @@
 import logging
 
 
-def get_logger(log_level, name="root"):
+def get_logger(log_level, name="pproot"):
     logger = logging.getLogger(name)
 
     # Avoid printing multiple logs

--- a/python/paddle/distributed/utils/log_utils.py
+++ b/python/paddle/distributed/utils/log_utils.py
@@ -15,7 +15,7 @@
 import logging
 
 
-def get_logger(log_level, name="pproot"):
+def get_logger(log_level, name="paddle"):
     logger = logging.getLogger(name)
 
     # Avoid printing multiple logs


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Change the default name used by logging.getLogger

修改调用logging.getLogger时使用的默认name，参考logging库，使用“root”作为name则相当于所有logger都会生效 会导致引用后上层使用logger重复调用(具体可参考https://github.com/PaddlePaddle/PaddleOCR/issues/13122)


### ps

logging库的实现：
![image](https://github.com/PaddlePaddle/Paddle/assets/17294469/5ed1ead4-955c-49a3-be5d-0e398f987d6a)
![image](https://github.com/PaddlePaddle/Paddle/assets/17294469/4959acc4-46eb-419b-9b9c-fa5c08381b4e)
