### PR TITLE
Replace phi::errors [fluid_ops] part5

### DIFF
--- a/paddle/common/enforce.h
+++ b/paddle/common/enforce.h
@@ -362,5 +362,5 @@ inline bool is_error(const T& stat) {
 }
 
 namespace pir {
-#define IR_THROW(...) PADDLE_THROW(phi::errors::Fatal(__VA_ARGS__))
+#define IR_THROW(...) PADDLE_THROW(common::errors::Fatal(__VA_ARGS__))
 }  // namespace pir

--- a/paddle/pir/include/core/builder.h
+++ b/paddle/pir/include/core/builder.h
@@ -110,7 +110,8 @@ class Builder {
   /// Set the insertion point to the end of the specified block.
   void SetInsertionPointToBlockEnd(Block *block) {
     PADDLE_ENFORCE_NOT_NULL(
-        block, phi::errors::PreconditionNotMet("argument of block is nullptr"));
+        block,
+        common::errors::PreconditionNotMet("argument of block is nullptr"));
     set_insertion_point(block, block->end());
   }
 

--- a/paddle/pir/include/core/builtin_attribute_storage.h
+++ b/paddle/pir/include/core/builtin_attribute_storage.h
@@ -141,7 +141,7 @@ struct ArrayAttributeStorage : public AttributeStorage {
     PADDLE_ENFORCE_LT(
         index,
         size_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The index (%d) must be less than size (%d).", index, size_));
     return data_[index];
   }

--- a/paddle/pir/include/core/builtin_type_interfaces.h
+++ b/paddle/pir/include/core/builtin_type_interfaces.h
@@ -82,7 +82,7 @@ class IR_API ShapedTypeInterface
   int64_t GetRank() const {
     PADDLE_ENFORCE_EQ((*this).HasRank(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Cannot query rank of unranked shaped type."));
     return (*this).GetShape().size();
   }
@@ -116,7 +116,7 @@ class IR_API ShapedTypeInterface
     PADDLE_ENFORCE_LT(
         idx,
         GetRank(),
-        phi::errors::InvalidArgument("Invalid index for shaped type."));
+        common::errors::InvalidArgument("Invalid index for shaped type."));
     return ShapedTypeInterface::IsDynamic((*this).GetShape()[idx]);
   }
 
@@ -138,7 +138,7 @@ class IR_API ShapedTypeInterface
     PADDLE_ENFORCE_LT(
         idx,
         GetRank(),
-        phi::errors::InvalidArgument("Invalid index for shaped type."));
+        common::errors::InvalidArgument("Invalid index for shaped type."));
     return (*this).GetShape()[idx];
   }
 

--- a/paddle/pir/include/core/interface_support.h
+++ b/paddle/pir/include/core/interface_support.h
@@ -46,7 +46,7 @@ class ConstructInterfacesOrTraits {
     PADDLE_ENFORCE_EQ(
         success,
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Interface: id[%u] is already registered. inset failed",
             TypeId::get<T>()));
   }

--- a/paddle/pir/include/core/ir_mapping.h
+++ b/paddle/pir/include/core/ir_mapping.h
@@ -87,7 +87,7 @@ class IrMapping {
     PADDLE_ENFORCE_GT(
         GetMap<IrType<T>>().count(from),
         0UL,
-        phi::errors::InvalidArgument("Not found key in IRMapping."));
+        common::errors::InvalidArgument("Not found key in IRMapping."));
     return GetMap<IrType<T>>().at(from);
   }
 

--- a/paddle/pir/include/core/op_base.h
+++ b/paddle/pir/include/core/op_base.h
@@ -34,7 +34,7 @@ class IR_API OpBase {
   Operation *operation() const {
     PADDLE_ENFORCE_NOT_NULL(
         operation_,
-        phi::errors::InvalidArgument("Can't use operation() in a null op."));
+        common::errors::InvalidArgument("Can't use operation() in a null op."));
     return operation_;
   }
 

--- a/paddle/pir/include/dialect/shape/utils/dim_expr.h
+++ b/paddle/pir/include/dialect/shape/utils/dim_expr.h
@@ -31,7 +31,7 @@
 namespace symbol {
 
 #define SYMBOL_NOT_IMPLEMENTED \
-  PADDLE_THROW(phi::errors::Unimplemented("Not Implemented"))
+  PADDLE_THROW(common::errors::Unimplemented("Not Implemented"))
 
 template <typename T>
 struct UnaryDimExpr {

--- a/paddle/pir/include/dialect/shape/utils/shape_or_data_expr.h
+++ b/paddle/pir/include/dialect/shape/utils/shape_or_data_expr.h
@@ -32,18 +32,18 @@ class ShapeOrData {
       PADDLE_ENFORCE_EQ(
           data.size(),
           1UL,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "When shape is 0-D, size of data should be 1, but got %d.",
               data.size()));
     } else if (shape.size() == 1) {
       PADDLE_ENFORCE_EQ(shape[0].template Has<int64_t>(),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "When shape is 1-D, value of shape should be int"));
       PADDLE_ENFORCE_EQ(
           shape[0].template Get<int64_t>() == static_cast<int64_t>(data.size()),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "When shape is 1-D, size of data should be the same as "
               "value[%d] of shape, but got [%d].",
               shape[0].template Get<std::int64_t>(),
@@ -192,12 +192,12 @@ class ShapeOrDataDimExprs : public ShapeOrDataDimExprsBase {
   }
 
   const std::vector<DimExpr>& shape() const {
-    PADDLE_ENFORCE_EQ(
-        std::holds_alternative<TensorShapeOrDataDimExprs>(*this),
-        true,
-        phi::errors::PreconditionNotMet("Shape of ShapeOrData is not a vector, "
-                                        "check whether the value is a "
-                                        "tensor-list or not."));
+    PADDLE_ENFORCE_EQ(std::holds_alternative<TensorShapeOrDataDimExprs>(*this),
+                      true,
+                      common::errors::PreconditionNotMet(
+                          "Shape of ShapeOrData is not a vector, "
+                          "check whether the value is a "
+                          "tensor-list or not."));
     return std::get<TensorShapeOrDataDimExprs>(*this).shape();
   }
 
@@ -205,7 +205,7 @@ class ShapeOrDataDimExprs : public ShapeOrDataDimExprsBase {
     PADDLE_ENFORCE_EQ(
         std::holds_alternative<TensorShapeOrDataDimExprs>(*this),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Data of ShapeOrData is not a vector, check whether the value is a "
             "tensor-list or not."));
     return std::get<TensorShapeOrDataDimExprs>(*this).data();
@@ -215,7 +215,7 @@ class ShapeOrDataDimExprs : public ShapeOrDataDimExprsBase {
     PADDLE_ENFORCE_EQ(
         std::holds_alternative<TensorShapeOrDataDimExprs>(*this),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Data of ShapeOrData is not a vector, check whether the value is a "
             "tensor-list or not."));
 

--- a/paddle/pir/include/pass/pass.h
+++ b/paddle/pir/include/pass/pass.h
@@ -93,7 +93,7 @@ class IR_API Pass {
   AttrType& Get(const std::string& attr_name) const {
     PADDLE_ENFORCE_EQ(attrs_.find(attr_name) != attrs_.end(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Attribute %s not registered for pass.", attr_name));
     try {
       return *std::any_cast<AttrType*>(attrs_.at(attr_name));
@@ -151,7 +151,7 @@ class IR_API Pass {
   void SetNotOwned(const std::string& attr_name, AttrType* attr) {
     PADDLE_ENFORCE_EQ(!Has(attr_name),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Attribute %s already set in the pass.", attr_name));
     attrs_[attr_name] = attr;
   }

--- a/paddle/pir/include/pass/pass_registry.h
+++ b/paddle/pir/include/pass/pass_registry.h
@@ -36,7 +36,7 @@ class IR_API PassRegistry {
   void Insert(const std::string &pass_type, const PassCreator &pass_creator) {
     PADDLE_ENFORCE_NE(Has(pass_type),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Pass %s has been registered.", pass_type));
     pass_map_.insert({pass_type, pass_creator});
   }
@@ -44,7 +44,7 @@ class IR_API PassRegistry {
   std::unique_ptr<Pass> Get(const std::string &pass_type) const {
     PADDLE_ENFORCE_EQ(Has(pass_type),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Pass %s has not been registered.", pass_type));
     return pass_map_.at(pass_type)();
   }

--- a/paddle/pir/src/core/block.cc
+++ b/paddle/pir/src/core/block.cc
@@ -41,7 +41,7 @@ void Block::pop_back() {
   PADDLE_ENFORCE_EQ(
       !ops_.empty(),
       true,
-      phi::errors::InvalidArgument("can't pop back from empty block."));
+      common::errors::InvalidArgument("can't pop back from empty block."));
   ops_.back()->Destroy();
   ops_.pop_back();
 }
@@ -60,7 +60,7 @@ Block::Iterator Block::erase(ConstIterator position) {
   PADDLE_ENFORCE_EQ(
       position->GetParent(),
       this,
-      phi::errors::InvalidArgument("iterator not own this block."));
+      common::errors::InvalidArgument("iterator not own this block."));
   position->Destroy();
   return ops_.erase(position);
 }
@@ -75,7 +75,7 @@ void Block::Assign(Iterator position, Operation *op) {
   PADDLE_ENFORCE_EQ(
       position->GetParent(),
       this,
-      phi::errors::InvalidArgument("position not own this block."));
+      common::errors::InvalidArgument("position not own this block."));
   position->Destroy();
   position.set_underlying_pointer(op);
   op->SetParent(this, position);
@@ -85,7 +85,7 @@ Operation *Block::Take(Operation *op) {
   PADDLE_ENFORCE_EQ(
       op && op->GetParent() == this,
       true,
-      phi::errors::InvalidArgument("iterator not own this block."));
+      common::errors::InvalidArgument("iterator not own this block."));
   ops_.erase(Iterator(*op));
   return op;
 }
@@ -101,11 +101,11 @@ bool Block::HasOneUse() const { return first_use_ && !first_use_.next_use(); }
 void Block::ResetOpListOrder(const OpListType &new_op_list) {
   PADDLE_ENFORCE_EQ(new_op_list.size(),
                     ops_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of new_op_list not same with ops_."));
   PADDLE_ENFORCE_EQ(TopoOrderCheck(new_op_list),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The new_op_list is not in topological order."));
 
   ops_.clear();
@@ -131,7 +131,7 @@ void Block::EraseArg(uint32_t index) {
   auto argument = arg(index);
   PADDLE_ENFORCE_EQ(argument.use_empty(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Erase a block argument that is still in use."));
   argument.dyn_cast<BlockArgument>().Destroy();
   args_.erase(args_.begin() + index);
@@ -147,7 +147,7 @@ void Block::ClearKwargs() {
 Value Block::AddKwarg(const std::string &keyword, Type type) {
   PADDLE_ENFORCE_EQ(kwargs_.find(keyword),
                     kwargs_.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Add keyword (%s) argument which has been existed.",
                         keyword.c_str()));
   auto arg = BlockArgument::Create(type, this, keyword);
@@ -158,14 +158,14 @@ Value Block::AddKwarg(const std::string &keyword, Type type) {
 void Block::EraseKwarg(const std::string &keyword) {
   PADDLE_ENFORCE_NE(kwargs_.find(keyword),
                     kwargs_.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Erase keyword (%s) argument which doesn't existed.",
                         keyword.c_str()));
   auto kwarg = kwargs_[keyword];
   PADDLE_ENFORCE_EQ(
       kwarg.use_empty(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Erase a block keyword argument that is still in use."));
   kwarg.dyn_cast<BlockArgument>().Destroy();
   kwargs_.erase(keyword);

--- a/paddle/pir/src/core/block_argument.cc
+++ b/paddle/pir/src/core/block_argument.cc
@@ -21,10 +21,10 @@
 
 #include "paddle/common/enforce.h"
 
-#define CHECK_NULL_IMPL(func_name)  \
-  PADDLE_ENFORCE_NOT_NULL(          \
-      impl_,                        \
-      phi::errors::InvalidArgument( \
+#define CHECK_NULL_IMPL(func_name)     \
+  PADDLE_ENFORCE_NOT_NULL(             \
+      impl_,                           \
+      common::errors::InvalidArgument( \
           "impl_ is null when called BlockArgument:" #func_name))
 
 #define IMPL_ static_cast<detail::BlockArgumentImpl *>(impl_)

--- a/paddle/pir/src/core/block_operand.cc
+++ b/paddle/pir/src/core/block_operand.cc
@@ -23,7 +23,7 @@ namespace pir {
 #define CHECK_BLOCK_OPERAND_NULL_IMPL(func_name)             \
   PADDLE_ENFORCE_NOT_NULL(                                   \
       impl_,                                                 \
-      phi::errors::InvalidArgument(                          \
+      common::errors::InvalidArgument(                       \
           "impl_ pointer is null when call func:" #func_name \
           " , in class: BlockOperand."))
 

--- a/paddle/pir/src/core/ir_context.cc
+++ b/paddle/pir/src/core/ir_context.cc
@@ -327,7 +327,7 @@ const AbstractType &AbstractType::lookup(TypeId type_id, IrContext *ctx) {
   AbstractType *abstract_type = ctx->impl().GetAbstractType(type_id);
   PADDLE_ENFORCE_NOT_NULL(
       abstract_type,
-      phi::errors::InvalidArgument("Abstract type not found in IrContext."));
+      common::errors::InvalidArgument("Abstract type not found in IrContext."));
   return *abstract_type;
 }
 
@@ -336,7 +336,7 @@ const AbstractAttribute &AbstractAttribute::lookup(TypeId type_id,
   AbstractAttribute *abstract_attribute =
       ctx->impl().GetAbstractAttribute(type_id);
   PADDLE_ENFORCE_NOT_NULL(abstract_attribute,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Abstract attribute not found in IrContext."));
   return *abstract_attribute;
 }

--- a/paddle/pir/src/core/ir_printer.cc
+++ b/paddle/pir/src/core/ir_printer.cc
@@ -369,7 +369,7 @@ void IrPrinter::AddValueAlias(Value v, const std::string& alias) {
   const void* key = v.impl();
   PADDLE_ENFORCE_EQ(aliases_.find(key),
                     aliases_.end(),
-                    phi::errors::InvalidArgument("Value already has alias"));
+                    common::errors::InvalidArgument("Value already has alias"));
   aliases_[key] = alias;
 }
 

--- a/paddle/pir/src/core/op_info_impl.cc
+++ b/paddle/pir/src/core/op_info_impl.cc
@@ -22,7 +22,7 @@ namespace pir {
 
 void OpInfo::AttachInterface(InterfaceValue &&interface_value) {
   PADDLE_ENFORCE_NOT_NULL(impl_,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Cann't attach interface to a nullptr OpInfo"));
   impl_->AttachInterface(std::move(interface_value));
 }
@@ -33,7 +33,7 @@ void OpInfoImpl::AttachInterface(InterfaceValue &&interface_value) {
   PADDLE_ENFORCE_EQ(
       success,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Interface: id[%u] is already registered. inset failed", type_id));
   VLOG(10) << "Attach a interface: id[" << type_id << "]. to " << op_name_;
 }

--- a/paddle/pir/src/core/op_operand.cc
+++ b/paddle/pir/src/core/op_operand.cc
@@ -20,7 +20,7 @@
 #define CHECK_NULL_IMPL(class_name, func_name)               \
   PADDLE_ENFORCE_NOT_NULL(                                   \
       impl_,                                                 \
-      phi::errors::InvalidArgument(                          \
+      common::errors::InvalidArgument(                       \
           "impl_ pointer is null when call func:" #func_name \
           " , in class: " #class_name "."))
 

--- a/paddle/pir/src/core/op_result.cc
+++ b/paddle/pir/src/core/op_result.cc
@@ -21,7 +21,7 @@
 #define CHECK_OPRESULT_NULL_IMPL(func_name) \
   PADDLE_ENFORCE_NOT_NULL(                  \
       impl_,                                \
-      phi::errors::InvalidArgument(         \
+      common::errors::InvalidArgument(      \
           "impl_ pointer is null when call OpResult::" #func_name))
 #define IMPL_ static_cast<detail::OpResultImpl *>(impl_)
 

--- a/paddle/pir/src/core/op_trait.cc
+++ b/paddle/pir/src/core/op_trait.cc
@@ -26,7 +26,7 @@ void VerifySameOperandsShapeTrait(pir::Operation *op) {
   PADDLE_ENFORCE_GT(
       op->num_operands(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s with SameOperandsShapeTrait requires at least 1 operands, "
           "but got %u operands.",
           op->name(),
@@ -41,7 +41,7 @@ void VerifySameOperandsShapeTrait(pir::Operation *op) {
   PADDLE_ENFORCE_EQ(
       VerifyCompatibleShapes(types),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s with SameOperandsShapeTrait requires the same shape for "
           "all operands.",
           op->name()));
@@ -53,7 +53,7 @@ void VerifySameOperandsAndResultShapeTrait(pir::Operation *op) {
   PADDLE_ENFORCE_GT(
       op->num_operands(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s with SameOperandsAndResultShapeTrait requires at least 1 "
           "operands, but got %u operands.",
           op->name(),
@@ -62,7 +62,7 @@ void VerifySameOperandsAndResultShapeTrait(pir::Operation *op) {
   PADDLE_ENFORCE_GT(
       op->num_results(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s with SameOperandsAndResultShapeTrait requires at least 1 "
           "results, but got %u results.",
           op->name(),
@@ -84,7 +84,7 @@ void VerifySameOperandsAndResultShapeTrait(pir::Operation *op) {
   PADDLE_ENFORCE_EQ(
       VerifyCompatibleShapes(types),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s with SameOperandsAndResultShapeTrait requires compatible "
           "shapes for operands and results.",
           op->name()));
@@ -96,7 +96,7 @@ void VerifySameOperandsElementTypeTrait(pir::Operation *op) {
   PADDLE_ENFORCE_GT(
       op->num_operands(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s with SameOperandsElementTypeTrait requires at least 1 "
           "operands, but got %u operands.",
           op->name(),
@@ -107,7 +107,7 @@ void VerifySameOperandsElementTypeTrait(pir::Operation *op) {
     PADDLE_ENFORCE_EQ(
         GetElementTypeOrSelf(operand.type()),
         elementType,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Op %s with SameOperandsElementTypeTrait requires the same "
             "element type for all operands.",
             op->name()));
@@ -121,7 +121,7 @@ void VerifySameOperandsAndResultElementTypeTrait(pir::Operation *op) {
   PADDLE_ENFORCE_GT(
       op->num_operands(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s with SameOperandsAndResultElementTypeTrait requires at "
           "least 1 operands, but got %u operands.",
           op->name(),
@@ -130,7 +130,7 @@ void VerifySameOperandsAndResultElementTypeTrait(pir::Operation *op) {
   PADDLE_ENFORCE_GT(
       op->num_results(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s with SameOperandsAndResultElementTypeTrait requires at "
           "least 1 results, but got %u results.",
           op->name(),
@@ -143,7 +143,7 @@ void VerifySameOperandsAndResultElementTypeTrait(pir::Operation *op) {
     PADDLE_ENFORCE_EQ(
         GetElementTypeOrSelf(result.type()),
         elementType,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Op %s with SameOperandsAndResultElementTypeTrait requires the "
             "same element type for all operands and results.",
             op->name()));
@@ -154,7 +154,7 @@ void VerifySameOperandsAndResultElementTypeTrait(pir::Operation *op) {
     PADDLE_ENFORCE_EQ(
         GetElementTypeOrSelf(operand.type()),
         elementType,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Op %s with SameOperandsAndResultElementTypeTrait requires the "
             "same element type for all operands and results.",
             op->name()));
@@ -167,7 +167,7 @@ void VerifySameOperandsAndResultTypeTrait(pir::Operation *op) {
   PADDLE_ENFORCE_GT(
       op->num_operands(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s with SameOperandsAndResultTypeTrait requires at least 1 "
           "operands, but got %u operands.",
           op->name(),
@@ -176,7 +176,7 @@ void VerifySameOperandsAndResultTypeTrait(pir::Operation *op) {
   PADDLE_ENFORCE_GT(
       op->num_results(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s with SameOperandsAndResultTypeTrait requires at least 1 "
           "results, but got %u results.",
           op->name(),
@@ -189,7 +189,7 @@ void VerifySameOperandsAndResultTypeTrait(pir::Operation *op) {
     PADDLE_ENFORCE_EQ(
         GetElementTypeOrSelf(result.type()),
         elementType,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Op %s with SameOperandsAndResultTypeTrait requires the same "
             "type for all operands and results.",
             op->name()));
@@ -197,7 +197,7 @@ void VerifySameOperandsAndResultTypeTrait(pir::Operation *op) {
     PADDLE_ENFORCE_EQ(
         VerifyCompatibleShape(result.type(), type),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Op %s with SameOperandsAndResultTypeTrait requires the same "
             "type for all operands and results.",
             op->name()));
@@ -207,7 +207,7 @@ void VerifySameOperandsAndResultTypeTrait(pir::Operation *op) {
     PADDLE_ENFORCE_EQ(
         GetElementTypeOrSelf(operand.type()),
         elementType,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Op %s with SameOperandsAndResultTypeTrait requires the same "
             "type for all operands and results.",
             op->name()));
@@ -215,7 +215,7 @@ void VerifySameOperandsAndResultTypeTrait(pir::Operation *op) {
     PADDLE_ENFORCE_EQ(
         VerifyCompatibleShape(operand.type(), type),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Op %s with SameOperandsAndResultTypeTrait requires the same "
             "type for all operands and results.",
             op->name()));
@@ -235,7 +235,7 @@ void VerifySameTypeOperandsTrait(pir::Operation *op) {
     PADDLE_ENFORCE_EQ(
         operand.type(),
         type,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Op %s with SameTypeOperandsTrait requires all operands to have "
             "the same type.",
             op->name()));
@@ -246,7 +246,7 @@ void VerifyOneResultTrait(pir::Operation *op) {
   PADDLE_ENFORCE_EQ(
       op->num_results(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s with OneResultTrait requires 1 result, but got %u results.",
           op->name(),
           op->num_results()));

--- a/paddle/pir/src/core/operation.cc
+++ b/paddle/pir/src/core/operation.cc
@@ -300,7 +300,7 @@ BlockOperand Operation::block_operand(uint32_t index) const {
   PADDLE_ENFORCE_LT(
       index,
       num_successors_,
-      phi::errors::InvalidArgument("Invalid block_operand index"));
+      common::errors::InvalidArgument("Invalid block_operand index"));
   return block_operands_ + index;
 }
 Block *Operation::successor(uint32_t index) const {
@@ -310,7 +310,7 @@ void Operation::set_successor(Block *block, unsigned index) {
   PADDLE_ENFORCE_LT(
       index,
       num_operands_,
-      phi::errors::InvalidArgument("Invalid block_operand index"));
+      common::errors::InvalidArgument("Invalid block_operand index"));
   (block_operands_ + index)->set_source(block);
 }
 
@@ -320,13 +320,13 @@ void Operation::set_successor(Block *block, unsigned index) {
 Region &Operation::region(unsigned index) {
   PADDLE_ENFORCE_LT(index,
                     num_regions_,
-                    phi::errors::InvalidArgument("invalid region index"));
+                    common::errors::InvalidArgument("invalid region index"));
   return regions_[index];
 }
 const Region &Operation::region(unsigned index) const {
   PADDLE_ENFORCE_LT(index,
                     num_regions_,
-                    phi::errors::InvalidArgument("invalid region index"));
+                    common::errors::InvalidArgument("invalid region index"));
   return regions_[index];
 }
 
@@ -354,7 +354,8 @@ void Operation::SetParent(Block *parent, const Block::Iterator &position) {
 
 void Operation::MoveTo(Block *block, Block::Iterator position) {
   PADDLE_ENFORCE_NOT_NULL(
-      parent_, phi::errors::InvalidArgument("Operation does not have parent"));
+      parent_,
+      common::errors::InvalidArgument("Operation does not have parent"));
   Operation *op = parent_->Take(this);
   block->insert(position, op);
 }
@@ -381,7 +382,7 @@ void Operation::ReplaceAllUsesWith(const std::vector<Value> &values) {
   PADDLE_ENFORCE_EQ(
       num_results_,
       values.size(),
-      phi::errors::InvalidArgument("the num of result should be the same."));
+      common::errors::InvalidArgument("the num of result should be the same."));
   for (uint32_t i = 0; i < num_results_; ++i) {
     result(i).ReplaceAllUsesWith(values[i]);
   }

--- a/paddle/pir/src/core/parser/ir_parser.cc
+++ b/paddle/pir/src/core/parser/ir_parser.cc
@@ -37,9 +37,9 @@ void IrParser::ConsumeAToken(std::string expect_token_val) {
   PADDLE_ENFORCE_EQ(
       token_val,
       expect_token_val,
-      phi::errors::InvalidArgument("The token value of expectation is " +
-                                   expect_token_val + " ,not" + token_val +
-                                   "." + GetErrorLocationInfo()));
+      common::errors::InvalidArgument("The token value of expectation is " +
+                                      expect_token_val + " ,not" + token_val +
+                                      "." + GetErrorLocationInfo()));
 }
 
 // Type := BuiltinType | OtherDialectsDefineType
@@ -110,8 +110,8 @@ Type IrParser::ParseType() {
     PADDLE_ENFORCE_NE(
         type_val.find('.'),
         std::string::npos,
-        phi::errors::InvalidArgument("No function parsing " + type_val +
-                                     " exists!" + GetErrorLocationInfo()));
+        common::errors::InvalidArgument("No function parsing " + type_val +
+                                        " exists!" + GetErrorLocationInfo()));
     auto dialect_name = type_val.substr(0, type_val.find('.'));
     auto dialect = ctx->GetRegisteredDialect(dialect_name);
     return dialect->ParseType(*this);
@@ -172,11 +172,11 @@ Attribute IrParser::ParseAttribute() {
   } else if (attribute_type == "Pointer") {
     IR_THROW("This attribute is not currently supported by parser");
   } else {
-    PADDLE_ENFORCE_NE(
-        attribute_type.find('.'),
-        std::string::npos,
-        phi::errors::InvalidArgument("No function parsing " + attribute_type +
-                                     " exists!" + GetErrorLocationInfo()));
+    PADDLE_ENFORCE_NE(attribute_type.find('.'),
+                      std::string::npos,
+                      common::errors::InvalidArgument(
+                          "No function parsing " + attribute_type + " exists!" +
+                          GetErrorLocationInfo()));
     auto dialect_name = attribute_type.substr(0, attribute_type.find('.'));
     auto dialect = ctx->GetRegisteredDialect(dialect_name);
     return dialect->ParseAttribute(*this);
@@ -197,10 +197,10 @@ std::unique_ptr<Program> IrParser::ParseProgram() {
 // Region := Block
 void IrParser::ParseRegion(Region& region) {  // NOLINT
   ParseBlock(region.front());
-  PADDLE_ENFORCE_NE(
-      PeekToken().val_,
-      "{",
-      phi::errors::InvalidArgument("Only one block in a region is supported"));
+  PADDLE_ENFORCE_NE(PeekToken().val_,
+                    "{",
+                    common::errors::InvalidArgument(
+                        "Only one block in a region is supported"));
 }
 
 // Block := "{" {Operation} "}"
@@ -312,7 +312,7 @@ AttributeMap IrParser::ParseAttributeMap() {
     } else {
       PADDLE_ENFORCE_EQ((token_val == "}") || (token_val == ","),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The token value of expectation is } or , , not " +
                             token_val + "." + GetErrorLocationInfo()));
     }

--- a/paddle/pir/src/core/region.cc
+++ b/paddle/pir/src/core/region.cc
@@ -40,7 +40,7 @@ Region::Iterator Region::erase(ConstIterator position) {
   PADDLE_ENFORCE_EQ(
       position->GetParent(),
       this,
-      phi::errors::InvalidArgument("iterator not own this region."));
+      common::errors::InvalidArgument("iterator not own this region."));
   delete position;
   return blocks_.erase(position);
 }
@@ -145,9 +145,9 @@ Program *Region::parent_program() const {
   return parent_ ? parent_->GetParentProgram() : nullptr;
 }
 IrContext *Region::ir_context() const {
-  PADDLE_ENFORCE_NOT_NULL(
-      parent_,
-      phi::errors::InvalidArgument("Region is not attached to a operation."));
+  PADDLE_ENFORCE_NOT_NULL(parent_,
+                          common::errors::InvalidArgument(
+                              "Region is not attached to a operation."));
   return parent_->ir_context();
 }
 }  // namespace pir

--- a/paddle/pir/src/core/value.cc
+++ b/paddle/pir/src/core/value.cc
@@ -25,7 +25,7 @@
 #define CHECK_NULL_IMPL(class_name, func_name)               \
   PADDLE_ENFORCE_NOT_NULL(                                   \
       impl_,                                                 \
-      phi::errors::InvalidArgument(                          \
+      common::errors::InvalidArgument(                       \
           "impl_ pointer is null when call func:" #func_name \
           " , in class: " #class_name "."))
 

--- a/paddle/pir/src/dialect/control_flow/ir/cf_interface.cc
+++ b/paddle/pir/src/dialect/control_flow/ir/cf_interface.cc
@@ -21,7 +21,7 @@ TuplePushOp ContainerOpInterface::tuple_push_op() {
   PADDLE_ENFORCE_EQ(
       value.HasOneUse(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The inlet value of container op can only be used once."));
   return value.first_use().owner()->dyn_cast<TuplePushOp>();
 }
@@ -30,7 +30,7 @@ TuplePopOp ContainerOpInterface::tuple_pop_op() {
   PADDLE_ENFORCE_EQ(
       value.HasOneUse(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The outlet value of container op can only be used once."));
   return value.first_use().owner()->dyn_cast<TuplePopOp>();
 }

--- a/paddle/pir/src/dialect/control_flow/ir/cf_op.cc
+++ b/paddle/pir/src/dialect/control_flow/ir/cf_op.cc
@@ -47,23 +47,23 @@ void TuplePushOp::Build(Builder &builder,             // NOLINT
 void TuplePushOp::VerifySig() {
   VLOG(4) << "Verifying inputs, outputs ,attributes for: TuplePushOp.";
   // Verify inputs:
-  PADDLE_ENFORCE_GE(
-      num_operands(),
-      1u,
-      phi::errors::InvalidArgument("The size of inputs must no less than 1."));
+  PADDLE_ENFORCE_GE(num_operands(),
+                    1u,
+                    common::errors::InvalidArgument(
+                        "The size of inputs must no less than 1."));
   PADDLE_ENFORCE_EQ(
       operand_source(0).type().isa<InletType>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The first input of cf.tuple_push must be inlet_type."));
 
   // No attributes should be verify.
 
   // Verify outputs:
-  PADDLE_ENFORCE_EQ(
-      num_results(),
-      0u,
-      phi::errors::InvalidArgument("The size of outputs must be equal to 0."));
+  PADDLE_ENFORCE_EQ(num_results(),
+                    0u,
+                    common::errors::InvalidArgument(
+                        "The size of outputs must be equal to 0."));
   VLOG(4) << "End Verifying for TuplePushOp.";
 }
 
@@ -73,7 +73,7 @@ void TuplePushOp::VerifyRegion() {
   PADDLE_ENFORCE_EQ(
       operand_source(0).HasOneUse(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The inlet value of cf.tuple_push can only be used once."));
 }
 
@@ -81,7 +81,7 @@ size_t TuplePushOp::tuple_size() {
   auto operands_size = num_operands();
   PADDLE_ENFORCE_GE(operands_size,
                     1u,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The operands of push op must no less than 1."));
   return operands_size - 1u;
 }
@@ -111,11 +111,11 @@ void TuplePopOp::VerifySig() {
   PADDLE_ENFORCE_EQ(
       num_operands(),
       1u,
-      phi::errors::InvalidArgument("The size of inputs must equal to 1."));
+      common::errors::InvalidArgument("The size of inputs must equal to 1."));
   PADDLE_ENFORCE_EQ(
       operand_source(0).type().isa<OutletType>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The first input of cf.tuple_pop must be outlet_type."));
 
   // No attributes should be verify.
@@ -127,7 +127,7 @@ void TuplePopOp::VerifyRegion() {
   PADDLE_ENFORCE_EQ(
       operand_source(0).HasOneUse(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The outlet value of cf.tuple_pop can only be used once."));
 
   // Verify stack validity:
@@ -137,18 +137,18 @@ void TuplePopOp::VerifyRegion() {
     auto pop_op = container_interface().tuple_pop_op();
     PADDLE_ENFORCE(
         *this == pop_op,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The pop_op of tuple_pop_op must be this tuple_pop_op self."));
 
     auto inlet_size = tuple_push_op().tuple_size();
     PADDLE_ENFORCE(
         inlet_size == tuple_size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The pop elements size must equal to push elements size."));
     for (size_t index = 0; index < inlet_size; ++index) {
       PADDLE_ENFORCE(
           outlet_element(index).type() == inlet_element(index).type(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The %d element's push type (%s) isn't equal to pop type (%s)",
               index,
               outlet_element(index).type(),
@@ -168,33 +168,33 @@ void StackCreateOp::Build(Builder &builder, OperationArgument &argument) {
 void StackCreateOp::VerifySig() {
   VLOG(4) << "Verifying inputs, outputs and attributes for: StackCreateOp.";
   // Verify inputs:
-  PADDLE_ENFORCE_EQ(
-      num_operands(),
-      0u,
-      phi::errors::InvalidArgument("The size of inputs must be equal to 0."));
+  PADDLE_ENFORCE_EQ(num_operands(),
+                    0u,
+                    common::errors::InvalidArgument(
+                        "The size of inputs must be equal to 0."));
 
   // No attributes should be verify.
 
   // Verify outputs:
-  PADDLE_ENFORCE_EQ(
-      num_results(),
-      3u,
-      phi::errors::InvalidArgument("The size of outputs must be equal to 3."));
+  PADDLE_ENFORCE_EQ(num_results(),
+                    3u,
+                    common::errors::InvalidArgument(
+                        "The size of outputs must be equal to 3."));
 
   PADDLE_ENFORCE_EQ(
       result(0).type().isa<StackType>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The first outputs of cf.stack_create must be stack_type."));
   PADDLE_ENFORCE_EQ(
       result(1).type().isa<InletType>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The first outputs of cf.stack_create must be inlet_type."));
   PADDLE_ENFORCE_EQ(
       result(2).type().isa<OutletType>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The first outputs of cf.stack_create must be outlet_type."));
 
   VLOG(4) << "End Verifying for StackCreateOp.";
@@ -215,7 +215,7 @@ TuplePushOp StackCreateOp::tuple_push_op() {
   PADDLE_ENFORCE_EQ(
       inlet_value.HasOneUse(),
       true,
-      phi::errors::InvalidArgument("The inlet value must has one use."));
+      common::errors::InvalidArgument("The inlet value must has one use."));
   return inlet_value.first_use().owner()->dyn_cast<TuplePushOp>();
 }
 
@@ -224,7 +224,7 @@ TuplePopOp StackCreateOp::tuple_pop_op() {
   PADDLE_ENFORCE_EQ(
       outlet_value.HasOneUse(),
       true,
-      phi::errors::InvalidArgument("The outlet value must has one use."));
+      common::errors::InvalidArgument("The outlet value must has one use."));
   return outlet_value.first_use().owner()->dyn_cast<TuplePopOp>();
 }
 

--- a/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
+++ b/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
@@ -222,7 +222,7 @@ class ShapeOptimizationPass : public pir::Pass {
     auto module_op = op->dyn_cast<pir::ModuleOp>();
     PADDLE_ENFORCE_NOT_NULL(
         module_op,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "ShapeOptimizationPass should run on module op."));
     PrintProgram(module_op, "Origin Program");
 

--- a/paddle/pir/src/dialect/shape/utils/dim_expr_builder.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_builder.cc
@@ -84,7 +84,7 @@ std::pair<std::vector<DimExpr>, std::vector<DimExpr>> DimExprBuilder::SplitAt(
   PADDLE_ENFORCE_EQ(
       index > 0 && index < static_cast<int>(dim_exprs.size()),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Index invalid, index = %d, dim_exprs.size() = %d. Please check "
           "your inputs.",
           index,

--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -46,7 +46,7 @@ struct SimplifyOneOperand {
     } else {
       return Op<DimExpr>{ret_operand};
     }
-    PADDLE_THROW(phi::errors::Fatal("Dead code."));
+    PADDLE_THROW(common::errors::Fatal("Dead code."));
   }
 };
 
@@ -71,7 +71,7 @@ struct SimplifyUnitOneOperand {
     } else {
       return expr;
     }
-    PADDLE_THROW(phi::errors::Fatal("Dead code."));
+    PADDLE_THROW(common::errors::Fatal("Dead code."));
   }
 };
 
@@ -126,7 +126,7 @@ struct SimplifyOperands {
     } else {
       return Op<DimExpr>{mut_operands};
     }
-    PADDLE_THROW(phi::errors::Fatal("Dead code."));
+    PADDLE_THROW(common::errors::Fatal("Dead code."));
   }
 };
 
@@ -395,7 +395,7 @@ struct GetInversed<Mul> {
 template <>
 struct GetInversed<Broadcast> {
   static DimExpr Call(const DimExpr& expr) {
-    PADDLE_THROW(phi::errors::Fatal("Broadcast is not a group in math."));
+    PADDLE_THROW(common::errors::Fatal("Broadcast is not a group in math."));
   }
 };
 
@@ -468,7 +468,7 @@ struct FoldUnitConstant {
     } else {
       return Op<DimExpr>{ret_operands};
     }
-    PADDLE_THROW(phi::errors::Fatal("Dead code."));
+    PADDLE_THROW(common::errors::Fatal("Dead code."));
   }
 };
 
@@ -507,7 +507,7 @@ struct FoldConstants {
     } else {
       return Op<DimExpr>{ret_operands};
     }
-    PADDLE_THROW(phi::errors::Fatal("Dead code."));
+    PADDLE_THROW(common::errors::Fatal("Dead code."));
   }
 };
 
@@ -640,7 +640,7 @@ ConstRational SimplifiedConstRational(int64_t num, int64_t dem) {
 
 template <typename T>
 std::optional<ConstRational> GetConstRationalImpl(const T& expr) {
-  PADDLE_THROW(phi::errors::Fatal("not supported."));
+  PADDLE_THROW(common::errors::Fatal("not supported."));
   return std::nullopt;
 }
 
@@ -711,7 +711,7 @@ struct FoldOperandTrait<Mul> {
     (*ret)->emplace_back(num);
     PADDLE_ENFORCE_NE(dem,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The denominator of rational can not be zero."));
     if (dem != 1) {
       (*ret)->emplace_back(Reciprocal<DimExpr>{DimExpr{dem}});
@@ -748,13 +748,13 @@ struct FoldOperandTrait<Broadcast> {
     if (*value == 1) {
       *value = expr_value;
     } else if (expr_value != 1) {
-      PADDLE_ENFORCE_EQ(
-          *value,
-          expr_value,
-          phi::errors::InvalidArgument("The value (%d) should be equal to expr "
-                                       "(%d) when they are both not 1.",
-                                       *value,
-                                       expr_value));
+      PADDLE_ENFORCE_EQ(*value,
+                        expr_value,
+                        common::errors::InvalidArgument(
+                            "The value (%d) should be equal to expr "
+                            "(%d) when they are both not 1.",
+                            *value,
+                            expr_value));
     } else {
       // do nothing.
     }
@@ -814,7 +814,7 @@ struct FoldInversedPairToUnit {
     } else {
       return Op<DimExpr>{ret_operands};
     }
-    PADDLE_THROW(phi::errors::Fatal("Dead code."));
+    PADDLE_THROW(common::errors::Fatal("Dead code."));
   }
 
   std::optional<SearchResult> SearchInversedPair(
@@ -868,7 +868,7 @@ struct FoldRedundantSymbolicBroadcast {
     } else {
       return Broadcast<DimExpr>{ret_operands};
     }
-    PADDLE_THROW(phi::errors::Fatal("Dead code."));
+    PADDLE_THROW(common::errors::Fatal("Dead code."));
   }
 
   std::optional<MaxInt64> SearchMaxInt64(const List<DimExpr>& operands) {
@@ -886,7 +886,7 @@ struct FoldRedundantSymbolicBroadcast {
             PADDLE_ENFORCE_EQ(
                 ret.value().value,
                 int64_value,
-                phi::errors::InvalidArgument(
+                common::errors::InvalidArgument(
                     "The value of return (%d) should be equal to expr (%d) of "
                     "operands at index (%d) when they are both > 1.",
                     ret.value().value,
@@ -935,7 +935,7 @@ struct FoldRedundantBroadcast {
     } else {
       return Broadcast<DimExpr>{ret_operands};
     }
-    PADDLE_THROW(phi::errors::Fatal("Dead code."));
+    PADDLE_THROW(common::errors::Fatal("Dead code."));
   }
 
   std::optional<SearchResult> SearchInversedPair(

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -98,7 +98,7 @@ InferSymbolicShapeContext::GetShapeOrDataForValue(Value val) const {
     return null_shape_or_data;
   }
   if (!HasShapeOrDataForValue(val)) {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "Fail to GetShapeOrDataForValue on InferSymbolicShape!"));
   }
 
@@ -140,7 +140,7 @@ void InferSymbolicShapeContext::SetSymbolForValueByStaticShape(Value val) {
     symbol::TensorListShapeOrDataDimExprs shape_data_list;
     for (const auto& vec : vec_data) {
       if (!vec.isa<DenseTensorType>()) {
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "Set static shape ONLY SUPPORT inner type DenseTensorType!"));
       } else {
         const DenseTensorType& type_info = vec.dyn_cast<DenseTensorType>();
@@ -151,7 +151,7 @@ void InferSymbolicShapeContext::SetSymbolForValueByStaticShape(Value val) {
     SetShapeOrDataForValue(val, shape_data_list);
     return;
   }
-  PADDLE_THROW(phi::errors::Fatal(
+  PADDLE_THROW(common::errors::Fatal(
       "Set static shape ONLY SUPPORT DenseTensorType and VectorType!"));
 }
 
@@ -472,8 +472,8 @@ void ShapeConstraintIRAnalysis::InferShapeOrDataForValue(Value val) {
           continue;
         }
         if (!context_.HasShapeOrDataForValue(result_value)) {
-          PADDLE_THROW(phi::errors::Fatal(op->name() +
-                                          " HAS ERROR on InferSymbolicShape!"));
+          PADDLE_THROW(common::errors::Fatal(
+              op->name() + " HAS ERROR on InferSymbolicShape!"));
         }
       }
     } else {
@@ -554,7 +554,7 @@ bool ShapeConstraintIRAnalysis::IsShapeEqual(Value lhs, Value rhs) {
       lhs_shape_data.isa<symbol::TensorShapeOrDataDimExprs>() &&
           rhs_shape_data.isa<symbol::TensorShapeOrDataDimExprs>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Currently, IsShapeEqual only support TensorShapeOrDataDimExprs "
           "but not TensorListShapeOrDataDimExprs."));
 
@@ -600,7 +600,7 @@ bool ShapeConstraintIRAnalysis::IsProductEqual(
       lhs_shape_data.isa<symbol::TensorShapeOrDataDimExprs>() &&
           rhs_shape_data.isa<symbol::TensorShapeOrDataDimExprs>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Currently, IsProductEqual only support TensorShapeOrDataDimExprs "
           "but not TensorListShapeOrDataDimExprs."));
 

--- a/paddle/pir/src/pass/pass.cc
+++ b/paddle/pir/src/pass/pass.cc
@@ -49,14 +49,14 @@ std::optional<detail::PassExecutionState>& Pass::pass_state() {
 void Pass::SignalPassFailure() {
   PADDLE_ENFORCE_EQ(pass_state_.has_value(),
                     true,
-                    phi::errors::InvalidArgument("pass state has no value"));
+                    common::errors::InvalidArgument("pass state has no value"));
   pass_state_->pass_failed = true;
 }
 
 AnalysisManager Pass::analysis_manager() {
   PADDLE_ENFORCE_EQ(pass_state_.has_value(),
                     true,
-                    phi::errors::InvalidArgument("pass state has no value"));
+                    common::errors::InvalidArgument("pass state has no value"));
   return pass_state_->am;
 }
 //===----------------------------------------------------------------------===//
@@ -67,7 +67,7 @@ bool PatternRewritePass::Initialize(IrContext* context) {
   PADDLE_ENFORCE_EQ(
       ps.Empty(),
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Pass creation failed."
           "When using PatternRewritePass to create a Pass, the number of "
           "customized Patterns is required to be greater than zero."

--- a/paddle/pir/src/pattern_rewrite/pattern_match.cc
+++ b/paddle/pir/src/pattern_rewrite/pattern_match.cc
@@ -93,7 +93,7 @@ void RewriterBase::ReplaceOpWithIf(
     const std::function<bool(OpOperand)>& functor) {
   PADDLE_ENFORCE_EQ(op->num_results(),
                     new_values.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "incorrect number of values to replace operation"));
   NotifyRootReplaced(op, new_values);
 
@@ -124,7 +124,7 @@ void RewriterBase::ReplaceOp(Operation* op,
   PADDLE_ENFORCE_EQ(
       op->num_results(),
       new_values.size(),
-      phi::errors::InvalidArgument("incorrect # of replacement values"));
+      common::errors::InvalidArgument("incorrect # of replacement values"));
   op->ReplaceAllUsesWith(new_values);
 
   NotifyOperationRemoved(op);
@@ -135,9 +135,9 @@ void RewriterBase::EraseOp(Operation* op) {
   PADDLE_ENFORCE_EQ(
       op->use_empty(),
       true,
-      phi::errors::InvalidArgument("Erase op failed. op(%s) is used, the "
-                                   "expectation is that it is not used",
-                                   op->name()));
+      common::errors::InvalidArgument("Erase op failed. op(%s) is used, the "
+                                      "expectation is that it is not used",
+                                      op->name()));
   NotifyOperationRemoved(op);
   op->Erase();
 }
@@ -167,7 +167,7 @@ void RewriterBase::ReplaceOpWithResultsOfAnotherOp(Operation* op,
                                                    Operation* new_op) {
   PADDLE_ENFORCE_EQ(op->num_results(),
                     new_op->num_results(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "replacement op doesn't match results of original op"));
   // TODO(zhangbopd): Add unit test for this.
   if (op->num_results() == 1) {

--- a/paddle/utils/pybind.cc
+++ b/paddle/utils/pybind.cc
@@ -39,8 +39,8 @@ void ShareTensor(PyObject* src, PyObject* dst) {
     const auto& dst_tensor = reinterpret_cast<TensorObject*>(dst)->tensor;
     src_tensor = dst_tensor;
   } else {
-    PADDLE_THROW(
-        phi::errors::InvalidArgument("Share tensor only support DenseTensor."));
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "Share tensor only support DenseTensor."));
   }
 }
 
@@ -49,7 +49,7 @@ paddle::Tensor& CastPyArg2Tensor(PyObject* obj, Py_ssize_t arg_pos) {
       PyObject_TypeCheck(obj, p_string_tensor_type)) {
     return reinterpret_cast<TensorObject*>(obj)->tensor;
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "argument (position %d) must be "
         "Tensor, but got %s",
         arg_pos + 1,
@@ -76,7 +76,7 @@ PyObject* ToPyObject(const paddle::Tensor& value,
     v->tensor = value;
   } else {
     PADDLE_THROW(
-        phi::errors::Fatal("tp_alloc return null, can not new a PyObject."));
+        common::errors::Fatal("tp_alloc return null, can not new a PyObject."));
   }
   return obj;
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/66145#issuecomment-2249572051

Replace phi::errors to common::errors in paddle/pir