### PR TITLE
【Hackathon 6th No.9】fix reshape op with zero-size tensor input in static mode -part

### DIFF
--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -160,13 +160,13 @@ class ReshapeOp : public framework::OperatorWithKernel {
         if (in_size == 0) {
           // zero-sized tensor case
           // index i could be < in_dims.size(): such as [3, 2, 0] -> [0, 0] is
-          // [0, 0]; [3, 2, 0] -> [10, 0] is [10, 0] index i could be >=
+          // [0, 0], [3, 2, 0] -> [10, 0] is [10, 0]; index i could be >=
           // in_dims.size(): such as [3, 2, 0] -> [1, 3, 0, 0] is [1, 3, 0, 0]
           output_shape[i] = 0;
         } else {
           // in other cases 0 means keep in_dims[i] unchanged
-          // index i should only be < in_dims.size(): such as [3, 2, 1] -> [0,
-          // 0] is [3, 2]; [3, 2, 1] -> [3, 2, 0] is [3, 2, 1]
+          // index i must be < in_dims.size(): such as [3, 2, 1] -> [0, 0]
+          // is [3, 2] or [3, 2, 1] -> [3, 2, 0] is [3, 2, 1]
           PADDLE_ENFORCE_LT(
               static_cast<int>(i),
               in_dims.size(),

--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -139,19 +139,13 @@ class ReshapeOp : public framework::OperatorWithKernel {
                                  const phi::DDim &in_dims) {
     const int64_t in_size = common::product(in_dims);
     auto in_dims_vec = common::vectorize(in_dims);
-    bool all_positive = std::all_of(in_dims_vec.cbegin(),
-                                    in_dims_vec.cend(),
-                                    [](int64_t i) { return i > 0; });
-    // only one dimension can be set to -1, whose size will be automatically
-    // infered.
-    const int64_t unk_dim_val = -1;
-    const int64_t copy_dim_val = 0;
-
     std::vector<int64_t> output_shape(shape.size(), 0);
     int64_t capacity = 1;
     int unk_dim_idx = -1;
+
     for (size_t i = 0; i < shape.size(); ++i) {
-      if (shape[i] == unk_dim_val) {
+      if (shape[i] == -1) {
+        // only one dimension can be set to -1, whose size will be infered.
         PADDLE_ENFORCE_EQ(
             unk_dim_idx,
             -1,
@@ -161,19 +155,27 @@ class ReshapeOp : public framework::OperatorWithKernel {
                 common::make_ddim(shape),
                 i));
         unk_dim_idx = static_cast<int>(i);
-      } else if (shape[i] == copy_dim_val) {
-        PADDLE_ENFORCE_LT(
-            static_cast<int>(i),
-            in_dims.size(),
-            phi::errors::InvalidArgument(
-                "The index of 0 in `shape` must be less than "
-                "the input tensor X's dimensions. "
-                "But received shape = [%s], shape[%d] = 0, X's shape = [%s], "
-                "X's dimensions = %d.",
-                common::make_ddim(shape),
-                i,
-                in_dims,
-                in_dims.size()));
+        output_shape[i] = shape[i];
+      } else if (shape[i] == 0) {
+        if (static_cast<int>(i) < in_dims.size()) {
+          if (in_size == 0) {
+            // such as [3, 2, 0] -> [0, 0] is [0, 0]; [3, 2, 0] -> [10, 0] is
+            // [10, 0]
+            output_shape[i] = 0;
+          } else {
+            // such as [3, 2, 1] -> [0, 0] is [3, 2]; [3, 2, 1] -> [3, 2, 0] is
+            // [3, 2, 1]
+            output_shape[i] = in_dims[static_cast<int>(i)];
+          }
+        } else {
+          PADDLE_ENFORCE_EQ(
+              in_size,
+              0,
+              phi::errors::InvalidArgument("If The index of 0 in `shape` >= "
+                                           "the input tensor X's dimensions, "
+                                           "It can only be Zero-Sized Tensor"));
+        }
+        capacity *= output_shape[i];
       } else {
         PADDLE_ENFORCE_GT(
             shape[i],
@@ -185,25 +187,36 @@ class ReshapeOp : public framework::OperatorWithKernel {
                 common::make_ddim(shape),
                 i,
                 shape[i]));
+        output_shape[i] = shape[i];
+        capacity *= output_shape[i];
       }
-
-      // NOTE all non-zero values will be converted to True (include negative
-      // value)
-      capacity *= (shape[i] ? shape[i] : in_dims[static_cast<int>(i)]);
-      output_shape[i] = (shape[i] ? static_cast<int64_t>(shape[i])
-                                  : in_dims[static_cast<int>(i)]);
     }
 
+    if (capacity == 0) {
+      PADDLE_ENFORCE_EQ(in_size,
+                        0,
+                        phi::errors::InvalidArgument(
+                            "Only Zero-Size Tensor'shape can contain 0"));
+      PADDLE_ENFORCE_EQ(unk_dim_idx,
+                        -1,
+                        phi::errors::InvalidArgument(
+                            "can not reshape %s to %s, because the unspecified "
+                            "dimension %i can be any number and is ambiguous",
+                            in_dims,
+                            common::make_ddim(shape),
+                            unk_dim_idx));
+    }
+
+    bool no_negative = std::all_of(in_dims_vec.cbegin(),
+                                   in_dims_vec.cend(),
+                                   [](int64_t i) { return i >= 0; });
     if (unk_dim_idx != -1) {
-      if (all_positive) {
-        // in_size < 0 and is un-determinate in compile time, skip the check,
-        // for example, in_dims = [-1, 8, 1, 1], shape = [-1, 3, 8],
-        // capacity = -24, in_size = -8, output_shape[0] = 0
-        // the following check will fail.
-        output_shape[unk_dim_idx] = -in_size / capacity;
+      // in compile time, no_negative may be False.
+      if (no_negative) {
+        output_shape[unk_dim_idx] = in_size / capacity;
         PADDLE_ENFORCE_EQ(
             output_shape[unk_dim_idx] * capacity,
-            -in_size,
+            in_size,
             phi::errors::InvalidArgument(
                 "The 'shape' attribute in ReshapeOp is invalid. "
                 "The input tensor X'size must be divisible by known "
@@ -215,10 +228,11 @@ class ReshapeOp : public framework::OperatorWithKernel {
                 common::make_ddim(shape),
                 capacity));
       } else {
+        // such as [-1, 8, 3]->[-1, 8], out_shape will remain [-1, 8]
         output_shape[unk_dim_idx] = -1;
       }
     } else {
-      if (all_positive) {
+      if (no_negative) {
         PADDLE_ENFORCE_EQ(
             capacity,
             in_size,
@@ -233,24 +247,6 @@ class ReshapeOp : public framework::OperatorWithKernel {
                 common::make_ddim(shape),
                 capacity));
       }
-    }
-
-    // support reshape with zero-input(input tensor with product(shape) == 0)
-    // by now we require that if the input tensor is zero shape, the target
-    // shape of output must be zero
-    if (in_size == 0) {
-      PADDLE_ENFORCE_LE(
-          capacity,
-          in_size,
-          phi::errors::InvalidArgument(
-              "The 'shape' in ReshapeOp is invalid. "
-              "The input tensor X's shape = [%s], X's capacity = %d."
-              "But the target shape of Out is [%s],  the "
-              "capacity of 'Out' is %d.",
-              in_dims,
-              in_size,
-              common::make_ddim(shape),
-              capacity));
     }
 
     return common::make_ddim(output_shape);

--- a/paddle/phi/kernels/reshape_kernel.cc
+++ b/paddle/phi/kernels/reshape_kernel.cc
@@ -32,10 +32,7 @@ void ReshapeInferKernel(const Context& dev_ctx,
                         DenseTensor* out) {
   MetaTensor meta_out(out);
   InferMetaFromVecValue(x, shape.GetData(), &meta_out);
-  // Zero-Size Tensor
-  if (x.numel() == 0) {
-    return;
-  }
+
   if (x.initialized() && x.Holder() == out->Holder()) {
     dev_ctx.Alloc(out, x.dtype());
     return;
@@ -57,9 +54,7 @@ void ReshapeInferKernel<phi::XPUContext>(const XPUContext& dev_ctx,
                                          DenseTensor* out) {
   MetaTensor meta_out(out);
   InferMetaFromVecValue(x, shape.GetData(), &meta_out);
-  if (x.numel() == 0) {
-    return;
-  }
+
   if (x.initialized() && x.Holder() == out->Holder()) {
     dev_ctx.Alloc(out, x.dtype());
     return;

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, overload
 
 import numpy as np
@@ -4721,8 +4722,6 @@ def reshape(x: Tensor, shape: ShapeLike, name: str | None = None) -> Tensor:
                     )
                     unk_dim_idx = dim_idx
                 elif dim_size == 0:
-                    import math
-
                     if math.prod(x.shape):
                         assert dim_idx < len(x.shape), (
                             "The index of 0 in `shape` must be less than "

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4721,12 +4721,15 @@ def reshape(x: Tensor, shape: ShapeLike, name: str | None = None) -> Tensor:
                     )
                     unk_dim_idx = dim_idx
                 elif dim_size == 0:
-                    assert dim_idx < len(x.shape), (
-                        "The index of 0 in `shape` must be less than "
-                        "the input tensor X's dimensions. "
-                        "But received shape[%d] = 0, X's dimensions = %d."
-                        % (dim_idx, len(x.shape))
-                    )
+                    import math
+
+                    if math.prod(x.shape):
+                        assert dim_idx < len(x.shape), (
+                            "The index of 0 in `shape` must be less than "
+                            "the input tensor X's dimensions. "
+                            "But received shape[%d] = 0, X's dimensions = %d."
+                            % (dim_idx, len(x.shape))
+                        )
                 else:
                     assert dim_size > 0, (
                         "Each dimension value of 'shape' in reshape must not "

--- a/test/legacy_test/test_zero_size_tensor.py
+++ b/test/legacy_test/test_zero_size_tensor.py
@@ -19,7 +19,10 @@
 
 import unittest
 
+import numpy as np
+
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 # Use to test zero-size of Sundry API, which is unique and can not be classified
@@ -39,7 +42,7 @@ class TestSundryAPI(unittest.TestCase):
         self.assertEqual(out.shape, (0, 2))
         self.assertEqual(out.size, 0)
 
-    def test_reshape(self):
+    def test_reshape_dygraph(self):
         # case 1
         x1 = paddle.rand([0, 2])
         x1.stop_gradient = False
@@ -76,6 +79,40 @@ class TestSundryAPI(unittest.TestCase):
         x5 = paddle.rand([0])
         with self.assertRaises(ValueError):
             out4 = paddle.reshape(x5, [2, 0, -1])
+
+    @test_with_pir_api
+    def test_reshape_static(self):
+        paddle.enable_static()
+        place = paddle.CPUPlace()
+        if paddle.is_compiled_with_cuda():
+            place = paddle.CUDAPlace(0)
+
+        input_cases = [
+            # (x, new_shape, desired_shape)
+            (np.random.rand(0, 2), [-1], [0]),
+            (np.random.rand(0, 2), [2, -1], [2, 0]),
+            (np.random.rand(0, 2), [2, 3, 0], [2, 3, 0]),
+            (np.random.rand(0, 2), [0], [0]),
+        ]
+        for case in input_cases:
+            data_np, new_shape, desired_shape = case
+            startup_program = paddle.static.Program()
+            main_program = paddle.static.Program()
+            executor = paddle.static.Executor(paddle.CUDAPlace(0))
+            with paddle.static.program_guard(main_program, startup_program):
+                x = paddle.static.data(
+                    name="x", shape=data_np.shape, dtype='float64'
+                )
+                out = paddle.reshape(x, new_shape)
+                fetch_list = [out]
+                feeds = {'x': data_np}
+
+                executor.run(startup_program)
+                res = executor.run(
+                    main_program, feed=feeds, fetch_list=fetch_list
+                )
+            np.testing.assert_equal(res[0], np.random.rand(*desired_shape))
+        paddle.disable_static()
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_zero_size_tensor.py
+++ b/test/legacy_test/test_zero_size_tensor.py
@@ -98,7 +98,7 @@ class TestSundryAPI(unittest.TestCase):
             data_np, new_shape, desired_shape = case
             startup_program = paddle.static.Program()
             main_program = paddle.static.Program()
-            executor = paddle.static.Executor(paddle.CUDAPlace(0))
+            executor = paddle.static.Executor(place)
             with paddle.static.program_guard(main_program, startup_program):
                 x = paddle.static.data(
                     name="x", shape=data_np.shape, dtype='float64'


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
1. 本 pr 是修复 https://github.com/PaddlePaddle/Paddle/pull/65605#discussion_r1661757666 出现的问题：静态图下 
    paddle.reshape 的输入如果是 zero-size tensor，结果返回的是 None。
    修改前：
    ```python
    paddle.enable_static()
    startup_program = paddle.static.Program()
    main_program = paddle.static.Program()
    executor = paddle.static.Executor()
    data_shape = [2, 1, 0]
    data_np = np.ones(d_shape, 'float32')
    with paddle.static.program_guard(main_program, startup_program):
        x = paddle.static.data(
            name="x", shape=d_shape, dtype='float32'
        )
        out = paddle.reshape(data_shape, [1, 0])
        fetch_list = [out]
        feeds = {"x": data_np}
        executor.run(startup_program)
        res = executor.run(
            main_program, feed=feeds, fetch_list=fetch_list
        )
    print(res[0])
    # None
    ```
    修改后：
    ```python
    paddle.enable_static()
    startup_program = paddle.static.Program()
    main_program = paddle.static.Program()
    executor = paddle.static.Executor()
    data_shape = [2, 1, 0]
    data_np = np.ones(d_shape, 'float32')
    with paddle.static.program_guard(main_program, startup_program):
        x = paddle.static.data(
            name="x", shape=d_shape, dtype='float32'
        )
        out = paddle.reshape(data_shape, [1, 0])
        fetch_list = [out]
        feeds = {"x": data_np}
        executor.run(startup_program)
        res = executor.run(
            main_program, feed=feeds, fetch_list=fetch_list
        )
    print(res[0])
    # []
    print(res[0].shape)
    # [1, 0]
    ```

2. 本 pr 把之前对 infermeta/unary.cc 中 ValidateShape 的修改迁移到了 fluid/operator/reshape_op.cc 的 ValidateShape 中， 
    之前的修改是：https://github.com/PaddlePaddle/Paddle/pull/64715 ，相比当时修改之前增加支持的 case 是：当输入是 
    zero-size tensor，且 output_shape 中 0 出现的位置小于 in_dims.size()，例如：
    修改前：
    ```python
    x = paddle.rand([2, 1, 0])
    x = paddle.reshape(x, [0])
    print(x)
    # ValueError: (InvalidArgument) The 'shape' in ReshapeOp is invalid. The input tensor X'size must be equal to the capacity 
    # of 'shape'. But received X's shape = [2, 1, 0], X's size = 0, 'shape' is [0], the capacity of 'shape' is 2.
    #  [Hint: Expected capacity == in_size, but received capacity:2 != in_size:0.] (at ..\paddle\phi\infermeta\unary.cc:1967)
    ```
    修改后：
    ```python
    x = paddle.rand([2, 1, 0])
    x = paddle.reshape(x, [0])
    print(x)
    # Tensor(shape=[0], dtype=float32, place=Place(cpu), stop_gradient=True,
    #  [])
    ```