### PR TITLE
【Fix PIR Unittest No.425 BUAA】修复legacy_test/test_nn_sigmoid_op.py 

### DIFF
--- a/test/deprecated/legacy_test/test_nn_sigmoid_op.py
+++ b/test/deprecated/legacy_test/test_nn_sigmoid_op.py
@@ -49,7 +49,12 @@ class TestNNSigmoidAPI(unittest.TestCase):
         exe = paddle.static.Executor(place)
         out = exe.run(main_program, feed={'x': self.x}, fetch_list=[y])
         np.testing.assert_allclose(out[0], self.y, rtol=1e-05)
-        self.assertTrue(y.name.startswith("api_sigmoid"))
+
+        if paddle.framework.in_pir_mode():
+            y_name = y.get_defining_op().name()
+            self.assertTrue(y_name.startswith("pd_op.sigmoid"))
+        else:
+            self.assertTrue(y.name.startswith("api_sigmoid"))
 
     def check_dynamic_api(self, place):
         paddle.disable_static(place)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Others
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others
### Description
<!-- Describe what you’ve done -->
模仿原有op名称检测，增加pir模式下op名称检测
