### PR TITLE
[Inference] Unify delete_pass api in old ir and pir

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -1505,8 +1505,8 @@ void AnalysisConfig::EnableCustomPasses(const std::vector<std::string> &passes,
   custom_pass_only_ = custom_pass_only;
 }
 
-void AnalysisConfig::DeletePass(const std::vector<std::string> &passes) {
-  deleted_passes_ = passes;
+void AnalysisConfig::DeletePass(const std::string &pass_name) {
+  deleted_passes_.push_back(pass_name);
 }
 
 void AnalysisConfig::SetOptimizationLevel(int opt_level) {

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -400,6 +400,11 @@ AnalysisPredictor::AnalysisPredictor(const AnalysisConfig &config)
       config_.SwitchIrOptim(false);
     }
   }
+  if (!config_.new_ir_enabled()) {
+    for (const auto &pass_name : config_.deleted_passes_) {
+      config_.pass_builder()->DeletePass(pass_name);
+    }
+  }
   int trt_identifier = config_.trt_engine_memory_sharing_identifier_;
   if (trt_identifier > 0) {
     // NOTE(liuyuanle): For convenience, we set the id of the predictor to

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -1175,7 +1175,12 @@ struct PD_INFER_DECL AnalysisConfig {
   void EnableCustomPasses(const std::vector<std::string>& passes,
                           bool custom_pass_only = false);
 
-  void DeletePass(const std::vector<std::string>& passes);
+  ///
+  /// \brief Delete a pass to prevent it to optimizing the model.
+  ///
+  /// \param pass_name The pass's name to be deleted.
+  ///
+  void DeletePass(const std::string& pass_name);
 
   ///
   /// \brief Set pir Optimization level.

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -1016,10 +1016,6 @@ void BindAnalysisConfig(py::module *m) {
       .def("set_mkldnn_op", &AnalysisConfig::SetMKLDNNOp)
       .def("set_model_buffer", &AnalysisConfig::SetModelBuffer)
       .def("model_from_memory", &AnalysisConfig::model_from_memory)
-      .def("delete_pass",
-           [](AnalysisConfig &self, const std::string &pass) {
-             self.pass_builder()->DeletePass(pass);
-           })
       .def("delete_pass", &AnalysisConfig::DeletePass)
       .def(
           "pass_builder",

--- a/test/dygraph_to_static/predictor_utils.py
+++ b/test/dygraph_to_static/predictor_utils.py
@@ -64,7 +64,7 @@ class PredictorTools:
             config.enable_new_ir()
             config.enable_new_executor()
             if os.name == 'nt':
-                config.delete_pass(["conv2d_bn_fuse_pass"])
+                config.delete_pass("conv2d_bn_fuse_pass")
 
         return config
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
pcard-71500
Unify delete_pass api in old ir and pir.