### PR TITLE
【Fix PIR Unittest BUAA No.143】Fix test_lazy_init in PIR mode

### DIFF
--- a/python/paddle/base/data_feeder.py
+++ b/python/paddle/base/data_feeder.py
@@ -161,7 +161,11 @@ def check_variable_and_dtype(
 ):
     if in_pir_mode():
         check_type(
-            input, input_name, (Value, ParameterMeta), op_name, extra_message
+            input,
+            input_name,
+            (Variable, Value, ParameterMeta),
+            op_name,
+            extra_message,
         )
     else:
         check_type(input, input_name, (Variable, Value), op_name, extra_message)

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -833,7 +833,11 @@ def max_unpool1d(
     padding = _expand_low_nd_padding(padding)
 
     if output_size is not None:
-        output_size = output_size[:2] + [1] + output_size[2:]
+        output_size = (
+            output_size[:2]
+            + ([1] if isinstance(output_size, list) else (1,))
+            + output_size[2:]
+        )
     output_size = _unpool_output_size(
         x, kernel_size, stride, padding, output_size
     )

--- a/test/legacy_test/test_unpool1d_op.py
+++ b/test/legacy_test/test_unpool1d_op.py
@@ -164,6 +164,35 @@ class TestUnpool1DOpAPI_dygraph4(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestUnpool1DOpAPI_dygraph5(unittest.TestCase):
+    def test_case(self):
+        places = [paddle.CPUPlace()]
+        if paddle.base.core.is_compiled_with_cuda():
+            places.append(paddle.CUDAPlace(0))
+        for place in places:
+            paddle.disable_static()
+            input_data = np.arange(3 * 16).reshape([1, 3, 16]).astype("float32")
+            input_x = paddle.to_tensor(input_data)
+            output, indices = F.max_pool1d(
+                input_x, kernel_size=2, stride=2, return_mask=True
+            )
+            output_unpool = F.max_unpool1d(
+                output.astype("int64"),
+                indices,
+                kernel_size=2,
+                stride=2,
+                output_size=tuple(input_x.shape),
+            )
+            expected_output_unpool = unpool1dmax_forward_naive(
+                output.numpy(), indices.numpy(), [2], [2], [0], [16]
+            )
+            np.testing.assert_allclose(
+                output_unpool.numpy(), expected_output_unpool, rtol=1e-05
+            )
+
+        paddle.enable_static()
+
+
 class TestUnpool1DOpAPI_static(unittest.TestCase):
     @test_with_pir_api
     def test_case(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
报错信息：
<img width="1015" alt="test_lazy_init_1" src="https://github.com/user-attachments/assets/516ecad0-1c0f-4180-b625-602cf4913550">
<img width="1017" alt="test_lazy_init_2" src="https://github.com/user-attachments/assets/b33a156a-f01b-494f-b2d3-25b668f9289e">
<img width="1012" alt="test_lazy_init_3" src="https://github.com/user-attachments/assets/d5d40029-d084-4622-a29e-86633b5939fd">
<img width="1011" alt="test_lazy_init_4" src="https://github.com/user-attachments/assets/ccc71ee2-01a1-40d0-ba93-2d2e0ff3f9bd">
尝试修改：python/paddle/base/data_feeder.py文件