### PR TITLE
[CodeStyle][UP031] fix `/{python, test, tools}/*` - part 19

### DIFF
--- a/paddle/fluid/operators/generator/templates/operator_utils.c.j2
+++ b/paddle/fluid/operators/generator/templates/operator_utils.c.j2
@@ -423,7 +423,7 @@ class {{op["op_name"] | to_pascal_case}}Op : public framework::OperatorWithKerne
   {% set kernel = op["kernel"] %}
   {% if kernel["data_type"] is not none or kernel["backend"] is not none
       or kernel["force_backend"] is not none
-      or "complex_promote" in op or "data_transform" in op 
+      or "complex_promote" in op or "data_transform" in op
       or "get_expected_kernel_type" in op%}
  protected:
     {% if kernel["data_type"] is not none or kernel["backend"] is not none
@@ -629,7 +629,7 @@ class {{name | to_pascal_case}}OpMaker : public framework::SingleGradOpMaker<T> 
       grad_op->SetInput("{{attr | to_int_array_tensors_name}}", this->Input("{{attr | to_int_array_tensors_name}}"));
     }
         {% endif %}
-      {% elif attr["typename"] is scalar and 
+      {% elif attr["typename"] is scalar and
       ("is_support_tensor" not in attr or attr["is_support_tensor"] is false)%}
     if (this->HasInput("{{attr | to_scalar_tensor_name}}")) {
       grad_op->SetInput("{{attr | to_scalar_tensor_name}}", this->Input("{{attr | to_scalar_tensor_name}}"));
@@ -848,7 +848,7 @@ class {{op_name | to_composite_grad_opmaker_name}} : public prim::CompositeGradO
     auto {{outputs[i] + "_t"}} = this->GetSingleInputGrad({{name_in_forward_orig | to_opmaker_name}});
     {% elif output_typename == "Tensor[]" %}
     auto {{outputs[i] + "_t"}} = this->GetMultiInputGrad({{name_in_forward_orig | to_opmaker_name}});
-    {%- endif %}    
+    {%- endif %}
   {%- endfor %}
 {%- endmacro %}
 
@@ -864,7 +864,7 @@ class {{op_name | to_composite_grad_opmaker_name}} : public prim::CompositeGradO
       {{outputs[i]}}[i] = &{{outputs[i] + "_t"}}[i];
     }
     {{outputs[i]}} = this->GetOutputPtr({{outputs[i]}});
-    {%- endif %}    
+    {%- endif %}
   {%- endfor %}
 {%- endmacro %}
 
@@ -876,7 +876,7 @@ class {{op_name | to_composite_grad_opmaker_name}} : public prim::CompositeGradO
     auto {{outputs[i] + "_name"}} = this->GetOutputName({{outputs[i] + "_t"}});
     {% elif output_typename == "Tensor[]" %}
     auto {{outputs[i] + "_name"}} = this->GetOutputName({{outputs[i] + "_t"}});
-    {%- endif %}    
+    {%- endif %}
   {%- endfor %}
 {%- endmacro %}
 

--- a/paddle/phi/api/generator/tensor_operants_gen.py
+++ b/paddle/phi/api/generator/tensor_operants_gen.py
@@ -489,9 +489,9 @@ class OperantsAPI(ForwardAPI):
     def get_declare_args_without_first_tensor(self, inplace_flag=False):
         func_name = self.get_api_func_name()
         declare_args = self.get_input_tensor_args(inplace_flag)
-        assert len(declare_args) >= 1, (
-            "Error! Api %s has no Tensor inputs" % func_name
-        )
+        assert (
+            len(declare_args) >= 1
+        ), f"Error! Api {func_name} has no Tensor inputs"
         first_input_type = " ".join(declare_args[0].split(" ")[:-1])
         # NOTE(HongyuJia): Do not consider "const paddle::optional<Tensor>&"
         assert (
@@ -510,9 +510,9 @@ class OperantsAPI(ForwardAPI):
     def get_define_args_without_first_tensor(self, inplace_flag=False):
         func_name = self.get_api_func_name()
         define_args = self.get_input_tensor_args(inplace_flag)
-        assert len(define_args) >= 1, (
-            "Error! Api %s has no Tensor inputs" % func_name
-        )
+        assert (
+            len(define_args) >= 1
+        ), f"Error! Api {func_name} has no Tensor inputs"
         first_input_type = " ".join(define_args[0].split(" ")[:-1])
         # NOTE(HongyuJia): Do not consider "const paddle::optional<Tensor>&"
         assert (
@@ -525,9 +525,9 @@ class OperantsAPI(ForwardAPI):
 
     def gene_tensor_api_implementation(self):
         func_name = self.get_api_func_name()
-        assert len(self.inputs['names']) >= 1, (
-            "Error! Api %s has no Tensor inputs" % func_name
-        )
+        assert (
+            len(self.inputs['names']) >= 1
+        ), f"Error! Api {func_name} has no Tensor inputs"
         # remove first Tensor argument
         func_args = self.inputs['names'][1:] + self.attrs['names']
         if len(func_args) > 0:

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -449,7 +449,7 @@ def remove_op(block, op, state):
 
             if value in state.sumvaluegrad_to_value:
                 raise ValueError(
-                    'input_grad in [%s] is value which need to sum ', op.name()
+                    f'input_grad in [%s] is value which need to sum {op.name()}'
                 )
     # NOTE(SigureMo): Ensure access to the op's results before removing it.
     # Otherwise, the op will be deconstructed and access the num_results

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -1216,7 +1216,7 @@ def append_backward(loss, parameter_list=None, no_grad_set=None):
         for i, param in enumerate(parameter_list):
             check_type(
                 param,
-                'parameter_list[%s]' % i,
+                f'parameter_list[{i}]',
                 paddle.pir.Value,
                 'base.backward.append_backward',
             )

--- a/python/paddle/base/backward.py
+++ b/python/paddle/base/backward.py
@@ -160,8 +160,7 @@ class ProgramStats:
         for name in checkpoints_name:
             if name not in self.var_op_deps:
                 _logger.info(
-                    "Recompute Optimizer: deleted %s from checkpoints, because it is not used in paddle program."
-                    % name
+                    f"Recompute Optimizer: deleted {name} from checkpoints, because it is not used in paddle program."
                 )
             elif self.var_op_deps[name]["var_as_output_ops"] == []:
                 # input nodes
@@ -1079,8 +1078,9 @@ def _append_backward_ops_with_checkpoints_(
             if op.has_attr("sub_block"):
                 raise Exception(
                     "Recompute don't support ops with sub_block"
-                    "invoke op: %s"
-                    % _pretty_op_desc_(op.desc, "with_sub_block")
+                    "invoke op: {}".format(
+                        _pretty_op_desc_(op.desc, "with_sub_block")
+                    )
                 )
             grad_op_desc, op_grad_to_var = core.get_grad_op_desc(
                 op.desc, no_grad_dict[block.idx], []
@@ -1109,8 +1109,9 @@ def _append_backward_ops_with_checkpoints_(
             if op.has_attr("sub_block"):
                 raise Exception(
                     "Recompute don't support ops with sub_block"
-                    "invoke op: %s"
-                    % _pretty_op_desc_(op.desc, "with_sub_block")
+                    "invoke op: {}".format(
+                        _pretty_op_desc_(op.desc, "with_sub_block")
+                    )
                 )
             grad_op_desc, op_grad_to_var = core.get_grad_op_desc(
                 op.desc, no_grad_dict[block.idx], []
@@ -1139,8 +1140,9 @@ def _append_backward_ops_with_checkpoints_(
             if op.has_attr("sub_block"):
                 raise Exception(
                     "Recompute don't support ops with sub_block"
-                    "invoke op: %s"
-                    % _pretty_op_desc_(op.desc, "with_sub_block")
+                    "invoke op: {}".format(
+                        _pretty_op_desc_(op.desc, "with_sub_block")
+                    )
                 )
             input_and_output_names = []
             input_and_output_names.extend(op.desc.input_arg_names())
@@ -1922,8 +1924,7 @@ def _get_no_grad_set_name(no_grad_set):
                     no_grad_set_name.add(no_grad_var)
                 else:
                     raise TypeError(
-                        "The type of no_grad_set's member must be paddle.base.Variable or str, but received %s."
-                        % (type(no_grad_var))
+                        f"The type of no_grad_set's member must be paddle.base.Variable or str, but received {type(no_grad_var)}."
                     )
         else:
             raise TypeError(
@@ -1941,8 +1942,7 @@ def _get_no_grad_set_value(no_grad_set):
                     no_grad_set_value.add(no_grad_value)
                 else:
                     raise TypeError(
-                        "The type of no_grad_set's member must be paddle.pir.Value, but received %s."
-                        % (type(no_grad_value))
+                        f"The type of no_grad_set's member must be paddle.pir.Value, but received {type(no_grad_value)}."
                     )
         else:
             raise TypeError(
@@ -2250,7 +2250,7 @@ def append_backward(
         for i, param in enumerate(parameter_list):
             check_type(
                 param,
-                'parameter_list[%s]' % i,
+                f'parameter_list[{i}]',
                 (framework.Variable, str),
                 'base.backward.append_backward',
             )

--- a/python/paddle/base/compiler.py
+++ b/python/paddle/base/compiler.py
@@ -143,8 +143,7 @@ class CompiledProgram:
             self._program = program_or_graph
         else:
             raise TypeError(
-                "The type of program_to_graph parameter is wrong, expected Graph or Program, but received %s"
-                % type(program_or_graph)
+                f"The type of program_to_graph parameter is wrong, expected Graph or Program, but received {type(program_or_graph)}"
             )
 
         self._scope = None
@@ -481,8 +480,7 @@ class IpuDynamicPatcher:
         def patch_getter(self, item):
             if not isinstance(item, CacheKey):
                 raise ValueError(
-                    'type(item) should be CacheKey, but received %s'
-                    % type(item).__name__
+                    f'type(item) should be CacheKey, but received {type(item).__name__}'
                 )
             item_id = hash(item)
             self._recent_key = item_id
@@ -1061,8 +1059,7 @@ class IpuCompiledProgram:
 
         if not isinstance(program, framework.Program):
             raise TypeError(
-                "The type of program is wrong, expected Program, but got %s"
-                % type(program)
+                f"The type of program is wrong, expected Program, but got {type(program)}"
             )
 
         self._program = program

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -127,7 +127,7 @@ def set_flags(flags):
             _global_flags()[key] = value
         else:
             raise ValueError(
-                "Flag %s cannot set its value through this function." % (key)
+                f"Flag {key} cannot set its value through this function."
             )
 
 
@@ -161,8 +161,7 @@ def get_flags(flags):
                 flags_value.update(temp)
             else:
                 raise ValueError(
-                    "Flag %s cannot get its value through this function."
-                    % (key)
+                    f"Flag {key} cannot get its value through this function."
                 )
     elif isinstance(flags, str):
         if _global_flags().is_public(flags):
@@ -171,7 +170,7 @@ def get_flags(flags):
             flags_value.update(temp)
         else:
             raise ValueError(
-                "Flag %s cannot get its value through this function." % (flags)
+                f"Flag {flags} cannot get its value through this function."
             )
     else:
         raise TypeError("Flags in get_flags should be a list, tuple or string.")
@@ -552,21 +551,19 @@ def require_version(min_version: str, max_version: str | None = None) -> None:
     """
     if not isinstance(min_version, str):
         raise TypeError(
-            "The type of 'min_version' in require_version must be str, but received %s."
-            % (type(min_version))
+            f"The type of 'min_version' in require_version must be str, but received {type(min_version)}."
         )
 
     if not isinstance(max_version, (str, type(None))):
         raise TypeError(
-            "The type of 'max_version' in require_version must be str or type(None), but received %s."
-            % (type(max_version))
+            f"The type of 'max_version' in require_version must be str or type(None), but received {type(max_version)}."
         )
 
     check_format = re.match(r"\d+(\.\d+){0,3}", min_version)
     if check_format is None or check_format.group() != min_version:
         raise ValueError(
             "The value of 'min_version' in require_version must be in format '\\d+(\\.\\d+){0,3}', "
-            "like '1.5.2.0', but received %s" % min_version
+            f"like '1.5.2.0', but received {min_version}"
         )
 
     if max_version is not None:
@@ -574,7 +571,7 @@ def require_version(min_version: str, max_version: str | None = None) -> None:
         if check_format is None or check_format.group() != max_version:
             raise ValueError(
                 "The value of 'max_version' in require_version must be in format '\\d+(\\.\\d+){0,3}', "
-                "like '1.5.2.0', but received %s" % max_version
+                f"like '1.5.2.0', but received {max_version}"
             )
 
     version_installed = [
@@ -638,9 +635,9 @@ def _dygraph_not_support_(
     func: Callable[_InputT, _RetT]
 ) -> Callable[_InputT, _RetT]:
     def __impl__(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
-        assert not in_dygraph_mode(), (
-            "We don't support %s in dynamic graph mode" % func.__name__
-        )
+        assert (
+            not in_dygraph_mode()
+        ), f"We don't support {func.__name__} in dynamic graph mode"
         return func(*args, **kwargs)
 
     return __impl__
@@ -648,10 +645,9 @@ def _dygraph_not_support_(
 
 def _dygraph_only_(func: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
     def __impl__(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
-        assert in_dygraph_mode(), (
-            "We only support '%s()' in dynamic graph mode, please call 'paddle.disable_static()' to enter dynamic graph mode."
-            % func.__name__
-        )
+        assert (
+            in_dygraph_mode()
+        ), f"We only support '{func.__name__}()' in dynamic graph mode, please call 'paddle.disable_static()' to enter dynamic graph mode."
         return func(*args, **kwargs)
 
     return __impl__
@@ -1335,7 +1331,7 @@ def convert_np_dtype_to_proto_type(np_dtype: np.dtype | str):
     elif dtype == np.complex128:
         return core.VarDesc.VarType.COMPLEX128
     else:
-        raise ValueError("Not supported numpy dtype %s" % dtype)
+        raise ValueError(f"Not supported numpy dtype {dtype}")
 
 
 def convert_np_dtype_to_dtype_(np_dtype):
@@ -3004,7 +3000,7 @@ class OpProtoHolder:
 
         """
         if type not in self.op_proto_map:
-            raise ValueError('Operator "%s" has not been registered.' % type)
+            raise ValueError(f'Operator "{type}" has not been registered.')
         return self.op_proto_map[type]
 
     def update_op_proto(self):
@@ -3204,7 +3200,7 @@ class Operator:
                     op_attrs[op_device] = _current_device
                 else:
                     warnings.warn(
-                        "The Op(%s) is not support to set device." % type
+                        f"The Op({type}) is not support to set device."
                     )
                 if "force_cpu" in op_attrs:
                     if (
@@ -3212,9 +3208,9 @@ class Operator:
                         and op_attrs["force_cpu"] is not None
                     ) or op_attrs["force_cpu"] is not False:
                         warnings.warn(
-                            "The Attr(force_cpu) of Op(%s) will be deprecated in the future, "
+                            f"The Attr(force_cpu) of Op({type}) will be deprecated in the future, "
                             "please use 'device_guard' instead. 'device_guard' has higher priority when they are "
-                            "used at the same time." % type
+                            "used at the same time."
                         )
             if _current_pipeline_stage is not None:
                 pipeline_attr_name = (
@@ -3468,7 +3464,7 @@ class Operator:
 
             if attr_type == core.AttrType.VARS:
                 attr_var_names = [
-                    "'%s'" % var.name() for var in self.desc.attr(name, True)
+                    f"'{var.name()}'" for var in self.desc.attr(name, True)
                 ]
                 a = "{name} = Vars[{value}]".format(
                     name=name, value=",".join(attr_var_names)
@@ -4259,12 +4255,14 @@ class Block:
                 self.parent_idx,
             )
             for var in list(self.vars.values()):
-                res_str += "\n  vars {\n    %s  }" % re_add_indent.sub(
-                    r"\n    \1", var.to_string(throw_on_error, with_details)
+                res_str += "\n  vars {{\n    {}  }}".format(
+                    re_add_indent.sub(
+                        r"\n    \1", var.to_string(throw_on_error, with_details)
+                    )
                 )
             for op in self.ops:
-                res_str += "\n  ops {\n    %s  }" % re_add_indent.sub(
-                    r"\n    \1", op.to_string(throw_on_error)
+                res_str += "\n  ops {{\n    {}  }}".format(
+                    re_add_indent.sub(r"\n    \1", op.to_string(throw_on_error))
                 )
             res_str += "\n}"
         else:
@@ -4323,12 +4321,11 @@ class Block:
         """
         if not isinstance(name, str):
             raise TypeError(
-                "var require string as parameter, but get %s instead."
-                % (type(name))
+                f"var require string as parameter, but get {type(name)} instead."
             )
         v = self.vars.get(name, None)
         if v is None:
-            raise ValueError("var %s not in this block" % name)
+            raise ValueError(f"var {name} not in this block")
         return v
 
     def _find_var_recursive(self, name):
@@ -4432,7 +4429,7 @@ class Block:
         )
 
         if not self.has_var(name):
-            raise ValueError("var %s is not in current block" % name)
+            raise ValueError(f"var {name} is not in current block")
         v = self.var(name)
         if type(v) == Parameter:
             var_type = "Parameter"
@@ -4559,9 +4556,9 @@ class Block:
         if in_dygraph_mode():
             attrs = kwargs.get("attrs", {})
             warnings.warn(
-                "Op `%s` is executed through `append_op` under the dynamic mode, "
+                f"Op `{op_type}` is executed through `append_op` under the dynamic mode, "
                 "the corresponding API implementation needs to be upgraded to "
-                "using `_C_ops` method." % type,
+                "using `_C_ops` method.",
                 DeprecationWarning,
             )
             op = Operator(
@@ -5629,12 +5626,12 @@ class IrGraph:
             node_in(IrNode): the input node.
             node_out(IrNode): the output node.
         """
-        assert node_in.node in self.graph.nodes(), (
-            "node_in(%s) must be in the graph nodes." % node_in.node.name()
-        )
-        assert node_out.node in self.graph.nodes(), (
-            "node_out(%s) must be in the graph nodes." % node_out.node.name()
-        )
+        assert (
+            node_in.node in self.graph.nodes()
+        ), f"node_in({node_in.node.name()}) must be in the graph nodes."
+        assert (
+            node_out.node in self.graph.nodes()
+        ), f"node_out({node_out.node.name()}) must be in the graph nodes."
         node_in.append_output(node_out)
         node_out.append_input(node_in)
 
@@ -5795,9 +5792,9 @@ class IrGraph:
         for n in nodes:
             if n.name() == node_name:
                 target_node = n
-        assert target_node is not None, (
-            "Cannot find the target node (%s)in the giving set." % node_name
-        )
+        assert (
+            target_node is not None
+        ), f"Cannot find the target node ({node_name})in the giving set."
         return target_node
 
     def _update_desc_attr(self, desc, name, val):
@@ -6631,7 +6628,7 @@ class Program:
             if not isinstance(var, str):
                 raise ValueError(
                     "All feeded_var_names of Program._prune_with_input() can only be "
-                    "str, but received %s." % type(var)
+                    f"str, but received {type(var)}."
                 )
 
         # find out all variables that can be generated or updated with given feed
@@ -6660,7 +6657,7 @@ class Program:
                 else:
                     raise ValueError(
                         "All targets of Program._prune_with_input() can only be "
-                        "Variable or Operator, but received %s." % type(t)
+                        f"Variable or Operator, but received {type(t)}."
                     )
 
                 # NOTE(zhiqiu): For variable to be fed in fetch_list, there two cases:
@@ -7002,8 +6999,7 @@ class Program:
     def random_seed(self, seed):
         if not isinstance(seed, int):
             raise ValueError(
-                "Program.random_seed's input seed must be an integer, but received %s."
-                % type(seed)
+                f"Program.random_seed's input seed must be an integer, but received {type(seed)}."
             )
         self._seed = seed
 
@@ -7153,8 +7149,7 @@ class Program:
         """
         if not isinstance(other, Program):
             raise TypeError(
-                "Function Program._copy_param_info_from() needs to pass in a source Program, but received %s"
-                % type(other)
+                f"Function Program._copy_param_info_from() needs to pass in a source Program, but received {type(other)}"
             )
 
         self.global_block()._copy_param_info_from(other.global_block())
@@ -7171,8 +7166,7 @@ class Program:
         """
         if not isinstance(other, Program):
             raise TypeError(
-                "Function Program._copy_param_info_from() needs to pass in a source Program, but received %s"
-                % type(other)
+                f"Function Program._copy_param_info_from() needs to pass in a source Program, but received {type(other)}"
             )
         self._is_distributed = other._is_distributed
         self._is_chief = other._is_chief
@@ -7200,8 +7194,7 @@ class Program:
         """
         if not isinstance(other, Program):
             raise TypeError(
-                "Function Program._copy_param_info_from() needs to pass in a source Program, but received %s"
-                % type(other)
+                f"Function Program._copy_param_info_from() needs to pass in a source Program, but received {type(other)}"
             )
 
         if not pruned_origin_block_id_map:
@@ -7518,8 +7511,7 @@ class Parameter(Variable, metaclass=ParameterMetaClass):
         for each in shape:
             if each < 0:
                 raise ValueError(
-                    "Each dimension of shape for Parameter must be greater than 0, but received %s"
-                    % list(shape)
+                    f"Each dimension of shape for Parameter must be greater than 0, but received {list(shape)}"
                 )
 
         Variable.__init__(
@@ -7628,8 +7620,7 @@ class EagerParamBase(core.eager.Tensor):
         for each in shape:
             if each < 0:
                 raise ValueError(
-                    "Each dimension of shape for Parameter must be greater than 0, but received %s"
-                    % list(shape)
+                    f"Each dimension of shape for Parameter must be greater than 0, but received {list(shape)}"
                 )
 
         if dtype is not None:
@@ -8084,7 +8075,7 @@ def device_guard(device=None):
     ):
         raise ValueError(
             "The Attr(device) should be 'cpu', 'xpu', 'gpu' or custom device, and it can also be empty string or None "
-            "when there is no need to specify device. But received %s" % device
+            f"when there is no need to specify device. But received {device}"
         )
     if index:
         device = ":".join([device, index])

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -4443,7 +4443,7 @@ class Block:
             error_clip = v.error_clip
             stop_gradient = v.stop_gradient
         else:
-            raise ValueError("unsupported var type: %s", type(v))
+            raise ValueError(f"unsupported var type: {type(v)}")
         orig_var_type = v.type
         self.desc._rename_var(name.encode(), new_name.encode())
         # NOTE: v is destroyed by C++ after calling _rename_var.
@@ -7701,8 +7701,7 @@ class EagerParamBase(core.eager.Tensor):
             self.stop_gradient = not trainable
         else:
             raise ValueError(
-                "The type of trainable MUST be bool, but the type is ",
-                type(trainable),
+                f"The type of trainable MUST be bool, but the type is {type(trainable)}"
             )
 
     def _create_init_op(self, block):

--- a/python/paddle/distributed/fleet/launch.py
+++ b/python/paddle/distributed/fleet/launch.py
@@ -305,8 +305,7 @@ def get_cluster_from_args(args, device_mode, devices_per_proc):
 def cpuonly_check(args):
     if args.ips and len(args.ips.split(',')) > 1:
         raise RuntimeError(
-            "CPUONLY launch only support single trainer, that is len(ips)=1, but got %s."
-            % args.ips
+            f"CPUONLY launch only support single trainer, that is len(ips)=1, but got {args.ips}."
         )
     if args.run_mode:
         assert (

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -198,10 +198,9 @@ def _load_state_dict_from_save_inference_model(model_path, config):
                 structured_name = extra_var_info[var_name].get(
                     'structured_name', None
                 )
-                assert structured_name is not None, (
-                    "Cannot find saved variable (%s)'s structured name in saved model."
-                    % var_name
-                )
+                assert (
+                    structured_name is not None
+                ), f"Cannot find saved variable ({var_name})'s structured name in saved model."
                 structured_para_dict[structured_name] = load_param_dict[
                     var_name
                 ]
@@ -339,8 +338,7 @@ def _parse_load_config(configs):
     for key in configs:
         if key not in supported_configs:
             raise ValueError(
-                "The additional config (%s) of `paddle.load` is not supported."
-                % key
+                f"The additional config ({key}) of `paddle.load` is not supported."
             )
 
     # construct inner config
@@ -364,8 +362,7 @@ def _parse_save_config(configs):
     for key in configs:
         if key not in supported_configs:
             raise ValueError(
-                "The additional config (%s) of `paddle.save` is not supported."
-                % key
+                f"The additional config ({key}) of `paddle.save` is not supported."
             )
 
     # construct inner config
@@ -932,7 +929,7 @@ def _legacy_save(obj, path, protocol=2):
     if not isinstance(obj, dict):
         raise NotImplementedError(
             "Now only supports save state_dict of Layer or Optimizer, "
-            "expect dict, but received %s." % type(obj)
+            f"expect dict, but received {type(obj)}."
         )
 
     if len(obj) == 0:

--- a/python/paddle/incubate/layers/nn.py
+++ b/python/paddle/incubate/layers/nn.py
@@ -552,8 +552,7 @@ def partial_concat(input, start_index=0, length=-1):
     """
     if not isinstance(input, list):
         warnings.warn(
-            "The type of input in partial_concat should be list, but received %s."
-            % (type(input))
+            f"The type of input in partial_concat should be list, but received {type(input)}."
         )
         input = [input]
     for id, x in enumerate(input):

--- a/python/paddle/io/multiprocess_utils.py
+++ b/python/paddle/io/multiprocess_utils.py
@@ -71,7 +71,7 @@ class CleanupFuncRegistrar:
 
         def _func_register(function):
             if not callable(function):
-                raise TypeError("%s is not callable object." % (function))
+                raise TypeError(f"{function} is not callable object.")
             # check function object whether hash-able {function}
             if function not in cls._registered_func_set:
                 atexit.register(_func_executor)

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -684,8 +684,7 @@ def deserialize_persistables(program, data, executor):
     """
     if not isinstance(program, Program):
         raise TypeError(
-            "program type must be `base.Program`, but received `%s`"
-            % type(program)
+            f"program type must be `base.Program`, but received `{type(program)}`"
         )
     # load params to a tmp program
     load_program = Program()

--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -923,21 +923,21 @@ def conv2d(
     if not isinstance(use_cudnn, bool):
         raise ValueError(
             "Attr(use_cudnn) should be True or False. Received "
-            "Attr(use_cudnn): %s. " % str(use_cudnn)
+            f"Attr(use_cudnn): {use_cudnn}. "
         )
 
     if data_format not in ["NCHW", "NHWC"]:
         raise ValueError(
             "Attr(data_format) should be 'NCHW' or 'NHWC'. Received "
-            "Attr(data_format): %s." % str(data_format)
+            f"Attr(data_format): {data_format}."
         )
 
     channel_last = data_format == "NHWC"
     num_channels = input.shape[3] if channel_last else input.shape[1]
     if num_channels < 0:
         raise ValueError(
-            f"The channel dimension of the input({str(input.shape)}) should be defined. "
-            f"Received: {str(num_channels)}."
+            f"The channel dimension of the input({input.shape}) should be defined. "
+            f"Received: {num_channels}."
         )
     assert param_attr is not False, "param_attr should not be False here."
 
@@ -987,8 +987,8 @@ def conv2d(
             ):
                 if not (padding[0] == [0, 0] and padding[1] == [0, 0]):
                     raise ValueError(
-                        "Non-zero padding(%s) in the batch or channel dimensions "
-                        "is not supported." % str(padding)
+                        f"Non-zero padding({padding}) in the batch or channel dimensions "
+                        "is not supported."
                     )
                 padding = padding[2:4]
                 padding = [ele for a_list in padding for ele in a_list]
@@ -997,8 +997,8 @@ def conv2d(
             ):
                 if not (padding[0] == [0, 0] and padding[3] == [0, 0]):
                     raise ValueError(
-                        "Non-zero padding(%s) in the batch or channel dimensions "
-                        "is not supported." % str(padding)
+                        f"Non-zero padding({padding}) in the batch or channel dimensions "
+                        "is not supported."
                     )
                 padding = padding[1:3]
                 padding = [ele for a_list in padding for ele in a_list]
@@ -1016,8 +1016,7 @@ def conv2d(
         padding = padding.upper()
         if padding not in ["SAME", "VALID"]:
             raise ValueError(
-                "Unknown padding: '%s'. It can only be 'SAME' or 'VALID'."
-                % str(padding)
+                f"Unknown padding: '{padding}'. It can only be 'SAME' or 'VALID'."
             )
         if padding == "VALID":
             padding_algorithm = "VALID"
@@ -1233,13 +1232,13 @@ def conv3d(
     if not isinstance(use_cudnn, bool):
         raise ValueError(
             "Attr(use_cudnn) should be True or False. Received "
-            "Attr(use_cudnn): %s. " % str(use_cudnn)
+            f"Attr(use_cudnn): {use_cudnn}. "
         )
 
     if data_format not in ["NCDHW", "NDHWC"]:
         raise ValueError(
             "Attr(data_format) should be 'NCDHW' or 'NDHWC'. Received "
-            "Attr(data_format): %s." % str(data_format)
+            f"Attr(data_format): {data_format}."
         )
 
     channel_last = data_format == "NDHWC"
@@ -1250,8 +1249,8 @@ def conv3d(
     num_channels = input.shape[4] if channel_last else input.shape[1]
     if num_channels < 0:
         raise ValueError(
-            f"The channel dimension of the input({str(input.shape)}) should be defined. "
-            f"Received: {str(num_channels)}."
+            f"The channel dimension of the input({input.shape}) should be defined. "
+            f"Received: {num_channels}."
         )
 
     if groups is None:
@@ -1264,7 +1263,7 @@ def conv3d(
         if num_channels % groups != 0:
             raise ValueError(
                 "The number of input channels must be divisible by Attr(groups). "
-                f"Received: number of channels({str(num_channels)}), groups({str(groups)})."
+                f"Received: number of channels({num_channels}), groups({groups})."
             )
         num_filter_channels = num_channels // groups
 
@@ -1279,8 +1278,8 @@ def conv3d(
             ):
                 if not (padding[0] == [0, 0] and padding[1] == [0, 0]):
                     raise ValueError(
-                        "Non-zero padding(%s) in the batch or channel dimensions "
-                        "is not supported." % str(padding)
+                        f"Non-zero padding({padding}) in the batch or channel dimensions "
+                        "is not supported."
                     )
                 padding = padding[2:5]
                 padding = [ele for a_list in padding for ele in a_list]
@@ -1289,8 +1288,8 @@ def conv3d(
             ):
                 if not (padding[0] == [0, 0] and padding[4] == [0, 0]):
                     raise ValueError(
-                        "Non-zero padding(%s) in the batch or channel dimensions "
-                        "is not supported." % str(padding)
+                        f"Non-zero padding({padding}) in the batch or channel dimensions "
+                        "is not supported."
                     )
                 padding = padding[1:4]
                 padding = [ele for a_list in padding for ele in a_list]
@@ -1311,8 +1310,7 @@ def conv3d(
         padding = padding.upper()
         if padding not in ["SAME", "VALID"]:
             raise ValueError(
-                "Unknown padding: '%s'. It can only be 'SAME' or 'VALID'."
-                % str(padding)
+                f"Unknown padding: '{padding}'. It can only be 'SAME' or 'VALID'."
             )
         if padding == "VALID":
             padding_algorithm = "VALID"
@@ -1600,8 +1598,8 @@ def conv2d_transpose(
             ):
                 if not (padding[0] == [0, 0] and padding[1] == [0, 0]):
                     raise ValueError(
-                        "Non-zero padding(%s) in the batch or channel dimensions "
-                        "is not supported." % str(padding)
+                        f"Non-zero padding({padding}) in the batch or channel dimensions "
+                        "is not supported."
                     )
                 padding = padding[2:4]
                 padding = [ele for a_list in padding for ele in a_list]
@@ -1610,8 +1608,8 @@ def conv2d_transpose(
             ):
                 if not (padding[0] == [0, 0] and padding[3] == [0, 0]):
                     raise ValueError(
-                        "Non-zero padding(%s) in the batch or channel dimensions "
-                        "is not supported." % str(padding)
+                        f"Non-zero padding({padding}) in the batch or channel dimensions "
+                        "is not supported."
                     )
                 padding = padding[1:3]
                 padding = [ele for a_list in padding for ele in a_list]
@@ -1626,8 +1624,7 @@ def conv2d_transpose(
         padding = padding.upper()
         if padding not in ["SAME", "VALID"]:
             raise ValueError(
-                "Unknown padding: '%s'. It can only be 'SAME' or 'VALID'."
-                % str(padding)
+                f"Unknown padding: '{padding}'. It can only be 'SAME' or 'VALID'."
             )
         if padding == "VALID":
             padding_algorithm = "VALID"
@@ -1971,8 +1968,8 @@ def conv3d_transpose(
             ):
                 if not (padding[0] == [0, 0] and padding[1] == [0, 0]):
                     raise ValueError(
-                        "Non-zero padding(%s) in the batch or channel dimensions "
-                        "is not supported." % str(padding)
+                        f"Non-zero padding({padding}) in the batch or channel dimensions "
+                        "is not supported."
                     )
                 padding = padding[2:5]
                 padding = [ele for a_list in padding for ele in a_list]
@@ -1981,8 +1978,8 @@ def conv3d_transpose(
             ):
                 if not (padding[0] == [0, 0] and padding[4] == [0, 0]):
                     raise ValueError(
-                        "Non-zero padding(%s) in the batch or channel dimensions "
-                        "is not supported." % str(padding)
+                        f"Non-zero padding({padding}) in the batch or channel dimensions "
+                        "is not supported."
                     )
                 padding = padding[1:4]
                 padding = [ele for a_list in padding for ele in a_list]
@@ -2008,8 +2005,7 @@ def conv3d_transpose(
         padding = padding.upper()
         if padding not in ["SAME", "VALID"]:
             raise ValueError(
-                "Unknown padding: '%s'. It can only be 'SAME' or 'VALID'."
-                % str(padding)
+                f"Unknown padding: '{padding}'. It can only be 'SAME' or 'VALID'."
             )
         if padding == "VALID":
             padding_algorithm = "VALID"

--- a/python/paddle/tensor/layer_function_generator.py
+++ b/python/paddle/tensor/layer_function_generator.py
@@ -71,8 +71,8 @@ def generate_layer_fn(op_type: str):
 
     if len(not_intermediate_outputs) != 1:
         raise ValueError(
-            "Only one non intermediate output operator can be",
-            f"automatically generated. {op_type}",
+            "Only one non intermediate output operator can be"
+            f"automatically generated. {op_type}"
         )
 
     if not_intermediate_outputs[0].duplicable:
@@ -83,8 +83,8 @@ def generate_layer_fn(op_type: str):
     for output in intermediate_outputs:
         if output.duplicable:
             raise ValueError(
-                "The op can be automatically generated only when ",
-                "all intermediate ops are not duplicable.",
+                "The op can be automatically generated only when "
+                "all intermediate ops are not duplicable."
             )
 
     o_name = not_intermediate_outputs[0].name

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -797,9 +797,9 @@ if '${WITH_CINN}' == 'ON':
         package_data['paddle.libs']+=['bfloat16.h']
 
     if '${CMAKE_BUILD_TYPE}' == 'Release' and os.name != 'nt':
-        command = f"patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_nvrtc/lib/:$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cublas/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/../../nvidia/curand/lib/:$ORIGIN/../../nvidia/cusolver/lib/:$ORIGIN/../../nvidia/nvtx/lib/:$ORIGIN/' {libs_path}/${{CINN_LIB_NAME}}"
+        command = f"patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_nvrtc/lib/:$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cublas/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/../../nvidia/curand/lib/:$ORIGIN/../../nvidia/cusolver/lib/:$ORIGIN/../../nvidia/nvtx/lib/:$ORIGIN/' {libs_path}/${CINN_LIB_NAME}"
         if os.system(command) != 0:
-            raise Exception(f"patch {libs_path}/${{CINN_LIB_NAME}} failed, command: {command}")
+            raise Exception(f"patch {libs_path}/${CINN_LIB_NAME} failed, command: {command}")
 
 if '${WITH_PSLIB}' == 'ON':
     shutil.copy('${PSLIB_LIB}', libs_path)
@@ -906,7 +906,7 @@ if '${CMAKE_BUILD_TYPE}' == 'Release':
         if platform.machine() != 'sw_64' and platform.machine() != 'mips64':
             for command in commands:
                 if os.system(command) != 0:
-                    raise Exception(f"patch ${{FLUID_CORE_NAME}}.{ext_name} failed, command: {command}")
+                    raise Exception(f"patch ${FLUID_CORE_NAME}.{ext_name} failed, command: {command}")
 
 ext_modules = [Extension('_foo', ['stub.cc'])]
 if os.name == 'nt':

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -797,9 +797,9 @@ if '${WITH_CINN}' == 'ON':
         package_data['paddle.libs']+=['bfloat16.h']
 
     if '${CMAKE_BUILD_TYPE}' == 'Release' and os.name != 'nt':
-        command = "patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_nvrtc/lib/:$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cublas/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/../../nvidia/curand/lib/:$ORIGIN/../../nvidia/cusolver/lib/:$ORIGIN/../../nvidia/nvtx/lib/:$ORIGIN/' %s/${CINN_LIB_NAME}" % libs_path
+        command = f"patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_nvrtc/lib/:$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cublas/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/../../nvidia/curand/lib/:$ORIGIN/../../nvidia/cusolver/lib/:$ORIGIN/../../nvidia/nvtx/lib/:$ORIGIN/' {libs_path}/${{CINN_LIB_NAME}}"
         if os.system(command) != 0:
-            raise Exception("patch %s/${CINN_LIB_NAME} failed, command: %s" % (libs_path, command))
+            raise Exception(f"patch {libs_path}/${{CINN_LIB_NAME}} failed, command: {command}")
 
 if '${WITH_PSLIB}' == 'ON':
     shutil.copy('${PSLIB_LIB}', libs_path)
@@ -820,7 +820,7 @@ if '${WITH_ONEDNN}' == 'ON':
         # thus, libdnnl.so.1 will find libmklml_intel.so and libiomp5.so.
         command = "patchelf --set-rpath '$ORIGIN/' ${ONEDNN_SHARED_LIB}"
         if os.system(command) != 0:
-            raise Exception("patch libdnnl.so failed, command: %s" % command)
+            raise Exception(f"patch libdnnl.so failed, command: {command}")
     shutil.copy('${ONEDNN_SHARED_LIB}', libs_path)
     if os.name != 'nt':
         package_data['paddle.libs']+=['libdnnl.so.3']
@@ -906,7 +906,7 @@ if '${CMAKE_BUILD_TYPE}' == 'Release':
         if platform.machine() != 'sw_64' and platform.machine() != 'mips64':
             for command in commands:
                 if os.system(command) != 0:
-                    raise Exception("patch ${FLUID_CORE_NAME}.%s failed, command: %s" % (ext_name, command))
+                    raise Exception(f"patch ${{FLUID_CORE_NAME}}.{ext_name} failed, command: {command}")
 
 ext_modules = [Extension('_foo', ['stub.cc'])]
 if os.name == 'nt':
@@ -1081,7 +1081,7 @@ if '${WITH_STRIP}' == 'ON':
         + '/python/paddle -name "*.so" | xargs -i strip {}'
     )
     if os.system(command) != 0:
-        raise Exception("strip *.so failed, command: %s" % command)
+        raise Exception(f"strip *.so failed, command: {command}")
 
 
 def check_build_dependency():

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -797,9 +797,9 @@ if '${WITH_CINN}' == 'ON':
         package_data['paddle.libs']+=['bfloat16.h']
 
     if '${CMAKE_BUILD_TYPE}' == 'Release' and os.name != 'nt':
-        command = f"patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_nvrtc/lib/:$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cublas/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/../../nvidia/curand/lib/:$ORIGIN/../../nvidia/cusolver/lib/:$ORIGIN/../../nvidia/nvtx/lib/:$ORIGIN/' {libs_path}/${CINN_LIB_NAME}"
+        command = "patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_nvrtc/lib/:$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cublas/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/../../nvidia/curand/lib/:$ORIGIN/../../nvidia/cusolver/lib/:$ORIGIN/../../nvidia/nvtx/lib/:$ORIGIN/' %s/${CINN_LIB_NAME}" % libs_path
         if os.system(command) != 0:
-            raise Exception(f"patch {libs_path}/${CINN_LIB_NAME} failed, command: {command}")
+            raise Exception("patch %s/${CINN_LIB_NAME} failed, command: %s" % (libs_path, command))
 
 if '${WITH_PSLIB}' == 'ON':
     shutil.copy('${PSLIB_LIB}', libs_path)
@@ -820,7 +820,7 @@ if '${WITH_ONEDNN}' == 'ON':
         # thus, libdnnl.so.1 will find libmklml_intel.so and libiomp5.so.
         command = "patchelf --set-rpath '$ORIGIN/' ${ONEDNN_SHARED_LIB}"
         if os.system(command) != 0:
-            raise Exception(f"patch libdnnl.so failed, command: {command}")
+            raise Exception("patch libdnnl.so failed, command: %s" % command)
     shutil.copy('${ONEDNN_SHARED_LIB}', libs_path)
     if os.name != 'nt':
         package_data['paddle.libs']+=['libdnnl.so.3']
@@ -906,7 +906,7 @@ if '${CMAKE_BUILD_TYPE}' == 'Release':
         if platform.machine() != 'sw_64' and platform.machine() != 'mips64':
             for command in commands:
                 if os.system(command) != 0:
-                    raise Exception(f"patch ${FLUID_CORE_NAME}.{ext_name} failed, command: {command}")
+                    raise Exception("patch ${FLUID_CORE_NAME}.%s failed, command: %s" % (ext_name, command))
 
 ext_modules = [Extension('_foo', ['stub.cc'])]
 if os.name == 'nt':
@@ -1081,7 +1081,7 @@ if '${WITH_STRIP}' == 'ON':
         + '/python/paddle -name "*.so" | xargs -i strip {}'
     )
     if os.system(command) != 0:
-        raise Exception(f"strip *.so failed, command: {command}")
+        raise Exception("strip *.so failed, command: %s" % command)
 
 
 def check_build_dependency():

--- a/setup.py
+++ b/setup.py
@@ -1181,8 +1181,7 @@ def get_package_data_and_package_dir():
 
         if env_dict.get("CMAKE_BUILD_TYPE") == 'Release' and os.name != 'nt':
             command = (
-                "patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_nvrtc/lib/:$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cublas/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/../../nvidia/curand/lib/:$ORIGIN/../../nvidia/cusolver/lib/:$ORIGIN/../../nvidia/nvtx/lib/:$ORIGIN/' %s/"
-                % libs_path
+                f"patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_nvrtc/lib/:$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cublas/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/../../nvidia/curand/lib/:$ORIGIN/../../nvidia/cusolver/lib/:$ORIGIN/../../nvidia/nvtx/lib/:$ORIGIN/' {libs_path}/"
                 + env_dict.get("CINN_LIB_NAME")
             )
             if os.system(command) != 0:
@@ -1192,7 +1191,7 @@ def get_package_data_and_package_dir():
                     + '/'
                     + env_dict.get("CINN_LIB_NAME")
                     + ' failed',
-                    'command: %s' % command,
+                    f'command: {command}',
                 )
     if env_dict.get("WITH_PSLIB") == 'ON':
         shutil.copy(env_dict.get("PSLIB_LIB"), libs_path)
@@ -1218,9 +1217,7 @@ def get_package_data_and_package_dir():
                 "ONEDNN_SHARED_LIB"
             )
             if os.system(command) != 0:
-                raise Exception(
-                    "patch libdnnl.so failed, command: %s" % command
-                )
+                raise Exception(f"patch libdnnl.so failed, command: {command}")
         shutil.copy(env_dict.get("ONEDNN_SHARED_LIB"), libs_path)
         if os.name != 'nt':
             package_data['paddle.libs'] += ['libdnnl.so.3']
@@ -1379,8 +1376,8 @@ def get_package_data_and_package_dir():
                         raise Exception(
                             'patch '
                             + env_dict.get("FLUID_CORE_NAME")
-                            + '%s failed' % ext_suffix,
-                            'command: %s' % command,
+                            + f'{ext_suffix} failed',
+                            f'command: {command}',
                         )
     # A list of extensions that specify c++ -written modules that compile source code into dynamically linked libraries
     ext_modules = [Extension('_foo', [paddle_binary_dir + '/python/stub.cc'])]
@@ -1943,7 +1940,7 @@ def main():
             + '/python/paddle -name "*.so" | xargs -i strip {}'
         )
         if os.system(command) != 0:
-            raise Exception("strip *.so failed, command: %s" % command)
+            raise Exception(f"strip *.so failed, command: {command}")
 
     # install cpp distribution
     if env_dict.get("WITH_CPP_DIST") == 'ON':

--- a/test/auto_parallel/test_static_gradient_sync.py
+++ b/test/auto_parallel/test_static_gradient_sync.py
@@ -222,7 +222,7 @@ class TestGradSync(unittest.TestCase):
                         )
                 else:
                     raise AssertionError(
-                        f"encounter redundant gradient synchronization: [{str(op)}]"
+                        f"encounter redundant gradient synchronization: [{op}]"
                     )
                 allreduce_count += 1
 
@@ -241,7 +241,7 @@ class TestGradSync(unittest.TestCase):
                     )
                 else:
                     raise AssertionError(
-                        f"encounter redundant gradient synchronization: [{str(op)}]"
+                        f"encounter redundant gradient synchronization: [{op}]"
                     )
 
                 scale_count += 1

--- a/test/cpp/inference/api/full_pascalvoc_test_preprocess.py
+++ b/test/cpp/inference/api/full_pascalvoc_test_preprocess.py
@@ -277,13 +277,13 @@ def download_pascalvoc(data_url, data_dir, tar_targethash, tar_path):
     print("Downloading pascalvcoc test set...")
     download(data_url, data_dir, tar_targethash)
     if not os.path.exists(tar_path):
-        print("Failed in downloading pascalvoc test set. URL %s\n" % data_url)
+        print(f"Failed in downloading pascalvoc test set. URL {data_url}\n")
     else:
         tmp_hash = hashlib.md5(open(tar_path, 'rb').read()).hexdigest()
         if tmp_hash != tar_targethash:
             print("Downloaded test set is broken, removing ...\n")
         else:
-            print("Downloaded successfully. Path: %s\n" % tar_path)
+            print(f"Downloaded successfully. Path: {tar_path}\n")
 
 
 def run_convert():
@@ -305,7 +305,7 @@ def run_convert():
         else:
             download_pascalvoc(DATA_URL, DATA_DIR, TAR_TARGETHASH, TAR_PATH)
             convert_pascalvoc_tar2bin(TAR_PATH, DATA_OUT_PATH)
-    print("Success!\nThe binary file can be found at %s\n" % DATA_OUT_PATH)
+    print(f"Success!\nThe binary file can be found at {DATA_OUT_PATH}\n")
 
 
 def main_pascalvoc_preprocess(args):

--- a/tools/handle_h_cu_file.py
+++ b/tools/handle_h_cu_file.py
@@ -65,8 +65,7 @@ def insert_pile_to_h_file(rootPath):
             f'echo "__attribute__((constructor)) static void calledFirst{func}()\n{{" >> {line}'
         )
         os.system(
-            'echo \'    fprintf(stderr,"precise test map fileeee: %%s\\\\n", __FILE__);\n}\' >> %s'
-            % line
+            f'echo \'    fprintf(stderr,"precise test map fileeee: %s\\\\n", __FILE__);\n}}\' >> {line}'
         )
         os.system(f'echo "\n#endif" >> {line}')
 
@@ -83,7 +82,7 @@ def add_simple_cxx_test(rootPath):
         os.system(
             f'echo "TEST(interface_test, type) {{ }}\n" >> {simple_test_path}'
         )
-        os.system('echo "cc_test(" >> %s' % variant_test_cmakeflie_path)
+        os.system(f'echo "cc_test(" >> {variant_test_cmakeflie_path}')
         os.system(
             f'echo "  simple_precision_test" >> {variant_test_cmakeflie_path}'
         )
@@ -117,7 +116,7 @@ def get_h_cu_file(file_path):
             f"cat {dir_path}/{filename} | grep 'precise test map fileeee:'| uniq >> {rootPath}/build/ut_map/{ut}/related_{ut}.txt"
         )
     else:
-        print("%s has failed,no has direcotory" % ut)
+        print(f"{ut} has failed,no has direcotory")
 
 
 def doFun(file_path):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing 

### Description
<!-- Describe what you’ve done -->

修复 Ruff 0.5.0 检测出来的 UP031 问题，为升级 Ruff 0.5.0 做准备

UP031 为将 `"aaa %s bbb" % x` 替换为 `"aaa {} bbb".format(x)` 的 rule，结合 UP032 可直接替换为可读性更佳的 f-string（即 `f"aaa {x} bbb"`），本 PR 接近收尾 PR，后续将会进行 Ruff 升级工作

相关pr:
* #65549
* #65552
* #65563
* #65564
* #65571
* #65572
* #65573
* #65574
* #65576
* #65577
* #65578
* #65580