### PR TITLE
fix stride transform bug

### DIFF
--- a/paddle/phi/api/lib/data_transform.cc
+++ b/paddle/phi/api/lib/data_transform.cc
@@ -433,7 +433,6 @@ std::unique_ptr<std::vector<phi::DenseTensor>> PrepareData(
       if (NeedTransform2Contiguous(is_stride_kernel,
                                    dense_tensor->meta().is_contiguous()) &&
           tensor_in->initialized()) {
-        std::cout << "lala" << std::endl;
         phi::DenseTensor out =
             *(static_cast<phi::DenseTensor*>(tensor_in.get()));
         out = Trans2Contiguous(out);

--- a/paddle/phi/api/lib/data_transform.cc
+++ b/paddle/phi/api/lib/data_transform.cc
@@ -379,6 +379,12 @@ std::shared_ptr<phi::DenseTensor> PrepareData(
                               transform_flag) &&
          !NeedTransform2Contiguous(is_stride_kernel,
                                    dense_tensor.meta().is_contiguous()))) {
+      if (NeedTransform2Contiguous(is_stride_kernel,
+                                   dense_tensor.meta().is_contiguous())) {
+        phi::DenseTensor out = dense_tensor;
+        out = Trans2Contiguous(out);
+        return std::make_shared<phi::DenseTensor>(std::move(out));
+      }
       return std::static_pointer_cast<phi::DenseTensor>(tensor_in);
     }
     phi::DenseTensor out = TransformData(
@@ -423,8 +429,16 @@ std::unique_ptr<std::vector<phi::DenseTensor>> PrepareData(
          !(dense_tensor &&
            NeedTransform2Contiguous(is_stride_kernel,
                                     dense_tensor->meta().is_contiguous())))) {
-      pt_tensors->emplace_back(
-          *std::dynamic_pointer_cast<phi::DenseTensor>(tensor_in));
+      if (NeedTransform2Contiguous(is_stride_kernel,
+                                   dense_tensor->meta().is_contiguous())) {
+        phi::DenseTensor out =
+            *(static_cast<phi::DenseTensor*>(tensor_in.get()));
+        out = Trans2Contiguous(out);
+        pt_tensors->emplace_back(out);
+      } else {
+        pt_tensors->emplace_back(
+            *std::dynamic_pointer_cast<phi::DenseTensor>(tensor_in));
+      }
     } else {
       pt_tensors->emplace_back(
           TransformData(*(static_cast<phi::DenseTensor*>(tensor_in.get())),
@@ -463,6 +477,14 @@ std::shared_ptr<phi::SelectedRows> PrepareDataForSelectedRows(
                               transform_flag))) &&
         !NeedTransform2Contiguous(
             false, selected_rows.value().meta().is_contiguous())) {
+      if (NeedTransform2Contiguous(
+              false, selected_rows.value().meta().is_contiguous())) {
+        auto out_new = std::make_shared<phi::SelectedRows>(
+            selected_rows.rows(), selected_rows.height());
+        auto dense_out = Trans2Contiguous(selected_rows.value());
+        *out_new->mutable_value() = dense_out;
+        return out_new;
+      }
       return std::static_pointer_cast<phi::SelectedRows>(tensor_in);
     }
 
@@ -949,6 +971,14 @@ std::shared_ptr<phi::distributed::DistTensor> PrepareDataForDistTensor(
                               transform_flag) &&
          !NeedTransform2Contiguous(is_stride_kernel,
                                    dense_tensor.meta().is_contiguous()))) {
+      if (NeedTransform2Contiguous(is_stride_kernel,
+                                   dense_tensor.meta().is_contiguous())) {
+        auto dist_out = std::make_shared<phi::distributed::DistTensor>(
+            dist_tensor->dims(), dist_tensor->dist_attr());
+        auto* out = dist_out->unsafe_mutable_value();
+        *out = Trans2Contiguous(dense_tensor);
+        return dist_out;
+      }
       return input;
     }
     // TODO(chenweihang): The global meta in DistTensor is not changed,
@@ -988,8 +1018,16 @@ PrepareDataForDistTensor(
                                 transform_flag) &&
            !NeedTransform2Contiguous(is_stride_kernel,
                                      dense_tensor.meta().is_contiguous()))) {
-        out.push_back(
-            std::static_pointer_cast<phi::distributed::DistTensor>(tensor_in));
+        if (NeedTransform2Contiguous(is_stride_kernel,
+                                     dense_tensor.meta().is_contiguous())) {
+          phi::DenseTensor trans_in_tensor = Trans2Contiguous(dense_tensor);
+          out.push_back(std::make_shared<phi::distributed::DistTensor>(
+              std::make_shared<phi::DenseTensor>(trans_in_tensor),
+              dist_tensor->dist_attr()));
+        } else {
+          out.push_back(std::static_pointer_cast<phi::distributed::DistTensor>(
+              tensor_in));
+        }
       } else {
         phi::DenseTensor trans_in_tensor = TransformData(
             dense_tensor, target_args_def, transform_flag, is_stride_kernel);

--- a/paddle/phi/api/lib/data_transform.cc
+++ b/paddle/phi/api/lib/data_transform.cc
@@ -380,7 +380,8 @@ std::shared_ptr<phi::DenseTensor> PrepareData(
          !NeedTransform2Contiguous(is_stride_kernel,
                                    dense_tensor.meta().is_contiguous()))) {
       if (NeedTransform2Contiguous(is_stride_kernel,
-                                   dense_tensor.meta().is_contiguous())) {
+                                   dense_tensor.meta().is_contiguous()) &&
+          dense_tensor.initialized()) {
         phi::DenseTensor out = dense_tensor;
         out = Trans2Contiguous(out);
         return std::make_shared<phi::DenseTensor>(std::move(out));
@@ -430,7 +431,9 @@ std::unique_ptr<std::vector<phi::DenseTensor>> PrepareData(
            NeedTransform2Contiguous(is_stride_kernel,
                                     dense_tensor->meta().is_contiguous())))) {
       if (NeedTransform2Contiguous(is_stride_kernel,
-                                   dense_tensor->meta().is_contiguous())) {
+                                   dense_tensor->meta().is_contiguous()) &&
+          tensor_in->initialized()) {
+        std::cout << "lala" << std::endl;
         phi::DenseTensor out =
             *(static_cast<phi::DenseTensor*>(tensor_in.get()));
         out = Trans2Contiguous(out);
@@ -478,7 +481,8 @@ std::shared_ptr<phi::SelectedRows> PrepareDataForSelectedRows(
         !NeedTransform2Contiguous(
             false, selected_rows.value().meta().is_contiguous())) {
       if (NeedTransform2Contiguous(
-              false, selected_rows.value().meta().is_contiguous())) {
+              false, selected_rows.value().meta().is_contiguous()) &&
+          selected_rows.initialized()) {
         auto out_new = std::make_shared<phi::SelectedRows>(
             selected_rows.rows(), selected_rows.height());
         auto dense_out = Trans2Contiguous(selected_rows.value());
@@ -972,7 +976,8 @@ std::shared_ptr<phi::distributed::DistTensor> PrepareDataForDistTensor(
          !NeedTransform2Contiguous(is_stride_kernel,
                                    dense_tensor.meta().is_contiguous()))) {
       if (NeedTransform2Contiguous(is_stride_kernel,
-                                   dense_tensor.meta().is_contiguous())) {
+                                   dense_tensor.meta().is_contiguous()) &&
+          dense_tensor.initialized()) {
         auto dist_out = std::make_shared<phi::distributed::DistTensor>(
             dist_tensor->dims(), dist_tensor->dist_attr());
         auto* out = dist_out->unsafe_mutable_value();
@@ -1019,7 +1024,8 @@ PrepareDataForDistTensor(
            !NeedTransform2Contiguous(is_stride_kernel,
                                      dense_tensor.meta().is_contiguous()))) {
         if (NeedTransform2Contiguous(is_stride_kernel,
-                                     dense_tensor.meta().is_contiguous())) {
+                                     dense_tensor.meta().is_contiguous()) &&
+            dense_tensor.initialized()) {
           phi::DenseTensor trans_in_tensor = Trans2Contiguous(dense_tensor);
           out.push_back(std::make_shared<phi::distributed::DistTensor>(
               std::make_shared<phi::DenseTensor>(trans_in_tensor),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
PHI中有skip_transform的标记，会跳过transform，但Contiguous不能跳过。

Pcard-67164