### PR TITLE
[Inference] update transfer_layout_pass when dealing data_format attr

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/layout_transformation.hpp
+++ b/paddle/fluid/pir/dialect/operator/interface/layout_transformation.hpp
@@ -19,6 +19,7 @@
 #include "paddle/common/enforce.h"
 #include "paddle/common/layout.h"
 #include "paddle/phi/common/data_type.h"
+#include "paddle/pir/include/core/builtin_attribute.h"
 #include "paddle/pir/include/core/builtin_type.h"
 #include "paddle/pir/include/core/operation.h"
 #include "paddle/pir/include/core/type_name.h"

--- a/paddle/fluid/pir/dialect/operator/interface/layout_transformation.hpp
+++ b/paddle/fluid/pir/dialect/operator/interface/layout_transformation.hpp
@@ -56,12 +56,11 @@ namespace dialect {
 
 template <typename ConcreteOp>
 common::DataLayout PreferLayoutImpl(pir::Operation* op) {
-  return common::DataLayout::ALL_LAYOUT;
-}
-
-template <typename ConcreteOp>
-common::DataLayout CurrentLayoutImpl(pir::Operation* op) {
-  return common::DataLayout::UNDEFINED;
+  auto data_format_attr = op->attribute<pir::StrAttribute>("data_format");
+  if (!data_format_attr) {
+    return common::DataLayout::ALL_LAYOUT;
+  }
+  return common::StringToDataLayout(data_format_attr.AsString());
 }
 
 template <typename ConcreteOp>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
此PR对transfer_layout_pass的策略引入了两点改动：
1. 未特化LayoutTransformationInterface::PreferLayout的算子，如果他有data_format属性，默认按照该属性分类其Layout，进而，该算子的Layout不会被Pass改动。
2. 对于含控制流算子的情形，由于PIR的特性，控制流算子与其他算子的依赖不完全反映到输入输出上，因此Pass建立网络流图时需要特别对控制流算子进行处理，正确的处理他和其他算子之间的连接。

#### Others
Pcard-71500