### PR TITLE
delete useless cinn shell code

### DIFF
--- a/tools/cinn/build.sh
+++ b/tools/cinn/build.sh
@@ -41,17 +41,6 @@ function onednn_off {
   onednn_config=OFF
 }
 
-
-function gpu_on {
-  cinn_whl_path=python/dist/cinn_gpu-0.0.0-py3-none-any.whl
-  cuda_config=ON
-  cudnn_config=ON
-}
-
-function cudnn_off {
-  cudnn_config=OFF
-}
-
 set +x
 OLD_HTTP_PROXY=$http_proxy &> /dev/null
 OLD_HTTPS_PROXY=$https_proxy &> /dev/null
@@ -169,19 +158,6 @@ function run_test {
     fi
 }
 
-function CI {
-    mkdir -p $build_dir
-    cd $build_dir
-    export runtime_include_dir=$workspace/paddle/cinn/runtime/cuda
-
-    prepare_ci
-    cmake_
-    build
-    run_demo
-    prepare_model
-    run_test
-}
-
 function CINNRT {
     mkdir -p $build_dir
     cd $build_dir
@@ -211,14 +187,6 @@ function main {
                 onednn_off
                 shift
                 ;;
-            gpu_on)
-                gpu_on
-                shift
-                ;;
-            cudnn_off)
-                cudnn_off
-                shift
-                ;;
             check_style)
                 codestyle_check
                 shift
@@ -233,10 +201,6 @@ function main {
                 ;;
             test)
                 run_test
-                shift
-                ;;
-            ci)
-                CI
                 shift
                 ;;
             CINNRT)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others
### Description
<!-- Describe what you’ve done -->
因为CI下掉了PR-CI-GPU-CUDNN-OFF和PR-CI-CINN-X86，所以删除对应的单测脚本
pcard-76996