### PR TITLE
【Dist-Dy2Stat】fix bug in concat

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/reshard.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard.py
@@ -2188,12 +2188,12 @@ class Resharder:
                             self.dist_context,
                             out_var,
                             [-1] * len(out_var.shape),
-                            src_tensor_attr.process_mesh,
+                            dst_input_attr[0],  # process_mesh
                             chunk_id=src_tensor_attr.chunk_id,
                         )
                     naive_set_dist_op_attr_for_program_by_mesh(
                         op,
-                        src_tensor_attr.process_mesh,
+                        dst_input_attr[0],  # process_mesh
                         self.dist_context,
                         chunk_id=src_tensor_attr.chunk_id,
                     )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
【Dist-Dy2Stat】fix bug in concat

**背景：**
动转静中用到 reshard 接口时，执行器跑失败。
**问题定位：**
当 reshard到不同mesh 且 placements 不同时，动转静后的 program 不符合预期，缺少算子。这是因为在 Resharder 中，会将 concat 算子删除。
Pcard-73145