### PR TITLE
[Cherry-pick][CINN]Delete pybind and PYTHON_LIBRARIES dependency in libcinnapi.so and make it dymanic lookup (#65316)

### DIFF
--- a/cmake/cinn.cmake
+++ b/cmake/cinn.cmake
@@ -164,7 +164,6 @@ cinn_cc_library(
   absl
   isl
   ginac
-  pybind
   op_fusion
   cinn_op_dialect
   ${jitify_deps})
@@ -173,7 +172,12 @@ add_dependencies(cinnapi GEN_LLVM_RUNTIME_IR_HEADER ${core_deps})
 target_link_libraries(cinnapi op_dialect pir phi)
 add_dependencies(cinnapi op_dialect pir phi)
 
-target_link_libraries(cinnapi ${PYTHON_LIBRARIES})
+add_dependencies(cinnapi python)
+if(LINUX)
+  target_link_libraries(cinnapi "-Wl,--unresolved-symbols=ignore-all")
+elseif(APPLE)
+  target_link_libraries(cinnapi "-Wl,-undefined,dynamic_lookup")
+endif()
 
 if(WITH_MKL)
   target_link_libraries(cinnapi cinn_mklml)


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164 