### PR TITLE
【Comm】switch c_allgather in fluid to all_gather in phi

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
@@ -146,7 +146,8 @@ platform::DeviceContext* ParseDeviceContext(
               static_cast<phi::distributed::NCCLCommContext*>(comm_context)
                   ->GetDevContext());
           dev_ctx->SetCommContext(comm_context);
-          if (op_name.compare(paddle::dialect::CReducescatterOp::name()) == 0) {
+          if (op_name.compare(paddle::dialect::CReducescatterOp::name()) == 0 ||
+              op_name.compare(paddle::dialect::CAllgatherOp::name()) == 0) {
             return dev_ctx;
           }
         } else {

--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
@@ -147,7 +147,7 @@ platform::DeviceContext* ParseDeviceContext(
                   ->GetDevContext());
           dev_ctx->SetCommContext(comm_context);
           if (op_name.compare(paddle::dialect::CReducescatterOp::name()) == 0 ||
-              op_name.compare(paddle::dialect::CAllgatherOp::name()) == 0) {
+              op_name.compare(paddle::dialect::AllGatherOp::name()) == 0) {
             return dev_ctx;
           }
         } else {

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -53,7 +53,6 @@ const std::unordered_set<std::string> LegacyOpList = {
     CReduceSum_Op::name(),
     CAllreduceMax_Op::name(),
     CAllreduceMin_Op::name(),
-    CAllgatherOp::name(),
     CSoftmaxWithCrossEntropyOp::name(),
     CSoftmaxWithCrossEntropyGradOp::name(),
     CSplitOp::name(),

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -53,6 +53,7 @@ const std::unordered_set<std::string> LegacyOpList = {
     CReduceSum_Op::name(),
     CAllreduceMax_Op::name(),
     CAllreduceMin_Op::name(),
+    CAllgatherOp::name(),
     CSoftmaxWithCrossEntropyOp::name(),
     CSoftmaxWithCrossEntropyGradOp::name(),
     CSplitOp::name(),

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -7,16 +7,6 @@
     func : all
   traits : paddle::dialect::ForwardOnlyTrait
 
-- op : all_gather
-  args : (Tensor x, int ring_id = 0, int nranks=0)
-  output : Tensor(out)
-  infer_meta :
-    func : AllGatherInferMeta
-    param: [x, nranks]
-  kernel :
-    func : all_gather
-    param: [x, nranks]
-
 - op : all_reduce
   args : (Tensor x, int ring_id = 0, int reduce_type = 0)
   output : Tensor(out)

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -653,6 +653,15 @@
     data_type : input
   backward: broadcast_tensors_grad
 
+# - op : c_allgather
+#   args : (Tensor x, int ring_id, int nranks, bool use_calc_stream)
+#   output : Tensor(out)
+#   infer_meta :
+#     func : AllGatherInferMeta
+#     param: [x, nranks]
+#   kernel :
+#     func : c_allgather
+
 - op : c_allgather
   args : (Tensor x, int ring_id, int nranks, bool use_calc_stream)
   output : Tensor(out)
@@ -660,7 +669,9 @@
     func : AllGatherInferMeta
     param: [x, nranks]
   kernel :
-    func : c_allgather
+    func : all_gather
+    param: [x, nranks]
+
 
 - op : c_allreduce_max
   args : (Tensor x, int ring_id, bool use_calc_stream, bool use_model_parallel)

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -179,6 +179,16 @@
   traits : paddle::dialect::ForwardOnlyTrait
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
+- op : all_gather
+  args : (Tensor x, int ring_id = 0, int nranks=0)
+  output : Tensor(out)
+  infer_meta :
+    func : AllGatherInferMeta
+    param: [x, nranks]
+  kernel :
+    func : all_gather
+    param: [x, nranks]
+
 - op : allclose
   args : (Tensor x, Tensor y, Scalar(double) rtol=1e-5, Scalar(double) atol=1e-8, bool equal_nan=false)
   output : Tensor(out)
@@ -653,15 +663,6 @@
     data_type : input
   backward: broadcast_tensors_grad
 
-# - op : c_allgather
-#   args : (Tensor x, int ring_id, int nranks, bool use_calc_stream)
-#   output : Tensor(out)
-#   infer_meta :
-#     func : AllGatherInferMeta
-#     param: [x, nranks]
-#   kernel :
-#     func : c_allgather
-
 - op : c_allgather
   args : (Tensor x, int ring_id, int nranks, bool use_calc_stream)
   output : Tensor(out)
@@ -671,7 +672,6 @@
   kernel :
     func : all_gather
     param: [x, nranks]
-
 
 - op : c_allreduce_max
   args : (Tensor x, int ring_id, bool use_calc_stream, bool use_model_parallel)

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -670,8 +670,7 @@
     func : AllGatherInferMeta
     param: [x, nranks]
   kernel :
-    func : all_gather
-    param: [x, nranks]
+    func : c_allgather
 
 - op : c_allreduce_max
   args : (Tensor x, int ring_id, bool use_calc_stream, bool use_model_parallel)

--- a/python/paddle/distributed/communication/stream/all_gather.py
+++ b/python/paddle/distributed/communication/stream/all_gather.py
@@ -101,7 +101,7 @@ def _all_gather_in_static_mode(tensor_list, tensor, group, sync_op):
 
     ring_id = 0 if group is None else group.id
     nranks = dist.get_world_size()
-    helper.append_op(
+    op = helper.append_op(
         type=op_type,
         inputs={'x': [tensor]},
         outputs={'out': [out]},
@@ -110,6 +110,8 @@ def _all_gather_in_static_mode(tensor_list, tensor, group, sync_op):
             'nranks': nranks,
         },
     )
+    if sync_op:
+        op.dist_attr.execution_stream = "default"
     tensor_list.clear()
     # 0-D use stack/unstack while others use concat/split
     if len(tensor.shape) == 0:

--- a/python/paddle/distributed/communication/stream/all_gather.py
+++ b/python/paddle/distributed/communication/stream/all_gather.py
@@ -60,7 +60,7 @@ def _all_gather_in_dygraph(
 
 
 def _all_gather_in_static_mode(tensor_list, tensor, group, sync_op):
-    op_type = 'c_allgather'
+    op_type = 'all_gather'
     helper = framework.LayerHelper(op_type, **locals())
     out = helper.create_variable_for_type_inference(dtype=tensor.dtype)
     for elem in tensor_list:
@@ -103,11 +103,10 @@ def _all_gather_in_static_mode(tensor_list, tensor, group, sync_op):
     nranks = dist.get_world_size()
     helper.append_op(
         type=op_type,
-        inputs={'X': [tensor]},
-        outputs={'Out': [out]},
+        inputs={'x': [tensor]},
+        outputs={'out': [out]},
         attrs={
             'ring_id': ring_id,
-            'use_calc_stream': sync_op,
             'nranks': nranks,
         },
     )

--- a/test/collective/test_collective_allgather_api.py
+++ b/test/collective/test_collective_allgather_api.py
@@ -83,7 +83,30 @@ class TestCollectiveAllgatherAPI(TestDistBase):
                 "allgather",
                 "nccl",
                 dtype=dtype,
-                need_envs={"FLAGS_dynamic_static_unified_comm": "1"},
+                need_envs={"FLAGS_dynamic_static_unified_comm": "true"},
+            )
+
+    def test_allgather_nccl_with_new_comm_pir(self):
+        dtypes_to_test = [
+            "float16",
+            "float32",
+            "float64",
+            "int32",
+            "int64",
+            "int8",
+            "uint8",
+            "bool",
+        ]
+        for dtype in dtypes_to_test:
+            self.check_with_place(
+                "collective_allgather_api.py",
+                "allgather",
+                "nccl",
+                dtype=dtype,
+                need_envs={
+                    "FLAGS_dynamic_static_unified_comm": "true",
+                    "FLAGS_enable_pir_in_executor": "1",
+                },
             )
 
     def test_allgather_gloo(self):

--- a/test/legacy_test/test_dist_hapi_model.py
+++ b/test/legacy_test/test_dist_hapi_model.py
@@ -77,7 +77,7 @@ def start_local_trainers(
             "PADDLE_CURRENT_ENDPOINT": f"{t.endpoint}",
             "PADDLE_TRAINERS_NUM": "%d" % cluster.trainers_nranks(),
             "PADDLE_TRAINER_ENDPOINTS": ",".join(cluster.trainers_endpoints()),
-            "FLAGS_dynamic_static_unified_comm": "0",
+            "FLAGS_dynamic_static_unified_comm": "true",
         }
 
         current_env.update(proc_env)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
1. fix comm bug for new_kernel: all_gather
2. replace `c_allgather` with `all_gather` in python api

NEXT:
1. replace `c_allgather` with `all_gather` everywhere
  - https://github.com/PaddlePaddle/Paddle/pull/66338
  - https://github.com/PaddlePaddle/Paddle/pull/66538
3. delete old op `c_allgather` 

PCard-85618
