### PR TITLE
【Fix PIR Unittest No.287 BUAA】Fix some test case in PIR

### DIFF
--- a/test/legacy_test/test_tensor.py
+++ b/test/legacy_test/test_tensor.py
@@ -377,7 +377,10 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor.set(array, place)
         tensor_dtype = tensor._dtype()
-        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType) and enable_pir_api == '1':
+        if (
+            isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType)
+            and enable_pir_api == '1'
+        ):
             tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
         self.assertEqual(tensor_dtype, paddle.float16)
         np.testing.assert_array_equal(np.array(tensor), array)
@@ -399,7 +402,10 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor.set(array, place)
         tensor_dtype = tensor._dtype()
-        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType) and enable_pir_api == '1':
+        if (
+            isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType)
+            and enable_pir_api == '1'
+        ):
             tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
         self.assertEqual(tensor_dtype, paddle.int16)
         np.testing.assert_array_equal(np.array(tensor), array)
@@ -459,7 +465,10 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor.set(array, place)
         tensor_dtype = tensor._dtype()
-        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType) and enable_pir_api == '1':
+        if (
+            isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType)
+            and enable_pir_api == '1'
+        ):
             tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
         self.assertEqual(tensor_dtype, paddle.complex128)
         tensor._set_complex128_element(0, 42.1 + 42.1j)
@@ -492,7 +501,10 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor.set(array, place)
         tensor_dtype = tensor._dtype()
-        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType) and enable_pir_api == '1':
+        if (
+            isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType)
+            and enable_pir_api == '1'
+        ):
             tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
         self.assertEqual(tensor_dtype, paddle.complex64)
         tensor._set_complex64_element(0, 42.1 + 42.1j)

--- a/test/legacy_test/test_tensor.py
+++ b/test/legacy_test/test_tensor.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import numbers
+import os
 import unittest
 
 import numpy as np

--- a/test/legacy_test/test_tensor.py
+++ b/test/legacy_test/test_tensor.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import numbers
 import unittest
 
@@ -20,6 +21,8 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import core
+
+enable_pir_api = os.getenv('FLAGS_enable_pir_api')
 
 
 class TestTensorPtr(unittest.TestCase):
@@ -346,7 +349,7 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor = var.get_tensor()
         dtype = paddle.float32
-        if isinstance(dtype, paddle.base.core.DataType):
+        if isinstance(dtype, paddle.base.core.DataType) and enable_pir_api == '1':
             dtype = paddle.pir.core.datatype_to_vartype[dtype]
         self.assertTrue(
             isinstance(tensor._mutable_data(place, dtype), numbers.Integral)
@@ -374,7 +377,7 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor.set(array, place)
         tensor_dtype = tensor._dtype()
-        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType):
+        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType) and enable_pir_api == '1':
             tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
         self.assertEqual(tensor_dtype, paddle.float16)
         np.testing.assert_array_equal(np.array(tensor), array)
@@ -396,7 +399,7 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor.set(array, place)
         tensor_dtype = tensor._dtype()
-        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType):
+        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType) and enable_pir_api == '1':
             tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
         self.assertEqual(tensor_dtype, paddle.int16)
         np.testing.assert_array_equal(np.array(tensor), array)
@@ -456,7 +459,7 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor.set(array, place)
         tensor_dtype = tensor._dtype()
-        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType):
+        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType) and enable_pir_api == '1':
             tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
         self.assertEqual(tensor_dtype, paddle.complex128)
         tensor._set_complex128_element(0, 42.1 + 42.1j)
@@ -489,7 +492,7 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor.set(array, place)
         tensor_dtype = tensor._dtype()
-        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType):
+        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType) and enable_pir_api == '1':
             tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
         self.assertEqual(tensor_dtype, paddle.complex64)
         tensor._set_complex64_element(0, 42.1 + 42.1j)

--- a/test/legacy_test/test_tensor.py
+++ b/test/legacy_test/test_tensor.py
@@ -346,6 +346,8 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor = var.get_tensor()
         dtype = paddle.float32
+        if isinstance(dtype, paddle.base.core.DataType):
+            dtype = paddle.pir.core.datatype_to_vartype[dtype]
         self.assertTrue(
             isinstance(tensor._mutable_data(place, dtype), numbers.Integral)
         )
@@ -371,18 +373,21 @@ class TestTensor(unittest.TestCase):
         tensor = base.Tensor()
         place = core.CPUPlace()
         tensor.set(array, place)
-        self.assertEqual(tensor._dtype(), paddle.float16)
+        tensor_dtype = tensor._dtype()
+        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType):
+            tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
+        self.assertEqual(tensor_dtype, paddle.float16)
         np.testing.assert_array_equal(np.array(tensor), array)
 
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             tensor.set(array, place)
-            self.assertEqual(tensor._dtype(), paddle.float16)
+            self.assertEqual(tensor_dtype, paddle.float16)
             np.testing.assert_array_equal(np.array(tensor), array)
 
             place = core.CUDAPinnedPlace()
             tensor.set(array, place)
-            self.assertEqual(tensor._dtype(), paddle.float16)
+            self.assertEqual(tensor_dtype, paddle.float16)
             np.testing.assert_array_equal(np.array(tensor), array)
 
     def test_tensor_set_int16(self):
@@ -390,18 +395,21 @@ class TestTensor(unittest.TestCase):
         tensor = base.Tensor()
         place = core.CPUPlace()
         tensor.set(array, place)
-        self.assertEqual(tensor._dtype(), paddle.int16)
+        tensor_dtype = tensor._dtype()
+        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType):
+            tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
+        self.assertEqual(tensor_dtype, paddle.int16)
         np.testing.assert_array_equal(np.array(tensor), array)
 
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             tensor.set(array, place)
-            self.assertEqual(tensor._dtype(), paddle.int16)
+            self.assertEqual(tensor_dtype, paddle.int16)
             np.testing.assert_array_equal(np.array(tensor), array)
 
             place = core.CUDAPinnedPlace()
             tensor.set(array, place)
-            self.assertEqual(tensor._dtype(), paddle.int16)
+            self.assertEqual(tensor_dtype, paddle.int16)
             np.testing.assert_array_equal(np.array(tensor), array)
 
     def test_tensor_set_from_array_list(self):
@@ -447,8 +455,10 @@ class TestTensor(unittest.TestCase):
         tensor = base.Tensor()
         place = core.CPUPlace()
         tensor.set(array, place)
-
-        self.assertEqual(tensor._dtype(), paddle.complex128)
+        tensor_dtype = tensor._dtype()
+        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType):
+            tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
+        self.assertEqual(tensor_dtype, paddle.complex128)
         tensor._set_complex128_element(0, 42.1 + 42.1j)
         np.testing.assert_allclose(
             tensor._get_complex128_element(0), 42.1 + 42.1j
@@ -457,7 +467,7 @@ class TestTensor(unittest.TestCase):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             tensor.set(array, place)
-            self.assertEqual(tensor._dtype(), paddle.complex128)
+            self.assertEqual(tensor_dtype, paddle.complex128)
             tensor._set_complex128_element(0, 42.1 + 42.1j)
             np.testing.assert_allclose(
                 tensor._get_complex128_element(0), 42.1 + 42.1j
@@ -465,7 +475,7 @@ class TestTensor(unittest.TestCase):
 
             place = core.CUDAPinnedPlace()
             tensor.set(array, place)
-            self.assertEqual(tensor._dtype(), paddle.complex128)
+            self.assertEqual(tensor_dtype, paddle.complex128)
             tensor._set_complex128_element(0, 42.1 + 42.1j)
             np.testing.assert_allclose(
                 tensor._get_complex128_element(0), 42.1 + 42.1j
@@ -478,8 +488,10 @@ class TestTensor(unittest.TestCase):
         tensor = base.Tensor()
         place = core.CPUPlace()
         tensor.set(array, place)
-
-        self.assertEqual(tensor._dtype(), paddle.complex64)
+        tensor_dtype = tensor._dtype()
+        if isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType):
+            tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
+        self.assertEqual(tensor_dtype, paddle.complex64)
         tensor._set_complex64_element(0, 42.1 + 42.1j)
         np.testing.assert_allclose(
             np.complex64(tensor._get_complex64_element(0)),
@@ -489,7 +501,7 @@ class TestTensor(unittest.TestCase):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             tensor.set(array, place)
-            self.assertEqual(tensor._dtype(), paddle.complex64)
+            self.assertEqual(tensor_dtype, paddle.complex64)
             tensor._set_complex64_element(0, 42.1 + 42.1j)
             np.testing.assert_allclose(
                 np.complex64(tensor._get_complex64_element(0)),
@@ -498,7 +510,7 @@ class TestTensor(unittest.TestCase):
 
             place = core.CUDAPinnedPlace()
             tensor.set(array, place)
-            self.assertEqual(tensor._dtype(), paddle.complex64)
+            self.assertEqual(tensor_dtype, paddle.complex64)
             tensor._set_complex64_element(0, 42.1 + 42.1j)
             np.testing.assert_allclose(
                 np.complex64(tensor._get_complex64_element(0)),

--- a/test/legacy_test/test_tensor.py
+++ b/test/legacy_test/test_tensor.py
@@ -349,7 +349,10 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor = var.get_tensor()
         dtype = paddle.float32
-        if isinstance(dtype, paddle.base.core.DataType) and enable_pir_api == '1':
+        if (
+            isinstance(dtype, paddle.base.core.DataType)
+            and enable_pir_api == '1'
+        ):
             dtype = paddle.pir.core.datatype_to_vartype[dtype]
         self.assertTrue(
             isinstance(tensor._mutable_data(place, dtype), numbers.Integral)

--- a/test/legacy_test/test_tensor.py
+++ b/test/legacy_test/test_tensor.py
@@ -498,7 +498,7 @@ class TestTensor(unittest.TestCase):
         tensor.set(array, place)
         tensor_dtype = tensor._dtype()
         if paddle.framework.use_pir_api() and isinstance(
-            isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType
+            tensor_dtype, paddle.base.libpaddle.VarDesc.VarType
         ):
             tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
         self.assertEqual(tensor_dtype, paddle.complex64)

--- a/test/legacy_test/test_tensor.py
+++ b/test/legacy_test/test_tensor.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import numbers
-import os
 import unittest
 
 import numpy as np
@@ -21,8 +20,6 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import core
-
-enable_pir_api = os.getenv('FLAGS_enable_pir_api')
 
 
 class TestTensorPtr(unittest.TestCase):
@@ -349,9 +346,8 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor = var.get_tensor()
         dtype = paddle.float32
-        if (
-            isinstance(dtype, paddle.base.core.DataType)
-            and enable_pir_api == '1'
+        if paddle.framework.use_pir_api() and isinstance(
+            dtype, paddle.base.core.DataType
         ):
             dtype = paddle.pir.core.datatype_to_vartype[dtype]
         self.assertTrue(
@@ -380,9 +376,8 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor.set(array, place)
         tensor_dtype = tensor._dtype()
-        if (
-            isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType)
-            and enable_pir_api == '1'
+        if paddle.framework.use_pir_api() and isinstance(
+            tensor_dtype, paddle.base.libpaddle.VarDesc.VarType
         ):
             tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
         self.assertEqual(tensor_dtype, paddle.float16)
@@ -405,9 +400,8 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor.set(array, place)
         tensor_dtype = tensor._dtype()
-        if (
-            isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType)
-            and enable_pir_api == '1'
+        if paddle.framework.use_pir_api() and isinstance(
+            tensor_dtype, paddle.base.libpaddle.VarDesc.VarType
         ):
             tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
         self.assertEqual(tensor_dtype, paddle.int16)
@@ -468,9 +462,8 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor.set(array, place)
         tensor_dtype = tensor._dtype()
-        if (
-            isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType)
-            and enable_pir_api == '1'
+        if paddle.framework.use_pir_api() and isinstance(
+            tensor_dtype, paddle.base.libpaddle.VarDesc.VarType
         ):
             tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
         self.assertEqual(tensor_dtype, paddle.complex128)
@@ -504,9 +497,8 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor.set(array, place)
         tensor_dtype = tensor._dtype()
-        if (
-            isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType)
-            and enable_pir_api == '1'
+        if paddle.framework.use_pir_api() and isinstance(
+            isinstance(tensor_dtype, paddle.base.libpaddle.VarDesc.VarType
         ):
             tensor_dtype = paddle.pir.core.vartype_to_datatype[tensor_dtype]
         self.assertEqual(tensor_dtype, paddle.complex64)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] --> Others


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] --> Others


### Description
<!-- Describe what you’ve done -->
tensor._dtype()获得到的类型是paddle.base.libpaddle.VarDesc.VarType，在新的PIR情况下需将其转为paddle.base.core.DataType才能保证assertEqual不报错；另外在test_tensor_pointer中，则需要将datatype转为vartype以保证传入tensor._mutable_data的参数正确。
