### PR TITLE
[Dy2St] Cleanup inplace related strategy

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1704,16 +1704,6 @@ void range_block_do(const Block *block, std::vector<int> range, F fn) {
   range_block_do(block, range, fn, [](Operation *op) { return false; });
 }
 
-template <typename K, typename V>
-bool ExistsInMapValues(const std::map<K, V> &m, V value) {
-  for (const auto &[k, v] : m) {
-    if (v == value) {
-      return true;
-    }
-  }
-  return false;
-}
-
 std::map<int, int> GetOpInplaceInfo(const pir::Operation *op) {
   std::map<int, int> inplace_info;
   if (!op->HasTrait<paddle::dialect::InplaceTrait>()) {
@@ -1745,100 +1735,6 @@ std::map<int, int> GetOpInplaceInfo(const pir::Operation *op) {
   }
 
   return inplace_info;
-}
-
-std::vector<std::vector<pir::Value>> GetOpInplaceChains(const Block *block) {
-  std::vector<std::vector<pir::Value>> inplace_chains;
-  std::map<pir::Value, int> value_to_inplace_chain_index;
-
-  for (auto &op : *block) {
-    pir::Walk(&op, [&](Operation *inner_op) {
-      auto op_inplace_info = GetOpInplaceInfo(inner_op);
-      for (auto &[out_idx, in_idx] : op_inplace_info) {
-        auto target_value = inner_op->results()[out_idx];
-        auto source_value = inner_op->operands()[in_idx].source();
-        VLOG(8) << "Inplace Mapping: " << Value2String(source_value) << " -> "
-                << Value2String(target_value);
-
-        if (value_to_inplace_chain_index.count(source_value) == 0 &&
-            value_to_inplace_chain_index.count(target_value) == 0) {
-          size_t chain_insertion_idx = inplace_chains.size();
-          inplace_chains.push_back({source_value, target_value});
-          value_to_inplace_chain_index.insert(
-              {source_value, chain_insertion_idx});
-          value_to_inplace_chain_index.insert(
-              {target_value, chain_insertion_idx});
-        } else {
-          PADDLE_ENFORCE_NE(
-              value_to_inplace_chain_index.count(source_value),
-              0,
-              phi::errors::Unavailable("source value should be in the chain"));
-          PADDLE_ENFORCE_EQ(value_to_inplace_chain_index.count(target_value),
-                            0,
-                            phi::errors::Unavailable(
-                                "target value should not be in the chain"));
-          size_t chain_insertion_idx =
-              value_to_inplace_chain_index[source_value];
-          inplace_chains[chain_insertion_idx].push_back(target_value);
-          value_to_inplace_chain_index.insert(
-              {target_value, chain_insertion_idx});
-        }
-      }
-    });
-  }
-  return inplace_chains;
-}
-
-std::optional<std::vector<pir::Value>> FindInplaceChain(
-    const std::vector<std::vector<pir::Value>> inplace_chains,
-    const pir::Value &value) {
-  if (value.impl() == nullptr) {
-    return std::nullopt;
-  }
-
-  for (auto &chain : inplace_chains) {
-    for (auto &v : chain) {
-      if (v == value) {
-        return chain;
-      }
-    }
-  }
-  return std::nullopt;
-}
-
-std::optional<pir::Value> FindInplaceSource(
-    const std::vector<std::vector<pir::Value>> inplace_chains,
-    pir::Value value) {
-  const auto &chain = FindInplaceChain(inplace_chains, value);
-  if (chain.has_value()) {
-    return chain.value()[0];
-  } else {
-    return std::nullopt;
-  }
-}
-
-std::map<pir::Value, pir::Value> ReplaceValueWithInplaceSource(
-    const std::vector<std::vector<pir::Value>> &source_domain,
-    std::vector<pir::Value> *target_values,
-    const std::vector<std::vector<pir::Value>> inplace_chains) {
-  std::map<pir::Value, pir::Value> replacements;
-  for (auto &target_value : *target_values) {
-    auto inplace_source = FindInplaceSource(inplace_chains, target_value);
-    if (!inplace_source.has_value()) {
-      continue;
-    }
-    for (auto &source_values : source_domain) {
-      if (std::find(source_values.begin(),
-                    source_values.end(),
-                    inplace_source.value()) != source_values.end()) {
-        VLOG(4) << "Replace " << Value2String(target_value) << " with "
-                << Value2String(inplace_source.value());
-        replacements.insert({target_value, inplace_source.value()});
-        target_value = inplace_source.value();
-      }
-    }
-  }
-  return replacements;
 }
 
 std::pair<std::vector<pir::Value>, std::unordered_set<pir::Value>>
@@ -1897,10 +1793,8 @@ using SplitedProgram = std::vector<std::shared_ptr<Program>>;
 using SplitedAttribute = std::map<std::string, std::vector<pir::Value>>;
 using SplitedResult = std::pair<SplitedProgram, SplitedAttribute>;
 
-static auto GetNoNeedBufferValue(
-    const ::pir::Block *whole_block,
-    std::vector<int> range,
-    const std::vector<std::vector<pir::Value>> &inplace_chains) {
+static auto GetNoNeedBufferValue(const ::pir::Block *whole_block,
+                                 std::vector<int> range) {
   // filter no need buffer values.
   std::unordered_set<::pir::Value> need_buffer_values;
   std::unordered_set<::pir::Value> no_need_buffer_values;
@@ -1935,29 +1829,16 @@ static auto GetNoNeedBufferValue(
           }
         }
       });
-  range_block_do(
-      whole_block,
-      range,
-      [&need_buffer_values, &no_need_buffer_values, &inplace_chains](
-          const ::pir::Operation *op) {
-        for (const auto &operand : op->operands_source()) {
-          const auto &chain = FindInplaceChain(inplace_chains, operand);
-          std::vector<pir::Value> chain_vec;
-          if (!chain.has_value()) {
-            chain_vec = {operand};
-          } else {
-            chain_vec = chain.value();
-          }
-
-          bool all = std::all_of(
-              chain_vec.begin(), chain_vec.end(), [&](const auto &v) {
-                return need_buffer_values.count(v) == 0;
-              });
-          if (all) {
-            no_need_buffer_values.insert(operand);
-          }
-        }
-      });
+  range_block_do(whole_block,
+                 range,
+                 [&need_buffer_values,
+                  &no_need_buffer_values](const ::pir::Operation *op) {
+                   for (const auto &operand : op->operands_source()) {
+                     if (need_buffer_values.count(operand) == 0) {
+                       no_need_buffer_values.insert(operand);
+                     }
+                   }
+                 });
   return std::vector<::pir::Value>(no_need_buffer_values.begin(),
                                    no_need_buffer_values.end());
 }
@@ -2080,26 +1961,11 @@ SplitedResult SplitForwardBackward(
   pir::IrContext *ctx = pir::IrContext::Instance();
   auto forward_program = std::make_shared<Program>(ctx);
   auto backward_program = std::make_shared<Program>(ctx);
-  std::vector<pir::Value> forward_outputs_mutable = forward_outputs;
   std::vector<pir::Value> middle_values;
   std::unordered_set<pir::Value> backward_inputs;
-  const auto &inplace_chains = GetOpInplaceChains(program.block());
   std::tie(middle_values, backward_inputs) = AnalysisMiddleVariable(
       program, forward_in_out_values, forward_range, backward_range);
 
-  // Replace inplace value with source value.
-  // NOTE(SigureMo): Why not process inplace value for forward_inputs in
-  // forward?
-  // Because all forward_inputs uses data op, after lower to kernel
-  // pass, the data op will following a non-inplace op shadow_feed, so we don't
-  // need to process inplace for forward_inputs in forward.
-  // Same reason for whole backward program, because all backward inputs are
-  // created by block kwargs, it also add a shadow_feed op after lower to kernel
-  // pass.
-  auto replacement_for_forward_middles = ReplaceValueWithInplaceSource(
-      {forward_params}, &middle_values, inplace_chains);
-  auto replacement_for_forward_outputs = ReplaceValueWithInplaceSource(
-      {forward_params}, &forward_outputs_mutable, inplace_chains);
   pir::Block &backward_block = *backward_program->block();
   bool has_backward = (backward_range[1] > backward_range[0]);
 
@@ -2172,9 +2038,8 @@ SplitedResult SplitForwardBackward(
   VLOG(4) << "start create forward outputs, inserting shadow_output ops.";
   std::for_each(
       middle_values.begin(), middle_values.end(), create_output_fn_forward);
-  std::for_each(forward_outputs_mutable.begin(),
-                forward_outputs_mutable.end(),
-                create_output_fn_forward);
+  std::for_each(
+      forward_outputs.begin(), forward_outputs.end(), create_output_fn_forward);
 
   pir::Block *forward_block = forward_program->block();
   const auto &forward_name_map = GetNameMap(forward_block);
@@ -2183,13 +2048,8 @@ SplitedResult SplitForwardBackward(
                           &backward_value_map,
                           &forward_value_map,
                           &forward_name_map,
-                          &replacement_for_forward_middles,
-                          &replacement_for_forward_outputs,
                           &counter](const pir::Value &v) {
-    if (v && !backward_value_map.count(v) &&
-        (backward_inputs.count(v) ||
-         ExistsInMapValues(replacement_for_forward_middles, v) ||
-         ExistsInMapValues(replacement_for_forward_outputs, v))) {
+    if (v && !backward_value_map.count(v) && (backward_inputs.count(v))) {
       auto forward_value = forward_value_map[v];
       std::string name = "input_" + std::to_string(counter++);
       if (forward_name_map.count(forward_value)) {
@@ -2205,9 +2065,8 @@ SplitedResult SplitForwardBackward(
     VLOG(4)
         << "Create keyword argument for backward program: fo, start with input_"
         << counter;
-    std::for_each(forward_outputs_mutable.begin(),
-                  forward_outputs_mutable.end(),
-                  create_kwarg_fn);
+    std::for_each(
+        forward_outputs.begin(), forward_outputs.end(), create_kwarg_fn);
     VLOG(4)
         << "Create keyword argument for backward program: fx, start with input_"
         << counter;
@@ -2230,19 +2089,6 @@ SplitedResult SplitForwardBackward(
                   create_kwarg_fn);
     VLOG(4) << "Create keyword argument for backward program end. input_"
             << counter;
-
-    // Update the value map with inplace source value.
-    VLOG(4) << "start update inplace names";
-    VLOG(4) << "replacement_for_forward_middles size is: "
-            << replacement_for_forward_middles.size();
-    for (auto &[target, source] : replacement_for_forward_middles) {
-      backward_value_map[target] = backward_value_map.at(source);
-    }
-    VLOG(4) << "replacement_for_forward_outputs size is: "
-            << replacement_for_forward_outputs.size();
-    for (auto &[target, source] : replacement_for_forward_outputs) {
-      backward_value_map[target] = backward_value_map.at(source);
-    }
   }
 
   // Step2. copy backward ops .
@@ -2278,24 +2124,23 @@ SplitedResult SplitForwardBackward(
 
   // construct all attributes we needed.
 
-  mapping_value(middle_values, forward_value_map, fm);            // write 'fm'
-  mapping_value(middle_values, backward_value_map, bm);           // write 'bm'
-  mapping_value(forward_inputs, forward_value_map, fx);           // write 'fx'
-  mapping_value(forward_inputs, backward_value_map, bx);          // write 'bx'
-  mapping_value(forward_params, forward_value_map, fp);           // write 'fp'
-  mapping_value(forward_params, backward_value_map, bp);          // write 'bp'
-  mapping_value(forward_outputs_mutable, forward_value_map, fo);  // write 'fo'
+  mapping_value(middle_values, forward_value_map, fm);    // write 'fm'
+  mapping_value(middle_values, backward_value_map, bm);   // write 'bm'
+  mapping_value(forward_inputs, forward_value_map, fx);   // write 'fx'
+  mapping_value(forward_inputs, backward_value_map, bx);  // write 'bx'
+  mapping_value(forward_params, forward_value_map, fp);   // write 'fp'
+  mapping_value(forward_params, backward_value_map, bp);  // write 'bp'
+  mapping_value(forward_outputs, forward_value_map, fo);  // write 'fo'
   mapping_value(
       forward_inputs_grads, backward_value_map, bx_g);  // write 'bx_g'
   mapping_value(
       forward_params_grads, backward_value_map, bp_g);  // write 'bp_g'
   mapping_value(
-      forward_outputs_grads, backward_value_map, bo_g);  // write 'bo_g'
-  mapping_value(forward_outputs_mutable, backward_value_map, bo);  // write 'bo'
-  mapping_value(
-      GetNoNeedBufferValue(program.block(), backward_range, inplace_chains),
-      forward_value_map,
-      no_need_buffer_values);  // write 'no_need_buffers'
+      forward_outputs_grads, backward_value_map, bo_g);    // write 'bo_g'
+  mapping_value(forward_outputs, backward_value_map, bo);  // write 'bo'
+  mapping_value(GetNoNeedBufferValue(program.block(), backward_range),
+                forward_value_map,
+                no_need_buffer_values);  // write 'no_need_buffers'
 
   std::map<std::string, std::vector<pir::Value>> attr = {
       {"fx", fx},


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

执行器中原来对于多个 inplace 的 Value，只会有同一个 Variable，这就导致了从 IR 层面的 Value 和执行层面的 Variable 是可能有 diff 的，为了确保 inplace 的 Value 的 name 唯一性、no need buffer 属性正确性等，动转静层做了很多额外的操作，这包括了 #62300、#63040、#63753、#63625 等等

#65491 终于对 inplace 进行改造，inplace 的 Value 之间是不同的 Variable，因此动转静层很多逻辑都可以清掉了

PCard-66972