### PR TITLE
[Prim][PIR] modify the relu_grad decomp

### DIFF
--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -1317,9 +1317,14 @@ void masked_select_grad(const Tensor& x,
 template <typename T>
 void relu_grad(const Tensor& out, const Tensor& out_grad, Tensor* x_grad) {
   if (x_grad) {
-    Tensor zeros = full_scalar<T>(0.0, out.dtype());
-    auto mask = greater_than<T>(out, zeros);
-    auto res = cast<T>(mask, out.dtype()) * out_grad;
+    Tensor zeros;
+    if (has_dynamic_shape(out.shape())) {
+      zeros = backend::full_with_tensor<T>(shape<T>(out), 0.0, out.dtype());
+    } else {
+      zeros = full<T>(common::vectorize(out.dims()), 0.0, out.dtype());
+    }
+    auto condition = greater_than<T>(out, zeros);
+    auto res = where<T>(condition, out_grad, zeros);
     set_output<T>(res, x_grad);
   }
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

原本relu_grad 反向拆解动态shape支持的写法，导致了部分模型的性能下降，现在对relu_grad反向拆解动态shape支持的写法进行修改