### PR TITLE
Reproduce flash attention template arguments problem

### DIFF
--- a/test_flashattn.py
+++ b/test_flashattn.py
@@ -1,0 +1,47 @@
+import paddle
+import paddle.nn.functional as F
+import numpy as np
+import time
+def time_paddle():
+    paddle.device.synchronize()
+    return time.time()
+
+
+def time_it(run_iter: int, warmup_iter: int, target_func):
+    for idx in range(run_iter + warmup_iter):
+        if idx == warmup_iter:
+            sta_time = time_paddle()
+        target_func()
+    end_time = time_paddle()
+    return (end_time - sta_time) / run_iter
+
+def genqkv(bsz, sq, sk, hq, hk, hdim, dtype):
+    shape_q = (bsz, sq, hq, hdim)
+    shape_k = (bsz, sk, hk, hdim)
+    q = paddle.randn(shape_q, dtype=dtype)
+    k = paddle.randn(shape_k, dtype=dtype)
+    v = paddle.randn(shape_k, dtype=dtype)
+    q.stop_gradient = False
+    k.stop_gradient = False
+    v.stop_gradient = False
+    return q, k, v
+
+if __name__ == "__main__":
+    bsz = 1
+    sq = 8192
+    sk = 8192
+    hq = 8
+    hk = 8
+    hdim = 128
+    dtype = "float16"
+    paddle.seed(0)
+    q, k, v = genqkv(bsz, sq, sk, hq, hk, hdim, dtype)
+
+    def fa_func():
+        o = F.flash_attention.flash_attention(q, k, v, causal=True)
+        o[0].backward()
+        return o[0]
+    x = fa_func()
+    np.save("out1.npy",x.numpy())
+    t = time_it(100, 10, fa_func)
+    print(f"FlashAttention Time: {t}s")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->


### Description
<!-- Describe what you’ve done -->
这个pr只在flash_attention forward的kernel上加了一个bool模板参数`Enable_bypass`
运行pr中根目录附带的`test_flashattn.py`，会调用`flash_attention`，将计算结果保存在文件，并输出运行时间，`flash_attention`需要A100运行
编译这个pr的Paddle，执行`test_flashattn.py`，与使用develop分支的Paddle执行`test_flashattn.py`对比，可以看到这个pr的计算结果错误并且运行时间慢了约10倍
已测试CUDA11.8可以复现
![d3d81a93fc7f696f43f946e3430897ff](https://github.com/PaddlePaddle/Paddle/assets/71395264/160051dc-e5c5-4cff-9a72-0686556291ad)
![130b625fe88d7046cdf4898917d0c5da](https://github.com/PaddlePaddle/Paddle/assets/71395264/a5ad06d1-c99a-40fd-b4d1-f339ff8f6ad7)
