### PR TITLE
[SOT][DynamicShape] Disallow convert bool to `SymbolicVariable`, add dynamic axes log

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -32,6 +32,7 @@ from ....utils import (
     ConstTypes,
     FallbackError,
     NameGenerator,
+    log,
     paddle_tensor_methods,
     printable,
 )
@@ -328,21 +329,40 @@ class TensorVariable(VariableBase):
         self.meta = meta
         dynamic_axes: list[int] = []
         if ENV_SOT_ALLOW_DYNAMIC_SHAPE.get() and self.tracker.is_traceable():
-            dynamic_axes = self.analyse_dynamic_axes()
+            dynamic_axes = self.analyse_dynamic_axes(tracker)
         self.meta = self.meta.with_dynamic_axes(dynamic_axes)
         self.origin_meta = self.meta
         self.var_name = TensorVariable.var_name_generator.next()
         self.graph.side_effects.record_mutable_variable(self)
 
-    def analyse_dynamic_axes(self):
+    def analyse_dynamic_axes(self, tracker: Tracker):
+        from ..executor_cache import OpcodeExecutorCache
+
         shape_dims = (
             self.shape.proxy.get_all()
         )  # Trigger convert all shape dims to Variable
-        return [
+        dynamic_axes = [
             i
             for i, dim in enumerate(shape_dims)
             if isinstance(dim, SymbolicVariable)
         ]
+        if dynamic_axes:
+            tracker_expr = tracker.trace_value_from_frame().inlined_expr
+            symbolic_inputs = OpcodeExecutorCache().get_symbolic_inputs(
+                self.graph.pycode_gen._origin_code
+            )
+            log(
+                1,
+                f"Start analyse dynamic axes for {tracker.trace_value_from_frame().inlined_expr} in {self.graph.pycode_gen._origin_code}\n",
+            )
+            for key in symbolic_inputs:
+                if key.startswith(tracker_expr):
+                    log(1, f"  {key}: {symbolic_inputs[key]}\n")
+            log(
+                1,
+                f"  -> Tensor {tracker_expr} with dynamic axes {dynamic_axes}\n",
+            )
+        return dynamic_axes
 
     def __len__(self):
         if isinstance(self.meta.shape[0], SymbolicInt):
@@ -740,7 +760,7 @@ class SymbolicVariable(VariableBase):
                 tensor_call_shape_var,
                 ConstantVariable.wrap_literal(shape_idx, graph),
             )
-        if not isinstance(value, int):
+        if type(value) is not int:
             return None
         if not tracker.is_traceable():
             return None


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

因为 Python bool 的实现是继承自 int，因此 `isinstance(b, int)` 会返回 `True`，但我们是不允许 traceable 变量是 bool 的

另外在 `analyse_dynamic_axes` 添加了一些 SOT log，确保能够感知动态 shape 的转化

PCard-66972