### PR TITLE
[Typing][A-60] Add type annotations for `paddle/nn/functional/input.py`

### DIFF
--- a/python/paddle/nn/functional/input.py
+++ b/python/paddle/nn/functional/input.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
+import paddle
 from paddle import _C_ops
 
 from ...base.data_feeder import check_variable_and_dtype
@@ -22,7 +24,11 @@ from ...framework import in_dynamic_or_pir_mode
 __all__ = []
 
 
-def one_hot(x, num_classes, name=None):
+def one_hot(
+    x: paddle.Tensor,
+    num_classes: int,
+    name: str | None = None,
+) -> paddle.Tensor:
     """
 
     The operator converts each id in the input `x` to an one-hot vector with a
@@ -70,7 +76,7 @@ def one_hot(x, num_classes, name=None):
            None by default.
 
     Returns:
-        Tensor: The one-hot representations of `x`. A Tensor with type float32.
+        Tensor, The one-hot representations of `x`. A Tensor with type float32.
 
     Examples:
         .. code-block:: python
@@ -117,7 +123,13 @@ def one_hot(x, num_classes, name=None):
         return one_hot_out
 
 
-def embedding(x, weight, padding_idx=None, sparse=False, name=None):
+def embedding(
+    x: paddle.Tensor,
+    weight: paddle.Tensor,
+    padding_idx: int | None = None,
+    sparse: bool = False,
+    name: str | None = None,
+) -> paddle.Tensor:
     r"""
     Used to lookup embeddings vector of ids provided by :attr:`x` .
 
@@ -157,7 +169,7 @@ def embedding(x, weight, padding_idx=None, sparse=False, name=None):
             True because sparse update is faster. But some optimizers does not support sparse update,
             such as :ref:`api_paddle_optimizer_adadelta_Adadelta` , :ref:`api_paddle_optimizer_adamax_Adamax` , :ref:`api_paddle_optimizer_lamb_Lamb`.
             In these cases, sparse must be False. Default: False.
-        padding_idx(int|long|None, optional): padding_idx needs to be in the interval [-weight.shape[0], weight.shape[0]).
+        padding_idx(int|None, optional): padding_idx needs to be in the interval [-weight.shape[0], weight.shape[0]).
             If :math:`padding\_idx < 0`, the :math:`padding\_idx` will automatically be converted
             to :math:`weight.shape[0] + padding\_idx` . It will output all-zero padding data whenever lookup
             encounters :math:`padding\_idx` in id. And the padding data will not be updated while training.
@@ -167,7 +179,7 @@ def embedding(x, weight, padding_idx=None, sparse=False, name=None):
            None by default.
 
     Returns:
-        Tensor: Embedding Tensor  mapped by x. The data type is the same as :attr:`weight`.
+        Tensor, Embedding Tensor  mapped by x. The data type is the same as :attr:`weight`.
 
     Examples:
 

--- a/python/paddle/nn/functional/input.py
+++ b/python/paddle/nn/functional/input.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 from __future__ import annotations
 
-import paddle
+from typing import TYPE_CHECKING
+
 from paddle import _C_ops
 
 from ...base.data_feeder import check_variable_and_dtype
@@ -21,14 +22,17 @@ from ...base.layer_helper import LayerHelper
 from ...common_ops_import import Variable
 from ...framework import in_dynamic_or_pir_mode
 
+if TYPE_CHECKING:
+    from paddle import Tensor
+
 __all__ = []
 
 
 def one_hot(
-    x: paddle.Tensor,
+    x: Tensor,
     num_classes: int,
     name: str | None = None,
-) -> paddle.Tensor:
+) -> Tensor:
     """
 
     The operator converts each id in the input `x` to an one-hot vector with a
@@ -124,12 +128,12 @@ def one_hot(
 
 
 def embedding(
-    x: paddle.Tensor,
-    weight: paddle.Tensor,
+    x: Tensor,
+    weight: Tensor,
     padding_idx: int | None = None,
     sparse: bool = False,
     name: str | None = None,
-) -> paddle.Tensor:
+) -> Tensor:
     r"""
     Used to lookup embeddings vector of ids provided by :attr:`x` .
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

类型标注：

- nn/functional/input.py

### Related links
 
- https://github.com/PaddlePaddle/Paddle/issues/65008

@SigureMo @megemini 

话说 `long` 在 python3 应该可以视为 `int` 吧？