### PR TITLE
Replace phi::errors [fluid_ops] part8

### DIFF
--- a/paddle/fluid/memory/allocation/aligned_allocator.cc
+++ b/paddle/fluid/memory/allocation/aligned_allocator.cc
@@ -44,10 +44,10 @@ AlignedAllocator::AlignedAllocator(
   PADDLE_ENFORCE_GT(
       alignment_,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Alignment should be larger than 0, but got %d", alignment_));
   if (alignment_ & (alignment_ - 1)) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Alignment should be power of 2 (2^N), but got %d", alignment_));
   }
 }

--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -267,7 +267,7 @@ class AllocatorFacadePrivate {
         if (FLAGS_use_cuda_malloc_async_allocator) {
           PADDLE_ENFORCE_EQ(FLAGS_use_cuda_managed_memory,
                             false,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "Async allocator cannot be used with CUDA "
                                 "managed memory."));
           WrapCUDAMallocAsyncAllocatorForDefault();
@@ -339,7 +339,7 @@ class AllocatorFacadePrivate {
       }
 
       default: {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "Unsupported allocator strategy: %d", static_cast<int>(strategy_)));
       }
     }
@@ -370,10 +370,10 @@ class AllocatorFacadePrivate {
                                                           : GetAllocatorMap())
                   : zero_size_allocators_);
     auto iter = allocators.find(place);
-    PADDLE_ENFORCE_NE(
-        iter,
-        allocators.end(),
-        phi::errors::NotFound("No allocator found for the place, %s", place));
+    PADDLE_ENFORCE_NE(iter,
+                      allocators.end(),
+                      common::errors::NotFound(
+                          "No allocator found for the place, %s", place));
     VLOG(6) << "[GetAllocator]"
             << " place = " << place << " size = " << size
             << " Allocator = " << iter->second;
@@ -424,7 +424,7 @@ class AllocatorFacadePrivate {
       } else {
         PADDLE_ENFORCE_NE(create_if_not_found,
                           false,
-                          phi::errors::NotFound(
+                          common::errors::NotFound(
                               "No allocator found for stream %s in place %s "
                               "with create_if_not_found = false",
                               stream,
@@ -450,7 +450,7 @@ class AllocatorFacadePrivate {
         iter != default_cuda_malloc_async_allocators_.end())
       return iter->second;
 #endif
-    PADDLE_THROW(phi::errors::NotFound(
+    PADDLE_THROW(common::errors::NotFound(
         "No StreamSafeCUDAAllocator found for the place, %s", place));
   }
 
@@ -465,7 +465,7 @@ class AllocatorFacadePrivate {
       return allocator->GetDefaultStream();
 #endif
     } else {
-      PADDLE_THROW(phi::errors::NotFound(
+      PADDLE_THROW(common::errors::NotFound(
           "No StreamSafeCUDAAllocator or CUDAMallocAsyncAllocator found for "
           "the place, %s",
           place));
@@ -475,16 +475,16 @@ class AllocatorFacadePrivate {
   void SetDefaultStream(const phi::GPUPlace& place, gpuStream_t stream) {
     if (auto allocator = std::dynamic_pointer_cast<StreamSafeCUDAAllocator>(
             GetDefaultStreamSafeCUDAAllocator(place))) {
-      PADDLE_ENFORCE_EQ(
-          allocator->GetDefaultStream(),
-          nullptr,
-          phi::errors::Unavailable("The default stream for "
-                                   "StreamSafeCUDAAllocator(%p) in %s has been "
-                                   "set to %p, not allow to change it to %p.",
-                                   allocator.get(),
-                                   place,
-                                   allocator->GetDefaultStream(),
-                                   stream));
+      PADDLE_ENFORCE_EQ(allocator->GetDefaultStream(),
+                        nullptr,
+                        common::errors::Unavailable(
+                            "The default stream for "
+                            "StreamSafeCUDAAllocator(%p) in %s has been "
+                            "set to %p, not allow to change it to %p.",
+                            allocator.get(),
+                            place,
+                            allocator->GetDefaultStream(),
+                            stream));
 
       allocator->SetDefaultStream(stream);
       VLOG(8) << "Set default stream to " << stream
@@ -494,23 +494,23 @@ class AllocatorFacadePrivate {
     } else if (auto allocator =
                    std::dynamic_pointer_cast<CUDAMallocAsyncAllocator>(
                        GetDefaultStreamSafeCUDAAllocator(place))) {
-      PADDLE_ENFORCE_EQ(
-          allocator->GetDefaultStream(),
-          nullptr,
-          phi::errors::Unavailable("The default stream for "
-                                   "StreamSafeCUDAAllocator(%p) in %s has been "
-                                   "set to %p, not allow to change it to %p.",
-                                   allocator.get(),
-                                   place,
-                                   allocator->GetDefaultStream(),
-                                   stream));
+      PADDLE_ENFORCE_EQ(allocator->GetDefaultStream(),
+                        nullptr,
+                        common::errors::Unavailable(
+                            "The default stream for "
+                            "StreamSafeCUDAAllocator(%p) in %s has been "
+                            "set to %p, not allow to change it to %p.",
+                            allocator.get(),
+                            place,
+                            allocator->GetDefaultStream(),
+                            stream));
       allocator->SetDefaultStream(stream);
       VLOG(8) << "Set default stream to " << stream
               << " for CUDAMallocAsyncAllocator(" << allocator.get() << ") in "
               << place;
 #endif
     } else {
-      PADDLE_THROW(phi::errors::NotFound(
+      PADDLE_THROW(common::errors::NotFound(
           "No StreamSafeCUDAAllocator or CUDAMallocAsyncAllocator found for "
           "the place, %s",
           place));
@@ -600,7 +600,7 @@ class AllocatorFacadePrivate {
       } else {
         PADDLE_ENFORCE_NE(create_if_not_found,
                           false,
-                          phi::errors::NotFound(
+                          common::errors::NotFound(
                               "No allocator found for stream %s in place %s "
                               "with create_if_not_found = false",
                               stream,
@@ -622,7 +622,7 @@ class AllocatorFacadePrivate {
     PADDLE_ENFORCE_NE(
         iter,
         default_stream_safe_xpu_allocators_.end(),
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "No StreamSafeXPUAllocator found for the place, %s", place));
     return iter->second;
   }
@@ -640,7 +640,7 @@ class AllocatorFacadePrivate {
     PADDLE_ENFORCE_EQ(
         allocator->GetDefaultStream(),
         nullptr,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "The default stream for StreamSafeXPUAllocator(%p) in %s has been "
             "set to %p, not allow to change it to %p.",
             allocator.get(),
@@ -709,7 +709,7 @@ class AllocatorFacadePrivate {
       } else {
         PADDLE_ENFORCE_NE(create_if_not_found,
                           false,
-                          phi::errors::NotFound(
+                          common::errors::NotFound(
                               "No allocator found for stream %s in place %s "
                               "with create_if_not_found = false",
                               stream,
@@ -732,7 +732,7 @@ class AllocatorFacadePrivate {
     PADDLE_ENFORCE_NE(
         iter,
         default_stream_safe_custom_device_allocators_.end(),
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "No StreamSafeCustomDeviceAllocator found for the place, %s",
             place));
     return iter->second;
@@ -751,7 +751,7 @@ class AllocatorFacadePrivate {
 
     PADDLE_ENFORCE_EQ(allocator->GetDefaultStream(),
                       nullptr,
-                      phi::errors::Unavailable(
+                      common::errors::Unavailable(
                           "The default stream for "
                           "StreamSafeCustomDeviceAllocator(%p) in %s has been "
                           "set to %p, not allow to change it to %p.",
@@ -855,7 +855,7 @@ class AllocatorFacadePrivate {
       PADDLE_ENFORCE_EQ(
           strategy_,
           AllocatorStrategy::kAutoGrowth,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "CUDA managed memory is only implemented for auto_growth "
               "strategy, not support %s strategy.\n"
               "Please use auto_growth strategy by command `export "
@@ -864,7 +864,7 @@ class AllocatorFacadePrivate {
               FLAGS_allocator_strategy));
 
       if (!platform::IsGPUManagedMemorySupported(p.device)) {
-        PADDLE_THROW(phi::errors::Unavailable(
+        PADDLE_THROW(common::errors::Unavailable(
             "Failed to create CUDAManagedAllocator on GPU %d.\n\n"
             "You have enabled CUDA managed memory, but the gpu device does not "
             "support allocating managed memory.\n"
@@ -882,7 +882,7 @@ class AllocatorFacadePrivate {
     PADDLE_ENFORCE_EQ(
         strategy_,
         AllocatorStrategy::kAutoGrowth,
-        phi::errors::Unimplemented(
+        common::errors::Unimplemented(
             "Only support auto-growth strategy for StreamSafeCUDAAllocator, "
             "the allocator strategy %d is unsupported for multi-stream",
             static_cast<int>(strategy_)));
@@ -890,7 +890,7 @@ class AllocatorFacadePrivate {
       PADDLE_ENFORCE_EQ(
           FLAGS_use_cuda_managed_memory,
           false,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Async allocator cannot be used with CUDA managed memory."));
       VLOG(8) << "[CUDAMallocAsyncAllocator] Init CUDA allocator for stream "
               << stream << " in place " << p;
@@ -916,7 +916,7 @@ class AllocatorFacadePrivate {
         std::make_shared<CUDAMallocAsyncAllocator>(allocator, p, stream);
 #else
     PADDLE_THROW(
-        phi::errors::Unavailable("CUDAMallocAsyncAllocator is not enabled"));
+        common::errors::Unavailable("CUDAMallocAsyncAllocator is not enabled"));
 #endif
   }
 
@@ -1207,7 +1207,7 @@ class AllocatorFacadePrivate {
     }
 #else
     PADDLE_THROW(
-        phi::errors::Unavailable("CUDAMallocAsyncAllocator is not enabled"));
+        common::errors::Unavailable("CUDAMallocAsyncAllocator is not enabled"));
 #endif
   }
 
@@ -1217,7 +1217,7 @@ class AllocatorFacadePrivate {
     PADDLE_ENFORCE_GT(
         retry_time,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Retry time should be larger than 0, but got %d", retry_time));
     std::shared_ptr<Allocator>& allocator = cuda_allocators_[p][stream];
     allocator = std::make_shared<RetryAllocator>(allocator, retry_time);
@@ -1242,7 +1242,7 @@ class AllocatorFacadePrivate {
       for (auto& stream_pair : place_pair.second) {
         PADDLE_ENFORCE_EQ(stream_pair.second->IsAllocThreadSafe(),
                           true,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Public allocators must be thread safe"));
       }
     }
@@ -1263,7 +1263,7 @@ class AllocatorFacadePrivate {
     PADDLE_ENFORCE_EQ(
         strategy_,
         AllocatorStrategy::kAutoGrowth,
-        phi::errors::Unimplemented(
+        common::errors::Unimplemented(
             "Only support auto-growth strategy for StreamSafeXPUAllocator, "
             "the allocator strategy %d is unsupported for multi-stream",
             static_cast<int>(strategy_)));
@@ -1339,7 +1339,7 @@ class AllocatorFacadePrivate {
     PADDLE_ENFORCE_GT(
         retry_time,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Retry time should be larger than 0, but got %d", retry_time));
     std::shared_ptr<Allocator>& allocator = xpu_allocators_[p][stream];
     allocator = std::make_shared<RetryAllocator>(allocator, retry_time);
@@ -1372,7 +1372,7 @@ class AllocatorFacadePrivate {
     PADDLE_ENFORCE_EQ(
         strategy_,
         AllocatorStrategy::kAutoGrowth,
-        phi::errors::Unimplemented(
+        common::errors::Unimplemented(
             "Only support auto-growth strategy for "
             "StreamSafeCustomDeviceAllocator, "
             "the allocator strategy %d is unsupported for multi-stream",
@@ -1523,7 +1523,7 @@ class AllocatorFacadePrivate {
     for (auto& pair : allocators) {
       PADDLE_ENFORCE_EQ(pair.second->IsAllocThreadSafe(),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Public allocators must be thread safe"));
     }
   }
@@ -1543,7 +1543,7 @@ class AllocatorFacadePrivate {
     PADDLE_ENFORCE_GT(
         retry_time,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Retry time should be larger than 0, but got %d", retry_time));
     for (auto& pair : allocators_) {
       if (phi::is_gpu_place(pair.first) || phi::is_xpu_place(pair.first)) {
@@ -1628,7 +1628,7 @@ AllocatorFacadePrivate* AllocatorFacade::GetPrivate() const {
     PADDLE_ENFORCE_NE(
         iter,
         cuda_graph_map_.end(),
-        phi::errors::PermissionDenied(
+        common::errors::PermissionDenied(
             "No memory pool is prepared for CUDA Graph capturing."));
     VLOG(10) << "Choose CUDA Graph memory pool";
     return iter->second.get();
@@ -1647,13 +1647,13 @@ void* AllocatorFacade::GetBasePtr(
     const std::shared_ptr<phi::Allocation>& allocation) {
   PADDLE_ENFORCE_EQ(GetAllocatorStrategy(),
                     AllocatorStrategy::kAutoGrowth,
-                    phi::errors::Unimplemented(
+                    common::errors::Unimplemented(
                         "GetBasePtr() is only implemented for auto_growth "
                         "strategy, not support allocator strategy: %d",
                         static_cast<int>(GetAllocatorStrategy())));
   PADDLE_ENFORCE_EQ(phi::is_gpu_place(allocation->place()),
                     true,
-                    phi::errors::Unimplemented(
+                    common::errors::Unimplemented(
                         "GetBasePtr() is only implemented for CUDAPlace(), not "
                         "support place: %s",
                         allocation->place()));
@@ -1740,7 +1740,7 @@ AllocationPtr AllocatorFacade::Alloc(const phi::Place& place,
     return m->GetAllocator(p, size)->Allocate(size);
   }
 #else
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "Not compiled with GPU or XPU or CustomDevice."));
 #endif
 }
@@ -1752,7 +1752,7 @@ bool AllocatorFacade::InSameStream(
   gpuStream_t s = reinterpret_cast<gpuStream_t>(stream.id());  // NOLINT
   return s == GetStream(allocation);
 #else
-  PADDLE_THROW(phi::errors::PreconditionNotMet("Not compiled with GPU."));
+  PADDLE_THROW(common::errors::PreconditionNotMet("Not compiled with GPU."));
 #endif
 }
 
@@ -1826,7 +1826,7 @@ void AllocatorFacade::SetDefaultStream(const phi::GPUPlace& place,
 void AllocatorFacade::PrepareMemoryPoolForCUDAGraph(int64_t id) {
   PADDLE_ENFORCE_EQ(GetAllocatorStrategy(),
                     AllocatorStrategy::kAutoGrowth,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "CUDA Graph is only supported when the "
                         "FLAGS_allocator_strategy=\"auto_growth\", but got "
                         "FLAGS_allocator_strategy=\"%s\"",
@@ -1849,7 +1849,7 @@ void AllocatorFacade::RemoveMemoryPoolOfCUDAGraph(int64_t id) {
   auto ref_cnt_iter = cuda_graph_ref_cnt_.find(id);
   PADDLE_ENFORCE_NE(ref_cnt_iter,
                     cuda_graph_ref_cnt_.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Cannot find CUDA Graph with memory ID = %d", id));
   auto& ref_cnt = ref_cnt_iter->second;
   --ref_cnt;

--- a/paddle/fluid/memory/allocation/allocator_strategy.cc
+++ b/paddle/fluid/memory/allocation/allocator_strategy.cc
@@ -36,7 +36,7 @@ static AllocatorStrategy GetStrategyFromFlag() {
     return AllocatorStrategy::kThreadLocal;
   }
 
-  PADDLE_THROW(phi::errors::InvalidArgument(
+  PADDLE_THROW(common::errors::InvalidArgument(
       "Unsupported allocator strategy: %s, candidates are naive_best_fit, "
       "auto_growth or thread_local.",
       FLAGS_allocator_strategy));

--- a/paddle/fluid/memory/allocation/best_fit_allocator.cc
+++ b/paddle/fluid/memory/allocation/best_fit_allocator.cc
@@ -63,13 +63,13 @@ BestFitAllocator::ListIt BestFitAllocator::SplitChunk(size_t request_size,
   auto to_split_it = bin_iterator->second;
   free_chunks_[free_chunk_offset].erase(bin_iterator);
 
-  PADDLE_ENFORCE_EQ(
-      to_split_it->is_free,
-      true,
-      phi::errors::PreconditionNotMet("The memory chunk to split is not free"));
+  PADDLE_ENFORCE_EQ(to_split_it->is_free,
+                    true,
+                    common::errors::PreconditionNotMet(
+                        "The memory chunk to split is not free"));
   PADDLE_ENFORCE_GE(to_split_it->size_,
                     request_size,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The size of memory chunk to split is "
                         "not larger than size of request memory"));
 
@@ -111,7 +111,7 @@ void BestFitAllocator::EraseFreeNode(const ListIt& it) {
   PADDLE_ENFORCE_NE(
       map_it,
       free_map.end(),
-      phi::errors::NotFound("The node to erase is not found in map"));
+      common::errors::NotFound("The node to erase is not found in map"));
   free_map.erase(map_it);
 }
 size_t BestFitAllocator::NumFreeChunks() const {
@@ -126,12 +126,12 @@ void BestFitAllocator::FreeImpl(phi::Allocation* allocation) {
   auto* bf_allocation = dynamic_cast<BestFitAllocation*>(allocation);
   PADDLE_ENFORCE_NOT_NULL(
       bf_allocation,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input allocation is not type of BestFitAllocation."));
   auto chunk_it = bf_allocation->ChunkIterator();
   PADDLE_ENFORCE_EQ(chunk_it->is_free,
                     false,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The chunk of allocation to free is freed already"));
   chunk_it->is_free = true;
   if (chunk_it != chunks_.begin()) {
@@ -169,7 +169,7 @@ phi::Allocation* BestFitAllocator::AllocateImpl(size_t size) {
     }
   }
   if (UNLIKELY(highest_set_bit == free_chunks_.size())) {
-    PADDLE_THROW_BAD_ALLOC(phi::errors::ResourceExhausted(
+    PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
         "Cannot allocate %d, All fragments size is %d.", size, FreeSize()));
   }
   auto chunk_it = SplitChunk(size, highest_set_bit, map_it);

--- a/paddle/fluid/memory/allocation/buffered_allocator.cc
+++ b/paddle/fluid/memory/allocation/buffered_allocator.cc
@@ -26,7 +26,7 @@ BufferedAllocator::BufferedAllocator(std::shared_ptr<Allocator> allocator)
     : underlying_allocator_(std::move(allocator)) {
   PADDLE_ENFORCE_NOT_NULL(
       underlying_allocator_,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Underlying allocator of BufferedAllocator is NULL"));
   if (underlying_allocator_->IsAllocThreadSafe()) {
     mtx_ = std::make_unique<std::mutex>();

--- a/paddle/fluid/memory/allocation/cpu_allocator.cc
+++ b/paddle/fluid/memory/allocation/cpu_allocator.cc
@@ -44,7 +44,7 @@ phi::Allocation *CPUAllocator::AllocateImpl(size_t size) {
   PADDLE_ENFORCE_EQ(
       error,
       0,
-      phi::errors::ResourceExhausted(
+      common::errors::ResourceExhausted(
           "Fail to alloc memory of %ld size, error code is %d.", size, error));
 #endif
   HOST_MEMORY_STAT_UPDATE(Reserved, 0, size);

--- a/paddle/fluid/memory/allocation/cuda_allocator.cc
+++ b/paddle/fluid/memory/allocation/cuda_allocator.cc
@@ -35,7 +35,7 @@ void CUDAAllocator::FreeImpl(phi::Allocation* allocation) {
   PADDLE_ENFORCE_EQ(
       allocation->place(),
       place_,
-      phi::errors::PermissionDenied(
+      common::errors::PermissionDenied(
           "GPU memory is freed in incorrect device. This may be a bug"));
   platform::RecordedGpuFree(
       allocation->ptr(), allocation->size(), place_.device);
@@ -68,7 +68,7 @@ phi::Allocation* CUDAAllocator::AllocateImpl(size_t size) {
         limit_size);
   }
 
-  PADDLE_THROW_BAD_ALLOC(phi::errors::ResourceExhausted(
+  PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
       "\n\nOut of memory error on GPU %d. "
       "Cannot allocate %s memory on GPU %d, %s memory has been allocated and "
       "available memory is only %s.\n\n"

--- a/paddle/fluid/memory/allocation/cuda_device_context_allocator.h
+++ b/paddle/fluid/memory/allocation/cuda_device_context_allocator.h
@@ -48,7 +48,7 @@ class GPUContextAllocation : public Allocation {
   ~GPUContextAllocation() {
     PADDLE_WARN_NOT_NULL(
         dev_ctx_,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Device context is not set for GPUContextAllocation"));
 
     auto *p_allocation = underlying_allocation_.release();
@@ -103,7 +103,7 @@ class GPUContextAllocator : public Allocator {
   phi::Allocation *AllocateImpl(size_t size) override {
     PADDLE_ENFORCE_NOT_NULL(
         default_stream_,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Default stream is not set for GPUContextAllocator"));
     platform::CUDADeviceGuard guard(place_.device);
     auto allocation = new GPUContextAllocation(
@@ -147,7 +147,7 @@ class GPUContextAllocatorPool {
     PADDLE_ENFORCE_NE(
         iter,
         allocators_.end(),
-        phi::errors::NotFound("No allocator found for CUDAPlace."));
+        common::errors::NotFound("No allocator found for CUDAPlace."));
     auto &allocator = iter->second;
     AllocationPtr allocation = allocator->Allocate(size);
     static_cast<GPUContextAllocation *>(allocation.get())

--- a/paddle/fluid/memory/allocation/cuda_malloc_async_allocator.cc
+++ b/paddle/fluid/memory/allocation/cuda_malloc_async_allocator.cc
@@ -367,7 +367,7 @@ phi::Allocation* CUDAMallocAsyncAllocator::AllocateImpl(size_t size) {
         limit_size);
   }
 
-  PADDLE_THROW_BAD_ALLOC(phi::errors::ResourceExhausted(
+  PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
       "\n\nOut of memory error on GPU %d. "
       "Cannot allocate %s memory on GPU %d, %s memory has been allocated and "
       "available memory is only %s.\n\n"

--- a/paddle/fluid/memory/allocation/cuda_managed_allocator.cc
+++ b/paddle/fluid/memory/allocation/cuda_managed_allocator.cc
@@ -38,7 +38,7 @@ void CUDAManagedAllocator::FreeImpl(phi::Allocation* allocation) {
   PADDLE_ENFORCE_EQ(
       allocation->place(),
       place_,
-      phi::errors::PermissionDenied(
+      common::errors::PermissionDenied(
           "GPU memory is freed in incorrect device. This may be a bug"));
   platform::RecordedGpuFree(
       allocation->ptr(), allocation->size(), place_.device);
@@ -75,7 +75,7 @@ phi::Allocation* CUDAManagedAllocator::AllocateImpl(size_t size) {
         limit_size_mb);
   }
 
-  PADDLE_THROW_BAD_ALLOC(phi::errors::ResourceExhausted(
+  PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
       "\n\nOut of memory error on GPU %d. "
       "Cannot allocate %s CUDA managed memory on GPU %d, %s memory has been "
       "allocated.\n\n"

--- a/paddle/fluid/memory/allocation/cuda_virtual_mem_allocator.cc
+++ b/paddle/fluid/memory/allocation/cuda_virtual_mem_allocator.cc
@@ -102,13 +102,13 @@ void CUDAVirtualMemAllocator::FreeImpl(phi::Allocation* allocation) {
   PADDLE_ENFORCE_EQ(
       allocation->place(),
       place_,
-      phi::errors::PermissionDenied(
+      common::errors::PermissionDenied(
           "GPU memory is freed in incorrect device. This may be a bug"));
 
   auto iter = virtual_2_physical_map_.find(
       reinterpret_cast<CUdeviceptr>(allocation->ptr()));
   if (iter == virtual_2_physical_map_.end()) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Can not find virtual memory address at %s", allocation->ptr()));
   }
 
@@ -143,7 +143,7 @@ phi::Allocation* CUDAVirtualMemAllocator::AllocateImpl(size_t size) {
   CUdeviceptr ptr = virtual_mem_base_ + virtual_mem_alloced_offset_;
 
   if (ptr + size > virtual_mem_base_ + virtual_mem_size_) {
-    PADDLE_THROW_BAD_ALLOC(phi::errors::ResourceExhausted(
+    PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
         "\n\nOut of memory error on GPU Virtual Memory %d. "
         "Cannot allocate %s memory on GPU Virtual Memory %d, %s memory has "
         "been allocated and "
@@ -173,7 +173,7 @@ phi::Allocation* CUDAVirtualMemAllocator::AllocateImpl(size_t size) {
       PADDLE_ENFORCE_GPU_SUCCESS(cudaMemGetInfo(&actual_avail, &actual_total));
       size_t actual_allocated = actual_total - actual_avail;
 
-      PADDLE_THROW_BAD_ALLOC(phi::errors::ResourceExhausted(
+      PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
           "\n\nOut of memory error on GPU %d. "
           "Cannot allocate %s memory on GPU %d, %s memory has been allocated "
           "and "

--- a/paddle/fluid/memory/allocation/custom_allocator.cc
+++ b/paddle/fluid/memory/allocation/custom_allocator.cc
@@ -27,11 +27,12 @@ namespace allocation {
 
 bool CustomAllocator::IsAllocThreadSafe() const { return true; }
 void CustomAllocator::FreeImpl(phi::Allocation* allocation) {
-  PADDLE_ENFORCE_EQ(allocation->place(),
-                    place_,
-                    phi::errors::PermissionDenied("CustomDevice memory is "
-                                                  "freed in incorrect device. "
-                                                  "This may be a bug"));
+  PADDLE_ENFORCE_EQ(
+      allocation->place(),
+      place_,
+      common::errors::PermissionDenied("CustomDevice memory is "
+                                       "freed in incorrect device. "
+                                       "This may be a bug"));
   if (phi::DeviceManager::HasDeviceType(place_.GetDeviceType())) {
     phi::DeviceManager::GetDeviceWithPlace(place_)->MemoryDeallocate(
         allocation->ptr(), allocation->size());
@@ -67,7 +68,7 @@ phi::Allocation* CustomAllocator::AllocateImpl(size_t size) {
   auto dev_type = phi::PlaceHelper::GetDeviceType(place_);
   auto dev_id = phi::PlaceHelper::GetDeviceId(place_);
 
-  PADDLE_THROW_BAD_ALLOC(phi::errors::ResourceExhausted(
+  PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
       "\n\nOut of memory error on %s:%d. "
       "Cannot allocate %s memory on %s:%d, "
       "available memory is only %s.\n\n"

--- a/paddle/fluid/memory/allocation/memory_block.cc
+++ b/paddle/fluid/memory/allocation/memory_block.cc
@@ -48,7 +48,7 @@ void MemoryBlock::Split(MetadataCache* cache,
   // make sure the split fits
   PADDLE_ENFORCE_GE(desc->total_size,
                     size,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of memory block (%d) to split is "
                         "not larger than size of request memory (%d)",
                         desc->total_size,
@@ -99,12 +99,12 @@ void MemoryBlock::Merge(MetadataCache* cache, MemoryBlock* right_buddy) {
   auto rb_desc = cache->LoadDesc(right_buddy);
   PADDLE_ENFORCE_EQ(desc->type,
                     FREE_CHUNK,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The destination chunk to merge is not free"));
-  PADDLE_ENFORCE_EQ(
-      rb_desc->type,
-      FREE_CHUNK,
-      phi::errors::PreconditionNotMet("The source chunk to merge is not free"));
+  PADDLE_ENFORCE_EQ(rb_desc->type,
+                    FREE_CHUNK,
+                    common::errors::PreconditionNotMet(
+                        "The source chunk to merge is not free"));
 
   // link this->buddy's buddy
   desc->right_buddy = rb_desc->right_buddy;
@@ -131,12 +131,12 @@ void MemoryBlock::MarkAsFree(MetadataCache* cache) {
   auto desc = cache->LoadDesc(this);
   PADDLE_ENFORCE_NE(desc->type,
                     FREE_CHUNK,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The chunk to mark as free is free already"));
-  PADDLE_ENFORCE_NE(
-      desc->type,
-      INVALID_CHUNK,
-      phi::errors::PreconditionNotMet("The chunk to mark as free is invalid"));
+  PADDLE_ENFORCE_NE(desc->type,
+                    INVALID_CHUNK,
+                    common::errors::PreconditionNotMet(
+                        "The chunk to mark as free is invalid"));
   desc->type = FREE_CHUNK;
   desc->UpdateGuards();
 }

--- a/paddle/fluid/memory/allocation/meta_cache.cc
+++ b/paddle/fluid/memory/allocation/meta_cache.cc
@@ -26,12 +26,12 @@ MemoryBlock::Desc* MetadataCache::LoadDesc(MemoryBlock* block) {
     PADDLE_ENFORCE_NE(
         iter,
         cache_.end(),
-        phi::errors::NotFound("The memory block is not found in cache"));
+        common::errors::NotFound("The memory block is not found in cache"));
     auto* desc = &(iter->second);
     PADDLE_ENFORCE_EQ(
         desc->CheckGuards(),
         true,
-        phi::errors::InvalidArgument("Invalid CPU memory access"));
+        common::errors::InvalidArgument("Invalid CPU memory access"));
     return desc;
   } else {
     auto* desc = reinterpret_cast<MemoryBlock::Desc*>(block);
@@ -39,7 +39,7 @@ MemoryBlock::Desc* MetadataCache::LoadDesc(MemoryBlock* block) {
     PADDLE_ENFORCE_EQ(
         desc->CheckGuards(),
         true,
-        phi::errors::InvalidArgument("Invalid CPU memory access"));
+        common::errors::InvalidArgument("Invalid CPU memory access"));
     return reinterpret_cast<MemoryBlock::Desc*>(block);
   }
 }

--- a/paddle/fluid/memory/allocation/mmap_allocator.cc
+++ b/paddle/fluid/memory/allocation/mmap_allocator.cc
@@ -80,7 +80,7 @@ void AllocateMemoryMap(std::string filename,
       PADDLE_ENFORCE_NE(
           fd,
           -1,
-          phi::errors::Unavailable(
+          common::errors::Unavailable(
               "File descriptor %s open failed, unable in read-write mode",
               filename.c_str()));
       VLOG(6) << "shm_open: " << filename;
@@ -90,7 +90,7 @@ void AllocateMemoryMap(std::string filename,
 
   PADDLE_ENFORCE_EQ(ftruncate(fd, size),
                     0,
-                    phi::errors::Unavailable(
+                    common::errors::Unavailable(
                         "Truncate a file to a specified length failed!"));
 
   if (flags & MAPPED_SHAREDMEM) {
@@ -104,17 +104,17 @@ void AllocateMemoryMap(std::string filename,
     shm_unlink(filename.c_str());
   }
 
-  PADDLE_ENFORCE_NE(
-      *map_ptr_,
-      MAP_FAILED,
-      phi::errors::Unavailable("Memory map failed when create shared memory."));
+  PADDLE_ENFORCE_NE(*map_ptr_,
+                    MAP_FAILED,
+                    common::errors::Unavailable(
+                        "Memory map failed when create shared memory."));
   if (flags & MAPPED_KEEPFD) {
     *shared_fd = fd;
     VLOG(6) << "keep fd: " << *shared_fd;
   } else {
     PADDLE_ENFORCE_NE(::close(fd),
                       -1,
-                      phi::errors::Unavailable(
+                      common::errors::Unavailable(
                           "Error closing memory mapped file <", filename, ">"));
 
     *shared_fd = -1;
@@ -164,7 +164,7 @@ void MemoryMapAllocation::close() {
     if (flags_ & MAPPED_KEEPFD) {
       PADDLE_ENFORCE_NE(::close(fd_),
                         -1,
-                        phi::errors::Unavailable(
+                        common::errors::Unavailable(
                             "Error closing file descriptor <", fd_, ">"));
     }
   }
@@ -213,10 +213,10 @@ void RefcountedMemoryMapAllocation::close() {
   --info->refcount;
   if (flags_ & MAPPED_KEEPFD) {
     closed_fd_ = true;
-    PADDLE_ENFORCE_NE(
-        ::close(fd_),
-        -1,
-        phi::errors::Unavailable("Error closing file descriptor <", fd_, ">"));
+    PADDLE_ENFORCE_NE(::close(fd_),
+                      -1,
+                      common::errors::Unavailable(
+                          "Error closing file descriptor <", fd_, ">"));
     VLOG(6) << "close fd: " << fd_;
   }
 
@@ -235,29 +235,29 @@ void RefcountedMemoryMapAllocation::close() {
         VLOG(6) << "shm_unlink file: " << ipc_name_;
       }
 
-      PADDLE_ENFORCE_NE(
-          munmap(map_ptr_, map_size_),
-          -1,
-          phi::errors::Unavailable("could not unmap the shared memory file: ",
-                                   strerror(errno),
-                                   " (",
-                                   errno,
-                                   ")"));
+      PADDLE_ENFORCE_NE(munmap(map_ptr_, map_size_),
+                        -1,
+                        common::errors::Unavailable(
+                            "could not unmap the shared memory file: ",
+                            strerror(errno),
+                            " (",
+                            errno,
+                            ")"));
     }
   }
 }
 
 MemoryMapWriterAllocation::~MemoryMapWriterAllocation() {
   if (munmap(this->ptr(), this->size()) == -1) {
-    phi::errors::Unavailable("could not unmap the shared memory file %s",
-                             this->ipc_name());
+    common::errors::Unavailable("could not unmap the shared memory file %s",
+                                this->ipc_name());
   }
 }
 
 MemoryMapReaderAllocation::~MemoryMapReaderAllocation() {
   if (munmap(this->ptr(), this->size()) == -1) {
-    phi::errors::Unavailable("could not unmap the shared memory file %s",
-                             this->ipc_name());
+    common::errors::Unavailable("could not unmap the shared memory file %s",
+                                this->ipc_name());
   }
 
   /* Here we do not pay attention to the result of shm_unlink,
@@ -290,18 +290,18 @@ std::shared_ptr<MemoryMapWriterAllocation> AllocateMemoryMapWriterAllocation(
 
   PADDLE_ENFORCE_NE(fd,
                     -1,
-                    phi::errors::Unavailable("File descriptor %s open failed",
-                                             ipc_name.c_str()));
+                    common::errors::Unavailable(
+                        "File descriptor %s open failed", ipc_name.c_str()));
   PADDLE_ENFORCE_EQ(ftruncate(fd, size),
                     0,
-                    phi::errors::Unavailable(
+                    common::errors::Unavailable(
                         "Truncate a file to a specified length failed!"));
 
   void *ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-  PADDLE_ENFORCE_NE(
-      ptr,
-      MAP_FAILED,
-      phi::errors::Unavailable("Memory map failed when create shared memory."));
+  PADDLE_ENFORCE_NE(ptr,
+                    MAP_FAILED,
+                    common::errors::Unavailable(
+                        "Memory map failed when create shared memory."));
   close(fd);
 
   return std::make_shared<MemoryMapWriterAllocation>(ptr, size, ipc_name);
@@ -314,12 +314,12 @@ std::shared_ptr<MemoryMapReaderAllocation> RebuildMemoryMapReaderAllocation(
   int fd = shm_open(ipc_name.c_str(), flags, 0600);
   PADDLE_ENFORCE_NE(fd,
                     -1,
-                    phi::errors::Unavailable("File descriptor %s open failed",
-                                             ipc_name.c_str()));
+                    common::errors::Unavailable(
+                        "File descriptor %s open failed", ipc_name.c_str()));
   void *ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   PADDLE_ENFORCE_NE(ptr,
                     MAP_FAILED,
-                    phi::errors::Unavailable(
+                    common::errors::Unavailable(
                         "Memory map failed when rebuild shared memory."));
   close(fd);
   return std::make_shared<MemoryMapReaderAllocation>(ptr, size, ipc_name);
@@ -410,11 +410,11 @@ void MemoryMapAllocationPool::Clear() {
     PADDLE_ENFORCE_NE(
         munmap(mmap.mmap_ptr_, mmap.data_size_ + mmap_alignment),
         -1,
-        phi::errors::Unavailable("could not unmap the shared memory file: ",
-                                 strerror(errno),
-                                 " (",
-                                 errno,
-                                 ")"));
+        common::errors::Unavailable("could not unmap the shared memory file: ",
+                                    strerror(errno),
+                                    " (",
+                                    errno,
+                                    ")"));
   }
   memory_map_allocations_.clear();
 }

--- a/paddle/fluid/memory/allocation/naive_best_fit_allocator.cc
+++ b/paddle/fluid/memory/allocation/naive_best_fit_allocator.cc
@@ -156,16 +156,17 @@ void *Alloc<phi::XPUPlace>(const phi::XPUPlace &place, size_t size) {
   PADDLE_ENFORCE_EQ(
       ret,
       XPU_SUCCESS,
-      phi::errors::External("XPU API return wrong value[%d], no enough memory",
-                            ret));
+      common::errors::External(
+          "XPU API return wrong value[%d], no enough memory", ret));
   if (FLAGS_init_allocated_mem) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "xpu memory FLAGS_init_allocated_mem is not implemented."));
   }
   VLOG(10) << "  pointer=" << p;
   return p;
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied("'XPUPlace' is not supported."));
+  PADDLE_THROW(
+      common::errors::PermissionDenied("'XPUPlace' is not supported."));
   return nullptr;
 #endif
 }
@@ -179,7 +180,8 @@ void Free<phi::XPUPlace>(const phi::XPUPlace &place, void *p, size_t size) {
   phi::backends::xpu::XPUDeviceGuard guard(place.device);
   xpu_free(p);
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied("'XPUPlace' is not supported."));
+  PADDLE_THROW(
+      common::errors::PermissionDenied("'XPUPlace' is not supported."));
 #endif
 }
 
@@ -188,7 +190,8 @@ uint64_t Release<phi::XPUPlace>(const phi::XPUPlace &place) {
 #ifdef PADDLE_WITH_XPU
   LOG(WARNING) << "Release XPU pool is not supported now, no action here.";
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied("'XPUPlace' is not supported."));
+  PADDLE_THROW(
+      common::errors::PermissionDenied("'XPUPlace' is not supported."));
 #endif
   return -1;
 }
@@ -199,7 +202,8 @@ size_t Used<phi::XPUPlace>(const phi::XPUPlace &place) {
   printf("Used func return 0 for XPUPlace\n");
   return 0;
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied("'XPUPlace' is not supported."));
+  PADDLE_THROW(
+      common::errors::PermissionDenied("'XPUPlace' is not supported."));
 #endif
 }
 
@@ -232,7 +236,7 @@ class GPUBuddyAllocatorList {
         devices_.begin(), std::find(devices_.begin(), devices_.end(), gpu_id));
     PADDLE_ENFORCE_LT(pos,
                       devices_.size(),
-                      phi::errors::OutOfRange(
+                      common::errors::OutOfRange(
                           "The index exceeds the size of devices, the size of "
                           "devices is %d, the index is %d",
                           devices_.size(),
@@ -278,7 +282,7 @@ size_t Used<phi::GPUPlace>(const phi::GPUPlace &place) {
 #if (defined PADDLE_WITH_CUDA || defined PADDLE_WITH_HIP)
   return GetGPUBuddyAllocator(place.device)->Used();
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CUDAPlace' is not supported in CPU only device."));
 #endif
 }
@@ -292,7 +296,7 @@ void *Alloc<phi::GPUPlace>(const phi::GPUPlace &place, size_t size) {
     platform::CUDADeviceGuard guard(place.device);
     size_t avail, total;
     platform::GpuMemoryUsage(&avail, &total);
-    PADDLE_THROW(phi::errors::ResourceExhausted(
+    PADDLE_THROW(common::errors::ResourceExhausted(
         "Cannot allocate %s in GPU %d, available %s, total %s, GpuMinChunkSize "
         "%s, GpuMaxChunkSize %s, GPU memory used: %s.",
         string::HumanReadableSize(size),
@@ -313,7 +317,7 @@ void *Alloc<phi::GPUPlace>(const phi::GPUPlace &place, size_t size) {
   }
   return ptr;
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CUDAPlace' is not supported in CPU only device."));
 #endif
 }
@@ -323,7 +327,7 @@ void Free<phi::GPUPlace>(const phi::GPUPlace &place, void *p, size_t size) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   GetGPUBuddyAllocator(place.device)->Free(p);
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CUDAPlace' is not supported in CPU only device."));
 #endif
 }
@@ -333,7 +337,7 @@ uint64_t Release<phi::GPUPlace>(const phi::GPUPlace &place) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   return GetGPUBuddyAllocator(place.device)->Release();
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CUDAPlace' is not supported in CPU only device."));
 #endif
 }
@@ -359,7 +363,7 @@ size_t Used<phi::GPUPinnedPlace>(const phi::GPUPinnedPlace &place) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   return GetCUDAPinnedBuddyAllocator()->Used();
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CUDAPinnedPlace' is not supported in CPU only device."));
 #endif
 }
@@ -380,7 +384,7 @@ void *Alloc<phi::GPUPinnedPlace>(const phi::GPUPinnedPlace &place,
   }
   return ptr;
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CUDAPinnedPlace' is not supported in CPU only device."));
 #endif
 }
@@ -393,7 +397,7 @@ void Free<phi::GPUPinnedPlace>(const phi::GPUPinnedPlace &place,
   VLOG(10) << "Free " << size << " bytes on " << phi::Place(place);
   GetCUDAPinnedBuddyAllocator()->Free(p);
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CUDAPinnedPlace' is not supported in CPU only device."));
 #endif
 }
@@ -404,7 +408,7 @@ uint64_t Release<phi::GPUPinnedPlace>(const phi::GPUPinnedPlace &place) {
   VLOG(10) << "Release on " << phi::Place(place);
   return GetCUDAPinnedBuddyAllocator()->Release();
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CUDAPinnedPlace' is not supported in CPU only device."));
 #endif
 }
@@ -438,7 +442,7 @@ class BuddyAllocatorList {
   BuddyAllocator *Get(int dev_id) {
     PADDLE_ENFORCE_NE(init_flags_.find(dev_id),
                       init_flags_.end(),
-                      phi::errors::OutOfRange(
+                      common::errors::OutOfRange(
                           "Cannot find %s %d, please check visible devices.",
                           device_type_,
                           dev_id));
@@ -474,7 +478,7 @@ BuddyAllocator *GetBuddyAllocator(const phi::Place &place) {
     return BuddyAllocatorList::Instance(phi::PlaceHelper::GetDeviceType(place))
         ->Get(phi::PlaceHelper::GetDeviceId(place));
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument("place must be CustomPlace"));
+    PADDLE_THROW(common::errors::InvalidArgument("place must be CustomPlace"));
   }
 }
 #endif
@@ -490,7 +494,7 @@ void *Alloc<phi::CustomPlace>(const phi::CustomPlace &place, size_t size) {
     phi::DeviceGuard guard(place);
     size_t avail, total;
     phi::DeviceManager::MemoryStats(place, &total, &avail);
-    PADDLE_THROW(phi::errors::ResourceExhausted(
+    PADDLE_THROW(common::errors::ResourceExhausted(
         "Cannot allocate %s in %s:%d, available %s, total %s, used "
         "%s. ",
         string::HumanReadableSize(size),
@@ -507,7 +511,7 @@ void *Alloc<phi::CustomPlace>(const phi::CustomPlace &place, size_t size) {
   VLOG(10) << "  pointer=" << ptr;
   return ptr;
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CustomPlace' is not supported in CPU only device."));
 #endif
 }
@@ -522,7 +526,7 @@ void Free<phi::CustomPlace>(const phi::CustomPlace &place,
     GetBuddyAllocator(place)->Free(p);
   }
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CustomPlace' is not supported in CPU only device."));
 #endif
 }
@@ -532,7 +536,7 @@ uint64_t Release<phi::CustomPlace>(const phi::CustomPlace &place) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
   return GetBuddyAllocator(place)->Release();
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CustomPlace' is not supported in CPU only device."));
 #endif
 }
@@ -542,7 +546,7 @@ size_t Used<phi::CustomPlace>(const phi::CustomPlace &place) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
   return GetBuddyAllocator(place)->Used();
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CustomPlace' is not supported in CPU only device."));
 #endif
 }
@@ -592,7 +596,7 @@ size_t Usage::operator()(const phi::GPUPlace &gpu) const {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   return Used(gpu);
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CUDAPlace' is not supported in CPU only device."));
 #endif
 }
@@ -601,7 +605,7 @@ size_t Usage::operator()(const phi::GPUPinnedPlace &cuda_pinned) const {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   return Used(cuda_pinned);
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "'CUDAPinnedPlace' is not supported in CPU only device."));
 #endif
 }

--- a/paddle/fluid/memory/allocation/retry_allocator.h
+++ b/paddle/fluid/memory/allocation/retry_allocator.h
@@ -34,12 +34,12 @@ class RetryAllocator : public Allocator {
       : underlying_allocator_(std::move(allocator)), retry_time_(retry_ms) {
     PADDLE_ENFORCE_NOT_NULL(
         underlying_allocator_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Underlying allocator of RetryAllocator is NULL"));
     PADDLE_ENFORCE_EQ(
         underlying_allocator_->IsAllocThreadSafe(),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Underlying allocator of RetryAllocator is not thread-safe"));
   }
 

--- a/paddle/fluid/memory/allocation/system_allocator.cc
+++ b/paddle/fluid/memory/allocation/system_allocator.cc
@@ -63,11 +63,11 @@ void* AlignedMalloc(size_t size) {
   PADDLE_ENFORCE_EQ(
       error,
       0,
-      phi::errors::ResourceExhausted(
+      common::errors::ResourceExhausted(
           "Fail to alloc memory of %ld size, error code is %d.", size, error));
 #endif
   PADDLE_ENFORCE_NOT_NULL(p,
-                          phi::errors::ResourceExhausted(
+                          common::errors::ResourceExhausted(
                               "Fail to alloc memory of %ld size.", size));
   return p;
 }
@@ -151,7 +151,7 @@ void* GPUAllocator::Alloc(size_t* index, size_t size) {
           limit_size);
     }
 
-    PADDLE_THROW_BAD_ALLOC(phi::errors::ResourceExhausted(
+    PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
         "\n\nOut of memory error on GPU %d. "
         "Cannot allocate %s memory on GPU %d, %s memory has been allocated and "
         "available memory is only %s.\n\n"
@@ -177,11 +177,11 @@ void* GPUAllocator::Alloc(size_t* index, size_t size) {
 void GPUAllocator::Free(void* p, size_t size, size_t index) {
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The index should be 0, index is %d", index));
   PADDLE_ENFORCE_GE(gpu_alloc_size_,
                     size,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of memory (%d) to free exceeds the size of "
                         "allocated gpu memory (%d)",
                         size,
@@ -237,14 +237,14 @@ void* CUDAPinnedAllocator::Alloc(size_t* index, size_t size) {
 
 void CUDAPinnedAllocator::Free(void* p, size_t size, size_t index) {
   gpuError_t err;
-  PADDLE_ENFORCE_EQ(
-      index,
-      1,
-      phi::errors::InvalidArgument("The index should be 1, but got %d", index));
+  PADDLE_ENFORCE_EQ(index,
+                    1,
+                    common::errors::InvalidArgument(
+                        "The index should be 1, but got %d", index));
 
   PADDLE_ENFORCE_GE(cuda_pinnd_alloc_size_,
                     size,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of memory (%d) to free exceeds the size of "
                         "allocated cuda pinned memory (%d)",
                         size,
@@ -256,7 +256,7 @@ void CUDAPinnedAllocator::Free(void* p, size_t size, size_t index) {
     PADDLE_ENFORCE_EQ(
         err,
         hipSuccess,
-        phi::errors::Fatal(
+        common::errors::Fatal(
             "hipFreeHost failed in GPUPinnedAllocator, error code is %d", err));
   }
 #else
@@ -271,7 +271,7 @@ void CUDAPinnedAllocator::Free(void* p, size_t size, size_t index) {
     PADDLE_ENFORCE_EQ(
         err,
         0,
-        phi::errors::Fatal(
+        common::errors::Fatal(
             "cudaFreeHost failed in GPUPinnedAllocator, error code is %d",
             err));
   }
@@ -306,15 +306,15 @@ void* CustomAllocator::Alloc(size_t* index, size_t size) {
     size_t avail, total;
 
     phi::DeviceManager::MemoryStats(place, &total, &avail);
-    PADDLE_THROW_BAD_ALLOC(
-        phi::errors::ResourceExhausted("\n\nOut of memory error on %s %d. "
-                                       "total memory is %s, used memory is %s, "
-                                       "available memory is only %s.\n\n",
-                                       dev_type_,
-                                       dev_id_,
-                                       string::HumanReadableSize(total),
-                                       string::HumanReadableSize(total - avail),
-                                       string::HumanReadableSize(avail)));
+    PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
+        "\n\nOut of memory error on %s %d. "
+        "total memory is %s, used memory is %s, "
+        "available memory is only %s.\n\n",
+        dev_type_,
+        dev_id_,
+        string::HumanReadableSize(total),
+        string::HumanReadableSize(total - avail),
+        string::HumanReadableSize(avail)));
   }
   return p;
 }
@@ -323,11 +323,11 @@ void CustomAllocator::Free(void* p, size_t size, size_t index) {
   VLOG(4) << "CustomAllocator::Free " << p << " size " << size;
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The index should be 0, index is %d", index));
   PADDLE_ENFORCE_GE(plug_alloc_size,
                     size,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of memory (%d) to free exceeds the size of "
                         "allocated gpu memory (%d)",
                         size,

--- a/paddle/fluid/memory/allocation/thread_local_allocator.cc
+++ b/paddle/fluid/memory/allocation/thread_local_allocator.cc
@@ -27,7 +27,7 @@ ThreadLocalAllocatorImpl::ThreadLocalAllocatorImpl(const phi::Place& p)
         platform::GpuMinChunkSize(),
         platform::GpuMaxChunkSize());
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Thread local allocator only supports CUDAPlace now."));
   }
 }
@@ -39,7 +39,7 @@ std::shared_ptr<ThreadLocalAllocatorImpl> ThreadLocalCUDAAllocatorPool::Get(
   PADDLE_ENFORCE_LT(
       pos,
       devices_.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The position of device should be less than the size of devices."));
   std::call_once(*init_flags_[pos], [this, pos, gpu_id] {
     platform::SetDeviceId(devices_[pos]);

--- a/paddle/fluid/memory/allocation/xpu_allocator.cc
+++ b/paddle/fluid/memory/allocation/xpu_allocator.cc
@@ -27,7 +27,7 @@ void XPUAllocator::FreeImpl(phi::Allocation* allocation) {
   PADDLE_ENFORCE_EQ(
       allocation->place(),
       place_,
-      phi::errors::PermissionDenied(
+      common::errors::PermissionDenied(
           "XPU memory is freed in incorrect device. This may be a bug"));
   platform::RecordedXPUFree(
       allocation->ptr(), allocation->size(), place_.device);
@@ -44,12 +44,12 @@ phi::Allocation* XPUAllocator::AllocateImpl(size_t size) {
     return new Allocation(ptr, size, phi::Place(place_));
   }
 
-  PADDLE_THROW_BAD_ALLOC(
-      phi::errors::ResourceExhausted("\n\nOut of memory error on XPU %d. "
-                                     "Cannot allocate %s memory on XPU %d.\n\n",
-                                     place_.device,
-                                     string::HumanReadableSize(size),
-                                     place_.device));
+  PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
+      "\n\nOut of memory error on XPU %d. "
+      "Cannot allocate %s memory on XPU %d.\n\n",
+      place_.device,
+      string::HumanReadableSize(size),
+      place_.device));
 }
 
 }  // namespace allocation

--- a/paddle/fluid/memory/memcpy.cc
+++ b/paddle/fluid/memory/memcpy.cc
@@ -101,7 +101,7 @@ void Copy<phi::CustomPlace, phi::CustomPlace>(phi::CustomPlace dst_place,
           dst_place, dst, src, num, &stream_wrapper);
     }
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Copy between %s and %s is not supported.", src_type, dst_type));
   }
 }

--- a/paddle/fluid/memory/stats.cc
+++ b/paddle/fluid/memory/stats.cc
@@ -34,7 +34,7 @@ class StatRegistry {
   StatBase* GetStat(const std::string& stat_type, int dev_id) {
     auto it = stat_map_.find(GetStatKey(stat_type, dev_id));
     if (it == stat_map_.end()) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "The STAT type \"%s\" for device %d has not been registered.",
           stat_type.c_str(),
           dev_id));

--- a/paddle/fluid/memory/stats.h
+++ b/paddle/fluid/memory/stats.h
@@ -162,7 +162,7 @@ void LogDeviceMemoryStats(const phi::Place& place, const std::string& op_name);
       DEVICE_MEMORY_STAT_FUNC_SWITCH_CASE(item, 14);                          \
       DEVICE_MEMORY_STAT_FUNC_SWITCH_CASE(item, 15);                          \
       default:                                                                \
-        PADDLE_THROW(phi::errors::OutOfRange(                                 \
+        PADDLE_THROW(common::errors::OutOfRange(                              \
             "Only support device id between [0, 15] for device memory stats," \
             "not support device id: %d",                                      \
             id));                                                             \
@@ -178,17 +178,17 @@ void LogDeviceMemoryStats(const phi::Place& place, const std::string& op_name);
 #define DEVICE_MEMORY_STAT_UPDATE(item, id, increment) \
   DEVICE_MEMORY_STAT_FUNC(item, id, Update, increment)
 
-#define HOST_MEMORY_STAT_FUNC(item, id, func, ...)                          \
-  [&] {                                                                     \
-    PADDLE_ENFORCE_EQ(                                                      \
-        id,                                                                 \
-        0,                                                                  \
-        phi::errors::OutOfRange("Only support device id 0 for host memory " \
-                                "stats, not support device id: %d",         \
-                                id));                                       \
-    return paddle::memory::Stat<                                            \
-               paddle::memory::HostMemoryStat##item##0>::GetInstance()      \
-        ->func(__VA_ARGS__);                                                \
+#define HOST_MEMORY_STAT_FUNC(item, id, func, ...)                             \
+  [&] {                                                                        \
+    PADDLE_ENFORCE_EQ(                                                         \
+        id,                                                                    \
+        0,                                                                     \
+        common::errors::OutOfRange("Only support device id 0 for host memory " \
+                                   "stats, not support device id: %d",         \
+                                   id));                                       \
+    return paddle::memory::Stat<                                               \
+               paddle::memory::HostMemoryStat##item##0>::GetInstance()         \
+        ->func(__VA_ARGS__);                                                   \
   }()
 
 #define HOST_MEMORY_STAT_CURRENT_VALUE(item, id) \

--- a/paddle/fluid/platform/bfloat16_test.cc
+++ b/paddle/fluid/platform/bfloat16_test.cc
@@ -130,8 +130,8 @@ TEST(bfloat16, floating) {
   PADDLE_ENFORCE_EQ(
       std::is_floating_point<bfloat16>::value,
       true,
-      phi::errors::Fatal("std::is_floating_point with bfloat16 data type "
-                         "should be equal to true but it is not"));
+      common::errors::Fatal("std::is_floating_point with bfloat16 data type "
+                            "should be equal to true but it is not"));
 }
 
 TEST(bfloat16, print) {

--- a/paddle/fluid/platform/collective_helper.cc
+++ b/paddle/fluid/platform/collective_helper.cc
@@ -81,29 +81,29 @@ NCCLCommContext& NCCLCommContext::Instance() {
 
 NCCLComm* NCCLCommContext::CreateComm(
     ncclUniqueId* nccl_id, int nranks, int rank, int dev_id, int ring_id) {
-  PADDLE_ENFORCE_NOT_NULL(
-      nccl_id,
-      phi::errors::InvalidArgument("The nccl unique id should not be null."));
+  PADDLE_ENFORCE_NOT_NULL(nccl_id,
+                          common::errors::InvalidArgument(
+                              "The nccl unique id should not be null."));
   PADDLE_ENFORCE_GT(
       nranks,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Expected nranks > 1. But received nranks is %d.", nranks));
   PADDLE_ENFORCE_GE(rank,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Expected rank >= 0. But received rank is %d.", rank));
   PADDLE_ENFORCE_LT(
       rank,
       nranks,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Expected rank < nranks. But received rank is %d, nranks is %d.",
           rank,
           nranks));
   PADDLE_ENFORCE_GE(
       dev_id,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Expected dev_id >= 0. But received dev_id is %d.", dev_id));
 
   ncclComm_t comm = nullptr;
@@ -128,9 +128,9 @@ void NCCLCommContext::CreateAllNCCLComms(const std::vector<int>& dev_ids,
   PADDLE_ENFORCE_GT(
       dev_ids.size(),
       0,
-      phi::errors::InvalidArgument("Expected the size of dev_ids > 0. But "
-                                   "received the size of dev_ids is %d.",
-                                   dev_ids.size()));
+      common::errors::InvalidArgument("Expected the size of dev_ids > 0. But "
+                                      "received the size of dev_ids is %d.",
+                                      dev_ids.size()));
 
   const int kDevices = dev_ids.size();
   ncclComm_t comms[kDevices];  // NOLINT
@@ -139,7 +139,7 @@ void NCCLCommContext::CreateAllNCCLComms(const std::vector<int>& dev_ids,
 
   PADDLE_ENFORCE_EQ(comm_map_.count(ring_id),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Expected comm_map_.count(ring_id) = 0. But received "
                         "comm_map_.count(ring_id) is %d.",
                         comm_map_.count(ring_id)));
@@ -163,8 +163,8 @@ void NCCLCommContext::CreateNCCLCommMultiTrainer(
   PADDLE_ENFORCE_GT(
       dev_ids.size(),
       0,
-      phi::errors::InvalidArgument("dev ids = [%d], it should greater than 0.",
-                                   dev_ids.size()));
+      common::errors::InvalidArgument(
+          "dev ids = [%d], it should greater than 0.", dev_ids.size()));
   const int kDevices = dev_ids.size();
   VLOG(1) << "Begin CreateNCCLCommMultiTrainer. device number: " << kDevices
           << ", ntrainers: " << ntrainers << ", train_id: " << train_id
@@ -187,7 +187,7 @@ void NCCLCommContext::CreateNCCLCommMultiTrainer(
   }
   PADDLE_ENFORCE_EQ(comm_map_.count(ring_id),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "comm_map_ of ring_id: %s should be 0. %s is provided",
                         ring_id,
                         comm_map_.count(ring_id)));
@@ -313,29 +313,29 @@ class BKCLCommImpl : public BKCLComm {
 
 BKCLComm* BKCLCommContext::CreateComm(
     BKCLUniqueId* bkcl_id, int nranks, int rank, int dev_id, int ring_id) {
-  PADDLE_ENFORCE_NOT_NULL(
-      bkcl_id,
-      phi::errors::InvalidArgument("The bkcl unique id should not be null."));
+  PADDLE_ENFORCE_NOT_NULL(bkcl_id,
+                          common::errors::InvalidArgument(
+                              "The bkcl unique id should not be null."));
   PADDLE_ENFORCE_GT(
       nranks,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Expected nranks > 1. But received nranks is %d.", nranks));
   PADDLE_ENFORCE_GE(rank,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Expected rank >= 0. But received rank is %d.", rank));
   PADDLE_ENFORCE_LT(
       rank,
       nranks,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Expected rank < nranks. But received rank is %d, nranks is %d.",
           rank,
           nranks));
   PADDLE_ENFORCE_GE(
       dev_id,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Expected dev_id >= 0. But received dev_id is %d.", dev_id));
 
   BKCLContext_t comm = nullptr;
@@ -484,29 +484,29 @@ XCCLComm* XCCLCommContext::CreateComm(phi::ccl::CCLRootId* xccl_id,
                                       int rank,
                                       int dev_id,
                                       int ring_id) {
-  PADDLE_ENFORCE_NOT_NULL(
-      xccl_id,
-      phi::errors::InvalidArgument("The xccl unique id should not be null."));
+  PADDLE_ENFORCE_NOT_NULL(xccl_id,
+                          common::errors::InvalidArgument(
+                              "The xccl unique id should not be null."));
   PADDLE_ENFORCE_GT(
       nranks,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Expected nranks > 1. But received nranks is %d.", nranks));
   PADDLE_ENFORCE_GE(rank,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Expected rank >= 0. But received rank is %d.", rank));
   PADDLE_ENFORCE_LT(
       rank,
       nranks,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Expected rank < nranks. But received rank is %d, nranks is %d.",
           rank,
           nranks));
   PADDLE_ENFORCE_GE(
       dev_id,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Expected dev_id >= 0. But received dev_id is %d.", dev_id));
 
   phi::ccl::CCLComm comm = nullptr;
@@ -531,8 +531,8 @@ void XCCLCommContext::CreateXCCLCommMultiTrainer(
   PADDLE_ENFORCE_GT(
       dev_ids.size(),
       0,
-      phi::errors::InvalidArgument("dev ids = [%d], it should greater than 0.",
-                                   dev_ids.size()));
+      common::errors::InvalidArgument(
+          "dev ids = [%d], it should greater than 0.", dev_ids.size()));
   const int kDevices = dev_ids.size();
   VLOG(1) << "Begin CreateXCCLCommMultiTrainer. device number: " << kDevices
           << ", ntrainers: " << ntrainers << ", train_id: " << train_id
@@ -552,7 +552,7 @@ void XCCLCommContext::CreateXCCLCommMultiTrainer(
   }
   PADDLE_ENFORCE_EQ(comm_map_.count(ring_id),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "comm_map_ of ring_id: %s should be 0. %s is provided",
                         ring_id,
                         comm_map_.count(ring_id)));

--- a/paddle/fluid/platform/collective_helper.h
+++ b/paddle/fluid/platform/collective_helper.h
@@ -89,11 +89,11 @@ class NCCLCommContext {
     PADDLE_ENFORCE_GT(
         comm_map_.count(ring_id),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Communicator in ring id %d has not been initialized.", ring_id));
     PADDLE_ENFORCE_EQ(comm_map_.at(ring_id).size(),
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "One device id should be specified to retrieve from "
                           "multiple communicators."));
     return comm_map_.at(ring_id).begin()->second.get();
@@ -115,12 +115,12 @@ class NCCLCommContext {
     PADDLE_ENFORCE_GT(
         comm_map_.count(ring_id),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Communicator of ring id %d has not been initialized.", ring_id));
     PADDLE_ENFORCE_GT(
         comm_map_.at(ring_id).count(dev_id),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Communicator at device id %d has not been initialized in ring %d.",
             dev_id,
             ring_id));
@@ -200,11 +200,11 @@ class BKCLCommContext {
     PADDLE_ENFORCE_GT(
         comm_map_.count(ring_id),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Communicator in ring id %d has not been initialized.", ring_id));
     PADDLE_ENFORCE_EQ(comm_map_.at(ring_id).size(),
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "One device id should be specified to retrieve from "
                           "multiple communicators."));
     return comm_map_.at(ring_id).begin()->second.get();
@@ -215,12 +215,12 @@ class BKCLCommContext {
     PADDLE_ENFORCE_GT(
         comm_map_.count(ring_id),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Communicator of ring id %d has not been initialized.", ring_id));
     PADDLE_ENFORCE_GT(
         comm_map_.at(ring_id).count(dev_id),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Communicator at device id %d has not been initialized in ring %d.",
             dev_id,
             ring_id));
@@ -293,11 +293,11 @@ class XCCLCommContext {
     PADDLE_ENFORCE_GT(
         comm_map_.count(ring_id),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Communicator in ring id %d has not been initialized.", ring_id));
     PADDLE_ENFORCE_EQ(comm_map_.at(ring_id).size(),
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "One device id should be specified to retrieve from "
                           "multiple communicators."));
     return comm_map_.at(ring_id).begin()->second.get();
@@ -319,12 +319,12 @@ class XCCLCommContext {
     PADDLE_ENFORCE_GT(
         comm_map_.count(ring_id),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Communicator of ring id %d has not been initialized.", ring_id));
     PADDLE_ENFORCE_GT(
         comm_map_.at(ring_id).count(dev_id),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Communicator at device id %d has not been initialized in ring %d.",
             dev_id,
             ring_id));

--- a/paddle/fluid/platform/cpu_helper.cc
+++ b/paddle/fluid/platform/cpu_helper.cc
@@ -51,7 +51,7 @@ void SetNumThreads(int num_threads) {
   // not sure about apple's blas
   return;
 #else
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "This library (except OPENBLAS, MKLML) is not supported yet, so the"
       "number of threads cannot be set."));
 #endif

--- a/paddle/fluid/platform/cuda_graph_with_memory_pool.cc
+++ b/paddle/fluid/platform/cuda_graph_with_memory_pool.cc
@@ -56,7 +56,7 @@ phi::DeviceContext* SelectCUDAGraphDeviceContext(phi::GPUPlace place,
     // Record method: RecordCapturingDeviceContext.
     PADDLE_ENFORCE_EQ(FLAGS_new_executor_use_cuda_graph,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "FLAGS_new_executor_use_cuda_graph must be True when "
                           "capturing stream is recorded."));
     if (num_stream > 1) {

--- a/paddle/fluid/platform/cuda_graph_with_memory_pool.h
+++ b/paddle/fluid/platform/cuda_graph_with_memory_pool.h
@@ -37,7 +37,7 @@ inline phi::GPUPlace CUDAGraphCapturingPlace() {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   return CUDAGraph::CapturingPlace();
 #else
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "CUDA Graph is only supported on NVIDIA GPU device."));
 #endif
 }

--- a/paddle/fluid/platform/device/custom/custom_device_resource_pool.cc
+++ b/paddle/fluid/platform/device/custom/custom_device_resource_pool.cc
@@ -23,7 +23,7 @@ CustomDeviceStreamResourcePool::CustomDeviceStreamResourcePool(
   PADDLE_ENFORCE_EQ(
       phi::is_custom_place(place),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Required device shall be CustomPlace, but received %d. ", place));
 
   int dev_cnt = phi::DeviceManager::GetDeviceCount(place.GetDeviceType());
@@ -76,7 +76,7 @@ CustomDeviceStreamResourcePool& CustomDeviceStreamResourcePool::Instance(
   PADDLE_ENFORCE_EQ(
       phi::is_custom_place(place),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Required device shall be CustomPlace, but received %d. ", place));
   if (pool.find(place.GetDeviceType()) == pool.end()) {
     pool.insert({place.GetDeviceType(),
@@ -92,10 +92,10 @@ CustomDeviceStreamResourcePool& CustomDeviceStreamResourcePool::Instance(
   PADDLE_ENFORCE_LT(
       place.GetDeviceId(),
       pool[place.GetDeviceType()].size(),
-      phi::errors::OutOfRange("Device id is out of range, device id shall "
-                              "be less than %d, but received %d. ",
-                              pool[place.GetDeviceType()].size(),
-                              place.GetDeviceId()));
+      common::errors::OutOfRange("Device id is out of range, device id shall "
+                                 "be less than %d, but received %d. ",
+                                 pool[place.GetDeviceType()].size(),
+                                 place.GetDeviceId()));
   return *pool[place.GetDeviceType()][place.GetDeviceId()];
 }
 
@@ -104,12 +104,12 @@ std::shared_ptr<CustomDeviceStreamObject> CustomDeviceStreamResourcePool::New(
   PADDLE_ENFORCE_GE(
       dev_idx,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The dev_idx should be not less than 0, but got %d.", dev_idx));
   PADDLE_ENFORCE_LT(
       dev_idx,
       pool_.size(),
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "The dev_idx should be less than device count %d, but got %d.",
           pool_.size(),
           dev_idx));
@@ -121,7 +121,7 @@ CustomDeviceEventResourcePool::CustomDeviceEventResourcePool(
   PADDLE_ENFORCE_EQ(
       phi::is_custom_place(place),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Required device shall be CustomPlace, but received %d. ", place));
 
   int dev_cnt = phi::DeviceManager::GetDeviceCount(place.GetDeviceType());
@@ -174,7 +174,7 @@ CustomDeviceEventResourcePool& CustomDeviceEventResourcePool::Instance(
   PADDLE_ENFORCE_EQ(
       phi::is_custom_place(place),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Required device shall be CustomPlace, but received %d. ", place));
   if (pool.find(place.GetDeviceType()) == pool.end()) {
     pool.insert(
@@ -190,10 +190,10 @@ CustomDeviceEventResourcePool& CustomDeviceEventResourcePool::Instance(
   PADDLE_ENFORCE_LT(
       place.GetDeviceId(),
       pool[place.GetDeviceType()].size(),
-      phi::errors::OutOfRange("Device id is out of range, device id shall "
-                              "be less than %d, but received %d. ",
-                              pool[place.GetDeviceType()].size(),
-                              place.GetDeviceId()));
+      common::errors::OutOfRange("Device id is out of range, device id shall "
+                                 "be less than %d, but received %d. ",
+                                 pool[place.GetDeviceType()].size(),
+                                 place.GetDeviceId()));
   return *pool[place.GetDeviceType()][place.GetDeviceId()];
 }
 
@@ -202,12 +202,12 @@ std::shared_ptr<CustomDeviceEventObject> CustomDeviceEventResourcePool::New(
   PADDLE_ENFORCE_GE(
       dev_idx,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The dev_idx should be not less than 0, but got %d.", dev_idx));
   PADDLE_ENFORCE_LT(
       dev_idx,
       pool_.size(),
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "The dev_idx should be less than device count %d, but got %d.",
           pool_.size(),
           dev_idx));

--- a/paddle/fluid/platform/device/gpu/cuda/cuda_profiler.cc
+++ b/paddle/fluid/platform/device/gpu/cuda/cuda_profiler.cc
@@ -21,7 +21,7 @@ void CudaProfilerInit(const std::string& output_file,
                       const std::string& config_file) {
 #if CUDA_VERSION < 11000
   PADDLE_ENFORCE(output_mode == "kvp" || output_mode == "csv",
-                 phi::errors::InvalidArgument(
+                 common::errors::InvalidArgument(
                      "Unsupported cuda profiler output mode, expect `kvp` or "
                      "`csv`, but received `%s`.",
                      output_mode));

--- a/paddle/fluid/platform/device/gpu/gpu_info.cc
+++ b/paddle/fluid/platform/device/gpu/gpu_info.cc
@@ -91,7 +91,7 @@ static size_t GpuAllocSize(bool realloc) {
   PADDLE_ENFORCE_GT(
       available_to_alloc,
       0,
-      phi::errors::ResourceExhausted("Not enough available GPU memory."));
+      common::errors::ResourceExhausted("Not enough available GPU memory."));
   // If FLAGS_initial_gpu_memory_in_mb is 0, then initial memory will be
   // allocated by fraction
   size_t flag_mb = realloc ? FLAGS_reallocate_gpu_memory_in_mb
@@ -103,7 +103,7 @@ static size_t GpuAllocSize(bool realloc) {
   PADDLE_ENFORCE_GE(
       available_to_alloc,
       alloc_bytes,
-      phi::errors::ResourceExhausted("Not enough available GPU memory."));
+      common::errors::ResourceExhausted("Not enough available GPU memory."));
   VLOG(10) << "Alloc size is " << (alloc_bytes >> 20)
            << " MiB, is it Re-alloc: " << realloc;
   return alloc_bytes;
@@ -188,14 +188,14 @@ class RecordedGpuMallocHelper {
     PADDLE_ENFORCE_GE(
         dev_id,
         0,
-        phi::errors::OutOfRange(
+        common::errors::OutOfRange(
             "Device id must be not less than 0, but got %d.", dev_id));
     PADDLE_ENFORCE_LT(
         dev_id,
         instances_.size(),
-        phi::errors::OutOfRange("Device id %d exceeds gpu card number %d.",
-                                dev_id,
-                                instances_.size()));
+        common::errors::OutOfRange("Device id %d exceeds gpu card number %d.",
+                                   dev_id,
+                                   instances_.size()));
     return instances_[dev_id].get();
   }
 
@@ -321,7 +321,7 @@ class RecordedGpuMallocHelper {
       return gpuErrorOutOfMemory;
     }
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "MallocAsync is not supported in this version of CUDA."));
 #endif
   }
@@ -400,7 +400,7 @@ class RecordedGpuMallocHelper {
 #endif
 
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "FreeAsync is not supported in this version of CUDA."));
 #endif
   }
@@ -413,7 +413,7 @@ class RecordedGpuMallocHelper {
     }
     return *(--it);
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "The RecordedGpuMallocHelper::GetBasePtr is only implemented with "
         "testing, should not use for release."));
     return nullptr;

--- a/paddle/fluid/platform/device/gpu/gpu_launch_config.h
+++ b/paddle/fluid/platform/device/gpu/gpu_launch_config.h
@@ -98,7 +98,7 @@ inline GpuLaunchConfig GetGpuLaunchConfig1D(const phi::GPUContext& context,
                                             int vec_size = 1) {
   PADDLE_ENFORCE_GE(numel,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "element quantity should be greater than or equal 0,"
                         " but received value is: %d.",
                         numel));
@@ -145,15 +145,15 @@ inline GpuLaunchConfig GetGpuLaunchConfig2D(const phi::GPUContext& context,
   PADDLE_ENFORCE_GT(
       x_dim,
       0,
-      phi::errors::InvalidArgument("x dim number should greater than 0,"
-                                   " but received value is: %d",
-                                   x_dim));
+      common::errors::InvalidArgument("x dim number should greater than 0,"
+                                      " but received value is: %d",
+                                      x_dim));
   PADDLE_ENFORCE_GT(
       y_dim,
       0,
-      phi::errors::InvalidArgument("y dim number should greater than 0,"
-                                   " but received value is: %d",
-                                   y_dim));
+      common::errors::InvalidArgument("y dim number should greater than 0,"
+                                      " but received value is: %d",
+                                      y_dim));
 
   const int kThreadsPerBlock = 256;
   // NOTE(zengjinle): cast std::min<int64_t> result to int is safe here, because

--- a/paddle/fluid/platform/device/gpu/gpu_resource_pool.cc
+++ b/paddle/fluid/platform/device/gpu/gpu_resource_pool.cc
@@ -60,12 +60,12 @@ std::shared_ptr<CudaStreamObject> CudaStreamResourcePool::New(int dev_idx) {
   PADDLE_ENFORCE_GE(
       dev_idx,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The dev_idx should be not less than 0, but got %d.", dev_idx));
   PADDLE_ENFORCE_LT(
       dev_idx,
       pool_.size(),
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "The dev_idx should be less than device count %d, but got %d.",
           pool_.size(),
           dev_idx));
@@ -111,12 +111,12 @@ std::shared_ptr<CudaEventObject> CudaEventResourcePool::New(int dev_idx) {
   PADDLE_ENFORCE_GE(
       dev_idx,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The dev_idx should be not less than 0, but got %d.", dev_idx));
   PADDLE_ENFORCE_LT(
       dev_idx,
       pool_.size(),
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "The dev_idx should be less than device count %d, but got %d.",
           pool_.size(),
           dev_idx));

--- a/paddle/fluid/platform/device/gpu/nccl_helper.h
+++ b/paddle/fluid/platform/device/gpu/nccl_helper.h
@@ -67,8 +67,8 @@ inline ncclDataType_t ToNCCLDataType(framework::proto::VarType::Type type) {
     return ncclBfloat16;
 #endif
   } else {
-    PADDLE_THROW(
-        phi::errors::Unimplemented("This datatype in nccl is not supported."));
+    PADDLE_THROW(common::errors::Unimplemented(
+        "This datatype in nccl is not supported."));
   }
 }
 
@@ -95,8 +95,8 @@ inline ncclDataType_t ToNCCLDataType(phi::DataType type) {
     return ncclBfloat16;
 #endif
   } else {
-    PADDLE_THROW(
-        phi::errors::Unimplemented("This datatype in nccl is not supported."));
+    PADDLE_THROW(common::errors::Unimplemented(
+        "This datatype in nccl is not supported."));
   }
 }
 
@@ -169,7 +169,7 @@ class NCCLContextMap {
     PADDLE_ENFORCE_EQ(
         !places.empty(),
         true,
-        phi::errors::InvalidArgument("The NCCL place should not be empty."));
+        common::errors::InvalidArgument("The NCCL place should not be empty."));
     order_.reserve(places.size());
     for (auto &p : places) {
       int dev_id = p.device;
@@ -179,8 +179,8 @@ class NCCLContextMap {
     PADDLE_ENFORCE_EQ(
         order_.size(),
         contexts_.size(),
-        phi::errors::Unavailable("NCCL Context Map does not support "
-                                 "contain two or more same device."));
+        common::errors::Unavailable("NCCL Context Map does not support "
+                                    "contain two or more same device."));
 
     std::unique_ptr<ncclComm_t[]> comms(new ncclComm_t[order_.size()]);
     // if num_trainers == 1, should create a new nccl id for local comms.
@@ -191,7 +191,7 @@ class NCCLContextMap {
     } else {
       PADDLE_ENFORCE_NOT_NULL(
           nccl_id,
-          phi::errors::InvalidArgument("The NCCL id should not be null."));
+          common::errors::InvalidArgument("The NCCL id should not be null."));
       {
         int nranks = num_trainers * order_.size();
         NCCLGroupGuard gurad;
@@ -341,7 +341,7 @@ class NCCLCommunicator {
                             size_t exter_trainers_num) {
     PADDLE_ENFORCE_EQ(trainers_num,
                       inter_trainers_num * exter_trainers_num,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "trainers_num:%llu != inter_trainers_num:%llu * "
                           "exter_trainers_num:%llu",
                           trainers_num,
@@ -351,7 +351,7 @@ class NCCLCommunicator {
     PADDLE_ENFORCE_GT(
         inter_trainers_num,
         1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The inter_trainers_num:%llu should be larger than 1.",
             inter_trainers_num));
 
@@ -386,7 +386,7 @@ class NCCLCommunicator {
   NCCLContextMap *GetHierarchicalInterCtx(size_t run_order) const {
     PADDLE_ENFORCE_GT(h_inter_ctxs_.size(),
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Hierarchical ctxs should be initialized firstly!"));
     return h_inter_ctxs_[run_order % h_inter_ctxs_.size()].get();
   }
@@ -394,7 +394,7 @@ class NCCLCommunicator {
   NCCLContextMap *GetHierarchicalExterCtx(size_t run_order) const {
     PADDLE_ENFORCE_GT(h_exter_ctxs_.size(),
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Hierarchical ctxs should be initialized firstly!"));
     return h_exter_ctxs_[run_order % h_exter_ctxs_.size()].get();
   }

--- a/paddle/fluid/platform/device/ipu/ipu_compiler.cc
+++ b/paddle/fluid/platform/device/ipu/ipu_compiler.cc
@@ -60,12 +60,12 @@ struct CustomOpAttrVisitor {
     attrs_->emplace(attr_name_, v);
   }
   void operator()(BlockDesc* desc) const {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Unsupported calling method for `BlockDesc` type when extracting "
         "custom operator attributes."));
   }
   void operator()(const std::vector<BlockDesc*>& v) const {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Unsupported calling method for `BlockDesc` type when extracting  "
         "custom operator attributes."));
   }
@@ -77,17 +77,17 @@ struct CustomOpAttrVisitor {
     attrs_->emplace(attr_name_, v);
   }
   void operator()(paddle::blank) const {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Unsupported calling method for `paddle::blank` type when extracting "
         "custom operator attributes."));
   }
   void operator()(framework::VarDesc*) const {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Unsupported calling method for `VarDesc*` type when extracting "
         "custom operator attributes."));
   }
   void operator()(const std::vector<framework::VarDesc*>&) const {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Unsupported calling method for `std::vector<framework::VarDesc*>` "
         "type when extracting custom operator attributes."));
   }
@@ -130,10 +130,10 @@ struct ConstantOpAttrVisitor {
                    [](double f) -> float { return static_cast<float>(f); });
     framework::TensorFromVector<float>(vec_fp32, tensor_);
   }
-#define RAISE_ERROR                                            \
-  PADDLE_THROW(                                                \
-      phi::errors::InvalidArgument("Constant value must be a " \
-                                   "vector"))
+#define RAISE_ERROR                                               \
+  PADDLE_THROW(                                                   \
+      common::errors::InvalidArgument("Constant value must be a " \
+                                      "vector"))
   void operator()(int v) const { RAISE_ERROR; }
   void operator()(float v) const { RAISE_ERROR; }
   void operator()(double v) const { RAISE_ERROR; }
@@ -166,7 +166,7 @@ popart::AdamMode AdamModeFromStr(const std::string& str,
     else
       return popart::AdamMode::LambNoBias;
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Unknown AdamMode: %s, AdamMode must be one of these values: adam, "
         "adamax or lamb",
         str));
@@ -183,7 +183,7 @@ popart::AdaptiveMode AdaptiveModeFromStr(const std::string& str) {
   } else if (str == "centered_rmsprop") {
     return popart::AdaptiveMode::CenteredRMSProp;
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Unknown AdaptiveMode: %s, AdaptiveMode must be one of these values: "
         "adadelta, adagrad, rmsprop or centered_rmsprop",
         str));
@@ -196,7 +196,7 @@ popart::WeightDecayMode WeightDecayModeFromStr(const std::string& str) {
   } else if (str == "l2_regularization") {
     return popart::WeightDecayMode::L2Regularization;
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Unknown WeightDecayMode: %s, WeightDecayMode must be decay or "
         "l2_regularization",
         str));
@@ -209,7 +209,8 @@ popart::DataType DataTypeFromStr(const std::string& str) {
   } else if (str == "FLOAT16") {
     return popart::DataType::FLOAT16;
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented("Unsupported DataType: %s", str));
+    PADDLE_THROW(
+        common::errors::Unimplemented("Unsupported DataType: %s", str));
   }
 }
 
@@ -386,7 +387,7 @@ void Compiler::InitOutputs(const std::vector<std::string>& fetch_list) {
     PADDLE_ENFORCE_NE(
         tensor,
         resources_->tensors.end(),
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Output tensor %s is not found, please check the model.",
             fetch_name));
     VLOG(10) << "fetch_name= " << fetch_name;
@@ -453,8 +454,8 @@ void Compiler::LowerWeights(const Scope* scope) {
       auto var = scope->FindVar(var_name);
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::NotFound("Tensor %s is not found in the scope",
-                                var_name));
+          common::errors::NotFound("Tensor %s is not found in the scope",
+                                   var_name));
       auto tensor = var->Get<phi::DenseTensor>();
       auto dtype = PhiDType2PopartDType(tensor.dtype());
       auto shape = std::vector<int64_t>();
@@ -529,7 +530,7 @@ void Compiler::LowerBody() {
       if (itr != name_function_.end()) {
         itr->second(node->Op());
       } else {
-        PADDLE_THROW(phi::errors::NotFound(
+        PADDLE_THROW(common::errors::NotFound(
             "%s is not registered, please check for unsupported operators for "
             "running on IPU",
             op_type));
@@ -785,7 +786,7 @@ void Compiler::LowerOptimizer(const Scope* scope) {
             popart::DataType::FLOAT,
             popart::DataType::UNDEFINED);
       } else {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "optimizer %s is not implemented", type));
       }
     } else if (op_type == "popart_identity_loss") {
@@ -793,12 +794,12 @@ void Compiler::LowerOptimizer(const Scope* scope) {
       PADDLE_ENFORCE_EQ(
           outputs.size(),
           1,
-          phi::errors::InvalidArgument("Can only support one loss key"));
+          common::errors::InvalidArgument("Can only support one loss key"));
       auto losses = outputs.begin()->second;
       PADDLE_ENFORCE_EQ(
           losses.size(),
           1,
-          phi::errors::InvalidArgument("Can only support one loss name"));
+          common::errors::InvalidArgument("Can only support one loss name"));
       auto loss_var = losses.front();
       resources_->loss_var = resources_->tensors[loss_var];
     }
@@ -829,7 +830,7 @@ void Compiler::PostLower(const std::vector<std::string>& tensor_ids,
   PADDLE_ENFORCE_EQ(
       pd_outs.size(),
       tensor_ids.size(),
-      phi::errors::Fatal("paddle and popart op have different outputs"));
+      common::errors::Fatal("paddle and popart op have different outputs"));
   for (int i = 0; i < tensor_ids.size(); ++i) {
     resources_->tensors.emplace(pd_outs[i], tensor_ids[i]);
   }
@@ -844,7 +845,7 @@ void Compiler::PostLower(const std::string& tensor_id, const OpDesc* op_desc) {
   PADDLE_ENFORCE_EQ(
       pd_outs.size(),
       1,
-      phi::errors::Fatal("paddle and popart op have different outputs"));
+      common::errors::Fatal("paddle and popart op have different outputs"));
   resources_->tensors.emplace(pd_outs[0], tensor_id);
   PostLower(tensor_id, op_desc, false);
 }
@@ -870,7 +871,7 @@ void Compiler::PostLower(const std::string& tensor_id,
     if (set_amp_for_all_) {
       auto amp = ipu_strategy_->available_memory_proportion;
       if (amp < 0.0f || amp > 1.0) {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "AvailableMemoryProportion %f is invalid, which should be in "
             "range [0.0, 1.0]",
             amp));
@@ -883,7 +884,7 @@ void Compiler::PostLower(const std::string& tensor_id,
         auto amp =
             PADDLE_GET_CONST(float, op_desc->GetAttr(sAvailMemAttribute));
         if (amp < 0.0f || amp > 1.0) {
-          PADDLE_THROW(phi::errors::InvalidArgument(
+          PADDLE_THROW(common::errors::InvalidArgument(
               "AvailableMemoryProportion %f is invalid, which should be in "
               "range [0.0, 1.0]",
               amp));

--- a/paddle/fluid/platform/device/ipu/ipu_device.cc
+++ b/paddle/fluid/platform/device/ipu/ipu_device.cc
@@ -48,8 +48,8 @@ int GetNumDevices() {
   PADDLE_ENFORCE_GT(
       num_devices,
       0,
-      phi::errors::Unavailable("Do not found any IPU devices, please "
-                               "make sure Poplar sdk is enabled"));
+      common::errors::Unavailable("Do not found any IPU devices, please "
+                                  "make sure Poplar sdk is enabled"));
   return num_devices;
 }
 
@@ -65,8 +65,8 @@ std::vector<int> GetDeviceIds() {
   PADDLE_ENFORCE_GT(
       devices.size(),
       0,
-      phi::errors::Unavailable("Do not found any IPU devices, please make "
-                               "sure Poplar sdk is enabled."));
+      common::errors::Unavailable("Do not found any IPU devices, please make "
+                                  "sure Poplar sdk is enabled."));
   for (auto device : devices) {
     device_ids.push_back(device->getId());
   }

--- a/paddle/fluid/platform/device/ipu/ipu_executor.cc
+++ b/paddle/fluid/platform/device/ipu/ipu_executor.cc
@@ -415,7 +415,7 @@ void Executor::RunPopef(const std::vector<const Tensor *> &inputs,
         output_shape[0] = batch_size;
       } else {
         // shape of output must have batch info when when auto batch enabled
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Auto batch doesn't support the tensor with no batch info. "
             "Expected batch size in output tensor: %d should equal to "
             "micro batch size: %d. Please make sure batch size is set "

--- a/paddle/fluid/platform/device/ipu/ipu_strategy.cc
+++ b/paddle/fluid/platform/device/ipu/ipu_strategy.cc
@@ -367,7 +367,7 @@ IpuStrategy::IpuStrategy() {
                        "Fwd0", "Fwd1", "Bwd0", "PreAlias", "Final"};
                    if (std::find(valid_dot.begin(), valid_dot.end(), p.first) ==
                        valid_dot.end()) {
-                     PADDLE_THROW(phi::errors::InvalidArgument(
+                     PADDLE_THROW(common::errors::InvalidArgument(
                          "Unknown dot check: %s", p.first));
                    }
                    popart_options.dotChecks.insert(p.first);
@@ -529,7 +529,7 @@ void IpuStrategy::SetTensorLocation(const std::string& tensor,
     settings = &popart_options.accumulatorTensorLocationSettings;
   } else {
     PADDLE_THROW(
-        phi::errors::InvalidArgument("Unknown tensor location: %s", tensor));
+        common::errors::InvalidArgument("Unknown tensor location: %s", tensor));
   }
 
   if (opt == "min_elements_for_off_chip") {
@@ -559,7 +559,7 @@ void IpuStrategy::SetTensorLocation(const std::string& tensor,
     settings->location.shardingDomain =
         popart::CommGroup(popart::CommGroupType::Orthogonal, value);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Unknown option ' %s' for tensor location: %s", opt, tensor));
   }
 }
@@ -574,7 +574,7 @@ void IpuStrategy::SetReplicatedCollectivesSettings(const std::string& opt,
     popart_options.replicatedCollectivesSettings.mergeAllReduceCollectives =
         value;
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Unknown option ' %s' for replicated collectives settings", opt));
   }
 }

--- a/paddle/fluid/platform/device/ipu/ipu_strategy.h
+++ b/paddle/fluid/platform/device/ipu/ipu_strategy.h
@@ -171,10 +171,10 @@ class IpuStrategy {
     PADDLE_ENFORCE_NE(
         it == options.end(),
         true,
-        phi::errors::InvalidArgument("Cannot find option: %s, type: %s "
-                                     "when setting IpuStrategy options",
-                                     key,
-                                     type_str));
+        common::errors::InvalidArgument("Cannot find option: %s, type: %s "
+                                        "when setting IpuStrategy options",
+                                        key,
+                                        type_str));
     it->second(value);
   }
 
@@ -186,7 +186,7 @@ class IpuStrategy {
     PADDLE_ENFORCE_NE(
         it == options.end(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Cannot find option name: %s when trying to get IpuStrategy option",
             key));
     return it->second();

--- a/paddle/fluid/platform/device/ipu/ipu_utils.cc
+++ b/paddle/fluid/platform/device/ipu/ipu_utils.cc
@@ -47,7 +47,7 @@ const popart::DataType VarType2PopartDType(const VarType::Type type) {
     case VarType::COMPLEX128:
       return popart::DataType::COMPLEX128;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported VarType::Type when converting to popart data type."));
   }
 }
@@ -79,7 +79,7 @@ const popart::DataType PhiDType2PopartDType(const phi::DataType type) {
     case phi::DataType::COMPLEX128:
       return popart::DataType::COMPLEX128;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported phi::DataType when converting to popart data type."));
   }
 }
@@ -105,7 +105,7 @@ const phi::DataType PopefDtype2PhiDtype(const popef::DataType type) {
     case popef::DataType::F16:
       return phi::DataType::FLOAT16;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported phi::DataType when converting to popef data type."));
   }
 }
@@ -137,7 +137,7 @@ const VarType::Type PopartDType2VarType(const popart::DataType type) {
     case popart::DataType::COMPLEX128:
       return VarType::COMPLEX128;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported popart::DataType when converting to var type."));
   }
 }
@@ -163,7 +163,7 @@ const VarType::Type PopefDType2VarType(const popef::DataType type) {
     case popef::DataType::F16:
       return VarType::FP16;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported popart::DataType when converting to var type."));
   }
 }
@@ -195,7 +195,7 @@ const popart::DataType OnnxDType2PopartType(const ONNXDataType type) {
     case ONNXDataType::COMPLEX128:
       return popart::DataType::COMPLEX128;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported ONNXDataType when converting to popart data type."));
   }
 }
@@ -227,7 +227,7 @@ const ONNXDataType VarType2OnnxDType(const VarType::Type type) {
     case VarType::COMPLEX128:
       return ONNXDataType::COMPLEX128;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported VarType::Type when converting to onnx data type."));
   }
 }
@@ -253,7 +253,7 @@ const std::string VarType2PopartStr(const VarType::Type type) {
     case VarType::FP16:
       return "FLOAT16";
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Unsupported VarType::Type when converting to popart type string."));
   }
 }

--- a/paddle/fluid/platform/device/ipu/popart_canonicalization/activation_ops.cc
+++ b/paddle/fluid/platform/device/ipu/popart_canonicalization/activation_ops.cc
@@ -327,7 +327,7 @@ Node *logsigmoid_handler(Graph *graph, Node *node) {
 Node *mish_handler(Graph *graph, Node *node) {
   auto threshold_ = PADDLE_GET_CONST(float, node->Op()->GetAttr("threshold"));
   if (!is_float_equal(threshold_, 20.0f)) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "For mish op, only support threshold = 20.0"));
   }
   auto x = GetInputVarNode("X", node);
@@ -346,7 +346,7 @@ Node *prelu_handler(Graph *graph, Node *node) {
   auto alpha_rank = alpha->Var()->GetShape().size();
   if (x_rank != alpha_rank) {
     if (alpha_rank > 1) {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "For prelu op, Only support rank of alpha <=1 while Rank(alpha) != "
           "Rank(input)."));
     }
@@ -354,14 +354,14 @@ Node *prelu_handler(Graph *graph, Node *node) {
 
   if (x_rank != alpha_rank) {
     if (alpha_rank > 1) {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "For prelu op, Only support rank of alpha <= 1 while rank of alpha "
           "is not equal with rank of input for operator prelu"));
     }
     if (x_rank <= 1) {
       PADDLE_THROW(
-          phi::errors::Unimplemented("For prelu op, Rank of input should "
-                                     "greater than 2 for operator prelu"));
+          common::errors::Unimplemented("For prelu op, Rank of input should "
+                                        "greater than 2 for operator prelu"));
     }
     auto shape = std::vector<int64_t>(x_rank - 1, 1);
     shape[0] = -1;

--- a/paddle/fluid/platform/device/ipu/popart_canonicalization/canonicalization_utils.cc
+++ b/paddle/fluid/platform/device/ipu/popart_canonicalization/canonicalization_utils.cc
@@ -123,8 +123,8 @@ const bool is_float_equal(float a, float b, float eps) {
 
 const ONNXDataType GetVarDType(const Node *node) {
   auto var = node->Var();
-  PADDLE_ENFORCE_NOT_NULL(var,
-                          phi::errors::Unavailable("Node is not a variable."));
+  PADDLE_ENFORCE_NOT_NULL(
+      var, common::errors::Unavailable("Node is not a variable."));
   auto proto_var_type = var->GetDataType();
   return VarType2OnnxDType(proto_var_type);
 }
@@ -133,7 +133,7 @@ const ONNXDataType GetOutputVarDType(const Node *node,
                                      const std::string &output_name) {
   auto out_node = GetOutputVarNode(output_name, node);
   PADDLE_ENFORCE_NOT_NULL(
-      out_node, phi::errors::Unavailable("Node's out node does not exist."));
+      out_node, common::errors::Unavailable("Node's out node does not exist."));
   return GetVarDType(out_node);
 }
 
@@ -186,7 +186,7 @@ int ConvertToPopartReduction(const std::string &reduction) {
   } else if (reduction == "none") {
     return 2;
   }
-  PADDLE_THROW(phi::errors::InvalidArgument(
+  PADDLE_THROW(common::errors::InvalidArgument(
       "reduction %s is not supported on ipu.", reduction));
 }
 

--- a/paddle/fluid/platform/device/ipu/popart_canonicalization/loss_ops.cc
+++ b/paddle/fluid/platform/device/ipu/popart_canonicalization/loss_ops.cc
@@ -46,8 +46,8 @@ Node *cross_entropy_general_handler(Graph *graph,
   Node *cast_and_reshape = nullptr;
   Node *final_loss_node = nullptr;
   if (soft_label) {
-    PADDLE_THROW(
-        phi::errors::InvalidArgument("soft_label is not supported yet in IPU"));
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "soft_label is not supported yet in IPU"));
   }
   bool append_identity_loss = is_dynamic_graph();
   bool is_last_var_node = IsLastVarNode(output);
@@ -559,7 +559,7 @@ Node *warpctc_handler(Graph *graph, Node *node) {
   bool append_identity_loss =
       is_dynamic_graph() && IsLastVarNode(GetOutputVarNode("Loss", node));
   if (norm_by_times) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "norm_by_times is not supported yet in IPU"));
   }
 

--- a/paddle/fluid/platform/device/ipu/popart_canonicalization/math_ops.cc
+++ b/paddle/fluid/platform/device/ipu/popart_canonicalization/math_ops.cc
@@ -130,7 +130,7 @@ Node *matmul_handler(Graph *graph, Node *node) {
     } else if (rank == 4) {
       perm = std::vector<int64_t>{0, 1, 3, 2};
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "op matmul with input rank == %d", rank));
     }
     return perm;
@@ -392,7 +392,7 @@ Node *matmul_v2_handler(Graph *graph, Node *node) {
     } else if (rank == 4) {
       perm = std::vector<int64_t>{0, 1, 3, 2};
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "op matmul with input rank == %d", rank));
     }
     return perm;

--- a/paddle/fluid/platform/device/ipu/popart_canonicalization/nn_ops.cc
+++ b/paddle/fluid/platform/device/ipu/popart_canonicalization/nn_ops.cc
@@ -118,7 +118,7 @@ Node *pool2d_handler(Graph *graph, Node *node) {
     if (adaptive) {
       auto ksize = PADDLE_GET_CONST(std::vector<int>, op->GetAttr("ksize"));
       if (ksize[0] != 1 || ksize[1] != 1) {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "Only support pool_size=1 with adaptive mode."));
       }
       // adaptive maxpool op is max_pool2d_with_index. Only process avgpool
@@ -136,7 +136,7 @@ Node *pool2d_handler(Graph *graph, Node *node) {
       return CreateBaseOp(
           graph, node, "popart_globalaveragepool", node->inputs, node->outputs);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "op pool2d with unkonwn pooling_type: %s", pooling_type));
     }
   }
@@ -144,7 +144,7 @@ Node *pool2d_handler(Graph *graph, Node *node) {
     auto padding_algorithm =
         PADDLE_GET_CONST(std::string, op->GetAttr("padding_algorithm"));
     if (padding_algorithm != "EXPLICIT") {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "op pool2d with unkonwn padding_algorithm: %s", padding_algorithm));
     }
   }
@@ -194,7 +194,7 @@ Node *pool2d_handler(Graph *graph, Node *node) {
                             {"strides", strides},
                         });
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "op pool2d with unkonwn pooling_type: %s", pooling_type));
   }
 }
@@ -203,7 +203,7 @@ Node *max_pool2d_with_index_handler(Graph *graph, Node *node) {
   auto *op = node->Op();
   auto ksize = PADDLE_GET_CONST(std::vector<int>, op->GetAttr("ksize"));
   if (ksize[0] != 1 || ksize[1] != 1) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Only support pool_size=1 with adaptive mode."));
   }
   return CreateBaseOp(graph,
@@ -356,7 +356,7 @@ Node *dropout_handler(Graph *graph, Node *node) {
                           {});
     } else {
       PADDLE_THROW(
-          phi::errors::InvalidArgument("Invalid dropout_implementation"));
+          common::errors::InvalidArgument("Invalid dropout_implementation"));
     }
   } else {
     if (dropout_implementation_ == "upscale_in_train") {
@@ -369,11 +369,11 @@ Node *dropout_handler(Graph *graph, Node *node) {
                           {GetOutputVarNode("Out", node)},
                           attrs_);
     } else if (dropout_implementation_ == "downgrade_in_infer") {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Do not support downgrade_in_infer with training"));
     } else {
       PADDLE_THROW(
-          phi::errors::InvalidArgument("Invalid dropout_implementation"));
+          common::errors::InvalidArgument("Invalid dropout_implementation"));
     }
   }
 }
@@ -384,7 +384,7 @@ Node *conv2d_transpose_handler(Graph *graph, Node *node) {
   auto data_format = PADDLE_GET_CONST(std::string, op->GetAttr("data_format"));
   if (data_format != "NCHW") {
     PADDLE_THROW(
-        phi::errors::InvalidArgument("Only support NCHW as data_format."));
+        common::errors::InvalidArgument("Only support NCHW as data_format."));
   }
 
   auto *kernel_info = GetInputVarNode("Filter", node);
@@ -472,7 +472,7 @@ Node *affine_channel_handler(Graph *graph, Node *node) {
   auto data_layout = PADDLE_GET_CONST(std::string, op->GetAttr("data_layout"));
   if (data_layout != "NCHW") {
     PADDLE_THROW(
-        phi::errors::InvalidArgument("Only support NCHW as data_format."));
+        common::errors::InvalidArgument("Only support NCHW as data_format."));
   }
 
   auto *scale = GetInputVarNode("Scale", node);
@@ -515,7 +515,7 @@ Node *interp_handler(Graph *graph, Node *node, const std::string &mode) {
   auto data_layout = PADDLE_GET_CONST(std::string, op->GetAttr("data_layout"));
   if (data_layout != "NCHW") {
     PADDLE_THROW(
-        phi::errors::InvalidArgument("Only support NCHW as data_format."));
+        common::errors::InvalidArgument("Only support NCHW as data_format."));
   }
 
   auto align_corners = PADDLE_GET_CONST(bool, op->GetAttr("align_corners"));
@@ -723,7 +723,7 @@ Node *data_norm_handler(Graph *graph, Node *node) {
 
   if (slot_dim > 0) {
     PADDLE_THROW(
-        phi::errors::InvalidArgument("slot_dim > 0 is not supported."));
+        common::errors::InvalidArgument("slot_dim > 0 is not supported."));
   }
 
   bool enable_scale_and_shift = false;
@@ -781,16 +781,17 @@ Node *pad_handler(Graph *graph, Node *node) {
   auto data_format = PADDLE_GET_CONST(std::string, op->GetAttr("data_format"));
 
   if (data_format == "NDHWC") {
-    PADDLE_THROW(phi::errors::Unimplemented("NDHWC format is not supported."));
+    PADDLE_THROW(
+        common::errors::Unimplemented("NDHWC format is not supported."));
   }
   if (mode == "replicate" || mode == "circular") {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "circular and replicate modes are not supported."));
   }
   if (op->Input("Paddings").size()) {
     // Paddings -> input tensor
     // PopART Pad Op only support `pad` as a constant
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Do not support Paddings as a inputs tensor"));
   }
   // Paddings -> Attr

--- a/paddle/fluid/platform/device/ipu/popart_canonicalization/op_builder.cc
+++ b/paddle/fluid/platform/device/ipu/popart_canonicalization/op_builder.cc
@@ -221,7 +221,7 @@ Node *CreateSoftmaxOpset11(Graph *graph,
   PADDLE_ENFORCE_EQ(
       inputs.size(),
       1,
-      phi::errors::InvalidArgument("Softmax op only support one input"));
+      common::errors::InvalidArgument("Softmax op only support one input"));
   auto x_shape = inputs[0]->Var()->GetShape();
   int x_rank = x_shape.size();
   if (axis < 0) {

--- a/paddle/fluid/platform/device/ipu/popart_canonicalization/search_ops.cc
+++ b/paddle/fluid/platform/device/ipu/popart_canonicalization/search_ops.cc
@@ -33,7 +33,7 @@ Node *topk_handler(Graph *graph, Node *node) {
     auto shape = GetInputVarNode("X", node)->Var()->GetShape();
     int rank = shape.size();
     if (rank < 1) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "The dimension of the shape of topK input should be large than 1"));
     }
     axis_ = rank - 1;

--- a/paddle/fluid/platform/device/ipu/popart_canonicalization/tensor_ops.cc
+++ b/paddle/fluid/platform/device/ipu/popart_canonicalization/tensor_ops.cc
@@ -27,7 +27,7 @@ Node *fill_constant_handler(Graph *graph, Node *node) {
   if (op_inputs.find("ShapeTensor") != op_inputs.end() &&
       !op->Input("ShapeTensor").empty()) {
     PADDLE_THROW(
-        phi::errors::Unimplemented("op fill_constant with ShapeTensor"));
+        common::errors::Unimplemented("op fill_constant with ShapeTensor"));
   }
   auto dtype_ = PADDLE_GET_CONST(int, op->GetAttr("dtype"));
   auto dtype = VarType2OnnxDType(static_cast<VarType::Type>(dtype_));
@@ -62,7 +62,7 @@ Node *fill_constant_handler(Graph *graph, Node *node) {
       break;
     default:
       PADDLE_THROW(
-          phi::errors::Unimplemented("fill_constant dtype: %d", dtype_));
+          common::errors::Unimplemented("fill_constant dtype: %d", dtype_));
   }
   return CreateConst(graph,
                      node,
@@ -419,7 +419,7 @@ Node *slice_handler(Graph *graph, Node *node) {
         (inputs.find(tensor_names[i] + "Tensor") != inputs.end() &&
          !inputs.at(tensor_names[i] + "Tensor").empty());
     if (is_tensor) {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Do not support starts, ends and strides as tensors."));
     } else {
       if (i == 2 && !op->HasAttr("strides")) {
@@ -471,7 +471,7 @@ Node *expand_handler(Graph *graph, Node *node) {
   auto *op = node->Op();
   if (!op->Input("expand_times_tensor").empty()) {
     PADDLE_THROW(
-        phi::errors::Unimplemented("Expand op with expand_times_tensor"));
+        common::errors::Unimplemented("Expand op with expand_times_tensor"));
   }
 
   Node *expand_times = nullptr;
@@ -546,7 +546,7 @@ Node *assign_value_handler(Graph *graph, Node *node) {
       values = PADDLE_GET_CONST(std::vector<int64_t>, op->GetAttr(value_name));
       break;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported data type(code %d) for AssignValue operator, only "
           "supports bool, int32, float32 and int64.",
           dtype));
@@ -598,7 +598,7 @@ Node *fill_any_like_handler(Graph *graph, Node *node) {
       break;
     default:
       PADDLE_THROW(
-          phi::errors::Unimplemented("fill_any_like dtype: %d", dtype));
+          common::errors::Unimplemented("fill_any_like dtype: %d", dtype));
   }
   return CreateConst(graph,
                      node,
@@ -617,8 +617,8 @@ Node *one_hot_handler(Graph *graph, Node *node) {
   auto allow_out_of_range =
       PADDLE_GET_CONST(bool, op->GetAttr("allow_out_of_range"));
   if (allow_out_of_range) {
-    PADDLE_THROW(
-        phi::errors::Unimplemented("Do not support allow_out_of_range=True"));
+    PADDLE_THROW(common::errors::Unimplemented(
+        "Do not support allow_out_of_range=True"));
   } else {
     auto depth_tensor = CreateConst(graph,
                                     node,
@@ -651,8 +651,8 @@ Node *one_hot_v2_handler(Graph *graph, Node *node) {
   auto allow_out_of_range =
       PADDLE_GET_CONST(bool, op->GetAttr("allow_out_of_range"));
   if (allow_out_of_range) {
-    PADDLE_THROW(
-        phi::errors::Unimplemented("Do not support allow_out_of_range=True"));
+    PADDLE_THROW(common::errors::Unimplemented(
+        "Do not support allow_out_of_range=True"));
   } else {
     auto depth_tensor = CreateConst(graph,
                                     node,
@@ -919,7 +919,7 @@ Node *expand_as_v2_handler(Graph *graph, Node *node) {
   auto op_inputs = op->Inputs();
   // PopART Expand Op only support the constant tensor as the input `shape`.
   if (op_inputs.find("target_tensor") != op_inputs.end()) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Do not support input tensor `target_tensor`. Please use the attribute "
         "`target_shape`."));
   }
@@ -933,7 +933,7 @@ Node *expand_as_v2_handler(Graph *graph, Node *node) {
     if (input_shape[input_shape_index] !=
             int64_t(shape_value[target_shape_index]) &&
         input_shape[input_shape_index] != int64_t(1)) {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "For input and `shape`, corresponding dimensions must have the same "
           "value or input dim = 1."));
     }
@@ -963,11 +963,11 @@ Node *expand_v2_handler(Graph *graph, Node *node) {
   // PopART Expand Op only support the constant tensor as the input `shape`.
   if (op->Input("Shape").size()) {
     PADDLE_THROW(
-        phi::errors::Unimplemented("Do not support input tensor `Shape`. "
-                                   "Please use the attribute `shape`."));
+        common::errors::Unimplemented("Do not support input tensor `Shape`. "
+                                      "Please use the attribute `shape`."));
   }
   if (op->Input("expand_shapes_tensor").size()) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Do not support input tensor `expand_shapes_tensor`. Please use the "
         "attribute `shape`."));
   }
@@ -980,7 +980,7 @@ Node *expand_v2_handler(Graph *graph, Node *node) {
     if (input_shape[input_shape_index] !=
             int64_t(shape_value[target_shape_index]) &&
         input_shape[input_shape_index] != int64_t(1)) {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "For input and `shape`, corresponding dimensions must have the same "
           "value or input dim = 1."));
     }
@@ -1204,7 +1204,7 @@ Node *tile_handler(Graph *graph, Node *node) {
        !inputs.at("repeat_times_tensor").empty());
   if (is_repeat_tensors) {
     PADDLE_THROW(
-        phi::errors::Unimplemented("Do not support repeats as tensors."));
+        common::errors::Unimplemented("Do not support repeats as tensors."));
   }
   auto repeat_times =
       PADDLE_GET_CONST(std::vector<int>, op->GetAttr("repeat_times"));

--- a/paddle/fluid/platform/device/xpu/bkcl_helper.h
+++ b/paddle/fluid/platform/device/xpu/bkcl_helper.h
@@ -60,7 +60,7 @@ inline BKCLDataType ToBKCLDataType(framework::proto::VarType::Type type) {
   } else if (type == framework::proto::VarType::BOOL) {
     return BKCL_UINT8;
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "BKCL currently only support FP32, INT64, INT32, FP64, FP16, BF16, "
         "UINT8 and BOOL, "
         "other data types are not supported."));
@@ -151,7 +151,7 @@ struct BKCLContextMap {
     PADDLE_ENFORCE_EQ(
         !places_.empty(),
         true,
-        phi::errors::InvalidArgument("The BKCL place should not be empty."));
+        common::errors::InvalidArgument("The BKCL place should not be empty."));
     order_.reserve(places_.size());
     for (auto &p : places_) {
       int dev_id = p.device;
@@ -161,8 +161,8 @@ struct BKCLContextMap {
     PADDLE_ENFORCE_EQ(
         order_.size(),
         contexts_.size(),
-        phi::errors::Unavailable("BKCL Context Map does not support "
-                                 "contain two or more same device"));
+        common::errors::Unavailable("BKCL Context Map does not support "
+                                    "contain two or more same device"));
 
     std::unique_ptr<BKCLContext_t[]> comms(new BKCLContext_t[order_.size()]);
     std::unique_ptr<InitBKCLPara[]> paras(new InitBKCLPara[order_.size()]);
@@ -174,13 +174,13 @@ struct BKCLContextMap {
       ret = bkcl_get_unique_id(&id);
       PADDLE_ENFORCE_EQ(BKCL_SUCCESS,
                         ret,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "bkcl get unique id failed [%d]", ret));
       bkcl_id_ = &id;
     }
     PADDLE_ENFORCE_NOT_NULL(
         bkcl_id_,
-        phi::errors::InvalidArgument("The BKCL id should not be null."));
+        common::errors::InvalidArgument("The BKCL id should not be null."));
     {
       int nranks = num_trainers_ * order_.size();
       for (size_t i = 0; i < order_.size(); ++i) {
@@ -202,7 +202,7 @@ struct BKCLContextMap {
                                          init_bkcl_context_func,
                                          reinterpret_cast<void *>(&paras[i])),
                           0,
-                          phi::errors::External("pthread_create failed"));
+                          common::errors::External("pthread_create failed"));
       }
       for (size_t i = 0; i < order_.size(); i++) {
         pthread_join(pids[i], nullptr);
@@ -265,7 +265,7 @@ class BKCLCommunicator {
                                    bool use_hierarchical_allreduce) const {
     PADDLE_ENFORCE_EQ(use_hierarchical_allreduce,
                       false,
-                      phi::errors::Unimplemented(
+                      common::errors::Unimplemented(
                           "Hierarchical all reduce is not support for XPU"));
     return GetFlatCtx(run_order);
   }
@@ -302,7 +302,7 @@ class BKCLCommunicator {
     } else {
       PADDLE_ENFORCE_EQ(bkcl_ids.size(),
                         1,
-                        phi::errors::Unimplemented(
+                        common::errors::Unimplemented(
                             "Multi-all-reduce-ring is not support for XPU"));
       for (size_t i = 0; i < bkcl_ids.size(); i++) {
         auto ptr = new platform::BKCLContextMap(

--- a/paddle/fluid/platform/device/xpu/xpu_info.cc
+++ b/paddle/fluid/platform/device/xpu/xpu_info.cc
@@ -133,14 +133,14 @@ class RecordedXPUMallocHelper {
     PADDLE_ENFORCE_GE(
         dev_id,
         0,
-        phi::errors::OutOfRange(
+        common::errors::OutOfRange(
             "Device id must be not less than 0, but got %d.", dev_id));
     PADDLE_ENFORCE_LT(
         dev_id,
         instances_.size(),
-        phi::errors::OutOfRange("Device id %d exceeds XPU card number %d.",
-                                dev_id,
-                                instances_.size()));
+        common::errors::OutOfRange("Device id %d exceeds XPU card number %d.",
+                                   dev_id,
+                                   instances_.size()));
     return instances_[dev_id].get();
   }
 

--- a/paddle/fluid/platform/device/xpu/xpu_resource_pool.cc
+++ b/paddle/fluid/platform/device/xpu/xpu_resource_pool.cc
@@ -46,12 +46,12 @@ std::shared_ptr<XpuStreamObject> XpuStreamResourcePool::New(int dev_idx) {
   PADDLE_ENFORCE_GE(
       dev_idx,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The dev_idx should be not less than 0, but got %d.", dev_idx));
   PADDLE_ENFORCE_LT(
       dev_idx,
       pool_.size(),
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "The dev_idx should be less than device count %d, but got %d.",
           pool_.size(),
           dev_idx));
@@ -87,12 +87,12 @@ std::shared_ptr<XpuEventObject> XpuEventResourcePool::New(int dev_idx) {
   PADDLE_ENFORCE_GE(
       dev_idx,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The dev_idx should be not less than 0, but got %d.", dev_idx));
   PADDLE_ENFORCE_LT(
       dev_idx,
       pool_.size(),
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "The dev_idx should be less than device count %d, but got %d.",
           pool_.size(),
           dev_idx));

--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -48,7 +48,7 @@ DeviceType Place2DeviceType(const phi::Place& place) {
   } else if (phi::is_custom_place(place)) {
     return platform::DeviceType::CUSTOM_DEVICE;
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Unsupported place %s to convert into platform::DeviceType.", place));
   }
 }
@@ -90,7 +90,7 @@ inline std::unique_ptr<DeviceContext> CreateDeviceContext(
     auto* cuda_ctx = dynamic_cast<phi::GPUContext*>(dev_ctx);
     PADDLE_ENFORCE_NOT_NULL(
         cuda_ctx,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Failed to dynamic_cast dev_ctx into phi::GPUContext."));
 
     if (!disable_setting_default_stream_for_allocator) {
@@ -113,7 +113,7 @@ inline std::unique_ptr<DeviceContext> CreateDeviceContext(
     auto* custom_ctx = dynamic_cast<phi::CustomContext*>(dev_ctx);
     PADDLE_ENFORCE_NOT_NULL(
         custom_ctx,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Failed to dynamic_cast dev_ctx into phi::CustomContext."));
 
     if (!disable_setting_default_stream_for_allocator) {
@@ -162,9 +162,9 @@ void EmplaceDeviceContexts(
   PADDLE_ENFORCE_GT(
       places.size(),
       0,
-      phi::errors::InvalidArgument("The number of platform places should "
-                                   "be larger than 0. But received %d.",
-                                   places.size()));
+      common::errors::InvalidArgument("The number of platform places should "
+                                      "be larger than 0. But received %d.",
+                                      places.size()));
   std::set<Place> set;
   for (auto& p : places) {
     set.insert(p);
@@ -193,8 +193,8 @@ void EmplaceDeviceContexts(
           stream_priority);
 #else
       PADDLE_THROW(
-          phi::errors::Unimplemented("GPUPlace is not supported. Please "
-                                     "re-compile with WITH_GPU option."));
+          common::errors::Unimplemented("GPUPlace is not supported. Please "
+                                        "re-compile with WITH_GPU option."));
 #endif
     } else if (place.GetType() == phi::AllocationType::XPU) {
 #ifdef PADDLE_WITH_XPU
@@ -205,8 +205,8 @@ void EmplaceDeviceContexts(
           /*unused*/ stream_priority);
 #else
       PADDLE_THROW(
-          phi::errors::Unimplemented("XPUPlace is not supported. Please "
-                                     "re-compile with WITH_XPU option."));
+          common::errors::Unimplemented("XPUPlace is not supported. Please "
+                                        "re-compile with WITH_XPU option."));
 #endif
     } else if (place.GetType() == phi::AllocationType::CUSTOM) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
@@ -216,7 +216,7 @@ void EmplaceDeviceContexts(
           disable_setting_default_stream_for_allocator,
           /*unused*/ stream_priority);
 #else
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "CustomPlace is not supported. Please re-compile with "
           "WITH_CUSTOM_DEVICE "
           "option."));
@@ -229,7 +229,7 @@ void EmplaceDeviceContexts(
           disable_setting_default_stream_for_allocator,
           /*unused*/ stream_priority);
 #else
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "GPUPlace is not supported. Please re-compile with WITH_GPU "
           "option."));
 #endif
@@ -242,8 +242,8 @@ void EmplaceDeviceContexts(
           /*unused*/ stream_priority);
 #else
       PADDLE_THROW(
-          phi::errors::Unimplemented("IPUPlace is not supported. Please "
-                                     "re-compile with WITH_IPU option."));
+          common::errors::Unimplemented("IPUPlace is not supported. Please "
+                                        "re-compile with WITH_IPU option."));
 #endif
     }
   }

--- a/paddle/fluid/platform/device_event_base.cc
+++ b/paddle/fluid/platform/device_event_base.cc
@@ -78,7 +78,7 @@ void DeviceEventRecordCPU(DeviceEvent* event, const DeviceContext* context) {
   PADDLE_ENFORCE_LT(
       wrapper->status_.load(),
       EventStatus::SCHEDULED,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "EventStatus shall be not SCHEDULED before Record(), but received %s",
           wrapper->status_.load()));
   if (wrapper->status_ == EventStatus::INITIALIZED) {
@@ -90,7 +90,7 @@ bool DeviceEventQueryCPU(const DeviceEvent* event) {
   auto* wrapper = static_cast<CPUDeviceEventWrapper*>(event->GetEvent().get());
   PADDLE_ENFORCE_NOT_NULL(
       wrapper,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Failed to dynamic_cast event into CPUDeviceEventWrapper."));
 
   return wrapper->status_ == EventStatus::SUCCESS;
@@ -117,7 +117,7 @@ void EventSetFinishedCPU(const DeviceEvent* event) {
 
   PADDLE_ENFORCE_LE(wrapper->status_.load(),
                     EventStatus::SCHEDULED,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "EventStatus shall be  INITIALIZED | SCHEDULED before "
                         "EventSetFinishedCPU()"));
   wrapper->status_ = EventStatus::SUCCESS;

--- a/paddle/fluid/platform/device_event_base.h
+++ b/paddle/fluid/platform/device_event_base.h
@@ -61,7 +61,7 @@ class DeviceEvent {
     type_id_ = DeviceTypeToId(platform::Place2DeviceType(place));
     PADDLE_ENFORCE_LT(type_id_,
                       MaxDeviceTypes,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Required type < %d, but received type = %d",
                           MaxDeviceTypes,
                           type_id_));
@@ -69,13 +69,13 @@ class DeviceEvent {
     // TODO(Aurelius84): only support CPU/CUDA.
     PADDLE_ENFORCE_LT(type_id_,
                       3,
-                      phi::errors::Unavailable(
+                      common::errors::Unavailable(
                           "Currently DeviceEvent do not support %s", place));
 #endif
     PADDLE_ENFORCE_NOT_NULL(
         event_creator_[type_id_],
-        phi::errors::Unavailable("event_creator_[%d] shall not be nullptr.",
-                                 type_id_));
+        common::errors::Unavailable("event_creator_[%d] shall not be nullptr.",
+                                    type_id_));
     event_creator_[type_id_](this, place, flag);
   }
 
@@ -84,8 +84,8 @@ class DeviceEvent {
   void Record(const DeviceContext* dev_ctx) {
     PADDLE_ENFORCE_NOT_NULL(
         event_recorder_[type_id_],
-        phi::errors::Unavailable("event_recorder_[%d] shall not be nullptr.",
-                                 type_id_));
+        common::errors::Unavailable("event_recorder_[%d] shall not be nullptr.",
+                                    type_id_));
     if (!recorded_) {
       recorded_ = true;
     }
@@ -95,8 +95,8 @@ class DeviceEvent {
   bool Query() {
     PADDLE_ENFORCE_NOT_NULL(
         event_querier_[type_id_],
-        phi::errors::Unavailable("event_querier_[%d] shall not be nullptr.",
-                                 type_id_));
+        common::errors::Unavailable("event_querier_[%d] shall not be nullptr.",
+                                    type_id_));
     if (!recorded_) {
       VLOG(4) << "Event " << this << " is not recorded yet, and skip query!";
       return true;
@@ -107,15 +107,15 @@ class DeviceEvent {
   void Finish() const {
     PADDLE_ENFORCE_NOT_NULL(
         event_finisher_[type_id_],
-        phi::errors::Unavailable("event_finisher_[%d] shall not be nullptr.",
-                                 type_id_));
+        common::errors::Unavailable("event_finisher_[%d] shall not be nullptr.",
+                                    type_id_));
     event_finisher_[type_id_](this);
   }
 
   void SetFinished() {
     PADDLE_ENFORCE_NOT_NULL(
         event_finished_setter_[type_id_],
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "event_finished_setter_[%d] shall not be nullptr.", type_id_));
     event_finished_setter_[type_id_](this);
   }
@@ -123,18 +123,18 @@ class DeviceEvent {
   void Reset() {
     PADDLE_ENFORCE_NOT_NULL(
         event_resetter_[type_id_],
-        phi::errors::Unavailable("event_resetter_[%d] shall not be nullptr.",
-                                 type_id_));
+        common::errors::Unavailable("event_resetter_[%d] shall not be nullptr.",
+                                    type_id_));
     event_resetter_[type_id_](this);
   }
 
   void Wait(const DeviceType& waiter_type, const DeviceContext* context) const {
     auto waiter_idx = DeviceTypeToId(waiter_type);
-    PADDLE_ENFORCE_NOT_NULL(
-        event_waiter_[waiter_idx][type_id_],
-        phi::errors::Unavailable("event_waiter_[%d][%d] shall not be nullptr.",
-                                 waiter_idx,
-                                 type_id_));
+    PADDLE_ENFORCE_NOT_NULL(event_waiter_[waiter_idx][type_id_],
+                            common::errors::Unavailable(
+                                "event_waiter_[%d][%d] shall not be nullptr.",
+                                waiter_idx,
+                                type_id_));
     if (!recorded_) {
       VLOG(4) << "Event " << this << " is not recorded yet, and skip wait!";
       return;

--- a/paddle/fluid/platform/device_event_cpu.h
+++ b/paddle/fluid/platform/device_event_cpu.h
@@ -28,7 +28,7 @@ struct CPUDeviceEventWrapper {
     PADDLE_ENFORCE_EQ(
         phi::is_cpu_place(place),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Required device shall be CPUPlace, but received %d. ", place));
   }
   std::mutex mutex_;

--- a/paddle/fluid/platform/device_event_custom_device.cc
+++ b/paddle/fluid/platform/device_event_custom_device.cc
@@ -24,14 +24,14 @@ struct CustomDeviceEventWrapper {
     PADDLE_ENFORCE_EQ(
         phi::is_custom_place(place),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Required device shall be CustomPlace, but received %d. ", place));
 
     device_id_ = place.device;  // NOLINT
     PADDLE_ENFORCE_GT(
         device_id_,
         -1,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Required DeviceOption.device_id > -1, but received %d. ",
             device_id_));
     inner_event_ =
@@ -55,7 +55,7 @@ void DeviceEventRecordCustomDevice(DeviceEvent* event,
       dynamic_cast<const platform::CustomDeviceContext*>(context);
   PADDLE_ENFORCE_NOT_NULL(
       custom_device_ctx,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Failed to dynamic_cast context into NPUDeviceContext."));
 
   phi::stream::Stream stream_wrapper(custom_device_ctx->GetPlace(),
@@ -68,7 +68,7 @@ bool DeviceEventQueryCustomDevice(const DeviceEvent* event) {
       static_cast<CustomDeviceEventWrapper*>(event->GetEvent().get());
   PADDLE_ENFORCE_NOT_NULL(
       wrapper,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Failed to dynamic_cast event into CustomDeviceEventWrapper."));
   return wrapper->inner_event_->Query();
 }
@@ -87,7 +87,7 @@ void DeviceEventCustomDeviceWaitCustomDevice(const DeviceEvent* event,
       dynamic_cast<const platform::CustomDeviceContext*>(context);
   PADDLE_ENFORCE_NOT_NULL(
       custom_device_ctx,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Failed to dynamic_cast context into NPUDeviceContext."));
   phi::stream::Stream stream_wrapper(custom_device_ctx->GetPlace(),
                                      custom_device_ctx->stream());

--- a/paddle/fluid/platform/device_event_gpu.cc
+++ b/paddle/fluid/platform/device_event_gpu.cc
@@ -24,14 +24,14 @@ struct CUDADeviceEventWrapper {
     PADDLE_ENFORCE_EQ(
         phi::is_gpu_place(place),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Required device shall be GPUPlace, but received %d. ", place));
 
     device_id_ = place.device;  // NOLINT
     PADDLE_ENFORCE_GT(
         device_id_,
         -1,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Required DeviceOption.device_id > -1, but received %d. ",
             device_id_));
   }
@@ -52,7 +52,7 @@ void DeviceEventRecordCUDA(DeviceEvent* event, const DeviceContext* context) {
   auto* cuda_dev_ctx = dynamic_cast<const phi::GPUContext*>(context);
   PADDLE_ENFORCE_NOT_NULL(
       cuda_dev_ctx,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Failed to dynamic_cast context into phi::GPUContext."));
 
   wrapper->inner_event_.Record(cuda_dev_ctx->stream());
@@ -62,7 +62,7 @@ bool DeviceEventQueryCUDA(const DeviceEvent* event) {
   auto* wrapper = static_cast<CUDADeviceEventWrapper*>(event->GetEvent().get());
   PADDLE_ENFORCE_NOT_NULL(
       wrapper,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Failed to dynamic_cast event into CUDADeviceEventWrapper."));
 
   return wrapper->inner_event_.Query();
@@ -80,7 +80,7 @@ void DeviceEventCUDAWaitCUDA(const DeviceEvent* event,
   auto* cuda_dev_ctx = dynamic_cast<const phi::GPUContext*>(context);
   PADDLE_ENFORCE_NOT_NULL(
       cuda_dev_ctx,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Failed to dynamic_cast context into phi::GPUContext."));
   // calling cudaStreamWaitEvent(stream, event, 0)
   cuda_dev_ctx->WaitEvent(wrapper->inner_event_.GetRawCudaEvent());

--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -135,7 +135,7 @@ using ::common::enforce::EnforceNotMet;
     PADDLE_ENFORCE_EQ(                                                       \
         __EXPR,                                                              \
         true,                                                                \
-        phi::errors::NotFound(                                               \
+        common::errors::NotFound(                                            \
             "No %s(%s) found for %s operator.", __ROLE, __NAME, __OP_TYPE)); \
   } while (0)
 

--- a/paddle/fluid/platform/enforce_test.cc
+++ b/paddle/fluid/platform/enforce_test.cc
@@ -17,21 +17,21 @@ limitations under the License. */
 #include "gtest/gtest.h"
 
 TEST(ENFORCE, OK) {
-  PADDLE_ENFORCE(
-      true,
-      phi::errors::Unavailable("PADDLE_ENFORCE is ok %d now %f.", 123, 0.345));
+  PADDLE_ENFORCE(true,
+                 common::errors::Unavailable(
+                     "PADDLE_ENFORCE is ok %d now %f.", 123, 0.345));
   size_t val = 1;
   const size_t limit = 10;
   PADDLE_ENFORCE(val < limit,
-                 phi::errors::Unavailable("PADDLE_ENFORCE tests failed."));
+                 common::errors::Unavailable("PADDLE_ENFORCE tests failed."));
 }
 
 TEST(ENFORCE, FAILED) {
   bool caught_exception = false;
   try {
-    PADDLE_ENFORCE(
-        false,
-        phi::errors::Unavailable("PADDLE_ENFORCE won't work %d at all.", 123));
+    PADDLE_ENFORCE(false,
+                   common::errors::Unavailable(
+                       "PADDLE_ENFORCE won't work %d at all.", 123));
   } catch (paddle::platform::EnforceNotMet& error) {
     caught_exception = true;
     std::string ex_msg = error.what();
@@ -43,7 +43,8 @@ TEST(ENFORCE, FAILED) {
   caught_exception = false;
   try {
     PADDLE_ENFORCE(
-        false, phi::errors::Unavailable("PADDLE_ENFORCE won't work at all."));
+        false,
+        common::errors::Unavailable("PADDLE_ENFORCE won't work at all."));
   } catch (paddle::platform::EnforceNotMet& error) {
     caught_exception = true;
     std::string ex_msg = error.what();
@@ -55,7 +56,8 @@ TEST(ENFORCE, FAILED) {
   caught_exception = false;
   try {
     PADDLE_ENFORCE(
-        false, phi::errors::Unavailable("PADDLE_ENFORCE won't work at all."));
+        false,
+        common::errors::Unavailable("PADDLE_ENFORCE won't work at all."));
   } catch (paddle::platform::EnforceNotMet& error) {
     caught_exception = true;
     EXPECT_NE(std::string(error.what()).find(" at "), 0UL);
@@ -67,12 +69,12 @@ TEST(ENFORCE, NO_ARG_OK) {
   int a = 2;
   int b = 2;
   PADDLE_ENFORCE_EQ(
-      a, b, phi::errors::Unavailable("PADDLE_ENFORCE_EQ tests failed."));
+      a, b, common::errors::Unavailable("PADDLE_ENFORCE_EQ tests failed."));
   // test enforce with extra message.
-  PADDLE_ENFORCE_EQ(
-      a,
-      b,
-      phi::errors::Unavailable("Some %s wrong in PADDLE_ENFORCE_EQ.", "info"));
+  PADDLE_ENFORCE_EQ(a,
+                    b,
+                    common::errors::Unavailable(
+                        "Some %s wrong in PADDLE_ENFORCE_EQ.", "info"));
 }
 
 TEST(ENFORCE_EQ, NO_EXTRA_MSG_FAIL) {
@@ -81,7 +83,7 @@ TEST(ENFORCE_EQ, NO_EXTRA_MSG_FAIL) {
   try {
     PADDLE_ENFORCE_EQ(a,
                       1 + 3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The result is not equal correct result."));
   } catch (paddle::platform::EnforceNotMet& error) {
     caught_exception = true;
@@ -98,7 +100,7 @@ TEST(ENFORCE_EQ, EXTRA_MSG_FAIL) {
   try {
     PADDLE_ENFORCE_EQ(a,
                       1 + 3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The result is not equal correct result."));
   } catch (paddle::platform::EnforceNotMet& error) {
     caught_exception = true;
@@ -112,9 +114,9 @@ TEST(ENFORCE_EQ, EXTRA_MSG_FAIL) {
 
 TEST(ENFORCE_NE, OK) {
   PADDLE_ENFORCE_NE(
-      1, 2, phi::errors::Unavailable("PADDLE_ENFORCE_NE tests failed."));
+      1, 2, common::errors::Unavailable("PADDLE_ENFORCE_NE tests failed."));
   PADDLE_ENFORCE_NE(
-      1.0, 2UL, phi::errors::Unavailable("PADDLE_ENFORCE_NE tests failed."));
+      1.0, 2UL, common::errors::Unavailable("PADDLE_ENFORCE_NE tests failed."));
 }
 TEST(ENFORCE_NE, FAIL) {
   bool caught_exception = false;
@@ -123,7 +125,7 @@ TEST(ENFORCE_NE, FAIL) {
     // 2UL here to check data type compatible
     PADDLE_ENFORCE_NE(1.0,
                       1UL,
-                      phi::errors::Unavailable(
+                      common::errors::Unavailable(
                           "Expected 1.0 != 1UL, but received 1.0:1 == 1UL:1."));
   } catch (paddle::platform::EnforceNotMet& error) {
     caught_exception = true;
@@ -136,14 +138,14 @@ TEST(ENFORCE_NE, FAIL) {
 
 TEST(ENFORCE_GT, OK) {
   PADDLE_ENFORCE_GT(
-      2, 1, phi::errors::Unavailable("PADDLE_ENFORCE_GT tests failed."));
+      2, 1, common::errors::Unavailable("PADDLE_ENFORCE_GT tests failed."));
 }
 TEST(ENFORCE_GT, FAIL) {
   bool caught_exception = false;
   try {
     PADDLE_ENFORCE_GT(1,
                       2,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Expected 1 > 2, but received 1:1 <= 2:2."));
   } catch (paddle::platform::EnforceNotMet& error) {
     caught_exception = true;
@@ -156,18 +158,20 @@ TEST(ENFORCE_GT, FAIL) {
 
 TEST(ENFORCE_GE, OK) {
   PADDLE_ENFORCE_GE(
-      2, 2, phi::errors::Unavailable("PADDLE_ENFORCE_GE tests failed."));
+      2, 2, common::errors::Unavailable("PADDLE_ENFORCE_GE tests failed."));
   PADDLE_ENFORCE_GE(
-      3, 2, phi::errors::Unavailable("PADDLE_ENFORCE_GE tests failed."));
+      3, 2, common::errors::Unavailable("PADDLE_ENFORCE_GE tests failed."));
   PADDLE_ENFORCE_GE(
-      3.21, 2.0, phi::errors::Unavailable("PADDLE_ENFORCE_GE tests failed."));
+      3.21,
+      2.0,
+      common::errors::Unavailable("PADDLE_ENFORCE_GE tests failed."));
 }
 TEST(ENFORCE_GE, FAIL) {
   bool caught_exception = false;
   try {
     PADDLE_ENFORCE_GE(1,
                       2,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Expected 1 >= 2, but received 1:1 < 2:2."));
   } catch (paddle::platform::EnforceNotMet& error) {
     caught_exception = true;
@@ -180,22 +184,22 @@ TEST(ENFORCE_GE, FAIL) {
 
 TEST(ENFORCE_LE, OK) {
   PADDLE_ENFORCE_LE(
-      1, 1, phi::errors::Unavailable("PADDLE_ENFORCE_LE tests failed."));
+      1, 1, common::errors::Unavailable("PADDLE_ENFORCE_LE tests failed."));
   PADDLE_ENFORCE_LE(
-      1UL, 1UL, phi::errors::Unavailable("PADDLE_ENFORCE_LE tests failed."));
+      1UL, 1UL, common::errors::Unavailable("PADDLE_ENFORCE_LE tests failed."));
   PADDLE_ENFORCE_LE(
-      2, 3, phi::errors::Unavailable("PADDLE_ENFORCE_LE tests failed."));
+      2, 3, common::errors::Unavailable("PADDLE_ENFORCE_LE tests failed."));
   PADDLE_ENFORCE_LE(
-      2UL, 3UL, phi::errors::Unavailable("PADDLE_ENFORCE_LE tests failed."));
+      2UL, 3UL, common::errors::Unavailable("PADDLE_ENFORCE_LE tests failed."));
   PADDLE_ENFORCE_LE(
-      2.0, 3.2, phi::errors::Unavailable("PADDLE_ENFORCE_LE tests failed."));
+      2.0, 3.2, common::errors::Unavailable("PADDLE_ENFORCE_LE tests failed."));
 }
 TEST(ENFORCE_LE, FAIL) {
   bool caught_exception = false;
   try {
     PADDLE_ENFORCE_GT(1,
                       2,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Expected 1 > 2, but received 1:1 <= 2:2."));
   } catch (paddle::platform::EnforceNotMet& error) {
     caught_exception = true;
@@ -208,11 +212,11 @@ TEST(ENFORCE_LE, FAIL) {
 
 TEST(ENFORCE_LT, OK) {
   PADDLE_ENFORCE_LT(
-      3, 10, phi::errors::Unavailable("PADDLE_ENFORCE_LT tests failed."));
+      3, 10, common::errors::Unavailable("PADDLE_ENFORCE_LT tests failed."));
   PADDLE_ENFORCE_LT(
-      2UL, 3UL, phi::errors::Unavailable("PADDLE_ENFORCE_LT tests failed."));
+      2UL, 3UL, common::errors::Unavailable("PADDLE_ENFORCE_LT tests failed."));
   PADDLE_ENFORCE_LT(
-      2, 3, phi::errors::Unavailable("PADDLE_ENFORCE_LT tests failed."));
+      2, 3, common::errors::Unavailable("PADDLE_ENFORCE_LT tests failed."));
 }
 TEST(ENFORCE_LT, FAIL) {
   bool caught_exception = false;
@@ -220,7 +224,7 @@ TEST(ENFORCE_LT, FAIL) {
     PADDLE_ENFORCE_LT(
         1UL,
         0.12,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Expected 1UL < 0.12, but received 1UL:1 >= 0.12:0.12."));
   } catch (paddle::platform::EnforceNotMet& error) {
     caught_exception = true;
@@ -235,7 +239,7 @@ TEST(ENFORCE_LT, FAIL) {
 TEST(ENFORCE_NOT_NULL, OK) {
   int* a = new int;
   PADDLE_ENFORCE_NOT_NULL(
-      a, phi::errors::Unavailable("PADDLE_ENFORCE_NOT_NULL tests failed."));
+      a, common::errors::Unavailable("PADDLE_ENFORCE_NOT_NULL tests failed."));
   delete a;
 }
 TEST(ENFORCE_NOT_NULL, FAIL) {
@@ -243,7 +247,7 @@ TEST(ENFORCE_NOT_NULL, FAIL) {
   try {
     int* a = nullptr;
     PADDLE_ENFORCE_NOT_NULL(
-        a, phi::errors::Unavailable("The a should not be null."));
+        a, common::errors::Unavailable("The a should not be null."));
   } catch (paddle::platform::EnforceNotMet& error) {
     caught_exception = true;
     std::string ex_msg = error.what();
@@ -281,7 +285,7 @@ std::ostream& operator<<(std::ostream& os, const Dims& d) {
 TEST(ENFORCE_USER_DEFINED_CLASS, EQ) {
   Dims a{{1, 2, 3, 4}}, b{{1, 2, 3, 4}};
   PADDLE_ENFORCE_EQ(
-      a, b, phi::errors::Unavailable("PADDLE_ENFORCE_EQ tests failed."));
+      a, b, common::errors::Unavailable("PADDLE_ENFORCE_EQ tests failed."));
 }
 
 TEST(ENFORCE_USER_DEFINED_CLASS, NE) {
@@ -289,7 +293,7 @@ TEST(ENFORCE_USER_DEFINED_CLASS, NE) {
   bool caught_exception = false;
   try {
     PADDLE_ENFORCE_EQ(
-        a, b, phi::errors::Unavailable("PADDLE_ENFORCE_EQ tests failed."));
+        a, b, common::errors::Unavailable("PADDLE_ENFORCE_EQ tests failed."));
   } catch (paddle::platform::EnforceNotMet&) {
     caught_exception = true;
   }
@@ -501,15 +505,15 @@ TEST(enforce, cannot_to_string_type) {
   PADDLE_ENFORCE_NE(
       obj1,
       obj2,
-      phi::errors::InvalidArgument("Object 1 is not equal to Object 2"));
+      common::errors::InvalidArgument("Object 1 is not equal to Object 2"));
   PADDLE_ENFORCE_EQ(
       obj1,
       obj3,
-      phi::errors::InvalidArgument("Object 1 is equal to Object 3"));
+      common::errors::InvalidArgument("Object 1 is equal to Object 3"));
 
   std::string msg = "Compare obj1 with obj2";
   try {
-    PADDLE_ENFORCE_EQ(obj1, obj2, phi::errors::InvalidArgument(msg));
+    PADDLE_ENFORCE_EQ(obj1, obj2, common::errors::InvalidArgument(msg));
   } catch (paddle::platform::EnforceNotMet& error) {
     std::string ex_msg = error.what();
     LOG(INFO) << ex_msg;
@@ -522,7 +526,7 @@ TEST(enforce, cannot_to_string_type) {
   msg = "Compare x with y";
   try {
     int x = 3, y = 2;
-    PADDLE_ENFORCE_EQ(x, y, phi::errors::InvalidArgument(msg));
+    PADDLE_ENFORCE_EQ(x, y, common::errors::InvalidArgument(msg));
   } catch (paddle::platform::EnforceNotMet& error) {
     std::string ex_msg = error.what();
     LOG(INFO) << ex_msg;
@@ -532,26 +536,26 @@ TEST(enforce, cannot_to_string_type) {
   }
 
   std::set<int> set;
-  PADDLE_ENFORCE_EQ(
-      set.begin(),
-      set.end(),
-      phi::errors::InvalidArgument("The begin and end of set is not equal."));
+  PADDLE_ENFORCE_EQ(set.begin(),
+                    set.end(),
+                    common::errors::InvalidArgument(
+                        "The begin and end of set is not equal."));
   set.insert(3);
   PADDLE_ENFORCE_NE(
       set.begin(),
       set.end(),
-      phi::errors::InvalidArgument("The begin and end of set is equal."));
+      common::errors::InvalidArgument("The begin and end of set is equal."));
 
   std::list<float> list;
-  PADDLE_ENFORCE_EQ(
-      list.begin(),
-      list.end(),
-      phi::errors::InvalidArgument("The begin and end of list is not equal."));
+  PADDLE_ENFORCE_EQ(list.begin(),
+                    list.end(),
+                    common::errors::InvalidArgument(
+                        "The begin and end of list is not equal."));
   list.push_back(4);
   PADDLE_ENFORCE_NE(
       list.begin(),
       list.end(),
-      phi::errors::InvalidArgument("The begin and end of list is equal."));
+      common::errors::InvalidArgument("The begin and end of list is equal."));
 }
 
 TEST(GET_DATA_SAFELY_MACRO, SUCCESS) {

--- a/paddle/fluid/platform/errors_test.cc
+++ b/paddle/fluid/platform/errors_test.cc
@@ -19,7 +19,7 @@ limitations under the License. */
 #include "gtest/gtest.h"
 #include "paddle/fluid/platform/enforce.h"
 
-using namespace phi::errors;  // NOLINT
+using namespace common::errors;  // NOLINT
 
 #define CHECK_PADDLE_THROW(EFUNC)                                          \
   do {                                                                     \

--- a/paddle/fluid/platform/float16_test.cc
+++ b/paddle/fluid/platform/float16_test.cc
@@ -138,7 +138,7 @@ TEST(float16, floating) {
   PADDLE_ENFORCE_EQ(
       std::is_floating_point<float16>::value,
       true,
-      phi::errors::Unavailable("The float16 support in CPU failed."));
+      common::errors::Unavailable("The float16 support in CPU failed."));
 }
 
 TEST(float16, print) {

--- a/paddle/fluid/platform/float16_test.cu
+++ b/paddle/fluid/platform/float16_test.cu
@@ -369,11 +369,11 @@ TEST(float16, typeid) {
   PADDLE_ENFORCE_EQ(
       functor(a),
       true,
-      phi::errors::Unavailable("The float16 support in GPU failed."));
+      common::errors::Unavailable("The float16 support in GPU failed."));
   PADDLE_ENFORCE_EQ(
       functor2(b),
       false,
-      phi::errors::Unavailable("The float16 support in GPU failed."));
+      common::errors::Unavailable("The float16 support in GPU failed."));
 }
 
 // GPU test

--- a/paddle/fluid/platform/gen_comm_id_helper.cc
+++ b/paddle/fluid/platform/gen_comm_id_helper.cc
@@ -61,7 +61,7 @@ struct CommHead {
   do {                                                      \
     RETRY_SYS_CALL_VAL(call, name, retval);                 \
     if (retval == -1) {                                     \
-      PADDLE_THROW(phi::errors::Unavailable(                \
+      PADDLE_THROW(common::errors::Unavailable(             \
           "Call to %s failed: %s", name, strerror(errno))); \
     }                                                       \
   } while (false)
@@ -125,10 +125,10 @@ static void BindOrConnectFailed(int timeout,
   PADDLE_ENFORCE_LT(
       *total_time,
       timeout,
-      phi::errors::Unavailable("%s addr=%s timeout, failed reason: %s",
-                               op,
-                               ep.c_str(),
-                               strerror(errno)));
+      common::errors::Unavailable("%s addr=%s timeout, failed reason: %s",
+                                  op,
+                                  ep.c_str(),
+                                  strerror(errno)));
   ++(*try_times);
   int retry_time = std::min(*try_times * 500, 3000);  // max 3 seconds
   *total_time += retry_time;
@@ -144,7 +144,7 @@ int CreateListenSocket(const std::string& ep) {
   PADDLE_ENFORCE_EQ(
       addr.size(),
       2UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The endpoint should contain host and port, but got %s.", ep));
   std::string host = addr[0];
   int port = std::stoi(addr[1]);
@@ -250,7 +250,7 @@ static int ConnectAddr(const std::string& ep, const CommHead head) {
   PADDLE_ENFORCE_EQ(
       addr.size(),
       2UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The endpoint should contain host and port, but got %s.", ep));
   std::string host = addr[0];
   int port = std::stoi(addr[1]);
@@ -273,7 +273,8 @@ static int ConnectAddr(const std::string& ep, const CommHead head) {
     LOG(WARNING) << "gethostbyname " << host.c_str() << " error!";
   }
   PADDLE_ENFORCE_NOT_NULL(
-      hp, phi::errors::InvalidArgument("Fail to get host by name %s.", host));
+      hp,
+      common::errors::InvalidArgument("Fail to get host by name %s.", host));
 
   int i = 0;
   while (hp->h_addr_list[i] != nullptr) {
@@ -284,7 +285,7 @@ static int ConnectAddr(const std::string& ep, const CommHead head) {
 
   PADDLE_ENFORCE_GT(inet_pton(AF_INET, ip, &server_addr.sin_addr),
                     0,
-                    phi::errors::Unavailable(
+                    common::errors::Unavailable(
                         "Open address %s failed: %s", ep, strerror(errno)));
 
   static_assert(sizeof(CommHead) <= 1024,
@@ -476,11 +477,11 @@ SocketServer& SocketServer::GetInstance(const std::string& end_point) {
   });
   PADDLE_ENFORCE_NE(instance.server_fd_,
                     -1,
-                    phi::errors::Unavailable(
+                    common::errors::Unavailable(
                         "listen socket failed with end_point=%s", end_point));
   PADDLE_ENFORCE_EQ(instance.end_point_,
                     end_point,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "old end_point=%s must equal with new end_point=%s",
                         instance.end_point_,
                         end_point));

--- a/paddle/fluid/platform/gloo_context.cc
+++ b/paddle/fluid/platform/gloo_context.cc
@@ -33,7 +33,7 @@ void GlooParallelContext::Barrier() {
   PADDLE_ENFORCE_EQ(
       gloo_ptr->IsInitialized(),
       true,
-      phi::errors::Unavailable("Gloo context is not initialized."));
+      common::errors::Unavailable("Gloo context is not initialized."));
   gloo_ptr->Barrier();
 }
 

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -115,20 +115,20 @@ void InitCupti() {
 #ifdef PADDLE_WITH_CUPTI
   if (FLAGS_multiple_of_cupti_buffer_size == 1) return;
   size_t attrValue = 0, attrValueSize = sizeof(size_t);
-#define MULTIPLY_ATTR_VALUE(attr)                                 \
-  {                                                               \
-    PADDLE_ENFORCE_EQ(                                            \
-        !phi::dynload::cuptiActivityGetAttribute(                 \
-            attr, &attrValueSize, &attrValue),                    \
-        true,                                                     \
-        phi::errors::Unavailable("Get cupti attribute failed.")); \
-    attrValue *= FLAGS_multiple_of_cupti_buffer_size;             \
-    LOG(WARNING) << "Set " #attr " " << attrValue << " byte";     \
-    PADDLE_ENFORCE_EQ(                                            \
-        !phi::dynload::cuptiActivitySetAttribute(                 \
-            attr, &attrValueSize, &attrValue),                    \
-        true,                                                     \
-        phi::errors::Unavailable("Set cupti attribute failed.")); \
+#define MULTIPLY_ATTR_VALUE(attr)                                    \
+  {                                                                  \
+    PADDLE_ENFORCE_EQ(                                               \
+        !phi::dynload::cuptiActivityGetAttribute(                    \
+            attr, &attrValueSize, &attrValue),                       \
+        true,                                                        \
+        common::errors::Unavailable("Get cupti attribute failed.")); \
+    attrValue *= FLAGS_multiple_of_cupti_buffer_size;                \
+    LOG(WARNING) << "Set " #attr " " << attrValue << " byte";        \
+    PADDLE_ENFORCE_EQ(                                               \
+        !phi::dynload::cuptiActivitySetAttribute(                    \
+            attr, &attrValueSize, &attrValue),                       \
+        true,                                                        \
+        common::errors::Unavailable("Set cupti attribute failed.")); \
   }
   MULTIPLY_ATTR_VALUE(CUPTI_ACTIVITY_ATTR_DEVICE_BUFFER_SIZE);
   MULTIPLY_ATTR_VALUE(CUPTI_ACTIVITY_ATTR_DEVICE_BUFFER_SIZE_CDP);
@@ -148,7 +148,7 @@ void LoadCustomDevice(const std::string &library_dir) {
     auto dso_handle = dlopen(lib_path.c_str(), RTLD_LAZY);
     PADDLE_ENFORCE_NOT_NULL(
         dso_handle,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Fail to open library: %s with error: %s", lib_path, dlerror()));
 
     phi::LoadCustomRuntimeLib(lib_path, dso_handle);
@@ -324,8 +324,8 @@ void SignalHandle(const char *data, int size) {
 
       sout << "\n----------------------\nError Message "
               "Summary:\n----------------------\n";
-      sout << phi::errors::Fatal("`%s` is detected by the operating system.",
-                                 ParseSignalErrorString(signal_info))
+      sout << common::errors::Fatal("`%s` is detected by the operating system.",
+                                    ParseSignalErrorString(signal_info))
                   .to_string();
       std::cout << sout.str() << (*signal_msg_dumper_ptr).str() << std::endl;
     }

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -480,7 +480,7 @@ void MemEventRecorder::PushMemRecord(const void *ptr,
   auto &events = address_memevent_[place];
   PADDLE_ENFORCE_EQ(events.count(ptr),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Place can't exist in the stage of PushMemRecord"));
   events.emplace(
       ptr, std::make_unique<MemEventRecorder::RecordMemEvent>(place, size));
@@ -516,7 +516,7 @@ void MemEventRecorder::PushMemRecord(const void *ptr,
   auto &events = address_memevent_[place];
   PADDLE_ENFORCE_EQ(events.count(ptr),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Place can't exist in the stage of PushMemRecord"));
   events.emplace(
       ptr, std::make_unique<MemEventRecorder::RecordMemEvent>(place, size));
@@ -669,7 +669,7 @@ void Mark(const std::string &name) {
 void EnableProfiler(ProfilerState state) {
   PADDLE_ENFORCE_NE(state,
                     ProfilerState::kDisabled,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Can't enable profiling, since the input state is"
                         "ProfilerState::kDisabled"));
   SynchronizeAllDevice();

--- a/paddle/fluid/platform/profiler/cuda_tracer.cc
+++ b/paddle/fluid/platform/profiler/cuda_tracer.cc
@@ -51,7 +51,7 @@ void CudaTracer::PrepareTracing() {
   PADDLE_ENFORCE_EQ(
       state_ == TracerState::UNINITED || state_ == TracerState::STOPED,
       true,
-      phi::errors::PreconditionNotMet("Tracer must be UNINITED"));
+      common::errors::PreconditionNotMet("Tracer must be UNINITED"));
   EnableCuptiActivity();
   state_ = TracerState::READY;
 }
@@ -60,24 +60,26 @@ void CudaTracer::StartTracing() {
   PADDLE_ENFORCE_EQ(
       state_ == TracerState::READY,
       true,
-      phi::errors::PreconditionNotMet("Tracer must be READY or STOPPED"));
+      common::errors::PreconditionNotMet("Tracer must be READY or STOPPED"));
   ConsumeBuffers();
   tracing_start_ns_ = phi::PosixInNsec();
   state_ = TracerState::STARTED;
 }
 
 void CudaTracer::StopTracing() {
-  PADDLE_ENFORCE_EQ(state_,
-                    TracerState::STARTED,
-                    phi::errors::PreconditionNotMet("Tracer must be STARTED"));
+  PADDLE_ENFORCE_EQ(
+      state_,
+      TracerState::STARTED,
+      common::errors::PreconditionNotMet("Tracer must be STARTED"));
   DisableCuptiActivity();
   state_ = TracerState::STOPED;
 }
 
 void CudaTracer::CollectTraceData(TraceEventCollector* collector) {
-  PADDLE_ENFORCE_EQ(state_,
-                    TracerState::STOPED,
-                    phi::errors::PreconditionNotMet("Tracer must be STOPED"));
+  PADDLE_ENFORCE_EQ(
+      state_,
+      TracerState::STOPED,
+      common::errors::PreconditionNotMet("Tracer must be STOPED"));
   ProcessCuptiActivity(collector);
 }
 

--- a/paddle/fluid/platform/profiler/custom_device/custom_tracer.cc
+++ b/paddle/fluid/platform/profiler/custom_device/custom_tracer.cc
@@ -62,7 +62,7 @@ void CustomTracer::PrepareTracing() {
   PADDLE_ENFORCE_EQ(
       state_ == TracerState::UNINITED || state_ == TracerState::STOPED,
       true,
-      phi::errors::PreconditionNotMet("CustomTracer must be UNINITED"));
+      common::errors::PreconditionNotMet("CustomTracer must be UNINITED"));
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
   phi::DeviceManager::ProfilerPrepareTracing(dev_type_, &collector_, context_);
 #endif
@@ -73,7 +73,7 @@ void CustomTracer::StartTracing() {
   PADDLE_ENFORCE_EQ(
       state_ == TracerState::READY,
       true,
-      phi::errors::PreconditionNotMet("Tracer must be READY or STOPPED"));
+      common::errors::PreconditionNotMet("Tracer must be READY or STOPPED"));
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
   phi::DeviceManager::ProfilerStartTracing(dev_type_, &collector_, context_);
 #endif
@@ -82,9 +82,10 @@ void CustomTracer::StartTracing() {
 }
 
 void CustomTracer::StopTracing() {
-  PADDLE_ENFORCE_EQ(state_,
-                    TracerState::STARTED,
-                    phi::errors::PreconditionNotMet("Tracer must be STARTED"));
+  PADDLE_ENFORCE_EQ(
+      state_,
+      TracerState::STARTED,
+      common::errors::PreconditionNotMet("Tracer must be STARTED"));
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
   phi::DeviceManager::ProfilerStopTracing(dev_type_, &collector_, context_);
 #endif
@@ -92,9 +93,10 @@ void CustomTracer::StopTracing() {
 }
 
 void CustomTracer::CollectTraceData(TraceEventCollector* collector) {
-  PADDLE_ENFORCE_EQ(state_,
-                    TracerState::STOPED,
-                    phi::errors::PreconditionNotMet("Tracer must be STOPED"));
+  PADDLE_ENFORCE_EQ(
+      state_,
+      TracerState::STOPED,
+      common::errors::PreconditionNotMet("Tracer must be STOPED"));
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
   phi::DeviceManager::ProfilerCollectTraceData(
       dev_type_, &collector_, tracing_start_ns_, context_);

--- a/paddle/fluid/platform/profiler/event_node.cc
+++ b/paddle/fluid/platform/profiler/event_node.cc
@@ -212,7 +212,7 @@ HostTraceEventNode* NodeTrees::BuildTreeRelationship(
         PADDLE_ENFORCE_LE(
             host_event_node->EndNs(),
             stack_top_node->EndNs(),
-            phi::errors::Fatal(
+            common::errors::Fatal(
                 "should not have time range intersection within one thread"));
         stack_top_node->AddChild(host_event_node);
         node_stack.push_back(host_event_node);

--- a/paddle/fluid/platform/profiler/event_node.h
+++ b/paddle/fluid/platform/profiler/event_node.h
@@ -111,7 +111,7 @@ class DeviceTraceEventNode {
     PADDLE_ENFORCE_EQ(
         device_event_.type,
         TracerEventType::Kernel,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Can not kernel_info, "
             "TracerEventType in node must be TracerEventType::Kernel."));
     return device_event_.kernel_info;
@@ -120,7 +120,7 @@ class DeviceTraceEventNode {
     PADDLE_ENFORCE_EQ(
         device_event_.type,
         TracerEventType::Memcpy,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Can not get memcpy_info, "
             "TracerEventType in node must be TracerEventType::Memcpy."));
     return device_event_.memcpy_info;
@@ -129,7 +129,7 @@ class DeviceTraceEventNode {
     PADDLE_ENFORCE_EQ(
         device_event_.type,
         TracerEventType::Memset,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Can not get memset_info, "
             "TracerEventType in node must be TracerEventType::Memset."));
     return device_event_.memset_info;

--- a/paddle/fluid/platform/profiler/host_tracer.cc
+++ b/paddle/fluid/platform/profiler/host_tracer.cc
@@ -141,7 +141,7 @@ void HostTracer::StartTracing() {
   PADDLE_ENFORCE_EQ(
       state_ == TracerState::READY || state_ == TracerState::STOPED,
       true,
-      phi::errors::PreconditionNotMet("TracerState must be READY"));
+      common::errors::PreconditionNotMet("TracerState must be READY"));
   HostEventRecorder<CommonEvent>::GetInstance().GatherEvents();
   HostEventRecorder<CommonMemEvent>::GetInstance().GatherEvents();
   HostEventRecorder<OperatorSupplementOriginEvent>::GetInstance()
@@ -154,7 +154,7 @@ void HostTracer::StopTracing() {
   PADDLE_ENFORCE_EQ(
       state_,
       TracerState::STARTED,
-      phi::errors::PreconditionNotMet("TracerState must be STARTED"));
+      common::errors::PreconditionNotMet("TracerState must be STARTED"));
   HostTraceLevel::GetInstance().SetLevel(HostTraceLevel::kDisabled);
   state_ = TracerState::STOPED;
 }
@@ -163,7 +163,7 @@ void HostTracer::CollectTraceData(TraceEventCollector* collector) {
   PADDLE_ENFORCE_EQ(
       state_,
       TracerState::STOPED,
-      phi::errors::PreconditionNotMet("TracerState must be STOPED"));
+      common::errors::PreconditionNotMet("TracerState must be STOPED"));
   HostEventSection<CommonEvent> host_events =
       HostEventRecorder<CommonEvent>::GetInstance().GatherEvents();
   ProcessHostEvents(host_events, collector);

--- a/paddle/fluid/platform/profiler/utils.h
+++ b/paddle/fluid/platform/profiler/utils.h
@@ -32,7 +32,9 @@ std::string string_format(const std::string& format, Args... args) {
   int size_s = std::snprintf(nullptr, 0, format.c_str(), args...) +
                1;  // Extra space for '\0'
   PADDLE_ENFORCE_GE(
-      size_s, 0, phi::errors::Fatal("Error during profiler data formatting."));
+      size_s,
+      0,
+      common::errors::Fatal("Error during profiler data formatting."));
   auto size = static_cast<size_t>(size_s);
   auto buf = std::make_unique<char[]>(size);
   std::snprintf(buf.get(), size, format.c_str(), args...);

--- a/paddle/fluid/platform/profiler/xpu_tracer.cc
+++ b/paddle/fluid/platform/profiler/xpu_tracer.cc
@@ -41,7 +41,7 @@ void XPUTracer::PrepareTracing() {
   PADDLE_ENFORCE_EQ(
       state_ == TracerState::UNINITED || state_ == TracerState::STOPED,
       true,
-      phi::errors::PreconditionNotMet("XPUTracer must be UNINITED"));
+      common::errors::PreconditionNotMet("XPUTracer must be UNINITED"));
 #ifdef PADDLE_WITH_XPTI
   XPTI_CALL(phi::dynload::xptiActivityEnable());
   VLOG(3) << "enable xpti activity";
@@ -53,7 +53,7 @@ void XPUTracer::StartTracing() {
   PADDLE_ENFORCE_EQ(
       state_ == TracerState::READY,
       true,
-      phi::errors::PreconditionNotMet("Tracer must be READY or STOPPED"));
+      common::errors::PreconditionNotMet("Tracer must be READY or STOPPED"));
 #ifdef PADDLE_WITH_XPTI
   XPTI_CALL(phi::dynload::xptiStartTracing());
 #endif
@@ -62,9 +62,10 @@ void XPUTracer::StartTracing() {
 }
 
 void XPUTracer::StopTracing() {
-  PADDLE_ENFORCE_EQ(state_,
-                    TracerState::STARTED,
-                    phi::errors::PreconditionNotMet("Tracer must be STARTED"));
+  PADDLE_ENFORCE_EQ(
+      state_,
+      TracerState::STARTED,
+      common::errors::PreconditionNotMet("Tracer must be STARTED"));
 #ifdef PADDLE_WITH_XPTI
   XPTI_CALL(phi::dynload::xptiStopTracing());
   XPTI_CALL(phi::dynload::xptiActivityDisable());
@@ -155,9 +156,10 @@ void AddMemcpyRecord(const baidu::xpu::xpti::XPTIEventMem* memcpy,
 #endif
 
 void XPUTracer::CollectTraceData(TraceEventCollector* collector) {
-  PADDLE_ENFORCE_EQ(state_,
-                    TracerState::STOPED,
-                    phi::errors::PreconditionNotMet("Tracer must be STOPED"));
+  PADDLE_ENFORCE_EQ(
+      state_,
+      TracerState::STOPED,
+      common::errors::PreconditionNotMet("Tracer must be STOPED"));
 #ifdef PADDLE_WITH_XPTI
   XPTI_CALL(phi::dynload::xptiActivityFlushAll());
   baidu::xpu::xpti::XPTIEvent* record = nullptr;

--- a/paddle/fluid/platform/profiler_helper.h
+++ b/paddle/fluid/platform/profiler_helper.h
@@ -625,7 +625,7 @@ void PrintProfiler(
     } else if (phi::ProfilerHelper::g_state == ProfilerState::kAll) {
       place = "All";
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Except profiler state must to be one of ['CPU', 'GPU' 'ALL'], but "
           "received Invalid profiler state."));
     }

--- a/paddle/fluid/platform/resource_pool.h
+++ b/paddle/fluid/platform/resource_pool.h
@@ -61,7 +61,7 @@ class ResourcePool : public std::enable_shared_from_this<ResourcePool<T>> {
     if (instances_.empty()) {
       obj = creator_();
       PADDLE_ENFORCE_NOT_NULL(obj,
-                              phi::errors::PermissionDenied(
+                              common::errors::PermissionDenied(
                                   "The creator should not return nullptr."));
       VLOG(10) << "Create new instance " << TypePtrName();
     } else {

--- a/paddle/fluid/platform/tensorrt/engine.cc
+++ b/paddle/fluid/platform/tensorrt/engine.cc
@@ -48,7 +48,7 @@ void TensorRTEngine::Weight::SetDataType(phi::DataType type) {
       break;
 #endif
     default:
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Paddle-TRT loads weights failed, found not supported data type %s.",
           type);
       break;
@@ -75,7 +75,7 @@ nvinfer1::IExecutionContext *TensorRTEngine::context() {
   if (infer_context_.find(predictor_id_per_thread) == infer_context_.end()) {
     PADDLE_ENFORCE_NOT_NULL(
         infer_engine_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "You should build engine first and then set the context."));
     // We may see trt warning: Profile 0 has been chosen by another
     // IExecutionContext...
@@ -89,7 +89,7 @@ nvinfer1::IExecutionContext *TensorRTEngine::context() {
     }
     PADDLE_ENFORCE_NOT_NULL(
         infer_context,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "TensorRT engine can not build execution context."));
     // need new profile if it's not the first
     if (cur_profile_num_ > 0) {
@@ -131,7 +131,7 @@ void TensorRTEngine::Execute(int batch_size,
     PADDLE_ENFORCE_EQ(
         ret,
         true,
-        phi::errors::PreconditionNotMet("Trt CudaGraph test run failed."));
+        common::errors::PreconditionNotMet("Trt CudaGraph test run failed."));
     cudaStreamSynchronize(stream);
 
     cuda_graph_.BeginCapture(stream);
@@ -194,11 +194,11 @@ void TensorRTEngine::FreezeNetwork() {
   FreshDeviceId();
   VLOG(3) << "TRT to freeze network";
   PADDLE_ENFORCE_NOT_NULL(infer_builder_,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Inference builder of TRT is null. Please make "
                               "sure you call InitNetwork first."));
   PADDLE_ENFORCE_NOT_NULL(network(),
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Call InitNetwork first to initialize network."));
 #if IS_TRT_VERSION_GE(8300)
   infer_builder_config_->setMemoryPoolLimit(
@@ -342,7 +342,7 @@ void TensorRTEngine::FreezeNetwork() {
                             max_shape_tensor().count(input_name) > 0 &&
                             optim_shape_tensor().count(input_name) > 0,
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Fail to find min/max/optim shape value for TRT "
                             "network's shape tensor input named %s.",
                             input_name));
@@ -403,8 +403,8 @@ void TensorRTEngine::FreezeNetwork() {
 
   PADDLE_ENFORCE_NOT_NULL(
       infer_engine_,
-      phi::errors::Fatal("Build TensorRT cuda engine failed! Please recheck "
-                         "you configurations related to paddle-TensorRT."));
+      common::errors::Fatal("Build TensorRT cuda engine failed! Please recheck "
+                            "you configurations related to paddle-TensorRT."));
 
 #if IS_TRT_VERSION_GE(10000)
   binding_num_ = infer_engine_->getNbIOTensors();
@@ -432,18 +432,18 @@ nvinfer1::ITensor *TensorRTEngine::DeclareInput(const std::string &name,
                                                 const nvinfer1::Dims &dims) {
   PADDLE_ENFORCE_EQ(network() != nullptr,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The TRT network should be initialized first."));
   auto *input = network()->addInput(name.c_str(), dtype, dims);
   PADDLE_ENFORCE_NOT_NULL(
       input,
-      phi::errors::InvalidArgument("Adding input %s failed in "
-                                   "TensorRT inference network. "
-                                   "Please recheck your input.",
-                                   name));
+      common::errors::InvalidArgument("Adding input %s failed in "
+                                      "TensorRT inference network. "
+                                      "Please recheck your input.",
+                                      name));
   PADDLE_ENFORCE_EQ(input->isNetworkInput(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input %s is not the input of TRT inference network. "
                         "Please recheck your input.",
                         name));
@@ -458,19 +458,19 @@ void TensorRTEngine::DeclareOutput(const nvinfer1::ILayer *layer,
   SetITensor(name, output);
   PADDLE_ENFORCE_NOT_NULL(
       output,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The output %s of TRT engine should not be null.", name));
   output->setName(name.c_str());
   PADDLE_ENFORCE_EQ(output->isNetworkInput(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The output %s of TRT engine should not be the input "
                         "of the network at the same time.",
                         name));
   network()->markOutput(*output);
   PADDLE_ENFORCE_EQ(output->isNetworkOutput(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The output %s of TRT engine should be the output "
                         "of the network.",
                         name));
@@ -480,12 +480,12 @@ void TensorRTEngine::DeclareOutput(const std::string &name) {
   auto *output = TensorRTEngine::GetITensor(name);
   PADDLE_ENFORCE_NOT_NULL(
       output,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The output %s of TRT engine should not be null.", name));
   output->setName(name.c_str());
   PADDLE_ENFORCE_EQ(output->isNetworkInput(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The output %s of TRT engine should not be the input "
                         "of the network at the same time.",
                         name));
@@ -503,12 +503,12 @@ void TensorRTEngine::DeleteITensor(const std::string &name,
                                    nvinfer1::ITensor *tensor) {
   PADDLE_ENFORCE_NOT_NULL(
       tensor,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Tensor named %s of TRT engine should not be null.", name));
   PADDLE_ENFORCE_EQ(
       true,
       itensor_map_.count(name),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Tensor named %s of TRT engine should not be null", name));
   itensor_map_.erase(name);
 }
@@ -517,12 +517,12 @@ void TensorRTEngine::SetITensor(const std::string &name,
                                 nvinfer1::ITensor *tensor) {
   PADDLE_ENFORCE_NOT_NULL(
       tensor,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Tensor named %s of TRT engine should not be null.", name));
   PADDLE_ENFORCE_EQ(
       0,
       itensor_map_.count(name),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Tensor named %s of TRT engine should not be duplicated", name));
   itensor_map_[name] = tensor;
 }
@@ -547,10 +547,10 @@ nvinfer1::ITensor *TensorRTEngine::ConvertWeight2ITensor(
   auto *var_v = scope_->FindVar(name);
   PADDLE_ENFORCE_NOT_NULL(
       var_v,
-      phi::errors::NotFound("You are converting a persistable weight to a "
-                            "tensor, but there is no "
-                            "persistable variable called %s in scope.",
-                            name));
+      common::errors::NotFound("You are converting a persistable weight to a "
+                               "tensor, but there is no "
+                               "persistable variable called %s in scope.",
+                               name));
   auto *var_t = var_v->GetMutable<phi::DenseTensor>();
   auto weight = this->GetTrtWeight(name, *var_t);
 
@@ -616,7 +616,7 @@ void TensorRTEngine::Deserialize(const std::string &engine_serialized_data) {
 
   PADDLE_ENFORCE_NOT_NULL(
       infer_engine_,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "Building TRT cuda engine failed when deserializing engine info. "
           "Please check:\n1. Your TRT serialization is generated and "
           "loaded "
@@ -651,7 +651,7 @@ TensorRTEngine::Weight TensorRTEngine::GetFp16TrtWeight(
   phi::CPUPlace cpu_place;
   PADDLE_ENFORCE_EQ(weight_map.count(name_with_suffix),
                     0,
-                    phi::errors::AlreadyExists(
+                    common::errors::AlreadyExists(
                         "The weight named %s is set into the weight map "
                         "twice in TRT OP converter.",
                         name_with_suffix));
@@ -725,7 +725,7 @@ TensorRTEngine::Weight TensorRTEngine::GetFp32TrtWeight(
   phi::CPUPlace cpu_place;
   PADDLE_ENFORCE_EQ(weight_map.count(name_with_suffix),
                     0,
-                    phi::errors::AlreadyExists(
+                    common::errors::AlreadyExists(
                         "The weight named %s is set into the weight map "
                         "twice in TRT OP converter.",
                         name_with_suffix));
@@ -798,7 +798,7 @@ TensorRTEngine::Weight TensorRTEngine::GetTrtWeight(
   phi::CPUPlace cpu_place;
   PADDLE_ENFORCE_EQ(weight_map.count(name_with_suffix),
                     0,
-                    phi::errors::AlreadyExists(
+                    common::errors::AlreadyExists(
                         "The weight named %s is set into the weight map "
                         "twice in TRT OP converter.",
                         name_with_suffix));
@@ -871,7 +871,7 @@ void TensorRTEngine::FreshDeviceId() {
   cudaGetDeviceCount(&count);
   PADDLE_ENFORCE_LT(device_id(),
                     count,
-                    phi::errors::OutOfRange(
+                    common::errors::OutOfRange(
                         "Device id %d exceeds the current device count: %d.",
                         device_id(),
                         count));

--- a/paddle/fluid/platform/tensorrt/engine.h
+++ b/paddle/fluid/platform/tensorrt/engine.h
@@ -79,15 +79,15 @@ class TrtCudaGraph {
     // be used.
     const auto ret = cudaStreamEndCapture(stream, &cuda_graph_);
     if (ret == cudaErrorStreamCaptureInvalidated) {
-      PADDLE_ENFORCE_EQ(
-          cuda_graph_ == nullptr,
-          true,
-          phi::errors::PreconditionNotMet("CudaGraph capture stream failed."));
+      PADDLE_ENFORCE_EQ(cuda_graph_ == nullptr,
+                        true,
+                        common::errors::PreconditionNotMet(
+                            "CudaGraph capture stream failed."));
     } else {
       PADDLE_ENFORCE_GPU_SUCCESS(ret);
-      PADDLE_ENFORCE_NOT_NULL(
-          cuda_graph_,
-          phi::errors::PreconditionNotMet("CudaGraph capture stream failed."));
+      PADDLE_ENFORCE_NOT_NULL(cuda_graph_,
+                              common::errors::PreconditionNotMet(
+                                  "CudaGraph capture stream failed."));
       PADDLE_ENFORCE_GPU_SUCCESS(cudaGraphDestroy(cuda_graph_));
       cuda_graph_ = nullptr;
     }
@@ -180,7 +180,7 @@ class TensorRTEngine {
   void ResetContext() {
     PADDLE_ENFORCE_NOT_NULL(
         infer_engine_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "You should build engine first and then set the context."));
     std::unique_lock<std::mutex> lock(mutex_);
     infer_context_[predictor_id_per_thread].reset(nullptr);
@@ -191,14 +191,14 @@ class TensorRTEngine {
   nvinfer1::IHostMemory* Serialize() {
     PADDLE_ENFORCE_NOT_NULL(
         infer_engine_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The TensorRT engine must be built first before serialization"));
 #if IS_TRT_VERSION_LT(8000)
     ihost_memory_.reset(infer_engine_->serialize());
 #else
     PADDLE_ENFORCE_NOT_NULL(
         ihost_memory_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "TensorRT >= 8.0 requires that buildSerializedNetwork is called"));
 #endif
     return ihost_memory_.get();
@@ -274,7 +274,7 @@ class TensorRTEngine {
     std::string name_with_suffix = w_name + splitter + suffix;
     PADDLE_ENFORCE_EQ(weight_map.count(name_with_suffix),
                       0,
-                      phi::errors::AlreadyExists(
+                      common::errors::AlreadyExists(
                           "The weight named %s is set into the weight map "
                           "twice in TRT OP converter.",
                           name_with_suffix));
@@ -341,7 +341,7 @@ class TensorRTEngine {
       } else {
         PADDLE_ENFORCE_EQ(params_.min_input_shape[name].size(),
                           input_shape.size(),
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "TRT dynamic_shape min_input_shape %s size not "
                               "equal, the min_input_shape[%s].size()=%d"
                               ", but the runtime_input_shape[%s].size()=%d.",
@@ -393,7 +393,7 @@ class TensorRTEngine {
       } else {
         PADDLE_ENFORCE_EQ(params_.min_shape_tensor[name].size(),
                           shape_tensor.size(),
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "TRT dynamic_shape min_shape_tensor %s size not "
                               "equal, the min_shape_tensor[%s].size()=%d"
                               ", but the runtime_shape_tensor[%s].size()=%d.",

--- a/paddle/fluid/platform/tensorrt/helper.h
+++ b/paddle/fluid/platform/tensorrt/helper.h
@@ -227,8 +227,8 @@ static inline nvinfer1::DataType PhiType2NvType(phi::DataType type) {
       break;
 #endif
     default:
-      phi::errors::InvalidArgument("phi::DataType not supported data type %s.",
-                                   type);
+      common::errors::InvalidArgument(
+          "phi::DataType not supported data type %s.", type);
       break;
   }
   return nv_type;
@@ -252,7 +252,7 @@ static TRT_DT FluidDataType2TRT(FluidDT type) {
 
 #endif
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "unsupported datatype in TRT op converter, type: %s. "
           "Boolean type is supported as TRT input/output "
           "using TensorRT v8.4+.",
@@ -268,7 +268,7 @@ static nvinfer1::Dims Vec2TRT_Dims(const std::vector<T>& shape,
                                    bool with_dynamic_shape = false) {
   PADDLE_ENFORCE_GE(shape.size(),
                     0UL,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TensorRT's tensor input requires at least 0 "
                         "dimensions, but input %s has %d dims.",
                         input,
@@ -290,7 +290,7 @@ static nvinfer1::Dims Vec2TRT_Dims(const std::vector<T>& shape,
   if (!with_dynamic_shape) {
     if (shape.size() == 4UL) {
       if (shape[2] == -1 || shape[3] == -1) {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "The input [%s] shape of trt subgraph is %s, please enable "
             "trt dynamic_shape mode by SetTRTDynamicShapeInfo.",
             input,
@@ -299,7 +299,7 @@ static nvinfer1::Dims Vec2TRT_Dims(const std::vector<T>& shape,
       return nvinfer1::Dims3(shape[1], shape[2], shape[3]);
     } else if (shape.size() == 5UL) {
       if (shape[2] == -1 || shape[3] == -1 || shape[4] == -1) {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "The input [%s] shape of trt subgraph is %s, please enable "
             "trt dynamic_shape mode by SetTRTDynamicShapeInfo.",
             input,
@@ -308,7 +308,7 @@ static nvinfer1::Dims Vec2TRT_Dims(const std::vector<T>& shape,
       return nvinfer1::Dims4(shape[1], shape[2], shape[3], shape[4]);
     } else if (shape.size() == 3UL) {
       if (shape[1] == -1 || shape[2] == -1) {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "The input [%s] shape of trt subgraph is %s, please enable "
             "trt dynamic_shape mode by SetTRTDynamicShapeInfo.",
             input,
@@ -317,7 +317,7 @@ static nvinfer1::Dims Vec2TRT_Dims(const std::vector<T>& shape,
       return nvinfer1::Dims2(shape[1], shape[2]);
     } else if (shape.size() == 2UL) {
       if (shape[1] == -1) {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "The input [%s] shape of trt subgraph is %s, please enable "
             "trt dynamic_shape mode by SetTRTDynamicShapeInfo.",
             input,
@@ -331,7 +331,7 @@ static nvinfer1::Dims Vec2TRT_Dims(const std::vector<T>& shape,
     // static shape doesn't support 1D op so far.
     PADDLE_ENFORCE_NE(shape.size(),
                       1UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input [%s] shape of trt subgraph is %s."
                           "it's not supported by trt so far",
                           input,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/66145#issuecomment-2249572051

Replace phi::errors to common::errors in paddle/fluid
