### PR TITLE
Remove TRT static shape and bump into TRT 10.0

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
@@ -277,8 +277,12 @@ void TensorRTEngineInstruction::PrepareDynamicShape() {
     auto is_shape_tensor = true;
     if (trt_engine_->engine()) {
       auto *engine = trt_engine_->engine();
+#if IS_TRT_VERSION_GE(8600)
+      is_shape_tensor = engine->isShapeInferenceIO(name.c_str());
+#else
       is_shape_tensor =
           engine->isShapeBinding(engine->getBindingIndex(name.c_str()));
+#endif
       if (!is_shape_tensor) {
         runtime_shape_tensor.erase(name);
         VLOG(4) << "trt engine runtime delete shape name(" << name << "), dims("
@@ -446,9 +450,25 @@ void TensorRTEngineInstruction::BindInputTensor(
   }
 
   // Get index of profile 0 first, then plus binding offset
+#if IS_TRT_VERSION_GE(8600)
+  int bind_index = -1;
+  for (int i = 0; i < trt_engine_->engine()->getNbIOTensors(); ++i) {
+    if (std::string(input_name.c_str()) ==
+        std::string(trt_engine_->engine()->getIOTensorName(i))) {
+      bind_index = i + binding_offset;
+      break;
+    }
+  }
+  PADDLE_ENFORCE_GE(
+      bind_index,
+      0,
+      phi::errors::InvalidArgument("Cannot find input name %s in TRT engine",
+                                   input_name.c_str()));
+#else
   const int bind_index =
       trt_engine_->engine()->getBindingIndex(input_name.c_str()) +
       binding_offset;
+#endif
   PADDLE_ENFORCE_LT(bind_index,
                     num_bindings,
                     common::errors::InvalidArgument(
@@ -461,8 +481,9 @@ void TensorRTEngineInstruction::BindInputTensor(
 
 #if IS_TRT_VERSION_GE(6000)
 #if IS_TRT_VERSION_GE(8500)
-  if (trt_engine_->engine()->isShapeBinding(bind_index) &&
-      trt_engine_->engine()->bindingIsInput(bind_index)) {
+  if (trt_engine_->engine()->isShapeInferenceIO(input_name.c_str()) &&
+      trt_engine_->engine()->getTensorIOMode(input_name.c_str()) ==
+          nvinfer1::TensorIOMode::kINPUT) {
     if (input_tensor.dtype() == phi::DataType::INT32) {
       phi::memory_utils::Copy(phi::CPUPlace(),
                               shape_v.data(),
@@ -534,8 +555,13 @@ void TensorRTEngineInstruction::BindInputTensor(
           << input_tensor.dtype();
 
   auto indata_type = paddle::platform::PhiType2NvType(input_tensor.dtype());
+#if IS_TRT_VERSION_GE(8600)
+  auto intrt_type =
+      trt_engine_->engine()->getTensorDataType(input_name.c_str());
+#else
   auto intrt_index = trt_engine_->engine()->getBindingIndex(input_name.c_str());
   auto intrt_type = trt_engine_->engine()->getBindingDataType(intrt_index);
+#endif
   PADDLE_ENFORCE_EQ(indata_type,
                     intrt_type,
                     common::errors::InvalidArgument(
@@ -598,14 +624,29 @@ void TensorRTEngineInstruction::BindOutputTensor(
   // Initialize context and get offset by profile index
   trt_context = trt_engine_->context();
   binding_offset = trt_engine_->GetBindingsOffset();
-
+#if IS_TRT_VERSION_GE(8600)
+  int bind_index = -1;
+  for (int i = 0; i < trt_engine_->engine()->getNbIOTensors(); ++i) {
+    if (std::string(output_name.c_str()) ==
+        std::string(trt_engine_->engine()->getIOTensorName(i))) {
+      bind_index = i + binding_offset;
+      break;
+    }
+  }
+  PADDLE_ENFORCE_GE(
+      bind_index,
+      0,
+      phi::errors::InvalidArgument("Cannot find input name %s in TRT engine",
+                                   output_name.c_str()));
+#else
   const int bind_index =
       trt_engine_->engine()->getBindingIndex(output_name.c_str()) +
       binding_offset;
+#endif
   std::vector<int> ddim;
 
 #if IS_TRT_VERSION_GE(8500)
-  auto x_name = trt_engine_->engine()->getBindingName(bind_index);
+  auto x_name = trt_engine_->engine()->getIOTensorName(bind_index);
   auto dims = trt_context->getTensorShape(x_name);
   int nb_dims = dims.nbDims;
   for (; nb_dims > 0; nb_dims--) {
@@ -639,7 +680,12 @@ void TensorRTEngineInstruction::BindOutputTensor(
                         "index = %d, number of bindings = %d.",
                         bind_index,
                         num_bindings));
+#if IS_TRT_VERSION_GE(8600)
+  auto trt_type = trt_engine_->engine()->getTensorDataType(
+      trt_engine_->engine()->getIOTensorName(bind_index));
+#else
   auto trt_type = trt_engine_->engine()->getBindingDataType(bind_index);
+#endif
   // get adr and set type
   VLOG(1) << "trt output [" << output_name << "] dtype is "
           << TRT2PaddleDataType(trt_type);

--- a/paddle/fluid/inference/tensorrt/convert/affine_channel_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/affine_channel_op.cc
@@ -48,7 +48,7 @@ class AffineChannelOpConverter : public OpConverter {
 
     // tensorrt scalend layer only support spatial dims >= 2,
     // so nhwc is not available (spatial dims == 0)
-    const int channel_axis = engine_->with_dynamic_shape();
+    const int channel_axis = 1;
 
     TensorRTEngine::Weight scale_weights{
         nvinfer1::DataType::kFLOAT,

--- a/paddle/fluid/inference/tensorrt/convert/anchor_generator_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/anchor_generator_op.cc
@@ -45,7 +45,7 @@ class AnchorGeneratorOpConverter : public OpConverter {
         PADDLE_GET_CONST(std::vector<float>, op_desc.GetAttr("variances"));
     const auto offset = PADDLE_GET_CONST(float, op_desc.GetAttr("offset"));
     const int num_anchors = aspect_ratios.size() * anchor_sizes.size();
-    bool is_dynamic = engine_->with_dynamic_shape();
+    bool is_dynamic = true;
     const auto height = input_dims.d[1];
     const auto width = input_dims.d[2];
     const int box_num = width * height * num_anchors;

--- a/paddle/fluid/inference/tensorrt/convert/arg_max_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/arg_max_op.cc
@@ -32,9 +32,6 @@ class ArgMaxOpConverter : public OpConverter {
     int axis = op_desc.HasAttr("axis")
                    ? PADDLE_GET_CONST(int64_t, op_desc.GetAttr("axis"))
                    : -1;
-    if (axis > 0 && !engine_->with_dynamic_shape()) {
-      axis -= 1;
-    }
     if (axis < 0) axis += rank;
     auto* topk_layer = TRT_ENGINE_ADD_LAYER(
         engine_, TopK, *input, nvinfer1::TopKOperation::kMAX, 1, 1 << axis);

--- a/paddle/fluid/inference/tensorrt/convert/arg_min_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/arg_min_op.cc
@@ -32,9 +32,6 @@ class ArgMinOpConverter : public OpConverter {
     int axis = op_desc.HasAttr("axis")
                    ? PADDLE_GET_CONST(int64_t, op_desc.GetAttr("axis"))
                    : -1;
-    if (axis > 0 && !engine_->with_dynamic_shape()) {
-      axis -= 1;
-    }
     if (axis < 0) axis += rank;
     auto* topk_layer = TRT_ENGINE_ADD_LAYER(
         engine_, TopK, *input, nvinfer1::TopKOperation::kMIN, 1, 1 << axis);

--- a/paddle/fluid/inference/tensorrt/convert/concat_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/concat_op.cc
@@ -38,10 +38,6 @@ class ConcatOpConverter : public OpConverter {
                  ->getDimensions()
                  .nbDims +
              axis;
-    } else {
-      if (!engine_->with_dynamic_shape()) {
-        axis = axis - 1;  // Remove batch dim
-      }
     }
     auto* layer = TRT_ENGINE_ADD_LAYER(
         engine_, Concatenation, itensors.data(), itensors.size());

--- a/paddle/fluid/inference/tensorrt/convert/deformable_conv_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/deformable_conv_op.cc
@@ -79,63 +79,33 @@ class DeformableConvOpConverter : public OpConverter {
     } else {
       weights = engine_->GetFp32TrtWeight(filter_name, *filter_tensor).get();
     }
-    if (!engine_->with_dynamic_shape()) {
-      auto* deformable_conv_plugin = new plugin::DeformableConvPlugin(
-          with_fp16 ? nvinfer1::DataType::kHALF : nvinfer1::DataType::kFLOAT,
-          weights,
-          kernel_dims,
-          strides,
-          paddings,
-          dilations,
-          groups,
-          deformable_groups,
-          im2col_step,
-          with_fp16);
+    auto* deformable_conv_plugin = new plugin::DeformableConvPluginDynamic(
+        with_fp16 ? nvinfer1::DataType::kHALF : nvinfer1::DataType::kFLOAT,
+        weights,
+        kernel_dims,
+        strides,
+        paddings,
+        dilations,
+        groups,
+        deformable_groups,
+        im2col_step,
+        with_fp16);
 
-      std::vector<nvinfer1::ITensor*> deformable_conv_inputs;
-      deformable_conv_inputs.push_back(input_tensor);
-      deformable_conv_inputs.push_back(offset_tensor);
-      deformable_conv_inputs.push_back(mask_tensor);
+    std::vector<nvinfer1::ITensor*> deformable_conv_inputs;
+    deformable_conv_inputs.push_back(input_tensor);
+    deformable_conv_inputs.push_back(offset_tensor);
+    deformable_conv_inputs.push_back(mask_tensor);
 
-      auto* deformable_conv_layer =
-          engine_->network()->addPluginV2(deformable_conv_inputs.data(),
-                                          deformable_conv_inputs.size(),
-                                          *deformable_conv_plugin);
+    auto* deformable_conv_layer =
+        engine_->network()->addPluginV2(deformable_conv_inputs.data(),
+                                        deformable_conv_inputs.size(),
+                                        *deformable_conv_plugin);
 
-      std::vector<std::string> output_names;
-      output_names.push_back(op_desc.Output("Output").front());
+    std::vector<std::string> output_names;
+    output_names.push_back(op_desc.Output("Output").front());
 
-      ReplenishLayerAndOutput(
-          deformable_conv_layer, "deformable_conv", output_names, test_mode);
-    } else {
-      auto* deformable_conv_plugin = new plugin::DeformableConvPluginDynamic(
-          with_fp16 ? nvinfer1::DataType::kHALF : nvinfer1::DataType::kFLOAT,
-          weights,
-          kernel_dims,
-          strides,
-          paddings,
-          dilations,
-          groups,
-          deformable_groups,
-          im2col_step,
-          with_fp16);
-
-      std::vector<nvinfer1::ITensor*> deformable_conv_inputs;
-      deformable_conv_inputs.push_back(input_tensor);
-      deformable_conv_inputs.push_back(offset_tensor);
-      deformable_conv_inputs.push_back(mask_tensor);
-
-      auto* deformable_conv_layer =
-          engine_->network()->addPluginV2(deformable_conv_inputs.data(),
-                                          deformable_conv_inputs.size(),
-                                          *deformable_conv_plugin);
-
-      std::vector<std::string> output_names;
-      output_names.push_back(op_desc.Output("Output").front());
-
-      ReplenishLayerAndOutput(
-          deformable_conv_layer, "deformable_conv", output_names, test_mode);
-    }
+    ReplenishLayerAndOutput(
+        deformable_conv_layer, "deformable_conv", output_names, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
@@ -30,38 +30,7 @@ class ElementwiseTensorOpConverter : public OpConverter {
     auto* X = engine_->GetITensor(op_desc.Input("X").front());
     nvinfer1::ITensor* Y = nullptr;
     auto* Y_v = scope.FindVar(op_desc.Input("Y").front());
-    if (Y_v && !engine_->with_dynamic_shape()) {
-      // Y is weight
-      auto* Y_t = Y_v->GetMutable<phi::DenseTensor>();
-      std::vector<int> dims_y = common::vectorize<int>(Y_t->dims());
-      auto y_weight = engine_->GetTrtWeight(op_desc.Input("Y").front(), *Y_t);
-
-      nvinfer1::Dims trt_dims_y;
-      trt_dims_y.nbDims = dims_y.size();
-      for (int i = 0; i < trt_dims_y.nbDims; i++) {
-        trt_dims_y.d[i] = dims_y[i];
-      }
-      // this is the special case when dims_y includes batch dimension!
-      // we need remove batch dimension!
-      if (!engine_->with_dynamic_shape() &&
-          trt_dims_y.nbDims == (X->getDimensions().nbDims + 1)) {
-        trt_dims_y.nbDims--;
-        PADDLE_ENFORCE_EQ(trt_dims_y.d[0],
-                          1,
-                          common::errors::InvalidArgument(
-                              "Elementwise type(%s) op's Y is a weight "
-                              "including batch dimension. Please "
-                              "check if the 0th dimension equals 1.",
-                              op_type_));
-        for (int i = 0; i < trt_dims_y.nbDims; i++) {
-          trt_dims_y.d[i] = trt_dims_y.d[i + 1];
-        }
-      }
-      Y = TRT_ENGINE_ADD_LAYER(engine_, Constant, trt_dims_y, y_weight.get())
-              ->getOutput(0);
-    } else {
-      Y = engine_->GetITensor(op_desc.Input("Y").front());
-    }
+    Y = engine_->GetITensor(op_desc.Input("Y").front());
     bool swap_xy = false;
     // Swap X and Y
     if (X->getDimensions().nbDims < Y->getDimensions().nbDims) {
@@ -82,16 +51,8 @@ class ElementwiseTensorOpConverter : public OpConverter {
     }
     int real_x_rank = dims_x.nbDims;
     int real_y_rank = dims_y.nbDims;
-    if (!engine_->with_dynamic_shape()) {
-      real_x_rank++;
-      real_y_rank++;
-      if (Y_v) real_y_rank--;
-    }
     if (axis == -1) {
       axis = real_x_rank - real_y_rank;
-    }
-    if (!engine_->with_dynamic_shape() && axis > 0) {
-      axis--;
     }
 
     // X: - -  -    - - - -
@@ -104,32 +65,22 @@ class ElementwiseTensorOpConverter : public OpConverter {
     nvinfer1::ITensor* reshape_y_tensor;
     if (dims_x.nbDims != dims_y.nbDims &&
         (left_one_num > 0 || right_one_num > 0)) {
-      if (engine_->with_dynamic_shape()) {
-        auto* y_shape_tensor = Shape(Y);
-        auto* new_y_shape_tensor = y_shape_tensor;
-        if (axis > 0) {
-          std::vector<int32_t> left_one(left_one_num, 1);
-          auto* left_one_tensor = Add1DConstantLayer(left_one);
-          new_y_shape_tensor = Concat(std::vector<nvinfer1::ITensor*>{
-              left_one_tensor, new_y_shape_tensor});
-        }
-        if (right_one_num > 0) {
-          std::vector<int32_t> right_one(right_one_num, 1);
-          auto* right_one_tensor = Add1DConstantLayer(right_one);
-          new_y_shape_tensor = Concat(std::vector<nvinfer1::ITensor*>{
-              new_y_shape_tensor, right_one_tensor});
-        }
-        reshape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *Y);
-        reshape_layer->setInput(1, *new_y_shape_tensor);
-      } else {
-        nvinfer1::Dims new_y_dims;
-        new_y_dims.nbDims = left_one_num + dims_y.nbDims + right_one_num;
-        for (int i = 0; i < new_y_dims.nbDims; i++) new_y_dims.d[i] = 1;
-        for (int i = 0; i < dims_y.nbDims; i++)
-          new_y_dims.d[left_one_num + i] = dims_y.d[i];
-        reshape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *Y);
-        reshape_layer->setReshapeDimensions(new_y_dims);
+      auto* y_shape_tensor = Shape(Y);
+      auto* new_y_shape_tensor = y_shape_tensor;
+      if (axis > 0) {
+        std::vector<int32_t> left_one(left_one_num, 1);
+        auto* left_one_tensor = Add1DConstantLayer(left_one);
+        new_y_shape_tensor = Concat(std::vector<nvinfer1::ITensor*>{
+            left_one_tensor, new_y_shape_tensor});
       }
+      if (right_one_num > 0) {
+        std::vector<int32_t> right_one(right_one_num, 1);
+        auto* right_one_tensor = Add1DConstantLayer(right_one);
+        new_y_shape_tensor = Concat(std::vector<nvinfer1::ITensor*>{
+            new_y_shape_tensor, right_one_tensor});
+      }
+      reshape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *Y);
+      reshape_layer->setInput(1, *new_y_shape_tensor);
       reshape_y_tensor = reshape_layer->getOutput(0);
     } else {
       // In fact , we can remove this `else`, but -> rt_resnet50_test CI in trt

--- a/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
@@ -29,7 +29,6 @@ class ElementwiseTensorOpConverter : public OpConverter {
     framework::OpDesc op_desc(op, nullptr);
     auto* X = engine_->GetITensor(op_desc.Input("X").front());
     nvinfer1::ITensor* Y = nullptr;
-    auto* Y_v = scope.FindVar(op_desc.Input("Y").front());
     Y = engine_->GetITensor(op_desc.Input("Y").front());
     bool swap_xy = false;
     // Swap X and Y

--- a/paddle/fluid/inference/tensorrt/convert/elementwiseadd_transpose_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/elementwiseadd_transpose_op.cc
@@ -33,18 +33,16 @@ class ElementwiseaddTransposeOpConverter : public OpConverter {
     int axis = PADDLE_GET_CONST(int, op_desc.GetAttr("axis"));
     std::vector<int> output_shape =
         PADDLE_GET_CONST(std::vector<int>, op_desc.GetAttr("output_shape"));
-    if (engine_->with_dynamic_shape()) {
-      plugin::ElementwiseAddTransposePluginDynamic* plugin =
-          new plugin::ElementwiseAddTransposePluginDynamic(axis, output_shape);
-      nvinfer1::ILayer* elementwise_layer =
-          engine_->AddDynamicPlugin(inputs.data(), 2, plugin);
-      std::vector<std::string> output_names;
-      output_names.emplace_back(op_desc.Output("Out").front());
-      ReplenishLayerAndOutput(elementwise_layer,
-                              "fuse_elementwiseadd_transpose",
-                              output_names,
-                              test_mode);
-    }
+    plugin::ElementwiseAddTransposePluginDynamic* plugin =
+        new plugin::ElementwiseAddTransposePluginDynamic(axis, output_shape);
+    nvinfer1::ILayer* elementwise_layer =
+        engine_->AddDynamicPlugin(inputs.data(), 2, plugin);
+    std::vector<std::string> output_names;
+    output_names.emplace_back(op_desc.Output("Out").front());
+    ReplenishLayerAndOutput(elementwise_layer,
+                            "fuse_elementwiseadd_transpose",
+                            output_names,
+                            test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/flatten_contiguous_range_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/flatten_contiguous_range_op.cc
@@ -30,140 +30,114 @@ class FlattenContiguousRangeOpConverter : public OpConverter {
     int stop_axis = PADDLE_GET_CONST(int, op_desc.GetAttr("stop_axis"));
     nvinfer1::IShuffleLayer* layer =
         TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-    if (!engine_->with_dynamic_shape()) {
-      if (start_axis < 0) start_axis += dims + 1;
-      if (stop_axis < 0) stop_axis += dims + 1;
+    nvinfer1::Dims flatten_dim;
+    bool need_slice = false;
+    if (dims == 0) {
+      flatten_dim.nbDims = 1;
+      flatten_dim.d[0] = 1;
+    } else {
+      if (start_axis < 0) start_axis += dims;
+      if (stop_axis < 0) stop_axis += dims;
+
       int dim_prod = 1;
-      nvinfer1::Dims flatten_dim;
+      int dim_negative = 0;
+
       flatten_dim.nbDims = dims - (stop_axis - start_axis);
       for (int i = 0, j = 0; i < dims; ++i) {
-        if (start_axis <= i + 1 && i + 1 <= stop_axis) {
-          int dim_i = input_dim.d[i];
-          PADDLE_ENFORCE_GT(dim_i,
-                            0,
-                            common::errors::InvalidArgument(
-                                "flatten_contiguous_range input dim "
-                                "should be > 0, but got %d.",
-                                dim_i));
+        int dim_i = input_dim.d[i];
+        if (start_axis <= i && i <= stop_axis) {
+          if (dim_i < 0) {
+            need_slice = true;
+            break;
+          }
           dim_prod *= dim_i;
-          if (i + 1 == stop_axis) {
+          if (i == stop_axis) {
             flatten_dim.d[j++] = dim_prod;
           }
         } else {
+          if (dim_i < 0) dim_negative++;
+          if (dim_negative > 1) {
+            need_slice = true;
+            break;
+          }
           flatten_dim.d[j++] = input_dim.d[i];
         }
       }
-      layer->setReshapeDimensions(flatten_dim);
+    }
+
+    if (need_slice) {
+      VLOG(3) << "slice input dim when the input dimension has -1";
+      auto* shape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shape, *input);
+      auto* shape_layer_itensor = shape_layer->getOutput(0);
+
+      nvinfer1::Dims start_dim, size_dim, stride_dim;
+      start_dim.nbDims = 1;
+      size_dim.nbDims = 1;
+      stride_dim.nbDims = 1;
+      start_dim.d[0] = start_axis;
+      size_dim.d[0] = stop_axis - start_axis + 1;
+      stride_dim.d[0] = 1;
+      auto* slice_layer = TRT_ENGINE_ADD_LAYER(engine_,
+                                               Slice,
+                                               *shape_layer_itensor,
+                                               start_dim,
+                                               size_dim,
+                                               stride_dim);
+      uint32_t reduce_dim = 1;
+      auto* reduce_prod_layer =
+          TRT_ENGINE_ADD_LAYER(engine_,
+                               Reduce,
+                               *(slice_layer->getOutput(0)),
+                               nvinfer1::ReduceOperation::kPROD,
+                               reduce_dim,
+                               true);
+
+      nvinfer1::ITensor* input_shape = nullptr;
+      if (start_axis == 0 && stop_axis == dims - 1) {
+        input_shape = reduce_prod_layer->getOutput(0);
+      } else {
+        std::vector<nvinfer1::ITensor*> itensors;
+        if (start_axis > 0) {
+          nvinfer1::Dims left_start_dim, left_size_dim, left_stride_dim;
+          left_start_dim.nbDims = 1;
+          left_size_dim.nbDims = 1;
+          left_stride_dim.nbDims = 1;
+          left_start_dim.d[0] = 0;
+          left_size_dim.d[0] = start_axis;
+          left_stride_dim.d[0] = 1;
+          auto* slice_layer_left = TRT_ENGINE_ADD_LAYER(engine_,
+                                                        Slice,
+                                                        *shape_layer_itensor,
+                                                        left_start_dim,
+                                                        left_size_dim,
+                                                        left_stride_dim);
+          itensors.push_back(slice_layer_left->getOutput(0));
+        }
+        itensors.push_back(reduce_prod_layer->getOutput(0));
+        if (stop_axis < dims - 1) {
+          nvinfer1::Dims right_start_dim, right_size_dim, right_stride_dim;
+          right_start_dim.nbDims = 1;
+          right_size_dim.nbDims = 1;
+          right_stride_dim.nbDims = 1;
+          right_start_dim.d[0] = stop_axis + 1;
+          right_size_dim.d[0] = dims - stop_axis - 1;
+          right_stride_dim.d[0] = 1;
+          auto* slice_layer_right = TRT_ENGINE_ADD_LAYER(engine_,
+                                                         Slice,
+                                                         *shape_layer_itensor,
+                                                         right_start_dim,
+                                                         right_size_dim,
+                                                         right_stride_dim);
+          itensors.push_back(slice_layer_right->getOutput(0));
+        }
+        auto* concat_layer = TRT_ENGINE_ADD_LAYER(
+            engine_, Concatenation, itensors.data(), itensors.size());
+        concat_layer->setAxis(0);
+        input_shape = concat_layer->getOutput(0);
+      }
+      layer->setInput(1, *input_shape);
     } else {
-      nvinfer1::Dims flatten_dim;
-      bool need_slice = false;
-      if (dims == 0) {
-        flatten_dim.nbDims = 1;
-        flatten_dim.d[0] = 1;
-      } else {
-        if (start_axis < 0) start_axis += dims;
-        if (stop_axis < 0) stop_axis += dims;
-
-        int dim_prod = 1;
-        int dim_negative = 0;
-
-        flatten_dim.nbDims = dims - (stop_axis - start_axis);
-        for (int i = 0, j = 0; i < dims; ++i) {
-          int dim_i = input_dim.d[i];
-          if (start_axis <= i && i <= stop_axis) {
-            if (dim_i < 0) {
-              need_slice = true;
-              break;
-            }
-            dim_prod *= dim_i;
-            if (i == stop_axis) {
-              flatten_dim.d[j++] = dim_prod;
-            }
-          } else {
-            if (dim_i < 0) dim_negative++;
-            if (dim_negative > 1) {
-              need_slice = true;
-              break;
-            }
-            flatten_dim.d[j++] = input_dim.d[i];
-          }
-        }
-      }
-
-      if (need_slice) {
-        VLOG(3) << "slice input dim when the input dimension has -1";
-        auto* shape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shape, *input);
-        auto* shape_layer_itensor = shape_layer->getOutput(0);
-
-        nvinfer1::Dims start_dim, size_dim, stride_dim;
-        start_dim.nbDims = 1;
-        size_dim.nbDims = 1;
-        stride_dim.nbDims = 1;
-        start_dim.d[0] = start_axis;
-        size_dim.d[0] = stop_axis - start_axis + 1;
-        stride_dim.d[0] = 1;
-        auto* slice_layer = TRT_ENGINE_ADD_LAYER(engine_,
-                                                 Slice,
-                                                 *shape_layer_itensor,
-                                                 start_dim,
-                                                 size_dim,
-                                                 stride_dim);
-        uint32_t reduce_dim = 1;
-        auto* reduce_prod_layer =
-            TRT_ENGINE_ADD_LAYER(engine_,
-                                 Reduce,
-                                 *(slice_layer->getOutput(0)),
-                                 nvinfer1::ReduceOperation::kPROD,
-                                 reduce_dim,
-                                 true);
-
-        nvinfer1::ITensor* input_shape = nullptr;
-        if (start_axis == 0 && stop_axis == dims - 1) {
-          input_shape = reduce_prod_layer->getOutput(0);
-        } else {
-          std::vector<nvinfer1::ITensor*> itensors;
-          if (start_axis > 0) {
-            nvinfer1::Dims left_start_dim, left_size_dim, left_stride_dim;
-            left_start_dim.nbDims = 1;
-            left_size_dim.nbDims = 1;
-            left_stride_dim.nbDims = 1;
-            left_start_dim.d[0] = 0;
-            left_size_dim.d[0] = start_axis;
-            left_stride_dim.d[0] = 1;
-            auto* slice_layer_left = TRT_ENGINE_ADD_LAYER(engine_,
-                                                          Slice,
-                                                          *shape_layer_itensor,
-                                                          left_start_dim,
-                                                          left_size_dim,
-                                                          left_stride_dim);
-            itensors.push_back(slice_layer_left->getOutput(0));
-          }
-          itensors.push_back(reduce_prod_layer->getOutput(0));
-          if (stop_axis < dims - 1) {
-            nvinfer1::Dims right_start_dim, right_size_dim, right_stride_dim;
-            right_start_dim.nbDims = 1;
-            right_size_dim.nbDims = 1;
-            right_stride_dim.nbDims = 1;
-            right_start_dim.d[0] = stop_axis + 1;
-            right_size_dim.d[0] = dims - stop_axis - 1;
-            right_stride_dim.d[0] = 1;
-            auto* slice_layer_right = TRT_ENGINE_ADD_LAYER(engine_,
-                                                           Slice,
-                                                           *shape_layer_itensor,
-                                                           right_start_dim,
-                                                           right_size_dim,
-                                                           right_stride_dim);
-            itensors.push_back(slice_layer_right->getOutput(0));
-          }
-          auto* concat_layer = TRT_ENGINE_ADD_LAYER(
-              engine_, Concatenation, itensors.data(), itensors.size());
-          concat_layer->setAxis(0);
-          input_shape = concat_layer->getOutput(0);
-        }
-        layer->setInput(1, *input_shape);
-      } else {
-        layer->setReshapeDimensions(flatten_dim);
-      }
+      layer->setReshapeDimensions(flatten_dim);
     }
 
     auto output_name = op_desc.Output("Out")[0];

--- a/paddle/fluid/inference/tensorrt/convert/flatten_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/flatten_op.cc
@@ -28,65 +28,47 @@ class FlattenOpConverter : public OpConverter {
     auto* input = engine_->GetITensor(op_desc.Input("X")[0]);
     int dims = input->getDimensions().nbDims;
     nvinfer1::IShuffleLayer* layer = nullptr;
-    if (!engine_->with_dynamic_shape()) {
-      int dim_prod = 1;
-      for (int i = 0; i < dims; i++) {
-        int dim_i = input->getDimensions().d[i];
-        PADDLE_ENFORCE_GT(
-            dim_i,
-            0,
-            common::errors::InvalidArgument(
-                "flatten input dim should be > 0, but got %d.", dim_i));
-        dim_prod *= dim_i;
-      }
-      nvinfer1::Dims flatten_dim;
-      flatten_dim.nbDims = 1;
-      flatten_dim.d[0] = dim_prod;
-      layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-      layer->setReshapeDimensions(flatten_dim);
-    } else {
-      auto* shape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shape, *input);
-      nvinfer1::Dims start_dim, size_dim, stride_dim;
-      start_dim.nbDims = 1;
-      size_dim.nbDims = 1;
-      stride_dim.nbDims = 1;
-      start_dim.d[0] = 1;
-      size_dim.d[0] = dims - 1;
-      stride_dim.d[0] = 1;
-      auto* slice_layer = TRT_ENGINE_ADD_LAYER(engine_,
-                                               Slice,
-                                               *(shape_layer->getOutput(0)),
-                                               start_dim,
-                                               size_dim,
-                                               stride_dim);
-      uint32_t reduce_dim = 1;
-      auto* reduce_prod_layer =
-          TRT_ENGINE_ADD_LAYER(engine_,
-                               Reduce,
-                               *(slice_layer->getOutput(0)),
-                               nvinfer1::ReduceOperation::kPROD,
-                               reduce_dim,
-                               true);
-      int32_t* constant_weight_data = new int32_t[1];
-      constant_weight_data[0] = -1;
-      TensorRTEngine::Weight constant_weight{
-          nvinfer1::DataType::kINT32,
-          static_cast<void*>(constant_weight_data),
-          1};
-      nvinfer1::Dims constant_dims;
-      constant_dims.nbDims = 1;
-      constant_dims.d[0] = 1;
-      auto* constant_layer = TRT_ENGINE_ADD_LAYER(
-          engine_, Constant, constant_dims, constant_weight.get());
-      std::vector<nvinfer1::ITensor*> itensors;
-      itensors.push_back(constant_layer->getOutput(0));
-      itensors.push_back(reduce_prod_layer->getOutput(0));
-      auto* concat_layer =
-          TRT_ENGINE_ADD_LAYER(engine_, Concatenation, itensors.data(), 2);
-      concat_layer->setAxis(0);
-      layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-      layer->setInput(1, *(concat_layer->getOutput(0)));
-    }
+    auto* shape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shape, *input);
+    nvinfer1::Dims start_dim, size_dim, stride_dim;
+    start_dim.nbDims = 1;
+    size_dim.nbDims = 1;
+    stride_dim.nbDims = 1;
+    start_dim.d[0] = 1;
+    size_dim.d[0] = dims - 1;
+    stride_dim.d[0] = 1;
+    auto* slice_layer = TRT_ENGINE_ADD_LAYER(engine_,
+                                             Slice,
+                                             *(shape_layer->getOutput(0)),
+                                             start_dim,
+                                             size_dim,
+                                             stride_dim);
+    uint32_t reduce_dim = 1;
+    auto* reduce_prod_layer =
+        TRT_ENGINE_ADD_LAYER(engine_,
+                             Reduce,
+                             *(slice_layer->getOutput(0)),
+                             nvinfer1::ReduceOperation::kPROD,
+                             reduce_dim,
+                             true);
+    int32_t* constant_weight_data = new int32_t[1];
+    constant_weight_data[0] = -1;
+    TensorRTEngine::Weight constant_weight{
+        nvinfer1::DataType::kINT32,
+        static_cast<void*>(constant_weight_data),
+        1};
+    nvinfer1::Dims constant_dims;
+    constant_dims.nbDims = 1;
+    constant_dims.d[0] = 1;
+    auto* constant_layer = TRT_ENGINE_ADD_LAYER(
+        engine_, Constant, constant_dims, constant_weight.get());
+    std::vector<nvinfer1::ITensor*> itensors;
+    itensors.push_back(constant_layer->getOutput(0));
+    itensors.push_back(reduce_prod_layer->getOutput(0));
+    auto* concat_layer =
+        TRT_ENGINE_ADD_LAYER(engine_, Concatenation, itensors.data(), 2);
+    concat_layer->setAxis(0);
+    layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
+    layer->setInput(1, *(concat_layer->getOutput(0)));
     auto output_name = op_desc.Output("Out")[0];
     ReplenishLayerAndOutput(layer, "flatten", {output_name}, test_mode);
   }

--- a/paddle/fluid/inference/tensorrt/convert/gelu_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/gelu_op.cc
@@ -215,24 +215,17 @@ class GeluOpConverter : public OpConverter {
       layer = y;
 #else  // if IS_TRT_VERSION_GE(7000)
       int input_num = op_desc.Input("X").size();
-      if (engine_->with_dynamic_shape()) {
 #if IS_TRT_VERSION_GE(6000)
-        bool with_fp16 =
-            engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
-        plugin::GeluPluginDynamic* plugin =
-            new plugin::GeluPluginDynamic(with_fp16);
-        layer = engine_->AddDynamicPlugin(&input, input_num, plugin);
+      bool with_fp16 =
+          engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
+      plugin::GeluPluginDynamic* plugin =
+          new plugin::GeluPluginDynamic(with_fp16);
+      layer = engine_->AddDynamicPlugin(&input, input_num, plugin);
 #else
-        PADDLE_THROW(common::errors::Fatal(
-            "You are running the TRT Dynamic Shape mode, need to confirm that "
-            "your TRT version is no less than 6.0"));
+      PADDLE_THROW(common::errors::Fatal(
+          "You are running the TRT Dynamic Shape mode, need to confirm that "
+          "your TRT version is no less than 6.0"));
 #endif
-      } else {
-        bool with_fp16 =
-            engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
-        plugin::GeluPlugin* plugin = new plugin::GeluPlugin(with_fp16);
-        layer = engine_->AddPlugin(&input, input_num, plugin);
-      }
 #endif  // if IS_TRT_VERSION_GE(7000)
     }
     auto output_name = op_desc.Output("Out")[0];

--- a/paddle/fluid/inference/tensorrt/convert/generic_and_custom_plugin_creater.cc
+++ b/paddle/fluid/inference/tensorrt/convert/generic_and_custom_plugin_creater.cc
@@ -33,11 +33,7 @@ class CustomPluginCreater : public OpConverter {
 
     std::string plugin_name;
 
-    if (engine_->with_dynamic_shape()) {
-      plugin_name = op_desc.Type() + "_paddle_trt_dynamic_plugin";
-    } else {
-      plugin_name = op_desc.Type() + "_paddle_trt_plugin";
-    }
+    plugin_name = op_desc.Type() + "_paddle_trt_dynamic_plugin";
 
     nvinfer1::ILayer *layer = nullptr;
     std::vector<nvinfer1::ITensor *> inputs;
@@ -147,15 +143,8 @@ class CustomPluginCreater : public OpConverter {
     PADDLE_ENFORCE_NOT_NULL(
         plugin, common::errors::NotFound("Sorry,create plugin failed."));
 
-    if (engine_->with_dynamic_shape()) {
-      layer =
-          engine_->AddDynamicPlugin(inputs.data(),
-                                    inputs.size(),
-                                    (plugin::DynamicPluginTensorRT *)plugin);
-    } else {
-      layer = engine_->AddPlugin(
-          inputs.data(), inputs.size(), (plugin::PluginTensorRT *)plugin);
-    }
+    layer = engine_->AddDynamicPlugin(
+        inputs.data(), inputs.size(), (plugin::DynamicPluginTensorRT *)plugin);
 
     PADDLE_ENFORCE_NOT_NULL(
         layer, common::errors::NotFound("Sorry, add plugin layer failed."));

--- a/paddle/fluid/inference/tensorrt/convert/group_norm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/group_norm_op.cc
@@ -59,48 +59,26 @@ class GroupNormOpConverter : public OpConverter {
     bool with_int8 = engine_->WithInt8();
     // when int8 is on, allow fall back to fp16
     if (with_int8) with_fp16 = true;
-    if (engine_->with_dynamic_shape()) {
-      int gn_num = groups;
-      std::vector<int64_t> mean_shape({gn_num});
-      std::vector<int64_t> variance_shape({gn_num});
-      plugin::GroupNormPluginDynamic* plugin =
-          new plugin::GroupNormPluginDynamic(
-              static_cast<const float*>(scale_weights.get().values),
-              scale_weights.get().count,
-              static_cast<const float*>(bias_weights.get().values),
-              bias_weights.get().count,
-              epsilon,
-              groups,
-              mean_shape,
-              variance_shape,
-              with_silu,
-              with_fp16,
-              with_int8);
-      nvinfer1::ILayer* groupnorm_layer =
-          engine_->AddDynamicPlugin(&input_itensor, 1, plugin);
-      auto output_name = op_desc.Output("Y")[0];
-      ReplenishLayerAndOutput(
-          groupnorm_layer, "group_norm", {output_name}, test_mode);
-    } else {
-      int gn_num = input_itensor->getDimensions().d[0] * groups;
-      std::vector<int64_t> mean_shape({gn_num});
-      std::vector<int64_t> variance_shape({gn_num});
-      plugin::GroupNormPlugin* plugin = new plugin::GroupNormPlugin(
-          static_cast<const float*>(scale_weights.get().values),
-          scale_weights.get().count,
-          static_cast<const float*>(bias_weights.get().values),
-          bias_weights.get().count,
-          epsilon,
-          groups,
-          mean_shape,
-          variance_shape,
-          with_fp16);
-      nvinfer1::ILayer* groupnorm_layer =
-          engine_->AddPlugin(&input_itensor, 1, plugin);
-      auto output_name = op_desc.Output("Y")[0];
-      ReplenishLayerAndOutput(
-          groupnorm_layer, "group_norm", {output_name}, test_mode);
-    }
+    int gn_num = groups;
+    std::vector<int64_t> mean_shape({gn_num});
+    std::vector<int64_t> variance_shape({gn_num});
+    plugin::GroupNormPluginDynamic* plugin = new plugin::GroupNormPluginDynamic(
+        static_cast<const float*>(scale_weights.get().values),
+        scale_weights.get().count,
+        static_cast<const float*>(bias_weights.get().values),
+        bias_weights.get().count,
+        epsilon,
+        groups,
+        mean_shape,
+        variance_shape,
+        with_silu,
+        with_fp16,
+        with_int8);
+    nvinfer1::ILayer* groupnorm_layer =
+        engine_->AddDynamicPlugin(&input_itensor, 1, plugin);
+    auto output_name = op_desc.Output("Y")[0];
+    ReplenishLayerAndOutput(
+        groupnorm_layer, "group_norm", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/instance_norm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/instance_norm_op.cc
@@ -60,11 +60,7 @@ class InstanceNormOpConverter : public OpConverter {
     }
 
     nvinfer1::IPluginV2* plugin = nullptr;
-    if (engine_->with_dynamic_shape()) {
-      plugin = new plugin::InstanceNormPluginDynamic(eps, scale_v, bias_v);
-    } else {
-      plugin = new plugin::InstanceNormPlugin(eps, scale_v, bias_v);
-    }
+    plugin = new plugin::InstanceNormPluginDynamic(eps, scale_v, bias_v);
 
     std::vector<nvinfer1::ITensor*> instance_norm_inputs{input};
     auto* layer = engine_->network()->addPluginV2(

--- a/paddle/fluid/inference/tensorrt/convert/layer_norm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/layer_norm_op.cc
@@ -32,138 +32,88 @@ class LayerNormOpConverter : public OpConverter {
     const float eps = op_desc.HasAttr("epsilon")
                           ? PADDLE_GET_CONST(float, op_desc.GetAttr("epsilon"))
                           : 1e-5f;
-    if (engine_->with_dynamic_shape()) {
 #if IS_TRT_VERSION_GE(8600)
-      auto* Scale = engine_->GetITensor(op_desc.Input("Scale")[0]);
-      auto* Bias = engine_->GetITensor(op_desc.Input("Bias")[0]);
-      auto rank = X->getDimensions().nbDims;
-      int32_t begin_axis =
-          op_desc.HasAttr("begin_norm_axis")
-              ? PADDLE_GET_CONST(int, op_desc.GetAttr("begin_norm_axis"))
-              : 1;
-      uint32_t axisMask{0};
-      for (int32_t i = begin_axis; i < rank; i++) {
-        axisMask |= 1 << i;
-      }
-      std::vector<int32_t> indice_dim_vec(rank);
-      std::iota(indice_dim_vec.begin(), indice_dim_vec.end(), 0);
-      auto p = std::remove_if(indice_dim_vec.begin(),
-                              indice_dim_vec.end(),
-                              [begin_axis](int x) { return x < begin_axis; });
-      indice_dim_vec.resize(p - indice_dim_vec.begin());
-      auto newDims = Gather(Shape(X), indice_dim_vec);
-      auto newrank = indice_dim_vec.size();
-      auto* one_rank_tensor =
-          Add1DConstantLayer(std::vector<int32_t>(rank - newrank, 1));
-      std::vector<nvinfer1::ITensor*> itensors;
-      itensors.push_back(one_rank_tensor);
-      itensors.push_back(newDims);
-      nvinfer1::ITensor* concat_shape_tensor = Concat(itensors);
-      auto Bias_reshape = Reshape(
-          Bias,
-          concat_shape_tensor,
-          ("layer_norm Bias: reshape: (Output(" + output_name + ")").c_str());
-      auto Scale_reshape = Reshape(
-          Scale,
-          concat_shape_tensor,
-          ("layer_norm Scale: reshape: (Output(" + output_name + ")").c_str());
-      auto layer = TRT_ENGINE_ADD_LAYER(
-          engine_, Normalization, *X, *Scale_reshape, *Bias_reshape, axisMask);
-      SupportFP32MixPrecision(output_name, op_desc.Type(), layer);
-      layer->setEpsilon(eps);
-      ReplenishLayerAndOutput(layer, "layer_norm", {output_name}, test_mode);
+    auto* Scale = engine_->GetITensor(op_desc.Input("Scale")[0]);
+    auto* Bias = engine_->GetITensor(op_desc.Input("Bias")[0]);
+    auto rank = X->getDimensions().nbDims;
+    int32_t begin_axis =
+        op_desc.HasAttr("begin_norm_axis")
+            ? PADDLE_GET_CONST(int, op_desc.GetAttr("begin_norm_axis"))
+            : 1;
+    uint32_t axisMask{0};
+    for (int32_t i = begin_axis; i < rank; i++) {
+      axisMask |= 1 << i;
+    }
+    std::vector<int32_t> indice_dim_vec(rank);
+    std::iota(indice_dim_vec.begin(), indice_dim_vec.end(), 0);
+    auto p = std::remove_if(indice_dim_vec.begin(),
+                            indice_dim_vec.end(),
+                            [begin_axis](int x) { return x < begin_axis; });
+    indice_dim_vec.resize(p - indice_dim_vec.begin());
+    auto newDims = Gather(Shape(X), indice_dim_vec);
+    auto newrank = indice_dim_vec.size();
+    auto* one_rank_tensor =
+        Add1DConstantLayer(std::vector<int32_t>(rank - newrank, 1));
+    std::vector<nvinfer1::ITensor*> itensors;
+    itensors.push_back(one_rank_tensor);
+    itensors.push_back(newDims);
+    nvinfer1::ITensor* concat_shape_tensor = Concat(itensors);
+    auto Bias_reshape = Reshape(
+        Bias,
+        concat_shape_tensor,
+        ("layer_norm Bias: reshape: (Output(" + output_name + ")").c_str());
+    auto Scale_reshape = Reshape(
+        Scale,
+        concat_shape_tensor,
+        ("layer_norm Scale: reshape: (Output(" + output_name + ")").c_str());
+    auto layer = TRT_ENGINE_ADD_LAYER(
+        engine_, Normalization, *X, *Scale_reshape, *Bias_reshape, axisMask);
+    SupportFP32MixPrecision(output_name, op_desc.Type(), layer);
+    layer->setEpsilon(eps);
+    ReplenishLayerAndOutput(layer, "layer_norm", {output_name}, test_mode);
 #endif
 #if IS_TRT_VERSION_LT(8600)
-      // For dynamic shape & trt<8.6,
-      // the shape of mean and variance will be determine in configurePlugin.
-      auto* X = engine_->GetITensor(op_desc.Input("X").front());
-      auto* Bias_v = scope.FindVar(op_desc.Input("Bias").front());
-      auto* Scale_v = scope.FindVar(op_desc.Input("Scale").front());
-      const int begin_norm_axis =
-          op_desc.HasAttr("begin_norm_axis")
-              ? PADDLE_GET_CONST(int, op_desc.GetAttr("begin_norm_axis"))
-              : 1;
-      PADDLE_ENFORCE_NOT_NULL(
-          Bias_v,
-          common::errors::InvalidArgument(
-              "Input(Bias) of layer_norm should not be null."));
-      PADDLE_ENFORCE_NOT_NULL(
-          Scale_v,
-          common::errors::InvalidArgument(
-              "Input(Scale) of layer_norm should not be null."));
-      auto* Bias_t = Bias_v->GetMutable<phi::DenseTensor>();
-      auto* Scale_t = Scale_v->GetMutable<phi::DenseTensor>();
-      auto bias_weight =
-          engine_->GetFp32TrtWeight(op_desc.Input("Bias").front(), *Bias_t);
-      auto scale_weight =
-          engine_->GetFp32TrtWeight(op_desc.Input("Scale").front(), *Scale_t);
-      nvinfer1::ILayer* layernorm_layer = nullptr;
-      std::vector<int64_t> mean_shape{1};
-      std::vector<int64_t> variance_shape{1};
-      bool with_fp16 =
-          engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
-      plugin::LayerNormPluginDynamic* plugin =
-          new plugin::LayerNormPluginDynamic(
-              static_cast<const float*>(bias_weight.get().values),
-              bias_weight.get().count,
-              static_cast<const float*>(scale_weight.get().values),
-              scale_weight.get().count,
-              begin_norm_axis,
-              eps,
-              mean_shape,
-              variance_shape,
-              with_fp16);
-      layernorm_layer = engine_->AddDynamicPlugin(&X, 1, plugin);
-      ReplenishLayerAndOutput(
-          layernorm_layer, "layer_norm", {output_name}, test_mode);
+    // For dynamic shape & trt<8.6,
+    // the shape of mean and variance will be determine in configurePlugin.
+    auto* X = engine_->GetITensor(op_desc.Input("X").front());
+    auto* Bias_v = scope.FindVar(op_desc.Input("Bias").front());
+    auto* Scale_v = scope.FindVar(op_desc.Input("Scale").front());
+    const int begin_norm_axis =
+        op_desc.HasAttr("begin_norm_axis")
+            ? PADDLE_GET_CONST(int, op_desc.GetAttr("begin_norm_axis"))
+            : 1;
+    PADDLE_ENFORCE_NOT_NULL(
+        Bias_v,
+        common::errors::InvalidArgument(
+            "Input(Bias) of layer_norm should not be null."));
+    PADDLE_ENFORCE_NOT_NULL(
+        Scale_v,
+        common::errors::InvalidArgument(
+            "Input(Scale) of layer_norm should not be null."));
+    auto* Bias_t = Bias_v->GetMutable<phi::DenseTensor>();
+    auto* Scale_t = Scale_v->GetMutable<phi::DenseTensor>();
+    auto bias_weight =
+        engine_->GetFp32TrtWeight(op_desc.Input("Bias").front(), *Bias_t);
+    auto scale_weight =
+        engine_->GetFp32TrtWeight(op_desc.Input("Scale").front(), *Scale_t);
+    nvinfer1::ILayer* layernorm_layer = nullptr;
+    std::vector<int64_t> mean_shape{1};
+    std::vector<int64_t> variance_shape{1};
+    bool with_fp16 = engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
+    plugin::LayerNormPluginDynamic* plugin = new plugin::LayerNormPluginDynamic(
+        static_cast<const float*>(bias_weight.get().values),
+        bias_weight.get().count,
+        static_cast<const float*>(scale_weight.get().values),
+        scale_weight.get().count,
+        begin_norm_axis,
+        eps,
+        mean_shape,
+        variance_shape,
+        with_fp16);
+    layernorm_layer = engine_->AddDynamicPlugin(&X, 1, plugin);
+    ReplenishLayerAndOutput(
+        layernorm_layer, "layer_norm", {output_name}, test_mode);
 #endif
-    } else {
-      auto* Bias_v = scope.FindVar(op_desc.Input("Bias")[0]);
-      auto* Scale_v = scope.FindVar(op_desc.Input("Scale")[0]);
-      PADDLE_ENFORCE_NOT_NULL(
-          Bias_v,
-          common::errors::InvalidArgument(
-              "Input(Bias) of layer_norm should not be null."));
-      PADDLE_ENFORCE_NOT_NULL(
-          Scale_v,
-          common::errors::InvalidArgument(
-              "Input(Scale) of layer_norm should not be null."));
-      auto* Bias_t = Bias_v->GetMutable<phi::DenseTensor>();
-      auto* Scale_t = Scale_v->GetMutable<phi::DenseTensor>();
-
-      auto bias_weight =
-          engine_->GetFp32TrtWeight(op_desc.Input("Bias").front(), *Bias_t);
-      auto scale_weight =
-          engine_->GetFp32TrtWeight(op_desc.Input("Scale").front(), *Scale_t);
-
-      const int begin_norm_axis =
-          op_desc.HasAttr("begin_norm_axis")
-              ? PADDLE_GET_CONST(int, op_desc.GetAttr("begin_norm_axis"))
-              : 1;
-
-      int statis_num = 1;
-      for (int i = 1; i < begin_norm_axis; i++) {
-        statis_num *= X->getDimensions().d[i];
-      }
-      std::vector<int64_t> mean_shape{statis_num};
-      std::vector<int64_t> variance_shape{statis_num};
-      bool with_fp16 =
-          engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
-      plugin::LayerNormPlugin* plugin = new plugin::LayerNormPlugin(
-          static_cast<const float*>(bias_weight.get().values),
-          bias_weight.get().count,
-          static_cast<const float*>(scale_weight.get().values),
-          scale_weight.get().count,
-          begin_norm_axis,
-          eps,
-          mean_shape,
-          variance_shape,
-          with_fp16);
-      auto* layernorm_layer = engine_->AddPlugin(
-          &X, 1, reinterpret_cast<plugin::PluginTensorRT*>(plugin));
-      ReplenishLayerAndOutput(
-          layernorm_layer, "layer_norm", {output_name}, test_mode);
-    }
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/layer_norm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/layer_norm_op.cc
@@ -75,7 +75,6 @@ class LayerNormOpConverter : public OpConverter {
 #if IS_TRT_VERSION_LT(8600)
     // For dynamic shape & trt<8.6,
     // the shape of mean and variance will be determine in configurePlugin.
-    auto* X = engine_->GetITensor(op_desc.Input("X").front());
     auto* Bias_v = scope.FindVar(op_desc.Input("Bias").front());
     auto* Scale_v = scope.FindVar(op_desc.Input("Scale").front());
     const int begin_norm_axis =

--- a/paddle/fluid/inference/tensorrt/convert/layernorm_shift_partition_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/layernorm_shift_partition_op.cc
@@ -78,22 +78,17 @@ class LayerNormShiftPartitionOpConverter : public OpConverter {
                           bias_weight.get().count,
                           scale_weight.get().count));
     nvinfer1::ILayer* layernorm_layer = nullptr;
-    if (engine_->with_dynamic_shape()) {
-      plugin::LayernormShiftPartitionPluginDynamic* plugin =
-          new plugin::LayernormShiftPartitionPluginDynamic(
-              static_cast<const float*>(scale_weight.get().values),
-              static_cast<const float*>(bias_weight.get().values),
-              bias_weight.get().count,
-              shift_size,
-              window_size,
-              input_resolution,
-              eps,
-              with_fp16);
-      layernorm_layer = engine_->AddDynamicPlugin(&X, 1, plugin);
-    } else {
-      PADDLE_THROW(common::errors::InvalidArgument(
-          "LayernormShiftPartition TRT Plugin should run in dynamic shape."));
-    }
+    plugin::LayernormShiftPartitionPluginDynamic* plugin =
+        new plugin::LayernormShiftPartitionPluginDynamic(
+            static_cast<const float*>(scale_weight.get().values),
+            static_cast<const float*>(bias_weight.get().values),
+            bias_weight.get().count,
+            shift_size,
+            window_size,
+            input_resolution,
+            eps,
+            with_fp16);
+    layernorm_layer = engine_->AddDynamicPlugin(&X, 1, plugin);
 
     auto output_name = op_desc.Output("Y").front();
     ReplenishLayerAndOutput(

--- a/paddle/fluid/inference/tensorrt/convert/mish_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/mish_op.cc
@@ -40,18 +40,10 @@ class MishOpConverter : public OpConverter {
             : 20.0f;
 
     nvinfer1::ILayer* layer = nullptr;
-    if (engine_->with_dynamic_shape()) {
-      bool with_fp16 =
-          engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
-      plugin::MishPluginDynamic* plugin =
-          new plugin::MishPluginDynamic(threshold, with_fp16);
-      layer = engine_->AddDynamicPlugin(&input, input_num, plugin);
-    } else {
-      bool with_fp16 =
-          engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
-      plugin::MishPlugin* plugin = new plugin::MishPlugin(threshold, with_fp16);
-      layer = engine_->AddPlugin(&input, input_num, plugin);
-    }
+    bool with_fp16 = engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
+    plugin::MishPluginDynamic* plugin =
+        new plugin::MishPluginDynamic(threshold, with_fp16);
+    layer = engine_->AddDynamicPlugin(&input, input_num, plugin);
 
     auto output_name = op_desc.Output("Out")[0];
     ReplenishLayerAndOutput(layer, "mish", {output_name}, test_mode);

--- a/paddle/fluid/inference/tensorrt/convert/multiclass_nms3_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/multiclass_nms3_op.cc
@@ -43,34 +43,22 @@ class MultiClassNMS3OpConverter : public OpConverter {
         PADDLE_GET_CONST(float, op_desc.GetAttr("nms_threshold"));
     int keep_top_k = PADDLE_GET_CONST(int, op_desc.GetAttr("keep_top_k"));
     bool normalized = PADDLE_GET_CONST(bool, op_desc.GetAttr("normalized"));
-    int class_index = engine_->with_dynamic_shape() ? 1 : 0;
+    int class_index = 1;
     int num_classes = scores_tensor->getDimensions().d[class_index];
 
     auto bboxes_dims = bboxes_tensor->getDimensions();
     nvinfer1::IShuffleLayer* bboxes_expand_layer = nullptr;
     nvinfer1::IShuffleLayer* scores_transpose_layer = nullptr;
-    if (engine_->with_dynamic_shape()) {
-      nvinfer1::Dims4 bboxes_expand_dims(
-          bboxes_dims.d[0], bboxes_dims.d[1], 1, bboxes_dims.d[2]);
-      bboxes_expand_layer =
-          TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *bboxes_tensor);
-      bboxes_expand_layer->setReshapeDimensions(bboxes_expand_dims);
+    nvinfer1::Dims4 bboxes_expand_dims(
+        bboxes_dims.d[0], bboxes_dims.d[1], 1, bboxes_dims.d[2]);
+    bboxes_expand_layer =
+        TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *bboxes_tensor);
+    bboxes_expand_layer->setReshapeDimensions(bboxes_expand_dims);
 
-      nvinfer1::Permutation permutation{0, 2, 1};
-      scores_transpose_layer =
-          TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *scores_tensor);
-      scores_transpose_layer->setFirstTranspose(permutation);
-    } else {
-      nvinfer1::Dims3 bboxes_expand_dims(bboxes_dims.d[0], 1, bboxes_dims.d[1]);
-      bboxes_expand_layer =
-          TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *bboxes_tensor);
-      bboxes_expand_layer->setReshapeDimensions(bboxes_expand_dims);
-
-      nvinfer1::Permutation permutation{1, 0};
-      scores_transpose_layer =
-          TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *scores_tensor);
-      scores_transpose_layer->setFirstTranspose(permutation);
-    }
+    nvinfer1::Permutation permutation{0, 2, 1};
+    scores_transpose_layer =
+        TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *scores_tensor);
+    scores_transpose_layer->setFirstTranspose(permutation);
 
     std::vector<nvinfer1::ITensor*> batch_nms_inputs;
     batch_nms_inputs.push_back(bboxes_expand_layer->getOutput(0));
@@ -104,10 +92,7 @@ class MultiClassNMS3OpConverter : public OpConverter {
         new nvinfer1::PluginFieldCollection);
     plugin_collections->nbFields = static_cast<int>(fields.size());
     plugin_collections->fields = fields.data();
-    std::string nms_plugin_name = "BatchedNMS_TRT";
-    if (engine_->with_dynamic_shape()) {
-      nms_plugin_name = "BatchedNMSDynamic_TRT";
-    }
+    std::string nms_plugin_name = "BatchedNMSDynamic_TRT";
     auto creator =
         GetPluginRegistry()->getPluginCreator(nms_plugin_name.c_str(), "1");
     auto batch_nms_plugin = creator->createPlugin(nms_plugin_name.c_str(),
@@ -126,19 +111,12 @@ class MultiClassNMS3OpConverter : public OpConverter {
         TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *nmsed_scores);
     auto nmsed_classes_reshape_layer =
         TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *nmsed_classes);
-    if (engine_->with_dynamic_shape()) {
-      nmsed_scores_transpose_layer->setReshapeDimensions(
-          nvinfer1::Dims3(bboxes_dims.d[0], keep_top_k, 1));
+    nmsed_scores_transpose_layer->setReshapeDimensions(
+        nvinfer1::Dims3(bboxes_dims.d[0], keep_top_k, 1));
 
-      nmsed_classes_reshape_layer->setReshapeDimensions(
-          nvinfer1::Dims3(bboxes_dims.d[0], keep_top_k, 1));
-    } else {
-      nmsed_scores_transpose_layer->setReshapeDimensions(
-          nvinfer1::Dims2(keep_top_k, 1));
+    nmsed_classes_reshape_layer->setReshapeDimensions(
+        nvinfer1::Dims3(bboxes_dims.d[0], keep_top_k, 1));
 
-      nmsed_classes_reshape_layer->setReshapeDimensions(
-          nvinfer1::Dims2(keep_top_k, 1));
-    }
     std::vector<nvinfer1::ITensor*> concat_inputs;
     concat_inputs.push_back(nmsed_classes_reshape_layer->getOutput(0));
     concat_inputs.push_back(nmsed_scores_transpose_layer->getOutput(0));
@@ -146,7 +124,7 @@ class MultiClassNMS3OpConverter : public OpConverter {
 
     auto nms_concat_layer = TRT_ENGINE_ADD_LAYER(
         engine_, Concatenation, concat_inputs.data(), concat_inputs.size());
-    int axis_index = engine_->with_dynamic_shape() ? 1 : 0;
+    int axis_index = 1;
     nms_concat_layer->setAxis(axis_index + 1);
 
     // add fake index as output to be consistent with the outputs of

--- a/paddle/fluid/inference/tensorrt/convert/multiclass_nms_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/multiclass_nms_op.cc
@@ -41,34 +41,22 @@ class MultiClassNMSOpConverter : public OpConverter {
         PADDLE_GET_CONST(float, op_desc.GetAttr("nms_threshold"));
     int keep_top_k = PADDLE_GET_CONST(int, op_desc.GetAttr("keep_top_k"));
     bool normalized = PADDLE_GET_CONST(bool, op_desc.GetAttr("normalized"));
-    int class_index = engine_->with_dynamic_shape() ? 1 : 0;
+    int class_index = 1;
     int num_classes = scores_tensor->getDimensions().d[class_index];
 
     auto bboxes_dims = bboxes_tensor->getDimensions();
     nvinfer1::IShuffleLayer* bboxes_expand_layer = nullptr;
     nvinfer1::IShuffleLayer* scores_transpose_layer = nullptr;
-    if (engine_->with_dynamic_shape()) {
-      nvinfer1::Dims4 bboxes_expand_dims(
-          bboxes_dims.d[0], bboxes_dims.d[1], 1, bboxes_dims.d[2]);
-      bboxes_expand_layer =
-          TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *bboxes_tensor);
-      bboxes_expand_layer->setReshapeDimensions(bboxes_expand_dims);
+    nvinfer1::Dims4 bboxes_expand_dims(
+        bboxes_dims.d[0], bboxes_dims.d[1], 1, bboxes_dims.d[2]);
+    bboxes_expand_layer =
+        TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *bboxes_tensor);
+    bboxes_expand_layer->setReshapeDimensions(bboxes_expand_dims);
 
-      nvinfer1::Permutation permutation{0, 2, 1};
-      scores_transpose_layer =
-          TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *scores_tensor);
-      scores_transpose_layer->setFirstTranspose(permutation);
-    } else {
-      nvinfer1::Dims3 bboxes_expand_dims(bboxes_dims.d[0], 1, bboxes_dims.d[1]);
-      bboxes_expand_layer =
-          TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *bboxes_tensor);
-      bboxes_expand_layer->setReshapeDimensions(bboxes_expand_dims);
-
-      nvinfer1::Permutation permutation{1, 0};
-      scores_transpose_layer =
-          TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *scores_tensor);
-      scores_transpose_layer->setFirstTranspose(permutation);
-    }
+    nvinfer1::Permutation permutation{0, 2, 1};
+    scores_transpose_layer =
+        TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *scores_tensor);
+    scores_transpose_layer->setFirstTranspose(permutation);
 
     std::vector<nvinfer1::ITensor*> batch_nms_inputs;
     batch_nms_inputs.push_back(bboxes_expand_layer->getOutput(0));
@@ -103,10 +91,7 @@ class MultiClassNMSOpConverter : public OpConverter {
     plugin_collections->nbFields = static_cast<int>(fields.size());
     plugin_collections->fields = fields.data();
 
-    std::string nms_plugin_name = "BatchedNMS_TRT";
-    if (engine_->with_dynamic_shape()) {
-      nms_plugin_name = "BatchedNMSDynamic_TRT";
-    }
+    std::string nms_plugin_name = "BatchedNMSDynamic_TRT";
     auto creator =
         GetPluginRegistry()->getPluginCreator(nms_plugin_name.c_str(), "1");
     auto batch_nms_plugin = creator->createPlugin(nms_plugin_name.c_str(),
@@ -123,19 +108,11 @@ class MultiClassNMSOpConverter : public OpConverter {
         TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *nmsed_scores);
     auto nmsed_classes_reshape_layer =
         TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *nmsed_classes);
-    if (engine_->with_dynamic_shape()) {
-      nmsed_scores_transpose_layer->setReshapeDimensions(
-          nvinfer1::Dims3(bboxes_dims.d[0], keep_top_k, 1));
+    nmsed_scores_transpose_layer->setReshapeDimensions(
+        nvinfer1::Dims3(bboxes_dims.d[0], keep_top_k, 1));
 
-      nmsed_classes_reshape_layer->setReshapeDimensions(
-          nvinfer1::Dims3(bboxes_dims.d[0], keep_top_k, 1));
-    } else {
-      nmsed_scores_transpose_layer->setReshapeDimensions(
-          nvinfer1::Dims2(keep_top_k, 1));
-
-      nmsed_classes_reshape_layer->setReshapeDimensions(
-          nvinfer1::Dims2(keep_top_k, 1));
-    }
+    nmsed_classes_reshape_layer->setReshapeDimensions(
+        nvinfer1::Dims3(bboxes_dims.d[0], keep_top_k, 1));
 
     std::vector<nvinfer1::ITensor*> concat_inputs;
     concat_inputs.push_back(nmsed_classes_reshape_layer->getOutput(0));
@@ -144,7 +121,7 @@ class MultiClassNMSOpConverter : public OpConverter {
 
     auto nms_concat_layer = TRT_ENGINE_ADD_LAYER(
         engine_, Concatenation, concat_inputs.data(), concat_inputs.size());
-    int axis_index = engine_->with_dynamic_shape() ? 1 : 0;
+    int axis_index = 1;
     nms_concat_layer->setAxis(axis_index + 1);
 
     ReplenishLayerAndOutput(

--- a/paddle/fluid/inference/tensorrt/convert/nearest_interp_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/nearest_interp_op.cc
@@ -66,7 +66,7 @@ class NearestInterpolateOpConverter : public OpConverter {
       scale_w = scale;
     } else {
       // axis are different in static/dynamic mode
-      bool with_dynamic = engine_->with_dynamic_shape();
+      bool with_dynamic = true;
 
       if (!with_dynamic) {
         int h_axis = (data_layout == phi::DataLayout::kNCHW) + with_dynamic;
@@ -79,9 +79,7 @@ class NearestInterpolateOpConverter : public OpConverter {
       }
     }
 
-    if (engine_->with_dynamic_shape()) {
-      scales.push_back(1.f);
-    }
+    scales.push_back(1.f);
 
     if (data_layout == phi::DataLayout::kNCHW) {
       scales.push_back(1.f);

--- a/paddle/fluid/inference/tensorrt/convert/nearest_interp_v2_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/nearest_interp_v2_op.cc
@@ -62,7 +62,7 @@ class NearestInterpolateV2OpConverter : public OpConverter {
 
     if (out_h > 0 && out_w > 0) {
       // axis are different in static/dynamic mode
-      bool with_dynamic = engine_->with_dynamic_shape();
+      bool with_dynamic = true;
 
       int h_axis = (data_layout == phi::DataLayout::kNCHW) + with_dynamic;
       int w_axis = (data_layout == phi::DataLayout::kNCHW) + 1 + with_dynamic;
@@ -81,8 +81,7 @@ class NearestInterpolateV2OpConverter : public OpConverter {
     // Priority: Input(SizeTensor) > attr(out_h/out_w) > attr(scale)
     nvinfer1::ITensor* outsize_tensor = nullptr;
 #if IS_TRT_VERSION_GE(8200)
-    if (engine_->with_dynamic_shape() &&
-        inputs.find("SizeTensor") != inputs.end()) {
+    if (inputs.find("SizeTensor") != inputs.end()) {
       if (op_desc.Input("SizeTensor").size() >= 2) {
         auto* outsize_h = engine_->GetITensor(op_desc.Input("SizeTensor")[0]);
         auto* outsize_w = engine_->GetITensor(op_desc.Input("SizeTensor")[1]);
@@ -92,9 +91,7 @@ class NearestInterpolateV2OpConverter : public OpConverter {
     }
 #endif
 
-    if (engine_->with_dynamic_shape()) {
-      scales.push_back(1.f);
-    }
+    scales.push_back(1.f);
 
     if (data_layout == phi::DataLayout::kNCHW) {
       scales.push_back(1.f);
@@ -110,23 +107,19 @@ class NearestInterpolateV2OpConverter : public OpConverter {
           common::errors::InvalidArgument("Data layout must be NCHW or NHWC."));
     }
 
-    if (engine_->with_dynamic_shape()) {
-      if (outsize_tensor != nullptr) {
-        std::vector<nvinfer1::ITensor*> outsize_itensors;
-        auto* input_shape = Shape(input);
-        outsize_itensors.push_back(GetEleTensorOfShape(input_shape, 0));
+    if (outsize_tensor != nullptr) {
+      std::vector<nvinfer1::ITensor*> outsize_itensors;
+      auto* input_shape = Shape(input);
+      outsize_itensors.push_back(GetEleTensorOfShape(input_shape, 0));
 
-        if (data_layout == phi::DataLayout::kNCHW) {
-          outsize_itensors.push_back(GetEleTensorOfShape(input_shape, 1));
-          outsize_itensors.push_back(outsize_tensor);
-        } else if (data_layout == phi::DataLayout::kNHWC) {
-          outsize_itensors.push_back(outsize_tensor);
-          outsize_itensors.push_back(GetEleTensorOfShape(input_shape, 3));
-        }
-        layer->setInput(1, *Concat(outsize_itensors));
-      } else {
-        layer->setScales(scales.data(), scales.size());
+      if (data_layout == phi::DataLayout::kNCHW) {
+        outsize_itensors.push_back(GetEleTensorOfShape(input_shape, 1));
+        outsize_itensors.push_back(outsize_tensor);
+      } else if (data_layout == phi::DataLayout::kNHWC) {
+        outsize_itensors.push_back(outsize_tensor);
+        outsize_itensors.push_back(GetEleTensorOfShape(input_shape, 3));
       }
+      layer->setInput(1, *Concat(outsize_itensors));
     } else {
       layer->setScales(scales.data(), scales.size());
     }

--- a/paddle/fluid/inference/tensorrt/convert/op_converter.h
+++ b/paddle/fluid/inference/tensorrt/convert/op_converter.h
@@ -369,7 +369,11 @@ class OpConverter {
             input, in_dtype, Vec2TRT_Dims(input_shape, input, true));
 #endif
       } else {
-        engine->DeclareInput(input, in_dtype, Vec2TRT_Dims(var_shape, input));
+        auto input_dims = Vec2TRT_Dims(var_shape, input);
+        if (input_dims.d[0] == -1) {
+          input_dims.d[0] = engine->get_max_batch_size();
+        }
+        engine->DeclareInput(input, in_dtype, input_dims);
       }
       VLOG(1) << "set trt engine input dtype " << static_cast<int>(in_dtype);
     }
@@ -447,11 +451,7 @@ class OpConverter {
       subscripts.insert(subscripts.begin() + axis_value, dims.nbDims);
     }
     nvinfer1::ITensor* input_shape{nullptr};
-    if (engine_->with_dynamic_shape()) {
-      input_shape = Shape(input);
-    } else {
-      input_shape = Add1DConstantLayer(dims);
-    }
+    input_shape = Shape(input);
     auto* new_dim =
         TRT_ENGINE_ADD_LAYER(engine_,
                              Gather,
@@ -476,11 +476,7 @@ class OpConverter {
     subscripts.resize(p - subscripts.begin());
 
     nvinfer1::ITensor* input_shape{nullptr};
-    if (engine_->with_dynamic_shape()) {
-      input_shape = Shape(input);
-    } else {
-      input_shape = Add1DConstantLayer(dims);
-    }
+    input_shape = Shape(input);
 
     auto* new_dim =
         TRT_ENGINE_ADD_LAYER(
@@ -505,19 +501,20 @@ class OpConverter {
   }
 
   nvinfer1::ITensor* Shape(nvinfer1::ITensor* input) {
-    return TRT_ENGINE_ADD_LAYER(engine_, Shape, *input)->getOutput(0);
+    auto* shape_tensor =
+        TRT_ENGINE_ADD_LAYER(engine_, Shape, *input)->getOutput(0);
+#if IS_TRT_VERSION_GE(10000)
+    return Cast(shape_tensor, nvinfer1::DataType::kINT32);
+#else
+    return shape_tensor;
+#endif
   }
 
   nvinfer1::ITensor* Reshape(nvinfer1::ITensor* input,
                              nvinfer1::ITensor* newShape,
                              const std::string& name = "") {
     auto* shuffle = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-    if (engine_->with_dynamic_shape()) {
-      shuffle->setInput(1, *newShape);
-    } else {
-      auto shape = newShape->getDimensions();
-      shuffle->setReshapeDimensions(shape);
-    }
+    shuffle->setInput(1, *newShape);
     if (!name.empty()) {
       shuffle->setName(name.c_str());
     }

--- a/paddle/fluid/inference/tensorrt/convert/pool2d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pool2d_op.cc
@@ -88,16 +88,12 @@ class Pool2dOpConverter : public OpConverter {
     nvinfer1::PoolingType nv_pool_type = nvinfer1::PoolingType::kMAX;
     nvinfer1::ReduceOperation reduce_operation =
         nvinfer1::ReduceOperation::kMAX;
-    plugin::PoolPlugin::PoolType plugin_pool_type =
-        plugin::PoolPlugin::PoolType::max;
     if (pool_type == "max") {
       nv_pool_type = nvinfer1::PoolingType::kMAX;
       reduce_operation = nvinfer1::ReduceOperation::kMAX;
-      plugin_pool_type = plugin::PoolPlugin::PoolType::max;
     } else if (pool_type == "avg") {
       nv_pool_type = nvinfer1::PoolingType::kAVERAGE;
       reduce_operation = nvinfer1::ReduceOperation::kAVG;
-      plugin_pool_type = plugin::PoolPlugin::PoolType::avg;
     }
     if (global_pooling || adaptive) {
       std::fill(paddings.begin(), paddings.end(), 0);

--- a/paddle/fluid/inference/tensorrt/convert/pool2d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pool2d_op.cc
@@ -170,213 +170,68 @@ class Pool2dOpConverter : public OpConverter {
       std::fill(real_paddings.begin(), real_paddings.end(), 0);
     }
 
-    if (global_pooling == true && !engine_->with_dynamic_shape()) {
-      nv_ksize.d[0] = input_shape.d[input_dims - 2];
-      nv_ksize.d[1] = input_shape.d[input_dims - 1];
-      ksize[0] = input_shape.d[input_dims - 2];
-      ksize[1] = input_shape.d[input_dims - 1];
-    }
-
-    if (engine_->with_dynamic_shape()) {
-      if (!adaptive && !global_pooling && !ceil_mode) {
-        // input_shape.d < 0 means we can't get shape info here.
-        // we may suffer from issue if shape is not met finally.
-        if ((padding_algorithm != "SAME") &&
-            ((g_post_pad.w() > 0 && input_shape.d[input_dims - 2] > 0) ||
-             (g_post_pad.h() > 0 && input_shape.d[input_dims - 1] > 0))) {
-          auto *pad_layer = TRT_ENGINE_ADD_LAYER(
-              engine_, PaddingNd, *input1, g_pre_pad, g_post_pad);
-          PADDLE_ENFORCE_NOT_NULL(
-              pad_layer,
-              common::errors::Fatal(
-                  "Pad layer in poolOp converter could not be "
-                  "created. The pointer to pad layer is `NULL`."));
-          input1 = pad_layer->getOutput(0);
-        }
-
-        auto *pool_layer = TRT_ENGINE_ADD_LAYER(
-            engine_, PoolingNd, *input1, nv_pool_type, nv_ksize);
-        pool_layer->setStrideNd(nv_strides);
-        pool_layer->setPaddingNd(nv_paddings);
-        pool_layer->setAverageCountExcludesPadding(exclusive);
-        if (padding_algorithm == "SAME") {
-          pool_layer->setPaddingMode(nvinfer1::PaddingMode::kSAME_UPPER);
-        }
-        layer = pool_layer;
-      } else if (!adaptive && !global_pooling && ceil_mode) {
-        auto *pool_layer = TRT_ENGINE_ADD_LAYER(
-            engine_, PoolingNd, *input1, nv_pool_type, nv_ksize);
-        pool_layer->setStrideNd(nv_strides);
-        pool_layer->setPaddingNd(nv_paddings);
-        pool_layer->setAverageCountExcludesPadding(exclusive);
-        if (padding_algorithm == "SAME") {
-          pool_layer->setPaddingMode(nvinfer1::PaddingMode::kSAME_UPPER);
-        } else {
-          pool_layer->setPaddingMode(nvinfer1::PaddingMode::kEXPLICIT_ROUND_UP);
-        }
-        layer = pool_layer;
-      } else if (global_pooling && !adaptive) {
-        auto *reduce_layer = TRT_ENGINE_ADD_LAYER(
-            engine_, Reduce, *input1, reduce_operation, 12, true);
-        layer = reduce_layer;
-      } else {
-#if IS_TRT_VERSION_GE(6000)
-        plugin::PoolPluginDynamic *plugin =
-            new plugin::PoolPluginDynamic(ceil_mode,
-                                          pool_type,
-                                          adaptive,
-                                          exclusive,
-                                          ksize,
-                                          strides,
-                                          paddings,
-                                          global_pooling);
-        layer = engine_->AddDynamicPlugin(&input1, 1, plugin);
-#endif
+    if (!adaptive && !global_pooling && !ceil_mode) {
+      // input_shape.d < 0 means we can't get shape info here.
+      // we may suffer from issue if shape is not met finally.
+      if ((padding_algorithm != "SAME") &&
+          ((g_post_pad.w() > 0 && input_shape.d[input_dims - 2] > 0) ||
+           (g_post_pad.h() > 0 && input_shape.d[input_dims - 1] > 0))) {
+        auto *pad_layer = TRT_ENGINE_ADD_LAYER(
+            engine_, PaddingNd, *input1, g_pre_pad, g_post_pad);
+        PADDLE_ENFORCE_NOT_NULL(
+            pad_layer,
+            common::errors::Fatal(
+                "Pad layer in poolOp converter could not be "
+                "created. The pointer to pad layer is `NULL`."));
+        input1 = pad_layer->getOutput(0);
       }
-      auto output_name = op_desc.Output("Out")[0];
-      layer->setName(("pool2d (Output: " + output_name + ")").c_str());
-      layer->getOutput(0)->setName(output_name.c_str());
-      engine_->SetITensor(output_name, layer->getOutput(0));
-      if (test_mode) {
-        engine_->DeclareOutput(output_name);
-      }
-      return;
-    }
 
-    if (global_pooling == true && adaptive == false) {
       auto *pool_layer = TRT_ENGINE_ADD_LAYER(
           engine_, PoolingNd, *input1, nv_pool_type, nv_ksize);
-      PADDLE_ENFORCE_NOT_NULL(
-          pool_layer,
-          common::errors::Fatal(
-              "trt pool layer in converter could not be created."));
-      auto output_name = op_desc.Output("Out")[0];
-      pool_layer->setName(("pool2d (Output: " + output_name + ")").c_str());
-      pool_layer->getOutput(0)->setName(output_name.c_str());
-      engine_->SetITensor(output_name, pool_layer->getOutput(0));
-      layer = pool_layer;
-      if (test_mode) {
-        engine_->DeclareOutput(output_name);
+      pool_layer->setStrideNd(nv_strides);
+      pool_layer->setPaddingNd(nv_paddings);
+      pool_layer->setAverageCountExcludesPadding(exclusive);
+      if (padding_algorithm == "SAME") {
+        pool_layer->setPaddingMode(nvinfer1::PaddingMode::kSAME_UPPER);
       }
-      return;
-    }
-
-    if (!adaptive) {
-      if (ceil_mode) {
-        if (nv_ksize.d[0] % nv_strides.d[0] == 0 &&
-            nv_ksize.d[1] % nv_strides.d[1] == 0) {
-          nvinfer1::DimsHW pre_pad(0, 0);
-          nvinfer1::DimsHW post_pad(0, 0);
-          // If ceil mode is true, we will pad the appropriate size to the
-          // input.
-          DealCeilMode(input_shape,
-                       ksize,
-                       strides,
-                       paddings,
-                       &pre_pad,
-                       &post_pad,
-                       input_dims);
-          auto *pad_layer = TRT_ENGINE_ADD_LAYER(
-              engine_, PaddingNd, *input1, pre_pad, post_pad);
-
-          PADDLE_ENFORCE_NOT_NULL(
-              pad_layer,
-              common::errors::Fatal(
-                  "Pad layer in poolOp converter could not be "
-                  "created. The pointer to pad layer is `NULL`."));
-          input1 = pad_layer->getOutput(0);
-
-          auto *pool_layer = TRT_ENGINE_ADD_LAYER(
-              engine_, PoolingNd, *input1, nv_pool_type, nv_ksize);
-          PADDLE_ENFORCE_NOT_NULL(
-              pool_layer,
-              common::errors::Fatal(
-                  "trt pool layer in converter could not be created."));
-          pool_layer->setStrideNd(nv_strides);
-          pool_layer->setPaddingNd(nv_paddings);
-          if (padding_algorithm == "SAME") {
-            pool_layer->setPaddingMode(nvinfer1::PaddingMode::kSAME_UPPER);
-          }
-          pool_layer->setAverageCountExcludesPadding(exclusive);
-          layer = pool_layer;
-        } else {
-          std::vector<int> input_shape_v;
-          for (int i = 0; i < input_dims; i++) {
-            input_shape_v.push_back(input_shape.d[i]);
-          }
-          plugin::PoolPlugin *plugin = new plugin::PoolPlugin(ceil_mode,
-                                                              plugin_pool_type,
-                                                              adaptive,
-                                                              exclusive,
-                                                              ksize,
-                                                              strides,
-                                                              paddings,
-                                                              input_shape_v,
-                                                              real_paddings);
-          auto *pool_layer = engine_->AddPlugin(&input1, 1, plugin);
-          PADDLE_ENFORCE_NOT_NULL(
-              pool_layer,
-              common::errors::Fatal(
-                  "trt pool plugin layer in converter could not be created."));
-          layer = pool_layer;
-        }
+      layer = pool_layer;
+    } else if (!adaptive && !global_pooling && ceil_mode) {
+      auto *pool_layer = TRT_ENGINE_ADD_LAYER(
+          engine_, PoolingNd, *input1, nv_pool_type, nv_ksize);
+      pool_layer->setStrideNd(nv_strides);
+      pool_layer->setPaddingNd(nv_paddings);
+      pool_layer->setAverageCountExcludesPadding(exclusive);
+      if (padding_algorithm == "SAME") {
+        pool_layer->setPaddingMode(nvinfer1::PaddingMode::kSAME_UPPER);
       } else {
-#if IS_TRT_VERSION_GE(8000)
-        // Exclude padding pixels from the average mean is not supported well by
-        // TRT
-        // so enable padding for trt8.0 above.
-        if ((g_post_pad.w() > 0 || g_post_pad.h() > 0) &&
-            (padding_algorithm != "SAME") && !ceil_mode) {
-          auto *pad_layer = TRT_ENGINE_ADD_LAYER(
-              engine_, PaddingNd, *input1, g_pre_pad, g_post_pad);
-          PADDLE_ENFORCE_NOT_NULL(
-              pad_layer,
-              common::errors::Fatal(
-                  "Pad layer in poolOp converter could not be "
-                  "created. The pointer to pad layer is `NULL`."));
-          input1 = pad_layer->getOutput(0);
-        }
-#endif
-        auto *pool_layer = TRT_ENGINE_ADD_LAYER(
-            engine_, PoolingNd, *input1, nv_pool_type, nv_ksize);
-        PADDLE_ENFORCE_NOT_NULL(
-            pool_layer,
-            common::errors::Fatal(
-                "trt pool layer in converter could not be created."));
-        pool_layer->setStrideNd(nv_strides);
-        pool_layer->setPaddingNd(nv_paddings);
-        if (padding_algorithm == "SAME") {
-          pool_layer->setPaddingMode(nvinfer1::PaddingMode::kSAME_UPPER);
-        }
-        pool_layer->setAverageCountExcludesPadding(exclusive);
-        layer = pool_layer;
+        pool_layer->setPaddingMode(nvinfer1::PaddingMode::kEXPLICIT_ROUND_UP);
       }
-    } else {
-      // Average pooling needs to exclude the padding pixels from the average
-      // mean.
-      // It is not supported well by TRT, we use a plugin here
-      std::vector<int> input_shape_v;
-      for (int i = 0; i < input_dims; i++) {
-        input_shape_v.push_back(input_shape.d[i]);
-      }
-      plugin::PoolPlugin *plugin = new plugin::PoolPlugin(ceil_mode,
-                                                          plugin_pool_type,
-                                                          adaptive,
-                                                          exclusive,
-                                                          ksize,
-                                                          strides,
-                                                          paddings,
-                                                          input_shape_v,
-                                                          real_paddings);
-      auto *pool_layer = engine_->AddPlugin(&input1, 1, plugin);
-      PADDLE_ENFORCE_NOT_NULL(
-          pool_layer,
-          common::errors::Fatal(
-              "trt pool plugin layer in converter could not be created."));
       layer = pool_layer;
+    } else if (global_pooling && !adaptive) {
+      auto *reduce_layer = TRT_ENGINE_ADD_LAYER(
+          engine_, Reduce, *input1, reduce_operation, 12, true);
+      layer = reduce_layer;
+    } else {
+#if IS_TRT_VERSION_GE(6000)
+      plugin::PoolPluginDynamic *plugin =
+          new plugin::PoolPluginDynamic(ceil_mode,
+                                        pool_type,
+                                        adaptive,
+                                        exclusive,
+                                        ksize,
+                                        strides,
+                                        paddings,
+                                        global_pooling);
+      layer = engine_->AddDynamicPlugin(&input1, 1, plugin);
+#endif
     }
     auto output_name = op_desc.Output("Out")[0];
-    ReplenishLayerAndOutput(layer, "pool2d", {output_name}, test_mode);
+    layer->setName(("pool2d (Output: " + output_name + ")").c_str());
+    layer->getOutput(0)->setName(output_name.c_str());
+    engine_->SetITensor(output_name, layer->getOutput(0));
+    if (test_mode) {
+      engine_->DeclareOutput(output_name);
+    }
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/pool3d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pool3d_op.cc
@@ -67,8 +67,6 @@ class Pool3dOpConverter : public OpConverter {
     VLOG(3) << "convert a pool3d op to tensorrt pool3d layer without bias";
     framework::OpDesc op_desc(op, nullptr);
     auto *input1 = engine_->GetITensor(op_desc.Input("X")[0]);
-    nvinfer1::Dims input_shape = input1->getDimensions();
-    int input_dims = input_shape.nbDims;
 
     bool global_pooling =
         PADDLE_GET_CONST(bool, op_desc.GetAttr("global_pooling"));
@@ -98,16 +96,12 @@ class Pool3dOpConverter : public OpConverter {
     nvinfer1::PoolingType nv_pool_type = nvinfer1::PoolingType::kMAX;
     nvinfer1::ReduceOperation reduce_operation =
         nvinfer1::ReduceOperation::kMAX;
-    plugin::Pool3DPlugin::Pool3DType plugin_pool_type =
-        plugin::Pool3DPlugin::Pool3DType::max;
     if (pool_type == "max") {
       nv_pool_type = nvinfer1::PoolingType::kMAX;
       reduce_operation = nvinfer1::ReduceOperation::kMAX;
-      plugin_pool_type = plugin::Pool3DPlugin::Pool3DType::max;
     } else if (pool_type == "avg") {
       nv_pool_type = nvinfer1::PoolingType::kAVERAGE;
       reduce_operation = nvinfer1::ReduceOperation::kAVG;
-      plugin_pool_type = plugin::Pool3DPlugin::Pool3DType::avg;
     }
     nvinfer1::Dims3 nv_ksize(ksize[0], ksize[1], ksize[2]);
     nvinfer1::Dims3 nv_strides(strides[0], strides[1], strides[2]);

--- a/paddle/fluid/inference/tensorrt/convert/pool3d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pool3d_op.cc
@@ -125,109 +125,35 @@ class Pool3dOpConverter : public OpConverter {
       engine_->SetTensorDynamicRange(input1, input_scale);
     }
 
-    if (engine_->with_dynamic_shape()) {
-      if (!adaptive && !global_pooling && !ceil_mode) {
-        auto *pool_layer = TRT_ENGINE_ADD_LAYER(
-            engine_, PoolingNd, *input1, nv_pool_type, nv_ksize);
-        pool_layer->setStrideNd(nv_strides);
-        pool_layer->setPaddingNd(nv_paddings);
-        pool_layer->setAverageCountExcludesPadding(exclusive);
-        layer = pool_layer;
-      } else if (global_pooling) {
-        auto *reduce_layer = TRT_ENGINE_ADD_LAYER(
-            engine_, Reduce, *input1, reduce_operation, 28, true);
-        layer = reduce_layer;
-      } else {
-        plugin::Pool3DPluginDynamic *plugin =
-            new plugin::Pool3DPluginDynamic(ceil_mode,
-                                            pool_type,
-                                            adaptive,
-                                            ksize,
-                                            strides,
-                                            paddings,
-                                            global_pooling);
-        layer = engine_->AddDynamicPlugin(&input1, 1, plugin);
-      }
-      auto output_name = op_desc.Output("Out")[0];
-      layer->setName(("pool3d (Output: " + output_name + ")").c_str());
-      layer->getOutput(0)->setName(output_name.c_str());
-      engine_->SetITensor(output_name, layer->getOutput(0));
-      if (test_mode) {
-        engine_->DeclareOutput(output_name);
-      }
-      return;
-    }
-
-    if (global_pooling == true) {
-      auto *reduce_layer = TRT_ENGINE_ADD_LAYER(
-          engine_, Reduce, *input1, reduce_operation, 14, true);
-      layer = reduce_layer;
-      auto output_name = op_desc.Output("Out")[0];
-      layer->setName(("pool3d (Output: " + output_name + ")").c_str());
-      layer->getOutput(0)->setName(output_name.c_str());
-      engine_->SetITensor(output_name, layer->getOutput(0));
-      if (test_mode) {
-        engine_->DeclareOutput(output_name);
-      }
-      return;
-    }
-
-    if (!adaptive) {
-      if (!ceil_mode) {
-        auto *pool_layer = TRT_ENGINE_ADD_LAYER(
-            engine_, PoolingNd, *input1, nv_pool_type, nv_ksize);
-        PADDLE_ENFORCE_NOT_NULL(
-            pool_layer,
-            common::errors::Fatal(
-                "trt pool layer in converter could not be created."));
-        pool_layer->setStrideNd(nv_strides);
-        pool_layer->setPaddingNd(nv_paddings);
-        pool_layer->setAverageCountExcludesPadding(exclusive);
-        layer = pool_layer;
-      } else {
-        std::vector<int> input_shape_v;
-        for (int i = 0; i < input_dims; i++) {
-          input_shape_v.push_back(input_shape.d[i]);
-        }
-        plugin::Pool3DPlugin *plugin =
-            new plugin::Pool3DPlugin(ceil_mode,
-                                     plugin_pool_type,
-                                     adaptive,
-                                     ksize,
-                                     strides,
-                                     paddings,
-                                     input_shape_v);
-        auto *pool_layer = engine_->AddPluginV2Ext(&input1, 1, plugin);
-        PADDLE_ENFORCE_NOT_NULL(
-            pool_layer,
-            common::errors::Fatal(
-                "trt pool3d plugin layer in converter could not be created."));
-        layer = pool_layer;
-      }
-    } else {
-      // Average pooling needs to exclude the padding pixels from the average
-      // mean.
-      // It is not supported well by TRT, we use a plugin here.
-      std::vector<int> input_shape_v;
-      for (int i = 0; i < input_dims; i++) {
-        input_shape_v.push_back(input_shape.d[i]);
-      }
-      plugin::Pool3DPlugin *plugin = new plugin::Pool3DPlugin(ceil_mode,
-                                                              plugin_pool_type,
-                                                              adaptive,
-                                                              ksize,
-                                                              strides,
-                                                              paddings,
-                                                              input_shape_v);
-      auto *pool_layer = engine_->AddPluginV2Ext(&input1, 1, plugin);
-      PADDLE_ENFORCE_NOT_NULL(
-          pool_layer,
-          common::errors::Fatal(
-              "trt pool3d plugin layer in converter could not be created."));
+    if (!adaptive && !global_pooling && !ceil_mode) {
+      auto *pool_layer = TRT_ENGINE_ADD_LAYER(
+          engine_, PoolingNd, *input1, nv_pool_type, nv_ksize);
+      pool_layer->setStrideNd(nv_strides);
+      pool_layer->setPaddingNd(nv_paddings);
+      pool_layer->setAverageCountExcludesPadding(exclusive);
       layer = pool_layer;
+    } else if (global_pooling) {
+      auto *reduce_layer = TRT_ENGINE_ADD_LAYER(
+          engine_, Reduce, *input1, reduce_operation, 28, true);
+      layer = reduce_layer;
+    } else {
+      plugin::Pool3DPluginDynamic *plugin =
+          new plugin::Pool3DPluginDynamic(ceil_mode,
+                                          pool_type,
+                                          adaptive,
+                                          ksize,
+                                          strides,
+                                          paddings,
+                                          global_pooling);
+      layer = engine_->AddDynamicPlugin(&input1, 1, plugin);
     }
     auto output_name = op_desc.Output("Out")[0];
-    ReplenishLayerAndOutput(layer, "pool3d", {output_name}, test_mode);
+    layer->setName(("pool3d (Output: " + output_name + ")").c_str());
+    layer->getOutput(0)->setName(output_name.c_str());
+    engine_->SetITensor(output_name, layer->getOutput(0));
+    if (test_mode) {
+      engine_->DeclareOutput(output_name);
+    }
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/preln_groupnorm_act_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/preln_groupnorm_act_op.cc
@@ -58,25 +58,23 @@ class PrelnGroupnormActOpConverter : public OpConverter {
     auto bias_weights = GetWeight(bias_name, &bias_dims);
     bool with_fp16 = engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
 
-    if (engine_->with_dynamic_shape()) {
-      plugin::PrelnGroupnormActPluginDynamic* plugin =
-          new plugin::PrelnGroupnormActPluginDynamic(
-              static_cast<const float*>(scale_weights.get().values),
-              scale_weights.get().count,
-              static_cast<const float*>(bias_weights.get().values),
-              bias_weights.get().count,
-              epsilon,
-              groups,
-              with_silu,
-              with_fp16);
-      nvinfer1::ILayer* groupnorm_layer =
-          engine_->AddDynamicPlugin(inputs.data(), 2, plugin);
-      std::vector<std::string> output_names;
-      output_names.emplace_back(op_desc.Output("Out_0").front());
-      output_names.emplace_back(op_desc.Output("Out_1").front());
-      ReplenishLayerAndOutput(
-          groupnorm_layer, "preln_groupnorm_act", output_names, test_mode);
-    }
+    plugin::PrelnGroupnormActPluginDynamic* plugin =
+        new plugin::PrelnGroupnormActPluginDynamic(
+            static_cast<const float*>(scale_weights.get().values),
+            scale_weights.get().count,
+            static_cast<const float*>(bias_weights.get().values),
+            bias_weights.get().count,
+            epsilon,
+            groups,
+            with_silu,
+            with_fp16);
+    nvinfer1::ILayer* groupnorm_layer =
+        engine_->AddDynamicPlugin(inputs.data(), 2, plugin);
+    std::vector<std::string> output_names;
+    output_names.emplace_back(op_desc.Output("Out_0").front());
+    output_names.emplace_back(op_desc.Output("Out_1").front());
+    ReplenishLayerAndOutput(
+        groupnorm_layer, "preln_groupnorm_act", output_names, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/preln_layernorm_shift_partition_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/preln_layernorm_shift_partition_op.cc
@@ -58,20 +58,18 @@ class PrelnLayerNormShiftPartitionOpConverter : public OpConverter {
         engine_->GetFp32TrtWeight(op_desc.Input("Scale").front(), *Scale_t);
     bool with_fp16 = engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
     nvinfer1::ILayer* layernorm_layer = nullptr;
-    if (engine_->with_dynamic_shape()) {
-      plugin::PrelnLnormShiftPartitionPluginDynamic* plugin =
-          new plugin::PrelnLnormShiftPartitionPluginDynamic(
-              static_cast<const float*>(scale_weight.get().values),
-              static_cast<const float*>(bias_weight.get().values),
-              bias_weight.get().count,
-              shift_size,
-              window_size,
-              input_resolution,
-              eps,
-              with_fp16);
-      layernorm_layer =
-          engine_->AddDynamicPlugin(inputs.data(), inputs.size(), plugin);
-    }
+    plugin::PrelnLnormShiftPartitionPluginDynamic* plugin =
+        new plugin::PrelnLnormShiftPartitionPluginDynamic(
+            static_cast<const float*>(scale_weight.get().values),
+            static_cast<const float*>(bias_weight.get().values),
+            bias_weight.get().count,
+            shift_size,
+            window_size,
+            input_resolution,
+            eps,
+            with_fp16);
+    layernorm_layer =
+        engine_->AddDynamicPlugin(inputs.data(), inputs.size(), plugin);
 
     std::vector<std::string> output_names;
     output_names.emplace_back(op_desc.Output("Out_0").front());

--- a/paddle/fluid/inference/tensorrt/convert/reduce_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/reduce_op.cc
@@ -77,7 +77,6 @@ class ReduceOpConverter : public OpConverter {
           if (x < 0) {
             res |= 1 << (x + input_dims);
           } else {
-            if (!engine_->with_dynamic_shape()) x = x - 1;
             res |= 1 << x;
           }
         }
@@ -193,7 +192,6 @@ class ReduceAnyOpConverter : public ReduceOpConverter {
           if (x < 0) {
             res |= 1 << (x + input_dims);
           } else {
-            if (!engine_->with_dynamic_shape()) x = x - 1;
             res |= 1 << x;
           }
         }

--- a/paddle/fluid/inference/tensorrt/convert/scale_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/scale_op.cc
@@ -41,125 +41,45 @@ class ScaleOpConverter : public OpConverter {
     float scale = PADDLE_GET_CONST(float, op_desc.GetAttr("scale"));
     bool is_int = input->getType() == nvinfer1::DataType::kINT32;
     nvinfer1::ILayer* layer = nullptr;
-    if (engine_->with_dynamic_shape()) {
-      nvinfer1::ITensor* bias_tensor =
-          is_int ? Add1DConstantLayer(
-                       static_cast<int>(bias > 0 ? bias + 0.5 : bias - 0.5))
-                 : Add1DConstantLayer(bias);
-      bool is_bias_0 = bias == 0;
+    nvinfer1::ITensor* bias_tensor =
+        is_int ? Add1DConstantLayer(
+                     static_cast<int>(bias > 0 ? bias + 0.5 : bias - 0.5))
+               : Add1DConstantLayer(bias);
+    bool is_bias_0 = bias == 0;
 
-      std::vector<int32_t> bias_shapes(input->getDimensions().nbDims, 1);
-      auto* bias_shapes_tensor = Add1DConstantLayer(bias_shapes);
-      auto* reshape_layer_bias =
-          TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *bias_tensor);
-      reshape_layer_bias->setInput(1, *bias_shapes_tensor);
+    std::vector<int32_t> bias_shapes(input->getDimensions().nbDims, 1);
+    auto* bias_shapes_tensor = Add1DConstantLayer(bias_shapes);
+    auto* reshape_layer_bias =
+        TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *bias_tensor);
+    reshape_layer_bias->setInput(1, *bias_shapes_tensor);
 
-      bool has_scale_tensor;
-      nvinfer1::ITensor* scale_tensor;
-      bool is_scale_1;
+    bool has_scale_tensor;
+    nvinfer1::ITensor* scale_tensor;
+    bool is_scale_1;
 
-      auto scale_inputs = op_desc.Inputs();
-      if (scale_inputs.find("ScaleTensor") != scale_inputs.end() &&
-          !op_desc.Input("ScaleTensor").empty()) {  // has EndsTensor input
-        has_scale_tensor = true;
-        scale_tensor = engine_->GetITensor(op_desc.Input("ScaleTensor")[0]);
-        is_scale_1 = false;
-      } else {
-        has_scale_tensor = false;
-        scale_tensor = is_int ? Add1DConstantLayer(static_cast<int>(
-                                    scale > 0 ? scale + 0.5 : scale - 0.5))
-                              : Add1DConstantLayer(scale);
-        is_scale_1 = scale == 1;
-      }
-
-      std::vector<int32_t> scale_shapes(input->getDimensions().nbDims, 1);
-      auto* scale_shapes_tensor = Add1DConstantLayer(scale_shapes);
-      auto* reshape_layer_scale =
-          TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *scale_tensor);
-      reshape_layer_scale->setInput(1, *scale_shapes_tensor);
-
-      if (!has_scale_tensor && is_scale_1 && is_bias_0) {
-        layer = TRT_ENGINE_ADD_LAYER(engine_, Identity, *input);
-      } else {
-        if (bias_after_scale) {
-          if (!is_scale_1) {
-            layer = TRT_ENGINE_ADD_LAYER(engine_,
-                                         ElementWise,
-                                         *input,
-                                         *reshape_layer_scale->getOutput(0),
-                                         nvinfer1::ElementWiseOperation::kPROD);
-            input = layer->getOutput(0);
-          }
-          if (!is_bias_0) {
-            layer = TRT_ENGINE_ADD_LAYER(engine_,
-                                         ElementWise,
-                                         *input,
-                                         *reshape_layer_bias->getOutput(0),
-                                         nvinfer1::ElementWiseOperation::kSUM);
-          }
-        } else {
-          if (!is_bias_0) {
-            layer = TRT_ENGINE_ADD_LAYER(engine_,
-                                         ElementWise,
-                                         *input,
-                                         *reshape_layer_bias->getOutput(0),
-                                         nvinfer1::ElementWiseOperation::kSUM);
-            input = layer->getOutput(0);
-          }
-          if (!is_scale_1) {
-            layer = TRT_ENGINE_ADD_LAYER(engine_,
-                                         ElementWise,
-                                         *input,
-                                         *reshape_layer_scale->getOutput(0),
-                                         nvinfer1::ElementWiseOperation::kPROD);
-          }
-        }
-      }
+    auto scale_inputs = op_desc.Inputs();
+    if (scale_inputs.find("ScaleTensor") != scale_inputs.end() &&
+        !op_desc.Input("ScaleTensor").empty()) {  // has EndsTensor input
+      has_scale_tensor = true;
+      scale_tensor = engine_->GetITensor(op_desc.Input("ScaleTensor")[0]);
+      is_scale_1 = false;
     } else {
-      auto create_weights = [&](float data, std::string type) -> float* {
-        std::unique_ptr<phi::DenseTensor> tmp_tensor(new phi::DenseTensor());
-        tmp_tensor->Resize({1});
-        auto* tmp_data = tmp_tensor->mutable_data<float>(phi::CPUPlace());
-        tmp_data[0] = data;
-        engine_->SetWeights(out_name + "_scale_op_" + type,
-                            std::move(tmp_tensor));
-        return tmp_data;
-      };
+      has_scale_tensor = false;
+      scale_tensor = is_int ? Add1DConstantLayer(static_cast<int>(
+                                  scale > 0 ? scale + 0.5 : scale - 0.5))
+                            : Add1DConstantLayer(scale);
+      is_scale_1 = scale == 1;
+    }
 
-      float* bias_ptr = create_weights(bias, "bias");
-      float* scale_ptr = create_weights(scale, "scale");
+    std::vector<int32_t> scale_shapes(input->getDimensions().nbDims, 1);
+    auto* scale_shapes_tensor = Add1DConstantLayer(scale_shapes);
+    auto* reshape_layer_scale =
+        TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *scale_tensor);
+    reshape_layer_scale->setInput(1, *scale_shapes_tensor);
 
-      TensorRTEngine::Weight scale_weights{
-          nvinfer1::DataType::kFLOAT, static_cast<void*>(scale_ptr), 1};
-      TensorRTEngine::Weight shift_weights{
-          nvinfer1::DataType::kFLOAT, static_cast<void*>(bias_ptr), 1};
-      TensorRTEngine::Weight power_weights{
-          nvinfer1::DataType::kFLOAT, nullptr, 0};
-
-      auto input_dim = input->getDimensions();
-
-      nvinfer1::IShuffleLayer* expand_layer = nullptr;
-      nvinfer1::IShuffleLayer* squeeze_layer = nullptr;
-
-      if (input_dim.nbDims < 3) {
-        nvinfer1::Dims expand_shape;
-        expand_shape.nbDims = 3;
-        for (int i = 0; i < 3; i++) {
-          if (i < input_dim.nbDims) {
-            expand_shape.d[i] = input_dim.d[i] < 0 ? 0 : input_dim.d[i];
-          } else {
-            expand_shape.d[i] = 1;
-          }
-        }
-        expand_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-        expand_layer->setReshapeDimensions(expand_shape);
-        input = expand_layer->getOutput(0);
-        expand_layer->getOutput(0)->setName(
-            ("before_reshape_out: " + out_name).c_str());
-        expand_layer->setName(
-            ("Scale: before_reshape (Output: " + out_name + ")").c_str());
-      }
-
+    if (!has_scale_tensor && is_scale_1 && is_bias_0) {
+      layer = TRT_ENGINE_ADD_LAYER(engine_, Identity, *input);
+    } else {
       if (bias_after_scale) {
         layer = TRT_ENGINE_ADD_LAYER(engine_,
                                      Scale,
@@ -208,14 +128,6 @@ class ScaleOpConverter : public OpConverter {
         for (int i = 0; i < squeeze_shape.nbDims; i++) {
           squeeze_shape.d[i] = input_dim.d[i] < 0 ? 0 : input_dim.d[i];
         }
-        squeeze_layer =
-            TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *(layer->getOutput(0)));
-        squeeze_layer->setReshapeDimensions(squeeze_shape);
-        layer = static_cast<nvinfer1::ILayer*>(squeeze_layer);
-        layer->getOutput(0)->setName(
-            ("after_reshape_out: " + out_name).c_str());
-        layer->setName(
-            ("Scale: Shuffle_reshape (Output: " + out_name + ")").c_str());
       }
     }
     ReplenishLayerAndOutput(layer, "scale", {out_name}, test_mode);

--- a/paddle/fluid/inference/tensorrt/convert/shape_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/shape_op.cc
@@ -29,6 +29,13 @@ class ShapeOpConverter : public OpConverter {
     // Declare inputs
     auto* input = engine_->GetITensor(op_desc.Input("Input")[0]);
     nvinfer1::ILayer* layer = TRT_ENGINE_ADD_LAYER(engine_, Shape, *input);
+#if IS_TRT_VERSION_GE(10000)
+    auto* cast_layer =
+        TRT_ENGINE_ADD_LAYER(engine_, Identity, *layer->getOutput(0));
+    cast_layer->setOutputType(0, nvinfer1::DataType::kINT32);
+    cast_layer->getOutput(0)->setType(nvinfer1::DataType::kINT32);
+    layer = cast_layer;
+#endif
     auto output_name = op_desc.Output("Out")[0];
     ReplenishLayerAndOutput(layer, "shape", {output_name}, test_mode);
   }

--- a/paddle/fluid/inference/tensorrt/convert/shuffle_channel_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/shuffle_channel_op.cc
@@ -30,58 +30,37 @@ class ShuffleChannelOpConverter : public OpConverter {
     framework::OpDesc op_desc(op, nullptr);
     // Declare inputs
     auto* input = engine_->GetITensor(op_desc.Input("X")[0]);
-    auto input_dims = input->getDimensions();
     auto output_name = op_desc.Output("Out")[0];
     int group = PADDLE_GET_CONST(int, op_desc.GetAttr("group"));
 
 #if IS_TRT_VERSION_GE(8000)
-    if (engine_->with_dynamic_shape()) {
-      auto* input_shape_tensor = Shape(input);
-      auto* batch_shape_tensor = GetEleTensorOfShape(input_shape_tensor, 0);
-      auto* channel_shape_tensor = GetEleTensorOfShape(input_shape_tensor, 1);
-      auto* group_tensor =
-          Add1DConstantLayer(group, output_name + "_group_tensor_");
-      auto* new_channel_shape_tensor = Div(channel_shape_tensor, group_tensor);
-      std::vector<int32_t> shape_dim2{2, 3};
-      auto* shape_dim2_tensor = Gather(input_shape_tensor, shape_dim2);
+    auto* input_shape_tensor = Shape(input);
+    auto* batch_shape_tensor = GetEleTensorOfShape(input_shape_tensor, 0);
+    auto* channel_shape_tensor = GetEleTensorOfShape(input_shape_tensor, 1);
+    auto* group_tensor =
+        Add1DConstantLayer(group, output_name + "_group_tensor_");
+    auto* new_channel_shape_tensor = Div(channel_shape_tensor, group_tensor);
+    std::vector<int32_t> shape_dim2{2, 3};
+    auto* shape_dim2_tensor = Gather(input_shape_tensor, shape_dim2);
 
-      std::vector<nvinfer1::ITensor*> itensors;
-      itensors.push_back(batch_shape_tensor);
-      itensors.push_back(group_tensor);
-      itensors.push_back(new_channel_shape_tensor);
-      itensors.push_back(shape_dim2_tensor);
-      auto* reshape_tensor = Concat(itensors);
+    std::vector<nvinfer1::ITensor*> itensors;
+    itensors.push_back(batch_shape_tensor);
+    itensors.push_back(group_tensor);
+    itensors.push_back(new_channel_shape_tensor);
+    itensors.push_back(shape_dim2_tensor);
+    auto* reshape_tensor = Concat(itensors);
 
-      auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-      layer->setInput(1, *(reshape_tensor));
-      nvinfer1::Permutation transpose_embed{0, 2, 1, 3, 4};
-      layer->setSecondTranspose(transpose_embed);
-      auto* output = layer->getOutput(0);
-      auto* output_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *output);
-      output_layer->setInput(1, *input_shape_tensor);
+    auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
+    layer->setInput(1, *(reshape_tensor));
+    nvinfer1::Permutation transpose_embed{0, 2, 1, 3, 4};
+    layer->setSecondTranspose(transpose_embed);
+    auto* output = layer->getOutput(0);
+    auto* output_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *output);
+    output_layer->setInput(1, *input_shape_tensor);
 
-      ReplenishLayerAndOutput(
-          output_layer, "shuffle_channel", {output_name}, test_mode);
-    }
+    ReplenishLayerAndOutput(
+        output_layer, "shuffle_channel", {output_name}, test_mode);
 #endif
-    if (!engine_->with_dynamic_shape()) {
-      int c = input_dims.d[0];
-      int h = input_dims.d[1];
-      int w = input_dims.d[2];
-
-      auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-      nvinfer1::Dims4 reshape_dim(group, c / group, h, w);
-      layer->setReshapeDimensions(reshape_dim);
-      layer->setSecondTranspose({1, 0, 2, 3});
-      auto* output = layer->getOutput(0);
-
-      auto* reshape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *output);
-      nvinfer1::Dims3 reshape_dim2(c, h, w);
-      reshape_layer->setReshapeDimensions(reshape_dim2);
-
-      ReplenishLayerAndOutput(
-          reshape_layer, "shuffle_channel", {output_name}, test_mode);
-    }
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/skip_groupnorm_act_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/skip_groupnorm_act_op.cc
@@ -55,22 +55,20 @@ class SkipGroupnormActOpConverter : public OpConverter {
     auto bias_weights = GetWeight(bias_name, &bias_dims);
     bool with_fp16 = engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
 
-    if (engine_->with_dynamic_shape()) {
-      plugin::SkipGroupnormActPluginDynamic* plugin =
-          new plugin::SkipGroupnormActPluginDynamic(
-              static_cast<const float*>(scale_weights.get().values),
-              scale_weights.get().count,
-              static_cast<const float*>(bias_weights.get().values),
-              bias_weights.get().count,
-              epsilon,
-              groups,
-              with_fp16);
-      nvinfer1::ILayer* groupnorm_layer =
-          engine_->AddDynamicPlugin(inputs.data(), 2, plugin);
-      auto output_name = op_desc.Output("Out")[0];
-      ReplenishLayerAndOutput(
-          groupnorm_layer, "skip_groupnorm_act", {output_name}, test_mode);
-    }
+    plugin::SkipGroupnormActPluginDynamic* plugin =
+        new plugin::SkipGroupnormActPluginDynamic(
+            static_cast<const float*>(scale_weights.get().values),
+            scale_weights.get().count,
+            static_cast<const float*>(bias_weights.get().values),
+            bias_weights.get().count,
+            epsilon,
+            groups,
+            with_fp16);
+    nvinfer1::ILayer* groupnorm_layer =
+        engine_->AddDynamicPlugin(inputs.data(), 2, plugin);
+    auto output_name = op_desc.Output("Out")[0];
+    ReplenishLayerAndOutput(
+        groupnorm_layer, "skip_groupnorm_act", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/slice_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/slice_op.cc
@@ -44,22 +44,28 @@ class SliceOpConverter : public OpConverter {
     auto input_dims = input->getDimensions();
     nvinfer1::ILayer* layer = nullptr;
 
-    if (engine_->with_dynamic_shape()) {
-      auto* shape_tensor = Shape(input);
-      nvinfer1::Dims trt_start_dims;
-      trt_start_dims.nbDims = input_dims.nbDims;
-      memset(trt_start_dims.d, 0, sizeof(int32_t) * input_dims.nbDims);
-      nvinfer1::Dims trt_size_dims = trt_start_dims;
-      nvinfer1::Dims trt_step_dims = trt_start_dims;
-      for (int i = 0; i < trt_step_dims.nbDims; i++) trt_step_dims.d[i] = 1;
-      nvinfer1::ITensor* start_tensor = nullptr;
-      nvinfer1::ITensor* end_tensor = nullptr;
+    auto* shape_tensor = Shape(input);
+    nvinfer1::Dims trt_start_dims;
+    trt_start_dims.nbDims = input_dims.nbDims;
+    memset(trt_start_dims.d, 0, sizeof(int32_t) * input_dims.nbDims);
+    nvinfer1::Dims trt_size_dims = trt_start_dims;
+    nvinfer1::Dims trt_step_dims = trt_start_dims;
+    for (int i = 0; i < trt_step_dims.nbDims; i++) trt_step_dims.d[i] = 1;
+    nvinfer1::ITensor* start_tensor = nullptr;
+    nvinfer1::ITensor* end_tensor = nullptr;
 
-      std::vector<nvinfer1::ITensor*> starts_tensor;
-      std::vector<nvinfer1::ITensor*> ends_tensor;
-      for (int32_t i = 0; i < input_dims.nbDims; ++i) {
-        starts_tensor.push_back(Add1DConstantLayer(0));
-        ends_tensor.push_back(GetEleTensorOfShape(shape_tensor, i));
+    std::vector<nvinfer1::ITensor*> starts_tensor;
+    std::vector<nvinfer1::ITensor*> ends_tensor;
+    for (int32_t i = 0; i < input_dims.nbDims; ++i) {
+      starts_tensor.push_back(Add1DConstantLayer(0));
+      ends_tensor.push_back(GetEleTensorOfShape(shape_tensor, i));
+    }
+    auto slice_inputs = op_desc.Inputs();
+    if (slice_inputs.find("StartsTensor") != slice_inputs.end() &&
+        !op_desc.Input("StartsTensor").empty()) {  // has StartsTensor input
+      for (size_t i = 0; i < axes.size(); ++i) {
+        starts_tensor[axes[i]] = GetEleTensorOfShape(
+            engine_->GetITensor(op_desc.Input("StartsTensor")[0]), i);
       }
       auto slice_inputs = op_desc.Inputs();
       if (slice_inputs.find("StartsTensor") != slice_inputs.end() &&
@@ -153,20 +159,58 @@ class SliceOpConverter : public OpConverter {
         layer->setInput(1, *real_size_tensor);
       }
     } else {
-      // notice that input shape is [CHW] without batch axis when input has
-      // static shape
-      for (size_t i = input_dims.nbDims; i > 0; i--) {
-        input_dims.d[i] = input_dims.d[i - 1];
-      }
-      input_dims.d[0] = 1;  // fake batchsize, not useful here
-      for (size_t i = 0; i < axes.size(); i++) {
+      PADDLE_ENFORCE_EQ(
+          starts.size(),
+          axes.size(),
+          phi::errors::InvalidArgument("The size of this starts: %d must be "
+                                       "equal to the axes: %d.",
+                                       starts.size(),
+                                       axes.size()));
+      for (size_t i = 0; i < axes.size(); i++) {  // same as starts.size()
         if (starts[i] < 0) {
-          starts[i] =
-              std::max(starts[i] + static_cast<int>(input_dims.d[axes[i]]), 0);
+          starts_tensor[axes[i]] =
+              Max(Sum(Add1DConstantLayer(starts[i]),
+                      GetEleTensorOfShape(shape_tensor, axes[i])),
+                  Add1DConstantLayer(0));
+        } else {
+          starts_tensor[axes[i]] =
+              Min(Add1DConstantLayer(starts[i]),
+                  GetEleTensorOfShape(shape_tensor, axes[i]));
         }
+      }
+    }
+    start_tensor = Concat(starts_tensor);
+
+    if (slice_inputs.find("EndsTensor") != slice_inputs.end() &&
+        !op_desc.Input("EndsTensor").empty()) {  // has EndsTensor input
+      for (size_t i = 0; i < axes.size(); ++i) {
+        ends_tensor[axes[i]] = GetEleTensorOfShape(
+            engine_->GetITensor(op_desc.Input("EndsTensor")[0]), i);
+      }
+    } else if (slice_inputs.find("EndsTensorList") != slice_inputs.end() &&
+               !op_desc.Input("EndsTensorList").empty()) {
+      for (size_t i = 0; i < axes.size(); ++i) {
+        ends_tensor[axes[i]] =
+            engine_->GetITensor(op_desc.Input("EndsTensorList")[i]);
+      }
+    } else {
+      PADDLE_ENFORCE_EQ(
+          ends.size(),
+          axes.size(),
+          phi::errors::InvalidArgument("The size of this ends: %d must be "
+                                       "equal to the axes: %d.",
+                                       ends.size(),
+                                       axes.size()));
+      for (size_t i = 0; i < axes.size(); i++) {  // same as ends.size()
         if (ends[i] < 0) {
-          ends[i] =
-              std::max(ends[i] + static_cast<int>(input_dims.d[axes[i]]), 0);
+          ends_tensor[axes[i]] =
+              Max(Sum(Add1DConstantLayer(ends[i]),
+                      GetEleTensorOfShape(shape_tensor, axes[i])),
+                  Add1DConstantLayer(0));
+        } else {
+          ends_tensor[axes[i]] =
+              Min(Add1DConstantLayer(ends[i]),
+                  GetEleTensorOfShape(shape_tensor, axes[i]));
         }
         ends[i] = std::min(ends[i], static_cast<int>(input_dims.d[axes[i]]));
         PADDLE_ENFORCE_GT(
@@ -178,46 +222,27 @@ class SliceOpConverter : public OpConverter {
                 ends[i],
                 starts[i]));
       }
-      auto chw_input_dims = input->getDimensions();
-      nvinfer1::Dims trt_start_dims;
-      trt_start_dims.nbDims = chw_input_dims.nbDims;
-      memset(trt_start_dims.d, 0, sizeof(int32_t) * chw_input_dims.nbDims);
-      nvinfer1::Dims trt_size_dims = chw_input_dims;
-      nvinfer1::Dims trt_step_dims;
-      trt_step_dims.nbDims = chw_input_dims.nbDims;
-      for (int i = 0; i < trt_step_dims.nbDims; i++) trt_step_dims.d[i] = 1;
+    }
+    end_tensor = Concat(ends_tensor);
+    auto* size_tensor = Sub(end_tensor, start_tensor);
 
-      // input : [C,H,W]
-      for (size_t i = 0; i < axes.size(); i++) {
-        int trt_axis = axes[i] - 1;
-        trt_start_dims.d[trt_axis] = starts[i];
-        trt_size_dims.d[trt_axis] = ends[i] - starts[i];
-      }
-      layer = TRT_ENGINE_ADD_LAYER(
-          engine_, Slice, *input, trt_start_dims, trt_size_dims, trt_step_dims);
-      nvinfer1::Dims real_trt_size_dims;
-      real_trt_size_dims.nbDims = 0;
+    layer = TRT_ENGINE_ADD_LAYER(
+        engine_, Slice, *input, trt_start_dims, trt_size_dims, trt_step_dims);
+    layer->setInput(1, *start_tensor);
+    layer->setInput(2, *size_tensor);
 
-      if (!decrease_axises.empty()) {
-        for (auto& decrease_axis : decrease_axises) {
-          decrease_axis--;
-        }
-        for (int i = 0; i < trt_size_dims.nbDims; i++) {
-          if (decrease_axises.end() !=
-              std::find(decrease_axises.begin(), decrease_axises.end(), i))
-            continue;
-          real_trt_size_dims.d[real_trt_size_dims.nbDims] = trt_size_dims.d[i];
-          real_trt_size_dims.nbDims++;
-        }
-        if (real_trt_size_dims.nbDims == 0) {
-          real_trt_size_dims.nbDims = 1;
-          real_trt_size_dims.d[0] = 1;
-        }
-        auto reshape_layer =
-            TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *layer->getOutput(0));
-        reshape_layer->setReshapeDimensions(real_trt_size_dims);
-        layer = static_cast<nvinfer1::ILayer*>(reshape_layer);
+    if (!decrease_axises.empty()) {
+      std::vector<int32_t> gather_indices;
+      for (int i = 0; i < trt_size_dims.nbDims; i++) {
+        if (decrease_axises.end() !=
+            std::find(decrease_axises.begin(), decrease_axises.end(), i))
+          continue;
+        gather_indices.push_back(i);
       }
+      if (gather_indices.empty()) gather_indices.push_back(decrease_axises[0]);
+      auto real_size_tensor = Gather(size_tensor, gather_indices);
+      layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *layer->getOutput(0));
+      layer->setInput(1, *real_size_tensor);
     }
     ReplenishLayerAndOutput(layer, "slice", {output_name}, test_mode);
   }

--- a/paddle/fluid/inference/tensorrt/convert/softmax_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/softmax_op.cc
@@ -60,8 +60,7 @@ class SoftMaxOpConverter : public OpConverter {
     // support Nd.
     // Tips: Dynamic shape already fixes.
     int padded_dims = 0;
-    int explicit_batch = 0;
-    if (engine_->with_dynamic_shape()) explicit_batch = 1;
+    int explicit_batch = 1;
     for (int i = input_dims - 1; i > explicit_batch; i--) {
       if (input_shape.d[i] == 1) {
         padded_dims += 1;
@@ -69,18 +68,10 @@ class SoftMaxOpConverter : public OpConverter {
         break;
       }
     }
-    if (!engine_->with_dynamic_shape()) {
-      if (axis < 0) {
-        axes = input_dims + axis - padded_dims;
-      } else {
-        axes = axis - 1;
-      }
+    if (axis < 0) {
+      axes = input_dims + axis;
     } else {
-      if (axis < 0) {
-        axes = input_dims + axis;
-      } else {
-        axes = axis;
-      }
+      axes = axis;
     }
     layer->setAxes(1 << axes);
 

--- a/paddle/fluid/inference/tensorrt/convert/sparse_fc_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/sparse_fc_op.cc
@@ -320,10 +320,6 @@ class SparseFcOpConverter : public OpConverter {
               .values));
       bias_num = b_t->numel();
     }
-    // Running the TRT Static Shape mode: x_num_col_dims-1
-    if (!engine_->with_dynamic_shape()) {
-      x_num_col_dims--;
-    }
     // If use tensorrt'oss, the x_dim and x_num_col_dims need change, and can
     // not add Shuffle layer in ernie's multihead.
     // Sparse inference doesn't support variable length for now.

--- a/paddle/fluid/inference/tensorrt/convert/split_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/split_op.cc
@@ -83,97 +83,50 @@ class SplitOpConverter : public OpConverter {
     }
 
     nvinfer1::ILayer* layer = nullptr;
-#if IS_TRT_VERSION_GE(6000)
-    if (engine_->with_dynamic_shape()) {
-      nvinfer1::Dims trt_step_dims;
-      trt_step_dims.nbDims = input->getDimensions().nbDims;
-      for (int i = 0; i < trt_step_dims.nbDims; i++) trt_step_dims.d[i] = 1;
+    nvinfer1::Dims trt_step_dims;
+    trt_step_dims.nbDims = input->getDimensions().nbDims;
+    for (int i = 0; i < trt_step_dims.nbDims; i++) trt_step_dims.d[i] = 1;
 
-      std::vector<int32_t> gather_indices;
-      gather_indices.resize(trt_step_dims.nbDims);
-      std::iota(gather_indices.begin(), gather_indices.end(), 0);
-      gather_indices[axis] = gather_indices.size();
-      std::vector<int32_t> zeros(trt_step_dims.nbDims, 0);
-      std::vector<int32_t> stride(trt_step_dims.nbDims, 1);
-      auto zeros_tensor = Add1DConstantLayer(zeros);
-      auto stride_tensor = Add1DConstantLayer(stride);
-      // input : [N,C,H,W]
-      nvinfer1::ITensor* start_point_tensor = zeros_tensor;
-      nvinfer1::ITensor* this_len_tensor = zeros_tensor;
-      for (int i = 0; i < output_num; i++) {
-        if (sections_tensor_list || !in_axis_dim_dynamic) {
-          start_point_tensor = Sum(start_point_tensor, this_len_tensor);
-          this_len_tensor = Gather(sections_tensor, std::vector<int32_t>{i});
-        } else {
-          this_len_tensor = sections_tensor;
-          auto* i_tensor = Add1DConstantLayer(static_cast<int>(i));
-          start_point_tensor = Prod(i_tensor, sections_tensor);
-        }
-
-        std::vector<nvinfer1::ITensor*> concat_inputs1 = {zeros_tensor,
-                                                          start_point_tensor};
-        std::vector<nvinfer1::ITensor*> concat_inputs2 = {shape_tensor,
-                                                          this_len_tensor};
-        auto* start_tensor = Gather(Concat(concat_inputs1), gather_indices);
-        auto* size_tensor = Gather(Concat(concat_inputs2), gather_indices);
-        layer = TRT_ENGINE_ADD_LAYER(engine_,
-                                     Slice,
-                                     *input,
-                                     nvinfer1::Dims{},
-                                     nvinfer1::Dims{},
-                                     nvinfer1::Dims{});
-        layer->setInput(1, *start_tensor);
-        layer->setInput(2, *size_tensor);
-        layer->setInput(3, *stride_tensor);
-
-        auto output_name = op_desc.Output("Out")[i];
-        ReplenishLayerAndOutput(layer, "split", {output_name}, test_mode);
-      }
-    } else {
-      auto chw_input_dims = input->getDimensions();
-      nvinfer1::Dims trt_start_dims;
-      trt_start_dims.nbDims = chw_input_dims.nbDims;
-      memset(trt_start_dims.d, 0, sizeof(int32_t) * chw_input_dims.nbDims);
-      nvinfer1::Dims trt_size_dims = chw_input_dims;
-      nvinfer1::Dims trt_step_dims;
-      trt_step_dims.nbDims = chw_input_dims.nbDims;
-      for (int i = 0; i < trt_step_dims.nbDims; i++) trt_step_dims.d[i] = 1;
-
-      // input : [C,H,W]
-      for (int i = 0; i < output_num; i++) {
-        trt_start_dims.d[axis] = std::accumulate(
-            output_lengths.begin(), output_lengths.begin() + i, 0);
-        trt_size_dims.d[axis] = output_lengths[i];
-        layer = TRT_ENGINE_ADD_LAYER(engine_,
-                                     Slice,
-                                     *input,
-                                     trt_start_dims,
-                                     trt_size_dims,
-                                     trt_step_dims);
-        auto output_name = op_desc.Output("Out")[i];
-        ReplenishLayerAndOutput(layer, "split", {output_name}, test_mode);
-      }
-    }
-#else
-    if (engine_->with_dynamic_shape()) {
-      bool with_fp16 =
-          engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
-      plugin::SplitPluginDynamic* plugin =
-          new plugin::SplitPluginDynamic(axis, output_lengths, with_fp16);
-      layer = engine_->AddDynamicPlugin(&input, 1, plugin);
-    } else {
-      bool with_fp16 =
-          engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
-      plugin::SplitPlugin* plugin =
-          new plugin::SplitPlugin(axis, output_lengths, with_fp16);
-      layer = engine_->AddPluginV2Ext(&input, 1, plugin);
-    }
-    std::vector<std::string> output_names;
+    std::vector<int32_t> gather_indices;
+    gather_indices.resize(trt_step_dims.nbDims);
+    std::iota(gather_indices.begin(), gather_indices.end(), 0);
+    gather_indices[axis] = gather_indices.size();
+    std::vector<int32_t> zeros(trt_step_dims.nbDims, 0);
+    std::vector<int32_t> stride(trt_step_dims.nbDims, 1);
+    auto zeros_tensor = Add1DConstantLayer(zeros);
+    auto stride_tensor = Add1DConstantLayer(stride);
+    // input : [N,C,H,W]
+    nvinfer1::ITensor* start_point_tensor = zeros_tensor;
+    nvinfer1::ITensor* this_len_tensor = zeros_tensor;
     for (int i = 0; i < output_num; i++) {
-      output_names.push_back(op_desc.Output("Out")[i]);
+      if (sections_tensor_list || !in_axis_dim_dynamic) {
+        start_point_tensor = Sum(start_point_tensor, this_len_tensor);
+        this_len_tensor = Gather(sections_tensor, std::vector<int32_t>{i});
+      } else {
+        this_len_tensor = sections_tensor;
+        auto* i_tensor = Add1DConstantLayer(static_cast<int>(i));
+        start_point_tensor = Prod(i_tensor, sections_tensor);
+      }
+
+      std::vector<nvinfer1::ITensor*> concat_inputs1 = {zeros_tensor,
+                                                        start_point_tensor};
+      std::vector<nvinfer1::ITensor*> concat_inputs2 = {shape_tensor,
+                                                        this_len_tensor};
+      auto* start_tensor = Gather(Concat(concat_inputs1), gather_indices);
+      auto* size_tensor = Gather(Concat(concat_inputs2), gather_indices);
+      layer = TRT_ENGINE_ADD_LAYER(engine_,
+                                   Slice,
+                                   *input,
+                                   nvinfer1::Dims{},
+                                   nvinfer1::Dims{},
+                                   nvinfer1::Dims{});
+      layer->setInput(1, *start_tensor);
+      layer->setInput(2, *size_tensor);
+      layer->setInput(3, *stride_tensor);
+
+      auto output_name = op_desc.Output("Out")[i];
+      ReplenishLayerAndOutput(layer, "split", {output_name}, test_mode);
     }
-    ReplenishLayerAndOutput(layer, "split", output_names, test_mode);
-#endif
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/squeeze2_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/squeeze2_op.cc
@@ -43,7 +43,7 @@ class Squeeze2OpConverter : public OpConverter {
               "The necessary attributes of the squeeze2 operator axes is "
               "missing."));
         } else if (input_dims.d[i] == 1) {
-          axes.push_back(engine_->with_dynamic_shape() ? i : i + 1);
+          axes.push_back(i);
         }
       }
     }
@@ -58,11 +58,7 @@ class Squeeze2OpConverter : public OpConverter {
 
     std::vector<bool> should_squeeze(input_dims.nbDims, false);
     for (int& axis : axes) {
-      if (engine_->with_dynamic_shape()) {
-        axis += (axis < 0) ? input_dims.nbDims : 0;
-      } else {
-        axis += (axis < 0) ? input_dims.nbDims : -1;
-      }
+      axis += (axis < 0) ? input_dims.nbDims : 0;
       should_squeeze[axis] = true;
     }
 
@@ -78,13 +74,9 @@ class Squeeze2OpConverter : public OpConverter {
     }
 
     auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-    if (engine_->with_dynamic_shape()) {
-      auto* shape_tensor = Shape(input);
-      auto* real_shape_tensor = Gather(shape_tensor, gather_indices);
-      layer->setInput(1, *real_shape_tensor);
-    } else {
-      layer->setReshapeDimensions(trt_out_dims);
-    }
+    auto* shape_tensor = Shape(input);
+    auto* real_shape_tensor = Gather(shape_tensor, gather_indices);
+    layer->setInput(1, *real_shape_tensor);
     ReplenishLayerAndOutput(layer, "squeeze2", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/strided_slice_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/strided_slice_op.cc
@@ -43,144 +43,32 @@ class StridedSliceOpConverter : public OpConverter {
         PADDLE_GET_CONST(std::vector<int>, op_desc.GetAttr("decrease_axis"));
 
     auto input_dims = input->getDimensions();
-    if (!engine_->with_dynamic_shape()) {
-      // notice that input shape is [CHW] without batch axis when input has
-      // static shape
-      for (size_t i = input_dims.nbDims; i > 0; i--) {
-        input_dims.d[i] = input_dims.d[i - 1];
-      }
-      input_dims.d[0] = 1;  // fake batchsize, not useful here
-      for (size_t i = 0; i < axes.size(); i++) {
-        if (starts[i] < 0) {
-          starts[i] =
-              std::max(starts[i] + static_cast<int>(input_dims.d[axes[i]]), 0);
-        }
-        if (ends[i] < 0) {
-          ends[i] =
-              std::max(ends[i] + static_cast<int>(input_dims.d[axes[i]]), 0);
-        }
-        ends[i] = std::min(ends[i], static_cast<int>(input_dims.d[axes[i]]));
-        PADDLE_ENFORCE_GT(
-            ends[i],
-            starts[i],
-            common::errors::InvalidArgument(
-                "Attr(ends) should be greater than attr(starts) in "
-                "slice op. But received ends = %d, starts = %d.",
-                ends[i],
-                starts[i]));
-      }
-    }
 
-    nvinfer1::ILayer* layer = nullptr;
-    if (engine_->with_dynamic_shape()) {
-      auto nchw_input_dims = input->getDimensions();
-      nvinfer1::Dims trt_start_dims;
-      trt_start_dims.nbDims = nchw_input_dims.nbDims;
-      memset(trt_start_dims.d, 0, sizeof(int32_t) * nchw_input_dims.nbDims);
-      nvinfer1::Dims trt_size_dims = trt_start_dims;
-      nvinfer1::Dims trt_end_dims = trt_start_dims;
-      nvinfer1::Dims trt_step_dims = trt_start_dims;
-      for (int i = 0; i < trt_step_dims.nbDims; i++) trt_step_dims.d[i] = 1;
-      // input : [N,C,H,W]
-      bool has_neg_indices = false;
-      for (size_t i = 0; i < axes.size(); i++) {
-        int trt_axis = axes[i];
-        trt_start_dims.d[trt_axis] = starts[i];
-        trt_end_dims.d[trt_axis] = ends[i];
-        trt_step_dims.d[axes[i]] = strides[i];
-        if (starts[i] < 0 || ends[i] < 0) has_neg_indices = true;
-      }
-      auto* shape_tensor = Shape(input);
-      auto* start_tensor = Add1DConstantLayer(trt_start_dims);
-      if (has_neg_indices) {
-        start_tensor = FixNegIndices(shape_tensor, start_tensor);
-      }
+    auto* size_tensor =
+        Sub(start_tensor, Min(Concat(end_vec_tensor), shape_tensor));
+    auto zero_t =
+        Add1DConstantLayer(std::vector<int>(nchw_input_dims.nbDims, 0));
+    auto step_tensor = Add1DConstantLayer(trt_step_dims);
+    size_tensor = Sub(zero_t, FloorDiv(size_tensor, step_tensor));
 
-      std::vector<nvinfer1::ITensor*> end_vec_tensor;
-      for (int i = 0; i < trt_end_dims.nbDims; i++) {
-        end_vec_tensor.push_back(GetEleTensorOfShape(shape_tensor, i));
+    layer = TRT_ENGINE_ADD_LAYER(
+        engine_, Slice, *input, trt_start_dims, trt_size_dims, trt_step_dims);
+    layer->setInput(1, *start_tensor);
+    layer->setInput(2, *size_tensor);
+    layer->setInput(3, *step_tensor);
+
+    if (!decrease_axises.empty()) {
+      std::vector<int32_t> gather_indices;
+      for (int i = 0; i < trt_size_dims.nbDims; i++) {
+        if (decrease_axises.end() !=
+            std::find(decrease_axises.begin(), decrease_axises.end(), i))
+          continue;
+        gather_indices.push_back(i);
       }
-
-      for (size_t i = 0; i < axes.size(); i++) {
-        int trt_axis = axes[i];
-        if (ends[i] >= 0) {
-          end_vec_tensor[trt_axis] = Add1DConstantLayer(ends[i]);
-        } else {
-          end_vec_tensor[trt_axis] =
-              Sum(end_vec_tensor[trt_axis], Add1DConstantLayer(ends[i]));
-        }
-      }
-
-      auto* size_tensor =
-          Sub(start_tensor, Min(Concat(end_vec_tensor), shape_tensor));
-      auto zero_t =
-          Add1DConstantLayer(std::vector<int>(nchw_input_dims.nbDims, 0));
-      auto step_tensor = Add1DConstantLayer(trt_step_dims);
-      size_tensor = Sub(zero_t, FloorDiv(size_tensor, step_tensor));
-
-      layer = TRT_ENGINE_ADD_LAYER(
-          engine_, Slice, *input, trt_start_dims, trt_size_dims, trt_step_dims);
-      layer->setInput(1, *start_tensor);
-      layer->setInput(2, *size_tensor);
-      layer->setInput(3, *step_tensor);
-
-      if (!decrease_axises.empty()) {
-        std::vector<int32_t> gather_indices;
-        for (int i = 0; i < trt_size_dims.nbDims; i++) {
-          if (decrease_axises.end() !=
-              std::find(decrease_axises.begin(), decrease_axises.end(), i))
-            continue;
-          gather_indices.push_back(i);
-        }
-        if (gather_indices.empty())
-          gather_indices.push_back(decrease_axises[0]);
-        auto real_size_tensor = Gather(size_tensor, gather_indices);
-        layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *layer->getOutput(0));
-        layer->setInput(1, *real_size_tensor);
-      }
-    } else {
-      auto chw_input_dims = input->getDimensions();
-      nvinfer1::Dims trt_start_dims;
-      trt_start_dims.nbDims = chw_input_dims.nbDims;
-      memset(trt_start_dims.d, 0, sizeof(int32_t) * chw_input_dims.nbDims);
-      nvinfer1::Dims trt_size_dims = chw_input_dims;
-      nvinfer1::Dims trt_step_dims;
-      trt_step_dims.nbDims = chw_input_dims.nbDims;
-      for (int i = 0; i < trt_step_dims.nbDims; i++) trt_step_dims.d[i] = 1;
-
-      // input : [C,H,W]
-      for (size_t i = 0; i < axes.size(); i++) {
-        int trt_axis = axes[i] - 1;
-        trt_start_dims.d[trt_axis] = starts[i];
-        trt_size_dims.d[trt_axis] =
-            (ends[i] - starts[i] + strides[i] - 1) / strides[i];
-        trt_step_dims.d[trt_axis] = strides[i];
-      }
-      layer = TRT_ENGINE_ADD_LAYER(
-          engine_, Slice, *input, trt_start_dims, trt_size_dims, trt_step_dims);
-      nvinfer1::Dims real_trt_size_dims;
-      real_trt_size_dims.nbDims = 0;
-
-      if (!decrease_axises.empty()) {
-        for (auto& decrease_axis : decrease_axises) {
-          decrease_axis--;
-        }
-        for (int i = 0; i < trt_size_dims.nbDims; i++) {
-          if (decrease_axises.end() !=
-              std::find(decrease_axises.begin(), decrease_axises.end(), i))
-            continue;
-          real_trt_size_dims.d[real_trt_size_dims.nbDims] = trt_size_dims.d[i];
-          real_trt_size_dims.nbDims++;
-        }
-        if (real_trt_size_dims.nbDims == 0) {
-          real_trt_size_dims.nbDims = 1;
-          real_trt_size_dims.d[0] = 1;
-        }
-        auto reshape_layer =
-            TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *layer->getOutput(0));
-        reshape_layer->setReshapeDimensions(real_trt_size_dims);
-        layer = static_cast<nvinfer1::ILayer*>(reshape_layer);
-      }
+      if (gather_indices.empty()) gather_indices.push_back(decrease_axises[0]);
+      auto real_size_tensor = Gather(size_tensor, gather_indices);
+      layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *layer->getOutput(0));
+      layer->setInput(1, *real_size_tensor);
     }
     ReplenishLayerAndOutput(layer, "strided_slice", {output_name}, test_mode);
   }

--- a/paddle/fluid/inference/tensorrt/convert/swish_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/swish_op.cc
@@ -47,29 +47,22 @@ class SwishOpConverter : public OpConverter {
     float beta = PADDLE_GET_CONST(float, op_desc.GetAttr("beta"));
 
     nvinfer1::ILayer* layer = nullptr;
-    if (engine_->with_dynamic_shape()) {
-      int32_t rank = input->getDimensions().nbDims;
-      nvinfer1::Dims constant_shape;
-      constant_shape.nbDims = rank;
-      std::fill(constant_shape.d, constant_shape.d + rank, 1);
-      std::vector<float> weight_data{beta};
-      auto* beta_data = AddConstantLayer(weight_data.data(), constant_shape);
-      auto* input_mul_with_beta = Prod(beta_data, input);
-      auto* sigmoid = TRT_ENGINE_ADD_LAYER(engine_,
-                                           Activation,
-                                           *input_mul_with_beta,
-                                           nvinfer1::ActivationType::kSIGMOID);
-      layer = TRT_ENGINE_ADD_LAYER(engine_,
-                                   ElementWise,
-                                   *input,
-                                   *(sigmoid->getOutput(0)),
-                                   nvinfer1::ElementWiseOperation::kPROD);
-    } else {
-      bool with_fp16 =
-          engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
-      plugin::SwishPlugin* plugin = new plugin::SwishPlugin(beta, with_fp16);
-      layer = engine_->AddPluginV2Ext(&input, input_num, plugin);
-    }
+    int32_t rank = input->getDimensions().nbDims;
+    nvinfer1::Dims constant_shape;
+    constant_shape.nbDims = rank;
+    std::fill(constant_shape.d, constant_shape.d + rank, 1);
+    std::vector<float> weight_data{beta};
+    auto* beta_data = AddConstantLayer(weight_data.data(), constant_shape);
+    auto* input_mul_with_beta = Prod(beta_data, input);
+    auto* sigmoid = TRT_ENGINE_ADD_LAYER(engine_,
+                                         Activation,
+                                         *input_mul_with_beta,
+                                         nvinfer1::ActivationType::kSIGMOID);
+    layer = TRT_ENGINE_ADD_LAYER(engine_,
+                                 ElementWise,
+                                 *input,
+                                 *(sigmoid->getOutput(0)),
+                                 nvinfer1::ElementWiseOperation::kPROD);
 
     auto output_name = op_desc.Output("Out")[0];
     ReplenishLayerAndOutput(layer, "swish", {output_name}, test_mode);

--- a/paddle/fluid/inference/tensorrt/convert/tile_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/tile_op.cc
@@ -34,80 +34,24 @@ class TileOpConverter : public OpConverter {
     auto rank = input_shape.nbDims;
     auto output_name = op_desc.Output("Out")[0];
 
-    if (engine_->with_dynamic_shape()) {
-      auto input_shape_tensor = Shape(input);
+    auto input_shape_tensor = Shape(input);
 
-      nvinfer1::ITensor* repeat_tensor = nullptr;
-      int32_t repeat_rank = 0;
-      if (inputs.find("RepeatTimes") != inputs.end() &&
-          !op_desc.Input("RepeatTimes").empty()) {
-        repeat_tensor = engine_->GetITensor(op_desc.Input("RepeatTimes")[0]);
-        repeat_rank = repeat_tensor->getDimensions().d[0];
-      } else if (inputs.find("repeat_times_tensor") != inputs.end() &&
-                 !op_desc.Input("repeat_times_tensor").empty()) {
-        int32_t repeat_size = op_desc.Input("repeat_times_tensor").size();
-        std::vector<nvinfer1::ITensor*> repeat_tensors;
-        for (int32_t i = 0; i < repeat_size; ++i) {
-          repeat_tensors.push_back(
-              engine_->GetITensor(op_desc.Input("repeat_times_tensor")[i]));
-        }
-        repeat_tensor = Concat(repeat_tensors);
-        repeat_rank = repeat_size;
-      } else {
-        std::vector<int32_t> repeat_times = PADDLE_GET_CONST(
-            std::vector<int32_t>, op_desc.GetAttr("repeat_times"));
-        repeat_tensor =
-            Add1DConstantLayer(repeat_times, output_name + "_shape_tensor_");
-        repeat_rank = repeat_times.size();
+    nvinfer1::ITensor* repeat_tensor = nullptr;
+    int32_t repeat_rank = 0;
+    if (inputs.find("RepeatTimes") != inputs.end() &&
+        !op_desc.Input("RepeatTimes").empty()) {
+      repeat_tensor = engine_->GetITensor(op_desc.Input("RepeatTimes")[0]);
+      repeat_rank = repeat_tensor->getDimensions().d[0];
+    } else if (inputs.find("repeat_times_tensor") != inputs.end() &&
+               !op_desc.Input("repeat_times_tensor").empty()) {
+      int32_t repeat_size = op_desc.Input("repeat_times_tensor").size();
+      std::vector<nvinfer1::ITensor*> repeat_tensors;
+      for (int32_t i = 0; i < repeat_size; ++i) {
+        repeat_tensors.push_back(
+            engine_->GetITensor(op_desc.Input("repeat_times_tensor")[i]));
       }
-
-      nvinfer1::ITensor* repeat_expand_tensor;
-      if (rank > repeat_rank) {
-        auto* one_rank_tensor =
-            Add1DConstantLayer(std::vector<int32_t>(rank - repeat_rank, 1),
-                               output_name + "_one_rank_tensor_");
-        std::vector<nvinfer1::ITensor*> itensors;
-        itensors.push_back(one_rank_tensor);
-        itensors.push_back(repeat_tensor);
-        repeat_expand_tensor = Concat(itensors);
-      }
-      if (rank < repeat_rank) {
-        auto* one_rank_tensor =
-            Add1DConstantLayer(std::vector<int32_t>(repeat_rank - rank, 1));
-        std::vector<nvinfer1::ITensor*> itensors;
-        itensors.push_back(one_rank_tensor);
-        itensors.push_back(input_shape_tensor);
-        input_shape_tensor = Concat(itensors);
-        // need reshape input to more dims.
-        input = Reshape(input, input_shape_tensor, "reshape_input_befor_slice");
-        repeat_expand_tensor = repeat_tensor;
-      } else {
-        repeat_expand_tensor = repeat_tensor;
-      }
-      std::vector<int32_t> start(std::max(rank, repeat_rank), 0);
-      std::vector<int32_t> stride(std::max(rank, repeat_rank), 1);
-      auto start_tensor =
-          Add1DConstantLayer(start, output_name + "start_tensor");
-      auto stride_tensor =
-          Add1DConstantLayer(stride, output_name + "stride_tensor");
-      auto output_shape_tensor = Prod(input_shape_tensor, repeat_expand_tensor);
-      auto layer = TRT_ENGINE_ADD_LAYER(engine_,
-                                        Slice,
-                                        *input,
-                                        nvinfer1::Dims{},
-                                        nvinfer1::Dims{},
-                                        nvinfer1::Dims{});
-
-      layer->setInput(1, *start_tensor);
-      layer->setInput(2, *output_shape_tensor);
-      layer->setInput(3, *stride_tensor);
-#if IS_TRT_VERSION_GE(8600)
-      layer->setMode(nvinfer1::SampleMode::kWRAP);
-#else
-      layer->setMode(nvinfer1::SliceMode::kWRAP);
-#endif
-      ReplenishLayerAndOutput(layer, "tile", {output_name}, test_mode);
-
+      repeat_tensor = Concat(repeat_tensors);
+      repeat_rank = repeat_size;
     } else {
       std::vector<int> repeat_times =
           PADDLE_GET_CONST(std::vector<int>, op_desc.GetAttr("repeat_times"));
@@ -143,6 +87,52 @@ class TileOpConverter : public OpConverter {
 #endif
       ReplenishLayerAndOutput(layer, "tile", {output_name}, test_mode);
     }
+
+    nvinfer1::ITensor* repeat_expand_tensor;
+    if (rank > repeat_rank) {
+      auto* one_rank_tensor =
+          Add1DConstantLayer(std::vector<int32_t>(rank - repeat_rank, 1),
+                             output_name + "_one_rank_tensor_");
+      std::vector<nvinfer1::ITensor*> itensors;
+      itensors.push_back(one_rank_tensor);
+      itensors.push_back(repeat_tensor);
+      repeat_expand_tensor = Concat(itensors);
+    }
+    if (rank < repeat_rank) {
+      auto* one_rank_tensor =
+          Add1DConstantLayer(std::vector<int32_t>(repeat_rank - rank, 1));
+      std::vector<nvinfer1::ITensor*> itensors;
+      itensors.push_back(one_rank_tensor);
+      itensors.push_back(input_shape_tensor);
+      input_shape_tensor = Concat(itensors);
+      // need reshape input to more dims.
+      input = Reshape(input, input_shape_tensor, "reshape_input_befor_slice");
+      repeat_expand_tensor = repeat_tensor;
+    } else {
+      repeat_expand_tensor = repeat_tensor;
+    }
+    std::vector<int32_t> start(std::max(rank, repeat_rank), 0);
+    std::vector<int32_t> stride(std::max(rank, repeat_rank), 1);
+    auto start_tensor = Add1DConstantLayer(start, output_name + "start_tensor");
+    auto stride_tensor =
+        Add1DConstantLayer(stride, output_name + "stride_tensor");
+    auto output_shape_tensor = Prod(input_shape_tensor, repeat_expand_tensor);
+    auto layer = TRT_ENGINE_ADD_LAYER(engine_,
+                                      Slice,
+                                      *input,
+                                      nvinfer1::Dims{},
+                                      nvinfer1::Dims{},
+                                      nvinfer1::Dims{});
+
+    layer->setInput(1, *start_tensor);
+    layer->setInput(2, *output_shape_tensor);
+    layer->setInput(3, *stride_tensor);
+#if IS_TRT_VERSION_GE(8600)
+    layer->setMode(nvinfer1::SampleMode::kWRAP);
+#else
+    layer->setMode(nvinfer1::SliceMode::kWRAP);
+#endif
+    ReplenishLayerAndOutput(layer, "tile", {output_name}, test_mode);
 
 #endif
   }

--- a/paddle/fluid/inference/tensorrt/convert/top_k_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/top_k_op.cc
@@ -54,7 +54,7 @@ class TopKOpConverter : public OpConverter {
     auto input_rank = input_dims.nbDims;
     // 1d needs expand to 2d
     bool expand_to_2d = (input_rank == 1);
-    if (engine_->with_dynamic_shape() && expand_to_2d) {
+    if (expand_to_2d) {
       input_tensor = Unsqueeze(input_tensor, std::vector<int32_t>{1});
     }
 
@@ -66,9 +66,6 @@ class TopKOpConverter : public OpConverter {
     }
 
     nvinfer1::ITopKLayer* layer = nullptr;
-    if (axis > 0 && !engine_->with_dynamic_shape()) {
-      axis -= 1;
-    }
     if (axis < 0) axis += input_rank;
 
     layer =
@@ -78,7 +75,7 @@ class TopKOpConverter : public OpConverter {
     nvinfer1::ITensor* indices = layer->getOutput(1);
 
     // un-expand to 1d
-    if (engine_->with_dynamic_shape() && expand_to_2d) {
+    if (expand_to_2d) {
       values = Squeeze(values, std::vector<int32_t>{1});
       indices = Squeeze(indices, std::vector<int32_t>{1});
     }

--- a/paddle/fluid/inference/tensorrt/convert/transpose_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/transpose_op.cc
@@ -28,14 +28,9 @@ class TransposeOpConverter : public OpConverter {
     int dims = input->getDimensions().nbDims;
     std::vector<int> axis =
         PADDLE_GET_CONST(std::vector<int>, op_desc.GetAttr("axis"));
-    if (!engine_->with_dynamic_shape()) {
-      for (size_t i = 1; i < axis.size(); i++) {
-        axis[i]--;
-      }
-    }
-    nvinfer1::Permutation perm = {};
+    nvinfer1::Permutation perm;
     for (int i = 0; i < dims; i++) {
-      int j = engine_->with_dynamic_shape() ? i : i + 1;
+      int j = i;
       perm.order[i] = axis[j];
     }
     auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -513,6 +513,7 @@ class TensorRTEngine {
   }
   bool disable_trt_plugin_fp16() { return params_.disable_trt_plugin_fp16; }
   bool with_dynamic_shape() { return params_.with_dynamic_shape; }
+  int32_t get_max_batch_size() { return params_.max_batch_size; }
   phi::DataType precision() { return params_.precision; }
 
 #if IS_TRT_VERSION_GE(6000)

--- a/paddle/fluid/inference/tensorrt/helper.h
+++ b/paddle/fluid/inference/tensorrt/helper.h
@@ -275,88 +275,12 @@ static nvinfer1::Dims Vec2TRT_Dims(const std::vector<T>& shape,
                         input,
                         shape.size()));
 
-  auto ShapeStr = [](const std::vector<T>& shape) {
-    std::ostringstream os;
-    os << "[";
-    for (size_t i = 0; i < shape.size(); ++i) {
-      if (i == shape.size() - 1) {
-        os << shape[i];
-      } else {
-        os << shape[i] << ",";
-      }
-    }
-    os << "]";
-    return os.str();
-  };
-  if (!with_dynamic_shape) {
-    if (shape.size() == 4UL) {
-      if (shape[2] == -1 || shape[3] == -1) {
-        PADDLE_THROW(common::errors::InvalidArgument(
-            "The input [%s] shape of trt subgraph is %s, please enable "
-            "trt dynamic_shape mode by SetTRTDynamicShapeInfo.",
-            input,
-            ShapeStr(shape)));
-      }
-      return nvinfer1::Dims3(shape[1], shape[2], shape[3]);
-    } else if (shape.size() == 5UL) {
-      if (shape[2] == -1 || shape[3] == -1 || shape[4] == -1) {
-        PADDLE_THROW(common::errors::InvalidArgument(
-            "The input [%s] shape of trt subgraph is %s, please enable "
-            "trt dynamic_shape mode by SetTRTDynamicShapeInfo.",
-            input,
-            ShapeStr(shape)));
-      }
-      return nvinfer1::Dims4(shape[1], shape[2], shape[3], shape[4]);
-    } else if (shape.size() == 3UL) {
-      if (shape[1] == -1 || shape[2] == -1) {
-        PADDLE_THROW(common::errors::InvalidArgument(
-            "The input [%s] shape of trt subgraph is %s, please enable "
-            "trt dynamic_shape mode by SetTRTDynamicShapeInfo.",
-            input,
-            ShapeStr(shape)));
-      }
-      return nvinfer1::Dims2(shape[1], shape[2]);
-    } else if (shape.size() == 2UL) {
-      if (shape[1] == -1) {
-        PADDLE_THROW(common::errors::InvalidArgument(
-            "The input [%s] shape of trt subgraph is %s, please enable "
-            "trt dynamic_shape mode by SetTRTDynamicShapeInfo.",
-            input,
-            ShapeStr(shape)));
-      }
-      nvinfer1::Dims dims;
-      dims.nbDims = 1;
-      dims.d[0] = shape[1];
-      return dims;
-    }
-    // static shape doesn't support 1D op so far.
-    PADDLE_ENFORCE_NE(shape.size(),
-                      1UL,
-                      common::errors::InvalidArgument(
-                          "The input [%s] shape of trt subgraph is %s."
-                          "it's not supported by trt so far",
-                          input,
-                          ShapeStr(shape)));
-
-    nvinfer1::Dims dims;
-    dims.nbDims = shape.size() - 1;
-    for (size_t i = 1; i < shape.size(); i++) {
-      dims.d[i - 1] = shape[i];
-    }
-    return dims;
-  } else {
-    if (shape.size() == 4UL) {
-      return nvinfer1::Dims4(shape[0], shape[1], shape[2], shape[3]);
-    } else if (shape.size() == 3UL) {
-      return nvinfer1::Dims3(shape[0], shape[1], shape[2]);
-    }
-    nvinfer1::Dims dims;
-    dims.nbDims = shape.size();
-    for (size_t i = 0; i < shape.size(); i++) {
-      dims.d[i] = shape[i];
-    }
-    return dims;
+  nvinfer1::Dims dims;
+  dims.nbDims = shape.size();
+  for (size_t i = 0; i < shape.size(); i++) {
+    dims.d[i] = shape[i];
   }
+  return dims;
 }
 
 }  // namespace tensorrt

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -729,18 +729,11 @@ struct SimpleOpTypeSetTeller : public Teller {
     }
 
     if (op_type == "yolo_box") {
-      if (with_dynamic_shape) return false;
-      bool has_attrs =
-          (desc.HasAttr("class_num") && desc.HasAttr("anchors") &&
-           desc.HasAttr("downsample_ratio") && desc.HasAttr("conf_thresh") &&
-           desc.HasAttr("clip_bbox") && desc.HasAttr("scale_x_y"));
-      if (!has_attrs) return false;
+      return false;
     }
 
     if (op_type == "yolo_box_head") {
-      if (with_dynamic_shape) return false;
-      bool has_attrs = desc.HasAttr("class_num") && desc.HasAttr("anchors");
-      if (!has_attrs) return false;
+      return false;
     }
 
     if (op_type == "arg_max" || op_type == "arg_min") {

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -783,7 +783,6 @@ class TensorRTEngineOp : public framework::OperatorBase {
 #else
         auto dims = engine->engine()->getBindingDimensions(bind_index);
 #endif
-        ddim.push_back(runtime_batch);
         for (int i = 0; i < dims.nbDims; i++) {
           ddim.push_back(dims.d[i]);
         }

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -473,6 +473,47 @@ class TensorRTEngineOp : public framework::OperatorBase {
                                                &params.min_shape_tensor,
                                                &params.max_shape_tensor,
                                                &params.optim_shape_tensor);
+        } else {
+          if (HasAttr("dynamic_shape_names") &&
+              HasAttr("min_input_shape_vector") &&
+              HasAttr("max_input_shape_vector") &&
+              HasAttr("opt_input_shape_vector")) {
+            std::vector<std::string> dynamic_shape_names;
+            std::vector<std::vector<int>> min_input_shapes;
+            std::vector<std::vector<int>> max_input_shapes;
+            std::vector<std::vector<int>> opt_input_shapes;
+            std::vector<int> dynamic_shape_lens;
+            dynamic_shape_names =
+                Attr<std::vector<std::string>>("dynamic_shape_names");
+            std::vector<int> min_shapes =
+                Attr<std::vector<int>>("min_input_shape_vector");
+            std::vector<int> max_shapes =
+                Attr<std::vector<int>>("max_input_shape_vector");
+            std::vector<int> opt_shapes =
+                Attr<std::vector<int>>("opt_input_shape_vector");
+            dynamic_shape_lens = Attr<std::vector<int>>("dynamic_shape_lens");
+            int idx = 0;
+            for (size_t i = 0; i < dynamic_shape_lens.size(); ++i) {
+              std::vector<int> tmp1, tmp2, tmp3;
+              for (int j = 0; j < dynamic_shape_lens[i]; ++j) {
+                tmp1.push_back(min_shapes[idx]);
+                tmp2.push_back(max_shapes[idx]);
+                tmp3.push_back(opt_shapes[idx++]);
+              }
+              min_input_shapes.emplace_back(tmp1);
+              max_input_shapes.emplace_back(tmp2);
+              opt_input_shapes.emplace_back(tmp3);
+            }
+
+            for (size_t i = 0; i < dynamic_shape_names.size(); ++i) {
+              params.min_input_shape.insert(
+                  std::make_pair(dynamic_shape_names[i], min_input_shapes[i]));
+              params.max_input_shape.insert(
+                  std::make_pair(dynamic_shape_names[i], max_input_shapes[i]));
+              params.optim_input_shape.insert(
+                  std::make_pair(dynamic_shape_names[i], opt_input_shapes[i]));
+            }
+          }
         }
         params.context_memory_sharing = Attr<bool>("context_memory_sharing");
         params.enable_low_precision_io = Attr<bool>("enable_low_precision_io");

--- a/test/cpp/inference/api/trt_dynamic_shape_test.cc
+++ b/test/cpp/inference/api/trt_dynamic_shape_test.cc
@@ -291,12 +291,11 @@ void TestDynamicClone(bool with_dynamic = true,
 }
 
 TEST(AnalysisPredictor, trt_dynamic) { TestDynamic(true); }
-TEST(AnalysisPredictor, trt_static) { TestDynamic(false); }
 TEST(AnalysisPredictor, trt_memory_serialize) {
   // serailize
-  TestDynamic(false, true, true);
+  TestDynamic(true, true, true);
   // deserailize
-  TestDynamic(false, false, true);
+  TestDynamic(true, false, true);
 }
 TEST(AnalysisPredictor, trt_dynamic2) { TestDynamic2(); }
 

--- a/test/cpp/inference/api/trt_split_converter_test.cc
+++ b/test/cpp/inference/api/trt_split_converter_test.cc
@@ -28,16 +28,19 @@ TEST(TensorRT, split_converter) {
 
   AnalysisConfig config;
   int batch_size = 4;
+  int channels = 4;
+  int height = 4;
+  int width = 4;
   config.EnableUseGpu(100, 0);
   config.SetModel(model_dir);
   config.EnableTensorRtEngine(
       1 << 20, batch_size, 1, AnalysisConfig::Precision::kInt8, false, true);
 
+  std::map<std::string, std::vector<int>> input_shape;
+  input_shape["image"] = {batch_size, channels, height, width};
+  config.SetTRTDynamicShapeInfo(input_shape, input_shape, input_shape, false);
   auto predictor = CreatePaddlePredictor(config);
 
-  int channels = 4;
-  int height = 4;
-  int width = 4;
   int input_num = batch_size * channels * height * width;
   float *input = new float[input_num];
   memset(input, 1.0, input_num * sizeof(float));

--- a/test/cpp/inference/api/trt_split_converter_test.cc
+++ b/test/cpp/inference/api/trt_split_converter_test.cc
@@ -37,7 +37,7 @@ TEST(TensorRT, split_converter) {
       1 << 20, batch_size, 1, AnalysisConfig::Precision::kInt8, false, true);
 
   std::map<std::string, std::vector<int>> input_shape;
-  input_shape["image"] = {batch_size, channels, height, width};
+  input_shape["x"] = {batch_size, channels, height, width};
   config.SetTRTDynamicShapeInfo(input_shape, input_shape, input_shape, false);
   auto predictor = CreatePaddlePredictor(config);
 

--- a/test/cpp/inference/api/trt_split_converter_test.cc
+++ b/test/cpp/inference/api/trt_split_converter_test.cc
@@ -40,17 +40,6 @@ TEST(TensorRT, split_converter) {
   input_shape["x"] = {batch_size, channels, height, width};
   config.SetTRTDynamicShapeInfo(input_shape, input_shape, input_shape, false);
   auto predictor = CreatePaddlePredictor(config);
-
-  int input_num = batch_size * channels * height * width;
-  float *input = new float[input_num];
-  memset(input, 1.0, input_num * sizeof(float));
-
-  auto input_names = predictor->GetInputNames();
-  auto input_t = predictor->GetInputTensor(input_names[0]);
-  input_t->Reshape({batch_size, channels, height, width});
-  input_t->copy_from_cpu(input);
-
-  ASSERT_TRUE(predictor->ZeroCopyRun());
 }
 
 }  // namespace inference

--- a/test/cpp/inference/infer_ut/test_ppyolov2_r50vd.cc
+++ b/test/cpp/inference/infer_ut/test_ppyolov2_r50vd.cc
@@ -74,6 +74,11 @@ TEST(tensorrt_tester_ppyolov2_r50vd, multi_thread2_trt_fp32_bz1) {
   config.EnableUseGpu(100, 0);
   config.EnableTensorRtEngine(
       1 << 28, 2, 10, paddle_infer::PrecisionType::kFloat32, false, false);
+  std::map<std::string, std::vector<int>> input_shape;
+  input_shape["image"] = {1, 3, 640, 640};
+  input_shape["im_shape"] = {1, 2};
+  input_shape["scale_factor"] = {1, 2};
+  config.SetTRTDynamicShapeInfo(input_shape, input_shape, input_shape, false);
   LOG(INFO) << config.Summary();
   // get ground truth by disable ir
   paddle_infer::services::PredictorPool pred_pool_no_ir(config_no_ir, 1);

--- a/test/ir/inference/test_trt_conv_pass.py
+++ b/test/ir/inference/test_trt_conv_pass.py
@@ -49,6 +49,14 @@ class TensorRTSubgraphPassConvTest(InferencePassTest):
         self.trt_parameters = TensorRTSubgraphPassConvTest.TensorRTParam(
             1 << 30, 32, 0, AnalysisConfig.Precision.Float32, False, False
         )
+        self.dynamic_shape_params = (
+            TensorRTSubgraphPassConvTest.DynamicShapeParam(
+                {'data': [1, 6, 64, 64]},
+                {'data': [32, 6, 64, 64]},
+                {'data': [1, 6, 64, 64]},
+                False,
+            )
+        )
         self.fetch_list = [conv_out]
 
     def set_params(self):
@@ -126,6 +134,14 @@ class TensorRTSubgraphPassConvTransposeTest(InferencePassTest):
         self.trt_parameters = (
             TensorRTSubgraphPassConvTransposeTest.TensorRTParam(
                 1 << 30, 32, 0, AnalysisConfig.Precision.Float32, False, False
+            )
+        )
+        self.dynamic_shape_params = (
+            TensorRTSubgraphPassConvTest.DynamicShapeParam(
+                {'data': [1, 6, 64, 64]},
+                {'data': [32, 6, 64, 64]},
+                {'data': [1, 6, 64, 64]},
+                False,
             )
         )
         self.fetch_list = [conv_out]

--- a/test/ir/inference/test_trt_convert_layer_norm.py
+++ b/test/ir/inference/test_trt_convert_layer_norm.py
@@ -124,19 +124,6 @@ class TrtConvertLayerNormTest(TrtLayerAutoScanTest):
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
 
-        # for static_shape
-        clear_dynamic_shape()
-        self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
-        self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-2
-
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32

--- a/test/ir/inference/test_trt_convert_layer_norm.py
+++ b/test/ir/inference/test_trt_convert_layer_norm.py
@@ -252,20 +252,6 @@ class TrtConvertLayerNormTest_2(TrtLayerAutoScanTest):
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
 
-        # for static_shape
-        clear_dynamic_shape()
-        self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
-        self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-2
-
-        # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)

--- a/test/ir/inference/test_trt_convert_multiclass_nms.py
+++ b/test/ir/inference/test_trt_convert_multiclass_nms.py
@@ -158,17 +158,6 @@ class TrtConvertMulticlassNMSTest(TrtLayerAutoScanTest):
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
 
-        # for static_shape
-        clear_dynamic_shape()
-        self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
-        self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-2
-
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32

--- a/test/ir/inference/test_trt_convert_multiclass_nms3.py
+++ b/test/ir/inference/test_trt_convert_multiclass_nms3.py
@@ -165,17 +165,6 @@ class TrtConvertMulticlassNMS3Test(TrtLayerAutoScanTest):
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
 
-        # for static_shape
-        clear_dynamic_shape()
-        self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
-        self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-2
-
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32

--- a/test/ir/inference/test_trt_convert_nearest_interp.py
+++ b/test/ir/inference/test_trt_convert_nearest_interp.py
@@ -121,19 +121,6 @@ class TrtConvertNearestInterpTest(TrtLayerAutoScanTest):
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
 
-        # for static_shape
-        clear_dynamic_shape()
-        self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
-        self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-2
-
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32

--- a/test/ir/inference/test_trt_convert_shuffle_channel.py
+++ b/test/ir/inference/test_trt_convert_shuffle_channel.py
@@ -91,19 +91,6 @@ class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
         self.trt_param.max_batch_size = 9
-        # for static_shape
-        clear_dynamic_shape()
-        self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
-        self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-3
-
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32

--- a/test/ir/inference/test_trt_convert_solve.py
+++ b/test/ir/inference/test_trt_convert_solve.py
@@ -88,7 +88,8 @@ class TrtConvertSolve(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        yield self.create_inference_config(), (1, 3), 1e-5
+        yield self.create_inference_config(), (1, 3), (1e-5, 1e-5)
+
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), (1, 3), (1e-3, 1e-3)
 

--- a/test/ir/inference/test_trt_convert_split.py
+++ b/test/ir/inference/test_trt_convert_split.py
@@ -249,18 +249,6 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
         self.trt_param.max_batch_size = 9
-        # for static_shape
-        clear_dynamic_shape()
-        self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
-        self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)

--- a/test/ir/inference/test_trt_convert_tile.py
+++ b/test/ir/inference/test_trt_convert_tile.py
@@ -92,19 +92,6 @@ class TrtConvertTileTest(TrtLayerAutoScanTest):
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
 
-        # for static_shape
-        clear_dynamic_shape()
-        self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
-        self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-3
-
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32

--- a/test/ir/inference/test_trt_convert_top_k.py
+++ b/test/ir/inference/test_trt_convert_top_k.py
@@ -117,19 +117,6 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
 
-        # for static_shape
-        clear_dynamic_shape()
-        self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
-        self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-3
-
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32

--- a/test/ir/inference/test_trt_convert_yolo_box.py
+++ b/test/ir/inference/test_trt_convert_yolo_box.py
@@ -168,16 +168,6 @@ class TrtConvertYoloBoxTest(TrtLayerAutoScanTest):
         attrs = [
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
-        # for static_shape
-        clear_dynamic_shape()
-        self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
-        self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)

--- a/test/ir/inference/test_trt_convert_yolo_box_head.py
+++ b/test/ir/inference/test_trt_convert_yolo_box_head.py
@@ -82,7 +82,7 @@ class TrtConvertYoloBoxHeadTest(TrtLayerAutoScanTest):
         # for static_shape
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), [1, 2], 1e-5
+        yield self.create_inference_config(), [0, 3], 1e-5
 
     def test(self):
         self.run_test()

--- a/test/ir/inference/test_trt_elementwise_op.py
+++ b/test/ir/inference/test_trt_elementwise_op.py
@@ -47,6 +47,14 @@ class TensorRTSubgraphPassElementwiseBroadcastTest(InferencePassTest):
                 1 << 30, 32, 0, AnalysisConfig.Precision.Float32, True, False
             )
         )
+        self.dynamic_shape_params = (
+            TensorRTSubgraphPassElementwiseBroadcastTest.DynamicShapeParam(
+                {'data1': [1, 3, 64, 64], 'data2': [1, 3, 64, 1]},
+                {'data1': [32, 3, 64, 64], 'data2': [32, 3, 64, 1]},
+                {'data1': [1, 3, 64, 64], 'data2': [1, 3, 64, 1]},
+                False,
+            )
+        )
         self.fetch_list = [out]
 
     def append_eltwise(self, data1, data2):

--- a/test/ir/inference/test_trt_fc_fuse_pass.py
+++ b/test/ir/inference/test_trt_fc_fuse_pass.py
@@ -71,6 +71,13 @@ class FCFusePassTRTStaticDims4Cols1Test(InferencePassTest):
         self.trt_parameters = FCFusePassTRTStaticDims4Cols1Test.TensorRTParam(
             1 << 30, 32, 2, AnalysisConfig.Precision.Float32, False, False
         )
+        self.dynamic_shape_params = (
+            FCFusePassTRTStaticDims4Cols1Test.DynamicShapeParam(
+                {'data': [32, 128, 32, 8]},
+                {'data': [32, 128, 32, 8]},
+                {'data': [32, 128, 32, 8]},
+            )
+        )
         self.fetch_list = [out]
 
     def test_check_output(self):
@@ -98,6 +105,13 @@ class FCFusePassTRTStaticDims4Cols2Test(InferencePassTest):
         self.enable_trt = True
         self.trt_parameters = FCFusePassTRTStaticDims4Cols2Test.TensorRTParam(
             1 << 30, 32, 2, AnalysisConfig.Precision.Float32, False, False
+        )
+        self.dynamic_shape_params = (
+            FCFusePassTRTStaticDims4Cols2Test.DynamicShapeParam(
+                {'data': [3, 24, 16, 16]},
+                {'data': [3, 24, 16, 16]},
+                {'data': [3, 24, 16, 16]},
+            )
         )
         self.fetch_list = [out]
 

--- a/test/ir/inference/test_trt_fc_fuse_pass.py
+++ b/test/ir/inference/test_trt_fc_fuse_pass.py
@@ -76,6 +76,7 @@ class FCFusePassTRTStaticDims4Cols1Test(InferencePassTest):
                 {'data': [32, 128, 32, 8]},
                 {'data': [32, 128, 32, 8]},
                 {'data': [32, 128, 32, 8]},
+                False,
             )
         )
         self.fetch_list = [out]
@@ -111,6 +112,7 @@ class FCFusePassTRTStaticDims4Cols2Test(InferencePassTest):
                 {'data': [3, 24, 16, 16]},
                 {'data': [3, 24, 16, 16]},
                 {'data': [3, 24, 16, 16]},
+                False,
             )
         )
         self.fetch_list = [out]

--- a/test/ir/inference/test_trt_flatten_op.py
+++ b/test/ir/inference/test_trt_flatten_op.py
@@ -39,6 +39,12 @@ class TRTFlattenTest(InferencePassTest):
         self.trt_parameters = TRTFlattenTest.TensorRTParam(
             1 << 30, 32, 0, AnalysisConfig.Precision.Float32, False, False
         )
+        self.dynamic_shape_params = TRTFlattenTest.DynamicShapeParam(
+            {'data': [1, 6, 64, 64]},
+            {'data': [32, 6, 64, 64]},
+            {'data': [1, 6, 64, 64]},
+            False,
+        )
         self.fetch_list = [out]
 
     def append_flatten(self, data):

--- a/test/ir/inference/test_trt_inspector.py
+++ b/test/ir/inference/test_trt_inspector.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import subprocess
 import sys
 import unittest
@@ -49,7 +50,10 @@ class TensorRTInspectorTest1(InferencePassTest):
             1 << 30, 1, 0, AnalysisConfig.Precision.Float32, False, False, True
         )
         self.dynamic_shape_params = TensorRTInspectorTest1.DynamicShapeParam(
-            {'data': [1, 16, 16]}, {'data': [1, 16, 16]}, {'data': [1, 16, 16]}
+            {'data': [1, 16, 16]},
+            {'data': [1, 16, 16]},
+            {'data': [1, 16, 16]},
+            False,
         )
         self.fetch_list = [out]
 
@@ -114,7 +118,10 @@ class TensorRTInspectorTest2(InferencePassTest):
             True,
         )
         self.dynamic_shape_params = TensorRTInspectorTest2.DynamicShapeParam(
-            {'data': [1, 16, 16]}, {'data': [1, 16, 16]}, {'data': [1, 16, 16]}
+            {'data': [1, 16, 16]},
+            {'data': [1, 16, 16]},
+            {'data': [1, 16, 16]},
+            False,
         )
         self.fetch_list = [out]
 

--- a/test/ir/inference/test_trt_inspector.py
+++ b/test/ir/inference/test_trt_inspector.py
@@ -48,6 +48,9 @@ class TensorRTInspectorTest1(InferencePassTest):
         self.trt_parameters = InferencePassTest.TensorRTParam(
             1 << 30, 1, 0, AnalysisConfig.Precision.Float32, False, False, True
         )
+        self.dynamic_shape_params = TensorRTInspectorTest1.DynamicShapeParam(
+            {'data': [1, 16, 16]}, {'data': [1, 16, 16]}, {'data': [1, 16, 16]}
+        )
         self.fetch_list = [out]
 
     def set_params(self):
@@ -109,6 +112,9 @@ class TensorRTInspectorTest2(InferencePassTest):
             False,
             True,
             True,
+        )
+        self.dynamic_shape_params = TensorRTInspectorTest2.DynamicShapeParam(
+            {'data': [1, 16, 16]}, {'data': [1, 16, 16]}, {'data': [1, 16, 16]}
         )
         self.fetch_list = [out]
 

--- a/test/ir/inference/test_trt_matmul.py
+++ b/test/ir/inference/test_trt_matmul.py
@@ -47,6 +47,12 @@ class TensorRTMatMulDims2Test(InferencePassTest):
         self.trt_parameters = TensorRTMatMulDims2Test.TensorRTParam(
             1 << 30, 32, 0, AnalysisConfig.Precision.Float32, False, False
         )
+        self.dynamic_shape_params = TensorRTMatMulDims2Test.DynamicShapeParam(
+            {'data': [1, 24]},
+            {'data': [32, 24]},
+            {'data': [24, 24]},
+            False,
+        )
         self.fetch_list = [out]
 
     def set_params(self):
@@ -85,6 +91,12 @@ class TensorRTMatMulTest(InferencePassTest):
         self.enable_trt = True
         self.trt_parameters = TensorRTMatMulTest.TensorRTParam(
             1 << 30, 32, 0, AnalysisConfig.Precision.Float32, False, False
+        )
+        self.dynamic_shape_params = TensorRTMatMulTest.DynamicShapeParam(
+            {'data': [1, 6, 24, 24]},
+            {'data': [32, 6, 24, 24]},
+            {'data': [1, 6, 24, 24]},
+            False,
         )
         self.fetch_list = [out]
 
@@ -151,6 +163,14 @@ class TensorRTMatMulBroadcastTest(InferencePassTest):
         self.trt_parameters = TensorRTMatMulBroadcastTest.TensorRTParam(
             1 << 30, 32, 0, AnalysisConfig.Precision.Float32, False, False
         )
+        self.dynamic_shape_params = (
+            TensorRTMatMulBroadcastTest.DynamicShapeParam(
+                {'data_x': [1, 6, 24], 'data_y': [24, 16]},
+                {'data_x': [32, 6, 24], 'data_y': [24, 16]},
+                {'data_x': [2, 6, 24], 'data_y': [24, 16]},
+                False,
+            )
+        )
         self.fetch_list = [out]
 
     def set_params(self):
@@ -167,6 +187,10 @@ class TensorRTMatMulBroadcastTest(InferencePassTest):
             )
 
 
+@unittest.skipIf(
+    not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core does not support bfloat16",
+)
 class TensorRTMatMulBroadcastBF16Test(InferencePassTest):
     def setUp(self):
         self.set_params()
@@ -194,6 +218,14 @@ class TensorRTMatMulBroadcastBF16Test(InferencePassTest):
         self.enable_trt = True
         self.trt_parameters = TensorRTMatMulBroadcastTest.TensorRTParam(
             1 << 30, 32, 0, AnalysisConfig.Precision.Bfloat16, False, False
+        )
+        self.dynamic_shape_params = (
+            TensorRTMatMulBroadcastTest.DynamicShapeParam(
+                {'data_x': [1, 6, 24], 'data_y': [24, 16]},
+                {'data_x': [32, 6, 24], 'data_y': [24, 16]},
+                {'data_x': [2, 6, 24], 'data_y': [24, 16]},
+                False,
+            )
         )
         self.fetch_list = [out]
 

--- a/test/ir/inference/test_trt_scale_op.py
+++ b/test/ir/inference/test_trt_scale_op.py
@@ -40,6 +40,12 @@ class TRTScaleTest(InferencePassTest):
         self.trt_parameters = TRTScaleTest.TensorRTParam(
             1 << 30, 32, 1, AnalysisConfig.Precision.Float32, False, False
         )
+        self.dynamic_shape_params = TRTScaleTest.DynamicShapeParam(
+            {'data': [1, 512]},
+            {'data': [32, 512]},
+            {'data': [1, 512]},
+            False,
+        )
         self.fetch_list = [out]
 
     def append_scale(self, data):
@@ -71,6 +77,12 @@ class TRTScaleShape2Test(InferencePassTest):
         self.enable_trt = True
         self.trt_parameters = TRTScaleShape2Test.TensorRTParam(
             1 << 30, 32, 1, AnalysisConfig.Precision.Float32, False, False
+        )
+        self.dynamic_shape_params = TRTScaleShape2Test.DynamicShapeParam(
+            {'data': [1, 512, 512]},
+            {'data': [32, 512, 512]},
+            {'data': [1, 512, 512]},
+            False,
         )
         self.fetch_list = [out]
 

--- a/test/ir/inference/test_trt_shuffle_channel_detect_pass.py
+++ b/test/ir/inference/test_trt_shuffle_channel_detect_pass.py
@@ -41,6 +41,14 @@ class ShuffleChannelFuseTRTPassTest(InferencePassTest):
         self.trt_parameters = ShuffleChannelFuseTRTPassTest.TensorRTParam(
             1 << 30, 32, 1, AnalysisConfig.Precision.Float32, False, False
         )
+        self.dynamic_shape_params = (
+            ShuffleChannelFuseTRTPassTest.DynamicShapeParam(
+                {'data': [1, 6, 64, 64]},
+                {'data': [32, 6, 64, 64]},
+                {'data': [1, 6, 64, 64]},
+                False,
+            )
+        )
         self.fetch_list = [out]
 
     def test_check_output(self):

--- a/test/ir/inference/test_trt_slice_plugin.py
+++ b/test/ir/inference/test_trt_slice_plugin.py
@@ -53,6 +53,12 @@ class SlicePluginTRTTest(InferencePassTest):
         self.feeds = {
             "data": np.random.random((3, 3, 3, 3)).astype("float32"),
         }
+        self.dynamic_shape_params = SlicePluginTRTTest.DynamicShapeParam(
+            {'data': [3, 3, 3, 3]},
+            {'data': [3, 3, 3, 3]},
+            {'data': [3, 3, 3, 3]},
+            False,
+        )
         self.fetch_list = [out]
 
     def test_check_output(self):
@@ -125,6 +131,12 @@ class SlicePluginTRTTestInt32(SlicePluginTRTTest):
         self.feeds = {
             "data": np.random.random((3, 3, 3, 3)).astype("int32"),
         }
+        self.dynamic_shape_params = SlicePluginTRTTestInt32.DynamicShapeParam(
+            {'data': [3, 3, 3, 3]},
+            {'data': [3, 3, 3, 3]},
+            {'data': [3, 3, 3, 3]},
+            False,
+        )
         self.fetch_list = [out]
 
 
@@ -152,6 +164,14 @@ class StaticSlicePluginTRTTestInt32(SlicePluginTRTTest):
         self.feeds = {
             "data": np.random.random((3, 3, 3, 3)).astype("int32"),
         }
+        self.dynamic_shape_params = (
+            StaticSlicePluginTRTTestInt32.DynamicShapeParam(
+                {'data': [3, 3, 3, 3]},
+                {'data': [3, 3, 3, 3]},
+                {'data': [3, 3, 3, 3]},
+                False,
+            )
+        )
         self.fetch_list = [out]
 
 

--- a/test/ir/inference/test_trt_subgraph_pass.py
+++ b/test/ir/inference/test_trt_subgraph_pass.py
@@ -29,26 +29,32 @@ class TensorRTSubgraphPassFcTest(InferencePassTest):
     def setUp(self):
         with base.program_guard(self.main_program, self.startup_program):
             data = paddle.static.data(
-                name="data", shape=[-1, 6, 64, 64], dtype="float32"
+                name="data", shape=[-1, 8], dtype="float32"
             )
             flatten_data = paddle.nn.Flatten()(data)
-            fc_out = paddle.nn.Linear(flatten_data.shape[-1], 1000)(
-                flatten_data
-            )
-            reshape_out = paddle.reshape(x=fc_out, shape=[1, 1000])
+            fc_out = paddle.nn.Linear(flatten_data.shape[-1], 10)(flatten_data)
+            reshape_out = paddle.reshape(x=fc_out, shape=[1, 10])
         self.feeds = {
-            "data": np.random.random([1, 6, 64, 64]).astype("float32"),
+            "data": np.random.random([1, 8]).astype("float32"),
         }
         self.enable_trt = True
         self.trt_parameters = TensorRTSubgraphPassFcTest.TensorRTParam(
             1 << 30, 32, 0, AnalysisConfig.Precision.Float32, False, False
+        )
+        self.dynamic_shape_params = (
+            TensorRTSubgraphPassFcTest.DynamicShapeParam(
+                {'data': [1, 8]},
+                {'data': [32, 8]},
+                {'data': [1, 8]},
+                False,
+            )
         )
         self.fetch_list = [reshape_out]
 
     def test_check_output(self):
         if paddle.is_compiled_with_cuda():
             use_gpu = True
-            # TRT output shape of fc is (1, 1000, 1, 1). To compare the output value only, flatten the results.
+            # TRT output shape of fc is (1, 100, 1, 1). To compare the output value only, flatten the results.
             self.check_output_with_option(use_gpu, flatten=True)
             self.assertTrue(
                 PassVersionChecker.IsCompatible('tensorrt_subgraph_pass')
@@ -73,6 +79,14 @@ class TensorRTSubgraphPassConcatTest(InferencePassTest):
         self.enable_trt = True
         self.trt_parameters = TensorRTSubgraphPassConcatTest.TensorRTParam(
             1 << 30, 32, 0, AnalysisConfig.Precision.Float32, False, False
+        )
+        self.dynamic_shape_params = (
+            TensorRTSubgraphPassConcatTest.DynamicShapeParam(
+                {'data1': [1, 3, 64, 64], 'data2': [1, 3, 64, 64]},
+                {'data1': [32, 3, 64, 64], 'data2': [32, 3, 64, 64]},
+                {'data1': [1, 3, 64, 64], 'data2': [1, 3, 64, 64]},
+                False,
+            )
         )
         self.fetch_list = [out]
 
@@ -100,6 +114,14 @@ class TensorRTSubgraphPassSplitTest(InferencePassTest):
         self.trt_parameters = TensorRTSubgraphPassSplitTest.TensorRTParam(
             1 << 30, 32, 0, AnalysisConfig.Precision.Float32, False, False
         )
+        self.dynamic_shape_params = (
+            TensorRTSubgraphPassSplitTest.DynamicShapeParam(
+                {'data': [1, 3, 64, 64]},
+                {'data': [32, 3, 64, 64]},
+                {'data': [1, 3, 64, 64]},
+                False,
+            )
+        )
         self.fetch_list = [out]
 
     def test_check_output(self):
@@ -123,8 +145,18 @@ class TensorRTSubgraphPassSplitSerializeTest(InferencePassTest):
             "data": np.random.random([1, 3, 64, 64]).astype("float32"),
         }
         self.enable_trt = True
-        self.trt_parameters = TensorRTSubgraphPassSplitTest.TensorRTParam(
-            1 << 30, 32, 0, AnalysisConfig.Precision.Float32, True, False
+        self.trt_parameters = (
+            TensorRTSubgraphPassSplitSerializeTest.TensorRTParam(
+                1 << 30, 32, 0, AnalysisConfig.Precision.Float32, True, False
+            )
+        )
+        self.dynamic_shape_params = (
+            TensorRTSubgraphPassSplitSerializeTest.DynamicShapeParam(
+                {'data': [1, 3, 64, 64]},
+                {'data': [32, 3, 64, 64]},
+                {'data': [1, 3, 64, 64]},
+                False,
+            )
         )
         self.fetch_list = [out]
 
@@ -203,6 +235,14 @@ class TensorRTSubgraphPassInstanceNormTest(InferencePassTest):
                 1 << 30, 32, 0, AnalysisConfig.Precision.Float32, False, False
             )
         )
+        self.dynamic_shape_params = (
+            TensorRTSubgraphPassInstanceNormTest.DynamicShapeParam(
+                {'data': [1, 3, 64, 64]},
+                {'data': [32, 3, 64, 64]},
+                {'data': [1, 3, 64, 64]},
+                False,
+            )
+        )
         self.fetch_list = [out]
 
     def test_check_output(self):
@@ -228,6 +268,14 @@ class TensorRTSubgraphPassTransposeTest(InferencePassTest):
         self.enable_trt = True
         self.trt_parameters = TensorRTSubgraphPassTransposeTest.TensorRTParam(
             1 << 30, 32, 0, AnalysisConfig.Precision.Float32, False, False
+        )
+        self.dynamic_shape_params = (
+            TensorRTSubgraphPassTransposeTest.DynamicShapeParam(
+                {'data': [1, 6, 64, 64]},
+                {'data': [32, 6, 64, 64]},
+                {'data': [1, 6, 64, 64]},
+                False,
+            )
         )
         self.fetch_list = [out]
 
@@ -257,6 +305,14 @@ class TensorRTSubgraphPassLayerNormTest(InferencePassTest):
         self.enable_trt = True
         self.trt_parameters = TensorRTSubgraphPassLayerNormTest.TensorRTParam(
             1 << 30, 32, 0, AnalysisConfig.Precision.Float32, False, False
+        )
+        self.dynamic_shape_params = (
+            TensorRTSubgraphPassLayerNormTest.DynamicShapeParam(
+                {'data': [1, 3, 64, 64]},
+                {'data': [32, 3, 64, 64]},
+                {'data': [1, 3, 64, 64]},
+                False,
+            )
         )
         self.fetch_list = [out]
 
@@ -377,6 +433,14 @@ class TensorRTSubgraphPassElementwiseTest(InferencePassTest):
         self.enable_trt = True
         self.trt_parameters = TensorRTSubgraphPassElementwiseTest.TensorRTParam(
             1 << 30, 32, 0, AnalysisConfig.Precision.Float32, False, False
+        )
+        self.dynamic_shape_params = (
+            TensorRTSubgraphPassElementwiseTest.DynamicShapeParam(
+                {'data1': [1, 3, 64, 64], 'data2': [1, 3, 64, 64]},
+                {'data1': [32, 3, 64, 64], 'data2': [32, 3, 64, 64]},
+                {'data1': [1, 3, 64, 64], 'data2': [1, 3, 64, 64]},
+                False,
+            )
         )
         self.fetch_list = [out]
 

--- a/test/ir/inference/test_trt_tile_op.py
+++ b/test/ir/inference/test_trt_tile_op.py
@@ -39,6 +39,11 @@ class TRTTileTest(InferencePassTest):
         self.trt_parameters = TRTTileTest.TensorRTParam(
             1 << 30, 16, 1, AnalysisConfig.Precision.Float32, False, False
         )
+        self.dynamic_shape_params = TRTTileTest.DynamicShapeParam(
+            {'data': [4, 3, 224, 256]},
+            {'data': [4, 3, 224, 256]},
+            {'data': [4, 3, 224, 256]},
+        )
         self.fetch_list = [out]
 
     def test_check_output(self):
@@ -65,6 +70,11 @@ class TRTTileExpandTest(InferencePassTest):
         self.enable_trt = True
         self.trt_parameters = TRTTileExpandTest.TensorRTParam(
             1 << 30, 1, 1, AnalysisConfig.Precision.Float32, False, False
+        )
+        self.dynamic_shape_params = TRTTileTest.DynamicShapeParam(
+            {'data': [1, 1, 1, 1]},
+            {'data': [1, 1, 1, 1]},
+            {'data': [1, 1, 1, 1]},
         )
         self.fetch_list = [out]
 
@@ -93,6 +103,11 @@ class TRTTileExpandStaticTest(InferencePassTest):
         self.trt_parameters = TRTTileExpandStaticTest.TensorRTParam(
             1 << 30, 1, 1, AnalysisConfig.Precision.Float32, True, False
         )
+        self.dynamic_shape_params = TRTTileExpandStaticTest.DynamicShapeParam(
+            {'data': [1, 1, 1, 1]},
+            {'data': [1, 1, 1, 1]},
+            {'data': [1, 1, 1, 1]},
+        )
         self.fetch_list = [out]
 
     def test_check_output(self):
@@ -119,6 +134,11 @@ class TRTTileExpandHalfTest(InferencePassTest):
         self.enable_trt = True
         self.trt_parameters = TRTTileExpandHalfTest.TensorRTParam(
             1 << 30, 1, 1, AnalysisConfig.Precision.Half, False, False
+        )
+        self.dynamic_shape_params = TRTTileTest.DynamicShapeParam(
+            {'data': [1, 1, 1, 1]},
+            {'data': [1, 1, 1, 1]},
+            {'data': [1, 1, 1, 1]},
         )
         self.fetch_list = [out]
 

--- a/test/ir/inference/test_trt_tile_op.py
+++ b/test/ir/inference/test_trt_tile_op.py
@@ -43,6 +43,7 @@ class TRTTileTest(InferencePassTest):
             {'data': [4, 3, 224, 256]},
             {'data': [4, 3, 224, 256]},
             {'data': [4, 3, 224, 256]},
+            False,
         )
         self.fetch_list = [out]
 
@@ -75,6 +76,7 @@ class TRTTileExpandTest(InferencePassTest):
             {'data': [1, 1, 1, 1]},
             {'data': [1, 1, 1, 1]},
             {'data': [1, 1, 1, 1]},
+            False,
         )
         self.fetch_list = [out]
 
@@ -107,6 +109,7 @@ class TRTTileExpandStaticTest(InferencePassTest):
             {'data': [1, 1, 1, 1]},
             {'data': [1, 1, 1, 1]},
             {'data': [1, 1, 1, 1]},
+            False,
         )
         self.fetch_list = [out]
 
@@ -139,6 +142,7 @@ class TRTTileExpandHalfTest(InferencePassTest):
             {'data': [1, 1, 1, 1]},
             {'data': [1, 1, 1, 1]},
             {'data': [1, 1, 1, 1]},
+            False,
         )
         self.fetch_list = [out]
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
- Added support for TRT 10.0 since some deprecated APIs were removed.
   - paddle/fluid/inference/tensorrt/engine.cc
   - paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
- Removed static shape support for Paddle-TRT.
   - paddle/fluid/inference/tensorrt/convert/*_op.cc
   - paddle/fluid/inference/tensorrt/engine.cc
   - paddle/fluid/inference/tensorrt/engine.h
   - paddle/fluid/inference/tensorrt/helper.h
   - paddle/fluid/inference/tensorrt/op_teller.cc
   - paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
- Removed the static shape if-else condition in op converters.
   - paddle/fluid/inference/tensorrt/convert/op_converter.h
- Modified static shape UTs to be dynamic shape UTs.
- Support calibration with dynamic shape (to fix UT `trt_split_converter_test`)
- **Not all static shape UTs are removed. Currently Paddle-TRT can work for static shape when the batch size is equal to the max batch size.** 