### PR TITLE
[Prim][PIR] fix the multiply_grad bug in dynamic shape case

### DIFF
--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -106,7 +106,7 @@ void divide_grad(const Tensor& x,
   if (dy) {
     // dy = -(x/y^2) * dout
     auto dy_res = -(x / (y * y)) * out_grad;
-    if (has_dynamic_shape(y.shape())) {
+    if (has_dynamic_shape(y.shape()) || has_dynamic_shape(out_grad.shape())) {
       auto dy_tmp = reduce_as<T>(dy_res, y);
       set_output<T>(dy_tmp, dy);
     } else {
@@ -126,7 +126,7 @@ void divide_grad(const Tensor& x,
     // dx = (1/y) * dout
     Tensor one_tensor = full_scalar<T>(1.0, y.dtype());
     auto dx_res = one_tensor / y * out_grad;
-    if (has_dynamic_shape(x.shape())) {
+    if (has_dynamic_shape(x.shape()) || has_dynamic_shape(out_grad.shape())) {
       auto dx_tmp = reduce_as<T>(dx_res, x);
       set_output<T>(dx_tmp, dx);
     } else {
@@ -577,7 +577,7 @@ void add_grad(const Tensor& x,
               Tensor* dx,
               Tensor* dy) {
   if (dy) {
-    if (has_dynamic_shape(y.shape())) {
+    if (has_dynamic_shape(y.shape()) || has_dynamic_shape(out_grad.shape())) {
       auto dy_tmp = reduce_as<T>(out_grad, y);
       set_output<T>(dy_tmp, dy);
     } else {
@@ -595,7 +595,7 @@ void add_grad(const Tensor& x,
     }
   }
   if (dx) {
-    if (has_dynamic_shape(x.shape())) {
+    if (has_dynamic_shape(x.shape()) || has_dynamic_shape(out_grad.shape())) {
       auto dx_tmp = reduce_as<T>(out_grad, x);
       set_output<T>(dx_tmp, dx);
     } else {
@@ -621,7 +621,7 @@ void subtract_grad(const Tensor& x,
                    Tensor* dy) {
   if (dy) {
     auto scale_out_grad = scale<T>(out_grad, -1.0, 0.0, true);
-    if (has_dynamic_shape(y.shape())) {
+    if (has_dynamic_shape(y.shape()) || has_dynamic_shape(out_grad.shape())) {
       auto dy_tmp = reduce_as<T>(scale_out_grad, y);
       set_output<T>(dy_tmp, dy);
     } else {
@@ -638,7 +638,7 @@ void subtract_grad(const Tensor& x,
     }
   }
   if (dx) {
-    if (has_dynamic_shape(x.shape())) {
+    if (has_dynamic_shape(x.shape()) || has_dynamic_shape(out_grad.shape())) {
       auto dx_tmp = reduce_as<T>(out_grad, x);
       set_output<T>(dx_tmp, dx);
     } else {
@@ -664,7 +664,8 @@ void multiply_grad(const Tensor& x,
                    Tensor* y_grad) {
   if (x_grad) {
     auto x_grad_unreduce = out_grad * y;
-    if (has_dynamic_shape(x.shape())) {
+    if (has_dynamic_shape(x.shape()) ||
+        has_dynamic_shape(x_grad_unreduce.shape())) {
       auto x_grad_reduced = reduce_as<T>(x_grad_unreduce, x);
       set_output<T>(x_grad_reduced, x_grad);
     } else {
@@ -683,7 +684,8 @@ void multiply_grad(const Tensor& x,
   }
   if (y_grad) {
     auto y_grad_unreduce = out_grad * x;
-    if (has_dynamic_shape(y.shape())) {
+    if (has_dynamic_shape(y.shape()) ||
+        has_dynamic_shape(y_grad_unreduce.shape())) {
       auto y_grad_reduced = reduce_as<T>(y_grad_unreduce, y);
       set_output<T>(y_grad_reduced, y_grad);
     } else {

--- a/test/prim/pir_prim/test_prim_sub_graph_backward_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_backward_dynamic_shape.py
@@ -432,6 +432,36 @@ class TestPrimAddWithGrad8(TestPrimTwoWithGrad):
         self.tol = 1e-6
 
 
+class TestPrimAddWithGrad9(TestPrimTwoWithGrad):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 40]
+        self.init_x_shape = [None, None, None]
+        self.y_shape = [200, 40]
+        self.init_y_shape = self.y_shape
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = add_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimAddWithGrad10(TestPrimTwoWithGrad):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [200, 40]
+        self.init_x_shape = self.x_shape
+        self.y_shape = [30, 200, 40]
+        self.init_y_shape = [None, 200, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = add_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
 class TestPrimSubtractWithGrad1(TestPrimTwoWithGrad):
     def setUp(self):
         np.random.seed(2023)
@@ -560,6 +590,36 @@ class TestPrimSubtractWithGrad9(TestPrimTwoWithGrad):
         self.init_x_shape = [None]
         self.y_shape = [30, 200, 40]
         self.init_y_shape = [None, None, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = subtract_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimSubtractWithGrad10(TestPrimTwoWithGrad):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [1, 1, 40]
+        self.init_x_shape = [None, None, None]
+        self.y_shape = [30, 200, 40]
+        self.init_y_shape = self.y_shape
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = subtract_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimSubtractWithGrad11(TestPrimTwoWithGrad):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [1, 1, 40]
+        self.init_x_shape = self.x_shape
+        self.y_shape = [30, 200, 40]
+        self.init_y_shape = [None, None, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.y = np.random.random(self.y_shape).astype(self.dtype)
         self.net = subtract_net
@@ -866,6 +926,36 @@ class TestPrimMultiplyWithGrad9(TestPrimTwoWithGrad):
         self.tol = 1e-5
 
 
+class TestPrimMultiplyWithGrad10(TestPrimTwoWithGrad):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 40]
+        self.init_x_shape = [None, 200, 40]
+        self.y_shape = [200, 40]
+        self.init_y_shape = self.y_shape
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = multiply_net
+        self.enable_cinn = False
+        self.tol = 1e-5
+
+
+class TestPrimMultiplyWithGrad11(TestPrimTwoWithGrad):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [200, 40]
+        self.init_x_shape = self.x_shape
+        self.y_shape = [30, 200, 40]
+        self.init_y_shape = [None, 200, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = multiply_net
+        self.enable_cinn = False
+        self.tol = 1e-5
+
+
 class TestPrimReluWithGrad(TestPrimBaseWithGrad):
     def setUp(self):
         np.random.seed(2023)
@@ -1018,6 +1108,36 @@ class TestPrimDivideWithGrad9(TestPrimTwoWithGrad):
         self.init_x_shape = [None]
         self.y_shape = [30, 200, 40]
         self.init_y_shape = [None, None, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = divide_net
+        self.enable_cinn = False
+        self.tol = 1e-5
+
+
+class TestPrimDivideWithGrad10(TestPrimTwoWithGrad):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 1]
+        self.init_x_shape = [None, None, None]
+        self.y_shape = [30, 200, 40]
+        self.init_y_shape = self.y_shape
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = divide_net
+        self.enable_cinn = False
+        self.tol = 1e-5
+
+
+class TestPrimDivideWithGrad11(TestPrimTwoWithGrad):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 1]
+        self.init_x_shape = self.x_shape
+        self.y_shape = [30, 200, 40]
+        self.init_y_shape = [None, None, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.y = np.random.random(self.y_shape).astype(self.dtype)
         self.net = divide_net

--- a/test/prim/pir_prim/test_prim_sub_graph_backward_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_backward_dynamic_shape.py
@@ -454,7 +454,7 @@ class TestPrimAddWithGrad10(TestPrimTwoWithGrad):
         self.x_shape = [200, 40]
         self.init_x_shape = self.x_shape
         self.y_shape = [30, 200, 40]
-        self.init_y_shape = [None, 200, 40]
+        self.init_y_shape = [None, None, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.y = np.random.random(self.y_shape).astype(self.dtype)
         self.net = add_net
@@ -601,9 +601,9 @@ class TestPrimSubtractWithGrad10(TestPrimTwoWithGrad):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [1, 1, 40]
+        self.x_shape = [30, 200, 40]
         self.init_x_shape = [None, None, None]
-        self.y_shape = [30, 200, 40]
+        self.y_shape = [200, 40]
         self.init_y_shape = self.y_shape
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.y = np.random.random(self.y_shape).astype(self.dtype)
@@ -616,7 +616,7 @@ class TestPrimSubtractWithGrad11(TestPrimTwoWithGrad):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [1, 1, 40]
+        self.x_shape = [200, 40]
         self.init_x_shape = self.x_shape
         self.y_shape = [30, 200, 40]
         self.init_y_shape = [None, None, None]
@@ -931,7 +931,7 @@ class TestPrimMultiplyWithGrad10(TestPrimTwoWithGrad):
         np.random.seed(2023)
         self.dtype = "float32"
         self.x_shape = [30, 200, 40]
-        self.init_x_shape = [None, 200, 40]
+        self.init_x_shape = [None, None, None]
         self.y_shape = [200, 40]
         self.init_y_shape = self.y_shape
         self.x = np.random.random(self.x_shape).astype(self.dtype)
@@ -948,7 +948,7 @@ class TestPrimMultiplyWithGrad11(TestPrimTwoWithGrad):
         self.x_shape = [200, 40]
         self.init_x_shape = self.x_shape
         self.y_shape = [30, 200, 40]
-        self.init_y_shape = [None, 200, 40]
+        self.init_y_shape = [None, None, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.y = np.random.random(self.y_shape).astype(self.dtype)
         self.net = multiply_net
@@ -1119,9 +1119,9 @@ class TestPrimDivideWithGrad10(TestPrimTwoWithGrad):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [30, 200, 1]
+        self.x_shape = [30, 200, 40]
         self.init_x_shape = [None, None, None]
-        self.y_shape = [30, 200, 40]
+        self.y_shape = [200, 40]
         self.init_y_shape = self.y_shape
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.y = np.random.random(self.y_shape).astype(self.dtype)
@@ -1134,7 +1134,7 @@ class TestPrimDivideWithGrad11(TestPrimTwoWithGrad):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [30, 200, 1]
+        self.x_shape = [200, 40]
         self.init_x_shape = self.x_shape
         self.y_shape = [30, 200, 40]
         self.init_y_shape = [None, None, None]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复multiply_grad的反向拆解在一个输入动态shape另一个输入是静态shape的场景下出现的bug，同时为同类算子新增对应的单测。