### PR TITLE
[Typing] tensor.prototype.pyi 添加额外的 import 并对 Literal 进行转换

### DIFF
--- a/python/paddle/tensor/tensor.prototype.pyi
+++ b/python/paddle/tensor/tensor.prototype.pyi
@@ -30,6 +30,10 @@ import numpy.typing as npt
 
 import paddle
 from paddle import _typing
+from paddle.base.dygraph.tensor_patch_methods import (
+    TensorHookRemoveHelper,  # noqa: F401
+)
+from paddle.base.param_attr import ParamAttr  # noqa: F401
 
 class Tensor:
     # annotation: ${tensor_docstring}

--- a/python/paddle/tensor/tensor.prototype.pyi
+++ b/python/paddle/tensor/tensor.prototype.pyi
@@ -29,11 +29,13 @@ from typing import Any, Literal, overload
 import numpy.typing as npt
 
 import paddle
-from paddle import _typing
+from paddle import (
+    ParamAttr,  # noqa: F401
+    _typing,
+)
 from paddle.base.dygraph.tensor_patch_methods import (
     TensorHookRemoveHelper,  # noqa: F401
 )
-from paddle.base.param_attr import ParamAttr  # noqa: F401
 
 class Tensor:
     # annotation: ${tensor_docstring}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

- tensor.prototype.pyi 添加额外的 import

  目前不确定什么原因，`ParamAttr` `TensorHookRemoveHelper` 写入签名的时候，没有使用 `paddle.xxx.xxx` 的形式，因此在模板中增加这两个模块

- 修改 `Literal` 

  `"Literal[('raise', 'wrap', 'clip')]"` 转换为 `"Literal['raise', 'wrap', 'clip']"` ，去掉中间的括号。`Literal` 写入签名的时候会有括号，但是 vscode 不能正确解析，所以需要将其去掉 ～

@SigureMo 
