### PR TITLE
fix test_spectral_op in numpy2.0

### DIFF
--- a/test/fft/spectral_op_np.py
+++ b/test/fft/spectral_op_np.py
@@ -37,14 +37,14 @@ def _get_norm_mode(norm, forward):
 def _get_inv_norm(n, norm_mode):
     assert isinstance(norm_mode, NormMode), f"invalid norm_type {norm_mode}"
     if norm_mode == NormMode.none:
-        return 1.0
+        return "forward"
     if norm_mode == NormMode.by_sqrt_n:
-        return np.sqrt(n)
-    return n
+        return "ortho"
+    return "backward"
 
 
 # 1d transforms
-def _fftc2c(a, n=None, axis=-1, norm=None, forward=None):
+def _fftc2c(a, n=None, axis=-1, norm=None, forward=None, out=None):
     a = asarray(a)
     if n is None:
         n = a.shape[axis]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Environment Adaptation 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
numpy2.0相比较numpy1.x内部接口变化较大，此PR修复
pcard-67164