### PR TITLE
[CINN] Support lower broasdcast branch in cinn backend

### DIFF
--- a/paddle/cinn/backends/codegen_device_util.cc
+++ b/paddle/cinn/backends/codegen_device_util.cc
@@ -50,6 +50,8 @@ struct PredicatePrinter : public ir::IrPrinter {
   void Visit(const ir::GE *x) { PrintBinaryOp("GE", x); }
   void Visit(const ir::And *x) { PrintBinaryOp("AND", x); }
   void Visit(const ir::Or *x) { PrintBinaryOp("OR", x); }
+  void Visit(const ir::Max *x) { PrintBinaryOp("MAX", x); }
+  void Visit(const ir::Min *x) { PrintBinaryOp("MIN", x); }
 
   template <typename IRN>
   void PrintBinaryOp(const std::string &op, const ir::BinaryOpNode<IRN> *x) {

--- a/paddle/cinn/common/dim_expr_converter.cc
+++ b/paddle/cinn/common/dim_expr_converter.cc
@@ -104,9 +104,15 @@ struct DimExprToIrExprVisitor {
     return min;
   }
 
+  // convert Broadcast to Max
   ir::Expr operator()(const Broadcast<DimExpr>& dim_expr) {
-    PADDLE_THROW(phi::errors::Fatal(
-        "no support for converting from Broadcast<DimExpr> to ir::Expr"));
+    const auto& [operands] = dim_expr;
+    CHECK(!operands->empty());
+    ir::Expr max = ConvertToIrExpr(operands->at(0));
+    for (std::size_t i = 1; i < operands->size(); ++i) {
+      max = ir::Max::Make(max, ConvertToIrExpr(operands->at(i)));
+    }
+    return max;
   }
 };
 

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
@@ -28,6 +28,8 @@
 #include "paddle/pir/include/core/builtin_type.h"
 #include "paddle/pir/include/pass/pass_registry.h"
 
+PD_DECLARE_bool(cinn_bc_branch_optimize);
+
 namespace cinn::dialect::ir::details {
 
 pir::Operation* ProcessDyShapeGroup(const OpLoweringGroupPtr& group,
@@ -39,7 +41,7 @@ pir::Operation* ProcessDyShapeGroup(const OpLoweringGroupPtr& group,
   GroupDimExprInfo group_dim_expr_info = GetGroupDimExprInfo(group);
   const auto& leaves = group_dim_expr_info.all_value_dim_exprs;
   // has multiple branch
-  if (NeedBroadcastWithCF(leaves)) {
+  if (FLAGS_cinn_bc_branch_optimize && NeedBroadcastWithCF(leaves)) {
     const auto& value_to_dim_expr_idx =
         group_dim_expr_info.value_to_dim_expr_idx;
     const std::shared_ptr<BroadcastTree> broadcast_tree =

--- a/paddle/cinn/hlir/pe/broadcast.h
+++ b/paddle/cinn/hlir/pe/broadcast.h
@@ -22,10 +22,6 @@ namespace cinn {
 namespace hlir {
 namespace pe {
 
-void GetBroadcastOutShape(const std::vector<int>& input_shape1,
-                          const std::vector<int>& input_shape2,
-                          std::vector<int>* common_shape,
-                          int axis = -1);
 /**
  * @brief Compute A && B with auto-broadcasting.
  *

--- a/paddle/cinn/runtime/flags.cc
+++ b/paddle/cinn/runtime/flags.cc
@@ -81,6 +81,11 @@ PD_DEFINE_bool(general_fusion_merge_pass,
                BoolFromEnv("FLAGS_general_fusion_merge_pass", true),
                "Whether to use general fusion_merge pass.");
 
+PD_DEFINE_bool(
+    cinn_bc_branch_optimize,
+    BoolFromEnv("FLAGS_cinn_bc_branch_optimize", true),
+    "Whether to open the broadcast branch optimization in frontend.");
+
 PD_DEFINE_bool(cinn_new_group_scheduler,
                BoolFromEnv("FLAGS_cinn_new_group_scheduler", true),
                "Whether to use new group scheduler.");

--- a/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
+++ b/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
@@ -296,7 +296,8 @@ void InferSymExprForOp(Operation* op,
       } else {
         // risk set
         LOG(WARNING) << "Not found symbolic shape cache for " << op->name()
-                     << "[id:" << op->id() << "]";
+                     << "[id:" << op->id()
+                     << "], op_infer_cache_key is :" << op_infer_cache_key;
         for (uint32_t i = 0; i < op->num_results(); ++i) {
           infer_context->SetSymbolForValueByStaticShape(op->result(i));
         }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

将 Broadcast 分支逻辑在后端通过取模运算代替，避免产生大量broadcast条件分支的代码编译。

设置`FLAGS_cinn_bc_branch_optimize=0`即可生效该功能。

示例子图：
```
(%0) = "pd_op.data" [id:83] () {dtype:(pd_op.DataType)float32,name:"var_0",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1],stop_gradient:[false],sym_shape_str:"shape[S0], data[NULL]"} : () -> builtin.tensor<-1xf32>
(%1) = "pd_op.data" [id:84] () {dtype:(pd_op.DataType)float32,name:"var_1",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1],stop_gradient:[false],sym_shape_str:"shape[S1], data[NULL]"} : () -> builtin.tensor<-1xf32>
(%2) = "pd_op.data" [id:85] () {dtype:(pd_op.DataType)float32,name:"var_2",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1],stop_gradient:[false],sym_shape_str:"shape[S2], data[NULL]"} : () -> builtin.tensor<-1xf32>
(%3) = "pd_op.data" [id:86] () {dtype:(pd_op.DataType)float32,name:"var_3",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1],stop_gradient:[false],sym_shape_str:"shape[S3], data[NULL]"} : () -> builtin.tensor<-1xf32>
(%4) = "pd_op.data" [id:87] () {dtype:(pd_op.DataType)float32,name:"var_4",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1],stop_gradient:[false],sym_shape_str:"shape[S4], data[NULL]"} : () -> builtin.tensor<-1xf32>
(%5) = "pd_op.data" [id:88] () {dtype:(pd_op.DataType)float32,name:"var_5",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1],stop_gradient:[false],sym_shape_str:"shape[S5], data[NULL]"} : () -> builtin.tensor<-1xf32>
(%6) = "pd_op.data" [id:89] () {dtype:(pd_op.DataType)float32,name:"var_6",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1],stop_gradient:[false],sym_shape_str:"shape[S6], data[NULL]"} : () -> builtin.tensor<-1xf32>
(%7) = "pd_op.data" [id:90] () {dtype:(pd_op.DataType)float32,name:"var_7",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1],stop_gradient:[false],sym_shape_str:"shape[S7], data[NULL]"} : () -> builtin.tensor<-1xf32>
(%8) = "builtin.combine" [id:91] (%6, %7, %0, %1, %2, %3, %4, %5) {stop_gradient:[false],sym_shape_str:"shape[S6], data[NULL], shape[S7], data[NULL], shape[S0], data[NULL], shape[S1], data[NULL], shape[S2], data[NULL], shape[S3], data[NULL], shape[S4], data[NULL], shape[S5], data[NULL]"} : (builtin.tensor<-1xf32>, builtin.tensor<-1xf32>, builtin.tensor<-1xf32>, builtin.tensor<-1xf32>, builtin.tensor<-1xf32>, builtin.tensor<-1xf32>, builtin.tensor<-1xf32>, builtin.tensor<-1xf32>) -> vec[builtin.tensor<-1xf32>,builtin.tensor<-1xf32>,builtin.tensor<-1xf32>,builtin.tensor<-1xf32>,builtin.tensor<-1xf32>,builtin.tensor<-1xf32>,builtin.tensor<-1xf32>,builtin.tensor<-1xf32>]
(%9) = "pd_op.add" [id:92] (%6, %7) {stop_gradient:[false],sym_shape_str:"shape[Broadcast(S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>, builtin.tensor<-1xf32>) -> builtin.tensor<-1xf32>
(%10) = "pd_op.add" [id:93] (%9, %0) {stop_gradient:[false],sym_shape_str:"shape[Broadcast(S0, S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>, builtin.tensor<-1xf32>) -> builtin.tensor<-1xf32>
(%11) = "pd_op.add" [id:94] (%10, %1) {stop_gradient:[false],sym_shape_str:"shape[Broadcast(S0, S1, S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>, builtin.tensor<-1xf32>) -> builtin.tensor<-1xf32>
(%12) = "pd_op.add" [id:95] (%11, %2) {stop_gradient:[false],sym_shape_str:"shape[Broadcast(S0, S1, S2, S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>, builtin.tensor<-1xf32>) -> builtin.tensor<-1xf32>
(%13) = "pd_op.add" [id:96] (%12, %3) {stop_gradient:[false],sym_shape_str:"shape[Broadcast(S0, S1, S2, S3, S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>, builtin.tensor<-1xf32>) -> builtin.tensor<-1xf32>
(%14) = "pd_op.add" [id:97] (%13, %4) {stop_gradient:[false],sym_shape_str:"shape[Broadcast(S0, S1, S2, S3, S4, S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>, builtin.tensor<-1xf32>) -> builtin.tensor<-1xf32>
(%15) = "pd_op.add" [id:98] (%14, %5) {stop_gradient:[false],sym_shape_str:"shape[Broadcast(S0, S1, S2, S3, S4, S5, S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>, builtin.tensor<-1xf32>) -> builtin.tensor<-1xf32>
() = "builtin.shadow_output" [id:99] (%9) {output_name:"output_1",sym_shape_str:"shape[Broadcast(S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>) -> 
() = "builtin.shadow_output" [id:100] (%10) {output_name:"output_2",sym_shape_str:"shape[Broadcast(S0, S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>) -> 
() = "builtin.shadow_output" [id:101] (%11) {output_name:"output_3",sym_shape_str:"shape[Broadcast(S0, S1, S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>) -> 
() = "builtin.shadow_output" [id:102] (%12) {output_name:"output_4",sym_shape_str:"shape[Broadcast(S0, S1, S2, S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>) -> 
() = "builtin.shadow_output" [id:103] (%13) {output_name:"output_5",sym_shape_str:"shape[Broadcast(S0, S1, S2, S3, S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>) -> 
() = "builtin.shadow_output" [id:104] (%14) {output_name:"output_6",sym_shape_str:"shape[Broadcast(S0, S1, S2, S3, S4, S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>) -> 
() = "builtin.shadow_output" [id:105] (%15) {output_name:"output_0",sym_shape_str:"shape[Broadcast(S0, S1, S2, S3, S4, S5, S6, S7)], data[NULL]"} : (builtin.tensor<-1xf32>) -> 

```

kerenel代码：
```
__global__
void __launch_bounds__(1) fn_generate_shape_broadcast_to_broadcast_to_elementwise_add_generate_shape_broadcast_to_broadcast_to_elementwise_add_generate_shape_broadcast_to_broadcast_to_elementwise_add_yield_store___COND__FPA_trueAND_FPA__FPA__FPA__FPA__FPA_S0MAXS1_BPA_MAXS6_BPA_MAXS7_BPA_GE1_BPA_AND_FPA__FPA__FPA__FPA_S0MAXS1_BPA_MAXS6_BPA_MAXS7_BPA_LE1023_BPA__BPA__BPA___kernel(const float* __restrict__ var, const float* __restrict__ var_0, const float* __restrict__ var_5, const float* __restrict__ var_6, const float* __restrict__ var_7, const float* __restrict__ var_8, const float* __restrict__ var_9, const float* __restrict__ var_10, float* __restrict__ var_19, int64_t S6, int64_t S7, int64_t S0, int64_t S1, int64_t S2, int64_t S3, int64_t S4, int64_t S5)
{
  if (((int)blockIdx.x < max(max(max(S0, S1), S6), S7))) {
    float local_var_92 = var[((((int)blockIdx.x % max(max(S0, S6), S7)) % max(S6, S7)) % S6)];
    float local_var_93 = var_0[((((int)blockIdx.x % max(max(S0, S6), S7)) % max(S6, S7)) % S7)];
    float local_var_94 = var_5[(((int)blockIdx.x % max(max(S0, S6), S7)) % S0)];
    float local_var_95 = var_6[((int)blockIdx.x % S1)];
    var_19[(int)blockIdx.x] = (((local_var_92 + local_var_93) + local_var_94) + local_var_95);
  };
}__global__
void __launch_bounds__(1024) fn_generate_shape_broadcast_to_broadcast_to_elementwise_add_generate_shape_broadcast_to_broadcast_to_elementwise_add_generate_shape_broadcast_to_broadcast_to_elementwise_add_yield_store___COND__FPA_trueAND_FPA__FPA__FPA__FPA__FPA_S0MAXS1_BPA_MAXS6_BPA_MAXS7_BPA_GE1048576_BPA_AND_FPA__FPA__FPA__FPA_S0MAXS1_BPA_MAXS6_BPA_MAXS7_BPA_LE2147483647_BPA__BPA__BPA___kernel(const float* __restrict__ var, const float* __restrict__ var_0, const float* __restrict__ var_5, const float* __restrict__ var_6, const float* __restrict__ var_7, const float* __restrict__ var_8, const float* __restrict__ var_9, const float* __restrict__ var_10, float* __restrict__ var_19, int64_t S6, int64_t S7, int64_t S0, int64_t S1, int64_t S2, int64_t S3, int64_t S4, int64_t S5)
{
  if (((int)blockIdx.x < max(max(max(((S0 / 4096ll) + 1ll), ((S1 / 4096ll) + 1ll)), ((S6 / 4096ll) + 1ll)), ((S7 / 4096ll) + 1ll)))) {
    for (int32_t i_36 = 0ll; i_36 < 4ll; i_36 += 1) {
      if (((int)threadIdx.x < 1024)) {
        if ((((4096ll * (int)blockIdx.x) + ((1024ll * i_36) + (int)threadIdx.x)) < max(max(max(S0, S1), S6), S7))) {
          float local_var_96 = var[(((((4096ll * (int)blockIdx.x) + ((1024ll * i_36) + (int)threadIdx.x)) % max(max(S0, S6), S7)) % max(S6, S7)) % S6)];
          float local_var_97 = var_0[(((((4096ll * (int)blockIdx.x) + ((1024ll * i_36) + (int)threadIdx.x)) % max(max(S0, S6), S7)) % max(S6, S7)) % S7)];
          float local_var_98 = var_5[((((4096ll * (int)blockIdx.x) + ((1024ll * i_36) + (int)threadIdx.x)) % max(max(S0, S6), S7)) % S0)];
          float local_var_99 = var_6[(((4096ll * (int)blockIdx.x) + ((1024ll * i_36) + (int)threadIdx.x)) % S1)];
          var_19[((4096ll * (int)blockIdx.x) + ((1024ll * i_36) + (int)threadIdx.x))] = (((local_var_96 + local_var_97) + local_var_98) + local_var_99);
        };
      };
    };
  };
}__global__
void __launch_bounds__(1024) fn_generate_shape_broadcast_to_broadcast_to_elementwise_add_generate_shape_broadcast_to_broadcast_to_elementwise_add_generate_shape_broadcast_to_broadcast_to_elementwise_add_yield_store___COND__FPA_trueAND_FPA__FPA__FPA__FPA__FPA_S0MAXS1_BPA_MAXS6_BPA_MAXS7_BPA_GE1024_BPA_AND_FPA__FPA__FPA__FPA_S0MAXS1_BPA_MAXS6_BPA_MAXS7_BPA_LE1048575_BPA__BPA__BPA___kernel(const float* __restrict__ var, const float* __restrict__ var_0, const float* __restrict__ var_5, const float* __restrict__ var_6, const float* __restrict__ var_7, const float* __restrict__ var_8, const float* __restrict__ var_9, const float* __restrict__ var_10, float* __restrict__ var_19, int64_t S6, int64_t S7, int64_t S0, int64_t S1, int64_t S2, int64_t S3, int64_t S4, int64_t S5)
{
  if (((int)blockIdx.x < max(max(max(((S0 / 4096ll) + 1ll), ((S1 / 4096ll) + 1ll)), ((S6 / 4096ll) + 1ll)), ((S7 / 4096ll) + 1ll)))) {
    for (int32_t i_39 = 0ll; i_39 < 4ll; i_39 += 1) {
      if (((int)threadIdx.x < 1024)) {
        if ((((4096ll * (int)blockIdx.x) + ((1024ll * i_39) + (int)threadIdx.x)) < max(max(max(S0, S1), S6), S7))) {
          float local_var_100 = var[(((((4096ll * (int)blockIdx.x) + ((1024ll * i_39) + (int)threadIdx.x)) % max(max(S0, S6), S7)) % max(S6, S7)) % S6)];
          float local_var_101 = var_0[(((((4096ll * (int)blockIdx.x) + ((1024ll * i_39) + (int)threadIdx.x)) % max(max(S0, S6), S7)) % max(S6, S7)) % S7)];
          float local_var_102 = var_5[((((4096ll * (int)blockIdx.x) + ((1024ll * i_39) + (int)threadIdx.x)) % max(max(S0, S6), S7)) % S0)];
          float local_var_103 = var_6[(((4096ll * (int)blockIdx.x) + ((1024ll * i_39) + (int)threadIdx.x)) % S1)];
          var_19[((4096ll * (int)blockIdx.x) + ((1024ll * i_39) + (int)threadIdx.x))] = (((local_var_100 + local_var_101) + local_var_102) + local_var_103);
        };
      };
    };
  };
}
```