### PR TITLE
Replace phi::errors [fluid_ops] part2

### DIFF
--- a/test/cpp/eager/performance_tests/benchmark_eager_cpu.cc
+++ b/test/cpp/eager/performance_tests/benchmark_eager_cpu.cc
@@ -71,7 +71,7 @@ TEST(Benchmark, EagerScaleCPU) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }
@@ -118,7 +118,7 @@ TEST(Benchmark, EagerMatmulCPU) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }
@@ -168,7 +168,7 @@ TEST(Benchmark, EagerIntermediateMatmulCPU) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }
@@ -236,7 +236,7 @@ TEST(Benchmark, EagerIntermediateMLPCPU) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }

--- a/test/cpp/eager/performance_tests/benchmark_eager_cuda.cc
+++ b/test/cpp/eager/performance_tests/benchmark_eager_cuda.cc
@@ -73,7 +73,7 @@ TEST(Benchmark, EagerScaleCUDA) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }
@@ -123,7 +123,7 @@ TEST(Benchmark, EagerMatmulCUDA) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }
@@ -177,7 +177,7 @@ TEST(Benchmark, EagerIntermediateMatmulCUDA) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }
@@ -249,7 +249,7 @@ TEST(Benchmark, EagerIntermediateMLPCUDA) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }

--- a/test/cpp/eager/performance_tests/benchmark_fluid_cpu.cc
+++ b/test/cpp/eager/performance_tests/benchmark_fluid_cpu.cc
@@ -78,7 +78,7 @@ TEST(Benchmark, FluidScaleCPU) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }
@@ -137,7 +137,7 @@ TEST(Benchmark, FluidMatmulCPU) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }
@@ -221,7 +221,7 @@ TEST(Benchmark, FluidMLPCPU) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }

--- a/test/cpp/eager/performance_tests/benchmark_fluid_cuda.cc
+++ b/test/cpp/eager/performance_tests/benchmark_fluid_cuda.cc
@@ -87,7 +87,7 @@ TEST(Benchmark, FluidScaleCUDA) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }
@@ -154,7 +154,7 @@ TEST(Benchmark, FluidMatmulCUDA) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }
@@ -248,7 +248,7 @@ TEST(Benchmark, FluidMLPCUDA) {
       std::cout << "Duration: " << elapsed_time_ms << " ms" << std::endl;
 
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unknown benchmark mode"));
+      PADDLE_THROW(common::errors::Fatal("Unknown benchmark mode"));
     }
   }
 }

--- a/test/cpp/eager/performance_tests/benchmark_utils.cc
+++ b/test/cpp/eager/performance_tests/benchmark_utils.cc
@@ -183,7 +183,7 @@ static void FluidCheckTensorValue(const std::shared_ptr<imperative::VarBase>& X,
   VLOG(6) << "Tensor Value: " << t_ptr[0] << ", Expected Value: " << value;
   PADDLE_ENFORCE(
       t_ptr[0] == value,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "Detected numerical Error, Expected %f but got %f", value, t_ptr[0]));
 }
 
@@ -214,7 +214,7 @@ static void FluidCheckGradTensorValue(
   VLOG(6) << "Tensor Value: " << g_ptr[0] << ", Expected Value: " << value;
   PADDLE_ENFORCE(
       g_ptr[0] == value,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "Detected numerical Error, Expected %f but got %f", value, g_ptr[0]));
 }
 

--- a/test/cpp/eager/task_tests/fwd_bwd_joint_test.cc
+++ b/test/cpp/eager/task_tests/fwd_bwd_joint_test.cc
@@ -206,11 +206,11 @@ TEST(FwdBwdJoint, BranchedNodes) {
     auto dense_out = std::dynamic_pointer_cast<phi::DenseTensor>(out2.impl());
     float* ptr = dense_out->mutable_data<float>(phi::CPUPlace());
     for (int i = 0; i < 20; i++) {
-      PADDLE_ENFORCE(
-          ptr[i] == 150.0,
-          phi::errors::Fatal("Detected numerical Error, Expected %f but got %f",
-                             150.0,
-                             ptr[i]));
+      PADDLE_ENFORCE(ptr[i] == 150.0,
+                     common::errors::Fatal(
+                         "Detected numerical Error, Expected %f but got %f",
+                         150.0,
+                         ptr[i]));
     }
   }
 

--- a/test/cpp/eager/test_utils.h
+++ b/test/cpp/eager/test_utils.h
@@ -76,7 +76,7 @@ bool CompareGradTensorWithValue(const paddle::Tensor& target, T value) {
   VLOG(6) << "CompareGradTensorWithValue";
   for (int i = 0; i < grad_dense->numel(); i++) {
     PADDLE_ENFORCE(value == ptr[i],
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Numerical Error in Compare Grad Variable With Value of "
                        "%d, we expected got value: %f, but got: %f instead. "
                        "Please check it later.",
@@ -113,7 +113,7 @@ bool CompareTensorWithValue(const paddle::Tensor& target, T value) {
   VLOG(6) << "CompareTensorWithValue";
   for (int i = 0; i < dense_t->numel(); i++) {
     PADDLE_ENFORCE(value == ptr[i],
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Numerical Error in Compare Grad Variable With Value of "
                        "%d, we expected got value: %f, but got: %f instead. "
                        "Please check it later.",

--- a/test/cpp/fluid/beam_search_decode_op_test.cc
+++ b/test/cpp/fluid/beam_search_decode_op_test.cc
@@ -38,7 +38,7 @@ void GenerateExample(const std::vector<size_t>& level_0,
                      LoDTensorArray* scores) {
   PADDLE_ENFORCE_EQ(level_0.back(),
                     level_1.size() - 1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "source level is used to describe candidate set"
                         ", so it's element should less than levle_1 length. "
                         "And the value of source"
@@ -46,7 +46,7 @@ void GenerateExample(const std::vector<size_t>& level_0,
                         level_1.size() - 1));
   PADDLE_ENFORCE_EQ(level_1.back(),
                     data.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "the lowest level is used to describe data"
                         ", so it's last element should be data length %d. ",
                         data.size()));

--- a/test/cpp/fluid/benchmark/op_tester.cc
+++ b/test/cpp/fluid/benchmark/op_tester.cc
@@ -51,7 +51,7 @@ void OpTester::Init(const OpTesterConfig &config) {
     CreateInputVarDesc();
     CreateOutputVarDesc();
   } else {
-    PADDLE_THROW(phi::errors::NotFound(
+    PADDLE_THROW(common::errors::NotFound(
         "Operator '%s' is not registered in OpTester.", config_.op_type));
   }
 
@@ -85,7 +85,7 @@ void OpTester::Run() {
       platform::EnableProfiler(platform::ProfilerState::kAll);
       platform::SetDeviceId(config_.device_id);
 #else
-      PADDLE_THROW(phi::errors::PermissionDenied(
+      PADDLE_THROW(common::errors::PermissionDenied(
           "'GPUPlace' is not supported in CPU only device."));
 #endif
     }
@@ -168,8 +168,8 @@ framework::proto::VarType::Type OpTester::TransToVarType(std::string str) {
   } else if (str == "fp64") {
     return framework::proto::VarType::FP64;
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented("Unsupported dtype %s in OpTester.",
-                                            str.c_str()));
+    PADDLE_THROW(common::errors::Unimplemented(
+        "Unsupported dtype %s in OpTester.", str.c_str()));
   }
 }
 
@@ -179,7 +179,7 @@ void OpTester::CreateInputVarDesc() {
     const OpInputConfig *input = config_.GetInput(name);
     PADDLE_ENFORCE_NOT_NULL(
         input,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "The input %s of operator %s is not correctly provided.",
             name,
             config_.op_type));
@@ -220,7 +220,7 @@ void OpTester::CreateOpDesc() {
     PADDLE_ENFORCE_NE(
         attr_types.find(name),
         attr_types.end(),
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Operator %s does not have attribute %d.", type_, name));
 
     const std::string &value_str = item.second;
@@ -243,7 +243,7 @@ void OpTester::CreateOpDesc() {
       case framework::proto::AttrType::INTS:
       case framework::proto::AttrType::FLOATS:
       case framework::proto::AttrType::STRINGS:
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Unsupported STRINGS type in OpTester yet."));
         break;
       case framework::proto::AttrType::LONG: {
@@ -252,7 +252,7 @@ void OpTester::CreateOpDesc() {
       } break;
       case framework::proto::AttrType::LONGS:
       default:
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Unsupport attr type %d in OpTester.", type));
     }
   }
@@ -312,7 +312,7 @@ void OpTester::SetupTensor(phi::DenseTensor *tensor,
     }
     is.close();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Unsupported initializer %s in OpTester.", initializer.c_str()));
   }
 
@@ -371,7 +371,7 @@ void OpTester::CreateVariables(framework::Scope *scope) {
                           item.second.initializer,
                           item.second.filename);
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported dtype %d in OpTester.", data_type));
     }
 
@@ -495,7 +495,7 @@ std::string OpTester::DebugString() {
            << "\n";
       } break;
       default:
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Unsupport attr type %d in OpTester.", attr_type));
     }
     ss << GenSpaces(--count) << "}\n";
@@ -510,8 +510,8 @@ TEST(op_tester, base) {
     PADDLE_ENFORCE_EQ(
         static_cast<bool>(fin),
         true,
-        phi::errors::InvalidArgument("OpTester cannot open file %s",
-                                     FLAGS_op_config_list.c_str()));
+        common::errors::InvalidArgument("OpTester cannot open file %s",
+                                        FLAGS_op_config_list.c_str()));
     std::vector<OpTesterConfig> op_configs;
     while (!fin.eof()) {
       VLOG(4) << "Reading config " << op_configs.size() << "...";

--- a/test/cpp/fluid/benchmark/op_tester_config.h
+++ b/test/cpp/fluid/benchmark/op_tester_config.h
@@ -136,7 +136,7 @@ void OpInputConfig::ParseDType(std::istream& is) {
   } else if (dtype_str == "fp64" || dtype_str == "double") {
     dtype = "fp64";
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Unsupported dtype %s in OpInputConfig.", dtype_str.c_str()));
   }
   VLOG(4) << "dtype of input " << name << " is: " << dtype;
@@ -150,7 +150,7 @@ void OpInputConfig::ParseInitializer(std::istream& is) {
   const std::vector<std::string> supported_initializers = {
       "random", "natural", "zeros", "file"};
   if (!Has(supported_initializers, initializer_str)) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Unsupported initializer %s in OpInputConfig.",
         initializer_str.c_str()));
   }
@@ -190,7 +190,7 @@ void OpInputConfig::ParseLoD(std::istream& is) {
   PADDLE_ENFORCE_GE(
       lod_str.length(),
       4U,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The length of lod string should be "
           "equal to or larger than 4. But length of lod string is %zu.",
           lod_str.length()));
@@ -223,8 +223,8 @@ OpTesterConfig::OpTesterConfig(const std::string& filename) {
   PADDLE_ENFORCE_EQ(
       static_cast<bool>(fin),
       true,
-      phi::errors::InvalidArgument("OpTesterConfig cannot open file %s.",
-                                   filename.c_str()));
+      common::errors::InvalidArgument("OpTesterConfig cannot open file %s.",
+                                      filename.c_str()));
 
   Init(fin);
 }

--- a/test/cpp/fluid/elementwise/test_elementwise_add_op_inplace.cc
+++ b/test/cpp/fluid/elementwise/test_elementwise_add_op_inplace.cc
@@ -41,8 +41,8 @@ static void Memcpy(void *dst, const void *src, size_t n, bool copy_to_gpu) {
     PADDLE_ENFORCE_GPU_SUCCESS(hipMemcpy(dst, src, n, hipMemcpyHostToDevice));
 #else
     PADDLE_THROW(
-        phi::errors::InvalidArgument("Check your paddle version, current "
-                                     "version is not compiled with cuda"));
+        common::errors::InvalidArgument("Check your paddle version, current "
+                                        "version is not compiled with cuda"));
 #endif
   } else {
     std::memcpy(dst, src, n);
@@ -98,20 +98,20 @@ bool TestMain(const phi::Place &place, const phi::DDim &dims, bool inplace) {
   PADDLE_ENFORCE_EQ(
       scope.kids().empty(),
       true,
-      phi::errors::InvalidArgument("The scope can not have the child scopes,"
-                                   "please check your code."));
+      common::errors::InvalidArgument("The scope can not have the child scopes,"
+                                      "please check your code."));
   if (inplace) {
     PADDLE_ENFORCE_EQ(
         &out_tensor,
         x,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The output tensor should be same as input x in inplace mode,"
             " but now is not same."));
   } else {
     PADDLE_ENFORCE_EQ(
         &out_tensor,
         z,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The output tensor should be same as output z in normal mode,"
             " but now is not same."));
   }

--- a/test/cpp/fluid/elementwise/test_elementwise_op_grad_grad.h
+++ b/test/cpp/fluid/elementwise/test_elementwise_op_grad_grad.h
@@ -93,7 +93,7 @@ class TestElementwiseOpGradGrad {
         auto dst_place = place_;
         memory::Copy(dst_place, dst, src_place, src, bytes, nullptr);
 #else
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "Check your paddle version, current version is not compiled with "
             "cuda"));
 #endif
@@ -110,11 +110,11 @@ class TestElementwiseOpGradGrad {
     op->Run(scope_, place_);
     phi::DeviceContextPool::Instance().Get(place_)->Wait();
     phi::DenseTensor cpu_out;
-    PADDLE_ENFORCE_EQ(
-        scope_.kids().empty(),
-        true,
-        phi::errors::InvalidArgument("The scope can not have the child scopes,"
-                                     "please check your code."));
+    PADDLE_ENFORCE_EQ(scope_.kids().empty(),
+                      true,
+                      common::errors::InvalidArgument(
+                          "The scope can not have the child scopes,"
+                          "please check your code."));
 
     // get outputs from scope and compare them with expected_outs
     bool all_equal = true;

--- a/test/cpp/fluid/framework/data_feed_test.cc
+++ b/test/cpp/fluid/framework/data_feed_test.cc
@@ -40,7 +40,7 @@ paddle::framework::DataFeedDesc load_datafeed_param_from_file(
   PADDLE_ENFORCE_NE(
       file_descriptor,
       -1,
-      phi::errors::Unavailable(
+      common::errors::Unavailable(
           "Cannot open file %s c load datafeed param from file.", filename));
   google::protobuf::io::FileInputStream fileInput(file_descriptor);
   google::protobuf::TextFormat::Parse(&fileInput, &data_feed_desc);
@@ -54,7 +54,7 @@ const std::vector<std::string> load_filelist_from_file(const char* filename) {
   PADDLE_ENFORCE_EQ(
       fin.good(),
       true,
-      phi::errors::Unavailable(
+      common::errors::Unavailable(
           "Cannot open file %s when load filelist from file.", filename));
   std::string line;
   while (getline(fin, line)) {
@@ -204,7 +204,7 @@ void GetElemSetFromReader(std::vector<MultiTypeSet>* reader_elem_set,
               }
             } else {
               PADDLE_THROW(
-                  phi::errors::InvalidArgument("Error type in proto file."));
+                  common::errors::InvalidArgument("Error type in proto file."));
             }
           } else {  // sparse branch
             if (slot.type() == "uint64") {
@@ -227,7 +227,7 @@ void GetElemSetFromReader(std::vector<MultiTypeSet>* reader_elem_set,
               }
             } else {
               PADDLE_THROW(
-                  phi::errors::InvalidArgument("Error type in proto file."));
+                  common::errors::InvalidArgument("Error type in proto file."));
             }
           }  // end sparse branch
           ++index;
@@ -284,7 +284,7 @@ void GetElemSetFromFile(std::vector<MultiTypeSet>* file_elem_set,
     PADDLE_ENFORCE_EQ(
         fin.good(),
         true,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Can not open %s when get element set from file.", file.c_str()));
     while (1) {
       bool end_flag = false;
@@ -312,7 +312,7 @@ void GetElemSetFromFile(std::vector<MultiTypeSet>* file_elem_set,
             }
           } else {
             PADDLE_THROW(
-                phi::errors::InvalidArgument("Error type in proto file."));
+                common::errors::InvalidArgument("Error type in proto file."));
           }
           if (slot.is_used()) {
             ++index;

--- a/test/cpp/fluid/framework/op_call_stack_test.cc
+++ b/test/cpp/fluid/framework/op_call_stack_test.cc
@@ -25,9 +25,9 @@ namespace details {
 
 static void ThrowEnforceNotMet() {
   PADDLE_THROW(
-      phi::errors::InvalidArgument("\n----------------------\nError Message "
-                                   "Summary:\n----------------------\n"
-                                   "Created error."));
+      common::errors::InvalidArgument("\n----------------------\nError Message "
+                                      "Summary:\n----------------------\n"
+                                      "Created error."));
 }
 
 }  // namespace details

--- a/test/cpp/fluid/framework/op_registry_test.cc
+++ b/test/cpp/fluid/framework/op_registry_test.cc
@@ -55,7 +55,9 @@ class MyTestOpProtoAndCheckerMaker : public OpProtoAndCheckerMaker {
     AddOutput("output", "output of cosine op").AsIntermediate();
     auto my_checker = [](int i) {
       PADDLE_ENFORCE_EQ(
-          i % 2, 0, phi::errors::InvalidArgument("'test_attr' must be even!"));
+          i % 2,
+          0,
+          common::errors::InvalidArgument("'test_attr' must be even!"));
     };
     AddAttr<int>("test_attr", "a simple test attribute")
         .AddCustomChecker(my_checker);

--- a/test/cpp/fluid/framework/operator_test.cc
+++ b/test/cpp/fluid/framework/operator_test.cc
@@ -491,7 +491,7 @@ class GetLoDLevelTest : public OperatorWithKernel {
     auto lod_level = ctx->GetLoDLevel("X");
     PADDLE_ENFORCE_GT(lod_level,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The LoD level Input(X) should be larger than 0."));
   }
 };

--- a/test/cpp/fluid/math/concat_test.cc
+++ b/test/cpp/fluid/math/concat_test.cc
@@ -83,14 +83,14 @@ void ConcatCase1(DeviceContext* context) {
   // check the dim of input_a, input_b
   PADDLE_ENFORCE_EQ(input_a.dims(),
                     dim_a,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_a.dims(),
                         dim_a));
   PADDLE_ENFORCE_EQ(input_b.dims(),
                     dim_b,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_b.dims(),
@@ -110,13 +110,13 @@ void ConcatCase1(DeviceContext* context) {
     if (j >= cols) {
       PADDLE_ENFORCE_EQ(out_ptr[j],
                         b_ptr[idx_b],
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Concat test failed, the result should be equal."));
       ++idx_b;
     } else {
       PADDLE_ENFORCE_EQ(out_ptr[j],
                         a_ptr[idx_a],
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Concat test failed, the result should be equal."));
       ++idx_a;
     }
@@ -187,14 +187,14 @@ void ConcatCase2(DeviceContext* context) {
   // check the dim of input_a, input_b
   PADDLE_ENFORCE_EQ(input_a.dims(),
                     dim_a,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_a.dims(),
                         dim_a));
   PADDLE_ENFORCE_EQ(input_b.dims(),
                     dim_b,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_b.dims(),
@@ -216,14 +216,14 @@ void ConcatCase2(DeviceContext* context) {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 28 + j],
             b_ptr[idx_b],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_b;
       } else {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 28 + j],
             a_ptr[idx_a],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_a;
       }
@@ -295,14 +295,14 @@ void ConcatCase3(DeviceContext* context) {
   // check the dim of input_a, input_b
   PADDLE_ENFORCE_EQ(input_a.dims(),
                     dim_a,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_a.dims(),
                         dim_a));
   PADDLE_ENFORCE_EQ(input_b.dims(),
                     dim_b,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_b.dims(),
@@ -325,14 +325,14 @@ void ConcatCase3(DeviceContext* context) {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 9 + j],
             b_ptr[idx_b],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_b;
       } else {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 9 + j],
             a_ptr[idx_a],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_a;
       }
@@ -406,14 +406,14 @@ void ConcatCase4(DeviceContext* context) {
   // check the dim of input_a, input_b
   PADDLE_ENFORCE_EQ(input_a.dims(),
                     dim_a,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_a.dims(),
                         dim_a));
   PADDLE_ENFORCE_EQ(input_b.dims(),
                     dim_b,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_b.dims(),
@@ -436,14 +436,14 @@ void ConcatCase4(DeviceContext* context) {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 24 + j],
             b_ptr[idx_b],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_b;
       } else {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 24 + j],
             a_ptr[idx_a],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_a;
       }

--- a/test/cpp/fluid/math/selected_rows_functor_test.cu.cc
+++ b/test/cpp/fluid/math/selected_rows_functor_test.cu.cc
@@ -42,12 +42,12 @@ TEST(selected_rows_functor, gpu_add) {
 #ifdef PADDLE_WITH_HIP
   PADDLE_ENFORCE_EQ(hipDeviceSynchronize(),
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The all synchronization on the cuda is error!"));
 #else
   PADDLE_ENFORCE_EQ(cudaDeviceSynchronize(),
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The all synchronization on the cuda is error!"));
 #endif
 

--- a/test/cpp/fluid/memory/buffered_allocator_test.cc
+++ b/test/cpp/fluid/memory/buffered_allocator_test.cc
@@ -46,7 +46,7 @@ class StubAllocator : public Allocator {
     auto *alloc = dynamic_cast<StubAllocation *>(allocation);
     PADDLE_ENFORCE_NOT_NULL(
         alloc,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input allocation is not type of StubAllocation."));
     if (alloc->ptr()) delete[] static_cast<uint8_t *>(alloc->ptr());
     ++destruct_count_;

--- a/test/cpp/fluid/memory/retry_allocator_test.cc
+++ b/test/cpp/fluid/memory/retry_allocator_test.cc
@@ -93,7 +93,7 @@ class DummyAllocator : public Allocator {
 
  protected:
   phi::Allocation *AllocateImpl(size_t size) override {
-    PADDLE_THROW_BAD_ALLOC(phi::errors::ResourceExhausted(
+    PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
         "Here is a test exception, always BadAlloc."));
   }
 

--- a/test/cpp/fluid/mkldnn/test_onednn_caching.cc
+++ b/test/cpp/fluid/mkldnn/test_onednn_caching.cc
@@ -132,10 +132,10 @@ TEST(test_conv2d_reuse_cache, cpu_place) {
   CacheTester ct;
   RunOperator<float>(p, "conv2d", dims, "input_signal");
   RunOperator<float>(p, "conv2d", dims, "input_signal");
-  PADDLE_ENFORCE_EQ(
-      ct.Analyze(9),
-      true,
-      phi::errors::InvalidArgument("Invalid number of cached oneDNN objects"));
+  PADDLE_ENFORCE_EQ(ct.Analyze(9),
+                    true,
+                    common::errors::InvalidArgument(
+                        "Invalid number of cached oneDNN objects"));
 }
 
 TEST(test_conv2d_noreuse_cache, cpu_place) {
@@ -144,10 +144,10 @@ TEST(test_conv2d_noreuse_cache, cpu_place) {
   CacheTester ct;
   RunOperator<float>(p, "conv2d", dims, "input_signal");
   RunOperator<float>(p, "conv2d", dims, "input_signal2");
-  PADDLE_ENFORCE_EQ(
-      ct.Analyze(18),
-      true,
-      phi::errors::InvalidArgument("Invalid number of cached oneDNN objects"));
+  PADDLE_ENFORCE_EQ(ct.Analyze(18),
+                    true,
+                    common::errors::InvalidArgument(
+                        "Invalid number of cached oneDNN objects"));
 }
 
 }  // namespace operators

--- a/test/cpp/fluid/mkldnn/test_onednn_op_inplace.cc
+++ b/test/cpp/fluid/mkldnn/test_onednn_op_inplace.cc
@@ -118,7 +118,7 @@ bool TestMain(const phi::Place &place,
   PADDLE_ENFORCE_EQ(
       &out_tensor,
       input_names[0].tensor,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input and output vars should share tensor for In-place test"));
 
   // compare results

--- a/test/cpp/fluid/mkldnn/test_onednn_op_nhwc.cc
+++ b/test/cpp/fluid/mkldnn/test_onednn_op_nhwc.cc
@@ -86,7 +86,7 @@ void Test_Pool2d_Transpose_NHWC(const std::string &transpose_type) {
   // Verify shape of output
   PADDLE_ENFORCE_EQ(z->dims(),
                     expected_dims,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Computed shape does not match expected shape"));
 }
 
@@ -154,7 +154,7 @@ TEST(test_pool2d_relu_relu_nhwc, cpu_place) {
   // Verify shape of output
   PADDLE_ENFORCE_EQ(z->dims(),
                     expected_dims,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Computed shape does not match expected shape"));
 }
 
@@ -209,7 +209,7 @@ TEST(test_pool2d_shape_nhwc, cpu_place) {
   // Verify shape of output
   PADDLE_ENFORCE_EQ(vzdata,
                     expected_dims,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Computed shape does not match expected shape"));
 }
 

--- a/test/cpp/fluid/nccl/nccl_op_test.cu.cc
+++ b/test/cpp/fluid/nccl/nccl_op_test.cu.cc
@@ -109,9 +109,10 @@ class NCCLTester : public ::testing::Test {
 
     lk.unlock();
 
-    PADDLE_ENFORCE_EQ(send_tensor->numel(),
-                      common::product(kDims),
-                      phi::errors::InvalidArgument("Tensor numel not match!"));
+    PADDLE_ENFORCE_EQ(
+        send_tensor->numel(),
+        common::product(kDims),
+        common::errors::InvalidArgument("Tensor numel not match!"));
 
     auto op = f::OpRegistry::CreateOp(*op1);
 

--- a/test/cpp/fluid/pscore/heter_listen_and_server_test.cc
+++ b/test/cpp/fluid/pscore/heter_listen_and_server_test.cc
@@ -229,7 +229,7 @@ TEST(HETER_LISTEN_AND_SERV, CPU) {
   PADDLE_ENFORCE_EQ(
       task.first,
       "x",
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Recv message and Send message name not match, Check your Code"));
 
   InitTensorsOnClient2((*micro_scope)[1], &place, rows_numel);
@@ -240,7 +240,7 @@ TEST(HETER_LISTEN_AND_SERV, CPU) {
   PADDLE_ENFORCE_EQ(
       task2.first,
       "x",
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Recv message and Send message name not match, Check your Code"));
 
   heter_client_ptr_->Stop();

--- a/test/cpp/fluid/pscore/heter_server_test.cc
+++ b/test/cpp/fluid/pscore/heter_server_test.cc
@@ -274,7 +274,7 @@ TEST(SENDANDRECV, CPU) {
   PADDLE_ENFORCE_EQ(
       task.first,
       "x",
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Recv message and Send message name not match, Check your Code"));
 
   InitTensorsOnClient2((*micro_scope)[1], &place, rows_numel);
@@ -288,7 +288,7 @@ TEST(SENDANDRECV, CPU) {
   PADDLE_ENFORCE_EQ(
       task2.first,
       "y",
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Recv message and Send message name not match, Check your Code"));
 
   heter_server_ptr_->Stop();

--- a/test/cpp/fluid/pscore/send_and_recv_op_cpu_test.cc
+++ b/test/cpp/fluid/pscore/send_and_recv_op_cpu_test.cc
@@ -219,10 +219,10 @@ TEST(SENDANDRECV, CPU) {
       distributed::HeterClient::GetInstance({endpoint}, {previous_endpoint}, 0)
           .get();
 
-  PADDLE_ENFORCE_NE(
-      rpc_client,
-      nullptr,
-      phi::errors::InvalidArgument("Client Start Fail, Check Your Code & Env"));
+  PADDLE_ENFORCE_NE(rpc_client,
+                    nullptr,
+                    common::errors::InvalidArgument(
+                        "Client Start Fail, Check Your Code & Env"));
 
   framework::Scope* scope = (*micro_scope)[0];
   phi::CPUPlace place;
@@ -290,14 +290,14 @@ TEST(SENDANDRECV, CPU) {
   PADDLE_ENFORCE_EQ(
       task.first,
       "x",
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Recv message and Send message name not match, Check your Code"));
 
   auto task2 = (*task_queue_)[0]->Pop();
   PADDLE_ENFORCE_EQ(
       task2.first,
       "x",
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Recv message and Send message name not match, Check your Code"));
 
   b_rpc_service->Stop();

--- a/test/cpp/fluid/pscore/send_and_recv_op_gpu_test.cc
+++ b/test/cpp/fluid/pscore/send_and_recv_op_gpu_test.cc
@@ -313,14 +313,14 @@ TEST(SENDANDRECV, GPU) {
   PADDLE_ENFORCE_EQ(
       task.first,
       "x",
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Recv message and Send message name not match, Check your Code"));
 
   auto task2 = (*task_queue_)[0]->Pop();
   PADDLE_ENFORCE_EQ(
       task2.first,
       "x",
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Recv message and Send message name not match, Check your Code"));
 
   b_rpc_service2->Stop();

--- a/test/cpp/imperative/test_prepare_op.cc
+++ b/test/cpp/imperative/test_prepare_op.cc
@@ -58,9 +58,9 @@ static framework::VariableNameMap CreateVarNameMap(
       PADDLE_ENFORCE_EQ(
           var.dispensable(),
           true,
-          phi::errors::NotFound("Variable %s is not dispensable and "
-                                "there are no such var in inputs",
-                                var.name()));
+          common::errors::NotFound("Variable %s is not dispensable and "
+                                   "there are no such var in inputs",
+                                   var.name()));
       result[var.name()] = {};
     } else {
       auto& var_vector = it->second;

--- a/test/cpp/inference/api/analyzer_capi_pd_tensor_tester.cc
+++ b/test/cpp/inference/api/analyzer_capi_pd_tensor_tester.cc
@@ -75,13 +75,13 @@ void PD_run() {
   PADDLE_ENFORCE_EQ(
       size,
       2,
-      phi::errors::InvalidArgument("The Output shape's size is NOT match."));
+      common::errors::InvalidArgument("The Output shape's size is NOT match."));
   std::vector<int> ref_outshape_size({9, 6});
   for (int i = 0; i < 2; ++i) {
-    PADDLE_ENFORCE_EQ(
-        out_shape[i],
-        ref_outshape_size[i],
-        phi::errors::InvalidArgument("The Output shape's size is NOT match."));
+    PADDLE_ENFORCE_EQ(out_shape[i],
+                      ref_outshape_size[i],
+                      common::errors::InvalidArgument(
+                          "The Output shape's size is NOT match."));
   }
   PD_DeletePaddleBuf(buf);
 }

--- a/test/cpp/inference/api/analyzer_detect_functional_mkldnn_tester.cc
+++ b/test/cpp/inference/api/analyzer_detect_functional_mkldnn_tester.cc
@@ -141,19 +141,21 @@ void validate_cache_onednn(int cache_capacity = 1) {
   // Compare results
   // First and last value should be equal e.g. before using cache (empty) and
   // after releasing executor
-  PADDLE_ENFORCE_EQ(cache_filling[0],
-                    cache_filling[cache_filling.size() - 1],
-                    phi::errors::Fatal("Cache size before execution and after "
-                                       "releasing Executor do not match"));
+  PADDLE_ENFORCE_EQ(
+      cache_filling[0],
+      cache_filling[cache_filling.size() - 1],
+      common::errors::Fatal("Cache size before execution and after "
+                            "releasing Executor do not match"));
 
   // Iterate to check if cache is not increasing
   // over exceeding cache capacity
   if (cache_capacity != 0) {
     for (int i = cache_capacity + 1; i < num_samples + 1; ++i) {
-      PADDLE_ENFORCE_EQ(cache_filling[cache_capacity],
-                        cache_filling[i],
-                        phi::errors::Fatal("Cache capacity should not increase "
-                                           "after full capacity is used"));
+      PADDLE_ENFORCE_EQ(
+          cache_filling[cache_capacity],
+          cache_filling[i],
+          common::errors::Fatal("Cache capacity should not increase "
+                                "after full capacity is used"));
     }
   }
 }

--- a/test/cpp/inference/api/analyzer_int8_object_detection_tester.cc
+++ b/test/cpp/inference/api/analyzer_int8_object_detection_tester.cc
@@ -153,9 +153,9 @@ std::shared_ptr<std::vector<PaddleTensor>> GetWarmupData(
   PADDLE_ENFORCE_LE(
       static_cast<size_t>(num_images),
       iterations * test_data_batch_size,
-      ::phi::errors::Fatal("The requested quantization warmup data size " +
-                           std::to_string(num_images) +
-                           " is bigger than all test data size."));
+      ::common::errors::Fatal("The requested quantization warmup data size " +
+                              std::to_string(num_images) +
+                              " is bigger than all test data size."));
 
   PaddleTensor images;
   images.name = "image";
@@ -246,9 +246,9 @@ std::shared_ptr<std::vector<PaddleTensor>> GetWarmupData(
   }
   PADDLE_ENFORCE_EQ(static_cast<size_t>(num_objects),
                     static_cast<size_t>(objects_accum),
-                    ::phi::errors::Fatal("The requested num of objects " +
-                                         std::to_string(num_objects) +
-                                         " is the same as objects_accum."));
+                    ::common::errors::Fatal("The requested num of objects " +
+                                            std::to_string(num_objects) +
+                                            " is the same as objects_accum."));
 
   auto warmup_data = std::make_shared<std::vector<PaddleTensor>>(4);
   (*warmup_data)[0] = std::move(images);

--- a/test/cpp/inference/api/analyzer_lexical_analysis_gru_tester.cc
+++ b/test/cpp/inference/api/analyzer_lexical_analysis_gru_tester.cc
@@ -63,7 +63,7 @@ std::shared_ptr<std::vector<PaddleTensor>> WarmupData(
 
   PADDLE_ENFORCE_LE(static_cast<size_t>(num_images),
                     data_size,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The requested quantization warmup data size must be "
                         "lower or equal to the test data size. But received"
                         "warmup size is %d and test data size is %d",

--- a/test/cpp/inference/api/analyzer_pyramid_dnn_tester.cc
+++ b/test/cpp/inference/api/analyzer_pyramid_dnn_tester.cc
@@ -141,17 +141,17 @@ TEST(Analyzer_Pyramid_DNN, profile) {
     PADDLE_ENFORCE_GT(
         outputs.size(),
         0,
-        phi::errors::Fatal("The size of output should be greater than 0."));
+        common::errors::Fatal("The size of output should be greater than 0."));
     auto output = outputs.back();
     PADDLE_ENFORCE_EQ(
         output.size(),
         1UL,
-        phi::errors::Fatal("The size of output should be equal to 1."));
+        common::errors::Fatal("The size of output should be equal to 1."));
     size_t size = GetSize(output[0]);
     PADDLE_ENFORCE_GT(
         size,
         0,
-        phi::errors::Fatal("The size of output should be greater than 0."));
+        common::errors::Fatal("The size of output should be greater than 0."));
     float *result = static_cast<float *>(output[0].data.data());
     // output is probability, which is in (0, 1).
     for (size_t i = 0; i < size; i++) {

--- a/test/cpp/inference/api/analyzer_seq_pool1_tester_helper.h
+++ b/test/cpp/inference/api/analyzer_seq_pool1_tester_helper.h
@@ -65,18 +65,19 @@ struct DataRecord {
       PADDLE_ENFORCE_EQ(
           slot_data.size() % 11,
           0UL,
-          ::phi::errors::Fatal(
+          ::common::errors::Fatal(
               "line %d, %s should be divisible", num_lines, name));
       datasets[name].emplace_back(std::move(slot_data));
     }
     num_samples = num_lines / num_slots;
-    PADDLE_ENFORCE_EQ(num_samples * num_slots,
-                      static_cast<size_t>(num_lines),
-                      ::phi::errors::Fatal("num samples should be divisible"));
-    PADDLE_ENFORCE_GT(
-        num_samples,
-        0UL,
-        ::phi::errors::Fatal("The num of samples should be greater than 0."));
+    PADDLE_ENFORCE_EQ(
+        num_samples * num_slots,
+        static_cast<size_t>(num_lines),
+        ::common::errors::Fatal("num samples should be divisible"));
+    PADDLE_ENFORCE_GT(num_samples,
+                      0UL,
+                      ::common::errors::Fatal(
+                          "The num of samples should be greater than 0."));
   }
 
   void Prepare(int bs) {
@@ -84,7 +85,7 @@ struct DataRecord {
       PADDLE_ENFORCE_EQ(
           it->second.size(),
           num_samples,
-          ::phi::errors::Fatal("size of each slot should be equal"));
+          ::common::errors::Fatal("size of each slot should be equal"));
     }
     size_t num_batches = num_samples / bs;
     EXPECT_GT(num_batches, 0UL);
@@ -109,7 +110,7 @@ struct DataRecord {
           PADDLE_ENFORCE_EQ(
               len * 11,
               datas[id].size(),
-              ::phi::errors::Fatal(
+              ::common::errors::Fatal(
                   "%s %d size should be divisible", slot.name, id));
           lod[k + 1] = lod[k] + len;
         }

--- a/test/cpp/inference/api/ipu_multi_model_profile.cc
+++ b/test/cpp/inference/api/ipu_multi_model_profile.cc
@@ -86,7 +86,7 @@ TEST(Analyzer_ipu_fp16, performance_profile) {
     config.SetModel(FLAGS_infer_model + "/model/");
     ErnieInputData(total_batch_size, FLAGS_ipu_enable_fp16, &inputs);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Only support Resnet50 and Ernie Currently"));
   }
   // ipu_device_num, ipu_micro_batch_size, ipu_enable_pipelining,

--- a/test/cpp/inference/api/mkldnn_quantizer_config_tester.cc
+++ b/test/cpp/inference/api/mkldnn_quantizer_config_tester.cc
@@ -56,51 +56,51 @@ TEST(Mkldnn_quantizer_config, configuration) {
 
   PADDLE_ENFORCE_EQ(cfg.mkldnn_quantizer_config()->warmup_data()->size(),
                     warmup_data_size,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Size of the warmup data got from config differs with "
                         "the one set previously."));
 
   PADDLE_ENFORCE_EQ(
       cfg.mkldnn_quantizer_config()->warmup_data()->at(0).name,
       "image",
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Warmup data got from config differs with the one set previously."));
 
   PADDLE_ENFORCE_EQ(cfg.mkldnn_quantizer_config()->warmup_batch_size(),
                     warmup_batch_size,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Warmup batch size got from config differs with the "
                         "one set previously."));
 
   PADDLE_ENFORCE_EQ(cfg.mkldnn_quantizer_config()->enabled_op_types(),
                     enabled_op_types,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Enabled op types list got from config differs with "
                         "the one set previously."));
 
   PADDLE_ENFORCE_EQ(cfg.mkldnn_quantizer_config()->excluded_op_ids(),
                     excluded_op_ids,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Excluded op ids list got from config differs with "
                         "the one set previously."));
 
   PADDLE_ENFORCE_EQ(cfg.mkldnn_quantizer_config()->default_scale_algo(),
                     default_scale_algo,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Default scale algorithm got from config differs with "
                         "the one set previously."));
 
   PADDLE_ENFORCE_EQ(
       cfg.mkldnn_quantizer_config()->scale_algo("conv2d", "Input"),
       conv2d_scale_algo,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Scale algorithm got from config differs with the "
           "one set previously."));
 
   PADDLE_ENFORCE_EQ(
       cfg.mkldnn_quantizer_config()->scale_algo("unknown", "unknown"),
       default_scale_algo,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Scale algorithm got from config for an uknown op "
           "differs with the one set previously."));
 }

--- a/test/cpp/inference/api/paddle_infer_api_errors_tester.cc
+++ b/test/cpp/inference/api/paddle_infer_api_errors_tester.cc
@@ -27,7 +27,7 @@ struct FakeException {
   void pd_exception(int a) const {
     PADDLE_ENFORCE_NE(a,
                       a,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "This is a preset error message used to verify "
                           "whether the exception meets expectations: %d, %d.",
                           a,

--- a/test/cpp/inference/api/tester_helper.h
+++ b/test/cpp/inference/api/tester_helper.h
@@ -200,7 +200,7 @@ std::shared_ptr<std::vector<PaddleTensor>> GetWarmupData(
   auto all_test_data_size = iterations * test_data_batch_size;
   PADDLE_ENFORCE_LE(static_cast<size_t>(num_images),
                     all_test_data_size,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The requested quantization warmup data size must be "
                         "lower or equal to the test data size. But received"
                         "warmup size is %d and test data size is %d. Please "
@@ -311,7 +311,7 @@ void CompareResult(const std::vector<PaddleTensor> &outputs,
       COMPARE(PaddleDType::UINT8, uint8_t, EXPECT_EQ);
       COMPARE(PaddleDType::INT8, int8_t, EXPECT_EQ);
       default:
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "VarMessageToVarType: Unsupported dtype %d",
             static_cast<int>(out.dtype)));
     }
@@ -350,7 +350,7 @@ void CompareResult(const std::vector<PaddleTensor> &outputs,
       COMPARE(PaddleDType::UINT8, uint8_t, EXPECT_EQ);
       COMPARE(PaddleDType::INT8, int8_t, EXPECT_EQ);
       default:
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "VarMessageToVarType: Unsupported dtype %d",
             static_cast<int>(out.dtype)));
     }
@@ -396,7 +396,7 @@ void SetFakeImageInput(std::vector<std::vector<PaddleTensor>> *inputs,
   // Set fake_image_data
   PADDLE_ENFORCE_EQ(FLAGS_test_all_data,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "In SetFakeImageInput, expected test_all_data = false, "
                         "but now test_all_data=",
                         FLAGS_test_all_data));
@@ -415,7 +415,7 @@ void SetFakeImageInput(std::vector<std::vector<PaddleTensor>> *inputs,
     PADDLE_ENFORCE_EQ(
         feed_names->size(),
         feed_target_shapes.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size of feeds_names and size of "
             "feed_target_shapes must be equal, but now feeds_names "
             "size is %d and feed_target_shapes size is %d",
@@ -658,7 +658,7 @@ void SummarizeAccuracy(float avg_acc_ref, float avg_acc, int compared_idx) {
   PADDLE_ENFORCE_LE(
       compared_idx,
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The compared_idx should be <= 2. But received compared_idx = %d. "
           "For top1 accuracy, set compared_idx = 1; For top5 accuracy or mean "
           "Average Precision (mAP), set compared_idx = 2.",
@@ -666,7 +666,7 @@ void SummarizeAccuracy(float avg_acc_ref, float avg_acc, int compared_idx) {
   PADDLE_ENFORCE_GE(
       compared_idx,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The compared_idx should be >= 1. But received compared_idx = %d. "
           "For top1 accuracy, set compared_idx = 1; For top5 accuracy or mean "
           "Average Precision (mAP), set compared_idx = 2.",
@@ -705,7 +705,7 @@ float CompareAccuracyOne(
     int compared_idx) {
   PADDLE_ENFORCE_GT(output_slots.size(),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The accuracy vector is empty. The accuracy vector "
                         "size should be bigger than 0"));
 
@@ -717,7 +717,7 @@ float CompareAccuracyOne(
         PADDLE_ENFORCE_GE(
             output_slots[i].size(),
             2UL,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "To achieve top 1 accuracy, output_slots size "
                 "must be bigger than or equal to 2, but now the size is %d",
                 output_slots[i].size()));
@@ -726,7 +726,7 @@ float CompareAccuracyOne(
         PADDLE_ENFORCE_GE(
             output_slots[i].size(),
             3UL,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "To achieve top 5 accuracy or mean Average "
                 "Precision (mAP), output_slots size must be "
                 "bigger than or equal to 3, but now the size is %d",
@@ -810,12 +810,12 @@ void CompareNativeAndAnalysis(
   TestOneThreadPrediction(config, inputs, &analysis_outputs, true);
   PADDLE_ENFORCE_GT(native_outputs.size(),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The native outputs is empty. The native outputs "
                         "vector size must be bigger than 0"));
   PADDLE_ENFORCE_GT(analysis_outputs.size(),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The analysis outputs is empty. The analysis outputs "
                         "vector size must be bigger than 0"));
   CompareResult(analysis_outputs.back(), native_outputs.back());
@@ -829,11 +829,11 @@ void CompareQuantizedAndAnalysis(
   PADDLE_ENFORCE_GT(
       inputs.size(),
       0,
-      phi::errors::PreconditionNotMet("There is no input data provided."));
+      common::errors::PreconditionNotMet("There is no input data provided."));
   PADDLE_ENFORCE_EQ(
       inputs[0][0].shape[0],
       FLAGS_batch_size,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input data has to be packed batch by batch. The batchsize is set to "
           "%d, but the real input is packed with batchsize = %d",
           FLAGS_batch_size,
@@ -885,7 +885,7 @@ void CompareBFloat16AndAnalysis(
   PADDLE_ENFORCE_EQ(
       inputs[0][0].shape[0],
       FLAGS_batch_size,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input data has to be packed batch by batch. The batchsize is set to "
           "%d, but the real input is packed with batchsize = %d",
           FLAGS_batch_size,
@@ -933,7 +933,7 @@ void CompareAnalysisAndAnalysis(
   PADDLE_ENFORCE_EQ(
       inputs[0][0].shape[0],
       FLAGS_batch_size,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input data has to be packed batch by batch. The batchsize is set to "
           "%d, but the real input is packed with batchsize = %d",
           FLAGS_batch_size,
@@ -1155,7 +1155,7 @@ void ConvertFP32toFP16(::paddle::PaddleTensor &tensor  // NOLINT
   PADDLE_ENFORCE_EQ(
       tensor.dtype,
       PaddleDType::FLOAT32,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The tensor dtype is not float32, only support float32 as input"));
   float *fp32_data = reinterpret_cast<float *>(tensor.data.data());
   float16 *fp16_data = new float16[num];
@@ -1176,7 +1176,7 @@ void ConvertFP16toFP32(::paddle::PaddleTensor &tensor  // NOLINT
   PADDLE_ENFORCE_EQ(
       tensor.dtype,
       PaddleDType::FLOAT16,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The tensor dtype is not float16, only support float16 as input"));
   float16 *fp16_data = reinterpret_cast<float16 *>(tensor.data.data());
   float *fp32_data = new float[num];

--- a/test/cpp/inference/tensorrt/test_tensorrt_engine_instruction.cc
+++ b/test/cpp/inference/tensorrt/test_tensorrt_engine_instruction.cc
@@ -84,7 +84,7 @@ TEST(TensorRTEngineInstructionTest, test_tensorrt_engine_instruction) {
   auto *fc_layer = TRT_ENGINE_ADD_LAYER(
       engine, FullyConnected, *x, size, weight.get(), bias.get());
   PADDLE_ENFORCE_NOT_NULL(fc_layer,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "TRT fully connected layer building failed."));
 
   engine->DeclareOutput(fc_layer, 0, "y");
@@ -212,7 +212,7 @@ TEST(TensorRTEngineInstructionTest, test_tensorrt_engine_instruction_dynamic) {
   layer->setInput(1, *shape);
   PADDLE_ENFORCE_NOT_NULL(
       layer,
-      phi::errors::InvalidArgument("TRT shuffle layer building failed."));
+      common::errors::InvalidArgument("TRT shuffle layer building failed."));
   engine->DeclareOutput(layer, 0, "y");
   engine->FreezeNetwork();
 

--- a/test/cpp/inference/test_helper.h
+++ b/test/cpp/inference/test_helper.h
@@ -183,7 +183,7 @@ void TestInference(const std::string& dirname,
     //   int device_id = place.GetDeviceId();
     paddle::platform::SetDeviceId(0);
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "'CUDAPlace' is not supported in CPU only device."));
 #endif
   }

--- a/test/cpp/phi/api/scale_api.h
+++ b/test/cpp/phi/api/scale_api.h
@@ -135,7 +135,7 @@ static void ScaleCPU(DataType kernel_dtype,
       break;
     }
     default: {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "Detected unsupported data type."
           "Only Float64, Float32, BFloat16, Int64, Int32, Int16, Int8, UInt8 "
           "are supported for now."));
@@ -194,7 +194,7 @@ static void ScaleGPU(DataType kernel_dtype,
       break;
     }
     default: {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "Detected unsupported data type."
           "Only Float64, Float32, Float16, Int64, Int32, Int16, Int8, UInt8 "
           "are "
@@ -272,7 +272,7 @@ Tensor scale_switch_case(const Tensor& x,
       break;
 #endif
     default:
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "Detected unsupported backend."
           "Only CPU and CUDA Backend are supported for now."
           "Please double check if your backend falls into the above two "

--- a/test/cpp/phi/kernels/sequence_pooling_test.cc
+++ b/test/cpp/phi/kernels/sequence_pooling_test.cc
@@ -56,7 +56,7 @@ void TestSequencePoolingSum(const DeviceContext &context,
   PADDLE_ENFORCE_EQ(
       in_grad.dims().size(),
       out_grad.dims().size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The dimension of input and output shall be same. Expected %ld == "
           "%ld, but got %ld != %ld. Please check the input value.",
           in_grad.dims().size(),
@@ -67,7 +67,7 @@ void TestSequencePoolingSum(const DeviceContext &context,
     PADDLE_ENFORCE_EQ(
         in_grad.dims()[i],
         out_grad.dims()[i],
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The dimension of input and output shall be same. Expected %ld == "
             "%ld, but got %ld != %ld. Please check the input value.",
             in_grad.dims()[i],

--- a/test/cpp/phi/kernels/test_math_function.cc
+++ b/test/cpp/phi/kernels/test_math_function.cc
@@ -297,12 +297,12 @@ TEST(math_function, set_constant) {
   dev_ctx->template Alloc<int>(&t);
   phi::funcs::set_constant(*dev_ctx, &t, static_cast<int>(10));
   for (int64_t i = 0; i < t.numel(); ++i) {
-    PADDLE_ENFORCE_EQ(
-        10,
-        t.data<int>()[i],
-        phi::errors::InvalidArgument("Each value of input tensor should be 10, "
-                                     "but received %d.",
-                                     t.data<int>()[i]));
+    PADDLE_ENFORCE_EQ(10,
+                      t.data<int>()[i],
+                      common::errors::InvalidArgument(
+                          "Each value of input tensor should be 10, "
+                          "but received %d.",
+                          t.data<int>()[i]));
   }
 }
 

--- a/test/cpp/phi/kernels/test_math_function.cu
+++ b/test/cpp/phi/kernels/test_math_function.cu
@@ -27,7 +27,7 @@ void fill_fp16_data(phi::dtype::float16* in_ptr,
   PADDLE_ENFORCE_EQ(
       size,
       data.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of argument data should"
           " be equal to the argument size. Expected %d, but received %d.",
           size,

--- a/test/cpp/pir/core/add_dialect_parser_test.cc
+++ b/test/cpp/pir/core/add_dialect_parser_test.cc
@@ -90,9 +90,9 @@ pir::Attribute TestParserDialect::ParseAttribute(
   PADDLE_ENFORCE_EQ(
       parenthesis_token_val,
       ")",
-      phi::errors::InvalidArgument("The token value of expectation is ), not " +
-                                   parenthesis_token_val + "." +
-                                   parser.GetErrorLocationInfo()));
+      common::errors::InvalidArgument(
+          "The token value of expectation is ), not " + parenthesis_token_val +
+          "." + parser.GetErrorLocationInfo()));
   return CharAttribute::Parse(parser);
 }
 

--- a/test/cpp/pir/core/ir_program_test.cc
+++ b/test/cpp/pir/core/ir_program_test.cc
@@ -52,10 +52,12 @@ class AddOp : public pir::Op<AddOp> {
 };
 void AddOp::VerifySig() {
   if (num_operands() != 2) {
-    PADDLE_THROW(phi::errors::Fatal("The size of inputs must be equal to 2."));
+    PADDLE_THROW(
+        common::errors::Fatal("The size of inputs must be equal to 2."));
   }
   if (num_results() != 1) {
-    PADDLE_THROW(phi::errors::Fatal("The size of outputs must be equal to 1."));
+    PADDLE_THROW(
+        common::errors::Fatal("The size of outputs must be equal to 1."));
   }
 }
 void AddOp::Build(pir::Builder &,

--- a/test/cpp/pir/pass/pass_manager_test.cc
+++ b/test/cpp/pir/pass/pass_manager_test.cc
@@ -80,10 +80,12 @@ class AddOp : public pir::Op<AddOp> {
 };
 void AddOp::VerifySig() {
   if (num_operands() != 2) {
-    PADDLE_THROW(phi::errors::Fatal("The size of inputs must be equal to 2."));
+    PADDLE_THROW(
+        common::errors::Fatal("The size of inputs must be equal to 2."));
   }
   if (num_results() != 1) {
-    PADDLE_THROW(phi::errors::Fatal("The size of outputs must be equal to 1."));
+    PADDLE_THROW(
+        common::errors::Fatal("The size of outputs must be equal to 1."));
   }
 }
 void AddOp::Build(pir::Builder &,
@@ -103,7 +105,7 @@ struct CountOpAnalysis {
     PADDLE_ENFORCE_GT(
         container_op->num_regions(),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "op must be a container with zero or multiple regions."));
 
     LOG(INFO) << "In CountOpAnalysis, op is " << container_op->name() << "\n";

--- a/test/cpp/pir/pattern_rewrite/pattern_rewrite_test.cc
+++ b/test/cpp/pir/pattern_rewrite/pattern_rewrite_test.cc
@@ -84,12 +84,12 @@ void Operation1::VerifySig() {
   auto &attributes = this->attributes();
   if (attributes.count("op2_attr1") == 0 ||
       (!attributes.at("op2_attr1").isa<pir::StrAttribute>())) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Type of attribute: parameter_name is not right."));
   }
   if (attributes.count("op2_attr2") == 0 ||
       (!attributes.at("op2_attr2").isa<pir::StrAttribute>())) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Type of attribute: parameter_name is not right."));
   }
 }
@@ -220,7 +220,7 @@ class RedundantTransposeFusePattern
       std::vector<int> axis_first = GetAxis(prev_trans_op);
       PADDLE_ENFORCE_EQ(axis_first.size(),
                         axis_last.size(),
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "transpose op's perm rank should be same."));
       auto new_perm = GetPerm(axis_first, axis_last);
       rewriter.set_insertion_point(op);

--- a/test/cpp/pir/tools/test_op.cc
+++ b/test/cpp/pir/tools/test_op.cc
@@ -35,10 +35,10 @@ void BranchOp::VerifySig() const {
   PADDLE_ENFORCE_EQ(
       (*this)->num_successors(),
       1u,
-      phi::errors::InvalidArgument("successors number must equal to 1."));
+      common::errors::InvalidArgument("successors number must equal to 1."));
   PADDLE_ENFORCE_NOT_NULL(
       (*this)->successor(0),
-      phi::errors::InvalidArgument("successor[0] can't be nullptr"));
+      common::errors::InvalidArgument("successor[0] can't be nullptr"));
 }
 
 const char *Operation1::attributes_name[2] = {"op1_attr1",   // NOLINT
@@ -56,13 +56,13 @@ void Operation1::VerifySig() const {
   auto &attributes = this->attributes();
   if (attributes.count("op1_attr1") == 0 ||
       !attributes.at("op1_attr1").isa<pir::StrAttribute>()) {
-    PADDLE_THROW(
-        phi::errors::Fatal("Type of attribute: parameter_name is not right."));
+    PADDLE_THROW(common::errors::Fatal(
+        "Type of attribute: parameter_name is not right."));
   }
   if (attributes.count("op1_attr2") == 0 ||
       !attributes.at("op1_attr2").isa<pir::StrAttribute>()) {
-    PADDLE_THROW(
-        phi::errors::Fatal("Type of attribute: parameter_name is not right."));
+    PADDLE_THROW(common::errors::Fatal(
+        "Type of attribute: parameter_name is not right."));
   }
 }
 

--- a/test/cpp/pir/tools/test_trait.cc
+++ b/test/cpp/pir/tools/test_trait.cc
@@ -21,7 +21,7 @@ void OneRegionTrait::Verify(pir::Operation *op) {
   VLOG(1) << "here";
   PADDLE_ENFORCE_EQ(op->num_regions(),
                     1u,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "%s op has one region trait, but its region size is %u",
                         op->name(),
                         op->num_regions()));

--- a/test/deprecated/cpp/inference/analysis/analyzer_tester.cc
+++ b/test/deprecated/cpp/inference/analysis/analyzer_tester.cc
@@ -81,12 +81,12 @@ void TestWord2vecPrediction(const std::string& model_path) {
 
   PADDLE_ENFORCE_EQ(outputs.size(),
                     1UL,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Output size should be 1, but got %d", outputs.size()));
   // Check the output buffer size and result of each tid.
   PADDLE_ENFORCE_EQ(outputs.front().data.length(),
                     33168UL,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Output's data length should be 33168 but got %d",
                         outputs.front().data.length()));
   std::array<float, 5> result = {

--- a/test/deprecated/cpp/inference/api/analyzer_bert_tester.cc
+++ b/test/deprecated/cpp/inference/api/analyzer_bert_tester.cc
@@ -139,12 +139,12 @@ TEST(Analyzer_bert, transfer_scope_cache) {
   PADDLE_ENFORCE_EQ(
       global_transfer_scope_cache.size(),
       threads_num,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "The size of scope cache is not equal to thread number."));
   PADDLE_ENFORCE_EQ(
       global_transfer_data_cache.size(),
       threads_num,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "The size of data cache is not equal to thread number."));
 }
 
@@ -161,7 +161,7 @@ void profile(bool use_mkldnn, bool use_bfloat16) {
 std::vector<std::vector<paddle::PaddleTensor>> LoadInputData() {
   if (FLAGS_infer_data.empty()) {
     LOG(ERROR) << "please set input data path";
-    PADDLE_THROW(phi::errors::NotFound("Missing input data path"));
+    PADDLE_THROW(common::errors::NotFound("Missing input data path"));
   }
 
   std::ifstream fin(FLAGS_infer_data);
@@ -192,7 +192,8 @@ std::vector<paddle::PaddleTensor> ParseInputStreamToVector(
     const std::string &line) {
   const auto fields = Split<std::string>(line, ';');
 
-  if (fields.size() < 5) PADDLE_THROW(phi::errors::Fatal("Invalid input line"));
+  if (fields.size() < 5)
+    PADDLE_THROW(common::errors::Fatal("Invalid input line"));
 
   std::vector<paddle::PaddleTensor> tensors;
 
@@ -230,7 +231,8 @@ AnalysisConfig SetConfig(bool use_mkldnn, bool use_bfloat16) {
 template <typename T>
 paddle::PaddleTensor ParseTensor(const std::string &field) {
   const auto data = Split<std::string>(field, ':');
-  if (data.size() < 2) PADDLE_THROW(phi::errors::Fatal("Invalid data field"));
+  if (data.size() < 2)
+    PADDLE_THROW(common::errors::Fatal("Invalid data field"));
 
   std::string shape_str = data[0];
   const auto shape = Split<int>(shape_str, ' ');

--- a/test/deprecated/cpp/inference/api/analyzer_dam_tester.cc
+++ b/test/deprecated/cpp/inference/api/analyzer_dam_tester.cc
@@ -128,8 +128,9 @@ void PrepareInputs(std::vector<PaddleTensor> *input_slots,
   std::string turn_mask_pre = "turn_mask_";
 
   auto one_batch = data->NextBatch();
-  PADDLE_ENFORCE(!one_batch.response.empty(),
-                 ::phi::errors::Fatal("The response of one batch is empty."));
+  PADDLE_ENFORCE(
+      !one_batch.response.empty(),
+      ::common::errors::Fatal("The response of one batch is empty."));
   int size = one_batch.response[0].size();
   CHECK_EQ(size, kMaxTurnLen);
   // turn tensor assignment
@@ -225,20 +226,20 @@ void profile(bool use_mkldnn = false) {
                  FLAGS_num_threads);
 
   if (FLAGS_num_threads == 1 && !FLAGS_test_all_data) {
-    PADDLE_ENFORCE_GT(
-        outputs.size(),
-        0,
-        ::phi::errors::Fatal("The size of outputs should be greater than 0."));
+    PADDLE_ENFORCE_GT(outputs.size(),
+                      0,
+                      ::common::errors::Fatal(
+                          "The size of outputs should be greater than 0."));
     auto output = outputs.back();
-    PADDLE_ENFORCE_GT(
-        output.size(),
-        0,
-        ::phi::errors::Fatal("The size of output should be greater than 0."));
+    PADDLE_ENFORCE_GT(output.size(),
+                      0,
+                      ::common::errors::Fatal(
+                          "The size of output should be greater than 0."));
     size_t size = GetSize(output[0]);
-    PADDLE_ENFORCE_GT(
-        size,
-        0,
-        ::phi::errors::Fatal("The size of output should be greater than 0."));
+    PADDLE_ENFORCE_GT(size,
+                      0,
+                      ::common::errors::Fatal(
+                          "The size of output should be greater than 0."));
     float *result = static_cast<float *>(output[0].data.data());
     for (size_t i = 0; i < size; i++) {
       EXPECT_NEAR(result[i], result_data[i], 1e-3);

--- a/test/deprecated/cpp/inference/api/analyzer_lac_tester.cc
+++ b/test/deprecated/cpp/inference/api/analyzer_lac_tester.cc
@@ -103,7 +103,7 @@ void GetOneBatch(std::vector<PaddleTensor> *input_slots,
   PADDLE_ENFORCE_EQ(
       batch_size,
       static_cast<int>(one_batch.lod.size() - 1),
-      ::phi::errors::Fatal("The lod size of one batch is invaild."));
+      ::common::errors::Fatal("The lod size of one batch is invaild."));
   input_slots->assign({input_tensor});
 }
 
@@ -144,20 +144,20 @@ TEST(Analyzer_LAC, profile) {
         24, 25, 25, 25, 38, 30, 31, 14, 15, 44, 24, 25, 25, 25, 25, 25,
         44, 24, 25, 25, 25, 36, 42, 43, 44, 14, 15, 44, 14, 15, 44, 14,
         15, 44, 38, 39, 14, 15, 44, 22, 23, 23, 23, 23, 23, 23, 23};
-    PADDLE_ENFORCE_GT(
-        outputs.size(),
-        0,
-        ::phi::errors::Fatal("The size of output should be greater than 0."));
+    PADDLE_ENFORCE_GT(outputs.size(),
+                      0,
+                      ::common::errors::Fatal(
+                          "The size of output should be greater than 0."));
     auto output = outputs.back();
     PADDLE_ENFORCE_EQ(
         output.size(),
         1UL,
-        ::phi::errors::Fatal("The size of output should be equal to 1."));
+        ::common::errors::Fatal("The size of output should be equal to 1."));
     size_t size = GetSize(output[0]);
     size_t batch1_size = sizeof(lac_ref_data) / sizeof(int64_t);
     PADDLE_ENFORCE_GE(size,
                       batch1_size,
-                      ::phi::errors::Fatal("The size of batch is invaild."));
+                      ::common::errors::Fatal("The size of batch is invaild."));
     int64_t *pdata = static_cast<int64_t *>(output[0].data.data());
     for (size_t i = 0; i < batch1_size; ++i) {
       EXPECT_EQ(pdata[i], lac_ref_data[i]);

--- a/test/deprecated/cpp/inference/api/analyzer_mmp_tester.cc
+++ b/test/deprecated/cpp/inference/api/analyzer_mmp_tester.cc
@@ -101,9 +101,9 @@ void compare(bool use_mkldnn = false) {
   PADDLE_ENFORCE_EQ(
       result,
       true,
-      ::phi::errors::Fatal("Results of model run independently "
-                           "differs from results of the same model "
-                           "run as a sequence of models"));
+      ::common::errors::Fatal("Results of model run independently "
+                              "differs from results of the same model "
+                              "run as a sequence of models"));
 }
 
 TEST(Analyzer_mmp, compare) { compare(); }

--- a/test/deprecated/cpp/inference/api/analyzer_ner_tester.cc
+++ b/test/deprecated/cpp/inference/api/analyzer_ner_tester.cc
@@ -125,17 +125,17 @@ void profile(bool memory_load = false) {
     PADDLE_ENFORCE_GT(
         outputs.size(),
         0,
-        phi::errors::Fatal("The size of output should be greater than 0."));
+        common::errors::Fatal("The size of output should be greater than 0."));
     auto output = outputs.back();
     PADDLE_ENFORCE_EQ(
         output.size(),
         1UL,
-        phi::errors::Fatal("The size of output should be equal to 1."));
+        common::errors::Fatal("The size of output should be equal to 1."));
     size_t size = GetSize(output[0]);
     PADDLE_ENFORCE_GT(
         size,
         0,
-        phi::errors::Fatal("The size of output should be greater than 0."));
+        common::errors::Fatal("The size of output should be greater than 0."));
     int64_t *result = static_cast<int64_t *>(output[0].data.data());
     for (size_t i = 0; i < std::min<size_t>(11, size); i++) {
       EXPECT_EQ(result[i], chinese_ner_result_data[i]);

--- a/test/deprecated/cpp/inference/api/analyzer_rnn2_tester.cc
+++ b/test/deprecated/cpp/inference/api/analyzer_rnn2_tester.cc
@@ -146,17 +146,17 @@ TEST(Analyzer_rnn2, profile) {
     PADDLE_ENFORCE_GT(
         outputs.size(),
         0,
-        phi::errors::Fatal("The size of output should be greater than 0."));
+        common::errors::Fatal("The size of output should be greater than 0."));
     auto output = outputs.back();
     PADDLE_ENFORCE_GT(
         output.size(),
         0,
-        phi::errors::Fatal("The size of output should be greater than 0."));
+        common::errors::Fatal("The size of output should be greater than 0."));
     size_t size = GetSize(output[0]);
     PADDLE_ENFORCE_GT(
         size,
         0,
-        phi::errors::Fatal("The size of output should be greater than 0."));
+        common::errors::Fatal("The size of output should be greater than 0."));
     float *result = static_cast<float *>(output[0].data.data());
     for (size_t i = 0; i < size; i++) {
       EXPECT_NEAR(result[i], result_data[i], 1e-3);

--- a/test/deprecated/cpp/inference/api/analyzer_seq_conv1_tester.cc
+++ b/test/deprecated/cpp/inference/api/analyzer_seq_conv1_tester.cc
@@ -66,8 +66,9 @@ struct DataRecord {
       num_lines++;
       std::vector<std::string> data;
       split(line, '\t', &data);
-      PADDLE_ENFORCE_GT(
-          data.size(), 4, phi::errors::Fatal("The size of data is invaild."));
+      PADDLE_ENFORCE_GT(data.size(),
+                        4,
+                        common::errors::Fatal("The size of data is invaild."));
       // load title1 data
       std::vector<int64_t> title1_data;
       split_to_int64(data[0], ' ', &title1_data);
@@ -147,17 +148,17 @@ TEST(Analyzer_seq_conv1, profile) {
     PADDLE_ENFORCE_GT(
         outputs.size(),
         0,
-        phi::errors::Fatal("The size of output should be greater than 0."));
+        common::errors::Fatal("The size of output should be greater than 0."));
     auto output = outputs.back();
     PADDLE_ENFORCE_EQ(
         output.size(),
         1UL,
-        phi::errors::Fatal("The size of output should be equal to 0."));
+        common::errors::Fatal("The size of output should be equal to 0."));
     size_t size = GetSize(output[0]);
     PADDLE_ENFORCE_GT(
         size,
         0,
-        phi::errors::Fatal("The size of output should be greater than 0."));
+        common::errors::Fatal("The size of output should be greater than 0."));
     float *result = static_cast<float *>(output[0].data.data());
     // output is probability, which is in (0, 1).
     for (size_t i = 0; i < size; i++) {

--- a/test/deprecated/cpp/inference/api/analyzer_text_classification_tester.cc
+++ b/test/deprecated/cpp/inference/api/analyzer_text_classification_tester.cc
@@ -25,7 +25,7 @@ struct DataReader {
     PADDLE_ENFORCE_EQ(
         batch_size,
         1,
-        phi::errors::Fatal("The size of batch should be equal to 1."));
+        common::errors::Fatal("The size of batch should be equal to 1."));
     std::string line;
     PaddleTensor tensor;
     tensor.dtype = PaddleDType::INT64;
@@ -89,7 +89,7 @@ TEST(Analyzer_Text_Classification, profile) {
     PADDLE_ENFORCE_GT(
         outputs.size(),
         0,
-        phi::errors::Fatal("The size of output should be greater than 0."));
+        common::errors::Fatal("The size of output should be greater than 0."));
     LOG(INFO) << "get outputs " << outputs.back().size();
     for (auto &output : outputs.back()) {
       LOG(INFO) << "output.shape: " << to_string(output.shape);

--- a/test/deprecated/cpp/inference/api/analyzer_vis_tester.cc
+++ b/test/deprecated/cpp/inference/api/analyzer_vis_tester.cc
@@ -64,7 +64,7 @@ void SetConfig(AnalysisConfig *cfg) {
 void SetInput(std::vector<std::vector<PaddleTensor>> *inputs) {
   PADDLE_ENFORCE_EQ(FLAGS_test_all_data,
                     0,
-                    ::phi::errors::Fatal("Only have single batch of data."));
+                    ::common::errors::Fatal("Only have single batch of data."));
   std::string line;
   std::ifstream file(FLAGS_infer_data);
   std::getline(file, line);
@@ -105,10 +105,10 @@ void profile(bool use_mkldnn = false) {
     auto refer = ProcessALine(line);
     file.close();
 
-    PADDLE_ENFORCE_GT(
-        outputs.size(),
-        0,
-        ::phi::errors::Fatal("The size of output should be greater than 0."));
+    PADDLE_ENFORCE_GT(outputs.size(),
+                      0,
+                      ::common::errors::Fatal(
+                          "The size of output should be greater than 0."));
     auto &output = outputs.back().front();
     size_t numel = output.data.length() / PaddleDtypeSize(output.dtype);
     CHECK_EQ(numel, refer.data.size());

--- a/test/deprecated/cpp/inference/api/api_impl_tester.cc
+++ b/test/deprecated/cpp/inference/api/api_impl_tester.cc
@@ -51,7 +51,7 @@ PaddleTensor LodTensorToPaddleTensor(phi::DenseTensor* t) {
     pt.data.Reset(t->data(), t->numel() * sizeof(int32_t));
     pt.dtype = PaddleDType::INT32;
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Unsupported tensor date type. Now only supports INT64, FP32, INT32."));
   }
   pt.shape = common::vectorize<int>(t->dims());

--- a/test/deprecated/custom_op/custom_raw_op_kernel_op.cc
+++ b/test/deprecated/custom_op/custom_raw_op_kernel_op.cc
@@ -24,7 +24,7 @@ void ReluCPUForward(const phi::DenseTensor &x, phi::DenseTensor *y) {
 void ReluGPUForward(const phi::DenseTensor &x, phi::DenseTensor *y);
 #else
 void ReluGPUForward(const phi::DenseTensor &x, phi::DenseTensor *y) {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "ReluGPUForward is not supported when not compiled with GPU."));
 }
 #endif
@@ -34,9 +34,9 @@ __PD_DEFINE_RAW_OP_KERNEL_FUNC(custom_raw_relu, ctx) {
   const auto *x = ctx.Input<phi::DenseTensor>("X");
   auto *y = ctx.Output<phi::DenseTensor>("Y");
   PADDLE_ENFORCE_NOT_NULL(
-      x, phi::errors::InvalidArgument("Input(X) should not be nullptr."));
+      x, common::errors::InvalidArgument("Input(X) should not be nullptr."));
   PADDLE_ENFORCE_NOT_NULL(
-      y, phi::errors::InvalidArgument("Input(X) should not be nullptr."));
+      y, common::errors::InvalidArgument("Input(X) should not be nullptr."));
   if (phi::is_gpu_place(x->place())) {
     ReluGPUForward(*x, y);
   } else {

--- a/test/xpu/cpp/beam_search_decode_op_xpu_test.cc
+++ b/test/xpu/cpp/beam_search_decode_op_xpu_test.cc
@@ -40,7 +40,7 @@ void GenerateXPUExample(const std::vector<size_t>& level_0,
                         LoDTensorArray* scores) {
   PADDLE_ENFORCE_EQ(level_0.back(),
                     level_1.size() - 1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "source level is used to describe candidate set"
                         ", so it's element should less than levle_1 length. "
                         "And the value of source"
@@ -48,7 +48,7 @@ void GenerateXPUExample(const std::vector<size_t>& level_0,
                         level_1.size() - 1));
   PADDLE_ENFORCE_EQ(level_1.back(),
                     data.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "the lowest level is used to describe data"
                         ", so it's last element should be data length %d. ",
                         data.size()));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/66145#issuecomment-2249572051

Replace phi::errors to common::errors in test/