### PR TITLE
fix GPUPINNED is CPU backend

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1820,3 +1820,8 @@ PHI_DEFINE_EXPORTED_double(accuracy_check_atol_bf16,
 PHI_DEFINE_EXPORTED_double(accuracy_check_rtol_bf16,
                            1e-3,
                            "It controls the rtol of accuracy_check op");
+
+PHI_DEFINE_EXPORTED_bool(
+    pinned_memory_as_cpu_backend,
+    false,
+    "Whether use CPU backend, when tensor is pinned_memory.");

--- a/paddle/phi/core/compat/convert_utils.cc
+++ b/paddle/phi/core/compat/convert_utils.cc
@@ -34,7 +34,7 @@ Backend TransToPhiBackend(const phi::Place& place) {
     case AllocationType::CPU:
       return Backend::CPU;
     case AllocationType::GPUPINNED:
-      return Backend::GPU;
+      return Backend::CPU;
     case AllocationType::XPU:
       return Backend::XPU;
     case AllocationType::IPU:

--- a/paddle/phi/core/compat/convert_utils.cc
+++ b/paddle/phi/core/compat/convert_utils.cc
@@ -14,15 +14,17 @@ limitations under the License. */
 
 #include "paddle/phi/core/compat/convert_utils.h"
 
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/backends/xpu/xpu_info.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/compat/op_utils.h"
 #include "paddle/phi/core/enforce.h"
-
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
 #include "paddle/phi/backends/device_manager.h"
 #endif
+
+COMMON_DECLARE_bool(pinned_memory_as_cpu_backend);
 
 namespace phi {
 
@@ -33,8 +35,13 @@ Backend TransToPhiBackend(const phi::Place& place) {
       return Backend::GPU;
     case AllocationType::CPU:
       return Backend::CPU;
-    case AllocationType::GPUPINNED:
-      return Backend::CPU;
+    case AllocationType::GPUPINNED: {
+      if (FLAGS_pinned_memory_as_cpu_backend) {
+        return Backend::CPU;
+      } else {
+        return Backend::GPU;
+      }
+    }
     case AllocationType::XPU:
       return Backend::XPU;
     case AllocationType::IPU:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
PinnedMemory应该是CPU backend

但由于目前套件库中PinnedMemory的Tensor大多都选择了GPU做kernel运算。修改后会导致非常多套件库性能下降需要修复：
1. 套件库Dataloader的Tensor如果是PinnedMemory需要集中转为GPU
2. 套件库中间变量如果是PinnedMemory需要转为GPU在运算
第二点非常难定位和修复，因此暂时通过FLGAS开关提供正确features。

Pcard-67164