### PR TITLE
【Fix PIR Unittest No.462 BUAA】Fix some test case in PIR

### DIFF
--- a/test/legacy_test/test_linspace.py
+++ b/test/legacy_test/test_linspace.py
@@ -157,23 +157,28 @@ class TestLinspaceAPI(unittest.TestCase):
         self.assertEqual((out.numpy() == np_res).all(), True)
 
     def test_dtype(self):
-        with paddle_static_guard():
-            out_1 = paddle.linspace(0, 10, 5, dtype='float32')
-            out_2 = paddle.linspace(0, 10, 5, dtype=np.float32)
-            out_3 = paddle.linspace(0, 10, 5, dtype=core.VarDesc.VarType.FP32)
-            exe = base.Executor(place=base.CPUPlace())
-            res_1, res_2, res_3 = exe.run(
-                base.default_main_program(), fetch_list=[out_1, out_2, out_3]
-            )
-            np.testing.assert_array_equal(res_1, res_2)
+        with paddle.pir_utils.OldIrGuard():
+            with paddle_static_guard():
+                out_1 = paddle.linspace(0, 10, 5, dtype='float32')
+                out_2 = paddle.linspace(0, 10, 5, dtype=np.float32)
+                out_3 = paddle.linspace(
+                    0, 10, 5, dtype=core.VarDesc.VarType.FP32
+                )
+                exe = base.Executor(place=base.CPUPlace())
+                res_1, res_2, res_3 = exe.run(
+                    base.default_main_program(),
+                    fetch_list=[out_1, out_2, out_3],
+                )
+                np.testing.assert_array_equal(res_1, res_2)
 
     def test_name(self):
-        with paddle_static_guard():
-            with paddle.static.program_guard(paddle.static.Program()):
-                out = paddle.linspace(
-                    0, 10, 5, dtype='float32', name='linspace_res'
-                )
-                assert 'linspace_res' in out.name
+        with paddle.pir_utils.OldIrGuard():
+            with paddle_static_guard():
+                with paddle.static.program_guard(paddle.static.Program()):
+                    out = paddle.linspace(
+                        0, 10, 5, dtype='float32', name='linspace_res'
+                    )
+                    assert 'linspace_res' in out.name
 
     def test_imperative(self):
         out1 = paddle.linspace(0, 10, 5, dtype='float32')
@@ -189,57 +194,58 @@ class TestLinspaceAPI(unittest.TestCase):
 
 class TestLinspaceOpError(unittest.TestCase):
     def test_errors(self):
-        with paddle_static_guard():
-            with program_guard(Program(), Program()):
+        with paddle.pir_utils.OldIrGuard():
+            with paddle_static_guard():
+                with program_guard(Program(), Program()):
 
-                def test_dtype():
-                    paddle.linspace(0, 10, 1, dtype="int8")
+                    def test_dtype():
+                        paddle.linspace(0, 10, 1, dtype="int8")
 
-                self.assertRaises(TypeError, test_dtype)
+                    self.assertRaises(TypeError, test_dtype)
 
-                def test_dtype1():
-                    paddle.linspace(0, 10, 1.33, dtype="int32")
+                    def test_dtype1():
+                        paddle.linspace(0, 10, 1.33, dtype="int32")
 
-                self.assertRaises(TypeError, test_dtype1)
+                    self.assertRaises(TypeError, test_dtype1)
 
-                def test_start_type():
-                    paddle.linspace([0], 10, 1, dtype="float32")
+                    def test_start_type():
+                        paddle.linspace([0], 10, 1, dtype="float32")
 
-                self.assertRaises(TypeError, test_start_type)
+                    self.assertRaises(TypeError, test_start_type)
 
-                def test_end_type():
-                    paddle.linspace(0, [10], 1, dtype="float32")
+                    def test_end_type():
+                        paddle.linspace(0, [10], 1, dtype="float32")
 
-                self.assertRaises(TypeError, test_end_type)
+                    self.assertRaises(TypeError, test_end_type)
 
-                def test_step_dtype():
-                    paddle.linspace(0, 10, [0], dtype="float32")
+                    def test_step_dtype():
+                        paddle.linspace(0, 10, [0], dtype="float32")
 
-                self.assertRaises(TypeError, test_step_dtype)
+                    self.assertRaises(TypeError, test_step_dtype)
 
-                def test_start_dtype():
-                    start = paddle.static.data(
-                        shape=[1], dtype="float64", name="start"
-                    )
-                    paddle.linspace(start, 10, 1, dtype="float32")
+                    def test_start_dtype():
+                        start = paddle.static.data(
+                            shape=[1], dtype="float64", name="start"
+                        )
+                        paddle.linspace(start, 10, 1, dtype="float32")
 
-                self.assertRaises(ValueError, test_start_dtype)
+                    self.assertRaises(ValueError, test_start_dtype)
 
-                def test_end_dtype():
-                    end = paddle.static.data(
-                        shape=[1], dtype="float64", name="end"
-                    )
-                    paddle.linspace(0, end, 1, dtype="float32")
+                    def test_end_dtype():
+                        end = paddle.static.data(
+                            shape=[1], dtype="float64", name="end"
+                        )
+                        paddle.linspace(0, end, 1, dtype="float32")
 
-                self.assertRaises(ValueError, test_end_dtype)
+                    self.assertRaises(ValueError, test_end_dtype)
 
-                def test_num_dtype():
-                    num = paddle.static.data(
-                        shape=[1], dtype="int32", name="step"
-                    )
-                    paddle.linspace(0, 10, num, dtype="float32")
+                    def test_num_dtype():
+                        num = paddle.static.data(
+                            shape=[1], dtype="int32", name="step"
+                        )
+                        paddle.linspace(0, 10, num, dtype="float32")
 
-                self.assertRaises(TypeError, test_step_dtype)
+                    self.assertRaises(TypeError, test_step_dtype)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

### PR Category
Others


### PR Types
Others


### Description
AssertionError: ValueError not raised by test_end_dtype
test_start_dtype 函数并没有抛出ValueError异常
原因暂不清楚
使用with paddle.pir_utils.OldIrGuard() 包裹问题代码块。