### PR TITLE
[Typing][C-16] Add type annotations for `python/paddle/distributed/communication/broadcast.py`

### DIFF
--- a/python/paddle/distributed/communication/broadcast.py
+++ b/python/paddle/distributed/communication/broadcast.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import paddle
 import paddle.distributed as dist
@@ -81,7 +81,7 @@ def broadcast(
 
 
 def broadcast_object_list(
-    object_list: list[dict[str, Tensor]], src: int, group: Group | None = None
+    object_list: list[Any], src: int, group: Group | None = None
 ) -> None:
     """
 

--- a/python/paddle/distributed/communication/broadcast.py
+++ b/python/paddle/distributed/communication/broadcast.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import paddle
 import paddle.distributed as dist
@@ -22,8 +25,15 @@ from .serialization_utils import (
     convert_tensor_to_object,
 )
 
+if TYPE_CHECKING:
+    from paddle import Tensor
+    from paddle.base.core import task
+    from paddle.distributed.communication.group import Group
 
-def broadcast(tensor, src, group=None, sync_op=True):
+
+def broadcast(
+    tensor: Tensor, src: int, group: Group | None = None, sync_op: bool = True
+) -> task:
     """
 
     Broadcast a tensor from the source to all others.
@@ -70,10 +80,12 @@ def broadcast(tensor, src, group=None, sync_op=True):
     )
 
 
-def broadcast_object_list(object_list, src, group=None):
+def broadcast_object_list(
+    object_list: list[dict[str, Tensor]], src: int, group: Group | None = None
+) -> None:
     """
 
-    Broadcast picklable objects from the source to all others. Similiar to broadcast(), but python object can be passed in.
+    Broadcast picklable objects from the source to all others. Similar to broadcast(), but python object can be passed in.
 
     Args:
         object_list (list): The list of objects to send if current rank is the source, or the list of objects to receive otherwise.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
- https://github.com/PaddlePaddle/Paddle/issues/65008
C16