### PR TITLE
[CINN]support backend compiler to link multiple modules

### DIFF
--- a/paddle/cinn/backends/codegen_cuda_dev.cc
+++ b/paddle/cinn/backends/codegen_cuda_dev.cc
@@ -282,8 +282,6 @@ std::string CodeGenCUDA_Dev::Compile(const ir::Module &module,
   if (output_kind == OutputKind::CHeader) {
     GenerateHeaderFile(module);
   } else if (output_kind == OutputKind::CImpl) {
-    PrintIncludes();
-
     if (for_nvrtc_) {
       str_ += "\nextern \"C\" {\n\n";
     }

--- a/paddle/cinn/backends/codegen_invoke_module.h
+++ b/paddle/cinn/backends/codegen_invoke_module.h
@@ -25,7 +25,7 @@ namespace backends {
 /**
  * CINN jit instructions support two kinds of invoke function, which can be
  * represented like this:
- * InvokeFunc = HostFunc | Switch<HostFunc>
+ * InvokeFunc = HostFunc | SwitchHostFunc
  * HostFunc = X86Func | CudaHostFunc | HipHostFunc | ......
  * CodeGenInvokeModule takes a CINN invoke Module(a module that only contains
  * functions that jit instructions actually invoke) and output a LLVM module.
@@ -67,7 +67,7 @@ class CodeGenHost : public CodeGenInvokeModule {
 };
 
 /**
- * In the Switch<HostFunc> pattern, InvokeFunc is a switch statement where
+ * In the SwitchHostFunc pattern, InvokeFunc is a switch statement where
  * every case is a call of HostFunc. All the callee functions have the same
  * parameters with the caller function.
  */

--- a/paddle/cinn/backends/compiler.h
+++ b/paddle/cinn/backends/compiler.h
@@ -106,7 +106,7 @@ class Compiler final {
   void Build(const ir::Module& module,
              const std::string& code = "",
              const bool end = true);
-  void AppendCX86(const ir::Module& module);
+  void AppendCX86(const ir::Module& module, const bool end = true);
 
   void ExportObject(const std::string& path);
 
@@ -123,15 +123,17 @@ class Compiler final {
   std::vector<void*> GetFnPtr() const { return fn_ptr_; }
 
  private:
+  // do not register device symbol until end=true for build fucntion
+  void RegisterDeviceModuleSymbol();
+
+  void RegisterCudaModuleSymbol();
+
   void CompileCudaModule(const ir::Module& module,
-                         const std::string& code = "",
-                         bool add_module = true);
+                         const std::string& code = "");
 
-  void CompileHipModule(const ir::Module& module,
-                        const std::string& code = "",
-                        bool add_module = true);
+  void CompileHipModule(const ir::Module& module, const std::string& code = "");
 
-  void CompileX86Module(const ir::Module& module, bool add_module = true);
+  void CompileX86Module(const ir::Module& module);
 
   explicit Compiler(const Target& target)
       : target_(target), engine_(ExecutionEngine::Create(ExecutionOptions())) {}
@@ -143,6 +145,9 @@ class Compiler final {
   std::unique_ptr<ExecutionEngine> engine_;
 
   std::vector<void*> fn_ptr_;
+  // only heterogeneous systems need to record device func and module
+  std::vector<std::string> device_fn_name_;
+  std::string device_fn_code_;
 #ifdef CINN_WITH_CUDA
   std::unique_ptr<runtime::cuda::CUDAModule> cuda_module_;
 #endif

--- a/paddle/cinn/backends/llvm/execution_engine.h
+++ b/paddle/cinn/backends/llvm/execution_engine.h
@@ -73,36 +73,33 @@ class ExecutionEngine {
   static std::unique_ptr<ExecutionEngine> Create(
       const ExecutionOptions &config);
 
-  static std::unique_ptr<ExecutionEngine> Create(
-      const ExecutionOptions &config, RuntimeSymbols &&module_symbols);
-
   void *Lookup(absl::string_view name);
 
   template <typename CodeGenT = CodeGenLLVM>
-  void Link(const ir::Module &module, bool add_module = true);
+  void Link(const ir::Module &module);
 
   void ExportObject(const std::string &path);
 
   bool AddModule(std::unique_ptr<llvm::Module> module,
                  std::unique_ptr<llvm::LLVMContext> context);
 
+  void RegisterModuleRuntimeSymbols(RuntimeSymbols &&module_symbols);
+
   bool AddSelfModule();
 
  protected:
-  explicit ExecutionEngine(bool enable_object_cache,
-                           RuntimeSymbols &&module_symbols)
+  explicit ExecutionEngine(bool enable_object_cache)
       : cache_(std::make_unique<NaiveObjectCache>()),
-        module_symbols_(std::move(module_symbols)),
         ctx(std::make_unique<llvm::LLVMContext>()),
         b(std::make_unique<llvm::IRBuilder<>>(*ctx)) {}
 
-  void RegisterRuntimeSymbols();
+  void RegisterGlobalRuntimeSymbols();
 
   bool SetupTargetTriple(llvm::Module *module);
 
   // This may not be a compatible implementation.
   friend std::unique_ptr<ExecutionEngine> std::make_unique<ExecutionEngine>(
-      bool &&, cinn::backends::RuntimeSymbols &&);
+      bool &&);
 
  private:
   mutable std::mutex mu_;

--- a/paddle/cinn/backends/llvm/runtime_symbol_registry.h
+++ b/paddle/cinn/backends/llvm/runtime_symbol_registry.h
@@ -40,6 +40,14 @@ class RuntimeSymbols {
     scalar_holder_ = std::move(rhs.scalar_holder_);
   }
 
+  RuntimeSymbols &operator=(RuntimeSymbols &&rhs) noexcept {
+    if (this != &rhs) {
+      symbols_ = std::move(rhs.symbols_);
+      scalar_holder_ = std::move(rhs.scalar_holder_);
+    }
+    return *this;
+  }
+
   /**
    * Register function address.
    * @param name Name of the symbol.

--- a/paddle/cinn/pybind/backends.cc
+++ b/paddle/cinn/pybind/backends.cc
@@ -61,10 +61,7 @@ void BindExecutionEngine(py::module *m) {
                &ExecutionEngine::Create)),
            py::arg("options") = ExecutionOptions())
       .def("lookup", lookup)
-      .def("link",
-           &ExecutionEngine::Link,
-           py::arg("module"),
-           py::arg("add_module") = true);
+      .def("link", &ExecutionEngine::Link, py::arg("module"));
 
   {
     auto lookup = [](Compiler &self, absl::string_view name) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR adds support for codegen of switch, which is the second step for lowering broadcast tree.
To learn more about the theoretical explanation of lowering broadcast tree in host wrapper function and the step-by-step arrangement for the Pull Request (PR), please refer to the [draft PR65604](https://github.com/PaddlePaddle/Paddle/pull/65604) for details.