### PR TITLE
support setting acc_steps for batch_sampler

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -2654,6 +2654,7 @@ class ShardDataloader:
                 shuffle=shuffle,
                 drop_last=drop_last,
             )
+            self.batch_sampler._acc_steps = dataloader.batch_sampler._acc_steps
             self._dataloader = paddle.io.DataLoader(
                 dataset=dataloader.dataset,
                 batch_sampler=self.batch_sampler,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
support setting acc_steps for batch_sampler

For example, DP=2, accumulation_steps=4, per_device_batch_size(mini_batch)=1
The original way of auto_parallel will set `batchsize=per_device_batch_size*accumulation_steps`,
```
per_device_batch_size = 1
dp_world_size = 2
accumulation_steps = 4
sampler = DistributedBatchSampler(dataset, ..., batch_size=per_device_batch_size*accumulation_steps, ...)

The results of input_ids:
card0: [0,1,2,3], [8,9,10,11], ...
card1: [4,5,6,7], [12,13,14,15], ...
```

The new way will set `batchsize=per_device_batch_size, and sampler._acc_steps=accumulation_steps`,
```
per_device_batch_size = 1
dp_world_size = 2
accumulation_steps = 4
sampler = DistributedBatchSampler(dataset, ..., batch_size=per_device_batch_size, ...)
sampler._acc_steps = accumulation_steps

The results of input_ids:
card0: [0,2,4,6], [8,10,12,14], ...
card1: [1,3,5,7], [9,11,13,15], ...
```

The two way are right, but the new way can be consistent with dynamic-hand-parallel. 
So this PR adds it.
Pcard-76459