### PR TITLE
fix ut with static.nn.prelu

### DIFF
--- a/test/xpu/test_prelu_op_xpu.py
+++ b/test/xpu/test_prelu_op_xpu.py
@@ -198,7 +198,7 @@ class TestModeError(unittest.TestCase):
         with base.program_guard(main_program, paddle.base.Program()):
             x = paddle.static.data(name='x', shape=[2, 3, 4, 5])
             try:
-                y = paddle.static.nn.prelu(x, 'channel', data_format='N')
+                y = paddle.nn.PReLU(3, data_format='N')(x)
             except ValueError as e:
                 pass
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
使用 `paddle.nn.PRelu` 替代 `static.nn.prelu`。

- `static.nn.prelu` 相较于 `paddle.nn.PRelu` 多了一种权重共享模式，element：每一个元素有一个独立的 alpha 值。测试中没有通过 `static.nn.prelu` 来使用这种方式，忽略