### PR TITLE
[Inference] fix Predictor support pir model save(.json)

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -1315,13 +1315,6 @@ void AnalysisConfig::DisableGlogInfo() {
   Update();
 }
 
-void AnalysisConfig::PartiallyRelease() {
-  prog_file_.clear();
-  prog_file_.shrink_to_fit();
-  params_file_.clear();
-  params_file_.shrink_to_fit();
-}
-
 void AnalysisConfig::EnableGpuMultiStream() { thread_local_stream_ = true; }
 
 std::string AnalysisConfig::Summary() {

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1238,7 +1238,7 @@ bool AnalysisPredictor::PrepareExecutor() {
 #endif
   }
 
-  if (load_pir_model_) {
+  if (config_.new_ir_enabled()) {
     executor_->Prepare(sub_scope_);
   } else {
     DisablePrepareDataOpt(inference_program_, 0, false);
@@ -1259,7 +1259,7 @@ bool AnalysisPredictor::PrepareExecutor() {
     execution_config.skip_gc_vars.insert(output_names.begin(),
                                          output_names.end());
 
-    VLOG(1) << "predictor program " << *pir_program_;
+    std::cout << "predictor program " << *pir_program_ << std::endl;
     if (config_.new_ir_enabled()) {
       executor_->PrepareInterpreterCore(
           sub_scope_, *pir_program_, execution_config);

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -2293,12 +2293,12 @@ void AnalysisPredictor::OptimizeInferenceProgram() {
 #endif
         delete prog;
       });
-  // The config and argument take a lot of storage,
-  // when the predictor settings are complete, we release these stores.
+
 #if defined(PADDLE_WITH_TESTING)
   fusion_statis_ = *argument_->fusion_statis_ptr();
 #endif
-
+  // The argument take a lot of storage,
+  // when the predictor settings are complete, we release these stores.
 #if defined(_WIN32)
   argument_->PartiallyRelease();
 #else

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -450,7 +450,6 @@ bool AnalysisPredictor::Init(
       optimized_model = optimized_model_path + "/" + "_optimized.json";
     } else {
       optimized_model = optimized_model_path + "/" + "_optimized.pdmodel";
-      LOG(INFO) << "optimized_model" << optimized_model;
     }
     std::string optimized_params =
         optimized_model_path + "/" + "_optimized.pdiparams";
@@ -651,9 +650,7 @@ void AnalysisPredictor::ClearExtraParams() {
       }
     }
   }
-  for (auto name : extra_params) {
-    LOG(INFO) << "清除的name " << name;
-  }
+
   scope_->EraseVars(extra_params);
   VLOG(1) << "Clear " << extra_params.size() << " extra params.";
 }
@@ -922,10 +919,8 @@ void AnalysisPredictor::OptimizeInferencePirProgram() {
     pass_pm.Run(pir_program_.get());
 
     if (config_.save_optimized_model_) {
-      std::string optimized_model_path = GetOptimizedModelPath();
-      LOG(INFO) << " optimized_model_path" << optimized_model_path;
       std::string optimized_model =
-          optimized_model_path + "/" + "_optimized.json";
+          GetOptimizedModelPath() + "/" + "_optimized.json";
       pir::WriteModule(*pir_program_, optimized_model, 1, true, false, true);
       LOG(INFO) << "Optimized model saved to " << optimized_model;
       SaveOrLoadPirParameters(true);

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1066,7 +1066,6 @@ bool AnalysisPredictor::SaveOrLoadPirParameters(bool for_save) {
     if (var == nullptr) {
       if (value && value.type().isa<pir::DenseTensorType>()) {
         var = sub_scope_->Var(param_names[i]);
-        LOG(INFO) << "Created new variable: " << param_names[i];
       } else {
         PADDLE_THROW(platform::errors::Unavailable(
             "Only support parameter data of type DenseTensor."));
@@ -2294,6 +2293,7 @@ void AnalysisPredictor::OptimizeInferenceProgram() {
       });
   // The config and argument take a lot of storage,
   // when the predictor settings are complete, we release these stores.
+  config_.PartiallyRelease();
 #if defined(PADDLE_WITH_TESTING)
   fusion_statis_ = *argument_->fusion_statis_ptr();
 #endif

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -1132,7 +1132,6 @@ struct PD_INFER_DECL AnalysisConfig {
   /// stream to the thread, and this behavior may be changed in the future.
   ///
   void EnableGpuMultiStream();
-  void PartiallyRelease();
 
   ///
   /// \brief Print the summary of config.

--- a/paddle/fluid/inference/capi_exp/pd_config.cc
+++ b/paddle/fluid/inference/capi_exp/pd_config.cc
@@ -487,10 +487,7 @@ void PD_ConfigSetExecStream(__pd_keep PD_Config* pd_config, void* stream) {
   CHECK_AND_CONVERT_PD_CONFIG;
   return config->SetExecStream(stream);
 }
-void PD_ConfigPartiallyRelease(__pd_keep PD_Config* pd_config) {
-  CHECK_AND_CONVERT_PD_CONFIG;
-  config->PartiallyRelease();
-}
+
 void PD_ConfigDeletePass(__pd_keep PD_Config* pd_config, const char* pass) {
   CHECK_AND_CONVERT_PD_CONFIG;
   config->pass_builder()->DeletePass(pass);

--- a/paddle/fluid/inference/capi_exp/pd_config.h
+++ b/paddle/fluid/inference/capi_exp/pd_config.h
@@ -721,13 +721,6 @@ PADDLE_CAPI_EXPORT extern void PD_ConfigSetInvalid(
 PADDLE_CAPI_EXPORT extern PD_Bool PD_ConfigIsValid(
     __pd_keep PD_Config* pd_config);
 ///
-/// \brief Partially release the memory
-///
-/// \param[in] pd_config config
-///
-PADDLE_CAPI_EXPORT extern void PD_ConfigPartiallyRelease(
-    __pd_keep PD_Config* pd_config);
-///
 /// \brief Delete all passes that has a certain type 'pass'.
 ///
 /// \param[in] pass the certain pass type to be deleted.

--- a/test/cpp/inference/api/analyzer_capi_exp_pd_config_tester.cc
+++ b/test/cpp/inference/api/analyzer_capi_exp_pd_config_tester.cc
@@ -112,7 +112,6 @@ TEST(PD_Config, interface) {
   bool is_valid = PD_ConfigIsValid(config);
   EXPECT_FALSE(is_valid);
 
-  PD_ConfigPartiallyRelease(config);
   PD_ConfigDestroy(config);
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
card-71500
修复了pdmodel模型跑pir的时候，因为跑了旧ir的pass，旧ir的pass设置了config_.PartiallyRelease();导致保存的路径不对，而json跑pir的时候，路径就正确，删除了config_.PartiallyRelease()，并解决了跑pdmodel，但是查询到了优化后的_optimized.json，代码跑到了prepareprogram里面的，导致core down的问题