### PR TITLE
[CodeStyle] Fix some lint errors discovered by ruff 0.5

### DIFF
--- a/python/paddle/jit/dy2static/error.py
+++ b/python/paddle/jit/dy2static/error.py
@@ -84,9 +84,11 @@ class TraceBackFrame(OriginInfo):
                 self.location.filepath,
                 self.location.lineno,
                 self.function_name,
-                self.source_code.lstrip()
-                if isinstance(self.source_code, str)
-                else self.source_code,
+                (
+                    self.source_code.lstrip()
+                    if isinstance(self.source_code, str)
+                    else self.source_code
+                ),
             )
         )
 
@@ -435,7 +437,7 @@ class ErrorData:
     def raise_new_exception(self):
         # Raises the origin error if disable dygraph2static error module,
         if int(os.getenv(DISABLE_ERROR_ENV_NAME, DEFAULT_DISABLE_NEW_ERROR)):
-            raise
+            raise self.error_value
 
         new_exception = self.create_exception()
         # NOTE(liym27):

--- a/test/legacy_test/test_newprofiler.py
+++ b/test/legacy_test/test_newprofiler.py
@@ -49,7 +49,7 @@ class TestProfiler(unittest.TestCase):
             targets=[profiler.ProfilerTarget.CPU],
         ) as prof:
             y = x / 2.0
-
+        prof = None
         self.assertEqual(utils._is_profiler_used, False)
         with profiler.RecordEvent(name='test'):
             y = x / 2.0
@@ -61,6 +61,7 @@ class TestProfiler(unittest.TestCase):
             with profiler.RecordEvent(name='test'):
                 y = x / 2.0
 
+        prof = None
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU],
             scheduler=profiler.make_scheduler(
@@ -69,7 +70,7 @@ class TestProfiler(unittest.TestCase):
             on_trace_ready=my_trace_back,
         ) as prof:
             y = x / 2.0
-
+        prof = None
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU],
             scheduler=profiler.make_scheduler(
@@ -80,7 +81,7 @@ class TestProfiler(unittest.TestCase):
             for i in range(3):
                 y = x / 2.0
                 prof.step()
-
+        prof = None
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU],
             scheduler=lambda x: profiler.ProfilerState.RECORD_AND_RETURN,
@@ -111,6 +112,7 @@ class TestProfiler(unittest.TestCase):
             else:
                 return profiler.ProfilerState.CLOSED
 
+        prof = None
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU],
             scheduler=lambda x: profiler.ProfilerState.RECORD_AND_RETURN,
@@ -119,7 +121,7 @@ class TestProfiler(unittest.TestCase):
             for i in range(2):
                 y = x / 2.0
                 prof.step()
-
+        prof = None
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU],
             scheduler=my_scheduler,
@@ -128,14 +130,14 @@ class TestProfiler(unittest.TestCase):
             for i in range(5):
                 y = x / 2.0
                 prof.step()
-
+        prof = None
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU], scheduler=my_scheduler1
         ) as prof:
             for i in range(5):
                 y = x / 2.0
                 prof.step()
-
+        prof = None
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU],
             scheduler=profiler.make_scheduler(
@@ -154,7 +156,7 @@ class TestProfiler(unittest.TestCase):
         prof.export(path=path, format='pb')
         prof.summary()
         result = profiler.utils.load_profiler_result(path)
-
+        prof = None
         dataset = RandomDataset(10 * 4)
         simple_net = SimpleNet()
         opt = paddle.optimizer.SGD(
@@ -175,7 +177,7 @@ class TestProfiler(unittest.TestCase):
             prof.step()
         prof.stop()
         prof.summary()
-
+        prof = None
         dataset = RandomDataset(10 * 4)
         simple_net = SimpleNet()
         loader = DataLoader(dataset, batch_size=4, shuffle=True, drop_last=True)

--- a/test/legacy_test/test_newprofiler.py
+++ b/test/legacy_test/test_newprofiler.py
@@ -49,7 +49,7 @@ class TestProfiler(unittest.TestCase):
             targets=[profiler.ProfilerTarget.CPU],
         ) as prof:
             y = x / 2.0
-        prof = None
+
         self.assertEqual(utils._is_profiler_used, False)
         with profiler.RecordEvent(name='test'):
             y = x / 2.0
@@ -61,7 +61,6 @@ class TestProfiler(unittest.TestCase):
             with profiler.RecordEvent(name='test'):
                 y = x / 2.0
 
-        prof = None
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU],
             scheduler=profiler.make_scheduler(
@@ -70,7 +69,7 @@ class TestProfiler(unittest.TestCase):
             on_trace_ready=my_trace_back,
         ) as prof:
             y = x / 2.0
-        prof = None
+
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU],
             scheduler=profiler.make_scheduler(
@@ -81,7 +80,7 @@ class TestProfiler(unittest.TestCase):
             for i in range(3):
                 y = x / 2.0
                 prof.step()
-        prof = None
+
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU],
             scheduler=lambda x: profiler.ProfilerState.RECORD_AND_RETURN,
@@ -112,7 +111,6 @@ class TestProfiler(unittest.TestCase):
             else:
                 return profiler.ProfilerState.CLOSED
 
-        prof = None
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU],
             scheduler=lambda x: profiler.ProfilerState.RECORD_AND_RETURN,
@@ -121,7 +119,7 @@ class TestProfiler(unittest.TestCase):
             for i in range(2):
                 y = x / 2.0
                 prof.step()
-        prof = None
+
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU],
             scheduler=my_scheduler,
@@ -130,14 +128,14 @@ class TestProfiler(unittest.TestCase):
             for i in range(5):
                 y = x / 2.0
                 prof.step()
-        prof = None
+
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU], scheduler=my_scheduler1
         ) as prof:
             for i in range(5):
                 y = x / 2.0
                 prof.step()
-        prof = None
+
         with profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU],
             scheduler=profiler.make_scheduler(
@@ -156,7 +154,7 @@ class TestProfiler(unittest.TestCase):
         prof.export(path=path, format='pb')
         prof.summary()
         result = profiler.utils.load_profiler_result(path)
-        prof = None
+
         dataset = RandomDataset(10 * 4)
         simple_net = SimpleNet()
         opt = paddle.optimizer.SGD(
@@ -177,7 +175,7 @@ class TestProfiler(unittest.TestCase):
             prof.step()
         prof.stop()
         prof.summary()
-        prof = None
+
         dataset = RandomDataset(10 * 4)
         simple_net = SimpleNet()
         loader = DataLoader(dataset, batch_size=4, shuffle=True, drop_last=True)

--- a/test/legacy_test/test_trapezoid.py
+++ b/test/legacy_test/test_trapezoid.py
@@ -13,11 +13,20 @@
 # limitations under the License.
 
 import unittest
+from distutils.version import LooseVersion
 
 import numpy as np
 
 import paddle
 from paddle.pir_utils import test_with_pir_api
+
+
+def get_ref_api():
+    return (
+        np.trapezoid
+        if LooseVersion(np.__version__) >= LooseVersion('2.0.0')
+        else np.trapz
+    )
 
 
 class TestTrapezoidAPI(unittest.TestCase):
@@ -38,7 +47,7 @@ class TestTrapezoidAPI(unittest.TestCase):
             )
 
     def set_api(self):
-        self.ref_api = np.trapz
+        self.ref_api = get_ref_api()
         self.paddle_api = paddle.trapezoid
 
     def setUp(self):
@@ -227,7 +236,7 @@ class TestTrapezoidError(unittest.TestCase):
 class Testfp16Trapezoid(TestTrapezoidAPI):
     def set_api(self):
         self.paddle_api = paddle.trapezoid
-        self.ref_api = np.trapz
+        self.ref_api = get_ref_api()
 
     @test_with_pir_api
     def test_fp16_with_gpu(self):

--- a/tools/get_pr_title.py
+++ b/tools/get_pr_title.py
@@ -22,6 +22,7 @@ import requests
 SKIP_COVERAGE_CHECKING_LABELS = [
     "cinn",
     "typing",
+    "codestyle",
 ]
 
 SKIP_COVERAGE_CHECKING_REGEX = re.compile(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

修复 Ruff 准备升级 0.5.0 的一些问题：

- PLE0704，悬空 raise
- ~~F811，prof 没有必要赋值给 None，因为下文中重新赋值自然会释放~~ 不能删，这些还是需要的，升级时候直接 noqa
- NPY201，`np.trapz` 在 NumPy 2.0 已经弃用，并会在未来版本删除，因此使用 `np.trapezoid`（2.0 才有的，不能直接替换，需要区分版本）

此外还有大量 UP031 待慢慢处理，才能先升级到 0.4

PCard-66972