### PR TITLE
fix bug: Inconsistent dtype between the old and new IR

### DIFF
--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -721,11 +721,12 @@ def _as_lodtensor(data, place, dtype=None):
         assert (
             dtype is not None
         ), 'The dtype should be given when feed data is not np.ndarray'
-        dtype = (
-            convert_dtype(dtype)
-            if isinstance(dtype, core.VarDesc.VarType)
-            else dtype
-        )
+        # dtype = (
+        #     convert_dtype(dtype)
+        #     if isinstance(dtype, core.VarDesc.VarType)
+        #     else dtype
+        # )
+        dtype = convert_dtype(dtype)
         if np.isscalar(data):
             data = np.array(data).astype(dtype)
         elif isinstance(data, (list, tuple)):

--- a/python/paddle/framework/dtype.py
+++ b/python/paddle/framework/dtype.py
@@ -186,7 +186,10 @@ def iinfo(dtype):
             uint8
 
     """
-    if dtype in _NUMPY_DTYPE_2_PADDLE_DTYPE:
+
+    if isinstance(dtype, paddle.pir.core.DataType):
+        dtype = paddle.base.framework.paddle_type_to_proto_type[dtype]
+    elif dtype in _NUMPY_DTYPE_2_PADDLE_DTYPE:
         dtype = _NUMPY_DTYPE_2_PADDLE_DTYPE[dtype]
     return core_iinfo(dtype)
 

--- a/test/legacy_test/test_executor_feed_non_tensor.py
+++ b/test/legacy_test/test_executor_feed_non_tensor.py
@@ -1,0 +1,68 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+from paddle import base
+
+
+class TestAsLodTensor(unittest.TestCase):
+    def test_as_lodtensor_int32(self):
+        cpu = base.CPUPlace()
+        tensor = base.executor._as_lodtensor(1.0, cpu, paddle.int32)
+        self.assertEqual(tensor._dtype(), base.core.VarDesc.VarType.INT32)
+
+    def test_as_lodtensor_fp64(self):
+        cpu = base.CPUPlace()
+        tensor = base.executor._as_lodtensor(1, cpu, paddle.float64)
+        self.assertEqual(tensor._dtype(), base.core.VarDesc.VarType.FP64)
+
+    def test_as_lodtensor_assertion_error(self):
+        cpu = base.CPUPlace()
+        self.assertRaises(AssertionError, base.executor._as_lodtensor, 1, cpu)
+
+    def test_as_lodtensor_type_error(self):
+        cpu = base.CPUPlace()
+        self.assertRaises(
+            TypeError,
+            base.executor._as_lodtensor,
+            {"a": 1},
+            cpu,
+            base.core.VarDesc.VarType.INT32,
+        )
+
+    def test_as_lodtensor_list(self):
+        cpu = base.CPUPlace()
+        tensor = base.executor._as_lodtensor([1, 2], cpu, paddle.float64)
+        self.assertEqual(tensor._dtype(), base.core.VarDesc.VarType.FP64)
+
+    def test_as_lodtensor_tuple(self):
+        cpu = base.CPUPlace()
+        tensor = base.executor._as_lodtensor((1, 2), cpu, paddle.float64)
+        self.assertEqual(tensor._dtype(), base.core.VarDesc.VarType.FP64)
+
+    def test_as_lodtensor_nested_list(self):
+        cpu = base.CPUPlace()
+        self.assertRaises(
+            TypeError,
+            base.executor._as_lodtensor,
+            [{1.2, 1.2}, {1, 2}],
+            cpu,
+            base.core.VarDesc.VarType.INT32,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/legacy_test/test_iinfo_and_finfo.py
+++ b/test/legacy_test/test_iinfo_and_finfo.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from distutils.version import LooseVersion
+
+import numpy as np
+
+import paddle
+
+
+class TestIInfoAndFInfoAPI(unittest.TestCase):
+    def test_invalid_input(self):
+        for dtype in [
+            paddle.float16,
+            paddle.float32,
+            paddle.float64,
+            paddle.bfloat16,
+            paddle.complex64,
+            paddle.complex128,
+            paddle.bool,
+            'float16',
+            'float32',
+            'float64',
+            'uint16',
+            'complex64',
+            'complex128',
+            'bool',
+        ]:
+            with self.assertRaises(ValueError):
+                _ = paddle.iinfo(dtype)
+
+    def test_iinfo(self):
+        for paddle_dtype, np_dtype in [
+            (paddle.int64, np.int64),
+            (paddle.int32, np.int32),
+            (paddle.int16, np.int16),
+            (paddle.int8, np.int8),
+            (paddle.uint8, np.uint8),
+            ('int64', np.int64),
+            ('int32', np.int32),
+            ('int16', np.int16),
+            ('int8', np.int8),
+            ('uint8', np.uint8),
+        ]:
+            xinfo = paddle.iinfo(paddle_dtype)
+            xninfo = np.iinfo(np_dtype)
+            self.assertEqual(xinfo.bits, xninfo.bits)
+            self.assertEqual(xinfo.max, xninfo.max)
+            self.assertEqual(xinfo.min, xninfo.min)
+            self.assertEqual(xinfo.dtype, xninfo.dtype)
+
+    def test_finfo(self):
+        for paddle_dtype, np_dtype in [
+            (paddle.float32, np.float32),
+            (paddle.float64, np.float64),
+            ('float32', np.float32),
+            ('float64', np.float64),
+        ]:
+            xinfo = paddle.finfo(paddle_dtype)
+            xninfo = np.finfo(np_dtype)
+            self.assertEqual(xinfo.dtype, xninfo.dtype)
+            self.assertEqual(xinfo.bits, xninfo.bits)
+            self.assertAlmostEqual(xinfo.max, xninfo.max)
+            self.assertAlmostEqual(xinfo.min, xninfo.min)
+            self.assertAlmostEqual(xinfo.eps, xninfo.eps)
+            self.assertAlmostEqual(xinfo.tiny, xninfo.tiny)
+            self.assertAlmostEqual(xinfo.resolution, xninfo.resolution)
+            if LooseVersion(np.__version__) >= LooseVersion('1.22.0'):
+                self.assertAlmostEqual(
+                    xinfo.smallest_normal, xninfo.smallest_normal
+                )
+
+        for paddle_dtype, np_dtype in [
+            (paddle.complex64, np.complex64),
+            (paddle.complex128, np.complex128),
+            ('complex64', np.complex64),
+            ('complex128', np.complex128),
+        ]:
+            xinfo = paddle.finfo(paddle_dtype)
+            xninfo = np.finfo(np_dtype)
+            self.assertEqual(xinfo.dtype, xninfo.dtype)
+            self.assertEqual(xinfo.bits, xninfo.bits)
+            self.assertAlmostEqual(xinfo.max, xninfo.max, places=16)
+            self.assertAlmostEqual(xinfo.min, xninfo.min, places=16)
+            self.assertAlmostEqual(xinfo.eps, xninfo.eps, places=16)
+            self.assertAlmostEqual(xinfo.tiny, xninfo.tiny, places=16)
+            self.assertAlmostEqual(xinfo.resolution, xninfo.resolution)
+            if LooseVersion(np.__version__) >= LooseVersion('1.22.0'):
+                self.assertAlmostEqual(
+                    xinfo.smallest_normal, xninfo.smallest_normal, places=16
+                )
+
+        xinfo = paddle.finfo(paddle.float16)
+        self.assertEqual(xinfo.dtype, "float16")
+        self.assertEqual(xinfo.bits, 16)
+        self.assertAlmostEqual(xinfo.max, 65504.0)
+        self.assertAlmostEqual(xinfo.min, -65504.0)
+        self.assertAlmostEqual(xinfo.eps, 0.0009765625)
+        self.assertAlmostEqual(xinfo.tiny, 6.103515625e-05)
+        self.assertAlmostEqual(xinfo.resolution, 0.001)
+        self.assertAlmostEqual(xinfo.smallest_normal, 6.103515625e-05)
+
+        xinfo = paddle.finfo('float16')
+        self.assertEqual(xinfo.dtype, "float16")
+        self.assertEqual(xinfo.bits, 16)
+        self.assertAlmostEqual(xinfo.max, 65504.0)
+        self.assertAlmostEqual(xinfo.min, -65504.0)
+        self.assertAlmostEqual(xinfo.eps, 0.0009765625)
+        self.assertAlmostEqual(xinfo.tiny, 6.103515625e-05)
+        self.assertAlmostEqual(xinfo.resolution, 0.001)
+        self.assertAlmostEqual(xinfo.smallest_normal, 6.103515625e-05)
+
+        xinfo = paddle.finfo(paddle.bfloat16)
+        self.assertEqual(xinfo.dtype, "bfloat16")
+        self.assertEqual(xinfo.bits, 16)
+        self.assertAlmostEqual(xinfo.max, 3.3895313892515355e38)
+        self.assertAlmostEqual(xinfo.min, -3.3895313892515355e38)
+        self.assertAlmostEqual(xinfo.eps, 0.0078125)
+        self.assertAlmostEqual(xinfo.tiny, 1.1754943508222875e-38)
+        self.assertAlmostEqual(xinfo.resolution, 0.01)
+        self.assertAlmostEqual(xinfo.smallest_normal, 1.1754943508222875e-38)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes


### Description
<!-- Describe what you’ve done -->
##### Inconsistent dtype between the old and new IR
* test_executor_feed_non_tensor.py
* test_iinfo_and_finfo.py


