### PR TITLE
[PIR][oneDNN] Revise operator_reshape_onednn_fuse_pass

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -642,7 +642,6 @@ const std::vector<std::string> kPirMkldnnPasses {
       "conv_elementwise_add_onednn_fuse_pass",    //
       "conv_activation_onednn_fuse_pass",         //
       "conv_concat_activation_onednn_fuse_pass",  //
-      "batch_norm_act_fuse_pass",                 //
       "matmul_scale_fuse_pass",                   //
       "scale_matmul_fuse_pass",                   //
       "reshape_transpose_matmul_fuse_pass",       //
@@ -658,12 +657,13 @@ const std::vector<std::string> kPirMkldnnPasses {
     defined(PADDLE_WITH_DNNL)
       "self_attention_fuse_pass",  //
 #endif
+      "batch_norm_act_fuse_pass",             //
       "softplus_activation_fuse_pass",        //
       "shuffle_channel_detect_pass",          //
-      "operator_reshape_onednn_fuse_pass",    //
       "elementwise_act_onednn_fuse_pass",     //
-      "operator_unsqueeze_onednn_fuse_pass",  //
       "operator_scale_onednn_fuse_pass",      //
+      "operator_unsqueeze_onednn_fuse_pass",  //
+      "operator_reshape_onednn_fuse_pass",    //
       "onednn_placement_pass"                 //
 };
 

--- a/paddle/fluid/pir/transforms/onednn/operator_reshape_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/operator_reshape_onednn_fuse_pass.cc
@@ -78,8 +78,7 @@ class FusedTransposeReshapeFusePattern : public paddle::drr::DrrPatternBase {
 
       for (auto item : reshape2_shape) {
         if (item == 0) {
-          VLOG(4) << "OneDNN op+reshape2 fuse pass does not support zero dims, "
-                     "skipping";
+          VLOG(4) << "OneDNN op+reshape2 fuse pass does not support zero dims";
           return false;
         } else if (item == -1) {
           ++num_of_minus_ones;
@@ -87,9 +86,7 @@ class FusedTransposeReshapeFusePattern : public paddle::drr::DrrPatternBase {
       }
 
       if (num_of_minus_ones > 1) {
-        VLOG(4)
-            << "Number of -1 values inside of reshape2 shouldn't be greater "
-               "than one in op+reshape2 oneDNN fuse pass, skipping";
+        VLOG(4) << "Number of -1 values inside of reshape2 should be 0 or 1";
         return false;
       }
       return true;
@@ -102,8 +99,7 @@ class FusedTransposeReshapeFusePattern : public paddle::drr::DrrPatternBase {
           match_ctx.Attr<std::vector<int>>("fused_reshape2_shape");
 
       if (fused_unsqueeze2_axes.size() > 0 || fused_reshape2_shape.size()) {
-        VLOG(4) << "Cannot do " << fusable_ops_ << " + reshape fuse, because "
-                << fusable_ops_ << " is already fused with unsqueeze/reshape!";
+        VLOG(4) << fusable_ops_ << " is already fused with unsqueeze/reshape";
         return false;
       }
       return true;
@@ -202,8 +198,7 @@ class FcReshapeFusePattern : public paddle::drr::DrrPatternBase {
 
       for (auto item : reshape2_shape) {
         if (item == 0) {
-          VLOG(4) << "OneDNN op+reshape2 fuse pass does not support zero dims, "
-                     "skipping";
+          VLOG(4) << "OneDNN op+reshape2 fuse pass does not support zero dims";
           return false;
         } else if (item == -1) {
           ++num_of_minus_ones;
@@ -211,9 +206,7 @@ class FcReshapeFusePattern : public paddle::drr::DrrPatternBase {
       }
 
       if (num_of_minus_ones > 1) {
-        VLOG(4)
-            << "Number of -1 values inside of reshape2 shouldn't be greater "
-               "than one in op+reshape2 oneDNN fuse pass, skipping";
+        VLOG(4) << "Number of -1 values inside of reshape2 should be 0 or 1";
         return false;
       }
       return true;
@@ -224,8 +217,7 @@ class FcReshapeFusePattern : public paddle::drr::DrrPatternBase {
           match_ctx.Attr<std::vector<int>>("fused_reshape2_shape");
 
       if (fused_reshape2_shape.size()) {
-        VLOG(4) << "Cannot do " << fusable_ops_ << " + reshape fuse, because "
-                << fusable_ops_ << " is already fused with reshape!";
+        VLOG(4) << fusable_ops_ << " is already fused with reshape";
         return false;
       }
       return true;
@@ -311,17 +303,15 @@ class TransposeReshapeFusePattern : public paddle::drr::DrrPatternBase {
 
       for (auto item : reshape2_shape) {
         if (item == 0) {
-          VLOG(4) << "OneDNN op+reshape2 fuse pass does not support zero dims, "
-                     "skipping";
+          VLOG(4) << "OneDNN op+reshape2 fuse pass does not support zero dims";
           return false;
         } else if (item == -1) {
           ++num_of_minus_ones;
         }
       }
+
       if (num_of_minus_ones > 1) {
-        VLOG(4)
-            << "Number of -1 values inside of reshape2 shouldn't be greater "
-               "than one in op+reshape2 oneDNN fuse pass, skipping";
+        VLOG(4) << "Number of -1 values inside of reshape2 should be 0 or 1";
         return false;
       }
       return true;

--- a/paddle/fluid/pir/transforms/onednn/operator_reshape_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/operator_reshape_onednn_fuse_pass.cc
@@ -22,16 +22,16 @@
 #include "paddle/pir/include/pass/pass_registry.h"
 
 namespace {
-class OperatorReshapeFusePattern : public paddle::drr::DrrPatternBase {
+class FusedTransposeReshapeFusePattern : public paddle::drr::DrrPatternBase {
  private:
   std::string fusable_ops_;
   std::string fused_ops_name_;
   uint32_t benefit_;
 
  public:
-  OperatorReshapeFusePattern(const std::string &fusable_ops,
-                             const std::string &fused_ops_name,
-                             uint32_t benefit)
+  FusedTransposeReshapeFusePattern(const std::string &fusable_ops,
+                                   const std::string &fused_ops_name,
+                                   uint32_t benefit)
       : fusable_ops_(fusable_ops),
         fused_ops_name_(fused_ops_name),
         benefit_(benefit) {}
@@ -46,61 +46,269 @@ class OperatorReshapeFusePattern : public paddle::drr::DrrPatternBase {
     paddle::drr::SourcePattern pat = ctx->SourcePattern();
 
     std::unordered_map<std::string, paddle::drr::Attribute> op_attrs;
-    if (fusable_ops_ == paddle::onednn::dialect::FcOp::name()) {
-      op_attrs.emplace("in_num_col_dims", pat.Attr("in_num_col_dims"));
-      op_attrs.emplace("activation_type", pat.Attr("activation_type"));
-      op_attrs.emplace("padding_weights", pat.Attr("padding_weights"));
-      op_attrs.emplace("use_quantizer", pat.Attr("use_quantizer"));
-      op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
-      op_attrs.emplace("scale_in", pat.Attr("scale_in"));
-      op_attrs.emplace("scale_weights", pat.Attr("scale_weights"));
-      op_attrs.emplace("scale_out", pat.Attr("scale_out"));
-      op_attrs.emplace("force_fp32_output", pat.Attr("force_fp32_output"));
-      op_attrs.emplace("fuse_activation", pat.Attr("fuse_activation"));
-      op_attrs.emplace("fuse_alpha", pat.Attr("fuse_alpha"));
-      op_attrs.emplace("fuse_beta", pat.Attr("fuse_beta"));
-      op_attrs.emplace("fused_output_scale", pat.Attr("fused_output_scale"));
-      op_attrs.emplace("fused_reshape2_shape",
-                       pat.Attr("fused_reshape2_shape"));
-
-    } else if (fusable_ops_ ==
-               paddle::onednn::dialect::FusedTransposeOp::name()) {
-      op_attrs.emplace("axis", pat.Attr("axis"));
-      op_attrs.emplace("fused_squeeze2_axes", pat.Attr("fused_squeeze2_axes"));
-      op_attrs.emplace("fused_unsqueeze2_axes",
-                       pat.Attr("fused_unsqueeze2_axes"));
-      op_attrs.emplace("fused_reshape2_shape",
-                       pat.Attr("fused_reshape2_shape"));
-      op_attrs.emplace("scale", pat.Attr("scale"));
-      op_attrs.emplace("shift", pat.Attr("shift"));
-      op_attrs.emplace("output_data_type", pat.Attr("output_data_type"));
-      op_attrs.emplace("data_format", pat.Attr("data_format"));
-      op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
-    } else if (fusable_ops_ == paddle::dialect::TransposeOp::name()) {
-      op_attrs.emplace("perm", pat.Attr("perm"));
-    }
+    op_attrs.emplace("axis", pat.Attr("axis"));
+    op_attrs.emplace("fused_squeeze2_axes", pat.Attr("fused_squeeze2_axes"));
+    op_attrs.emplace("fused_unsqueeze2_axes",
+                     pat.Attr("fused_unsqueeze2_axes"));
+    op_attrs.emplace("fused_reshape2_shape", pat.Attr("fused_reshape2_shape"));
+    op_attrs.emplace("scale", pat.Attr("scale"));
+    op_attrs.emplace("shift", pat.Attr("shift"));
+    op_attrs.emplace("output_data_type", pat.Attr("output_data_type"));
+    op_attrs.emplace("data_format", pat.Attr("data_format"));
+    op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
 
     const auto &op = pat.Op(fusable_ops_, op_attrs);
 
     const auto &full_1 = pat.Op(paddle::dialect::FullIntArrayOp::name(),
                                 {{"value", pat.Attr("full_1_value")}});
 
+    pat.Tensor("shape") = full_1();
+
     const auto &reshape = pat.Op(paddle::dialect::ReshapeOp::name());
 
-    if (fusable_ops_ == paddle::onednn::dialect::FcOp::name()) {
-      op({&pat.Tensor("X"), &pat.Tensor("Y"), &pat.Tensor("Input3")},
-         {&pat.Tensor("Out")});
-    } else {
-      op({&pat.Tensor("X")}, {&pat.Tensor("Out")});
-    }
+    op({&pat.Tensor("X")}, {&pat.Tensor("Out")});
 
-    reshape({&pat.Tensor("Out"), &full_1()},
+    reshape({&pat.Tensor("Out"), &pat.Tensor("shape")},
             {&pat.Tensor("ShapeOut"), &pat.Tensor("XShape")});
 
     pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
       int num_of_minus_ones = 0;
       auto reshape2_shape =
           match_ctx.Attr<std::vector<int64_t>>("full_1_value");
+
+      for (auto item : reshape2_shape) {
+        if (item == 0) {
+          VLOG(4) << "OneDNN op+reshape2 fuse pass does not support zero dims, "
+                     "skipping";
+          return false;
+        } else if (item == -1) {
+          ++num_of_minus_ones;
+        }
+      }
+
+      if (num_of_minus_ones > 1) {
+        VLOG(4)
+            << "Number of -1 values inside of reshape2 shouldn't be greater "
+               "than one in op+reshape2 oneDNN fuse pass, skipping";
+        return false;
+      }
+      return true;
+    });
+
+    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+      auto fused_unsqueeze2_axes =
+          match_ctx.Attr<std::vector<int>>("fused_unsqueeze2_axes");
+      auto fused_reshape2_shape =
+          match_ctx.Attr<std::vector<int>>("fused_reshape2_shape");
+
+      if (fused_unsqueeze2_axes.size() > 0 || fused_reshape2_shape.size()) {
+        VLOG(4) << "Cannot do " << fusable_ops_ << " + reshape fuse, because "
+                << fusable_ops_ << " is already fused with unsqueeze/reshape!";
+        return false;
+      }
+      return true;
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+    std::unordered_map<std::string, paddle::drr::Attribute> fused_op_attrs{};
+
+    const auto &fused_reshape2_shape = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int> {
+          std::vector<int> int_array_value;
+          auto shape = match_ctx.Attr<std::vector<int64_t>>("full_1_value");
+          for (auto i : shape) {
+            int_array_value.emplace_back(static_cast<int>(i));
+          }
+          return int_array_value;
+        });
+
+    fused_op_attrs.emplace("axis", pat.Attr("axis"));
+    fused_op_attrs.emplace("fused_squeeze2_axes",
+                           pat.Attr("fused_squeeze2_axes"));
+    fused_op_attrs.emplace("fused_unsqueeze2_axes",
+                           pat.Attr("fused_unsqueeze2_axes"));
+    fused_op_attrs.emplace("fused_reshape2_shape", fused_reshape2_shape);
+    fused_op_attrs.emplace("scale", pat.Attr("scale"));
+    fused_op_attrs.emplace("shift", pat.Attr("shift"));
+    fused_op_attrs.emplace("output_data_type", pat.Attr("output_data_type"));
+    fused_op_attrs.emplace("data_format", pat.Attr("data_format"));
+    fused_op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
+
+    const auto &fused_op = res.Op(fused_ops_name_, fused_op_attrs);
+
+    fused_op({&res.Tensor("X")}, {&res.Tensor("ShapeOut")});
+  }
+};
+
+class FcReshapeFusePattern : public paddle::drr::DrrPatternBase {
+ private:
+  std::string fusable_ops_;
+  std::string fused_ops_name_;
+  uint32_t benefit_;
+
+ public:
+  FcReshapeFusePattern(const std::string &fusable_ops,
+                       const std::string &fused_ops_name,
+                       uint32_t benefit)
+      : fusable_ops_(fusable_ops),
+        fused_ops_name_(fused_ops_name),
+        benefit_(benefit) {}
+
+  std::string name() const override {
+    return fusable_ops_ + "ReshapeFusePattern";
+  }
+
+  uint32_t benefit() const override { return benefit_; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+
+    std::unordered_map<std::string, paddle::drr::Attribute> op_attrs;
+
+    op_attrs.emplace("in_num_col_dims", pat.Attr("in_num_col_dims"));
+    op_attrs.emplace("activation_type", pat.Attr("activation_type"));
+    op_attrs.emplace("padding_weights", pat.Attr("padding_weights"));
+    op_attrs.emplace("use_quantizer", pat.Attr("use_quantizer"));
+    op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
+    op_attrs.emplace("scale_in", pat.Attr("scale_in"));
+    op_attrs.emplace("scale_weights", pat.Attr("scale_weights"));
+    op_attrs.emplace("scale_out", pat.Attr("scale_out"));
+    op_attrs.emplace("force_fp32_output", pat.Attr("force_fp32_output"));
+    op_attrs.emplace("fuse_activation", pat.Attr("fuse_activation"));
+    op_attrs.emplace("fuse_alpha", pat.Attr("fuse_alpha"));
+    op_attrs.emplace("fuse_beta", pat.Attr("fuse_beta"));
+    op_attrs.emplace("fused_output_scale", pat.Attr("fused_output_scale"));
+    op_attrs.emplace("fused_reshape2_shape", pat.Attr("fused_reshape2_shape"));
+
+    const auto &op = pat.Op(fusable_ops_, op_attrs);
+
+    const auto &full_1 = pat.Op(paddle::dialect::FullIntArrayOp::name(),
+                                {{"value", pat.Attr("full_1_value")}});
+
+    pat.Tensor("shape") = full_1();
+
+    const auto &reshape = pat.Op(paddle::dialect::ReshapeOp::name());
+
+    op({&pat.Tensor("X"), &pat.Tensor("Y"), &pat.Tensor("Input3")},
+       {&pat.Tensor("Out")});
+
+    reshape({&pat.Tensor("Out"), &pat.Tensor("shape")},
+            {&pat.Tensor("ShapeOut"), &pat.Tensor("XShape")});
+
+    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+      int num_of_minus_ones = 0;
+      auto reshape2_shape =
+          match_ctx.Attr<std::vector<int64_t>>("full_1_value");
+
+      for (auto item : reshape2_shape) {
+        if (item == 0) {
+          VLOG(4) << "OneDNN op+reshape2 fuse pass does not support zero dims, "
+                     "skipping";
+          return false;
+        } else if (item == -1) {
+          ++num_of_minus_ones;
+        }
+      }
+
+      if (num_of_minus_ones > 1) {
+        VLOG(4)
+            << "Number of -1 values inside of reshape2 shouldn't be greater "
+               "than one in op+reshape2 oneDNN fuse pass, skipping";
+        return false;
+      }
+      return true;
+    });
+
+    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+      auto fused_reshape2_shape =
+          match_ctx.Attr<std::vector<int>>("fused_reshape2_shape");
+
+      if (fused_reshape2_shape.size()) {
+        VLOG(4) << "Cannot do " << fusable_ops_ << " + reshape fuse, because "
+                << fusable_ops_ << " is already fused with reshape!";
+        return false;
+      }
+      return true;
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+    std::unordered_map<std::string, paddle::drr::Attribute> fused_op_attrs{};
+
+    const auto &fused_reshape2_shape = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int> {
+          std::vector<int> int_array_value;
+          auto shape = match_ctx.Attr<std::vector<int64_t>>("full_1_value");
+          for (auto i : shape) {
+            int_array_value.emplace_back(static_cast<int>(i));
+          }
+          return int_array_value;
+        });
+
+    fused_op_attrs.emplace("in_num_col_dims", pat.Attr("in_num_col_dims"));
+    fused_op_attrs.emplace("activation_type", pat.Attr("activation_type"));
+    fused_op_attrs.emplace("padding_weights", pat.Attr("padding_weights"));
+    fused_op_attrs.emplace("use_quantizer", pat.Attr("use_quantizer"));
+    fused_op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
+    fused_op_attrs.emplace("scale_in", pat.Attr("scale_in"));
+    fused_op_attrs.emplace("scale_weights", pat.Attr("scale_weights"));
+    fused_op_attrs.emplace("scale_out", pat.Attr("scale_out"));
+    fused_op_attrs.emplace("force_fp32_output", pat.Attr("force_fp32_output"));
+    fused_op_attrs.emplace("fuse_activation", pat.Attr("fuse_activation"));
+    fused_op_attrs.emplace("fuse_alpha", pat.Attr("fuse_alpha"));
+    fused_op_attrs.emplace("fuse_beta", pat.Attr("fuse_beta"));
+    fused_op_attrs.emplace("fused_output_scale",
+                           pat.Attr("fused_output_scale"));
+    fused_op_attrs.emplace("fused_reshape2_shape", fused_reshape2_shape);
+
+    const auto &fused_op = res.Op(fused_ops_name_, fused_op_attrs);
+
+    fused_op({&res.Tensor("X"), &res.Tensor("Y"), &res.Tensor("Input3")},
+             {&res.Tensor("ShapeOut")});
+  }
+};
+
+class TransposeReshapeFusePattern : public paddle::drr::DrrPatternBase {
+ private:
+  std::string fusable_ops_;
+  std::string fused_ops_name_;
+  uint32_t benefit_;
+
+ public:
+  TransposeReshapeFusePattern(const std::string &fusable_ops,
+                              const std::string &fused_ops_name,
+                              uint32_t benefit)
+      : fusable_ops_(fusable_ops),
+        fused_ops_name_(fused_ops_name),
+        benefit_(benefit) {}
+
+  std::string name() const override {
+    return fusable_ops_ + "ReshapeFusePattern";
+  }
+
+  uint32_t benefit() const override { return benefit_; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+
+    const auto &op = pat.Op(fusable_ops_, {{"perm", pat.Attr("axis")}});
+
+    const auto &full_1 = pat.Op(paddle::dialect::FullIntArrayOp::name(),
+                                {{"value", pat.Attr("full_1_value")}});
+
+    pat.Tensor("shape") = full_1();
+
+    const auto &reshape = pat.Op(paddle::dialect::ReshapeOp::name());
+
+    op({&pat.Tensor("X")}, {&pat.Tensor("Out")});
+
+    reshape({&pat.Tensor("Out"), &pat.Tensor("shape")},
+            {&pat.Tensor("ShapeOut"), &pat.Tensor("XShape")});
+
+    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+      int num_of_minus_ones = 0;
+      auto reshape2_shape =
+          match_ctx.Attr<std::vector<int64_t>>("full_1_value");
+
       for (auto item : reshape2_shape) {
         if (item == 0) {
           VLOG(4) << "OneDNN op+reshape2 fuse pass does not support zero dims, "
@@ -119,19 +327,6 @@ class OperatorReshapeFusePattern : public paddle::drr::DrrPatternBase {
       return true;
     });
 
-    if (fusable_ops_ == paddle::onednn::dialect::FusedTransposeOp::name()) {
-      pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
-        auto fused_unsqueeze2_axes =
-            match_ctx.Attr<std::vector<int>>("fused_unsqueeze2_axes");
-        if (fused_unsqueeze2_axes.size() > 0) {
-          VLOG(4) << "Cannot do " << fusable_ops_ << " + reshape fuse, because "
-                  << fusable_ops_ << " is already fused with unsqueeze!";
-          return false;
-        }
-        return true;
-      });
-    }
-
     paddle::drr::ResultPattern res = pat.ResultPattern();
     std::unordered_map<std::string, paddle::drr::Attribute> fused_op_attrs{};
 
@@ -145,58 +340,19 @@ class OperatorReshapeFusePattern : public paddle::drr::DrrPatternBase {
           return int_array_value;
         });
 
-    if (fusable_ops_ == paddle::onednn::dialect::FcOp::name()) {
-      fused_op_attrs.emplace("in_num_col_dims", pat.Attr("in_num_col_dims"));
-      fused_op_attrs.emplace("activation_type", pat.Attr("activation_type"));
-      fused_op_attrs.emplace("padding_weights", pat.Attr("padding_weights"));
-      fused_op_attrs.emplace("use_quantizer", pat.Attr("use_quantizer"));
-      fused_op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
-      fused_op_attrs.emplace("scale_in", pat.Attr("scale_in"));
-      fused_op_attrs.emplace("scale_weights", pat.Attr("scale_weights"));
-      fused_op_attrs.emplace("scale_out", pat.Attr("scale_out"));
-      fused_op_attrs.emplace("force_fp32_output",
-                             pat.Attr("force_fp32_output"));
-      fused_op_attrs.emplace("fuse_activation", pat.Attr("fuse_activation"));
-      fused_op_attrs.emplace("fuse_alpha", pat.Attr("fuse_alpha"));
-      fused_op_attrs.emplace("fuse_beta", pat.Attr("fuse_beta"));
-      fused_op_attrs.emplace("fused_output_scale",
-                             pat.Attr("fused_output_scale"));
-      fused_op_attrs.emplace("fused_reshape2_shape", fused_reshape2_shape);
-
-    } else if (fusable_ops_ ==
-               paddle::onednn::dialect::FusedTransposeOp::name()) {
-      fused_op_attrs.emplace("axis", pat.Attr("axis"));
-      fused_op_attrs.emplace("fused_squeeze2_axes",
-                             pat.Attr("fused_squeeze2_axes"));
-      fused_op_attrs.emplace("fused_unsqueeze2_axes",
-                             pat.Attr("fused_unsqueeze2_axes"));
-      fused_op_attrs.emplace("fused_reshape2_shape", fused_reshape2_shape);
-      fused_op_attrs.emplace("scale", pat.Attr("scale"));
-      fused_op_attrs.emplace("shift", pat.Attr("shift"));
-      fused_op_attrs.emplace("output_data_type", pat.Attr("output_data_type"));
-      fused_op_attrs.emplace("data_format", pat.Attr("data_format"));
-      fused_op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
-
-    } else if (fusable_ops_ == paddle::dialect::TransposeOp::name()) {
-      fused_op_attrs.emplace("axis", pat.Attr("perm"));
-      fused_op_attrs.emplace("fused_squeeze2_axes", res.VectorInt32Attr({}));
-      fused_op_attrs.emplace("fused_unsqueeze2_axes", res.VectorInt32Attr({}));
-      fused_op_attrs.emplace("fused_reshape2_shape", fused_reshape2_shape);
-      fused_op_attrs.emplace("scale", res.Float32Attr(1.0f));
-      fused_op_attrs.emplace("shift", res.Float32Attr(0.0f));
-      fused_op_attrs.emplace("output_data_type", res.StrAttr("fp32"));
-      fused_op_attrs.emplace("data_format", res.StrAttr("AnyLayout"));
-      fused_op_attrs.emplace("mkldnn_data_type", res.StrAttr("float32"));
-    }
+    fused_op_attrs.emplace("axis", pat.Attr("axis"));
+    fused_op_attrs.emplace("fused_squeeze2_axes", res.VectorInt32Attr({}));
+    fused_op_attrs.emplace("fused_unsqueeze2_axes", res.VectorInt32Attr({}));
+    fused_op_attrs.emplace("fused_reshape2_shape", fused_reshape2_shape);
+    fused_op_attrs.emplace("scale", res.Float32Attr(1.0f));
+    fused_op_attrs.emplace("shift", res.Float32Attr(0.0f));
+    fused_op_attrs.emplace("output_data_type", res.StrAttr(""));
+    fused_op_attrs.emplace("data_format", res.StrAttr("AnyLayout"));
+    fused_op_attrs.emplace("mkldnn_data_type", res.StrAttr("float32"));
 
     const auto &fused_op = res.Op(fused_ops_name_, fused_op_attrs);
 
-    if (fusable_ops_ == paddle::onednn::dialect::FcOp::name()) {
-      fused_op({&res.Tensor("X"), &res.Tensor("Y"), &res.Tensor("Input3")},
-               {&res.Tensor("ShapeOut")});
-    } else {
-      fused_op({&res.Tensor("X")}, {&res.Tensor("ShapeOut")});
-    }
+    fused_op({&res.Tensor("X")}, {&res.Tensor("ShapeOut")});
   }
 };
 
@@ -207,24 +363,25 @@ class OperatorReshapePass : public pir::PatternRewritePass {
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
-    const std::vector<std::string> fusable_ops{
-        paddle::onednn::dialect::FcOp::name(),
-        paddle::onednn::dialect::FusedTransposeOp::name(),
-        paddle::dialect::TransposeOp::name(),
-    };
-
-    const std::vector<std::string> fused_ops{
-        paddle::onednn::dialect::FcOp::name(),
-        paddle::onednn::dialect::FusedTransposeOp::name(),
-        paddle::onednn::dialect::FusedTransposeOp::name(),
-    };
     int benefit_idx = 1;
-    int fused = 0;
-    for (auto op : fusable_ops) {
-      ps.Add(paddle::drr::Create<OperatorReshapeFusePattern>(
-          context, op, fused_ops[fused++], benefit_idx));
-      benefit_idx++;
-    }
+
+    ps.Add(paddle::drr::Create<FcReshapeFusePattern>(
+        context,
+        paddle::onednn::dialect::FcOp::name(),
+        paddle::onednn::dialect::FcOp::name(),
+        benefit_idx++));
+
+    ps.Add(paddle::drr::Create<FusedTransposeReshapeFusePattern>(
+        context,
+        paddle::onednn::dialect::FusedTransposeOp::name(),
+        paddle::onednn::dialect::FusedTransposeOp::name(),
+        benefit_idx++));
+
+    ps.Add(paddle::drr::Create<TransposeReshapeFusePattern>(
+        context,
+        paddle::dialect::TransposeOp::name(),
+        paddle::onednn::dialect::FusedTransposeOp::name(),
+        benefit_idx++));
 
     return ps;
   }

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -50,7 +50,6 @@ USE_PIR_PASS(fused_rotary_position_embedding_pass);
 #ifdef PADDLE_WITH_DNNL
 USE_PIR_PASS(depthwise_conv_onednn_pass);
 USE_PIR_PASS(squeeze_transpose_onednn_fuse_pass);
-USE_PIR_PASS(batch_norm_act_fuse_pass);
 USE_PIR_PASS(conv2d_bn_onednn_fuse_pass);
 USE_PIR_PASS(conv2d_bias_fuse_pass);
 USE_PIR_PASS(conv2d_transpose_bias_fuse_pass);
@@ -67,13 +66,14 @@ USE_PIR_PASS(self_attention_fuse_pass);
 #endif
 USE_PIR_PASS(softplus_activation_fuse_pass);
 USE_PIR_PASS(shuffle_channel_detect_pass);
-USE_PIR_PASS(operator_reshape_onednn_fuse_pass);
+USE_PIR_PASS(batch_norm_act_fuse_pass);
 USE_PIR_PASS(conv_elementwise_add_onednn_fuse_pass);
 USE_PIR_PASS(conv_activation_onednn_fuse_pass);
 USE_PIR_PASS(conv_concat_activation_onednn_fuse_pass);
 USE_PIR_PASS(elementwise_act_onednn_fuse_pass);
-USE_PIR_PASS(operator_unsqueeze_onednn_fuse_pass);
 USE_PIR_PASS(operator_scale_onednn_fuse_pass);
+USE_PIR_PASS(operator_unsqueeze_onednn_fuse_pass);
+USE_PIR_PASS(operator_reshape_onednn_fuse_pass);
 USE_PIR_PASS(onednn_placement_pass);
 #endif
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
In model `SwinTransformer_base`, there are few subgraphs composed of "fc+reshape+transpose+reshape", which will be fused to "(fc+reshape)+transpose+reshape" after old pattern. While such matching will cause error if 1st reshape changes dims of fc_output, since `FcInferMeta` doesn't take account of impact of reshape, causing mismatch of `x & axis`. Hence we revise the `operator_reshape_onednn_fuse_pass` to avoid possible errors.

