### PR TITLE
【Fix PIR Unittest】fix some public API and inference UT in pir

### DIFF
--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -307,3 +307,55 @@ if(WITH_GPU AND TENSORRT_FOUND)
     endif()
   endif()
 endif()
+
+if(WITH_GPU AND TENSORRT_FOUND)
+  if(WITH_ONEDNN)
+    py_test_modules(test_matmul_scale_fuse_pass_pir MODULES
+                    test_matmul_scale_fuse_pass ENVS FLAGS_enable_pir_api=1)
+    if(WIN32)
+      set_tests_properties(test_matmul_scale_fuse_pass_pir PROPERTIES TIMEOUT
+                                                                      300)
+    else()
+      py_test_modules(
+        test_matmul_v2_scale_fuse_pass_pir MODULES
+        test_matmul_v2_scale_fuse_pass ENVS FLAGS_enable_pir_api=1)
+      set_tests_properties(test_matmul_scale_fuse_pass_pir PROPERTIES TIMEOUT
+                                                                      60)
+      set_tests_properties(test_matmul_v2_scale_fuse_pass_pir PROPERTIES TIMEOUT
+                                                                         120)
+    endif()
+    if(WIN32 AND WIN_UNITTEST_LEVEL LESS 2)
+      message(STATUS "Skip tests unrelated to CUDA/TRT")
+    else()
+      set(PIR_COVERAGE_MKLDNN_TESTS
+          test_mkldnn_conv_affine_channel_fuse_pass
+          test_mkldnn_conv_gelu_fuse_pass
+          test_mkldnn_conv_hard_sigmoid_fuse_pass
+          test_mkldnn_conv_hard_swish_fuse_pass
+          test_mkldnn_conv_mish_fuse_pass
+          test_mkldnn_conv_transpose_bias_fuse_pass
+          test_mkldnn_conv3d_op
+          test_mkldnn_depthwise_conv_pass)
+      foreach(target ${PIR_COVERAGE_MKLDNN_TESTS})
+        py_test_modules(${target}_pir MODULES ${target} ENVS
+                        FLAGS_enable_pir_api=1)
+        set_tests_properties(${target} PROPERTIES LABELS "RUN_TYPE=INFER")
+        message(STATUS "PIR Copied Test: ${target}_pir in inference test")
+      endforeach()
+
+      set_tests_properties(test_mkldnn_conv_affine_channel_fuse_pass_pir
+                           PROPERTIES TIMEOUT 120)
+      set_tests_properties(test_mkldnn_conv_hard_sigmoid_fuse_pass_pir
+                           PROPERTIES TIMEOUT 300)
+      set_tests_properties(test_mkldnn_conv_hard_swish_fuse_pass_pir
+                           PROPERTIES TIMEOUT 300)
+      set_tests_properties(test_mkldnn_conv_mish_fuse_pass_pir
+                           PROPERTIES TIMEOUT 300)
+      set_tests_properties(test_mkldnn_conv_transpose_bias_fuse_pass_pir
+                           PROPERTIES TIMEOUT 100)
+      set_tests_properties(test_mkldnn_conv3d_op_pir PROPERTIES TIMEOUT 300)
+      set_tests_properties(test_mkldnn_depthwise_conv_pass_pir
+                           PROPERTIES TIMEOUT 120)
+    endif()
+  endif()
+endif()

--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -345,6 +345,8 @@ if(WITH_GPU AND TENSORRT_FOUND)
 
       set_tests_properties(test_mkldnn_conv_affine_channel_fuse_pass_pir
                            PROPERTIES TIMEOUT 120)
+      set_tests_properties(test_mkldnn_conv_gelu_fuse_pass_pir
+                           PROPERTIES TIMEOUT 300)
       set_tests_properties(test_mkldnn_conv_hard_sigmoid_fuse_pass_pir
                            PROPERTIES TIMEOUT 300)
       set_tests_properties(test_mkldnn_conv_hard_swish_fuse_pass_pir

--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -132,18 +132,19 @@ class AutoScanTest(unittest.TestCase):
         """
         Test a single case.
         """
-        pred_config.set_model_buffer(model, len(model), params, len(params))
-        predictor = paddle_infer.create_predictor(pred_config)
-        self.available_passes_in_framework = (
-            self.available_passes_in_framework
-            | set(pred_config.pass_builder().all_passes())
-        )
-        for name, _ in prog_config.inputs.items():
-            input_tensor = predictor.get_input_handle(name)
-            input_tensor.copy_from_cpu(feed_data[name]["data"])
-            if feed_data[name]["lod"] is not None:
-                input_tensor.set_lod(feed_data[name]["lod"])
-        predictor.run()
+        with paddle.pir_utils.OldIrGuard():
+            pred_config.set_model_buffer(model, len(model), params, len(params))
+            predictor = paddle_infer.create_predictor(pred_config)
+            self.available_passes_in_framework = (
+                self.available_passes_in_framework
+                | set(pred_config.pass_builder().all_passes())
+            )
+            for name, _ in prog_config.inputs.items():
+                input_tensor = predictor.get_input_handle(name)
+                input_tensor.copy_from_cpu(feed_data[name]["data"])
+                if feed_data[name]["lod"] is not None:
+                    input_tensor.set_lod(feed_data[name]["lod"])
+            predictor.run()
         result = {}
         for out_name, o_name in zip(
             prog_config.outputs, predictor.get_output_names()

--- a/test/ir/inference/program_config.py
+++ b/test/ir/inference/program_config.py
@@ -350,133 +350,147 @@ def create_fake_model(program_config):
     program_config = copy.deepcopy(program_config)
     program_config._cast()
     paddle.enable_static()
-    main_program_desc = core.ProgramDesc()
-    util_program = base.Program()
-    main_block_desc = main_program_desc.block(0)
+    with paddle.pir_utils.OldIrGuard():
+        main_program_desc = core.ProgramDesc()
+        # util_program = base.Program()
+        util_program = paddle.static.Program()
+        main_block_desc = main_program_desc.block(0)
 
-    var_desc = main_block_desc.var(b"feed")
-    var_desc.set_type(core.VarDesc.VarType.FEED_MINIBATCH)
-    var_desc.set_persistable(True)
-
-    index = 0
-    for name, tensor_config in program_config.inputs.items():
-        var_desc = main_block_desc.var(name.encode())
-        var_desc.set_type(core.VarDesc.VarType.LOD_TENSOR)
-        var_desc.set_dtype(convert_np_dtype_to_proto_type(tensor_config.dtype))
-        var_desc.set_shape(tensor_config.shape)
-        var_desc.set_need_check_feed(True)
-        if tensor_config.lod is not None:
-            var_desc.set_lod_level(len(tensor_config.lod))
-        op_desc = main_block_desc._prepend_op()
-        op_desc.set_type("feed")
-        op_desc.set_input('X', ["feed"])
-        op_desc.set_output('Out', [name])
-        op_desc._set_attr("col", index)
-        index = index + 1
-
-    save_var_map = {}
-    for name, tensor_config in program_config.weights.items():
-        var_desc = main_block_desc.var(name.encode())
-        var_desc.set_type(core.VarDesc.VarType.LOD_TENSOR)
-        var_desc.set_dtype(convert_np_dtype_to_proto_type(tensor_config.dtype))
-        var_desc.set_shape(tensor_config.shape)
+        var_desc = main_block_desc.var(b"feed")
+        var_desc.set_type(core.VarDesc.VarType.FEED_MINIBATCH)
         var_desc.set_persistable(True)
 
-        save_var_map[name] = util_program.global_block().create_parameter(
-            dtype=tensor_config.dtype,
-            shape=tensor_config.shape,
-            type=core.VarDesc.VarType.LOD_TENSOR,
-            name=name,
-            initializer=paddle.nn.initializer.Assign(tensor_config.data),
-        )
-    in_vars = []
-    for name in sorted(save_var_map.keys()):
-        in_vars.append(save_var_map[name])
-
-    out_var = util_program.global_block().create_var(
-        type=core.VarDesc.VarType.RAW, name="out_var_0"
-    )
-    out_var.desc.set_persistable(True)
-    util_program.global_block().append_op(
-        type='save_combine',
-        inputs={'X': in_vars},
-        outputs={'Y': out_var},
-        attrs={'file_path': '', 'save_to_memory': True},
-    )
-    for op_config in program_config.ops:
-        op_desc = main_block_desc.append_op()
-        op_desc.set_type(op_config.type)
-        # canonicalize scalar attrs
-        if OpProtoHolder.instance().has_op_proto(op_config.type):
-            proto = OpProtoHolder.instance().get_op_proto(op_config.type)
-            canonicalized_attrs = framework.canonicalize_attrs(
-                op_config.attrs, proto
+        index = 0
+        for name, tensor_config in program_config.inputs.items():
+            var_desc = main_block_desc.var(name.encode())
+            var_desc.set_type(core.VarDesc.VarType.LOD_TENSOR)
+            var_desc.set_dtype(
+                convert_np_dtype_to_proto_type(tensor_config.dtype)
             )
-        else:
-            canonicalized_attrs = op_config.attrs
+            var_desc.set_shape(tensor_config.shape)
+            var_desc.set_need_check_feed(True)
+            if tensor_config.lod is not None:
+                var_desc.set_lod_level(len(tensor_config.lod))
+            op_desc = main_block_desc._prepend_op()
+            op_desc.set_type("feed")
+            op_desc.set_input('X', ["feed"])
+            op_desc.set_output('Out', [name])
+            op_desc._set_attr("col", index)
+            index = index + 1
 
-        for name, values in op_config.inputs.items():
-            op_desc.set_input(name, values)
-        for name, values in canonicalized_attrs.items():
-            if name == 'sub_block':
-                sub_block_desc = main_program_desc.append_block(main_block_desc)
-                values.fill_block_desc(sub_block_desc)
-                op_desc._set_attr(name, sub_block_desc)
+        save_var_map = {}
+        for name, tensor_config in program_config.weights.items():
+            var_desc = main_block_desc.var(name.encode())
+            var_desc.set_type(core.VarDesc.VarType.LOD_TENSOR)
+            var_desc.set_dtype(
+                convert_np_dtype_to_proto_type(tensor_config.dtype)
+            )
+            var_desc.set_shape(tensor_config.shape)
+            var_desc.set_persistable(True)
+
+            save_var_map[name] = util_program.global_block().create_parameter(
+                dtype=tensor_config.dtype,
+                shape=tensor_config.shape,
+                type=core.VarDesc.VarType.LOD_TENSOR,
+                name=name,
+                initializer=paddle.nn.initializer.Assign(tensor_config.data),
+            )
+        in_vars = []
+        for name in sorted(save_var_map.keys()):
+            in_vars.append(save_var_map[name])
+
+        out_var = util_program.global_block().create_var(
+            type=core.VarDesc.VarType.RAW, name="out_var_0"
+        )
+        out_var.desc.set_persistable(True)
+        util_program.global_block().append_op(
+            type='save_combine',
+            inputs={'X': in_vars},
+            outputs={'Y': out_var},
+            attrs={'file_path': '', 'save_to_memory': True},
+        )
+        for op_config in program_config.ops:
+            op_desc = main_block_desc.append_op()
+            op_desc.set_type(op_config.type)
+            # canonicalize scalar attrs
+            if OpProtoHolder.instance().has_op_proto(op_config.type):
+                proto = OpProtoHolder.instance().get_op_proto(op_config.type)
+                canonicalized_attrs = framework.canonicalize_attrs(
+                    op_config.attrs, proto
+                )
             else:
-                op_desc._set_attr(name, values)
-        for name, values in op_config.outputs.items():
-            op_desc.set_output(name, values)
-            for v in values:
-                if main_block_desc.has_var_recursive(v.encode()):
-                    continue
-                var_desc = main_block_desc.var(v.encode())
-                var_desc.set_type(core.VarDesc.VarType.LOD_TENSOR)
-                if (
-                    op_config.outputs_var_type is not None
-                    and v in op_config.outputs_var_type.keys()
-                ):
-                    if (
-                        op_config.outputs_var_type[v]
-                        == VarType.LOD_TENSOR_ARRAY
-                    ):
-                        var_desc.set_type(core.VarDesc.VarType.LOD_TENSOR_ARRAY)
-                    elif op_config.outputs_var_type[v] == VarType.STEP_SCOPES:
-                        var_desc.set_type(core.VarDesc.VarType.STEP_SCOPES)
-                        continue
-                var_desc.set_dtype(convert_np_dtype_to_proto_type(np.float32))
-                if (
-                    op_config.outputs_dtype is not None
-                    and v in op_config.outputs_dtype.keys()
-                ):
-                    var_desc.set_dtype(
-                        convert_np_dtype_to_proto_type(
-                            op_config.outputs_dtype[v]
-                        )
+                canonicalized_attrs = op_config.attrs
+
+            for name, values in op_config.inputs.items():
+                op_desc.set_input(name, values)
+            for name, values in canonicalized_attrs.items():
+                if name == 'sub_block':
+                    sub_block_desc = main_program_desc.append_block(
+                        main_block_desc
                     )
-        if op_config.type not in _OP_WITHOUT_KERNEL_SET:
-            op_desc.infer_var_type(main_block_desc)
-            op_desc.infer_shape(main_block_desc)
-        op_desc.check_attrs()
+                    values.fill_block_desc(sub_block_desc)
+                    op_desc._set_attr(name, sub_block_desc)
+                else:
+                    op_desc._set_attr(name, values)
+            for name, values in op_config.outputs.items():
+                op_desc.set_output(name, values)
+                for v in values:
+                    if main_block_desc.has_var_recursive(v.encode()):
+                        continue
+                    var_desc = main_block_desc.var(v.encode())
+                    var_desc.set_type(core.VarDesc.VarType.LOD_TENSOR)
+                    if (
+                        op_config.outputs_var_type is not None
+                        and v in op_config.outputs_var_type.keys()
+                    ):
+                        if (
+                            op_config.outputs_var_type[v]
+                            == VarType.LOD_TENSOR_ARRAY
+                        ):
+                            var_desc.set_type(
+                                core.VarDesc.VarType.LOD_TENSOR_ARRAY
+                            )
+                        elif (
+                            op_config.outputs_var_type[v] == VarType.STEP_SCOPES
+                        ):
+                            var_desc.set_type(core.VarDesc.VarType.STEP_SCOPES)
+                            continue
+                    var_desc.set_dtype(
+                        convert_np_dtype_to_proto_type(np.float32)
+                    )
+                    if (
+                        op_config.outputs_dtype is not None
+                        and v in op_config.outputs_dtype.keys()
+                    ):
+                        var_desc.set_dtype(
+                            convert_np_dtype_to_proto_type(
+                                op_config.outputs_dtype[v]
+                            )
+                        )
+            if op_config.type not in _OP_WITHOUT_KERNEL_SET:
+                op_desc.infer_var_type(main_block_desc)
+                op_desc.infer_shape(main_block_desc)
+            op_desc.check_attrs()
 
-    for index, name in enumerate(program_config.outputs):
-        var_desc = main_block_desc.var(b"fetch")
-        var_desc.set_type(core.VarDesc.VarType.FETCH_LIST)
-        var_desc.set_need_check_feed(True)
-        op_desc = main_block_desc.append_op()
-        op_desc.set_type("fetch")
-        op_desc.set_input('X', [name])
-        op_desc.set_output('Out', ["fetch"])
-        op_desc._set_attr("col", index)
+        for index, name in enumerate(program_config.outputs):
+            var_desc = main_block_desc.var(b"fetch")
+            var_desc.set_type(core.VarDesc.VarType.FETCH_LIST)
+            var_desc.set_need_check_feed(True)
+            op_desc = main_block_desc.append_op()
+            op_desc.set_type("fetch")
+            op_desc.set_input('X', [name])
+            op_desc.set_output('Out', ["fetch"])
+            op_desc._set_attr("col", index)
 
-    model = main_program_desc.serialize_to_string()
+        model = main_program_desc.serialize_to_string()
 
-    util_program._sync_with_cpp()
-    place = base.CPUPlace()
-    executor = base.Executor(place)
-    scope = base.Scope()
-    with base.scope_guard(scope):
-        executor.run(util_program)
-        params = scope.find_var("out_var_0").get_bytes()
+        util_program._sync_with_cpp()
+        place = base.CPUPlace()
+        executor = base.Executor(place)
+        scope = base.Scope()
+        with base.scope_guard(scope):
+            executor.run(util_program)
+            params = scope.find_var("out_var_0").get_bytes()
 
     return model, params
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
 Inference


### PR Types
 Bug fixes


### Description

- test/ir/inference/ 下大部分单测依赖于create_fake_model()和run_test_config()等公共API来构建，公共API使用了PIR不支持的旧IR接口导致PIR模式下大量单测运行失败。

- pr使用with paddle.pir_utils.OldIrGuard():使得API能够在PIR模式下运行。

- PIR模式下已验证修复10个单测，其余inference下单测可基于修改进行验证。

card-71500