### PR TITLE
[PIR][static.nn] fix pir ut used in static.nn.conv3d

### DIFF
--- a/test/ir/inference/test_trt_conv3d_op.py
+++ b/test/ir/inference/test_trt_conv3d_op.py
@@ -21,6 +21,7 @@ import paddle
 from paddle import base
 from paddle.base import core
 from paddle.base.core import AnalysisConfig, PassVersionChecker
+from paddle.pir_utils import test_with_pir_api
 
 
 class TensorRTSubgraphPassConv3dTest(InferencePassTest):
@@ -31,17 +32,16 @@ class TensorRTSubgraphPassConv3dTest(InferencePassTest):
             data = paddle.static.data(
                 name="data", shape=[-1, 3, 6, 32, 32], dtype="float32"
             )
-            conv_out = paddle.static.nn.conv3d(
-                input=data,
-                num_filters=self.conv_num_filters,
-                filter_size=self.conv_filter_size,
+            conv_out = paddle.nn.Conv3D(
+                in_channels=3,
+                out_channels=self.conv_num_filters,
+                kernel_size=self.conv_filter_size,
                 groups=self.conv_groups,
+                stride=self.stride,
                 padding=self.conv_padding,
                 bias_attr=False,
-                use_cudnn=self.use_cudnn,
-                stride=self.stride,
-                act=None,
-            )
+                data_format="NCDHW",
+            )(data)
         self.feeds = {
             "data": np.random.random([1, 3, 6, 32, 32]).astype("float32"),
         }
@@ -64,6 +64,7 @@ class TensorRTSubgraphPassConv3dTest(InferencePassTest):
     def set_params(self):
         pass
 
+    @test_with_pir_api
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             use_gpu = True
@@ -115,17 +116,16 @@ class DynamicShapeTensorRTSubgraphPassConv3dTest(InferencePassTest):
             data = paddle.static.data(
                 name="data", shape=[-1, 6, -1, -1, -1], dtype="float32"
             )
-            conv_out = paddle.static.nn.conv3d(
-                input=data,
-                num_filters=self.conv_num_filters,
-                filter_size=self.conv_filter_size,
+            conv_out = paddle.nn.Conv3D(
+                in_channels=6,
+                out_channels=self.conv_num_filters,
+                kernel_size=self.conv_filter_size,
                 groups=self.conv_groups,
+                stride=self.stride,
                 padding=self.conv_padding,
                 bias_attr=False,
-                use_cudnn=self.use_cudnn,
-                stride=self.stride,
-                act=None,
-            )
+                data_format="NCDHW",
+            )(data)
         self.feeds = {
             "data": np.random.random([1, 6, 32, 32, 8]).astype("float32"),
         }
@@ -162,6 +162,7 @@ class DynamicShapeTensorRTSubgraphPassConv3dTest(InferencePassTest):
         self.use_cudnn = True
         self.stride = [2, 2, 2]
 
+    @test_with_pir_api
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             use_gpu = True

--- a/test/ir/inference/test_trt_conv3d_op.py
+++ b/test/ir/inference/test_trt_conv3d_op.py
@@ -21,7 +21,6 @@ import paddle
 from paddle import base
 from paddle.base import core
 from paddle.base.core import AnalysisConfig, PassVersionChecker
-from paddle.pir_utils import test_with_pir_api
 
 
 class TensorRTSubgraphPassConv3dTest(InferencePassTest):
@@ -64,7 +63,6 @@ class TensorRTSubgraphPassConv3dTest(InferencePassTest):
     def set_params(self):
         pass
 
-    @test_with_pir_api
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             use_gpu = True
@@ -162,7 +160,6 @@ class DynamicShapeTensorRTSubgraphPassConv3dTest(InferencePassTest):
         self.use_cudnn = True
         self.stride = [2, 2, 2]
 
-    @test_with_pir_api
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             use_gpu = True

--- a/test/legacy_test/test_conv3d_op.py
+++ b/test/legacy_test/test_conv3d_op.py
@@ -1400,14 +1400,14 @@ class TestPIRConv3DAPI_Error(unittest.TestCase):
             # ValueError: filter num
             def run_8():
                 paddle.nn.Conv3D(
-                    in_channels=x_NCDHW_in_channel,
+                    in_channels=x_NDHWC_in_channel,
                     out_channels=0,
                     kernel_size=0,
                     stride=0,
                     padding=0,
                     dilation=0,
                     groups=1,
-                    data_format="NCDHW",
+                    data_format="NDHWC",
                 )(x)
 
             self.assertRaises(AssertionError, run_8)

--- a/test/legacy_test/test_conv3d_op.py
+++ b/test/legacy_test/test_conv3d_op.py
@@ -19,7 +19,6 @@ from op_test import (
     OpTest,
     convert_float_to_uint16,
     get_numeric_gradient,
-    paddle_static_guard,
 )
 from testsuite import create_op
 
@@ -1044,90 +1043,97 @@ create_test_cudnn_channel_last_class(TestWith1x1_AsyPadding)
 
 # --------- test python API ---------------
 class TestConv3DAPI(unittest.TestCase):
+    def api_run(self):
+        input_NDHWC = paddle.static.data(
+            name="input_NDHWC",
+            shape=[2, 5, 5, 5, 3],
+            dtype="float32",
+        )
+        input_NDHWC_in_channel = 5
+
+        input_NCDHW = paddle.static.data(
+            name="input_NCDHW",
+            shape=[2, 3, 5, 5, 3],
+            dtype="float32",
+        )
+        input_NCDHW_in_channel = 3
+
+        paddle.nn.Conv3D(
+            in_channels=input_NCDHW_in_channel,
+            out_channels=3,
+            kernel_size=[3, 3, 3],
+            stride=[1, 1, 1],
+            padding=0,
+            dilation=[1, 1, 1],
+            groups=1,
+            data_format="NCDHW",
+        )(input_NCDHW)
+
+        paddle.nn.Conv3D(
+            in_channels=input_NCDHW_in_channel,
+            out_channels=3,
+            kernel_size=[3, 3, 3],
+            stride=[1, 1, 1],
+            padding=[1, 2, 1, 0, 1, 0],
+            dilation=[1, 1, 1],
+            groups=1,
+            data_format="NCDHW",
+        )(input_NCDHW)
+
+        paddle.nn.Conv3D(
+            in_channels=input_NCDHW_in_channel,
+            out_channels=3,
+            kernel_size=[3, 3, 3],
+            stride=[1, 1, 1],
+            padding=[[0, 0], [0, 0], [1, 1], [1, 1], [1, 1]],
+            dilation=[1, 1, 1],
+            groups=1,
+            data_format="NCDHW",
+        )(input_NCDHW)
+
+        paddle.nn.Conv3D(
+            in_channels=input_NDHWC_in_channel,
+            out_channels=3,
+            kernel_size=[3, 3, 3],
+            stride=[1, 1, 1],
+            padding=[[0, 0], [1, 1], [1, 1], [1, 1], [0, 0]],
+            dilation=[1, 1, 1],
+            groups=1,
+            data_format="NDHWC",
+        )(input_NDHWC)
+
+        paddle.nn.Conv3D(
+            in_channels=input_NCDHW_in_channel,
+            out_channels=3,
+            kernel_size=[3, 3, 3],
+            stride=[1, 1, 1],
+            padding="SAME",
+            dilation=[1, 1, 1],
+            groups=1,
+            data_format="NCDHW",
+        )(input_NCDHW)
+
+        paddle.nn.Conv3D(
+            in_channels=input_NCDHW_in_channel,
+            out_channels=3,
+            kernel_size=[3, 3, 3],
+            stride=[1, 1, 1],
+            padding="VALID",
+            dilation=[1, 1, 1],
+            groups=1,
+            data_format="NCDHW",
+        )(input_NCDHW)
+
     def test_api(self):
-        with paddle_static_guard():
-            input_NDHWC = paddle.static.data(
-                name="input_NDHWC",
-                shape=[2, 5, 5, 5, 3],
-                dtype="float32",
-            )
-
-            input_NCDHW = paddle.static.data(
-                name="input_NCDHW",
-                shape=[2, 3, 5, 5, 3],
-                dtype="float32",
-            )
-
-            paddle.static.nn.conv3d(
-                input=input_NDHWC,
-                num_filters=3,
-                filter_size=[3, 3, 3],
-                stride=[1, 1, 1],
-                padding=0,
-                dilation=[1, 1, 1],
-                groups=1,
-                data_format="NCDHW",
-            )
-
-            paddle.static.nn.conv3d(
-                input=input_NCDHW,
-                num_filters=3,
-                filter_size=[3, 3, 3],
-                stride=[1, 1, 1],
-                padding=[1, 2, 1, 0, 1, 0],
-                dilation=[1, 1, 1],
-                groups=1,
-                data_format="NCDHW",
-            )
-
-            paddle.static.nn.conv3d(
-                input=input_NCDHW,
-                num_filters=3,
-                filter_size=[3, 3, 3],
-                stride=[1, 1, 1],
-                padding=[[0, 0], [0, 0], [1, 1], [1, 1], [1, 1]],
-                dilation=[1, 1, 1],
-                groups=1,
-                data_format="NCDHW",
-            )
-
-            paddle.static.nn.conv3d(
-                input=input_NDHWC,
-                num_filters=3,
-                filter_size=[3, 3, 3],
-                stride=[1, 1, 1],
-                padding=[[0, 0], [1, 1], [1, 1], [1, 1], [0, 0]],
-                dilation=[1, 1, 1],
-                groups=1,
-                data_format="NDHWC",
-            )
-
-            paddle.static.nn.conv3d(
-                input=input_NCDHW,
-                num_filters=3,
-                filter_size=[3, 3, 3],
-                stride=[1, 1, 1],
-                padding="SAME",
-                dilation=[1, 1, 1],
-                groups=1,
-                data_format="NCDHW",
-            )
-
-            paddle.static.nn.conv3d(
-                input=input_NCDHW,
-                num_filters=3,
-                filter_size=[3, 3, 3],
-                stride=[1, 1, 1],
-                padding="VALID",
-                dilation=[1, 1, 1],
-                groups=1,
-                data_format="NCDHW",
-            )
+        with paddle.pir_utils.OldIrGuard():
+            self.api_run()
+        with paddle.pir_utils.IrGuard():
+            self.api_run()
 
 
 class TestConv3DAPI_Error(unittest.TestCase):
     def test_api(self):
-        with paddle_static_guard():
+        with paddle.pir_utils.OldIrGuard():
             input = paddle.static.data(
                 name="input",
                 shape=[2, 5, 5, 5, 4],
@@ -1265,6 +1271,146 @@ class TestConv3DAPI_Error(unittest.TestCase):
                 )
 
             self.assertRaises(ValueError, run_8)
+
+
+class TestPIRConv3DAPI_Error(unittest.TestCase):
+    def test_api(self):
+        with paddle.pir_utils.IrGuard():
+            input = paddle.static.data(
+                name="input",
+                shape=[2, 5, 5, 5, 4],
+                dtype="float32",
+            )
+            input_NCDHW_in_channel = 5
+            input_NDHWC_in_channel = 4
+
+            # ValueError: cudnn
+            # def run_1():
+            #     model = paddle.nn.Conv3D(
+            #         in_channels=input_NCDHW_in_channel,
+            #         out_channels=3,
+            #         kernel_size=3,
+            #         stride=1,
+            #         padding=0,
+            #         dilation=1,
+            #         groups=1,
+            #         data_format="NCDHW",
+            #     )
+            #     model._use_cudnn = [0]
+            #     model(input)
+            #
+            # self.assertRaises(ValueError, run_1)
+
+            # ValueError: data_format
+            def run_2():
+                paddle.nn.Conv3D(
+                    in_channels=input_NCDHW_in_channel,
+                    out_channels=3,
+                    kernel_size=[3, 3, 3],
+                    stride=[1, 1, 1],
+                    padding=0,
+                    dilation=[1, 1, 1],
+                    groups=1,
+                    data_format="NCHWC",
+                )(input)
+
+            self.assertRaises(ValueError, run_2)
+
+            # ValueError: padding
+            def run_3():
+                paddle.nn.Conv3D(
+                    in_channels=input_NCDHW_in_channel,
+                    out_channels=3,
+                    kernel_size=3,
+                    stride=1,
+                    padding="SAMEE",
+                    dilation=1,
+                    groups=1,
+                    data_format="NCDHW",
+                )(input)
+
+            self.assertRaises(ValueError, run_3)
+
+            def run_4():
+                paddle.nn.Conv3D(
+                    in_channels=input_NCDHW_in_channel,
+                    out_channels=3,
+                    kernel_size=3,
+                    stride=1,
+                    padding=[[0, 1], [0, 0], [0, 1], [0, 1], [0, 1]],
+                    dilation=1,
+                    groups=1,
+                    data_format="NCDHW",
+                )(input)
+
+            self.assertRaises(ValueError, run_4)
+
+            def run_5():
+                paddle.nn.Conv3D(
+                    in_channels=input_NDHWC_in_channel,
+                    out_channels=3,
+                    kernel_size=0,
+                    stride=0,
+                    padding=[[0, 1], [0, 1], [0, 1], [0, 1], [0, 1]],
+                    dilation=1,
+                    groups=1,
+                    data_format="NDHWC",
+                )(input)
+
+            self.assertRaises(ValueError, run_5)
+
+            # ValueError: channel dimension
+            x = paddle.static.data(
+                name="x",
+                shape=[2, 5, 5, 5, -1],
+                dtype="float32",
+            )
+            x_NCDHW_in_channel = 5
+            x_NDHWC_in_channel = -1
+
+            def run_6():
+                paddle.nn.Conv3D(
+                    in_channels=x_NDHWC_in_channel,
+                    out_channels=3,
+                    kernel_size=3,
+                    stride=1,
+                    padding=0,
+                    dilation=1,
+                    groups=1,
+                    data_format="NDHWC",
+                )(x)
+
+            self.assertRaises(AssertionError, run_6)
+
+            # ValueError: groups
+            def run_7():
+                paddle.nn.Conv3D(
+                    in_channels=x_NDHWC_in_channel,
+                    out_channels=3,
+                    kernel_size=3,
+                    stride=1,
+                    padding=0,
+                    dilation=1,
+                    groups=3,
+                    data_format="NDHWC",
+                )(x)
+
+            self.assertRaises(ValueError, run_7)
+
+            # ValueError: filter num
+            def run_8():
+                paddle.nn.Conv3D(
+                    in_channels=x_NCDHW_in_channel,
+                    out_channels=0,
+                    kernel_size=0,
+                    stride=0,
+                    padding=0,
+                    dilation=0,
+                    groups=1,
+                    data_format="NCDHW",
+                )(x)
+
+            self.assertRaises(AssertionError, run_8)
 
 
 if __name__ == '__main__':

--- a/test/xpu/test_conv3d_op_xpu.py
+++ b/test/xpu/test_conv3d_op_xpu.py
@@ -560,225 +560,374 @@ class XPUTestConv3DOp_v2(XPUOpTestWrapper):
 
 # --------- test python API ---------------
 class TestConv3DAPI(unittest.TestCase):
-    def test_api(self):
+    def api_run(self):
         input_NDHWC = paddle.static.data(
             name="input_NDHWC",
             shape=[2, 5, 5, 5, 3],
             dtype="float32",
         )
+        input_NDHWC_in_channel = 5
 
         input_NCDHW = paddle.static.data(
             name="input_NCDHW",
             shape=[2, 3, 5, 5, 3],
             dtype="float32",
         )
+        input_NCDHW_in_channel = 3
 
-        paddle.static.nn.conv3d(
-            input=input_NDHWC,
-            num_filters=3,
-            filter_size=[3, 3, 3],
+        paddle.nn.Conv3D(
+            in_channels=input_NCDHW_in_channel,
+            out_channels=3,
+            kernel_size=[3, 3, 3],
             stride=[1, 1, 1],
             padding=0,
             dilation=[1, 1, 1],
             groups=1,
             data_format="NCDHW",
-        )
+        )(input_NCDHW)
 
-        paddle.static.nn.conv3d(
-            input=input_NCDHW,
-            num_filters=3,
-            filter_size=[3, 3, 3],
+        paddle.nn.Conv3D(
+            in_channels=input_NCDHW_in_channel,
+            out_channels=3,
+            kernel_size=[3, 3, 3],
             stride=[1, 1, 1],
             padding=[1, 2, 1, 0, 1, 0],
             dilation=[1, 1, 1],
             groups=1,
             data_format="NCDHW",
-        )
+        )(input_NCDHW)
 
-        paddle.static.nn.conv3d(
-            input=input_NCDHW,
-            num_filters=3,
-            filter_size=[3, 3, 3],
+        paddle.nn.Conv3D(
+            in_channels=input_NCDHW_in_channel,
+            out_channels=3,
+            kernel_size=[3, 3, 3],
             stride=[1, 1, 1],
             padding=[[0, 0], [0, 0], [1, 1], [1, 1], [1, 1]],
             dilation=[1, 1, 1],
             groups=1,
             data_format="NCDHW",
-        )
+        )(input_NCDHW)
 
-        paddle.static.nn.conv3d(
-            input=input_NDHWC,
-            num_filters=3,
-            filter_size=[3, 3, 3],
+        paddle.nn.Conv3D(
+            in_channels=input_NDHWC_in_channel,
+            out_channels=3,
+            kernel_size=[3, 3, 3],
             stride=[1, 1, 1],
             padding=[[0, 0], [1, 1], [1, 1], [1, 1], [0, 0]],
             dilation=[1, 1, 1],
             groups=1,
             data_format="NDHWC",
-        )
+        )(input_NDHWC)
 
-        paddle.static.nn.conv3d(
-            input=input_NCDHW,
-            num_filters=3,
-            filter_size=[3, 3, 3],
+        paddle.nn.Conv3D(
+            in_channels=input_NCDHW_in_channel,
+            out_channels=3,
+            kernel_size=[3, 3, 3],
             stride=[1, 1, 1],
             padding="SAME",
             dilation=[1, 1, 1],
             groups=1,
             data_format="NCDHW",
-        )
+        )(input_NCDHW)
 
-        paddle.static.nn.conv3d(
-            input=input_NCDHW,
-            num_filters=3,
-            filter_size=[3, 3, 3],
+        paddle.nn.Conv3D(
+            in_channels=input_NCDHW_in_channel,
+            out_channels=3,
+            kernel_size=[3, 3, 3],
             stride=[1, 1, 1],
             padding="VALID",
             dilation=[1, 1, 1],
             groups=1,
             data_format="NCDHW",
-        )
+        )(input_NCDHW)
+
+    def test_api(self):
+        with paddle.pir_utils.OldIrGuard():
+            self.api_run()
+        with paddle.pir_utils.IrGuard():
+            self.api_run()
 
 
 class TestConv3DAPI_Error(unittest.TestCase):
     def test_api(self):
-        input = paddle.static.data(
-            name="input",
-            shape=[2, 5, 5, 5, 4],
-            dtype="float32",
-        )
-
-        # ValueError: cudnn
-        def run_1():
-            paddle.static.nn.conv3d(
-                input=input,
-                num_filters=3,
-                filter_size=3,
-                stride=1,
-                padding=0,
-                dilation=1,
-                groups=1,
-                use_cudnn=[0],
-                data_format="NCDHW",
+        with paddle.pir_utils.OldIrGuard():
+            input = paddle.static.data(
+                name="input",
+                shape=[2, 5, 5, 5, 4],
+                dtype="float32",
             )
 
-        self.assertRaises(ValueError, run_1)
+            # ValueError: cudnn
+            def run_1():
+                paddle.static.nn.conv3d(
+                    input=input,
+                    num_filters=3,
+                    filter_size=3,
+                    stride=1,
+                    padding=0,
+                    dilation=1,
+                    groups=1,
+                    use_cudnn=[0],
+                    data_format="NCDHW",
+                )
 
-        # ValueError: data_format
-        def run_2():
-            paddle.static.nn.conv3d(
-                input=input,
-                num_filters=3,
-                filter_size=[3, 3, 3],
-                stride=[1, 1, 1],
-                padding=0,
-                dilation=[1, 1, 1],
-                groups=1,
-                use_cudnn=False,
-                data_format="NCHWC",
+            self.assertRaises(ValueError, run_1)
+
+            # ValueError: data_format
+            def run_2():
+                paddle.static.nn.conv3d(
+                    input=input,
+                    num_filters=3,
+                    filter_size=[3, 3, 3],
+                    stride=[1, 1, 1],
+                    padding=0,
+                    dilation=[1, 1, 1],
+                    groups=1,
+                    use_cudnn=False,
+                    data_format="NCHWC",
+                )
+
+            self.assertRaises(ValueError, run_2)
+
+            # ValueError: padding
+            def run_3():
+                paddle.static.nn.conv3d(
+                    input=input,
+                    num_filters=3,
+                    filter_size=3,
+                    stride=1,
+                    padding="SAMEE",
+                    dilation=1,
+                    groups=1,
+                    use_cudnn=False,
+                    data_format="NCDHW",
+                )
+
+            self.assertRaises(ValueError, run_3)
+
+            def run_4():
+                paddle.static.nn.conv3d(
+                    input=input,
+                    num_filters=3,
+                    filter_size=3,
+                    stride=1,
+                    padding=[[0, 1], [0, 0], [0, 1], [0, 1], [0, 1]],
+                    dilation=1,
+                    groups=1,
+                    use_cudnn=False,
+                    data_format="NCDHW",
+                )
+
+            self.assertRaises(ValueError, run_4)
+
+            def run_5():
+                paddle.static.nn.conv3d(
+                    input=input,
+                    num_filters=3,
+                    filter_size=0,
+                    stride=0,
+                    padding=[[0, 1], [0, 1], [0, 1], [0, 1], [0, 1]],
+                    dilation=1,
+                    groups=1,
+                    use_cudnn=False,
+                    data_format="NDHWC",
+                )
+
+            self.assertRaises(ValueError, run_5)
+
+            # ValueError: channel dimension
+            x = paddle.static.data(
+                name="x",
+                shape=[2, 5, 5, 5, -1],
+                dtype="float32",
             )
 
-        self.assertRaises(ValueError, run_2)
+            def run_6():
+                paddle.static.nn.conv3d(
+                    input=x,
+                    num_filters=3,
+                    filter_size=3,
+                    stride=1,
+                    padding=0,
+                    dilation=1,
+                    groups=1,
+                    use_cudnn=False,
+                    data_format="NDHWC",
+                )
 
-        # ValueError: padding
-        def run_3():
-            paddle.static.nn.conv3d(
-                input=input,
-                num_filters=3,
-                filter_size=3,
-                stride=1,
-                padding="SAMEE",
-                dilation=1,
-                groups=1,
-                use_cudnn=False,
-                data_format="NCDHW",
+            self.assertRaises(ValueError, run_6)
+
+            # ValueError: groups
+            def run_7():
+                paddle.static.nn.conv3d(
+                    input=input,
+                    num_filters=3,
+                    filter_size=3,
+                    stride=1,
+                    padding=0,
+                    dilation=1,
+                    groups=3,
+                    use_cudnn=False,
+                    data_format="NDHWC",
+                )
+
+            self.assertRaises(ValueError, run_7)
+
+            # ValueError: filter num
+            def run_8():
+                paddle.static.nn.conv3d(
+                    input=input,
+                    num_filters=0,
+                    filter_size=0,
+                    stride=0,
+                    padding=0,
+                    dilation=0,
+                    groups=1,
+                    use_cudnn=False,
+                    data_format="NDHWC",
+                )
+
+            self.assertRaises(ValueError, run_8)
+
+
+class TestPIRConv3DAPI_Error(unittest.TestCase):
+    def test_api(self):
+        with paddle.pir_utils.IrGuard():
+            input = paddle.static.data(
+                name="input",
+                shape=[2, 5, 5, 5, 4],
+                dtype="float32",
             )
+            input_NCDHW_in_channel = 5
+            input_NDHWC_in_channel = 4
 
-        self.assertRaises(ValueError, run_3)
+            # ValueError: cudnn
+            # def run_1():
+            #     model = paddle.nn.Conv3D(
+            #         in_channels=input_NCDHW_in_channel,
+            #         out_channels=3,
+            #         kernel_size=3,
+            #         stride=1,
+            #         padding=0,
+            #         dilation=1,
+            #         groups=1,
+            #         data_format="NCDHW",
+            #     )
+            #     model._use_cudnn = [0]
+            #     model(input)
+            #
+            # self.assertRaises(ValueError, run_1)
 
-        def run_4():
-            paddle.static.nn.conv3d(
-                input=input,
-                num_filters=3,
-                filter_size=3,
-                stride=1,
-                padding=[[0, 1], [0, 0], [0, 1], [0, 1], [0, 1]],
-                dilation=1,
-                groups=1,
-                use_cudnn=False,
-                data_format="NCDHW",
+            # ValueError: data_format
+            def run_2():
+                paddle.nn.Conv3D(
+                    in_channels=input_NCDHW_in_channel,
+                    out_channels=3,
+                    kernel_size=[3, 3, 3],
+                    stride=[1, 1, 1],
+                    padding=0,
+                    dilation=[1, 1, 1],
+                    groups=1,
+                    data_format="NCHWC",
+                )(input)
+
+            self.assertRaises(ValueError, run_2)
+
+            # ValueError: padding
+            def run_3():
+                paddle.nn.Conv3D(
+                    in_channels=input_NCDHW_in_channel,
+                    out_channels=3,
+                    kernel_size=3,
+                    stride=1,
+                    padding="SAMEE",
+                    dilation=1,
+                    groups=1,
+                    data_format="NCDHW",
+                )(input)
+
+            self.assertRaises(ValueError, run_3)
+
+            def run_4():
+                paddle.nn.Conv3D(
+                    in_channels=input_NCDHW_in_channel,
+                    out_channels=3,
+                    kernel_size=3,
+                    stride=1,
+                    padding=[[0, 1], [0, 0], [0, 1], [0, 1], [0, 1]],
+                    dilation=1,
+                    groups=1,
+                    data_format="NCDHW",
+                )(input)
+
+            self.assertRaises(ValueError, run_4)
+
+            def run_5():
+                paddle.nn.Conv3D(
+                    in_channels=input_NDHWC_in_channel,
+                    out_channels=3,
+                    kernel_size=0,
+                    stride=0,
+                    padding=[[0, 1], [0, 1], [0, 1], [0, 1], [0, 1]],
+                    dilation=1,
+                    groups=1,
+                    data_format="NDHWC",
+                )(input)
+
+            self.assertRaises(ValueError, run_5)
+
+            # ValueError: channel dimension
+            x = paddle.static.data(
+                name="x",
+                shape=[2, 5, 5, 5, -1],
+                dtype="float32",
             )
+            x_NCDHW_in_channel = 5
+            x_NDHWC_in_channel = -1
 
-        self.assertRaises(ValueError, run_4)
+            def run_6():
+                paddle.nn.Conv3D(
+                    in_channels=x_NDHWC_in_channel,
+                    out_channels=3,
+                    kernel_size=3,
+                    stride=1,
+                    padding=0,
+                    dilation=1,
+                    groups=1,
+                    data_format="NDHWC",
+                )(x)
 
-        def run_5():
-            paddle.static.nn.conv3d(
-                input=input,
-                num_filters=3,
-                filter_size=0,
-                stride=0,
-                padding=[[0, 1], [0, 1], [0, 1], [0, 1], [0, 1]],
-                dilation=1,
-                groups=1,
-                use_cudnn=False,
-                data_format="NDHWC",
-            )
+            self.assertRaises(AssertionError, run_6)
 
-        self.assertRaises(ValueError, run_5)
+            # ValueError: groups
+            def run_7():
+                paddle.nn.Conv3D(
+                    in_channels=x_NDHWC_in_channel,
+                    out_channels=3,
+                    kernel_size=3,
+                    stride=1,
+                    padding=0,
+                    dilation=1,
+                    groups=3,
+                    data_format="NDHWC",
+                )(x)
 
-        # ValueError: channel dimmention
-        x = paddle.static.data(
-            name="x",
-            shape=[2, 5, 5, 5, -1],
-            dtype="float32",
-        )
+            self.assertRaises(ValueError, run_7)
 
-        def run_6():
-            paddle.static.nn.conv3d(
-                input=x,
-                num_filters=3,
-                filter_size=3,
-                stride=1,
-                padding=0,
-                dilation=1,
-                groups=1,
-                use_cudnn=False,
-                data_format="NDHWC",
-            )
+            # ValueError: filter num
+            def run_8():
+                paddle.nn.Conv3D(
+                    in_channels=x_NCDHW_in_channel,
+                    out_channels=0,
+                    kernel_size=0,
+                    stride=0,
+                    padding=0,
+                    dilation=0,
+                    groups=1,
+                    data_format="NCDHW",
+                )(x)
 
-        self.assertRaises(ValueError, run_6)
-
-        # ValueError: groups
-        def run_7():
-            paddle.static.nn.conv3d(
-                input=input,
-                num_filters=3,
-                filter_size=3,
-                stride=1,
-                padding=0,
-                dilation=1,
-                groups=3,
-                use_cudnn=False,
-                data_format="NDHWC",
-            )
-
-        self.assertRaises(ValueError, run_7)
-
-        # ValueError: filter num
-        def run_8():
-            paddle.static.nn.conv3d(
-                input=input,
-                num_filters=0,
-                filter_size=0,
-                stride=0,
-                padding=0,
-                dilation=0,
-                groups=1,
-                use_cudnn=False,
-                data_format="NDHWC",
-            )
-
-        self.assertRaises(ValueError, run_8)
+            self.assertRaises(AssertionError, run_8)
 
 
 for stype in ["float32"]:

--- a/test/xpu/test_conv3d_op_xpu.py
+++ b/test/xpu/test_conv3d_op_xpu.py
@@ -917,14 +917,14 @@ class TestPIRConv3DAPI_Error(unittest.TestCase):
             # ValueError: filter num
             def run_8():
                 paddle.nn.Conv3D(
-                    in_channels=x_NCDHW_in_channel,
+                    in_channels=x_NDHWC_in_channel,
                     out_channels=0,
                     kernel_size=0,
                     stride=0,
                     padding=0,
                     dilation=0,
                     groups=1,
-                    data_format="NCDHW",
+                    data_format="NDHWC",
                 )(x)
 
             self.assertRaises(AssertionError, run_8)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description

由于 `static.nn` 是废弃API不再计划支持PIR. 将当前 `static.nn.conv3d` 替换成更为准确的 `paddle.nn.Con3d`。
<!-- Describe what you’ve done -->

- **test/legacy_test/test_conv3d_op.py** 中，
    - 由于 Conv3d 中的 use_cudnn 是 `__init__` 阶段，根据当前环境自动初始化的，此后也没有对此参数的检查  ，所以 PIR 下没有进行测试
    - 在 PIR 下，初始化 class 时，使用 create_paramter 创建 weight 时，会根据 shape 直接 AssertionError，而不是 staic.nn.cond 的显式参数检查 ValueError
    ```filter_shape = [
                out_channels,
                in_channels // groups,
            ] + self._kernel_size```
     因此修改了 run_6 , run_8。
- test/ir/inference/test_trt_conv3d_op.py 中
    - 将 static.nn.conv3d 修改成 nn.Conv3d。暂时没有进行 PIR 适配，还没有想到合适的方法