### PR TITLE
【Fix PIR Unittest No.82 BUAA】fix test_standalone_custom_event.py

### DIFF
--- a/test/standalone_executor/test_standalone_custom_event.py
+++ b/test/standalone_executor/test_standalone_custom_event.py
@@ -183,9 +183,13 @@ class TestMannulEvent(unittest.TestCase):
         with paddle.pir_utils.OldIrGuard():
             baselines = self.run_program()
             stream_outs = self.run_program(apply_custom_stream=True)
-            split_outs = self.run_program(apply_custom_stream=True, split_prog=True)
+            split_outs = self.run_program(
+                apply_custom_stream=True, split_prog=True
+            )
             manual_outs = self.run_program(
-                apply_custom_stream=True, split_prog=True, apply_manual_event=True
+                apply_custom_stream=True, 
+                split_prog=True, 
+                apply_manual_event=True,
             )
             for bl, out0, out1, out2 in zip(
                 baselines, stream_outs, split_outs, manual_outs

--- a/test/standalone_executor/test_standalone_custom_event.py
+++ b/test/standalone_executor/test_standalone_custom_event.py
@@ -187,8 +187,8 @@ class TestMannulEvent(unittest.TestCase):
                 apply_custom_stream=True, split_prog=True
             )
             manual_outs = self.run_program(
-                apply_custom_stream=True, 
-                split_prog=True, 
+                apply_custom_stream=True,
+                split_prog=True,
                 apply_manual_event=True,
             )
             for bl, out0, out1, out2 in zip(

--- a/test/standalone_executor/test_standalone_custom_event.py
+++ b/test/standalone_executor/test_standalone_custom_event.py
@@ -180,19 +180,19 @@ class TestMannulEvent(unittest.TestCase):
     def test_result(self):
         if not core.is_compiled_with_cuda():
             return
-
-        baselines = self.run_program()
-        stream_outs = self.run_program(apply_custom_stream=True)
-        split_outs = self.run_program(apply_custom_stream=True, split_prog=True)
-        manual_outs = self.run_program(
-            apply_custom_stream=True, split_prog=True, apply_manual_event=True
-        )
-        for bl, out0, out1, out2 in zip(
-            baselines, stream_outs, split_outs, manual_outs
-        ):
-            self.assertEqual(bl[0], out0[0])
-            self.assertEqual(bl[0], out2[0])
-            # self.assertNotEqual(bl[0], out1[0])
+        with paddle.pir_utils.OldIrGuard():
+            baselines = self.run_program()
+            stream_outs = self.run_program(apply_custom_stream=True)
+            split_outs = self.run_program(apply_custom_stream=True, split_prog=True)
+            manual_outs = self.run_program(
+                apply_custom_stream=True, split_prog=True, apply_manual_event=True
+            )
+            for bl, out0, out1, out2 in zip(
+                baselines, stream_outs, split_outs, manual_outs
+            ):
+                self.assertEqual(bl[0], out0[0])
+                self.assertEqual(bl[0], out2[0])
+                # self.assertNotEqual(bl[0], out1[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Others


### PR Types
Bug fixes 


### Description
遇到AttributeError: 'paddle.base.libpaddle.pir.Block' object has no attribute 'vars'问题，和导师交流后用with paddle.pir_utils.OldIrGuard():包裹，后续等待进一步修复
