### PR TITLE
fix pir ut used in static.nn.batch_norm

### DIFF
--- a/test/amp/test_amp_api.py
+++ b/test/amp/test_amp_api.py
@@ -381,7 +381,7 @@ class TestFp16Guard(AmpTestBase):
             )
             self.assertEqual(
                 paddle.static.global_scope()
-                .find_var("fc_0.b_0")
+                .find_var("linear_0.b_0")
                 .get_tensor()
                 ._dtype(),
                 paddle.float32,

--- a/test/amp/test_amp_api.py
+++ b/test/amp/test_amp_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-from functools import reduce
 
 import numpy as np
 from amp_base_models import AmpTestBase
@@ -335,7 +334,7 @@ class TestFp16Guard(AmpTestBase):
 
                 pool = F.max_pool2d(bn, kernel_size=2, stride=2)
                 hidden = paddle.nn.Linear(
-                    in_features=reduce(lambda x, y: x * y, pool.shape[1:]),
+                    in_features=pool.shape[-1],
                     out_features=10,
                 )(pool)
                 loss = paddle.mean(hidden)

--- a/test/amp/test_amp_api.py
+++ b/test/amp/test_amp_api.py
@@ -325,18 +325,13 @@ class TestFp16Guard(AmpTestBase):
                     data = paddle.static.data(
                         name='X', shape=[None, 1, 28, 28], dtype='float32'
                     )
-                    conv2d = paddle.nn.Conv2D(
-                        in_channels=1, out_channels=6, kernel_size=3
-                    )(data)
-                    bn = paddle.nn.BatchNorm(
-                        num_channels=conv2d.shape[1], act="relu"
-                    )(conv2d)
+                    conv2d = paddle.static.nn.conv2d(
+                        input=data, num_filters=6, filter_size=3
+                    )
+                    bn = paddle.static.nn.batch_norm(input=conv2d, act="relu")
 
                 pool = F.max_pool2d(bn, kernel_size=2, stride=2)
-                hidden = paddle.nn.Linear(
-                    in_features=pool.shape[-1],
-                    out_features=10,
-                )(pool)
+                hidden = paddle.static.nn.fc(pool, size=10)
                 loss = paddle.mean(hidden)
                 fetch_vars = [loss]
                 # 2) Create the optimizer and set `multi_precision` to True.
@@ -381,7 +376,7 @@ class TestFp16Guard(AmpTestBase):
             )
             self.assertEqual(
                 paddle.static.global_scope()
-                .find_var("linear_0.b_0")
+                .find_var("fc_0.b_0")
                 .get_tensor()
                 ._dtype(),
                 paddle.float32,

--- a/test/contrib/test_multi_precision_fp16_train.py
+++ b/test/contrib/test_multi_precision_fp16_train.py
@@ -52,16 +52,17 @@ def resnet_cifar10(input, depth=32):
     def conv_bn_layer(
         input, ch_out, filter_size, stride, padding, act='relu', bias_attr=False
     ):
-        tmp = paddle.static.nn.conv2d(
-            input=input,
-            filter_size=filter_size,
-            num_filters=ch_out,
+        conv = paddle.nn.Conv2D(
+            in_channels=input.shape[1],
+            out_channels=ch_out,
+            kernel_size=filter_size,
             stride=stride,
             padding=padding,
-            act=None,
             bias_attr=bias_attr,
         )
-        return paddle.static.nn.batch_norm(input=tmp, act=act)
+        tmp = conv(input)
+        bn = paddle.nn.BatchNorm(tmp.shape[1], act=act)
+        return bn(tmp)
 
     def shortcut(input, ch_in, ch_out, stride):
         if ch_in != ch_out:

--- a/test/ipu/test_batch_norm_op_ipu.py
+++ b/test/ipu/test_batch_norm_op_ipu.py
@@ -55,11 +55,14 @@ class TestBase(IPUOpTest):
         x = paddle.static.data(
             name=self.feed_list[0], shape=self.feed_shape[0], dtype='float32'
         )
-        x = paddle.static.nn.conv2d(
-            x, num_filters=3, filter_size=3, bias_attr=False
+        x = paddle.nn.Conv2D(
+            in_channels=x.shape[1],
+            out_channels=3,
+            kernel_size=3,
+            bias_attr=False,
         )
-        x = paddle.static.nn.batch_norm(x, **self.attrs)
-        self.fetch_list = [x.name]
+        x = paddle.nn.BatchNorm(num_channels=x.shape[1], **self.attrs)(x)
+        self.fetch_list = [x]
 
     def run_model(self, exec_mode):
         self.run_op_test(exec_mode)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
测试使用 `paddle.nn.BatchNorm` 替代 `paddle.static.nn.batch_norm`
