### PR TITLE
[XPU] refine xpu.cmake for xpti

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -158,6 +158,10 @@ if(WITH_XPU_BKCL)
   include_directories(${XPU_BKCL_INC_DIR})
 endif()
 
+if(WITH_XPTI)
+  set(XPU_XPTI_OPTION "1")
+endif()
+
 ExternalProject_Add(
   ${XPU_PROJECT}
   ${EXTERNAL_PROJECT_LOG_ARGS}
@@ -168,7 +172,7 @@ ExternalProject_Add(
     ${XPU_XRE_DIR_NAME} ${XPU_XHPC_URL} ${XPU_XHPC_DIR_NAME} ${XPU_XCCL_URL}
     ${XPU_XCCL_DIR_NAME} ${XPU_XHPC_URL} ${XPU_XHPC_DIR_NAME} && wget
     ${XPU_XFT_GET_DEPENCE_URL} && bash get_xft_dependence.sh ${XPU_XFT_URL}
-    ${XPU_XFT_DIR_NAME} && WITH_XPTI=${WITH_XPTI} bash
+    ${XPU_XFT_DIR_NAME} && WITH_XPTI=${XPU_XPTI_OPTION} bash
     ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpti_dependence.sh ${XPU_XPTI_URL}
     ${XPU_XPTI_DIR_NAME}
   DOWNLOAD_NO_PROGRESS 1

--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -52,9 +52,12 @@ if(NOT XPU_XFT_BASE_URL)
   )
 endif()
 
-set(XPU_XPTI_BASE_URL
-    "https://klx-sdk-release-public.su.bcebos.com/xpti/dev/${XPU_XPTI_BASE_VERSION}"
-)
+if(WITH_XPTI)
+  set(XPU_XPTI_BASE_URL
+      "https://klx-sdk-release-public.su.bcebos.com/xpti/dev/${XPU_XPTI_BASE_VERSION}"
+  )
+  set(XPU_XPTI_DIR_NAME "xpti")
+endif()
 
 if(WITH_XPU_XRE5)
   set(XPU_XRE_BASE_VERSION "5.0.3.1")
@@ -102,7 +105,6 @@ else()
   set(XPU_XCCL_DIR_NAME "${XPU_XCCL_PREFIX}-ubuntu_x86_64")
   set(XPU_XFT_DIR_NAME "xft_ubuntu1604_x86_64")
 endif()
-set(XPU_XPTI_DIR_NAME "xpti")
 
 set(XPU_XRE_URL
     "${XPU_XRE_BASE_URL}/${XPU_XRE_DIR_NAME}.tar.gz"
@@ -111,12 +113,15 @@ set(XPU_XCCL_URL
     "${XPU_XCCL_BASE_URL}/${XPU_XCCL_DIR_NAME}.tar.gz"
     CACHE STRING "" FORCE)
 set(XPU_XFT_URL "${XPU_XFT_BASE_URL}/${XPU_XFT_DIR_NAME}.tar.gz")
-set(XPU_XPTI_URL
-    "${XPU_XPTI_BASE_URL}/${XPU_XPTI_DIR_NAME}.tar.gz"
-    CACHE STRING "" FORCE)
 set(XPU_XFT_GET_DEPENCE_URL
     "https://baidu-kunlun-public.su.bcebos.com/paddle_depence/get_xft_dependence.sh"
     CACHE STRING "" FORCE)
+
+if(WITH_XPTI)
+  set(XPU_XPTI_URL
+      "${XPU_XPTI_BASE_URL}/${XPU_XPTI_DIR_NAME}.tar.gz"
+      CACHE STRING "" FORCE)
+endif()
 
 set(XPU_XHPC_URL
     "https://klx-sdk-release-public.su.bcebos.com/xhpc/dev/${XPU_XHPC_BASE_DATE}/${XPU_XHPC_DIR_NAME}.tar.gz"
@@ -158,10 +163,6 @@ if(WITH_XPU_BKCL)
   include_directories(${XPU_BKCL_INC_DIR})
 endif()
 
-if(WITH_XPTI)
-  set(XPU_XPTI_OPTION "1")
-endif()
-
 ExternalProject_Add(
   ${XPU_PROJECT}
   ${EXTERNAL_PROJECT_LOG_ARGS}
@@ -172,9 +173,8 @@ ExternalProject_Add(
     ${XPU_XRE_DIR_NAME} ${XPU_XHPC_URL} ${XPU_XHPC_DIR_NAME} ${XPU_XCCL_URL}
     ${XPU_XCCL_DIR_NAME} ${XPU_XHPC_URL} ${XPU_XHPC_DIR_NAME} && wget
     ${XPU_XFT_GET_DEPENCE_URL} && bash get_xft_dependence.sh ${XPU_XFT_URL}
-    ${XPU_XFT_DIR_NAME} && WITH_XPTI=${XPU_XPTI_OPTION} bash
-    ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpti_dependence.sh ${XPU_XPTI_URL}
-    ${XPU_XPTI_DIR_NAME}
+    ${XPU_XFT_DIR_NAME} && bash ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpti_dependence.sh
+    ${XPU_XPTI_URL} ${XPU_XPTI_DIR_NAME}
   DOWNLOAD_NO_PROGRESS 1
   UPDATE_COMMAND ""
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${XPU_INSTALL_ROOT}

--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -173,8 +173,9 @@ ExternalProject_Add(
     ${XPU_XRE_DIR_NAME} ${XPU_XHPC_URL} ${XPU_XHPC_DIR_NAME} ${XPU_XCCL_URL}
     ${XPU_XCCL_DIR_NAME} ${XPU_XHPC_URL} ${XPU_XHPC_DIR_NAME} && wget
     ${XPU_XFT_GET_DEPENCE_URL} && bash get_xft_dependence.sh ${XPU_XFT_URL}
-    ${XPU_XFT_DIR_NAME} && bash ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpti_dependence.sh
-    ${XPU_XPTI_URL} ${XPU_XPTI_DIR_NAME}
+    ${XPU_XFT_DIR_NAME} && bash
+    ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpti_dependence.sh ${XPU_XPTI_URL}
+    ${XPU_XPTI_DIR_NAME}
   DOWNLOAD_NO_PROGRESS 1
   UPDATE_COMMAND ""
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${XPU_INSTALL_ROOT}

--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -118,13 +118,7 @@ set(XPU_XFT_GET_DEPENCE_URL
     CACHE STRING "" FORCE)
 
 if(WITH_XPTI)
-  set(XPU_XPTI_URL
-      "${XPU_XPTI_BASE_URL}/${XPU_XPTI_DIR_NAME}.tar.gz"
-      CACHE STRING "" FORCE)
-else()
-  set(XPU_XPTI_URL
-      ""
-      CACHE STRING "" FORCE)
+  set(XPU_XPTI_URL "${XPU_XPTI_BASE_URL}/${XPU_XPTI_DIR_NAME}.tar.gz")
 endif()
 
 set(XPU_XHPC_URL

--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -121,6 +121,10 @@ if(WITH_XPTI)
   set(XPU_XPTI_URL
       "${XPU_XPTI_BASE_URL}/${XPU_XPTI_DIR_NAME}.tar.gz"
       CACHE STRING "" FORCE)
+else()
+  set(XPU_XPTI_URL
+      ""
+      CACHE STRING "" FORCE)
 endif()
 
 set(XPU_XHPC_URL

--- a/tools/xpu/get_xpti_dependence.sh
+++ b/tools/xpu/get_xpti_dependence.sh
@@ -19,7 +19,7 @@ set -ex
 XPTI_URL=$1
 XPTI_DIR_NAME=$2
 
-if ! [ -n "$WITH_XPTI" ]; then
+if ! [ -n "$XPTI_URL" ]; then
   exit 0
 fi
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Custom Device


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
- There are many string literals representing `false` in CMake Option, including `false`, `OFF`, `""`, and `0` and they are case-insensitive.
- Using an empty string to determine whether to include the XPTI is insufficient.
https://github.com/PaddlePaddle/Paddle/blob/11f07ea22168452ecb329cb523d3d1795f6dc85c/tools/xpu/get_xpti_dependence.sh#L22
- So we use `XPU_XPTI_URL` to determine whether to include XPTI. It's value can only be either real_url or `""` now that `cmake -DWITH_XPTI=OFF` won't include the XPTI dependency.
https://github.com/PaddlePaddle/Paddle/blob/c33bfddd2f21f457608edba1ecfc11856f2dcc7f/tools/xpu/get_xpti_dependence.sh#L22