### PR TITLE
Fix test spectral op

### DIFF
--- a/test/fft/spectral_op_np.py
+++ b/test/fft/spectral_op_np.py
@@ -27,6 +27,8 @@ class NormMode(enum.Enum):
 
 
 def _get_norm_mode(norm, forward):
+    if int(np.__version__.split('.')[0]) >= 2:
+        return norm
     if norm == "ortho":
         return NormMode.by_sqrt_n
     if norm is None or norm == "backward":
@@ -35,6 +37,8 @@ def _get_norm_mode(norm, forward):
 
 
 def _get_inv_norm(n, norm_mode):
+    if int(np.__version__.split('.')[0]) >= 2:
+        return norm_mode
     assert isinstance(norm_mode, NormMode), f"invalid norm_type {norm_mode}"
     if norm_mode == NormMode.none:
         return 1.0
@@ -44,7 +48,7 @@ def _get_inv_norm(n, norm_mode):
 
 
 # 1d transforms
-def _fftc2c(a, n=None, axis=-1, norm=None, forward=None):
+def _fftc2c(a, n=None, axis=-1, norm=None, forward=None, out=None):
     a = asarray(a)
     if n is None:
         n = a.shape[axis]

--- a/test/fft/test_spectral_op.py
+++ b/test/fft/test_spectral_op.py
@@ -168,7 +168,7 @@ class TestFFTC2COp(OpTest):
             ).astype(np.complex128),
             [0, 1],
             'forward',
-            True,
+            False,
             26,
         ),
         (
@@ -198,7 +198,7 @@ class TestFFTC2COp(OpTest):
             ).astype(np.complex128),
             (0,),
             "backward",
-            True,
+            False,
             22,
         ),
         (
@@ -259,7 +259,7 @@ class TestFFTC2ROp(OpTest):
             (0, 1),
             "backward",
             False,
-            True,
+            False,
         ),
         (
             'test_norm_forward',


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复在numpy2.x下test_spectral_op
pcard-67164