### PR TITLE
[CINN] remove unused for loop in compute_inline_expand

### DIFF
--- a/paddle/cinn/optim/compute_inline_expand.cc
+++ b/paddle/cinn/optim/compute_inline_expand.cc
@@ -49,13 +49,7 @@ struct TensorInlineExpandMutator : public ir::IRMutator<> {
         all_tensor_map_(all_tensor_map),
         stages_(stages) {}
 
-  void operator()(Expr *expr) {
-    ir::IRMutator<>::Visit(expr, expr);
-    for (int i = 0; i < tensor_names.size(); i++) {
-      for (auto &var : replace_var[i]) {
-      }
-    }
-  }
+  void operator()(Expr *expr) { ir::IRMutator<>::Visit(expr, expr); }
 
   void Visit(const ir::_Var_ *expr, Expr *op) override {
     if (inline_code && temp_buffer) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->
[CINN] remove unused for loop in compute_inline_expand