### PR TITLE
inference use FLAGS_enable_pir_api control pir mode

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -391,6 +391,10 @@ AnalysisPredictor::AnalysisPredictor(const AnalysisConfig &config)
   if (config_.shape_range_info_collected()) {
     config_.SwitchIrOptim(false);
   }
+  if (FLAGS_enable_pir_api) {
+    config_.EnableNewExecutor(true);
+    config_.EnableNewIR(true);
+  }
   if (config_.new_executor_enabled()) {
     config_.EnableMemoryOptim(false);
     if (config_.new_ir_enabled()) {
@@ -417,11 +421,6 @@ AnalysisPredictor::AnalysisPredictor(const AnalysisConfig &config)
             "context memory of multiple predictors."));
   } else {
     predictor_id_ = inference::GetUniqueId();
-  }
-
-  if (FLAGS_enable_pir_api) {
-    config_.EnableNewExecutor(true);
-    config_.EnableNewIR(true);
   }
 }
 

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -139,6 +139,7 @@
 #include "paddle/pir/include/pass/pass_registry.h"
 
 COMMON_DECLARE_bool(pir_apply_inplace_pass);
+COMMON_DECLARE_bool(enable_pir_api);
 
 namespace paddle {
 namespace {
@@ -416,6 +417,11 @@ AnalysisPredictor::AnalysisPredictor(const AnalysisConfig &config)
             "context memory of multiple predictors."));
   } else {
     predictor_id_ = inference::GetUniqueId();
+  }
+
+  if (FLAGS_enable_pir_api) {
+    config_.EnableNewExecutor(true);
+    config_.EnableNewIR(true);
   }
 }
 

--- a/test/cpp/jit/layer_test.cc
+++ b/test/cpp/jit/layer_test.cc
@@ -55,6 +55,8 @@ PD_DECLARE_KERNEL(mean, GPU, ALL_LAYOUT);
 PD_DECLARE_KERNEL(scale, GPU, ALL_LAYOUT);
 #endif
 
+COMMON_DECLARE_bool(enable_pir_api);
+
 namespace paddle {
 namespace jit {
 using DenseTensor = phi::DenseTensor;
@@ -77,6 +79,9 @@ TEST(CpuLayerTest, Function) {
 }
 
 TEST(CpuLayerTest, Construct) {
+  if (FLAGS_enable_pir_api) {
+    return;
+  }
   auto place = phi::CPUPlace();
   std::string path = "./multi_program_load/export";
   paddle::platform::Timer timer;
@@ -125,6 +130,9 @@ TEST(CpuLayerTest, Construct) {
 }
 
 TEST(CpuLayerTest, Clone) {
+  if (FLAGS_enable_pir_api) {
+    return;
+  }
   auto place = phi::CPUPlace();
   std::string path = "./multi_program_load/export";
 
@@ -161,6 +169,9 @@ TEST(CpuLayerTest, Clone) {
 
 #if defined(PADDLE_WITH_CUDA)
 TEST(GpuLayerTest, Construct) {
+  if (FLAGS_enable_pir_api) {
+    return;
+  }
   auto place = phi::GPUPlace();
 
   std::string path = "./multi_program_load/export";
@@ -189,6 +200,9 @@ TEST(GpuLayerTest, Construct) {
 }
 
 TEST(GpuLayerTest, Clone) {
+  if (FLAGS_enable_pir_api) {
+    return;
+  }
   auto place = phi::GPUPlace();
 
   std::string path = "./multi_program_load/export";


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
pcard-71500
inference use FLAGS_enable_pir_api control pir mode