### PR TITLE
【PIR】fix scalar default data type from float to double

### DIFF
--- a/paddle/fluid/operators/generator/generate_op.py
+++ b/paddle/fluid/operators/generator/generate_op.py
@@ -90,7 +90,7 @@ def restruct_io(op):
 
 def process_scalar(op_item, scalar_configs):
     scalar_map = {
-        'Scalar': 'float',
+        'Scalar': 'double',
         'Scalar(float)': 'float',
         'Scalar(double)': 'double',
         'Scalar(int)': 'int',

--- a/paddle/fluid/operators/generator/type_mapping.py
+++ b/paddle/fluid/operators/generator/type_mapping.py
@@ -55,7 +55,7 @@ attr_types_map = {
 opmaker_attr_types_map = {
     # special types
     'IntArray': 'std::vector<int64_t>',
-    'Scalar': 'float',
+    'Scalar': 'double',
     'Scalar(bool)': 'bool',
     'Scalar(int)': 'int',
     'Scalar(int64_t)': 'int64_t',


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
将Scalar类型参数的默认数据类型从float改为double，防止出现精度损失。
Pcard-67164