### PR TITLE
[CINN] Fix bug in InferSymbolicShape interface of split_with_num op

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -191,20 +191,14 @@ struct SplitOpInferSymbolicShapeInterfaceModel
     : public InferSymbolicShapeInterface::Concept {
   static inline bool InferSymbolicShape(
       pir::Operation* op, pir::InferSymbolicShapeContext* infer_context) {
-    const auto& shape_data_list =
+    const symbol::TensorListShapeOrDataDimExprs& shape_data_list =
         infer_context->GetShapeOrDataForValue(op->operand_source(0))
             .dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
 
     for (uint32_t rst_idx = 0; rst_idx < op->num_results(); rst_idx++) {
-      PADDLE_ENFORCE_EQ(
-          shape_data_list[rst_idx].data().has_value(),
-          false,
-          paddle::platform::errors::InvalidArgument(
-              "Currently InferSymbolicShape of SplitOp only support "
-              "input without value."));
       infer_context->SetShapeOrDataForValue(
           op->result(rst_idx),
-          symbol::ShapeOrDataDimExprs{shape_data_list[rst_idx]});
+          symbol::ShapeOrDataDimExprs{shape_data_list.at(rst_idx)});
     }
     return true;
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
1. 修复 split_with_num op 的符号推导接口强制约束 axis 为 int 类型的问题
2. 优化 split op 的符号推导代码