### PR TITLE
[PIR][oneDNN] Add conv2d_bias_bn_onednn_fuse_pass

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -636,6 +636,7 @@ const std::vector<std::string> kPirMkldnnPasses {
       "depthwise_conv_onednn_pass",               //
       "squeeze_transpose_onednn_fuse_pass",       //
       "conv2d_bn_onednn_fuse_pass",               //
+      "conv2d_bias_bn_onednn_fuse_pass",          //
       "conv2d_bias_fuse_pass",                    //
       "conv2d_transpose_bias_fuse_pass",          //
       "conv3d_bias_fuse_pass",                    //

--- a/paddle/fluid/pir/transforms/onednn/conv2d_bn_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/conv2d_bn_onednn_fuse_pass.cc
@@ -147,11 +147,11 @@ class Conv2dBiasBnOneDNNFusePattern
     // The prev op should be add op.
     paddle::dialect::AddOp add_op =
         pir::GetDefiningOpForInput(op, 0)->dyn_cast<paddle::dialect::AddOp>();
+    if (!add_op) return false;
     // The prev prev op should be conv2d op.
     paddle::dialect::Conv2dOp conv2d_op =
         pir::GetDefiningOpForInput(add_op, 0)
             ->dyn_cast<paddle::dialect::Conv2dOp>();
-    if (!add_op) return false;
     if (!conv2d_op) return false;
 
     auto conv2d_attributes = conv2d_op->attributes();

--- a/paddle/fluid/pir/transforms/onednn/conv2d_bn_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/conv2d_bn_onednn_fuse_pass.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,8 +58,7 @@ class Conv2dBnOneDNNFusePattern
       return false;
     }
     if (!conv2d_op.out().HasOneUse()) return false;
-    // (bukejiyu): The bn
-    // outputs(mean_out\variance_out\saved_mean\saved_variance)
+    // The bn outputs(mean_out\variance_out\saved_mean\saved_variance)
     //  cannot be used in conv bn fusion
     if (!op.mean_out().use_empty()) return false;
     if (!op.variance_out().use_empty()) return false;
@@ -138,10 +137,137 @@ class Conv2dBnOneDNNFusePattern
   }
 };
 
+class Conv2dBiasBnOneDNNFusePattern
+    : public pir::OpRewritePattern<paddle::dialect::BatchNorm_Op> {
+ public:
+  using pir::OpRewritePattern<paddle::dialect::BatchNorm_Op>::OpRewritePattern;
+  bool MatchAndRewrite(
+      paddle::dialect::BatchNorm_Op op,
+      pir::PatternRewriter &rewriter) const override {  // NOLINT
+    // The prev op should be add op.
+    paddle::dialect::AddOp add_op =
+        pir::GetDefiningOpForInput(op, 0)->dyn_cast<paddle::dialect::AddOp>();
+    // The prev prev op should be conv2d op.
+    paddle::dialect::Conv2dOp conv2d_op =
+        pir::GetDefiningOpForInput(add_op, 0)
+            ->dyn_cast<paddle::dialect::Conv2dOp>();
+    if (!add_op) return false;
+    if (!conv2d_op) return false;
+
+    auto conv2d_attributes = conv2d_op->attributes();
+    auto padding_algorithm = conv2d_attributes.at("padding_algorithm")
+                                 .dyn_cast<pir::StrAttribute>()
+                                 .AsString();
+    if (padding_algorithm != "EXPLICIT" && padding_algorithm != "SAME" &&
+        padding_algorithm != "VALID") {
+      return false;
+    }
+    auto data_format = conv2d_attributes.at("data_format")
+                           .dyn_cast<pir::StrAttribute>()
+                           .AsString();
+    if (data_format != "NCHW" && data_format != "AnyLayout" &&
+        data_format != "NHWC") {
+      return false;
+    }
+    auto groups =
+        conv2d_attributes.at("groups").dyn_cast<pir::Int32Attribute>().data();
+    if (groups < 1) {
+      return false;
+    }
+    if (!conv2d_op.out().HasOneUse()) return false;
+    if (!add_op.out().HasOneUse()) return false;
+    // The bn outputs(mean_out\variance_out\saved_mean\saved_variance)
+    //  cannot be used in conv bn fusion
+    if (!op.mean_out().use_empty()) return false;
+    if (!op.variance_out().use_empty()) return false;
+    if (!op.saved_mean().use_empty()) return false;
+    if (!op.saved_variance().use_empty()) return false;
+
+    pir::Value add_y = add_op.y();
+    if (!pir::ValueIsPersistable(add_y)) return false;
+    pir::Value conv2d_filter = conv2d_op.filter();
+    pir::Value bn_mean = op.mean();
+    pir::Value bn_variance = op.variance();
+    pir::Value bn_scale = op.scale();
+    pir::Value bn_bias = op.bias();
+
+    auto add_y_shape = pir::GetShapeFromValue(add_y);
+    // bias currently only support per_tensor add
+    if (add_y_shape.size() != 1 || add_y_shape[0] != 1) return false;
+
+    // --- deal with filter ---
+    auto bn_variance_shape = pir::GetShapeFromValue(bn_variance);
+    float epsilon = op.attribute<pir::FloatAttribute>("epsilon").data();
+    if (epsilon < 0.0f || epsilon > 0.001f) {
+      return false;
+    }
+    paddle::dialect::FullOp full_op =
+        rewriter.Build<paddle::dialect::FullOp>(bn_variance_shape, epsilon);
+    paddle::dialect::AddOp add_op_1 =
+        rewriter.Build<paddle::dialect::AddOp>(bn_variance, full_op.out());
+    paddle::dialect::SqrtOp sqrt_op =
+        rewriter.Build<paddle::dialect::SqrtOp>(add_op_1.out());
+    paddle::dialect::DivideOp div_op =
+        rewriter.Build<paddle::dialect::DivideOp>(bn_scale, sqrt_op.out());
+    // reshape scale
+    auto conv2d_filter_shape = pir::GetShapeFromValue(conv2d_filter);
+    auto bn_scale_shape = pir::GetShapeFromValue(bn_scale);
+    std::vector<int64_t> bn_scale_new_shape(conv2d_filter_shape.size(), 1);
+    bn_scale_new_shape[0] = bn_scale_shape[0];
+    paddle::dialect::ReshapeOp reshape_scale_op =
+        rewriter.Build<paddle::dialect::ReshapeOp>(div_op.out(),
+                                                   bn_scale_new_shape);
+
+    paddle::onednn::dialect::FusedConv2dOp new_conv2d_op;
+
+    conv2d_attributes["force_fp32_output"] = rewriter.bool_attr(false);
+    conv2d_attributes["fuse_residual_connection"] = rewriter.bool_attr(false);
+    conv2d_attributes["mkldnn_data_type"] = rewriter.str_attr("float32");
+    conv2d_attributes["fuse_activation"] = rewriter.str_attr("");
+    conv2d_attributes["fuse_alpha"] = rewriter.float_attr(0.0f);
+    conv2d_attributes["fuse_beta"] = rewriter.float_attr(0.0f);
+    conv2d_attributes["scale_in"] = rewriter.float_attr(1.0f);
+    conv2d_attributes["scale_out"] = rewriter.float_attr(1.0f);
+    conv2d_attributes["scale_in_eltwise"] = rewriter.float_attr(1.0f);
+    conv2d_attributes["scale_weights"] =
+        rewriter.array_attr({rewriter.float_attr(1.0f)});
+
+    auto conv2d_filter_dtype = pir::GetDataTypeFromValue(conv2d_filter);
+    if (conv2d_filter_dtype.isa<pir::Float16Type>()) {
+      return false;
+    }
+    auto mul_op = rewriter.Build<paddle::dialect::MultiplyOp>(
+        conv2d_filter, reshape_scale_op.out());
+
+    // --- deal with bias ---
+    paddle::dialect::MultiplyOp mul_bias_op =
+        rewriter.Build<paddle::dialect::MultiplyOp>(bn_mean, div_op.out());
+    // new bias --> sub_op.out() + add_op.y()
+    paddle::dialect::SubtractOp sub_op =
+        rewriter.Build<paddle::dialect::SubtractOp>(bn_bias, mul_bias_op.out());
+    paddle::dialect::AddOp add_op_2 =
+        rewriter.Build<paddle::dialect::AddOp>(sub_op.out(), add_op.y());
+    // fuse new bias to fused_conv2d
+    new_conv2d_op = rewriter.Build<paddle::onednn::dialect::FusedConv2dOp>(
+        conv2d_op.input(),
+        mul_op.out(),
+        add_op_2.out(),
+        pir::Value{},
+        conv2d_attributes);
+
+    rewriter.ReplaceAllUsesWith(op.out(), new_conv2d_op.output());
+
+    rewriter.EraseOp(op);
+    rewriter.EraseOp(add_op);
+    rewriter.EraseOp(conv2d_op);
+    return true;
+  }
+};
+
 class Conv2dBnOneDNNFusePass : public pir::PatternRewritePass {
  public:
   Conv2dBnOneDNNFusePass()
-      : pir::PatternRewritePass("conv2d_bn_onednn_fuse_pass", 2) {}
+      : pir::PatternRewritePass("conv2d_bn_onednn_fuse_pass", 3) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
@@ -167,6 +293,36 @@ class Conv2dBnOneDNNFusePass : public pir::PatternRewritePass {
   }
 };
 
+class Conv2dBiasBnOneDNNFusePass : public pir::PatternRewritePass {
+ public:
+  Conv2dBiasBnOneDNNFusePass()
+      : pir::PatternRewritePass("conv2d_bias_bn_onednn_fuse_pass", 3) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
+    pir::RewritePatternSet ps(context);
+    auto conv_bias_bn_onednn_pattern =
+        std::make_unique<Conv2dBiasBnOneDNNFusePattern>(
+            context,
+            1,
+            std::vector<std::string>{
+                paddle::dialect::FullOp::name(),
+                paddle::dialect::AddOp::name(),
+                paddle::dialect::SqrtOp::name(),
+                paddle::dialect::DivideOp::name(),
+                paddle::dialect::ReshapeOp::name(),
+                paddle::dialect::MultiplyOp::name(),
+                paddle::dialect::SubtractOp::name(),
+                paddle::dialect::Conv2dOp::name(),
+                paddle::onednn::dialect::FusedConv2dOp::name(),
+            });
+
+    // Currently BN on graph are all BN_, so no need to add BN replace pattern
+    // conv2d+bias+bn_->conv2d
+    ps.Add(std::move(conv_bias_bn_onednn_pattern));
+    return ps;
+  }
+};
+
 }  // namespace
 
 namespace pir {
@@ -175,6 +331,11 @@ std::unique_ptr<Pass> CreateConv2dBnOneDNNFusePass() {
   return std::make_unique<Conv2dBnOneDNNFusePass>();
 }
 
+std::unique_ptr<Pass> CreateConv2dBiasBnOneDNNFusePass() {
+  return std::make_unique<Conv2dBiasBnOneDNNFusePass>();
+}
+
 }  // namespace pir
 
 REGISTER_IR_PASS(conv2d_bn_onednn_fuse_pass, Conv2dBnOneDNNFusePass);
+REGISTER_IR_PASS(conv2d_bias_bn_onednn_fuse_pass, Conv2dBiasBnOneDNNFusePass);

--- a/paddle/fluid/pir/transforms/onednn/conv2d_bn_onednn_fuse_pass.h
+++ b/paddle/fluid/pir/transforms/onednn/conv2d_bn_onednn_fuse_pass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,5 +22,6 @@ namespace pir {
 class Pass;
 
 IR_API std::unique_ptr<Pass> CreateConv2dBnOneDNNFusePass();
+IR_API std::unique_ptr<Pass> CreateConv2dBiasBnOneDNNFusePass();
 
 }  // namespace pir

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -51,6 +51,7 @@ USE_PIR_PASS(fused_rotary_position_embedding_pass);
 USE_PIR_PASS(depthwise_conv_onednn_pass);
 USE_PIR_PASS(squeeze_transpose_onednn_fuse_pass);
 USE_PIR_PASS(conv2d_bn_onednn_fuse_pass);
+USE_PIR_PASS(conv2d_bias_bn_onednn_fuse_pass);
 USE_PIR_PASS(conv2d_bias_fuse_pass);
 USE_PIR_PASS(conv2d_transpose_bias_fuse_pass);
 USE_PIR_PASS(conv3d_bias_fuse_pass);

--- a/test/ir/pir/fused_pass/onednn/test_conv2d_bn_onednn_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_conv2d_bn_onednn_fuse_pass.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -60,6 +60,78 @@ class TestConv2dBnOneDNNPassPattern(PassTest):
                 self.pass_attr_list = [{'conv2d_bn_onednn_fuse_pass': {}}]
                 self.feeds = {
                     "x": np.random.random((3, 1, 28, 28)).astype("float32")
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.fused_conv2d": 1,
+                    "pd_op.batch_norm_": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        pir_program = self.build_ir_program()
+        yield pir_program, False
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+
+class TestConv2dBiasBnOneDNNPassPattern(PassTest):
+    r"""
+    x_var   f_var
+      \      /
+       conv2d  add_y
+          \     /
+            add
+             |
+         BatchNorm
+             |
+    """
+
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(
+                    name='x', shape=[3, 1, 28, 28], dtype='float32'
+                )
+                bias_attr = paddle.ParamAttr(
+                    learning_rate=0.0,
+                    initializer=paddle.nn.initializer.Normal(mean=0.0, std=2.0),
+                )
+                y = paddle.static.create_parameter(
+                    shape=[1],
+                    dtype='float32',
+                    attr=bias_attr,
+                    is_bias=False,
+                )
+                conv2d = paddle.nn.Conv2D(
+                    in_channels=1,
+                    out_channels=32,
+                    kernel_size=3,
+                    padding=1,
+                    data_format='NCHW',
+                    bias_attr=False,
+                )
+                bn = paddle.nn.BatchNorm2D(
+                    num_features=32,
+                    data_format='NCHW',
+                    use_global_stats=True,
+                )
+                add_out = paddle.add(conv2d(x), y)
+                out = bn(add_out)
+                out = paddle.assign(out)
+                self.pass_attr_list = [{'conv2d_bias_bn_onednn_fuse_pass': {}}]
+                self.feeds = {
+                    "x": np.random.random((3, 1, 28, 28)).astype("float32"),
+                    "y": np.random.random(1).astype("float32"),
                 }
                 self.fetch_list = [out]
                 self.valid_op_map = {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Due to the changes of new IR scheme and per the request from Paddle, we hereby add `conv2d_bias_bn_onednn_fuse_pass` from oneDNN side. To fulfill more fusion chances.