### PR TITLE
Fix bug of some quantize ops because of lack of float16 registration

### DIFF
--- a/paddle/phi/kernels/fake_quantize_grad_kernel.cc
+++ b/paddle/phi/kernels/fake_quantize_grad_kernel.cc
@@ -98,7 +98,7 @@ PD_REGISTER_KERNEL(fake_quantize_dequantize_abs_max_grad,
                    ALL_LAYOUT,
                    phi::FakeQuantizeDequantizeAbsMaxGradKernel,
                    float,
-                   phi::dtype::bfloat16) {}
+                   phi::dtype::float16) {}
 PD_REGISTER_KERNEL(fake_quantize_dequantize_moving_average_abs_max_grad,
                    GPU,
                    ALL_LAYOUT,

--- a/paddle/phi/kernels/fake_quantize_grad_kernel.cc
+++ b/paddle/phi/kernels/fake_quantize_grad_kernel.cc
@@ -97,10 +97,12 @@ PD_REGISTER_KERNEL(fake_quantize_dequantize_abs_max_grad,
                    GPU,
                    ALL_LAYOUT,
                    phi::FakeQuantizeDequantizeAbsMaxGradKernel,
-                   float) {}
+                   float,
+                   phi::dtype::bfloat16) {}
 PD_REGISTER_KERNEL(fake_quantize_dequantize_moving_average_abs_max_grad,
                    GPU,
                    ALL_LAYOUT,
                    phi::FakeQuantizeDequantizeMovingAverageAbsMaxGradKernel,
-                   float) {}
+                   float,
+                   phi::dtype::float16) {}
 #endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes

### Description
Fix bugs caused by https://github.com/PaddlePaddle/Paddle/pull/63737 . Some of the ops missed float16 registration.

Pcard-67164