### PR TITLE
【Fix PIR Unittest No.63 BUAA】(第一批)test_radam_op修复

### DIFF
--- a/python/paddle/static/amp/decorator.py
+++ b/python/paddle/static/amp/decorator.py
@@ -198,6 +198,14 @@ class OptimizerWithMixedPrecision:
                         value=float(self._optimizer._learning_rate)
                     ),
                 )
+            self._loss_scaling = paddle.pir.core.create_persistable_value(
+                dtype='float32',
+                shape=[1],
+                name=unique_name.generate("loss_scaling"),
+                initializer=paddle.nn.initializer.ConstantInitializer(
+                    value=self._init_loss_scaling
+                ),
+            )
 
             return
 

--- a/test/legacy_test/test_radam_op.py
+++ b/test/legacy_test/test_radam_op.py
@@ -535,7 +535,7 @@ class TestNdamaxMultiPrecision2_0(unittest.TestCase):
         out = []
         for idx in range(5):
             (loss_data,) = exe.run(
-                train_program, feed={"X": x}, fetch_list=[loss.name]
+                train_program, feed={"X": x}, fetch_list=[loss]
             )
             out.append(loss_data)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
修复了pir模式下amp测试的报错

此外，并未修改test_radam_op.py中的paddle.static.nn.fc
因为自行查找nn.Linear的相关api，并没有发现支持float16设置