### PR TITLE
[Paddle Inference] Fix matching constraints for add_norm_fuse_pass

### DIFF
--- a/paddle/fluid/pir/transforms/gpu/add_norm_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/add_norm_fuse_pass.cc
@@ -241,7 +241,14 @@ class AddLayerNormFusePattern : public paddle::drr::DrrPatternBase {
               ? add1(pat.Tensor("any_tensor"), pat.Tensor("add_out"))
               : add1(pat.Tensor("add_out"), pat.Tensor("any_tensor"));
     }
-
+    pat.AddConstraint([](const paddle::drr::MatchContext &match_ctx) {
+      auto x_shape = pir::GetShapeFromValue(match_ctx.Tensor("x"));
+      auto r_shape = pir::GetShapeFromValue(match_ctx.Tensor("residual"));
+      if (x_shape[0] != r_shape[0]) {
+        return false;
+      }
+      return true;
+    });
     paddle::drr::ResultPattern res = pat.ResultPattern();
     const auto &cast_op_dtype = res.ComputeAttr(
         [](const paddle::drr::MatchContext &match_ctx) -> phi::DataType {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-71500
增加add_layer_norm 的匹配限制
fused_bias_residual_layernorm不支持残差广播
