### PR TITLE
[PIR][oneDNN] Reorder pass and add repetitive pass for better fusion

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -640,37 +640,40 @@ const std::vector<std::string> kPirXpuPasses{
     "fc_xpu_fuse_pass"};
 
 const std::vector<std::string> kPirMkldnnPasses {
-  "delete_quant_dequant_linear_op_pass", "delete_weight_dequant_linear_op_pass",
-      "matmul_scale_fuse_pass", "matmul_transpose_fuse_pass",
-      "depthwise_conv_onednn_pass",
-      "squeeze_transpose_onednn_fuse_pass",  //
-      "conv2d_bn_onednn_fuse_pass",          //
-      "conv2d_bias_fuse_pass",               //
-      "conv2d_transpose_bias_fuse_pass",     //
-      "conv3d_bias_fuse_pass",               //
-      "batch_norm_act_fuse_pass",            //
-      "scale_matmul_fuse_pass",              //
-      "reshape_transpose_matmul_fuse_pass",  //
-      "matmul_transpose_reshape_fuse_pass",  //
-      "matmul_elementwise_add_fuse_pass",    //
-      "matmul_activation_fuse_pass",         //
-      "matmul_add_act_fuse_pass",            //
-      "fc_onednn_enable_pass",               //
-      "fc_activation_fuse_pass",             //
+  "delete_quant_dequant_linear_op_pass",          //
+      "delete_weight_dequant_linear_op_pass",     //
+      "depthwise_conv_onednn_pass",               //
+      "squeeze_transpose_onednn_fuse_pass",       //
+      "conv2d_bn_onednn_fuse_pass",               //
+      "conv2d_bias_fuse_pass",                    //
+      "conv2d_transpose_bias_fuse_pass",          //
+      "conv3d_bias_fuse_pass",                    //
+      "conv_elementwise_add_onednn_fuse_pass",    //
+      "conv_activation_onednn_fuse_pass",         //
+      "conv_concat_activation_onednn_fuse_pass",  //
+      "batch_norm_act_fuse_pass",                 //
+      "matmul_scale_fuse_pass",                   //
+      "scale_matmul_fuse_pass",                   //
+      "reshape_transpose_matmul_fuse_pass",       //
+      "matmul_transpose_reshape_fuse_pass",       //
+      "matmul_add_act_fuse_pass",                 //
+      "fc_onednn_enable_pass",                    //
+      "matmul_elementwise_add_fuse_pass",         //
+      "matmul_activation_fuse_pass",              //
+      "matmul_add_act_fuse_pass",                 //
+      "fc_onednn_enable_pass",                    //
+      "fc_activation_fuse_pass",                  //
 #if defined(PADDLE_WITH_AVX512F) && defined(PADDLE_WITH_MKLML) && \
     defined(PADDLE_WITH_DNNL)
       "self_attention_fuse_pass",  //
 #endif
-      "softplus_activation_fuse_pass",            //
-      "shuffle_channel_detect_pass",              //
-      "operator_reshape_onednn_fuse_pass",        //
-      "conv_elementwise_add_onednn_fuse_pass",    //
-      "conv_activation_onednn_fuse_pass",         //
-      "conv_concat_activation_onednn_fuse_pass",  //
-      "elementwise_act_onednn_fuse_pass",         //
-      "operator_unsqueeze_onednn_fuse_pass",      //
-      "operator_scale_onednn_fuse_pass",          //
-      "onednn_placement_pass"                     //
+      "softplus_activation_fuse_pass",        //
+      "shuffle_channel_detect_pass",          //
+      "operator_reshape_onednn_fuse_pass",    //
+      "elementwise_act_onednn_fuse_pass",     //
+      "operator_unsqueeze_onednn_fuse_pass",  //
+      "operator_scale_onednn_fuse_pass",      //
+      "onednn_placement_pass"                 //
 };
 
 const std::vector<std::string> kPirCpuPasses{


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Performance Optimization


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Adding `matmul_add_act_fuse_pass` and `fc_onednn_enable_pass` before `matmul_elementwise_add_fuse_pass`, avoiding to fuse matmul+add before fc fusion.
This will improve performance when there is fc fusion possibilities. Take **ViT_base_patch16_224** as example:
Before:
```
[2024/06/28 13:35:08] root INFO:  preprocess_time(ms): 1.5481, inference_time(ms): 501.8447, postprocess_time(ms): 0.2269
```
After:
```
[2024/06/28 10:39:49] root INFO:  preprocess_time(ms): 1.7761, inference_time(ms): 449.5973, postprocess_time(ms): 0.3206
```
