### PR TITLE
[FIX]Add timeout for test_while_api

### DIFF
--- a/test/ir/pir/CMakeLists.txt
+++ b/test/ir/pir/CMakeLists.txt
@@ -31,6 +31,7 @@ endforeach()
 
 set_tests_properties(test_pd_inplace_pass PROPERTIES TIMEOUT 60)
 set_tests_properties(test_map_op_another_pass PROPERTIES TIMEOUT 60)
+set_tests_properties(test_while_api PROPERTIES TIMEOUT 100)
 
 py_test_modules(
   test_subgraph_exporter


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
pcard-67164
Add timeout for test_while_api