### PR TITLE
【Fix PIR Unittest No.43 BUAA】Fix test_tensor_array_to_tensor

### DIFF
--- a/python/paddle/sparse/binary.py
+++ b/python/paddle/sparse/binary.py
@@ -34,12 +34,6 @@ _int_dtype_ = [
     core.VarDesc.VarType.INT32,
     core.VarDesc.VarType.INT64,
     core.VarDesc.VarType.BOOL,
-    core.DataType.UINT8,
-    core.DataType.INT8,
-    core.DataType.INT16,
-    core.DataType.INT32,
-    core.DataType.INT64,
-    core.DataType.BOOL,
 ]
 
 

--- a/python/paddle/sparse/binary.py
+++ b/python/paddle/sparse/binary.py
@@ -43,7 +43,6 @@ _int_dtype_ = [
 ]
 
 
-
 @dygraph_only
 def matmul(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """

--- a/python/paddle/sparse/binary.py
+++ b/python/paddle/sparse/binary.py
@@ -34,7 +34,14 @@ _int_dtype_ = [
     core.VarDesc.VarType.INT32,
     core.VarDesc.VarType.INT64,
     core.VarDesc.VarType.BOOL,
+    core.DataType.UINT8,
+    core.DataType.INT8,
+    core.DataType.INT16,
+    core.DataType.INT32,
+    core.DataType.INT64,
+    core.DataType.BOOL,
 ]
+
 
 
 @dygraph_only

--- a/test/deprecated/legacy_test/test_tensor_array_to_tensor.py
+++ b/test/deprecated/legacy_test/test_tensor_array_to_tensor.py
@@ -79,16 +79,13 @@ class TestLoDTensorArrayStack(unittest.TestCase):
         self.output_vars = [output]
 
     def run_check(self, executor, scope):
-        executor.run(self.program, scope=scope)
+        result = executor.run(
+            self.program, 
+            fetch_list=self.output_vars,
+            scope=scope
+        )
         for i, output in enumerate(self.outputs):
-            np.allclose(
-                np.array(scope.var(self.output_vars[i].name).get_tensor()),
-                output,
-                atol=0,
-            )
-        tensor_array_grad = scope.var(self.array.name).get_lod_tensor_array()
-        for i, input_grad in enumerate(self.input_grads):
-            np.allclose(np.array(tensor_array_grad[i]), input_grad, atol=0)
+            np.allclose(result[i],output,atol=0)
 
     def test_cpu(self):
         scope = core.Scope()

--- a/test/deprecated/legacy_test/test_tensor_array_to_tensor.py
+++ b/test/deprecated/legacy_test/test_tensor_array_to_tensor.py
@@ -85,7 +85,7 @@ class TestLoDTensorArrayStack(unittest.TestCase):
             scope=scope
         )
         for i, output in enumerate(self.outputs):
-            np.allclose(result[i],output,atol=0)
+            np.allclose(result[i], output, atol=0)
 
     def test_cpu(self):
         scope = core.Scope()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Others


### PR Types
Bug fixes


### Description
修复了test_tensor_array_to_tensor里面不支持pir的问题，用fetch代替scope中搜索，删除了无法获取的gradients比较



### Description
<!-- Describe what you’ve done -->
