### PR TITLE
【Comm】Fix c_allreduce_min and c_allreduce_max

### DIFF
--- a/test/ir/inference/test_trt_c_allreduce_infer_script.py
+++ b/test/ir/inference/test_trt_c_allreduce_infer_script.py
@@ -24,7 +24,7 @@ from paddle.distributed import fleet
 from paddle.inference import Config, PrecisionType, create_predictor
 
 
-def run(op_type, precision):
+def run(op_type, reduce_type, precision):
     fleet.init(is_collective=True)
     paddle.enable_static()
     main_program = paddle.static.Program()
@@ -43,10 +43,11 @@ def run(op_type, precision):
         )
         block.append_op(
             type=op_type,
-            inputs={'X': data},
-            outputs={'Out': c_data},
+            inputs={'x': data},
+            outputs={'out': c_data},
             attrs={
                 'ring_id': 0,
+                'reduce_type': reduce_type,
                 'use_calc_stream': True,
                 'use_model_parallel': True,
             },
@@ -117,5 +118,6 @@ if __name__ == "__main__":
         # This script just be called by test_trt_convert_c_allreduce.py
         sys.exit(0)
     op_type = sys.argv[1]
-    precision = sys.argv[2]
-    run(op_type, precision)
+    reduce_type = sys.argv[2]
+    precision = sys.argv[3]
+    run(op_type, reduce_type, precision)

--- a/test/ir/inference/test_trt_convert_c_allreduce.py
+++ b/test/ir/inference/test_trt_convert_c_allreduce.py
@@ -25,7 +25,8 @@ class TestDistTRT(unittest.TestCase):
         self.script = "test_trt_c_allreduce_infer_script.py"
 
     def init_case(self):
-        self.op_type = "c_allreduce_sum"
+        self.op_type = "all_reduce"
+        self.reduce_type = 0,
         self.target_value = 4.0
         self.precision = "fp16"
 
@@ -61,7 +62,8 @@ class TestDistTRT(unittest.TestCase):
 
 class TestMin(TestDistTRT):
     def init_case(self):
-        self.op_type = "c_allreduce_min"
+        self.op_type = "all_reduce"
+        self.reduce_type = 5,
         self.target_value = 2.0
         self.precision = "int8"
 

--- a/test/ir/inference/test_trt_convert_c_allreduce.py
+++ b/test/ir/inference/test_trt_convert_c_allreduce.py
@@ -26,7 +26,7 @@ class TestDistTRT(unittest.TestCase):
 
     def init_case(self):
         self.op_type = "all_reduce"
-        self.reduce_type = 0,
+        self.reduce_type = (0,)
         self.target_value = 4.0
         self.precision = "fp16"
 
@@ -63,7 +63,7 @@ class TestDistTRT(unittest.TestCase):
 class TestMin(TestDistTRT):
     def init_case(self):
         self.op_type = "all_reduce"
-        self.reduce_type = 5,
+        self.reduce_type = (5,)
         self.target_value = 2.0
         self.precision = "int8"
 

--- a/test/ir/pir/translator/test_all_reduce_translator.py
+++ b/test/ir/pir/translator/test_all_reduce_translator.py
@@ -24,17 +24,17 @@ paddle.pir_utils._switch_to_old_ir_()
 
 class TestCAllReduceMinOpTranslator(test_op_translator.TestOpTranslator):
     def append_op(self):
-        self.op_type = "c_allreduce_min"
+        self.op_type = "all_reduce"
         x = paddle.ones(shape=(100, 2, 3), dtype='float32')
         y = paddle.ones(shape=(100, 2, 3), dtype='float32')
         attrs = {
-            'reduce_type': 0,
+            'reduce_type': 5,
         }
         helper = LayerHelper(self.op_type)
         helper.append_op(
             type=self.op_type,
-            inputs={"X": x},
-            outputs={"Out": y},
+            inputs={"x": x},
+            outputs={"out": y},
             attrs=attrs,
         )
 

--- a/test/ir/pir/translator/test_c_allreduce_min_translator.py
+++ b/test/ir/pir/translator/test_c_allreduce_min_translator.py
@@ -24,19 +24,20 @@ paddle.pir_utils._switch_to_old_ir_()
 
 class TestCAllReduceMinOpTranslator(test_op_translator.TestOpTranslator):
     def append_op(self):
-        self.op_type = "c_allreduce_min"
+        self.op_type = "all_reduce"
         x = paddle.ones(shape=(100, 2, 3), dtype='float32')
         y = paddle.ones(shape=(100, 2, 3), dtype='float32')
         attrs = {
             'ring_id': 0,
+            'reduce_type': 5,
             'use_calc_stream': False,
             'use_model_parallel': False,
         }
         helper = LayerHelper(self.op_type)
         helper.append_op(
             type=self.op_type,
-            inputs={"X": x},
-            outputs={"Out": y},
+            inputs={"x": x},
+            outputs={"out": y},
             attrs=attrs,
         )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

1. replace `c_allreduce_min` and c_allreduce_max` with `all_reduce`

Pcard-70448