### PR TITLE
[CINN] Remove the simplification of expand op for broadcast subgraph in front end

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/broadcast_with_cf.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/broadcast_with_cf.cc
@@ -513,15 +513,11 @@ pir::Operation* CompileBroadcastTreeToConditionBlock(
                                                  rewriter,
                                                  rewriter.block(),
                                                  &group_map);
-  // 2. simply every condition block
-  auto* program = group->ops().front()->GetParentProgram();
-  VLOG(6) << "Before simply condition block: " << *program;
 
-  SimplyConditionBlock(rewriter, &group_map);
-  VLOG(6) << "After simply condition block: " << *program;
-
-  // 3. compile condition block to jit_kernel_op
+  // 2. compile condition block to jit_kernel_op
   CompileGroupToJitKernelOp(rewriter, &group_map);
+
+  auto* program = group->ops().front()->GetParentProgram();
   VLOG(6) << "compile condition block to jit_kernel_op: " << *program;
 
   return cond_op;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164

移除编译器前端对于broadcast分支中expand算子的化简逻辑，相关优化改为由后端支持。