### PR TITLE
[AutoParallel] Add dist_stack and gather_nd spmd rule

### DIFF
--- a/paddle/phi/core/distributed/auto_parallel/inferspmd_utils.cc
+++ b/paddle/phi/core/distributed/auto_parallel/inferspmd_utils.cc
@@ -17,6 +17,17 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 
+InferSpmdContext::InferSpmdContext(
+    paddle::small_vector<DistMetaTensor, phi::kInputSmallVectorSize> inputs,
+    paddle::small_vector<Attribute, phi::kAttrSmallVectorSize> attrs) {
+  for (size_t i = 0; i < inputs.size(); i++) {
+    EmplaceBackInput(inputs[i]);
+  }
+  for (size_t i = 0; i < attrs.size(); i++) {
+    EmplaceBackAttr(attrs[i]);
+  }
+}
+
 void InferSpmdContext::EmplaceBackInput(DistMetaTensor input) {
   int index = static_cast<int>(inputs_.size());
   inputs_.emplace_back(std::move(input));

--- a/paddle/phi/core/distributed/auto_parallel/inferspmd_utils.h
+++ b/paddle/phi/core/distributed/auto_parallel/inferspmd_utils.h
@@ -40,8 +40,7 @@ class InferSpmdContext {
   InferSpmdContext() = default;
   InferSpmdContext(
       paddle::small_vector<DistMetaTensor, phi::kInputSmallVectorSize> inputs,
-      paddle::small_vector<Attribute, phi::kAttrSmallVectorSize> attrs)
-      : inputs_(std::move(inputs)), attrs_(std::move(attrs)) {}
+      paddle::small_vector<Attribute, phi::kAttrSmallVectorSize> attrs);
 
   void EmplaceBackInput(DistMetaTensor input);
   void EmplaceBackAttr(Attribute attr);

--- a/paddle/phi/core/distributed/auto_parallel/inferspmd_utils.h
+++ b/paddle/phi/core/distributed/auto_parallel/inferspmd_utils.h
@@ -101,7 +101,7 @@ struct InferSpmdFnImpl<Return (*)(Args...), infer_spmd_fn> {
       static_assert(attr_idx == 0,
                     "InferSpmd's Input should appear before Attributes.");
       const std::pair<int, int> range = ctx.InputRangeAt(range.first);
-      const DistMetaTensor& arg = ctx.InputAt(in_idx);
+      const DistMetaTensor& arg = ctx.InputAt(range.first);
       return InferSpmdFnCallHelper<Tail...>::template Call<in_idx + 1,
                                                            attr_idx>(
           ctx, pargs..., arg);

--- a/paddle/phi/core/distributed/auto_parallel/inferspmd_utils.h
+++ b/paddle/phi/core/distributed/auto_parallel/inferspmd_utils.h
@@ -100,6 +100,7 @@ struct InferSpmdFnImpl<Return (*)(Args...), infer_spmd_fn> {
     static SpmdInfo Call(const InferSpmdContext& ctx, PreviousArgs&... pargs) {
       static_assert(attr_idx == 0,
                     "InferSpmd's Input should appear before Attributes.");
+      const std::pair<int, int> range = ctx.InputRangeAt(range.first);
       const DistMetaTensor& arg = ctx.InputAt(in_idx);
       return InferSpmdFnCallHelper<Tail...>::template Call<in_idx + 1,
                                                            attr_idx>(

--- a/paddle/phi/core/distributed/auto_parallel/inferspmd_utils.h
+++ b/paddle/phi/core/distributed/auto_parallel/inferspmd_utils.h
@@ -100,7 +100,7 @@ struct InferSpmdFnImpl<Return (*)(Args...), infer_spmd_fn> {
     static SpmdInfo Call(const InferSpmdContext& ctx, PreviousArgs&... pargs) {
       static_assert(attr_idx == 0,
                     "InferSpmd's Input should appear before Attributes.");
-      const std::pair<int, int> range = ctx.InputRangeAt(range.first);
+      const std::pair<int, int> range = ctx.InputRangeAt(in_idx);
       const DistMetaTensor& arg = ctx.InputAt(range.first);
       return InferSpmdFnCallHelper<Tail...>::template Call<in_idx + 1,
                                                            attr_idx>(

--- a/paddle/phi/infermeta/spmd_rules/gather_nd.cc
+++ b/paddle/phi/infermeta/spmd_rules/gather_nd.cc
@@ -37,7 +37,7 @@ SpmdInfo GatherNdInferSpmd(const DistMetaTensor& x,
   std::vector<int64_t> x_dims_mapping(x_dims_mapping_src);
   std::vector<int64_t> index_dims_mapping(index_dims_mapping_src);
 
-  int index_axis = index_shape[index_shape.size() - 1];
+  int index_axis = index_shape[index_ndim - 1];
   index_dims_mapping[index_ndim - 1] = -1;
 
   for (int axis = 0; axis < index_axis; axis++) {

--- a/paddle/phi/infermeta/spmd_rules/gather_nd.cc
+++ b/paddle/phi/infermeta/spmd_rules/gather_nd.cc
@@ -37,18 +37,18 @@ SpmdInfo GatherNdInferSpmd(const DistMetaTensor& x,
   std::vector<int64_t> x_dims_mapping(x_dims_mapping_src);
   std::vector<int64_t> index_dims_mapping(index_dims_mapping_src);
 
-  int64_t index_axis = index_shape[index_shape.size() - 1];
-  index_dims_mapping[index_dims_mapping.size() - 1] = -1;
+  int index_axis = index_shape[index_shape.size() - 1];
+  index_dims_mapping[index_ndim - 1] = -1;
 
-  for (size_t axis = 0; axis < index_axis; axis++) {
+  for (int axis = 0; axis < index_axis; axis++) {
     x_dims_mapping[axis] = -1;
   }
 
   std::vector<int64_t> out_dims_mapping;
-  for (int i = 0; i < index_dims_mapping.size() - 1; ++i) {
+  for (int i = 0; i < index_ndim - 1; ++i) {
     out_dims_mapping.emplace_back(index_dims_mapping[i]);
   }
-  for (int64_t i = index_axis; i < x_dims_mapping.size(); ++i) {
+  for (int i = index_axis; i < x_ndim; ++i) {
     out_dims_mapping.emplace_back(x_dims_mapping[i]);
   }
 
@@ -59,13 +59,11 @@ SpmdInfo GatherNdInferSpmd(const DistMetaTensor& x,
       CopyTensorDistAttrForOutput(index_dist_attr_src);
   index_dist_attr_dst.set_dims_mapping(index_dims_mapping);
 
-  const std::vector<int64_t> out_shape;
-  for (int i = 0; i < index_shape.size() - 1; ++i) {
+  std::vector<int64_t> out_shape;
+  for (int i = 0; i < index_ndim - 1; ++i) {
     out_shape.emplace_back(index_shape[i]);
   }
-  for (int i = static_cast<int>(index_shape[index_shape.size() - 1]);
-       i < x_shape.size();
-       ++i) {
+  for (int i = static_cast<int>(index_shape[index_ndim - 1]); i < x_ndim; ++i) {
     out_shape.emplace_back(x_shape[i]);
   }
 
@@ -93,16 +91,16 @@ SpmdInfo GatherNdInferSpmdReverse(const DistMetaTensor& x,
   std::vector<int64_t> index_dims_mapping(index_dims_mapping_src);
   std::vector<int64_t> out_dims_mapping(out_dims_mapping_src);
 
-  for (int64_t axis = 0; axis < index_ndim - 1; ++axis) {
+  for (int axis = 0; axis < index_ndim - 1; ++axis) {
     index_dims_mapping[axis] = out_dims_mapping[axis];
   }
   index_dims_mapping[index_ndim - 1] = -1;
 
-  int64_t index_axis = index_shape[index_ndim - 1];
-  for (size_t axis = 0; axis < index_axis; axis++) {
+  int index_axis = index_shape[index_ndim - 1];
+  for (int axis = 0; axis < index_axis; axis++) {
     x_dims_mapping[axis] = -1;
   }
-  for (size_t axis = x_ndim - 1; axis >= index_axis; axis--) {
+  for (int axis = x_ndim - 1; axis >= index_axis; axis--) {
     x_dims_mapping[axis] = out_dims_mapping[out_ndim + (axis - x_ndim)];
   }
 

--- a/paddle/phi/infermeta/spmd_rules/gather_nd.cc
+++ b/paddle/phi/infermeta/spmd_rules/gather_nd.cc
@@ -1,0 +1,122 @@
+/* Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/phi/infermeta/spmd_rules/gather_nd.h"
+
+#include "glog/logging.h"
+
+#include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
+#include "paddle/phi/core/distributed/auto_parallel/inferspmd_utils.h"
+#include "paddle/phi/core/distributed/auto_parallel/utils.h"
+#include "paddle/phi/infermeta/spmd_rules/spmd_rule_macro_define.h"
+#include "paddle/phi/infermeta/spmd_rules/utils.h"
+
+namespace phi::distributed {
+
+using phi::distributed::auto_parallel::str_join;
+
+SpmdInfo GatherNdInferSpmd(const DistMetaTensor& x,
+                           const DistMetaTensor& index) {
+  // Step0: Verify Input Args Based on Gather Logic
+  // extract and check x_ndim, x_shape, x_dist_attr_src and
+  // x_dims_mapping_src with the macro
+  EXTRACT_SHAPE_AND_DIST_ATTR(x);
+  EXTRACT_SHAPE_AND_DIST_ATTR(index);
+
+  std::vector<int64_t> x_dims_mapping(x_dims_mapping_src);
+  std::vector<int64_t> index_dims_mapping(index_dims_mapping_src);
+
+  int64_t index_axis = index_shape[index_shape.size() - 1];
+  index_dims_mapping[index_dims_mapping.size() - 1] = -1;
+
+  for (size_t axis = 0; axis < index_axis; axis++) {
+    x_dims_mapping[axis] = -1;
+  }
+
+  std::vector<int64_t> out_dims_mapping;
+  for (int i = 0; i < index_dims_mapping.size() - 1; ++i) {
+    out_dims_mapping.emplace_back(index_dims_mapping[i]);
+  }
+  for (int64_t i = index_axis; i < x_dims_mapping.size(); ++i) {
+    out_dims_mapping.emplace_back(x_dims_mapping[i]);
+  }
+
+  TensorDistAttr x_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  x_dist_attr_dst.set_dims_mapping(x_dims_mapping);
+
+  TensorDistAttr index_dist_attr_dst =
+      CopyTensorDistAttrForOutput(index_dist_attr_src);
+  index_dist_attr_dst.set_dims_mapping(index_dims_mapping);
+
+  const std::vector<int64_t> out_shape;
+  for (int i = 0; i < index_shape.size() - 1; ++i) {
+    out_shape.emplace_back(index_shape[i]);
+  }
+  for (int i = static_cast<int>(index_shape[index_shape.size() - 1]);
+       i < x_shape.size();
+       ++i) {
+    out_shape.emplace_back(x_shape[i]);
+  }
+
+  TensorDistAttr out_dist_attr = TensorDistAttr(out_shape);
+  out_dist_attr.set_dims_mapping(out_dims_mapping);
+
+  LOG_SPMD_INPUT(x);
+  LOG_SPMD_INPUT(index);
+  VLOG(4) << "out";
+  VLOG(4) << "dist_attr: [" << out_dist_attr.to_string() << "]";
+  return {{x_dist_attr_dst, index_dist_attr_dst}, {out_dist_attr}};
+}
+
+SpmdInfo GatherNdInferSpmdReverse(const DistMetaTensor& x,
+                                  const DistMetaTensor& index,
+                                  const DistMetaTensor& out) {
+  // Step0: Verify Input Args Based on Gather Logic
+  // extract and check out_ndim, out_shape, out_dist_attr_src and
+  // out_dims_mapping_src with the macro
+  EXTRACT_SHAPE_AND_DIST_ATTR(x);
+  EXTRACT_SHAPE_AND_DIST_ATTR(index);
+  EXTRACT_SHAPE_AND_DIST_ATTR(out);
+
+  std::vector<int64_t> x_dims_mapping(x_dims_mapping_src);
+  std::vector<int64_t> index_dims_mapping(index_dims_mapping_src);
+  std::vector<int64_t> out_dims_mapping(out_dims_mapping_src);
+
+  for (int64_t axis = 0; axis < index_ndim - 1; ++axis) {
+    index_dims_mapping[axis] = out_dims_mapping[axis];
+  }
+  index_dims_mapping[index_ndim - 1] = -1;
+
+  int64_t index_axis = index_shape[index_ndim - 1];
+  for (size_t axis = 0; axis < index_axis; axis++) {
+    x_dims_mapping[axis] = -1;
+  }
+  for (size_t axis = x_ndim - 1; axis >= index_axis; axis--) {
+    x_dims_mapping[axis] = out_dims_mapping[out_ndim + (axis - x_ndim)];
+  }
+
+  TensorDistAttr x_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  x_dist_attr_dst.set_dims_mapping(x_dims_mapping);
+  TensorDistAttr index_dist_attr_dst =
+      CopyTensorDistAttrForOutput(index_dist_attr_src);
+  index_dist_attr_dst.set_dims_mapping(index_dims_mapping);
+
+  VLOG(4) << "out dist_attr: [" << out_dist_attr_src.to_string() << "]";
+  LOG_SPMD_INPUT(x);
+  LOG_SPMD_INPUT(index);
+  VLOG(4) << std::endl;
+  return {{x_dist_attr_dst, index_dist_attr_dst}, {out_dist_attr_src}};
+}
+
+}  // namespace phi::distributed

--- a/paddle/phi/infermeta/spmd_rules/gather_nd.h
+++ b/paddle/phi/infermeta/spmd_rules/gather_nd.h
@@ -1,0 +1,33 @@
+/* Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <vector>
+
+#include "paddle/phi/common/scalar.h"
+#include "paddle/phi/core/distributed/auto_parallel/dist_meta_tensor.h"
+#include "paddle/phi/core/distributed/type_defs.h"
+
+namespace phi {
+namespace distributed {
+SpmdInfo GatherNdInferSpmd(const DistMetaTensor& x,
+                           const DistMetaTensor& index);
+
+SpmdInfo GatherNdInferSpmdReverse(const DistMetaTensor& x,
+                                  const DistMetaTensor& index,
+                                  const DistMetaTensor& out);
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -651,6 +651,11 @@ PD_REGISTER_SPMD_RULE(
     PD_INFER_SPMD(phi::distributed::GatherInferSpmdBase),
     PD_INFER_SPMD(phi::distributed::GatherInferSpmdReverseBase));
 
+PD_REGISTER_SPMD_RULE(
+    gather_nd,
+    PD_INFER_SPMD(phi::distributed::GatherNdInferSpmd),
+    PD_INFER_SPMD(phi::distributed::GatherNdInferSpmdReverse));
+
 // one_hot
 PD_REGISTER_SPMD_RULE(one_hot,
                       PD_INFER_SPMD(phi::distributed::OneHotInferSpmd),

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -572,6 +572,10 @@ PD_REGISTER_SPMD_RULE(concat,
                       PD_INFER_SPMD(phi::distributed::ConcatInferSpmd),
                       PD_INFER_SPMD(phi::distributed::ConcatInferSpmdReverse));
 
+PD_REGISTER_SPMD_RULE(stack,
+                      PD_INFER_SPMD(phi::distributed::StackInferSpmd),
+                      PD_INFER_SPMD(phi::distributed::StackInferSpmdReverse));
+
 // transpose rule
 PD_REGISTER_SPMD_RULE(
     transpose,

--- a/paddle/phi/infermeta/spmd_rules/rules.h
+++ b/paddle/phi/infermeta/spmd_rules/rules.h
@@ -30,6 +30,7 @@ limitations under the License. */
 #include "paddle/phi/infermeta/spmd_rules/fused_linear_param_grad_add.h"
 #include "paddle/phi/infermeta/spmd_rules/fused_rope.h"
 #include "paddle/phi/infermeta/spmd_rules/gather.h"
+#include "paddle/phi/infermeta/spmd_rules/gather_nd.h"
 #include "paddle/phi/infermeta/spmd_rules/layer_norm.h"
 #include "paddle/phi/infermeta/spmd_rules/matmul.h"
 #include "paddle/phi/infermeta/spmd_rules/numel.h"

--- a/python/paddle/distributed/auto_parallel/static/completion.py
+++ b/python/paddle/distributed/auto_parallel/static/completion.py
@@ -188,6 +188,7 @@ def _can_apply_infer_spmd_rule(dist_op):
         "fused_rms_norm",
         "strided_slice",
         "stack",
+        "gather_nd",
     ]
     parallel_ce = os.getenv("PARALLEL_CROSS_ENTROPY")
     if parallel_ce == "true":

--- a/python/paddle/distributed/auto_parallel/static/completion.py
+++ b/python/paddle/distributed/auto_parallel/static/completion.py
@@ -187,6 +187,7 @@ def _can_apply_infer_spmd_rule(dist_op):
         "tile",
         "fused_rms_norm",
         "strided_slice",
+        "stack",
     ]
     parallel_ce = os.getenv("PARALLEL_CROSS_ENTROPY")
     if parallel_ce == "true":

--- a/python/paddle/distributed/auto_parallel/static/operators/__init__.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/__init__.py
@@ -39,6 +39,7 @@ from . import (  # noqa: F401
     dist_slice,
     dist_softmax,
     dist_split,
+    dist_stack,
     dist_strided_slice,
     dist_tile,
     dist_transpose,

--- a/python/paddle/distributed/auto_parallel/static/operators/__init__.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/__init__.py
@@ -29,6 +29,7 @@ from . import (  # noqa: F401
     dist_fused_feedforward,
     dist_fused_rms_norm,
     dist_fused_rope,
+    dist_gather_nd,
     dist_layer_norm,
     dist_matmul,
     dist_pnorm,

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_gather_nd.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_gather_nd.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+from ..completion import get_phi_spmd_rule
+from ..utils import get_dist_tensor_spec
+from .common import (
+    DistributedOperatorImplContainer,
+    get_default_distributed_operator_impl,
+    register_distributed_operator_impl_container,
+    update_op_dims_mapping,
+)
+
+
+class DistributedGatherNd(DistributedOperatorImplContainer):
+    def __init__(self, op_type):
+        super().__init__(op_type)
+
+    @staticmethod
+    def update_dims_mapping(dist_op):
+        # step1: prepare inputs need for rule (order args as PHI definition and filter out unnecessary args)
+        op_desc = dist_op.serial_op.desc
+
+        x_name = op_desc.input('X')[0]
+        index_name = op_desc.input('Index')[0]
+        out_name = op_desc.output('Out')[0]
+
+        x_specs = get_dist_tensor_spec(dist_op, x_name)
+        index_specs = get_dist_tensor_spec(dist_op, index_name)
+        output_spec = get_dist_tensor_spec(dist_op, out_name, False)
+
+        # step2: infer spmd
+        rule = get_phi_spmd_rule("gather_nd")
+        # tensor order following order in PHI definition
+        fw_results = rule.infer_forward(x_specs, index_specs)
+        bw_results = rule.infer_backward(x_specs, index_specs, output_spec)
+
+        # step3: update dist_attr
+        # tensor order following order in PHI definition
+        changed = update_op_dims_mapping(
+            dist_op,
+            [x_name, index_name],
+            [out_name],
+            fw_results,
+            bw_results,
+        )
+
+        return changed
+
+    @staticmethod
+    def mapping_to_dist_operator_impl(dist_op, original_op_dist_attr):
+        op_dist_attr = dist_op.dist_attr
+        default_impl = get_default_distributed_operator_impl()
+        op_dist_attr.impl_type = default_impl.type
+        op_dist_attr.impl_idx = default_impl.idx
+
+        return False
+
+
+register_distributed_operator_impl_container(DistributedGatherNd("gather_nd"))

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_stack.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_stack.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+from ..completion import get_phi_spmd_rule
+from ..utils import get_dist_tensor_spec
+from .common import (
+    DistributedOperatorImplContainer,
+    get_default_distributed_operator_impl,
+    register_distributed_operator_impl_container,
+    update_op_dims_mapping,
+)
+
+
+class DistributedStack(DistributedOperatorImplContainer):
+    def __init__(self, op_type):
+        super().__init__(op_type)
+
+    @staticmethod
+    def update_dims_mapping(dist_op):
+        # step1: prepare inputs need for rule (order args as PHI definition and filter out unnecessary args)
+        op_desc = dist_op.serial_op.desc
+
+        input_arg_names = op_desc.input_arg_names()
+        output_arg_names = op_desc.output_arg_names()
+        axis = op_desc.attr('axis')
+
+        input_specs = []
+        for name in input_arg_names:
+            input_specs.append(get_dist_tensor_spec(dist_op, name))
+        output_spec = get_dist_tensor_spec(dist_op, output_arg_names[0], False)
+
+        # step2: infer spmd
+        rule = get_phi_spmd_rule("stack")
+        # tensor order following order in PHI definition
+        fw_results = rule.infer_forward(input_specs, axis)
+        bw_results = rule.infer_backward(output_spec, axis)
+
+        # step3: update dist_attr
+        # tensor order following order in PHI definition
+        changed = update_op_dims_mapping(
+            dist_op,
+            input_arg_names,
+            output_arg_names,
+            fw_results,
+            bw_results,
+        )
+
+        return changed
+
+    @staticmethod
+    def mapping_to_dist_operator_impl(dist_op, original_op_dist_attr):
+        op_dist_attr = dist_op.dist_attr
+        default_impl = get_default_distributed_operator_impl()
+        op_dist_attr.impl_type = default_impl.type
+        op_dist_attr.impl_idx = default_impl.idx
+
+        return False
+
+
+register_distributed_operator_impl_container(DistributedStack("stack"))

--- a/test/auto_parallel/spmd_rules/CMakeLists.txt
+++ b/test/auto_parallel/spmd_rules/CMakeLists.txt
@@ -35,6 +35,8 @@ if(WITH_DISTRIBUTE)
   py_test_modules(test_cumsum_rule MODULES test_cumsum_rule)
   py_test_modules(test_argmax_rule MODULES test_argmax_rule)
   py_test_modules(test_unbind_rule MODULES test_unbind_rule)
+  py_test_modules(test_stack_rule MODULES test_stack_rule)
+  py_test_modules(test_gather_nd_rule MODULES test_gather_nd_rule)
   # End of unittests WITH single card WITHOUT timeout
 
 endif()

--- a/test/auto_parallel/spmd_rules/test_gather_nd_rule.py
+++ b/test/auto_parallel/spmd_rules/test_gather_nd_rule.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from paddle.distributed.auto_parallel.static.dist_attribute import (
+    DistTensorSpec,
+    TensorDistAttr,
+)
+from paddle.distributed.fleet import auto
+from paddle.framework import core
+
+
+class TestGatherNdSPMDRule(unittest.TestCase):
+    """
+    Unit tests for gather_nd spmd rule.
+    """
+
+    def setUp(self):
+        x_shape = [10, 20]
+        index_shape = [2, 4, 1]
+        self.process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2, 3], [4, 5, 6, 7]])
+        self.rule = core.get_phi_spmd_rule("gather_nd")
+
+        x_dist_attr = TensorDistAttr()
+        x_dist_attr.dims_mapping = [-1, -1]
+        x_dist_attr.process_mesh = self.process_mesh
+        self.x_spec = DistTensorSpec(x_shape, x_dist_attr)
+
+        index_dist_attr = TensorDistAttr()
+        index_dist_attr.dims_mapping = [0, -1, -1]
+        index_dist_attr.process_mesh = self.process_mesh
+        self.index_spec = DistTensorSpec(index_shape, index_dist_attr)
+
+    def test_forward_mesh_dim(self):
+        # dims_mapping: [-1, -1], [0, -1, -1] --> [0, -1, -1]
+        self.x_spec.set_dims_mapping([-1, -1])
+        self.index_spec.set_dims_mapping([0, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_spec, self.index_spec
+        )
+
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+
+    def test_reverse_mesh_dim(self):
+        self.x_spec.set_process_mesh(self.process_mesh)
+        self.index_spec.set_process_mesh(self.process_mesh)
+
+        out_shape = [2, 4, 20]
+        out_dist_attr = TensorDistAttr()
+        out_dist_attr.dims_mapping = [0, -1, -1]
+        out_dist_attr.process_mesh = self.process_mesh
+        self.out_spec = DistTensorSpec(out_shape, out_dist_attr)
+
+        # axis = 1
+        # [0, -1, -1] --> [-1, -1], [0, -1, -1]
+        result_dist_attrs = self.rule.infer_backward(
+            self.x_spec,
+            self.index_spec,
+            self.out_spec,
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/auto_parallel/spmd_rules/test_stack_rule.py
+++ b/test/auto_parallel/spmd_rules/test_stack_rule.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from paddle.distributed.auto_parallel.static.dist_attribute import (
+    DistTensorSpec,
+    TensorDistAttr,
+)
+from paddle.distributed.fleet import auto
+from paddle.framework import core
+
+
+class TestStackSPMDRule(unittest.TestCase):
+    """
+    Unit tests for split spmd rule.
+    """
+
+    def setUp(self):
+        self.process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2, 3], [4, 5, 6, 7]])
+        self.shapes = [[2, 4], [2, 4]]
+        self.dim_mappings = [[0, -1], [0, -1]]
+
+    def build_inputs(self):
+        inputs = []
+        for shape, dim_mapping in zip(self.shapes, self.dim_mappings):
+            tensor_dist_attr = TensorDistAttr()
+            tensor_dist_attr.dims_mapping = dim_mapping
+            tensor_dist_attr.process_mesh = self.process_mesh
+            inputs.append(DistTensorSpec(shape, tensor_dist_attr))
+        return inputs
+
+    def build_outputs(self):
+        tensor_dist_attr = TensorDistAttr()
+        tensor_dist_attr.dims_mapping = [0, -1, -1]
+        tensor_dist_attr.process_mesh = self.process_mesh
+        return DistTensorSpec([2, 4, 2], tensor_dist_attr)
+
+    def test_infer_forward(self):
+        inputs = self.build_inputs()
+        rule = core.get_phi_spmd_rule("stack")
+        infered_dist_attrs = rule.infer_forward(inputs, -1)
+
+        infered_output_dist_attrs = infered_dist_attrs[1]
+        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+
+    def test_infer_backward(self):
+        inputs = self.build_inputs()
+        output = self.build_outputs()
+        rule = core.get_phi_spmd_rule("stack")
+        infered_dist_attrs = rule.infer_backward(inputs, output, -1)
+
+        infered_input_dist_attrs = infered_dist_attrs[0]
+        self.assertEqual(len(infered_input_dist_attrs), 1)
+        for input_dist_attr in infered_input_dist_attrs[0]:
+            self.assertEqual(input_dist_attr.dims_mapping, [0, -1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Add dist_stack and gather_nd spmd rule. 
Fix InferSpmdFnCallHelper bug when first input of spmd function is a vector<DistMetaTensor>.
Pcard-73145
