### PR TITLE
[CINN] Fix some bug of infer symbol shape

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_pass.cc
@@ -93,7 +93,8 @@ class BlockDimExprsAsserter {
       for (int i = 0; i < op->num_operands(); ++i) {
         const auto& input = op->operand_source(i);
         if (!input || !input.type()) continue;
-        if (input.type().isa<pir::VectorType>()) {
+        if (input.type().isa<pir::VectorType>() ||
+            input.type().isa<paddle::dialect::DenseTensorArrayType>()) {
           return std::vector<pir::Value>{};
         }
         inputs.push_back(input);

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
@@ -217,12 +217,13 @@ bool SliceOpInferSymbolicShape(pir::Operation *op,
   infer_context->SetShapeOrDataForValue(
       op->result(0),
       paddle::dialect::slice_utils::SliceRawInferSymbolicShape(
-          infer_context->GetShapeOrDataForValue(op->operand_source(0)),
+          op->operand_source(0),
           starts,
           ends,
           axes_raw,
           infer_flags_raw,
-          decrease_axis_raw));
+          decrease_axis_raw,
+          infer_context));
 
   return true;
 }

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
@@ -128,12 +128,14 @@ inline std::vector<int64_t> FormatSliceAxes(
 }
 
 inline ShapeOrData SliceRawInferSymbolicShape(
-    const ShapeOrData &in_shapeordata,
+    const pir::Value x,
     const ExprVec &starts_expr,
     const ExprVec &ends_expr,
     const std::vector<int64_t> &axes_raw,
     const std::vector<int64_t> &infer_flags_raw,
-    const std::vector<int64_t> &decrease_axis) {
+    const std::vector<int64_t> &decrease_axis,
+    pir::InferSymbolicShapeContext *infer_context) {
+  const auto &in_shapeordata = infer_context->GetShapeOrDataForValue(x);
   ExprVec starts = starts_expr;
   ExprVec ends = ends_expr;
   std::vector<int64_t> infer_flags = [&infer_flags_raw, &axes_raw] {
@@ -148,6 +150,20 @@ inline ShapeOrData SliceRawInferSymbolicShape(
     ExprVec slice_dims =
         GetSliceDims(in_dims, axes, starts, ends, &infer_flags);
     ExprVec out_dims = GetDecreasedDims(slice_dims, decrease_axis);
+
+    auto IsOne = [](const symbol::DimExpr &expr) {
+      return expr.isa<int64_t>() && expr.dyn_cast<int64_t>() == 1;
+    };
+    auto IsIntType = [](pir::Value value) {
+      const auto &dtype = value.type().dyn_cast<pir::DenseTensorType>().dtype();
+      return dtype.isa<pir::Int32Type>() || dtype.isa<pir::Int64Type>();
+    };
+    if (IsIntType(x) &&
+        (out_dims.empty() || (out_dims.size() == 1 && IsOne(out_dims[0])))) {
+      return symbol::ShapeOrDataDimExprs{symbol::TensorShapeOrDataDimExprs(
+          out_dims,
+          std::vector<symbol::DimExpr>{infer_context->GetNextSymName()})};
+    }
 
     return symbol::ShapeOrDataDimExprs{
         symbol::TensorShapeOrDataDimExprs(out_dims)};

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -771,8 +771,6 @@ bool SliceOpInferSymbolicShape(pir::Operation *op,
   pir::Value operand_ends = op->operand_source(2);
   pir::Value res = op->result(0);
 
-  const symbol::ShapeOrDataDimExprs &operand_shape_or_data =
-      infer_context->GetShapeOrDataForValue(operand_source);
   const symbol::ShapeOrDataDimExprs &starts_shape_data =
       infer_context->GetShapeOrDataForValue(operand_starts);
   const symbol::ShapeOrDataDimExprs &ends_shape_data =
@@ -791,12 +789,13 @@ bool SliceOpInferSymbolicShape(pir::Operation *op,
 
   infer_context->SetShapeOrDataForValue(
       res,
-      slice_utils::SliceRawInferSymbolicShape(operand_shape_or_data,
+      slice_utils::SliceRawInferSymbolicShape(operand_source,
                                               starts,
                                               ends,
                                               axes_vec,
                                               infer_flags,
-                                              decrease_axis));
+                                              decrease_axis,
+                                              infer_context));
 
   return true;
 }

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -3031,19 +3031,15 @@ bool ExpandOp::InferSymbolicShape(
       const auto &dims_list =
           expand_shape_shape_or_data
               .dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
-      for (const auto &shape_data : dims_list) {
-        const auto &dim_expr = shape_data.data().has_value()
-                                   ? shape_data.data().value()[0]
-                                   : shape_data.shape()[0];
-        dims.emplace_back(dim_expr);
+      if (dims_list.size() == 1) {
+        dims = dims_list.at(0).data().value();
+      } else {
+        for (const auto &shape_data : dims_list) {
+          dims.emplace_back(shape_data.data()->at(0));
+        }
       }
     } else {
-      dims = expand_shape_shape_or_data.data().has_value()
-                 ? expand_shape_shape_or_data.data().value()
-                 : expand_shape_shape_or_data.shape();
-    }
-    if (dims.empty()) {
-      dims = std::vector<symbol::DimExpr>(x_dims.size(), -1);
+      dims = expand_shape_shape_or_data.data().value();
     }
     return dims;
   }();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复Expand符号推导实现BUG, 并完善Slice符号推导逻辑。