### PR TITLE
[Typing][C-63] Add type annotations for `python/paddle/incubate/framework/random.py`

### DIFF
--- a/python/paddle/incubate/framework/random.py
+++ b/python/paddle/incubate/framework/random.py
@@ -112,11 +112,38 @@ def get_rng_state(device=None, use_index=False):
     return state_list
 
 
+@overload
+def set_rng_state(
+    state_list: Sequence[int],
+    device: PlaceLike | None = ...,
+    use_index: Literal[True] = ...,
+) -> None:
+    ...
+
+
+@overload
 def set_rng_state(
     state_list: Sequence[_GeneratorState],
-    device: PlaceLike | None = None,
-    use_index: bool = False,
+    device: PlaceLike | None = ...,
+    use_index: Literal[False] = ...,
 ) -> None:
+    ...
+
+
+@overload
+def set_rng_state(
+    state_list: Sequence[int] | Sequence[_GeneratorState],
+    device: PlaceLike | None = ...,
+    use_index: bool = ...,
+) -> None:
+    ...
+
+
+def set_rng_state(
+    state_list,
+    device=None,
+    use_index=False,
+):
     """
 
     Sets generator state for all device generators.

--- a/python/paddle/incubate/framework/random.py
+++ b/python/paddle/incubate/framework/random.py
@@ -12,12 +12,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, Protocol, Sequence, overload
+
 # TODO: define random api
 import paddle
 from paddle import base
 from paddle.base import core
 
+if TYPE_CHECKING:
+    from paddle._typing import PlaceLike
+
+    class _GeneratorState(Protocol):
+        def current_seed(self) -> int:
+            ...
+
+
 __all__ = []
+
+
+@overload
+def get_rng_state(
+    device: PlaceLike | None = ..., use_index: Literal[True] = ...
+) -> list[int]:
+    ...
+
+
+@overload
+def get_rng_state(
+    device: PlaceLike | None = ..., use_index: Literal[False] = ...
+) -> list[_GeneratorState]:
+    ...
+
+
+@overload
+def get_rng_state(
+    device: PlaceLike | None = ..., use_index: bool = ...
+) -> list[int] | list[_GeneratorState]:
+    ...
 
 
 def get_rng_state(device=None, use_index=False):
@@ -79,7 +112,11 @@ def get_rng_state(device=None, use_index=False):
     return state_list
 
 
-def set_rng_state(state_list, device=None, use_index=False):
+def set_rng_state(
+    state_list: Sequence[_GeneratorState],
+    device: PlaceLike | None = None,
+    use_index: bool = False,
+) -> None:
     """
 
     Sets generator state for all device generators.
@@ -156,7 +193,10 @@ def set_rng_state(state_list, device=None, use_index=False):
         )
 
 
-def register_rng_state_as_index(state_list=None, device=None):
+def register_rng_state_as_index(
+    state_list: Sequence[_GeneratorState] | None = None,
+    device: PlaceLike | None = None,
+) -> list[int]:
     """
 
     The register_rng_state_as_index function creates and registers a new generator state within the generator.

--- a/python/paddle/incubate/framework/random.py
+++ b/python/paddle/incubate/framework/random.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Protocol, Sequence, overload
 
-# TODO: define random api
 import paddle
 from paddle import base
 from paddle.base import core


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

类型标注：

- `python/paddle/incubate/framework/random.py`

### Related links
 
- https://github.com/PaddlePaddle/Paddle/issues/65008

@SigureMo @megemini 
