### PR TITLE
fix pir ut used in static.nn.instance_norm

### DIFF
--- a/test/ipu/test_instancenorm_op_ipu.py
+++ b/test/ipu/test_instancenorm_op_ipu.py
@@ -60,17 +60,20 @@ class TestBase(IPUOpTest):
             )
             scale = paddle.ParamAttr(trainable=True)
             bias = paddle.ParamAttr(trainable=True)
-            out = paddle.static.nn.instance_norm(
-                conv1, param_attr=scale, bias_attr=bias, **self.attrs
-            )
+            out = paddle.nn.InstanceNorm2D(
+                num_features=ch, weight_attr=scale, bias_attr=bias, **self.attrs
+            )(conv1)
             loss = paddle.mean(out)
             adam = paddle.optimizer.Adam(learning_rate=1e-2)
             adam.minimize(loss)
             self.fetch_list = [loss.name]
         else:
-            out = paddle.static.nn.instance_norm(
-                x, param_attr=True, bias_attr=True, **self.attrs
-            )
+            out = paddle.nn.InstanceNorm2D(
+                num_features=self.feed_shape[0][1],
+                weight_attr=True,
+                bias_attr=True,
+                **self.attrs
+            )(x)
             self.fetch_list = [out.name]
 
     def run_model(self, exec_mode):

--- a/test/ir/inference/test_trt_subgraph_pass.py
+++ b/test/ir/inference/test_trt_subgraph_pass.py
@@ -188,9 +188,9 @@ class TensorRTSubgraphPassInstanceNormTest(InferencePassTest):
                 name='instance_norm_b',
                 initializer=paddle.nn.initializer.Constant(value=0.0),
             )
-            out = paddle.static.nn.instance_norm(
-                input=data, param_attr=param_attr, bias_attr=bias_attr
-            )
+            out = paddle.nn.InstanceNorm2D(
+                num_features=3, weight_attr=param_attr, bias_attr=bias_attr
+            )(data)
         self.feeds = {
             "data": np.random.random([1, 3, 64, 64]).astype("float32"),
         }

--- a/test/legacy_test/test_imperative_star_gan_with_gradient_penalty.py
+++ b/test/legacy_test/test_imperative_star_gan_with_gradient_penalty.py
@@ -109,6 +109,7 @@ class InstanceNorm(paddle.nn.Layer):
     def __init__(self, num_channels, epsilon=1e-5):
         super().__init__()
         self.epsilon = epsilon
+        self.num_channels = num_channels
 
         self.scale = self.create_parameter(shape=[num_channels], is_bias=False)
         self.bias = self.create_parameter(shape=[num_channels], is_bias=True)
@@ -120,10 +121,10 @@ class InstanceNorm(paddle.nn.Layer):
             )
             return out
         else:
-            return paddle.static.nn.instance_norm(
-                input,
+            return paddle.nn.InstanceNorm2D(
+                num_features=self.num_channels,
                 epsilon=self.epsilon,
-                param_attr=base.ParamAttr(self.scale.name),
+                weight_attr=base.ParamAttr(self.scale.name),
                 bias_attr=base.ParamAttr(self.bias.name),
             )
 

--- a/test/legacy_test/test_imperative_star_gan_with_gradient_penalty.py
+++ b/test/legacy_test/test_imperative_star_gan_with_gradient_penalty.py
@@ -126,7 +126,7 @@ class InstanceNorm(paddle.nn.Layer):
                 epsilon=self.epsilon,
                 weight_attr=base.ParamAttr(self.scale.name),
                 bias_attr=base.ParamAttr(self.bias.name),
-            )
+            )(input)
 
 
 class Conv2DLayer(paddle.nn.Layer):

--- a/test/legacy_test/test_norm_nn_grad.py
+++ b/test/legacy_test/test_norm_nn_grad.py
@@ -81,7 +81,9 @@ class TestInstanceNormDoubleGradCheckWithoutParamBias(
             eps = 0.005
             atol = 1e-4
             x = paddle.create_parameter(dtype=dtype, shape=shape, name='x')
-            z = paddle.nn.InstanceNorm2D(3, bias_attr=False)(x)
+            z = paddle.nn.InstanceNorm2D(3, weight_attr=False, bias_attr=False)(
+                x
+            )
             x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
             gradient_checker.double_grad_check(
                 [x], z, x_init=x_arr, atol=atol, place=place, eps=eps

--- a/test/legacy_test/test_norm_nn_grad.py
+++ b/test/legacy_test/test_norm_nn_grad.py
@@ -35,7 +35,7 @@ class TestInstanceNormDoubleGradCheck(unittest.TestCase):
             eps = 0.005
             atol = 1e-4
             x = paddle.create_parameter(dtype=dtype, shape=shape, name='x')
-            z = paddle.static.nn.instance_norm(input=x)
+            z = paddle.nn.InstanceNorm2D(3)(x)
             x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
             gradient_checker.double_grad_check(
                 [x], z, x_init=x_arr, atol=atol, place=place, eps=eps
@@ -81,9 +81,7 @@ class TestInstanceNormDoubleGradCheckWithoutParamBias(
             eps = 0.005
             atol = 1e-4
             x = paddle.create_parameter(dtype=dtype, shape=shape, name='x')
-            z = paddle.static.nn.instance_norm(
-                input=x, param_attr=False, bias_attr=False
-            )
+            z = paddle.nn.InstanceNorm2D(3, bias_attr=False)(x)
             x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
             gradient_checker.double_grad_check(
                 [x], z, x_init=x_arr, atol=atol, place=place, eps=eps

--- a/test/xpu/test_instance_norm_op_xpu.py
+++ b/test/xpu/test_instance_norm_op_xpu.py
@@ -25,6 +25,7 @@ from op_test_xpu import XPUOpTest
 import paddle
 from paddle import base
 from paddle.base import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -173,6 +174,7 @@ class XPUTestInstanceNormOp(XPUOpTestWrapper):
             self.__class__.no_need_check_grad = True
             self.dtype = self.in_type
 
+        @test_with_pir_api
         def test_errors(self):
             with program_guard(Program(), Program()):
                 # the input of instance_norm must be Variable.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
测试使用 `paddle.nn.InstanceNorm2D` 替代 `paddle.static.nn.instance_norm`
