### PR TITLE
[CINN]support InferSymbolicShape without data

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
@@ -116,6 +116,10 @@ bool MakeGenerateShapeOpAttribute(
     std::vector<pir::Attribute>* output_dim_expr_attrs,
     GenerateShapeOp::SymbolBindings* symbol_bindings) {
   const auto& shape_or_data_dim_exprs = ShapeOrDataDimExprs4Value(output_shape);
+  if (!paddle::dialect::details::HasCompleteData(shape_or_data_dim_exprs)) {
+    LOG(WARNING) << "The output_shape has no data.";
+    return false;
+  }
   ExprVec data_vec =
       paddle::dialect::details::GetExprVecFromData(shape_or_data_dim_exprs);
   // CHECK(shape_or_data_dim_exprs.data().has_value());

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
@@ -81,22 +81,46 @@ std::vector<T> GetVectorAttr(const ::pir::Operation *op,
   return vec_res;
 }
 
-inline ExprVec GetExprVecFromData(const ShapeOrData &shapeordata) {
-  if (shapeordata.isa<TensorListExprs>()) {
-    ExprVec result;
-    TensorListExprs list =
-        shapeordata.dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
-    for (size_t i = 0; i < list.size(); i++) {
-      if (list[i].data().has_value()) {
-        for (auto expr : list[i].data().value()) {
-          result.emplace_back(expr);
+inline bool HasCompleteData(const ShapeOrData &shapeordata) {
+  return shapeordata.Match(
+      [&](const symbol::TensorShapeOrDataDimExprs &impl) {
+        return impl.data().has_value();
+      },
+      [&](const symbol::TensorListShapeOrDataDimExprs &impl) {
+        for (size_t i = 0; i < impl.size(); i++) {
+          if (!impl[i].data().has_value()) {
+            return false;
+          }
         }
-      }
-    }
-    return result;
-  } else {
-    return shapeordata.data().value();
-  }
+        return true;
+      },
+      [&](const symbol::RankedTensorArrayShapeOrDataDimExprs &impl) {
+        return false;
+      },
+      [&](const symbol::NullShapeOrDataDimExpr &impl) { return false; });
+}
+
+inline ExprVec GetExprVecFromData(const ShapeOrData &shapeordata) {
+  PADDLE_ENFORCE_EQ(
+      HasCompleteData(shapeordata),
+      true,
+      phi::errors::Fatal("ShapeOrDataDimExprs must have complete data info "
+                         "when calling GetExprVecFromData"));
+  ExprVec result;
+  shapeordata.Match(
+      [&](const symbol::TensorShapeOrDataDimExprs &impl) {
+        result = impl.data().value();
+      },
+      [&](const symbol::TensorListShapeOrDataDimExprs &impl) {
+        for (size_t i = 0; i < impl.size(); i++) {
+          for (auto expr : impl[i].data().value()) {
+            result.emplace_back(expr);
+          }
+        }
+      },
+      [&](const symbol::RankedTensorArrayShapeOrDataDimExprs &impl) { return; },
+      [&](const symbol::NullShapeOrDataDimExpr &impl) { return; });
+  return result;
 }
 
 inline ExprVec GetExprVecFromShape(const ShapeOrData &shapeordata) {

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
@@ -81,6 +81,8 @@ std::vector<T> GetVectorAttr(const ::pir::Operation *op,
   return vec_res;
 }
 
+// Complete means that all the items in tensor or tensor_list have symbolic data
+// representations.
 inline bool HasCompleteData(const ShapeOrData &shapeordata) {
   return shapeordata.Match(
       [&](const symbol::TensorShapeOrDataDimExprs &impl) {

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -3093,49 +3093,76 @@ bool ExpandOp::InferSymbolicShape(
 
   const std::vector<symbol::DimExpr> &x_dims = x_shape_or_data.shape();
 
-  const std::vector<symbol::DimExpr> &expand_shape = [&] {
-    std::vector<symbol::DimExpr> dims;
+  const auto &DealWithMinusOneAndSetOutput =
+      [&](std::vector<symbol::DimExpr> &expand_shape) {
+        for (size_t i = 0; i < expand_shape.size(); i++) {
+          if (expand_shape[i] == symbol::DimExpr{-1}) {  // copy the dim from x
+            // the shape is right aligned
+            int index = i - (expand_shape.size() - x_dims.size());
+            PADDLE_ENFORCE_GE(
+                index,
+                0,
+                phi::errors::InvalidArgument("in ExpandOpInferSymbolicShape, "
+                                             "the dim to copy must >= 0, "
+                                             "but got %d",
+                                             index));
 
-    if (expand_shape_shape_or_data
-            .isa<symbol::TensorListShapeOrDataDimExprs>()) {
-      const auto &dims_list =
-          expand_shape_shape_or_data
-              .dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
-      if (dims_list.size() == 1) {
-        dims = dims_list.at(0).data().value();
-      } else {
-        for (const auto &shape_data : dims_list) {
-          dims.emplace_back(shape_data.data()->at(0));
+            expand_shape[i] = x_dims[index];
+          }
         }
-      }
-    } else {
-      dims = expand_shape_shape_or_data.data().value();
-    }
-    return dims;
-  }();
 
-  std::vector<symbol::DimExpr> out_shape = expand_shape;
-  for (size_t i = 0; i < expand_shape.size(); i++) {
-    if (expand_shape[i] == -1) {  // copy the dim from x
-      // the shape is right aligned
-      int index = i - (expand_shape.size() - x_dims.size());
-      PADDLE_ENFORCE_GE(
-          index,
-          0,
-          phi::errors::InvalidArgument(
-              "in ExpandOpInferSymbolicShape, the dim to copy must >= 0, "
-              "but got %d",
-              index));
+        infer_context->SetShapeOrDataForValue(
+            out(),
+            symbol::ShapeOrDataDimExprs{
+                symbol::TensorShapeOrDataDimExprs(expand_shape)});
+      };
 
-      out_shape[i] = x_dims[index];
-    }
-  }
+  const auto &InferWithTensorShapeOrDataDimExprs =
+      [&](const symbol::TensorShapeOrDataDimExprs &shape_or_data) {
+        if (shape_or_data.data()) {
+          std::vector<symbol::DimExpr> expand_shape =
+              shape_or_data.data().value();
+          DealWithMinusOneAndSetOutput(expand_shape);
+        } else {
+          infer_context->SetSymbolForValueByStaticShape(out());
+        }
+      };
 
-  infer_context->SetShapeOrDataForValue(
-      out(),
-      symbol::ShapeOrDataDimExprs{
-          symbol::TensorShapeOrDataDimExprs(out_shape)});
+  const auto &InferWithTensorListShapeOrDataDimExprs =
+      [&](const symbol::TensorListShapeOrDataDimExprs &shape_or_data_list) {
+        if (shape_or_data_list.size() == 1) {
+          InferWithTensorShapeOrDataDimExprs(shape_or_data_list.at(0));
+        } else {
+          std::vector<symbol::DimExpr> expand_shape;
+          for (const auto &shape_data : shape_or_data_list) {
+            if (shape_data.data()) {
+              expand_shape.emplace_back(shape_data.data()->at(0));
+            } else {
+              infer_context->SetSymbolForValueByStaticShape(out());
+              return;
+            }
+          }
+          DealWithMinusOneAndSetOutput(expand_shape);
+        }
+      };
 
+  expand_shape_shape_or_data.Match(
+      [&](const symbol::TensorShapeOrDataDimExprs &impl) {
+        InferWithTensorShapeOrDataDimExprs(impl);
+      },
+      [&](const symbol::TensorListShapeOrDataDimExprs &impl) {
+        InferWithTensorListShapeOrDataDimExprs(impl);
+      },
+      [&](const symbol::RankedTensorArrayShapeOrDataDimExprs &impl) {
+        PADDLE_THROW(
+            phi::errors::Fatal("Dead code, TensorArray should not be "
+                               "shape value for expand."));
+      },
+      [&](const symbol::NullShapeOrDataDimExpr &impl) {
+        PADDLE_THROW(
+            phi::errors::Fatal("Dead code, null value should not be "
+                               "shape value for expand."));
+      });
   return true;
 }
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -3138,8 +3138,8 @@ bool ExpandOp::InferSymbolicShape(
             if (shape_data.data()) {
               expand_shape.emplace_back(shape_data.data()->at(0));
             } else {
-              infer_context->SetSymbolForValueByStaticShape(out());
-              return;
+              expand_shape.emplace_back(
+                  symbol::DimExpr{infer_context->GetNextSymName()});
             }
           }
           DealWithMinusOneAndSetOutput(expand_shape);

--- a/test/ir/pir/cinn/symbolic/test_cinn_input_shape_symbolic.py
+++ b/test/ir/pir/cinn/symbolic/test_cinn_input_shape_symbolic.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class LayerCase(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(
+        self,
+        var_0,  # (shape: [150, 256], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+    ):
+        var_2 = var_0.unsqueeze(axis=0)
+        var_3 = var_2.transpose(
+            (
+                0,
+                2,
+                1,
+            )
+        )
+        var_4 = var_3.expand(
+            (
+                var_1,
+                256,
+                150,
+            )
+        )
+        return var_4
+
+
+def create_inputspec():
+    inputspec = (
+        paddle.static.InputSpec(
+            shape=(150, 256), dtype=paddle.float32, stop_gradient=False
+        ),
+        paddle.static.InputSpec(
+            shape=(-1,), dtype=paddle.int32, stop_gradient=False
+        ),
+    )
+    return inputspec
+
+
+def create_tensor_inputs():
+    inputs = (
+        paddle.rand(shape=[150, 256], dtype=paddle.float32),
+        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+    )
+    return inputs
+
+
+def create_numpy_inputs():
+    inputs = (
+        np.random.random(size=[150, 256]).astype('float32'),
+        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+    )
+    return inputs
+
+
+class TestLayer(unittest.TestCase):
+    def setUp(self):
+        self.inputs = create_tensor_inputs()
+        self.net = LayerCase()
+
+    def train(self, net, to_static, with_prim=False, with_cinn=False):
+        if to_static:
+            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            if with_cinn:
+                build_strategy = paddle.static.BuildStrategy()
+                build_strategy.build_cinn_pass = True
+                net = paddle.jit.to_static(
+                    net, build_strategy=build_strategy, full_graph=True
+                )
+            else:
+                net = paddle.jit.to_static(net, full_graph=True)
+        paddle.seed(123)
+        outs = net(*self.inputs)
+        return outs
+
+    def test_ast_prim_cinn(self):
+        st_out = self.train(self.net, to_static=True)
+        cinn_out = self.train(
+            self.net, to_static=True, with_prim=True, with_cinn=True
+        )
+        for st, cinn in zip(
+            paddle.utils.flatten(st_out), paddle.utils.flatten(cinn_out)
+        ):
+            np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/ir/pir/cinn/symbolic/test_cinn_input_shape_symbolic.py
+++ b/test/ir/pir/cinn/symbolic/test_cinn_input_shape_symbolic.py
@@ -11,11 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
+from os.path import dirname
+
+sys.path.append(dirname(dirname(__file__)))
+
 import unittest
 
 import numpy as np
+import utils
 
 import paddle
+from paddle.static import InputSpec
 
 
 class LayerCase(paddle.nn.Layer):
@@ -46,30 +53,26 @@ class LayerCase(paddle.nn.Layer):
 
 
 def create_inputspec():
-    inputspec = (
-        paddle.static.InputSpec(
-            shape=(150, 256), dtype=paddle.float32, stop_gradient=False
-        ),
-        paddle.static.InputSpec(
-            shape=(-1,), dtype=paddle.int32, stop_gradient=False
-        ),
-    )
+    inputspec = [
+        InputSpec(shape=(-1, -1), dtype=paddle.float32, stop_gradient=False),
+        InputSpec(shape=(-1,), dtype=paddle.int32, stop_gradient=False),
+    ]
     return inputspec
 
 
 def create_tensor_inputs():
-    inputs = (
+    inputs = [
         paddle.rand(shape=[150, 256], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-    )
+        paddle.randint(low=1, high=10, shape=[1], dtype=paddle.int32),
+    ]
     return inputs
 
 
 def create_numpy_inputs():
-    inputs = (
+    inputs = [
         np.random.random(size=[150, 256]).astype('float32'),
         np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-    )
+    ]
     return inputs
 
 
@@ -78,26 +81,15 @@ class TestLayer(unittest.TestCase):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
 
-    def train(self, net, to_static, with_prim=False, with_cinn=False):
-        if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
-            if with_cinn:
-                build_strategy = paddle.static.BuildStrategy()
-                build_strategy.build_cinn_pass = True
-                net = paddle.jit.to_static(
-                    net, build_strategy=build_strategy, full_graph=True
-                )
-            else:
-                net = paddle.jit.to_static(net, full_graph=True)
-        paddle.seed(123)
-        outs = net(*self.inputs)
-        return outs
+    def train(self, net, use_cinn=False):
+        net = utils.apply_to_static(self.net, use_cinn, create_inputspec())
+        net.eval()
+        out = net(self.inputs[0], self.inputs[1])
+        return out
 
     def test_ast_prim_cinn(self):
-        st_out = self.train(self.net, to_static=True)
-        cinn_out = self.train(
-            self.net, to_static=True, with_prim=True, with_cinn=True
-        )
+        st_out = self.train(self.net)
+        cinn_out = self.train(self.net, use_cinn=True)
         for st, cinn in zip(
             paddle.utils.flatten(st_out), paddle.utils.flatten(cinn_out)
         ):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR adds support for InferSymbolicShape without data.
