### PR TITLE
[FIX]: Inconsistent dtype between the old and new IR

### DIFF
--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -721,11 +721,12 @@ def _as_lodtensor(data, place, dtype=None):
         assert (
             dtype is not None
         ), 'The dtype should be given when feed data is not np.ndarray'
-        dtype = (
-            convert_dtype(dtype)
-            if isinstance(dtype, core.VarDesc.VarType)
-            else dtype
-        )
+        # dtype = (
+        #     convert_dtype(dtype)
+        #     if isinstance(dtype, core.VarDesc.VarType)
+        #     else dtype
+        # )
+        dtype = convert_dtype(dtype)
         if np.isscalar(data):
             data = np.array(data).astype(dtype)
         elif isinstance(data, (list, tuple)):

--- a/python/paddle/framework/dtype.py
+++ b/python/paddle/framework/dtype.py
@@ -186,7 +186,9 @@ def iinfo(dtype):
             uint8
 
     """
-    if dtype in _NUMPY_DTYPE_2_PADDLE_DTYPE:
+    if isinstance(dtype, paddle.pir.core.DataType):
+        dtype = paddle.base.framework.paddle_type_to_proto_type[dtype]
+    elif dtype in _NUMPY_DTYPE_2_PADDLE_DTYPE:
         dtype = _NUMPY_DTYPE_2_PADDLE_DTYPE[dtype]
     return core_iinfo(dtype)
 

--- a/test/legacy_test/test_executor_feed_non_tensor.py
+++ b/test/legacy_test/test_executor_feed_non_tensor.py
@@ -22,12 +22,12 @@ class TestAsLodTensor(unittest.TestCase):
     def test_as_lodtensor_int32(self):
         cpu = base.CPUPlace()
         tensor = base.executor._as_lodtensor(1.0, cpu, paddle.int32)
-        self.assertEqual(tensor._dtype(), paddle.int32)
+        self.assertEqual(tensor._dtype(), base.core.VarDesc.VarType.INT32)
 
     def test_as_lodtensor_fp64(self):
         cpu = base.CPUPlace()
         tensor = base.executor._as_lodtensor(1, cpu, paddle.float64)
-        self.assertEqual(tensor._dtype(), paddle.float64)
+        self.assertEqual(tensor._dtype(), base.core.VarDesc.VarType.FP64)
 
     def test_as_lodtensor_assertion_error(self):
         cpu = base.CPUPlace()
@@ -46,12 +46,12 @@ class TestAsLodTensor(unittest.TestCase):
     def test_as_lodtensor_list(self):
         cpu = base.CPUPlace()
         tensor = base.executor._as_lodtensor([1, 2], cpu, paddle.float64)
-        self.assertEqual(tensor._dtype(), paddle.float64)
+        self.assertEqual(tensor._dtype(), base.core.VarDesc.VarType.FP64)
 
     def test_as_lodtensor_tuple(self):
         cpu = base.CPUPlace()
         tensor = base.executor._as_lodtensor((1, 2), cpu, paddle.float64)
-        self.assertEqual(tensor._dtype(), paddle.float64)
+        self.assertEqual(tensor._dtype(), base.core.VarDesc.VarType.FP64)
 
     def test_as_lodtensor_nested_list(self):
         cpu = base.CPUPlace()

--- a/test/legacy_test/test_iinfo_and_finfo.py
+++ b/test/legacy_test/test_iinfo_and_finfo.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from distutils.version import LooseVersion
 
 import numpy as np
 
@@ -76,7 +77,7 @@ class TestIInfoAndFInfoAPI(unittest.TestCase):
             self.assertAlmostEqual(xinfo.eps, xninfo.eps)
             self.assertAlmostEqual(xinfo.tiny, xninfo.tiny)
             self.assertAlmostEqual(xinfo.resolution, xninfo.resolution)
-            if np.lib.NumpyVersion(np.__version__) >= "1.22.0":
+            if LooseVersion(np.__version__) >= LooseVersion('1.22.0'):
                 self.assertAlmostEqual(
                     xinfo.smallest_normal, xninfo.smallest_normal
                 )
@@ -96,7 +97,7 @@ class TestIInfoAndFInfoAPI(unittest.TestCase):
             self.assertAlmostEqual(xinfo.eps, xninfo.eps, places=16)
             self.assertAlmostEqual(xinfo.tiny, xninfo.tiny, places=16)
             self.assertAlmostEqual(xinfo.resolution, xninfo.resolution)
-            if np.lib.NumpyVersion(np.__version__) >= "1.22.0":
+            if LooseVersion(np.__version__) >= LooseVersion('1.22.0'):
                 self.assertAlmostEqual(
                     xinfo.smallest_normal, xninfo.smallest_normal, places=16
                 )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
[FIX]: Inconsistent dtype between the old and new IR
* test_executor_feed_non_tensor.py
* test_iinfo_and_finfo.py