### PR TITLE
[DO NOT MERGE] fix dcu test failure

### DIFF
--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -470,15 +470,27 @@ function(cc_test_run TARGET_NAME)
       NAME ${TARGET_NAME}
       COMMAND ${cc_test_COMMAND} ${cc_test_ARGS}
       WORKING_DIRECTORY ${cc_test_DIR})
-    set_property(
-      TEST ${TARGET_NAME}
-      PROPERTY
-        ENVIRONMENT
-        FLAGS_cpu_deterministic=true
-        FLAGS_init_allocated_mem=true
-        FLAGS_cudnn_deterministic=true
-        LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PADDLE_BINARY_DIR}/python/paddle/libs:${PADDLE_BINARY_DIR}/python/paddle/base
-    )
+    if(WITH_ROCM)
+      set_property(
+        TEST ${TARGET_NAME}
+        PROPERTY
+          ENVIRONMENT
+          FLAGS_cpu_deterministic=true
+          FLAGS_init_allocated_mem=true
+          FLAGS_cudnn_deterministic=true
+          LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${PADDLE_BINARY_DIR}/python/paddle/libs:${PADDLE_BINARY_DIR}/python/paddle/base
+      )
+    else()
+      set_property(
+        TEST ${TARGET_NAME}
+        PROPERTY
+          ENVIRONMENT
+          FLAGS_cpu_deterministic=true
+          FLAGS_init_allocated_mem=true
+          FLAGS_cudnn_deterministic=true
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PADDLE_BINARY_DIR}/python/paddle/libs:${PADDLE_BINARY_DIR}/python/paddle/base
+      )
+    endif()
     # No unit test should exceed 2 minutes.
     if(WIN32)
       set_tests_properties(${TARGET_NAME} PROPERTIES TIMEOUT 150)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
**注意**：此修复仅是一个work-around，请不要合入

**背景**：PR-CI-Hygon-DCU-Test 流水线中大量纯CPP单测挂，提示错误如下 (hip_test都可以通过，只有部分 cc_test 会挂)
![3abb10a4c8ae3762bbea419e37b23a69](https://github.com/PaddlePaddle/Paddle/assets/16605440/dcf6ce99-6783-4919-9082-07b656f08af3)
挂的原因是因为ctest命令在执行的时候没有正确解析 `$LD_LIBRARY_PATH` 环境变量导致 (手动执行 cc_test 生成的CPP可执行文件可以成功，但是ctest命令执行就会报以上错误)。

**现象**：DTK的2个镜像存在不同现象，DTK24.04镜像没有以上问题，DTK24.04.1的镜像存在以上问题
- DTK24.04的镜像：registry.baidubce.com/device/paddle-dcu:dtk24.04-kylinv10-gcc73-py310
- DTK24.04.1的镜像：registry.baidubce.com/device/paddle-dcu:dtk24.04.1-kylinv10-gcc73-py310

此PR的修改仅仅是一个 work-around，因为此修改会在编译时将编译环境的的 LD_LIBRARY_PATH 的信息展开在 CTestTestfile.cmake 中，当编译环境与测试环境的LD_LIBRARY_PATH不一致的情况下会导致冲突，即

1. 正常无此PR的修改的情况下，CTestTestfile.cmake中生成的内容是 `LD_LIBRARY_PATH=$LD_LIBRARY_PATH:...`，ctest执行的时候会在执行时自动加载测试环境中的LD_LIBRARY_PATH的设置
2. 有了此PR的修改，CTestTestfile.cmake 中生成的内容是 `LD_LIBRARY_PATH=/usr/local/lib:/opt/dtk-24.04.1/lib:...`，即 LD_LIBRARY_PATH 已经被展开成编译环境中LD_LIBRARY_PATH的设置；当单测运行环境和编译环境不一致的情况下，根据编译环境写死了ctest运行的 LD_LIBRARY_PATH 设置，而不是正常根据单测运行环境自动加载的话，会导致冲突。

因此，这个PR仅记录DCU单测失败的问题，root cause待定位后修复。

