### PR TITLE
【Fix PIR Unittest】fix some dtype bugs in UT test_dygraph_sharding_stage1_fp16

### DIFF
--- a/python/paddle/distributed/fleet/utils/tensor_fusion_helper.py
+++ b/python/paddle/distributed/fleet/utils/tensor_fusion_helper.py
@@ -41,9 +41,9 @@ alignment = {
 }
 
 align = {
-    paddle.float16.value: 2,
-    paddle.bfloat16.value: 2,
-    paddle.float32.value: 4,
+    paddle.float16: 2,
+    paddle.bfloat16: 2,
+    paddle.float32: 4,
 }
 
 

--- a/python/paddle/distributed/parallel.py
+++ b/python/paddle/distributed/parallel.py
@@ -136,7 +136,7 @@ def build_groups(vars, group_size):
         var_dtype = var.dtype
         if isinstance(var_dtype, core.DataType):
             var_dtype = paddle.pir.core.datatype_to_vartype[var_dtype]
-        bytes = np.prod(var.shape) * core.size_of_dtype[var_dtype]
+        bytes = np.prod(var.shape) * core.size_of_dtype(var_dtype)
         if memory_counter < group_size and dtype == var.dtype:
             memory_counter += bytes
         else:

--- a/python/paddle/distributed/parallel.py
+++ b/python/paddle/distributed/parallel.py
@@ -136,7 +136,7 @@ def build_groups(vars, group_size):
         var_dtype = var.dtype
         if isinstance(var_dtype, core.DataType):
             var_dtype = paddle.pir.core.datatype_to_vartype[var_dtype]
-        bytes = np.prod(var.shape) * core.size_of_dtype(var_dtype)
+        bytes = np.prod(var.shape) * core.size_of_dtype[var_dtype]
         if memory_counter < group_size and dtype == var.dtype:
             memory_counter += bytes
         else:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Others


### PR Types
Bug fixes


### Description
Pcard-67164
修复单测test_dygraph_sharding_stage1_fp16中PIR下的报错，使用的dict align使用dtype.value作为key，但是在使用时直接通过align[dtype]调用，因此将align的key统一调整成dtype
