### PR TITLE
[CINN]Register GenerateXShapeOp  and fix set stop_gradient error

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
@@ -58,6 +58,7 @@ void OperatorDialect::initialize() {
   RegisterOp<SplitOp>();
   RegisterOp<YieldStoreOp>();
   RegisterOp<GenerateShapeOp>();
+  RegisterOp<GenerateXShapeOp>();
   RegisterAttribute<GroupInfoAttribute>();
   RegisterAttribute<CINNKernelInfoAttribute>();
 }

--- a/test/ir/pir/cinn/sub_graphs/base.py
+++ b/test/ir/pir/cinn/sub_graphs/base.py
@@ -39,7 +39,8 @@ class TestBase(unittest.TestCase):
     def set_input_grad(self):
         if self.with_train:
             for i in range(len(self.inputs)):
-                self.inputs[i].stop_gradient = False
+                if self.inputs[i].dtype in [paddle.float32, paddle.float64]:
+                    self.inputs[i].stop_gradient = False
 
     def init(self):
         pass

--- a/test/ir/pir/cinn/sub_graphs/test_sub_graph_3.py
+++ b/test/ir/pir/cinn/sub_graphs/test_sub_graph_3.py
@@ -89,7 +89,7 @@ class TestLayer(TestBase):
             paddle.randint(low=0, high=10, shape=[16, 49], dtype=paddle.int64),
         )
         self.net = LayerCase
-        self.with_train = False
+        self.with_train = True
 
 
 if __name__ == '__main__':

--- a/test/ir/pir/cinn/sub_graphs/test_sub_graph_47.py
+++ b/test/ir/pir/cinn/sub_graphs/test_sub_graph_47.py
@@ -47,7 +47,7 @@ class TestLayer(TestBase):
             paddle.randint(low=0, high=10, shape=[2], dtype=paddle.int64),
         )
         self.net = LayerCase
-        self.with_train = False
+        self.with_train = True
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Fix set stop_gradient error
pcard-72718