### PR TITLE
fix relu bug

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3237,7 +3237,7 @@ struct CudaReluFunctor : public BaseActivationFunctor<T> {
 
   // relu(x) = max(x, 0)
   __device__ __forceinline__ T operator()(const T x) const {
-    return x > zero ? x : zero;
+    return x < zero ? zero : x;
   }
 };
 

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -2668,6 +2668,30 @@ class TestRelu_ZeroDim(TestRelu):
         self.shape = []
 
 
+class TestRelu_NanInput(TestActivation):
+    def setUp(self):
+        self.init_dtype()
+        self.init_shape()
+        self.if_enable_cinn()
+
+        np.random.seed(1024)
+        x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        # The same reason with TestAbs
+        x[np.abs(x) < 0.005] = 0.02
+        x[-1] = float('nan')
+        tensor_x = paddle.to_tensor(x)
+        out = paddle.nn.functional.relu(tensor_x)
+        self.outputs_paddle = out
+
+    def test_check_output(self):
+        self.assertTrue(
+            paddle.isnan(self.outputs_paddle).cast('int32').sum() > 0
+        )
+
+    def test_check_grad(self):
+        pass
+
+
 class TestReluAPI(unittest.TestCase):
     # test paddle.nn.ReLU, paddle.nn.functional.relu
     def setUp(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Others


### PR Types
Bug fixes


### Description
[Fix Bug] The input has 'NAN', but the output of relu do not have 'NAN'.
<img width="551" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/79366697/6eb8d532-71c8-4945-8524-ecc3db62479c">

