### PR TITLE
[CodeStyle] Fix pass multiple arg to error message

### DIFF
--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -1459,8 +1459,7 @@ class Executor:
                 _fetch_list.append(item)
             else:
                 raise TypeError(
-                    "The item in fetch_list should be str, variable or optimize_op, but received %s.",
-                    type(item),
+                    f"The item in fetch_list should be str, variable or optimize_op, but received {type(item)}.",
                 )
 
         for index, item in enumerate(fetch_list):

--- a/python/paddle/base/layers/math_op_patch.py
+++ b/python/paddle/base/layers/math_op_patch.py
@@ -116,7 +116,7 @@ def monkey_patch_variable():
         try:
             dtype = var.dtype
         except:
-            raise ValueError("Cannot get data type from %s", var.name)
+            raise ValueError(f"Cannot get data type from {var.name}")
         return dtype
 
     def current_block(var):

--- a/python/paddle/device/cuda/graphs.py
+++ b/python/paddle/device/cuda/graphs.py
@@ -93,8 +93,7 @@ def wrap_cuda_graph(function, mode="thread_local", memory_pool="default"):
             memory_pool_id = CoreCUDAGraph.gen_new_memory_pool_id()
         else:
             raise ValueError(
-                "memory_pool should be one of default or new under static graph mode, but got",
-                memory_pool,
+                f"memory_pool should be one of default or new under static graph mode, but got {memory_pool}",
             )
         return _cuda_graph_guard(
             mode + ';' + str(memory_pool_id) + ';' + graph_id

--- a/python/paddle/distributed/fleet/runtime/parameter_server_runtime.py
+++ b/python/paddle/distributed/fleet/runtime/parameter_server_runtime.py
@@ -382,7 +382,7 @@ class ParameterServerRuntime(RuntimeBase):
             return
 
         if not os.path.isdir(model_dirname):
-            raise ValueError("There is no directory named '%s'", model_dirname)
+            raise ValueError(f"There is no directory named '{model_dirname}'")
 
         # load dense
         paddle.static.load_vars(

--- a/python/paddle/distributed/ps/utils/ps_program_builder.py
+++ b/python/paddle/distributed/ps/utils/ps_program_builder.py
@@ -103,8 +103,7 @@ class GeoPsProgramBuilder(PsProgramBuilder):  # 仅 CPU 模式
         super().__init__(pass_ctx)
         if self.ps_mode != DistributedMode.GEO:
             raise ValueError(
-                "ps mode: {} not matched {}",
-                format(self.ps_mode, "GeoPsProgramBuilder"),
+                f"ps mode: {self.ps_mode} not matched GeoPsProgramBuilder",
             )
 
     def _build_trainer_programs(self):
@@ -180,8 +179,7 @@ class CpuSyncPsProgramBuilder(PsProgramBuilder):
             and self.ps_mode != DistributedMode.ASYNC
         ):
             raise ValueError(
-                "ps mode: {} not matched {}",
-                format(self.ps_mode, "PsProgramBuilder"),
+                f"ps mode: {self.ps_mode} not matched PsProgramBuilder"
             )
 
     def _build_trainer_programs(self):

--- a/python/paddle/distributed/ps/utils/public.py
+++ b/python/paddle/distributed/ps/utils/public.py
@@ -477,8 +477,7 @@ def get_dense_send_context(
 def get_geo_trainer_send_context(attrs):
     if attrs['ps_mode'] != DistributedMode.GEO:
         raise ValueError(
-            "ps mode: {} not matched {}",
-            format(attrs['ps_mode'], "get_geo_trainer_send_context"),
+            f"ps mode: {attrs['ps_mode']} not matched get_geo_trainer_send_context",
         )
     send_ctx = {}
     trainer_id = get_role_id(attrs['role_maker'])

--- a/python/paddle/incubate/distributed/fleet/parameter_server/distribute_transpiler/__init__.py
+++ b/python/paddle/incubate/distributed/fleet/parameter_server/distribute_transpiler/__init__.py
@@ -252,7 +252,7 @@ class FleetTranspiler(Fleet):
 
         if model_dir:
             if not os.path.isdir(model_dir):
-                raise ValueError("There is no directory named '%s'", model_dir)
+                raise ValueError(f"There is no directory named '{model_dir}'")
 
             sparse_varnames = self.compiled_config.get_sparse_varname_on_ps(
                 True

--- a/python/paddle/incubate/distributed/models/moe/moe_layer.py
+++ b/python/paddle/incubate/distributed/models/moe/moe_layer.py
@@ -400,7 +400,7 @@ class MoELayer(nn.Layer):
         elif isinstance(gate, NaiveGate):
             self.top_k = gate.top_k
         elif isinstance(gate, BaseGate):
-            raise TypeError("Unimplemented gate type: ", type(gate))
+            raise TypeError(f"Unimplemented gate type: {type(gate)}")
         else:
             raise TypeError("gate's type must be either dict or moe.BaseGate")
         self.gate = gate

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -4516,7 +4516,7 @@ def adaptive_log_softmax_with_loss(
         if input.dim() != 2:
             raise ValueError(
                 '1D label tensor expects 2D input tensors, '
-                'but found inputs with size {input.shape}'
+                f'but found inputs with size {input.shape}'
             )
     elif targt_dim == 0:
         if input.dim() != 1:

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -4516,15 +4516,13 @@ def adaptive_log_softmax_with_loss(
         if input.dim() != 2:
             raise ValueError(
                 '1D label tensor expects 2D input tensors, '
-                'but found inputs with size',
-                input.shape,
+                'but found inputs with size {input.shape}'
             )
     elif targt_dim == 0:
         if input.dim() != 1:
             raise ValueError(
                 '0D label tensor expects 1D input tensors, '
-                'but found inputs with size',
-                input.shape,
+                f'but found inputs with size {input.shape}'
             )
     else:
         raise ValueError(

--- a/python/paddle/nn/initializer/assign.py
+++ b/python/paddle/nn/initializer/assign.py
@@ -116,7 +116,7 @@ class NumpyArrayInitializer(Initializer):
             value_name = "int8_values"
             values = [int(v) for v in np_value.flat]
         else:
-            raise ValueError("Unsupported dtype %s", self._value.dtype)
+            raise ValueError(f"Unsupported dtype {self._value.dtype}")
         if self._value.size > 1024 * 1024 * 1024:
             raise ValueError(
                 "The size of input is too big. Please consider "

--- a/python/paddle/nn/initializer/bilinear.py
+++ b/python/paddle/nn/initializer/bilinear.py
@@ -156,7 +156,7 @@ class Bilinear(Initializer):
             value_name = "values"
             values = [float(v) for v in weight.flat]
         else:
-            raise TypeError("Unsupported dtype %s", var.dtype)
+            raise TypeError(f"Unsupported dtype {var.dtype}")
 
         if np.prod(shape) > 1024 * 1024:
             raise ValueError("The size of input is too big. ")

--- a/python/paddle/nn/initializer/normal.py
+++ b/python/paddle/nn/initializer/normal.py
@@ -52,8 +52,8 @@ class NormalInitializer(Initializer):
         if isinstance(self._mean, complex):
             if self._mean.real != self._mean.imag:
                 raise ValueError(
-                    "if mean is a complex number, its real part should equal imag part, ",
-                    f"but got real part: {self._mean.real} != imag part: {self._mean.imag}",
+                    "if mean is a complex number, its real part should equal imag part, "
+                    f"but got real part: {self._mean.real} != imag part: {self._mean.imag}"
                 )
             self._mean = self._mean.real
 

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -279,9 +279,7 @@ class LayerObjectHelper(LayerHelperBase):
         if isinstance(act, str):
             act = {'type': act}
         else:
-            raise TypeError(
-                str(act) + " should be unicode or str in %s ", self.name
-            )
+            raise TypeError(f"{act} should be unicode or str in {self.name}")
 
         if (use_cudnn is not None) and use_cudnn:
             act['use_cudnn'] = use_cudnn
@@ -2491,8 +2489,7 @@ class Layer:
             excluded_layers = list(excluded_layers)
         else:
             raise TypeError(
-                "excluded_layers should be type nn.Layer or list, but got %s.",
-                type(excluded_layers).__name__,
+                f"excluded_layers should be type nn.Layer or list, but got {type(excluded_layers).__name__}.",
             )
 
         def layer_trans(layer):
@@ -2558,8 +2555,7 @@ class Layer:
             excluded_layers = list(excluded_layers)
         else:
             raise TypeError(
-                "excluded_layers should be type nn.Layer or list, but got %s.",
-                type(excluded_layers).__name__,
+                f"excluded_layers should be type nn.Layer or list, but got {type(excluded_layers).__name__}.",
             )
 
         def layer_trans(layer):
@@ -2626,8 +2622,7 @@ class Layer:
             excluded_layers = list(excluded_layers)
         else:
             raise TypeError(
-                "excluded_layers should be type nn.Layer or list, but got %s.",
-                type(excluded_layers).__name__,
+                f"excluded_layers should be type nn.Layer or list, but got {type(excluded_layers).__name__}.",
             )
 
         def layer_trans(layer):

--- a/python/paddle/tensor/layer_function_generator.py
+++ b/python/paddle/tensor/layer_function_generator.py
@@ -71,8 +71,8 @@ def generate_layer_fn(op_type: str):
 
     if len(not_intermediate_outputs) != 1:
         raise ValueError(
-            "Only one non intermediate output operator can be "
-            f"automatically generated. {op_type}"
+            "Only one non intermediate output operator can be",
+            f"automatically generated. {op_type}",
         )
 
     if not_intermediate_outputs[0].duplicable:
@@ -83,7 +83,7 @@ def generate_layer_fn(op_type: str):
     for output in intermediate_outputs:
         if output.duplicable:
             raise ValueError(
-                "The op can be automatically generated only when "
+                "The op can be automatically generated only when ",
                 "all intermediate ops are not duplicable.",
             )
 

--- a/python/paddle/tensor/layer_function_generator.py
+++ b/python/paddle/tensor/layer_function_generator.py
@@ -71,8 +71,8 @@ def generate_layer_fn(op_type: str):
 
     if len(not_intermediate_outputs) != 1:
         raise ValueError(
-            "Only one non intermediate output operator can be",
-            f"automatically generated. {op_type}",
+            "Only one non intermediate output operator can be "
+            f"automatically generated. {op_type}"
         )
 
     if not_intermediate_outputs[0].duplicable:
@@ -83,7 +83,7 @@ def generate_layer_fn(op_type: str):
     for output in intermediate_outputs:
         if output.duplicable:
             raise ValueError(
-                "The op can be automatically generated only when ",
+                "The op can be automatically generated only when "
                 "all intermediate ops are not duplicable.",
             )
 

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -686,12 +686,12 @@ def gaussian(
             core.DataType.COMPLEX128,
         ]:
             raise TypeError(
-                "if mean is a complex number, dtype should be complex64 or complex128, ",
+                "if mean is a complex number, dtype should be complex64 or complex128, "
                 f"but got dtype = {dtype}",
             )
         if mean.real != mean.imag:
             raise ValueError(
-                "The mean of complex gaussian distribution should be a complex number with ",
+                "The mean of complex gaussian distribution should be a complex number with "
                 f"real part equal imaginary part, but got {mean.real} != {mean.imag}",
             )
         mean = mean.real
@@ -778,12 +778,12 @@ def gaussian_(
             core.DataType.COMPLEX128,
         ]:
             raise TypeError(
-                "if mean is a complex number, x's dtype should be complex64 or complex128, ",
+                "if mean is a complex number, x's dtype should be complex64 or complex128, "
                 f"but dtype = {x.dtype}",
             )
         if mean.real != mean.imag:
             raise ValueError(
-                "The mean of complex gaussian distribution should be a complex number with ",
+                "The mean of complex gaussian distribution should be a complex number with "
                 f"real part equal imaginary part, but got {mean.real} != {mean.imag}",
             )
         mean = mean.real


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

TypeError、ValueError 等 builtin Error 只应该接受一个参数[^1]，就是 error message，虽然接收多个也不会报其他错，但是会让报错信息很奇怪（是个 tuple）

```python
>>> raise TypeError("a", "b")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: ('a', 'b')
>>> raise ValueError("a", "b")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: ('a', 'b')
>>> 
```

大多看样子是沿用的 C++ 的习惯，把第一个位置当模板，之后当模板参数了……

PCard-66972

[^1]: https://docs.python.org/3/library/exceptions.html#BaseException.args