### PR TITLE
[PIR] Fix 5 uts in PIR mode (`test_imperative_mnist`, `test_imperative_mnist_sorted_gradient`, `test_imperative_reinforcement`, `test_imperative_transformer_sorted_gradient`, `test_inverse_op`)

### DIFF
--- a/python/paddle/static/input.py
+++ b/python/paddle/static/input.py
@@ -142,6 +142,10 @@ def data(
     for i in range(len(shape)):
         if shape[i] is None:
             shape[i] = -1
+        if isinstance(shape[i], int) and shape[i] < 0 and shape[i] != -1:
+            raise ValueError(
+                f"Only -1 can be used in shape to indicate unknown dimension, but received {shape[i]}"
+            )
 
     if dtype is None:
         dtype = paddle.get_default_dtype()

--- a/test/deprecated/legacy_test/CMakeLists.txt
+++ b/test/deprecated/legacy_test/CMakeLists.txt
@@ -651,8 +651,6 @@ endif()
 set_tests_properties(test_add_reader_dependency_deprecated PROPERTIES TIMEOUT
                                                                       120)
 set_tests_properties(test_fleet_util PROPERTIES TIMEOUT 120)
-set_tests_properties(test_imperative_transformer_sorted_gradient
-                     PROPERTIES TIMEOUT 120)
 
 if(WITH_NV_JETSON)
   set_tests_properties(test_conv3d_transpose_part2_op_deprecated
@@ -705,11 +703,6 @@ set_tests_properties(test_pretrained_model PROPERTIES TIMEOUT 600)
 
 if(APPLE)
   set_tests_properties(test_callback_early_stop PROPERTIES TIMEOUT 300)
-endif()
-
-if(APPLE)
-  set_tests_properties(test_imperative_transformer_sorted_gradient
-                       PROPERTIES TIMEOUT 300)
 endif()
 
 set_tests_properties(test_inplace_addto_strategy_deprecated PROPERTIES TIMEOUT

--- a/test/deprecated/legacy_test/CMakeLists.txt
+++ b/test/deprecated/legacy_test/CMakeLists.txt
@@ -400,8 +400,6 @@ endfunction()
 list(REMOVE_ITEM TEST_OPS test_feed_data_check_shape_type_deprecated)
 list(REMOVE_ITEM TEST_OPS test_fetch_lod_tensor_array)
 list(REMOVE_ITEM TEST_OPS test_data_norm_op_deprecated)
-list(REMOVE_ITEM TEST_OPS test_imperative_mnist_sorted_gradient)
-list(REMOVE_ITEM TEST_OPS test_imperative_mnist)
 list(REMOVE_ITEM TEST_OPS test_layers_deprecated)
 list(REMOVE_ITEM TEST_OPS test_imperative_ocr_attention_model)
 list(REMOVE_ITEM TEST_OPS test_install_check)
@@ -480,11 +478,6 @@ foreach(TEST_OP ${TEST_OPS})
 endforeach()
 set_tests_properties(test_logcumsumexp_op PROPERTIES TIMEOUT 30)
 
-py_test_modules(test_imperative_mnist MODULES test_imperative_mnist ENVS
-                FLAGS_cudnn_deterministic=1)
-py_test_modules(
-  test_imperative_mnist_sorted_gradient MODULES
-  test_imperative_mnist_sorted_gradient ENVS FLAGS_cudnn_deterministic=1)
 py_test_modules(
   test_imperative_ocr_attention_model MODULES
   test_imperative_ocr_attention_model ENVS FLAGS_cudnn_deterministic=1)
@@ -685,7 +678,6 @@ set_tests_properties(test_fuse_bn_act_pass_deprecated PROPERTIES TIMEOUT 120)
 set_tests_properties(test_conv2d_api_deprecated PROPERTIES TIMEOUT 120)
 set_tests_properties(test_dygraph_multi_forward PROPERTIES TIMEOUT 120)
 set_tests_properties(test_imperative_ocr_attention_model PROPERTIES TIMEOUT 120)
-set_tests_properties(test_imperative_mnist PROPERTIES TIMEOUT 120)
 set_tests_properties(test_regularizer_deprecated PROPERTIES TIMEOUT 150)
 set_tests_properties(test_slice_op PROPERTIES TIMEOUT 120)
 set_tests_properties(test_slice_op_deprecated PROPERTIES TIMEOUT 120)

--- a/test/ir/pir/test_data_op.py
+++ b/test/ir/pir/test_data_op.py
@@ -49,6 +49,20 @@ class TestPir(unittest.TestCase):
                 out = data()
 
 
+class TestDataOpError(unittest.TestCase):
+    def test_invalid_shape(self):
+        paddle.enable_static()
+        place = paddle.CPUPlace()
+        exe = paddle.static.Executor(place)
+
+        main_program = paddle.static.Program()
+        new_scope = paddle.static.Scope()
+        with paddle.static.scope_guard(new_scope):
+            with paddle.static.program_guard(main_program):
+                with self.assertRaises(ValueError):
+                    out = paddle.static.data("x", shape=[-2, 1])
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -539,8 +539,14 @@ if(WITH_GPU
 endif()
 py_test_modules(test_imperative_resnet MODULES test_imperative_resnet ENVS
                 FLAGS_cudnn_deterministic=1)
+set_tests_properties(test_imperative_mnist PROPERTIES TIMEOUT 120)
 set_tests_properties(test_imperative_resnet
                      PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE:NIGHTLY")
+py_test_modules(test_imperative_mnist MODULES test_imperative_mnist ENVS
+                FLAGS_cudnn_deterministic=1)
+py_test_modules(
+  test_imperative_mnist_sorted_gradient MODULES
+  test_imperative_mnist_sorted_gradient ENVS FLAGS_cudnn_deterministic=1)
 py_test_modules(
   test_imperative_resnet_sorted_gradient MODULES
   test_imperative_resnet_sorted_gradient ENVS FLAGS_cudnn_deterministic=1)

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -860,6 +860,8 @@ set_tests_properties(
   PROPERTIES TIMEOUT 120)
 set_tests_properties(test_pool_max_op PROPERTIES TIMEOUT 500)
 set_tests_properties(test_group_norm_op PROPERTIES TIMEOUT 1000)
+set_tests_properties(test_imperative_transformer_sorted_gradient
+                     PROPERTIES TIMEOUT 120)
 set_tests_properties(test_imperative_optimizer PROPERTIES TIMEOUT 250)
 set_tests_properties(test_activation_op PROPERTIES TIMEOUT 270)
 set_tests_properties(test_normal PROPERTIES TIMEOUT 120)
@@ -899,6 +901,8 @@ if(APPLE)
   set_tests_properties(test_callback_reduce_lr_on_plateau PROPERTIES TIMEOUT
                                                                      300)
   set_tests_properties(test_vision_models PROPERTIES TIMEOUT 300)
+  set_tests_properties(test_imperative_transformer_sorted_gradient
+                       PROPERTIES TIMEOUT 300)
 endif()
 set_tests_properties(test_decorator PROPERTIES TIMEOUT 120)
 

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -541,9 +541,6 @@ if(WITH_GPU
 endif()
 py_test_modules(test_imperative_resnet MODULES test_imperative_resnet ENVS
                 FLAGS_cudnn_deterministic=1)
-set_tests_properties(test_imperative_mnist PROPERTIES TIMEOUT 120)
-set_tests_properties(test_imperative_resnet
-                     PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE:NIGHTLY")
 py_test_modules(test_imperative_mnist MODULES test_imperative_mnist ENVS
                 FLAGS_cudnn_deterministic=1)
 py_test_modules(
@@ -552,10 +549,13 @@ py_test_modules(
 py_test_modules(
   test_imperative_resnet_sorted_gradient MODULES
   test_imperative_resnet_sorted_gradient ENVS FLAGS_cudnn_deterministic=1)
-set_tests_properties(test_imperative_resnet_sorted_gradient
-                     PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE:NIGHTLY")
 py_test_modules(test_imperative_se_resnext MODULES test_imperative_se_resnext
                 ENVS FLAGS_cudnn_deterministic=1)
+set_tests_properties(test_imperative_mnist PROPERTIES TIMEOUT 120)
+set_tests_properties(test_imperative_resnet
+                     PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE:NIGHTLY")
+set_tests_properties(test_imperative_resnet_sorted_gradient
+                     PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE:NIGHTLY")
 set_tests_properties(test_imperative_se_resnext
                      PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE:NIGHTLY")
 

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -429,6 +429,8 @@ endfunction()
 
 list(REMOVE_ITEM TEST_OPS test_data_norm_op)
 list(REMOVE_ITEM TEST_OPS test_warpctc_op)
+list(REMOVE_ITEM TEST_OPS test_imperative_mnist_sorted_gradient)
+list(REMOVE_ITEM TEST_OPS test_imperative_mnist)
 list(REMOVE_ITEM TEST_OPS test_imperative_resnet)
 list(REMOVE_ITEM TEST_OPS test_imperative_resnet_sorted_gradient)
 list(REMOVE_ITEM TEST_OPS test_imperative_se_resnext)

--- a/test/legacy_test/test_imperative_mnist.py
+++ b/test/legacy_test/test_imperative_mnist.py
@@ -20,7 +20,6 @@ from utils import DyGraphProgramDescTracerTestHelper
 
 import paddle
 from paddle import base
-from paddle.base import core
 from paddle.nn import Linear
 
 
@@ -119,7 +118,13 @@ class TestImperativeMnist(unittest.TestCase):
 
         traced_layer = None
 
-        with base.dygraph.guard():
+        place = (
+            paddle.CPUPlace()
+            if not paddle.is_compiled_with_cuda()
+            else paddle.CUDAPlace(0)
+        )
+
+        with base.dygraph.guard(place):
             paddle.seed(seed)
 
             mnist = MNIST()
@@ -178,11 +183,7 @@ class TestImperativeMnist(unittest.TestCase):
         with new_program_scope():
             paddle.seed(seed)
 
-            exe = base.Executor(
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            exe = paddle.static.Executor(place)
 
             mnist = MNIST()
             sgd = paddle.optimizer.SGD(learning_rate=1e-3)

--- a/test/legacy_test/test_imperative_mnist.py
+++ b/test/legacy_test/test_imperative_mnist.py
@@ -20,8 +20,33 @@ from utils import DyGraphProgramDescTracerTestHelper
 
 import paddle
 from paddle import base
+from paddle.autograd.backward_utils import ValueDict
 from paddle.base import core
 from paddle.nn import Linear
+
+
+def create_parameter_mapping(startup_program, main_program):
+    startup_params = {}
+    main_params = {}
+    parameter_mapping = ValueDict()
+    for op in startup_program.global_block().ops:
+        if op.name() == "builtin.set_parameter":
+            name = op.attrs()["parameter_name"]
+            param = op.operand(0).source()
+            startup_params[name] = param
+
+    for op in main_program.global_block().ops:
+        if op.name() == "builtin.parameter":
+            name = op.attrs()["parameter_name"]
+            param = op.result(0)
+            main_params[name] = param
+
+    assert len(startup_params) == len(main_params)
+    for name, startup_param in startup_params.items():
+        assert name in main_params
+        main_param = main_params[name]
+        parameter_mapping[main_param] = startup_param
+    return parameter_mapping
 
 
 class SimpleImgConvPool(paddle.nn.Layer):
@@ -213,17 +238,25 @@ class TestImperativeMnist(unittest.TestCase):
                 static_param_name_list.append(param.name)
                 static_params.append(param)
 
+            if paddle.framework.use_pir_api():
+                parameter_mapping = create_parameter_mapping(
+                    paddle.static.default_startup_program(),
+                    paddle.static.default_main_program(),
+                )
+                startup_params = [
+                    parameter_mapping[param] for param in static_params
+                ]
+            else:
+                startup_params = static_params
+
             out = exe.run(
-                base.default_startup_program(),
+                paddle.static.default_startup_program(),
+                fetch_list=startup_params,
             )
 
             for i in range(len(static_params)):
                 param_name = static_param_name_list[i]
-                static_param_init_value[param_name] = np.asarray(
-                    paddle.static.global_scope()
-                    .find_var(param_name)
-                    .get_tensor()
-                )
+                static_param_init_value[param_name] = out[i]
 
             for epoch in range(epoch_num):
                 for batch_id, data in enumerate(train_reader()):

--- a/test/legacy_test/test_imperative_mnist.py
+++ b/test/legacy_test/test_imperative_mnist.py
@@ -20,6 +20,7 @@ from utils import DyGraphProgramDescTracerTestHelper
 
 import paddle
 from paddle import base
+from paddle.base import core
 from paddle.nn import Linear
 
 
@@ -118,13 +119,7 @@ class TestImperativeMnist(unittest.TestCase):
 
         traced_layer = None
 
-        place = (
-            paddle.CPUPlace()
-            if not paddle.is_compiled_with_cuda()
-            else paddle.CUDAPlace(0)
-        )
-
-        with base.dygraph.guard(place):
+        with base.dygraph.guard():
             paddle.seed(seed)
 
             mnist = MNIST()
@@ -183,7 +178,11 @@ class TestImperativeMnist(unittest.TestCase):
         with new_program_scope():
             paddle.seed(seed)
 
-            exe = paddle.static.Executor(place)
+            exe = base.Executor(
+                base.CPUPlace()
+                if not core.is_compiled_with_cuda()
+                else base.CUDAPlace(0)
+            )
 
             mnist = MNIST()
             sgd = paddle.optimizer.SGD(learning_rate=1e-3)

--- a/test/legacy_test/test_imperative_mnist_sorted_gradient.py
+++ b/test/legacy_test/test_imperative_mnist_sorted_gradient.py
@@ -20,19 +20,15 @@ from test_imperative_mnist import MNIST
 
 import paddle
 from paddle import base
+from paddle.base import core
 
 
 class TestImperativeMnistSortGradient(unittest.TestCase):
     def test_mnist_sort_gradient_float32(self):
         seed = 90
         epoch_num = 1
-        place = (
-            paddle.CPUPlace()
-            if not paddle.is_compiled_with_cuda()
-            else paddle.CUDAPlace(0)
-        )
 
-        with base.dygraph.guard(place):
+        with base.dygraph.guard():
             paddle.seed(seed)
             base.set_flags({'FLAGS_sort_sum_gradient': True})
 
@@ -86,7 +82,11 @@ class TestImperativeMnistSortGradient(unittest.TestCase):
         with new_program_scope():
             paddle.seed(seed)
 
-            exe = paddle.static.Executor(place)
+            exe = base.Executor(
+                base.CPUPlace()
+                if not core.is_compiled_with_cuda()
+                else base.CUDAPlace(0)
+            )
 
             mnist = MNIST()
             sgd = paddle.optimizer.SGD(learning_rate=1e-3)

--- a/test/legacy_test/test_imperative_mnist_sorted_gradient.py
+++ b/test/legacy_test/test_imperative_mnist_sorted_gradient.py
@@ -110,16 +110,23 @@ class TestImperativeMnistSortGradient(unittest.TestCase):
             # initialize params and fetch them
             static_param_init_value = {}
             static_param_name_list = []
+            static_params = []
+
             for param in mnist.parameters():
                 static_param_name_list.append(param.name)
+                static_params.append(param)
 
             out = exe.run(
                 base.default_startup_program(),
-                fetch_list=static_param_name_list,
             )
 
             for i in range(len(static_param_name_list)):
-                static_param_init_value[static_param_name_list[i]] = out[i]
+                param_name = static_param_name_list[i]
+                static_param_init_value[param_name] = np.asarray(
+                    paddle.static.global_scope()
+                    .find_var(param_name)
+                    .get_tensor()
+                )
 
             for epoch in range(epoch_num):
                 for batch_id, data in enumerate(train_reader()):
@@ -132,8 +139,8 @@ class TestImperativeMnistSortGradient(unittest.TestCase):
                         .reshape([128, 1])
                     )
 
-                    fetch_list = [avg_loss.name]
-                    fetch_list.extend(static_param_name_list)
+                    fetch_list = [avg_loss]
+                    fetch_list.extend(static_params)
                     out = exe.run(
                         base.default_main_program(),
                         feed={"pixel": static_x_data, "label": y_data},
@@ -167,4 +174,5 @@ class TestImperativeMnistSortGradient(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    paddle.enable_static()
     unittest.main()

--- a/test/legacy_test/test_imperative_mnist_sorted_gradient.py
+++ b/test/legacy_test/test_imperative_mnist_sorted_gradient.py
@@ -20,15 +20,19 @@ from test_imperative_mnist import MNIST
 
 import paddle
 from paddle import base
-from paddle.base import core
 
 
 class TestImperativeMnistSortGradient(unittest.TestCase):
     def test_mnist_sort_gradient_float32(self):
         seed = 90
         epoch_num = 1
+        place = (
+            paddle.CPUPlace()
+            if not paddle.is_compiled_with_cuda()
+            else paddle.CUDAPlace(0)
+        )
 
-        with base.dygraph.guard():
+        with base.dygraph.guard(place):
             paddle.seed(seed)
             base.set_flags({'FLAGS_sort_sum_gradient': True})
 
@@ -82,11 +86,7 @@ class TestImperativeMnistSortGradient(unittest.TestCase):
         with new_program_scope():
             paddle.seed(seed)
 
-            exe = base.Executor(
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            exe = paddle.static.Executor(place)
 
             mnist = MNIST()
             sgd = paddle.optimizer.SGD(learning_rate=1e-3)

--- a/test/legacy_test/test_imperative_mnist_sorted_gradient.py
+++ b/test/legacy_test/test_imperative_mnist_sorted_gradient.py
@@ -20,7 +20,32 @@ from test_imperative_mnist import MNIST
 
 import paddle
 from paddle import base
+from paddle.autograd.backward_utils import ValueDict
 from paddle.base import core
+
+
+def create_parameter_mapping(startup_program, main_program):
+    startup_params = {}
+    main_params = {}
+    parameter_mapping = ValueDict()
+    for op in startup_program.global_block().ops:
+        if op.name() == "builtin.set_parameter":
+            name = op.attrs()["parameter_name"]
+            param = op.operand(0).source()
+            startup_params[name] = param
+
+    for op in main_program.global_block().ops:
+        if op.name() == "builtin.parameter":
+            name = op.attrs()["parameter_name"]
+            param = op.result(0)
+            main_params[name] = param
+
+    assert len(startup_params) == len(main_params)
+    for name, startup_param in startup_params.items():
+        assert name in main_params
+        main_param = main_params[name]
+        parameter_mapping[main_param] = startup_param
+    return parameter_mapping
 
 
 class TestImperativeMnistSortGradient(unittest.TestCase):
@@ -116,17 +141,25 @@ class TestImperativeMnistSortGradient(unittest.TestCase):
                 static_param_name_list.append(param.name)
                 static_params.append(param)
 
+            if paddle.framework.use_pir_api():
+                parameter_mapping = create_parameter_mapping(
+                    paddle.static.default_startup_program(),
+                    paddle.static.default_main_program(),
+                )
+                startup_params = [
+                    parameter_mapping[param] for param in static_params
+                ]
+            else:
+                startup_params = static_params
+
             out = exe.run(
-                base.default_startup_program(),
+                paddle.static.default_startup_program(),
+                fetch_list=startup_params,
             )
 
             for i in range(len(static_param_name_list)):
                 param_name = static_param_name_list[i]
-                static_param_init_value[param_name] = np.asarray(
-                    paddle.static.global_scope()
-                    .find_var(param_name)
-                    .get_tensor()
-                )
+                static_param_init_value[param_name] = out[i]
 
             for epoch in range(epoch_num):
                 for batch_id, data in enumerate(train_reader()):

--- a/test/legacy_test/test_imperative_reinforcement.py
+++ b/test/legacy_test/test_imperative_reinforcement.py
@@ -20,6 +20,7 @@ from test_imperative_base import new_program_scope
 import paddle
 import paddle.nn.functional as F
 from paddle import base
+from paddle.base import core
 
 
 class Policy(paddle.nn.Layer):
@@ -46,11 +47,6 @@ class TestImperativeMnist(unittest.TestCase):
     def test_mnist_float32(self):
         seed = 90
         epoch_num = 1
-        place = (
-            paddle.CPUPlace()
-            if not paddle.is_compiled_with_cuda()
-            else paddle.CUDAPlace(0)
-        )
 
         state = np.random.normal(size=4).astype("float32")
         state_list = state.tolist()
@@ -111,10 +107,10 @@ class TestImperativeMnist(unittest.TestCase):
 
             return dy_out, dy_param_init_value, dy_param_value
 
-        with base.dygraph.guard(place):
+        with base.dygraph.guard():
             dy_out, dy_param_init_value, dy_param_value = run_dygraph()
 
-        with base.dygraph.guard(place):
+        with base.dygraph.guard():
             (
                 eager_out,
                 eager_param_init_value,
@@ -131,7 +127,11 @@ class TestImperativeMnist(unittest.TestCase):
             else:
                 paddle.framework.random._manual_program_seed(seed)
 
-            exe = paddle.static.Executor(place)
+            exe = base.Executor(
+                base.CPUPlace()
+                if not core.is_compiled_with_cuda()
+                else base.CUDAPlace(0)
+            )
 
             policy = Policy(input_size=4)
 

--- a/test/legacy_test/test_imperative_reinforcement.py
+++ b/test/legacy_test/test_imperative_reinforcement.py
@@ -20,7 +20,6 @@ from test_imperative_base import new_program_scope
 import paddle
 import paddle.nn.functional as F
 from paddle import base
-from paddle.base import core
 
 
 class Policy(paddle.nn.Layer):
@@ -47,6 +46,11 @@ class TestImperativeMnist(unittest.TestCase):
     def test_mnist_float32(self):
         seed = 90
         epoch_num = 1
+        place = (
+            paddle.CPUPlace()
+            if not paddle.is_compiled_with_cuda()
+            else paddle.CUDAPlace(0)
+        )
 
         state = np.random.normal(size=4).astype("float32")
         state_list = state.tolist()
@@ -107,10 +111,10 @@ class TestImperativeMnist(unittest.TestCase):
 
             return dy_out, dy_param_init_value, dy_param_value
 
-        with base.dygraph.guard():
+        with base.dygraph.guard(place):
             dy_out, dy_param_init_value, dy_param_value = run_dygraph()
 
-        with base.dygraph.guard():
+        with base.dygraph.guard(place):
             (
                 eager_out,
                 eager_param_init_value,
@@ -127,11 +131,7 @@ class TestImperativeMnist(unittest.TestCase):
             else:
                 paddle.framework.random._manual_program_seed(seed)
 
-            exe = base.Executor(
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            exe = paddle.static.Executor(place)
 
             policy = Policy(input_size=4)
 

--- a/test/legacy_test/test_imperative_transformer_sorted_gradient.py
+++ b/test/legacy_test/test_imperative_transformer_sorted_gradient.py
@@ -223,9 +223,11 @@ def make_all_inputs(input_fields):
             name=input_field,
             shape=input_descs[input_field][0],
             dtype=input_descs[input_field][1],
-            lod_level=input_descs[input_field][2]
-            if len(input_descs[input_field]) == 3
-            else 0,
+            lod_level=(
+                input_descs[input_field][2]
+                if len(input_descs[input_field]) == 3
+                else 0
+            ),
         )
         inputs.append(input_var)
     return inputs
@@ -287,11 +289,17 @@ input_descs = {
     "enc_output": [(batch_size, seq_len, ModelHyperParams.d_model), "float32"],
     # The actual data shape of label_word is:
     # [batch_size * max_trg_len_in_batch, 1]
-    "lbl_word": [(batch_size * seq_len, 1), "int64"],
+    "lbl_word": [
+        (-1 if batch_size == -1 else batch_size * seq_len, 1),
+        "int64",
+    ],
     # This input is used to mask out the loss of padding tokens.
     # The actual data shape of label_weight is:
     # [batch_size * max_trg_len_in_batch, 1]
-    "lbl_weight": [(batch_size * seq_len, 1), "float32"],
+    "lbl_weight": [
+        (-1 if batch_size == -1 else batch_size * seq_len, 1),
+        "float32",
+    ],
     # This input is used in beam-search decoder.
     "init_score": [(batch_size, 1), "float32", 2],
     # This input is used in beam-search decoder for the first gather
@@ -1112,7 +1120,13 @@ class TestDygraphTransformerSortGradient(unittest.TestCase):
             # NOTE(xiongkun03): In new executor, the inplace strategy is on by default, which will cause result of sumop have some differences. So we disable inplace.
             base.set_flags({'FLAGS_new_executor_use_inplace': False})
             paddle.seed(seed)
-            paddle.framework.random._manual_program_seed(seed)
+            if paddle.framework.use_pir_api():
+                with paddle.pir_utils.OldIrGuard():
+                    # Note: dygraph use self.main_program.global_block().create_parameter(), it's need manual seed to old Program
+                    paddle.framework.random._manual_program_seed(seed)
+                paddle.framework.random._manual_program_seed(seed)
+            else:
+                paddle.framework.random._manual_program_seed(seed)
             transformer = TransFormer(
                 ModelHyperParams.src_vocab_size,
                 ModelHyperParams.trg_vocab_size,
@@ -1191,7 +1205,13 @@ class TestDygraphTransformerSortGradient(unittest.TestCase):
 
         with new_program_scope():
             paddle.seed(seed)
-            paddle.framework.random._manual_program_seed(seed)
+            if paddle.framework.use_pir_api():
+                with paddle.pir_utils.OldIrGuard():
+                    # Note: dygraph use self.main_program.global_block().create_parameter(), it's need manual seed to old Program
+                    paddle.framework.random._manual_program_seed(seed)
+                paddle.framework.random._manual_program_seed(seed)
+            else:
+                paddle.framework.random._manual_program_seed(seed)
             transformer = TransFormer(
                 ModelHyperParams.src_vocab_size,
                 ModelHyperParams.trg_vocab_size,
@@ -1237,6 +1257,7 @@ class TestDygraphTransformerSortGradient(unittest.TestCase):
             static_param_updated = {}
             static_param_init = {}
             static_param_name_list = []
+            static_params = []
             (
                 static_sum_cost,
                 static_avg_cost,
@@ -1246,12 +1267,17 @@ class TestDygraphTransformerSortGradient(unittest.TestCase):
             optimizer.minimize(static_avg_cost)
             for param in transformer.parameters():
                 static_param_name_list.append(param.name)
+                static_params.append(param)
             out = exe.run(
                 base.default_startup_program(),
-                fetch_list=static_param_name_list,
             )
             for i in range(len(static_param_name_list)):
-                static_param_init[static_param_name_list[i]] = out[i]
+                param_name = static_param_name_list[i]
+                static_param_init[param_name] = np.asarray(
+                    paddle.static.global_scope()
+                    .find_var(param_name)
+                    .get_tensor()
+                )
             static_sum_cost_value = None
             static_avg_cost_value = None
             static_predict_value = None
@@ -1265,7 +1291,7 @@ class TestDygraphTransformerSortGradient(unittest.TestCase):
                     static_token_num,
                 ]
 
-                fetch_list.extend(static_param_name_list)
+                fetch_list.extend(static_params)
                 out = exe.run(
                     base.default_main_program(),
                     feed=feed_dict,

--- a/test/legacy_test/test_imperative_transformer_sorted_gradient.py
+++ b/test/legacy_test/test_imperative_transformer_sorted_gradient.py
@@ -20,7 +20,6 @@ from test_imperative_base import new_program_scope
 import paddle
 import paddle.nn.functional as F
 from paddle import base
-from paddle.base import core
 from paddle.base.dygraph import guard
 from paddle.nn import Layer, Linear
 
@@ -1115,6 +1114,11 @@ class TestDygraphTransformerSortGradient(unittest.TestCase):
 
     def transformer_sort_gradient_float32(self, is_sparse):
         seed = 90
+        place = (
+            paddle.CPUPlace()
+            if not paddle.is_compiled_with_cuda()
+            else paddle.CUDAPlace(0)
+        )
 
         def run_dygraph():
             # NOTE(xiongkun03): In new executor, the inplace strategy is on by default, which will cause result of sumop have some differences. So we disable inplace.
@@ -1233,11 +1237,7 @@ class TestDygraphTransformerSortGradient(unittest.TestCase):
                 is_test=False,
                 is_sparse=is_sparse,
             )
-            exe = base.Executor(
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            exe = paddle.static.Executor(place)
             optimizer = paddle.optimizer.SGD(learning_rate=0.003)
 
             data_input_names = (
@@ -1308,7 +1308,7 @@ class TestDygraphTransformerSortGradient(unittest.TestCase):
                         ] = out[k]
 
         # compare eager result with imperative result
-        with guard():
+        with guard(place):
             base.set_flags({'FLAGS_sort_sum_gradient': False})
             (
                 dy_avg_cost_value,
@@ -1319,7 +1319,7 @@ class TestDygraphTransformerSortGradient(unittest.TestCase):
                 dy_param_updated,
             ) = run_dygraph()
 
-        with guard():
+        with guard(place):
             (
                 eager_avg_cost_value,
                 eager_sum_cost_value,

--- a/test/legacy_test/test_imperative_transformer_sorted_gradient.py
+++ b/test/legacy_test/test_imperative_transformer_sorted_gradient.py
@@ -20,6 +20,7 @@ from test_imperative_base import new_program_scope
 import paddle
 import paddle.nn.functional as F
 from paddle import base
+from paddle.autograd.backward_utils import ValueDict
 from paddle.base import core
 from paddle.base.dygraph import guard
 from paddle.nn import Layer, Linear
@@ -27,6 +28,30 @@ from paddle.nn import Layer, Linear
 np.set_printoptions(suppress=True)
 
 from utils import DyGraphProgramDescTracerTestHelper
+
+
+def create_parameter_mapping(startup_program, main_program):
+    startup_params = {}
+    main_params = {}
+    parameter_mapping = ValueDict()
+    for op in startup_program.global_block().ops:
+        if op.name() == "builtin.set_parameter":
+            name = op.attrs()["parameter_name"]
+            param = op.operand(0).source()
+            startup_params[name] = param
+
+    for op in main_program.global_block().ops:
+        if op.name() == "builtin.parameter":
+            name = op.attrs()["parameter_name"]
+            param = op.result(0)
+            main_params[name] = param
+
+    assert len(startup_params) == len(main_params)
+    for name, startup_param in startup_params.items():
+        assert name in main_params
+        main_param = main_params[name]
+        parameter_mapping[main_param] = startup_param
+    return parameter_mapping
 
 
 # Copy from models
@@ -1268,16 +1293,25 @@ class TestDygraphTransformerSortGradient(unittest.TestCase):
             for param in transformer.parameters():
                 static_param_name_list.append(param.name)
                 static_params.append(param)
+
+            if paddle.framework.use_pir_api():
+                parameter_mapping = create_parameter_mapping(
+                    paddle.static.default_startup_program(),
+                    paddle.static.default_main_program(),
+                )
+                startup_params = [
+                    parameter_mapping[param] for param in static_params
+                ]
+            else:
+                startup_params = static_params
+
             out = exe.run(
-                base.default_startup_program(),
+                paddle.static.default_startup_program(),
+                fetch_list=startup_params,
             )
             for i in range(len(static_param_name_list)):
                 param_name = static_param_name_list[i]
-                static_param_init[param_name] = np.asarray(
-                    paddle.static.global_scope()
-                    .find_var(param_name)
-                    .get_tensor()
-                )
+                static_param_init[param_name] = out[i]
             static_sum_cost_value = None
             static_avg_cost_value = None
             static_predict_value = None

--- a/test/legacy_test/test_inverse_op.py
+++ b/test/legacy_test/test_inverse_op.py
@@ -176,13 +176,6 @@ class TestInverseAPIError(unittest.TestCase):
             )
             self.assertRaises(TypeError, paddle.inverse, input)
 
-        # When out is set, the data type must be the same as input.
-        input = paddle.static.data(
-            name='input_1', shape=[4, 4], dtype="float32"
-        )
-        out = paddle.static.data(name='output', shape=[4, 4], dtype="float64")
-        self.assertRaises(TypeError, paddle.inverse, input, out)
-
         # The number of dimensions of input must be >= 2.
         input = paddle.static.data(name='input_2', shape=[4], dtype="float32")
         self.assertRaises(ValueError, paddle.inverse, input)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 5 个 PIR 模式单测，主要是写法修改

- `test_imperative_mnist` 纯写法修改，~~PIR 下从 scope 拿 startup program 初始化的 params（发现 CPU 下有精度 diff，此方法弃用）~~ 因为 parameters 返回的是 main program parameter OP 得到的 Value，直接用它们是不能在 startup program 里 fetch 的，因此 PIR 下将其映射回了 startup program 的 Value
- `test_imperative_mnist_sorted_gradient` 同上
- `test_imperative_reinforcement` 同上，加了 manual seed 修改
- `test_imperative_transformer_sorted_gradient` 同上，加了对动态 shape 的特判，这里 `batch_size` 为 -1，不修改的话会 `-1x4` 得到 `-4`，作为奇怪的 shape 传进 data OP，这种 -4 应该直接从 API 层面杜绝，因此加了报错和相应单测
- `test_inverse_op` 见代码处的 review

PCard-66972