### PR TITLE
Add code owners for collective directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 # Code owners are expected to take responsibility for review patches to respective file.
 
 /CMakeLists.txt @wanghuancoder @Aurelius84 @XiaoguangHu01 @qili93
+paddle/fluid/distributed/collective @sneaxiy @ForFishes
 paddle/fluid/eager/autograd_meta.cc @JiabinYang @phlrain
 paddle/fluid/eager/autograd_meta.h @JiabinYang @phlrain
 paddle/fluid/eager/backward.cc @JiabinYang @phlrain


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Others

### PR Types
Others

### Description
Add CODEOWNERS for collective communication library.

Pcard-67164