### PR TITLE
fix relu grad bug

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3261,7 +3261,7 @@ struct CudaReluGradFunctor : public BaseActivationFunctor<T> {
 
   // dx = dout * (out > 0)
   __device__ __forceinline__ T operator()(const T dout, const T out) const {
-    return out < zero ? zero : dout;
+    return out <= zero ? zero : dout;
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3261,7 +3261,7 @@ struct CudaReluGradFunctor : public BaseActivationFunctor<T> {
 
   // dx = dout * (out > 0)
   __device__ __forceinline__ T operator()(const T dout, const T out) const {
-    return out > zero ? dout : zero;
+    return out < zero ? zero : dout;
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -2712,8 +2712,11 @@ class TestRelu_NanInput(TestActivation):
         x[np.abs(x) < 0.005] = 0.02
         x[-1] = float('nan')
         tensor_x = paddle.to_tensor(x)
+        tensor_x.stop_gradient = False
         out = paddle.nn.functional.relu(tensor_x)
         self.outputs_paddle = out
+        grad = paddle.grad([out], [tensor_x])[0]
+        self.grad_paddle = grad
 
     def test_check_output(self):
         self.assertTrue(
@@ -2721,7 +2724,7 @@ class TestRelu_NanInput(TestActivation):
         )
 
     def test_check_grad(self):
-        pass
+        self.assertTrue((self.grad_paddle[-1] == 1.0).any().numpy())
 
 
 class TestReluAPI(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Others


### PR Types
Bug fixes


### Description
[Fix Bug] The input has 'NAN', but the grad of relu in 'NAN' is 0.
<img width="547" alt="image" src="https://github.com/user-attachments/assets/6cbfdc29-88b9-461a-be50-9f8de9754ae4">
