### PR TITLE
【AutoParallel】Support to split program into sub-program in PIR

### DIFF
--- a/paddle/fluid/pir/transforms/general/inplace_pass.cc
+++ b/paddle/fluid/pir/transforms/general/inplace_pass.cc
@@ -211,6 +211,10 @@ bool IsNoNeedBuffer(pir::Operation* op, pir::Value value) {
 std::unordered_set<pir::Value> GetSkipDeletionValues(const pir::Block& block) {
   std::unordered_set<pir::Value> skip_dels;
   for (auto& op : block) {
+    if (op.name() == "builtin.shadow_output") {
+      skip_dels.insert(op.operand_source(0));
+      continue;
+    }
     if (op.dialect()->name() != paddle::dialect::KernelDialect::name()) {
       continue;
     }
@@ -228,8 +232,7 @@ std::unordered_set<pir::Value> GetSkipDeletionValues(const pir::Block& block) {
       continue;
     }
     // TODO(chenxi67) add logic for shadow_feed_tensors op
-    if (upper_op_name == "pd_op.fetch" ||
-        upper_op_name == "builtin.shadow_output") {
+    if (upper_op_name == "pd_op.fetch") {
       skip_dels.insert(op.operand_source(0));
       continue;
     }

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1174,6 +1174,21 @@ void BindOperation(py::module *m) {
           },
           [](Operation &self, OperationDistAttribute op_dist_attr) {
             self.set_attribute(kAttrOpDistAttr, op_dist_attr);
+          })
+      .def_property(
+          "op_role",
+          [](Operation &self) -> py::object {
+            auto int_attr = self.attribute<Int32Attribute>("op_role");
+            if (int_attr) {
+              return py::cast(int_attr.data());
+            } else {
+              return py::cast<py::none>(Py_None);
+            }
+          },
+          [](Operation &self, const int &op_role) {
+            self.set_attribute(
+                "op_role",
+                Int32Attribute::get(pir::IrContext::Instance(), op_role));
           });
   py::class_<Operation::BlockContainer> block_container(
       *m, "Operation_BlockContainer", R"DOC(

--- a/paddle/pir/src/core/program.cc
+++ b/paddle/pir/src/core/program.cc
@@ -67,6 +67,17 @@ std::shared_ptr<Program> Program::Clone(IrMapping& ir_mapping) const {
   pir::IrContext* ctx = pir::IrContext::Instance();
   auto new_program = std::make_shared<Program>(ctx);
   auto clone_options = CloneOptions::All();
+
+  // deal kwargs
+  for (auto [key, value] : block()->kwargs()) {
+    auto new_arg = new_program->block()->AddKwarg(key, value.type());
+    auto tmp_block_arg = value.dyn_cast<BlockArgument>();
+    for (auto [name, attr_value] : tmp_block_arg.attributes()) {
+      new_arg.set_attribute(name, attr_value);
+    }
+    ir_mapping.Add(value, new_arg);
+  }
+
   for (const auto& op : *block()) {
     auto* new_op = op.Clone(ir_mapping, clone_options);
     new_program->block()->push_back(new_op);

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -533,6 +533,20 @@ def _add_pir_fetch_ops(program, fetch_list, fetch_var_name):
                 out.persistable = True
 
 
+def _add_single_pir_fetch_op(program, fetch_value, fetch_name, fetch_col):
+    import paddle
+
+    global_block = program.global_block()
+    fetch_op = "pd_op.fetch"
+    need_fetch_info = has_fetch_operations(
+        global_block, [fetch_value], fetch_name, fetch_op
+    )
+    if need_fetch_info:
+        with paddle.static.program_guard(program):
+            out = paddle._pir_ops.fetch(fetch_value, fetch_name, fetch_col)
+            out.persistable = True
+
+
 def _merge_tensors(tensor, micro_batch_num):
     if micro_batch_num <= 1:
         return tensor
@@ -856,6 +870,7 @@ class _ExecutorCache:
             fetch_var_name,
             place,
             scope,
+            plan=None,
         ):
             self.program = program
             self.feed = feed
@@ -864,6 +879,7 @@ class _ExecutorCache:
             self.fetch_var_name = fetch_var_name
             self.place = place
             self.scope = scope
+            self.plan = plan
 
             # NOTE(Ruibiao): Not all changeable item is considered for key at present,
             # ONLY: program, feed, and fetch_list
@@ -1114,10 +1130,17 @@ class _ExecutorCache:
         fetch_var_name,
         place,
         scope,
+        plan,
     ):
-        _add_pir_fetch_ops(
-            program, fetch_list=fetch_list, fetch_var_name=fetch_var_name
-        )
+        if plan is None:
+            _add_pir_fetch_ops(
+                program, fetch_list=fetch_list, fetch_var_name=fetch_var_name
+            )
+        else:
+            for i, value in enumerate(fetch_list):
+                _add_single_pir_fetch_op(
+                    value.block.program, value, fetch_var_name + str(i), i
+                )
         return self._get_cached_program_and_executor_pir_mode(
             self._CachedData(
                 program,
@@ -1127,6 +1150,7 @@ class _ExecutorCache:
                 fetch_var_name,
                 place,
                 scope,
+                plan,
             )
         )
 
@@ -1139,9 +1163,12 @@ class _ExecutorCache:
         place = cached_data.place
         scope = cached_data.scope
 
-        default_job = core.Job("default")
-        type_to_program = {"default": program}
-        plan = core.Plan([default_job], type_to_program)
+        if cached_data.plan is None:
+            default_job = core.Job("default")
+            type_to_program = {"default": program}
+            plan = core.Plan([default_job], type_to_program)
+        else:
+            plan = cached_data.plan
 
         new_exe = _StandaloneExecutor(place, plan, scope)
 
@@ -1252,6 +1279,7 @@ class Executor:
         self._closed = False
         self.pruned_program_scope_caches = {}
         self._prepare_to_run_called = False
+        self.plan = None
 
         self._auto_checkpoint_name = unique_name.generate(
             "__auto_checkpoint_executor__"
@@ -1279,6 +1307,9 @@ class Executor:
         # that brings errors to mkl-dnn unit tests (see ClearMKLDNNCache in interpretercore.cc for why).
         self.close()
         self._executor_cache.clear()
+
+    def _set_plan(self, plan):
+        self.plan = plan
 
     def _get_scope_cache(self, program_cache_key):
         return self.scope_caches.get(program_cache_key, None)
@@ -2094,6 +2125,7 @@ class Executor:
             fetch_var_name,
             self.place,
             scope,
+            self.plan,
         )
         self._pir_feed_data(program, feed, scope, data_op_infos)
 

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -58,6 +58,8 @@ from .parallelizer_v2 import Parallelizer
 from .pir_pass import (
     apply_partition_pass,
     apply_reshard_pass,
+    complete_op_role,
+    pipeline_pass,
     remove_other_rank_input_output_pass,
     remove_other_rank_op_pass,
     remove_unuseful_comm_op_pass,
@@ -252,6 +254,7 @@ class Engine:
         self._dygraph_mode = False
         self._tuning = self._strategy.tuning
         self._acc_steps = 1
+        self._pipeline_plan = None
         self._in_pir_mode = paddle.base.framework.get_flags(
             "FLAGS_enable_pir_api"
         )["FLAGS_enable_pir_api"]
@@ -649,6 +652,9 @@ class Engine:
         mix_fw_program = self._fwd_main_progs[mode]
         startup_program = self._startup_progs[mode]
 
+        forward_op_start_idx = 0
+        backward_op_start_idx = -1
+        opt_op_start_idx = -1
         # Part 1: Complete program
         # Step 1.1: Mix2Dist Pass
         # TODO(JZ-LIANG) regulization pass with pass management.
@@ -656,6 +662,7 @@ class Engine:
         apply_mix2dist_pass(dist_program)
 
         # Step 1.2: pir backward
+        last_forward_op = dist_program.global_block().ops[-1]
         if mode == "train" and self._loss and self._optimizer:
             loss = dist_program.get_output_value_by_name(self._loss_names[0])
             if loss.initialized():
@@ -693,15 +700,57 @@ class Engine:
                             and self._strategy.amp.dtype != 'bfloat16',
                         )
                         scaled = scaler.scale(loss)
-                        scaler.minimize(self._optimizer, scaled)
+                        last_forward_op = dist_program.global_block().ops[-1]
+                        optimizer_ops, params_grads = scaler.minimize(
+                            self._optimizer, scaled
+                        )
+                        first_opt_op = optimizer_ops[0]
+                        backward_op_start_idx = (
+                            dist_program.global_block().ops.index(
+                                last_forward_op
+                            )
+                            + 1
+                        )
+                        opt_op_start_idx = (
+                            dist_program.global_block().ops.index(first_opt_op)
+                        )
                         # print('after minimize', dist_program, flush=1)
-
+                        complete_op_role(
+                            dist_program,
+                            [
+                                [forward_op_start_idx, backward_op_start_idx],
+                                [backward_op_start_idx, opt_op_start_idx],
+                                [opt_op_start_idx, dist_program.num_ops()],
+                            ],
+                        )
                     else:
                         params_grads = (
                             paddle.autograd.ir_backward.append_backward(loss)
                         )
+                        last_backward_op = dist_program.global_block().ops[-1]
                         self._optimizer._apply_optimize(
                             loss, startup_program, params_grads=params_grads
+                        )
+
+                        backward_op_start_idx = (
+                            dist_program.global_block().ops.index(
+                                last_forward_op
+                            )
+                            + 1
+                        )
+                        opt_op_start_idx = (
+                            dist_program.global_block().ops.index(
+                                last_backward_op
+                            )
+                            + 1
+                        )
+                        complete_op_role(
+                            dist_program,
+                            [
+                                [forward_op_start_idx, backward_op_start_idx],
+                                [backward_op_start_idx, opt_op_start_idx],
+                                [opt_op_start_idx, dist_program.num_ops()],
+                            ],
                         )
                         # self._optimizer.minimize(loss, startup_program=startup_program)
 
@@ -777,6 +826,11 @@ class Engine:
         dense_program = dist_program.clone()
         paddle.base.libpaddle.pir.apply_dist2dense_pass(dense_program)
         remove_unuseful_comm_op_pass(dense_program)
+
+        if self._strategy.pipeline.enable:
+            self._pipeline_plan = pipeline_pass(
+                [dense_program], [dense_program], self._strategy.pipeline
+            )
 
         self._pir_dense_main_progs[mode] = dense_program
         self._pir_dist_main_progs[mode] = dist_program
@@ -1200,6 +1254,11 @@ class Engine:
                 for del_op in del_ops:
                     del_op.erase()
                 self._executor.run(startup_prog)
+                if self._pipeline_plan is not None:
+                    # pipeline scheduling should be enabled after running
+                    # startup program, otherwise the startup program cannot
+                    # run correctly.
+                    self._executor._set_plan(self._pipeline_plan)
             return
 
         if self._strategy.seed:
@@ -1941,7 +2000,17 @@ class Engine:
         if self._in_pir_mode:
             use_cache = False
             no_fetch = False  # not last rank should not fetch loss in pipeline parallel
-            loss_value = self.main_program.get_output_value_by_name(
+            if self._pipeline_plan is None:
+                program_for_executor = self.main_program
+            else:
+                # NOTE: If pipeline scheduling is enabled, The program_for_executor
+                # is used to tell the executor where to feed data and add fetch op,
+                # not the program to be executed. The ``plan`` object is already
+                # constructed, and the programs to be executed are  stored in the
+                # ``plan`` object.
+                program_for_executor = self._pipeline_plan.ir_program("forward")
+
+            loss_value = program_for_executor.get_output_value_by_name(
                 self._loss_names[0]
             )
             if paddle.pir.is_fake_value(loss_value):

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -708,6 +708,8 @@ def _program_for_fthenb_and_1f1b(program, enable_send_recv_overlap=False):
 def forward_complete_op_role(main_program):
     all_ops = main_program.global_block().ops
     ops_len = len(all_ops)
+    if len(all_ops) == 0:
+        return
 
     iop = 0
     first_left_op_role = None

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -297,6 +297,28 @@ def set_skip_gc_vars(num_micro_batches, job_types, sub_programs, jobs):
     return type_to_program
 
 
+def set_pir_skip_gc_vars(num_micro_batches, job_types, sub_programs, jobs):
+    assert num_micro_batches >= 1, "num_micro_batches needs to be >= 1"
+    type_to_var_names = {}
+    type_to_program = dict(zip(job_types, sub_programs))
+    for type, program in type_to_program.items():
+        type_to_var_names[type] = set()
+        ops = program.global_block().ops
+        for op in ops:
+            if op.name() == "builtin.shadow_output":
+                # if a value is renamed by shadow_output,
+                # it will be used by other sub_programs
+                type_to_var_names[type].add(op.attrs()["output_name"])
+    # NOTE(lizhiyu): After finishing the gradient merge, enbale this checking.
+    # assert "backward" not in type_to_var_names.keys(), f"The backward sub_program can't have skip_gc_vars."
+
+    for job in jobs:
+        job_type = job.type()
+        job.set_skip_gc_vars(type_to_var_names[job_type])
+
+    return type_to_program
+
+
 def shadow_var_between_sub_programs(sub_programs):
     """
     Add shadow_output and data op pair to share vars between sub_programs.
@@ -681,6 +703,171 @@ def _program_for_fthenb_and_1f1b(program, enable_send_recv_overlap=False):
 
     # It MUST return in this order
     return [fwd_prog, bwd_prog, opt_prog]
+
+
+def forward_complete_op_role(main_program):
+    all_ops = main_program.global_block().ops
+    ops_len = len(all_ops)
+
+    iop = 0
+    first_left_op_role = None
+    first_right_op_role = None
+    while iop < ops_len:
+        if all_ops[iop].op_role is not None:
+            first_left_op_role = all_ops[iop].op_role
+            iop += 1
+            continue
+        else:
+            right_idx = iop + 1
+            while right_idx < ops_len and all_ops[right_idx].op_role is None:
+                right_idx += 1
+            if right_idx >= ops_len:  # [first_left_op_role, xx, xx, xx, xx]
+                assert (
+                    first_left_op_role is not None
+                ), "first_left_op_role can't be None."
+                for idx in range(iop, right_idx):
+                    all_ops[idx].op_role = first_left_op_role
+                break
+            else:  # [first_left_op_role, xx, xx, xx, xx, first_right_op_role]
+                first_right_op_role = all_ops[right_idx].op_role
+                assert (
+                    first_left_op_role is None
+                    or first_left_op_role == first_right_op_role
+                ), f"The left and right operators of (idx[{iop}]) have different op_role."
+                for idx in range(iop, right_idx):
+                    all_ops[idx].op_role = first_right_op_role
+                    iop = right_idx + 1
+    if first_left_op_role is None and first_right_op_role is None:
+        raise ValueError("all the ops don't have the op_role.")
+
+
+def _pir_program_for_fthenb_and_1f1b(
+    main_program, enable_send_recv_overlap=False
+):
+    forward_complete_op_role(main_program)
+    complete_ops = main_program.global_block().ops
+
+    fwd_program = main_program.clone()
+    bwd_program = main_program.clone()
+    opt_program = main_program.clone()
+    fwd_ops = fwd_program.global_block().ops
+    bwd_ops = bwd_program.global_block().ops
+    opt_ops = opt_program.global_block().ops
+    opt_block = opt_program.global_block()
+    bwd_block = bwd_program.global_block()
+
+    region = "opt"
+    for op_idx in range(len(complete_ops) - 1, -1, -1):
+        if complete_ops[op_idx].op_role is not None:
+            if complete_ops[op_idx].op_role == 1:
+                region = "bwd"
+            elif complete_ops[op_idx].op_role == 0:
+                region = "fwd"
+            elif complete_ops[op_idx].op_role == 2:
+                region = "opt"
+
+        if region == "opt":
+            fwd_ops[op_idx].erase()
+            bwd_ops[op_idx].erase()
+        elif region == "bwd":
+            fwd_ops[op_idx].erase()
+            # in optimize program, both forward and backward ops should be removed
+            for idx in range(opt_ops[op_idx].num_results()):
+                # if this op's output is used, create the persistable
+                # var to be used in other programs.
+                result_in_opt = opt_ops[op_idx].result(idx)
+                if result_in_opt.use_empty() is False:
+                    name = (
+                        "var_"
+                        + str(op_idx)
+                        + "_"
+                        + complete_ops[op_idx].name()
+                        + "_"
+                        + str(idx)
+                    )
+                    paddle.pir.set_insertion_point_after(bwd_ops[op_idx])
+                    paddle._C_ops.set_persistable_value(
+                        bwd_ops[op_idx].result(idx), name
+                    )
+                    # bwd_ops[op_idx].result(idx).persistable = True
+                    new_result_var_in_opt = opt_block.add_kwarg(
+                        name, result_in_opt.type()
+                    )
+                    new_result_var_in_opt.persistable = (
+                        result_in_opt.persistable
+                    )
+                    opt_ops[op_idx].result(idx).replace_all_uses_with(
+                        new_result_var_in_opt
+                    )
+            opt_ops[op_idx].erase()
+        else:
+            # in backward program, only the forward ops should be removed
+            for idx in range(opt_ops[op_idx].num_results()):
+                # if this op's output is used, create the persistable
+                # var to be used in other programs.
+                result_in_opt = opt_ops[op_idx].result(idx)
+                result_in_bwd = bwd_ops[op_idx].result(idx)
+
+                if (
+                    result_in_opt.use_empty() is False
+                    or result_in_bwd.use_empty() is False
+                ):
+                    if (
+                        fwd_ops[op_idx].name() == "pd_op.data"
+                        or fwd_ops[op_idx].name() == "builtin.parameter"
+                    ):
+                        name = fwd_ops[op_idx].result(idx).name
+                        # fwd_ops[op_idx].result(idx).persistable = True
+                    else:
+                        result_value = complete_ops[op_idx].result(idx)
+                        used_ops = result_value.all_used_ops()
+                        shadow_output_op_used = None
+                        for used_op in used_ops:
+                            if used_op.name() == "builtin.shadow_output":
+                                shadow_output_op_used = used_op
+                        if shadow_output_op_used is not None:
+                            name = shadow_output_op_used.attrs()["output_name"]
+                            # fwd_ops[op_idx].result(idx).persistable = True
+                        else:
+                            name = (
+                                "var_"
+                                + str(op_idx)
+                                + "_"
+                                + complete_ops[op_idx].name()
+                                + "_"
+                                + str(idx)
+                            )
+                            paddle.pir.set_insertion_point_after(
+                                fwd_ops[op_idx]
+                            )
+                            paddle._C_ops.set_persistable_value(
+                                fwd_ops[op_idx].result(idx), name
+                            )
+                            # fwd_ops[op_idx].result(idx).persistable = True
+                if result_in_opt.use_empty() is False:
+                    new_result_var_in_opt = opt_block.add_kwarg(
+                        name, result_in_opt.type()
+                    )
+                    new_result_var_in_opt.persistable = (
+                        result_in_opt.persistable
+                    )
+                    opt_ops[op_idx].result(idx).replace_all_uses_with(
+                        new_result_var_in_opt
+                    )
+                if result_in_bwd.use_empty() is False:
+                    new_result_var_in_bwd = bwd_block.add_kwarg(
+                        name, result_in_bwd.type()
+                    )
+                    new_result_var_in_bwd.persistable = (
+                        result_in_bwd.persistable
+                    )
+                    bwd_ops[op_idx].result(idx).replace_all_uses_with(
+                        new_result_var_in_bwd
+                    )
+            opt_ops[op_idx].erase()
+            bwd_ops[op_idx].erase()
+
+    return fwd_program, bwd_program, opt_program
 
 
 def _program_for_vpp(

--- a/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_fthenb.py
+++ b/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_fthenb.py
@@ -18,7 +18,10 @@ from paddle.base import core
 
 from ...utils.log_utils import get_logger
 from ..pass_base import register_pass
-from ..pass_utils import _program_for_fthenb_and_1f1b
+from ..pass_utils import (
+    _pir_program_for_fthenb_and_1f1b,
+    _program_for_fthenb_and_1f1b,
+)
 from .pipeline_pass_base import PipelinePassBase
 
 FORWARD = "forward"
@@ -58,6 +61,15 @@ class PipelineFThenBPass(PipelinePassBase):
         enable_send_recv_overlap = self.get_attr("enable_send_recv_overlap")
         types = [FORWARD, BACKWARD, OPT]
         sub_program_list = _program_for_fthenb_and_1f1b(
+            program, enable_send_recv_overlap
+        )
+        return types, sub_program_list
+
+    def _partial_pir_programs(self, program):
+        # NOTE: The flag "enable_send_recv_overlap" may increase the reserved memory of GPUs.
+        enable_send_recv_overlap = self.get_attr("enable_send_recv_overlap")
+        types = [FORWARD, BACKWARD, OPT]
+        sub_program_list = _pir_program_for_fthenb_and_1f1b(
             program, enable_send_recv_overlap
         )
         return types, sub_program_list

--- a/test/standalone_executor/test_standalone_executor_1f1b_plan.py
+++ b/test/standalone_executor/test_standalone_executor_1f1b_plan.py
@@ -14,12 +14,13 @@
 
 import unittest
 
-from paddle import static
+from paddle import base, static
 from paddle.distributed.passes import PassContext, new_pass
 
 
 class TestStandaloneExecutor1F1BPlan(unittest.TestCase):
     def test_standalone_executor_1f1b_plan_stage0(self):
+        base.set_flags({'FLAGS_enable_pir_api': 0})
         config = {"num_micro_batches": 8, "pp_stage": 0, "pp_degree": 4}
         pass_context = PassContext()
 
@@ -78,6 +79,7 @@ class TestStandaloneExecutor1F1BPlan(unittest.TestCase):
         self.assertEqual(micro_batch_id_list, expect_micro_batch_id_list)
 
     def test_standalone_executor_1f1b_plan_stage1(self):
+        base.set_flags({'FLAGS_enable_pir_api': 0})
         config = {"num_micro_batches": 8, "pp_stage": 1, "pp_degree": 4}
         pass_context = PassContext()
 
@@ -136,6 +138,7 @@ class TestStandaloneExecutor1F1BPlan(unittest.TestCase):
         self.assertEqual(micro_batch_id_list, expect_micro_batch_id_list)
 
     def test_standalone_executor_1f1b_plan_stage2(self):
+        base.set_flags({'FLAGS_enable_pir_api': 0})
         config = {"num_micro_batches": 8, "pp_stage": 2, "pp_degree": 4}
         pass_context = PassContext()
 
@@ -194,6 +197,7 @@ class TestStandaloneExecutor1F1BPlan(unittest.TestCase):
         self.assertEqual(micro_batch_id_list, expect_micro_batch_id_list)
 
     def test_standalone_executor_1f1b_plan_stage3(self):
+        base.set_flags({'FLAGS_enable_pir_api': 0})
         config = {"num_micro_batches": 8, "pp_stage": 3, "pp_degree": 4}
         pass_context = PassContext()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
Pcard-76459
Mainly support to split program into sub-program, such as `forward`,`backward`,`optimizer` in PIR.
1. Add `op_role` attribute in order to split program
2. Add the funtion to split program
3. Fix some bug, such as `set_skip_gc` for `shadow_output`, how to deal `kwargs` when cloning program.
4. Polish the executor to fit the PIR pipeline.