### PR TITLE
[Fix PIR Unittest] fix pir ut for comm op

### DIFF
--- a/test/collective/init_process_group.py
+++ b/test/collective/init_process_group.py
@@ -20,6 +20,9 @@ import paddle
 class TestProcessGroupFp32(unittest.TestCase):
     def setUp(self):
         self.config()
+        self._in_pir_mode = paddle.base.framework.get_flags(
+            "FLAGS_enable_pir_api"
+        )["FLAGS_enable_pir_api"]
 
     def config(self):
         pass
@@ -33,7 +36,8 @@ class TestProcessGroupFp32(unittest.TestCase):
         group = paddle.distributed.collective.Group(-1, 2, 0, [-1, -2])
         ret = paddle.distributed.barrier(group)
         assert ret is None
-        paddle.enable_static()
+        if not self._in_pir_mode:
+            paddle.enable_static()
         in_tensor = paddle.empty((1, 2))
         in_tensor2 = paddle.empty((1, 2))
         paddle.distributed.broadcast(in_tensor, src=0)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
修复coverage UT挂的问题。pir下静态图使用了append op来把通信算子加入计算图，但目前通信算子不支持pir。所以pir模式下，ut不应测试通信算子的静态图模式。

Pcard-67164