### PR TITLE
[SOT][dynamic shape] Use guard value instead of raise_break_graph_fn to call int/float

### DIFF
--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -56,6 +56,8 @@ class SymbolicFloat(SymbolicValue):
 
 
 class MetaInfo:
+    shape: list[int | SymbolicInt]
+
     def __init__(
         self,
         shape,
@@ -73,7 +75,7 @@ class MetaInfo:
         self.persistable = persistable
         self.type = type
         self.place = place
-        self.shape: list[int | SymbolicInt] = shape
+        self.shape = shape
         self.dtype = dtype
         self.stop_gradient = stop_gradient
 
@@ -81,7 +83,7 @@ class MetaInfo:
         self, dynamic_symbol: DynamicSymbolT = -1
     ) -> list[int | DynamicSymbolT]:
         return [
-            dim if not isinstance(dim, SymbolicInt) else dynamic_symbol
+            dynamic_symbol if isinstance(dim, SymbolicInt) else dim
             for dim in self.shape
         ]
 

--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -41,17 +41,17 @@ class SymbolicValue(metaclass=Singleton):
 
 
 class SymbolicBool(SymbolicValue):
-    def get_static_type(self) -> type:
+    def get_static_type(self) -> type[bool]:
         return bool
 
 
 class SymbolicInt(SymbolicValue):
-    def get_static_type(self) -> type:
+    def get_static_type(self) -> type[int]:
         return int
 
 
 class SymbolicFloat(SymbolicValue):
-    def get_static_type(self) -> type:
+    def get_static_type(self) -> type[float]:
         return float
 
 

--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -58,7 +58,7 @@ class OpcodeExecutorCache(metaclass=Singleton):
     MAX_CACHE_SIZE = 20
     cache: dict[types.CodeType, GuardedFunctions]
     translate_count: int
-    code_symbolic_inputs: dict[types.CodeType, dict[str, dict[int, int]]]
+    code_symbolic_inputs: dict[types.CodeType, dict[str, None | dict[int, int]]]
 
     def __init__(self):
         self.cache = {}

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -893,11 +893,10 @@ fallback_tensor_unary_method = {
 Dispatcher.register(tensor_numel, ("TensorVariable",), lambda x: x.numel())
 
 for unary_fn in UNARY_OPS:
-    # TODO(zrr1999): SymbolicVariable should have special dispatch for fallback_tensor_unary_method
     if unary_fn in fallback_tensor_unary_method:
         Dispatcher.register(
             unary_fn,
-            ("TensorVariable | SymbolicVariable",),
+            ("TensorVariable",),
             raise_break_graph_fn,
         )
         continue
@@ -982,6 +981,16 @@ for binary_fn in BINARY_OPS:
                     ),
                 )
 # Symbolic
+Dispatcher.register(
+    float,
+    ("SymbolicVariable",),
+    lambda var: var.float(),
+)
+Dispatcher.register(
+    int,
+    ("SymbolicVariable",),
+    lambda var: var.int(),
+)
 for binary_fn in BINARY_OPS:
     for magic_method in magic_method_builtin_dispatch(binary_fn):
         if magic_method.name not in get_tensor_methods():

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -583,6 +583,18 @@ Dispatcher.register(
     ),
 )
 
+# bool
+Dispatcher.register(
+    bool,
+    ("ContainerVariable | SymbolicVariable",),
+    lambda var: var.bool(),
+)
+Dispatcher.register(
+    operator.truth,
+    ("ConstantVariable | SymbolicVariable",),
+    lambda var: var.bool(),
+)
+
 # str
 Dispatcher.register(
     str,

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -686,7 +686,7 @@ class SymbolicVariable(VariableBase):
             )
         self.need_guard_value = False
 
-    def get_py_value(self, allow_tensor=False):
+    def get_py_value(self, allow_tensor: bool = False) -> bool | int | float:
         self.need_guard_value = True
         if isinstance(self.value, SymbolicValue):
             assert isinstance(
@@ -698,6 +698,7 @@ class SymbolicVariable(VariableBase):
             self.value = getattr(
                 inputs[0].get_py_value(), self.tracker.method_name
             )(*other_inputs_value)
+            assert isinstance(self.value, (bool, int, float))
         return self.value
 
     def get_py_type(self):
@@ -713,6 +714,18 @@ class SymbolicVariable(VariableBase):
 
     def bool(self):
         return ConstantVariable(bool(self), self.graph, DummyTracker([self]))
+
+    def __int__(self) -> int:
+        return int(self.get_py_value())
+
+    def int(self):
+        return ConstantVariable(int(self), self.graph, DummyTracker([self]))
+
+    def __float__(self) -> float:
+        return int(self.get_py_value())
+
+    def float(self):
+        return ConstantVariable(float(self), self.graph, DummyTracker([self]))
 
     @property
     def out_var_name(self):

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -722,7 +722,7 @@ class SymbolicVariable(VariableBase):
         return ConstantVariable(int(self), self.graph, DummyTracker([self]))
 
     def __float__(self) -> float:
-        return int(self.get_py_value())
+        return float(self.get_py_value())
 
     def float(self):
         return ConstantVariable(float(self), self.graph, DummyTracker([self]))

--- a/test/sot/test_sot_dynamic_shape.py
+++ b/test/sot/test_sot_dynamic_shape.py
@@ -137,23 +137,23 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
                 self.assert_results(func, 1)
                 self.assert_results(func, 2)
 
-    # def test_dynamic_shape_in_list(self):
-    #     with with_allow_dynamic_shape_guard(
-    #         True
-    #     ), test_instruction_translator_cache_context() as ctx:
-    #         self.assert_results(
-    #             dynamic_shape_in_list,
-    #             paddle.randn([1, 4, 5]),
-    #             [4, 5],
-    #         )
-    #         self.assertEqual(ctx.translate_count, 1)
-    #         for i in range(2, 6):
-    #             self.assert_results(
-    #                 dynamic_shape_in_list,
-    #                 paddle.randn([i, 4, 5]),
-    #                 [i * 4, 5],
-    #             )
-    #             self.assertEqual(ctx.translate_count, 2)
+    def test_dynamic_shape_in_list(self):
+        with with_allow_dynamic_shape_guard(
+            True
+        ), test_instruction_translator_cache_context() as ctx:
+            self.assert_results(
+                dynamic_shape_in_list,
+                paddle.randn([1, 4, 5]),
+                [4, 5],
+            )
+            self.assertEqual(ctx.translate_count, 1)
+            for i in range(2, 6):
+                self.assert_results(
+                    dynamic_shape_in_list,
+                    paddle.randn([i, 4, 5]),
+                    [i * 4, 5],
+                )
+                self.assertEqual(ctx.translate_count, 2)
 
 
 if __name__ == '__main__':

--- a/test/sot/test_sot_dynamic_shape.py
+++ b/test/sot/test_sot_dynamic_shape.py
@@ -22,6 +22,7 @@ from test_case_base import (
 )
 
 import paddle
+from paddle.jit.sot.psdb import check_no_breakgraph
 from paddle.jit.sot.utils import (
     with_allow_dynamic_shape_guard,
 )
@@ -129,9 +130,9 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
         with with_allow_dynamic_shape_guard(
             True
         ), test_instruction_translator_cache_context() as ctx:
-            func1 = lambda n: bool(n)
-            func2 = lambda n: int(n)
-            func3 = lambda n: float(n)
+            func1 = check_no_breakgraph(lambda n: bool(n))
+            func2 = check_no_breakgraph(lambda n: int(n))
+            func3 = check_no_breakgraph(lambda n: float(n))
             for func in [func1, func2, func3]:
                 self.assert_results(func, 1)
                 self.assert_results(func, 2)

--- a/test/sot/test_sot_dynamic_shape.py
+++ b/test/sot/test_sot_dynamic_shape.py
@@ -22,7 +22,9 @@ from test_case_base import (
 )
 
 import paddle
-from paddle.jit.sot.utils import with_allow_dynamic_shape_guard
+from paddle.jit.sot.utils import (
+    with_allow_dynamic_shape_guard,
+)
 
 
 def dynamic_shape_input_func1(x):
@@ -122,6 +124,17 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
                     paddle.randn([i, 4, 5]),
                 )
                 self.assertEqual(ctx.translate_count, 2)
+
+    def test_dynamic_shape_cast(self):
+        with with_allow_dynamic_shape_guard(
+            True
+        ), test_instruction_translator_cache_context() as ctx:
+            func1 = lambda n: bool(n)
+            func2 = lambda n: int(n)
+            func3 = lambda n: float(n)
+            for func in [func1, func2, func3]:
+                self.assert_results(func, 1)
+                self.assert_results(func, 2)
 
     # def test_dynamic_shape_in_list(self):
     #     with with_allow_dynamic_shape_guard(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->
Use guard value instead of raise_break_graph_fn to call int/float