### PR TITLE
【Fix PIR Unittest No.27】Fix test_slice_var PIR mode 

### DIFF
--- a/test/deprecated/legacy_test/test_slice_var.py
+++ b/test/deprecated/legacy_test/test_slice_var.py
@@ -14,7 +14,7 @@
 
 import random
 import unittest
-
+import paddle
 from paddle import base
 from paddle.distributed.transpiler.distribute_transpiler import slice_variable
 
@@ -22,14 +22,15 @@ from paddle.distributed.transpiler.distribute_transpiler import slice_variable
 class TestSliceVar(unittest.TestCase):
     def check_slice_output(self, shapes, expected_sizes, min_size):
         var_list = []
-        program = base.Program()
-        for shape in shapes:
-            var = program.global_block().create_var(
-                name=str(random.randint(10000, 99999)),
-                persistable=True,
-                shape=shape,
-            )
-            var_list.append(var)
+        with paddle.pir_utils.OldIrGuard():
+            program = base.Program()
+            for shape in shapes:
+                var = program.global_block().create_var(
+                    name=str(random.randint(10000, 99999)),
+                    persistable=True,
+                    shape=shape,
+                )
+                var_list.append(var)
         blocks = slice_variable(var_list, 10, min_size)
         all_sizes = []
         for s in expected_sizes:


### PR DESCRIPTION


### PR Category

Others

### PR Types

Bug fixes

### Description
实例报错：AttributeError: 'paddle.base.libpaddle.pir.Block' object has no attribute 'create_var'
推测可能是部分使用了不兼容API；
使用 with paddle.pir_utils.OldIrGuard() 包裹问题代码块。
关联 issue：https://github.com/PaddlePaddle/Paddle/issues/63740