### PR TITLE
fix contiguous warning bug

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1046,6 +1046,50 @@ static PyObject* tensor__share_buffer_to(TensorObject* self,
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }
 
+static PyObject* tensor__unsafe_share_buffer_to(TensorObject* self,
+                                                PyObject* args,
+                                                PyObject* kwargs) {
+  EAGER_TRY
+  paddle::Tensor* dst_ptr =
+      &(reinterpret_cast<TensorObject*>(PyTuple_GET_ITEM(args, 0))->tensor);
+  if (!self->tensor.initialized()) {
+    if (self->tensor.numel() == 0) {
+      // Do nothing for 0-size Tensor
+      Py_RETURN_NONE;
+    } else {
+      PADDLE_THROW(platform::errors::InvalidArgument(
+          "Tensor %s has not been initialized! please initialize "
+          "src tensor before share_buffer_with to other.",
+          self->tensor.name()));
+    }
+  }
+  if (self->tensor.is_dist_tensor()) {
+    auto* src_tensor =
+        static_cast<phi::distributed::DistTensor*>(self->tensor.impl().get())
+            ->unsafe_mutable_value();
+    if (!dst_ptr->defined()) {
+      dst_ptr->set_impl(std::make_shared<phi::distributed::DistTensor>());
+    }
+    auto dst_tensor =
+        static_cast<phi::distributed::DistTensor*>(dst_ptr->impl().get())
+            ->unsafe_mutable_value();
+    dst_tensor->ShareBufferWith(*src_tensor);
+    dst_tensor->ShareDataTypeWith(*src_tensor);
+  } else {
+    auto* src_tensor =
+        static_cast<phi::DenseTensor*>(self->tensor.impl().get());
+    if (!dst_ptr->defined()) {
+      dst_ptr->set_impl(std::make_shared<phi::DenseTensor>());
+    }
+    auto dst_tensor = static_cast<phi::DenseTensor*>(dst_ptr->impl().get());
+    dst_tensor->ShareBufferWith(*src_tensor);
+    dst_tensor->ShareDataTypeWith(*src_tensor);
+  }
+  RETURN_PY_NONE
+
+  EAGER_CATCH_AND_THROW_RETURN_NULL
+}
+
 static PyObject* tensor__is_shared_buffer_with(TensorObject* self,
                                                PyObject* args,
                                                PyObject* kwargs) {
@@ -3286,6 +3330,10 @@ PyMethodDef variable_methods[] = {  // NOLINT
      nullptr},
     {"_share_buffer_to",
      (PyCFunction)(void (*)())tensor__share_buffer_to,
+     METH_VARARGS | METH_KEYWORDS,
+     nullptr},
+    {"_unsafe_share_buffer_to",
+     (PyCFunction)(void (*)())tensor__unsafe_share_buffer_to,
      METH_VARARGS | METH_KEYWORDS,
      nullptr},
     {"_is_shared_buffer_with",

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -347,33 +347,28 @@ def _recompute_without_reentrant(
                 if holder_list[unpack_counter - 1]() is None:
                     return
 
-                if inner_x.is_contiguous():
-                    if inner_x.is_dist():
-                        # TODO(jeff41404): it seems better to use `tmp_tensor = core.eager.Tensor(inner_x)`,
-                        # but other errors will be triggered during the current period, and can be modified after resolution
-                        tmp_tensor = core.eager.Tensor(
-                            inner_x.dtype,
-                            inner_x.shape,
-                            inner_x.name + "cpy",
-                            core.VarDesc.VarType.LOD_TENSOR,
-                            inner_x.persistable,
-                            inner_x.process_mesh,
-                            inner_x.placements,
-                        )
-                    else:
-                        tmp_tensor = core.eager.Tensor(
-                            inner_x.dtype,
-                            inner_x.shape,
-                            inner_x.name + "cpy",
-                            core.VarDesc.VarType.LOD_TENSOR,
-                            inner_x.persistable,
-                        )
-                    inner_x._share_buffer_to(tmp_tensor)
-                    storage[holder_list[unpack_counter - 1]()] = tmp_tensor
+                if inner_x.is_dist():
+                    # TODO(jeff41404): it seems better to use `tmp_tensor = core.eager.Tensor(inner_x)`,
+                    # but other errors will be triggered during the current period, and can be modified after resolution
+                    tmp_tensor = core.eager.Tensor(
+                        inner_x.dtype,
+                        inner_x.shape,
+                        inner_x.name + "cpy",
+                        core.VarDesc.VarType.LOD_TENSOR,
+                        inner_x.persistable,
+                        inner_x.process_mesh,
+                        inner_x.placements,
+                    )
                 else:
-                    storage[
-                        holder_list[unpack_counter - 1]()
-                    ] = inner_x.contiguous()
+                    tmp_tensor = core.eager.Tensor(
+                        inner_x.dtype,
+                        inner_x.shape,
+                        inner_x.name + "cpy",
+                        core.VarDesc.VarType.LOD_TENSOR,
+                        inner_x.persistable,
+                    )
+                inner_x._unsafe_share_buffer_to(tmp_tensor)
+                storage[holder_list[unpack_counter - 1]()] = tmp_tensor
                 return
 
             def inner_unpack(inner_x):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

https://github.com/PaddlePaddle/Paddle/pull/65050 中不允许非连续Tensor share buffer，为此修改了recompute的逻辑。
但是saved_tensors_hook，的逻辑是，pack时保留了tensor的meta信息，unpack时，只是用获得的Tensor的Holder。因此，unpack时不能转为连续的Tensor，需要强制share 不连续的Holder。

Pcard-67164