### PR TITLE
[CINN]support PirCompiler to build broadcast tree

### DIFF
--- a/paddle/cinn/backends/codegen_device_util.cc
+++ b/paddle/cinn/backends/codegen_device_util.cc
@@ -51,7 +51,7 @@ ir::Module CreateSwitchWithBroadcastConditionModule(
       ir::Argument(kernel_args_num, ir::Argument::IO::kInput),
       ir::Argument(tensor_shape_args, ir::Argument::IO::kOutput)};
 
-  const auto &CreateSymbolArgDefines = [&]() -> std::vector<ir::Expr> {
+  const auto &symbolic_arg_define = [&]() -> std::vector<ir::Expr> {
     std::vector<ir::Expr> arg_defs;
     for (const auto &item : symbolic_shape_var_index) {
       ir::Expr call_get_value_in_kernel_args =
@@ -68,13 +68,13 @@ ir::Module CreateSwitchWithBroadcastConditionModule(
       arg_defs.push_back(stmt);
     }
     return arg_defs;
-  };
+  }();
 
   const auto &CreateSwitchFunction =
       [&](std::vector<ir::Argument> func_arguments,
           const std::vector<ir::Expr> &read_args,
           std::string name_extend) -> ir::Expr {
-    std::vector<ir::Expr> body_stmts(CreateSymbolArgDefines());
+    std::vector<ir::Expr> body_stmts(symbolic_arg_define);
     for (int i = 0; i < broadcast_conditions.size(); ++i) {
       ir::Expr callee = ir::Call::Make(Void(),
                                        case_func_names[i] + name_extend,
@@ -113,8 +113,11 @@ ir::Module CreateSwitchWithBroadcastConditionModule(
   module_builder.AddFunctionWithoutOptim(
       infer_shape_func_caller.as_lowered_func_ref());
   // no need cx86 func
-  ir::Expr cx86_func_caller = ir::_LoweredFunc_::Make(
-      wrapper_func_name + "_CX86", host_func_arguments, ir::Expr(), {});
+  ir::Expr cx86_func_caller =
+      ir::_LoweredFunc_::Make(wrapper_func_name + "_CX86",
+                              host_func_arguments,
+                              ir::Block::Make({}),
+                              {});
   module_builder.AddFunctionWithoutOptim(
       cx86_func_caller.as_lowered_func_ref());
   return module_builder.Build();

--- a/paddle/cinn/backends/compiler.h
+++ b/paddle/cinn/backends/compiler.h
@@ -103,10 +103,13 @@ class Compiler final {
   /**
    * Compile and link to a CINN module.
    */
-  void Build(const ir::Module& module,
-             const std::string& code = "",
-             const bool end = true);
-  void AppendCX86(const ir::Module& module, const bool end = true);
+  void Build(const ir::Module& module, const std::string& code = "");
+
+  void AppendCX86(const ir::Module& module);
+
+  void AppendBroadcastSwitchModule(const ir::Module& module);
+
+  void EndCompile();
 
   void ExportObject(const std::string& path);
 

--- a/paddle/cinn/backends/llvm/execution_engine.cc
+++ b/paddle/cinn/backends/llvm/execution_engine.cc
@@ -231,7 +231,7 @@ void ExecutionEngine::RegisterModuleRuntimeSymbols(
   module_symbols_ = std::forward<RuntimeSymbols>(module_symbols);
   auto *session = &jit_->getExecutionSession();
   for (const auto &sym : module_symbols_.All()) {
-    VLOG(0) << "Add symbol: {" << sym.first << ":" << sym.second << "}";
+    VLOG(3) << "Add symbol: {" << sym.first << ":" << sym.second << "}";
     llvm::cantFail(jit_->define(llvm::orc::absoluteSymbols(
         {{session->intern(sym.first),
           {llvm::pointerToJITTargetAddress(sym.second),
@@ -276,5 +276,7 @@ void ExecutionEngine::RegisterGlobalRuntimeSymbols() {
 template void ExecutionEngine::Link<CodeGenLLVM>(const ir::Module &module);
 template void ExecutionEngine::Link<CodeGenX86>(const ir::Module &module);
 template void ExecutionEngine::Link<CodeGenCUDA_Host>(const ir::Module &module);
+template void ExecutionEngine::Link<CodeGenSwitchHost>(
+    const ir::Module &module);
 
 }  // namespace cinn::backends

--- a/paddle/cinn/hlir/framework/pir/compilation_task.cc
+++ b/paddle/cinn/hlir/framework/pir/compilation_task.cc
@@ -15,8 +15,13 @@
 #pragma once
 
 #include "paddle/cinn/hlir/framework/pir/compilation_task.h"
+
+#include "paddle/cinn/backends/codegen_device_util.h"
+#include "paddle/cinn/common/dim_expr_converter.h"
 #include "paddle/cinn/common/target.h"
 #include "paddle/cinn/hlir/framework/op_lowering.h"
+#include "paddle/cinn/hlir/framework/pir/op_lowering_group.h"
+#include "paddle/cinn/hlir/framework/pir/utils.h"
 #include "paddle/common/enforce.h"
 namespace cinn {
 namespace hlir {
@@ -47,6 +52,99 @@ std::string GroupCompilationContext::PrintPredicate2Funcs() const {
   return ss.str();
 }
 
+void GroupCompilationContext::PrepareModuleBuilder() {
+  PADDLE_ENFORCE_EQ(predicates_.size(),
+                    lowered_funcs_.size(),
+                    phi::errors::InvalidArgument(
+                        "The size of predicates and lowered_funcs should be "
+                        "the same."));
+  PADDLE_ENFORCE_EQ(predicates_.size(),
+                    priorities_.size(),
+                    phi::errors::InvalidArgument(
+                        "The size of predicates and priorites should be "
+                        "the same."));
+  for (const ir::Expr& predicate : predicates_) {
+    module_builder_.AddPredicate(predicate);
+  }
+  for (const ir::LoweredFunc& func : lowered_funcs_) {
+    module_builder_.AddFunction(func);
+  }
+  for (int& priority : priorities_) {
+    module_builder_.AddPriority(priority);
+  }
+  module_builder_.SetInferShapeFunc(infer_shape_lowered_func_);
+
+  PADDLE_ENFORCE_EQ(CX86_predicates_.size(),
+                    CX86_lowered_funcs_.size(),
+                    phi::errors::InvalidArgument(
+                        "The size of predicates and lowered_funcs should be "
+                        "the same."));
+  for (const ir::Expr& predicate : CX86_predicates_) {
+    CX86_module_builder_.AddPredicate(predicate);
+  }
+  for (const ir::LoweredFunc& func : CX86_lowered_funcs_) {
+    CX86_module_builder_.AddFunction(func);
+  }
+}
+
+/**
+ * For functions belonging to different broadcast groups, int args and the name
+ * of the tensor args may be variate, but the number of the tensor args should
+ * be fixed. So we need to unify the tensor args and int args. For exmaple,
+ * func1(_var, _var_1, S4, S5); func2(_var, _var_2, S1) would be unified to
+ * func1(_var, _var_1, S4, S5, S1); func2(_var, _var_2, S4, S5, S1).
+ */
+void UnifyBroadcastGroupFuncArgs(
+    std::vector<GroupCompilationContext>* contexts,
+    pir::OpLoweringGroupPtr origin_group,
+    std::unordered_map<int, ir::Var>* symbolic_shape_var_index) {
+  std::unordered_map<ir::Var, pir::CINNKernelInfo::ArgDimIdx> new_args_map;
+  std::vector<ir::Argument> new_args_vec;
+  int total_args_num = 0;
+
+  const auto& AddTensorArgs = [&](GroupCompilationContext& context) {
+    const auto& func_args = context.lowered_funcs_[0]->args;
+    const auto& origin_int_args = context.group_->int_args_map();
+    for (size_t arg_idx = 0; arg_idx < func_args.size(); ++arg_idx) {
+      if (func_args[arg_idx].is_var()) {
+        new_args_map[func_args[arg_idx].var_arg()] =
+            origin_int_args.at(arg_idx);
+      } else {
+        new_args_vec.emplace_back(func_args[arg_idx]);
+      }
+    }
+    for (ir::LoweredFunc& func : context.lowered_funcs_) {
+      func->args = new_args_vec;
+    }
+  };
+  for (size_t i = 0; i < contexts->size(); ++i) {
+    AddTensorArgs((*contexts)[i]);
+    if (i == 0) total_args_num += new_args_vec.size();
+    new_args_vec.clear();
+  }
+
+  origin_group->mut_int_args_map().clear();
+  const auto& new_int_args_vec = [&]() -> std::vector<ir::Argument> {
+    std::vector<ir::Argument> res;
+    for (const auto& [arg, idx_info] : new_args_map) {
+      symbolic_shape_var_index->insert({total_args_num, arg});
+      origin_group->mut_int_args_map()[total_args_num++] = idx_info;
+      res.emplace_back(ir::Argument{arg});
+    }
+    return res;
+  }();
+
+  const auto& AddUnifiedIntArgs = [&](GroupCompilationContext& context) {
+    for (ir::LoweredFunc& func : context.lowered_funcs_) {
+      func->args.insert(
+          func->args.end(), new_int_args_vec.begin(), new_int_args_vec.end());
+    }
+  };
+  for (int i = 0; i < contexts->size(); ++i) {
+    AddUnifiedIntArgs((*contexts)[i]);
+  }
+}
+
 std::shared_ptr<pir::CompilationResult> CompilationTask::operator()() {
   Lowering();
   return CodegenAndJit();
@@ -60,49 +158,55 @@ void CompilationTask::Lowering() {
                              /* apply op schedule = */ false,
                              /* apply group schedule = */ true,
                              /* apply pass = */ true));
+
+  if (context_->group_->IsBroadcastLeaf()) {
+    const auto& broadcast_condition_dimexprs =
+        context_->group_->GetBroadcastConditions();
+
+    using BranchType = pir::OpLoweringGroup::BranchType;
+    const auto& GetSingleBranchExprFromBroadcastCond =
+        [](const symbol::Broadcastable<symbol::DimExpr>& broadcast_expr,
+           const BranchType& condition) -> ir::Expr {
+      const auto& expr_converter = common::DimExprConverter();
+      ir::Expr lhs = expr_converter.ConvertToIrExpr(broadcast_expr->lhs);
+      ir::Expr rhs = expr_converter.ConvertToIrExpr(broadcast_expr->rhs);
+      ir::Expr one = ir::Expr(1);
+      ir::Expr condition_expr;
+      if (condition == BranchType::LHS_EQ_RHS) {
+        condition_expr = ir::EQ::Make(lhs, rhs);
+      } else {
+        condition_expr = ir::NE::Make(lhs, rhs);
+        ir::Expr eq_one_expr;
+        if (condition == BranchType::LHS_EQ_ONE) {
+          eq_one_expr = ir::EQ::Make(lhs, one);
+        } else {  // BranchType::RHS_EQ_ONE
+          eq_one_expr = ir::EQ::Make(rhs, one);
+        }
+        condition_expr = ir::And::Make(condition_expr, eq_one_expr);
+      }
+      return condition_expr;
+    };
+
+    const auto& ChangeBroadcastConditionToExpr = [&]() -> ir::Expr {
+      ir::Expr result = ir::Expr(true);
+      for (const auto& [broadcast_expr, condition] :
+           broadcast_condition_dimexprs) {
+        result = ir::And::Make(
+            result,
+            GetSingleBranchExprFromBroadcastCond(broadcast_expr, condition));
+      }
+      return result;
+    };
+
+    context_->broadcast_condition_ = ChangeBroadcastConditionToExpr();
+  }
   VLOG(5) << "End to lowering: " << context_->PrintPredicate2Funcs();
 }
 
 std::shared_ptr<pir::CompilationResult> CompilationTask::CodegenAndJit() {
-  ir::Module::Builder builder(cinn::common::UniqName("module"),
-                              context_->target_);
-  PADDLE_ENFORCE_EQ(context_->predicates_.size(),
-                    context_->lowered_funcs_.size(),
-                    phi::errors::InvalidArgument(
-                        "The size of predicates and lowered_funcs should be "
-                        "the same."));
-  PADDLE_ENFORCE_EQ(context_->predicates_.size(),
-                    context_->priorities_.size(),
-                    phi::errors::InvalidArgument(
-                        "The size of predicates and priorites should be "
-                        "the same."));
-  for (const ir::Expr& predicate : context_->predicates_) {
-    builder.AddPredicate(predicate);
-  }
-  for (const ir::LoweredFunc& func : context_->lowered_funcs_) {
-    builder.AddFunction(func);
-  }
-  for (int& priority : context_->priorities_) {
-    builder.AddPriority(priority);
-  }
-  builder.SetInferShapeFunc(context_->infer_shape_lowered_func_);
-  ir::Module ir_module = builder.Build();
-
-  ir::Module::Builder builder_CX86(cinn::common::UniqName("module"),
-                                   common::DefaultHostTarget());
-  PADDLE_ENFORCE_EQ(context_->CX86_predicates_.size(),
-                    context_->CX86_lowered_funcs_.size(),
-                    phi::errors::InvalidArgument(
-                        "The size of predicates and lowered_funcs should be "
-                        "the same."));
-  for (const ir::Expr& predicate : context_->CX86_predicates_) {
-    builder_CX86.AddPredicate(predicate);
-  }
-  for (const ir::LoweredFunc& func : context_->CX86_lowered_funcs_) {
-    builder_CX86.AddFunction(func);
-  }
-  ir::Module ir_moduleCX86 = builder_CX86.Build();
-
+  context_->PrepareModuleBuilder();
+  ir::Module ir_module = context_->module_builder_.Build();
+  ir::Module ir_moduleCX86 = context_->CX86_module_builder_.Build();
   return BuildPirCINNKernelInfo(ir_module, ir_moduleCX86);
 }
 
@@ -116,8 +220,47 @@ std::shared_ptr<pir::CompilationResult> CompilationTask::BuildPirCINNKernelInfo(
       context_->group_->FuncName() + "_infer_shape",
       context_->group_->int_args_map());
   VLOG(5) << "Start to compile module into cuda kernel...";
-  backend_resource->GetBackendCompiler()->Build(module, "", false);
+  backend_resource->GetBackendCompiler()->Build(module, "");
   backend_resource->GetBackendCompiler()->AppendCX86(CX86module);
+  backend_resource->GetBackendCompiler()->EndCompile();
+  compilation_result->SetBackendResource(backend_resource);
+  VLOG(5) << "End to compile module into cuda kernel.";
+  return compilation_result;
+}
+
+std::shared_ptr<pir::CompilationResult>
+CompilationTask::CompileBroadcastModules(
+    std::vector<GroupCompilationContext>* leaf_group_contexts,
+    const std::unordered_map<int, ir::Var>& symbolic_shape_var_index) {
+  auto compilation_result =
+      std::make_shared<pir::CompilationResult>(context_->target_);
+  auto backend_resource = std::make_shared<pir::BackendResource>(
+      context_->target_,
+      context_->group_->FuncName(),
+      context_->group_->FuncName() + "_infer_shape",
+      context_->group_->int_args_map());
+
+  std::vector<std::string> case_func_names;
+  std::vector<ir::Expr> broadcast_conditions;
+  for (auto& context : *leaf_group_contexts) {
+    context.PrepareModuleBuilder();
+    case_func_names.emplace_back(context.group_->FuncName());
+    broadcast_conditions.emplace_back(context.broadcast_condition_);
+    ir::Module ir_module = context.module_builder_.Build();
+    ir::Module ir_moduleCX86 = context.CX86_module_builder_.Build();
+    backend_resource->GetBackendCompiler()->Build(ir_module, "");
+    backend_resource->GetBackendCompiler()->AppendCX86(ir_moduleCX86);
+  }
+
+  ir::Module wrapper_module(
+      cinn::backends::CreateSwitchWithBroadcastConditionModule(
+          broadcast_conditions,
+          case_func_names,
+          context_->group_->FuncName(),
+          symbolic_shape_var_index));
+  backend_resource->GetBackendCompiler()->AppendBroadcastSwitchModule(
+      wrapper_module);
+  backend_resource->GetBackendCompiler()->EndCompile();
   compilation_result->SetBackendResource(backend_resource);
   VLOG(5) << "End to compile module into cuda kernel.";
   return compilation_result;

--- a/paddle/cinn/hlir/framework/pir/compilation_task.h
+++ b/paddle/cinn/hlir/framework/pir/compilation_task.h
@@ -30,21 +30,33 @@ class GroupCompilationContext {
  public:
   GroupCompilationContext(const Target& target,
                           const pir::OpLoweringGroupPtr& group)
-      : target_(target), group_(group) {}
+      : target_(target),
+        group_(group),
+        module_builder_(cinn::common::UniqName("module"), target),
+        CX86_module_builder_(cinn::common::UniqName("module"),
+                             common::DefaultHostTarget()) {}
 
   void SetLoweredFuncs(BucketLoweredFuncsWrapper&& funcs);
+  void PrepareModuleBuilder();
   std::string PrintPredicate2Funcs() const;
 
  private:
   friend class CompilationTask;
+  friend void UnifyBroadcastGroupFuncArgs(
+      std::vector<GroupCompilationContext>* contexts,
+      pir::OpLoweringGroupPtr origin_group,
+      std::unordered_map<int, ir::Var>* symbolic_shape_var_index);
   const Target& target_;
   const pir::OpLoweringGroupPtr& group_;
+  ir::SymbolicPredicate broadcast_condition_;
   std::vector<ir::SymbolicPredicate> predicates_;
   std::vector<int> priorities_;
   std::vector<ir::LoweredFunc> lowered_funcs_;
   std::vector<ir::SymbolicPredicate> CX86_predicates_;
   std::vector<ir::LoweredFunc> CX86_lowered_funcs_;
   ir::LoweredFunc infer_shape_lowered_func_;
+  ir::Module::Builder module_builder_;
+  ir::Module::Builder CX86_module_builder_;
 };
 
 class CompilationTask {
@@ -53,9 +65,12 @@ class CompilationTask {
       : context_(context) {}
 
   std::shared_ptr<pir::CompilationResult> operator()();
+  void Lowering();
+  std::shared_ptr<pir::CompilationResult> CompileBroadcastModules(
+      std::vector<GroupCompilationContext>* leaf_group_contexts,
+      const std::unordered_map<int, ir::Var>& symbolic_shape_var_index);
 
  private:
-  void Lowering();
   std::shared_ptr<pir::CompilationResult> CodegenAndJit();
   std::shared_ptr<pir::CompilationResult> BuildPirCINNKernelInfo(
       const ir::Module& module, const ir::Module& CX86module);

--- a/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
@@ -145,7 +145,8 @@ std::shared_ptr<OpLoweringGroup> OpLoweringGroup::Clone(
     ops_mapper[op] = new_op;
   }
 
-  const auto new_fn_name = this->fn_name_ + "_cloned";
+  const auto new_fn_name =
+      this->fn_name_ + std::to_string(new_ops[0]->id()) + "_cloned";
   // Construct Base information for new Group
   auto new_group = std::make_shared<OpLoweringGroup>(new_ops, new_fn_name);
   for (auto* op : this->output_ops_) {

--- a/paddle/cinn/hlir/framework/pir/op_lowering_group.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_group.h
@@ -77,6 +77,17 @@ class OpLoweringGroup {
     is_broadcast_leaf_ = is_broadcast_leaf;
   }
 
+  enum class BranchType { LHS_EQ_RHS, LHS_EQ_ONE, RHS_EQ_ONE };
+  using BroadcastCond =
+      std::pair<symbol::Broadcastable<symbol::DimExpr>, BranchType>;
+  const std::vector<BroadcastCond>& GetBroadcastConditions() {
+    return broadcast_conditions_;
+  }
+  void SetBroadcastConditions(
+      const std::vector<BroadcastCond>& broadcast_conditions) {
+    broadcast_conditions_ = broadcast_conditions;
+  }
+
   const std::vector<::pir::Operation*>& ops() const { return ops_; }
   std::vector<::pir::Operation*>& mut_ops() { return ops_; }
   void SetOps(const std::vector<::pir::Operation*>& new_ops) { ops_ = new_ops; }
@@ -205,6 +216,7 @@ class OpLoweringGroup {
   // from local and global ShapeAnalysis. It will be removed after
   // refactoring logic of OpLoweringGroup.
   bool is_broadcast_leaf_{false};
+  std::vector<BroadcastCond> broadcast_conditions_;
 
   std::vector<std::string> input_names_;
   std::vector<std::string> output_names_;

--- a/paddle/cinn/hlir/framework/pir_compiler.cc
+++ b/paddle/cinn/hlir/framework/pir_compiler.cc
@@ -97,6 +97,58 @@ std::vector<pir::CINNKernelInfo> PirCompiler::Build(
   return ctx_mapper.RecoverKernelInfos();
 }
 
+pir::CINNKernelInfo PirCompiler::BuildBroadcastTree(
+    const std::vector<pir::OpLoweringGroupPtr>& leaf_groups,
+    pir::OpLoweringGroupPtr origin_group) {
+  const auto& fusion_info = pir::FusionInfo(*origin_group);
+  if (CompilationCache::Instance().Has(fusion_info)) {
+    return CompilationCache::Instance().GetKernelInfo(fusion_info);
+  }
+  CompilationContextMapper ctx_mapper(target_, leaf_groups);
+  auto& group_compilation_contexts = ctx_mapper.UniqueCompilationContexts();
+  auto& compilation_results = ctx_mapper.MutableCompilationResult();
+
+  const size_t task_size = group_compilation_contexts.size();
+  PADDLE_ENFORCE_EQ(task_size,
+                    leaf_groups.size(),
+                    phi::errors::InvalidArgument(
+                        "While compiling broadcast tree, the size of "
+                        "group_compilation_contexts and groups should be "
+                        "the same."));
+
+  const auto& ParallelLowering = [&]() {
+    cinn::ir::InitScheduleConfig();
+    auto worker_fn = [&](int index) {
+      CompilationTask task(&group_compilation_contexts[index]);
+      task.Lowering();
+    };
+    const size_t thread_size = GetThreadNum(task_size);
+    utils::parallel_run(worker_fn,
+                        utils::SequenceDispatcher(0, task_size),
+                        /*thread_num=*/thread_size);
+  };
+
+  const auto& SerialBackendCompile =
+      [&](const std::unordered_map<int, ir::Var>& shape_idx)
+      -> pir::CINNKernelInfo {
+    GroupCompilationContext origin_group_ctx(target_, origin_group);
+    CompilationTask compilation_task(&origin_group_ctx);
+    const auto device_id = runtime::GetArchDevice(target_);
+    runtime::SetArchDevice(target_, device_id);
+    auto result = compilation_task.CompileBroadcastModules(
+        &group_compilation_contexts, shape_idx);
+    const auto kernel_info = result->GetKernelInfo();
+    CompilationCache::Instance().Insert(fusion_info, result);
+    return kernel_info;
+  };
+
+  ParallelLowering();
+  std::unordered_map<int, ir::Var> symbolic_shape_var_index;
+  UnifyBroadcastGroupFuncArgs(
+      &group_compilation_contexts, origin_group, &symbolic_shape_var_index);
+  return SerialBackendCompile(symbolic_shape_var_index);
+}
+
 void CompilationContextMapper::Construct(
     const Target& target, const std::vector<pir::OpLoweringGroupPtr>& groups) {
   std::unordered_set<size_t> unique_infos;

--- a/paddle/cinn/hlir/framework/pir_compiler.h
+++ b/paddle/cinn/hlir/framework/pir_compiler.h
@@ -27,6 +27,10 @@ class PirCompiler final {
   std::vector<pir::CINNKernelInfo> Build(
       const std::vector<pir::OpLoweringGroupPtr>& groups);
 
+  pir::CINNKernelInfo BuildBroadcastTree(
+      const std::vector<pir::OpLoweringGroupPtr>& leaf_groups,
+      pir::OpLoweringGroupPtr origin_group);
+
  private:
   CINN_DISALLOW_COPY_AND_ASSIGN(PirCompiler);
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR supports PirCompiler to build broadcast tree.
To learn more about the theoretical explanation of lowering broadcast tree in host wrapper function and the step-by-step arrangement for the Pull Request (PR), please refer to the [draft PR65604](https://github.com/PaddlePaddle/Paddle/pull/65604) for details.