### PR TITLE
[CINN]add ShapeOrDataDimExpr represent for TensorArray type

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_util.cc
@@ -188,6 +188,7 @@ struct ShapeSignatureGenerator {
             }
           },
           [&](const symbol::TensorListShapeOrDataDimExprs& impl) { return; },
+          [&](const symbol::TensorArrayShapeOrDataDimExprs& impl) { return; },
           [&](const symbol::NullShapeOrDataDimExpr& impl) { return; });
     };
 
@@ -247,6 +248,9 @@ struct ShapeSignatureGenerator {
           return std::make_pair(shape, data);
         },
         [&](const symbol::TensorListShapeOrDataDimExprs& impl) -> ResType {
+          return std::make_pair(std::nullopt, std::nullopt);
+        },
+        [&](const symbol::TensorArrayShapeOrDataDimExprs& impl) -> ResType {
           return std::make_pair(std::nullopt, std::nullopt);
         },
         [&](const symbol::NullShapeOrDataDimExpr& impl) -> ResType {

--- a/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_util.cc
@@ -188,7 +188,9 @@ struct ShapeSignatureGenerator {
             }
           },
           [&](const symbol::TensorListShapeOrDataDimExprs& impl) { return; },
-          [&](const symbol::TensorArrayShapeOrDataDimExprs& impl) { return; },
+          [&](const symbol::RankedTensorArrayShapeOrDataDimExprs& impl) {
+            return;
+          },
           [&](const symbol::NullShapeOrDataDimExpr& impl) { return; });
     };
 
@@ -250,9 +252,8 @@ struct ShapeSignatureGenerator {
         [&](const symbol::TensorListShapeOrDataDimExprs& impl) -> ResType {
           return std::make_pair(std::nullopt, std::nullopt);
         },
-        [&](const symbol::TensorArrayShapeOrDataDimExprs& impl) -> ResType {
-          return std::make_pair(std::nullopt, std::nullopt);
-        },
+        [&](const symbol::RankedTensorArrayShapeOrDataDimExprs& impl)
+            -> ResType { return std::make_pair(std::nullopt, std::nullopt); },
         [&](const symbol::NullShapeOrDataDimExpr& impl) -> ResType {
           return std::make_pair(std::nullopt, std::nullopt);
         });

--- a/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
@@ -70,6 +70,9 @@ std::vector<pir::Value> FindSourceDenseTensorOfDimTensor(
       [](const symbol::TensorListShapeOrDataDimExprs& dim_expr) {
         return true;
       },
+      [](const symbol::TensorArrayShapeOrDataDimExprs& dim_expr) {
+        return false;
+      },
       [](const symbol::NullShapeOrDataDimExpr& null_shape_or_data) {
         return false;
       }};

--- a/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
@@ -70,7 +70,7 @@ std::vector<pir::Value> FindSourceDenseTensorOfDimTensor(
       [](const symbol::TensorListShapeOrDataDimExprs& dim_expr) {
         return true;
       },
-      [](const symbol::TensorArrayShapeOrDataDimExprs& dim_expr) {
+      [](const symbol::RankedTensorArrayShapeOrDataDimExprs& dim_expr) {
         return false;
       },
       [](const symbol::NullShapeOrDataDimExpr& null_shape_or_data) {

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/simplify_dim_expr_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/simplify_dim_expr_pass.cc
@@ -89,10 +89,10 @@ symbol::ShapeOrDataDimExprs SimplifyShapeOrData(
         }
         return symbol::ShapeOrDataDimExprs(simplified_tensor_list);
       },
-      [](const symbol::TensorArrayShapeOrDataDimExprs& tensor_array) {
+      [](const symbol::RankedTensorArrayShapeOrDataDimExprs& tensor_array) {
         return symbol::ShapeOrDataDimExprs(
-            symbol::TensorArrayShapeOrDataDimExprs(
-                SimplifyDimExprVector(tensor_array.GetShapeOfFirstItem())));
+            symbol::RankedTensorArrayShapeOrDataDimExprs(
+                SimplifyDimExprVector(tensor_array.GetShapeHint())));
       },
       [](const symbol::NullShapeOrDataDimExpr& null_shape_or_data) {
         return symbol::ShapeOrDataDimExprs(null_shape_or_data);

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/simplify_dim_expr_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/simplify_dim_expr_pass.cc
@@ -51,25 +51,24 @@ void VisitEachValue(const pir::Operation& op, const DoEachT& DoEach) {
   }
 }
 
+std::vector<symbol::DimExpr> SimplifyDimExprVector(
+    const std::vector<symbol::DimExpr>& original_dim_exprs) {
+  std::vector<symbol::DimExpr> simplified_dim_exprs{};
+  for (const symbol::DimExpr& dim_expr : original_dim_exprs) {
+    simplified_dim_exprs.push_back(symbol::SimplifyDimExpr(dim_expr));
+  }
+  return simplified_dim_exprs;
+}
+
 symbol::TensorShapeOrDataDimExprs SimplifyTensorShapeOrData(
     const symbol::TensorShapeOrDataDimExprs& shape_or_data) {
-  const auto& SimplifyDimExpr =
-      [](const std::vector<symbol::DimExpr>& original_dim_expr)
-      -> std::vector<symbol::DimExpr> {
-    std::vector<symbol::DimExpr> simplified_dim_expr{};
-    for (const symbol::DimExpr& dim_expr : original_dim_expr) {
-      simplified_dim_expr.push_back(symbol::SimplifyDimExpr(dim_expr));
-    }
-    return simplified_dim_expr;
-  };
-
   std::vector<symbol::DimExpr> simplified_shape =
-      SimplifyDimExpr(shape_or_data.shape());
+      SimplifyDimExprVector(shape_or_data.shape());
   if (!shape_or_data.data().has_value()) {
     return symbol::ShapeOrData<symbol::DimExpr>(simplified_shape);
   }
   std::vector<symbol::DimExpr> simplified_data =
-      SimplifyDimExpr(shape_or_data.data().value());
+      SimplifyDimExprVector(shape_or_data.data().value());
   return symbol::ShapeOrData<symbol::DimExpr>(simplified_shape,
                                               simplified_data);
 }
@@ -90,7 +89,12 @@ symbol::ShapeOrDataDimExprs SimplifyShapeOrData(
         }
         return symbol::ShapeOrDataDimExprs(simplified_tensor_list);
       },
-      [&](const symbol::NullShapeOrDataDimExpr& null_shape_or_data) {
+      [](const symbol::TensorArrayShapeOrDataDimExprs& tensor_array) {
+        return symbol::ShapeOrDataDimExprs(
+            symbol::TensorArrayShapeOrDataDimExprs(
+                SimplifyDimExprVector(tensor_array.GetShapeOfFirstItem())));
+      },
+      [](const symbol::NullShapeOrDataDimExpr& null_shape_or_data) {
         return symbol::ShapeOrDataDimExprs(null_shape_or_data);
       }};
   return std::visit(lambdas, shape_or_data.variant());

--- a/paddle/cinn/hlir/dialect/operator/transforms/local_infer_symbolic_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/local_infer_symbolic_util.cc
@@ -76,10 +76,11 @@ void InitLocalShapeAnalysis(const pir::Operation& op,
         return symbol::ShapeOrDataDimExprs(ret);
       };
   auto NewSymbolReplacedTensorArray =
-      [&](const symbol::TensorArrayShapeOrDataDimExprs& tensor_array_shape) {
+      [&](const symbol::RankedTensorArrayShapeOrDataDimExprs&
+              tensor_array_shape) {
         return symbol::ShapeOrDataDimExprs(
-            symbol::TensorArrayShapeOrDataDimExprs(NewSymbolReplacedDimExprs(
-                tensor_array_shape.GetShapeOfFirstItem())));
+            symbol::RankedTensorArrayShapeOrDataDimExprs(
+                NewSymbolReplacedDimExprs(tensor_array_shape.GetShapeHint())));
       };
   auto NewSymbolReplacedNull =
       [&](const symbol::NullShapeOrDataDimExpr& null_shape_or_data) {

--- a/paddle/cinn/hlir/dialect/operator/transforms/local_infer_symbolic_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/local_infer_symbolic_util.cc
@@ -75,6 +75,12 @@ void InitLocalShapeAnalysis(const pir::Operation& op,
         }
         return symbol::ShapeOrDataDimExprs(ret);
       };
+  auto NewSymbolReplacedTensorArray =
+      [&](const symbol::TensorArrayShapeOrDataDimExprs& tensor_array_shape) {
+        return symbol::ShapeOrDataDimExprs(
+            symbol::TensorArrayShapeOrDataDimExprs(NewSymbolReplacedDimExprs(
+                tensor_array_shape.GetShapeOfFirstItem())));
+      };
   auto NewSymbolReplacedNull =
       [&](const symbol::NullShapeOrDataDimExpr& null_shape_or_data) {
         return symbol::ShapeOrDataDimExprs(null_shape_or_data);
@@ -82,6 +88,7 @@ void InitLocalShapeAnalysis(const pir::Operation& op,
   auto GetNewSymbolReplaced = [&](const auto& value_dim_exprs) {
     auto patterns = common::Overloaded{NewSymbolReplacedTensor,
                                        NewSymbolReplacedTensorList,
+                                       NewSymbolReplacedTensorArray,
                                        NewSymbolReplacedNull};
     return std::visit(patterns, value_dim_exprs.variant());
   };

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/collect_sym_expr.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/collect_sym_expr.cc
@@ -73,10 +73,9 @@ void VisitEachDimExpr(const symbol::ShapeOrDataDimExprs& shape_or_data,
           VisitEachDimExprFromTensorShapeOrData(tensor_shape_or_data, DoEach);
         }
       },
-      [&](const symbol::TensorArrayShapeOrDataDimExprs& tensor_array) {
+      [&](const symbol::RankedTensorArrayShapeOrDataDimExprs& tensor_array) {
         PADDLE_THROW(phi::errors::Fatal("Dead code"));
-        for (const symbol::DimExpr& dim_expr :
-             tensor_array.GetShapeOfFirstItem()) {
+        for (const symbol::DimExpr& dim_expr : tensor_array.GetShapeHint()) {
           DoEach(dim_expr);
         }
         return;

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/collect_sym_expr.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/collect_sym_expr.cc
@@ -73,6 +73,14 @@ void VisitEachDimExpr(const symbol::ShapeOrDataDimExprs& shape_or_data,
           VisitEachDimExprFromTensorShapeOrData(tensor_shape_or_data, DoEach);
         }
       },
+      [&](const symbol::TensorArrayShapeOrDataDimExprs& tensor_array) {
+        PADDLE_THROW(phi::errors::Fatal("Dead code"));
+        for (const symbol::DimExpr& dim_expr :
+             tensor_array.GetShapeOfFirstItem()) {
+          DoEach(dim_expr);
+        }
+        return;
+      },
       [&](const symbol::NullShapeOrDataDimExpr& null_shape_or_data) {
         return;
       }};

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/collect_sym_expr.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/collect_sym_expr.cc
@@ -74,7 +74,8 @@ void VisitEachDimExpr(const symbol::ShapeOrDataDimExprs& shape_or_data,
         }
       },
       [&](const symbol::RankedTensorArrayShapeOrDataDimExprs& tensor_array) {
-        PADDLE_THROW(phi::errors::Fatal("Dead code"));
+        PADDLE_THROW(phi::errors::Fatal(
+            "Dead code, TensorArray should not be handled in backend."));
         for (const symbol::DimExpr& dim_expr : tensor_array.GetShapeHint()) {
           DoEach(dim_expr);
         }

--- a/paddle/cinn/hlir/dialect/operator/transforms/pir_to_py_code_converter.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pir_to_py_code_converter.cc
@@ -670,6 +670,10 @@ struct PirToPyCodeConverterHelper {
         [](const symbol::TensorListShapeOrDataDimExprs& impl) {
           return ConvertTensorListShapeOrData(impl);
         },
+        [](const symbol::TensorArrayShapeOrDataDimExprs& impl) {
+          // TODO(Hongqing-work): support tensor_array to py
+          return std::string("self.s_tensor_array()");
+        },
         [](const symbol::NullShapeOrDataDimExpr& impl) {
           return std::string("self.s_null()");
         });

--- a/paddle/cinn/hlir/dialect/operator/transforms/pir_to_py_code_converter.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pir_to_py_code_converter.cc
@@ -670,7 +670,7 @@ struct PirToPyCodeConverterHelper {
         [](const symbol::TensorListShapeOrDataDimExprs& impl) {
           return ConvertTensorListShapeOrData(impl);
         },
-        [](const symbol::TensorArrayShapeOrDataDimExprs& impl) {
+        [](const symbol::RankedTensorArrayShapeOrDataDimExprs& impl) {
           // TODO(Hongqing-work): support tensor_array to py
           return std::string("self.s_tensor_array()");
         },

--- a/paddle/fluid/pir/dialect/operator/utils/shape_analysis_utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/shape_analysis_utils.cc
@@ -45,10 +45,10 @@ symbol::ShapeOrDataDimExprs ClearDataInfo(
         }
         return symbol::ShapeOrDataDimExprs{new_shape_exprs};
       },
-      [](const symbol::TensorArrayShapeOrDataDimExprs& shape_exprs) {
+      [](const symbol::RankedTensorArrayShapeOrDataDimExprs& shape_exprs) {
         return symbol::ShapeOrDataDimExprs{
-            symbol::TensorArrayShapeOrDataDimExprs{
-                shape_exprs.GetShapeOfFirstItem()}};
+            symbol::RankedTensorArrayShapeOrDataDimExprs{
+                shape_exprs.GetShapeHint()}};
       },
       [](const symbol::NullShapeOrDataDimExpr& null_shape_or_data) {
         return symbol::ShapeOrDataDimExprs{null_shape_or_data};

--- a/paddle/fluid/pir/dialect/operator/utils/shape_analysis_utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/shape_analysis_utils.cc
@@ -45,6 +45,11 @@ symbol::ShapeOrDataDimExprs ClearDataInfo(
         }
         return symbol::ShapeOrDataDimExprs{new_shape_exprs};
       },
+      [](const symbol::TensorArrayShapeOrDataDimExprs& shape_exprs) {
+        return symbol::ShapeOrDataDimExprs{
+            symbol::TensorArrayShapeOrDataDimExprs{
+                shape_exprs.GetShapeOfFirstItem()}};
+      },
       [](const symbol::NullShapeOrDataDimExpr& null_shape_or_data) {
         return symbol::ShapeOrDataDimExprs{null_shape_or_data};
       }};

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -273,9 +273,9 @@ InferSymbolicShapeContext::SimplifyBroadcastForShapeOrData(
         }
         return symbol::ShapeOrDataDimExprs(simplified_tensor_list);
       },
-      [&](const symbol::TensorArrayShapeOrDataDimExprs& tensor_array) {
-        symbol::TensorArrayShapeOrDataDimExprs simplified_tensor_array(
-            DimExprsVisitor(tensor_array.GetShapeOfFirstItem()));
+      [&](const symbol::RankedTensorArrayShapeOrDataDimExprs& tensor_array) {
+        symbol::RankedTensorArrayShapeOrDataDimExprs simplified_tensor_array(
+            DimExprsVisitor(tensor_array.GetShapeHint()));
         return symbol::ShapeOrDataDimExprs(simplified_tensor_array);
       },
       [&](const symbol::NullShapeOrDataDimExpr& null_shape_or_data) {

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -273,6 +273,11 @@ InferSymbolicShapeContext::SimplifyBroadcastForShapeOrData(
         }
         return symbol::ShapeOrDataDimExprs(simplified_tensor_list);
       },
+      [&](const symbol::TensorArrayShapeOrDataDimExprs& tensor_array) {
+        symbol::TensorArrayShapeOrDataDimExprs simplified_tensor_array(
+            DimExprsVisitor(tensor_array.GetShapeOfFirstItem()));
+        return symbol::ShapeOrDataDimExprs(simplified_tensor_array);
+      },
       [&](const symbol::NullShapeOrDataDimExpr& null_shape_or_data) {
         return symbol::ShapeOrDataDimExprs(null_shape_or_data);
       });

--- a/paddle/pir/src/dialect/shape/utils/shape_or_data_expr.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_or_data_expr.cc
@@ -15,28 +15,27 @@
 #include "paddle/pir/include/dialect/shape/utils/shape_or_data_expr.h"
 
 namespace symbol {
+std::vector<DimExpr> SubstituteDimExprVector(
+    const std::vector<DimExpr>& original_dim_expr,
+    const std::unordered_map<DimExpr, DimExpr>& substitution_pattern) {
+  std::vector<DimExpr> substituted_dim_expr{};
+  for (const DimExpr& dim_expr : original_dim_expr) {
+    const auto& tmp_dim_expr =
+        SubstituteDimExpr(dim_expr, substitution_pattern);
+    substituted_dim_expr.push_back(SimplifyDimExpr(tmp_dim_expr));
+  }
+  return substituted_dim_expr;
+}
+
 TensorShapeOrDataDimExprs SubstituteTensorShapeOrData(
     const TensorShapeOrDataDimExprs& shape_or_data,
     const std::unordered_map<DimExpr, DimExpr>& substitution_pattern) {
-  auto SubstituteOneDimExpr =
-      [](const std::vector<DimExpr>& original_dim_expr,
-         const std::unordered_map<DimExpr, DimExpr>& substitution_pattern)
-      -> std::vector<DimExpr> {
-    std::vector<DimExpr> substituted_dim_expr{};
-    for (const DimExpr& dim_expr : original_dim_expr) {
-      const auto& tmp_dim_expr =
-          SubstituteDimExpr(dim_expr, substitution_pattern);
-      substituted_dim_expr.push_back(SimplifyDimExpr(tmp_dim_expr));
-    }
-    return substituted_dim_expr;
-  };
-
   std::vector<DimExpr> substituted_shape =
-      SubstituteOneDimExpr(shape_or_data.shape(), substitution_pattern);
+      SubstituteDimExprVector(shape_or_data.shape(), substitution_pattern);
   if (!shape_or_data.data().has_value()) {
     return ShapeOrData<DimExpr>(substituted_shape);
   } else {
-    std::vector<DimExpr> substituted_data = SubstituteOneDimExpr(
+    std::vector<DimExpr> substituted_data = SubstituteDimExprVector(
         shape_or_data.data().value(), substitution_pattern);
     return ShapeOrData<DimExpr>(substituted_shape, substituted_data);
   }
@@ -58,6 +57,12 @@ ShapeOrDataDimExprs SubstituteShapeOrData(
               tensor_shape_or_data, substitution_pattern));
         }
         return ShapeOrDataDimExprs(substituted_tensor_list);
+      },
+      [&](const TensorArrayShapeOrDataDimExprs& tensor_array) {
+        TensorArrayShapeOrDataDimExprs substituted_tensor_array(
+            SubstituteDimExprVector(tensor_array.GetShapeOfFirstItem(),
+                                    substitution_pattern));
+        return ShapeOrDataDimExprs(substituted_tensor_array);
       },
       [&](const NullShapeOrDataDimExpr& null_shape_or_data) {
         return ShapeOrDataDimExprs(null_shape_or_data);
@@ -88,6 +93,10 @@ std::ostream& operator<<(std::ostream& stream,
             stream << ", ";
           }
         }
+      },
+      [&](const TensorArrayShapeOrDataDimExprs& tensor_array_shape_data) {
+        stream << "TensorArray with first item shape"
+               << tensor_array_shape_data.GetShapeOfFirstItem();
       },
       [&](const NullShapeOrDataDimExpr& null_shape_data) {
         stream << "shape[NULL], data[NULL]";

--- a/paddle/pir/src/dialect/shape/utils/shape_or_data_expr.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_or_data_expr.cc
@@ -95,7 +95,7 @@ std::ostream& operator<<(std::ostream& stream,
         }
       },
       [&](const RankedTensorArrayShapeOrDataDimExprs& tensor_array_shape_data) {
-        stream << "TensorArray with first item shape"
+        stream << "TensorArray with shape hint: "
                << tensor_array_shape_data.GetShapeHint();
       },
       [&](const NullShapeOrDataDimExpr& null_shape_data) {

--- a/paddle/pir/src/dialect/shape/utils/shape_or_data_expr.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_or_data_expr.cc
@@ -58,9 +58,9 @@ ShapeOrDataDimExprs SubstituteShapeOrData(
         }
         return ShapeOrDataDimExprs(substituted_tensor_list);
       },
-      [&](const TensorArrayShapeOrDataDimExprs& tensor_array) {
-        TensorArrayShapeOrDataDimExprs substituted_tensor_array(
-            SubstituteDimExprVector(tensor_array.GetShapeOfFirstItem(),
+      [&](const RankedTensorArrayShapeOrDataDimExprs& tensor_array) {
+        RankedTensorArrayShapeOrDataDimExprs substituted_tensor_array(
+            SubstituteDimExprVector(tensor_array.GetShapeHint(),
                                     substitution_pattern));
         return ShapeOrDataDimExprs(substituted_tensor_array);
       },
@@ -94,9 +94,9 @@ std::ostream& operator<<(std::ostream& stream,
           }
         }
       },
-      [&](const TensorArrayShapeOrDataDimExprs& tensor_array_shape_data) {
+      [&](const RankedTensorArrayShapeOrDataDimExprs& tensor_array_shape_data) {
         stream << "TensorArray with first item shape"
-               << tensor_array_shape_data.GetShapeOfFirstItem();
+               << tensor_array_shape_data.GetShapeHint();
       },
       [&](const NullShapeOrDataDimExpr& null_shape_data) {
         stream << "shape[NULL], data[NULL]";


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR add ShapeOrDataDimExpr represent for TensorArray type.
#### Design note
TensorArray can append tensors dynamically during the execution of a computation graph, so we can't get a static Shape represenation of TensorArray. However, we can still record the shape of one element tensor as a hint, which can already provide some useful information for subsequent processing, since the elements in TensorArray most likely have the same rank and certain dimensions may have equal constraints.