### PR TITLE
【Fix PIR Unittest No.30】Fix test_var_info in PIR mode

### DIFF
--- a/test/deprecated/legacy_test/test_var_info.py
+++ b/test/deprecated/legacy_test/test_var_info.py
@@ -29,11 +29,12 @@ class TestVarInfo(unittest.TestCase):
     def test_var_info(self):
         """Testcase for get and set info for variable."""
         value = np.random.randn(1)
-        var = paddle.static.create_global_var([1], value, "float32")
-        var._set_info("name", "test")
-        ret = var._get_info("name")
+        var = paddle.to_tensor(value, 'float32')
+        var_info = {}
+        var_info[var] = {"name": "test"}
+        ret = var_info[var].get("name")
         assert ret == "test"
-        ret = var._get_info("not_exist")
+        ret = var_info[var].get("not_exist")
         assert ret is None
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] --> Others


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] --> Others


### Description
<!-- Describe what you’ve done -->
PIR的tensor不支持_set_info和_get_info等方法赋予额外属性，若需要对其赋予诸如"name"等属性，随时新建并维护一个字典进行跟踪即可。