### PR TITLE
[tmp] `GlobalThreadLocal` 中使用 `__slots__` 从而在线程间共享数据

### DIFF
--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -179,6 +179,15 @@ def get_flags(flags):
 
 # use thread local to create thread save global variables.
 class GlobalThreadLocal(threading.local):
+    """use `__slots__` to share across threads"""
+
+    __slots__ = (
+        '_in_to_static_mode_',
+        '_functional_dygraph_context_manager',
+        '_dygraph_tracer_',
+        '_use_pir_api_',
+    )
+
     def __init__(self):
         """
         init the thread local data.
@@ -207,7 +216,7 @@ class GlobalThreadLocal(threading.local):
             global _dygraph_tracer_
             _dygraph_tracer_ = val
             core._switch_tracer(val)
-        self.__dict__[name] = val
+        super().__setattr__(name, val)
 
 
 _dygraph_tracer_ = None


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
`GlobalThreadLocal` 中使用 `__slots__` 从而在线程间共享数据

参考如下代码：

``` python
import queue
import threading
import functools

import paddle
paddle.disable_static()

def test():
    import paddle

    paddle.enable_static()
    data = paddle.static.data(name='X', shape=[None, 2, 28, 28], dtype='float32')

    return data


result_queue = queue.Queue()
exec_processer = functools.partial(threading.Thread, daemon=True)

def _execute_with_queue(queue):
    queue.put(test())


processer = exec_processer(
    target=_execute_with_queue,
    args=(result_queue,)
)

processer.start()
result = result_queue.get(timeout=100)
processer.join()

print(result)
```

由于 `GlobalThreadLocal` 使用 `threading.local` ，因此，子线程中无法得到主线程中设置的 `_functional_dygraph_context_manager` ，从而导致子线程 `paddle.enable_static()` 失败 ～

`threading.local` 本意就是只在当前线程生效，所以，以上代码失败应该是预期之中的，但，之所以提本 PR ，是因为，`GlobalThreadLocal` 中有注释

> TODO(xiongkun): how to access another thread local data ?

即，需要在线程间共享数据？

若，需要在线程间共享数据，则 PR 使用 `__slots__` 可以尝试解决此问题，参考：https://github.com/python/cpython/blob/3.12/Lib/_threading_local.py 中的示例代码 ～

@SigureMo 


