### PR TITLE
check inplace api when FLAGS_use_stride_kernel closed

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -157,12 +157,24 @@ strided_op_list = {
     "view_dtype",
 }
 
-
-strided_op_no_need_flags_check_list = {
-    "flatten",
-    "reshape",
-    "squeeze",
-    "unsqueeze",
+strided_op_need_flags_check_list = {
+    "as_complex_",
+    "as_real_",
+    "as_strided_",
+    "real_",
+    "imag_",
+    "diagonal_",
+    "flatten_infer_",
+    "slice_",
+    "squeeze_infer_",
+    "strided_slice_",
+    "strided_slice_raw_",
+    "tensor_unfold_",
+    "transpose_",
+    "unbind_",
+    "unsqueeze_infer_",
+    "view_shape_",
+    "view_dtype_",
 }
 
 
@@ -1988,10 +2000,9 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
         log_str = AFTER_LOG_PRINT_TEMPLATE.format(var_str)
 
         strided_flags_check = ""
-        if (
-            is_inplaced
-            and (forward_api_name in strided_op_list)
-            and (forward_api_name not in strided_op_no_need_flags_check_list)
+        print("forward_api_name = ", forward_api_name)
+        if is_inplaced and (
+            forward_api_name in strided_op_need_flags_check_list
         ):
             strided_flags_check = STRIDED_FLAGS_CHECK_TEMPLATE
         # Generate forward_definition_str and forward_declaration_str

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -2000,7 +2000,6 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
         log_str = AFTER_LOG_PRINT_TEMPLATE.format(var_str)
 
         strided_flags_check = ""
-        print("forward_api_name = ", forward_api_name)
         if is_inplaced and (
             forward_api_name in strided_op_need_flags_check_list
         ):

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -497,7 +497,6 @@ NODE_CC_FILE_TEMPLATE = """
 #include "paddle/fluid/memory/stats.h"
 #include "paddle/phi/api/lib/data_transform.h"
 COMMON_DECLARE_bool(check_nan_inf);
-COMMON_DECLARE_bool(use_stride_kernel);
 {}
 """
 
@@ -530,6 +529,7 @@ FORWARD_CC_FILE_TEMPLATE = """
 
 COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_string(tensor_operants_mode);
+COMMON_DECLARE_bool(use_stride_kernel);
 {}
 {}
 """


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
FLAGS_use_stride_kernel关闭时，如果调用strided相关的inplace API则报错。
Pcard-67164