### PR TITLE
[PIR][CSE] Use copied value for `ShadowOutputOp` only

### DIFF
--- a/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.h"
-#include <algorithm>
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

CSE 中，当被替换的 OP 被 `ShadowOutputOp` 使用时，我们会创建一个 AssignOp 来 copy，并 `ReplaceAllUsesWith` 这个 copy 后的 value，这会导致一些 OP 比如 gather 原本输入是 full，现在变成了一个非预期的 assign，会对下游 pass 造成一定影响，因此仅仅在 ShadowOutput 这里使用 copy 后的 value，其他的地方还用原来的 value，避免出现这个问题

PCard-66972