### PR TITLE
[CINN] Close check for symbol constraints

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_util.cc
@@ -622,7 +622,8 @@ void CheckInferSymbolicIfNeed(pir::Program* program,
   if (!FLAGS_prim_all || !FLAGS_check_infer_symbolic) return;
   const auto& GraphDimExprs4Value =
       MakeDimExprs4Value(program, CreatePassManager);
-  CheckProgramDimExprConstraints(program, GraphDimExprs4Value);
+  // CheckProgramDimExprConstraints has some bug, so we comment it.
+  // CheckProgramDimExprConstraints(program, GraphDimExprs4Value);
   std::shared_ptr<pir::PassManager> pass_manager = CreatePassManager();
   pass_manager->AddPass(CreateCheckInferSymbolicPass(GraphDimExprs4Value));
   pass_manager->AddPass(CreateSplitGenerateShapeIntoShapeOpsPass());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

由于C++端的符号约束检查存在Bug，导致在大量模型上出现死循环的问题，故在此PR中先关闭相关检查。