### PR TITLE
[pir] Assert is_symmetric==true while in running time

### DIFF
--- a/python/paddle/incubate/optimizer/functional/utils.py
+++ b/python/paddle/incubate/optimizer/functional/utils.py
@@ -57,6 +57,17 @@ def check_initial_inverse_hessian_estimate(H0):
             10,
             name="The initial_inverse_hessian_estimate should be symmetric and positive definite, but the specified is not.",
         )
+        eigvals = paddle.linalg.eigvals(H0)
+        is_positive = paddle.all(eigvals.real() > 0.0) and paddle.all(
+            eigvals.imag() == 0.0
+        )
+        paddle.static.nn.control_flow.Assert(
+            is_positive,
+            None,
+            10,
+            name="The initial_inverse_hessian_estimate should be symmetric and positive definite, but the specified is not.",
+        )
+
     else:
 
         def create_tmp_var(program, name, dtype, shape):

--- a/python/paddle/incubate/optimizer/functional/utils.py
+++ b/python/paddle/incubate/optimizer/functional/utils.py
@@ -14,7 +14,7 @@
 
 import paddle
 from paddle.base.data_feeder import check_type
-from paddle.base.framework import Variable
+from paddle.base.framework import Variable, in_pir_mode
 
 
 def check_input_type(input, name, op_name):
@@ -50,6 +50,13 @@ def check_initial_inverse_hessian_estimate(H0):
             paddle.linalg.cholesky(H0)
         except RuntimeError as error:
             raise_func()
+    elif in_pir_mode():
+        paddle.static.nn.control_flow.Assert(
+            is_symmetric,
+            None,
+            10,
+            name="The initial_inverse_hessian_estimate should be symmetric and positive definite, but the specified is not.",
+        )
     else:
 
         def create_tmp_var(program, name, dtype, shape):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
原来的 create_tmp_var func 在 pir 下无法运行，因为没有 current_block() 接口
但这部分代码的作用是验证执行期 is_symmetric==True ，所以直接绕过 create_tmp_var，调用 Assert 接口实现即可