### PR TITLE
【Fix PIR Unittest BUAA No. 11】Fix test_get_tensor_from_selected_rows_op

### DIFF
--- a/test/legacy_test/test_get_tensor_from_selected_rows_op.py
+++ b/test/legacy_test/test_get_tensor_from_selected_rows_op.py
@@ -39,7 +39,9 @@ class TestGetTensorFromSelectedRowsError(unittest.TestCase):
             def test_SELECTED_ROWS():
                 clip.get_tensor_from_selected_rows(x=x_var)
 
-            self.assertRaises(TypeError, test_SELECTED_ROWS)
+            self.assertRaises(
+                (TypeError, NotImplementedError), test_SELECTED_ROWS
+            )
 
 
 class TestGetTensorFromSelectedRows(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
test_get_tensor_from_selected_rows_op.py Line 43 “self.assertRaises(NotImplementedError, test_SELECTED_ROWS)”—>”self.assertRaises((TypeError,NotImplementedError), test_SELECTED_ROWS)”