### PR TITLE
[Prim] fix the stack op bug in the old IR

### DIFF
--- a/test/legacy_test/test_stack_op.py
+++ b/test/legacy_test/test_stack_op.py
@@ -390,19 +390,20 @@ class TestStackAPI_ZeroDim(unittest.TestCase):
         paddle.enable_static()
 
 
-# class TestStackListOfSingleTensor(unittest.TestCase):
-#     def setUp(self):
-#         paddle.disable_static()
-#         paddle.seed(2022)
-#         self.x = [paddle.randn((4, 2, 6), dtype="float32")]
+class TestStackListOfSingleTensor(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+        paddle.seed(2022)
+        self.x = [paddle.randn((4, 2, 6), dtype="float32")]
+        self.x[0].stop_gradient = False
 
-#     def test_list_single_tensor(self):
-#         expect = paddle.stack(self.x)
-#         paddle.base.core._set_prim_all_enabled(True)
-#         st_model = paddle.jit.to_static(paddle.stack, full_graph=True)
-#         actual = st_model(self.x)
-#         np.testing.assert_allclose(expect, actual)
-#         paddle.enable_static()
+    def test_list_single_tensor(self):
+        expect = paddle.stack(self.x)
+        paddle.base.core._set_prim_all_enabled(True)
+        st_model = paddle.jit.to_static(paddle.stack, full_graph=True)
+        actual = st_model(self.x)
+        np.testing.assert_allclose(expect, actual)
+        paddle.enable_static()
 
 
 class TestPrimStackGrad(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

当Tensor不开启梯度计算时，在旧IR下梯度初始化似乎不是初始化为空值，而是初始化成一个维度为[]的Tensor，这旧导致了其会进入到反向计算prim拆解的流程中，而其中涉及到了一个对梯度（维度为[]）reshape操作，这就导致了这个测试失败。因此需要在初始化变量时开启梯度计算