### PR TITLE
throw error for no striede

### DIFF
--- a/paddle/phi/core/tensor_meta.cc
+++ b/paddle/phi/core/tensor_meta.cc
@@ -13,7 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/core/tensor_meta.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/core/enforce.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -208,8 +211,14 @@ bool DenseTensorMeta::valid() const noexcept {
   return valid;
 }
 
-bool DenseTensorMeta::is_contiguous() const noexcept {
-  return strides == calc_strides(dims);
+bool DenseTensorMeta::is_contiguous() const {
+  bool is_contiguous = strides == calc_strides(dims);
+  if (!is_contiguous && !FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Not contiguous "
+                           "Tensor found, something wrong has happened!"));
+  }
+  return is_contiguous;
 }
 
 StringTensorMeta::StringTensorMeta(const DDim& dims) : dims(dims) {}

--- a/paddle/phi/core/tensor_meta.cc
+++ b/paddle/phi/core/tensor_meta.cc
@@ -212,7 +212,7 @@ bool DenseTensorMeta::valid() const noexcept {
 }
 
 bool DenseTensorMeta::is_contiguous() const {
-  bool is_contiguous = strides == calc_strides(dims);
+  bool is_contiguous = (strides == calc_strides(dims));
   if (!is_contiguous && !FLAGS_use_stride_kernel) {
     PADDLE_THROW(
         phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Not contiguous "

--- a/paddle/phi/core/tensor_meta.h
+++ b/paddle/phi/core/tensor_meta.h
@@ -71,7 +71,7 @@ struct TEST_API DenseTensorMeta {
   /// \return Whether the metadata is valid.
   bool valid() const noexcept;
 
-  bool is_contiguous() const noexcept;
+  bool is_contiguous() const;
 
   bool is_scalar{false};
   /// \brief Determine whether using gpudnn speed-up library in the new dygraph.

--- a/paddle/phi/kernels/stride/as_complex_kernel.cc
+++ b/paddle/phi/kernels/stride/as_complex_kernel.cc
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/as_complex_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/common/complex.h"
 #include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -23,6 +26,12 @@ template <typename T, typename Context>
 void AsComplexStridedKernel(const Context& dev_ctx,
                             const DenseTensor& x,
                             DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
+
   PADDLE_ENFORCE_EQ(
       x.strides()[x.strides().size() - 1],
       1,

--- a/paddle/phi/kernels/stride/as_real_kernel.cc
+++ b/paddle/phi/kernels/stride/as_real_kernel.cc
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/as_real_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -21,6 +24,11 @@ template <typename T, typename Context>
 void AsRealStridedKernel(const Context& dev_ctx,
                          const DenseTensor& x,
                          DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   auto out_stride_v = common::vectorize(x.strides());
   for (auto& v : out_stride_v) {
     v *= 2;

--- a/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/as_strided_grad_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/as_strided_kernel.h"
 #include "paddle/phi/kernels/funcs/strided_utils.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -28,6 +31,11 @@ void AsStridedGradKernel(const Context& dev_ctx,
                          const std::vector<int64_t>& stride,
                          int64_t offset,
                          DenseTensor* input_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   dev_ctx.Alloc(input_grad, input_grad->dtype());
   input_grad->set_strides(DenseTensorMeta::calc_strides(input_grad->dims()));
   PD_VISIT_ALL_TYPES(input_grad->dtype(), "AsStridedGradKernel", ([&] {

--- a/paddle/phi/kernels/stride/as_strided_kernel.cc
+++ b/paddle/phi/kernels/stride/as_strided_kernel.cc
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/as_strided_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -24,6 +27,11 @@ void AsStridedKernel(const Context& dev_ctx,
                      const std::vector<int64_t>& stride,
                      int64_t offset,
                      DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   auto meta = out->meta();
   meta.dims = DDim(dims.data(), static_cast<int>(dims.size()));
   meta.strides = DDim(stride.data(), static_cast<int>(stride.size()));

--- a/paddle/phi/kernels/stride/complex_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/complex_grad_kernel.cc
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/complex_grad_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/funcs/strided_utils.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -24,6 +27,11 @@ template <typename T, typename Context>
 void RealGradStridedKernel(const Context& dev_ctx,
                            const DenseTensor& dout,
                            DenseTensor* dx) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   dev_ctx.Alloc(dx, dx->dtype());
   dx->set_strides(DenseTensorMeta::calc_strides(dx->dims()));
   PD_VISIT_ALL_TYPES(dx->dtype(), "RealGradStridedKernel", ([&] {
@@ -46,6 +54,11 @@ template <typename T, typename Context>
 void ImagGradStridedKernel(const Context& dev_ctx,
                            const DenseTensor& dout,
                            DenseTensor* dx) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   dev_ctx.Alloc(dx, dx->dtype());
   dx->set_strides(DenseTensorMeta::calc_strides(dx->dims()));
   PD_VISIT_ALL_TYPES(dx->dtype(), "ImagGradStridedKernel", ([&] {

--- a/paddle/phi/kernels/stride/complex_kernel.cc
+++ b/paddle/phi/kernels/stride/complex_kernel.cc
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/complex_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -22,6 +25,11 @@ template <typename T, typename Context>
 void RealStridedKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   if (x.dtype() != DataType::COMPLEX64 && x.dtype() != DataType::COMPLEX128) {
     PADDLE_THROW(
         phi::errors::NotFound("paddle.real only support COMPLEX64 and "
@@ -42,6 +50,11 @@ template <typename T, typename Context>
 void ImagStridedKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   if (x.dtype() != DataType::COMPLEX64 && x.dtype() != DataType::COMPLEX128) {
     PADDLE_THROW(
         phi::errors::NotFound("paddle.imag only support COMPLEX64 and "

--- a/paddle/phi/kernels/stride/diagonal_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/diagonal_grad_kernel.cc
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/diagonal_grad_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/diagonal_kernel.h"
 #include "paddle/phi/kernels/funcs/strided_utils.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -28,6 +31,11 @@ void DiagonalGradStridedKernel(const Context& dev_ctx,
                                int axis1,
                                int axis2,
                                DenseTensor* in_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   dev_ctx.Alloc(in_grad, in_grad->dtype());
   in_grad->set_strides(DenseTensorMeta::calc_strides(in_grad->dims()));
   PD_VISIT_ALL_TYPES(in_grad->dtype(), "DiagonalGradStridedKernel", ([&] {

--- a/paddle/phi/kernels/stride/diagonal_kernel.cc
+++ b/paddle/phi/kernels/stride/diagonal_kernel.cc
@@ -16,8 +16,11 @@
 
 #include "glog/logging.h"
 
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -28,6 +31,11 @@ void DiagonalStridedKernel(const Context& dev_ctx,
                            int axis1,
                            int axis2,
                            DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   size_t x_rank = x.dims().size();
   if (axis1 < 0) {
     axis1 += static_cast<int>(x_rank);

--- a/paddle/phi/kernels/stride/flatten_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/flatten_grad_kernel.cc
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/flatten_grad_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/reshape_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -23,6 +26,11 @@ void FlattenGradStridedKernel(const Context& dev_ctx,
                               const DenseTensor& xshape,
                               const DenseTensor& out_grad,
                               DenseTensor* x_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   auto xshape_dims = xshape.dims();
   auto x_dims = common::slice_ddim(xshape_dims, 1, xshape_dims.size());
   ReshapeStridedKernel<Context>(dev_ctx,

--- a/paddle/phi/kernels/stride/flatten_kernel.cc
+++ b/paddle/phi/kernels/stride/flatten_kernel.cc
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/flatten_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/reshape_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -25,6 +28,11 @@ void FlattenInferStridedKernel(const Context& dev_ctx,
                                int stop_axis UNUSED,
                                DenseTensor* out,
                                DenseTensor* xshape) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   ReshapeStridedKernel<Context>(
       dev_ctx,
       x,
@@ -40,6 +48,11 @@ void FlattenStridedKernel(const Context& dev_ctx,
                           int stop_axis,
                           DenseTensor* out,
                           DenseTensor* xshape) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   FlattenInferStridedKernel<Context>(
       dev_ctx, x, start_axis, stop_axis, out, xshape);
 }

--- a/paddle/phi/kernels/stride/index_select_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/index_select_grad_kernel.cc
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/index_select_grad_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/strided_utils.h"
 #include "paddle/phi/kernels/index_select_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -27,6 +30,11 @@ void IndexSelectGradStridedKernel(const Context& dev_ctx,
                                   int64_t index,
                                   int dim,
                                   DenseTensor* x_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   dev_ctx.Alloc(x_grad, x_grad->dtype());
   x_grad->set_strides(DenseTensorMeta::calc_strides(x_grad->dims()));
   PD_VISIT_ALL_TYPES(x_grad->dtype(), "IndexSelectGradStridedKernel", ([&] {

--- a/paddle/phi/kernels/stride/index_select_kernel.cc
+++ b/paddle/phi/kernels/stride/index_select_kernel.cc
@@ -16,8 +16,11 @@
 
 #include "glog/logging.h"
 
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -27,6 +30,11 @@ void IndexSelectStridedKernel(const Context& ctx,
                               int64_t index,
                               int dim,
                               DenseTensor* output) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   auto input_dim = x.dims();
   dim = dim >= 0 ? dim : dim + input_dim.size();
 

--- a/paddle/phi/kernels/stride/reshape_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/reshape_grad_kernel.cc
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/reshape_grad_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/reshape_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -23,6 +26,11 @@ template <typename Context>
 void ReshapeGradStridedKernel(const Context& dev_ctx,
                               const DenseTensor& out_grad,
                               DenseTensor* x_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   ReshapeStridedKernel<Context>(
       dev_ctx,
       out_grad,
@@ -36,6 +44,11 @@ void ReshapeDoubleGradStridedKernel(const Context& dev_ctx,
                                     const DenseTensor& out_grad UNUSED,
                                     const DenseTensor& x_grad_grad,
                                     DenseTensor* out_grad_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   ReshapeGradStridedKernel<Context>(dev_ctx, x_grad_grad, out_grad_grad);
 }
 

--- a/paddle/phi/kernels/stride/reshape_kernel.cc
+++ b/paddle/phi/kernels/stride/reshape_kernel.cc
@@ -14,10 +14,13 @@
 
 #include "paddle/phi/kernels/reshape_kernel.h"
 #include <algorithm>
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/strided_reshape_utils.h"
 #include "paddle/phi/kernels/funcs/strided_utils.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 template <typename Context>
@@ -26,6 +29,11 @@ void ReshapeStridedKernel(const Context& dev_ctx,
                           const IntArray& shape,
                           DenseTensor* out,
                           DenseTensor* xshape) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   DDim x_dims = x.dims();
   DDim x_stride = x.strides();
   size_t x_offset = x.offset();

--- a/paddle/phi/kernels/stride/slice_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/slice_grad_kernel.cc
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/slice_grad_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/strided_utils.h"
 #include "paddle/phi/kernels/slice_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -30,6 +33,11 @@ void SliceGradStridedKernel(const Context& dev_ctx,
                             const std::vector<int64_t>& infer_flags,
                             const std::vector<int64_t>& decrease_axis,
                             DenseTensor* input_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   dev_ctx.Alloc(input_grad, input_grad->dtype());
   input_grad->set_strides(DenseTensorMeta::calc_strides(input_grad->dims()));
   PD_VISIT_ALL_TYPES(input.dtype(), "SliceGradStridedKernel", ([&] {

--- a/paddle/phi/kernels/stride/slice_kernel.cc
+++ b/paddle/phi/kernels/stride/slice_kernel.cc
@@ -16,9 +16,12 @@
 
 #include "glog/logging.h"
 
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/slice_utils.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -31,6 +34,11 @@ void SliceStridedKernel(const Context& ctx,
                         const std::vector<int64_t>& infer_flags,
                         const std::vector<int64_t>& decrease_axis,
                         DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   std::vector<int64_t> starts = starts_arr.GetData();
   std::vector<int64_t> ends = ends_arr.GetData();
   const auto& in_dims = input.dims();

--- a/paddle/phi/kernels/stride/split_kernel.cc
+++ b/paddle/phi/kernels/stride/split_kernel.cc
@@ -16,9 +16,12 @@
 
 #include "glog/logging.h"
 
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/slice_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -28,6 +31,11 @@ void SplitStridedKernel(const Context& dev_ctx,
                         const IntArray& sections UNUSED,
                         const Scalar& axis_scalar,
                         std::vector<DenseTensor*> outs) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   int64_t num = static_cast<int64_t>(outs.size());
   int64_t start = 0;
 
@@ -53,6 +61,11 @@ void SplitWithNumStridedKernel(const Context& dev_ctx,
                                int num,
                                const Scalar& axis_scalar,
                                std::vector<DenseTensor*> outs) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   int axis_value = axis_scalar.to<int>();
   auto input_axis_dim = x.dims().at(axis_value);
   std::vector<int64_t> sections_vec;

--- a/paddle/phi/kernels/stride/squeeze_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/squeeze_grad_kernel.cc
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/squeeze_grad_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/reshape_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -24,6 +27,11 @@ void SqueezeGradStridedKernel(const Context& dev_ctx,
                               const DenseTensor& dout,
                               const IntArray& axes UNUSED,
                               DenseTensor* dx) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   const auto& xshape_dims = xshape.dims();
   auto x_dims = common::slice_ddim(xshape_dims, 1, xshape_dims.size());
   ReshapeStridedKernel<Context>(

--- a/paddle/phi/kernels/stride/squeeze_kernel.cc
+++ b/paddle/phi/kernels/stride/squeeze_kernel.cc
@@ -16,8 +16,11 @@
 #include <set>
 
 #include "glog/logging.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -26,6 +29,11 @@ void SqueezeInferStridedKernel(const Context& dev_ctx,
                                const DenseTensor& input,
                                const IntArray& axes_arr,
                                DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   std::vector<int64_t> axes = axes_arr.GetData();
   std::vector<int64_t> output_dims;
   std::vector<int64_t> output_stride;
@@ -120,6 +128,11 @@ void SqueezeStridedKernel(const Context& dev_ctx,
                           const IntArray& axes,
                           DenseTensor* out,
                           DenseTensor* xshape UNUSED) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   SqueezeInferStridedKernel<Context>(dev_ctx, x, axes, out);
 }
 

--- a/paddle/phi/kernels/stride/strided_slice_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/strided_slice_grad_kernel.cc
@@ -13,10 +13,14 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/strided_slice_grad_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/strided_utils.h"
 #include "paddle/phi/kernels/strided_slice_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
+
 namespace phi {
 
 template <typename Context>
@@ -30,6 +34,11 @@ void StridedSliceRawGradStridedKernel(const Context& dev_ctx,
                                       const std::vector<int>& infer_flags,
                                       const std::vector<int>& decrease_axis,
                                       DenseTensor* x_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   dev_ctx.Alloc(x_grad, x_grad->dtype());
   x_grad->set_strides(DenseTensorMeta::calc_strides(x_grad->dims()));
   PD_VISIT_ALL_TYPES(x_grad->dtype(), "StridedSliceRawGradStridedKernel", ([&] {
@@ -69,6 +78,11 @@ void StridedSliceGradStridedKernel(const Context& dev_ctx,
                                    const IntArray& ends,
                                    const IntArray& strides,
                                    DenseTensor* x_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   std::vector<int> infer_flags(axes.size(), 1);
   std::vector<int> decrease_axis;
   StridedSliceRawGradStridedKernel<Context>(dev_ctx,

--- a/paddle/phi/kernels/stride/strided_slice_kernel.cc
+++ b/paddle/phi/kernels/stride/strided_slice_kernel.cc
@@ -16,8 +16,11 @@
 
 #include "glog/logging.h"
 
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -31,6 +34,11 @@ void StridedSliceRawStridedKernel(const Context& dev_ctx,
                                   const std::vector<int>& infer_flags,
                                   const std::vector<int>& decrease_axis,
                                   DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   std::vector<int64_t> starts = starts_arr.GetData();
   std::vector<int64_t> ends = ends_arr.GetData();
   std::vector<int64_t> strides = strides_arr.GetData();
@@ -133,6 +141,11 @@ void StridedSliceStridedKernel(const Context& dev_ctx,
                                const IntArray& ends,
                                const IntArray& strides,
                                DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   std::vector<int> infer_flags(axes.size(), 1);
   std::vector<int> decrease_axis;
   StridedSliceRawStridedKernel<Context>(

--- a/paddle/phi/kernels/stride/tensor_unfold_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/tensor_unfold_grad_kernel.cc
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/tensor_unfold_grad_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/strided_utils.h"
 #include "paddle/phi/kernels/tensor_unfold_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -27,6 +30,11 @@ void TensorUnfoldGradKernel(const Context& dev_ctx,
                             int64_t size,
                             int64_t step,
                             DenseTensor* input_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   if (axis < 0) {
     axis += input.dims().size();
   }

--- a/paddle/phi/kernels/stride/tensor_unfold_kernel.cc
+++ b/paddle/phi/kernels/stride/tensor_unfold_kernel.cc
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/tensor_unfold_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -24,6 +27,11 @@ void TensorUnfoldKernel(const Context& dev_ctx,
                         int64_t size,
                         int64_t step,
                         DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   if (axis < 0) {
     axis += input.dims().size();
   }

--- a/paddle/phi/kernels/stride/transpose_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/transpose_grad_kernel.cc
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/transpose_grad_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/transpose_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -24,6 +27,11 @@ void TransposeGradStridedKernel(const Context& dev_ctx,
                                 const DenseTensor& out_grad,
                                 const std::vector<int>& axis,
                                 DenseTensor* x_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   size_t axis_size = axis.size();
   std::vector<int> formatted_axis = axis;
   for (size_t i = 0; i < axis_size; i++) {

--- a/paddle/phi/kernels/stride/transpose_kernel.cc
+++ b/paddle/phi/kernels/stride/transpose_kernel.cc
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/transpose_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -23,6 +26,11 @@ void TransposeStridedKernel(const Context& ctx,
                             const DenseTensor& x,
                             const std::vector<int>& axis,
                             DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   size_t x_rank = x.dims().size();
   std::vector<int> formatted_axis = axis;
   for (size_t i = 0; i < axis.size(); i++) {

--- a/paddle/phi/kernels/stride/unbind_kernel.cc
+++ b/paddle/phi/kernels/stride/unbind_kernel.cc
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/unbind_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/slice_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -24,6 +27,11 @@ void UnbindStridedKernel(const Context& dev_ctx,
                          const DenseTensor& x,
                          int axis,
                          std::vector<DenseTensor*> outs) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   int64_t num = static_cast<int64_t>(outs.size());
   int64_t start = 0;
 

--- a/paddle/phi/kernels/stride/unsqueeze_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/unsqueeze_grad_kernel.cc
@@ -11,10 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/flatten_grad_kernel.h"
 #include "paddle/phi/kernels/reshape_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -23,6 +26,11 @@ void UnsqueezeGradStridedKernel(const Context& dev_ctx,
                                 const DenseTensor& x_shape,
                                 const DenseTensor& dout,
                                 DenseTensor* dx) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   const auto& xshape_dims = x_shape.dims();
   auto x_dims = common::slice_ddim(xshape_dims, 1, xshape_dims.size());
   ReshapeStridedKernel<Context>(

--- a/paddle/phi/kernels/stride/unsqueeze_kernel.cc
+++ b/paddle/phi/kernels/stride/unsqueeze_kernel.cc
@@ -16,9 +16,12 @@
 
 #include "glog/logging.h"
 
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/unsqueeze.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -27,6 +30,11 @@ void UnsqueezeInferStridedKernel(const Context& dev_ctx,
                                  const DenseTensor& input,
                                  const IntArray& axes_arr,
                                  DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   std::vector<int64_t> axes = axes_arr.GetData();
   std::vector<int64_t> input_dims = common::vectorize<int64_t>(input.dims());
   std::vector<int64_t> input_stride =

--- a/paddle/phi/kernels/stride/view_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/view_grad_kernel.cc
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/view_grad_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/view_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -24,6 +27,11 @@ void ViewShapeGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const std::vector<int64_t>& dims,
                          DenseTensor* input_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   ViewShapeKernel<Context>(
       dev_ctx, out_grad, common::vectorize<int64_t>(input.dims()), input_grad);
 }
@@ -34,6 +42,11 @@ void ViewDtypeGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          DataType dtype,
                          DenseTensor* input_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   ViewDtypeKernel<Context>(dev_ctx, out_grad, input.dtype(), input_grad);
 }
 }  // namespace phi

--- a/paddle/phi/kernels/stride/view_kernel.cc
+++ b/paddle/phi/kernels/stride/view_kernel.cc
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/view_kernel.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/strided_reshape_utils.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
 
@@ -23,6 +26,11 @@ void ViewShapeKernel(const Context& dev_ctx,
                      const DenseTensor& input,
                      const std::vector<int64_t>& dims,
                      DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   // infer dims
   auto infer_dim = -1;
   auto new_size = 1;
@@ -69,6 +77,11 @@ void ViewDtypeKernel(const Context& dev_ctx,
                      const DenseTensor& input,
                      DataType dtype,
                      DenseTensor* out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(
+        phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
+                           "be called, something wrong has happened!"));
+  }
   size_t input_dtype_size = phi::SizeOf(input.dtype());
   size_t output_dtype_size = phi::SizeOf(dtype);
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
FLAGS_use_stride_kernel是早期stride机制调试使用的一个FLAGS。由于后期较多代码依托strided机制开发无法追溯。FLAGS_use_stride_kernel=0，并不能保证strided机制彻底关闭。
由于业务调试存在FLAGS_use_stride_kernel=0的需求，为防止意外发生，在特定环节检查strided机制是否彻底关闭。
Pcard-67164