### PR TITLE
[Cleanup] Cleanup some unreachable `_legacy_C_ops` branches

### DIFF
--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -18,9 +18,9 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops
 
-from .. import core, framework
+from .. import core
 from ..framework import convert_np_dtype_to_dtype_
 
 if TYPE_CHECKING:
@@ -102,10 +102,7 @@ def monkey_patch_math_tensor():
     def _scalar_elementwise_op_(
         var: Tensor, scale: float, bias: float
     ) -> Tensor:
-        if framework.in_dygraph_mode():
-            return _C_ops.scale(var, float(scale), bias, True)
-        else:
-            return _legacy_C_ops.scale(var, 'scale', scale, 'bias', bias)
+        return _C_ops.scale(var, float(scale), bias, True)
 
     def _neg_(var: Tensor) -> Tensor:
         return _scalar_elementwise_op_(var, -1.0, 0.0)

--- a/python/paddle/nn/functional/activation.py
+++ b/python/paddle/nn/functional/activation.py
@@ -146,9 +146,7 @@ def elu_(x: Tensor, alpha: float = 1.0, name: str | None = None) -> Tensor:
     Please refer to :ref:`api_paddle_nn_functional_elu`.
     """
     assert alpha >= 0.0, "elu_ only support alpha >= 0, please use elu instead."
-    if in_dynamic_mode():
-        return _C_ops.elu_(x, alpha)
-    return _legacy_C_ops.elu_(x, 'alpha', alpha)
+    return _C_ops.elu_(x, alpha)
 
 
 def gelu(

--- a/test/legacy_test/test_merged_adam_op.py
+++ b/test/legacy_test/test_merged_adam_op.py
@@ -18,7 +18,6 @@ import numpy as np
 
 import paddle
 from paddle import _C_ops, _legacy_C_ops
-from paddle.base.framework import in_dygraph_mode
 
 
 def run_adam_op(
@@ -83,47 +82,21 @@ def run_adam_op(
                 multi_precision,
             )
     else:
-        if in_dygraph_mode():
-            _, _, _, _, _, _ = _C_ops.merged_adam_(
-                param_vars,
-                grad_vars,
-                lr_vars,
-                moment1_vars,
-                moment2_vars,
-                beta1_pow_vars,
-                beta2_pow_vars,
-                master_param_vars,
-                beta1,
-                beta2,
-                epsilon,
-                multi_precision,
-                False,
-            )
-        else:
-            _, _, _, _, _, _ = _legacy_C_ops.merged_adam(
-                param_vars,
-                grad_vars,
-                lr_vars,
-                moment1_vars,
-                moment2_vars,
-                beta1_pow_vars,
-                beta2_pow_vars,
-                master_param_vars,
-                param_vars,
-                moment1_vars,
-                moment2_vars,
-                beta1_pow_vars,
-                beta2_pow_vars,
-                master_param_vars,
-                'epsilon',
-                epsilon,
-                'beta1',
-                beta1,
-                'beta2',
-                beta2,
-                'multi_precision',
-                multi_precision,
-            )
+        _, _, _, _, _, _ = _C_ops.merged_adam_(
+            param_vars,
+            grad_vars,
+            lr_vars,
+            moment1_vars,
+            moment2_vars,
+            beta1_pow_vars,
+            beta2_pow_vars,
+            master_param_vars,
+            beta1,
+            beta2,
+            epsilon,
+            multi_precision,
+            False,
+        )
 
     outputs = {
         'ParamOut': param_vars,

--- a/test/legacy_test/test_squared_l2_norm_op.py
+++ b/test/legacy_test/test_squared_l2_norm_op.py
@@ -21,17 +21,9 @@ from op_test import OpTest
 import paddle
 import paddle.distributed as dist
 from paddle import _C_ops, _legacy_C_ops
-from paddle.framework import in_dynamic_mode
 
 
 def test_squared_l2_norm(x):
-    if in_dynamic_mode():
-        return _C_ops.squared_l2_norm(x)
-    else:
-        return _legacy_C_ops.squared_l2_norm(x)
-
-
-def test_squared_l2_norm_prim(x):
     return _C_ops.squared_l2_norm(x)
 
 
@@ -85,7 +77,7 @@ class TestL2LossOp(OpTest):
     def setUp(self):
         self.config()
         self.python_api = test_squared_l2_norm
-        self.public_python_api = test_squared_l2_norm_prim
+        self.public_python_api = test_squared_l2_norm
         self.op_type = "squared_l2_norm"
         self.prim_op_type = "comp"
         self.max_relative_error = 0.05

--- a/test/xpu/test_merged_adam_op_xpu.py
+++ b/test/xpu/test_merged_adam_op_xpu.py
@@ -26,7 +26,6 @@ import paddle
 # from op import Operator
 # from op_test_xpu import XPUOpTest
 from paddle import _C_ops, _legacy_C_ops
-from paddle.base.framework import in_dygraph_mode
 
 
 def run_adam_op(
@@ -91,47 +90,21 @@ def run_adam_op(
                 False,
             )
     else:
-        if in_dygraph_mode():
-            _, _, _, _, _, _ = _C_ops.merged_adam_(
-                param_vars,
-                grad_vars,
-                lr_vars,
-                moment1_vars,
-                moment2_vars,
-                beta1_pow_vars,
-                beta2_pow_vars,
-                master_param_vars,
-                beta1,
-                beta2,
-                epsilon,
-                False,
-                False,
-            )
-        else:
-            _, _, _, _, _, _ = _legacy_C_ops.merged_adam(
-                param_vars,
-                grad_vars,
-                lr_vars,
-                moment1_vars,
-                moment2_vars,
-                beta1_pow_vars,
-                beta2_pow_vars,
-                master_param_vars,
-                param_vars,
-                moment1_vars,
-                moment2_vars,
-                beta1_pow_vars,
-                beta2_pow_vars,
-                master_param_vars,
-                'epsilon',
-                epsilon,
-                'beta1',
-                beta1,
-                'beta2',
-                beta2,
-                'multi_precision',
-                multi_precision,
-            )
+        _, _, _, _, _, _ = _C_ops.merged_adam_(
+            param_vars,
+            grad_vars,
+            lr_vars,
+            moment1_vars,
+            moment2_vars,
+            beta1_pow_vars,
+            beta2_pow_vars,
+            master_param_vars,
+            beta1,
+            beta2,
+            epsilon,
+            False,
+            False,
+        )
 
     outputs = {
         'ParamOut': param_vars,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

清理曾经为新老动态图分流的分支逻辑，清理掉不可达的 `_legacy_C_ops` 分支

PCard-66972