### PR TITLE
[CodeStyle][UP031] fix `/test/{deprecated, dygraph_to_static, ir, mkldnn, quantization}*` - part 16

### DIFF
--- a/test/deprecated/legacy_test/auto_parallel_op_test.py
+++ b/test/deprecated/legacy_test/auto_parallel_op_test.py
@@ -496,7 +496,7 @@ class AutoParallelForwardChecker:
             # check eager auto parallel forward
             if len(actual_ret) != len(self.eager_forward_desire):
                 msg = (
-                    f"The eager auto parallel out tensor nums is different with eager out tensor nums on {str(self.place)}."
+                    f"The eager auto parallel out tensor nums is different with eager out tensor nums on {self.place}."
                     f'eager auto parallel out tensor nums = {len(actual_ret)}, eager out tensor nums = {len(self.eager_forward_desire)}. \n'
                 )
                 raise RuntimeError(msg)
@@ -715,7 +715,7 @@ class AutoParallelGradChecker(AutoParallelForwardChecker):
             # check eager auto parallel forward
             if len(actual_forward_res) != len(self.eager_forward_desire):
                 msg = (
-                    f"The eager auto parallel out tensor nums is different with eager out tensor nums on {str(self.place)}."
+                    f"The eager auto parallel out tensor nums is different with eager out tensor nums on {self.place}."
                     f'eager auto parallel out tensor nums = {len(actual_forward_res)}, eager out tensor nums = {len(self.eager_forward_desire)}. \n'
                 )
                 raise RuntimeError(msg)
@@ -741,7 +741,7 @@ class AutoParallelGradChecker(AutoParallelForwardChecker):
             # check eager auto parallel grad
             if len(actual_grad_res) != len(self.eager_grad_desire):
                 msg = (
-                    f"The eager auto parallel grad out tensor nums is different with eager grad out tensor nums on {str(self.place)}."
+                    f"The eager auto parallel grad out tensor nums is different with eager grad out tensor nums on {self.place}."
                     f'eager auto parallel grad out tensor nums = {len(actual_grad_res)}, eager grad out tensor nums = {len(self.eager_grad_desire)}. \n'
                 )
                 raise RuntimeError(msg)

--- a/test/deprecated/legacy_test/test_executor_and_use_program_cache_deprecated.py
+++ b/test/deprecated/legacy_test/test_executor_and_use_program_cache_deprecated.py
@@ -67,22 +67,22 @@ class TestExecutor(unittest.TestCase):
         run_time_with_cache = _train(
             use_program_cache=True, max_iters=max_iters
         )
-        print("run time with program cache: %f" % run_time_with_cache)
+        print(f"run time with program cache: {run_time_with_cache:f}")
 
         run_time_without_cache = _train(
             use_program_cache=False, max_iters=max_iters
         )
-        print("run time without program cache: %f" % run_time_without_cache)
+        print(f"run time without program cache: {run_time_without_cache:f}")
 
         run_time_with_cache = _train(
             use_program_cache=True, max_iters=max_iters
         )
-        print("run time with program cache: %f" % run_time_with_cache)
+        print(f"run time with program cache: {run_time_with_cache:f}")
 
         run_time_with_cache = _train(
             use_program_cache=True, max_iters=max_iters
         )
-        print("run time with program cache: %f" % run_time_with_cache)
+        print(f"run time with program cache: {run_time_with_cache:f}")
 
 
 if __name__ == '__main__':

--- a/test/deprecated/legacy_test/test_inference_model_io_deprecated.py
+++ b/test/deprecated/legacy_test/test_inference_model_io_deprecated.py
@@ -138,7 +138,7 @@ class TestBook(unittest.TestCase):
 
             self.assertEqual(model.feed_var_names, ["x", "y"])
             self.assertEqual(len(model.fetch_vars), 1)
-            print("fetch %s" % str(model.fetch_vars[0]))
+            print(f"fetch {str(model.fetch_vars[0])}")
             self.assertEqual(expected, actual)
 
         root_path.cleanup()

--- a/test/deprecated/legacy_test/test_inference_model_io_deprecated.py
+++ b/test/deprecated/legacy_test/test_inference_model_io_deprecated.py
@@ -138,7 +138,7 @@ class TestBook(unittest.TestCase):
 
             self.assertEqual(model.feed_var_names, ["x", "y"])
             self.assertEqual(len(model.fetch_vars), 1)
-            print(f"fetch {str(model.fetch_vars[0])}")
+            print(f"fetch {model.fetch_vars[0]}")
             self.assertEqual(expected, actual)
 
         root_path.cleanup()

--- a/test/deprecated/legacy_test/test_learning_rate_scheduler.py
+++ b/test/deprecated/legacy_test/test_learning_rate_scheduler.py
@@ -419,7 +419,7 @@ class TestLearningRateDecay(unittest.TestCase):
                 python_decayed_lr,
                 lr_val[0],
                 places=6,
-                msg=f'Failed lr scheduler is {python_decay_fn.__name__}, step {str(step)}, Python result is {str(python_decayed_lr)}, Fluid result is {str(lr_val[0])}',
+                msg=f'Failed lr scheduler is {python_decay_fn.__name__}, step {step}, Python result is {python_decayed_lr}, Fluid result is {lr_val[0]}',
             )
 
     def test_decay(self):
@@ -541,7 +541,7 @@ class TestLinearWamrupLearningRateDecay(unittest.TestCase):
             self.assertAlmostEqual(
                 python_decayed_lr,
                 lr_val[0],
-                msg=f'Test {python_decay_fn.__name__} Failed, step {str(step)}, Python result is {str(python_decayed_lr)}, Fluid result is {str(lr_val[0])}',
+                msg=f'Test {python_decay_fn.__name__} Failed, step {step}, Python result is {python_decayed_lr}, Fluid result is {lr_val[0]}',
             )
 
 

--- a/test/deprecated/legacy_test/test_signal.py
+++ b/test/deprecated/legacy_test/test_signal.py
@@ -111,7 +111,7 @@ def normalize(S, norm=np.inf, axis=0, threshold=None, fill=None):
         return S
 
     else:
-        raise Exception(f"Unsupported norm: {repr(norm)}")
+        raise Exception(f"Unsupported norm: {norm!r}")
 
     # indices where norm is below the threshold
     small_idx = length < threshold

--- a/test/deprecated/quantization/test_imperative_qat.py
+++ b/test/deprecated/quantization/test_imperative_qat.py
@@ -179,7 +179,7 @@ class TestImperativeQat(unittest.TestCase):
                 print('eval_acc_top1', eval_acc_top1)
                 self.assertTrue(
                     eval_acc_top1 > 0.9,
-                    msg="The test acc {%f} is less than 0.9." % eval_acc_top1,
+                    msg=f"The test acc {{{eval_acc_top1:f}}} is less than 0.9.",
                 )
 
             # test the correctness of `paddle.jit.save`
@@ -207,7 +207,7 @@ class TestImperativeQat(unittest.TestCase):
                     )
                 ],
             )
-            print('Quantized model saved in %s' % tmpdir)
+            print(f'Quantized model saved in {tmpdir}')
 
             if core.is_compiled_with_cuda():
                 place = core.CUDAPlace(0)

--- a/test/deprecated/quantization/test_post_training_quantization_while.py
+++ b/test/deprecated/quantization/test_post_training_quantization_while.py
@@ -59,14 +59,14 @@ class TestPostTrainingQuantization(unittest.TestCase):
         try:
             os.system("mkdir -p " + self.int8_model_path)
         except Exception as e:
-            print(f"Failed to create {self.int8_model_path} due to {str(e)}")
+            print(f"Failed to create {self.int8_model_path} due to {e}")
             sys.exit(-1)
 
     def tearDown(self):
         try:
             os.system(f"rm -rf {self.int8_model_path}")
         except Exception as e:
-            print(f"Failed to delete {self.int8_model_path} due to {str(e)}")
+            print(f"Failed to delete {self.int8_model_path} due to {e}")
 
     def cache_unzipping(self, target_folder, zip_path):
         cmd = f'tar xf {zip_path} -C {target_folder}'

--- a/test/deprecated/quantization/test_weight_quantization_mobilenetv1.py
+++ b/test/deprecated/quantization/test_weight_quantization_mobilenetv1.py
@@ -114,7 +114,7 @@ class TestWeightQuantization(unittest.TestCase):
         try:
             os.system(f"rm -rf {save_model_dir}")
         except Exception as e:
-            print(f"Failed to delete {save_model_dir} due to {str(e)}")
+            print(f"Failed to delete {save_model_dir} due to {e}")
 
     def convert_to_fp16(
         self,
@@ -166,7 +166,7 @@ class TestWeightQuantization(unittest.TestCase):
         try:
             os.system(f"rm -rf {save_model_dir}")
         except Exception as e:
-            print(f"Failed to delete {save_model_dir} due to {str(e)}")
+            print(f"Failed to delete {save_model_dir} due to {e}")
 
     def run_models(
         self,

--- a/test/dygraph_to_static/simnet_dygraph_model.py
+++ b/test/dygraph_to_static/simnet_dygraph_model.py
@@ -70,8 +70,8 @@ class FCLayer:
         """
         fc = FC(
             size=self.fc_dim,
-            param_attr=paddle.ParamAttr(name="%s.w" % self.name),
-            bias_attr=paddle.ParamAttr(name="%s.b" % self.name),
+            param_attr=paddle.ParamAttr(name=f"{self.name}.w"),
+            bias_attr=paddle.ParamAttr(name=f"{self.name}.b"),
             act=self.act,
         )
         return fc

--- a/test/dygraph_to_static/test_transformer.py
+++ b/test/dygraph_to_static/test_transformer.py
@@ -275,7 +275,7 @@ def predict_dygraph(args, batch_generator):
         if step_idx == STEP_NUM:
             break
     logging.info(
-        "Dygraph Predict:  avg_speed: %.4f steps/s" % (np.mean(speed_list))
+        f"Dygraph Predict:  avg_speed: {np.mean(speed_list):.4f} steps/s"
     )
     return seq_ids, seq_scores
 

--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -162,7 +162,7 @@ class AutoScanTest(unittest.TestCase):
         for key, arr in tensor.items():
             self.assertTrue(
                 baseline[key].shape == arr.shape,
-                f"The output shapes are not equal, the baseline shape is {baseline[key].shape}, but got {str(arr.shape)}",
+                f"The output shapes are not equal, the baseline shape is {baseline[key].shape}, but got {arr.shape}",
             )
             diff = abs(baseline[key] - arr)
             np.testing.assert_allclose(
@@ -699,7 +699,7 @@ class TrtLayerAutoScanTest(AutoScanTest):
             self.assertEqual(
                 baseline[key].shape,
                 arr.shape,
-                f"The output shapes are not equal, the baseline shape is {baseline[key].shape}, but got {str(arr.shape)}",
+                f"The output shapes are not equal, the baseline shape is {baseline[key].shape}, but got {arr.shape}",
             )
             np.testing.assert_allclose(arr, baseline[key], rtol=rtol, atol=atol)
 
@@ -953,7 +953,7 @@ class CutlassAutoScanTest(AutoScanTest):
                 except Exception as e:
                     self.fail_log(
                         self.inference_config_str(pred_config)
-                        + f'\033[1;31m \nERROR INFO: {str(e)}\033[0m'
+                        + f'\033[1;31m \nERROR INFO: {e}\033[0m'
                     )
                     if not ignore_flag:
                         status = False

--- a/test/mkldnn/test_pool2d_bf16_mkldnn_op.py
+++ b/test/mkldnn/test_pool2d_bf16_mkldnn_op.py
@@ -64,8 +64,8 @@ def pool2d_backward_naive(
         padding_algorithm = padding_algorithm.upper()
         if padding_algorithm not in ["SAME", "VALID", "EXPLICIT"]:
             raise ValueError(
-                "Unknown Attr(padding_algorithm): '%s'. "
-                "It can only be 'SAME' or 'VALID'." % str(padding_algorithm)
+                f"Unknown Attr(padding_algorithm): '{str(padding_algorithm)}'. "
+                "It can only be 'SAME' or 'VALID'."
             )
 
         if padding_algorithm == "VALID":

--- a/test/mkldnn/test_pool2d_bf16_mkldnn_op.py
+++ b/test/mkldnn/test_pool2d_bf16_mkldnn_op.py
@@ -64,7 +64,7 @@ def pool2d_backward_naive(
         padding_algorithm = padding_algorithm.upper()
         if padding_algorithm not in ["SAME", "VALID", "EXPLICIT"]:
             raise ValueError(
-                f"Unknown Attr(padding_algorithm): '{str(padding_algorithm)}'. "
+                f"Unknown Attr(padding_algorithm): '{padding_algorithm}'. "
                 "It can only be 'SAME' or 'VALID'."
             )
 

--- a/test/quantization/test_imperative_ptq.py
+++ b/test/quantization/test_imperative_ptq.py
@@ -229,7 +229,7 @@ class TestImperativePTQ(unittest.TestCase):
             self.ptq.save_quantized_model(
                 model=quant_model, path=save_path, input_spec=input_spec
             )
-            print('Quantized model saved in {%s}' % save_path)
+            print(f'Quantized model saved in {{{save_path}}}')
 
             after_acc_top1 = self.model_test(
                 quant_model, self.batch_num, self.batch_size
@@ -242,9 +242,9 @@ class TestImperativePTQ(unittest.TestCase):
             paddle.disable_static()
 
             # Check
-            print('Before converted acc_top1: %s' % before_acc_top1)
-            print('After converted acc_top1: %s' % after_acc_top1)
-            print('Infer acc_top1: %s' % infer_acc_top1)
+            print(f'Before converted acc_top1: {before_acc_top1}')
+            print(f'After converted acc_top1: {after_acc_top1}')
+            print(f'Infer acc_top1: {infer_acc_top1}')
 
             self.assertTrue(
                 after_acc_top1 >= self.eval_acc_top1,
@@ -295,7 +295,7 @@ class TestImperativePTQfuse(TestImperativePTQ):
             self.ptq.save_quantized_model(
                 model=quant_model, path=save_path, input_spec=input_spec
             )
-            print('Quantized model saved in {%s}' % save_path)
+            print(f'Quantized model saved in {{{save_path}}}')
 
             after_acc_top1 = self.model_test(
                 quant_model, self.batch_num, self.batch_size
@@ -308,9 +308,9 @@ class TestImperativePTQfuse(TestImperativePTQ):
             paddle.disable_static()
 
             # Check
-            print('Before converted acc_top1: %s' % before_acc_top1)
-            print('After converted acc_top1: %s' % after_acc_top1)
-            print('Infer acc_top1: %s' % infer_acc_top1)
+            print(f'Before converted acc_top1: {before_acc_top1}')
+            print(f'After converted acc_top1: {after_acc_top1}')
+            print(f'Infer acc_top1: {infer_acc_top1}')
 
             # Check whether the quant_model is correct after converting.
             # The acc of quantized model should be higher than 0.95.

--- a/test/quantization/test_imperative_qat_amp.py
+++ b/test/quantization/test_imperative_qat_amp.py
@@ -226,7 +226,7 @@ class TestImperativeQatAmp(unittest.TestCase):
             paddle.static.InputSpec(shape=[None, 1, 28, 28], dtype='float32')
         ]
         paddle.jit.save(layer=model, path=self.save_path, input_spec=input_spec)
-        print('Quantized model saved in {%s}' % self.save_path)
+        print(f'Quantized model saved in {{{self.save_path}}}')
 
         end_time = time.time()
         print("total time: %ss" % (end_time - start_time))

--- a/test/quantization/test_post_training_quantization_lstm_model.py
+++ b/test/quantization/test_post_training_quantization_lstm_model.py
@@ -45,7 +45,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
         try:
             os.system("mkdir -p " + self.int8_model_path)
         except Exception as e:
-            print(f"Failed to create {self.int8_model_path} due to {str(e)}")
+            print(f"Failed to create {self.int8_model_path} due to {e}")
             sys.exit(-1)
 
     def tearDown(self):

--- a/test/quantization/test_post_training_quantization_mnist.py
+++ b/test/quantization/test_post_training_quantization_mnist.py
@@ -61,7 +61,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
             os.system("mkdir -p " + self.int8_model_path)
             os.system("mkdir -p " + self.cache_folder)
         except Exception as e:
-            print(f"Failed to create {self.int8_model_path} due to {str(e)}")
+            print(f"Failed to create {self.int8_model_path} due to {e}")
             sys.exit(-1)
 
     def tearDown(self):

--- a/test/quantization/test_post_training_quantization_mobilenetv1.py
+++ b/test/quantization/test_post_training_quantization_mobilenetv1.py
@@ -317,7 +317,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
         try:
             os.system("mkdir " + self.int8_model)
         except Exception as e:
-            _logger.info(f"Failed to create {self.int8_model} due to {str(e)}")
+            _logger.info(f"Failed to create {self.int8_model} due to {e}")
             sys.exit(-1)
 
         place = paddle.CPUPlace()

--- a/test/quantization/test_post_training_quantization_program_resnet50.py
+++ b/test/quantization/test_post_training_quantization_program_resnet50.py
@@ -203,7 +203,7 @@ class TestPostTrainingQuantizationProgram(TestPostTrainingQuantization):
         try:
             os.system("mkdir " + self.int8_model)
         except Exception as e:
-            print(f"Failed to create {self.int8_model} due to {str(e)}")
+            print(f"Failed to create {self.int8_model} due to {e}")
             sys.exit(-1)
 
         place = paddle.CPUPlace()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing 

### Description
<!-- Describe what you’ve done -->

修复 ruff UP031 部分文件

* `/test/deprecated`
* `/test/dygraph_to_static`
* `/test/ir`
* `/test/mkldnn`
* `/test/quantization`

相关pr:
* #65549
* #65552
* #65563
* #65564
* #65571
* #65572
* #65573
* #65574
* #65576