### PR TITLE
[XPU] fix conflict of float16.h

### DIFF
--- a/test/cpp/fluid/save_load_combine_op_test_xpu.cc
+++ b/test/cpp/fluid/save_load_combine_op_test_xpu.cc
@@ -14,8 +14,8 @@
 
 #include "gtest/gtest.h"
 #include "paddle/fluid/framework/op_registry.h"
-#include "paddle/fluid/platform/float16.h"
 #include "paddle/phi/backends/xpu/xpu_info.h"  // Include XPU initialization headers
+#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 template <typename Place, typename T>
@@ -193,20 +193,20 @@ TEST(SaveLoadCombineOp, XPU) {
   EXPECT_EQ(r, 0);
 
   r = SaveLoadCombineOpTest<phi::XPUPlace,
-                            paddle::platform::float16,
-                            paddle::platform::float16>(xpu_place);
+                            phi::dtype::float16,
+                            phi::dtype::float16>(xpu_place);
   EXPECT_EQ(r, 0);
   r = SaveLoadCombineOpTest<phi::CPUPlace,
-                            paddle::platform::float16,
-                            paddle::platform::float16>(cpu_place);
+                            phi::dtype::float16,
+                            phi::dtype::float16>(cpu_place);
   EXPECT_EQ(r, 0);
 
   r = SaveLoadCombineOpTest<phi::XPUPlace,
-                            paddle::platform::bfloat16,
-                            paddle::platform::bfloat16>(xpu_place);
+                            phi::dtype::bfloat16,
+                            phi::dtype::bfloat16>(xpu_place);
   EXPECT_EQ(r, 0);
   r = SaveLoadCombineOpTest<phi::CPUPlace,
-                            paddle::platform::bfloat16,
-                            paddle::platform::bfloat16>(cpu_place);
+                            phi::dtype::bfloat16,
+                            phi::dtype::bfloat16>(cpu_place);
   EXPECT_EQ(r, 0);
 }

--- a/test/cpp/fluid/save_load_combine_op_test_xpu.cc
+++ b/test/cpp/fluid/save_load_combine_op_test_xpu.cc
@@ -14,8 +14,8 @@
 
 #include "gtest/gtest.h"
 #include "paddle/fluid/framework/op_registry.h"
-#include "paddle/fluid/platform/float16.h"
 #include "paddle/phi/backends/xpu/xpu_info.h"  // Include XPU initialization headers
+#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 template <typename Place, typename T>


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
这个PR https://github.com/PaddlePaddle/Paddle/pull/66126 里面的新增代码使用了`paddle/fluid/platform/float16.h`，而这个PR https://github.com/PaddlePaddle/Paddle/pull/66121 删除了这个头文件，导致出现了冲突。

本PR修复了此问题，改成引用新的头文件。