### PR TITLE
[CINN] Coalesce read for transpose+reduce fusion

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -94,6 +94,7 @@ std::shared_ptr<GroupInfo> OpLowererImpl::GetGroupInfo(
     const std::unordered_map<::pir::Value, ir::Tensor>& tensor_map) {
   std::shared_ptr<GroupInfo> group_info = std::make_shared<GroupInfo>();
   group_info->data_space = fusion_group_info.loop_ranges;
+  group_info->loop_transform_map = fusion_group_info.loop_transform_map;
   group_info->reduce_axis = fusion_group_info.reduce_axis;
   group_info->reduce_var_names =
       std::set<std::string>(fusion_group_info.reduce_var_name.begin(),
@@ -102,14 +103,6 @@ std::shared_ptr<GroupInfo> OpLowererImpl::GetGroupInfo(
   for (auto& val : group->output_values()) {
     group_info->direct_output_var_names.insert(ValueName(val));
   }
-
-  group->WalkOps([&group_info](::pir::Operation* op) {
-    if (CompatibleInfo::OpKind(*op) == OpPatternKind::kReduction) {
-      group_info->raw_reduce_axis = cinn::fusion::GetReduceAxisIdx(op);
-      group_info->raw_data_rank =
-          cinn::fusion::GetCompitableRank(op->operand_source(0));
-    }
-  });
   return group_info;
 }
 

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
@@ -50,8 +50,7 @@ typedef bool (OpLowererImpl::*ScheduleDetermineFunction)(::pir::Operation*);
 struct GroupInfo {
   std::vector<int64_t> data_space;
   std::vector<int64_t> reduce_axis;
-  int64_t raw_data_rank;
-  std::vector<int64_t> raw_reduce_axis;
+  std::vector<int64_t> loop_transform_map;
   std::set<std::string> reduce_var_names;
   std::set<std::string> shared_var_names;
   std::set<std::string> direct_output_var_names;

--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
@@ -165,6 +165,7 @@ std::vector<ir::Var> GetAllForIters(const ir::Expr& expr);
 
 struct FusionGroupInfo {
   std::vector<int64_t> loop_ranges;
+  std::vector<int64_t> loop_transform_map;
   std::vector<int64_t> reduce_axis;
   std::vector<std::string> reduce_var_name;
 

--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
@@ -282,6 +282,15 @@ ExprSetFinder ScheduleBlockRealizeIsInit = FilterMaker(
     },
     "ScheduleBlockRealizeIsInit");
 
+ExprSetFinder ScheduleBlockRealizeIsSplitTransform = FilterMaker(
+    [](const ir::Expr& e) -> bool {
+      return (e.As<ir::ScheduleBlockRealize>() &&
+              e.As<ir::ScheduleBlockRealize>()
+                      ->schedule_block.As<ir::ScheduleBlock>()
+                      ->name.find("_split_transform") != std::string::npos);
+    },
+    "ScheduleBlockRealizeIsSplitTransform");
+
 ExprSetFinder IsFor = FilterMaker(
     [](const ir::Expr& e) -> bool { return e.As<ir::For>(); }, "IsFor");
 

--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.h
@@ -163,6 +163,8 @@ extern ExprSetFinder ScheduleBlockRealizeIsNotInit;
 
 extern ExprSetFinder ScheduleBlockRealizeIsInit;
 
+extern ExprSetFinder ScheduleBlockRealizeIsSplitTransform;
+
 extern ExprSetFinder IsFor;
 
 extern ExprSetFinder ChildScheduleBlocks;

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -97,7 +97,7 @@ std::shared_ptr<ScheduleConfig::BaseInfo> InitBasicInfo(
   base_info->shared_var_names = group_info->shared_var_names;
   base_info->direct_output_var_names = group_info->direct_output_var_names;
   base_info->data_rank = group_info->data_space.size();
-  base_info->raw_data_rank = group_info->raw_data_rank;
+  base_info->loop_transform_map = group_info->loop_transform_map;
 
   std::set<int64_t> reduce_dim_loc;
   for (int64_t dim : group_info->reduce_axis) {
@@ -106,13 +106,6 @@ std::shared_ptr<ScheduleConfig::BaseInfo> InitBasicInfo(
     }
     base_info->reduce_axis.push_back(dim);
     reduce_dim_loc.insert(dim);
-  }
-
-  for (int64_t dim : group_info->raw_reduce_axis) {
-    if (dim < 0) {
-      dim += base_info->data_rank;
-    }
-    base_info->raw_reduce_axis.push_back(dim);
   }
 
   base_info->spatial_numel = 1;

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.h
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.h
@@ -31,9 +31,8 @@ using IterSpaceType = std::vector<std::pair<std::string, std::string>>;
 struct ScheduleConfig {
   struct BaseInfo {
     std::vector<int64_t> reduce_axis;
-    std::vector<int64_t> raw_reduce_axis;
+    std::vector<int64_t> loop_transform_map;
     int64_t data_rank;
-    int64_t raw_data_rank;
     int64_t reduce_numel;
     int64_t spatial_numel;
     bool has_dynamic_spatial{false};


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Performance


### Description
When `transpose` and `reduce` are fused in a `FusionOp`, the input and output have different axis order. CINN used to align the loops to the output, which made write coalesced and read not coalesced. However, as `reduce` reads much more than it writes, we will get better performance if we make read coalesced.

This PR reorders spatial/reduce loops to match the memory layout of input (instead of output) at the beginning of `TileFirstGeneralTactic`. The relation between loops and input is stored in the `loop_transform_map`.

pcard-85711