### PR TITLE
[Typing] Refine typing for `PartialProgramLayer`

### DIFF
--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 from functools import cached_property
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -36,6 +39,9 @@ from .utils import (
     cinn_is_enabled,
     cse_is_enabled,
 )
+
+if TYPE_CHECKING:
+    from .program_translator import ConcreteProgram
 
 __all__ = []
 
@@ -134,11 +140,11 @@ class RunnableProgram:
     """
 
     @cached_property
-    def get_value_name_map(self):
+    def get_value_name_map(self) -> ValueDict:
         return self._get_value_name_map_from_program(self.program)
 
     @classmethod
-    def _get_value_name_map_from_program(cls, program):
+    def _get_value_name_map_from_program(cls, program) -> ValueDict:
         ret = ValueDict()
         ret[fake_value()] = "FakeVar"
         for keyword, arg in program.global_block().kwargs().items():
@@ -686,7 +692,7 @@ class PartialProgramLayer:
         return restored_nest_out
 
     @cached_property
-    def origin_runnable_program(self):
+    def origin_runnable_program(self) -> RunnableProgram:
         inputs = list(self._inputs.var_list)
         outputs = list(self._outputs.var_list)
         params = self._param_values
@@ -1322,7 +1328,9 @@ class PartialProgramLayer:
         return vars if vars else None
 
 
-def partial_program_from(concrete_program, from_method=False):
+def partial_program_from(
+    concrete_program: ConcreteProgram, from_method: bool = False
+) -> PartialProgramLayer:
     inputs = concrete_program.inputs
 
     # NOTE(SigureMo): Remove the first arg `self` from method args.

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -538,7 +538,7 @@ class StaticFunction(Generic[_InputT, _RetT]):
 
     def get_concrete_program(
         self, *args: _InputT.args, **kwargs: _InputT.kwargs
-    ) -> tuple[ConcreteProgram, PartialProgramLayer | PirPartialProgramLayer]:
+    ) -> tuple[ConcreteProgram, PirPartialProgramLayer]:
         raise NotImplementedError("Not implemented yet.")
 
     def get_concrete_program_with_cache_key(self, cached_key):
@@ -829,7 +829,7 @@ class ASTStaticFunction(StaticFunction[_InputT, _RetT]):
 
     def get_concrete_program(
         self, *args: _InputT.args, **kwargs: _InputT.kwargs
-    ) -> tuple[ConcreteProgram, PartialProgramLayer | PirPartialProgramLayer]:
+    ) -> tuple[ConcreteProgram, PirPartialProgramLayer]:
         """
         Returns traced concrete program and inner executable partial layer.
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

优化 `PartialProgramLayer` 类型提示使用体验，`get_concrete_program` 不再返回 `PartialProgramLayer | PirPartialProgramLayer`，面向 3.0 只返回 `PirPartialProgramLayer`

PCard-66972