### PR TITLE
[Typing][C-59] Add type annotations for `python/paddle/incubate/autograd/functional.py`

### DIFF
--- a/python/paddle/incubate/autograd/functional.py
+++ b/python/paddle/incubate/autograd/functional.py
@@ -12,11 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import typing
+from typing import TYPE_CHECKING, Protocol, Sequence, overload
 
 import paddle
 from paddle.base import framework
 from paddle.incubate.autograd import primapi, utils
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeVar
+
+    from paddle import Tensor
+    from paddle._typing import TensorOrTensors
+
+    _T_TensorOrTensors = TypeVar("_T_TensorOrTensors", Tensor, Sequence[Tensor])
+
+    class _Func(Protocol):
+        def __call__(self, _T_TensorOrTensors) -> _T_TensorOrTensors:
+            ...
+
+
+@overload
+def vjp(func: _Func, xs: Tensor, v: TensorOrTensors | None = None) -> Tensor:
+    ...
+
+
+@overload
+def vjp(
+    func: _Func, xs: Sequence[Tensor], v: TensorOrTensors | None = None
+) -> tuple[Tensor]:
+    ...
 
 
 def vjp(func, xs, v=None):
@@ -75,6 +102,18 @@ def vjp(func, xs, v=None):
     _check_v_shape(v, ys)
 
     return ys, _grad(ys, xs, v)
+
+
+@overload
+def jvp(func: _Func, xs: Tensor, v: TensorOrTensors | None = None) -> Tensor:
+    ...
+
+
+@overload
+def jvp(
+    func: _Func, xs: Sequence[Tensor], v: TensorOrTensors | None = None
+) -> tuple[Tensor]:
+    ...
 
 
 def jvp(func, xs, v=None):
@@ -239,17 +278,19 @@ class Jacobian:
 
     """
 
-    def __init__(self, func, xs, is_batched=False):
+    def __init__(
+        self, func: _Func, xs: TensorOrTensors, is_batched: bool = False
+    ) -> None:
         if not is_batched:
             self._jacobian = _JacobianNoBatch(func, xs)
         else:
             self._jacobian = _JacobianBatchFirst(func, xs)
 
-    def __getitem__(self, indexes):
+    def __getitem__(self, indexes: int | slice) -> Tensor:
         return self._jacobian[indexes]
 
     @property
-    def shape(self):
+    def shape(self) -> list[int]:
         """The shape of flattened Jacobian matrix."""
         return self._jacobian.shape
 
@@ -302,7 +343,11 @@ class Hessian:
 
     """
 
-    def __init__(self, func, xs, is_batched=False):
+    symbolic: Jacobian
+
+    def __init__(
+        self, func: _Func, xs: TensorOrTensors, is_batched: bool = False
+    ) -> None:
         def _jac_func(*xs):
             jac = Jacobian(func, xs, is_batched=is_batched)
             if (is_batched and jac.shape[1] != 1) or (
@@ -315,11 +360,11 @@ class Hessian:
 
         self.symbolic = Jacobian(_jac_func, xs, is_batched=is_batched)
 
-    def __getitem__(self, indexes):
+    def __getitem__(self, indexes: int | slice) -> Tensor:
         return self.symbolic[indexes]
 
     @property
-    def shape(self):
+    def shape(self) -> list[int]:
         """The shape of flattened Hessian matrix."""
         return self.symbolic.shape
 

--- a/python/paddle/incubate/autograd/functional.py
+++ b/python/paddle/incubate/autograd/functional.py
@@ -15,15 +15,13 @@
 from __future__ import annotations
 
 import typing
-from typing import TYPE_CHECKING, Protocol, Sequence, overload
+from typing import TYPE_CHECKING, Protocol, Sequence, TypeVar, overload
 
 import paddle
 from paddle.base import framework
 from paddle.incubate.autograd import primapi, utils
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeVar
-
     from paddle import Tensor
     from paddle._typing import TensorOrTensors
 

--- a/python/paddle/incubate/autograd/functional.py
+++ b/python/paddle/incubate/autograd/functional.py
@@ -15,12 +15,7 @@
 from __future__ import annotations
 
 import typing
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    Sequence,
-    overload,
-)
+from typing import TYPE_CHECKING, Callable, Sequence, Tuple, TypeVar, overload
 
 import paddle
 from paddle.base import framework
@@ -30,40 +25,24 @@ if TYPE_CHECKING:
     from paddle import Tensor
     from paddle._typing import TensorOrTensors
 
+    _OutputT = TypeVar("_OutputT", Tensor, Tuple[Tensor, ...])
+
 
 @overload
 def vjp(
-    func: Callable[..., Tensor],
+    func: Callable[..., _OutputT],
     xs: Tensor,
     v: TensorOrTensors | None = None,
-) -> tuple[Tensor, Tensor]:
+) -> tuple[_OutputT, Tensor]:
     ...
 
 
 @overload
 def vjp(
-    func: Callable[..., tuple[Tensor, ...]],
-    xs: Tensor,
-    v: TensorOrTensors | None = None,
-) -> tuple[tuple[Tensor, ...], Tensor]:
-    ...
-
-
-@overload
-def vjp(
-    func: Callable[..., Tensor],
+    func: Callable[..., _OutputT],
     xs: Sequence[Tensor],
     v: TensorOrTensors | None = None,
-) -> tuple[Tensor, tuple[Tensor, ...]]:
-    ...
-
-
-@overload
-def vjp(
-    func: Callable[..., tuple[Tensor, ...]],
-    xs: Sequence[Tensor],
-    v: TensorOrTensors | None = None,
-) -> tuple[tuple[Tensor, ...], tuple[Tensor, ...]]:
+) -> tuple[_OutputT, tuple[Tensor, ...]]:
     ...
 
 
@@ -127,37 +106,19 @@ def vjp(func, xs, v=None):
 
 @overload
 def jvp(
-    func: Callable[..., Tensor],
+    func: Callable[..., _OutputT],
     xs: Tensor,
     v: TensorOrTensors | None = None,
-) -> tuple[Tensor, Tensor]:
+) -> tuple[_OutputT, Tensor]:
     ...
 
 
 @overload
 def jvp(
-    func: Callable[..., tuple[Tensor, ...]],
-    xs: Tensor,
-    v: TensorOrTensors | None = None,
-) -> tuple[tuple[Tensor, ...], Tensor]:
-    ...
-
-
-@overload
-def jvp(
-    func: Callable[..., Tensor],
+    func: Callable[..., _OutputT],
     xs: Sequence[Tensor],
     v: TensorOrTensors | None = None,
-) -> tuple[Tensor, tuple[Tensor, ...]]:
-    ...
-
-
-@overload
-def jvp(
-    func: Callable[..., tuple[Tensor, ...]],
-    xs: Sequence[Tensor],
-    v: TensorOrTensors | None = None,
-) -> tuple[tuple[Tensor, ...], tuple[Tensor, ...]]:
+) -> tuple[_OutputT, tuple[Tensor, ...]]:
     ...
 
 

--- a/python/paddle/incubate/autograd/functional.py
+++ b/python/paddle/incubate/autograd/functional.py
@@ -18,7 +18,6 @@ import typing
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Protocol,
     Sequence,
     overload,
 )
@@ -28,24 +27,13 @@ from paddle.base import framework
 from paddle.incubate.autograd import primapi, utils
 
 if TYPE_CHECKING:
-    from typing_extensions import Unpack
-
     from paddle import Tensor
     from paddle._typing import TensorOrTensors
 
-    class _Func(Protocol):
-        @overload
-        def __call__(self, arg: Tensor, /) -> Tensor:
-            ...
-
-        @overload
-        def __call__(self, *args: Tensor) -> Tensor:
-            ...
-
 
 @overload
 def vjp(
-    func: Callable[[Tensor], Tensor],
+    func: Callable[..., Tensor],
     xs: Tensor,
     v: TensorOrTensors | None = None,
 ) -> tuple[Tensor, Tensor]:
@@ -54,16 +42,16 @@ def vjp(
 
 @overload
 def vjp(
-    func: Callable[[Unpack[tuple[Tensor, ...]]], Tensor],
+    func: Callable[..., tuple[Tensor, ...]],
     xs: Tensor,
     v: TensorOrTensors | None = None,
-) -> tuple[Tensor, Tensor]:
+) -> tuple[tuple[Tensor, ...], Tensor]:
     ...
 
 
 @overload
 def vjp(
-    func: Callable[[Tensor], Tensor],
+    func: Callable[..., Tensor],
     xs: Sequence[Tensor],
     v: TensorOrTensors | None = None,
 ) -> tuple[Tensor, tuple[Tensor, ...]]:
@@ -72,10 +60,10 @@ def vjp(
 
 @overload
 def vjp(
-    func: Callable[[Unpack[tuple[Tensor, ...]]], Tensor],
+    func: Callable[..., tuple[Tensor, ...]],
     xs: Sequence[Tensor],
     v: TensorOrTensors | None = None,
-) -> tuple[Tensor, tuple[Tensor, ...]]:
+) -> tuple[tuple[Tensor, ...], tuple[Tensor, ...]]:
     ...
 
 
@@ -139,7 +127,7 @@ def vjp(func, xs, v=None):
 
 @overload
 def jvp(
-    func: Callable[[Tensor], Tensor],
+    func: Callable[..., Tensor],
     xs: Tensor,
     v: TensorOrTensors | None = None,
 ) -> tuple[Tensor, Tensor]:
@@ -148,16 +136,16 @@ def jvp(
 
 @overload
 def jvp(
-    func: Callable[[Unpack[tuple[Tensor, ...]]], Tensor],
+    func: Callable[..., tuple[Tensor, ...]],
     xs: Tensor,
     v: TensorOrTensors | None = None,
-) -> tuple[Tensor, Tensor]:
+) -> tuple[tuple[Tensor, ...], Tensor]:
     ...
 
 
 @overload
 def jvp(
-    func: Callable[[Tensor], Tensor],
+    func: Callable[..., Tensor],
     xs: Sequence[Tensor],
     v: TensorOrTensors | None = None,
 ) -> tuple[Tensor, tuple[Tensor, ...]]:
@@ -166,10 +154,10 @@ def jvp(
 
 @overload
 def jvp(
-    func: Callable[[Unpack[tuple[Tensor, ...]]], Tensor],
+    func: Callable[..., tuple[Tensor, ...]],
     xs: Sequence[Tensor],
     v: TensorOrTensors | None = None,
-) -> tuple[Tensor, tuple[Tensor, ...]]:
+) -> tuple[tuple[Tensor, ...], tuple[Tensor, ...]]:
     ...
 
 
@@ -336,7 +324,10 @@ class Jacobian:
     """
 
     def __init__(
-        self, func: _Func, xs: TensorOrTensors, is_batched: bool = False
+        self,
+        func: Callable[..., TensorOrTensors],
+        xs: TensorOrTensors,
+        is_batched: bool = False,
     ) -> None:
         if not is_batched:
             self._jacobian = _JacobianNoBatch(func, xs)
@@ -403,7 +394,10 @@ class Hessian:
     symbolic: Jacobian
 
     def __init__(
-        self, func: _Func, xs: TensorOrTensors, is_batched: bool = False
+        self,
+        func: Callable[..., TensorOrTensors],
+        xs: TensorOrTensors,
+        is_batched: bool = False,
     ) -> None:
         def _jac_func(*xs):
             jac = Jacobian(func, xs, is_batched=is_batched)

--- a/python/paddle/incubate/autograd/functional.py
+++ b/python/paddle/incubate/autograd/functional.py
@@ -15,32 +15,67 @@
 from __future__ import annotations
 
 import typing
-from typing import TYPE_CHECKING, Protocol, Sequence, TypeVar, overload
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Protocol,
+    Sequence,
+    overload,
+)
 
 import paddle
 from paddle.base import framework
 from paddle.incubate.autograd import primapi, utils
 
 if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
     from paddle import Tensor
     from paddle._typing import TensorOrTensors
 
-    _T_TensorOrTensors = TypeVar("_T_TensorOrTensors", Tensor, Sequence[Tensor])
-
     class _Func(Protocol):
-        def __call__(self, _T_TensorOrTensors) -> _T_TensorOrTensors:
+        @overload
+        def __call__(self, arg: Tensor, /) -> Tensor:
+            ...
+
+        @overload
+        def __call__(self, *args: Tensor) -> Tensor:
             ...
 
 
 @overload
-def vjp(func: _Func, xs: Tensor, v: TensorOrTensors | None = None) -> Tensor:
+def vjp(
+    func: Callable[[Tensor], Tensor],
+    xs: Tensor,
+    v: TensorOrTensors | None = None,
+) -> tuple[Tensor, Tensor]:
     ...
 
 
 @overload
 def vjp(
-    func: _Func, xs: Sequence[Tensor], v: TensorOrTensors | None = None
-) -> tuple[Tensor]:
+    func: Callable[[Unpack[tuple[Tensor, ...]]], Tensor],
+    xs: Tensor,
+    v: TensorOrTensors | None = None,
+) -> tuple[Tensor, Tensor]:
+    ...
+
+
+@overload
+def vjp(
+    func: Callable[[Tensor], Tensor],
+    xs: Sequence[Tensor],
+    v: TensorOrTensors | None = None,
+) -> tuple[Tensor, tuple[Tensor, ...]]:
+    ...
+
+
+@overload
+def vjp(
+    func: Callable[[Unpack[tuple[Tensor, ...]]], Tensor],
+    xs: Sequence[Tensor],
+    v: TensorOrTensors | None = None,
+) -> tuple[Tensor, tuple[Tensor, ...]]:
     ...
 
 
@@ -103,14 +138,38 @@ def vjp(func, xs, v=None):
 
 
 @overload
-def jvp(func: _Func, xs: Tensor, v: TensorOrTensors | None = None) -> Tensor:
+def jvp(
+    func: Callable[[Tensor], Tensor],
+    xs: Tensor,
+    v: TensorOrTensors | None = None,
+) -> tuple[Tensor, Tensor]:
     ...
 
 
 @overload
 def jvp(
-    func: _Func, xs: Sequence[Tensor], v: TensorOrTensors | None = None
-) -> tuple[Tensor]:
+    func: Callable[[Unpack[tuple[Tensor, ...]]], Tensor],
+    xs: Tensor,
+    v: TensorOrTensors | None = None,
+) -> tuple[Tensor, Tensor]:
+    ...
+
+
+@overload
+def jvp(
+    func: Callable[[Tensor], Tensor],
+    xs: Sequence[Tensor],
+    v: TensorOrTensors | None = None,
+) -> tuple[Tensor, tuple[Tensor, ...]]:
+    ...
+
+
+@overload
+def jvp(
+    func: Callable[[Unpack[tuple[Tensor, ...]]], Tensor],
+    xs: Sequence[Tensor],
+    v: TensorOrTensors | None = None,
+) -> tuple[Tensor, tuple[Tensor, ...]]:
     ...
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

类型标注：

- `python/paddle/incubate/autograd/functional.py`

### Related links
 
- https://github.com/PaddlePaddle/Paddle/issues/65008

@SigureMo @megemini 
