### PR TITLE
【Fix PIR Unittest No.53 BUAA】fix test_multiply

### DIFF
--- a/test/legacy_test/test_linspace.py
+++ b/test/legacy_test/test_linspace.py
@@ -227,7 +227,6 @@ class TestLinspaceOpError(unittest.TestCase):
                     )
                     paddle.linspace(start, 10, 1, dtype="float32")
 
-                # test_start_dtype()
                 self.assertRaises(ValueError, test_start_dtype)
 
                 def test_end_dtype():

--- a/test/legacy_test/test_multiply.py
+++ b/test/legacy_test/test_multiply.py
@@ -17,13 +17,13 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle import tensor
-from paddle.static import Program, program_guard
+from paddle import static, tensor
+from paddle.base.framework import in_pir_mode
 
 
 class TestMultiplyApi(unittest.TestCase):
     def _run_static_graph_case(self, x_data, y_data):
-        with program_guard(Program(), Program()):
+        with static.program_guard(static.Program(), static.Program()):
             paddle.enable_static()
             x = paddle.static.data(
                 name='x', shape=x_data.shape, dtype=x_data.dtype
@@ -110,13 +110,14 @@ class TestMultiplyError(unittest.TestCase):
     def test_errors(self):
         # test static computation graph: dtype can not be int8
         paddle.enable_static()
-        with program_guard(Program(), Program()):
+        with static.program_guard(static.Program(), static.Program()):
             x = paddle.static.data(name='x', shape=[100], dtype=np.int8)
             y = paddle.static.data(name='y', shape=[100], dtype=np.int8)
-            self.assertRaises(TypeError, tensor.multiply, x, y)
+            if not in_pir_mode():
+                self.assertRaises(TypeError, tensor.multiply, x, y)
 
         # test static computation graph: inputs must be broadcastable
-        with program_guard(Program(), Program()):
+        with static.program_guard(static.Program(), static.Program()):
             x = paddle.static.data(name='x', shape=[20, 50], dtype=np.float64)
             y = paddle.static.data(name='y', shape=[20], dtype=np.float64)
             self.assertRaises(ValueError, tensor.multiply, x, y)
@@ -183,7 +184,7 @@ class TestMultiplyError(unittest.TestCase):
 
 class TestMultiplyInplaceApi(TestMultiplyApi):
     def _run_static_graph_case(self, x_data, y_data):
-        with program_guard(Program(), Program()):
+        with static.program_guard(static.Program(), static.Program()):
             paddle.enable_static()
             x = paddle.static.data(
                 name='x', shape=x_data.shape, dtype=x_data.dtype


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Others


### PR Types
Others


### Description
<img width="685" alt="截屏2024-07-24 11 19 46" src="https://github.com/user-attachments/assets/d82f3a45-95d9-4f6b-bd81-71471fe13dcb">

pir mode 下没有raise type error
经组里老师讨论，这个样例在pir mode下可以不检测类型错误
顺手删除了之前在test_linspace下添加的注释
