### PR TITLE
[SOT] Rename `StringifyGuard` to `StringifiedGuard`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -51,7 +51,7 @@ from ...utils import (
     tmp_name_guard,
 )
 from ..instruction_utils import get_instructions
-from .guard import Guard, StringifyExpression, make_guard
+from .guard import Guard, StringifiedExpression, make_guard
 from .mutable_data import MutationDel, MutationNew, MutationSet
 from .pycode_generator import PyCodeGen
 from .side_effects import (
@@ -291,19 +291,19 @@ class FunctionGraph:
     @event_register("guard_fn")
     def guard_fn(self) -> Guard:
         with tmp_name_guard():
-            guards: list[StringifyExpression] = []
-            with EventGuard("guard_fn: find vars and make stringify guard"):
+            guards: list[StringifiedExpression] = []
+            with EventGuard("guard_fn: find vars and make stringified guard"):
                 for variable in find_traceable_vars(
                     self.input_variables + list(self._global_guarded_variables)
                 ):
-                    guards.extend(variable.make_stringify_guard())
+                    guards.extend(variable.make_stringified_guard())
 
             guards = OrderedSet(guards)  # type: ignore
 
             for guard in guards:
                 assert isinstance(
-                    guard, StringifyExpression
-                ), "guard must be StringifyExpression."
+                    guard, StringifiedExpression
+                ), "guard must be StringifiedExpression."
 
             return make_guard(guards)
 

--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
     CheckGuardInputT = TypeVar("CheckGuardInputT", bound=VariableBase)
 
-# NOTE(SigureMo): [How to write Stringify Guard?]
+# NOTE(SigureMo): [How to write Stringified Guard?]
 # 1. we should capture free variables manually, the string cannot capture free
 #    variables automatically.
 # 2. Be aware that the comparison logic before and after stringify may be different.
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 #    runtime overhead.
 
 
-class StringifyExpression:
+class StringifiedExpression:
     """
     Used to store string based expressions for generating Guard.
     """
@@ -63,23 +63,23 @@ def union_free_vars(*free_vars: dict[str, Any]):
     return {k: v for d in free_vars for k, v in d.items()}
 
 
-def make_guard(stringify_guards: list[StringifyExpression]) -> Guard:
+def make_guard(stringified_guards: list[StringifiedExpression]) -> Guard:
     """
-    Make a guard from a list of StringifyExpression.
+    Make a guard from a list of StringifiedExpression.
 
-    For more design ideas, refer to the `Stringify guard <https://github.com/PaddlePaddle/PaddleSOT/blob/develop/docs/design/stringify-guard.md>`_ for details.
+    For more design ideas, refer to the `Stringified guard <https://github.com/PaddlePaddle/PaddleSOT/blob/develop/docs/design/stringify-guard.md>`_ for details.
 
     Args:
-        stringify_guards: a list of StringifyExpression.
+        stringified_guards: a list of StringifiedExpression.
     """
     with EventGuard("make_guard"):
-        num_guards = len(stringify_guards)
+        num_guards = len(stringified_guards)
         if not num_guards:
             guard = lambda frame: True
             guard.expr = "lambda frame: True"
             return guard
 
-        def analyse_expressions(stringify_exprs, tmp_names):
+        def analyse_expressions(stringified_exprs, tmp_names):
             func_string = "def built_guard_fn(frame):\n"
             lambda_string = "lambda frame: "
             free_vars = {}
@@ -88,7 +88,7 @@ def make_guard(stringify_guards: list[StringifyExpression]) -> Guard:
                 func_string += f"    {v} = {k}\n"
 
             func_result = ""
-            for str_expr in stringify_exprs:
+            for str_expr in stringified_exprs:
                 func_result += str_expr.expr + " and "
                 lambda_string += str_expr.inlined_expr + " and "
                 free_vars = union_free_vars(free_vars, str_expr.free_vars)
@@ -102,7 +102,7 @@ def make_guard(stringify_guards: list[StringifyExpression]) -> Guard:
             free_vars,
             lambda_string,
         ) = analyse_expressions(
-            stringify_guards, current_tmp_name_records().tmp_names_record
+            stringified_guards, current_tmp_name_records().tmp_names_record
         )
 
         exec(
@@ -126,9 +126,9 @@ def support_weak_ref(obj):
 
 
 def check_guard(
-    fn: Callable[[CheckGuardInputT], list[StringifyExpression]]
-) -> Callable[[CheckGuardInputT], list[StringifyExpression]]:
-    def wrapper(self: CheckGuardInputT) -> list[StringifyExpression]:
+    fn: Callable[[CheckGuardInputT], list[StringifiedExpression]]
+) -> Callable[[CheckGuardInputT], list[StringifiedExpression]]:
+    def wrapper(self: CheckGuardInputT) -> list[StringifiedExpression]:
         assert (
             self.tracker.is_traceable()
         ), "Cannot make guard from a non-tracable guard variable."
@@ -146,7 +146,7 @@ def check_guard(
 
 
 @check_guard
-def object_equal_stringify_guard(self) -> list[StringifyExpression]:
+def object_equal_stringified_guard(self) -> list[StringifiedExpression]:
     frame_value_tracer = self.tracker.trace_value_from_frame()
 
     obj_free_var_name = f"__{self.id}"
@@ -154,7 +154,7 @@ def object_equal_stringify_guard(self) -> list[StringifyExpression]:
     if support_weak_ref(weak_ref_obj):
         weak_ref_obj = weakref.ref(self.get_py_value())
         return [
-            StringifyExpression(
+            StringifiedExpression(
                 f"{obj_free_var_name}() is not None and {{}} == {obj_free_var_name}()",
                 [frame_value_tracer],
                 union_free_vars(
@@ -164,7 +164,7 @@ def object_equal_stringify_guard(self) -> list[StringifyExpression]:
             )
         ]
     return [
-        StringifyExpression(
+        StringifiedExpression(
             f"{{}} == {obj_free_var_name}",
             [frame_value_tracer],
             union_free_vars(

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 from ...profiler import event_register
 from ...utils import BreakGraphError, log
 from ..instruction_utils import Instruction
-from .guard import StringifyExpression, union_free_vars
+from .guard import StringifiedExpression, union_free_vars
 from .opcode_executor import OpcodeExecutorBase, Stop
 from .tracker import ConstTracker, DanglingTracker, DummyTracker, Tracker
 from .variables import (
@@ -67,16 +67,16 @@ class FunctionGlobalTracker(Tracker):
         codegen.gen_load_const(self.name)
         codegen.gen_subscribe()
 
-    def trace_value_from_frame(self) -> StringifyExpression:
+    def trace_value_from_frame(self) -> StringifiedExpression:
         """
         Trace the value of the function global variable from the frame.
 
         Returns:
-            StringifyExpression: The traced value of the function global variable.
+            StringifiedExpression: The traced value of the function global variable.
 
         """
         fn_tracer = self.fn.tracker.trace_value_from_frame()
-        return StringifyExpression(
+        return StringifiedExpression(
             f"{{}}.__globals__['{self.name}']",
             [fn_tracer],
             union_free_vars(fn_tracer.free_vars),
@@ -124,7 +124,7 @@ class FunctionClosureTracker(Tracker):
 
         """
         fn_tracer = self.fn.tracker.trace_value_from_frame()
-        return StringifyExpression(
+        return StringifiedExpression(
             f"{{}}.__closure__[{self.idx}].cell_contents",
             [fn_tracer],
             union_free_vars(fn_tracer.free_vars),

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
@@ -26,7 +26,7 @@ from ....profiler import event_register
 from ....utils import NameGenerator, get_unbound_method, log
 from ....utils.exceptions import FallbackError, HasNoAttributeError
 from ..dispatcher import Dispatcher
-from ..guard import StringifyExpression, check_guard, union_free_vars
+from ..guard import StringifiedExpression, check_guard, union_free_vars
 from ..mutable_data import MutableDictLikeData
 from ..tracker import (
     DummyTracker,
@@ -330,24 +330,24 @@ class VariableBase:
         return hash(self.id)
 
     @check_guard
-    def make_stringify_guard(self) -> list[StringifyExpression]:
+    def make_stringified_guard(self) -> list[StringifiedExpression]:
         """
-        Create a StringifyExpression object that represents a guard expression for this variable.
+        Create a StringifiedExpression object that represents a guard expression for this variable.
 
         Returns:
-            StringifyExpression: An object that contains the guard expression and the free variables used in the expression.
+            StringifiedExpression: An object that contains the guard expression and the free variables used in the expression.
         """
 
         # Get a ValueTracer object from the Tracker object associated with the variable
         frame_value_tracer = self.tracker.trace_value_from_frame()
 
         return [
-            StringifyExpression(
+            StringifiedExpression(
                 f"id(type({{}})) == {id(self.get_py_type())}",
                 [frame_value_tracer],
                 union_free_vars(frame_value_tracer.free_vars),
             ),
-            StringifyExpression(
+            StringifiedExpression(
                 f"{{}} == {self.get_py_value()!r}",
                 [frame_value_tracer],
                 union_free_vars(frame_value_tracer.free_vars),

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -39,9 +39,9 @@ from ....utils import (
 from ....utils.exceptions import HasNoAttributeError, InnerError
 from ..dispatch_functions import tensor_numel
 from ..guard import (
-    StringifyExpression,
+    StringifiedExpression,
     check_guard,
-    object_equal_stringify_guard,
+    object_equal_stringified_guard,
     stringify_pyobject,
     union_free_vars,
 )
@@ -262,7 +262,7 @@ class TensorDtypeVariable(DataVariable):
         super().__init__(value, graph, tracker)
 
     @check_guard
-    def make_stringify_guard(self) -> list[StringifyExpression]:
+    def make_stringified_guard(self) -> list[StringifiedExpression]:
         if isinstance(self.tracker, GetAttrTracker) and isinstance(
             self.tracker.obj, TensorVariable
         ):
@@ -271,7 +271,7 @@ class TensorDtypeVariable(DataVariable):
             )
             dtype_str, dtype_free_vars = stringify_pyobject(self.value)
             return [
-                StringifyExpression(
+                StringifiedExpression(
                     f"MetaInfo.from_tensor({{}}).dtype == {dtype_str}",
                     [tensor_value_tracer],
                     union_free_vars(
@@ -281,7 +281,7 @@ class TensorDtypeVariable(DataVariable):
                 )
             ]
         else:
-            return object_equal_stringify_guard(self)
+            return object_equal_stringified_guard(self)
 
     def get_py_value(self, allow_tensor=False):
         return super().get_py_value(allow_tensor)
@@ -409,7 +409,7 @@ class TensorVariable(VariableBase):
         codegen.gen_load_fast(self.out_var_name)
 
     @check_guard
-    def make_stringify_guard(self) -> list[StringifyExpression]:
+    def make_stringified_guard(self) -> list[StringifiedExpression]:
         frame_value_tracer = self.tracker.trace_value_from_frame()
 
         if ENV_SOT_ALLOW_DYNAMIC_SHAPE.get():
@@ -417,7 +417,7 @@ class TensorVariable(VariableBase):
         else:
             str_left_expr = "MetaInfo.from_tensor({}).guard_str()"
         return [
-            StringifyExpression(
+            StringifiedExpression(
                 f"{str_left_expr} == '{self.origin_meta.guard_str()}'",
                 [frame_value_tracer],
                 union_free_vars(
@@ -684,7 +684,7 @@ class SymbolicVariable(VariableBase):
         codegen.gen_call_method(0)  # TODO
 
     @check_guard
-    def make_stringify_guard(self) -> list[StringifyExpression]:
+    def make_stringified_guard(self) -> list[StringifiedExpression]:
         assert ENV_SOT_ALLOW_DYNAMIC_SHAPE.get()
         from ..executor_cache import OpcodeExecutorCache
 
@@ -700,9 +700,9 @@ class SymbolicVariable(VariableBase):
         symbolic_input.setdefault(self.value, 0)
         symbolic_input[self.value] += 1
         if self.need_guard_value:
-            return super().make_stringify_guard()
+            return super().make_stringified_guard()
         return [
-            StringifyExpression(
+            StringifiedExpression(
                 f"id(type({{}})) == {id(self.get_py_type())}",
                 [frame_value_tracer],
                 union_free_vars(frame_value_tracer.free_vars),
@@ -807,7 +807,7 @@ class ObjectVariable(VariableBase):
         tracker(Tracker): The Tracker object that tracks the information of this variable.
     """
 
-    make_stringify_guard = object_equal_stringify_guard
+    make_stringified_guard = object_equal_stringified_guard
 
     def __init__(self, obj, graph, tracker):
         super().__init__(graph, tracker)
@@ -872,19 +872,19 @@ class SliceVariable(VariableBase):
         )
 
     @check_guard
-    def make_stringify_guard(self) -> list[StringifyExpression]:
+    def make_stringified_guard(self) -> list[StringifiedExpression]:
         frame_value_tracer = self.tracker.trace_value_from_frame()
         result = (
             [
-                StringifyExpression(
+                StringifiedExpression(
                     "isinstance({}, slice)",
                     [frame_value_tracer],
                     frame_value_tracer.free_vars,
                 ),
             ]
-            + self.getattr("start").make_stringify_guard()
-            + self.getattr("stop").make_stringify_guard()
-            + self.getattr("step").make_stringify_guard()
+            + self.getattr("start").make_stringified_guard()
+            + self.getattr("stop").make_stringified_guard()
+            + self.getattr("step").make_stringified_guard()
         )
         return result
 
@@ -946,7 +946,7 @@ class ModuleVariable(VariableBase):
         return None
 
     # Happened in a inline import statement.
-    make_stringify_guard = object_equal_stringify_guard
+    make_stringified_guard = object_equal_stringified_guard
 
 
 class DygraphTracerVariable(VariableBase):
@@ -959,7 +959,7 @@ class DygraphTracerVariable(VariableBase):
         return self.value
 
     @check_guard
-    def make_stringify_guard(self) -> list[StringifyExpression]:
+    def make_stringified_guard(self) -> list[StringifiedExpression]:
         return []
 
     @property
@@ -997,7 +997,7 @@ class NumpyVariable(VariableBase):
         return self.value
 
     @check_guard
-    def make_stringify_guard(self) -> list[StringifyExpression]:
+    def make_stringified_guard(self) -> list[StringifiedExpression]:
         if isinstance(self.get_py_value(), np.number):
             frame_value_tracer = self.tracker.trace_value_from_frame()
 
@@ -1008,19 +1008,19 @@ class NumpyVariable(VariableBase):
                 return f"{format_dtype(number.dtype)}({number.item()})"
 
             return [
-                StringifyExpression(
+                StringifiedExpression(
                     f"{{}} == {format_number(self.get_py_value())}",
                     [frame_value_tracer],
                     union_free_vars(frame_value_tracer.free_vars, {"np": np}),
                 ),
-                StringifyExpression(
+                StringifiedExpression(
                     f"{{}}.dtype == {format_dtype(self.get_py_value().dtype)}",
                     [frame_value_tracer],
                     union_free_vars(frame_value_tracer.free_vars, {"np": np}),
                 ),
             ]
         else:
-            return object_equal_stringify_guard(self)
+            return object_equal_stringified_guard(self)
 
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 from ....utils import ConstTypes
 from ....utils.exceptions import FallbackError, InnerError
 from ..dispatcher import Dispatcher
-from ..guard import StringifyExpression, check_guard
+from ..guard import StringifiedExpression, check_guard
 from ..mutable_data import MutableDictLikeData, MutableListLikeData
 from ..tracker import (
     ConstTracker,
@@ -71,15 +71,15 @@ class ContainerVariable(VariableBase):
         return ConstantVariable(bool(self), self.graph, DummyTracker([self]))
 
     @check_guard
-    def make_stringify_guard(self) -> list[StringifyExpression]:
+    def make_stringified_guard(self) -> list[StringifiedExpression]:
         frame_value_tracer = self.tracker.trace_value_from_frame()
 
-        type_guard = StringifyExpression(
+        type_guard = StringifiedExpression(
             f"isinstance({{}}, {self.get_py_type().__name__})",
             [frame_value_tracer],
             frame_value_tracer.free_vars,
         )
-        len_guard = StringifyExpression(
+        len_guard = StringifiedExpression(
             f"len({{}}) == {len(self.init_value)}",
             [frame_value_tracer],
             frame_value_tracer.free_vars,
@@ -97,7 +97,7 @@ class ContainerVariable(VariableBase):
         return reduce(
             operator.add,
             [[type_guard, len_guard]]
-            + [item.make_stringify_guard() for item in guard_variables],
+            + [item.make_stringified_guard() for item in guard_variables],
         )
 
 
@@ -715,11 +715,11 @@ class RangeVariable(ContainerVariable):
         return None
 
     @check_guard
-    def make_stringify_guard(self) -> list[StringifyExpression]:
+    def make_stringified_guard(self) -> list[StringifiedExpression]:
         frame_value_tracer = self.tracker.trace_value_from_frame()
 
         return [
-            StringifyExpression(
+            StringifiedExpression(
                 "isinstance({0}, range) and "
                 + f"{{0}}.start == {self.init_value.start} and "
                 + f"{{0}}.stop == {self.init_value.stop} and "

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
@@ -39,8 +39,8 @@ class IterVariable(VariableBase):
         super().__init__(graph, tracker)
         self.hold = obj
 
-    def make_stringify_guard(self):
-        return self.hold.make_stringify_guard()
+    def make_stringified_guard(self):
+        return self.hold.make_stringified_guard()
 
     def next(self):
         raise NotImplementedError(f"Can not simulate `next` for {type(self)}")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

`StringifyGuard` 并不合适，因为应该是字符串化「的」guard 而不是字符串化这个过程，因此修改为 `StringifiedGuard`，确保语法上是正确的

另外还有一个候选词 `stringize`，比如在 Python 对于类型提示的字符串化描述相关文档中常用该词（如 [Annotations Best Practices](https://docs.python.org/3/howto/annotations.html#manually-un-stringizing-stringized-annotations)），但该词貌似并不常用（至少 ChatGPT 是这么说的……），因此还是选择了 `stringify`

PCard-66972