### PR TITLE
Add FLAGS_check_etw_add_coo_indices

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -83,6 +83,18 @@ PHI_DEFINE_EXPORTED_bool(
 
 /**
  * Operator related FLAG
+ * Name: FLAGS_jump_sparse_add_input_equal
+ * Since Version:
+ * Value Range: bool, default=false
+ * Example:
+ * Note: Used to debug. Checking whether operator produce NAN/INF or not.
+ */
+PHI_DEFINE_EXPORTED_bool(
+    jump_sparse_add_input_equal,
+    false,
+    "Jumping sparse_add input equal case. If true, then skip such cases");
+/**
+ * Operator related FLAG
  * Name: FLAGS_check_nan_inf_level
  * Since Version: 2.5.0
  * Value Range: int32, default=0

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -83,16 +83,16 @@ PHI_DEFINE_EXPORTED_bool(
 
 /**
  * Operator related FLAG
- * Name: FLAGS_jump_sparse_add_input_equal
+ * Name: check_etw_add_coo_indices
  * Since Version:
- * Value Range: bool, default=false
+ * Value Range: bool, default=true
  * Example:
- * Note: Used to debug. Checking whether operator produce NAN/INF or not.
+ * Note: Whether skip ElementWiseAddCooGPUKernel indices check or not.
  */
 PHI_DEFINE_EXPORTED_bool(
-    jump_sparse_add_input_equal,
-    false,
-    "Jumping sparse_add input equal case. If true, then skip such cases");
+    check_etw_add_coo_indices,
+    true,
+    "Skip ElementWiseAddCooGPUKernel indices check. If false, then skip check");
 /**
  * Operator related FLAG
  * Name: FLAGS_check_nan_inf_level

--- a/paddle/phi/kernels/sparse/gpu/elementwise_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/elementwise_kernel.cu
@@ -24,7 +24,7 @@ limitations under the License. */
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/visit_type.h"
 
-COMMON_DECLARE_bool(jump_sparse_add_input_equal);
+COMMON_DECLARE_bool(check_etw_add_coo_indices);
 
 namespace phi {
 namespace sparse {
@@ -45,7 +45,7 @@ void ElementWiseAddCooGPUKernel(const GPUContext& dev_ctx,
   const IntT* x_indices_ptr = x_indices.data<IntT>();
   const IntT* y_indices_ptr = y_indices.data<IntT>();
   bool is_same = false;
-  if (FLAGS_jump_sparse_add_input_equal) {
+  if (FLAGS_check_etw_add_coo_indices) {
     is_same = true;
   } else {
 #ifdef PADDLE_WITH_HIP

--- a/paddle/phi/kernels/sparse/gpu/elementwise_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/elementwise_kernel.cu
@@ -46,8 +46,6 @@ void ElementWiseAddCooGPUKernel(const GPUContext& dev_ctx,
   const IntT* y_indices_ptr = y_indices.data<IntT>();
   bool is_same = false;
   if (FLAGS_check_etw_add_coo_indices) {
-    is_same = true;
-  } else {
 #ifdef PADDLE_WITH_HIP
     is_same = thrust::equal(thrust::hip::par.on(dev_ctx.stream()),
 #else
@@ -56,6 +54,8 @@ void ElementWiseAddCooGPUKernel(const GPUContext& dev_ctx,
                             x_indices_ptr,
                             x_indices_ptr + x_indices.numel(),
                             y_indices_ptr);
+  } else {
+    is_same = true;
   }
   PADDLE_ENFORCE_EQ(
       is_same,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Pcard-71501
sparse_add_coo利用thrust::equal方法保证输入的indices相同，thrust::equal内部的GPU利用率较低。
增加标志位FLAGS_check_etw_add_coo_indices，在已知输入indices相同时，可以跳过调用thrust::equal方法。
FLAGS_check_etw_add_coo_indices默认为True，保留输入indices判断，设置为false，可以跳过判断。