### PR TITLE
[CINN]Fix SplitWithNum BUG while splitted shape is -1

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -642,7 +642,7 @@ class SplitWithNumOpPattern
       paddle::dialect::SplitWithNumOp>::OpRewritePattern;
 
   bool Match(paddle::dialect::SplitWithNumOp op) const override {
-    return IsDefinedBy<FullOp>(op, 1);
+    return IsDefinedBy<FullOp>(op, 1) && GetSpitDim(op) > 0;
   }
 
   void Rewrite(paddle::dialect::SplitWithNumOp op,
@@ -674,8 +674,7 @@ class SplitWithNumOpPattern
   std::vector<int64_t> GetSections(paddle::dialect::SplitWithNumOp op,
                                    int axis) const {
     std::vector<int64_t> result;
-    auto split_dim =
-        op.x().type().dyn_cast<paddle::dialect::DenseTensorType>().dims()[axis];
+    const int64_t split_dim = GetSpitDim(op);
     auto split_num = op->attribute<::pir::Int32Attribute>("num").data();
     auto part_ele = (split_dim + split_num - 1) / split_num;
     int total_split_num = 0;
@@ -686,6 +685,14 @@ class SplitWithNumOpPattern
 
     result.push_back(split_dim - total_split_num);
     return result;
+  }
+
+  int64_t GetSpitDim(paddle::dialect::SplitWithNumOp op) {
+    const int axis = GetAxis(op);
+    return op.x()
+        .type()
+        .dyn_cast<paddle::dialect::DenseTensorType>()
+        .dims()[axis];
   }
 };
 

--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -687,7 +687,7 @@ class SplitWithNumOpPattern
     return result;
   }
 
-  int64_t GetSpitDim(paddle::dialect::SplitWithNumOp op) {
+  int64_t GetSpitDim(paddle::dialect::SplitWithNumOp op) const {
     const int axis = GetAxis(op);
     return op.x()
         .type()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164