### PR TITLE
[Typing] Disallow generic without type arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,8 @@ check_untyped_defs = true
 follow_imports = "normal"
 # Miscellaneous
 warn_unused_configs = true
+# Disallow generic without type arguments
+disallow_any_generics = true
 # Configuring warnings
 warn_redundant_casts = true
 warn_unused_ignores = true


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

当类型提示中存在泛型时，不允许不指定泛型参数，即便指定为 `Any`，使用 mypy `disallow_any_generics`[^1] 强制规避（这条规则的名字有点奇怪，事实上只是不允许不指定泛型参数，但泛型参数写 `Any` 是允许的，比如 `list` 会挂掉，`list[Any]` 是允许的，刚好满足需求）

@megemini 

PCard-66972

[^1]: https://mypy.readthedocs.io/en/stable/config_file.html#confval-disallow_any_generics