### PR TITLE
Add label for fluid ops to skip coverage

### DIFF
--- a/tools/get_pr_title.py
+++ b/tools/get_pr_title.py
@@ -23,6 +23,7 @@ SKIP_COVERAGE_CHECKING_LABELS = [
     "cinn",
     "typing",
     "codestyle",
+    "ops",
 ]
 
 SKIP_COVERAGE_CHECKING_REGEX = re.compile(

--- a/tools/get_pr_title.py
+++ b/tools/get_pr_title.py
@@ -23,7 +23,7 @@ SKIP_COVERAGE_CHECKING_LABELS = [
     "cinn",
     "typing",
     "codestyle",
-    "ops",
+    "fluid_ops",
 ]
 
 SKIP_COVERAGE_CHECKING_REGEX = re.compile(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
用于fluid 算子迁移，增加标题标签跳过覆盖率检查，标签是 ops，fluid 算子迁移后再取消