### PR TITLE
[Typing][A-87] Add type annotations for `python/paddle/vision/datasets/flowers.py`

### DIFF
--- a/python/paddle/vision/datasets/flowers.py
+++ b/python/paddle/vision/datasets/flowers.py
@@ -12,6 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    from paddle.vision.transforms.transforms import _Transform
+
+    from ..image import _ImageBackend, _ImageDataType
+
+    _DatasetMode = Literal["train", "valid", "test"]
+
 import os
 import tarfile
 
@@ -44,16 +57,16 @@ class Flowers(Dataset):
     dataset.
 
     Args:
-        data_file (str, optional): Path to data file, can be set None if
+        data_file (str|None, optional): Path to data file, can be set None if
             :attr:`download` is True. Default: None, default data path: ~/.cache/paddle/dataset/flowers/.
-        label_file (str, optional): Path to label file, can be set None if
+        label_file (str|None, optional): Path to label file, can be set None if
             :attr:`download` is True. Default: None, default data path: ~/.cache/paddle/dataset/flowers/.
-        setid_file (str, optional): Path to subset index file, can be set
+        setid_file (str|None, optional): Path to subset index file, can be set
             None if :attr:`download` is True. Default: None, default data path: ~/.cache/paddle/dataset/flowers/.
         mode (str, optional): Either train or test mode. Default 'train'.
-        transform (Callable, optional): transform to perform on image, None for no transform. Default: None.
-        download (bool, optional): download dataset automatically if :attr:`data_file` is None. Default: True.
-        backend (str, optional): Specifies which type of image to be returned:
+        transform (Callable|None, optional): transform to perform on image, None for no transform. Default: None.
+        download (bool|None, optional): download dataset automatically if :attr:`data_file` is None. Default: True.
+        backend (str|None, optional): Specifies which type of image to be returned:
             PIL.Image or numpy.ndarray. Should be one of {'pil', 'cv2'}.
             If this option is not set, will get backend from :ref:`paddle.vision.get_image_backend <api_paddle_vision_get_image_backend>`,
             default backend is 'pil'. Default: None.
@@ -105,16 +118,23 @@ class Flowers(Dataset):
             ...     # <class 'paddle.Tensor'> [3, 64, 96] [1]
     """
 
+    backend: _ImageBackend
+    data_file: str | None
+    label_file: str | None
+    setid_file: str | None
+    mode: _DatasetMode
+    transform: _Transform[Any, Any] | None
+
     def __init__(
         self,
-        data_file=None,
-        label_file=None,
-        setid_file=None,
-        mode='train',
-        transform=None,
-        download=True,
-        backend=None,
-    ):
+        data_file: str | None = None,
+        label_file: str | None = None,
+        setid_file: str | None = None,
+        mode: _DatasetMode = 'train',
+        transform: _Transform[Any, Any] | None = None,
+        download: bool = True,
+        backend: _ImageBackend | None = None,
+    ) -> None:
         assert mode.lower() in [
             'train',
             'valid',
@@ -167,7 +187,7 @@ class Flowers(Dataset):
         self.labels = scio.loadmat(label_file)['labels'][0]
         self.indexes = scio.loadmat(setid_file)[flag][0]
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int) -> tuple[_ImageDataType, npt.NDArray[Any]]:
         index = self.indexes[idx]
         label = np.array([self.labels[index - 1]])
         img_name = "jpg/image_%05d.jpg" % index

--- a/python/paddle/vision/datasets/flowers.py
+++ b/python/paddle/vision/datasets/flowers.py
@@ -90,7 +90,7 @@ class Flowers(Dataset):
             >>> for i in range(5):  # only show first 5 images
             ...     img, label = flowers[i]
             ...     # do something with img and label
-            ...     print(type(img), img.size, label)  # type: ignore
+            ...     print(type(img), img.size, label)
             ...     # <class 'PIL.JpegImagePlugin.JpegImageFile'> (523, 500) [1]
 
             >>> transform = T.Compose(
@@ -114,7 +114,7 @@ class Flowers(Dataset):
 
             >>> for img, label in itertools.islice(iter(flowers_test), 5):  # only show first 5 images
             ...     # do something with img and label
-            ...     print(type(img), img.shape, label)
+            ...     print(type(img), img.shape, label) # type: ignore
             ...     # <class 'paddle.Tensor'> [3, 64, 96] [1]
     """
 

--- a/python/paddle/vision/datasets/flowers.py
+++ b/python/paddle/vision/datasets/flowers.py
@@ -90,7 +90,7 @@ class Flowers(Dataset):
             >>> for i in range(5):  # only show first 5 images
             ...     img, label = flowers[i]
             ...     # do something with img and label
-            ...     print(type(img), img.size, label)
+            ...     print(type(img), img.size, label)  # type: ignore
             ...     # <class 'PIL.JpegImagePlugin.JpegImageFile'> (523, 500) [1]
 
             >>> transform = T.Compose(
@@ -187,7 +187,9 @@ class Flowers(Dataset):
         self.labels = scio.loadmat(label_file)['labels'][0]
         self.indexes = scio.loadmat(setid_file)[flag][0]
 
-    def __getitem__(self, idx: int) -> tuple[_ImageDataType, npt.NDArray[Any]]:
+    def __getitem__(
+        self, idx: int
+    ) -> tuple[_ImageDataType, npt.NDArray[np.int64]]:
         index = self.indexes[idx]
         label = np.array([self.labels[index - 1]])
         img_name = "jpg/image_%05d.jpg" % index


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
- https://github.com/PaddlePaddle/Paddle/issues/65008
A-87