### PR TITLE
[XPU], temporally fix the bug of matmul op with imputs' shape([b,k,m,…

### DIFF
--- a/paddle/phi/kernels/xpu/xpu_api_wrapper.h
+++ b/paddle/phi/kernels/xpu/xpu_api_wrapper.h
@@ -162,7 +162,10 @@ static void GetFCInfo(const phi::DDim& x_dims,
       mat_dim_a.batch_size_ = 0;
     } else {
       mat_dim_b.batch_size_ = mat_dim_a.batch_size_;
-      mat_dim_b.height_ = mat_dim_b.height_ / mat_dim_b.batch_size_;
+      // TODO(lilujia): support all shapes like CPU
+      if (!(x_dims.size() == 3 && y_dims.size() == 2)) {
+        mat_dim_b.height_ = mat_dim_b.height_ / mat_dim_b.batch_size_;
+      }
     }
   }
 

--- a/test/xpu/test_matmul_v2_op_xpu.py
+++ b/test/xpu/test_matmul_v2_op_xpu.py
@@ -316,6 +316,18 @@ class XPUTestMatmulV2Op(XPUOpTestWrapper):
             self.trans_x = True
             self.trans_y = False
 
+    class TestMatMulOp21(TestMatMulV2Op):
+        """
+        case 21: (x.ndim == 3) && (y.ndim == 2),
+                  trans_x is true
+        """
+
+        def config(self):
+            self.x_shape = (2, 11, 20)
+            self.y_shape = (11, 30)
+            self.trans_x = True
+            self.trans_y = False
+
     @check_run_big_shape_test()
     class TestMatMulOpLargeShape1(TestMatMulV2Op):
         """


### PR DESCRIPTION
### PR Category
Custom Device


### PR Types
Bug fixes


### Description
XPU matmul算子在输入为[x三维、transpose=True，y二维]时会触发维度错误，复现代码如下
`import paddle`
`a = paddle.ones([10, 4082, 1])`
`b = paddle.ones([4082,1])`
`c = paddle.matmul(a,b,transpose_x=True)`
本PR临时避开了这一bad case，后续PR再重构代码，统一解决matmul维度问题，并支持更多维度，与CPU对齐