### PR TITLE
Replace platform::dynload::ncclGetUniqueId in test/cpp [fluid_ops]

### DIFF
--- a/test/cpp/imperative/nccl_context_test.cc
+++ b/test/cpp/imperative/nccl_context_test.cc
@@ -53,7 +53,7 @@ TEST(BcastNCCLId, Run) {
   std::vector<ncclUniqueId> nccl_ids;
   nccl_ids.resize(nrings);
   for (int i = 0; i < nrings; ++i) {
-    platform::dynload::ncclGetUniqueId(&nccl_ids[i]);
+    phi::dynload::ncclGetUniqueId(&nccl_ids[i]);
   }
 
   std::thread t(BcastNCCLId, 0, &nccl_ids);
@@ -61,7 +61,7 @@ TEST(BcastNCCLId, Run) {
   std::vector<ncclUniqueId> recv_nccl_ids;
   recv_nccl_ids.resize(nrings);
   for (int i = 0; i < nrings; ++i) {
-    platform::dynload::ncclGetUniqueId(&recv_nccl_ids[i]);
+    phi::dynload::ncclGetUniqueId(&recv_nccl_ids[i]);
   }
   BcastNCCLId(1, &recv_nccl_ids);
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Replace platform::dynload::ncclGetUniqueId in test/cpp
使用 phi::dynload::ncclGetUniqueId