### PR TITLE
【Fix PIR Unittest No.33 BUAA】Fix some test case in PIR

### DIFF
--- a/test/deprecated/legacy_test/test_imperative_selected_rows_to_lod_tensor.py
+++ b/test/deprecated/legacy_test/test_imperative_selected_rows_to_lod_tensor.py
@@ -92,7 +92,8 @@ class TestDygraphSimpleNet(unittest.TestCase):
             if not core.is_compiled_with_rocm():
                 dtype_list.append("float64")
             for dtype in dtype_list:
-                self.simple_net_float(is_sparse, dtype)
+                with paddle.pir_utils.OldIrGuard():
+                    self.simple_net_float(is_sparse, dtype)
 
     def simple_net_float(self, is_sparse, dtype):
         places = [base.CPUPlace()]


### PR DESCRIPTION
### PR Category
others

### PR Types
others

### Description
**该项目未完全修复**
修复三个问题
#### 1.set_need_check_feed
#### 2.framework.default_startup_program()
类型错误修改为paddle.base
#### 3. param.name
不支持str

还存在报错
<img width="1047" alt="截屏2024-07-23 12 23 57" src="https://github.com/user-attachments/assets/95403fcc-5c22-45cd-858c-5a9fa186dd1b">
线下debug为精度问题