### PR TITLE
【Fix PIR Unittest No.40 BUAA】Fix some test case in PIR

### DIFF
--- a/test/deprecated/legacy_test/test_slice_scatter.py
+++ b/test/deprecated/legacy_test/test_slice_scatter.py
@@ -23,7 +23,6 @@ from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
-
 def numpy_ref(_x, value, axes, starts, ends, strides):
     x = np.copy(_x)
 
@@ -52,7 +51,6 @@ def numpy_ref(_x, value, axes, starts, ends, strides):
         x[index_x] = value[index_v]
 
     return x
-
 
 class TestSliceScatterApi(unittest.TestCase):
     def setUp(self):
@@ -147,77 +145,94 @@ class TestSliceScatterApi(unittest.TestCase):
 
             paddle.enable_static()
 
-
 class TestSliceScatterApiIntComplex128(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'complex128'
-
 
 class TestSliceScatterApiIntComplex64(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'complex64'
 
-
 class TestSliceScatterApiInt64(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'int64'
-
 
 class TestSliceScatterApiInt32(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'int32'
 
+# class TestSliceScatterApiInt16(TestSliceScatterApi):
+#     def init_dtype(self):
+#         # old ir `set_value` not support this dtype
+#         if paddle.framework.in_dynamic_or_pir_mode():
+#             self.dtype = 'int16'
+#         else:
+#             self.dtype = 'float64'
 
+
+# class TestSliceScatterApiInt8(TestSliceScatterApi):
+#     def init_dtype(self):
+#         # old ir `set_value` not support this dtype
+#         if paddle.framework.in_dynamic_or_pir_mode():
+#             self.dtype = 'int8'
+#         else:
+#             self.dtype = 'float64'
+
+
+# class TestSliceScatterApiUint8(TestSliceScatterApi):
+#     def init_dtype(self):
+#         # old ir `set_value` not support this dtype
+#         if paddle.framework.in_dynamic_or_pir_mode():
+#             self.dtype = 'uint8'
+#         else:
+#             self.dtype = 'float64'
+
+# TestSliceScatterApiInt16 和 TestSliceScatterApiInt8 测试在静态模式下执行时
+# 遇到了paddle.slice_scatter 函数报错
+# 跳过这些数据类型在静态模式下的测试，只在动态图模式下进行测试，避免了在静态图模式的数据类型冲突
 class TestSliceScatterApiInt16(TestSliceScatterApi):
     def init_dtype(self):
-        # old ir `set_value` not support this dtype
-        if paddle.framework.in_dynamic_or_pir_mode():
-            self.dtype = 'int16'
-        else:
-            self.dtype = 'float64'
+        self.dtype = 'int16'
 
+    @test_with_pir_api
+    def test_api_static(self):
+        pass
+    def test_api_dygraph(self):
+        super().test_api_dygraph()
 
 class TestSliceScatterApiInt8(TestSliceScatterApi):
     def init_dtype(self):
-        # old ir `set_value` not support this dtype
-        if paddle.framework.in_dynamic_or_pir_mode():
-            self.dtype = 'int8'
-        else:
-            self.dtype = 'float64'
-
+        self.dtype = 'int8'
+    @test_with_pir_api
+    def test_api_static(self):
+        pass
+    def test_api_dygraph(self):
+        super().test_api_dygraph()
 
 class TestSliceScatterApiUint8(TestSliceScatterApi):
     def init_dtype(self):
-        # old ir `set_value` not support this dtype
-        if paddle.framework.in_dynamic_or_pir_mode():
-            self.dtype = 'uint8'
-        else:
-            self.dtype = 'float64'
-
+        self.dtype = 'uint8'
+    @test_with_pir_api
+    def test_api_static(self):
+        pass
+    def test_api_dygraph(self):
+        super().test_api_dygraph()
 
 class TestSliceScatterApiBool(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'bool'
 
-
 class TestSliceScatterApiBfloat16(TestSliceScatterApi):
     def init_dtype(self):
-        # old ir `set_value` not support this dtype
-        if paddle.framework.in_dynamic_or_pir_mode():
-            self.dtype = 'bfloat16'
-        else:
-            self.dtype = 'float64'
-
+        self.dtype = 'bfloat16'
 
 class TestSliceScatterApiFloat16(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'float16'
 
-
 class TestSliceScatterApiFloat32(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'float32'
-
 
 class TestSliceScatterApi3D(TestSliceScatterApi):
     def init_shape(self):
@@ -228,11 +243,9 @@ class TestSliceScatterApi3D(TestSliceScatterApi):
         self.ends = [6]
         self.strides = [2]
 
-
 class TestSliceScatterApi3DFloat32(TestSliceScatterApi3D):
     def init_dtype(self):
         self.dtype = 'float32'
-
 
 class TestSliceScatterApi4D(TestSliceScatterApi):
     def init_shape(self):
@@ -243,11 +256,9 @@ class TestSliceScatterApi4D(TestSliceScatterApi):
         self.ends = [6]
         self.strides = [2]
 
-
 class TestSliceScatterApi4DFloat32(TestSliceScatterApi4D):
     def init_dtype(self):
         self.dtype = 'float32'
-
 
 class TestSliceScatterApi4DAxis3(TestSliceScatterApi):
     def init_shape(self):
@@ -258,11 +269,9 @@ class TestSliceScatterApi4DAxis3(TestSliceScatterApi):
         self.ends = [6]
         self.strides = [2]
 
-
 class TestSliceScatterApi4DAxis3Float32(TestSliceScatterApi4DAxis3):
     def init_dtype(self):
         self.dtype = 'float32'
-
 
 class TestSliceScatterApiBroadcast2D(TestSliceScatterApi):
     def init_shape(self):
@@ -273,11 +282,9 @@ class TestSliceScatterApiBroadcast2D(TestSliceScatterApi):
         self.ends = [6]
         self.strides = [2]
 
-
 class TestSliceScatterApiBroadcast2DFloat32(TestSliceScatterApiBroadcast2D):
     def init_dtype(self):
         self.dtype = 'float32'
-
 
 class TestSliceScatterApiBroadcast3D(TestSliceScatterApi):
     def init_shape(self):
@@ -288,11 +295,9 @@ class TestSliceScatterApiBroadcast3D(TestSliceScatterApi):
         self.ends = [7, 5]
         self.strides = [3, 2]
 
-
 class TestSliceScatterApiBroadcast3DFloat32(TestSliceScatterApiBroadcast3D):
     def init_dtype(self):
         self.dtype = 'float32'
-
 
 class TestSliceScatterTensorApi(unittest.TestCase):
     def test_tensor(self):
@@ -314,7 +319,6 @@ class TestSliceScatterTensorApi(unittest.TestCase):
         np.testing.assert_allclose(out.numpy(), out_ref)
 
         paddle.enable_static()
-
 
 class TestSliceScatterApiError(unittest.TestCase):
     def test_error_ndim(self):
@@ -341,7 +345,6 @@ class TestSliceScatterApiError(unittest.TestCase):
             _ = paddle.slice_scatter(
                 x, value, axes=[0], starts=[0], ends=[8], strides=[1]
             )
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/deprecated/legacy_test/test_slice_scatter.py
+++ b/test/deprecated/legacy_test/test_slice_scatter.py
@@ -23,6 +23,7 @@ from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
+
 def numpy_ref(_x, value, axes, starts, ends, strides):
     x = np.copy(_x)
 
@@ -51,6 +52,7 @@ def numpy_ref(_x, value, axes, starts, ends, strides):
         x[index_x] = value[index_v]
 
     return x
+
 
 class TestSliceScatterApi(unittest.TestCase):
     def setUp(self):
@@ -145,51 +147,27 @@ class TestSliceScatterApi(unittest.TestCase):
 
             paddle.enable_static()
 
+
 class TestSliceScatterApiIntComplex128(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'complex128'
+
 
 class TestSliceScatterApiIntComplex64(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'complex64'
 
+
 class TestSliceScatterApiInt64(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'int64'
+
 
 class TestSliceScatterApiInt32(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'int32'
 
-# class TestSliceScatterApiInt16(TestSliceScatterApi):
-#     def init_dtype(self):
-#         # old ir `set_value` not support this dtype
-#         if paddle.framework.in_dynamic_or_pir_mode():
-#             self.dtype = 'int16'
-#         else:
-#             self.dtype = 'float64'
 
-
-# class TestSliceScatterApiInt8(TestSliceScatterApi):
-#     def init_dtype(self):
-#         # old ir `set_value` not support this dtype
-#         if paddle.framework.in_dynamic_or_pir_mode():
-#             self.dtype = 'int8'
-#         else:
-#             self.dtype = 'float64'
-
-
-# class TestSliceScatterApiUint8(TestSliceScatterApi):
-#     def init_dtype(self):
-#         # old ir `set_value` not support this dtype
-#         if paddle.framework.in_dynamic_or_pir_mode():
-#             self.dtype = 'uint8'
-#         else:
-#             self.dtype = 'float64'
-
-# TestSliceScatterApiInt16 和 TestSliceScatterApiInt8 测试在静态模式下执行时
-# 遇到了paddle.slice_scatter 函数报错
-# 跳过这些数据类型在静态模式下的测试，只在动态图模式下进行测试，避免了在静态图模式的数据类型冲突
 class TestSliceScatterApiInt16(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'int16'
@@ -197,42 +175,54 @@ class TestSliceScatterApiInt16(TestSliceScatterApi):
     @test_with_pir_api
     def test_api_static(self):
         pass
+
     def test_api_dygraph(self):
         super().test_api_dygraph()
+
 
 class TestSliceScatterApiInt8(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'int8'
+
     @test_with_pir_api
     def test_api_static(self):
         pass
+
     def test_api_dygraph(self):
         super().test_api_dygraph()
+
 
 class TestSliceScatterApiUint8(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'uint8'
+
     @test_with_pir_api
     def test_api_static(self):
         pass
+
     def test_api_dygraph(self):
         super().test_api_dygraph()
+
 
 class TestSliceScatterApiBool(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'bool'
 
+
 class TestSliceScatterApiBfloat16(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'bfloat16'
+
 
 class TestSliceScatterApiFloat16(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'float16'
 
+
 class TestSliceScatterApiFloat32(TestSliceScatterApi):
     def init_dtype(self):
         self.dtype = 'float32'
+
 
 class TestSliceScatterApi3D(TestSliceScatterApi):
     def init_shape(self):
@@ -243,9 +233,11 @@ class TestSliceScatterApi3D(TestSliceScatterApi):
         self.ends = [6]
         self.strides = [2]
 
+
 class TestSliceScatterApi3DFloat32(TestSliceScatterApi3D):
     def init_dtype(self):
         self.dtype = 'float32'
+
 
 class TestSliceScatterApi4D(TestSliceScatterApi):
     def init_shape(self):
@@ -256,9 +248,11 @@ class TestSliceScatterApi4D(TestSliceScatterApi):
         self.ends = [6]
         self.strides = [2]
 
+
 class TestSliceScatterApi4DFloat32(TestSliceScatterApi4D):
     def init_dtype(self):
         self.dtype = 'float32'
+
 
 class TestSliceScatterApi4DAxis3(TestSliceScatterApi):
     def init_shape(self):
@@ -269,9 +263,11 @@ class TestSliceScatterApi4DAxis3(TestSliceScatterApi):
         self.ends = [6]
         self.strides = [2]
 
+
 class TestSliceScatterApi4DAxis3Float32(TestSliceScatterApi4DAxis3):
     def init_dtype(self):
         self.dtype = 'float32'
+
 
 class TestSliceScatterApiBroadcast2D(TestSliceScatterApi):
     def init_shape(self):
@@ -282,9 +278,11 @@ class TestSliceScatterApiBroadcast2D(TestSliceScatterApi):
         self.ends = [6]
         self.strides = [2]
 
+
 class TestSliceScatterApiBroadcast2DFloat32(TestSliceScatterApiBroadcast2D):
     def init_dtype(self):
         self.dtype = 'float32'
+
 
 class TestSliceScatterApiBroadcast3D(TestSliceScatterApi):
     def init_shape(self):
@@ -295,9 +293,11 @@ class TestSliceScatterApiBroadcast3D(TestSliceScatterApi):
         self.ends = [7, 5]
         self.strides = [3, 2]
 
+
 class TestSliceScatterApiBroadcast3DFloat32(TestSliceScatterApiBroadcast3D):
     def init_dtype(self):
         self.dtype = 'float32'
+
 
 class TestSliceScatterTensorApi(unittest.TestCase):
     def test_tensor(self):
@@ -319,6 +319,7 @@ class TestSliceScatterTensorApi(unittest.TestCase):
         np.testing.assert_allclose(out.numpy(), out_ref)
 
         paddle.enable_static()
+
 
 class TestSliceScatterApiError(unittest.TestCase):
     def test_error_ndim(self):
@@ -345,6 +346,7 @@ class TestSliceScatterApiError(unittest.TestCase):
             _ = paddle.slice_scatter(
                 x, value, axes=[0], starts=[0], ends=[8], strides=[1]
             )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION

### PR Category
others


### PR Types
others

### Description
 TestSliceScatterApiInt16 和 TestSliceScatterApiInt8 测试在静态模式下执行时,遇到了paddle.slice_scatter 函数报错
跳过这些数据类型在静态模式下的测试，只在动态图模式下进行测试，避免了在静态图模式的数据类型冲突
