### PR TITLE
【Fix PIR Unittest No.26】Fix test_scale_op PIR mode

### DIFF
--- a/test/deprecated/legacy_test/test_scale_op.py
+++ b/test/deprecated/legacy_test/test_scale_op.py
@@ -321,16 +321,17 @@ class TestScaleTripleGradCheck(unittest.TestCase):
 
 class TestScaleOpZeroNumelVariable(unittest.TestCase):
     def test_check_zero_numel_cpu(self):
-        paddle.set_device('cpu')
-        data = paddle.ones([0, 1])
-        out = paddle.scale(data, 2)
-        self.assertEqual(out, data)
-
-        if paddle.is_compiled_with_cuda():
-            paddle.set_device('gpu')
+        with paddle.pir_utils.OldIrGuard():
+            paddle.set_device('cpu')
             data = paddle.ones([0, 1])
             out = paddle.scale(data, 2)
             self.assertEqual(out, data)
+
+            if paddle.is_compiled_with_cuda():
+                paddle.set_device('gpu')
+                data = paddle.ones([0, 1])
+                out = paddle.scale(data, 2)
+                self.assertEqual(out, data)
 
 
 if __name__ == "__main__":

--- a/test/deprecated/legacy_test/test_slice_var.py
+++ b/test/deprecated/legacy_test/test_slice_var.py
@@ -14,7 +14,7 @@
 
 import random
 import unittest
-
+import paddle
 from paddle import base
 from paddle.distributed.transpiler.distribute_transpiler import slice_variable
 
@@ -22,14 +22,15 @@ from paddle.distributed.transpiler.distribute_transpiler import slice_variable
 class TestSliceVar(unittest.TestCase):
     def check_slice_output(self, shapes, expected_sizes, min_size):
         var_list = []
-        program = base.Program()
-        for shape in shapes:
-            var = program.global_block().create_var(
-                name=str(random.randint(10000, 99999)),
-                persistable=True,
-                shape=shape,
-            )
-            var_list.append(var)
+        with paddle.pir_utils.OldIrGuard():
+            program = base.Program()
+            for shape in shapes:
+                var = program.global_block().create_var(
+                    name=str(random.randint(10000, 99999)),
+                    persistable=True,
+                    shape=shape,
+                )
+                var_list.append(var)
         blocks = slice_variable(var_list, 10, min_size)
         all_sizes = []
         for s in expected_sizes:


### PR DESCRIPTION

### PR Category

Others

### PR Types

Bug fixes

### Description

实例报错：TypeError: bool(Value) is not supported in static graph mode. If you are using @to_static, you can try this:
1. If you want to get the value of Value, you can switch to non-fullgraph mode by setting @to_static(full_graph=True).
2. If you want to run it in full graph mode, you need use Value.astype(paddle.bool), and do not use bool(Value).
推测可能是静态图的版本问题；
使用 with paddle.pir_utils.OldIrGuard() 包裹问题代码块。
关联 issue：https://github.com/PaddlePaddle/Paddle/issues/63740