### PR TITLE
fix identity_op_clean_pass dropout pattern

### DIFF
--- a/paddle/fluid/pir/transforms/general/identity_op_clean_pass.cc
+++ b/paddle/fluid/pir/transforms/general/identity_op_clean_pass.cc
@@ -199,7 +199,7 @@ class DeleteDropoutOpPattern : public paddle::drr::DrrPatternBase {
         pat.Op("pd_op.dropout",
                {{"is_test", pat.Attr("is_test")}, {"mode", pat.Attr("mode")}});
     dropout_op(
-        {&pat.Tensor("dropout_in"), &pat.Tensor("none"), &pat.Tensor("p")},
+        {&pat.Tensor("dropout_in"), &pat.InputNoneTensor(), &pat.Tensor("p")},
         {&pat.Tensor("dropout_out"), &pat.Tensor("dropout_mask")});
     pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
       auto is_test = match_ctx.Attr<bool>("is_test");
@@ -230,7 +230,7 @@ class ReplaceDropoutWithScalePattern : public paddle::drr::DrrPatternBase {
         pat.Op("pd_op.dropout",
                {{"is_test", pat.Attr("is_test")}, {"mode", pat.Attr("mode")}});
     dropout_op(
-        {&pat.Tensor("dropout_in"), &pat.Tensor("none"), &pat.Tensor("p")},
+        {&pat.Tensor("dropout_in"), &pat.InputNoneTensor(), &pat.Tensor("p")},
         {&pat.Tensor("dropout_out"), &pat.Tensor("dropout_mask")});
 
     pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
pcard-71500
fix identity_op_clean_pass dropout pattern.