### PR TITLE
[Infra] Avoid to use `distutils.version.LosseVersion`

### DIFF
--- a/test/deprecated/legacy_test/test_iinfo_and_finfo.py
+++ b/test/deprecated/legacy_test/test_iinfo_and_finfo.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-from distutils.version import LooseVersion
 
 import numpy as np
 
@@ -77,7 +76,7 @@ class TestIInfoAndFInfoAPI(unittest.TestCase):
             self.assertAlmostEqual(xinfo.eps, xninfo.eps)
             self.assertAlmostEqual(xinfo.tiny, xninfo.tiny)
             self.assertAlmostEqual(xinfo.resolution, xninfo.resolution)
-            if LooseVersion(np.__version__) >= LooseVersion('1.22.0'):
+            if np.lib.NumpyVersion(np.__version__) >= "1.22.0":
                 self.assertAlmostEqual(
                     xinfo.smallest_normal, xninfo.smallest_normal
                 )
@@ -97,7 +96,7 @@ class TestIInfoAndFInfoAPI(unittest.TestCase):
             self.assertAlmostEqual(xinfo.eps, xninfo.eps, places=16)
             self.assertAlmostEqual(xinfo.tiny, xninfo.tiny, places=16)
             self.assertAlmostEqual(xinfo.resolution, xninfo.resolution)
-            if LooseVersion(np.__version__) >= LooseVersion('1.22.0'):
+            if np.lib.NumpyVersion(np.__version__) >= "1.22.0":
                 self.assertAlmostEqual(
                     xinfo.smallest_normal, xninfo.smallest_normal, places=16
                 )

--- a/test/fft/spectral_op_np.py
+++ b/test/fft/spectral_op_np.py
@@ -27,7 +27,7 @@ class NormMode(enum.Enum):
 
 
 def _get_norm_mode(norm, forward):
-    if int(np.__version__.split('.')[0]) >= 2:
+    if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
         return norm
     if norm == "ortho":
         return NormMode.by_sqrt_n
@@ -37,7 +37,7 @@ def _get_norm_mode(norm, forward):
 
 
 def _get_inv_norm(n, norm_mode):
-    if int(np.__version__.split('.')[0]) >= 2:
+    if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
         return norm_mode
     assert isinstance(norm_mode, NormMode), f"invalid norm_type {norm_mode}"
     if norm_mode == NormMode.none:

--- a/test/legacy_test/test_corr.py
+++ b/test/legacy_test/test_corr.py
@@ -19,12 +19,10 @@ import numpy as np
 import paddle
 from paddle import base
 
-np_minor_version = int((np.__version__).split('.')[1])
-
 
 def numpy_corr(np_arr, rowvar=True, dtype='float64'):
     # np.corrcoef support parameter 'dtype' since 1.20
-    if np_minor_version < 20:
+    if np.lib.NumpyVersion(np.__version__) < "1.20.0":
         return np.corrcoef(np_arr, rowvar=rowvar)
     return np.corrcoef(np_arr, rowvar=rowvar, dtype=dtype)
 

--- a/test/legacy_test/test_trapezoid.py
+++ b/test/legacy_test/test_trapezoid.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-from distutils.version import LooseVersion
 
 import numpy as np
 
@@ -24,7 +23,7 @@ from paddle.pir_utils import test_with_pir_api
 def get_ref_api():
     return (
         np.trapezoid
-        if LooseVersion(np.__version__) >= LooseVersion('2.0.0')
+        if np.lib.NumpyVersion(np.__version__) >= "2.0.0"
         else np.trapz  # noqa: NPY201
     )
 

--- a/test/legacy_test/test_unique.py
+++ b/test/legacy_test/test_unique.py
@@ -222,7 +222,7 @@ class TestUniqueOpAxisNone(TestUniqueOp):
             return_counts=True,
             axis=None,
         )
-        if np.__version__.startswith('2.'):
+        if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
             inverse = inverse.flatten()
         self.attrs = {
             'dtype': int(core.VarDesc.VarType.INT32),
@@ -276,7 +276,7 @@ class TestUniqueOpAxisNeg(TestUniqueOp):
             return_counts=True,
             axis=-1,
         )
-        if np.__version__.startswith('2.'):
+        if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
             inverse = inverse.flatten()
         self.attrs = {
             'dtype': int(core.VarDesc.VarType.INT32),
@@ -330,7 +330,7 @@ class TestUniqueOpAxis1(TestUniqueOp):
             return_counts=True,
             axis=1,
         )
-        if np.__version__.startswith('2.'):
+        if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
             inverse = inverse.flatten()
         self.attrs = {
             'dtype': int(core.VarDesc.VarType.INT32),
@@ -396,7 +396,7 @@ class TestUniqueAPI(unittest.TestCase):
             return_counts=True,
             axis=0,
         )
-        if np.__version__.startswith('2.'):
+        if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
             np_inverse = np_inverse.flatten()
         self.assertTrue((out.numpy() == np_out).all(), True)
         self.assertTrue((index.numpy() == np_index).all(), True)

--- a/test/xpu/test_unique_op_xpu.py
+++ b/test/xpu/test_unique_op_xpu.py
@@ -116,7 +116,7 @@ class XPUTestUniqueOp(XPUOpTestWrapper):
                 return_counts=True,
                 axis=None,
             )
-            if np.__version__.startswith('2.'):
+            if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
                 inverse = inverse.flatten()
             self.attrs = {
                 'dtype': int(core.VarDesc.VarType.INT64),
@@ -162,7 +162,7 @@ class XPUTestUniqueOp(XPUOpTestWrapper):
                 return_counts=True,
                 axis=1,
             )
-            if np.__version__.startswith('2.'):
+            if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
                 inverse = inverse.flatten()
             self.attrs = {
                 'dtype': int(core.VarDesc.VarType.INT32),
@@ -192,7 +192,7 @@ class XPUTestUniqueOp(XPUOpTestWrapper):
                 return_counts=True,
                 axis=0,
             )
-            if np.__version__.startswith('2.'):
+            if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
                 inverse = inverse.flatten()
             self.attrs = {
                 'dtype': int(core.VarDesc.VarType.INT32),
@@ -222,7 +222,7 @@ class XPUTestUniqueOp(XPUOpTestWrapper):
                 return_counts=True,
                 axis=-1,
             )
-            if np.__version__.startswith('2.'):
+            if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
                 inverse = inverse.flatten()
             self.attrs = {
                 'dtype': int(core.VarDesc.VarType.INT32),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

避免使用在 3.12 已经弃用了的 distutils 模块，使用 NumPy 官方的 `np.lib.NumpyVersion` 来完成 NumPy 版本对比

其它一些直接使用 `np.__version__` 的地方也进行了统一

PCard-66972