### PR TITLE
[Typing] 使用 `Callable` 代替 `type[xxx]`

### DIFF
--- a/python/paddle/vision/models/mobilenetv2.py
+++ b/python/paddle/vision/models/mobilenetv2.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import (
     TYPE_CHECKING,
+    Callable,
     TypedDict,
 )
 
@@ -53,7 +54,7 @@ class InvertedResidual(nn.Layer):
         oup: int,
         stride: int,
         expand_ratio: float,
-        norm_layer: type[nn.Layer] = nn.BatchNorm2D,
+        norm_layer: Callable[..., nn.Layer] = nn.BatchNorm2D,
     ) -> None:
         super().__init__()
         self.stride = stride

--- a/python/paddle/vision/models/mobilenetv3.py
+++ b/python/paddle/vision/models/mobilenetv3.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from functools import partial
 from typing import (
     TYPE_CHECKING,
+    Callable,
     TypedDict,
 )
 
@@ -69,8 +70,8 @@ class SqueezeExcitation(nn.Layer):
         self,
         input_channels: int,
         squeeze_channels: int,
-        activation: type[nn.Layer] = nn.ReLU,
-        scale_activation: type[nn.Layer] = nn.Sigmoid,
+        activation: Callable[..., nn.Layer] = nn.ReLU,
+        scale_activation: Callable[..., nn.Layer] = nn.Sigmoid,
     ) -> None:
         super().__init__()
         self.avgpool = nn.AdaptiveAvgPool2D(1)
@@ -136,8 +137,8 @@ class InvertedResidual(nn.Layer):
         filter_size: int,
         stride: int,
         use_se: bool,
-        activation_layer: type[nn.Layer],
-        norm_layer: type[nn.Layer],
+        activation_layer: Callable[..., nn.Layer],
+        norm_layer: Callable[..., nn.Layer],
     ) -> None:
         super().__init__()
         self.use_res_connect = stride == 1 and in_channels == out_channels

--- a/python/paddle/vision/models/resnet.py
+++ b/python/paddle/vision/models/resnet.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 import paddle
 from paddle import nn
@@ -121,7 +121,7 @@ class BasicBlock(nn.Layer):
         groups: int = 1,
         base_width: int = 64,
         dilation: int = 1,
-        norm_layer: type[nn.Layer] | None = None,
+        norm_layer: Callable[..., nn.Layer] | None = None,
     ) -> None:
         super().__init__()
         if norm_layer is None:
@@ -173,7 +173,7 @@ class BottleneckBlock(nn.Layer):
         groups: int = 1,
         base_width: int = 64,
         dilation: int = 1,
-        norm_layer: type[nn.Layer] | None = None,
+        norm_layer: Callable[..., nn.Layer] | None = None,
     ) -> None:
         super().__init__()
         if norm_layer is None:

--- a/python/paddle/vision/models/shufflenetv2.py
+++ b/python/paddle/vision/models/shufflenetv2.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 import paddle
 from paddle import nn
@@ -121,7 +121,7 @@ class InvertedResidual(nn.Layer):
         in_channels: int,
         out_channels: int,
         stride: Size2,
-        activation_layer: type[nn.Layer] = nn.ReLU,
+        activation_layer: Callable[..., nn.Layer] = nn.ReLU,
     ) -> None:
         super().__init__()
         self._conv_pw = ConvNormActivation(
@@ -171,7 +171,7 @@ class InvertedResidualDS(nn.Layer):
         in_channels: int,
         out_channels: int,
         stride: Size2,
-        activation_layer: type[nn.Layer] = nn.ReLU,
+        activation_layer: Callable[..., nn.Layer] = nn.ReLU,
     ) -> None:
         super().__init__()
 

--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Sequence, overload
+from typing import TYPE_CHECKING, Callable, Literal, Sequence, overload
 
 import numpy as np
 
@@ -1902,8 +1902,8 @@ class ConvNormActivation(Sequential):
         stride: Size2 = 1,
         padding: _PaddingSizeMode | Size2 | Size4 | str | None = None,
         groups: int = 1,
-        norm_layer: type[nn.Layer] = BatchNorm2D,
-        activation_layer: type[nn.Layer] = ReLU,
+        norm_layer: Callable[..., nn.Layer] = BatchNorm2D,
+        activation_layer: Callable[..., nn.Layer] = ReLU,
         dilation: int = 1,
         bias: bool | None = None,
     ) -> None:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

使用 `Callable` 代替 `type[xxx]`，如：

``` python
norm_layer: type[nn.Layer] = BatchNorm2D,
```

改为

``` python
norm_layer: Callable[..., nn.Layer] = BatchNorm2D,
```

主要是因为，原 API 文档中是 `norm_layer (Callable[..., paddle.nn.Layer], optional)`，若使用 `type[xxx]` 可能会不兼容，如：

``` python
from __future__ import annotations

from typing import Callable

class A: ...

def test1(a: type[A]) -> None:
    return

def test2(a: Callable[..., A]) -> None:
    return

test1(A)
test2(A)

def fn() -> A:
    return A()

test1(fn) # fail
test2(fn)

```

@SigureMo 