### PR TITLE
[CINN] Fix bug of CrossEntropyWithSoftmaxOp infer symbolic shape

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -306,7 +306,6 @@ bool CrossEntropyWithSoftmaxOpInferSymbolicShape(
   if (axis < 0) axis += input_shape.shape().size();
   bool soft_label =
       attributes.at("soft_label").dyn_cast<pir::BoolAttribute>().data();
-
   PADDLE_ENFORCE(!soft_label || input_dim.size() == index_dim.size(),
                  phi::errors::InvalidArgument(
                      "The input and index should have the same rank when "
@@ -319,9 +318,7 @@ bool CrossEntropyWithSoftmaxOpInferSymbolicShape(
   auto out_dim = index_dim;
 
   if (index_dim.size() == input_dim.size()) {
-    if (!soft_label) {
-      out_dim.erase(out_dim.begin() + axis);
-    } else {
+    if (soft_label) {
       out_dim[axis] = 1;
     }
     softmax_dim[axis] = input_dim[axis];


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
修复 CrossEntropyWithSoftmaxOp 的符号推导接口推导出的shape与预期不一致的bug