### PR TITLE
[Prim][PIR] Modify the function get_reduce_dims_from_out

### DIFF
--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -39,12 +39,15 @@ using Program = pir::Program;
 
 // some outputs like xshape will no longer used after decomp, and those outputs
 // will skip checking.
-std::unordered_set<std::string> decomp_op_contain_none = {"pd_op.squeeze",
-                                                          "pd_op.unsqueeze",
-                                                          "pd_op.flatten",
-                                                          "pd_op.batch_norm",
-                                                          "pd_op.batch_norm_",
-                                                          "pd_op.dropout"};
+std::unordered_set<std::string> decomp_op_contain_none = {
+    "pd_op.squeeze",
+    "pd_op.unsqueeze",
+    "pd_op.flatten",
+    "pd_op.batch_norm",
+    "pd_op.batch_norm_",
+    "pd_op.dropout",
+    "pd_op.instance_norm",
+};
 //
 std::unordered_set<std::string> dynamic_shape_blacklist = {"pd_op.squeeze",
                                                            "pd_op.unsqueeze",

--- a/paddle/fluid/primitive/utils/utils.h
+++ b/paddle/fluid/primitive/utils/utils.h
@@ -149,24 +149,30 @@ static std::vector<int64_t> process_dims(const Tensor& origin,
 static phi::DDim get_reduce_dims_from_out(const phi::DDim& dout_dims,
                                           const phi::DDim& in_dims) {
   bool has_dynamic_shape = false;
-  int bat = dout_dims.size() - in_dims.size();
-  for (int i = 0; i < dout_dims.size(); ++i) {
-    if (dout_dims[i] == -1) {
-      has_dynamic_shape = true;
-      break;
-    }
-    if (i >= bat && in_dims[i - bat] == -1) {
-      has_dynamic_shape = true;
-      break;
-    }
+  for (int i = 0; i < dout_dims.size(); i++) {
+    if (dout_dims[i] == -1) has_dynamic_shape = true;
+    break;
   }
   PADDLE_ENFORCE_EQ(
       has_dynamic_shape,
       false,
       platform::errors::InvalidArgument(
           "Function get_reduce_dims_from_out() only use in static shape case, "
-          "but the inputs have the dynamic shape."));
+          "but the input [dout_dims] have the dynamic shape."));
 
+  has_dynamic_shape = false;
+  for (int i = 0; i < in_dims.size(); i++) {
+    if (in_dims[i] == -1) has_dynamic_shape = true;
+    break;
+  }
+  PADDLE_ENFORCE_EQ(
+      has_dynamic_shape,
+      false,
+      platform::errors::InvalidArgument(
+          "Function get_reduce_dims_from_out() only use in static shape case, "
+          "but the input [in_dims] have the dynamic shape."));
+
+  int bat = dout_dims.size() - in_dims.size();
   std::vector<int64_t> result;
   for (int i = 0; i < bat; ++i) {
     result.push_back(i);

--- a/paddle/fluid/primitive/utils/utils.h
+++ b/paddle/fluid/primitive/utils/utils.h
@@ -162,7 +162,6 @@ static phi::DDim get_reduce_dims_from_out(const phi::DDim& dout_dims,
           "Function get_reduce_dims_from_out() only use in static shape case, "
           "but the input [dout_dims] have the dynamic shape."));
 
-  has_dynamic_shape = false;
   for (int i = 0; i < in_dims.size(); i++) {
     if (in_dims[i] == -1) {
       has_dynamic_shape = true;

--- a/paddle/fluid/primitive/utils/utils.h
+++ b/paddle/fluid/primitive/utils/utils.h
@@ -145,10 +145,29 @@ static std::vector<int64_t> process_dims(const Tensor& origin,
 }
 
 // These method don't need to be specified
+// These method only handle the static shape case
 static phi::DDim get_reduce_dims_from_out(const phi::DDim& dout_dims,
                                           const phi::DDim& in_dims) {
-  std::vector<int64_t> result;
+  bool has_dynamic_shape = false;
   int bat = dout_dims.size() - in_dims.size();
+  for (int i = 0; i < dout_dims.size(); ++i) {
+    if (dout_dims[i] == -1) {
+      has_dynamic_shape = true;
+      break;
+    }
+    if (i >= bat && in_dims[i - bat] == -1) {
+      has_dynamic_shape = true;
+      break;
+    }
+  }
+  PADDLE_ENFORCE_EQ(
+      has_dynamic_shape,
+      false,
+      platform::errors::InvalidArgument(
+          "Function get_reduce_dims_from_out() only use in static shape case, "
+          "but the inputs have the dynamic shape."));
+
+  std::vector<int64_t> result;
   for (int i = 0; i < bat; ++i) {
     result.push_back(i);
   }

--- a/paddle/fluid/primitive/utils/utils.h
+++ b/paddle/fluid/primitive/utils/utils.h
@@ -150,8 +150,10 @@ static phi::DDim get_reduce_dims_from_out(const phi::DDim& dout_dims,
                                           const phi::DDim& in_dims) {
   bool has_dynamic_shape = false;
   for (int i = 0; i < dout_dims.size(); i++) {
-    if (dout_dims[i] == -1) has_dynamic_shape = true;
-    break;
+    if (dout_dims[i] == -1) {
+      has_dynamic_shape = true;
+      break;
+    }
   }
   PADDLE_ENFORCE_EQ(
       has_dynamic_shape,
@@ -162,8 +164,10 @@ static phi::DDim get_reduce_dims_from_out(const phi::DDim& dout_dims,
 
   has_dynamic_shape = false;
   for (int i = 0; i < in_dims.size(); i++) {
-    if (in_dims[i] == -1) has_dynamic_shape = true;
-    break;
+    if (in_dims[i] == -1) {
+      has_dynamic_shape = true;
+      break;
+    }
   }
   PADDLE_ENFORCE_EQ(
       has_dynamic_shape,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

目前发现get_reduce_dims_from_out在某些动态shape场景下也能正常工作，但是函数设计的本身目的是用于处理静态shape的场景，因此在该函数中添加了动态shap的检测