### PR TITLE
test_get_tensor_from_selected_rows_op.py change line 41 TypeError int…

### DIFF
--- a/test/deprecated/legacy_test/test_get_tensor_from_selected_rows_op.py
+++ b/test/deprecated/legacy_test/test_get_tensor_from_selected_rows_op.py
@@ -38,7 +38,7 @@ class TestGetTensorFromSelectedRowsError(unittest.TestCase):
             def test_SELECTED_ROWS():
                 clip.get_tensor_from_selected_rows(x=x_var)
 
-            self.assertRaises(TypeError, test_SELECTED_ROWS)
+            self.assertRaises(NotImplementedError, test_SELECTED_ROWS)
 
 
 class TestGetTensorFromSelectedRows(unittest.TestCase):


### PR DESCRIPTION
…o NotImplementedError

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
others

### Description
<!-- Describe what you’ve done -->
test_get_tensor_from_selected_rows_op.py change line 41 TypeError into NotImplementedError