### PR TITLE
[Typing][B-85] Add type annotations for `python/paddle/nn/utils/clip_grad_norm_.py`

### DIFF
--- a/python/paddle/nn/utils/clip_grad_norm_.py
+++ b/python/paddle/nn/utils/clip_grad_norm_.py
@@ -12,18 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable
+
 import paddle
+
+if TYPE_CHECKING:
+    from paddle import Tensor
 
 __all__ = []
 
 
 @paddle.autograd.no_grad()
 def clip_grad_norm_(
-    parameters,
-    max_norm,
-    norm_type=2.0,
-    error_if_nonfinite=False,
-):
+    parameters: Iterable[Tensor] | Tensor,
+    max_norm: float,
+    norm_type: float = 2.0,
+    error_if_nonfinite: bool = False,
+) -> Tensor:
     r"""Clips gradient norm of the iteratable parameters.
 
     Norms are calculated together on all gradients, just as they are


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

类型标注：

- `python/paddle/nn/utils/clip_grad_norm_.py`

### Related links
 
- https://github.com/PaddlePaddle/Paddle/issues/65008

@SigureMo @megemini 
