### PR TITLE
[CINN] Perfect the inspection loggic of symbolic shape 

### DIFF
--- a/test/deprecated/legacy_test/test_slice_op.py
+++ b/test/deprecated/legacy_test/test_slice_op.py
@@ -68,7 +68,7 @@ class TestSliceOp(OpTest):
         self.out = self.input[1:3, 0:3, 2:4, :]
 
     def test_check_output(self):
-        self.check_output(check_pir=True, check_symbol_infer=True)
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
         self.check_grad(
@@ -127,9 +127,7 @@ class TestSliceZerosShapeTensor(OpTest):
         self.out = self.input[1:2]
 
     def test_check_output(self):
-        self.check_output_with_place(
-            paddle.CPUPlace(), check_pir=True, check_symbol_infer=True
-        )
+        self.check_output_with_place(paddle.CPUPlace(), check_pir=True)
 
 
 # 1.2 with attr(decrease)
@@ -161,7 +159,7 @@ class TestSliceOp_decs_dim(OpTest):
         self.out = self.input[1:2, 0:3, 2:4, :]
 
     def test_check_output(self):
-        self.check_output(check_pir=True, check_symbol_infer=True)
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
         self.check_grad(
@@ -207,7 +205,7 @@ class TestSliceOp_starts_ListTensor(OpTest):
         self.starts_infer = [-1, 0, -1]
 
     def test_check_output(self):
-        self.check_output(check_pir=True, check_symbol_infer=True)
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
         self.check_grad(

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -56,7 +56,7 @@ from white_list import (
 )
 
 import paddle
-from paddle import base, pir
+from paddle import base
 from paddle.autograd.ir_backward import grad as ir_grad
 from paddle.base import Scope, core, unique_name
 from paddle.base.backward import append_backward
@@ -1611,8 +1611,46 @@ class OpTest(unittest.TestCase):
         else:
             return outs, fetch_list
 
-    def _infer_and_compare_symbol(self):
+    def _compare_symbol(self, program, outs):
+        i = 0
+        # check that all ops have defined the InferSymbolicShapeInterface
+        if paddle.base.libpaddle.pir.all_ops_defined_symbol_infer(program):
+            # compare expect & actual
+            shape_analysis = (
+                paddle.base.libpaddle.pir.get_shape_constraint_ir_analysis(
+                    program
+                )
+            )
+            for block in program.blocks:
+                for op in block.ops:
+                    if op.name() == "pd_op.fetch":
+                        for j, var in enumerate(op.results()):
+                            if (
+                                var.is_dense_tensor_type()
+                                or var.is_selected_row_type()
+                            ):
+                                shape_or_data = (
+                                    shape_analysis.get_shape_or_data_for_var(
+                                        var
+                                    )
+                                )
+                                expect_shape = outs[i].shape
+                                i += 1
+                                expect_data = []
+                                if not shape_or_data.is_equal(
+                                    expect_shape, expect_data
+                                ):
+                                    raise AssertionError(
+                                        f"The shape or data of Operator {self.op_type}'s result_value[{j}] is different from expected."
+                                    )
+        else:
+            # TODO(gongshaotian): raise error
+            pass
+
+    def _infer_and_compare_symbol(self, place):
         """Don't caculate the program, only infer the shape of var"""
+
+        kernel_sig = self.get_kernel_signature(place)
         program = paddle.static.Program()
         with paddle.static.program_guard(program):
             with scope_guard(Scope()):
@@ -1623,29 +1661,55 @@ class OpTest(unittest.TestCase):
                     input_dict,
                     feed,
                 ) = self.get_ir_input_attr_dict_and_feed(stop_gradient=True)
-
-                # run the program with pass
-                pm = pir.PassManager()
-                paddle.base.libpaddle.pir.infer_symbolic_shape_pass(pm, program)
-                pm.run(program)
-
-                # compare expect & actual
-                shape_analysis = (
-                    paddle.base.libpaddle.pir.get_shape_constraint_ir_analysis(
-                        program
-                    )
+                # prepare args
+                args = OpTestUtils.prepare_python_api_arguments(
+                    self.python_api,
+                    static_inputs,
+                    attrs,
+                    kernel_sig,
+                    target_dtype=paddle.pir.core.DataType,
                 )
-                for var in program.list_vars():
-                    shape_or_data = shape_analysis.get_shape_or_data_for_var(
-                        var
-                    )
-                    expect_shape = var.shape
-                    expect_data = []
-                    if not shape_or_data.is_equal(expect_shape, expect_data):
-                        raise AssertionError(
-                            f"Operator {self.op_type} Value {var.name}'s shape or data is different from expected."
+                inputs_sig, attrs_sig, outputs_sig = kernel_sig
+                if hasattr(self, "python_out_sig"):
+                    outputs_sig = self.python_out_sig
+                args = OpTestUtils.assumption_assert_and_transform(
+                    args, len(inputs_sig)
+                )
+                # add op to program
+                ret_tuple = self.python_api(*args)
+                fetch_list = getattr(self, "fetch_list", [])
+                # if the fetch_list is customized by user, we use it directly.
+                # if not, fill the fetch_list by the user configured outputs in test.
+                # filter ret_tuple
+                ret_to_check = []
+                if len(fetch_list) == 0:
+                    if isinstance(ret_tuple, (tuple, list)):
+                        assert len(ret_tuple) == len(outputs_sig)
+                        for var, sig_name in zip(ret_tuple, outputs_sig):
+                            if not self._need_fetch(sig_name):
+                                continue
+                            if isinstance(var, list):
+                                ret_to_check.append(var)
+                                for v in var:
+                                    fetch_list.append(v)
+                            else:
+                                ret_to_check.append(var)
+                                fetch_list.append(var)
+                    elif isinstance(ret_tuple, paddle.base.libpaddle.pir.Value):
+                        fetch_list.append(ret_tuple)
+                        ret_to_check = ret_tuple
+                    elif ret_tuple is None:
+                        pass
+                    else:
+                        raise ValueError(
+                            "output of python api should be Value or list of Value or tuple of Value"
                         )
-                return True
+
+                # executor run
+                executor = Executor(place)
+                outs = executor.run(program, feed=feed, fetch_list=[fetch_list])
+
+                self._compare_symbol(program, outs)
 
     def _compare_expect_and_actual_outputs(
         self, place, fetch_list, expect_outs, actual_outs, inplace_atol=None
@@ -2578,7 +2642,7 @@ class OpTest(unittest.TestCase):
             def infer_and_compare_symbol(self):
                 """infer symbol and compare it with actualy shape and data"""
                 self.is_python_api_test = True
-                self.op_test._infer_and_compare_symbol()
+                self.op_test._infer_and_compare_symbol(place)
 
         # set some flags by the combination of arguments.
         if self.is_float16_op():
@@ -2712,7 +2776,7 @@ class OpTest(unittest.TestCase):
                     pir_checker = PirChecker(self, self.outputs)
                     pir_checker.check()
 
-        if check_symbol_infer:
+        if check_pir and check_symbol_infer:
             if (
                 type(place) is paddle.base.libpaddle.CPUPlace
                 or type(place) is paddle.base.libpaddle.CUDAPlace

--- a/test/legacy_test/test_gather_op.py
+++ b/test/legacy_test/test_gather_op.py
@@ -42,7 +42,7 @@ class TestGatherOp(OpTest):
         self.if_enable_cinn()
 
     def test_check_output(self):
-        self.check_output(check_pir=True, check_symbol_infer=True)
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(

--- a/test/legacy_test/test_reshape_op.py
+++ b/test/legacy_test/test_reshape_op.py
@@ -45,9 +45,7 @@ class TestReshapeOp(OpTest):
         self.infered_shape = (12, 10)
 
     def test_check_output(self):
-        self.check_output(
-            no_check_set=['XShape'], check_pir=True, check_symbol_infer=True
-        )
+        self.check_output(no_check_set=['XShape'], check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
1.perfect the inspection loggic of symbolic shape
2.set the flag check_symbol_infer as False