### PR TITLE
[PIR] fix pir xpu

### DIFF
--- a/test/xpu/test_diag_v2_op_xpu.py
+++ b/test/xpu/test_diag_v2_op_xpu.py
@@ -286,7 +286,8 @@ class XPUTestDiagV2Op(XPUOpTestWrapper):
             np.testing.assert_allclose(res0, self.expected0, rtol=1e-05)
             np.testing.assert_allclose(res1, self.expected1, rtol=1e-05)
             np.testing.assert_allclose(res2, self.expected2, rtol=1e-05)
-            self.assertTrue('aaa' in result3.name)
+            if not paddle.framework.use_pir_api():
+                self.assertTrue('aaa' in result3.name)
             np.testing.assert_allclose(res4, self.expected3, rtol=1e-05)
             np.testing.assert_allclose(res5, self.expected4, rtol=1e-05)
             np.testing.assert_allclose(res6, self.expected5, rtol=1e-05)

--- a/test/xpu/test_elementwise_add_op_xpu.py
+++ b/test/xpu/test_elementwise_add_op_xpu.py
@@ -304,7 +304,8 @@ class XPUTestElementwiseAddOp(XPUOpTestWrapper):
                 y = paddle.static.data(name='y', shape=[2, 3], dtype='float32')
 
                 y_1 = paddle.add(x, y, name='add_res')
-                self.assertEqual(('add_res' in y_1.name), True)
+                if not paddle.framework.use_pir_api():
+                    self.assertEqual(('add_res' in y_1.name), True)
 
         def test_declarative(self):
             with base.program_guard(base.Program()):
@@ -321,7 +322,7 @@ class XPUTestElementwiseAddOp(XPUOpTestWrapper):
 
                 place = base.XPUPlace(0)
                 exe = base.Executor(place)
-                z_value = exe.run(feed=gen_data(), fetch_list=[z.name])
+                z_value = exe.run(feed=gen_data(), fetch_list=[z])
                 z_expected = np.array([3.0, 8.0, 6.0])
                 self.assertEqual((z_value == z_expected).all(), True)
 

--- a/test/xpu/test_elementwise_add_op_xpu_kp.py
+++ b/test/xpu/test_elementwise_add_op_xpu_kp.py
@@ -313,7 +313,8 @@ class TestAddOp(unittest.TestCase):
             y = paddle.static.data(name='y', shape=[2, 3], dtype='float32')
 
             y_1 = paddle.add(x, y, name='add_res')
-            self.assertEqual(('add_res' in y_1.name), True)
+            if not paddle.framework.use_pir_api():
+                self.assertEqual(('add_res' in y_1.name), True)
 
     def test_declarative(self):
         with base.program_guard(base.Program()):
@@ -330,7 +331,7 @@ class TestAddOp(unittest.TestCase):
 
             place = base.XPUPlace(0)
             exe = base.Executor(place)
-            z_value = exe.run(feed=gen_data(), fetch_list=[z.name])
+            z_value = exe.run(feed=gen_data(), fetch_list=[z])
             z_expected = np.array([3.0, 8.0, 6.0])
             self.assertEqual((z_value == z_expected).all(), True)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复XPU几个单测，并修复一个基类共性问题。由于op单测基类有些逻辑必须依赖老静态图，只能guard到老静态图测试。包括op_test.py也是这么做的。

Pcard-67164