### PR TITLE
Replace phi::errors [fluid_ops] part4

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/attribute_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/attribute_translator.cc
@@ -70,9 +70,9 @@ class AttributeVisitor {
   virtual pir::Attribute operator()(
       const paddle::experimental::Scalar& scalar) {
     VLOG(10) << "translating scalar";
-    PADDLE_THROW(
-        phi::errors::Unimplemented("not support "
-                                   "translating paddle::experimental::Scalar"));
+    PADDLE_THROW(common::errors::Unimplemented(
+        "not support "
+        "translating paddle::experimental::Scalar"));
   }
 
   virtual pir::Attribute operator()(const std::vector<std::string>& strs) {

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -204,11 +204,11 @@ inline pir::Operation* InsertFullOperationForAttributeInput(
 
 inline pir::Operation* InsertFullArrayOperationForAttributeInput(
     pir::IrContext* ctx, pir::Block* block, pir::Attribute attr) {
-  PADDLE_ENFORCE_EQ(
-      attr.isa<dialect::IntArrayAttribute>(),
-      true,
-      phi::errors::InvalidArgument("Encounter non IntArray type when trying to "
-                                   "insert IntArray mutable attribute"));
+  PADDLE_ENFORCE_EQ(attr.isa<dialect::IntArrayAttribute>(),
+                    true,
+                    common::errors::InvalidArgument(
+                        "Encounter non IntArray type when trying to "
+                        "insert IntArray mutable attribute"));
   phi::IntArray int_array = attr.dyn_cast<dialect::IntArrayAttribute>().data();
   pir::Builder builder(ctx, block);
   dialect::FullIntArrayOp full_int_array_op =
@@ -316,9 +316,9 @@ pir::OpInfo OpTranscriber::LookUpOpInfo(pir::IrContext* ctx,
       PADDLE_ENFORCE_NE(
           var_desc,
           nullptr,
-          phi::errors::InvalidArgument("[Op:%s] Input %s should not be null",
-                                       op_desc.Type(),
-                                       pair.second[0]));
+          common::errors::InvalidArgument("[Op:%s] Input %s should not be null",
+                                          op_desc.Type(),
+                                          pair.second[0]));
       if (var_desc->GetType() ==
           paddle::framework::proto::VarType::SPARSE_COO) {
         input_types.emplace_back("sparse_coo");
@@ -329,7 +329,7 @@ pir::OpInfo OpTranscriber::LookUpOpInfo(pir::IrContext* ctx,
                  paddle::framework::proto::VarType::LOD_TENSOR) {
         input_types.emplace_back("dense");
       } else {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "Op %d only support dense tensor ,sparse_coo and sparse_csr, but "
             "not %d",
             op_desc.Type(),
@@ -360,7 +360,7 @@ pir::OpInfo OpTranscriber::LookUpOpInfo(pir::IrContext* ctx,
     }
     PADDLE_ENFORCE_EQ(!target_op_name.empty(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Op %d should have corresponding OpInfo %d",
                           op_desc.Type(),
                           target_op_name));
@@ -371,7 +371,7 @@ pir::OpInfo OpTranscriber::LookUpOpInfo(pir::IrContext* ctx,
     }
     auto op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op %d should have corresponding OpInfo %d",
           op_desc.Type(),
           target_op_name));
@@ -400,12 +400,12 @@ pir::OpInfo OpTranscriber::LookUpOpInfo(pir::IrContext* ctx,
     std::string legacy_input_name =
         op_normalizer.GetLegacyArgName(op_desc.Type(), info.name);
     auto legacy_input_vars = op_desc.Input(legacy_input_name, true);
-    PADDLE_ENFORCE_EQ(
-        legacy_input_vars.size() <= 1,
-        true,
-        phi::errors::InvalidArgument("Do not support duplicable tensor input, "
-                                     "when op have multi kernels. OP is %s.",
-                                     op_desc.Type()));
+    PADDLE_ENFORCE_EQ(legacy_input_vars.size() <= 1,
+                      true,
+                      common::errors::InvalidArgument(
+                          "Do not support duplicable tensor input, "
+                          "when op have multi kernels. OP is %s.",
+                          op_desc.Type()));
 
     if (legacy_input_vars.empty()) {
       need_inputs_sig.emplace_back("");
@@ -415,9 +415,9 @@ pir::OpInfo OpTranscriber::LookUpOpInfo(pir::IrContext* ctx,
     PADDLE_ENFORCE_NE(
         var,
         nullptr,
-        phi::errors::InvalidArgument("[Op:%s] Input %s should not be null",
-                                     op_desc.Type(),
-                                     legacy_input_vars[0]));
+        common::errors::InvalidArgument("[Op:%s] Input %s should not be null",
+                                        op_desc.Type(),
+                                        legacy_input_vars[0]));
 
     if (var->GetType() == paddle::framework::proto::VarType::LOD_TENSOR) {
       need_inputs_sig.emplace_back("dense");
@@ -425,7 +425,7 @@ pir::OpInfo OpTranscriber::LookUpOpInfo(pir::IrContext* ctx,
                paddle::framework::proto::VarType::SELECTED_ROWS) {
       need_inputs_sig.emplace_back("selected_rows");
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op %d only support dense tensor and selected_rows, but not %d",
           op_desc.Type(),
           var->GetType()));
@@ -456,19 +456,19 @@ pir::OpInfo OpTranscriber::LookUpOpInfo(pir::IrContext* ctx,
     }
   }
 
-  PADDLE_ENFORCE_EQ(
-      !target_op_name.empty(),
-      true,
-      phi::errors::InvalidArgument("Op %d should have corresponding OpInfo %d",
-                                   op_desc.Type(),
-                                   target_op_name));
+  PADDLE_ENFORCE_EQ(!target_op_name.empty(),
+                    true,
+                    common::errors::InvalidArgument(
+                        "Op %d should have corresponding OpInfo %d",
+                        op_desc.Type(),
+                        target_op_name));
 
   target_op_name = GetPrefix(ctx, op_desc) + target_op_name;
   if (IsInplace(op_desc) && *target_op_name.rbegin() != '_') {
     target_op_name += "_";
   }
   if (!op_info) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Op %d should have corresponding OpInfo %d",
         op_desc.Type(),
         target_op_name));
@@ -525,9 +525,9 @@ pir::Value OpTranscriber::GetAttributeAsInput(pir::IrContext* ctx,
 
   if (!op_desc.HasAttr(legacy_attr_name)) {
     PADDLE_THROW(
-        phi::errors::InvalidArgument("Op %s arg %s should not be zero size",
-                                     op_desc.Type(),
-                                     legacy_attr_name));
+        common::errors::InvalidArgument("Op %s arg %s should not be zero size",
+                                        op_desc.Type(),
+                                        legacy_attr_name));
   }
   paddle::framework::Attribute legacy_attr = op_desc.GetAttr(legacy_attr_name);
   VLOG(10) << "[" << op_desc.Type() << "][attribute]"
@@ -631,9 +631,9 @@ std::vector<pir::Value> OpTranscriber::GenerateOperationInput(
       PADDLE_ENFORCE_NE(
           var,
           nullptr,
-          phi::errors::InvalidArgument("[op:%s] Input %s should not be null",
-                                       op_desc.Type(),
-                                       legacy_input_vars[0]));
+          common::errors::InvalidArgument("[op:%s] Input %s should not be null",
+                                          op_desc.Type(),
+                                          legacy_input_vars[0]));
       if (var->GetType() ==
           paddle::framework::proto::VarType::LOD_TENSOR_ARRAY) {
         is_vector = false;
@@ -642,15 +642,15 @@ std::vector<pir::Value> OpTranscriber::GenerateOperationInput(
 
     // if src type is Tensor
     if (!is_vector) {
-      PADDLE_ENFORCE_EQ(
-          legacy_input_vars.size(),
-          1UL,
-          phi::errors::InvalidArgument("Input %s not found when parsing op %s",
-                                       info.name,
-                                       op_desc.Type()));
+      PADDLE_ENFORCE_EQ(legacy_input_vars.size(),
+                        1UL,
+                        common::errors::InvalidArgument(
+                            "Input %s not found when parsing op %s",
+                            info.name,
+                            op_desc.Type()));
       PADDLE_ENFORCE_NE(param_map->count(legacy_input_vars[0]),
                         0UL,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Input [%s: %s] of op [%s] not found in param map",
                             info.name,
                             legacy_input_vars[0],
@@ -698,7 +698,7 @@ OpTranscriber::GenerateOperationOutput(pir::IrContext* ctx,
       PADDLE_ENFORCE_EQ(
           info.optional,
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Op %s arg %s should be optional if it can be empty",
               op_desc.Type(),
               legacy_output_name));
@@ -718,12 +718,12 @@ OpTranscriber::GenerateOperationOutput(pir::IrContext* ctx,
     // Vector<DenseTensor>
     if (legacy_output_vars.size() == 1) {
       VarDesc* var = block->FindVarRecursive(legacy_output_vars[0]);
-      PADDLE_ENFORCE_NE(
-          var,
-          nullptr,
-          phi::errors::InvalidArgument("[op:%s] Output %s should not be null",
-                                       op_desc.Type(),
-                                       legacy_output_vars[0]));
+      PADDLE_ENFORCE_NE(var,
+                        nullptr,
+                        common::errors::InvalidArgument(
+                            "[op:%s] Output %s should not be null",
+                            op_desc.Type(),
+                            legacy_output_vars[0]));
       if (var->GetType() ==
           paddle::framework::proto::VarType::LOD_TENSOR_ARRAY) {
         pir::Type translated_var_type =
@@ -747,12 +747,12 @@ OpTranscriber::GenerateOperationOutput(pir::IrContext* ctx,
 
       auto& var_name = legacy_output_vars[0];
       VarDesc* var = block->FindVarRecursive(var_name);
-      PADDLE_ENFORCE_NE(
-          var,
-          nullptr,
-          phi::errors::InvalidArgument("[op:%s] Output %s should not be null",
-                                       op_desc.Type(),
-                                       var_name));
+      PADDLE_ENFORCE_NE(var,
+                        nullptr,
+                        common::errors::InvalidArgument(
+                            "[op:%s] Output %s should not be null",
+                            op_desc.Type(),
+                            var_name));
       VLOG(10) << "[output translating]"
                << "[" << op_desc.Type() << "]" << info.name
                << " var: " << var_name << " type: " << var->GetType();
@@ -778,12 +778,12 @@ OpTranscriber::GenerateOperationOutput(pir::IrContext* ctx,
           continue;
         }
         VarDesc* var = block->FindVarRecursive(var_name);
-        PADDLE_ENFORCE_NE(
-            var,
-            nullptr,
-            phi::errors::InvalidArgument("[op:%s] Output %s should not be null",
-                                         op_desc.Type(),
-                                         var_name));
+        PADDLE_ENFORCE_NE(var,
+                          nullptr,
+                          common::errors::InvalidArgument(
+                              "[op:%s] Output %s should not be null",
+                              op_desc.Type(),
+                              var_name));
         VLOG(10) << "[output translating]"
                  << "[" << op_desc.Type() << "]" << info.name
                  << " var: " << var_name << " type: " << var->GetType();
@@ -964,12 +964,12 @@ struct Assign2AssignOpTranscriber : public OpTranscriber {
 
     PADDLE_ENFORCE_EQ(op_desc.HasInput("X"),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "op %s should have input `X`", op_desc.Type()));
     const auto& input_vars = op_desc.Input("X");
     PADDLE_ENFORCE_EQ(input_vars.size() == 1,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "op %s should have one input `X`, but got %d.",
                           op_desc.Type(),
                           input_vars.size()));
@@ -982,7 +982,7 @@ struct Assign2AssignOpTranscriber : public OpTranscriber {
 
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op assign should have corresponding OpInfo %s.", target_op_name));
     }
 
@@ -996,7 +996,7 @@ struct Assign2AssignOutOpTranscriber : public OpTranscriber {
     const auto& op_info =
         ctx->GetRegisteredOpInfo(paddle::dialect::AssignOut_Op::name());
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op assign should have corresponding OpInfo %s.",
           paddle::dialect::AssignOut_Op::name()));
     }
@@ -1131,7 +1131,7 @@ struct AssignValueOpTranscriber : public OpTranscriber {
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
       PADDLE_ENFORCE(false,
-                     phi::errors::InvalidArgument(
+                     common::errors::InvalidArgument(
                          "Op assign_value should have corresponding OpInfo "
                          "pd_op.assign_value"));
     }
@@ -1164,7 +1164,7 @@ struct AssignValueOpTranscriber : public OpTranscriber {
     if (op_desc.HasAttr("shape")) {
       legacy_attr = op_desc.GetAttr("shape");
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op assign_value should have attribute `shape` but not find"));
     }
     pir::Attribute attr_shape =
@@ -1174,7 +1174,7 @@ struct AssignValueOpTranscriber : public OpTranscriber {
     if (op_desc.HasAttr("dtype")) {
       legacy_attr = op_desc.GetAttr("dtype");
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op assign_value should have attribute `dtype` but not find"));
     }
     pir::Attribute attr_dtype =
@@ -1203,11 +1203,11 @@ struct AssignValueOpTranscriber : public OpTranscriber {
       }
     }
 
-    PADDLE_ENFORCE_NE(
-        attribute_map.find("values"),
-        attribute_map.end(),
-        phi::errors::InvalidArgument("Op assign_value should have attribute "
-                                     "`**_values` or `values` but not find"));
+    PADDLE_ENFORCE_NE(attribute_map.find("values"),
+                      attribute_map.end(),
+                      common::errors::InvalidArgument(
+                          "Op assign_value should have attribute "
+                          "`**_values` or `values` but not find"));
 
     TranslateOpDistAttribute(op_desc, &attribute_map);
 
@@ -1258,16 +1258,16 @@ pir::Value TranslateDropOutStateIn(pir::IrContext* ctx,
   PADDLE_ENFORCE_NE(
       dropout_state,
       nullptr,
-      phi::errors::InvalidArgument("[op:%s] Output %s should not be null",
-                                   op_desc.Type(),
-                                   legacy_output_vars[0]));
+      common::errors::InvalidArgument("[op:%s] Output %s should not be null",
+                                      op_desc.Type(),
+                                      legacy_output_vars[0]));
   auto& type_translator = TypeTranslator::instance();
   pir::Type translated_var_type =
       type_translator[dropout_state->GetType()](ctx, *dropout_state);
   PADDLE_ENFORCE_EQ(
       translated_var_type.isa<dialect::DenseTensorType>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Unexpected: Rnn Op's output DropoutState should be a DenseTensor"));
   auto tensor_type = translated_var_type.dyn_cast<dialect::DenseTensorType>();
 
@@ -1319,7 +1319,7 @@ struct EmbeddingGradOpTranscriber : public OpTranscriber {
             << target_op_name;
     auto op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op %d should have corresponding OpInfo %d",
           op_desc.Type(),
           target_op_name));
@@ -1421,7 +1421,7 @@ struct SplitOpTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_EQ(
         x_input_vars.size(),
         1UL,
-        phi::errors::InvalidArgument("x input of split MUST be a tensor"));
+        common::errors::InvalidArgument("x input of split MUST be a tensor"));
     auto x_defining_info = (*param_map)[x_input_vars[0]];
     op_inputs.push_back(x_defining_info.value);
 
@@ -1453,7 +1453,7 @@ struct SplitOpTranscriber : public OpTranscriber {
       auto axis_var_list = op_desc.Input("AxisTensor");
       PADDLE_ENFORCE_EQ(axis_var_list.size(),
                         1UL,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "axis tensor input of split MUST be a tensor"));
       auto axis_defining_info = (*param_map)[axis_var_list[0]];
       op_inputs.push_back(axis_defining_info.value);
@@ -1512,7 +1512,7 @@ struct SplitOpTranscriber : public OpTranscriber {
 
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op assign_value should have corresponding OpInfo %s.",
           target_op_name));
     }
@@ -1605,7 +1605,7 @@ struct AddNOpTranscriber : public OpTranscriber {
 
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op add_n should have corresponding OpInfo %s", target_op_name));
     }
 
@@ -1625,9 +1625,9 @@ struct TrilAndTriuOpTranscriber : public OpTranscriber {
     }
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("Op tril_triu should have corresponding "
-                                       "OpInfo pd_op.tril or pd_op.triu."));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Op tril_triu should have corresponding "
+          "OpInfo pd_op.tril or pd_op.triu."));
     }
 
     return op_info;
@@ -1646,11 +1646,11 @@ struct TrilAndTriuGradOpTranscriber : public OpTranscriber {
     }
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("Op tril_triu_grad should have "
-                                       "corresponding OpInfo pd_op.tril_grad "
-                                       "or "
-                                       "pd_op.triu_grad."));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Op tril_triu_grad should have "
+          "corresponding OpInfo pd_op.tril_grad "
+          "or "
+          "pd_op.triu_grad."));
     }
 
     return op_info;
@@ -1667,7 +1667,7 @@ ValueInfo GetTensorInfoByVarName(const OpDesc& op_desc,
   PADDLE_ENFORCE_EQ(
       names.size(),
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Expected op[%s]'s input %s has only 1 variable, but got %d",
           op_desc.Type(),
           var_name,
@@ -1676,7 +1676,7 @@ ValueInfo GetTensorInfoByVarName(const OpDesc& op_desc,
   PADDLE_ENFORCE_GT(
       param_map->count(name),
       0UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Expected op[%s]'s input %s has been parsed", op_desc.Type(), name));
   const auto& defining_info = param_map->at(name);
 
@@ -1684,12 +1684,12 @@ ValueInfo GetTensorInfoByVarName(const OpDesc& op_desc,
   PADDLE_ENFORCE_NE(
       value,
       nullptr,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Expected op[%s]'s input %s is not null", op_desc.Type(), name));
   const pir::Type& type = value.type();
   PADDLE_ENFORCE_EQ(type.isa<dialect::DenseTensorType>(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Expected op[%s]'s input %s is DenseTensor but got %s",
                         op_desc.Type(),
                         name,
@@ -1724,7 +1724,7 @@ struct MulOpTranscriber : public OpTranscriber {
     const std::string& target_op_name = paddle::dialect::MatmulOp::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op %d should have corresponding OpInfo %d",
           op_desc.Type(),
           target_op_name));
@@ -1765,7 +1765,7 @@ struct MulOpTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_EQ(
         x_num_col_dims <= static_cast<int>(x_shape.size()),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected op[%s]'s attr `x_num_col_dims` less than or equal to "
             "dim of input X %s, but got %d",
             op_desc.Type(),
@@ -1780,7 +1780,7 @@ struct MulOpTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_EQ(
         y_num_col_dims <= static_cast<int>(y_shape.size()),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected op[%s]'s attr `y_num_col_dims` less than or equal to "
             "dim of input Y %s, but got %d",
             op_desc.Type(),
@@ -1903,7 +1903,7 @@ struct MulGradOpTranscriber : public OpTranscriber {
             << target_op_name;
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op %d should have corresponding OpInfo %d",
           op_desc.Type(),
           target_op_name));
@@ -1944,7 +1944,7 @@ struct MulGradOpTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_EQ(
         x_num_col_dims <= static_cast<int>(x_shape.size()),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected op[%s]'s attr `x_num_col_dims` less than or equal to "
             "dim of input X %s, but got %d",
             op_desc.Type(),
@@ -1959,7 +1959,7 @@ struct MulGradOpTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_EQ(
         y_num_col_dims <= static_cast<int>(y_shape.size()),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected op[%s]'s attr `y_num_col_dims` less than or equal to "
             "dim of input Y %s, but got %d",
             op_desc.Type(),
@@ -2045,7 +2045,7 @@ struct MulGradOpTranscriber : public OpTranscriber {
       PADDLE_ENFORCE_EQ(
           grad_output.size(),
           1UL,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Expected op[%s]'s output %s has only 1 variable, but got %d",
               op_desc.Type(),
               var_name,
@@ -2054,7 +2054,7 @@ struct MulGradOpTranscriber : public OpTranscriber {
 
       auto idx_iter = arg_to_idx.find(grad_var_name);
       if (idx_iter == arg_to_idx.end()) {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "op[%s] should have got its %s", op_desc.Type(), var_name));
       }
       auto [idx_in_op, idx_in_vec] = idx_iter->second;
@@ -2067,9 +2067,9 @@ struct MulGradOpTranscriber : public OpTranscriber {
       PADDLE_ENFORCE_NE(
           var_desc,
           nullptr,
-          phi::errors::InvalidArgument("[op:%s] Input %s should not be null",
-                                       op_desc.Type(),
-                                       var_name.substr(0, 1)));
+          common::errors::InvalidArgument("[op:%s] Input %s should not be null",
+                                          op_desc.Type(),
+                                          var_name.substr(0, 1)));
       std::vector<int64_t> shape = var_desc->GetShape();
       DenseTensorTypeStorage::Dim dim = common::make_ddim(shape);
 
@@ -2077,7 +2077,7 @@ struct MulGradOpTranscriber : public OpTranscriber {
       auto reshape_op = builder.Build<dialect::ReshapeOp>(value_res, shape);
       PADDLE_ENFORCE_NE(value_res,
                         nullptr,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "Expected op[%s]'s input %s is not null",
                             op_desc.Type(),
                             grad_var_name));
@@ -2085,7 +2085,7 @@ struct MulGradOpTranscriber : public OpTranscriber {
       PADDLE_ENFORCE_EQ(
           grad_type.isa<dialect::DenseTensorType>(),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Expected op[%s]'s input %s is DenseTensor but got %s",
               op_desc.Type(),
               grad_var_name,
@@ -2115,7 +2115,7 @@ struct FillConstant2FullTranscriber : public OpTranscriber {
                            const OpDesc& op_desc) override {
     const auto& op_info = ctx->GetRegisteredOpInfo(dialect::FullOp::name());
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op fill_constant should have corresponding OpInfo pd_op.full"));
     }
 
@@ -2197,7 +2197,7 @@ struct FillConstant2FullWithTensorTranscriber : public OpTranscriber {
                            const OpDesc& op_desc) override {
     const auto& op_info = ctx->GetRegisteredOpInfo("pd_op.full_with_tensor");
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op fill_constant should have corresponding OpInfo "
           "pd_op.full_with_tensor"));
     }
@@ -2301,7 +2301,7 @@ struct SelectInputOpTranscriber : public OpTranscriber {
     auto& Input_name = op_desc.Input("X");
     PADDLE_ENFORCE_GT(param_map->count(Mask_name),
                       0UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Expected op[%s]'s input %s has been parsed",
                           op_desc.Type(),
                           Mask_name));
@@ -2309,7 +2309,7 @@ struct SelectInputOpTranscriber : public OpTranscriber {
     for (auto in_name : Input_name) {
       PADDLE_ENFORCE_GT(param_map->count(in_name),
                         0UL,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Expected op[%s]'s input %s has been parsed",
                             op_desc.Type(),
                             in_name));
@@ -2350,7 +2350,7 @@ struct SelectInputOpTranscriber : public OpTranscriber {
                        0, undefined_prefix.size()) == undefined_prefix) {
           // do nothing
         } else {
-          PADDLE_THROW(phi::errors::InvalidArgument(
+          PADDLE_THROW(common::errors::InvalidArgument(
               "select_input only support same type or DenseTensorType with "
               "only different dim, but get dtype:[%s, %s], layout:[%s, "
               "%s], "
@@ -2375,10 +2375,11 @@ struct SelectInputOpTranscriber : public OpTranscriber {
         PADDLE_ENFORCE_EQ(
             undefine_value.defining_op()->isa<dialect::AssignValueOp>(),
             true,
-            phi::errors::InvalidArgument("undefined_var %s should be generated "
-                                         "by assign_value, but got %s",
-                                         Input_name[undefined_var_index],
-                                         undefine_value.defining_op()));
+            common::errors::InvalidArgument(
+                "undefined_var %s should be generated "
+                "by assign_value, but got %s",
+                Input_name[undefined_var_index],
+                undefine_value.defining_op()));
 
         undefine_value.set_type(target_var_type);
         undefine_value.defining_op()->set_attribute(
@@ -2415,12 +2416,12 @@ struct SelectInputOpTranscriber : public OpTranscriber {
                                                 tensor1.lod(),
                                                 tensor1.offset()));
     } else {
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("select_input only support same type or "
-                                       "DenseTensorType with only "
-                                       "different dim, now is %s != %s.",
-                                       input1,
-                                       input2));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "select_input only support same type or "
+          "DenseTensorType with only "
+          "different dim, now is %s != %s.",
+          input1,
+          input2));
     }
 
     pir::Operation* operation = pir::Operation::Create(
@@ -2446,14 +2447,14 @@ struct SelectOutputOpTranscriber : public OpTranscriber {
     auto& Input_name = op_desc.Input("X")[0];
     PADDLE_ENFORCE_GT(param_map->count(Mask_name),
                       0UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Expected op[%s]'s input %s has been parsed",
                           op_desc.Type(),
                           Mask_name));
     op_inputs.push_back(param_map->at(Mask_name).value);
     PADDLE_ENFORCE_GT(param_map->count(Input_name),
                       0UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Expected op[%s]'s input %s has been parsed",
                           op_desc.Type(),
                           Input_name));
@@ -2467,7 +2468,7 @@ struct SelectOutputOpTranscriber : public OpTranscriber {
     auto Out_names = op_desc.Output("Out");
     PADDLE_ENFORCE_EQ(Out_names.size(),
                       2UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Expected SelectOutput's output size is 2."));
     for (size_t idx = 0; idx < Out_names.size(); idx++) {
       VarDesc* var = op_desc.Block()->FindVarRecursive(Out_names[idx]);
@@ -2499,17 +2500,17 @@ pir::Value TranslateNumClassesForOneHot(pir::IrContext* ctx,
     legacy_vars = op_desc.Input(legacy_tensor_name);
     PADDLE_ENFORCE_EQ(legacy_vars.size(),
                       1UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "depth_tensor input of one hot MUST be a tensor"));
     auto var_name = legacy_vars[0];
     PADDLE_ENFORCE_EQ(legacy_vars.size(),
                       1UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "depth_tensor input of one hot MUST be a tensor"));
     PADDLE_ENFORCE_NE(
         param_map->count(legacy_vars[0]),
         0UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "%s should be existed in one_hot_v2 as input depth_tensor.",
             legacy_vars[0]));
     auto defining_info = param_map->at(legacy_vars[0]);
@@ -2519,9 +2520,9 @@ pir::Value TranslateNumClassesForOneHot(pir::IrContext* ctx,
   auto& attribute_translator = AttributeTranslator::instance();
   if (!op_desc.HasAttr(legacy_attr_name)) {
     PADDLE_THROW(
-        phi::errors::InvalidArgument("Op %s arg %s should not be zero size",
-                                     op_desc.Type(),
-                                     legacy_attr_name));
+        common::errors::InvalidArgument("Op %s arg %s should not be zero size",
+                                        op_desc.Type(),
+                                        legacy_attr_name));
   }
   paddle::framework::Attribute legacy_attr = op_desc.GetAttr(legacy_attr_name);
   VLOG(10) << "[" << op_desc.Type() << "][attribute]"
@@ -2565,15 +2566,15 @@ pir::Attribute TranslateDtypeForArange(pir::IrContext* ctx,
   PADDLE_ENFORCE_EQ(
       op_desc.Input("Start").size(),
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "[op:%s] Input [Start]'s size should be equal to 1", op_desc.Type()));
   auto var_desc = op_desc.Block()->FindVarRecursive(op_desc.Input("Start")[0]);
   PADDLE_ENFORCE_NE(
       var_desc,
       nullptr,
-      phi::errors::InvalidArgument("[op:%s] Input %s should not be null",
-                                   op_desc.Type(),
-                                   op_desc.Input("Start")[0]));
+      common::errors::InvalidArgument("[op:%s] Input %s should not be null",
+                                      op_desc.Type(),
+                                      op_desc.Input("Start")[0]));
   auto start_proto_dtype = var_desc->GetDataType();
   auto start_phi_dtype = phi::TransToPhiDataType(start_proto_dtype);
   auto dtype_attr =
@@ -2640,14 +2641,14 @@ struct ElementwiseTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_EQ(
         x_names.size(),
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected op[%s]'s input X has only 1 variable, but got %d",
             op_desc.Type(),
             x_names.size()));
     auto x_name = x_names[0];
     PADDLE_ENFORCE_GT(param_map->count(x_name),
                       0UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Expected op[%s]'s input %s has been parsed",
                           op_desc.Type(),
                           x_name));
@@ -2661,13 +2662,13 @@ struct ElementwiseTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_NE(
         x_value,
         nullptr,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Expected op[%s]'s input %s is not null", op_desc.Type(), x_name));
     pir::Type x_type = x_value.type();
     PADDLE_ENFORCE_EQ(
         x_type.isa<dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected op[%s]'s input %s is DenseTensor but got %s",
             op_desc.Type(),
             x_name,
@@ -2680,14 +2681,14 @@ struct ElementwiseTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_EQ(
         y_names.size(),
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected op[%s]'s input Y has only 1 variable, but got %d",
             op_desc.Type(),
             y_names.size()));
     auto y_name = y_names[0];
     PADDLE_ENFORCE_GT(param_map->count(y_name),
                       0UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Expected op[%s]'s input %s has been parsed",
                           op_desc.Type(),
                           y_name));
@@ -2701,13 +2702,13 @@ struct ElementwiseTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_NE(
         y_value,
         nullptr,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Expected op[%s]'s input %s is not null", op_desc.Type(), y_name));
     pir::Type y_type = y_value.type();
     PADDLE_ENFORCE_EQ(
         y_type.isa<dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected op[%s]'s input %s is DenseTensor but got %s",
             op_desc.Type(),
             y_name,
@@ -2728,7 +2729,7 @@ struct ElementwiseTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_GT(
         append_size,
         0UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected op[%s] have append size > 0 with axis=%d but got %d",
             op_desc.Type(),
             axis,
@@ -2775,7 +2776,7 @@ struct GradAddOpTranscriber : public ElementwiseTranscriber {
     }
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op assign_value should have corresponding OpInfo "
           "pd_op.assign_value_"));
     }
@@ -2805,7 +2806,7 @@ struct ElementwiseGradTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_EQ(
         y_grad_output.size(),
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected op[%s]'s output Y@GRAD has only 1 variable, but got %d",
             op_desc.Type(),
             y_grad_output.size()));
@@ -2813,7 +2814,7 @@ struct ElementwiseGradTranscriber : public OpTranscriber {
 
     auto idx_iter = arg_to_idx.find(y_grad_var_name);
     if (idx_iter == arg_to_idx.end()) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "op[%s] should have got its y_grad", op_desc.Type()));
     }
     auto [idx_in_op, idx_in_vec] = idx_iter->second;
@@ -2825,7 +2826,7 @@ struct ElementwiseGradTranscriber : public OpTranscriber {
     auto y_name = y_names[0];
     PADDLE_ENFORCE_GT(param_map->count(y_name),
                       0UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Expected op[%s]'s input %s has been parsed",
                           op_desc.Type(),
                           y_name));
@@ -2834,13 +2835,13 @@ struct ElementwiseGradTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_NE(
         y_value,
         nullptr,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Expected op[%s]'s input %s is not null", op_desc.Type(), y_name));
     pir::Type y_type = y_value.type();
     PADDLE_ENFORCE_EQ(
         y_type.isa<dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected op[%s]'s input %s is DenseTensor but got %s",
             op_desc.Type(),
             y_name,
@@ -2855,7 +2856,7 @@ struct ElementwiseGradTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_EQ(
         y_grad_type.isa<dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected op[%s]'s input %s is DenseTensor but got %s",
             op_desc.Type(),
             y_grad_var_name,
@@ -2886,10 +2887,10 @@ struct SetValueOpTranscriber : public OpTranscriber {
         op_normalizer.GetLegacyAttrName(op_desc.Type(), input_info.name);
 
     if (!op_desc.HasAttr(legacy_attr_name)) {
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("Op %s arg %s should not be zero size",
-                                       op_desc.Type(),
-                                       legacy_attr_name));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Op %s arg %s should not be zero size",
+          op_desc.Type(),
+          legacy_attr_name));
     }
     framework::Attribute legacy_attr = op_desc.GetAttr(legacy_attr_name);
     VLOG(10) << "[" << op_desc.Type() << "][attribute]"
@@ -2909,7 +2910,7 @@ struct SetValueWithTensorOpTranscriber : public SetValueOpTranscriber {
     std::string target_op_name = dialect::SetValueWithTensorOp::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op set_value should have corresponding OpInfo "
           "pd_op.set_value_with_tensor"));
     }
@@ -2929,17 +2930,17 @@ struct SetValueWithTensorOpTranscriber : public SetValueOpTranscriber {
               const OpInputInfo& info,
               pir::Block* block) -> pir::Value {
       std::vector<std::string> legacy_input_vars;
-      PADDLE_ENFORCE_EQ(
-          op_desc.HasInput("ValueTensor"),
-          true,
-          phi::errors::InvalidArgument("[set_value] should have ValueTensor"));
+      PADDLE_ENFORCE_EQ(op_desc.HasInput("ValueTensor"),
+                        true,
+                        common::errors::InvalidArgument(
+                            "[set_value] should have ValueTensor"));
       legacy_input_vars = op_desc.Input("ValueTensor", true);
-      PADDLE_ENFORCE_EQ(
-          legacy_input_vars.size(),
-          1UL,
-          phi::errors::InvalidArgument("[set_value][ValueTensor] should only "
-                                       "have 1 variable, but got %d",
-                                       legacy_input_vars.size()));
+      PADDLE_ENFORCE_EQ(legacy_input_vars.size(),
+                        1UL,
+                        common::errors::InvalidArgument(
+                            "[set_value][ValueTensor] should only "
+                            "have 1 variable, but got %d",
+                            legacy_input_vars.size()));
       auto var_name = legacy_input_vars[0];
       auto defining_info = (*param_map)[var_name];
       if (defining_info.generated_by_vector) {
@@ -2958,7 +2959,7 @@ struct SetValueGradOpTranscriber : public SetValueWithTensorOpTranscriber {
     std::string target_op_name = dialect::SetValueWithTensorGradOp::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op set_value_grad should have corresponding OpInfo "
           "pd_op.set_value_with_tensor_grad"));
     }
@@ -3037,7 +3038,7 @@ struct FusedFeedForwardOpTranscriber : public OpTranscriber {
       const auto& output_vars = op_desc.Output("Out");
       PADDLE_ENFORCE_EQ(output_vars.size(),
                         1UL,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Expected op[%s]'s Out has only 1 var but got %s",
                             op_desc.Type(),
                             output_vars.size()));
@@ -3056,7 +3057,7 @@ struct ShareBufferOpTranscriber : public OpTranscriber {
     std::string target_op_name = dialect::ShareData_Op::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op share_buffer should have corresponding OpInfo "
           "pd_op.share_data_"));
     }
@@ -3083,7 +3084,7 @@ struct RandIntOpTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_NE(
         var,
         nullptr,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "[op:%s] Output %s should not be null", op_desc.Type(), var_name));
     int dtype_attr_val = PADDLE_GET_CONST(int, op_desc.GetAttr("dtype"));
 
@@ -3213,7 +3214,7 @@ struct FusedElemwiseAddActivationGradOpTranscriber
                            const OpDesc& op_desc) override {
     const auto inter_out_grad = op_desc.Output("IntermediateOut@GRAD");
     if (inter_out_grad.size() > 0) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "pd_op.fused_elemwise_add_activation_grad doesn't have "
           "Intermediate_out_grad output"));
     }
@@ -3251,11 +3252,11 @@ struct MatrixRankOpTranscriber : public OpTranscriber {
     }
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("Op matrix_rank should have "
-                                       "corresponding OpInfo pd_op.matrix_rank "
-                                       "or "
-                                       "pd_op.matrix_rank_tol."));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Op matrix_rank should have "
+          "corresponding OpInfo pd_op.matrix_rank "
+          "or "
+          "pd_op.matrix_rank_tol."));
     }
     return op_info;
   }
@@ -3267,7 +3268,7 @@ struct LodArrayLengthOpTranscriber : public OpTranscriber {
     std::string target_op_name = dialect::ArrayLengthOp::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op lod_array_length should have corresponding OpInfo "
           "pd_op.array_length"));
     }
@@ -3290,20 +3291,20 @@ struct LodArrayLengthOpTranscriber : public OpTranscriber {
       PADDLE_ENFORCE_EQ(
           op_desc.HasInput("X"),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Op lod_array_length should have input `X` but not found"));
       const auto& vars = op_desc.Input("X");
       PADDLE_ENFORCE_EQ(
           vars.size(),
           1UL,
-          phi::errors::InvalidArgument("Input `X` should be one variable %s",
-                                       op_desc.Type()));
+          common::errors::InvalidArgument("Input `X` should be one variable %s",
+                                          op_desc.Type()));
       VLOG(10) << "[" << op_desc.Type() << "][input `x`] from " << vars[0];
       const VarDesc* var_desc = op_desc.Block()->FindVarRecursive(vars[0]);
       PADDLE_ENFORCE_NE(
           var_desc,
           nullptr,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "VarDesc `%s` should be exist in legacy program", vars[0]));
       auto defining_value = pir::Value(nullptr);
       if (param_map->count(var_desc->Name())) {
@@ -3327,7 +3328,7 @@ struct WriteArrayOpTranscriber : public OpTranscriber {
     std::string target_op_name = dialect::ArrayWrite_Op::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op write_to_array should have corresponding OpInfo "
           "pd_op.array_write_"));
     }
@@ -3350,20 +3351,20 @@ struct WriteArrayOpTranscriber : public OpTranscriber {
       PADDLE_ENFORCE_EQ(
           op_desc.HasOutput("Out"),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Op write_to_array should have output `Out` but not found"));
       const auto& vars = op_desc.Output("Out");
       PADDLE_ENFORCE_EQ(
           vars.size(),
           1UL,
-          phi::errors::InvalidArgument("Output `Out` should be one variable %s",
-                                       op_desc.Type()));
+          common::errors::InvalidArgument(
+              "Output `Out` should be one variable %s", op_desc.Type()));
       VLOG(10) << "[" << op_desc.Type() << "][input `array`] from " << vars[0];
       const VarDesc* var_desc = op_desc.Block()->FindVarRecursive(vars[0]);
       PADDLE_ENFORCE_NE(
           var_desc,
           nullptr,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "VarDesc `%s` should be exist in legacy program", vars[0]));
       auto defining_value = pir::Value(nullptr);
       if (param_map->count(var_desc->Name())) {
@@ -3387,7 +3388,7 @@ struct ReadArrayOpTranscriber : public OpTranscriber {
     std::string target_op_name = dialect::ArrayReadOp::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op read_from_array should have corresponding OpInfo "
           "pd_op.read_array"));
     }
@@ -3403,12 +3404,12 @@ struct SliceOpTranscriber : public OpTranscriber {
 
     PADDLE_ENFORCE_EQ(op_desc.HasInput("Input"),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "op %s should have input `Input`", op_desc.Type()));
     const auto& input_vars = op_desc.Input("Input");
     PADDLE_ENFORCE_EQ(input_vars.size(),
                       1UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "op %s should have one input `Input`, but got %d.",
                           op_desc.Type(),
                           input_vars.size()));
@@ -3416,12 +3417,12 @@ struct SliceOpTranscriber : public OpTranscriber {
     if (input_var->GetType() == framework::proto::VarType::LOD_TENSOR_ARRAY) {
       PADDLE_ENFORCE_EQ(op_desc.HasOutput("Out"),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "op %s should have input `Out`", op_desc.Type()));
       const auto& output_vars = op_desc.Output("Out");
       PADDLE_ENFORCE_EQ(output_vars.size(),
                         1UL,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "op %s should have one input `Out`, but got %d.",
                             op_desc.Type(),
                             output_vars.size()));
@@ -3429,7 +3430,7 @@ struct SliceOpTranscriber : public OpTranscriber {
           op_desc.Block()->FindVarRecursive(output_vars[0]);
       PADDLE_ENFORCE_NE(output_var,
                         nullptr,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "op %s should have non-empty output `%s`.",
                             op_desc.Type(),
                             output_vars[0]));
@@ -3443,7 +3444,7 @@ struct SliceOpTranscriber : public OpTranscriber {
 
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op slice should have corresponding OpInfo %s", target_op_name));
     }
 
@@ -3484,11 +3485,11 @@ struct LegacyMatmulOpTranscriber : public OpTranscriber {
       }
       float v = PADDLE_GET_CONST(float, op_desc.GetAttr(attr_name));
       if (abs(v - expected_value) > 1e-6f) {
-        PADDLE_THROW(
-            phi::errors::InvalidArgument("Expected op[%s]'s attr %s is not %f",
-                                         op_desc.Type(),
-                                         attr_name,
-                                         v));
+        PADDLE_THROW(common::errors::InvalidArgument(
+            "Expected op[%s]'s attr %s is not %f",
+            op_desc.Type(),
+            attr_name,
+            v));
       }
     };
 
@@ -3499,7 +3500,7 @@ struct LegacyMatmulOpTranscriber : public OpTranscriber {
     std::string target_op_name = dialect::MatmulOp::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Op read_from_array should have corresponding OpInfo "
           "pd_op.read_array"));
     }
@@ -3524,14 +3525,14 @@ struct LegacyMatmulOpTranscriber : public OpTranscriber {
     PADDLE_ENFORCE_EQ(
         output_vars.size(),
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected op[%s]'s output `Out` has only 1 variable, but got %d",
             op_desc.Type(),
             output_vars.size()));
 
     auto idx_iter = arg_to_idx.find(output_vars[0]);
     if (idx_iter == arg_to_idx.end()) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "op[%s] should have got its `Out`", op_desc.Type()));
     }
     auto [idx_in_op, idx_in_vec] = idx_iter->second;

--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -77,13 +77,13 @@ const TCValue& TranslationContext::at(const TCKey& key) const {
   }
   PADDLE_ENFORCE_NE(it,
                     container_.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "param %s should exists in TranslationContext", key));
   const auto& values = it->second;
   PADDLE_ENFORCE_NE(
       values.size(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "param %s should have size > 0, but get:%d", key, values.size()));
   return values.back();
 }
@@ -103,7 +103,7 @@ size_t TranslationContext::count(const TCKey& key) const {
   PADDLE_ENFORCE_NE(
       values.size(),
       0u,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "param %s should have size > 0, but get:%d", key, values.size()));
   return values.size();
 }
@@ -199,7 +199,7 @@ void ProgramTranslator::TranslateBlock(const BlockDesc& src_block,
   VLOG(8) << "=============>start to translate a block: " << &src_block;
   PADDLE_ENFORCE(
       (src_block.OpSize() >= end_id) && (start_id <= end_id),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Translation of Block needs to meet the requirements of start_id <= "
           "end_id <= block_size, but get start_id=%d, end_id=%d, block_size=%d",
           start_id,
@@ -213,7 +213,7 @@ void ProgramTranslator::TranslateBlock(const BlockDesc& src_block,
 
     PADDLE_ENFORCE_EQ(unsupported_ops.count(op->Type()),
                       0,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Not support translated %s op", op->Type()));
 
     if (op->Type() == "conditional_block") {
@@ -350,7 +350,7 @@ void ProgramTranslator::TranslateIfOperation(
   std::vector<pir::Type> if_op_output_types;
   for (auto var_desc : cond_op_output_vars) {
     PADDLE_ENFORCE_NOT_NULL(var_desc,
-                            phi::errors::PreconditionNotMet(
+                            common::errors::PreconditionNotMet(
                                 "[control flow] Output should not be null"));
     pir::Type translated_var_type =
         type_translator[var_desc->GetType()](ctx_, *var_desc);
@@ -453,7 +453,7 @@ void ProgramTranslator::TranslateIfOperation(
             InsertInitOpOrCreateArrayToBlock(&false_region.front(), true_type);
         PADDLE_ENFORCE_NOT_NULL(
             init_op,
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "Only support insert full or data op for DenseTensor or "
                 "DenseTensorArray to false block failed."));
         false_block_context->PushValue(
@@ -625,7 +625,7 @@ void ProgramTranslator::GetParameterForSingleBlock(const BlockDesc& block) {
         if (need_parameter_op) {
           PADDLE_ENFORCE_NOT_NULL(
               var_desc,
-              phi::errors::PreconditionNotMet(
+              common::errors::PreconditionNotMet(
                   "VarDesc of [%s] can not be nullptr", var_name));
           pir::Operation* op = InsertGetParamaterOp(ctx_, var_desc);
           program_->block()->push_back(op);
@@ -692,7 +692,7 @@ void ProgramTranslator::SetParameterFromSingleBlock(const BlockDesc& block) {
 
           PADDLE_ENFORCE_NE(insert_pos,
                             block->end(),
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "Parameter %s must have corresponding its "
                                 "defining operation",
                                 var_name));
@@ -726,7 +726,7 @@ void ProgramTranslator::SetStopGradientAttributeForAllValue(
       auto* defining_op = value.owner();
       PADDLE_ENFORCE_NOT_NULL(
           defining_op,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "Defining operator of [%s] can not be nullptr", var_name));
       VLOG(8) << "[op translated][stop gradient]" << var_name
               << " from: " << defining_op->name();
@@ -793,7 +793,7 @@ void ProgramTranslator::SetIsPersistableAttributeForAllValue(
       auto* defining_op = value.owner();
       PADDLE_ENFORCE_NOT_NULL(
           defining_op,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "Defining operator of [%s] can not be nullptr", var_name));
       VLOG(8) << "[op translated][is persistable]" << var_name
               << " from: " << defining_op->name();

--- a/paddle/fluid/ir_adaptor/translator/type_translator.h
+++ b/paddle/fluid/ir_adaptor/translator/type_translator.h
@@ -53,7 +53,7 @@ class TypeTranslator {
     PADDLE_ENFORCE_NE(
         handlers.count(type),
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "ProtoType %d has no corresponding translator", type));
 
     return handlers[type];

--- a/paddle/fluid/ir_adaptor/translator/utils.h
+++ b/paddle/fluid/ir_adaptor/translator/utils.h
@@ -99,7 +99,7 @@ inline DataType VarTypeToDataType(
     case paddle::framework::proto::VarType_Type::VarType_Type_PSTRING:
       return DataType::PSTRING;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported proto::VarType_Type `%s` when casting it into DataType.",
           var_type));
   }

--- a/paddle/fluid/jit/compilation_unit.cc
+++ b/paddle/fluid/jit/compilation_unit.cc
@@ -25,7 +25,7 @@ std::shared_ptr<BaseEngine> CompilationUnit::GetEngine(
   PADDLE_ENFORCE_EQ(
       engine_map_.count(name),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Function named %s is not existed in engine_map_.", name));
   return engine_map_.at(name);
 }

--- a/paddle/fluid/jit/engine/interpreter_engine.cc
+++ b/paddle/fluid/jit/engine/interpreter_engine.cc
@@ -36,7 +36,8 @@ InterpreterEngine::InterpreterEngine(
   PADDLE_ENFORCE_GT(
       static_cast<int64_t>(info_->ProgramDesc().Block(0).OpSize()),
       0,
-      phi::errors::PreconditionNotMet("There is no operator in ProgramDesc."));
+      common::errors::PreconditionNotMet(
+          "There is no operator in ProgramDesc."));
   utils::ShareParamsIntoScope(info_->ParamNames(), params_dict_, &scope_);
   VLOG(6) << framework::GenScopeTreeDebugInfo(&scope_);
   CreateInterpreterCore();

--- a/paddle/fluid/jit/function.cc
+++ b/paddle/fluid/jit/function.cc
@@ -32,7 +32,7 @@ std::vector<Tensor> Function::operator()(
     const std::vector<Tensor>& inputs) const {
   PADDLE_ENFORCE_EQ(IsValid(),
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Function engine ptr is nullptr, please check it."));
   auto dense_tensors = utils::ToDenseTensors(inputs);
   return utils::ToTensors(this->operator()(dense_tensors));
@@ -42,7 +42,7 @@ std::vector<DenseTensor> Function::operator()(
     const std::vector<DenseTensor>& inputs) const {
   PADDLE_ENFORCE_EQ(IsValid(),
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Function engine ptr is nullptr, please check it."));
   return (*engine_)(inputs);
 }

--- a/paddle/fluid/jit/function_utils.cc
+++ b/paddle/fluid/jit/function_utils.cc
@@ -57,7 +57,7 @@ void ShareIntoScope(const std::vector<std::string> &ordered_input_names,
   PADDLE_ENFORCE_EQ(
       tensors.size(),
       ordered_input_names.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "tensors.size() should be equal to ordered_input_names.size()."));
   for (size_t i = 0; i < tensors.size(); ++i) {
     VLOG(3) << "share into scope: " << ordered_input_names[i];
@@ -73,7 +73,7 @@ void ShareParamsIntoScope(const std::vector<std::string> &param_names,
   for (auto name : param_names) {
     PADDLE_ENFORCE_EQ(params_dict->count(name),
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Parameter named %s is not existed in params_dict. "
                           "Please check that your model was saved correctly",
                           name));

--- a/paddle/fluid/jit/layer.cc
+++ b/paddle/fluid/jit/layer.cc
@@ -63,7 +63,7 @@ const std::shared_ptr<jit::FunctionInfo>& Layer::FunctionInfo(
   PADDLE_ENFORCE_EQ(
       info_map_.count(name),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "FunctionInfo named %s is not existed in info_map_.", name));
   return info_map_.at(name);
 }
@@ -80,7 +80,7 @@ std::vector<std::string> Layer::FunctionNames() const {
   template <>                                                         \
   T Layer::Attribute<T>(const std::string& name) const {              \
     if (attrs_map_->find(name) == attrs_map_->end()) {                \
-      PADDLE_THROW(phi::errors::NotFound(                             \
+      PADDLE_THROW(common::errors::NotFound(                          \
           "Attribute can not found %s, please check if it exists.")); \
       return T();                                                     \
     }                                                                 \

--- a/paddle/fluid/jit/property.cc
+++ b/paddle/fluid/jit/property.cc
@@ -31,7 +31,7 @@ void Property::DeserializationFromString(const std::string &str) {
   PADDLE_ENFORCE_EQ(
       this->Proto()->ParsePartialFromString(str),
       true,
-      phi::errors::InvalidArgument("Failed to parse pb from string"));
+      common::errors::InvalidArgument("Failed to parse pb from string"));
   return;
 }
 
@@ -39,7 +39,7 @@ std::string Property::SerializationToString() {
   std::string retv;
   PADDLE_ENFORCE_EQ(this->Proto()->SerializePartialToString(&retv),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Failed to serialize input Desc to string."));
   return retv;
 }
@@ -142,19 +142,19 @@ float Property::GetFloat(const std::string &name) const {
     auto e = property_.entrys(i);
 
     if (e.has_name() && e.name() == name) {
-      PADDLE_ENFORCE(
-          e.has_type() && e.type() == proto::ValueProto::FLOAT,
-          phi::errors::PreconditionNotMet("JIT::Property GetFloat: idx=%d type "
-                                          "is not float. Expect %d, but %d",
-                                          i,
-                                          proto::ValueProto::FLOAT,
-                                          e.type()));
+      PADDLE_ENFORCE(e.has_type() && e.type() == proto::ValueProto::FLOAT,
+                     common::errors::PreconditionNotMet(
+                         "JIT::Property GetFloat: idx=%d type "
+                         "is not float. Expect %d, but %d",
+                         i,
+                         proto::ValueProto::FLOAT,
+                         e.type()));
 
       return e.f();
     }
   }
 
-  PADDLE_THROW(phi::errors::NotFound(
+  PADDLE_THROW(common::errors::NotFound(
       "JIT::Property GetFloat: name: %s not found", name));
   return 0;
 }
@@ -163,7 +163,7 @@ float Property::GetFloat(const int &idx) const {
   PADDLE_ENFORCE_EQ(
       idx < Size() && idx >= 0,
       true,
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "JIT::Property GetFloat: idx=%d out of range %d", idx, Size()));
 
   auto e = property_.entrys(idx);
@@ -171,7 +171,7 @@ float Property::GetFloat(const int &idx) const {
     return e.f();
   }
 
-  PADDLE_THROW(phi::errors::InvalidArgument(
+  PADDLE_THROW(common::errors::InvalidArgument(
       "JIT::Property GetFloat: input idx (%d) element is not a float.", idx));
   return 0;
 }
@@ -205,7 +205,7 @@ std::vector<float> Property::GetFloats(const std::string &name) {
     if (e.has_name() && e.name() == name) {
       PADDLE_ENFORCE(
           e.has_type() && e.type() == proto::ValueProto::FLOATS,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "JIT::Property GetFloats: idx=%d type is not floats.", i));
 
       // auto items = e.floats();
@@ -213,7 +213,7 @@ std::vector<float> Property::GetFloats(const std::string &name) {
     }
   }
 
-  PADDLE_THROW(phi::errors::NotFound(
+  PADDLE_THROW(common::errors::NotFound(
       "JIT::Property GetFloats: name: %s not found", name));
   return std::vector<float>();
 }
@@ -241,14 +241,14 @@ int64_t Property::GetInt64(const std::string &name) {
 
     if (e.has_name() && e.name() == name) {
       PADDLE_ENFORCE(e.has_type() && e.type() == proto::ValueProto::INT,
-                     phi::errors::PreconditionNotMet(
+                     common::errors::PreconditionNotMet(
                          "JIT::Property GetInt64: idx=%d type is not int.", i));
 
       return e.i();
     }
   }
 
-  PADDLE_THROW(phi::errors::NotFound(
+  PADDLE_THROW(common::errors::NotFound(
       "JIT::Property GetInt64: name: %s not found", name));
   return 0;
 }
@@ -282,7 +282,7 @@ std::vector<int> Property::GetInt64s(const std::string &name) {
     if (e.has_name() && e.name() == name) {
       PADDLE_ENFORCE(
           e.has_type() && e.type() == proto::ValueProto::INTS,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "JIT::Property GetInt64s: idx=%d type is not ints.", i));
 
       auto items = e.ints();
@@ -295,7 +295,7 @@ std::vector<int> Property::GetInt64s(const std::string &name) {
     }
   }
 
-  PADDLE_THROW(phi::errors::NotFound(
+  PADDLE_THROW(common::errors::NotFound(
       "JIT::Property GetInt64s: name: %s not found", name));
   return {};
 }
@@ -324,13 +324,13 @@ std::string Property::GetString(const std::string &name) {
     if (e.has_name() && e.name() == name) {
       PADDLE_ENFORCE(
           e.has_type() && e.type() == proto::ValueProto::STRING,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "JIT::Property GetString: idx=%d type is not string.", i));
       return e.s();
     }
   }
 
-  PADDLE_THROW(phi::errors::NotFound(
+  PADDLE_THROW(common::errors::NotFound(
       "JIT::Property GetString: name: %s not found", name));
   return {};
 }
@@ -364,7 +364,7 @@ std::vector<std::string> Property::GetStrings(const std::string &name) {
     if (e.has_name() && e.name() == name) {
       PADDLE_ENFORCE(
           e.has_type() && e.type() == proto::ValueProto::STRINGS,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "JIT::Property GetStrings: idx=%d type is not strings.", i));
 
       // auto items = e.strings();
@@ -372,7 +372,7 @@ std::vector<std::string> Property::GetStrings(const std::string &name) {
     }
   }
 
-  PADDLE_THROW(phi::errors::NotFound(
+  PADDLE_THROW(common::errors::NotFound(
       "JIT::Property GetStrings: name: %s not found", name));
   return {};
 }

--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -813,8 +813,8 @@ void group_norm_grad(const Tensor& x,
   // d_bias = sum(dy, axes=(0,2,3))
   DataLayout data_layout_ = common::StringToDataLayout(data_layout);
   if (data_layout_ != DataLayout::kNCHW) {
-    PADDLE_THROW(phi::errors::InvalidArgument("Unsupported storage order: %s",
-                                              data_layout));
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "Unsupported storage order: %s", data_layout));
   }
   Tensor x_data = x;
   Tensor out_grad_data = out_grad;
@@ -1630,8 +1630,8 @@ void batch_norm_grad(const Tensor& x,
     }
 
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument("Unknown storage order: %s",
-                                                data_layout));
+      PADDLE_THROW(common::errors::InvalidArgument("Unknown storage order: %s",
+                                                   data_layout));
   }
 }
 

--- a/paddle/fluid/prim/api/manual_prim/static_prim_api.cc
+++ b/paddle/fluid/prim/api/manual_prim/static_prim_api.cc
@@ -89,7 +89,7 @@ Tensor full<DescTensor>(const IntArray& shape,
       op->SetAttr("str_value", std::to_string(value.to<uint64_t>()));
       break;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "We support "
           "bool/float16/bfloat16/float32/float64/int8/int16/int32/int64/uint8/"
           "uint16/"

--- a/paddle/fluid/prim/api/manual_prim/utils/utils.h
+++ b/paddle/fluid/prim/api/manual_prim/utils/utils.h
@@ -67,7 +67,7 @@ static phi::DDim get_reduce_dims_from_out(const phi::DDim& dout_dims,
       PADDLE_ENFORCE_EQ(
           in_dims[i],
           dout_dims[i + bat],
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "ReduceDims dimension mismatch. Operands could "
               "not be broadcast together with the shape of X = [%s] and "
               "the shape of Y = [%s]. X.shape[%d](%d) is not equal to "
@@ -148,10 +148,10 @@ static std::vector<int64_t> get_unsqueeze_dims(
       PADDLE_ENFORCE_LT(
           k,
           origin_dims.size(),
-          phi::errors::OutOfRange("Your index [%lu] exceeds the number of "
-                                  "elements in origin_dims[%lu].",
-                                  k,
-                                  origin_dims.size()));
+          common::errors::OutOfRange("Your index [%lu] exceeds the number of "
+                                     "elements in origin_dims[%lu].",
+                                     k,
+                                     origin_dims.size()));
       result.push_back(origin_dims[k]);
       k++;
     }

--- a/paddle/fluid/prim/utils/static/composite_grad_desc_maker.h
+++ b/paddle/fluid/prim/utils/static/composite_grad_desc_maker.h
@@ -315,7 +315,7 @@ class CompositeGradOpMakerBase {
     framework::VarDesc* original_var = original_block_->FindVar(name);
     PADDLE_ENFORCE_NOT_NULL(
         original_var,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Can't find var: %s in block %s", name, original_block_));
     *StaticCompositeContext::Instance().GetBlock()->Var(name) = *original_var;
   }
@@ -444,7 +444,7 @@ class CompositeGradOpMakerBase {
       PADDLE_ENFORCE_EQ(
           fwd_in_names.size(),
           1,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "When calling SingleForward for op: %s's Input: %s, we should "
               "only get one input tensor, but we got %d instead.",
               fwd_op_.Type(),
@@ -465,7 +465,7 @@ class CompositeGradOpMakerBase {
       PADDLE_ENFORCE_EQ(
           fwd_out_names.size(),
           1,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "When calling SingleForward for op: %s's Output: %s, we should "
               "only get one input tensor, but we got %d instead.",
               fwd_op_.Type(),
@@ -518,7 +518,7 @@ class CompositeGradOpMakerBase {
                          const std::vector<std::string>& origin_names) {
     PADDLE_ENFORCE_EQ(outputs.size(),
                       origin_names.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The size of outputs must be equal to the size "
                           "of the origin_names.",
                           outputs.size(),
@@ -575,7 +575,7 @@ class CompositeGradOpMakerBase {
     PADDLE_ENFORCE_NE(
         it,
         map.end(),
-        phi::errors::NotFound("Cannot find attribute (%s).", name));
+        common::errors::NotFound("Cannot find attribute (%s).", name));
     return it->second;
   }
 

--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -104,7 +104,8 @@ static bool has_dynamic_shape(const phi::DDim& dims) {
 static const phi::DDim GetValueDims(pir::Value value) {
   pir::Type origin_type = value.type();
   if (!origin_type) {
-    PADDLE_THROW(phi::errors::InvalidArgument("The type of value is nullptr."));
+    PADDLE_THROW(
+        common::errors::InvalidArgument("The type of value is nullptr."));
   }
   auto getdims = [](pir::Type value_type) -> phi::DDim {
     if (value_type.isa<DenseTensorType>()) {
@@ -112,7 +113,7 @@ static const phi::DDim GetValueDims(pir::Value value) {
     } else if (value_type.isa<SelectedRowsType>()) {
       return value_type.dyn_cast<SelectedRowsType>().dims();
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "[Prim] Currently, we can only get shape for dense "
           "tensor."));
     }
@@ -141,7 +142,7 @@ static phi::DataType GetValueDtype(pir::Value value) {
     return paddle::dialect::TransToPhiDataType(
         value.type().dyn_cast<SelectedRowsType>().dtype());
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Currently, we can only get phi::DataType from DenseTensorType and "
         "SelectedRowsType."));
   }
@@ -183,7 +184,7 @@ void DecompProgram::check_ops() {
       decomposed_ops_stream.append(" ");
       decomposed_ops_stream.append(item);
     }
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "[Prim] Currently, decomposed program "
         "should not contain none primitive ops: %s .",
         decomposed_ops_stream));
@@ -374,7 +375,7 @@ std::vector<std::vector<pir::Value>> call_decomp_rule(pir::Operation* op) {
   paddle::dialect::DecompInterface decomp_interface =
       op->dyn_cast<paddle::dialect::DecompInterface>();
   PADDLE_ENFORCE(decomp_interface,
-                 phi::errors::InvalidArgument(
+                 common::errors::InvalidArgument(
                      "[Prim] The decomp function is not registered in %s op ",
                      op->name()));
   std::vector<std::vector<pir::Value>> decomp_res = decomp_interface.Decomp(op);

--- a/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
+++ b/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
@@ -82,7 +82,7 @@ std::vector<std::vector<pir::Value>> {{class_name}}::Decomp(pir::Operation* op) 
           .defining_op();
   if ({{item.name}}_define_op->name() != "pd_op.full") {
     PADDLE_THROW(
-        phi::errors::Unimplemented("We don't support dynamic tensors "
+        common::errors::Unimplemented("We don't support dynamic tensors "
                                         "attribute {{item.name}} for {{fwd_name}} decomposition "
                                         "for now. "));
   }
@@ -98,7 +98,7 @@ std::vector<std::vector<pir::Value>> {{class_name}}::Decomp(pir::Operation* op) 
           .defining_op();
   if ({{item.name}}_define_op->name() != "pd_op.full_int_array") {
     PADDLE_THROW(
-        phi::errors::Unimplemented("We don't support dynamic tensors "
+        common::errors::Unimplemented("We don't support dynamic tensors "
                                         "attribute {{item.name}} for {{fwd_name}} decomposition "
                                         "for now. "));
   }
@@ -120,7 +120,7 @@ std::vector<std::vector<pir::Value>> {{class_name}}::Decomp(pir::Operation* op) 
       }
 
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented("attr is not vector of {{temp_type}} "));
+      PADDLE_THROW(common::errors::Unimplemented("attr is not vector of {{temp_type}} "));
     }
   }
         {% else %}

--- a/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp_vjp.j2
+++ b/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp_vjp.j2
@@ -84,7 +84,7 @@ std::vector<std::vector<pir::Value>> {{class_name}}::DecompVjp(pir::Operation* o
           .defining_op();
   if ({{item.name}}_define_op->name() != "pd_op.full") {
     PADDLE_THROW(
-        phi::errors::Unimplemented("We don't support dynamic tensors "
+        common::errors::Unimplemented("We don't support dynamic tensors "
                                         "attribute {{item.name}} for {{fwd_name}} decomposition "
                                         "for now. "));
   }
@@ -100,7 +100,7 @@ std::vector<std::vector<pir::Value>> {{class_name}}::DecompVjp(pir::Operation* o
           .defining_op();
   if ({{item.name}}_define_op->name() != "pd_op.full_int_array") {
     PADDLE_THROW(
-        phi::errors::Unimplemented("We don't support dynamic tensors "
+        common::errors::Unimplemented("We don't support dynamic tensors "
                                         "attribute {{item.name}} for {{fwd_name}} decomposition "
                                         "for now. "));
   }
@@ -122,7 +122,7 @@ std::vector<std::vector<pir::Value>> {{class_name}}::DecompVjp(pir::Operation* o
       }
 
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented("attr is not vector of {{temp_type}} "));
+      PADDLE_THROW(common::errors::Unimplemented("attr is not vector of {{temp_type}} "));
     }
   }
         {% else %}

--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -109,8 +109,8 @@ static void check_valid_type(const DataType& dtype) {
     case DataType::FLOAT64:
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument("Unsupported data type: %s",
-                                                phi::DataTypeToString(dtype)));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Unsupported data type: %s", phi::DataTypeToString(dtype)));
   }
 }
 
@@ -286,13 +286,13 @@ Tensor bmm_decomp(const Tensor& x, const Tensor& y) {
   std::size_t x_ndims = x.dims().size();
   std::size_t y_ndims = y.dims().size();
   if (x_ndims != 3) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Input(X) of BmmOp must be 3-dimensional in BmmOp, "
         "but received X's shape: [%s].",
         x_ndims));
   }
   if (y_ndims != 3) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Input(Y) of BmmOp must be 3-dimensional in BmmOp, "
         "but received Y's shape: [%s].",
         y_ndims));
@@ -302,7 +302,7 @@ Tensor bmm_decomp(const Tensor& x, const Tensor& y) {
   auto y_shape = phi::vectorize(y.dims());
 
   if (x_shape[0] != y_shape[0]) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Input(X) and Input(Y) must have the same batch size in BmmOp, "
         "but received X's batch size: [%s],"
         "Y's batch size [%s].",
@@ -311,7 +311,7 @@ Tensor bmm_decomp(const Tensor& x, const Tensor& y) {
   }
 
   if (x_shape[2] != y_shape[1]) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Input(X)'s width must be equal with Input(Y)'s height in BmmOp,"
         "but receive X's width: [%s],"
         "Y's height: [%s].",
@@ -352,8 +352,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
   } else if (data_layout_ == DataLayout::kNHWC) {
     feature_axis = rank - 1;
   } else {
-    PADDLE_THROW(
-        phi::errors::InvalidArgument("Unknown storage order: %s", data_layout));
+    PADDLE_THROW(common::errors::InvalidArgument("Unknown storage order: %s",
+                                                 data_layout));
   }
   std::vector<int64_t> reduce_axes;
   for (int i = 0; i < rank; ++i) {
@@ -653,7 +653,8 @@ std::vector<Tensor> unbind_decomp(const Tensor x, int axis) {
     axis = x.shape().size() + axis;
   }
   if (x.shape()[axis] == -1) {
-    PADDLE_THROW(phi::errors::Unimplemented("unbind axis must not be dynamic"));
+    PADDLE_THROW(
+        common::errors::Unimplemented("unbind axis must not be dynamic"));
   }
   size_t num = x.shape()[axis];
   std::vector<Tensor> tmp = backend::split_with_num<T>(x, num, axis);
@@ -1080,7 +1081,7 @@ std::tuple<Tensor, Tensor> flatten_decomp(const Tensor& x,
     end_axis = 0;
   }
   if (end_axis < start_axis) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "end_axis must be greater than or equal to start_axis."));
   }
 
@@ -1201,11 +1202,11 @@ std::tuple<Tensor, Tensor, Tensor> group_norm_decomp(
     c_axis = {1, 3};
   } else {
     PADDLE_THROW(
-        phi::errors::Unimplemented("Only support NCHW and NHWC format."));
+        common::errors::Unimplemented("Only support NCHW and NHWC format."));
   }
   size_t rank = x.shape().size();
   if (rank < 3 || rank > 5) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support NCHW and NHWC format in rank {3, 4, 5}."));
   }
 
@@ -1407,7 +1408,8 @@ Tensor embedding_decomp(const Tensor& x,
                         const int64_t padding_idx,
                         const bool sparse) {
   if (weight.dims().size() != 2) {
-    PADDLE_THROW(phi::errors::Unimplemented("Only support weight with 2-D."));
+    PADDLE_THROW(
+        common::errors::Unimplemented("Only support weight with 2-D."));
   }
 
   const int64_t NoPadding = -1;

--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -1880,8 +1880,8 @@ void batch_norm_grad(const Tensor& x,
     }
 
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument("Unknown storage order: %s",
-                                                data_layout));
+      PADDLE_THROW(common::errors::InvalidArgument("Unknown storage order: %s",
+                                                   data_layout));
   }
 }
 
@@ -2081,7 +2081,7 @@ void group_norm_grad(const Tensor& x,
   std::vector<int64_t> x_dims = x.shape();
   int rank = x_dims.size();
   if (rank < 3 || rank > 5) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support NCHW and NHWC format in rank {3, 4, 5}."));
   }
   int N = x_dims[0];
@@ -2102,8 +2102,8 @@ void group_norm_grad(const Tensor& x,
       reduce_axis.push_back(i);
     }
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument("Unsupported storage order: %s",
-                                              data_layout));
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "Unsupported storage order: %s", data_layout));
   }
 
   int g_num = C / groups;

--- a/paddle/fluid/primitive/utils/utils.h
+++ b/paddle/fluid/primitive/utils/utils.h
@@ -68,10 +68,10 @@ static std::vector<int64_t> get_expand_dims(const Tensor& origin,
     PADDLE_ENFORCE_LE(
         offset,
         result.size(),
-        phi::errors::OutOfRange("Your index [%lu] exceeds the number of "
-                                "elements in origin_dims[%lu].",
-                                offset,
-                                result.size()));
+        common::errors::OutOfRange("Your index [%lu] exceeds the number of "
+                                   "elements in origin_dims[%lu].",
+                                   offset,
+                                   result.size()));
     result.insert(result.begin() + offset, 1);
   }
   return result;
@@ -92,10 +92,10 @@ static std::vector<int64_t> get_unsqueeze_dims(
       PADDLE_ENFORCE_LT(
           k,
           origin_dims.size(),
-          phi::errors::OutOfRange("Your index [%lu] exceeds the number of "
-                                  "elements in origin_dims[%lu].",
-                                  k,
-                                  origin_dims.size()));
+          common::errors::OutOfRange("Your index [%lu] exceeds the number of "
+                                     "elements in origin_dims[%lu].",
+                                     k,
+                                     origin_dims.size()));
       result.push_back(origin_dims[k]);
       k++;
     }
@@ -158,7 +158,7 @@ static phi::DDim get_reduce_dims_from_out(const phi::DDim& dout_dims,
   PADDLE_ENFORCE_EQ(
       has_dynamic_shape,
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Function get_reduce_dims_from_out() only use in static shape case, "
           "but the input [dout_dims] have the dynamic shape."));
 
@@ -171,7 +171,7 @@ static phi::DDim get_reduce_dims_from_out(const phi::DDim& dout_dims,
   PADDLE_ENFORCE_EQ(
       has_dynamic_shape,
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Function get_reduce_dims_from_out() only use in static shape case, "
           "but the input [in_dims] have the dynamic shape."));
 
@@ -187,7 +187,7 @@ static phi::DDim get_reduce_dims_from_out(const phi::DDim& dout_dims,
       PADDLE_ENFORCE_EQ(
           in_dims[i],
           dout_dims[i + bat],
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "ReduceDims dimension mismatch. Operands could "
               "not be broadcast together with the shape of dout = [%s] and "
               "the shape of in_dims = [%s]. Received [%d] in X is not equal to "

--- a/paddle/fluid/sub_graph/sub_graph_checker.cc
+++ b/paddle/fluid/sub_graph/sub_graph_checker.cc
@@ -58,7 +58,7 @@ bool AllClose(const phi::DenseTensor& a,
       }
     }
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ONLY support float32, but received %s", a.dtype()));
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/66145#issuecomment-2249572051

Replace phi::errors to common::errors in paddle/fluid