### PR TITLE
[Typing][C-55] Add type annotations for `python/paddle/incubate/autotune.py`

### DIFF
--- a/python/paddle/incubate/autotune.py
+++ b/python/paddle/incubate/autotune.py
@@ -12,16 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 import warnings
+from typing import TYPE_CHECKING, TypedDict
 
 import paddle
 from paddle.base import core
 
+if TYPE_CHECKING:
+    from typing_extensions import NotRequired
+
+    class _Kernel(TypedDict):
+        enable: bool
+        tuning_range: list[int] | tuple[int, int]
+
+    class _Layout(TypedDict):
+        enable: bool
+
+    class _Dataloader(TypedDict):
+        enable: bool
+        tuning_steps: int
+
+    class _ConfigKernel(TypedDict):
+        kernel: NotRequired[_Kernel]
+        layout: NotRequired[_Layout]
+        dataloader: NotRequired[_Dataloader]
+
+
 __all__ = ['set_config']
 
 
-def set_config(config=None):
+def set_config(config: _ConfigKernel | str | None = None) -> None:
     r"""
     Set the configuration for kernel, layout and dataloader auto-tuning.
 

--- a/python/paddle/incubate/autotune.py
+++ b/python/paddle/incubate/autotune.py
@@ -95,7 +95,7 @@ def set_config(config: _ConfigKernel | str | None = None) -> None:
             ...         "enable": True,
             ...     }
             >>> }
-            >>> paddle.incubate.autotune.set_config(config)
+            >>> paddle.incubate.autotune.set_config(config) # type: ignore[arg-type]
 
             >>> # config is the path of json file.
             >>> config_json = json.dumps(config)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

类型标注：

- `python/paddle/incubate/autotune.py`

### Related links
 
- https://github.com/PaddlePaddle/Paddle/issues/65008

@SigureMo @megemini 