### PR TITLE
【Fix PIR Unittest No.38 BUAA】fix TruncatedNormalInitializer according to NormalInitializer and fix test_cuda_random_seed

### DIFF
--- a/python/paddle/nn/initializer/normal.py
+++ b/python/paddle/nn/initializer/normal.py
@@ -235,7 +235,9 @@ class TruncatedNormalInitializer(Initializer):
             The initialization op
         """
         block = self._check_block(block)
-        assert isinstance(var, (framework.Variable, paddle.pir.core.ParameterMeta))
+        assert isinstance(
+            var, (framework.Variable, paddle.pir.core.ParameterMeta)
+        )
         assert isinstance(block, (framework.Block, pir.Block))
 
         if self._seed == 0:
@@ -277,7 +279,7 @@ class TruncatedNormalInitializer(Initializer):
             else:
                 out_var._share_underline_tensor_to(var)
             return None
-        
+
         elif in_pir_mode():
             out_var = _C_ops.truncated_gaussian_random(
                 var.shape,

--- a/python/paddle/nn/initializer/normal.py
+++ b/python/paddle/nn/initializer/normal.py
@@ -234,10 +234,12 @@ class TruncatedNormalInitializer(Initializer):
         Returns:
             The initialization op
         """
+        assert not (
+            isinstance(var, framework.EagerParamBase) and var.is_dist()
+        ), "Currently, normal initializer not support lazy init for dist param."
         block = self._check_block(block)
 
-        assert isinstance(var, framework.Variable)
-        assert isinstance(block, framework.Block)
+        assert isinstance(block, (framework.Block, pir.Block))
 
         if self._seed == 0:
             self._seed = block.program.random_seed
@@ -278,6 +280,25 @@ class TruncatedNormalInitializer(Initializer):
             else:
                 out_var._share_underline_tensor_to(var)
             return None
+
+        elif in_pir_mode():
+            out_var = _C_ops.truncated_gaussian_random(
+                var.shape,
+                self._mean,
+                self._std_dev,
+                self._seed,
+                self._a,
+                self._b,
+                out_dtype,
+                _current_expected_place(),
+            )
+            if var.dtype in [
+                core.VarDesc.VarType.FP16,
+                core.VarDesc.VarType.BF16,
+            ]:
+                var_tmp = _C_ops.cast(out_var, var.dtype)
+                var_tmp._share_underline_tensor_to(var)
+            return out_var
 
         else:
             op = block.append_op(

--- a/python/paddle/nn/initializer/normal.py
+++ b/python/paddle/nn/initializer/normal.py
@@ -234,11 +234,8 @@ class TruncatedNormalInitializer(Initializer):
         Returns:
             The initialization op
         """
-        assert not (
-            isinstance(var, framework.EagerParamBase) and var.is_dist()
-        ), "Currently, normal initializer not support lazy init for dist param."
         block = self._check_block(block)
-
+        assert isinstance(var, (framework.Variable, paddle.pir.core.ParameterMeta))
         assert isinstance(block, (framework.Block, pir.Block))
 
         if self._seed == 0:
@@ -280,7 +277,7 @@ class TruncatedNormalInitializer(Initializer):
             else:
                 out_var._share_underline_tensor_to(var)
             return None
-
+        
         elif in_pir_mode():
             out_var = _C_ops.truncated_gaussian_random(
                 var.shape,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Others


### PR Types
Others 


### Description
<img width="912" alt="截屏2024-07-23 18 27 09" src="https://github.com/user-attachments/assets/b3c6fea6-08ee-4082-b7fb-abcb3eb47bb3">
首先遇到的是assertion value问题，仿照NormalInitializer类进行修改：

`assert isinstance(var, (framework.Variable, paddle.pir.core.ParameterMeta))`
`assert isinstance(block, (framework.Block, pir.Block))`
然后在forward中添加in_pir_mode分支进行pir适配