### PR TITLE
[XPU] fix flash_attn_unpadded on kl2

### DIFF
--- a/paddle/phi/kernels/xpu/flash_attn_kernel.cc
+++ b/paddle/phi/kernels/xpu/flash_attn_kernel.cc
@@ -43,7 +43,6 @@ void FlashAttnUnpaddedKernel(
     DenseTensor* softmax,
     DenseTensor* softmax_lse,
     DenseTensor* seed_offset) {
-#ifdef PADDLE_WITH_XPU_XRE5
   xpu::ctx_guard RAII_GUARD(ctx.x_context());
   // q, k, v [batch_size * seq_len, num_heads, head_dim]
   std::vector<int64_t> dims = common::vectorize(q.dims());
@@ -170,10 +169,6 @@ void FlashAttnUnpaddedKernel(
         nullptr);
     PADDLE_ENFORCE_EQ(r, 0, "xpu::qk_v_attention failed.");
   }
-#else
-  PADDLE_THROW(phi::errors::Unimplemented(
-      "re-compile using -DWITH_XPU_XRE5=ON to use FlashAttnUnpaddedKernel"));
-#endif
 }
 
 template <typename T, typename Context>


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
在之前的 https://github.com/PaddlePaddle/Paddle/pull/65221 中，错误地将`FlashAttnUnpaddedKernel`也包在了`PADDLE_WITH_XPU_XRE5`宏定义里面，导致在KL2下面这个算子会被跳过。本PR修复了此问题。

感谢 @runzhech 指出。