### PR TITLE
Revert "Wrong parameter order in `all_to_all`"

### DIFF
--- a/python/paddle/distributed/communication/stream/all_to_all.py
+++ b/python/paddle/distributed/communication/stream/all_to_all.py
@@ -27,10 +27,10 @@ def _all_to_all_tensor_in_dygraph(
 ):
     if use_calc_stream:
         return group.process_group.all_to_all_tensor_on_calc_stream(
-            out_tensor, in_tensor
+            in_tensor, out_tensor
         )
 
-    task = group.process_group.all_to_all_tensor(out_tensor, in_tensor, sync_op)
+    task = group.process_group.all_to_all_tensor(in_tensor, out_tensor, sync_op)
     if sync_op:
         task.wait()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
 Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Reverts PaddlePaddle/Paddle#65093，此PR会导致RLHF仓库出nan
Pcard-73145
