### PR TITLE
【Fix PIR Unittest No.389 BUAA】Fix some test case in PIR

### DIFF
--- a/test/legacy_test/test_real_imag_op.py
+++ b/test/legacy_test/test_real_imag_op.py
@@ -140,10 +140,13 @@ class TestRealAPI(unittest.TestCase):
                     np.testing.assert_array_equal(np_res, res_t)
 
     def test_name_argument(self):
-        with static.program_guard(static.Program()):
-            x = static.data(name="x", shape=self._shape, dtype=self.dtypes[0])
-            out = paddle_apis[self.api](x, name="real_res")
-            self.assertTrue("real_res" in out.name)
+        with paddle.pir_utils.OldIrGuard():
+            with static.program_guard(static.Program()):
+                x = static.data(
+                    name="x", shape=self._shape, dtype=self.dtypes[0]
+                )
+                out = paddle_apis[self.api](x, name="real_res")
+                self.assertTrue("real_res" in out.name)
 
     @test_with_pir_api
     def test_dtype_static_error(self):


### PR DESCRIPTION
### PR Category
Others


### PR Types
Others

### Description
使用 with paddle.pir_utils.OldIrGuard() 包裹问题代码块。


