### PR TITLE
[Typing][TCH001][TCH003] Move annotation only imports under `TYPE_CHECKING` (part1)

### DIFF
--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -22,8 +22,7 @@ import logging
 import os
 import pdb  # noqa: T100
 import re
-import types
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import numpy
 
@@ -44,6 +43,9 @@ from .program_translator import (
     unwrap_decorators,
 )
 from .utils import is_builtin, is_paddle_func
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 __all__ = []
 
@@ -103,7 +105,7 @@ def builtin_modules():
 BUILTIN_LIKELY_MODULES = builtin_modules()
 
 
-def add_ignore_module(modules: list[types.ModuleType]):
+def add_ignore_module(modules: list[ModuleType]):
     """
     Adds modules that ignore transcription
     """

--- a/python/paddle/jit/sot/opcode_translator/custom_code.py
+++ b/python/paddle/jit/sot/opcode_translator/custom_code.py
@@ -14,10 +14,12 @@
 
 from __future__ import annotations
 
-import types
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from types import CodeType
 
 
 class CustomCode(NamedTuple):
-    code: types.CodeType | None
+    code: CodeType | None
     disable_eval_frame: bool

--- a/python/paddle/jit/sot/opcode_translator/eval_frame_callback.py
+++ b/python/paddle/jit/sot/opcode_translator/eval_frame_callback.py
@@ -16,11 +16,14 @@ from __future__ import annotations
 
 import dis
 from functools import partial
+from typing import TYPE_CHECKING
 
 from ..profiler import EventGuard
 from ..utils import log_do, log_format
-from .custom_code import CustomCode
 from .executor.executor_cache import OpcodeExecutorCache
+
+if TYPE_CHECKING:
+    from .custom_code import CustomCode
 
 
 def print_locals(frame):

--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 import gc
 import traceback
-import types
-from typing import List, Tuple
+from typing import TYPE_CHECKING, List, Tuple
 
 from ...profiler import EventGuard, event_register
 from ...psdb import NO_FALLBACK_CODES
@@ -34,6 +33,9 @@ from ...utils import (
 from ..custom_code import CustomCode
 from .guard import Guard
 from .opcode_executor import OpcodeExecutor, OpcodeExecutorBase
+
+if TYPE_CHECKING:
+    import types
 
 GuardedFunction = Tuple[CustomCode, Guard]
 GuardedFunctions = List[GuardedFunction]

--- a/python/paddle/jit/sot/opcode_translator/executor/side_effects.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/side_effects.py
@@ -16,12 +16,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
-from .mutable_data import MutableData
-from .variables import VariableBase
-
 if TYPE_CHECKING:
-    from .mutable_data import DataGetter
+    from .mutable_data import DataGetter, MutableData
     from .pycode_generator import PyCodeGen
+    from .variables import VariableBase
 
     MutableDataT = TypeVar("MutableDataT", bound=MutableData)
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
@@ -28,7 +28,6 @@ from ....utils.exceptions import FallbackError, HasNoAttributeError
 from ..dispatcher import Dispatcher
 from ..guard import StringifyExpression, check_guard, union_free_vars
 from ..mutable_data import MutableDictLikeData
-from ..pycode_generator import PyCodeGen
 from ..tracker import (
     DummyTracker,
     GetAttrTracker,
@@ -38,11 +37,14 @@ from ..tracker import (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
     from ..function_graph import FunctionGraph
+    from ..pycode_generator import PyCodeGen
 
     # Each variable object should implement a method called `from_value`,
     # which should adhere to the FromValueFunc signature.
-    FromValueFunc = Callable[
+    FromValueFunc: TypeAlias = Callable[
         [Any, FunctionGraph, Tracker], Optional["VariableBase"]
     ]
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -46,7 +46,6 @@ from ..guard import (
     union_free_vars,
 )
 from ..mutable_data import MutableDictLikeData
-from ..pycode_generator import PyCodeGen
 from ..tracker import (
     ConstTracker,
     DanglingTracker,
@@ -62,6 +61,7 @@ from .base import VariableBase, VariableFactory
 
 if TYPE_CHECKING:
     from ..function_graph import FunctionGraph
+    from ..pycode_generator import PyCodeGen
     from .callable import FunctionVariable
 
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
@@ -24,7 +24,6 @@ from ....utils.exceptions import FallbackError, InnerError
 from ..dispatcher import Dispatcher
 from ..guard import StringifyExpression, check_guard
 from ..mutable_data import MutableDictLikeData, MutableListLikeData
-from ..pycode_generator import PyCodeGen
 from ..tracker import (
     ConstTracker,
     DanglingTracker,
@@ -39,6 +38,7 @@ from .callable import BuiltinVariable, UserDefinedFunctionVariable
 
 if TYPE_CHECKING:
     from ..function_graph import FunctionGraph
+    from ..pycode_generator import PyCodeGen
 
 
 class ContainerVariable(VariableBase):

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Sequence
 
 from ....utils import BreakGraphError, FallbackError
-from ..pycode_generator import PyCodeGen
 from ..tracker import ConstTracker, DummyTracker
 from .base import VariableBase, VariableFactory
 from .basic import ConstantVariable
@@ -25,6 +24,7 @@ from .container import ContainerVariable, TupleVariable
 
 if TYPE_CHECKING:
     from ..function_graph import FunctionGraph
+    from ..pycode_generator import PyCodeGen
     from ..tracker import Tracker
 
 

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_analysis.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_analysis.py
@@ -15,16 +15,19 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import TYPE_CHECKING
 
 from paddle.jit.utils import OrderedSet
 
-from .instruction_utils import Instruction
 from .opcode_info import (
     ALL_JUMP,
     HAS_FREE,
     HAS_LOCAL,
     UNCONDITIONAL_JUMP,
 )
+
+if TYPE_CHECKING:
+    from .instruction_utils import Instruction
 
 
 @dataclasses.dataclass

--- a/python/paddle/jit/sot/psdb.py
+++ b/python/paddle/jit/sot/psdb.py
@@ -15,16 +15,18 @@
 from __future__ import annotations
 
 import builtins
-import types
-from typing import Callable, TypeVar
+from typing import TYPE_CHECKING, Callable, TypeVar
 
 from typing_extensions import ParamSpec
+
+if TYPE_CHECKING:
+    from types import CodeType
 
 T = TypeVar("T")
 P = ParamSpec("P")
 
-NO_BREAKGRAPH_CODES: set[types.CodeType] = set()
-NO_FALLBACK_CODES: set[types.CodeType] = set()
+NO_BREAKGRAPH_CODES: set[CodeType] = set()
+NO_FALLBACK_CODES: set[CodeType] = set()
 
 
 def assert_true(input: bool):

--- a/python/paddle/jit/sot/symbolic/compile_cache.py
+++ b/python/paddle/jit/sot/symbolic/compile_cache.py
@@ -21,7 +21,6 @@ import paddle
 from paddle.amp.auto_cast import amp_state
 from paddle.base.data_feeder import convert_dtype
 from paddle.framework import _dygraph_tracer, use_pir_api
-from paddle.static import InputSpec
 
 from ..infer_meta import convert_meta_to_input_spec
 from ..profiler import EventGuard
@@ -39,6 +38,8 @@ from .export import export
 from .interpreter import compile_sir
 
 if TYPE_CHECKING:
+    from paddle.static import InputSpec
+
     from .symbolic_context import SymbolicTraceContext
 
 

--- a/python/paddle/jit/sot/symbolic/symbolic_context.py
+++ b/python/paddle/jit/sot/symbolic/symbolic_context.py
@@ -14,9 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
-
-from paddle.static import InputSpec
+from typing import TYPE_CHECKING, Any, Callable
 
 from ..utils import log
 from .compile_cache import CompileSIRCache
@@ -30,6 +28,9 @@ from .statement_ir import (
     StatementIRFactory,
     Symbol,
 )
+
+if TYPE_CHECKING:
+    from paddle.static import InputSpec
 
 
 class SymbolicTraceContext:

--- a/python/paddle/jit/sot/utils/utils.py
+++ b/python/paddle/jit/sot/utils/utils.py
@@ -23,13 +23,12 @@ import weakref
 from collections import OrderedDict
 from contextlib import contextmanager
 from enum import Enum
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 from weakref import WeakValueDictionary
 
 import numpy as np
 
 import paddle
-from paddle.framework import Program
 from paddle.utils import flatten, map_structure
 
 from .envs import (
@@ -43,6 +42,9 @@ from .paddle_api_config import (
     paddle_api_list,
     paddle_api_module_prefix,
 )
+
+if TYPE_CHECKING:
+    from paddle.framework import Program
 
 T = TypeVar("T")
 ConstTypes = (int, float, str, bool, type(None))

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Callable
 
 import paddle
@@ -25,6 +24,8 @@ from .. import functional as F
 from .layers import Layer
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor
     from paddle._typing import ParamAttrLike
 

--- a/python/paddle/profiler/utils.py
+++ b/python/paddle/profiler/utils.py
@@ -16,12 +16,15 @@ from __future__ import annotations
 
 import functools
 import sys
-import types
 from contextlib import ContextDecorator, contextmanager
+from typing import TYPE_CHECKING
 from warnings import warn
 
 from paddle.base import core
 from paddle.base.core import TracerEventType, _RecordEvent
+
+if TYPE_CHECKING:
+    import types
 
 _is_profiler_used = False
 _has_optimizer_wrapped = False

--- a/test/sot/test_instruction_translator_cache.py
+++ b/test/sot/test_instruction_translator_cache.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 
 import inspect
 import random
-import types
 import unittest
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from test_case_base import (
@@ -30,14 +30,17 @@ from paddle.jit.sot.opcode_translator.executor.executor_cache import (
     OpcodeExecutorCache,
 )
 
+if TYPE_CHECKING:
+    from types import FrameType
+
 
 def fake_frames() -> (
     tuple[
-        types.FrameType,
-        types.FrameType,
-        types.FrameType,
-        types.FrameType,
-        types.FrameType,
+        FrameType,
+        FrameType,
+        FrameType,
+        FrameType,
+        FrameType,
     ]
 ):
     def fake_inner_fn_1():
@@ -83,7 +86,7 @@ def fake_frames() -> (
 ) = fake_frames()
 
 
-def mock_start_translate(frame: types.FrameType, **kwargs):
+def mock_start_translate(frame: FrameType, **kwargs):
     translate_map = {
         FRAME_1: (CustomCode(FRAME_2.f_code, False), lambda frame: True),
         FRAME_3: (

--- a/tools/gen_tensor_stub.py
+++ b/tools/gen_tensor_stub.py
@@ -20,12 +20,14 @@ import inspect
 import logging
 import re
 import sys
-import types
 from dataclasses import dataclass
 from functools import cached_property, lru_cache
-from typing import Any, Callable, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol
 
 from typing_extensions import TypeAlias
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 logging.basicConfig(style="{", format="{message}", level=logging.INFO)
 logger = logging.getLogger("Generating stub file for paddle.Tensor")
@@ -403,7 +405,7 @@ def func_doc_to_method_doc(func_doc: str) -> str:
     return method_doc
 
 
-def try_import_paddle() -> types.ModuleType | None:
+def try_import_paddle() -> ModuleType | None:
     try:
         return importlib.import_module('paddle')
     except ModuleNotFoundError:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

准备引入 Ruff TCH rules[^1]，确保用于类型提示的 imports 清晰地放在 `TYPE_CHECKING` 下，本 PR 为 part1

PCard-66972

[^1]: https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch