### PR TITLE
support none input for saved_for_backward hook

### DIFF
--- a/paddle/fluid/pybind/eager_py_layer.cc
+++ b/paddle/fluid/pybind/eager_py_layer.cc
@@ -619,6 +619,11 @@ void call_pack_hook(PyLayerObject* self, PyObject* value) {
                            j,
                            reinterpret_cast<PyObject*>(
                                (*pack_hook)(reinterpret_cast<void*>(o))));
+        } else if (o == Py_None) {
+          PyTuple_SET_ITEM(tmp_list,
+                           j,
+                           reinterpret_cast<PyObject*>(
+                               (*pack_hook)(reinterpret_cast<void*>(o))));
         } else {
           PADDLE_THROW(platform::errors::InvalidArgument(
               "save_for_backward only support Tensor, list of Tensor, tuple of "
@@ -636,6 +641,11 @@ void call_pack_hook(PyLayerObject* self, PyObject* value) {
                            j,
                            reinterpret_cast<PyObject*>(
                                (*pack_hook)(reinterpret_cast<void*>(o))));
+        } else if (o == Py_None) {
+          PyTuple_SET_ITEM(tmp_tuple,
+                           j,
+                           reinterpret_cast<PyObject*>(
+                               (*pack_hook)(reinterpret_cast<void*>(o))));
         } else {
           PADDLE_THROW(platform::errors::InvalidArgument(
               "save_for_backward only support Tensor, list of Tensor, tuple of "
@@ -643,6 +653,11 @@ void call_pack_hook(PyLayerObject* self, PyObject* value) {
         }
       }
       PyTuple_SET_ITEM(packed_value, i, tmp_tuple);
+    } else if (obj == Py_None) {
+      PyTuple_SET_ITEM(packed_value,
+                       i,
+                       reinterpret_cast<PyObject*>(
+                           (*pack_hook)(reinterpret_cast<void*>(obj))));
     } else {
       PADDLE_THROW(platform::errors::InvalidArgument(
           "save_for_backward only support Tensor, list of Tensor, tuple of "

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -2611,6 +2611,10 @@ void* PackHook::operator()(void* py_tensor) {
   Py_INCREF(reinterpret_cast<PyObject*>(py_tensor));
   PyTuple_SET_ITEM(args, 0, reinterpret_cast<PyObject*>(py_tensor));
   PyObject* ret = PyObject_Call(hook_, args, nullptr);
+  if (ret == Py_None) {
+    Py_XDECREF(args);
+    return Py_None;
+  }
   PADDLE_ENFORCE_NOT_NULL(ret,
                           paddle::platform::errors::External(
                               pybind11::detail::error_string().c_str()));
@@ -2670,6 +2674,10 @@ void* UnPackHook::operator()(void* packed_value, void* other) {
   Py_INCREF(reinterpret_cast<PyObject*>(packed_value));
   PyTuple_SET_ITEM(args, 0, reinterpret_cast<PyObject*>(packed_value));
   PyObject* ret = PyObject_Call(hook_, args, nullptr);
+  if (ret == Py_None) {
+    Py_XDECREF(args);
+    return Py_None;
+  }
   PADDLE_ENFORCE_NOT_NULL(ret,
                           paddle::platform::errors::External(
                               pybind11::detail::error_string().c_str()));

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -346,6 +346,9 @@ def _recompute_without_reentrant(
 
                 if holder_list[unpack_counter - 1]() is None:
                     return
+                if inner_x is None:
+                    storage[holder_list[unpack_counter - 1]()] = None
+                    return
 
                 if inner_x.is_dist():
                     # TODO(jeff41404): it seems better to use `tmp_tensor = core.eager.Tensor(inner_x)`,
@@ -368,7 +371,10 @@ def _recompute_without_reentrant(
                         inner_x.persistable,
                     )
                 inner_x._unsafe_share_buffer_to(tmp_tensor)
-                storage[holder_list[unpack_counter - 1]()] = tmp_tensor
+                if hasattr(inner_x, "main_grad"):
+                    storage[holder_list[unpack_counter - 1]()] = inner_x
+                else:
+                    storage[holder_list[unpack_counter - 1]()] = tmp_tensor
                 return
 
             def inner_unpack(inner_x):

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -349,31 +349,30 @@ def _recompute_without_reentrant(
                 if inner_x is None:
                     storage[holder_list[unpack_counter - 1]()] = None
                     return
-
-                if inner_x.is_dist():
-                    # TODO(jeff41404): it seems better to use `tmp_tensor = core.eager.Tensor(inner_x)`,
-                    # but other errors will be triggered during the current period, and can be modified after resolution
-                    tmp_tensor = core.eager.Tensor(
-                        inner_x.dtype,
-                        inner_x.shape,
-                        inner_x.name + "cpy",
-                        core.VarDesc.VarType.LOD_TENSOR,
-                        inner_x.persistable,
-                        inner_x.process_mesh,
-                        inner_x.placements,
-                    )
-                else:
-                    tmp_tensor = core.eager.Tensor(
-                        inner_x.dtype,
-                        inner_x.shape,
-                        inner_x.name + "cpy",
-                        core.VarDesc.VarType.LOD_TENSOR,
-                        inner_x.persistable,
-                    )
-                inner_x._unsafe_share_buffer_to(tmp_tensor)
                 if hasattr(inner_x, "main_grad"):
                     storage[holder_list[unpack_counter - 1]()] = inner_x
                 else:
+                    if inner_x.is_dist():
+                        # TODO(jeff41404): it seems better to use `tmp_tensor = core.eager.Tensor(inner_x)`,
+                        # but other errors will be triggered during the current period, and can be modified after resolution
+                        tmp_tensor = core.eager.Tensor(
+                            inner_x.dtype,
+                            inner_x.shape,
+                            inner_x.name + "cpy",
+                            core.VarDesc.VarType.LOD_TENSOR,
+                            inner_x.persistable,
+                            inner_x.process_mesh,
+                            inner_x.placements,
+                        )
+                    else:
+                        tmp_tensor = core.eager.Tensor(
+                            inner_x.dtype,
+                            inner_x.shape,
+                            inner_x.name + "cpy",
+                            core.VarDesc.VarType.LOD_TENSOR,
+                            inner_x.persistable,
+                        )
+                    inner_x._unsafe_share_buffer_to(tmp_tensor)
                     storage[holder_list[unpack_counter - 1]()] = tmp_tensor
                 return
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-85260
当前saved_for_backward hook在recompute不支持输入为None
但当前组网中会有相关case，例如：
https://github.com/PaddlePaddle/PaddleNLP/blob/fbe613bbc53df5af9e36dd9f9f0491f0651427e0/llm/utils/fused_layers.py#L36
在开启enable_linear_fused_grad_add及recompute时即会触发报错
该PR修改了pack/unpack 及recompute hook 以支持输入为None.
自测记录：在开启enable_linear_fused_grad_add下开关recompute进行对齐
[workerlog_recompute_true.log](https://github.com/user-attachments/files/16140448/workerlog_recompute_true.log)
[workerlog_recompute_false.log](https://github.com/user-attachments/files/16140454/workerlog_recompute_false.log)
