### PR TITLE
[CINN] Fix bug of ArgsortOp infer symbolic shape

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
@@ -33,7 +33,6 @@ OP_SAME_OPERANDS_AND_RESULT(Acos_)
 OP_SAME_OPERANDS_AND_RESULT(Acosh)
 OP_SAME_OPERANDS_AND_RESULT(Acosh_)
 OP_SAME_OPERANDS_AND_RESULT(Angle)
-OP_SAME_OPERANDS_AND_RESULT(Argsort)
 OP_SAME_OPERANDS_AND_RESULT(Asin)
 OP_SAME_OPERANDS_AND_RESULT(Asin_)
 OP_SAME_OPERANDS_AND_RESULT(Asinh)
@@ -173,6 +172,15 @@ bool ScaleOpInferSymbolicShape(pir::Operation *op,
     infer_context->SetShapeOrDataForValue(op->result(0), operand_shape_or_data);
   }
 
+  return true;
+}
+
+bool ArgsortOpInferSymbolicShape(
+    pir::Operation *op, pir::InferSymbolicShapeContext *infer_context) {
+  const symbol::ShapeOrDataDimExprs &operand_shape_or_data =
+      infer_context->GetShapeOrDataForValue(op->operand_source(0));
+  infer_context->SetShapeOrDataForValue(op->result(0), operand_shape_or_data);
+  infer_context->SetShapeOrDataForValue(op->result(1), operand_shape_or_data);
   return true;
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
修复ArgsortOp的符号推导接口中的bug