### PR TITLE
[CINN] Fix bug of split_generate_shape_op

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/split_generate_shape_into_shape_ops_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/split_generate_shape_into_shape_ops_pass.cc
@@ -372,9 +372,35 @@ pir::Value GetValueOfRewrittenOps(const std::vector<symbol::DimExpr>& dim_exprs,
   const std::vector<pir::Value>& values_from_dim_exprs =
       GetValuesOfRewrittenOps(dim_exprs, converter);
   if (values_from_dim_exprs.size() == 1) return values_from_dim_exprs.at(0);
-  pir::Value vec =
-      converter->rewriter->Build<pir::CombineOp>(values_from_dim_exprs).out();
-  return converter->rewriter->Build<paddle::dialect::ConcatOp>(vec).out();
+
+  auto IsZeroDim = [](const pir::Value& value) {
+    return value.type()
+               .dyn_cast<paddle::dialect::DenseTensorType>()
+               .dims()
+               .size() == 0;
+  };
+  pir::Value combine_values = [&] {
+    const int zero_dim_value_count = std::count_if(
+        values_from_dim_exprs.begin(), values_from_dim_exprs.end(), IsZeroDim);
+    if (zero_dim_value_count != 0 &&
+        zero_dim_value_count != values_from_dim_exprs.size()) {
+      std::vector<pir::Value> new_values = values_from_dim_exprs;
+      for (size_t i = 0; i < new_values.size(); ++i) {
+        if (IsZeroDim(new_values[i])) {
+          new_values[i] = converter->rewriter
+                              ->Build<paddle::dialect::ReshapeOp>(
+                                  new_values[i], std::vector<int64_t>{1})
+                              .out();
+        }
+      }
+      return converter->rewriter->Build<pir::CombineOp>(new_values).out();
+    }
+    return converter->rewriter->Build<pir::CombineOp>(values_from_dim_exprs)
+        .out();
+  }();
+
+  return converter->rewriter->Build<paddle::dialect::ConcatOp>(combine_values)
+      .out();
 }
 
 std::optional<pir::Value> GetOutReplacement(cinn::dialect::GenerateShapeOp op,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复generate_shape拆分为普通算子时 concat 输入 value 的 rank 不一致问题。