### PR TITLE
[XPU] fix bugs for test_elementwise_mul_op_xpu large shape

### DIFF
--- a/test/xpu/test_elementwise_mul_op_xpu.py
+++ b/test/xpu/test_elementwise_mul_op_xpu.py
@@ -217,7 +217,7 @@ class XPUTestElementwiseMulOp(XPUOpTestWrapper):
     class TestElementwiseMulOpLargeShape1(ElementwiseMulOp):
         def init_data(self):
             self.x = self.gen_data_depend_on_dtype([8192, 1])
-            self.y = self.gen_data_depend_on_dtype([1, 64])
+            self.y = self.gen_data_depend_on_dtype([1, 128])
 
     @check_run_big_shape_test()
     class TestElementwiseMulOpLargeShape2(ElementwiseMulOp):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Custom Device 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
1. fix errors in large shape test of element_mul caused by `y.numel() < 100`