### PR TITLE
【Fix PIR Unittest】add datatype check and cast in PIR

### DIFF
--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -365,8 +365,14 @@ def _recompute_without_reentrant(
                             inner_x.placements,
                         )
                     else:
+                        if isinstance(inner_x.dtype, paddle.base.core.DataType):
+                            inner_x_dtype = paddle.pir.core.datatype_to_vartype[
+                                inner_x.dtype
+                            ]
+                        else:
+                            inner_x_dtype = inner_x.dtype
                         tmp_tensor = core.eager.Tensor(
-                            inner_x.dtype,
+                            inner_x_dtype,
                             inner_x.shape,
                             inner_x.name + "cpy",
                             core.VarDesc.VarType.LOD_TENSOR,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Others


### PR Types
Bug fixes


### Description
Pcard-67164
开启PIR后，单测test_dygraph_recompute_for_eager中使用了paddle.float16，这个在PIR下是DataType类型，单测中check的是是否VarType类型，因此遇到之后要做类型检查和转换
