### PR TITLE
[Infra] Skip clang-tidy check in PR-CI-Codestyle-Check

### DIFF
--- a/tools/codestyle/clang-tidy.py
+++ b/tools/codestyle/clang-tidy.py
@@ -469,6 +469,20 @@ def main():
 
 
 if __name__ == '__main__':
+    if os.getenv("SKIP_CLANG_TIDY_CHECK", "").lower() in [
+        'y',
+        'yes',
+        't',
+        'true',
+        'on',
+        '1',
+    ]:
+        print(
+            "SKIP_CLANG_TIDY_CHECK is set, skip clang-tidy check.",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
     target_version = "15.0.2"
     try:
         out = subprocess.check_output(['clang-tidy', '--version'], shell=True)
@@ -485,7 +499,11 @@ if __name__ == '__main__':
         print(
             "clang-tidy not found, attempting auto-install...", file=sys.stderr
         )
-        subprocess.check_output(
-            'pip install --no-cache clang-tidy=="15.0.2.1"', shell=True
-        )
+        try:
+            subprocess.check_output(
+                'pip install --no-cache clang-tidy=="15.0.2.1"', shell=True
+            )
+        except:
+            print("clang-tidy install failed...", file=sys.stderr)
+            sys.exit(0)
     main()

--- a/tools/codestyle/clang-tidy.py
+++ b/tools/codestyle/clang-tidy.py
@@ -499,11 +499,7 @@ if __name__ == '__main__':
         print(
             "clang-tidy not found, attempting auto-install...", file=sys.stderr
         )
-        try:
-            subprocess.check_output(
-                'pip install --no-cache clang-tidy=="15.0.2.1"', shell=True
-            )
-        except:
-            print("clang-tidy install failed...", file=sys.stderr)
-            sys.exit(0)
+        subprocess.check_output(
+            'pip install --no-cache clang-tidy=="15.0.2.1"', shell=True
+        )
     main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
问题 closes #66158

closes #66265

如果 clang-tidy 安装失败，需要设置退出为0，否则检查不通过
