### PR TITLE
【Fix PIR Unittest 】fix some pir ut 

### DIFF
--- a/test/amp/test_amp_api.py
+++ b/test/amp/test_amp_api.py
@@ -463,10 +463,10 @@ class TestDy2STWithSetValue(AmpTestBase):
         if not paddle.framework.use_pir_api():
             return
         expected_fp16_calls = {
-            "cast": 1,
-            "layer_norm": 1,
-            "scale": 3,
-            "set_value": 1,
+            "pd_op.cast_": 1,
+            "pd_op.layer_norm": 1,
+            "pd_op.scale": 3,
+            "pd_op.set_value_with_tensor_": 1,
         }
 
         func = SimpleModelIncludeSetValue()
@@ -477,13 +477,10 @@ class TestDy2STWithSetValue(AmpTestBase):
         with paddle.amp.auto_cast(level='O2'):
             res = func(input)
             loss = res.sum()
-            prog = func.forward.get_concrete_program(input)[1].program.program
-            # amp.debugging.collect_operator_stats(prog)
-            # op_stats_list = amp.debugging._get_op_stats_list(prog)
+            paddle.amp.debugging.disable_operator_stats_collection()
+            op_stats = paddle.base.core.get_low_precision_op_list()
         loss.backward()
-        # self._check_op_calls(
-        #     op_stats_list, expected_fp16_calls=expected_fp16_calls
-        # )
+        self._check_op_calls(op_stats, expected_fp16_calls=expected_fp16_calls)
 
 
 if __name__ == '__main__':

--- a/test/amp/test_amp_api.py
+++ b/test/amp/test_amp_api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from contextlib import contextmanager
 
 import numpy as np
 from amp_base_models import AmpTestBase
@@ -413,6 +414,16 @@ class SimpleModelIncludeSetValue(nn.Layer):
         return z
 
 
+# Copy from ../dygraph_to_static/dygraph_to_static_utils.py
+@contextmanager
+def pir_dygraph_guard():
+    in_dygraph_mode = paddle.in_dynamic_mode()
+    with paddle.pir_utils.IrGuard():
+        if in_dygraph_mode:
+            paddle.disable_static()
+        yield
+
+
 @unittest.skipIf(
     not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
     "Require compiled with CUDA or XPU.",
@@ -448,7 +459,7 @@ class TestDy2STWithSetValue(AmpTestBase):
         func = paddle.jit.to_static(func, full_graph=True)
         input = paddle.randn((2, 3))
 
-        with paddle.amp.auto_cast(level='O2'):
+        with paddle.amp.auto_cast(level='O2', use_promote=False):
             res = func(input)
             loss = res.sum()
             prog = func.forward.get_concrete_program(input)[1].forward_program
@@ -460,27 +471,31 @@ class TestDy2STWithSetValue(AmpTestBase):
         )
 
     def test_pir_op_called_as_expected(self):
-        if not paddle.framework.use_pir_api():
-            return
         expected_fp16_calls = {
             "pd_op.cast_": 1,
             "pd_op.layer_norm": 1,
-            "pd_op.scale": 3,
+            "pd_op.scale": 1,
+            "pd_op.scale_": 2,
             "pd_op.set_value_with_tensor_": 1,
         }
 
-        func = SimpleModelIncludeSetValue()
-        func = paddle.amp.decorate(func, level='O2')
-        func = paddle.jit.to_static(func, full_graph=True)
-        input = paddle.randn((2, 3))
+        with pir_dygraph_guard():
+            func = SimpleModelIncludeSetValue()
+            func = paddle.amp.decorate(func, level='O2')
+            func = paddle.jit.to_static(func, full_graph=True)
+            input = paddle.randn((2, 3))
 
-        with paddle.amp.auto_cast(level='O2'):
-            res = func(input)
-            loss = res.sum()
-            paddle.amp.debugging.disable_operator_stats_collection()
-            op_stats = paddle.base.core.get_low_precision_op_list()
-        loss.backward()
-        self._check_op_calls(op_stats, expected_fp16_calls=expected_fp16_calls)
+            paddle.amp.debugging.enable_operator_stats_collection()
+            with paddle.amp.auto_cast(level='O2', use_promote=False):
+                res = func(input)
+                loss = res.sum()
+                paddle.amp.debugging.disable_operator_stats_collection()
+                op_stats = paddle.base.core.get_low_precision_op_list()
+
+            loss.backward()
+            self._check_op_calls(
+                op_stats, expected_fp16_calls=expected_fp16_calls
+            )
 
 
 if __name__ == '__main__':

--- a/test/amp/test_amp_api.py
+++ b/test/amp/test_amp_api.py
@@ -394,7 +394,7 @@ class TestFp16Guard(AmpTestBase):
             paddle.is_compiled_with_xpu()
             and len(paddle.static.xpu_places()) > 0
         ):
-            with paddle.pir_utils.IrGuard():
+            with paddle.pir_utils.OldIrGuard():
                 run_example_code()
         paddle.disable_static()
 

--- a/test/amp/test_amp_list.py
+++ b/test/amp/test_amp_list.py
@@ -141,14 +141,28 @@ class TestAMPList(unittest.TestCase):
             self.assertEqual(
                 fp16_lists.get_low_precision_dtypestr(dtype), dtype
             )
-        self.assertEqual(
-            fp16_lists.get_low_precision_dtypestr(core.VarDesc.VarType.FP16),
-            "float16",
-        )
-        self.assertEqual(
-            fp16_lists.get_low_precision_dtypestr(core.VarDesc.VarType.BF16),
-            "bfloat16",
-        )
+        if paddle.framework.use_pir_api():
+            self.assertEqual(
+                fp16_lists.get_low_precision_dtypestr(core.DataType.FLOAT16),
+                "float16",
+            )
+            self.assertEqual(
+                fp16_lists.get_low_precision_dtypestr(core.DataType.BFLOAT16),
+                "bfloat16",
+            )
+        else:
+            self.assertEqual(
+                fp16_lists.get_low_precision_dtypestr(
+                    core.VarDesc.VarType.FP16
+                ),
+                "float16",
+            )
+            self.assertEqual(
+                fp16_lists.get_low_precision_dtypestr(
+                    core.VarDesc.VarType.BF16
+                ),
+                "bfloat16",
+            )
 
         def _run_get_dtypestr():
             fp16_lists.get_low_precision_dtypestr(dtype="int64")

--- a/test/amp/test_amp_promote.py
+++ b/test/amp/test_amp_promote.py
@@ -94,14 +94,15 @@ class TestStaticAmpPromoteStats(AmpTestBase):
             "reduce_mean": 0,
             "adamw": 0,
         }
-        self.check_promote_results(
-            True,
-            'float16',
-            'O1',
-            use_promote=True,
-            expected_op_calls=expected_fp16_calls,
-            debug_info="TestStaticAmpPromoteStats/test_static_amp_o1",
-        )
+        with paddle.pir_utils.OldIrGuard():
+            self.check_promote_results(
+                True,
+                'float16',
+                'O1',
+                use_promote=True,
+                expected_op_calls=expected_fp16_calls,
+                debug_info="TestStaticAmpPromoteStats/test_static_amp_o1",
+            )
 
     def test_static_amp_o2(self):
         expected_fp16_calls = {
@@ -113,14 +114,15 @@ class TestStaticAmpPromoteStats(AmpTestBase):
             "reduce_mean": 1,
             "adamw": 4,
         }
-        self.check_promote_results(
-            True,
-            'float16',
-            'O2',
-            use_promote=True,
-            expected_op_calls=expected_fp16_calls,
-            debug_info="TestStaticAmpPromoteStats/test_static_amp_o2",
-        )
+        with paddle.pir_utils.OldIrGuard():
+            self.check_promote_results(
+                True,
+                'float16',
+                'O2',
+                use_promote=True,
+                expected_op_calls=expected_fp16_calls,
+                debug_info="TestStaticAmpPromoteStats/test_static_amp_o2",
+            )
 
 
 @unittest.skipIf(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
- 给旧静态图 amp 测试加上 OldIrGuard
- 同时 test_pir_op_called_as_expected 增加 PIR 单测，其中在旧单测下存在传参错误的问题，旧IR动转静时use_promote=True，但是在调用pass的时候是False，PIR没有传参问题需要传入False
- 如果要在动转静场景下使用 PIR 测试(不在 test\dygraph_to_static 目录下)，可以根据 `test\dygraph_to_static\dygraph_to_static_utils.py` 中进行设置（少数情况
```python
@contextmanager
def pir_dygraph_guard():
    in_dygraph_mode = paddle.in_dynamic_mode()
    with paddle.pir_utils.IrGuard():
        if in_dygraph_mode:
            paddle.disable_static()
        yield

```