### PR TITLE
[CINN]lower broadcast tree with wrapper function

### DIFF
--- a/paddle/cinn/backends/codegen_cuda_dev.cc
+++ b/paddle/cinn/backends/codegen_cuda_dev.cc
@@ -282,7 +282,7 @@ std::string CodeGenCUDA_Dev::Compile(const ir::Module &module,
   if (output_kind == OutputKind::CHeader) {
     GenerateHeaderFile(module);
   } else if (output_kind == OutputKind::CImpl) {
-    PrintIncludes();
+    // PrintIncludes();
 
     if (for_nvrtc_) {
       str_ += "\nextern \"C\" {\n\n";

--- a/paddle/cinn/backends/codegen_cuda_host.cc
+++ b/paddle/cinn/backends/codegen_cuda_host.cc
@@ -401,5 +401,17 @@ llvm::Value* CodeGenCUDA_Host::LowerCUDAKernelCall(const ir::Call* call_ir) {
   return nullptr;
 }
 
+llvm::Value* CodeGenCUDA_Host::LowerWrappedCall(const ir::Call* op) {
+  std::vector<llvm::Value*> ll_function_args;
+  std::transform(f_->arg_begin(),
+                 f_->arg_end(),
+                 std::back_inserter(ll_function_args),
+                 [](auto& arg) { return std::addressof(arg); });
+  llvm::Function* call_func = m_->getFunction(op->name);
+  CHECK(call_func) << "Unknown function referenced. [" << op->name << "]";
+  b_->CreateCall(call_func, ll_function_args);
+  return nullptr;
+}
+
 }  // namespace backends
 }  // namespace cinn

--- a/paddle/cinn/backends/codegen_cuda_host.h
+++ b/paddle/cinn/backends/codegen_cuda_host.h
@@ -52,6 +52,8 @@ class CodeGenCUDA_Host : public CodeGenLLVM {
       return LowerParseArgsValueCall(op);
     } else if (op->name == runtime::intrinsic::call_cuda_kernel) {
       return LowerCUDAKernelCall(op);
+    } else if (op->name.find("_leaf") != std::string::npos) {
+      return LowerWrappedCall(op);
     } else {
       return CodeGenLLVM::Visit(op);
     }
@@ -78,6 +80,8 @@ class CodeGenCUDA_Host : public CodeGenLLVM {
   llvm::Value *LowerParseArgsValueCall(const ir::Call *call_ir);
 
   llvm::Value *LowerCUDAKernelCall(const ir::Call *op);
+
+  llvm::Value *LowerWrappedCall(const ir::Call *op);
 };
 
 }  // namespace backends

--- a/paddle/cinn/backends/codegen_device_util.h
+++ b/paddle/cinn/backends/codegen_device_util.h
@@ -47,6 +47,12 @@ namespace backends {
  */
 std::tuple<ir::Module, ir::Module> SplitDeviceAndHostModule(ir::Module module);
 
+ir::Module CreateBroadcastWrapperModule(
+    const std::vector<std::string>& func_names,
+    const std::vector<ir::Expr>& broadcast_conditions,
+    const std::string& origin_func_name,
+    const std::unordered_map<int, ir::Var>& symbolic_shape_var_index);
+
 namespace detail {
 
 struct CollectHostFunctionVisitor : public ir::IRMutator<> {

--- a/paddle/cinn/backends/llvm/execution_engine.h
+++ b/paddle/cinn/backends/llvm/execution_engine.h
@@ -83,6 +83,8 @@ class ExecutionEngine {
 
   void ExportObject(const std::string &path);
 
+  void AddModuleSymbols(RuntimeSymbols &&module_symbols);
+
   bool AddModule(std::unique_ptr<llvm::Module> module,
                  std::unique_ptr<llvm::LLVMContext> context);
 

--- a/paddle/cinn/backends/llvm/runtime_symbol_registry.h
+++ b/paddle/cinn/backends/llvm/runtime_symbol_registry.h
@@ -40,6 +40,14 @@ class RuntimeSymbols {
     scalar_holder_ = std::move(rhs.scalar_holder_);
   }
 
+  RuntimeSymbols &operator=(RuntimeSymbols &&rhs) noexcept {
+    if (this != &rhs) {
+      symbols_ = std::move(rhs.symbols_);
+      scalar_holder_ = std::move(rhs.scalar_holder_);
+    }
+    return *this;
+  }
+
   /**
    * Register function address.
    * @param name Name of the symbol.

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/broadcast_with_cf.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/broadcast_with_cf.cc
@@ -23,7 +23,8 @@
 
 using OpLoweringGroup = cinn::hlir::framework::pir::OpLoweringGroup;
 using OpLoweringGroupPtr = std::shared_ptr<OpLoweringGroup>;
-using cinn::dialect::ir::details::CompileGroupAsOpAttribute;
+using BroadcastCond = cinn::hlir::framework::pir::BroadcastCond;
+using cinn::dialect::ir::details::CompileBroadcastGroupsAsOpAttribute;
 using cinn::dialect::ir::details::GetBlockOutsideInput;
 
 namespace {
@@ -52,48 +53,18 @@ static bool SameInputOutputShape(
   return x.shape() == out.shape();
 }
 
-void CompileGroupToJitKernelOp(
-    pir::PatternRewriter& rewriter,  // NOLINT
-    std::unordered_map<pir::Block*, OpLoweringGroupPtr>* group_map) {
+std::unordered_map<std::string, pir::Attribute>
+CompileBroadcastGroupsToJitKernelOp(
+    const std::unordered_map<pir::Block*, OpLoweringGroupPtr>& group_map,
+    OpLoweringGroupPtr broadcast_origin_group) {
   // prepare attribute for jit_kernel_op
   std::vector<OpLoweringGroupPtr> group_list;
-  group_list.reserve(group_map->size());
-  for (const auto& [_, group] : *group_map) {
+  group_list.reserve(group_map.size());
+  for (const auto& [_, group] : group_map) {
     group_list.push_back(group);
   }
-  auto op_attr_map = CompileGroupAsOpAttribute(group_list);
-  VLOG(4) << "The size of group_map is : " << group_map->size();
-  for (auto& [block, group] : *group_map) {
-    auto& yield_op = block->back();
-    CHECK(yield_op.isa<pir::YieldOp>()) << "Last op of block should be yield";
-    std::vector<pir::Type> output_types;
-    const auto& group_output_values = yield_op.operands_source();
-    for (size_t i = 0; i < group_output_values.size(); ++i) {
-      output_types.push_back(group_output_values[i].type());
-    }
-    rewriter.set_insertion_point(&yield_op);
-    const auto& group_inputs = GetBlockOutsideInput(group->ops());
-    auto jit_kernel_op = rewriter.Build<cinn::dialect::JitKernelOp>(
-        group_inputs, op_attr_map.at(group), output_types);
-    CHECK(jit_kernel_op.num_results() == group_output_values.size());
-    for (size_t i = 0; i < jit_kernel_op.num_results(); ++i) {
-      rewriter.ReplaceAllUsesWith(group_output_values[i],
-                                  jit_kernel_op.result(i));
-    }
-
-    // Delete origin group ops
-    std::vector<pir::Operation*> group_ops;
-    for (auto iter = block->rbegin(); iter != block->rend(); iter++) {
-      if (!iter->isa<pir::YieldOp>()) {
-        group_ops.push_back(&(*iter));
-      }
-    }
-    for (auto* op : group_ops) {
-      if (op->use_empty()) {
-        op->Erase();
-      }
-    }
-  }
+  return CompileBroadcastGroupsAsOpAttribute(group_list,
+                                             broadcast_origin_group);
 }
 
 void UpdateGroupShapeExprs(
@@ -200,86 +171,20 @@ void ReplaceExpandWithBroadcast(pir::IrContext* ir_context,
   }
 }
 
-std::tuple<pir::Value, pir::Value, pir::Value> BroadcastableToCondValue(
-    const symbol::Broadcastable<symbol::DimExpr>& broadcastable_condition,
-    const ShapeOrDataDimExprs4ValueT& ShapeOrDataDimExprs4Value,
-    const std::vector<pir::Value>& group_inputs,
-    pir::Builder& builder) {  // NOLINT
-  const auto& lhs_expr = broadcastable_condition->lhs;
-  const auto& rhs_expr = broadcastable_condition->rhs;
-
-  std::vector<pir::Value> lhs_minimal_inputs;
-  std::vector<pir::Attribute> lhs_output_dim_expr_attrs;
-  cinn::dialect::GenerateShapeOp::SymbolBindings lhs_symbol_bindings;
-  bool success =
-      cinn::dialect::MakeGenerateShapeOpAttribute(builder.ir_context(),
-                                                  ShapeOrDataDimExprs4Value,
-                                                  {lhs_expr},
-                                                  group_inputs,
-                                                  &lhs_minimal_inputs,
-                                                  &lhs_output_dim_expr_attrs,
-                                                  &lhs_symbol_bindings);
-  CHECK(success);
-  std::vector<pir::Value> rhs_minimal_inputs;
-  std::vector<pir::Attribute> rhs_output_dim_expr_attrs;
-  cinn::dialect::GenerateShapeOp::SymbolBindings rhs_symbol_bindings;
-  success =
-      cinn::dialect::MakeGenerateShapeOpAttribute(builder.ir_context(),
-                                                  ShapeOrDataDimExprs4Value,
-                                                  {rhs_expr},
-                                                  group_inputs,
-                                                  &rhs_minimal_inputs,
-                                                  &rhs_output_dim_expr_attrs,
-                                                  &rhs_symbol_bindings);
-  CHECK(success);
-
-  auto out_type = paddle::dialect::DenseTensorType::get(
-      builder.ir_context(),
-      pir::Int64Type::get(builder.ir_context()),
-      ::common::make_ddim({1}));
-
-  auto lhs_value =
-      builder
-          .Build<cinn::dialect::GenerateShapeOp>(lhs_minimal_inputs,
-                                                 lhs_output_dim_expr_attrs,
-                                                 lhs_symbol_bindings,
-                                                 out_type)
-          .out();
-  auto rhs_value =
-      builder
-          .Build<cinn::dialect::GenerateShapeOp>(rhs_minimal_inputs,
-                                                 rhs_output_dim_expr_attrs,
-                                                 rhs_symbol_bindings,
-                                                 out_type)
-          .out();
-
-  auto const_one = builder
-                       .Build<paddle::dialect::FullOp>(
-                           std::vector<int64_t>{1}, 1, phi::DataType::INT64)
-                       .out();
-  auto lhs_eq_rhs_cond =
-      builder.Build<paddle::dialect::EqualOp>(lhs_value, rhs_value).out();
-  auto lhs_eq_one_cond =
-      builder.Build<paddle::dialect::EqualOp>(lhs_value, const_one).out();
-  auto rhs_eq_one_cond =
-      builder.Build<paddle::dialect::EqualOp>(rhs_value, const_one).out();
-  return std::tuple<pir::Value, pir::Value, pir::Value>(
-      lhs_eq_rhs_cond, lhs_eq_one_cond, rhs_eq_one_cond);
-}
-
 OpLoweringGroupPtr CloneGroup(const OpLoweringGroupPtr& group,
                               pir::Block* block,
                               pir::IrMapping* ir_mapping) {
   return group->Clone(block, ir_mapping);
 }
 
-void SetLeafBlockByGroupView(
+void SetBroadcastLeafGroup(
     const OpLoweringGroupPtr& origin_group,
     const cinn::common::BroadcastLeaf& value_dim_exprs_list,
     const std::unordered_map<pir::Value, size_t>& value_to_dim_expr_idx,
     pir::Builder& builder,  // NOLINT
     pir::Block* block,
-    std::unordered_map<pir::Block*, OpLoweringGroupPtr>* group_map) {
+    std::unordered_map<pir::Block*, OpLoweringGroupPtr>* group_map,
+    const std::vector<BroadcastCond>& broadcast_conditions) {
   pir::IrMapping ir_mapping;
   auto origin_group_inputs = GetBlockOutsideInput(origin_group->ops());
   for (auto input : origin_group_inputs) {
@@ -288,6 +193,7 @@ void SetLeafBlockByGroupView(
 
   auto new_group = CloneGroup(origin_group, block, &ir_mapping);
   new_group->SetIsBroadcastLeaf(true);
+  new_group->SetBroadcastConditions(broadcast_conditions);
   PADDLE_ENFORCE_EQ(
       origin_group->ops().size(),
       new_group->ops().size(),
@@ -326,7 +232,7 @@ void InsertYieldOpForCondBlock(pir::Operation* cond_op,
 pir::Operation* CreateConditionBlock(
     const cinn::common::BroadcastTree& broadcast_tree,
     const OpLoweringGroupPtr& origin_group,
-    const ShapeOrDataDimExprs4ValueT& ShapeOrDataDimExprs4Value,
+    std::vector<BroadcastCond>* current_branch_conditions,
     const std::unordered_map<pir::Value, size_t>& value_to_dim_expr_idx,
     const std::vector<pir::Value>& group_inputs,
     const std::vector<pir::Type>& output_types,
@@ -336,29 +242,38 @@ pir::Operation* CreateConditionBlock(
   if (broadcast_tree.Has<cinn::common::BroadcastLeaf>()) {
     const auto& broadcast_leaf =
         broadcast_tree.Get<cinn::common::BroadcastLeaf>();
-    SetLeafBlockByGroupView(origin_group,
-                            broadcast_leaf,
-                            value_to_dim_expr_idx,
-                            builder,
-                            block,
-                            group_map);
+    SetBroadcastLeafGroup(origin_group,
+                          broadcast_leaf,
+                          value_to_dim_expr_idx,
+                          builder,
+                          block,
+                          group_map,
+                          *current_branch_conditions);
     return nullptr;
   } else {
     const auto& branch =
         broadcast_tree
             .Get<cinn::common::BroadcastBranch<cinn::common::BroadcastTree>>();
-    const auto& [lhs_eq_rhs_cond, lhs_eq_one_cond, rhs_eq_one_cond] =
-        BroadcastableToCondValue(
-            branch.Get<0>(), ShapeOrDataDimExprs4Value, group_inputs, builder);
-
+    const symbol::Broadcastable<symbol::DimExpr> broadcastable_condition =
+        branch.Get<0>();
+    // create fake if op with fake value
+    auto lhs_eq_rhs_cond =
+        builder
+            .Build<paddle::dialect::FullOp>(std::vector<int64_t>({1}),
+                                            1,
+                                            phi::DataType::BOOL,
+                                            phi::CPUPlace())
+            .result(0);
     // lhs == rhs
+    current_branch_conditions->emplace_back(
+        broadcastable_condition, OpLoweringGroup::BranchType::LHS_EQ_RHS);
     auto lhs_eq_rhs_cond_op = builder.Build<paddle::dialect::IfOp>(
         lhs_eq_rhs_cond, std::vector<pir::Type>{output_types});
     pir::Block& lhs_eq_rhs_block = lhs_eq_rhs_cond_op.true_block();
     builder.SetInsertionPointToBlockEnd(&lhs_eq_rhs_block);
     auto* lhs_eq_rhs_block_op = CreateConditionBlock(branch.Get<1>(),
                                                      origin_group,
-                                                     ShapeOrDataDimExprs4Value,
+                                                     current_branch_conditions,
                                                      value_to_dim_expr_idx,
                                                      group_inputs,
                                                      output_types,
@@ -366,18 +281,29 @@ pir::Operation* CreateConditionBlock(
                                                      &lhs_eq_rhs_block,
                                                      group_map);
     InsertYieldOpForCondBlock(lhs_eq_rhs_block_op, builder);
+    current_branch_conditions->pop_back();
 
     pir::Block& lhs_not_eq_rhs_block = lhs_eq_rhs_cond_op.false_block();
     builder.SetInsertionPointToBlockEnd(&lhs_not_eq_rhs_block);
 
     // lhs != rhs && lhs == 1
+    current_branch_conditions->emplace_back(
+        broadcastable_condition, OpLoweringGroup::BranchType::LHS_EQ_ONE);
+    // create fake if op with fake value
+    auto lhs_eq_one_cond =
+        builder
+            .Build<paddle::dialect::FullOp>(std::vector<int64_t>({1}),
+                                            1,
+                                            phi::DataType::BOOL,
+                                            phi::CPUPlace())
+            .result(0);
     auto lhs_eq_one_cond_op = builder.Build<paddle::dialect::IfOp>(
         lhs_eq_one_cond, std::vector<pir::Type>{output_types});
     pir::Block& lhs_eq_one_block = lhs_eq_one_cond_op.true_block();
     builder.SetInsertionPointToBlockEnd(&lhs_eq_one_block);
     auto* lhs_eq_one_block_op = CreateConditionBlock(branch.Get<2>(),
                                                      origin_group,
-                                                     ShapeOrDataDimExprs4Value,
+                                                     current_branch_conditions,
                                                      value_to_dim_expr_idx,
                                                      group_inputs,
                                                      output_types,
@@ -385,13 +311,16 @@ pir::Operation* CreateConditionBlock(
                                                      &lhs_eq_one_block,
                                                      group_map);
     InsertYieldOpForCondBlock(lhs_eq_one_block_op, builder);
+    current_branch_conditions->pop_back();
 
     // lhs != rhs && rhs == 1
+    current_branch_conditions->emplace_back(
+        broadcastable_condition, OpLoweringGroup::BranchType::RHS_EQ_ONE);
     pir::Block& rhs_eq_one_block = lhs_eq_one_cond_op.false_block();
     builder.SetInsertionPointToBlockEnd(&rhs_eq_one_block);
     auto* rhs_eq_one_block_op = CreateConditionBlock(branch.Get<3>(),
                                                      origin_group,
-                                                     ShapeOrDataDimExprs4Value,
+                                                     current_branch_conditions,
                                                      value_to_dim_expr_idx,
                                                      group_inputs,
                                                      output_types,
@@ -399,6 +328,7 @@ pir::Operation* CreateConditionBlock(
                                                      &rhs_eq_one_block,
                                                      group_map);
     InsertYieldOpForCondBlock(rhs_eq_one_block_op, builder);
+    current_branch_conditions->pop_back();
 
     builder.SetInsertionPointToBlockEnd(&lhs_not_eq_rhs_block);
     builder.Build<pir::YieldOp>(GetOpOuputValues(lhs_eq_one_cond_op));
@@ -490,7 +420,7 @@ bool NeedBroadcastWithCF(const cinn::common::BroadcastLeaf& leaves) {
   return broadcastable_condition.has_value();
 }
 
-pir::Operation* CompileBroadcastTreeToConditionBlock(
+pir::Operation* CompileBroadcastTree(
     const OpLoweringGroupPtr& group,
     const BroadcastTree& broadcast_tree,
     const std::unordered_map<pir::Value, size_t>& value_to_dim_expr_idx,
@@ -504,15 +434,17 @@ pir::Operation* CompileBroadcastTreeToConditionBlock(
   // 1. broadcast tree to condition op
   VLOG(4) << "broadcast tree to condition op";
   std::unordered_map<pir::Block*, OpLoweringGroupPtr> group_map;
-  pir::Operation* cond_op = CreateConditionBlock(broadcast_tree,
-                                                 group,
-                                                 ShapeOrDataDimExprs4Value,
-                                                 value_to_dim_expr_idx,
-                                                 group_inputs,
-                                                 output_types,
-                                                 rewriter,
-                                                 rewriter.block(),
-                                                 &group_map);
+  std::vector<BroadcastCond> current_branch_conditions;
+  pir::Operation* fake_cond_op =
+      CreateConditionBlock(broadcast_tree,
+                           group,
+                           &current_branch_conditions,
+                           value_to_dim_expr_idx,
+                           group_inputs,
+                           output_types,
+                           rewriter,
+                           rewriter.block(),
+                           &group_map);
   // 2. simply every condition block
   auto* program = group->ops().front()->GetParentProgram();
   VLOG(6) << "Before simply condition block: " << *program;
@@ -521,9 +453,21 @@ pir::Operation* CompileBroadcastTreeToConditionBlock(
   VLOG(6) << "After simply condition block: " << *program;
 
   // 3. compile condition block to jit_kernel_op
-  CompileGroupToJitKernelOp(rewriter, &group_map);
+  auto op_attr = CompileBroadcastGroupsToJitKernelOp(group_map, group);
   VLOG(6) << "compile condition block to jit_kernel_op: " << *program;
 
-  return cond_op;
+  // 4. replace condition block with merged jit_kernel_op
+  // std::vector<pir::Type> output_types;
+  // const auto& group_output_values = cond_op->results();
+  // for (size_t i = 0; i < group_output_values.size(); ++i) {
+  //   output_types.push_back(group_output_values[i].type());
+  // }
+  rewriter.SetInsertionPointAfter(group->GetParentBlock()->GetParentOp());
+  auto jit_kernel_op = rewriter.Build<cinn::dialect::JitKernelOp>(
+      group_inputs, op_attr, output_types);
+  auto fake_full_op = fake_cond_op->operand_source(0).defining_op();
+  fake_cond_op->Erase();
+  fake_full_op->Erase();
+  return jit_kernel_op;
 }
 }  // namespace cinn::dialect::ir::details

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/broadcast_with_cf.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/broadcast_with_cf.h
@@ -34,7 +34,7 @@ bool NeedBroadcastWithCF(const OpLoweringGroupPtr& group);
 bool NeedBroadcastWithCF(const common::BroadcastLeaf& leaves);
 GroupDimExprInfo GetGroupDimExprInfo(const OpLoweringGroupPtr& group);
 
-pir::Operation* CompileBroadcastTreeToConditionBlock(
+pir::Operation* CompileBroadcastTree(
     const OpLoweringGroupPtr& group,
     const BroadcastTree& broadcast_tree,
     const std::unordered_map<pir::Value, size_t>& value_to_dim_expr_idx,

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
@@ -49,12 +49,12 @@ pir::Operation* ProcessDyShapeGroup(const OpLoweringGroupPtr& group,
     for (size_t i = 0; i < group_output_values.size(); ++i) {
       output_types.push_back(group_output_values[i].type());
     }
-    return CompileBroadcastTreeToConditionBlock(group,
-                                                *broadcast_tree,
-                                                value_to_dim_expr_idx,
-                                                group_inputs,
-                                                output_types,
-                                                rewriter);
+    return CompileBroadcastTree(group,
+                                *broadcast_tree,
+                                value_to_dim_expr_idx,
+                                group_inputs,
+                                output_types,
+                                rewriter);
   } else {  // no condition block
     // compile group to jit_kernel_op
     std::vector<pir::Type> output_types;

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/utils.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/utils.cc
@@ -58,24 +58,18 @@ std::vector<pir::Value> GetBlockOutsideInput(
   return vec_res;
 }
 
-std::unordered_map<OpLoweringGroupPtr,
-                   std::unordered_map<std::string, pir::Attribute>>
-CompileGroupAsOpAttribute(const std::vector<OpLoweringGroupPtr>& group_list) {
+std::unordered_map<std::string, pir::Attribute>
+CompileBroadcastGroupsAsOpAttribute(
+    const std::vector<OpLoweringGroupPtr>& group_list,
+    OpLoweringGroupPtr broadcast_origin_group) {
   PirCompiler pir_compiler(cinn::common::DefaultDeviceTarget());
-  auto fn_ptr_res = pir_compiler.Build(group_list);
-
-  std::unordered_map<OpLoweringGroupPtr,
-                     std::unordered_map<std::string, pir::Attribute>>
-      result;
-  for (size_t i = 0; i < group_list.size(); ++i) {
-    std::unordered_map<std::string, ::pir::Attribute> op_attrs{
-        {cinn::dialect::JitKernelOp::kAttrName,
-         cinn::dialect::CINNKernelInfoAttribute::get(pir::IrContext::Instance(),
-                                                     fn_ptr_res[i])},
-    };
-    result.insert({group_list[i], op_attrs});
-  }
-  return result;
+  auto fn_ptr_res = pir_compiler.Build(group_list, broadcast_origin_group);
+  CHECK_EQ(fn_ptr_res.size(), 1);
+  std::unordered_map<std::string, ::pir::Attribute> op_attrs{
+      {cinn::dialect::JitKernelOp::kAttrName,
+       cinn::dialect::CINNKernelInfoAttribute::get(pir::IrContext::Instance(),
+                                                   fn_ptr_res[0])}};
+  return op_attrs;
 }
 
 std::unordered_map<std::string, ::pir::Attribute> GetJitKernelAttr(

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/utils.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/utils.h
@@ -22,9 +22,10 @@ using OpLoweringGroupPtr = std::shared_ptr<OpLoweringGroup>;
 std::vector<pir::Value> GetBlockOutsideInput(
     const std::vector<pir::Operation*>& op_list);
 
-std::unordered_map<OpLoweringGroupPtr,
-                   std::unordered_map<std::string, pir::Attribute>>
-CompileGroupAsOpAttribute(const std::vector<OpLoweringGroupPtr>& group_list);
+std::unordered_map<std::string, pir::Attribute>
+CompileBroadcastGroupsAsOpAttribute(
+    const std::vector<OpLoweringGroupPtr>& group_list,
+    OpLoweringGroupPtr broadcast_origin_group);
 
 std::unordered_map<std::string, ::pir::Attribute> GetJitKernelAttr(
     const OpLoweringGroupPtr& group);

--- a/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
@@ -145,7 +145,8 @@ std::shared_ptr<OpLoweringGroup> OpLoweringGroup::Clone(
     ops_mapper[op] = new_op;
   }
 
-  const auto new_fn_name = this->fn_name_ + "_cloned";
+  const auto new_fn_name =
+      this->fn_name_ + std::to_string(new_ops[0]->id()) + "_leaf";
   // Construct Base information for new Group
   auto new_group = std::make_shared<OpLoweringGroup>(new_ops, new_fn_name);
   for (auto* op : this->output_ops_) {

--- a/paddle/cinn/hlir/framework/pir/op_lowering_group.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_group.h
@@ -77,6 +77,17 @@ class OpLoweringGroup {
     is_broadcast_leaf_ = is_broadcast_leaf;
   }
 
+  enum class BranchType { LHS_EQ_RHS, LHS_EQ_ONE, RHS_EQ_ONE };
+  using BroadcastCond =
+      std::pair<symbol::Broadcastable<symbol::DimExpr>, BranchType>;
+  const std::vector<BroadcastCond>& GetBroadcastConditions() {
+    return broadcast_conditions_;
+  }
+  void SetBroadcastConditions(
+      const std::vector<BroadcastCond>& broadcast_conditions) {
+    broadcast_conditions_ = broadcast_conditions;
+  }
+
   const std::vector<::pir::Operation*>& ops() const { return ops_; }
   std::vector<::pir::Operation*>& mut_ops() { return ops_; }
   void SetOps(const std::vector<::pir::Operation*>& new_ops) { ops_ = new_ops; }
@@ -205,6 +216,7 @@ class OpLoweringGroup {
   // from local and global ShapeAnalysis. It will be removed after
   // refactoring logic of OpLoweringGroup.
   bool is_broadcast_leaf_{false};
+  std::vector<BroadcastCond> broadcast_conditions_;
 
   std::vector<std::string> input_names_;
   std::vector<std::string> output_names_;
@@ -221,6 +233,8 @@ class OpLoweringGroup {
       value_to_shape_or_data_exprs_;
 };
 
+using BroadcastCond = std::pair<symbol::Broadcastable<symbol::DimExpr>,
+                                OpLoweringGroup::BranchType>;
 std::ostream& operator<<(std::ostream& os, const OpLoweringGroup& group);
 }  // namespace pir
 }  // namespace framework

--- a/paddle/cinn/hlir/framework/pir_compiler.h
+++ b/paddle/cinn/hlir/framework/pir_compiler.h
@@ -25,7 +25,8 @@ class PirCompiler final {
   PirCompiler(const Target& target) : target_(target) {}
 
   std::vector<pir::CINNKernelInfo> Build(
-      const std::vector<pir::OpLoweringGroupPtr>& groups);
+      const std::vector<pir::OpLoweringGroupPtr>& groups,
+      pir::OpLoweringGroupPtr broadcast_origin_group = nullptr);
 
  private:
   CINN_DISALLOW_COPY_AND_ASSIGN(PirCompiler);

--- a/paddle/cinn/runtime/cuda/cuda_util.cc
+++ b/paddle/cinn/runtime/cuda/cuda_util.cc
@@ -101,6 +101,7 @@ void cinn_call_cuda_kernel(void *kernel_fn,
           << ", shared_memory_bytes=" << shared_memory_bytes
           << ", stream=" << stream << ", kernel_fn=" << kernel_fn;
 
+  VLOG(0) << "before prepare args";
   std::vector<void *> kernel_args;
   {
     cinn::utils::RecordEvent record_run("prepare_args",
@@ -116,8 +117,12 @@ void cinn_call_cuda_kernel(void *kernel_fn,
       }
     }
   }
+  VLOG(0) << "after prepare args";
 
+  VLOG(0) << "before launch kernel";
   {
+    char *ptr = static_cast<char *>(kernel_fn);
+    VLOG(0) << ptr[0];
     cinn::utils::RecordEvent record_run("cuLaunchKernel",
                                         cinn::utils::EventType::kInstruction);
     CUDA_DRIVER_CALL(cuLaunchKernel(static_cast<CUfunction>(kernel_fn),
@@ -132,6 +137,7 @@ void cinn_call_cuda_kernel(void *kernel_fn,
                                     kernel_args.data(),
                                     nullptr))
   }
+  VLOG(0) << "after launch kernel";
 }
 
 void cinn_call_cublas(void *v_args,

--- a/test/ir/pir/cinn/symbolic/test_cinn_broadcast_symbolic.py
+++ b/test/ir/pir/cinn/symbolic/test_cinn_broadcast_symbolic.py
@@ -57,17 +57,7 @@ class TestCinnSubGraphBase(unittest.TestCase):
         self.y.stop_gradient = False
 
     def check_jit_kernel_info(self, static_fn):
-        utils.check_jit_kernel_number(static_fn, 3)
-        utils.check_jit_kernel_structure(
-            static_fn,
-            {
-                'if_0': {utils.JIT_KERNEL_NAME: 1},
-                'else_0': {
-                    'if_0_0': {utils.JIT_KERNEL_NAME: 1},
-                    'else_0_0': {utils.JIT_KERNEL_NAME: 1},
-                },
-            },
-        )
+        utils.check_jit_kernel_number(static_fn, 1)
 
     def eval_symbolic(self, use_cinn):
         paddle.seed(2022)

--- a/test/ir/pir/cinn/symbolic/test_llama_group_swiglu.py
+++ b/test/ir/pir/cinn/symbolic/test_llama_group_swiglu.py
@@ -50,35 +50,7 @@ class TestTransposeReshape(unittest.TestCase):
         self.y = paddle.randn([4, 32, 11008], dtype="float16")
 
     def check_jit_kernel_info(self, static_fn):
-        utils.check_jit_kernel_number(static_fn, 9)
-        utils.check_jit_kernel_structure(
-            static_fn,
-            {
-                'if_0': {
-                    'if_0_0': {'jit_kernel': 1},
-                    'else_0_0': {
-                        'if_0_0_0': {'jit_kernel': 1},
-                        'else_0_0_0': {'jit_kernel': 1},
-                    },
-                },
-                'else_0': {
-                    'if_0_0': {
-                        'if_0_0_0': {'jit_kernel': 1},
-                        'else_0_0_0': {
-                            'if_0_0_0_0': {'jit_kernel': 1},
-                            'else_0_0_0_0': {'jit_kernel': 1},
-                        },
-                    },
-                    'else_0_0': {
-                        'if_0_0_0': {'jit_kernel': 1},
-                        'else_0_0_0': {
-                            'if_0_0_0_0': {'jit_kernel': 1},
-                            'else_0_0_0_0': {'jit_kernel': 1},
-                        },
-                    },
-                },
-            },
-        )
+        utils.check_jit_kernel_number(static_fn, 1)
 
     def eval(self, use_cinn=False, mode="jit"):
         net = TransposeReshapeNet()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR lower broadcast tree by adding a wrapper function for host kernel launch function.

## broadcast tree lowering design
### key goals
Binary element operations in paddle follow numpy-style implicit broadcast semantics, which causes potential performance issue: introduce some redundant broadcast ops. For example, the following code:
```python
x #shape:[S0]
y #shape:[S1]
z = x - y #shape:[broadcast(S0, S1)]
```
will be converted to:
```text
(%0) = "pd_op.data" ()
(%1) = "pd_op.data" ()
(%2) = "pd_op.shape" (%0)
(%3) = "pd_op.shape" (%1)
(%4) = "pd_op.shape_broadcast" (%2, %3)
(%5) = "pd_op.expand" (%0, %4)
(%6) = "pd_op.expand" (%1, %4)
(%7) = "pd_op.subtract" (%5, %6)
```

To avoid redundant broadcast ops and simplify code generation, we use control flow to decide whether to broadcast or not. In the above example, if S0 == S1, we do not need to broadcast both of the 2 operands in the subgraph. If S0 != S1, and S0 == 1, we need to broadcast x. If S0 != S1, and S1 == 1, we need to broadcast y.

In a subgraph, there may be multiple broadcast ops, so we represent this information in a broadcast tree.
```c++
using BroadcastBranch = adt::Tuple<symbol::Broadcastable<symbol::DimExpr>,
                                   /*cstr_lhs_eq_rhs_branch*/ T,
                                   /*cstr_lhs_eq_one_branch*/ T,
                                   /*cstr_rhs_eq_one_branch*/ T>;
using BroadcastTree = adt::Tree<BroadcastBranch, BroadcastLeaf>;
```

Generally, we can represent the control flow in three places:
1. in the control flow of pd_op.if.
2. in the control flow of kernel launch host function.
3. in the control flow of device function.

We used to represent the broadcast tree control flow in pir with pd_op.if, which is very friendly to codegen. However, we found that control flow in pir is very inefficient because it will add some shape related ops and introduce a lot of operation scheduling overhead. It is known that control flow in device like GPU is very inefficient and also unfriendly to codegen, so we finally decided to lower broadcast tree to host funcion.

### detail design
```
BroadcastLeaf == CINNGroup
CINNGroup ====compile====> HostFuncPtr
BroadcastTree(BroadcastBranch, BroadcastLeaf) == switch(BroadcastCondtion, HostFuncPtr)
```
To decouple the switch semantic from CINN Group compile, we use a wrapper function `switch(BroadcastCondtion, HostFuncPtr)` to lower broadcast tree control flow.
So for CINN jit instruction, The invoke function can be:
```
invokeFunc = HostFunc
           | SwichHostFunc
```
In the switch function, each case is a HostFunc call and each condition is a broadcast tree branch trace.

To achieve this, we should do the fowllowing steps:
- Support llvm codegen for SwitchHostFunc pattern CINN module
- Support backend compiler to link multiple modules
- Add switch wrapper CINN module generation according to broadcast tree condition and inner host func names.
- Support parameter unification for different functions belonging to one broadcast tree.
- Change PirCompiler to compile multiple groups belonging to one broadcast tree to 1 jit kernel.
- Apply the above steps to lower_cinn_fusion_op_pass.