### PR TITLE
【Fix PIR Unittest BUAA No.329】Fix test_inplace in PIR mode

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -7523,7 +7523,7 @@ def ldexp_(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     if not isinstance(y, (paddle.Tensor, Variable)):
         raise TypeError(f"y must be tensor type, but got {type(y)}")
     if x.dtype == paddle.float64 or y.dtype == paddle.float64:
-        out_dtype = paddle.float64
+        out_dtype = "float64"
     else:
         out_dtype = paddle.get_default_dtype()
     x = paddle.cast_(x, dtype=out_dtype)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -7523,7 +7523,7 @@ def ldexp_(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     if not isinstance(y, (paddle.Tensor, Variable)):
         raise TypeError(f"y must be tensor type, but got {type(y)}")
     if x.dtype == paddle.float64 or y.dtype == paddle.float64:
-        out_dtype = "float64"
+        out_dtype = paddle.float64
     else:
         out_dtype = paddle.get_default_dtype()
     x = paddle.cast_(x, dtype=out_dtype)

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -1221,22 +1221,23 @@ class TestDygraphInplaceLdexp(TestDygraphInplaceWithContinuous):
     def test_backward_error(self):
         # It raises an error because the inplace operator will result
         # in incorrect gradient computation.
-        with paddle.base.dygraph.guard():
-            var_a = paddle.to_tensor(self.input_var_numpy).astype("float64")
-            var_a.stop_gradient = False
+        with paddle.pir_utils.OldIrGuard():
+            with paddle.base.dygraph.guard():
+                var_a = paddle.to_tensor(self.input_var_numpy).astype("float64")
+                var_a.stop_gradient = False
 
-            var_b = var_a**2
+                var_b = var_a**2
 
-            # Here, the gradient computation will use the value of var_b
-            var_c = var_b**2
-            self.inplace_api_processing(var_b)
+                # Here, the gradient computation will use the value of var_b
+                var_c = var_b**2
+                self.inplace_api_processing(var_b)
 
-            loss = paddle.nn.functional.relu(var_c)
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "received tensor_version:2 != wrapper_version_snapshot:0",
-            ):
-                loss.backward()
+                loss = paddle.nn.functional.relu(var_c)
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "received tensor_version:2 != wrapper_version_snapshot:0",
+                ):
+                    loss.backward()
 
     def test_error(self):
         x = 1

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -1222,22 +1222,21 @@ class TestDygraphInplaceLdexp(TestDygraphInplaceWithContinuous):
         # It raises an error because the inplace operator will result
         # in incorrect gradient computation.
         with paddle.pir_utils.OldIrGuard():
-            with paddle.base.dygraph.guard():
-                var_a = paddle.to_tensor(self.input_var_numpy).astype("float64")
-                var_a.stop_gradient = False
+            var_a = paddle.to_tensor(self.input_var_numpy).astype("float64")
+            var_a.stop_gradient = False
 
-                var_b = var_a**2
+            var_b = var_a**2
 
-                # Here, the gradient computation will use the value of var_b
-                var_c = var_b**2
-                self.inplace_api_processing(var_b)
+            # Here, the gradient computation will use the value of var_b
+            var_c = var_b**2
+            self.inplace_api_processing(var_b)
 
-                loss = paddle.nn.functional.relu(var_c)
-                with self.assertRaisesRegex(
-                    RuntimeError,
-                    "received tensor_version:2 != wrapper_version_snapshot:0",
-                ):
-                    loss.backward()
+            loss = paddle.nn.functional.relu(var_c)
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "received tensor_version:2 != wrapper_version_snapshot:0",
+            ):
+                loss.backward()
 
     def test_error(self):
         x = 1

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -1221,7 +1221,7 @@ class TestDygraphInplaceLdexp(TestDygraphInplaceWithContinuous):
     def test_backward_error(self):
         # It raises an error because the inplace operator will result
         # in incorrect gradient computation.
-        with paddle.pir_utils.OldIrGuard():
+        with paddle.base.dygraph.guard():
             var_a = paddle.to_tensor(self.input_var_numpy).astype("float64")
             var_a.stop_gradient = False
 


### PR DESCRIPTION
### PR Category

Others

### PR Types

Bug fixes

### Description
报错信息：
<img width="853" alt="test_inplace" src="https://github.com/user-attachments/assets/8f7f6964-514f-47b6-9732-7065461a747b">

可能原因：新版的PIR类型问题
解决方法：进入报错栈中的`Paddle/build/python/paddle/tensor/math.py`文件报错位置，输出报错的`out_dtype`发现是由于paddle.float64和需要输入的数据类型冲突，将其修改为float64即可。
说明：由于使用的是AIStudio上运行的build文件夹中的程序，实际上需要在Paddle的python文件夹下直接修改`math.py`
