### PR TITLE
[CINN]Add InferSymbolicShape for some TensorArray ops

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -642,6 +642,19 @@ void InitBlockArgSymbolicShape(const pir::Value &origin_input,
   origin_input_shape_or_data.Match(
       [&](const symbol::TensorShapeOrDataDimExprs &impl) {
         infer_context->SetSymbolForValueByStaticShape(block_arg);
+        const auto &origin_data = origin_input_shape_or_data.data();
+        if (origin_data) {
+          const auto &block_arg_shape =
+              infer_context->GetShapeOrDataForValue(block_arg).shape();
+          std::vector<symbol::DimExpr> block_arg_data;
+          for (size_t i = 0; i < origin_data.value().size(); ++i) {
+            block_arg_data.emplace_back(infer_context->GetNextSymName());
+          }
+          infer_context->SetShapeOrDataForValue(
+              block_arg,
+              symbol::ShapeOrDataDimExprs(symbol::TensorShapeOrDataDimExprs(
+                  block_arg_shape, block_arg_data)));
+        }
       },
       [&](const symbol::TensorListShapeOrDataDimExprs &impl) {
         PADDLE_THROW(phi::errors::Fatal(

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -642,9 +642,6 @@ void InitBlockArgSymbolicShape(const pir::Value &origin_input,
   origin_input_shape_or_data.Match(
       [&](const symbol::TensorShapeOrDataDimExprs &impl) {
         infer_context->SetSymbolForValueByStaticShape(block_arg);
-        const auto &origin_input_shape = impl.shape();
-        const auto &block_arg_shape =
-            infer_context->GetShapeOrDataForValue(block_arg).shape();
       },
       [&](const symbol::TensorListShapeOrDataDimExprs &impl) {
         PADDLE_THROW(phi::errors::Fatal(
@@ -653,7 +650,7 @@ void InitBlockArgSymbolicShape(const pir::Value &origin_input,
       [&](const symbol::RankedTensorArrayShapeOrDataDimExprs &impl) {
         const auto &input_shape_hint = impl.GetShapeHint();
         std::vector<symbol::DimExpr> block_arg_shape_hint;
-        for (int i = 0; i < input_shape_hint.size(); ++i) {
+        for (size_t i = 0; i < input_shape_hint.size(); ++i) {
           block_arg_shape_hint.emplace_back(infer_context->GetNextSymName());
         }
         infer_context->SetShapeOrDataForValue(

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -2132,6 +2132,13 @@ bool ArrayToTensorOp::InferSymbolicShape(
   } else {
     infer_context->SetShapeOrDataForValue(out(), UseConcatInfer());
   }
+
+  std::vector<symbol::DimExpr> out_index_shape{
+      symbol::DimExpr{infer_context->GetNextSymName()}};
+  infer_context->SetShapeOrDataForValue(
+      out_index(),
+      symbol::ShapeOrDataDimExprs(
+          symbol::TensorShapeOrDataDimExprs(out_index_shape)));
   return true;
 }
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -1257,6 +1257,16 @@ std::vector<pir::Type> CreateArrayOp::InferMeta(
   return argument_outputs;
 }
 
+bool CreateArrayOp::InferSymbolicShape(
+    pir::InferSymbolicShapeContext *infer_context) {
+  infer_context->SetShapeOrDataForValue(
+      out(),
+      symbol::ShapeOrDataDimExprs{symbol::RankedTensorArrayShapeOrDataDimExprs(
+          std::vector<symbol::DimExpr>{})});
+
+  return true;
+}
+
 const char *CreateArrayLikeOp::attributes_name[1] = {"val"};  // NOLINT
 
 OpInfoTuple CreateArrayLikeOp::GetOpInfo() {
@@ -1513,6 +1523,16 @@ std::vector<pir::Type> ArrayLengthOp::InferMeta(
       dense_out.offset());
   argument_outputs.push_back(out_dense_tensor_type);
   return argument_outputs;
+}
+
+bool ArrayLengthOp::InferSymbolicShape(
+    pir::InferSymbolicShapeContext *infer_context) {
+  infer_context->SetShapeOrDataForValue(
+      out(),
+      symbol::ShapeOrDataDimExprs{
+          symbol::TensorShapeOrDataDimExprs({symbol::DimExpr{1}})});
+
+  return true;
 }
 
 OpInfoTuple ArrayReadOp::GetOpInfo() {
@@ -1879,6 +1899,17 @@ std::vector<pir::Type> ArrayWrite_Op::InferMeta(
   return argument_outputs;
 }
 
+bool ArrayWrite_Op::InferSymbolicShape(
+    pir::InferSymbolicShapeContext *infer_context) {
+  const auto &x_shape = infer_context->GetShapeOrDataForValue(x()).shape();
+  infer_context->SetShapeOrDataForValue(
+      out(),
+      symbol::ShapeOrDataDimExprs{
+          symbol::RankedTensorArrayShapeOrDataDimExprs(x_shape)});
+
+  return true;
+}
+
 const char *ArrayToTensorOp::attributes_name[2] = {"axis",
                                                    "use_stack"};  //  NOLINT
 
@@ -2070,6 +2101,38 @@ std::vector<pir::Type> ArrayToTensorOp::InferMeta(
       dense_out_index.offset());
   argument_outputs.push_back(out_index_dense_tensor_type);
   return argument_outputs;
+}
+
+bool ArrayToTensorOp::InferSymbolicShape(
+    pir::InferSymbolicShapeContext *infer_context) {
+  int axis =
+      this->attributes().at("axis").dyn_cast<pir::Int32Attribute>().data();
+  bool use_stack =
+      this->attributes().at("use_stack").dyn_cast<pir::BoolAttribute>().data();
+  const auto &x_shape_data =
+      infer_context->GetShapeOrDataForValue(x())
+          .dyn_cast<symbol::RankedTensorArrayShapeOrDataDimExprs>();
+
+  const auto &UseStackInfer = [&]() {
+    std::vector<symbol::DimExpr> result_shape = x_shape_data.GetShapeHint();
+    result_shape.insert(result_shape.begin() + axis,
+                        symbol::DimExpr{infer_context->GetNextSymName()});
+    return symbol::ShapeOrDataDimExprs(
+        symbol::TensorShapeOrDataDimExprs(result_shape));
+  };
+
+  const auto &UseConcatInfer = [&]() {
+    std::vector<symbol::DimExpr> result_shape = x_shape_data.GetShapeHint();
+    result_shape[axis] = symbol::DimExpr{infer_context->GetNextSymName()};
+    return symbol::ShapeOrDataDimExprs(
+        symbol::TensorShapeOrDataDimExprs(result_shape));
+  };
+  if (use_stack) {
+    infer_context->SetShapeOrDataForValue(out(), UseStackInfer());
+  } else {
+    infer_context->SetShapeOrDataForValue(out(), UseConcatInfer());
+  }
+  return true;
 }
 
 const char *TensorToArrayOp::attributes_name[2] = {"axis",

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.h
@@ -175,6 +175,7 @@ class SplitGradOp : public pir::Op<SplitGradOp, OpYamlInfoInterface> {
 class CreateArrayOp : public pir::Op<CreateArrayOp,
                                      OpYamlInfoInterface,
                                      InferMetaInterface,
+                                     InferSymbolicShapeInterface,
                                      paddle::dialect::ForwardOnlyTrait> {
  public:
   using Op::Op;
@@ -191,6 +192,7 @@ class CreateArrayOp : public pir::Op<CreateArrayOp,
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
       pir::AttributeMap *p_attributes);
+  bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
 };
 
 class CreateArrayLikeOp : public pir::Op<CreateArrayLikeOp,
@@ -219,6 +221,7 @@ class CreateArrayLikeOp : public pir::Op<CreateArrayLikeOp,
 class ArrayLengthOp : public pir::Op<ArrayLengthOp,
                                      OpYamlInfoInterface,
                                      InferMetaInterface,
+                                     InferSymbolicShapeInterface,
                                      paddle::dialect::ForwardOnlyTrait> {
  public:
   using Op::Op;
@@ -236,6 +239,7 @@ class ArrayLengthOp : public pir::Op<ArrayLengthOp,
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
       pir::AttributeMap *p_attributes);
+  bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
 };
 
 class ArrayReadOp : public pir::Op<ArrayReadOp,
@@ -277,6 +281,7 @@ class ArrayWrite_Op : public pir::Op<ArrayWrite_Op,
                                      OpYamlInfoInterface,
                                      paddle::dialect::VjpInterface,
                                      InferMetaInterface,
+                                     InferSymbolicShapeInterface,
                                      InplaceTrait,
                                      paddle::dialect::ForwardOnlyTrait> {
  public:
@@ -299,6 +304,7 @@ class ArrayWrite_Op : public pir::Op<ArrayWrite_Op,
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
       pir::AttributeMap *p_attributes);
+  bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
   static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
@@ -310,7 +316,8 @@ class ArrayWrite_Op : public pir::Op<ArrayWrite_Op,
 class ArrayToTensorOp : public pir::Op<ArrayToTensorOp,
                                        OpYamlInfoInterface,
                                        paddle::dialect::VjpInterface,
-                                       InferMetaInterface> {
+                                       InferMetaInterface,
+                                       InferSymbolicShapeInterface> {
  public:
   using Op::Op;
   static const char *name() { return "pd_op.array_to_tensor"; }
@@ -330,6 +337,7 @@ class ArrayToTensorOp : public pir::Op<ArrayToTensorOp,
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
       pir::AttributeMap *p_attributes);
+  bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
   static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR adds InferSymbolicShape for some TensorArray ops.