### PR TITLE
[Typing][TCH001] Move annotation only imports under `TYPE_CHECKING` (part2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ select = [
     # Pygrep-hooks
     "PGH004",
 
+    # Flake8-type-checking
+    "TCH",
+
     # Ruff-specific rules
     "RUF100",
 ]

--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -19,13 +19,13 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from paddle import _C_ops, _legacy_C_ops
-from paddle._typing import DTypeLike
 
 from .. import core, framework
 from ..framework import convert_np_dtype_to_dtype_
 
 if TYPE_CHECKING:
     from paddle import Tensor
+    from paddle._typing import DTypeLike
 
 _supported_int_dtype_ = [
     core.VarDesc.VarType.UINT8,

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -24,7 +24,6 @@ import numpy.typing as npt
 
 import paddle
 from paddle import _C_ops, profiler
-from paddle._typing import DTypeLike, PlaceLike, TensorIndex
 from paddle.base.data_feeder import (
     _PADDLE_DTYPE_2_NUMPY_DTYPE,
     convert_uint16_to_float,
@@ -44,6 +43,7 @@ from .math_op_patch import monkey_patch_math_tensor
 
 if TYPE_CHECKING:
     from paddle import Tensor
+    from paddle._typing import DTypeLike, PlaceLike, TensorIndex
 
 
 _grad_scalar = None

--- a/python/paddle/distributed/launch/job/pod.py
+++ b/python/paddle/distributed/launch/job/pod.py
@@ -16,9 +16,12 @@ from __future__ import annotations
 
 import random
 import time
+from typing import TYPE_CHECKING
 
-from .container import Container
 from .status import Status
+
+if TYPE_CHECKING:
+    from .container import Container
 
 
 class PodSpec:

--- a/python/paddle/hapi/hub.py
+++ b/python/paddle/hapi/hub.py
@@ -18,12 +18,14 @@ import os
 import shutil
 import sys
 import zipfile
-from typing import Any, List, Literal
+from typing import TYPE_CHECKING, Any, List, Literal
 
 from typing_extensions import TypeAlias
 
-import paddle
 from paddle.utils.download import get_path_from_url
+
+if TYPE_CHECKING:
+    import paddle
 
 __all__ = []
 

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -27,6 +27,7 @@ from collections.abc import Sequence
 from contextlib import contextmanager
 from types import ModuleType
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Protocol,
@@ -44,7 +45,6 @@ from typing_extensions import (
 )
 
 import paddle
-from paddle._typing import NestedStructure
 from paddle.base import core, dygraph
 from paddle.base.compiler import (
     BuildStrategy,
@@ -63,7 +63,6 @@ from paddle.base.framework import (
 from paddle.base.wrapped_decorator import wrap_decorator
 from paddle.framework import use_pir_api
 from paddle.nn import Layer
-from paddle.static import InputSpec
 from paddle.static.io import save_inference_model
 from paddle.utils.environments import (
     BooleanEnvironmentVariable,
@@ -87,6 +86,10 @@ from .translated_layer import (
     INFER_PROPERTY_SUFFIX,
     TranslatedLayer,
 )
+
+if TYPE_CHECKING:
+    from paddle._typing import NestedStructure
+    from paddle.static import InputSpec
 
 ENV_ENABLE_SOT = BooleanEnvironmentVariable("ENABLE_FALL_BACK", True)
 

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -26,7 +26,6 @@ from typing_extensions import ParamSpec, Self
 import paddle
 import paddle.pir.core as ir_static
 from paddle import decomposition, get_flags
-from paddle._typing import NestedSequence
 from paddle.base import core, framework
 from paddle.base.data_feeder import check_type
 from paddle.base.dygraph.base import (
@@ -38,7 +37,6 @@ from paddle.framework import in_dynamic_mode, use_pir_api
 from paddle.nn.layer import layers
 from paddle.pir import Value
 from paddle.pir.core import _convert_into_value, static_op_arg_cast_guard
-from paddle.static import InputSpec, Program
 from paddle.utils import flatten, gast
 
 from . import error, logging_utils
@@ -75,6 +73,8 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
+    from paddle._typing import NestedSequence
+    from paddle.static import InputSpec, Program
     from paddle.static.amp.fp16_utils import AmpOptions
 
 _RetT = TypeVar("_RetT")

--- a/python/paddle/static/input.py
+++ b/python/paddle/static/input.py
@@ -22,7 +22,6 @@ import numpy.typing as npt
 from typing_extensions import Self
 
 import paddle
-from paddle._typing import DTypeLike, ShapeLike, Size1
 from paddle.base import Variable, core
 from paddle.base.data_feeder import check_type
 from paddle.base.framework import (
@@ -41,6 +40,7 @@ from ..base.variable_index import _setitem_static
 
 if TYPE_CHECKING:
     from paddle import Tensor
+    from paddle._typing import DTypeLike, ShapeLike, Size1
 
 __all__ = []
 

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -23,14 +23,6 @@ import numpy.typing as npt
 
 import paddle
 from paddle import _C_ops
-from paddle._typing import (
-    DTypeLike,
-    NestedNumbericSequence,
-    Numberic,
-    PlaceLike,
-    ShapeLike,
-    TensorLike,
-)
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
 
 from ..base.data_feeder import (
@@ -56,7 +48,15 @@ from ..framework import (
 )
 
 if TYPE_CHECKING:
-    from paddle._typing import ParamAttrLike
+    from paddle._typing import (
+        DTypeLike,
+        NestedNumbericSequence,
+        Numberic,
+        ParamAttrLike,
+        PlaceLike,
+        ShapeLike,
+        TensorLike,
+    )
 
 __all__ = []
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -20,14 +20,6 @@ import numpy as np
 
 import paddle
 from paddle import _C_ops
-from paddle._typing import (
-    DTypeLike,
-    NestedList,
-    NestedSequence,
-    Numberic,
-    ShapeLike,
-    TensorOrTensors,
-)
 from paddle.tensor import fill_constant
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
 
@@ -51,6 +43,14 @@ from .creation import _complex_to_real_dtype, _real_to_complex_dtype, zeros
 
 if TYPE_CHECKING:
     from paddle import Tensor
+    from paddle._typing import (
+        DTypeLike,
+        NestedList,
+        NestedSequence,
+        Numberic,
+        ShapeLike,
+        TensorOrTensors,
+    )
 
 __all__ = []
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -22,7 +22,6 @@ import numpy as np
 
 import paddle
 from paddle import _C_ops
-from paddle._typing import DTypeLike
 from paddle.base.libpaddle import DataType
 from paddle.common_ops_import import VarDesc, dygraph_utils
 from paddle.pir import Value
@@ -97,6 +96,7 @@ from .ops import (  # noqa: F401
 
 if TYPE_CHECKING:
     from paddle import Tensor
+    from paddle._typing import DTypeLike
 
 __all__ = []
 

--- a/python/paddle/utils/layers_utils.py
+++ b/python/paddle/utils/layers_utils.py
@@ -26,7 +26,6 @@ import numpy as np
 from typing_extensions import TypeGuard
 
 import paddle
-from paddle._typing import NestedStructure, ShapeLike
 from paddle.pir.core import convert_np_dtype_to_dtype_
 
 from ..base.data_feeder import check_dtype, convert_dtype
@@ -36,6 +35,9 @@ from ..base.framework import (
     in_dygraph_mode,
 )
 from ..pir import Value
+
+if typing.TYPE_CHECKING:
+    from paddle._typing import NestedStructure, ShapeLike
 
 _T = TypeVar("_T")
 _U = TypeVar("_U")

--- a/test/standalone_executor/test_standalone_measure_real_op_cost.py
+++ b/test/standalone_executor/test_standalone_measure_real_op_cost.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import unittest
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 import paddle
 from paddle.base import core
-from paddle.base.framework import Block
 from paddle.distributed.auto_parallel.static.cost import (
     measure_program_real_op_cost,
 )
@@ -29,6 +29,9 @@ from paddle.distributed.auto_parallel.static.dist_context import (
     DistributedContext,
 )
 from paddle.static import Executor, Program, program_guard
+
+if TYPE_CHECKING:
+    from paddle.base.framework import Block
 
 paddle.enable_static()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

同 #65558，存量基本清理完成（部分在 #65559、#65454 对相关文件进行处理、收尾），引入 TCH rules

PCard-66972