### PR TITLE
【Inference】Fix fused_flash_attn_pass bug

### DIFF
--- a/paddle/fluid/pir/transforms/gpu/fused_flash_attn_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_flash_attn_pass.cc
@@ -139,9 +139,8 @@ class FlashAttnPatternQscaleWithMask : public paddle::drr::DrrPatternBase {
       }
       // mask's shape [bs, 1, seq_len, seq_len]
       auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
-      auto q_shape = pir::GetShapeFromValue(match_ctx.Tensor("q"));
       if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
-          mask_add.at(0) != q_shape.at(0)) {
+          mask_add.at(0) != q.at(0)) {
         return false;
       }
 
@@ -287,9 +286,8 @@ class FlashAttnPatternOutscaleWithMask : public paddle::drr::DrrPatternBase {
       }
       // mask's shape [bs, 1, seq_len, seq_len]
       auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
-      auto q_shape = pir::GetShapeFromValue(match_ctx.Tensor("q"));
       if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
-          mask_add.at(0) != q_shape.at(0)) {
+          mask_add.at(0) != q.at(0)) {
         return false;
       }
 
@@ -561,9 +559,8 @@ class TransposeSliceFlashAttnPattern : public paddle::drr::DrrPatternBase {
       }
       // mask's shape [bs, 1, seq_len, seq_len]
       auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
-      auto q_shape = pir::GetShapeFromValue(match_ctx.Tensor("q"));
       if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
-          mask_add.at(0) != q_shape.at(0)) {
+          mask_add.at(0) != q.at(0)) {
         return false;
       }
 

--- a/paddle/fluid/pir/transforms/gpu/fused_flash_attn_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_flash_attn_pass.cc
@@ -139,7 +139,9 @@ class FlashAttnPatternQscaleWithMask : public paddle::drr::DrrPatternBase {
       }
       // mask's shape [bs, 1, seq_len, seq_len]
       auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
-      if (mask_add.size() != 4 || mask_add.at(1) != 1 || mask_add.at(0) != -1) {
+      auto q_shape = pir::GetShapeFromValue(match_ctx.Tensor("q"));
+      if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
+          mask_add.at(0) != q_shape.at(0)) {
         return false;
       }
 
@@ -285,7 +287,9 @@ class FlashAttnPatternOutscaleWithMask : public paddle::drr::DrrPatternBase {
       }
       // mask's shape [bs, 1, seq_len, seq_len]
       auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
-      if (mask_add.size() != 4 || mask_add.at(1) != 1 || mask_add.at(0) != -1) {
+      auto q_shape = pir::GetShapeFromValue(match_ctx.Tensor("q"));
+      if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
+          mask_add.at(0) != q_shape.at(0)) {
         return false;
       }
 
@@ -504,6 +508,7 @@ class TransposeSliceFlashAttnPattern : public paddle::drr::DrrPatternBase {
 
     // mask
     const auto &mask_add = src.Op("pd_op.add");
+
     src.Tensor("mask_add_out") =
         mask_add(src.Tensor("qk_scale_out"), src.Tensor("mask"));
 
@@ -556,7 +561,9 @@ class TransposeSliceFlashAttnPattern : public paddle::drr::DrrPatternBase {
       }
       // mask's shape [bs, 1, seq_len, seq_len]
       auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
-      if (mask_add.size() != 4 || mask_add.at(1) != 1 || mask_add.at(0) != -1) {
+      auto q_shape = pir::GetShapeFromValue(match_ctx.Tensor("q"));
+      if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
+          mask_add.at(0) != q_shape.at(0)) {
         return false;
       }
 

--- a/paddle/fluid/pir/transforms/gpu/fused_flash_attn_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_flash_attn_pass.cc
@@ -140,7 +140,7 @@ class FlashAttnPatternQscaleWithMask : public paddle::drr::DrrPatternBase {
       // mask's shape [bs, 1, seq_len, seq_len]
       auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
       if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
-          mask_add.at(0) != q.at(0)) {
+          mask_add.at(0) != q_transpose_out.at(0)) {
         return false;
       }
 
@@ -287,7 +287,7 @@ class FlashAttnPatternOutscaleWithMask : public paddle::drr::DrrPatternBase {
       // mask's shape [bs, 1, seq_len, seq_len]
       auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
       if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
-          mask_add.at(0) != q.at(0)) {
+          mask_add.at(0) != q_transpose_out.at(0)) {
         return false;
       }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
card-71500
修复了test_fused_flash_attn_pass.py单侧没匹配上fused_flash_attn_pass的bug