### PR TITLE
[CINN]Apply broadcast device lowering for too many broadcast tree bugs

### DIFF
--- a/paddle/cinn/common/broadcast_tree.h
+++ b/paddle/cinn/common/broadcast_tree.h
@@ -15,7 +15,10 @@
 #pragma once
 
 #include "paddle/cinn/adt/tree.h"
+#include "paddle/common/flags.h"
 #include "paddle/pir/include/dialect/shape/utils/dim_expr.h"
+
+COMMON_DECLARE_int64(pir_broadcast_tree_limit);
 
 namespace cinn::common {
 

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/broadcast_with_cf.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/broadcast_with_cf.h
@@ -27,11 +27,12 @@ struct GroupDimExprInfo {
   std::unordered_map<pir::Value, size_t> value_to_dim_expr_idx;
 };
 
-std::shared_ptr<BroadcastTree> ConstructBroadcastTree(
+std::optional<std::shared_ptr<BroadcastTree>> ConstructBroadcastTree(
     const common::BroadcastLeaf& leaves);
 
-bool NeedBroadcastWithCF(const OpLoweringGroupPtr& group);
-bool NeedBroadcastWithCF(const common::BroadcastLeaf& leaves);
+std::optional<std::shared_ptr<BroadcastTree>> GetBroadcastTreeForOptimize(
+    const OpLoweringGroupPtr& group);
+bool ContainBroadcastShape(const common::BroadcastLeaf& leaves);
 GroupDimExprInfo GetGroupDimExprInfo(const OpLoweringGroupPtr& group);
 
 pir::Operation* CompileBroadcastTreeToConditionBlock(

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
@@ -28,24 +28,17 @@
 #include "paddle/pir/include/core/builtin_type.h"
 #include "paddle/pir/include/pass/pass_registry.h"
 
-PD_DECLARE_bool(cinn_bc_branch_optimize);
-
 namespace cinn::dialect::ir::details {
 
 pir::Operation* ProcessDyShapeGroup(const OpLoweringGroupPtr& group,
                                     pir::PatternRewriter& rewriter) {  // NOLINT
-  // NOTE(dev): Need UpdateShapeOrDataExprs firstly and the logic
-  // will be migated into BucketLower later.
-  UpdateGroupShapeOrDataExprs(const_cast<OpLoweringGroupPtr&>(group));
-  auto group_inputs = GetBlockOutsideInput(group->ops());
-  GroupDimExprInfo group_dim_expr_info = GetGroupDimExprInfo(group);
-  const auto& leaves = group_dim_expr_info.all_value_dim_exprs;
-  // has multiple branch
-  if (FLAGS_cinn_bc_branch_optimize && NeedBroadcastWithCF(leaves)) {
-    const auto& value_to_dim_expr_idx =
-        group_dim_expr_info.value_to_dim_expr_idx;
+  const auto& group_inputs = GetBlockOutsideInput(group->ops());
+  const auto& optional_broadcast_tree = GetBroadcastTreeForOptimize(group);
+  if (optional_broadcast_tree.has_value()) {
     const std::shared_ptr<BroadcastTree> broadcast_tree =
-        ConstructBroadcastTree(leaves);
+        optional_broadcast_tree.value();
+    const auto& value_to_dim_expr_idx =
+        GetGroupDimExprInfo(group).value_to_dim_expr_idx;
     std::vector<pir::Type> output_types;
     auto group_output_values = group->GetGroupOutputValues();
     for (size_t i = 0; i < group_output_values.size(); ++i) {

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/pre_analysis.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/pre_analysis.cc
@@ -51,7 +51,9 @@ void FusionOpAnalysis::PreCompileGroup() {
 
   std::vector<OpLoweringGroupPtr> groups;
   for (auto& group_info : *group_infos_) {
-    if (is_dy_shape_ && NeedBroadcastWithCF(group_info.second)) continue;
+    if (is_dy_shape_ &&
+        GetBroadcastTreeForOptimize(group_info.second).has_value())
+      continue;
     groups.push_back(group_info.second);
   }
   // Build and trigger compilaion cache.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR applys broadcast device lowering for too many broadcast tree bugs.
