### PR TITLE
[CINN]Fix pir_to_py_code DumpTensor bug while tensor holder is empty

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pir_to_py_code_converter.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pir_to_py_code_converter.cc
@@ -94,7 +94,7 @@ void VisitFeedName(const pir::Program& program,
 std::optional<std::vector<int64_t>> GetTensorData(
     const phi::DenseTensor& tensor) {
   constexpr int kLimit = 64;
-  if (tensor.numel() > kLimit) return std::nullopt;
+  if (tensor.numel() > kLimit || !tensor.IsInitialized()) return std::nullopt;
   if (tensor.dtype() == phi::DataType::INT64) {
     return phi::GetVectorFromTensor<int64_t>(&tensor);
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复了 DumpTensor时对空Tensor的处理BUG，空Tensor来源可能：
+ 此Tensor的shape包含了0，如XShape 
+ 也可能已经被GC （?）