### PR TITLE
[Typing] 修改 tensor stub 中的 __qualname__

### DIFF
--- a/python/paddle/tensor/tensor.prototype.pyi
+++ b/python/paddle/tensor/tensor.prototype.pyi
@@ -293,8 +293,8 @@ class AbstractTensor(Protocol):
     def _grad_ivar(self) -> Tensor | None: ...
 
     # annotation: ${tensor_alias}
-    __qualname__: Literal["Tensor"]
 
 # annotation: ${tensor_end}
 
-class Tensor(AbstractTensor, AbstractEagerParamBase): ...
+class Tensor(AbstractTensor, AbstractEagerParamBase):
+    __qualname__: Literal["Tensor"]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

mypy 在检查 `Tensor` 的时候，会尝试实例化：

``` python
error: Cannot instantiate abstract class "Tensor" with abstract attribute "__qualname__"  [abstract]
```

特此将 `__qualname__` 从 `AbstractTensor` 移入 `Tensor`

@SigureMo