### PR TITLE
Fix new comm dev ctx

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
@@ -134,6 +134,27 @@ platform::DeviceContext* ParseDeviceContext(
       }
       return dev_ctx;
     }
+    if (FLAGS_dynamic_static_unified_comm) {
+      if (op_attributes.count("ring_id") != 0) {
+        int ring_id =
+            op_attributes.at("ring_id").dyn_cast<pir::Int32Attribute>().data();
+        const auto& comm_context_manager =
+            phi::distributed::CommContextManager::GetInstance();
+        if (comm_context_manager.Has(std::to_string(ring_id))) {
+          auto comm_context = comm_context_manager.Get(std::to_string(ring_id));
+          dev_ctx = static_cast<platform::DeviceContext*>(
+              static_cast<phi::distributed::NCCLCommContext*>(comm_context)
+                  ->GetDevContext());
+          dev_ctx->SetCommContext(comm_context);
+          if (op_name.compare(paddle::dialect::CReducescatterOp::name()) == 0) {
+            return dev_ctx;
+          }
+        } else {
+          VLOG(10) << "ring_id " << ring_id
+                   << " not found in comm_context_manager for op " << op_name;
+        }
+      }
+    }
 #endif
   }
 

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -51,7 +51,6 @@ const std::unordered_set<std::string> LegacyOpList = {
     CAllreduceAvg_Op::name(),
     CReduceSumOp::name(),
     CReduceSum_Op::name(),
-    CReducescatterOp::name(),
     CAllreduceMax_Op::name(),
     CAllreduceMin_Op::name(),
     CAllgatherOp::name(),

--- a/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
@@ -161,7 +161,8 @@
     func : ReduceScatterInferMeta
     param: [x, nranks]
   kernel :
-    func : c_reducescatter
+    func : reduce_scatter
+    param: [x, nranks]
 
 - op : c_scatter
   args : (Tensor x, int ring_id = 0, int root = 0, int nranks = 0, bool use_calc_stream = false)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-70448
Bug: Comm op are failing during training, the size of the comm group does not match in new op + new comm lib.
Fix bug with reduce_scatter in new comm lib related to dev_ctx and comm_ctx.  New comm should employ the dev_ctx maintained by comm_ctx_manager.  To adjust other op, only reduce_scatter return dev_ctx for now.
The accuracy and performance of the llama-13b and gpt3-13B-en models before and after the code change have be aligned.