### PR TITLE
[CINN][new hardware] check compile option in target Constructor

### DIFF
--- a/paddle/cinn/common/target.cc
+++ b/paddle/cinn/common/target.cc
@@ -38,7 +38,24 @@ Target::Target(OS o,
                Bit b,
                const std::vector<Feature> &features,
                const std::vector<Lib> &libs)
-    : os(o), arch(a), bits(b), features(features), libs(libs) {}
+    : os(o), arch(a), bits(b), features(features), libs(libs) {
+  // check compile option
+  arch.Match([&](UnknownArch) {},
+             [&](X86Arch) {},
+             [&](ARMArch) {},
+             [&](NVGPUArch) {
+#ifndef CINN_WITH_CUDA
+               PADDLE_THROW(phi::errors::Unimplemented(
+                   "Please recompile with flag WITH_GPU and WITH_CINN."));
+#endif
+             },
+             [&](HygonDCUArchHIP) {
+#ifndef CINN_WITH_HIP
+               PADDLE_THROW(phi::errors::Unimplemented(
+                   "Please recompile with flag WITH_ROCM and WITH_CINN."));
+#endif
+             });
+}
 
 bool Target::operator==(const Target &other) const {
   return os == other.os &&      //


### PR DESCRIPTION
### PR Category
CINN


### PR Types
Improvements


### Description
在Target的构造函数处检查宏`CINN_WITH_*`，这样做有以下好处：

- 尽早报错
- 集中检查`CINN_WITH_*`，可以确保使用`target.arch.Match`时`arch`对应宏已开启，因此在模式匹配时无需考虑`CINN_WITH_*`未设置的异常。

Pcard-67164
