### PR TITLE
[CodeStyle][SIM114] Cleanup duplicate branches (part2)

### DIFF
--- a/paddle/fluid/prim/api/auto_code_generated/eager_gen.py
+++ b/paddle/fluid/prim/api/auto_code_generated/eager_gen.py
@@ -282,10 +282,7 @@ template <typename T>
         input_args = []
         for name in self.inputs['names']:
             name = name.split('@')[0]
-            if inplace_flag and name in self.inplace_map.values():
-                input_args.append(name)
-            else:
-                input_args.append(name)
+            input_args.append(name)
         return input_args
 
     def get_ad_func_args(self, inplace_flag=False):

--- a/paddle/fluid/prim/api/auto_code_generated/tensor_operants_gen.py
+++ b/paddle/fluid/prim/api/auto_code_generated/tensor_operants_gen.py
@@ -344,10 +344,7 @@ class PrimTensorAPI(BaseAPI):
         input_args = []
         for name in self.inputs['names']:
             name = name.split('@')[0]
-            if inplace_flag and name in self.inplace_map.values():
-                input_args.append(name)
-            else:
-                input_args.append(name)
+            input_args.append(name)
         return input_args
 
     def get_func_args(self, inplace_flag=False):

--- a/python/paddle/dataset/conll05.py
+++ b/python/paddle/dataset/conll05.py
@@ -48,9 +48,7 @@ def load_label_dict(filename):
     with open(filename, 'r') as f:
         for i, line in enumerate(f):
             line = line.strip()
-            if line.startswith("B-"):
-                tag_dict.add(line[2:])
-            elif line.startswith("I-"):
+            if line.startswith(("B-", "I-")):
                 tag_dict.add(line[2:])
         index = 0
         for tag in tag_dict:

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -2186,9 +2186,7 @@ class DistModel:
         for feed_item in list(args):
             if isinstance(feed_item, (list, tuple)):
                 feed_list += list(feed_item)
-            elif isinstance(feed_item, paddle.Tensor):
-                feed_list += [feed_item]
-            elif isinstance(feed_item, core.LoDTensor):
+            elif isinstance(feed_item, (paddle.Tensor, core.LoDTensor)):
                 feed_list += [feed_item]
             else:
                 raise TypeError(

--- a/python/paddle/distributed/auto_parallel/static/reshard.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard.py
@@ -1874,9 +1874,9 @@ class Resharder:
         for rank_id in op_desc_seq:
             op_desc_list = op_desc_seq[rank_id]
             for op_desc in op_desc_list:
-                if isinstance(op_desc, AllGatherOpDesc):
-                    new_process_group(op_desc.group)
-                elif isinstance(op_desc, AllGatherConcatOpDesc):
+                if isinstance(
+                    op_desc, (AllGatherOpDesc, AllGatherConcatOpDesc)
+                ):
                     new_process_group(op_desc.group)
                 elif isinstance(op_desc, SendOpDesc):
                     new_process_group(
@@ -2703,9 +2703,11 @@ class Resharder:
                     idx + 2,
                     type='cast',
                     inputs={
-                        'X': [recv_cast_out]
-                        if reset_lod_out is None
-                        else [reset_lod_out]
+                        'X': (
+                            [recv_cast_out]
+                            if reset_lod_out is None
+                            else [reset_lod_out]
+                        )
                     },
                     outputs={'Out': [var]},
                     attrs={

--- a/python/paddle/framework/io_utils.py
+++ b/python/paddle/framework/io_utils.py
@@ -181,9 +181,7 @@ def _load_program_scope(main=None, startup=None, scope=None):
 @static_only
 def _legacy_static_save(param_dict, model_path, protocol=2):
     def get_tensor(var):
-        if isinstance(var, core.eager.Tensor):
-            return np.array(var)
-        elif isinstance(var, core.LoDTensor):
+        if isinstance(var, (paddle.Tensor, core.LoDTensor)):
             return np.array(var)
         return var
 

--- a/python/paddle/incubate/distributed/fleet/fleet_util.py
+++ b/python/paddle/incubate/distributed/fleet/fleet_util.py
@@ -996,22 +996,13 @@ class FleetUtil:
         self.pull_all_dense_params(scope, program)
         if fleet.worker_index() == 0:
             with base.scope_guard(scope):
-                if save_combine:
-                    paddle.static.io.save_inference_model(
-                        model_name,
-                        feeded_vars,
-                        target_vars,
-                        executor,
-                        program=program.clone(),
-                    )
-                else:
-                    paddle.static.io.save_inference_model(
-                        model_name,
-                        feeded_vars,
-                        target_vars,
-                        executor,
-                        program=program.clone(),
-                    )
+                paddle.static.io.save_inference_model(
+                    model_name,
+                    feeded_vars,
+                    target_vars,
+                    executor,
+                    program=program.clone(),
+                )
 
             configs = {
                 "fs.default.name": hadoop_fs_name,

--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -1343,12 +1343,9 @@ class BatchNorm2D(_BatchNormBase):
     """
 
     def _check_data_format(self, input: DataLayout2D) -> None:
-        if input == 'NCHW':
-            self._data_format = input
-        elif input == "NHWC":
-            self._data_format = input
-        else:
+        if input not in ["NCHW", "NHWC"]:
             raise ValueError('expected NCHW or NHWC for data_format input')
+        self._data_format = input
 
     def _check_input_dim(self, input: Tensor) -> None:
         if len(input.shape) != 4:

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -630,7 +630,7 @@ def _to_tensor_non_static(
                     "\n\tFailed to convert input data to a regular ndarray :\n\t - Usually "
                     "this means the input data contains nested lists with different lengths. "
                 )
-        elif isinstance(data, paddle.Tensor) and not in_dynamic_mode():
+        elif isinstance(data, paddle.Tensor):
             data = data._copy_to(place, False)
             data = _handle_tensor_dtype(data, dtype)
             data.stop_gradient = stop_gradient

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -635,11 +635,6 @@ def _to_tensor_non_static(
             data = _handle_tensor_dtype(data, dtype)
             data.stop_gradient = stop_gradient
             return data
-        elif isinstance(data, core.eager.Tensor) and in_dynamic_mode():
-            data = data._copy_to(place, False)
-            data = _handle_tensor_dtype(data, dtype)
-            data.stop_gradient = stop_gradient
-            return data
         elif isinstance(data, (core.LoDTensor, core.Tensor)):
             # should't expose it to users, just for internal use.
             # convert core.Tensor/core.LoDTensor to Tensor first

--- a/test/ir/inference/test_onednn_reshape_transpose_matmul_fuse_pass.py
+++ b/test/ir/inference/test_onednn_reshape_transpose_matmul_fuse_pass.py
@@ -69,9 +69,7 @@ class TestOneDNNReshapeTransposeMatmulFusePass(PassAutoScanTest):
                     matmul_shape[-1],
                     int(self.num / matmul_shape[-1]),
                 ]
-            elif attrs[2]['transpose_X']:
-                shape_y = matmul_shape
-            elif attrs[2]['transpose_Y']:
+            elif attrs[2]['transpose_X'] or attrs[2]['transpose_Y']:
                 shape_y = matmul_shape
             else:
                 shape_y = [

--- a/test/legacy_test/auto_parallel_gpt_model.py
+++ b/test/legacy_test/auto_parallel_gpt_model.py
@@ -841,12 +841,7 @@ class GPTPretrainingCriterion(nn.Layer):
         loss_mask.stop_gradient = True
 
         mesh = None
-        if _global_parallel_strategy == "dp":
-            mesh = _global_process_mesh
-            dims_mapping = ["x"] + [
-                None for i in range(len(loss_mask.shape) - 1)
-            ]
-        elif _global_parallel_strategy == "dp_mp":
+        if _global_parallel_strategy in ["dp", "dp_mp"]:
             mesh = _global_process_mesh
             dims_mapping = ["x"] + [
                 None for i in range(len(loss_mask.shape) - 1)

--- a/test/legacy_test/test_chunk_eval_op.py
+++ b/test/legacy_test/test_chunk_eval_op.py
@@ -35,9 +35,7 @@ class TestChunkEvalOp(OpTest):
     batch_size = 50
 
     def parse_scheme(self):
-        if self.scheme == 'IOB':
-            self.num_tag_types = 2
-        elif self.scheme == 'IOE':
+        if self.scheme in ['IOB', 'IOE']:
             self.num_tag_types = 2
 
     def fill_with_chunks(self, data, chunks):

--- a/tools/CrossStackProfiler/ProfileFileReader.py
+++ b/tools/CrossStackProfiler/ProfileFileReader.py
@@ -502,10 +502,7 @@ class profileFileReader(FileReader):
 
     def parseFileByGroup(self, groupId, processNum=8):
         fileFist = self.getFileListByGroup(groupId)
-        if processNum == 0:
-            return self._parseTask(fileFist)
-        else:
-            return self._parseTask(fileFist)
+        return self._parseTask(fileFist)
 
 
 def test_profileFileReader():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

同 #66004，清理一些剩余的无用 if-else 分支，同时使用 ruff SIM114 检测一些无用分支进行清理

与上个 PR 中的结论不同，仔细检查过所有 SIM114 发现大多数分支直接合并反而会导致代码风格回退，因为合并后的 cond 会非常难以阅读，不如不合并的形式，因此不引入 SIM114（而且自动修复只会直接加 `or`，其实大多数情况并不合适，所有 case 均为手动按照最合适的方式修改，没有自动加 `or`）

但对于 if-else 分支完全相同的情况检测时有必要引入的，如果将来 ruff 有新的 rule 覆盖了这一点的话

PCard-66972