### PR TITLE
[Dy2St] Unify name analysis in `pir_partial_program`

### DIFF
--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -47,6 +47,8 @@ __all__ = []
 
 prog_logger = TranslatorLogger()
 
+# TODO: check the var not found fallback to FakeVar
+
 
 def get_value_name(value):
     if is_fake_value(value):

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -47,7 +47,6 @@ __all__ = []
 
 prog_logger = TranslatorLogger()
 
-# TODO: check the var not found fallback to FakeVar
 
 FAKE_VALUE_NAME = "FakeValue"
 
@@ -333,17 +332,16 @@ class RunnableProgram:
     def unify_value_names(
         program, rename_mapping: dict[str, str]
     ) -> dict[str, str]:
+        """Ensure every value at most has one name in the program."""
         rename_mapping = dict(rename_mapping)
         for value in RunnableProgram._get_program_all_values(program):
             if not value.has_name:
                 continue
-            new_name = value.name
+            new_name = value.name  # get first name
             new_name = rename_mapping.get(new_name, new_name)
-            for name in value._names:
-                if name == new_name:
-                    continue
-                rename_mapping[name] = new_name
-            value._rename(new_name, program.global_block())
+            rename_mapping.update(
+                value._rename(new_name, program.global_block())
+            )
         return rename_mapping
 
     @cached_property

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -49,10 +49,12 @@ prog_logger = TranslatorLogger()
 
 # TODO: check the var not found fallback to FakeVar
 
+FAKE_VALUE_NAME = "FakeValue"
+
 
 def get_value_name(value):
     if is_fake_value(value):
-        return "FakeVar"
+        return FAKE_VALUE_NAME
     return value.name
 
 
@@ -126,7 +128,7 @@ class RunnableProgram:
 
     @staticmethod
     def _get_name_value_map_from_program(program) -> dict[str, Value]:
-        name_to_value_dict: dict[str, Value] = {}
+        name_to_value_dict: dict[str, Value] = {FAKE_VALUE_NAME: fake_value()}
         all_values: list[Value] = []
         all_values.extend(
             arg for arg in program.global_block().kwargs().values()

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -1193,7 +1193,6 @@ class PartialProgramLayer:
                     var for var in out_vars if not self._is_no_value(var)
                 )
             else:
-                # isinstance(out_vars, list)
                 res = [var for var in out_vars if not self._is_no_value(var)]
 
             has_removed = len(out_vars) > len(res)

--- a/test/dygraph_to_static/test_deal_inplace.py
+++ b/test/dygraph_to_static/test_deal_inplace.py
@@ -79,24 +79,28 @@ class TestDealInplace(Dy2StTestBase):
     def test_deal_view(self):
         bn_layer = paddle.nn.BatchNorm2D(10)
         x = paddle.to_tensor(np.random.random((2, 10, 3, 3)).astype('float32'))
+        x.stop_gradient = False
         self.run_test(fn_with_inplace_op, bn_layer, x, static_n_times=2)
 
     @test_pir_only
     def test_deal_inplace(self):
         sigmoid_layer = paddle.nn.Sigmoid()
         x = paddle.to_tensor(np.random.random((2, 10, 3, 3)).astype('float32'))
+        x.stop_gradient = False
         self.run_test(fn_with_inplace_op, sigmoid_layer, x, static_n_times=2)
 
     @test_pir_only
     def test_param_inplace(self):
         net = ParamInplaceNet()
         x = paddle.to_tensor(np.random.random(10).astype('float32'))
+        x.stop_gradient = False
         self.run_test(fn_with_inplace_op, net, x, static_n_times=2)
 
     @test_pir_only
     def test_param_directly_return(self):
         net = ParamDirectlyReturnNet()
         x = paddle.to_tensor(np.random.random(10).astype('float32'))
+        x.stop_gradient = False
         self.run_test(fn_with_inplace_op, net, x, static_n_times=2)
 
 

--- a/test/dygraph_to_static/test_deal_inplace.py
+++ b/test/dygraph_to_static/test_deal_inplace.py
@@ -111,7 +111,7 @@ class TestDealInplace(Dy2StTestBase):
         net = ParamInplaceNet()
         x = paddle.to_tensor(np.random.random(10).astype('float32'))
         x.stop_gradient = False
-        self.run_test(fn_with_inplace_op, net, x, static_n_times=2)
+        self.run_test(net, x, static_n_times=2)
 
     @test_pir_only
     def test_param_directly_return(self):

--- a/test/dygraph_to_static/test_deal_inplace.py
+++ b/test/dygraph_to_static/test_deal_inplace.py
@@ -49,7 +49,24 @@ class ParamDirectlyReturnNet(paddle.nn.Layer):
         self.weight = self.create_parameter(shape=[10], dtype='float32')
 
     def forward(self, x):
+        return self.weight
+
+
+class ParamReturnAfterAssignNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.weight = self.create_parameter(shape=[10], dtype='float32')
+
+    def forward(self, x):
         return paddle.assign(self.weight)
+
+
+class InputDirectlyReturnNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return x
 
 
 class TestDealInplace(Dy2StTestBase):
@@ -101,7 +118,21 @@ class TestDealInplace(Dy2StTestBase):
         net = ParamDirectlyReturnNet()
         x = paddle.to_tensor(np.random.random(10).astype('float32'))
         x.stop_gradient = False
-        self.run_test(fn_with_inplace_op, net, x, static_n_times=2)
+        self.run_test(net, x, static_n_times=2)
+
+    @test_pir_only
+    def test_param_return_after_assign(self):
+        net = ParamReturnAfterAssignNet()
+        x = paddle.to_tensor(np.random.random(10).astype('float32'))
+        x.stop_gradient = False
+        self.run_test(net, x, static_n_times=2)
+
+    @test_pir_only
+    def test_input_directly_return(self):
+        net = InputDirectlyReturnNet()
+        x = paddle.to_tensor(np.random.random(10).astype('float32'))
+        x.stop_gradient = False
+        self.run_test(net, x, static_n_times=2)
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_deal_inplace.py
+++ b/test/dygraph_to_static/test_deal_inplace.py
@@ -43,6 +43,15 @@ class ParamInplaceNet(paddle.nn.Layer):
             return paddle._C_ops.assign_(self.weight)
 
 
+class ParamDirectlyReturnNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.weight = self.create_parameter(shape=[10], dtype='float32')
+
+    def forward(self, x):
+        return paddle.assign(self.weight)
+
+
 class TestDealInplace(Dy2StTestBase):
     def copy_inputs(self, inputs):
         # Make a copy for inputs to avoid inplace effect.
@@ -81,6 +90,12 @@ class TestDealInplace(Dy2StTestBase):
     @test_pir_only
     def test_param_inplace(self):
         net = ParamInplaceNet()
+        x = paddle.to_tensor(np.random.random(10).astype('float32'))
+        self.run_test(fn_with_inplace_op, net, x, static_n_times=2)
+
+    @test_pir_only
+    def test_param_directly_return(self):
+        net = ParamDirectlyReturnNet()
         x = paddle.to_tensor(np.random.random(10).astype('float32'))
         self.run_test(fn_with_inplace_op, net, x, static_n_times=2)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

统一 name 分析，复用 #66363 公用的逻辑，优化 name 管理，在 pass 后、执行前对前反向 Program 的 value 统一进行 rename 处理，确保只有一个 name

<p align="center">
   <img src="https://github.com/user-attachments/assets/254318d8-5f79-4485-b47b-3211415c6d8c" alt="multiple-name-handling drawio" width="500px" />
</p>

比如这里的 `a`、`b`、`c`、`d` ... `i` 全都应该是同一个名字 `a`，因此在执行前会将它们统一 rename 为 `a`

PCard-66972