### PR TITLE
[Strided Kernel]fix bug when fallback strided inplace kernel

### DIFF
--- a/paddle/phi/api/generator/api_base.py
+++ b/paddle/phi/api/generator/api_base.py
@@ -1328,11 +1328,12 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
 {code_indent}  if(kernel_record_event != nullptr){{
 {code_indent}    delete kernel_record_event;
 {code_indent}  }}
-{transdata2strided}
 {code_indent}  if (kernel_result.has_fallback_cpu) {{
 {fallback_kernel_output_trans}
 {self.reset_view_after_fallback(self.outputs['types'], code_indent, inplace_flag)}
 {code_indent}  }}
+{code_indent}  dev_ctx = GetDeviceContextByBackend(kernel_backend);
+{transdata2strided}
 {code_indent}  {self.gene_return_code()}"""
 
     def get_condition_code(self, kernel_name):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复strided且inplace的kernel fallback时的bug。当前若算子是inplace且strided的，会对输入做备份。若此时算子发生fallback，计算结束后得到的结果kernel_out在cpu上，而备份的tensor backup仍在其他设备上，此时调用TransStride()会因为2个tensor位置不一致而报错。这里将TransStride()移到TransDataBackend()后面，并在执行TransStride()前获取fallback前的device context，可以解决该问题。