### PR TITLE
[Infra][NumPy2] Use `np.array` in np1 and use `np.asarray` in np2

### DIFF
--- a/python/paddle/vision/transforms/functional_pil.py
+++ b/python/paddle/vision/transforms/functional_pil.py
@@ -50,7 +50,7 @@ def _as_np_array(array, dtype=None):
     if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
         array = np.asarray(array, dtype=dtype, copy=False)
     else:
-        array = np.array(array, dtype=dtype)
+        array = np.array(array, dtype=dtype, copy=False)
     return array
 
 

--- a/python/paddle/vision/transforms/functional_pil.py
+++ b/python/paddle/vision/transforms/functional_pil.py
@@ -40,7 +40,18 @@ except:
         'hamming': Image.HAMMING,
     }
 
+
 __all__ = []
+
+
+def _as_np_array(array, dtype=None):
+    # See more details in:
+    # https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword
+    if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+        array = np.asarray(array, dtype=dtype, copy=False)
+    else:
+        array = np.array(array, dtype=dtype)
+    return array
 
 
 def to_tensor(pic, data_format='CHW'):
@@ -63,16 +74,16 @@ def to_tensor(pic, data_format='CHW'):
 
     # PIL Image
     if pic.mode == 'I':
-        img = paddle.to_tensor(np.asarray(pic, np.int32, copy=False))
+        img = paddle.to_tensor(_as_np_array(pic, np.int32))
     elif pic.mode == 'I;16':
         # cast and reshape not support int16
-        img = paddle.to_tensor(np.asarray(pic, np.int32, copy=False))
+        img = paddle.to_tensor(_as_np_array(pic, np.int32))
     elif pic.mode == 'F':
-        img = paddle.to_tensor(np.asarray(pic, np.float32, copy=False))
+        img = paddle.to_tensor(_as_np_array(pic, np.float32))
     elif pic.mode == '1':
-        img = 255 * paddle.to_tensor(np.asarray(pic, np.uint8, copy=False))
+        img = 255 * paddle.to_tensor(_as_np_array(pic, np.uint8))
     else:
-        img = paddle.to_tensor(np.asarray(pic, copy=False))
+        img = paddle.to_tensor(_as_np_array(pic))
 
     if pic.mode == 'YCbCr':
         nchannel = 3


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

根据 np1 还是 np2 分别使用 `np.array` 或者 `np.asarray`，参考 https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword

PCard-66972