### PR TITLE
[CINN] Fix infer_symbol_shape of interpolate

### DIFF
--- a/test/legacy_test/test_nearest_interp_v2_op.py
+++ b/test/legacy_test/test_nearest_interp_v2_op.py
@@ -383,7 +383,9 @@ class TestNearestInterpOp(OpTest):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(
+            check_pir=True, check_symbol_infer=(self.out_size is None)
+        )
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out', in_place=True, check_pir=True)
@@ -445,7 +447,9 @@ class TestNearestNeighborInterpActualShape(TestNearestInterpOp):
 
 class TestNearestInterpOpFP16(TestNearestInterpOp):
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(
+            check_pir=True, check_symbol_infer=(self.out_size is None)
+        )
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out', in_place=True, check_pir=True)
@@ -741,7 +745,10 @@ class TestNearestInterpOpUint8(OpTest):
 
     def test_check_output(self):
         self.check_output_with_place(
-            place=core.CPUPlace(), atol=1, check_pir=True
+            place=core.CPUPlace(),
+            atol=1,
+            check_pir=True,
+            check_symbol_infer=(self.out_size is None),
         )
 
     def init_test_case(self):
@@ -897,7 +904,9 @@ class TestNearestInterpOp_attr_tensor(OpTest):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(
+            check_pir=True, check_symbol_infer=(self.out_size is None)
+        )
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out', in_place=True, check_pir=True)

--- a/test/legacy_test/test_trilinear_interp_v2_op.py
+++ b/test/legacy_test/test_trilinear_interp_v2_op.py
@@ -362,7 +362,9 @@ class TestTrilinearInterpOp(OpTest):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(
+            check_pir=True, check_symbol_infer=(self.out_size is None)
+        )
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out', in_place=True, check_pir=True)
@@ -454,7 +456,9 @@ class TestTrilinearInterpDatalayout(TestTrilinearInterpOp):
 
 class TestTrilinearInterpOpFP16(TestTrilinearInterpOp):
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(
+            check_pir=True, check_symbol_infer=(self.out_size is None)
+        )
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out', in_place=True, check_pir=True)
@@ -725,7 +729,10 @@ class TestTrilinearInterpOpUint8(OpTest):
 
     def test_check_output(self):
         self.check_output_with_place(
-            place=core.CPUPlace(), atol=1, check_pir=True
+            place=core.CPUPlace(),
+            atol=1,
+            check_pir=True,
+            check_symbol_infer=(self.out_size is None),
         )
 
     def init_test_case(self):
@@ -904,7 +911,9 @@ class TestTrilinearInterpOp_attr_tensor(OpTest):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(
+            check_pir=True, check_symbol_infer=(self.out_size is None)
+        )
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out', in_place=True, check_pir=True)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复 interpolate 算子符号推导接口实现。