### PR TITLE
Replace phi::errors [fluid_ops] part9

### DIFF
--- a/paddle/fluid/inference/analysis/analyzer.cc
+++ b/paddle/fluid/inference/analysis/analyzer.cc
@@ -30,7 +30,7 @@ void Analyzer::Run(Argument *argument) { RunAnalysis(argument); }
 void Analyzer::RunAnalysis(Argument *argument) {
   PADDLE_ENFORCE_EQ(argument->analysis_passes_valid(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "analysis_passes is not valid in the argument."));
   const bool disable_logs = argument->disable_logs();
   for (auto &pass : argument->analysis_passes()) {
@@ -42,7 +42,7 @@ void Analyzer::RunAnalysis(Argument *argument) {
     auto *ptr = PassRegistry::Global().Retrieve(pass);
     PADDLE_ENFORCE_NOT_NULL(
         ptr,
-        phi::errors::PreconditionNotMet("no analysis pass called %s", pass));
+        common::errors::PreconditionNotMet("no analysis pass called %s", pass));
     ptr->Run(argument);
   }
 }

--- a/paddle/fluid/inference/analysis/argument.h
+++ b/paddle/fluid/inference/analysis/argument.h
@@ -74,42 +74,42 @@ struct Argument {
     }
   }
 
-#define DECL_ARGUMENT_FIELD(field__, Field, type__)                 \
- public:                                                            \
-  type__& field__() {                                               \
-    PADDLE_ENFORCE_EQ(                                              \
-        Has(#field__),                                              \
-        true,                                                       \
-        phi::errors::PreconditionNotMet("There is no such field")); \
-    return field__##_;                                              \
-  }                                                                 \
-  void Set##Field(const type__& x) {                                \
-    field__##_ = x;                                                 \
-    valid_fields_.insert(#field__);                                 \
-  }                                                                 \
-  DECL_ARGUMENT_FIELD_VALID(field__);                               \
-  type__* field__##_ptr() { return &field__##_; }                   \
-                                                                    \
- private:                                                           \
+#define DECL_ARGUMENT_FIELD(field__, Field, type__)                    \
+ public:                                                               \
+  type__& field__() {                                                  \
+    PADDLE_ENFORCE_EQ(                                                 \
+        Has(#field__),                                                 \
+        true,                                                          \
+        common::errors::PreconditionNotMet("There is no such field")); \
+    return field__##_;                                                 \
+  }                                                                    \
+  void Set##Field(const type__& x) {                                   \
+    field__##_ = x;                                                    \
+    valid_fields_.insert(#field__);                                    \
+  }                                                                    \
+  DECL_ARGUMENT_FIELD_VALID(field__);                                  \
+  type__* field__##_ptr() { return &field__##_; }                      \
+                                                                       \
+ private:                                                              \
   type__ field__##_;
 
-#define DECL_POINTER_ARGUMENT_FIELD(field__, Field, type__)         \
- public:                                                            \
-  type__& field__() {                                               \
-    PADDLE_ENFORCE_EQ(                                              \
-        Has(#field__),                                              \
-        true,                                                       \
-        phi::errors::PreconditionNotMet("There is no such field")); \
-    return field__##_;                                              \
-  }                                                                 \
-  void Set##Field(type__ x) {                                       \
-    field__##_ = x;                                                 \
-    valid_fields_.insert(#field__);                                 \
-  }                                                                 \
-  DECL_ARGUMENT_FIELD_VALID(field__);                               \
-  type__* field__##_ptr() { return &field__##_; }                   \
-                                                                    \
- private:                                                           \
+#define DECL_POINTER_ARGUMENT_FIELD(field__, Field, type__)            \
+ public:                                                               \
+  type__& field__() {                                                  \
+    PADDLE_ENFORCE_EQ(                                                 \
+        Has(#field__),                                                 \
+        true,                                                          \
+        common::errors::PreconditionNotMet("There is no such field")); \
+    return field__##_;                                                 \
+  }                                                                    \
+  void Set##Field(type__ x) {                                          \
+    field__##_ = x;                                                    \
+    valid_fields_.insert(#field__);                                    \
+  }                                                                    \
+  DECL_ARGUMENT_FIELD_VALID(field__);                                  \
+  type__* field__##_ptr() { return &field__##_; }                      \
+                                                                       \
+ private:                                                              \
   type__ field__##_;
 
 #define DECL_ARGUMENT_FIELD_VALID(field__) \
@@ -120,11 +120,11 @@ struct Argument {
   type__& field__() {                                                     \
     PADDLE_ENFORCE_NOT_NULL(                                              \
         field__##_,                                                       \
-        phi::errors::PreconditionNotMet("filed should not be null."));    \
+        common::errors::PreconditionNotMet("filed should not be null.")); \
     PADDLE_ENFORCE_EQ(                                                    \
         Has(#field__),                                                    \
         true,                                                             \
-        phi::errors::PreconditionNotMet("There is no such field"));       \
+        common::errors::PreconditionNotMet("There is no such field"));    \
     return *static_cast<type__*>(field__##_.get());                       \
   }                                                                       \
   void Set##Field(type__* x) {                                            \
@@ -141,14 +141,14 @@ struct Argument {
     PADDLE_ENFORCE_EQ(                                                    \
         Has(#field__),                                                    \
         true,                                                             \
-        phi::errors::PreconditionNotMet("There is no such field"));       \
+        common::errors::PreconditionNotMet("There is no such field"));    \
     return static_cast<type__*>(field__##_.get());                        \
   }                                                                       \
   type__* Release##Field() {                                              \
     PADDLE_ENFORCE_EQ(                                                    \
         Has(#field__),                                                    \
         true,                                                             \
-        phi::errors::PreconditionNotMet("There is no such field"));       \
+        common::errors::PreconditionNotMet("There is no such field"));    \
     valid_fields_.erase(#field__);                                        \
     return static_cast<type__*>(field__##_.release());                    \
   }                                                                       \
@@ -417,12 +417,12 @@ struct Argument {
   std::unordered_set<std::string> valid_fields_;
 };
 
-#define ARGUMENT_CHECK_FIELD(argument__, fieldname__)                          \
-  PADDLE_ENFORCE_EQ(                                                           \
-      argument__->Has(#fieldname__),                                           \
-      true,                                                                    \
-      phi::errors::PreconditionNotMet("the argument field [%s] should be set", \
-                                      #fieldname__));
+#define ARGUMENT_CHECK_FIELD(argument__, fieldname__) \
+  PADDLE_ENFORCE_EQ(                                  \
+      argument__->Has(#fieldname__),                  \
+      true,                                           \
+      common::errors::PreconditionNotMet(             \
+          "the argument field [%s] should be set", #fieldname__));
 
 }  // namespace analysis
 }  // namespace inference

--- a/paddle/fluid/inference/analysis/helper.h
+++ b/paddle/fluid/inference/analysis/helper.h
@@ -77,7 +77,7 @@ struct DataTypeNamer {
     PADDLE_ENFORCE_GT(
         dic_.count(x),
         0,
-        phi::errors::PreconditionNotMet("unknown type for representation"));
+        common::errors::PreconditionNotMet("unknown type for representation"));
     return dic_.at(x);
   }
 
@@ -85,7 +85,7 @@ struct DataTypeNamer {
     PADDLE_ENFORCE_GT(
         dic_.count(type),
         0,
-        phi::errors::PreconditionNotMet("unknown type for representation"));
+        common::errors::PreconditionNotMet("unknown type for representation"));
     return dic_.at(type);
   }
 
@@ -125,7 +125,7 @@ class OrderedRegistry {
   T *Register(const std::string &name, T *x) {
     PADDLE_ENFORCE_EQ(dic_.count(name),
                       0,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "There exists duplicate key [%s]", name));
     dic_[name] = elements_.size();
     elements_.emplace_back(std::unique_ptr<T>(x));
@@ -148,7 +148,7 @@ T &GetFromScope(const framework::Scope &scope, const std::string &name) {
   framework::Variable *var = scope.FindVar(name);
   PADDLE_ENFORCE_NOT_NULL(
       var,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The var which name is %s should not be nullptr.", name));
   return *var->GetMutable<T>();
 }
@@ -190,7 +190,7 @@ static void MakeDirIfNotExists(const std::string &path) {
     PADDLE_ENFORCE_NE(
         MKDIR(path.c_str()),
         -1,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Can not create optimize cache directory: %s, Make sure you "
             "have permission to write",
             path));

--- a/paddle/fluid/inference/analysis/ir_pass_manager.cc
+++ b/paddle/fluid/inference/analysis/ir_pass_manager.cc
@@ -202,7 +202,7 @@ void IRPassManager::CreatePasses(Argument *argument,
       PADDLE_ENFORCE_EQ(
           int8_valid,
           true,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "When you are in TRT INT8 mode, and load model from "
               "memory, you should set optim_cache_dir using "
               "config.SetOptimCacheDir()"));
@@ -210,7 +210,7 @@ void IRPassManager::CreatePasses(Argument *argument,
         PADDLE_ENFORCE_EQ(
             optim_cache_dir.empty(),
             false,
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "When you are using Paddle-TRT, and using load model "
                 "from memory, and also set the use_static to true. "
                 "you must set optim_cache_dir using "
@@ -222,7 +222,7 @@ void IRPassManager::CreatePasses(Argument *argument,
           PADDLE_ENFORCE_NE(
               MKDIR(optim_cache_dir.c_str()),
               -1,
-              phi::errors::PreconditionNotMet(
+              common::errors::PreconditionNotMet(
                   "Can not create optimize cache directory: %s, Make sure you "
                   "have permission to write",
                   optim_cache_dir));
@@ -309,7 +309,7 @@ void IRPassManager::CreatePasses(Argument *argument,
 
 std::unique_ptr<Graph> IRPassManager::Apply(std::unique_ptr<Graph> graph) {
   PADDLE_ENFORCE_NOT_NULL(
-      graph.get(), phi::errors::InvalidArgument("Graph cannot be null."));
+      graph.get(), common::errors::InvalidArgument("Graph cannot be null."));
   // Apply all the passes
   for (const auto &pass : passes_) {
     if (pass->Type() != "graph_viz_pass" && !disable_logs_) {

--- a/paddle/fluid/inference/analysis/ir_passes/subgraph_util.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/subgraph_util.cc
@@ -128,7 +128,7 @@ void RenameAndGetOutputs(
     auto arg_var_node = graph_var_map.find(graph_arg);
     PADDLE_ENFORCE_NE(arg_var_node,
                       graph_var_map.end(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Can not find %s in graph_var_map", graph_arg));
     auto *var_t = block_desc->Var(block_arg);
     var_t->SetShape(arg_var_node->second->Var()->GetShape());
@@ -143,9 +143,9 @@ void RenameAndGetOutputs(
     PADDLE_ENFORCE_EQ(
         correspond_node->Name(),
         op->type(),
-        phi::errors::PreconditionNotMet("We should get %s, but get %s",
-                                        op->type(),
-                                        correspond_node->Name()));
+        common::errors::PreconditionNotMet("We should get %s, but get %s",
+                                           op->type(),
+                                           correspond_node->Name()));
 
     std::unordered_map<std::string, size_t> var2id;
     std::unordered_map<std::string, framework::ir::Node *> in_vars;

--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -64,7 +64,7 @@ void OutputProcess(framework::ir::Graph *graph,
   } else if (precision == phi::DataType::FLOAT32) {
     return;
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "mixed_precision currently not supported dtype %d, we now only support "
         "fp16 and bf16.",
         static_cast<int>(precision)));
@@ -237,7 +237,7 @@ void analysis::TensorRtSubgraphPass::ApplyImpl(
               inference::tensorrt::TRTEngineManager>::Global()
               .Has(name),
           true,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "TRTEngineManager should has engine %s, but not found.", name));
       paddle::inference::Singleton<
           inference::tensorrt::TRTEngineManager>::Global()
@@ -305,7 +305,7 @@ std::string TensorRtSubgraphPass::CreateTensorRTOp(
   PADDLE_ENFORCE_EQ(
       subgraph.empty(),
       false,
-      phi::errors::PreconditionNotMet("The subgraph should not be empty."));
+      common::errors::PreconditionNotMet("The subgraph should not be empty."));
 
   framework::ProgramDesc *program_desc =
       Get<framework::ProgramDesc *>("program");
@@ -596,7 +596,7 @@ std::string TensorRtSubgraphPass::CreateTensorRTOp(
   for (auto name : output_names) {
     PADDLE_ENFORCE_NE(output_name_map.count(name),
                       0,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The output_name_map should have %s", name));
     output_mapping.push_back(output_name_map[name]);
     renamed_output_rank.push_back(origin_name_output_rank[name]);
@@ -626,12 +626,12 @@ std::string TensorRtSubgraphPass::CreateTensorRTOp(
   }
   PADDLE_ENFORCE_EQ(output_mapping.empty(),
                     false,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The output_mapping should not be empty."));
   PADDLE_ENFORCE_EQ(
       !block_desc.Proto()->vars().empty(),
       true,
-      phi::errors::PreconditionNotMet("the block has no var-desc"));
+      common::errors::PreconditionNotMet("the block has no var-desc"));
 
   // Get pass attrs.
   auto use_varseqlen = Get<bool>("use_varseqlen");

--- a/paddle/fluid/inference/analysis/pass_result_info.h
+++ b/paddle/fluid/inference/analysis/pass_result_info.h
@@ -48,7 +48,7 @@ class PassResultInfoForRuntime {
     PADDLE_ENFORCE_EQ(
         map.count(predictor_id) && map[predictor_id].count(pass_name),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Not find predictor_id %d and pass_name %s",
             predictor_id,
             pass_name));

--- a/paddle/fluid/inference/analysis/passes/convert_to_mixed_precision.cc
+++ b/paddle/fluid/inference/analysis/passes/convert_to_mixed_precision.cc
@@ -49,7 +49,7 @@ ConvertToMixedPrecisionPass::ConvertToMixedPrecisionPass(
     case phi::Backend::GPU:
       PADDLE_ENFORCE(mixed_precision_ == phi::DataType::FLOAT16 ||
                          mixed_precision_ == phi::DataType::BFLOAT16,
-                     phi::errors::InvalidArgument(
+                     common::errors::InvalidArgument(
                          "mixed_precision of %s currently only supported fp16 "
                          "and bf16, not support %s.",
                          experimental::BackendToString(backend_),
@@ -58,14 +58,14 @@ ConvertToMixedPrecisionPass::ConvertToMixedPrecisionPass(
     case phi::Backend::XPU:
     case phi::Backend::CUSTOM:
       PADDLE_ENFORCE(mixed_precision_ == phi::DataType::FLOAT16,
-                     phi::errors::InvalidArgument(
+                     common::errors::InvalidArgument(
                          "mixed_precision of %s currently only supported fp16 "
                          "and bf16, not support %s.",
                          experimental::BackendToString(backend_),
                          phi::DataTypeToString(mixed_precision_)));
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "mixed_precision currently not supported place GPU or XPU or CUSTOM, "
           "not support %s.",
           experimental::BackendToString(backend_)));

--- a/paddle/fluid/inference/analysis/passes/ir_analysis_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/ir_analysis_pass.cc
@@ -33,7 +33,7 @@ void IrAnalysisPass::RunImpl(Argument* argument) {
   PADDLE_ENFORCE_GT(
       graph->Nodes().size(),
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The graph nodes size should be greater than 0, but got 0"));
   argument->SetMainGraph(graph.release());
   CollectFusionStatis(argument);

--- a/paddle/fluid/inference/analysis/passes/ir_graph_build_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/ir_graph_build_pass.cc
@@ -36,7 +36,7 @@ void IrGraphBuildPass::RunImpl(Argument *argument) {
   PADDLE_ENFORCE_EQ(
       argument->use_gpu_valid(),
       true,
-      phi::errors::PreconditionNotMet("The use_gpu field should be valid"));
+      common::errors::PreconditionNotMet("The use_gpu field should be valid"));
 
   // The load program should run on the same device with the inference program,
   // so that the parameters will on the same device, or they will keep copying
@@ -59,7 +59,7 @@ void IrGraphBuildPass::RunImpl(Argument *argument) {
         argument->skip_load_params());
     argument->SetMainProgram(program.release());
   } else {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "either model_dir or (program path and parameter path) should be "
         "set."));
   }
@@ -67,9 +67,9 @@ void IrGraphBuildPass::RunImpl(Argument *argument) {
   auto graph = std::make_unique<framework::ir::Graph>(argument->main_program());
   argument->SetMainGraph(graph.release());
   auto *scope_ptr = argument->scope_ptr();
-  PADDLE_ENFORCE_NOT_NULL(
-      scope_ptr,
-      phi::errors::PreconditionNotMet("The scope ptr should not be nullptr."));
+  PADDLE_ENFORCE_NOT_NULL(scope_ptr,
+                          common::errors::PreconditionNotMet(
+                              "The scope ptr should not be nullptr."));
   argument->main_graph().SetNotOwned(framework::ir::kParamScopeAttr, scope_ptr);
 
 // ipu related

--- a/paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.cc
@@ -50,7 +50,7 @@ void IrParamsSyncAmongDevicesPass::CopyParamsToGpu(Argument *argument) {
 
   PADDLE_ENFORCE_EQ(argument->gpu_device_id_valid(),
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The gpu_device_id field should be valid"));
   phi::Place place = phi::GPUPlace(argument->gpu_device_id());
   auto *scope = argument->scope_ptr();
@@ -93,7 +93,7 @@ void IrParamsSyncAmongDevicesPass::CopyParamsToGpu(Argument *argument) {
       auto *var = scope->FindLocalVar(var_name);
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::PreconditionNotMet("The var should not be nullptr"));
+          common::errors::PreconditionNotMet("The var should not be nullptr"));
       if (var->IsType<phi::DenseTensor>()) {
         auto *t = var->GetMutable<phi::DenseTensor>();
         auto var_data_type = var_node->Var()->GetDataType();
@@ -121,7 +121,7 @@ void IrParamsSyncAmongDevicesPass::CopyParamsToCustomDevice(
     PADDLE_ENFORCE_EQ(
         FLAGS_custom_model_save_cpu,
         false,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "'FLAGS_custom_model_save_cpu = false' is only for the developers "
             "who have not completed custom device memory settings. Setting to "
             "true will make "
@@ -148,7 +148,8 @@ void IrParamsSyncAmongDevicesPass::CopyParamsToCustomDevice(
   for (auto &var_name : all_vars) {
     auto *var = scope->FindLocalVar(var_name);
     PADDLE_ENFORCE_NOT_NULL(
-        var, phi::errors::PreconditionNotMet("The var should not be nullptr"));
+        var,
+        common::errors::PreconditionNotMet("The var should not be nullptr"));
 
     if (var->IsType<phi::DenseTensor>()) {
       auto *t = var->GetMutable<phi::DenseTensor>();
@@ -171,7 +172,7 @@ void IrParamsSyncAmongDevicesPass::CopyParamsToXpu(Argument *argument) {
 
   PADDLE_ENFORCE_EQ(argument->xpu_device_id_valid(),
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The xpu_device_id field should be valid"));
 
   LOG(INFO) << "Sync params from CPU to XPU: "
@@ -210,7 +211,7 @@ void IrParamsSyncAmongDevicesPass::RunImpl(Argument *argument) {
   PADDLE_ENFORCE_EQ(
       argument->scope_valid(),
       true,
-      phi::errors::PreconditionNotMet("The scope field should be valid"));
+      common::errors::PreconditionNotMet("The scope field should be valid"));
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   if (argument->use_gpu_valid()) {
     CopyParamsToGpu(argument);

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -107,7 +107,7 @@ AnalysisConfig::AnalysisConfig(const std::string &prog_file_or_model_dir,
   PADDLE_ENFORCE_EQ(
       paddle::inference::IsFileExists(prog_file_),
       true,
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Cannot open file %s, please confirm whether the file is normal.",
           prog_file_));
 
@@ -155,7 +155,7 @@ void AnalysisConfig::EnableUseGpu(uint64_t memory_pool_init_size_mb,
     enable_gpu_mixed_ = true;
     mixed_precision_mode_ = precision_mode;
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The GPU inference currently only supports float32/float16/bfloat16 "
         "precision. Please check the parameters you specified in EnableUseGpu "
         "or enable_use_gpu function."));
@@ -181,7 +181,8 @@ void AnalysisConfig::Exp_EnableUseCutlass() {
 
 void AnalysisConfig::SetExecStream(void *stream) {
   PADDLE_ENFORCE_NOT_NULL(
-      stream, phi::errors::InvalidArgument("`stream` should not be nullptr"));
+      stream,
+      common::errors::InvalidArgument("`stream` should not be nullptr"));
   exec_stream_ = stream;
   use_external_stream_ = true;
   Update();
@@ -190,7 +191,7 @@ void AnalysisConfig::SetExecStream(void *stream) {
 void *AnalysisConfig::GetExecStream() const {
   PADDLE_ENFORCE_NOT_NULL(
       exec_stream_,
-      phi::errors::InvalidArgument("`stream` should not be nullptr"));
+      common::errors::InvalidArgument("`stream` should not be nullptr"));
   return exec_stream_;
 }
 
@@ -238,7 +239,7 @@ void AnalysisConfig::EnableXpu(int l3_size,
       transformer_encoder_adaptive_seqlen;
   Update();
 #else
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "To use XPU inference, please compile with option 'WITH_XPU' or "
       "'LITE_WITH_XPU' first."));
 #endif
@@ -247,7 +248,7 @@ void AnalysisConfig::EnableXpu(int l3_size,
 void AnalysisConfig::SetXpuDeviceId(int device_id) {
   PADDLE_ENFORCE_EQ(use_xpu_,
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Should call EnableXpu before SetXpuDeviceId."));
   xpu_config_.device_id = device_id;
   Update();
@@ -255,12 +256,12 @@ void AnalysisConfig::SetXpuDeviceId(int device_id) {
 
 void AnalysisConfig::SetXpuConfig(const XpuConfig &config) {
   PADDLE_ENFORCE(use_xpu_,
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Should call EnableXpu before SetXpuConfig."));
   PADDLE_ENFORCE_LE(
       config.l3_autotune_size,
       config.l3_size,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "l3_autotune_size(%zu) should be less than or equal to l3_size(%zu).",
           config.l3_autotune_size,
           config.l3_size));
@@ -283,7 +284,7 @@ void AnalysisConfig::EnableCustomDevice(const std::string &device_type,
     enable_custom_device_mixed_ = true;
     LOG(INFO) << "enable_custom_device_mixed_";
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The Paddle-CustomDevice inference currently only supports "
         "float32/float16/bfloat16 precision. Please check the parameters "
         "you specified in EnableCustomDevice function."));
@@ -346,7 +347,7 @@ void AnalysisConfig::LoadIpuConfig(const std::string &config_path) {
   PADDLE_ENFORCE_EQ(
       static_cast<bool>(fin.is_open()),
       true,
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Cannot open file %s, please confirm whether the file is normal.",
           config_path));
   std::string line;
@@ -391,8 +392,8 @@ void AnalysisConfig::LoadIpuConfig(const std::string &config_path) {
     };
 
     if (ipu_config_mapper_.find(key) == ipu_config_mapper_.end()) {
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("invalid key %s in IPU config: ", key));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "invalid key %s in IPU config: ", key));
     }
     switch (ipu_config_mapper_.at(key)) {
       case ipu_config_code::ipu_device_num:
@@ -429,8 +430,8 @@ void AnalysisConfig::LoadIpuConfig(const std::string &config_path) {
         ipu_enable_model_runtime_executor_ = string2bool(value);
         break;
       default:
-        PADDLE_THROW(
-            phi::errors::InvalidArgument("invalid key %s in IPU config", key));
+        PADDLE_THROW(common::errors::InvalidArgument(
+            "invalid key %s in IPU config", key));
         break;
     }
   }
@@ -611,7 +612,7 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   if (use_gpu_) {
     PADDLE_ENFORCE_EQ(use_xpu_,
                       false,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Only one choice can be made between CPU and XPU."));
     pass_builder_ = std::make_unique<GpuPassStrategy>(
         *static_cast<GpuPassStrategy *>(other.pass_builder()));
@@ -744,9 +745,9 @@ void AnalysisConfig::EnableMkldnnInt8(
 }
 
 MkldnnQuantizerConfig *AnalysisConfig::mkldnn_quantizer_config() const {
-  PADDLE_ENFORCE_NOT_NULL(
-      mkldnn_quantizer_config_,
-      phi::errors::PreconditionNotMet("MkldnnQuantizer was not enabled yet."));
+  PADDLE_ENFORCE_NOT_NULL(mkldnn_quantizer_config_,
+                          common::errors::PreconditionNotMet(
+                              "MkldnnQuantizer was not enabled yet."));
   return mkldnn_quantizer_config_.get();
 }
 
@@ -778,7 +779,7 @@ void AnalysisConfig::EnableTensorRtEngine(int64_t workspace_size,
 
   Update();
 #else
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "To use Paddle-TensorRT, please compile with TENSORRT first."));
 #endif
 }
@@ -799,18 +800,18 @@ void AnalysisConfig::EnableTensorRTMemoryOptim(bool engine_memory_sharing,
   PADDLE_ENFORCE_EQ(
       use_tensorrt_,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "To enable TensorRT memory optim, please call "
           "EnableTensorRtEngine or enable_tensorrt_engine first."));
   PADDLE_ENFORCE_GE(sharing_identifier,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The value of sharing_identifier must be greater "
                         "than or equal to 0."));
   if (!engine_memory_sharing) {
     PADDLE_ENFORCE_EQ(sharing_identifier,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The value of sharing_identifier must be equal to 0 "
                           "when engine_memory_sharing is false."));
   }
@@ -822,7 +823,7 @@ void AnalysisConfig::EnableLowPrecisionIO(bool x) {
   PADDLE_ENFORCE_EQ(
       enable_gpu_mixed_ || !x,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "To enable low precision io, please call EnableUseGPU() to specify "
           "precision mode as low precision."));
   enable_low_precision_io_ = x;
@@ -886,7 +887,7 @@ void AnalysisConfig::EnableVarseqlen() { trt_use_varseqlen_ = true; }
 void AnalysisConfig::SetTensorRtOptimizationLevel(int level) {
   PADDLE_ENFORCE(
       level >= 0 && level <= 5,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input level in SetTRTOptimizationLevel is invalid. The "
           "level must be in range [0, 5], but received level = %d (default "
           "level is 3).",
@@ -917,14 +918,14 @@ void AnalysisConfig::Update() {
       PADDLE_ENFORCE_EQ(
           use_gpu(),
           false,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Only one choice can be made between CPU and XPU."));
       pass_builder_ = std::make_unique<XpuPassStrategy>();
     } else if (use_custom_device()) {
       PADDLE_ENFORCE_EQ(
           use_gpu(),
           false,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Only one choice can be made between GPU and CustomDevice."));
       pass_builder_ = std::make_unique<CustomDevicePassStrategy>();
     } else {
@@ -943,7 +944,7 @@ void AnalysisConfig::Update() {
       PADDLE_ENFORCE_EQ(
           use_gpu(),
           false,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Only one choice can be made between CPU and XPU."));
       pass_builder_ = std::make_unique<XpuPassStrategy>(
           *static_cast<XpuPassStrategy *>(pass_builder_.get()));
@@ -951,7 +952,7 @@ void AnalysisConfig::Update() {
       PADDLE_ENFORCE_EQ(
           use_gpu(),
           false,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Only one choice can be made between GPU and CustomDevice."));
       pass_builder_ = std::make_unique<CustomDevicePassStrategy>(
           *static_cast<CustomDevicePassStrategy *>(pass_builder_.get()));
@@ -1071,25 +1072,25 @@ void AnalysisConfig::Update() {
 #if (defined PADDLE_WITH_XPU)
     PADDLE_ENFORCE_EQ(use_gpu_,
                       false,
-                      phi::errors::Unavailable(
+                      common::errors::Unavailable(
                           "Currently, XPU and GPU cannot be enabled in the "
                           "same analysis configuration."));
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "You tried to use an XPU device, but Paddle was not compiled "
         "with XPU-runtime."));
 #endif
   }
   if (use_ipu_) {
 #ifndef PADDLE_WITH_IPU
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "You tried to enable the ipu "
         "but did not have the option -DWITH_IPU compiled."));
 #endif
   }
   if (use_custom_device_) {
 #ifndef PADDLE_WITH_CUSTOM_DEVICE
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "You tried to enable the custom device "
         "but did not have the option -DWITH_CUSTOM_DEVICE compiled."));
 #endif
@@ -1475,7 +1476,7 @@ void AnalysisConfig::CollectShapeRangeInfo(
   collect_shape_range_info_ = true;
   PADDLE_ENFORCE_EQ(shape_range_info_path.empty(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The shape_range_info_path should not be empty, please "
                         "re-check the argument."));
   shape_range_info_path_ = shape_range_info_path;
@@ -1519,7 +1520,7 @@ void AnalysisConfig::EnableCINN() {
   use_cinn_ = true;
   Update();
 #else
-  PADDLE_THROW(phi::errors::Unavailable(
+  PADDLE_THROW(common::errors::Unavailable(
       "You tried to use CINN compiler, but Paddle was not compiled "
       "with CINN."));
 #endif

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -227,7 +227,7 @@ phi::DataType ConvertPrecision(AnalysisConfig::Precision precision) {
     case AnalysisConfig::Precision::kInt8:
       return phi::DataType::INT8;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Paddle Inference not support precision. We now only support "
           "Float32, Half, Bfloat16 and Int8"));
       return phi::DataType::FLOAT32;
@@ -248,7 +248,7 @@ phi::Backend ConvertBackend(paddle_infer::PlaceType backend) {
     case paddle_infer::PlaceType::kCUSTOM:
       return phi::Backend::CUSTOM;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Paddle Inference not support backend, we now only support GPU, XPU "
           "and CPU."));
       return phi::Backend::CPU;
@@ -282,16 +282,16 @@ bool PaddleTensorToDenseTensor(const PaddleTensor &pt,
   if (!has_zero_dim) {
     PADDLE_ENFORCE_NOT_NULL(
         input_ptr,
-        phi::errors::Fatal(
+        common::errors::Fatal(
             "Cannot convert to LoDTensor because LoDTensor creation failed."));
     PADDLE_ENFORCE_NOT_NULL(
         pt.data.data(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The data contained in the input PaddleTensor is illegal."));
     PADDLE_ENFORCE_EQ(
         pt.data.length(),
         t->numel() * phi::SizeOf(t->dtype()),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The data contained in the input PaddleTensor had wrong length."));
   }
 
@@ -306,13 +306,13 @@ bool PaddleTensorToDenseTensor(const PaddleTensor &pt,
     std::memcpy(
         static_cast<void *>(input_ptr), pt.data.data(), pt.data.length());
 #else
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "Not compile with WITH_IPU, should not reach here."));
 #endif
   } else if (phi::is_gpu_place(place)) {
     PADDLE_ENFORCE_EQ(phi::is_xpu_place(place),
                       false,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Only one choice can be made between CPU and XPU."));
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
@@ -326,7 +326,7 @@ bool PaddleTensorToDenseTensor(const PaddleTensor &pt,
                  dev_ctx->stream());
 #else
     PADDLE_THROW(
-        phi::errors::Fatal("Not compile with CUDA, should not reach here."));
+        common::errors::Fatal("Not compile with CUDA, should not reach here."));
 #endif
   } else if (phi::is_xpu_place(place)) {
 #ifdef PADDLE_WITH_XPU
@@ -338,7 +338,7 @@ bool PaddleTensorToDenseTensor(const PaddleTensor &pt,
                  pt.data.length());
 #else
     PADDLE_THROW(
-        phi::errors::Fatal("Not compile with XPU, should not reach here."));
+        common::errors::Fatal("Not compile with XPU, should not reach here."));
 #endif
   } else if (phi::is_custom_place(place)) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
@@ -353,11 +353,11 @@ bool PaddleTensorToDenseTensor(const PaddleTensor &pt,
                  pt.data.length(),
                  dev_ctx->stream());
 #else
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "Not compile with CUSTOM_DEVICE, should not reach here."));
 #endif
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The analysis predictor supports CPU, GPU, XPU and CUSTOM_DEVICE "
         "now."));
   }
@@ -418,7 +418,7 @@ AnalysisPredictor::AnalysisPredictor(const AnalysisConfig &config)
     PADDLE_ENFORCE_EQ(
         config_.new_executor_enabled(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Please call the config.enable_new_executor() in python or "
             "config.EnableNewExecutor() in c++ when you want share the engine "
             "context memory of multiple predictors."));
@@ -453,7 +453,7 @@ bool AnalysisPredictor::Init(
     PADDLE_ENFORCE_EQ(
         FLAGS_enable_pir_api || (config_.use_pir_ && config_.use_new_executor_),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Models with a .json suffix can only run in PIR mode. Please set "
             "export FLAGS_enable_pir_api=True or "
             "config.EnableNewExecutor(true)) and config.EnableNewIR(true)"));
@@ -562,7 +562,7 @@ void AnalysisPredictor::InitPlace() {
   if (config_.use_gpu()) {
     PADDLE_ENFORCE_EQ(config_.use_xpu(),
                       false,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Only one choice can be made between CPU and XPU."));
     place_ = phi::GPUPlace(config_.gpu_device_id());
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
@@ -576,7 +576,7 @@ void AnalysisPredictor::InitPlace() {
     phi::backends::xpu::SetXPUDeviceId(config_.xpu_device_id());
     place_ = phi::XPUPlace(config_.xpu_device_id());
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "You tried to use XPU forward propagation (inference without lite "
         "engine), but Paddle was not compiled "
         "with WITH_XPU."));
@@ -585,7 +585,7 @@ void AnalysisPredictor::InitPlace() {
 #ifdef PADDLE_WITH_IPU
     place_ = phi::IPUPlace();
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "You tried to use IPU forward propagation, but Paddle was not compiled "
         "with WITH_IPU."));
 #endif
@@ -594,7 +594,7 @@ void AnalysisPredictor::InitPlace() {
     place_ = phi::CustomPlace(config_.custom_device_type(),
                               config_.custom_device_id());
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "You tried to use CustomDevice forward propagation, but Paddle was not "
         "compiled "
         "with WITH_CUSTOM_DEVICE."));
@@ -611,7 +611,7 @@ std::string AnalysisPredictor::GetOptimizedModelPath() {
       PADDLE_ENFORCE_NE(
           MKDIR(model_opt_cache_dir.c_str()),
           -1,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "Can not create optimize cache directory: %s, Make sure you "
               "have permission to write",
               model_opt_cache_dir));
@@ -792,7 +792,7 @@ bool AnalysisPredictor::PrepareScope(
   if (parent_scope) {
     PADDLE_ENFORCE_NOT_NULL(
         parent_scope,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Both program and parent_scope should be set in Clone mode."));
     scope_ = parent_scope;
     status_is_cloned_ = true;
@@ -1087,7 +1087,7 @@ bool AnalysisPredictor::SaveOrLoadPirParameters(bool for_save) {
         phi::DataType type_data = paddle::dialect::TransToPhiDataType(type_);
         dev_ctx->Alloc(tensor_temp, type_data);
       } else {
-        PADDLE_THROW(phi::errors::Unavailable(
+        PADDLE_THROW(common::errors::Unavailable(
             "Only support parameter data of type DenseTensor."));
       }
     }
@@ -1114,9 +1114,10 @@ bool AnalysisPredictor::PreparePirProgram() {
   pir::IrContext *ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
 
-  PADDLE_ENFORCE_EQ(pir_program_,
-                    nullptr,
-                    phi::errors::Fatal("Here, pir_program must be a nullptr!"));
+  PADDLE_ENFORCE_EQ(
+      pir_program_,
+      nullptr,
+      common::errors::Fatal("Here, pir_program must be a nullptr!"));
 
   pir_program_ = std::make_shared<pir::Program>(pir::IrContext::Instance());
   pir::ReadModule(config_.prog_file(), pir_program_.get(), 1 /*pir_version*/);
@@ -1181,7 +1182,7 @@ bool AnalysisPredictor::PrepareProgram(
     PADDLE_ENFORCE_EQ(
         pir_program_,
         nullptr,
-        phi::errors::Fatal("Here, pir_program must be a nullptr!"));
+        common::errors::Fatal("Here, pir_program must be a nullptr!"));
     pir_program_ = paddle::TranslateLegacyProgramToProgram(*inference_program_);
     OptimizeInferencePirProgram();
   }
@@ -1233,16 +1234,16 @@ static void DisablePrepareDataOpt(
 }
 
 bool AnalysisPredictor::PrepareExecutor() {
-  PADDLE_ENFORCE_NOT_NULL(
-      sub_scope_,
-      phi::errors::PreconditionNotMet("The sub_scope should not be nullptr."));
+  PADDLE_ENFORCE_NOT_NULL(sub_scope_,
+                          common::errors::PreconditionNotMet(
+                              "The sub_scope should not be nullptr."));
 
   if (config_.dist_config().use_dist_model()) {
 #if defined(PADDLE_WITH_DISTRIBUTE) && defined(PADDLE_WITH_PSCORE)
     VLOG(3) << "use_dist_model is enabled, will init FleetExecutor.";
     return PrepareFleetExecutor();
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't use FleetExecutor since it's not compiled with PSCORE,"
         "Please recompile or reinstall Paddle with PSCORE support."));
 #endif
@@ -1504,7 +1505,7 @@ bool AnalysisPredictor::LoadConverterConfig(
   PADDLE_ENFORCE_EQ(
       static_cast<bool>(fin.is_open()),
       true,
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Cannot open file %s, please confirm whether the file is normal.",
           config_.dist_config().comm_init_config()));
   std::string line;
@@ -1657,7 +1658,7 @@ bool AnalysisPredictor::Run(const std::vector<PaddleTensor> &inputs,
   framework::Scope *scope = sub_scope_ ? sub_scope_ : scope_.get();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::PreconditionNotMet("The scope should not be nullptr."));
+      common::errors::PreconditionNotMet("The scope should not be nullptr."));
   if (!SetFeed(inputs, scope)) {
     LOG(ERROR) << "fail to set feed";
     return false;
@@ -1734,7 +1735,7 @@ bool AnalysisPredictor::Run(const std::vector<paddle::Tensor> &inputs,
   framework::Scope *scope = sub_scope_ ? sub_scope_ : scope_.get();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::PreconditionNotMet("The scope should not be nullptr."));
+      common::errors::PreconditionNotMet("The scope should not be nullptr."));
   if (!SetFeed(inputs, scope)) {
     LOG(ERROR) << "fail to set feed";
     return false;
@@ -1759,7 +1760,7 @@ bool AnalysisPredictor::Run(const std::vector<paddle::Tensor> &inputs,
   if (config_.use_xpu_) {
     PADDLE_ENFORCE(
         private_context_,
-        phi::errors::Fatal(
+        common::errors::Fatal(
             "Must use private context if run predictor on xpu place."));
     auto *dev_ctxs = reinterpret_cast<const std::map<
         phi::Place,
@@ -1862,14 +1863,14 @@ bool AnalysisPredictor::SetFeed(const std::vector<paddle::Tensor> &inputs,
   if (load_pir_model_) {
     PADDLE_ENFORCE_EQ(inputs.size(),
                       pir_feeds_.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "wrong feed input size, need %d but get %d.",
                           pir_feeds_.size(),
                           inputs.size()));
   } else {
     PADDLE_ENFORCE_EQ(inputs.size(),
                       feeds_.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "wrong feed input size, need %d but get %d.",
                           feeds_.size(),
                           inputs.size()));
@@ -1878,12 +1879,12 @@ bool AnalysisPredictor::SetFeed(const std::vector<paddle::Tensor> &inputs,
   for (const auto &input : inputs) {
     PADDLE_ENFORCE_EQ(input.defined(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input Tensor expected to be defined."));
     PADDLE_ENFORCE_EQ(
         input.is_dense_tensor(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input Tensor expected to be type of dense tensor."));
   }
 
@@ -1939,7 +1940,7 @@ bool AnalysisPredictor::GetFetch(std::vector<PaddleTensor> *outputs,
     PADDLE_ENFORCE_EQ(
         static_cast<size_t>(idx),
         i,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Fetch op's col attr(%d) should be equal to the index(%d)",
             idx,
             i));
@@ -2015,7 +2016,7 @@ void AnalysisPredictor::PrepareArgument() {
   } else {
     PADDLE_ENFORCE_EQ(config_.prog_file().empty(),
                       false,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Either model_dir or prog_file should be set."));
 
     argument_->SetModelProgramPath(config_.prog_file());
@@ -2255,7 +2256,7 @@ void AnalysisPredictor::OptimizeInferenceProgram() {
   PADDLE_ENFORCE_EQ(
       argument_->scope_valid(),
       true,
-      phi::errors::InvalidArgument("The argument scope should be valid."));
+      common::errors::InvalidArgument("The argument scope should be valid."));
   VLOG(5) << "to prepare executor";
   ARGUMENT_CHECK_FIELD((argument_.get()), ir_analyzed_program);
   inference_program_.reset(
@@ -2313,7 +2314,7 @@ CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kAnalysis>(
   PADDLE_ENFORCE_EQ(
       config.is_valid(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Note: Each config can only be used for one predictor."));
 
   // Register custom operators compiled by the user.
@@ -2329,7 +2330,7 @@ CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kAnalysis>(
       PADDLE_ENFORCE_EQ(
           success,
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Fail to set gflag: %s, please make sure the gflag exists.",
               name));
       VLOG(3) << "set gflag: --" << name << "=" << value;
@@ -2349,11 +2350,11 @@ CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kAnalysis>(
         PADDLE_ENFORCE_GE(
             config.memory_pool_init_size_mb(),
             0.f,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The size of memory pool should be greater than 0."));
         PADDLE_ENFORCE_GE(config.gpu_device_id(),
                           0,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Invalid device id (%d). The device id should be "
                               "greater than 0.",
                               config.gpu_device_id()));
@@ -2394,7 +2395,7 @@ CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kAnalysis>(
 
       if (config.thread_local_stream_enabled() &&
           process_level_allocator_enabled) {
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "When binding threads and streams, the use of "
             "process-level allocators will result in undefined result "
             "errors due to memory asynchronous operations."
@@ -2445,7 +2446,7 @@ void AnalysisPredictor::PrepareFeedFetch() {
   }
   PADDLE_ENFORCE_NOT_NULL(
       sub_scope_,
-      phi::errors::InvalidArgument("The sub_scope should not be nullptr."));
+      common::errors::InvalidArgument("The sub_scope should not be nullptr."));
   CreateFeedFetchVar(sub_scope_);
   for (auto *op : inference_program_->Block(0).AllOps()) {
     if (op->Type() == framework::kFeedOpType) {
@@ -2469,7 +2470,8 @@ void AnalysisPredictor::PrepareFeedFetch() {
 
 void AnalysisPredictor::CreateFeedFetchVar(framework::Scope *scope) {
   PADDLE_ENFORCE_NOT_NULL(
-      scope, phi::errors::InvalidArgument("The scope should not be nullptr."));
+      scope,
+      common::errors::InvalidArgument("The scope should not be nullptr."));
   auto *var = scope->Var(framework::kFeedOpType);
   var->GetMutable<framework::FeedList>();
   var = scope->Var(framework::kFetchOpType);
@@ -2491,7 +2493,8 @@ AnalysisPredictor::GetInputTensorShape() {
   for (std::string const &name : names) {
     auto *var = inference_program_->Block(0).FindVar(name);
     PADDLE_ENFORCE_NOT_NULL(
-        var, phi::errors::PreconditionNotMet("Input %s does not exist.", name));
+        var,
+        common::errors::PreconditionNotMet("Input %s does not exist.", name));
     input_shapes[name] = var->GetShape();
   }
   return input_shapes;
@@ -2505,7 +2508,7 @@ AnalysisPredictor::GetInputTypes() {
     auto *var = inference_program_->Block(0).FindVar(name);
     PADDLE_ENFORCE_NOT_NULL(
         var,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Input %s does not exist inference_program_.", name));
     auto dtype = var->GetDataType();
     if (dtype == paddle::framework::proto::VarType::FP32) {
@@ -2527,7 +2530,7 @@ AnalysisPredictor::GetInputTypes() {
     } else if (dtype == paddle::framework::proto::VarType::BOOL) {
       input_type[name] = paddle_infer::DataType::BOOL;
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported data type `%s` when get input dtype ", dtype));
     }
   }
@@ -2550,7 +2553,7 @@ AnalysisPredictor::GetOutputTensorShape() {
     auto *var = inference_program_->Block(0).FindVar(name);
     PADDLE_ENFORCE_NOT_NULL(
         var,
-        phi::errors::PreconditionNotMet("Output %s does not exist.", name));
+        common::errors::PreconditionNotMet("Output %s does not exist.", name));
     output_shapes[name] = var->GetShape();
   }
   return output_shapes;
@@ -2564,7 +2567,7 @@ AnalysisPredictor::GetOutputTypes() {
     auto *var = inference_program_->Block(0).FindVar(name);
     PADDLE_ENFORCE_NOT_NULL(
         var,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Output %s does not exist inference_program_.", name));
     auto dtype = var->GetDataType();
     if (dtype == paddle::framework::proto::VarType::FP32) {
@@ -2582,7 +2585,7 @@ AnalysisPredictor::GetOutputTypes() {
     } else if (dtype == paddle::framework::proto::VarType::INT8) {
       output_type[name] = paddle_infer::DataType::INT8;
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported data type `%s` when get output dtype ", dtype));
     }
   }
@@ -2603,7 +2606,7 @@ std::unique_ptr<ZeroCopyTensor> AnalysisPredictor::GetInputTensor(
 #endif
   PADDLE_ENFORCE_NOT_NULL(
       scope->FindVar(name),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The variable named %s is not found in the scope of the executor.",
           name));
   std::unique_ptr<ZeroCopyTensor> res(new ZeroCopyTensor(
@@ -2645,7 +2648,7 @@ std::unique_ptr<ZeroCopyTensor> AnalysisPredictor::GetOutputTensor(
 #endif
   PADDLE_ENFORCE_NOT_NULL(
       scope->FindVar(name),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The variable named %s is not found in the scope of the executor.",
           name));
   std::unique_ptr<ZeroCopyTensor> res(new ZeroCopyTensor(
@@ -2723,7 +2726,7 @@ bool AnalysisPredictor::ZeroCopyRun(bool switch_stream) {
   if (config_.use_xpu_) {
     PADDLE_ENFORCE(
         private_context_,
-        phi::errors::Fatal(
+        common::errors::Fatal(
             "Must use private context if run predictor on xpu place."));
     auto *dev_ctxs = reinterpret_cast<const std::map<
         phi::Place,
@@ -2794,7 +2797,7 @@ bool AnalysisPredictor::ZeroCopyRun(bool switch_stream) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 bool AnalysisPredictor::ExpRunWithExternalStream(const gpuStream_t stream) {
   if (!private_context_) {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "Please use config.SetExecStream to init gpu resources, and then we "
         "will bind gpu resources to execution stream."));
   }
@@ -2868,7 +2871,7 @@ void AnalysisPredictor::HookCollectShapeRangeInfo() {
       // This must be a zero dimension tensor.
       PADDLE_ENFORCE_EQ(tensor->numel(),
                         1UL,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "This tensor must have one element, but got %ld.",
                             tensor->numel()));
       std::vector<int32_t> zero_shape(1, 1);
@@ -2942,7 +2945,7 @@ bool AnalysisPredictor::ExpRunWithRuntimeConfig(void *config) {
   PADDLE_ENFORCE_LE(
       l3_autotune_size,
       l3_size,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "l3_autotune_size(%zu) should be less than or equal to l3_size(%zu).",
           l3_autotune_size,
           l3_size));
@@ -3048,7 +3051,7 @@ bool AnalysisPredictor::LoadProgramDesc() {
     PADDLE_ENFORCE_EQ(
         static_cast<bool>(fin.is_open()),
         true,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Cannot open file %s, please confirm whether the file is normal.",
             filename));
     fin.seekg(0, std::ios::end);
@@ -3067,7 +3070,7 @@ bool AnalysisPredictor::LoadProgramDesc() {
 
 bool AnalysisPredictor::LoadParameters() {
   PADDLE_ENFORCE_NOT_NULL(inference_program_.get(),
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "The inference program should be loaded first."));
 
   const auto &global_block = inference_program_->MutableBlock(0);
@@ -3134,7 +3137,7 @@ uint64_t AnalysisPredictor::TryShrinkMemory() {
 
 void AnalysisPredictor::ClearIntermediateTensor() {
   PADDLE_ENFORCE_NOT_NULL(inference_program_.get(),
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "The inference program should be loaded first."));
   const auto &global_block = inference_program_->MutableBlock(0);
   for (auto *var : global_block->AllVars()) {
@@ -3156,7 +3159,7 @@ using inference::Singleton;
 bool AnalysisPredictor::SaveTrtCalibToDisk() {
   PADDLE_ENFORCE_EQ(config_.tensorrt_engine_enabled(),
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "This func can be invoked only in trt mode"));
   auto &block = inference_program_->Block(0);
   for (auto &op_desc : block.AllOps()) {
@@ -3270,11 +3273,11 @@ std::unique_ptr<PaddlePredictor> AnalysisPredictor::Clone(void *stream) {
   x->root_predictor_id_ = this->root_predictor_id_;
   x->config_.apply_optim_ = false;
   if (config_.use_external_stream_ && stream == nullptr) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "config has been configured to use external stream, but the Clone "
         "function has not received a valid stream parameter."));
   } else if (!config_.use_external_stream_ && stream != nullptr) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "config has not been configured to use external stream, but the Clone "
         "function has received a stream parameter."));
   }
@@ -3801,7 +3804,7 @@ PredictorPool::PredictorPool(const Config &config, size_t size) : preds_() {
   PADDLE_ENFORCE_GE(
       size,
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The predictor pool size should be greater than 1, but it's (%d)",
           size));
   Config copy_config(config);
@@ -3820,7 +3823,7 @@ Predictor *PredictorPool::Retrieve(size_t idx) {
   PADDLE_ENFORCE_LT(
       idx,
       preds_.size() + 1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "There are (%d) predictors in the pool, but the idx is (%d)",
           idx,
           preds_.size() + 1));

--- a/paddle/fluid/inference/api/api.cc
+++ b/paddle/fluid/inference/api/api.cc
@@ -66,7 +66,7 @@ PaddleBuf &PaddleBuf::operator=(const PaddleBuf &other) {
     if (other.length() && other.data())
       memcpy(data_, other.data(), other.length());
     else if (other.length())
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Invalid argument, null pointer data with length %u is passed",
           other.length()));
 
@@ -96,7 +96,7 @@ void PaddleBuf::Resize(size_t length) {
     length_ = length;
     memory_owned_ = true;
   } else {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "The memory is allocated externally, can not Resized"));
   }
 }
@@ -113,7 +113,7 @@ void PaddleBuf::Free() {
     PADDLE_ENFORCE_GT(
         length_,
         0UL,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The memory used in PaddleBuf %d should be greater than 0",
             length_));
     delete[] static_cast<char *>(data_);
@@ -146,7 +146,7 @@ void UpdateDllFlag(const char *name, const char *value) {
   PADDLE_ENFORCE_EQ(
       success,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Fail to update flag: %s, please make sure the flag exists.", name));
 }
 

--- a/paddle/fluid/inference/api/api_impl.cc
+++ b/paddle/fluid/inference/api/api_impl.cc
@@ -77,7 +77,7 @@ bool NativePaddlePredictor::Init(
   if (config_.use_gpu) {
     PADDLE_ENFORCE_EQ(config_.use_xpu,
                       false,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Only one choice can be made between CPU and XPU."));
     place_ = phi::GPUPlace(config_.device);
   } else if (config_.use_xpu) {
@@ -89,7 +89,7 @@ bool NativePaddlePredictor::Init(
     scope_ = parent_scope;
     sub_scope_ = &(parent_scope->NewScope());
     PADDLE_ENFORCE_NOT_NULL(sub_scope_,
-                            phi::errors::PreconditionNotMet(
+                            common::errors::PreconditionNotMet(
                                 "The sub_scope should not be nullptr."));
   } else {
     paddle::framework::InitMemoryMethod();
@@ -190,7 +190,7 @@ std::unique_ptr<PaddlePredictor> NativePaddlePredictor::Clone(void *stream) {
   // TODO(Superjomn) re-implement a real clone here.
   PADDLE_ENFORCE_NOT_NULL(
       dynamic_cast<NativePaddlePredictor *>(cls.get()),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Dynamic_cast from PaddlePredictor to NativePaddlePredictor failed"));
   if (!dynamic_cast<NativePaddlePredictor *>(cls.get())->Init(nullptr)) {
     LOG(ERROR) << "fail to call Init";
@@ -228,17 +228,17 @@ bool NativePaddlePredictor::SetFeed(const std::vector<PaddleTensor> &inputs,
       return false;
     }
 
-    PADDLE_ENFORCE_NOT_NULL(
-        input_ptr,
-        phi::errors::InvalidArgument("The input_ptr should not be nullptr."));
+    PADDLE_ENFORCE_NOT_NULL(input_ptr,
+                            common::errors::InvalidArgument(
+                                "The input_ptr should not be nullptr."));
     PADDLE_ENFORCE_NOT_NULL(
         inputs[i].data.data(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The data of input tensor should not be null."));
     PADDLE_ENFORCE_EQ(
         inputs[i].data.length(),
         input.numel() * phi::SizeOf(input.dtype()),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The data contained in the input PaddleTensor had wrong length."));
 
     if (phi::is_cpu_place(place_)) {
@@ -250,7 +250,7 @@ bool NativePaddlePredictor::SetFeed(const std::vector<PaddleTensor> &inputs,
       PADDLE_ENFORCE_EQ(
           phi::is_xpu_place(place_),
           false,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Only one choice can be made between CPU and XPU."));
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
       phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
@@ -263,7 +263,7 @@ bool NativePaddlePredictor::SetFeed(const std::vector<PaddleTensor> &inputs,
                    inputs[i].data.length(),
                    dev_ctx->stream());
 #else
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Not compile with CUDA, should not reach here."));
 #endif
     } else if (phi::is_xpu_place(place_)) {
@@ -275,7 +275,7 @@ bool NativePaddlePredictor::SetFeed(const std::vector<PaddleTensor> &inputs,
                    inputs[i].data.data(),
                    inputs[i].data.length());
 #else
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Not compile with XPU, should not reach here."));
 #endif
     }
@@ -325,7 +325,7 @@ bool NativePaddlePredictor::GetFetch(std::vector<PaddleTensor> *outputs,
     PADDLE_ENFORCE_EQ(
         static_cast<size_t>(idx),
         i,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Fetch op's col attr(%d) should be equal to the index(%d)",
             idx,
             i));
@@ -362,12 +362,12 @@ CreatePaddlePredictor<NativeConfig, PaddleEngineKind::kNative>(
     // 1. GPU memory
     PADDLE_ENFORCE_GE(config.fraction_of_gpu_memory,
                       0.f,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "fraction_of_gpu_memory in the config should be set "
                           "to range (0., 1.]"));
     PADDLE_ENFORCE_GE(config.device,
                       0,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Invalid device id %d, the device id should be "
                           "greater than or equal to 0.",
                           config.device));
@@ -385,7 +385,7 @@ CreatePaddlePredictor<NativeConfig, PaddleEngineKind::kNative>(
   std::unique_ptr<PaddlePredictor> predictor(new NativePaddlePredictor(config));
   PADDLE_ENFORCE_NOT_NULL(
       dynamic_cast<NativePaddlePredictor *>(predictor.get()),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Dynamic_cast from PaddlePredictor to NativePaddlePredictor failed"));
   if (!dynamic_cast<NativePaddlePredictor *>(predictor.get())->Init(nullptr)) {
     return nullptr;

--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -45,18 +45,18 @@ void Tensor::Reshape(const std::vector<int> &shape) {
   PADDLE_ENFORCE_EQ(
       name_.empty(),
       false,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Need to SetName first, so that the corresponding tensor can "
           "be retrieved."));
   PADDLE_ENFORCE_EQ(input_or_output_,
                     true,
-                    phi::errors::PermissionDenied(
+                    common::errors::PermissionDenied(
                         "Can't reshape the output tensor, it is readonly"));
   auto *scope = static_cast<paddle::framework::Scope *>(scope_);
   auto *var = scope->FindVar(name_);
   PADDLE_ENFORCE_NOT_NULL(
       var,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "No tensor called [%s] in the runtime scope", name_));
   auto *tensor = var->GetMutable<phi::DenseTensor>();
   tensor->Resize(common::make_ddim(shape));
@@ -66,18 +66,18 @@ void Tensor::ReshapeStrings(const size_t &shape) {
   PADDLE_ENFORCE_EQ(
       name_.empty(),
       false,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Need to SetName first, so that the corresponding tensor can "
           "be retrieved."));
   PADDLE_ENFORCE_EQ(input_or_output_,
                     true,
-                    phi::errors::PermissionDenied(
+                    common::errors::PermissionDenied(
                         "Can't reshape the output tensor, it is readonly"));
   auto *scope = static_cast<paddle::framework::Scope *>(scope_);
   auto *var = scope->FindVar(name_);
   PADDLE_ENFORCE_NOT_NULL(
       var,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "No tensor called [%s] in the runtime scope", name_));
   paddle::framework::Strings *tensor =
       var->GetMutable<paddle::framework::Strings>();
@@ -101,7 +101,7 @@ T *Tensor::mutable_data(PlaceType place) {
   PADDLE_ENFORCE_GT(
       tensor->numel(),
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "You should call Tensor::Reshape(const std::vector<int> "
           "&shape)"
           "function before retrieving mutable_data from input tensor."));
@@ -130,7 +130,7 @@ T *Tensor::mutable_data(PlaceType place) {
       return tensor->mutable_data<T>(phi::CustomPlace(device_type_, device_));
     }
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Only CPU / CUDA / XPU places is supported. The place `%d` is "
           "not supported.",
           static_cast<int>(place)));
@@ -197,7 +197,7 @@ void Tensor::CopyFromCpu(const T *data) {
   EAGER_GET_TENSOR(phi::DenseTensor);
   PADDLE_ENFORCE_GE(tensor->numel(),
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "You should call Tensor::Reshape(const "
                         "std::vector<int> &shape)"
                         "function before copying data from cpu."));
@@ -225,7 +225,7 @@ void Tensor::CopyFromCpu(const T *data) {
                          ele_size,
                          dev_ctx->stream());
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Can not create tensor with CUDA place because paddle is not compiled "
         "with CUDA."));
 #endif
@@ -239,7 +239,7 @@ void Tensor::CopyFromCpu(const T *data) {
                          data,
                          ele_size);
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Can not create tensor with XPU place because paddle is not compiled "
         "with XPU."));
 #endif
@@ -257,13 +257,13 @@ void Tensor::CopyFromCpu(const T *data) {
                          ele_size,
                          dev_ctx->stream());
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Can not create tensor with Custom place because paddle is not "
         "compiled "
         "with XPU."));
 #endif
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The analysis predictor supports CPU, GPU, XPU and CUSTOM_DEVICE "
         "now."));
   }
@@ -321,7 +321,7 @@ phi::DataLayout LayoutConvert(DataLayout layout) {
   PADDLE_ENFORCE_EQ(
       layout,
       DataLayout::kNCHW,
-      phi::errors::InvalidArgument("Only NCHW is supported now."));
+      common::errors::InvalidArgument("Only NCHW is supported now."));
   return phi::DataLayout::NCHW;
 }
 
@@ -361,7 +361,7 @@ void Tensor::ShareExternalData(const T *data,
                              meta);
     *tensor = std::move(dtensor);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "PlaceType must be one of [PlaceType::kCPU, PlaceType::kGPU, "
         "PlaceType::kXPU]."));
   }
@@ -371,7 +371,7 @@ void Tensor::CopyStringsFromCpu(const paddle_infer::Strings *data) {
   EAGER_GET_TENSOR(paddle::framework::Strings);
   PADDLE_ENFORCE_GE(tensor->size(),
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "You should call Tensor::Reshape(const "
                         "std::size_t &shape)function before copying"
                         "the string data from cpu."));
@@ -413,7 +413,7 @@ void Tensor::CopyToCpuImpl(T *data,
 #ifdef PADDLE_WITH_IPU
     std::memcpy(static_cast<void *>(data), t_data, ele_num * sizeof(T));
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Can not create tensor with IPU place because paddle is not compiled "
         "with IPU."));
 #endif
@@ -447,7 +447,7 @@ void Tensor::CopyToCpuImpl(T *data,
     }
 #endif
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Can not create tensor with CUDA place because paddle is not compiled "
         "with CUDA."));
 #endif
@@ -460,7 +460,7 @@ void Tensor::CopyToCpuImpl(T *data,
                          t_data,
                          ele_num * sizeof(T));
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Can not create tensor with XPU place because paddle is not compiled "
         "with XPU."));
 #endif
@@ -478,7 +478,7 @@ void Tensor::CopyToCpuImpl(T *data,
                          dev_ctx->stream());
     dev_ctx->GetStream()->Synchronize();
 #else
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The analysis predictor supports CPU, GPU and XPU now."));
 #endif
   }
@@ -677,14 +677,14 @@ void *Tensor::FindTensor() const {
   PADDLE_ENFORCE_EQ(
       name_.empty(),
       false,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Need to SetName first, so that the corresponding tensor can "
           "be retrieved."));
   auto *scope = static_cast<paddle::framework::Scope *>(scope_);
   auto *var = scope->FindVar(name_);
   PADDLE_ENFORCE_NOT_NULL(
       var,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "No tensor called [%s] in the runtime scope", name_));
   auto *tensor = var->GetMutable<T>();
   return tensor;
@@ -700,7 +700,7 @@ std::vector<int> Tensor::shape() const {
     } else {  // output handle
       auto binding = binding_.lock();
       PADDLE_ENFORCE_NOT_NULL(binding,
-                              phi::errors::PreconditionNotMet(
+                              common::errors::PreconditionNotMet(
                                   "output tensor [%s] no binding ptr", name_));
       std::vector<Ort::Value> outputs = binding->GetOutputValues();
       Ort::Value &value = outputs[idx_];
@@ -714,8 +714,8 @@ std::vector<int> Tensor::shape() const {
   EAGER_GET_TENSOR(phi::DenseTensor);
   PADDLE_ENFORCE_NOT_NULL(
       tensor_,
-      phi::errors::PreconditionNotMet("Not found tensor called %s in the scope",
-                                      name_));
+      common::errors::PreconditionNotMet(
+          "Not found tensor called %s in the scope", name_));
 // oneDNN may does layout transform internally, so need to reorder before
 // return
 #ifdef PADDLE_WITH_DNNL
@@ -787,7 +787,7 @@ template <typename T>
 T *Tensor::ORTGetMutableData() {
   auto binding = binding_.lock();
   PADDLE_ENFORCE_NOT_NULL(binding,
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "output tensor [%s] no binding ptr", name_));
   std::vector<Ort::Value> outputs = binding->GetOutputValues();
   Ort::Value &value = outputs[idx_];
@@ -798,7 +798,7 @@ template <typename T>
 void Tensor::ORTCopyToCpu(T *data) const {
   auto binding = binding_.lock();
   PADDLE_ENFORCE_NOT_NULL(binding,
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "output tensor [%s] no binding ptr", name_));
   std::vector<Ort::Value> outputs = binding->GetOutputValues();
   Ort::Value &value = outputs[idx_];
@@ -808,7 +808,7 @@ void Tensor::ORTCopyToCpu(T *data) const {
   if (place_ == PlaceType::kCPU) {
     std::memcpy(static_cast<void *>(data), value.GetTensorData<void *>(), size);
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "CopyToCpu error.The current ONNXRuntime backend doesn't support "
         "GPU."));
   }
@@ -831,14 +831,14 @@ void InternalUtils::CopyFromCpuWithIoStream(paddle_infer::Tensor *t,
     PADDLE_ENFORCE_EQ(
         t->name_.empty(),
         false,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Need to SetName first, so that the corresponding tensor can "
             "be retrieved."));
     auto *scope = static_cast<paddle::framework::Scope *>(t->scope_);
     auto *var = scope->FindVar(t->name_);
     PADDLE_ENFORCE_NOT_NULL(
         var,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "No tensor called [%s] in the runtime scope", t->name_));
     auto *tensor = var->GetMutable<phi::DenseTensor>();
     t->tensor_ = tensor;
@@ -847,7 +847,7 @@ void InternalUtils::CopyFromCpuWithIoStream(paddle_infer::Tensor *t,
   auto *tensor = static_cast<phi::DenseTensor *>(t->tensor_);
   PADDLE_ENFORCE_GE(tensor->numel(),
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "You should call Tensor::Reshape(const "
                         "std::vector<int> &shape)"
                         "function before copying data from cpu."));
@@ -866,12 +866,12 @@ void InternalUtils::CopyFromCpuWithIoStream(paddle_infer::Tensor *t,
                          ele_size,
                          stream);
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Can not create tensor with CUDA place because paddle is not compiled "
         "with CUDA."));
 #endif
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "CopyFromCpuWithIoStream only supports CPU and GPU now."));
   }
 }
@@ -884,14 +884,14 @@ void InternalUtils::CopyToCpuWithIoStream(paddle_infer::Tensor *t,
     PADDLE_ENFORCE_EQ(
         t->name_.empty(),
         false,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Need to SetName first, so that the corresponding tensor can "
             "be retrieved."));
     auto *scope = static_cast<paddle::framework::Scope *>(t->scope_);
     auto *var = scope->FindVar(t->name_);
     PADDLE_ENFORCE_NOT_NULL(
         var,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "No tensor called [%s] in the runtime scope", t->name_));
     auto *tensor = var->GetMutable<phi::DenseTensor>();
     t->tensor_ = tensor;
@@ -932,12 +932,12 @@ void InternalUtils::CopyToCpuWithIoStream(paddle_infer::Tensor *t,
                          ele_num * sizeof(T),
                          stream);
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Can not create tensor with CUDA place because paddle is not compiled "
         "with CUDA."));
 #endif
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "CopyToCpuWithIoStream only supports CPU and GPU now."));
   }
 }

--- a/paddle/fluid/inference/api/helper.cc
+++ b/paddle/fluid/inference/api/helper.cc
@@ -103,7 +103,7 @@ void RegisterAllCustomOperator(bool use_pir) {
             PADDLE_ENFORCE_EQ(
                 meta_inputs.size(),
                 inputs.size(),
-                phi::errors::InvalidArgument(
+                common::errors::InvalidArgument(
                     "The number of inputs for the custom operator [%s] given "
                     "in the Pattern needs to be consistent with the number at "
                     "implementation time.",
@@ -111,7 +111,7 @@ void RegisterAllCustomOperator(bool use_pir) {
             PADDLE_ENFORCE_EQ(
                 meta_attrs.size(),
                 attrs.size(),
-                phi::errors::InvalidArgument(
+                common::errors::InvalidArgument(
                     "The number of attrs for the custom operator [%s] given "
                     "in the Pattern needs to be consistent with the number at "
                     "implementation time.",
@@ -162,7 +162,7 @@ void RegisterAllCustomOperator(bool use_pir) {
                 PADDLE_ENFORCE_EQ(
                     inputs[i].type().isa<::pir::VectorType>(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The [%d] input of the custom operator [%s] "
                         "should be a pir::VectorType.",
                         i,
@@ -204,7 +204,7 @@ void RegisterAllCustomOperator(bool use_pir) {
               auto attr_type = attr_name_and_type[1];
               PADDLE_ENFORCE_EQ(attrs.count(attr_name),
                                 true,
-                                phi::errors::InvalidArgument(
+                                common::errors::InvalidArgument(
                                     "The attr [%s] in the custom operator [%s] "
                                     "specified in the Pattern needs to be "
                                     "consistent with the implementation",
@@ -278,7 +278,7 @@ void RegisterAllCustomOperator(bool use_pir) {
                 }
                 custom_attrs.emplace_back(vec_string_attr);
               } else {
-                PADDLE_THROW(phi::errors::Unimplemented(
+                PADDLE_THROW(common::errors::Unimplemented(
                     "Unsupported `%s` type value as custom attribute now. "
                     "Supported data types include `bool`, `int`, `float`, "
                     "`int64_t`, `std::string`, `std::vector<int>`, "
@@ -315,7 +315,7 @@ void RegisterAllCustomOperator(bool use_pir) {
               if (paddle::framework::detail::IsDuplicableVar(output)) {
                 PADDLE_ENFORCE_NE(inplace_reverse_map.find(output),
                                   inplace_reverse_map.end(),
-                                  phi::errors::InvalidArgument(
+                                  common::errors::InvalidArgument(
                                       "Only support vector output that is set "
                                       "for inplace, Please use "
                                       "`SetInplaceMap` in your output when "
@@ -341,29 +341,29 @@ void RegisterAllCustomOperator(bool use_pir) {
               all_values_num += output_name2value_num[output];
             }
 
-            PADDLE_ENFORCE_EQ(
-                output_shapes.size(),
-                all_values_num,
-                phi::errors::InvalidArgument("The number of output shapes "
-                                             "after running custom operator's "
-                                             "InferShapeFunc is wrong, "
-                                             "expected contains %d Tensors' "
-                                             "shape, but actually contains %d "
-                                             "Tensors' shape",
-                                             all_values_num,
-                                             output_shapes.size()));
+            PADDLE_ENFORCE_EQ(output_shapes.size(),
+                              all_values_num,
+                              common::errors::InvalidArgument(
+                                  "The number of output shapes "
+                                  "after running custom operator's "
+                                  "InferShapeFunc is wrong, "
+                                  "expected contains %d Tensors' "
+                                  "shape, but actually contains %d "
+                                  "Tensors' shape",
+                                  all_values_num,
+                                  output_shapes.size()));
 
-            PADDLE_ENFORCE_EQ(
-                output_dtypes.size(),
-                all_values_num,
-                phi::errors::InvalidArgument("The number of output dtypes "
-                                             "after running custom operator's "
-                                             "InferDtypeFunc is wrong, "
-                                             "expected contains %d Tensors' "
-                                             "dtype, but actually contains %d "
-                                             "Tensors' dtype",
-                                             all_values_num,
-                                             output_dtypes.size()));
+            PADDLE_ENFORCE_EQ(output_dtypes.size(),
+                              all_values_num,
+                              common::errors::InvalidArgument(
+                                  "The number of output dtypes "
+                                  "after running custom operator's "
+                                  "InferDtypeFunc is wrong, "
+                                  "expected contains %d Tensors' "
+                                  "dtype, but actually contains %d "
+                                  "Tensors' dtype",
+                                  all_values_num,
+                                  output_dtypes.size()));
 
             size_t value_index = 0;
             for (const auto &output : meta_outputs) {

--- a/paddle/fluid/inference/api/helper.h
+++ b/paddle/fluid/inference/api/helper.h
@@ -73,7 +73,7 @@ inline PaddleDType ConvertToPaddleDType(
   } else if (type == paddle::framework::proto::VarType::UINT8) {
     return PaddleDType::UINT8;
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "The paddle dtype convert function only supports FLOAT32, INT64, INT32 "
         "and UINT8 now. But "
         "we get %d here.",
@@ -148,18 +148,18 @@ static T convert(const std::string &item,
     std::string message =
         "invalid_argument exception when try to convert : " + item;
     LOG(ERROR) << message;
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "invalid_argument exception when try to convert %s.", item));
   } catch (std::out_of_range &e) {
     std::string message =
         "out_of_range exception when try to convert : " + item;
     LOG(ERROR) << message;
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "out_of_range exception when try to convert %s.", item));
   } catch (...) {
     std::string message = "unexpected exception when try to convert " + item;
     LOG(ERROR) << message;
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "unexpected exception when try to convert %s.", item));
   }
   return res;
@@ -238,7 +238,7 @@ void CheckAssignedData(const std::vector<std::vector<T>> &data,
   PADDLE_ENFORCE_EQ(
       num,
       num_elems,
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "The number of elements out of bounds. "
           "Expected number of elements = %d. But received %d. Suggested Fix: "
           "If the tensor is expected to assign %d elements, check the number "
@@ -409,7 +409,9 @@ static void PrintTime(int batch_size,
                       const framework::proto::VarType::Type data_type =
                           framework::proto::VarType::FP32) {
   PADDLE_ENFORCE_GT(
-      batch_size, 0, phi::errors::InvalidArgument("Non-positive batch size."));
+      batch_size,
+      0,
+      common::errors::InvalidArgument("Non-positive batch size."));
   double sample_latency = batch_latency / batch_size;
   LOG(INFO) << "====== threads: " << num_threads << ", thread id: " << tid
             << " ======";

--- a/paddle/fluid/inference/api/infer_context.cc
+++ b/paddle/fluid/inference/api/infer_context.cc
@@ -155,8 +155,8 @@ void InferXPUContext::SetConvAutotuneInfo(std::string conv_autotune_file,
     PADDLE_ENFORCE_EQ(
         ret,
         0,
-        phi::errors::Unavailable("Failed to set XPU conv autotune file %s.",
-                                 conv_autotune_file));
+        common::errors::Unavailable("Failed to set XPU conv autotune file %s.",
+                                    conv_autotune_file));
   }
   if (conv_autotune_level > 0) {
     int ret;
@@ -165,8 +165,8 @@ void InferXPUContext::SetConvAutotuneInfo(std::string conv_autotune_file,
     PADDLE_ENFORCE_EQ(
         ret,
         0,
-        phi::errors::Unavailable("Failed to set XPU conv autotune  %d.",
-                                 conv_autotune_level));
+        common::errors::Unavailable("Failed to set XPU conv autotune  %d.",
+                                    conv_autotune_level));
   }
   if (conv_autotune_file_writeback) {
     int ret;
@@ -175,7 +175,7 @@ void InferXPUContext::SetConvAutotuneInfo(std::string conv_autotune_file,
         (std::to_string(conv_autotune_file_writeback)).c_str());
     PADDLE_ENFORCE_EQ(ret,
                       0,
-                      phi::errors::Unavailable(
+                      common::errors::Unavailable(
                           "Failed to set XPU conv autotune writeback %d.",
                           conv_autotune_file_writeback));
   }
@@ -186,7 +186,9 @@ void InferXPUContext::SetContextOption(const char* name, const char* value) {
   int ret;
   ret = x_context()->set_option(name, value);
   PADDLE_ENFORCE_EQ(
-      ret, 0, phi::errors::Unavailable("Failed to set XPU option %s.", name));
+      ret,
+      0,
+      common::errors::Unavailable("Failed to set XPU option %s.", name));
 }
 
 void InferXPUContext::SetFcAutotuneInfo(std::string fc_autotune_file,
@@ -206,8 +208,8 @@ void InferXPUContext::SetFcAutotuneInfo(std::string fc_autotune_file,
     PADDLE_ENFORCE_EQ(
         ret,
         0,
-        phi::errors::Unavailable("Failed to set XPU fc autotune file %s.",
-                                 fc_autotune_file));
+        common::errors::Unavailable("Failed to set XPU fc autotune file %s.",
+                                    fc_autotune_file));
   }
   if (fc_autotune_level > 0) {
     int ret;
@@ -216,19 +218,19 @@ void InferXPUContext::SetFcAutotuneInfo(std::string fc_autotune_file,
     PADDLE_ENFORCE_EQ(
         ret,
         0,
-        phi::errors::Unavailable("Failed to set XPU fc autotune  %d.",
-                                 fc_autotune_level));
+        common::errors::Unavailable("Failed to set XPU fc autotune  %d.",
+                                    fc_autotune_level));
   }
   if (fc_autotune_file_writeback) {
     int ret;
     ret = x_context()->set_option(
         "XPU_FC_AUTOTUNE_WRITEBACK",
         (std::to_string(fc_autotune_file_writeback)).c_str());
-    PADDLE_ENFORCE_EQ(
-        ret,
-        0,
-        phi::errors::Unavailable("Failed to set XPU fc autotune writeback %d.",
-                                 fc_autotune_file_writeback));
+    PADDLE_ENFORCE_EQ(ret,
+                      0,
+                      common::errors::Unavailable(
+                          "Failed to set XPU fc autotune writeback %d.",
+                          fc_autotune_file_writeback));
   }
 }
 

--- a/paddle/fluid/inference/api/onednn_quantizer.cc
+++ b/paddle/fluid/inference/api/onednn_quantizer.cc
@@ -50,17 +50,19 @@ static phi::DenseTensor CreateScaleTensor(int64_t channels_num = 1);
 
 static void check_var(const Variable* var, const std::string& var_name) {
   PADDLE_ENFORCE_NOT_NULL(
-      var, phi::errors::PreconditionNotMet("%s is not in the scope", var_name));
+      var,
+      common::errors::PreconditionNotMet("%s is not in the scope", var_name));
   PADDLE_ENFORCE_EQ(
       var->IsType<phi::DenseTensor>(),
       true,
-      phi::errors::PreconditionNotMet("Only support lod tensor now."));
+      common::errors::PreconditionNotMet("Only support lod tensor now."));
 }
 
 static void check_tensor(const phi::DenseTensor& tensor) {
-  PADDLE_ENFORCE_GT(tensor.dims().size(),
-                    0,
-                    phi::errors::InvalidArgument("Tensor dimension is empty."));
+  PADDLE_ENFORCE_GT(
+      tensor.dims().size(),
+      0,
+      common::errors::InvalidArgument("Tensor dimension is empty."));
 }
 
 void AnalysisPredictor::MkldnnQuantizer::CalculateScalesForRNNWeights(
@@ -133,7 +135,7 @@ void AnalysisPredictor::MkldnnQuantizer::CalculateScalesForOpOutputs(
         auto input_var_name = op->Input("X")[0];
         PADDLE_ENFORCE_NE(scales_.find(input_var_name),
                           scales_.end(),
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "Input scales must be calculated before the "
                               "output scales to infer if output is unsigned."));
         if (scales_.find(input_var_name) != scales_.end()) {
@@ -144,7 +146,7 @@ void AnalysisPredictor::MkldnnQuantizer::CalculateScalesForOpOutputs(
         auto input_var_name = op->Input("Input")[0];
         PADDLE_ENFORCE_NE(scales_.find(input_var_name),
                           scales_.end(),
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "Input scales must be calculated before the "
                               "output scales to infer if output is unsigned."));
         if (scales_.find(input_var_name) != scales_.end()) {
@@ -159,7 +161,7 @@ void AnalysisPredictor::MkldnnQuantizer::CalculateScalesForOpOutputs(
           PADDLE_ENFORCE_NE(
               scales_.find(input_var_name),
               scales_.end(),
-              phi::errors::PreconditionNotMet(
+              common::errors::PreconditionNotMet(
                   "Input scales must be calculated before the "
                   "output scales to infer if output is unsigned."));
           is_unsigned = is_unsigned && scales_[input_var_name].first;
@@ -203,7 +205,7 @@ void AnalysisPredictor::MkldnnQuantizer::CalculateSingleScale(
 
   PADDLE_ENFORCE_GT(var_tensor.numel(),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "MkldnnQuantizer: phi::DenseTensor of variable %s for "
                         "quantization of op "
                         "%s of connection %s should not be empty.",
@@ -281,7 +283,7 @@ AnalysisPredictor::MkldnnQuantizer::GetKLScalingFactor(
     PADDLE_ENFORCE_EQ(
         is_positive,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Tensor is claimed to be unsigned, but its min value (%f) is < 0.0",
             min_val));
 
@@ -394,7 +396,7 @@ AnalysisPredictor::MkldnnQuantizer::GetMaxScalingFactor(
     PADDLE_ENFORCE_GE(
         min_val,
         0.0f,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Tensor is claimed to be unsigned, but its min value (%f) is < 0.0",
             min_val));
 
@@ -418,7 +420,7 @@ AnalysisPredictor::MkldnnQuantizer::GetMaxChScalingFactor(
     PADDLE_ENFORCE_GE(
         min_val,
         0.0f,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Tensor is claimed to be unsigned, but its min value (%f) is < 0.0",
             min_val));
 
@@ -545,17 +547,17 @@ AnalysisPredictor::MkldnnQuantizer::Histogram(
     size_t num_bins) const {
   PADDLE_ENFORCE_GT(num_bins,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "MkldnnQuantizer: To calculate Histogram, num_bins (" +
                         std::to_string(num_bins) + ") must be positive."));
   PADDLE_ENFORCE_GT(var_tensor.numel(),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "MkldnnQuantizer: To calculate Histogram, the tensor "
                         "must not be empty."));
   PADDLE_ENFORCE_GE(max_val,
                     min_val,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "MkldnnQuantizer: To calculate Histogram, max_val (" +
                         std::to_string(max_val) +
                         ") must be greater or equal"
@@ -592,7 +594,7 @@ void AnalysisPredictor::MkldnnQuantizer::PrepareArgument() const {
   auto* scope_ptr = arg->scope_ptr();
   PADDLE_ENFORCE_NOT_NULL(
       scope_ptr,
-      phi::errors::PreconditionNotMet("The scope should not be nullptr."));
+      common::errors::PreconditionNotMet("The scope should not be nullptr."));
   arg->main_graph().SetNotOwned(framework::ir::kParamScopeAttr, scope_ptr);
 
   auto* builder = predictor_.config_.pass_builder();
@@ -626,7 +628,7 @@ bool AnalysisPredictor::MkldnnQuantizer::RunQuantizePasses() const {
   PADDLE_ENFORCE_EQ(
       arg->scope_valid(),
       true,
-      phi::errors::PreconditionNotMet("The scope should be valid."));
+      common::errors::PreconditionNotMet("The scope should be valid."));
   VLOG(5) << "to prepare executor";
   ARGUMENT_CHECK_FIELD(arg.get(), ir_analyzed_program);
   predictor_.inference_program_.reset(
@@ -641,7 +643,7 @@ bool AnalysisPredictor::MkldnnQuantizer::RunWarmup() const {
   VLOG(3) << "Predictor: run a quantization warmup iteration";
   auto warmup_data = qconfig_->warmup_data();
   PADDLE_ENFORCE_NOT_NULL(warmup_data,
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "Warmup data cannot be NULL in the config."));
   PrettyLogH1("--- Running warmup iteration for quantization");
 
@@ -657,12 +659,12 @@ float AnalysisPredictor::MkldnnQuantizer::SafeEntropy(
     int P_sum,
     std::vector<int> candidate_distr_Q,
     int Q_sum) const {
-  PADDLE_ENFORCE_EQ(
-      reference_distr_P.size(),
-      candidate_distr_Q.size(),
-      phi::errors::InvalidArgument("The P size %d should be equal to Q size %d",
-                                   reference_distr_P.size(),
-                                   candidate_distr_Q.size()));
+  PADDLE_ENFORCE_EQ(reference_distr_P.size(),
+                    candidate_distr_Q.size(),
+                    common::errors::InvalidArgument(
+                        "The P size %d should be equal to Q size %d",
+                        reference_distr_P.size(),
+                        candidate_distr_Q.size()));
   float tmp_sum1 = 0;
   float tmp_sum2 = 0;
   for (size_t idx = 0; idx < reference_distr_P.size(); idx++) {
@@ -675,7 +677,7 @@ float AnalysisPredictor::MkldnnQuantizer::SafeEntropy(
       PADDLE_ENFORCE_NE(
           q_idx,
           0,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "MkldnnQuantizer: Fatal error!, idx = " + std::to_string(idx) +
               " qindex = 0! p_idx = " + std::to_string(p_idx)));
     }

--- a/paddle/fluid/inference/api/onnxruntime_predictor.cc
+++ b/paddle/fluid/inference/api/onnxruntime_predictor.cc
@@ -205,7 +205,7 @@ CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kONNXRuntime>(
   PADDLE_ENFORCE_EQ(
       config.is_valid(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Note: Each config can only be used for one predictor."));
 
   VLOG(3) << "create ONNXRuntimePredictor";
@@ -262,7 +262,7 @@ bool ONNXRuntimePredictor::FindONNXDesc(const std::string &name,
 std::unique_ptr<ZeroCopyTensor> ONNXRuntimePredictor::GetInputTensor(
     const std::string &name) {
   PADDLE_ENFORCE_NOT_NULL(scope_->FindVar(name),
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "The in variable named %s is not found in the "
                               "ONNXPredictor.",
                               name));
@@ -283,7 +283,7 @@ std::unique_ptr<ZeroCopyTensor> ONNXRuntimePredictor::GetOutputTensor(
     const std::string &name) {
   PADDLE_ENFORCE_EQ(FindONNXDesc(name, false),
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The out variable named %s is not found in the "
                         "ONNXPredictor.",
                         name));

--- a/paddle/fluid/inference/api/paddle_infer_contrib.cc
+++ b/paddle/fluid/inference/api/paddle_infer_contrib.cc
@@ -49,11 +49,11 @@ void TensorUtils::CopyTensorImpl(Tensor* p_dst,
   dst.Reshape(src.shape());
   PADDLE_ENFORCE(
       src.place() == PlaceType::kCPU || src.place() == PlaceType::kGPU,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "CopyTensor only support PlaceType kCPU/kGPU now."));
   PADDLE_ENFORCE(
       dst.place() == PlaceType::kCPU || dst.place() == PlaceType::kGPU,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "CopyTensor only support PlaceType kCPU/kGPU now."));
   // copy to cpu, gpu => cpu or cpu => cpu
   if (dst.place() == PlaceType::kCPU) {
@@ -115,7 +115,7 @@ void TensorUtils::CopyTensorImpl(Tensor* p_dst,
             cb_params);
         break;
       default:
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Only INT32, INT64, UINT8, INT8, BOOL, FLOAT16, BFLOAT16, FLOAT32 "
             "and "
             "FLOAT64 is supported in Tensor. Others not implements"));
@@ -187,7 +187,7 @@ void TensorUtils::CopyTensorImpl(Tensor* p_dst,
         data_len = data_size * 2;
         break;
       default:
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Only INT32, INT64, UINT8, INT8, BOOL, FLOAT16, BFLOAT16, FLOAT32 "
             "and "
             "FLOAT64 is supported in Tensor. Others not implements"));
@@ -221,7 +221,7 @@ void TensorUtils::CopyTensorImpl(Tensor* p_dst,
       cudaStreamSynchronize(dev_ctx->stream());
     }
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Can not copy tensor to GPU CUDA place because paddle is not compiled "
         "with CUDA."));
 #endif

--- a/paddle/fluid/inference/api/resource_manager.cc
+++ b/paddle/fluid/inference/api/resource_manager.cc
@@ -392,7 +392,7 @@ void ResourceManager::InitCPUResource() {
 CPUContextResource* ResourceManager::GetCPUResource() const {
   PADDLE_ENFORCE_NOT_NULL(
       cpu_resource_.get(),
-      phi::errors::PreconditionNotMet("cpu_resource should be not null!"));
+      common::errors::PreconditionNotMet("cpu_resource should be not null!"));
   return cpu_resource_.get();
 }
 
@@ -415,7 +415,7 @@ void* ResourceManager::InitGPUResource(const phi::Place& place, void* stream) {
 void ResourceManager::DestroyGPUResource(void* stream) {
   PADDLE_ENFORCE_EQ(gpu_resources_.count(stream),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The stream[%p] not found in gpu_resources.", stream));
   Decrease(stream);
 }
@@ -435,7 +435,7 @@ void ResourceManager::Increase(void* stream) { ++ref_count_[stream]; }
 GPUContextResource* ResourceManager::GetGPUResource(void* stream) const {
   PADDLE_ENFORCE_EQ(gpu_resources_.count(stream),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The stream[%p] not found in gpu_resources.", stream));
   return gpu_resources_.at(stream).get();
 }
@@ -448,8 +448,8 @@ void ResourceManager::GpuResourceSwitchStream(void* old_stream,
   PADDLE_ENFORCE_EQ(
       gpu_resources_.count(old_stream),
       true,
-      phi::errors::InvalidArgument("The stream[%p] not found in gpu_resources.",
-                                   old_stream));
+      common::errors::InvalidArgument(
+          "The stream[%p] not found in gpu_resources.", old_stream));
 
   // NOTE: stream may be used by multiple predictor, skip resource
   //       operation if resource of new_stream is already exists

--- a/paddle/fluid/inference/capi/c_api.cc
+++ b/paddle/fluid/inference/capi/c_api.cc
@@ -37,35 +37,35 @@ void PD_DeletePaddleBuf(PD_PaddleBuf* buf) {
 
 void PD_PaddleBufResize(PD_PaddleBuf* buf, size_t length) {
   PADDLE_ENFORCE_NOT_NULL(buf,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The pointer of Buffer shouldn't be nullptr"));
   buf->buf.Resize(length);
 }
 
 void PD_PaddleBufReset(PD_PaddleBuf* buf, void* data, size_t length) {
   PADDLE_ENFORCE_NOT_NULL(buf,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The pointer of Buffer shouldn't be nullptr"));
   buf->buf.Reset(data, length);
 }
 
 bool PD_PaddleBufEmpty(PD_PaddleBuf* buf) {
   PADDLE_ENFORCE_NOT_NULL(buf,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The pointer of Buffer shouldn't be nullptr"));
   return buf->buf.empty();
 }
 
 void* PD_PaddleBufData(PD_PaddleBuf* buf) {
   PADDLE_ENFORCE_NOT_NULL(buf,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The pointer of Buffer shouldn't be nullptr"));
   return buf->buf.data();
 }
 
 size_t PD_PaddleBufLength(PD_PaddleBuf* buf) {
   PADDLE_ENFORCE_NOT_NULL(buf,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The pointer of Buffer shouldn't be nullptr"));
   return buf->buf.length();
 }

--- a/paddle/fluid/inference/capi/pd_config.cc
+++ b/paddle/fluid/inference/capi/pd_config.cc
@@ -45,7 +45,7 @@ void PD_SetModel(PD_AnalysisConfig* config,
   LOG(INFO) << model_dir;
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   LOG(INFO) << std::string(model_dir);
   if (!params_path) {
@@ -58,7 +58,7 @@ void PD_SetModel(PD_AnalysisConfig* config,
 void PD_SetProgFile(PD_AnalysisConfig* config, const char* x) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.SetProgFile(std::string(x));
 }
@@ -66,7 +66,7 @@ void PD_SetProgFile(PD_AnalysisConfig* config, const char* x) {
 void PD_SetParamsFile(PD_AnalysisConfig* config, const char* x) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.SetParamsFile(std::string(x));
 }
@@ -74,7 +74,7 @@ void PD_SetParamsFile(PD_AnalysisConfig* config, const char* x) {
 void PD_SetOptimCacheDir(PD_AnalysisConfig* config, const char* opt_cache_dir) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.SetOptimCacheDir(std::string(opt_cache_dir));
 }
@@ -82,7 +82,7 @@ void PD_SetOptimCacheDir(PD_AnalysisConfig* config, const char* opt_cache_dir) {
 const char* PD_ModelDir(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.model_dir().c_str();
 }
@@ -90,7 +90,7 @@ const char* PD_ModelDir(const PD_AnalysisConfig* config) {
 const char* PD_ProgFile(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.prog_file().c_str();
 }
@@ -98,7 +98,7 @@ const char* PD_ProgFile(const PD_AnalysisConfig* config) {
 const char* PD_ParamsFile(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.params_file().c_str();
 }
@@ -108,7 +108,7 @@ void PD_EnableUseGpu(PD_AnalysisConfig* config,
                      int device_id) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.EnableUseGpu(static_cast<uint64_t>(memory_pool_init_size_mb),
                               device_id);
@@ -117,7 +117,7 @@ void PD_EnableUseGpu(PD_AnalysisConfig* config,
 void PD_EnableXpu(PD_AnalysisConfig* config, int l3_workspace_size) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.EnableXpu(l3_workspace_size);
 }
@@ -125,7 +125,7 @@ void PD_EnableXpu(PD_AnalysisConfig* config, int l3_workspace_size) {
 void PD_DisableGpu(PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.DisableGpu();
 }
@@ -133,7 +133,7 @@ void PD_DisableGpu(PD_AnalysisConfig* config) {
 bool PD_UseGpu(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.use_gpu();
 }
@@ -141,7 +141,7 @@ bool PD_UseGpu(const PD_AnalysisConfig* config) {
 bool PD_UseXpu(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.use_xpu();
 }
@@ -149,7 +149,7 @@ bool PD_UseXpu(const PD_AnalysisConfig* config) {
 int PD_GpuDeviceId(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.gpu_device_id();
 }
@@ -157,7 +157,7 @@ int PD_GpuDeviceId(const PD_AnalysisConfig* config) {
 int PD_XpuDeviceId(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.xpu_device_id();
 }
@@ -165,7 +165,7 @@ int PD_XpuDeviceId(const PD_AnalysisConfig* config) {
 int PD_MemoryPoolInitSizeMb(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.memory_pool_init_size_mb();
 }
@@ -173,7 +173,7 @@ int PD_MemoryPoolInitSizeMb(const PD_AnalysisConfig* config) {
 float PD_FractionOfGpuMemoryForPool(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.fraction_of_gpu_memory_for_pool();
 }
@@ -181,7 +181,7 @@ float PD_FractionOfGpuMemoryForPool(const PD_AnalysisConfig* config) {
 void PD_EnableCUDNN(PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.EnableCUDNN();
 }
@@ -189,7 +189,7 @@ void PD_EnableCUDNN(PD_AnalysisConfig* config) {
 bool PD_CudnnEnabled(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.cudnn_enabled();
 }
@@ -197,7 +197,7 @@ bool PD_CudnnEnabled(const PD_AnalysisConfig* config) {
 void PD_SwitchIrOptim(PD_AnalysisConfig* config, bool x) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.SwitchIrOptim(x);
 }
@@ -205,7 +205,7 @@ void PD_SwitchIrOptim(PD_AnalysisConfig* config, bool x) {
 bool PD_IrOptim(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.ir_optim();
 }
@@ -213,7 +213,7 @@ bool PD_IrOptim(const PD_AnalysisConfig* config) {
 void PD_SwitchUseFeedFetchOps(PD_AnalysisConfig* config, bool x) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.SwitchUseFeedFetchOps(x);
 }
@@ -221,7 +221,7 @@ void PD_SwitchUseFeedFetchOps(PD_AnalysisConfig* config, bool x) {
 bool PD_UseFeedFetchOpsEnabled(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.use_feed_fetch_ops_enabled();
 }
@@ -229,7 +229,7 @@ bool PD_UseFeedFetchOpsEnabled(const PD_AnalysisConfig* config) {
 void PD_SwitchSpecifyInputNames(PD_AnalysisConfig* config, bool x) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.SwitchSpecifyInputNames(x);
 }
@@ -237,7 +237,7 @@ void PD_SwitchSpecifyInputNames(PD_AnalysisConfig* config, bool x) {
 bool PD_SpecifyInputName(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.specify_input_name();
 }
@@ -251,7 +251,7 @@ void PD_EnableTensorRtEngine(PD_AnalysisConfig* config,
                              bool use_calib_mode) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.EnableTensorRtEngine(workspace_size,
                                       max_batch_size,
@@ -264,7 +264,7 @@ void PD_EnableTensorRtEngine(PD_AnalysisConfig* config,
 bool PD_TensorrtEngineEnabled(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.tensorrt_engine_enabled();
 }
@@ -272,7 +272,7 @@ bool PD_TensorrtEngineEnabled(const PD_AnalysisConfig* config) {
 void PD_SwitchIrDebug(PD_AnalysisConfig* config, bool x) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.SwitchIrDebug(x);
 }
@@ -280,7 +280,7 @@ void PD_SwitchIrDebug(PD_AnalysisConfig* config, bool x) {
 void PD_EnableMKLDNN(PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.EnableMKLDNN();
 }
@@ -288,7 +288,7 @@ void PD_EnableMKLDNN(PD_AnalysisConfig* config) {
 void PD_SetMkldnnCacheCapacity(PD_AnalysisConfig* config, int capacity) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.SetMkldnnCacheCapacity(capacity);
 }
@@ -296,7 +296,7 @@ void PD_SetMkldnnCacheCapacity(PD_AnalysisConfig* config, int capacity) {
 bool PD_MkldnnEnabled(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.mkldnn_enabled();
 }
@@ -305,7 +305,7 @@ void PD_SetCpuMathLibraryNumThreads(PD_AnalysisConfig* config,
                                     int cpu_math_library_num_threads) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.SetCpuMathLibraryNumThreads(cpu_math_library_num_threads);
 }
@@ -313,7 +313,7 @@ void PD_SetCpuMathLibraryNumThreads(PD_AnalysisConfig* config,
 int PD_CpuMathLibraryNumThreads(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.cpu_math_library_num_threads();
 }
@@ -321,7 +321,7 @@ int PD_CpuMathLibraryNumThreads(const PD_AnalysisConfig* config) {
 void PD_EnableMkldnnQuantizer(PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.EnableMkldnnQuantizer();
 }
@@ -329,7 +329,7 @@ void PD_EnableMkldnnQuantizer(PD_AnalysisConfig* config) {
 bool PD_MkldnnQuantizerEnabled(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.mkldnn_quantizer_enabled();
 }
@@ -337,7 +337,7 @@ bool PD_MkldnnQuantizerEnabled(const PD_AnalysisConfig* config) {
 void PD_EnableMkldnnBfloat16(PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.EnableMkldnnBfloat16();
 }
@@ -345,7 +345,7 @@ void PD_EnableMkldnnBfloat16(PD_AnalysisConfig* config) {
 bool PD_MkldnnBfloat16Enabled(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.mkldnn_bfloat16_enabled();
 }
@@ -357,7 +357,7 @@ void PD_SetModelBuffer(PD_AnalysisConfig* config,
                        size_t params_buffer_size) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.SetModelBuffer(
       prog_buffer, prog_buffer_size, params_buffer, params_buffer_size);
@@ -366,7 +366,7 @@ void PD_SetModelBuffer(PD_AnalysisConfig* config,
 bool PD_ModelFromMemory(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.model_from_memory();
 }
@@ -374,7 +374,7 @@ bool PD_ModelFromMemory(const PD_AnalysisConfig* config) {
 void PD_EnableMemoryOptim(PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.EnableMemoryOptim();
 }
@@ -382,7 +382,7 @@ void PD_EnableMemoryOptim(PD_AnalysisConfig* config) {
 bool PD_MemoryOptimEnabled(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.enable_memory_optim();
 }
@@ -390,7 +390,7 @@ bool PD_MemoryOptimEnabled(const PD_AnalysisConfig* config) {
 void PD_EnableProfile(PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.EnableProfile();
 }
@@ -398,7 +398,7 @@ void PD_EnableProfile(PD_AnalysisConfig* config) {
 bool PD_ProfileEnabled(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.profile_enabled();
 }
@@ -406,7 +406,7 @@ bool PD_ProfileEnabled(const PD_AnalysisConfig* config) {
 void PD_SetInValid(PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   config->config.SetInValid();
 }
@@ -414,7 +414,7 @@ void PD_SetInValid(PD_AnalysisConfig* config) {
 bool PD_IsValid(const PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   return config->config.is_valid();
 }

--- a/paddle/fluid/inference/capi/pd_predictor.cc
+++ b/paddle/fluid/inference/capi/pd_predictor.cc
@@ -51,7 +51,7 @@ inline void VisitDataType(PD_DataType type, Visitor visitor) {
 
   _DataType_(VisitDataTypeCallback);
 #undef VisitDataTypeCallback
-  PADDLE_THROW(phi::errors::InvalidArgument("Unsupported data type."));
+  PADDLE_THROW(common::errors::InvalidArgument("Unsupported data type."));
 }
 
 struct PD_ZeroCopyFunctor {
@@ -89,7 +89,7 @@ bool PD_PredictorRun(const PD_AnalysisConfig* config,
                      int batch_size) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   VLOG(3) << "Predictor: PD_PredictorRun. ";
   static std::map<std::string, std::unique_ptr<paddle::PaddlePredictor>>
@@ -124,7 +124,7 @@ bool PD_PredictorZeroCopyRun(const PD_AnalysisConfig* config,
                              int* out_size) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of analysis configuration shouldn't be nullptr"));
   static std::map<std::string, std::unique_ptr<paddle::PaddlePredictor>>
       predictors;
@@ -138,7 +138,7 @@ bool PD_PredictorZeroCopyRun(const PD_AnalysisConfig* config,
   PADDLE_ENFORCE_EQ(
       input_names.size(),
       in_size,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of input and the number of model's input must match. The "
           "number of input is %d, the number of model's input is %d.",
           input_names.size(),
@@ -163,7 +163,7 @@ bool PD_PredictorZeroCopyRun(const PD_AnalysisConfig* config,
         input_t->copy_from_cpu(static_cast<uint8_t*>(inputs[i].data));
         break;
       default:
-        PADDLE_THROW(phi::errors::InvalidArgument("Unsupported data type."));
+        PADDLE_THROW(common::errors::InvalidArgument("Unsupported data type."));
         break;
     }
   }
@@ -252,7 +252,7 @@ void PD_SetZeroCopyInput(PD_Predictor* predictor,
       input->copy_from_cpu(static_cast<uint8_t*>(tensor->data.data));
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument("Unsupported data type."));
+      PADDLE_THROW(common::errors::InvalidArgument("Unsupported data type."));
       break;
   }
 
@@ -322,7 +322,7 @@ void PD_GetZeroCopyOutput(PD_Predictor* predictor, PD_ZeroCopyTensor* tensor) {
       output->copy_to_cpu(reinterpret_cast<uint8_t*>(tensor->data.data));
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument("Unsupported data type."));
+      PADDLE_THROW(common::errors::InvalidArgument("Unsupported data type."));
       break;
   }
 }

--- a/paddle/fluid/inference/capi/pd_tensor.cc
+++ b/paddle/fluid/inference/capi/pd_tensor.cc
@@ -40,49 +40,49 @@ void PD_DeletePaddleTensor(PD_Tensor* tensor) {
 
 void PD_SetPaddleTensorName(PD_Tensor* tensor, char* name) {
   PADDLE_ENFORCE_NOT_NULL(tensor,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The pointer of tensor shouldn't be nullptr"));
   tensor->tensor.name = std::string(name);
 }
 
 void PD_SetPaddleTensorDType(PD_Tensor* tensor, PD_DataType dtype) {
   PADDLE_ENFORCE_NOT_NULL(tensor,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The pointer of tensor shouldn't be nullptr"));
   tensor->tensor.dtype = paddle::ConvertToPaddleDType(dtype);
 }
 
 void PD_SetPaddleTensorData(PD_Tensor* tensor, PD_PaddleBuf* buf) {
   PADDLE_ENFORCE_NOT_NULL(tensor,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The pointer of tensor shouldn't be nullptr"));
   tensor->tensor.data = buf->buf;
 }
 
 void PD_SetPaddleTensorShape(PD_Tensor* tensor, int* shape, int size) {
   PADDLE_ENFORCE_NOT_NULL(tensor,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The pointer of tensor shouldn't be nullptr"));
   tensor->tensor.shape.assign(shape, shape + size);
 }
 
 const char* PD_GetPaddleTensorName(const PD_Tensor* tensor) {
   PADDLE_ENFORCE_NOT_NULL(tensor,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The pointer of tensor shouldn't be nullptr"));
   return tensor->tensor.name.c_str();
 }
 
 PD_DataType PD_GetPaddleTensorDType(const PD_Tensor* tensor) {
   PADDLE_ENFORCE_NOT_NULL(tensor,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The pointer of tensor shouldn't be nullptr"));
   return ConvertToPDDataType(tensor->tensor.dtype);
 }
 
 PD_PaddleBuf* PD_GetPaddleTensorData(const PD_Tensor* tensor) {
   PADDLE_ENFORCE_NOT_NULL(tensor,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The pointer of tensor shouldn't be nullptr"));
   PD_PaddleBuf* ret = PD_NewPaddleBuf();
   ret->buf = tensor->tensor.data;
@@ -91,7 +91,7 @@ PD_PaddleBuf* PD_GetPaddleTensorData(const PD_Tensor* tensor) {
 
 const int* PD_GetPaddleTensorShape(const PD_Tensor* tensor, int* size) {
   PADDLE_ENFORCE_NOT_NULL(tensor,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The pointer of tensor shouldn't be nullptr"));
   const std::vector<int>& shape = tensor->tensor.shape;
   *size = shape.size();

--- a/paddle/fluid/inference/capi_exp/pd_config.cc
+++ b/paddle/fluid/inference/capi_exp/pd_config.cc
@@ -19,16 +19,16 @@
 #include "paddle/fluid/inference/capi_exp/utils_internal.h"
 #include "paddle/fluid/platform/enforce.h"
 
-#define CHECK_NULL_POINTER_PARM(param)                      \
-  PADDLE_ENFORCE_NOT_NULL(                                  \
-      param,                                                \
-      phi::errors::InvalidArgument("The pointer of " #param \
-                                   " shouldn't be nullptr"))
+#define CHECK_NULL_POINTER_PARM(param)                         \
+  PADDLE_ENFORCE_NOT_NULL(                                     \
+      param,                                                   \
+      common::errors::InvalidArgument("The pointer of " #param \
+                                      " shouldn't be nullptr"))
 
 #define CHECK_AND_CONVERT_PD_CONFIG                              \
   PADDLE_ENFORCE_NOT_NULL(                                       \
       pd_config,                                                 \
-      phi::errors::InvalidArgument(                              \
+      common::errors::InvalidArgument(                           \
           "The pointer of paddle config shouldn't be nullptr")); \
   Config* config = reinterpret_cast<Config*>(pd_config)
 
@@ -43,7 +43,7 @@ static Config::Precision ConvertToCxxPrecisionType(PD_PrecisionType precision) {
     case PD_PRECISION_HALF:
       return Config::Precision::kHalf;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupport paddle precision type %d.", precision));
       return Config::Precision::kFloat32;
   }

--- a/paddle/fluid/inference/capi_exp/pd_predictor.cc
+++ b/paddle/fluid/inference/capi_exp/pd_predictor.cc
@@ -25,7 +25,7 @@
 #define CHECK_AND_CONVERT_PD_PREDICTOR                              \
   PADDLE_ENFORCE_NOT_NULL(                                          \
       pd_predictor,                                                 \
-      phi::errors::InvalidArgument(                                 \
+      common::errors::InvalidArgument(                              \
           "The pointer of paddle predictor shouldn't be nullptr")); \
   auto& predictor = pd_predictor->predictor
 
@@ -33,7 +33,7 @@ extern "C" {
 __pd_give PD_Predictor* PD_PredictorCreate(__pd_take PD_Config* pd_config) {
   PADDLE_ENFORCE_NOT_NULL(
       pd_config,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The pointer of paddle predictor shouldn't be nullptr"));
   PD_Predictor* pd_predictor = new PD_Predictor();
   paddle_infer::Config* config =

--- a/paddle/fluid/inference/capi_exp/pd_tensor.cc
+++ b/paddle/fluid/inference/capi_exp/pd_tensor.cc
@@ -24,7 +24,7 @@
 #define CHECK_AND_CONVERT_PD_TENSOR                              \
   PADDLE_ENFORCE_NOT_NULL(                                       \
       pd_tensor,                                                 \
-      phi::errors::InvalidArgument(                              \
+      common::errors::InvalidArgument(                           \
           "The pointer of paddle tensor shouldn't be nullptr")); \
   auto& tensor = pd_tensor->tensor
 
@@ -60,10 +60,10 @@ REPEAT_ALL_DATA_TYPE(PD_TENSOR_MUTABLE_DATA_IMPL)
       __pd_keep PD_Tensor* pd_tensor, PD_PlaceType* place, int32_t* size) {    \
     CHECK_AND_CONVERT_PD_TENSOR;                                               \
     PADDLE_ENFORCE_NOT_NULL(place,                                             \
-                            phi::errors::InvalidArgument(                      \
+                            common::errors::InvalidArgument(                   \
                                 "The pointer of place shouldn't be nullptr")); \
     PADDLE_ENFORCE_NOT_NULL(size,                                              \
-                            phi::errors::InvalidArgument(                      \
+                            common::errors::InvalidArgument(                   \
                                 "The pointer of size shouldn't be nullptr"));  \
     paddle_infer::PlaceType cxx_place_type;                                    \
     int cxx_size;                                                              \

--- a/paddle/fluid/inference/capi_exp/pd_utils.cc
+++ b/paddle/fluid/inference/capi_exp/pd_utils.cc
@@ -225,7 +225,7 @@ PlaceType CvtToCxxPlaceType(PD_PlaceType place_type) {
     case PD_PLACE_CUSTOM:
       return PlaceType::kCUSTOM;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupport paddle place type %d.", place_type));
       return PlaceType::kUNK;
   }
@@ -259,7 +259,7 @@ DataType CvtToCxxDatatype(PD_DataType data_type) {
     case PD_DATA_INT8:
       return DataType::INT8;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupport paddle data type %d.", data_type));
       return DataType::FLOAT32;
   }

--- a/paddle/fluid/inference/io.cc
+++ b/paddle/fluid/inference/io.cc
@@ -57,7 +57,7 @@ void ReadBinaryFile(const std::string& filename, std::string* contents) {
   PADDLE_ENFORCE_EQ(
       fin.is_open(),
       true,
-      phi::errors::Unavailable("Failed to open file %s.", filename));
+      common::errors::Unavailable("Failed to open file %s.", filename));
   fin.seekg(0, std::ios::end);
   contents->clear();
   contents->resize(fin.tellg());
@@ -149,8 +149,8 @@ std::unique_ptr<framework::ProgramDesc> Load(framework::Executor* executor,
   PADDLE_ENFORCE_EQ(
       framework::IsProgramVersionSupported(main_program->Version()),
       true,
-      phi::errors::Unavailable("Model version %ld is not supported.",
-                               main_program->Version()));
+      common::errors::Unavailable("Model version %ld is not supported.",
+                                  main_program->Version()));
 
   // model_from_memory is false in separate parameters.
   LoadPersistables(executor,
@@ -175,8 +175,8 @@ std::unique_ptr<framework::ProgramDesc> Load(framework::Executor* executor,
   PADDLE_ENFORCE_EQ(
       framework::IsProgramVersionSupported(main_program->Version()),
       true,
-      phi::errors::Unavailable("Model version %ld is not supported.",
-                               main_program->Version()));
+      common::errors::Unavailable("Model version %ld is not supported.",
+                                  main_program->Version()));
   if (load_params) {
     LoadPersistables(executor,
                      scope,
@@ -198,8 +198,8 @@ std::unique_ptr<framework::ProgramDesc> LoadFromMemory(
   PADDLE_ENFORCE_EQ(
       framework::IsProgramVersionSupported(main_program->Version()),
       true,
-      phi::errors::Unavailable("Model version %ld is not supported.",
-                               main_program->Version()));
+      common::errors::Unavailable("Model version %ld is not supported.",
+                                  main_program->Version()));
 
   LoadPersistables(executor,
                    scope,

--- a/paddle/fluid/inference/tensorrt/convert/batch_norm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/batch_norm_op.cc
@@ -40,19 +40,19 @@ class BatchNormOpConverter : public OpConverter {
     auto output_name = op_desc.Output("Y").front();
     PADDLE_ENFORCE_NOT_NULL(
         Bias_v,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Variable of Bias of batch_norm TRT converter is not found."));
     PADDLE_ENFORCE_NOT_NULL(
         Mean_v,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Variable of Mean of batch_norm TRT converter is not found."));
     PADDLE_ENFORCE_NOT_NULL(
         Scale_v,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Variable of Scale of batch_norm TRT converter is not found."));
     PADDLE_ENFORCE_NOT_NULL(
         Variance_v,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Variable of Variance of batch_norm TRT converter is not found."));
 
     // get tensor

--- a/paddle/fluid/inference/tensorrt/convert/bitwise_and_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/bitwise_and_op.cc
@@ -42,7 +42,7 @@ class BitwiseAndConverter : public OpConverter {
                                    *y_tensor,
                                    nvinfer1::ElementWiseOperation::kAND);
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "bitwise_and TRT converter is only supported on bool"));
     }
 

--- a/paddle/fluid/inference/tensorrt/convert/bitwise_or_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/bitwise_or_op.cc
@@ -42,7 +42,7 @@ class BitwiseOrConverter : public OpConverter {
                                    *y_tensor,
                                    nvinfer1::ElementWiseOperation::kOR);
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "bitwise_or TRT converter is only supported on bool"));
     }
 

--- a/paddle/fluid/inference/tensorrt/convert/c_allreduce_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/c_allreduce_op.cc
@@ -32,8 +32,8 @@ class CAllReduceOpConverter : public OpConverter {
     VLOG(4) << "convert callreduce op to tensorrt layer";
     if (!engine_->with_dynamic_shape()) {
       PADDLE_THROW(
-          phi::errors::Fatal("Unsupported static graph mode. Please set "
-                             "dynamic shape of inputs."));
+          common::errors::Fatal("Unsupported static graph mode. Please set "
+                                "dynamic shape of inputs."));
     }
     ReduceType red_type = op_to_reduce_type[op.type()];
     std::string name = op.type();
@@ -44,7 +44,7 @@ class CAllReduceOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         input_num,
         1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input X's size must equal to 1 in TRT c_allreduce op."
             " But received X's size %d.",
             input_num));
@@ -54,7 +54,7 @@ class CAllReduceOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         output_num,
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The output Out's size must equal to 1 in TRT c_allreduce op. "
             "But received Out's size %u.",
             output_num));
@@ -76,7 +76,7 @@ class CAllReduceOpConverter : public OpConverter {
             ring_id, use_calc_stream, red_type, with_fp16);
     layer = engine_->AddDynamicPlugin(&input, input_num, plugin);
 #else
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "You are running the TRT Dynamic Shape mode, need to confirm that "
         "your TRT version is no less than 6.0"));
 #endif

--- a/paddle/fluid/inference/tensorrt/convert/celu_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/celu_op.cc
@@ -28,7 +28,7 @@ class CeluOpConverter : public OpConverter {
     int input_num = op_desc.Input("X").size();
     PADDLE_ENFORCE_EQ(input_num,
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input X's size must equal to 1 in TRT celu op."
                           " But received X's size %d.",
                           input_num));
@@ -38,7 +38,7 @@ class CeluOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         output_num,
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The output Out's size must equal to 1 in TRT celu op. "
             "But received Out's size %u.",
             output_num));

--- a/paddle/fluid/inference/tensorrt/convert/clip_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/clip_op.cc
@@ -42,8 +42,8 @@ class ClipOpConverter : public OpConverter {
     ReplenishLayerAndOutput(layer, "clip", {output_name}, test_mode);
 #else
     PADDLE_THROW(
-        phi::errors::Fatal("clip TRT converter is only supported on TRT "
-                           "5.1.3.0 or higher version."));
+        common::errors::Fatal("clip TRT converter is only supported on TRT "
+                              "5.1.3.0 or higher version."));
 #endif
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/conv2d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/conv2d_op.cc
@@ -56,7 +56,7 @@ void ConvertConv2d(TensorRTEngine* engine,
     PADDLE_ENFORCE_EQ(
         Y_t->dims().size(),
         4UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The conv2d filter's dims size should be 4, but got %d",
             Y_t->dims().size()));
     n_output = Y_t->dims()[0];
@@ -68,7 +68,7 @@ void ConvertConv2d(TensorRTEngine* engine,
     PADDLE_ENFORCE_EQ(
         filter->getDimensions().nbDims,
         4UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The conv2d filter's dims size should be 4, but got %d",
             filter->getDimensions().nbDims));
     n_output = filter->getDimensions().d[0];
@@ -156,8 +156,8 @@ void ConvertConv2d(TensorRTEngine* engine,
 
   PADDLE_ENFORCE_NOT_NULL(
       layer,
-      phi::errors::Fatal("TensorRT create conv2d/conv2d_transpose"
-                         " layer failed."));
+      common::errors::Fatal("TensorRT create conv2d/conv2d_transpose"
+                            " layer failed."));
   layer->setStrideNd(nv_strides);
 
   layer->setPrePadding(nv_pre_paddings);
@@ -169,7 +169,7 @@ void ConvertConv2d(TensorRTEngine* engine,
     nv_post_paddings.d[1] -= output_padding[1];
   }
   if (nv_post_paddings.d[0] < 0 || nv_post_paddings.d[1] < 0) {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The value in conv2d_transpose's PostPadding should be >= 0."));
   }
   layer->setPostPadding(nv_post_paddings);

--- a/paddle/fluid/inference/tensorrt/convert/conv3d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/conv3d_op.cc
@@ -33,8 +33,8 @@ void ConvertConv3d(TensorRTEngine* engine,
   auto* Y_v = scope.FindVar(filter_var_name);
   PADDLE_ENFORCE_NOT_NULL(
       Y_v,
-      phi::errors::NotFound("Can not find %s presistable var in scope.",
-                            filter_var_name));
+      common::errors::NotFound("Can not find %s presistable var in scope.",
+                               filter_var_name));
   auto* Y_t = Y_v->GetMutable<phi::DenseTensor>();
   bool enable_int8 = op_desc.HasAttr("enable_int8");
 
@@ -45,7 +45,7 @@ void ConvertConv3d(TensorRTEngine* engine,
 
   PADDLE_ENFORCE_EQ(Y_t->dims().size(),
                     5UL,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The conv3d filter's dims size should be 5, but got %d",
                         Y_t->dims().size()));
 
@@ -91,8 +91,8 @@ void ConvertConv3d(TensorRTEngine* engine,
 
   PADDLE_ENFORCE_NOT_NULL(
       layer,
-      phi::errors::Fatal("TensorRT create conv3d/conv3d_transpose"
-                         " layer failed."));
+      common::errors::Fatal("TensorRT create conv3d/conv3d_transpose"
+                            " layer failed."));
   layer->setStrideNd(nv_strides);
   layer->setPrePadding(nv_pre_paddings);
   nvinfer1::Dims3 nv_post_paddings = nv_pre_paddings;
@@ -105,7 +105,7 @@ void ConvertConv3d(TensorRTEngine* engine,
 
     if (nv_post_paddings.d[0] < 0 || nv_post_paddings.d[1] < 0 ||
         nv_post_paddings.d[2] < 0) {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "The value in conv3d_transpose's PostPadding should be >= 0."));
     }
 

--- a/paddle/fluid/inference/tensorrt/convert/cross_multihead_matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/cross_multihead_matmul_op.cc
@@ -34,7 +34,7 @@ class CrossMultiheadMatMulOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         with_fp16,
         true,
-        phi::errors::Unimplemented(
+        common::errors::Unimplemented(
             "Trt cross attention oss plugin only support fp16 mode yet."));
     framework::OpDesc op_desc(op, nullptr);
     auto* input_q = engine_->GetITensor(op_desc.Input("Input_q").front());

--- a/paddle/fluid/inference/tensorrt/convert/dequantize_linear_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/dequantize_linear_op.cc
@@ -32,8 +32,8 @@ class DequantizeLinearOpConverter : public OpConverter {
     // Create constant layer for scale
     PADDLE_ENFORCE_NOT_NULL(
         scale_var,
-        phi::errors::NotFound("Can not find %s presistable var in scope.",
-                              op_desc.Input("Scale")[0]));
+        common::errors::NotFound("Can not find %s presistable var in scope.",
+                                 op_desc.Input("Scale")[0]));
     auto* scale_t = scale_var->GetMutable<phi::DenseTensor>();
     int n_scale = scale_t->numel();
     std::vector<float> scale_data(n_scale, 0.0f);
@@ -53,8 +53,8 @@ class DequantizeLinearOpConverter : public OpConverter {
         layer, "dequantize_linear", {output_name}, test_model);
 #else
     PADDLE_THROW(
-        phi::errors::Fatal("Paddle-TRT explicit quantization does not "
-                           "support Paddle compiled with TRT < 8.5"));
+        common::errors::Fatal("Paddle-TRT explicit quantization does not "
+                              "support Paddle compiled with TRT < 8.5"));
 #endif
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
@@ -48,7 +48,7 @@ class ElementwiseTensorOpConverter : public OpConverter {
         trt_dims_y.nbDims--;
         PADDLE_ENFORCE_EQ(trt_dims_y.d[0],
                           1,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Elementwise type(%s) op's Y is a weight "
                               "including batch dimension. Please "
                               "check if the 0th dimension equals 1.",
@@ -209,7 +209,7 @@ class ElementwiseTensorOpConverter : public OpConverter {
       PADDLE_ENFORCE_NE(
           op_pair,
           ops.end(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Elementwise op's type(%s) is not supported. Please "
               "check if the op_type is correct.",
               op_type_));

--- a/paddle/fluid/inference/tensorrt/convert/emb_eltwise_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/emb_eltwise_layernorm.cc
@@ -91,7 +91,7 @@ class EmbEltwiseLayerNormOpConverter : public OpConverter {
       PADDLE_ENFORCE_EQ(
           output_fp16,
           1,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Only Precision::KHalf(fp16) is supported when infering "
               "ernie(bert) model with config.EnableVarseqlen(). "
               "But Precision::KFloat32 is setted."));
@@ -152,7 +152,7 @@ class EmbEltwiseLayerNormOpConverter : public OpConverter {
                    "with_interleaved";
         if (!enable_int8) {
           PADDLE_THROW(
-              phi::errors::Fatal("use with_interleaved must be int8."));
+              common::errors::Fatal("use with_interleaved must be int8."));
         }
         auto* shuffler_embed = TRT_ENGINE_ADD_LAYER(
             engine_, Shuffle, *(plugin_layer->getOutput(0)));

--- a/paddle/fluid/inference/tensorrt/convert/fill_constant_batch_size_like_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/fill_constant_batch_size_like_op.cc
@@ -31,7 +31,7 @@ class FillConstantBatchSizeLikeOpConverter : public OpConverter {
     // be float
     PADDLE_ENFORCE_EQ(dtype,
                       5,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "fill_constant_batch_size_like's input data type "
                           "must be float in Paddle-TRT."));
 

--- a/paddle/fluid/inference/tensorrt/convert/fill_constant_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/fill_constant_op.cc
@@ -44,7 +44,7 @@ class FillConstantOpConverter : public OpConverter {
         auto shape_nbDims = shapes_tensor->getDimensions().nbDims;
         PADDLE_ENFORCE_EQ(shape_nbDims,
                           1,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "ShapeTensor nbDims must be 1, but received %d.",
                               shape_nbDims));
         tensor_rank = shapes_tensor->getDimensions().d[0];

--- a/paddle/fluid/inference/tensorrt/convert/flash_multihead_matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/flash_multihead_matmul_op.cc
@@ -36,7 +36,7 @@ class FlashMultiheadMatMulOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         with_fp16,
         true,
-        phi::errors::Unimplemented(
+        common::errors::Unimplemented(
             "Trt flash attention oss plugin only support fp16 mode yet."));
 
     framework::OpDesc op_desc(op, nullptr);
@@ -418,7 +418,7 @@ class FlashMultiheadMatMulOpConverter : public OpConverter {
         input->getType() == nvinfer1::DataType::kHALF ||
             input->getType() == nvinfer1::DataType::kFLOAT,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "This op has no dynamic plugin infershape function!"));
 
     if (input->getType() == nvinfer1::DataType::kHALF) {

--- a/paddle/fluid/inference/tensorrt/convert/flatten_contiguous_range_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/flatten_contiguous_range_op.cc
@@ -39,12 +39,12 @@ class FlattenContiguousRangeOpConverter : public OpConverter {
       for (int i = 0, j = 0; i < dims; ++i) {
         if (start_axis <= i + 1 && i + 1 <= stop_axis) {
           int dim_i = input_dim.d[i];
-          PADDLE_ENFORCE_GT(
-              dim_i,
-              0,
-              phi::errors::InvalidArgument("flatten_contiguous_range input dim "
-                                           "should be > 0, but got %d.",
-                                           dim_i));
+          PADDLE_ENFORCE_GT(dim_i,
+                            0,
+                            common::errors::InvalidArgument(
+                                "flatten_contiguous_range input dim "
+                                "should be > 0, but got %d.",
+                                dim_i));
           dim_prod *= dim_i;
           if (i + 1 == stop_axis) {
             flatten_dim.d[j++] = dim_prod;

--- a/paddle/fluid/inference/tensorrt/convert/flatten_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/flatten_op.cc
@@ -35,7 +35,7 @@ class FlattenOpConverter : public OpConverter {
         PADDLE_ENFORCE_GT(
             dim_i,
             0,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "flatten input dim should be > 0, but got %d.", dim_i));
         dim_prod *= dim_i;
       }

--- a/paddle/fluid/inference/tensorrt/convert/fused_token_prune_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/fused_token_prune_op.cc
@@ -98,7 +98,7 @@ class FusedTokenPruneOpConverter : public OpConverter {
       layer->setName(
           ("fused_token_prune(Output: " + output_name + ")").c_str());
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "You are running the Ernie(Bert) model in static shape mode, which "
           "is not supported for the time being.\n"
           "You can use the config.SetTRTDynamicShapeInfo(...) interface to set "

--- a/paddle/fluid/inference/tensorrt/convert/gelu_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/gelu_op.cc
@@ -140,7 +140,7 @@ class GeluOpConverter : public OpConverter {
                                     nvinfer1::ElementWiseOperation::kPROD);
       layer = y;
 #else
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "You are running GeLU Op with approximate True, need to confirm that "
           "your TRT version is no less than 7.0"));
 #endif
@@ -223,7 +223,7 @@ class GeluOpConverter : public OpConverter {
             new plugin::GeluPluginDynamic(with_fp16);
         layer = engine_->AddDynamicPlugin(&input, input_num, plugin);
 #else
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "You are running the TRT Dynamic Shape mode, need to confirm that "
             "your TRT version is no less than 6.0"));
 #endif

--- a/paddle/fluid/inference/tensorrt/convert/generic_and_custom_plugin_creater.cc
+++ b/paddle/fluid/inference/tensorrt/convert/generic_and_custom_plugin_creater.cc
@@ -197,7 +197,7 @@ class GenericPluginCreater : public OpConverter {
         phi_kernel_signature.input_names.empty() ||
             phi_kernel_signature.output_names.empty(),
         false,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The %s op's kernel signature (inputs and output) should not null.",
             op_desc.Type()));
 
@@ -212,13 +212,13 @@ class GenericPluginCreater : public OpConverter {
         auto *var = block_desc.FindVar(arg_name);
         PADDLE_ENFORCE_NOT_NULL(
             var,
-            phi::errors::NotFound("There is no variable called %s in block.",
-                                  arg_name.c_str()));
+            common::errors::NotFound("There is no variable called %s in block.",
+                                     arg_name.c_str()));
         PADDLE_ENFORCE_EQ(
             var->GetType(),
             FluidDT::VarType_Type_LOD_TENSOR,
-            phi::errors::InvalidArgument("TensorRT engine only takes "
-                                         "LoDTensor as input"));
+            common::errors::InvalidArgument("TensorRT engine only takes "
+                                            "LoDTensor as input"));
         in_out_info.inputs_data_type.push_back(
             ProtoTypeToGeneratePluginDataType(var->GetDataType()));
       }
@@ -231,13 +231,13 @@ class GenericPluginCreater : public OpConverter {
         auto *var = block_desc.FindVar(arg_name);
         PADDLE_ENFORCE_NOT_NULL(
             var,
-            phi::errors::NotFound("There is no variable called %s in block.",
-                                  arg_name.c_str()));
+            common::errors::NotFound("There is no variable called %s in block.",
+                                     arg_name.c_str()));
         PADDLE_ENFORCE_EQ(
             var->GetType(),
             FluidDT::VarType_Type_LOD_TENSOR,
-            phi::errors::InvalidArgument("TensorRT engine only takes "
-                                         "LoDTensor as input"));
+            common::errors::InvalidArgument("TensorRT engine only takes "
+                                            "LoDTensor as input"));
         in_out_info.outputs_data_type.push_back(
             ProtoTypeToGeneratePluginDataType(var->GetDataType()));
       }
@@ -288,13 +288,13 @@ class CustomGenericPluginCreater : public OpConverter {
         auto *var = block_desc.FindVar(arg_name);
         PADDLE_ENFORCE_NOT_NULL(
             var,
-            phi::errors::NotFound("There is no variable called %s in block.",
-                                  arg_name.c_str()));
+            common::errors::NotFound("There is no variable called %s in block.",
+                                     arg_name.c_str()));
         PADDLE_ENFORCE_EQ(
             var->GetType(),
             FluidDT::VarType_Type_LOD_TENSOR,
-            phi::errors::InvalidArgument("TensorRT engine only takes "
-                                         "LoDTensor as input"));
+            common::errors::InvalidArgument("TensorRT engine only takes "
+                                            "LoDTensor as input"));
         in_out_info.inputs_data_type.push_back(
             ProtoTypeToGenerateCustomGenericPluginDataType(var->GetDataType()));
       }
@@ -313,13 +313,13 @@ class CustomGenericPluginCreater : public OpConverter {
         auto *var = block_desc.FindVar(arg_name);
         PADDLE_ENFORCE_NOT_NULL(
             var,
-            phi::errors::NotFound("There is no variable called %s in block.",
-                                  arg_name.c_str()));
+            common::errors::NotFound("There is no variable called %s in block.",
+                                     arg_name.c_str()));
         PADDLE_ENFORCE_EQ(
             var->GetType(),
             FluidDT::VarType_Type_LOD_TENSOR,
-            phi::errors::InvalidArgument("TensorRT engine only takes "
-                                         "LoDTensor as input"));
+            common::errors::InvalidArgument("TensorRT engine only takes "
+                                            "LoDTensor as input"));
         in_out_info.outputs_data_type.push_back(
             ProtoTypeToGenerateCustomGenericPluginDataType(var->GetDataType()));
       }

--- a/paddle/fluid/inference/tensorrt/convert/hard_sigmoid_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/hard_sigmoid_op.cc
@@ -42,7 +42,7 @@ class HardSigmoidOpConverter : public OpConverter {
     auto output_name = op_desc.Output("Out")[0];
     ReplenishLayerAndOutput(layer, "hard_sigmoid", {output_name}, test_mode);
 #else
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "Hard sigmoid TRT converter is only supported on TRT 5 or higher. "
         "Please confirm your TRT version is no less than 5.0."));
 #endif

--- a/paddle/fluid/inference/tensorrt/convert/instance_norm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/instance_norm_op.cc
@@ -33,18 +33,18 @@ class InstanceNormOpConverter : public OpConverter {
     auto* bias_var = scope.FindVar(op_desc.Input("Bias")[0]);
     PADDLE_ENFORCE_NOT_NULL(
         scale_var,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input [Scale] of instance_norm op converter should not be null"));
     PADDLE_ENFORCE_NOT_NULL(
         bias_var,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input [Bias] of instance_norm op converter should not be null"));
     auto* scale_tensor = scale_var->GetMutable<phi::DenseTensor>();
     auto* bias_tensor = bias_var->GetMutable<phi::DenseTensor>();
     PADDLE_ENFORCE_EQ(
         scale_tensor->numel(),
         bias_tensor->numel(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Num of input [Scale] and [Bias] of instance_norm op converter "
             "should be equal. Got Scale num = %ld, but Bias num = %ld",
             scale_tensor->numel(),

--- a/paddle/fluid/inference/tensorrt/convert/io_converter.cc
+++ b/paddle/fluid/inference/tensorrt/convert/io_converter.cc
@@ -33,10 +33,10 @@ class DefaultIOConverter : public EngineIOConverter {
                           void* out,
                           size_t max_size) override {
     PADDLE_ENFORCE_NOT_NULL(out,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "The input param 'out' must not be nullptr."));
     PADDLE_ENFORCE_NOT_NULL(stream_,
-                            phi::errors::PreconditionNotMet(
+                            common::errors::PreconditionNotMet(
                                 "You should set up stream_ by SetStream() "
                                 "before you call the operator()."));
     const auto& place = in.place();
@@ -44,7 +44,7 @@ class DefaultIOConverter : public EngineIOConverter {
     PADDLE_ENFORCE_LE(
         size,
         max_size,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input Tensor in's memory_size should be less than or equal to "
             "the input max_size. But in's memory_size = %u, max_size = %u.",
             size,
@@ -57,10 +57,10 @@ class DefaultIOConverter : public EngineIOConverter {
           0,
           cudaMemcpyAsync(
               out, in.data<float>(), size, cudaMemcpyDeviceToDevice, *stream_),
-          phi::errors::External(
+          common::errors::External(
               "cudaMemcpyAsync(cudaMemcpyDeviceToDevice) error."));
     } else {
-      PADDLE_THROW(phi::errors::NotFound("Unknown device for converter"));
+      PADDLE_THROW(common::errors::NotFound("Unknown device for converter"));
     }
     cudaStreamSynchronize(*stream_);
   }
@@ -69,10 +69,10 @@ class DefaultIOConverter : public EngineIOConverter {
                           LoDTensor* out,
                           size_t max_size) override {
     PADDLE_ENFORCE_NOT_NULL(in,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "The input param 'in' must not be nullptr."));
     PADDLE_ENFORCE_NOT_NULL(stream_,
-                            phi::errors::PreconditionNotMet(
+                            common::errors::PreconditionNotMet(
                                 "You should set up stream_ by SetStream() "
                                 "before you call the operator()."));
     const auto& place = out->place();
@@ -80,7 +80,7 @@ class DefaultIOConverter : public EngineIOConverter {
     PADDLE_ENFORCE_LE(
         size,
         max_size,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input Tensor out's memory_size should be less than or equal "
             "to the input max_size. "
             "But out's memory_size = %u, max_size = %u.",
@@ -91,17 +91,17 @@ class DefaultIOConverter : public EngineIOConverter {
           0,
           cudaMemcpyAsync(
               out->data<float>(), in, size, cudaMemcpyDeviceToHost, *stream_),
-          phi::errors::External(
+          common::errors::External(
               "cudaMemcpyAsync(cudaMemcpyDeviceToHost) error."));
     } else if (is_gpu_place(place)) {
       PADDLE_ENFORCE_EQ(
           0,
           cudaMemcpyAsync(
               out->data<float>(), in, size, cudaMemcpyDeviceToDevice, *stream_),
-          phi::errors::External(
+          common::errors::External(
               "cudaMemcpyAsync(cudaMemcpyDeviceToDevice) error."));
     } else {
-      PADDLE_THROW(phi::errors::NotFound("Unknown device for converter"));
+      PADDLE_THROW(common::errors::NotFound("Unknown device for converter"));
     }
     cudaStreamSynchronize(*stream_);
   }

--- a/paddle/fluid/inference/tensorrt/convert/io_converter.h
+++ b/paddle/fluid/inference/tensorrt/convert/io_converter.h
@@ -50,15 +50,15 @@ class EngineIOConverter {
                            void* out,
                            size_t max_size,
                            cudaStream_t* stream) {
-    PADDLE_ENFORCE_NOT_NULL(
-        stream,
-        phi::errors::InvalidArgument("The input stream must not be nullptr."));
+    PADDLE_ENFORCE_NOT_NULL(stream,
+                            common::errors::InvalidArgument(
+                                "The input stream must not be nullptr."));
     auto* converter = Registry<EngineIOConverter>::Global().Lookup(
         op_type, "default" /* default_type */);
     PADDLE_ENFORCE_NOT_NULL(
         converter,
-        phi::errors::Unimplemented("The %s in is not supported yet.",
-                                   op_type.c_str()));
+        common::errors::Unimplemented("The %s in is not supported yet.",
+                                      op_type.c_str()));
     converter->SetStream(stream);
     (*converter)(in, out, max_size);
   }
@@ -68,15 +68,15 @@ class EngineIOConverter {
                             phi::DenseTensor* out,
                             size_t max_size,
                             cudaStream_t* stream) {
-    PADDLE_ENFORCE_NOT_NULL(
-        stream,
-        phi::errors::InvalidArgument("The input stream must not be nullptr."));
+    PADDLE_ENFORCE_NOT_NULL(stream,
+                            common::errors::InvalidArgument(
+                                "The input stream must not be nullptr."));
     auto* converter = Registry<EngineIOConverter>::Global().Lookup(
         op_type, "default" /* default_type */);
     PADDLE_ENFORCE_NOT_NULL(
         converter,
-        phi::errors::Unimplemented("The %s in not supported yet.",
-                                   op_type.c_str()));
+        common::errors::Unimplemented("The %s in not supported yet.",
+                                      op_type.c_str()));
     converter->SetStream(stream);
     (*converter)(in, out, max_size);
   }

--- a/paddle/fluid/inference/tensorrt/convert/layer_norm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/layer_norm_op.cc
@@ -85,11 +85,11 @@ class LayerNormOpConverter : public OpConverter {
               : 1;
       PADDLE_ENFORCE_NOT_NULL(
           Bias_v,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Input(Bias) of layer_norm should not be null."));
       PADDLE_ENFORCE_NOT_NULL(
           Scale_v,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Input(Scale) of layer_norm should not be null."));
       auto* Bias_t = Bias_v->GetMutable<phi::DenseTensor>();
       auto* Scale_t = Scale_v->GetMutable<phi::DenseTensor>();
@@ -122,11 +122,11 @@ class LayerNormOpConverter : public OpConverter {
       auto* Scale_v = scope.FindVar(op_desc.Input("Scale")[0]);
       PADDLE_ENFORCE_NOT_NULL(
           Bias_v,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Input(Bias) of layer_norm should not be null."));
       PADDLE_ENFORCE_NOT_NULL(
           Scale_v,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Input(Scale) of layer_norm should not be null."));
       auto* Bias_t = Bias_v->GetMutable<phi::DenseTensor>();
       auto* Scale_t = Scale_v->GetMutable<phi::DenseTensor>();

--- a/paddle/fluid/inference/tensorrt/convert/layernorm_shift_partition_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/layernorm_shift_partition_op.cc
@@ -49,16 +49,16 @@ class LayerNormShiftPartitionOpConverter : public OpConverter {
 
     PADDLE_ENFORCE_NOT_NULL(
         Bias_v,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input(Bias) of layer_norm should not be null."));
     PADDLE_ENFORCE_NOT_NULL(
         Scale_v,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input(Scale) of layer_norm should not be null."));
     PADDLE_ENFORCE_EQ(
         begin_norm_axis,
         2,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The begin_norm_axis of LayernormShiftPartition should be %d",
             begin_norm_axis));
 
@@ -72,7 +72,7 @@ class LayerNormShiftPartitionOpConverter : public OpConverter {
     bool with_fp16 = engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
     PADDLE_ENFORCE_EQ(bias_weight.get().count,
                       scale_weight.get().count,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The num between bias_weight and scale_weight should "
                           "be equal. (%d vs %d)",
                           bias_weight.get().count,
@@ -91,7 +91,7 @@ class LayerNormShiftPartitionOpConverter : public OpConverter {
               with_fp16);
       layernorm_layer = engine_->AddDynamicPlugin(&X, 1, plugin);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "LayernormShiftPartition TRT Plugin should run in dynamic shape."));
     }
 

--- a/paddle/fluid/inference/tensorrt/convert/leaky_relu_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/leaky_relu_op.cc
@@ -64,7 +64,7 @@ class LeakyReluOpConverter : public OpConverter {
                                              power.get());
     PADDLE_ENFORCE_NOT_NULL(
         scale_layer,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Invalid scale layer in leaky_relu TRT op converter. "
             "The scale layer should not be null."));
     // y_relu = (x > 0) : x : 0
@@ -72,7 +72,7 @@ class LeakyReluOpConverter : public OpConverter {
         engine_, Activation, *input, nvinfer1::ActivationType::kRELU);
     PADDLE_ENFORCE_NOT_NULL(
         relu_layer,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Invalid relu layer in leaky_relu TRT op converter. "
             "The relu layer should not be null."));
     //
@@ -87,7 +87,7 @@ class LeakyReluOpConverter : public OpConverter {
                                                   power.get());
     PADDLE_ENFORCE_NOT_NULL(
         scale_relu_layer,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Invalid scale_relu layer in leaky_relu TRT op converter. The "
             "scale_relu layer should not be null."));
     output_layer = TRT_ENGINE_ADD_LAYER(engine_,
@@ -97,7 +97,7 @@ class LeakyReluOpConverter : public OpConverter {
                                         nvinfer1::ElementWiseOperation::kSUM);
     PADDLE_ENFORCE_NOT_NULL(
         output_layer,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Invalid output layer in leaky_relu TRT op "
             "converter. The output layer should not be null."));
     // keep alpha tensor to avoid release it's memory
@@ -106,7 +106,7 @@ class LeakyReluOpConverter : public OpConverter {
         (engine_->weight_map.find(alpha_name) == engine_->weight_map.end());
     PADDLE_ENFORCE_EQ(alpha_not_in_weight_map,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The name of parameter alpha in leaky_relu TRT op "
                           "converter is already "
                           "found in the weight map. The same weight cannot be "

--- a/paddle/fluid/inference/tensorrt/convert/logsigmoid_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/logsigmoid_op.cc
@@ -31,7 +31,7 @@ class LogSigmoidOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         input_num,
         1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input X's size must equal to 1 in TRT LogSigmoid op."
             " But received X's size %d.",
             input_num));
@@ -41,7 +41,7 @@ class LogSigmoidOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         output_num,
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The output Out's size must equal to 1 in TRT LogSigmoid op. "
             "But received Out's size %u.",
             output_num));

--- a/paddle/fluid/inference/tensorrt/convert/matrix_multiply_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/matrix_multiply_op.cc
@@ -146,7 +146,7 @@ class MatrixMultiplyOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         y_num_col_dims,
         y_rank - 1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The matrix_multiply op'y_num_col_dims should be equal "
             "to y'rank - 1, but got y_num_col_dims = %d, and y_rank = %d",
             y_num_col_dims,

--- a/paddle/fluid/inference/tensorrt/convert/merge_layernorm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/merge_layernorm_op.cc
@@ -36,16 +36,16 @@ class MergeLayernormOpConverter : public OpConverter {
                           : 1e-5f;
     PADDLE_ENFORCE_NOT_NULL(
         Bias_v,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input(Bias) of layer_norm should not be null."));
     PADDLE_ENFORCE_NOT_NULL(
         Scale_v,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input(Scale) of layer_norm should not be null."));
     PADDLE_ENFORCE_EQ(
         begin_norm_axis,
         2,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The begin_norm_axis of LayernormShiftPartition should be %d",
             begin_norm_axis));
     auto* Bias_t = Bias_v->GetMutable<phi::DenseTensor>();
@@ -69,7 +69,7 @@ class MergeLayernormOpConverter : public OpConverter {
               with_fp16);
       merge_layernorm_layer = engine_->AddDynamicPlugin(&X, 1, plugin);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Currently, MergeLayernorm TRT Plugin only support dynamic shape "
           "mode."));
     }

--- a/paddle/fluid/inference/tensorrt/convert/multihead_matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/multihead_matmul_op.cc
@@ -102,7 +102,7 @@ class MultiheadMatMulOpConverter : public OpConverter {
           auto bias_qk_dims = bias_qk_tensor->getDimensions();
           PADDLE_ENFORCE_EQ(bias_qk_dims.nbDims,
                             4,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "The rank of Multihead Matmul'BiasQK must be "
                                 "4, but got rank is %d.",
                                 bias_qk_dims.nbDims));
@@ -191,7 +191,7 @@ class MultiheadMatMulOpConverter : public OpConverter {
                      "with_interleaved";
           if (!op_desc.HasAttr("Input_scale")) {
             PADDLE_THROW(
-                phi::errors::Fatal("use with_interleaved must be int8."));
+                common::errors::Fatal("use with_interleaved must be int8."));
           }
           nvinfer1::ILayer* fc_layer = nullptr;
           float dp_probs = 1.0 / 127.0;
@@ -205,7 +205,7 @@ class MultiheadMatMulOpConverter : public OpConverter {
           PADDLE_ENFORCE_EQ(
               op_desc.HasAttr("fc_out_threshold"),
               true,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "must have out_threshold in multihead layers in int8 mode"));
           float out_scale =
               PADDLE_GET_CONST(float, op_desc.GetAttr("fc_out_threshold"));
@@ -378,7 +378,7 @@ class MultiheadMatMulOpConverter : public OpConverter {
           if (op_desc.HasAttr("fc_out_threshold")) {
             PADDLE_ENFORCE_EQ(op_desc.HasAttr("fc_out_threshold"),
                               true,
-                              phi::errors::InvalidArgument(
+                              common::errors::InvalidArgument(
                                   "must have out threshold in multihead layers "
                                   "in int8 mode"));
             float out_scale =
@@ -593,7 +593,7 @@ class MultiheadMatMulOpConverter : public OpConverter {
           if (op_desc.HasAttr("Input_scale")) {
             PADDLE_ENFORCE_EQ(op_desc.HasAttr("fc_out_threshold"),
                               true,
-                              phi::errors::InvalidArgument(
+                              common::errors::InvalidArgument(
                                   "must have out threshold in multihead layers "
                                   "in int8 mode"));
             float out_scale =
@@ -637,7 +637,7 @@ class MultiheadMatMulOpConverter : public OpConverter {
                                      bias);
             PADDLE_ENFORCE_EQ(op_desc.HasAttr("fc_out_threshold"),
                               true,
-                              phi::errors::InvalidArgument(
+                              common::errors::InvalidArgument(
                                   "must have out threshold in multihead layers "
                                   "in int8 mode"));
             float out_scale =
@@ -789,7 +789,7 @@ class MultiheadMatMulOpConverter : public OpConverter {
           PADDLE_ENFORCE_EQ(
               input->getDimensions().nbDims,
               3,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "The Input dim of the MultiheadMatMul should be 3, "
                   "but it's (%d) now.",
                   input->getDimensions().nbDims));
@@ -833,7 +833,7 @@ class MultiheadMatMulOpConverter : public OpConverter {
           if (op_desc.HasAttr("Input_scale")) {
             PADDLE_ENFORCE_EQ(op_desc.HasAttr("fc_out_threshold"),
                               true,
-                              phi::errors::InvalidArgument(
+                              common::errors::InvalidArgument(
                                   "must have out threshold in multihead layers "
                                   "in int8 mode"));
             float out_scale =
@@ -902,7 +902,7 @@ class MultiheadMatMulOpConverter : public OpConverter {
           if (op_desc.HasAttr("fc_out_threshold")) {
             PADDLE_ENFORCE_EQ(op_desc.HasAttr("fc_out_threshold"),
                               true,
-                              phi::errors::InvalidArgument(
+                              common::errors::InvalidArgument(
                                   "must have out threshold in multihead layers "
                                   "in int8 mode"));
             float out_scale =
@@ -949,7 +949,7 @@ class MultiheadMatMulOpConverter : public OpConverter {
         }
       }
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "You are running the Ernie(Bert) model in static shape mode, which "
           "is not supported for the time being.\n"
           "You can use the config.SetTRTDynamicShapeInfo(...) interface to set "

--- a/paddle/fluid/inference/tensorrt/convert/multihead_matmul_roformer_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/multihead_matmul_roformer_op.cc
@@ -86,12 +86,13 @@ class MultiheadMatMulRoformerOpConverter : public OpConverter {
 
     if (engine_->with_dynamic_shape()) {
       if (flag_varseqlen) {
-        PADDLE_THROW(phi::errors::Fatal("roformer not support varseqlen yet"));
+        PADDLE_THROW(
+            common::errors::Fatal("roformer not support varseqlen yet"));
       } else {
         PADDLE_ENFORCE_EQ(
             input->getDimensions().nbDims,
             3,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The Input dim of the MultiheadMatMul should be 3, "
                 "but it's (%d) now.",
                 input->getDimensions().nbDims));
@@ -133,7 +134,7 @@ class MultiheadMatMulRoformerOpConverter : public OpConverter {
           PADDLE_ENFORCE_EQ(
               op_desc.HasAttr("fc_out_threshold"),
               true,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "must have out threshold in multihead layers in int8 mode"));
           float out_scale =
               PADDLE_GET_CONST(float, op_desc.GetAttr("fc_out_threshold"));
@@ -199,7 +200,7 @@ class MultiheadMatMulRoformerOpConverter : public OpConverter {
           PADDLE_ENFORCE_EQ(
               op_desc.HasAttr("fc_out_threshold"),
               true,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "must have out threshold in multihead layers in int8 mode"));
           float out_scale =
               PADDLE_GET_CONST(float, op_desc.GetAttr("fc_out_threshold"));
@@ -233,7 +234,7 @@ class MultiheadMatMulRoformerOpConverter : public OpConverter {
         layer = engine_->AddDynamicPlugin(plugin_inputs.data(), 4, plugin);
       }
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "You are running the Ernie(Bert) model in static shape mode, which "
           "is not supported for the time being.\n"
           "You can use the config.SetTRTDynamicShapeInfo(...) interface to set "

--- a/paddle/fluid/inference/tensorrt/convert/nearest_interp_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/nearest_interp_op.cc
@@ -94,7 +94,7 @@ class NearestInterpolateOpConverter : public OpConverter {
       scales.push_back(1.f);
     } else {
       PADDLE_THROW(
-          phi::errors::InvalidArgument("Data layout must be NCHW or NHWC."));
+          common::errors::InvalidArgument("Data layout must be NCHW or NHWC."));
     }
     layer->setScales(scales.data(), scales.size());
 

--- a/paddle/fluid/inference/tensorrt/convert/nearest_interp_v2_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/nearest_interp_v2_op.cc
@@ -107,7 +107,7 @@ class NearestInterpolateV2OpConverter : public OpConverter {
       scales.push_back(1.f);
     } else {
       PADDLE_THROW(
-          phi::errors::InvalidArgument("Data layout must be NCHW or NHWC."));
+          common::errors::InvalidArgument("Data layout must be NCHW or NHWC."));
     }
 
     if (engine_->with_dynamic_shape()) {

--- a/paddle/fluid/inference/tensorrt/convert/one_hot_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/one_hot_op.cc
@@ -57,7 +57,7 @@ class OneHotOpConverter : public OpConverter {
         VLOG(3) << "trt not support float64, so it is converted to float32.";
       }
     } else {
-      PADDLE_THROW(phi::errors::Fatal("one_hot is not supported"));
+      PADDLE_THROW(common::errors::Fatal("one_hot is not supported"));
     }
 
     auto depth_name = op_desc.Input("depth_tensor");

--- a/paddle/fluid/inference/tensorrt/convert/op_converter.h
+++ b/paddle/fluid/inference/tensorrt/convert/op_converter.h
@@ -68,7 +68,7 @@ class OpConverter {
               "add", "mul", "sub", "div", "max", "min", "pow", "mod"};
           PADDLE_ENFORCE_EQ(op_desc.Input("Y").size(),
                             1UL,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "The input op's Input(\"Y\")."
                                 "size() should equal to 1, but received "
                                 "Input(\"Y\").size() = %u.",
@@ -81,64 +81,64 @@ class OpConverter {
             PADDLE_ENFORCE_GT(
                 add_weight_op_set.count(op_type),
                 0,
-                phi::errors::Unimplemented("Unsupported elementwise type %s",
-                                           op_type.c_str()));
+                common::errors::Unimplemented("Unsupported elementwise type %s",
+                                              op_type.c_str()));
             it = Registry<OpConverter>::Global().Lookup("elementwise_" +
                                                         op_type + "_weight");
             PADDLE_ENFORCE_NOT_NULL(
                 it,
-                phi::errors::Unimplemented("no OpConverter for optype [%s]",
-                                           op_desc.Type()));
+                common::errors::Unimplemented("no OpConverter for optype [%s]",
+                                              op_desc.Type()));
           } else {
             PADDLE_ENFORCE_GT(
                 add_tensor_op_set.count(op_type),
                 0,
-                phi::errors::Unimplemented("Unsupported elementwise type %s",
-                                           op_type.c_str()));
+                common::errors::Unimplemented("Unsupported elementwise type %s",
+                                              op_type.c_str()));
             it = Registry<OpConverter>::Global().Lookup("elementwise_" +
                                                         op_type + "_tensor");
           }
           PADDLE_ENFORCE_NOT_NULL(
               it,
-              phi::errors::Unimplemented("no OpConverter for optype [%s]",
-                                         op_desc.Type()));
+              common::errors::Unimplemented("no OpConverter for optype [%s]",
+                                            op_desc.Type()));
         }
 
         if (op_desc.Type() == "depthwise_conv2d") {
           it = Registry<OpConverter>::Global().Lookup("conv2d");
           PADDLE_ENFORCE_NOT_NULL(
               it,
-              phi::errors::Unimplemented("no OpConverter for optype [%s]",
-                                         op_desc.Type()));
+              common::errors::Unimplemented("no OpConverter for optype [%s]",
+                                            op_desc.Type()));
         }
         if (op_desc.Type() == "depthwise_conv2d_transpose") {
           it = Registry<OpConverter>::Global().Lookup("conv2d_transpose");
           PADDLE_ENFORCE_NOT_NULL(
               it,
-              phi::errors::Unimplemented("no OpConverter for optype [%s]",
-                                         op_desc.Type()));
+              common::errors::Unimplemented("no OpConverter for optype [%s]",
+                                            op_desc.Type()));
         }
         if (op_desc.Type() == "transpose2") {
           it = Registry<OpConverter>::Global().Lookup("transpose");
           PADDLE_ENFORCE_NOT_NULL(
               it,
-              phi::errors::Unimplemented("no OpConverter for optype [%s]",
-                                         op_desc.Type()));
+              common::errors::Unimplemented("no OpConverter for optype [%s]",
+                                            op_desc.Type()));
         }
         if (op_desc.Type() == "flatten2") {
           it = Registry<OpConverter>::Global().Lookup("flatten");
           PADDLE_ENFORCE_NOT_NULL(
               it,
-              phi::errors::Unimplemented("no OpConverter for optype [%s]",
-                                         op_desc.Type()));
+              common::errors::Unimplemented("no OpConverter for optype [%s]",
+                                            op_desc.Type()));
         }
         // reshape2 == reshape
         if (op_desc.Type() == "reshape2") {
           it = Registry<OpConverter>::Global().Lookup("reshape");
           PADDLE_ENFORCE_NOT_NULL(
               it,
-              phi::errors::Unimplemented("no OpConverter for optype [%s]",
-                                         op_desc.Type()));
+              common::errors::Unimplemented("no OpConverter for optype [%s]",
+                                            op_desc.Type()));
         }
         if (!it) {
           it = Registry<OpConverter>::Global().Lookup(op_desc.Type());
@@ -170,8 +170,8 @@ class OpConverter {
 
     PADDLE_ENFORCE_NOT_NULL(
         it,
-        phi::errors::Unimplemented("no OpConverter for optype [%s]",
-                                   op_desc.Type()));
+        common::errors::Unimplemented("no OpConverter for optype [%s]",
+                                      op_desc.Type()));
 
     std::string all_outpus_name = "(Outputs:";
     std::string all_inpus_name = "(Inputs:";
@@ -212,10 +212,10 @@ class OpConverter {
         output_name = op_desc.Output("Y").front();
       } else {
         PADDLE_THROW(
-            phi::errors::NotFound("Op %s has out threshold but doesn't "
-                                  "have an output named \"Output\", "
-                                  "\"Out\" or \"Y\".",
-                                  op_desc.Type()));
+            common::errors::NotFound("Op %s has out threshold but doesn't "
+                                     "have an output named \"Output\", "
+                                     "\"Out\" or \"Y\".",
+                                     op_desc.Type()));
       }
 
       auto* output_itensor = engine->GetITensor(output_name);
@@ -321,13 +321,13 @@ class OpConverter {
       auto* var = block_desc->FindVar(input);
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::NotFound("no variable called %s in block.",
-                                input.c_str()));
+          common::errors::NotFound("no variable called %s in block.",
+                                   input.c_str()));
       PADDLE_ENFORCE_EQ(
           var->GetType(),
           FluidDT::VarType_Type_LOD_TENSOR,
-          phi::errors::InvalidArgument("TensorRT engine only takes "
-                                       "LoDTensor as input"));
+          common::errors::InvalidArgument("TensorRT engine only takes "
+                                          "LoDTensor as input"));
       nvinfer1::DataType in_dtype = FluidDataType2TRT(var->GetDataType());
       if (engine->precision() == phi::DataType::FLOAT16 &&
           in_dtype == nvinfer1::DataType::kFLOAT &&
@@ -341,7 +341,7 @@ class OpConverter {
         if (!(engine->min_input_shape().count(input) &&
               engine->max_input_shape().count(input) &&
               engine->optim_input_shape().count(input))) {
-          PADDLE_THROW(phi::errors::InvalidArgument(
+          PADDLE_THROW(common::errors::InvalidArgument(
               "Cannot get %s min/max/opt shape", input));
         }
         auto min_input_shape = engine->min_input_shape().at(input);
@@ -359,7 +359,7 @@ class OpConverter {
             // the i dimension should be same.
             PADDLE_ENFORCE_EQ(min_input_shape[i],
                               optim_input_shape[i],
-                              phi::errors::InvalidArgument(
+                              common::errors::InvalidArgument(
                                   "The dim (%d) of the min_input_shape and "
                                   "optim_input_shape should be same."));
           }
@@ -380,12 +380,12 @@ class OpConverter {
       auto* var = block_desc->FindVar(output);
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::NotFound("no variable called %s in block.",
-                                output.c_str()));
+          common::errors::NotFound("no variable called %s in block.",
+                                   output.c_str()));
       PADDLE_ENFORCE_EQ(
           var->GetType(),
           FluidDT::VarType_Type_LOD_TENSOR,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The output tensor in TensorRT subgraph should be LoDTensor"));
       nvinfer1::DataType out_dtype = FluidDataType2TRT(var->GetDataType());
       if (engine->precision() == phi::DataType::FLOAT16 &&
@@ -541,7 +541,7 @@ class OpConverter {
     auto oldShapeDims = oldShape->getDimensions();
     const int rank = oldShapeDims.nbDims;
     if (rank > nbDims) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Cannot broadcast a higher rank tensor to a lower rank tensor."));
     }
     if (rank < nbDims) {
@@ -662,7 +662,7 @@ class OpConverter {
     PADDLE_ENFORCE_GE(
         index,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The index should be greater or equal than 0, but got %d", index));
 
     auto* tensor =
@@ -699,7 +699,7 @@ class OpConverter {
     if (!(std::is_same<T, float>::value ||
           std::is_same<T, phi::dtype::float16>::value ||
           std::is_same<T, int32_t>::value)) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupported data type (%s) for TensorRT AddConstantLayer, only "
           "supports float, half or int32_t."));
     }
@@ -736,7 +736,7 @@ class OpConverter {
     if (!(std::is_same<T, float>::value ||
           std::is_same<T, phi::dtype::float16>::value ||
           std::is_same<T, int32_t>::value)) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupported data type (%s) for TensorRT AddConstantLayer, only "
           "supports float, half or int32_t."));
     }
@@ -818,7 +818,7 @@ class OpConverter {
       // PADDLE_ENFORCE_GE(
       //     layer->getOutput(i)->getDimensions().nbDims,
       //     0,
-      //     phi::errors::InvalidArgument(
+      //     common::errors::InvalidArgument(
       //         "Error occures in Paddle-TRT layer with output name: %s",
       //         output_tensor_names[i].c_str()));
     }

--- a/paddle/fluid/inference/tensorrt/convert/pad3d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pad3d_op.cc
@@ -57,7 +57,7 @@ class Pad3dOpConverter : public OpConverter {
     const int pad_size = paddings->getDimensions().d[0];
     PADDLE_ENFORCE_EQ(input_dim * 2 - 4,
                       pad_size,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Expected paddings size is %d, but received %d.",
                           input_dim * 2 - 4,
                           pad_size));
@@ -163,7 +163,7 @@ class Pad3dOpConverter : public OpConverter {
       slice_layer->setMode(nvinfer1::SliceMode::kCLAMP);
 #endif
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Unsupported mode: %s", padding_mode));
+      PADDLE_THROW(common::errors::Fatal("Unsupported mode: %s", padding_mode));
     }
 
     auto output_name = op_desc.Output("Out")[0];

--- a/paddle/fluid/inference/tensorrt/convert/pad_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pad_op.cc
@@ -48,7 +48,7 @@ class PadOpConverter : public OpConverter {
 
     PADDLE_ENFORCE_NOT_NULL(
         layer,
-        phi::errors::External("add padding layer to tensorrt engine error"));
+        common::errors::External("add padding layer to tensorrt engine error"));
     auto output_name = op_desc.Output("Out")[0];
     ReplenishLayerAndOutput(layer, "pad", {output_name}, test_mode);
   }

--- a/paddle/fluid/inference/tensorrt/convert/pool2d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pool2d_op.cc
@@ -183,7 +183,7 @@ class Pool2dOpConverter : public OpConverter {
               engine_, PaddingNd, *input1, g_pre_pad, g_post_pad);
           PADDLE_ENFORCE_NOT_NULL(
               pad_layer,
-              phi::errors::Fatal(
+              common::errors::Fatal(
                   "Pad layer in poolOp converter could not be "
                   "created. The pointer to pad layer is `NULL`."));
           input1 = pad_layer->getOutput(0);
@@ -243,7 +243,7 @@ class Pool2dOpConverter : public OpConverter {
           engine_, PoolingNd, *input1, nv_pool_type, nv_ksize);
       PADDLE_ENFORCE_NOT_NULL(
           pool_layer,
-          phi::errors::Fatal(
+          common::errors::Fatal(
               "trt pool layer in converter could not be created."));
       auto output_name = op_desc.Output("Out")[0];
       pool_layer->setName(("pool2d (Output: " + output_name + ")").c_str());
@@ -276,7 +276,7 @@ class Pool2dOpConverter : public OpConverter {
 
           PADDLE_ENFORCE_NOT_NULL(
               pad_layer,
-              phi::errors::Fatal(
+              common::errors::Fatal(
                   "Pad layer in poolOp converter could not be "
                   "created. The pointer to pad layer is `NULL`."));
           input1 = pad_layer->getOutput(0);
@@ -285,7 +285,7 @@ class Pool2dOpConverter : public OpConverter {
               engine_, PoolingNd, *input1, nv_pool_type, nv_ksize);
           PADDLE_ENFORCE_NOT_NULL(
               pool_layer,
-              phi::errors::Fatal(
+              common::errors::Fatal(
                   "trt pool layer in converter could not be created."));
           pool_layer->setStrideNd(nv_strides);
           pool_layer->setPaddingNd(nv_paddings);
@@ -311,7 +311,7 @@ class Pool2dOpConverter : public OpConverter {
           auto *pool_layer = engine_->AddPlugin(&input1, 1, plugin);
           PADDLE_ENFORCE_NOT_NULL(
               pool_layer,
-              phi::errors::Fatal(
+              common::errors::Fatal(
                   "trt pool plugin layer in converter could not be created."));
           layer = pool_layer;
         }
@@ -326,7 +326,7 @@ class Pool2dOpConverter : public OpConverter {
               engine_, PaddingNd, *input1, g_pre_pad, g_post_pad);
           PADDLE_ENFORCE_NOT_NULL(
               pad_layer,
-              phi::errors::Fatal(
+              common::errors::Fatal(
                   "Pad layer in poolOp converter could not be "
                   "created. The pointer to pad layer is `NULL`."));
           input1 = pad_layer->getOutput(0);
@@ -336,7 +336,7 @@ class Pool2dOpConverter : public OpConverter {
             engine_, PoolingNd, *input1, nv_pool_type, nv_ksize);
         PADDLE_ENFORCE_NOT_NULL(
             pool_layer,
-            phi::errors::Fatal(
+            common::errors::Fatal(
                 "trt pool layer in converter could not be created."));
         pool_layer->setStrideNd(nv_strides);
         pool_layer->setPaddingNd(nv_paddings);
@@ -366,7 +366,7 @@ class Pool2dOpConverter : public OpConverter {
       auto *pool_layer = engine_->AddPlugin(&input1, 1, plugin);
       PADDLE_ENFORCE_NOT_NULL(
           pool_layer,
-          phi::errors::Fatal(
+          common::errors::Fatal(
               "trt pool plugin layer in converter could not be created."));
       layer = pool_layer;
     }

--- a/paddle/fluid/inference/tensorrt/convert/pool3d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pool3d_op.cc
@@ -173,7 +173,7 @@ class Pool3dOpConverter : public OpConverter {
             engine_, PoolingNd, *input1, nv_pool_type, nv_ksize);
         PADDLE_ENFORCE_NOT_NULL(
             pool_layer,
-            phi::errors::Fatal(
+            common::errors::Fatal(
                 "trt pool layer in converter could not be created."));
         pool_layer->setStrideNd(nv_strides);
         pool_layer->setPaddingNd(nv_paddings);
@@ -195,7 +195,7 @@ class Pool3dOpConverter : public OpConverter {
         auto *pool_layer = engine_->AddPluginV2Ext(&input1, 1, plugin);
         PADDLE_ENFORCE_NOT_NULL(
             pool_layer,
-            phi::errors::Fatal(
+            common::errors::Fatal(
                 "trt pool3d plugin layer in converter could not be created."));
         layer = pool_layer;
       }
@@ -217,7 +217,7 @@ class Pool3dOpConverter : public OpConverter {
       auto *pool_layer = engine_->AddPluginV2Ext(&input1, 1, plugin);
       PADDLE_ENFORCE_NOT_NULL(
           pool_layer,
-          phi::errors::Fatal(
+          common::errors::Fatal(
               "trt pool3d plugin layer in converter could not be created."));
       layer = pool_layer;
     }

--- a/paddle/fluid/inference/tensorrt/convert/preln_emb_eltwise_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/preln_emb_eltwise_layernorm.cc
@@ -40,14 +40,14 @@ class PrelnEmbEltwiseLayerNormOpConverter : public OpConverter {
                              !mask_id_name.empty();
 
     if (!flag_prelayernorm) {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "PrelnErnie: If you want to use varseqlen, must be with interleaved, "
           "set pos_id_name, set mask_id_name."));
     }
     framework::OpDesc op_desc(op, nullptr);
     bool enable_int8 = op_desc.HasAttr("enable_int8");
     if (!enable_int8) {
-      PADDLE_THROW(phi::errors::Fatal("use with_interleaved must be int8."));
+      PADDLE_THROW(common::errors::Fatal("use with_interleaved must be int8."));
     }
     // Declare inputs
     std::vector<nvinfer1::ITensor*> input_ids;
@@ -144,7 +144,7 @@ class PrelnEmbEltwiseLayerNormOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         output_fp16,
         1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Only Precision::KHalf(fp16) is supported when infering "
             "ernie(bert) model with config.EnableVarseqlen(). "
             "But Precision::KFloat32 is setted."));
@@ -227,7 +227,7 @@ class PrelnEmbEltwiseLayerNormOpConverter : public OpConverter {
             .c_str());
 
 #else
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "PreInErnie want to use oss, must be with interleaved, "
         "your TRT version is no less than 7.0"));
 #endif

--- a/paddle/fluid/inference/tensorrt/convert/preln_skip_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/preln_skip_layernorm.cc
@@ -24,13 +24,13 @@ class PrelnSkipLayerNormOpConverter : public OpConverter {
 #if IS_TRT_VERSION_GE(7000)
     VLOG(4) << "convert fused preln_skip_layernorm op to tensorrt layer";
     if (!(engine_->use_varseqlen() && engine_->with_interleaved())) {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "PrelnErnie: If you want to use oss, must be with interleaved"));
     }
     framework::OpDesc op_desc(op, nullptr);
     bool enable_int8 = op_desc.HasAttr("enable_int8");
     if (!enable_int8) {
-      PADDLE_THROW(phi::errors::Fatal("use with_interleaved must be int8."));
+      PADDLE_THROW(common::errors::Fatal("use with_interleaved must be int8."));
     }
     // Declare inputs
     auto* input1 = engine_->GetITensor(op_desc.Input("X")[0]);
@@ -67,7 +67,7 @@ class PrelnSkipLayerNormOpConverter : public OpConverter {
     PADDLE_ENFORCE_NE(
         creator,
         nullptr,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "fail to get creator of CustomPrelnSkipLayerNormPluginDynamic"));
     const std::vector<nvinfer1::PluginField> fields{
         {"beta", bias, nvinfer1::PluginFieldType::kFLOAT32, bias_size},
@@ -90,7 +90,7 @@ class PrelnSkipLayerNormOpConverter : public OpConverter {
     PADDLE_ENFORCE_NE(
         plugin_layer,
         nullptr,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "fail to add CustomPrelnSkipLayerNormPluginDynamic layer"));
     layer = plugin_layer;
 
@@ -100,7 +100,7 @@ class PrelnSkipLayerNormOpConverter : public OpConverter {
     ReplenishLayerAndOutput(
         layer, "preln_skip_layernorm", {output_names}, test_mode);
 #else
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "PreInErnie want to use oss, must be with interleaved, "
         "your TRT version is no less than 7.0"));
 #endif

--- a/paddle/fluid/inference/tensorrt/convert/prompt_tuning_emb_eltwise_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/prompt_tuning_emb_eltwise_layernorm.cc
@@ -90,7 +90,7 @@ class PromptTuningEmbEltwiseLayerNormOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         output_fp16,
         1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Only Precision::KHalf(fp16) is supported when infering "
             "ernie(bert) model with config.EnableVarseqlen(). "
             "But Precision::KFloat32 is setted."));

--- a/paddle/fluid/inference/tensorrt/convert/quantize_linear_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/quantize_linear_op.cc
@@ -31,8 +31,8 @@ class QuantizeLinearOpConverter : public OpConverter {
     // Create constant layer for scale
     PADDLE_ENFORCE_NOT_NULL(
         scale_var,
-        phi::errors::NotFound("Can not find %s presistable var in scope.",
-                              op_desc.Input("Scale")[0]));
+        common::errors::NotFound("Can not find %s presistable var in scope.",
+                                 op_desc.Input("Scale")[0]));
     auto* scale_t = scale_var->GetMutable<phi::DenseTensor>();
     int n_scale = scale_t->numel();
     std::vector<float> scale_data(n_scale, 0.0f);
@@ -52,8 +52,8 @@ class QuantizeLinearOpConverter : public OpConverter {
         layer, "quantize_linear", {output_name}, test_model);
 #else
     PADDLE_THROW(
-        phi::errors::Fatal("Paddle-TRT explicit quantization does not "
-                           "support Paddle compiled with TRT < 8.5"));
+        common::errors::Fatal("Paddle-TRT explicit quantization does not "
+                              "support Paddle compiled with TRT < 8.5"));
 #endif
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/recover_padding_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/recover_padding_op.cc
@@ -26,7 +26,7 @@ class RecoverPadding : public OpConverter {
                   const framework::Scope& scope,
                   bool test_mode) override {
     if (!engine_->with_dynamic_shape()) {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "recover_padding_op: If you want to use transformer, must "
           "be with dynamic shape"));
     }
@@ -39,7 +39,8 @@ class RecoverPadding : public OpConverter {
       VLOG(3) << "with_interleaved data format: Recover padding of "
                  "transformer'output: VarSeqlen -> Padding.";
       if (!op_desc.HasAttr("out_threshold")) {
-        PADDLE_THROW(phi::errors::Fatal("use with_interleaved must be int8."));
+        PADDLE_THROW(
+            common::errors::Fatal("use with_interleaved must be int8."));
       }
       auto* transpose = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
       transpose->setSecondTranspose({2, 1, 0, 3});

--- a/paddle/fluid/inference/tensorrt/convert/remove_padding_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/remove_padding_op.cc
@@ -28,7 +28,7 @@ class RemovePadding : public OpConverter {
                   const framework::Scope& scope,
                   bool test_mode) override {
     if (!engine_->with_dynamic_shape()) {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "remove_padding_op: If you want to use transformer, must "
           "be with dynamic shape"));
     }
@@ -49,7 +49,8 @@ class RemovePadding : public OpConverter {
       VLOG(3) << "with_interleaved data format: Remove padding of "
                  "transformer'input: Padding -> VarSeqlen.";
       if (!op_desc.HasAttr("out_threshold")) {
-        PADDLE_THROW(phi::errors::Fatal("use with_interleaved must be int8."));
+        PADDLE_THROW(
+            common::errors::Fatal("use with_interleaved must be int8."));
       }
       float out_scale =
           PADDLE_GET_CONST(float, op_desc.GetAttr("out_threshold"));

--- a/paddle/fluid/inference/tensorrt/convert/reshape_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/reshape_op.cc
@@ -66,7 +66,7 @@ class ReshapeOpConverter : public OpConverter {
     PADDLE_ENFORCE_GE(
         layer->getOutput(0)->getDimensions().nbDims,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Errors occurs in Paddle-TRT reshape2 op, try to use C++ Api "
             "config.Exp_DisableTensorRtOPs({\"reshape2\"})\n; or Python Api "
             "config.exp_disable_tensorrt_ops([\"reshape2\"]) to forbid "

--- a/paddle/fluid/inference/tensorrt/convert/reverse_roll_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/reverse_roll_op.cc
@@ -37,7 +37,7 @@ class ReverseRollOpConverter : public OpConverter {
         PADDLE_GET_CONST(int, op_desc.GetAttr("input_resolution"));
     PADDLE_ENFORCE_EQ(window_size * window_size,
                       window_len,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The window_len should equal to window_size * "
                           "window_size, but got window_size:%d, window_len:%d",
                           window_size,
@@ -45,7 +45,7 @@ class ReverseRollOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         window_number * window_len,
         input_resolution * input_resolution,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input_resolution*input_resolution should equal to "
             "window_number * window_len, but got window_len:%d, "
             "window_number:%d, input_resolution:%d",
@@ -64,7 +64,7 @@ class ReverseRollOpConverter : public OpConverter {
                                                with_fp16);
       reverse_roll_layer = engine_->AddDynamicPlugin(&X, 1, plugin);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "ReverseROll TRT Plugin should run in dynamic shape."));
     }
     auto output_name = op_desc.Output("Out").front();

--- a/paddle/fluid/inference/tensorrt/convert/rnn_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/rnn_op.cc
@@ -34,7 +34,7 @@ class RnnNativeOpConverter : public OpConverter {
 
     PADDLE_ENFORCE_EQ(input->getDimensions().nbDims,
                       3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "RNN(LSTM)'s input must be 3 dimensions, i.e. "
                           "[seq_len, batch, input_size],"
                           "but now is %d  dimensions.",
@@ -42,7 +42,7 @@ class RnnNativeOpConverter : public OpConverter {
 
     PADDLE_ENFORCE_EQ(prev_h->getDimensions().nbDims,
                       3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "RNN(LSTM)'s PreState(Hidden) must be 3 dimensions, "
                           "i.e. [num_layers, batch, hidden_size],"
                           "but now is %d  dimensions.",
@@ -50,7 +50,7 @@ class RnnNativeOpConverter : public OpConverter {
 
     PADDLE_ENFORCE_EQ(prev_c->getDimensions().nbDims,
                       3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "RNN(LSTM)'s PreState(Cell) must be 3 dimensions, "
                           "i.e. [num_layers, batch, hidden_size],"
                           "but now is %d  dimensions.",

--- a/paddle/fluid/inference/tensorrt/convert/scale_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/scale_op.cc
@@ -200,7 +200,7 @@ class ScaleOpConverter : public OpConverter {
 
       PADDLE_ENFORCE_EQ(layer != nullptr,
                         true,
-                        phi::errors::Fatal("Create scale layer failed."));
+                        common::errors::Fatal("Create scale layer failed."));
 
       if (input_dim.nbDims < 3) {
         nvinfer1::Dims squeeze_shape;

--- a/paddle/fluid/inference/tensorrt/convert/set_value_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/set_value_op.cc
@@ -24,7 +24,7 @@ limitations under the License. */
         attr_name__ = vec_##attr_name__[0];                                \
         PADDLE_ENFORCE_EQ(vec_##attr_name__.size(),                        \
                           1UL,                                             \
-                          phi::errors::InvalidArgument(                    \
+                          common::errors::InvalidArgument(                 \
                               "attr axes/starts/ends/steps 's size in "    \
                               "set_value must be one, but got %d",         \
                               vec_##attr_name__.size()));                  \
@@ -94,7 +94,7 @@ class SetValueConverter : public OpConverter {
       PADDLE_ENFORCE_EQ(
           dtype,
           5,
-          phi::errors::InvalidArgument("set_value OP dtype must be float"));
+          common::errors::InvalidArgument("set_value OP dtype must be float"));
       float value = PADDLE_GET_CONST(std::vector<paddle::experimental::Scalar>,
                                      op_desc.GetAttr("values"))[0]
                         .to<float>();
@@ -146,7 +146,7 @@ class SetValueConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         updates->getDimensions().nbDims,
         input_rank,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "ValueTensor‘s rank not equal to Input's rank, "
             "you should try use C++ API "
             "config.exp_disable_tensorrt_ops({\"%s\"}) to forbid this op "
@@ -174,7 +174,7 @@ class SetValueConverter : public OpConverter {
     PADDLE_ENFORCE_GT(
         input_dims.d[axes],
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "the input_dims.d[%d] must be greater than 0, but received %d",
             axes,
             input_dims.d[axes]));
@@ -182,22 +182,22 @@ class SetValueConverter : public OpConverter {
     PADDLE_ENFORCE_GT(
         update_dims.d[axes],
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "the update_dims.d[%d] must be greater than 0, but received %d",
             axes,
             update_dims.d[axes]));
 
-    PADDLE_ENFORCE_LE(
-        axes,
-        input_dims.nbDims,
-        phi::errors::InvalidArgument("The axes %d is larger than total axes %d",
-                                     axes,
-                                     input_dims.nbDims));
+    PADDLE_ENFORCE_LE(axes,
+                      input_dims.nbDims,
+                      common::errors::InvalidArgument(
+                          "The axes %d is larger than total axes %d",
+                          axes,
+                          input_dims.nbDims));
 
     PADDLE_ENFORCE_LE(
         starts,
         input_dims.d[axes],
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The start %d of dim %d is larger than origin shape %d",
             starts,
             axes,
@@ -206,7 +206,7 @@ class SetValueConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         update_dims.d[axes],
         (ends - 1 - starts) / steps + 1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "the %dth axis of update dim error, should be %d, but we got %d",
             axes,
             (ends - 1 - starts) / steps + 1,
@@ -249,7 +249,7 @@ class SetValueConverter : public OpConverter {
 
       ReplenishLayerAndOutput(layer, "set_value", {output_name}, test_mode);
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "static shape mode not supported in set value yet"));
     }
   }

--- a/paddle/fluid/inference/tensorrt/convert/silu_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/silu_op.cc
@@ -28,7 +28,7 @@ class SiluOpConverter : public OpConverter {
     int input_num = op_desc.Input("X").size();
     PADDLE_ENFORCE_EQ(input_num,
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input X's size must equal to 1 in TRT silu op."
                           " But received X's size %d.",
                           input_num));
@@ -38,7 +38,7 @@ class SiluOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         output_num,
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The output Out's size must equal to 1 in TRT silu op. "
             "But received Out's size %u.",
             output_num));

--- a/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
@@ -27,7 +27,7 @@ class SkipLayerNormOpConverter : public OpConverter {
     VLOG(4) << "convert fused skip layernorm op to tensorrt layer";
     PADDLE_ENFORCE_EQ(engine_->with_dynamic_shape(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Skip_layernorm must run the dynamic shape mode."));
     framework::OpDesc op_desc(op, nullptr);
     auto output_name = op_desc.Output("Out")[0];
@@ -128,14 +128,15 @@ class SkipLayerNormOpConverter : public OpConverter {
     if (flag_varseqlen && engine_->with_interleaved()) {
       VLOG(4) << "fused skip_layernorm op: use_varseqlen and with_interleaved";
       if (!enable_int8) {
-        PADDLE_THROW(phi::errors::Fatal("use with_interleaved must be int8."));
+        PADDLE_THROW(
+            common::errors::Fatal("use with_interleaved must be int8."));
       }
       auto creator = GetPluginRegistry()->getPluginCreator(
           "CustomSkipLayerNormPluginDynamic", "3");
       PADDLE_ENFORCE_NE(
           creator,
           nullptr,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "fail to get creator of CustomSkipLayerNormPluginDynamic"));
       const std::vector<nvinfer1::PluginField> fields{
           {"beta",
@@ -162,7 +163,7 @@ class SkipLayerNormOpConverter : public OpConverter {
       PADDLE_ENFORCE_NE(
           plugin_layer,
           nullptr,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "fail to add CustomSkipLayerNormPluginDynamic layer"));
       layer = plugin_layer;
     } else {
@@ -171,7 +172,7 @@ class SkipLayerNormOpConverter : public OpConverter {
       PADDLE_ENFORCE_NE(
           creator,
           nullptr,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "fail to get creator of CustomSkipLayerNormPluginDynamic"));
       int32_t type = static_cast<int32_t>((engine_->WithFp16() == 1)
                                               ? nvinfer1::DataType::kHALF
@@ -183,7 +184,7 @@ class SkipLayerNormOpConverter : public OpConverter {
           PADDLE_GET_CONST(int32_t, op_desc.GetAttr("hidden_size"));
       PADDLE_ENFORCE_GT(hidden_size,
                         0,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "in CustomSkipLayerNormPluginDynamic hidden "
                             "dimension should > 0"));
 
@@ -224,7 +225,7 @@ class SkipLayerNormOpConverter : public OpConverter {
         PADDLE_ENFORCE_NE(
             plugin_layer,
             nullptr,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "fail to add CustomSkipLayerNormPluginDynamicWithSmooth "
                 "layer"));
         layer = plugin_layer;
@@ -245,7 +246,7 @@ class SkipLayerNormOpConverter : public OpConverter {
         PADDLE_ENFORCE_NE(
             plugin_layer,
             nullptr,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "fail to add CustomSkipLayerNormPluginDynamic layer"));
         layer = plugin_layer;
       }

--- a/paddle/fluid/inference/tensorrt/convert/skip_merge_layernorm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/skip_merge_layernorm_op.cc
@@ -38,16 +38,16 @@ class SkipMergeLayernormOpConverter : public OpConverter {
                           : 1e-5f;
     PADDLE_ENFORCE_NOT_NULL(
         Bias_v,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input(Bias) of layer_norm should not be null."));
     PADDLE_ENFORCE_NOT_NULL(
         Scale_v,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input(Scale) of layer_norm should not be null."));
     PADDLE_ENFORCE_EQ(
         begin_norm_axis,
         2,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The begin_norm_axis of SkipLayerLayernorm should be %d",
             begin_norm_axis));
     auto* Bias_t = Bias_v->GetMutable<phi::DenseTensor>();
@@ -73,7 +73,7 @@ class SkipMergeLayernormOpConverter : public OpConverter {
       skip_merge_layernorm_layer =
           engine_->AddDynamicPlugin(plugin_inputs.data(), 2, plugin);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Currently, MergeLayernorm TRT Plugin only support dynamic shape "
           "mode."));
     }

--- a/paddle/fluid/inference/tensorrt/convert/slice_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/slice_op.cc
@@ -75,13 +75,13 @@ class SliceOpConverter : public OpConverter {
               engine_->GetITensor(op_desc.Input("StartsTensorList")[i]);
         }
       } else {
-        PADDLE_ENFORCE_EQ(
-            starts.size(),
-            axes.size(),
-            phi::errors::InvalidArgument("The size of this starts: %d must be "
-                                         "equal to the axes: %d.",
-                                         starts.size(),
-                                         axes.size()));
+        PADDLE_ENFORCE_EQ(starts.size(),
+                          axes.size(),
+                          common::errors::InvalidArgument(
+                              "The size of this starts: %d must be "
+                              "equal to the axes: %d.",
+                              starts.size(),
+                              axes.size()));
         for (size_t i = 0; i < axes.size(); i++) {  // same as starts.size()
           if (starts[i] < 0) {
             starts_tensor[axes[i]] =
@@ -113,10 +113,10 @@ class SliceOpConverter : public OpConverter {
         PADDLE_ENFORCE_EQ(
             ends.size(),
             axes.size(),
-            phi::errors::InvalidArgument("The size of this ends: %d must be "
-                                         "equal to the axes: %d.",
-                                         ends.size(),
-                                         axes.size()));
+            common::errors::InvalidArgument("The size of this ends: %d must be "
+                                            "equal to the axes: %d.",
+                                            ends.size(),
+                                            axes.size()));
         for (size_t i = 0; i < axes.size(); i++) {  // same as ends.size()
           if (ends[i] < 0) {
             ends_tensor[axes[i]] =
@@ -172,7 +172,7 @@ class SliceOpConverter : public OpConverter {
         PADDLE_ENFORCE_GT(
             ends[i],
             starts[i],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Attr(ends) should be greater than attr(starts) in "
                 "slice op. But received ends = %d, starts = %d.",
                 ends[i],

--- a/paddle/fluid/inference/tensorrt/convert/sparse_fc_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/sparse_fc_op.cc
@@ -83,8 +83,8 @@ class SparseFcOpConverter : public OpConverter {
     } else if (activation_type == "gelu") {
       act = plugin::SpmmPluginDynamic::Activation::kGelu;
     } else if (activation_type != "") {
-      PADDLE_THROW(phi::errors::Fatal("unknown activation_type %s",
-                                      activation_type.c_str()));
+      PADDLE_THROW(common::errors::Fatal("unknown activation_type %s",
+                                         activation_type.c_str()));
     }
     return new plugin::SpmmPluginDynamic("CustomSpmmPluginDynamic",
                                          type,
@@ -115,7 +115,7 @@ class SparseFcOpConverter : public OpConverter {
     auto* Y_v = scope.FindVar(op_desc.Input(w_name).front());
     PADDLE_ENFORCE_NOT_NULL(
         Y_v,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Can not find %s presistable var of sparse_fc in scope.", w_name));
     auto* Y_t = Y_v->GetMutable<phi::DenseTensor>();
     int x_num_col_dims =
@@ -152,7 +152,7 @@ class SparseFcOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         Y_t->dims().size(),
         2UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The sparse_fc's weight should be a matrix with 2 dims, but "
             "it's %d-dimensional.",
             Y_t->dims().size()));  // a matrix
@@ -187,7 +187,7 @@ class SparseFcOpConverter : public OpConverter {
           PADDLE_ENFORCE_EQ(
               op_desc.HasAttr("out_threshold"),
               true,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "must have out threshold in fc layers in int8 mode"));
           float out_scale = 0;
           if (enable_int8) {
@@ -246,7 +246,7 @@ class SparseFcOpConverter : public OpConverter {
           PADDLE_ENFORCE_EQ(
               op_desc.HasAttr("out_threshold"),
               true,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "must have out threshold in sparse_fc layers in int8 mode"));
           out_scale = PADDLE_GET_CONST(float, op_desc.GetAttr("out_threshold"));
         } else {
@@ -340,7 +340,7 @@ class SparseFcOpConverter : public OpConverter {
       PADDLE_ENFORCE_GT(
           x_dim.nbDims,
           x_num_col_dims,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Params and input dims mismatch. Paddle-TRT FC "
               "converter expects x_dim.nbDims > x_num_col_dims, but "
               "x_dim.nbDims : %d, x_num_col_dims : %d.",

--- a/paddle/fluid/inference/tensorrt/convert/sparse_multihead_matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/sparse_multihead_matmul_op.cc
@@ -102,7 +102,7 @@ class SparseMultiheadMatMulOpConverter : public OpConverter {
     if (engine_->with_dynamic_shape()) {
       if (flag_varseqlen) {
         if (engine_->precision() == phi::DataType::FLOAT32) {
-          PADDLE_THROW(phi::errors::Fatal(
+          PADDLE_THROW(common::errors::Fatal(
               "use use_varseqlen must be int8 or half, not float32."));
         }
         nvinfer1::Weights weight{nvinfer1::DataType::kFLOAT,
@@ -118,7 +118,7 @@ class SparseMultiheadMatMulOpConverter : public OpConverter {
                      "with_interleaved";
           if (!op_desc.HasAttr("Input_scale")) {
             PADDLE_THROW(
-                phi::errors::Fatal("use with_interleaved must be int8."));
+                common::errors::Fatal("use with_interleaved must be int8."));
           }
           nvinfer1::ILayer* fc_layer = nullptr;
           float dp_probs = 1.0 / 127.0;
@@ -132,7 +132,7 @@ class SparseMultiheadMatMulOpConverter : public OpConverter {
           PADDLE_ENFORCE_EQ(
               op_desc.HasAttr("fc_out_threshold"),
               true,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "must have out_threshold in multihead layers in int8 mode"));
           float out_scale =
               PADDLE_GET_CONST(float, op_desc.GetAttr("fc_out_threshold"));
@@ -242,7 +242,7 @@ class SparseMultiheadMatMulOpConverter : public OpConverter {
           if (op_desc.HasAttr("fc_out_threshold")) {
             PADDLE_ENFORCE_EQ(op_desc.HasAttr("fc_out_threshold"),
                               true,
-                              phi::errors::InvalidArgument(
+                              common::errors::InvalidArgument(
                                   "must have out threshold in multihead layers "
                                   "in int8 mode"));
             float out_scale =
@@ -307,7 +307,7 @@ class SparseMultiheadMatMulOpConverter : public OpConverter {
         PADDLE_ENFORCE_EQ(
             input->getDimensions().nbDims,
             3,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The Input dim of the SparseMultiheadMatMul should be 3, "
                 "but it's (%d) now.",
                 input->getDimensions().nbDims));
@@ -396,7 +396,7 @@ class SparseMultiheadMatMulOpConverter : public OpConverter {
           PADDLE_ENFORCE_EQ(
               op_desc.HasAttr("fc_out_threshold"),
               true,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "must have out threshold in multihead layers in int8 mode"));
           float out_scale =
               PADDLE_GET_CONST(float, op_desc.GetAttr("fc_out_threshold"));
@@ -426,7 +426,7 @@ class SparseMultiheadMatMulOpConverter : public OpConverter {
         layer = engine_->AddDynamicPlugin(plugin_inputs.data(), 2, plugin);
       }
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "You are running the Ernie(Bert) model in static shape mode, which "
           "is not supported for the time being.\n"
           "You can use the config.SetTRTDynamicShapeInfo(...) interface to set "

--- a/paddle/fluid/inference/tensorrt/convert/squeeze2_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/squeeze2_op.cc
@@ -39,7 +39,7 @@ class Squeeze2OpConverter : public OpConverter {
     if (axes.empty()) {
       for (int i = 0; i < input_dims.nbDims; i++) {
         if (input_dims.d[i] == -1) {
-          PADDLE_THROW(phi::errors::InvalidArgument(
+          PADDLE_THROW(common::errors::InvalidArgument(
               "The necessary attributes of the squeeze2 operator axes is "
               "missing."));
         } else if (input_dims.d[i] == 1) {
@@ -51,7 +51,7 @@ class Squeeze2OpConverter : public OpConverter {
     PADDLE_ENFORCE_GT(
         axes.size(),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Attr(axes).size should be > 0 in squeeze2 op in TensorRT,"
             "but received axes.size() = %d.",
             axes.size()));

--- a/paddle/fluid/inference/tensorrt/convert/strided_slice_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/strided_slice_op.cc
@@ -63,7 +63,7 @@ class StridedSliceOpConverter : public OpConverter {
         PADDLE_ENFORCE_GT(
             ends[i],
             starts[i],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Attr(ends) should be greater than attr(starts) in "
                 "slice op. But received ends = %d, starts = %d.",
                 ends[i],

--- a/paddle/fluid/inference/tensorrt/convert/swish_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/swish_op.cc
@@ -29,7 +29,7 @@ class SwishOpConverter : public OpConverter {
     int input_num = op_desc.Input("X").size();
     PADDLE_ENFORCE_EQ(input_num,
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input X's size must equal to 1 in TRT swish op."
                           " But received X's size %d.",
                           input_num));
@@ -39,7 +39,7 @@ class SwishOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         output_num,
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The output Out's size must equal to 1 in TRT swish op. "
             "But received Out's size %u.",
             output_num));

--- a/paddle/fluid/inference/tensorrt/convert/tanhshrink_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/tanhshrink_op.cc
@@ -29,7 +29,7 @@ class TanhshrinkOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         input_num,
         1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input X's size must equal to 1 in TRT Tanhshrink op."
             " But received X's size %d.",
             input_num));
@@ -39,7 +39,7 @@ class TanhshrinkOpConverter : public OpConverter {
     PADDLE_ENFORCE_EQ(
         output_num,
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The output Out's size must equal to 1 in TRT Tanhshrink op. "
             "But received Out's size %u.",
             output_num));

--- a/paddle/fluid/inference/tensorrt/convert/tile_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/tile_op.cc
@@ -118,7 +118,7 @@ class TileOpConverter : public OpConverter {
       PADDLE_ENFORCE_GE(
           rank + 1,
           repeat_times.size(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Can't change batchsize, please check repeat_times"));
       int32_t diff = rank + 1 - repeat_times.size();
       if (diff > 0) repeat_times.insert(repeat_times.begin(), diff, 1);
@@ -127,7 +127,7 @@ class TileOpConverter : public OpConverter {
       PADDLE_ENFORCE_EQ(
           repeat_times[0],
           1,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Can't expand on batchsize, please check repeat_times"));
       output_stride.nbDims = rank;
       for (int32_t i = 0; i < rank; i++) {

--- a/paddle/fluid/inference/tensorrt/convert/trans_layernorm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/trans_layernorm_op.cc
@@ -33,11 +33,11 @@ class TransLayerNormOpConverter : public OpConverter {
                           : 1e-5f;
     PADDLE_ENFORCE_NOT_NULL(
         Bias_v,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input(Bias) of layer_norm should not be null."));
     PADDLE_ENFORCE_NOT_NULL(
         Scale_v,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input(Scale) of layer_norm should not be null."));
 
     auto* Bias_t = Bias_v->GetMutable<phi::DenseTensor>();
@@ -69,7 +69,7 @@ class TransLayerNormOpConverter : public OpConverter {
               with_fp16);
       layernorm_layer = engine_->AddDynamicPlugin(&X, 1, plugin);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "trans_layernorm do not support static shape mode yet"));
     }
 

--- a/paddle/fluid/inference/tensorrt/convert/transformer_input_convert_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/transformer_input_convert_op.cc
@@ -28,7 +28,7 @@ class TransformerInputConvert : public OpConverter {
     VLOG(3) << "Convert Transformer Input(pos_id, max_seqlen), use "
                "transformer_input_convert_plugin";
     if (!engine_->with_dynamic_shape()) {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "transformer_input_convert_op: If you want to use transformer, must "
           "be with dynamic shape"));
     }

--- a/paddle/fluid/inference/tensorrt/convert/unsqueeze2_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/unsqueeze2_op.cc
@@ -35,7 +35,7 @@ class Unsqueeze2OpConverter : public OpConverter {
     PADDLE_ENFORCE_GT(
         axes.size(),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Attr(axes).size should be > 0 in unsqueeze2 op in TensorRT,"
             "but received axes.size() = %d.",
             axes.size()));

--- a/paddle/fluid/inference/tensorrt/convert/ut_helper.h
+++ b/paddle/fluid/inference/tensorrt/convert/ut_helper.h
@@ -53,8 +53,8 @@ void RandomizeTensor(phi::DenseTensor* tensor,
   PADDLE_ENFORCE_GT(
       num_elements,
       0UL,
-      phi::errors::PermissionDenied("RandomizeTensor only can be used for "
-                                    "tensor which dims is not zero."));
+      common::errors::PermissionDenied("RandomizeTensor only can be used for "
+                                       "tensor which dims is not zero."));
 
   phi::CPUPlace cpu_place;
   phi::DenseTensor temp_tensor;
@@ -87,7 +87,7 @@ class TRTConvertValidation {
         max_batch_size_(max_batch_size) {
     PADDLE_ENFORCE_EQ(cudaStreamCreate(&stream_),
                       0,
-                      phi::errors::External("cudaStreamCreate error."));
+                      common::errors::External("cudaStreamCreate error."));
     TensorRTEngine::ConstructionParams params;
     params.max_batch_size = max_batch_size;
     params.max_workspace_size = workspace_size;
@@ -169,7 +169,7 @@ class TRTConvertValidation {
     // Execute Fluid Op
     PADDLE_ENFORCE_LE(batch_size,
                       max_batch_size_,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Runtime batch_size should be less than or equal to "
                           "max_batch_size_. "
                           "But received batch_size:%d, max_batch_size_:%d",

--- a/paddle/fluid/inference/tensorrt/dynamic_shape_infermeta.cc
+++ b/paddle/fluid/inference/tensorrt/dynamic_shape_infermeta.cc
@@ -180,12 +180,12 @@ nvinfer1::DimsExprs YoloBoxInferMeta(
     int nb_inputs,
     nvinfer1::IExprBuilder& expr_builder,  // NOLINT
     const framework::OpDesc& op_desc) {
-  PADDLE_ENFORCE_EQ(
-      nb_inputs,
-      2,
-      phi::errors::InvalidArgument("inputs of yolo_box should be equal to 2, "
-                                   "But received (%s)",
-                                   nb_inputs));
+  PADDLE_ENFORCE_EQ(nb_inputs,
+                    2,
+                    common::errors::InvalidArgument(
+                        "inputs of yolo_box should be equal to 2, "
+                        "But received (%s)",
+                        nb_inputs));
 
   const nvinfer1::DimsExprs dim_x = inputs[0];
 
@@ -271,9 +271,9 @@ nvinfer1::DimsExprs UnfoldInferMeta(
   PADDLE_ENFORCE_EQ(
       nb_inputs,
       1,
-      phi::errors::InvalidArgument("inputs of unfold should be equal to 1, "
-                                   "But received (%s)",
-                                   nb_inputs));
+      common::errors::InvalidArgument("inputs of unfold should be equal to 1, "
+                                      "But received (%s)",
+                                      nb_inputs));
 
   const nvinfer1::DimsExprs in_dims = inputs[0];
   std::vector<const nvinfer1::IDimensionExpr*> out_dims;
@@ -331,7 +331,7 @@ nvinfer1::DimsExprs ScatterNdAddInferMeta(
     const framework::OpDesc& op_desc) {
   PADDLE_ENFORCE_EQ(nb_inputs,
                     3,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "inputs of scatter_nd_add should be equal to 3, "
                         "But received (%s)",
                         nb_inputs));
@@ -347,7 +347,7 @@ nvinfer1::DimsExprs UnchangedInferMeta(
     const framework::OpDesc& op_desc) {
   PADDLE_ENFORCE_EQ(nb_inputs,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "inputs of UnchangedInferMeta should be equal to 1, "
                         "But received (%s)",
                         nb_inputs));
@@ -450,7 +450,7 @@ nvinfer1::DimsExprs PNormInferMeta(
 
   PADDLE_ENFORCE_GE(axis,
                     -x_rank,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Attr(axis) value should be in range [-R, R-1], R is "
                         "the rank of Input(X). But received axis: %d, R: %d. "
                         "Current Input(X)'s shape is=[%s].",
@@ -459,7 +459,7 @@ nvinfer1::DimsExprs PNormInferMeta(
                         x_dim.d));
   PADDLE_ENFORCE_LT(axis,
                     x_rank,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Attr(axis) value should be in range [-R, R-1], R is "
                         "the rank of Input(X). But received axis: %d, R: %d. "
                         "Current Input(X)'s shape is=[%s].",
@@ -471,7 +471,7 @@ nvinfer1::DimsExprs PNormInferMeta(
   PADDLE_ENFORCE_EQ(
       asvector,
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "p_norm only support asvector=false, but received asvector: %d.",
           asvector));
 
@@ -702,18 +702,18 @@ nvinfer1::DimsExprs MemoryEfficientAttentionInferMeta(
     int nb_inputs,
     nvinfer1::IExprBuilder& expr_builder,  // NOLINT
     const framework::OpDesc& op_desc) {
-  PADDLE_ENFORCE_LE(
-      output_index,
-      2,
-      phi::errors::InvalidArgument("memory_efficient_attention only has three "
-                                   "output, but received asvector: %d.",
-                                   output_index));
+  PADDLE_ENFORCE_LE(output_index,
+                    2,
+                    common::errors::InvalidArgument(
+                        "memory_efficient_attention only has three "
+                        "output, but received asvector: %d.",
+                        output_index));
   PADDLE_ENFORCE_EQ(
       nb_inputs,
       8,
-      phi::errors::InvalidArgument("memory_efficient_attention has three "
-                                   "input, but received asvector: %d.",
-                                   nb_inputs));
+      common::errors::InvalidArgument("memory_efficient_attention has three "
+                                      "input, but received asvector: %d.",
+                                      nb_inputs));
   if (output_index == 0) {
     return inputs[0];
   } else if (output_index == 1) {
@@ -841,9 +841,9 @@ nvinfer1::DimsExprs ScatterInferMeta(
   PADDLE_ENFORCE_EQ(
       nb_inputs,
       3,
-      phi::errors::InvalidArgument("inputs of scatter should be equal to 3, "
-                                   "But received (%s)",
-                                   nb_inputs));
+      common::errors::InvalidArgument("inputs of scatter should be equal to 3, "
+                                      "But received (%s)",
+                                      nb_inputs));
   const nvinfer1::DimsExprs ref_dims = inputs[0];
   return ref_dims;
 }
@@ -872,9 +872,9 @@ nvinfer1::DimsExprs SolveInferMeta(
   PADDLE_ENFORCE_EQ(
       nb_inputs,
       2,
-      phi::errors::InvalidArgument("inputs of solve should be equal to 2, "
-                                   "But received (%s)",
-                                   nb_inputs));
+      common::errors::InvalidArgument("inputs of solve should be equal to 2, "
+                                      "But received (%s)",
+                                      nb_inputs));
   const nvinfer1::DimsExprs ref_dims = inputs[1];
   return ref_dims;
 }

--- a/paddle/fluid/inference/tensorrt/dynamic_shape_infermeta_factory.h
+++ b/paddle/fluid/inference/tensorrt/dynamic_shape_infermeta_factory.h
@@ -48,7 +48,7 @@ class DynamicMetaFnFactory {
     PADDLE_ENFORCE_NE(
         Contains(op_name),
         true,
-        phi::errors::AlreadyExists(
+        common::errors::AlreadyExists(
             "`%s` op's DynamicInferMetaFn has been registered.", op_name));
     meta_fn_map_.insert({std::move(op_name), std::move(infer_meta_fn)});
   }
@@ -58,7 +58,7 @@ class DynamicMetaFnFactory {
     PADDLE_ENFORCE_NE(
         it,
         meta_fn_map_.end(),
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "`%s` op's DynamicInferMetaFn has been registered.", op_name));
     return it->second;
   }

--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -49,7 +49,7 @@ void TensorRTEngine::Weight::SetDataType(phi::DataType type) {
       break;
 #endif
     default:
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Paddle-TRT loads weights failed, found not supported data type %s.",
           type);
       break;
@@ -80,7 +80,7 @@ nvinfer1::IExecutionContext *TensorRTEngine::context() {
   if (infer_context_.find(predictor_id_per_thread) == infer_context_.end()) {
     PADDLE_ENFORCE_NOT_NULL(
         infer_engine_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "You should build engine first and then set the context."));
     // We may see trt warning: Profile 0 has been chosen by another
     // IExecutionContext...
@@ -94,7 +94,7 @@ nvinfer1::IExecutionContext *TensorRTEngine::context() {
     }
     PADDLE_ENFORCE_NOT_NULL(
         infer_context,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "TensorRT engine can not build execution context."));
     if (with_dynamic_shape()) {
       // need new profile if it's not the first
@@ -137,7 +137,7 @@ void TensorRTEngine::Execute(int batch_size,
     PADDLE_ENFORCE_EQ(
         ret,
         true,
-        phi::errors::PreconditionNotMet("Trt CudaGraph test run failed."));
+        common::errors::PreconditionNotMet("Trt CudaGraph test run failed."));
     cudaStreamSynchronize(stream);
 
     cuda_graph_.BeginCapture(stream);
@@ -204,11 +204,11 @@ void TensorRTEngine::FreezeNetwork() {
   FreshDeviceId();
   VLOG(3) << "TRT to freeze network";
   PADDLE_ENFORCE_NOT_NULL(infer_builder_,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Inference builder of TRT is null. Please make "
                               "sure you call InitNetwork first."));
   PADDLE_ENFORCE_NOT_NULL(network(),
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Call InitNetwork first to initialize network."));
   // build engine.
   if (!with_dynamic_shape()) {
@@ -359,7 +359,7 @@ void TensorRTEngine::FreezeNetwork() {
                               max_shape_tensor().count(input_name) > 0 &&
                               optim_shape_tensor().count(input_name) > 0,
                           true,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Fail to find min/max/optim shape value for TRT "
                               "network's shape tensor input named %s.",
                               input_name));
@@ -424,8 +424,8 @@ void TensorRTEngine::FreezeNetwork() {
 
   PADDLE_ENFORCE_NOT_NULL(
       infer_engine_,
-      phi::errors::Fatal("Build TensorRT cuda engine failed! Please recheck "
-                         "you configurations related to paddle-TensorRT."));
+      common::errors::Fatal("Build TensorRT cuda engine failed! Please recheck "
+                            "you configurations related to paddle-TensorRT."));
 
 #if IS_TRT_VERSION_GE(10000)
   binding_num_ = infer_engine_->getNbIOTensors();
@@ -453,18 +453,18 @@ nvinfer1::ITensor *TensorRTEngine::DeclareInput(const std::string &name,
                                                 const nvinfer1::Dims &dims) {
   PADDLE_ENFORCE_EQ(network() != nullptr,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The TRT network should be initialized first."));
   auto *input = network()->addInput(name.c_str(), dtype, dims);
   PADDLE_ENFORCE_NOT_NULL(
       input,
-      phi::errors::InvalidArgument("Adding input %s failed in "
-                                   "TensorRT inference network. "
-                                   "Please recheck your input.",
-                                   name));
+      common::errors::InvalidArgument("Adding input %s failed in "
+                                      "TensorRT inference network. "
+                                      "Please recheck your input.",
+                                      name));
   PADDLE_ENFORCE_EQ(input->isNetworkInput(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input %s is not the input of TRT inference network. "
                         "Please recheck your input.",
                         name));
@@ -479,19 +479,19 @@ void TensorRTEngine::DeclareOutput(const nvinfer1::ILayer *layer,
   SetITensor(name, output);
   PADDLE_ENFORCE_NOT_NULL(
       output,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The output %s of TRT engine should not be null.", name));
   output->setName(name.c_str());
   PADDLE_ENFORCE_EQ(output->isNetworkInput(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The output %s of TRT engine should not be the input "
                         "of the network at the same time.",
                         name));
   network()->markOutput(*output);
   PADDLE_ENFORCE_EQ(output->isNetworkOutput(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The output %s of TRT engine should be the output "
                         "of the network.",
                         name));
@@ -501,12 +501,12 @@ void TensorRTEngine::DeclareOutput(const std::string &name) {
   auto *output = TensorRTEngine::GetITensor(name);
   PADDLE_ENFORCE_NOT_NULL(
       output,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The output %s of TRT engine should not be null.", name));
   output->setName(name.c_str());
   PADDLE_ENFORCE_EQ(output->isNetworkInput(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The output %s of TRT engine should not be the input "
                         "of the network at the same time.",
                         name));
@@ -524,12 +524,12 @@ void TensorRTEngine::DeleteITensor(const std::string &name,
                                    nvinfer1::ITensor *tensor) {
   PADDLE_ENFORCE_NOT_NULL(
       tensor,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Tensor named %s of TRT engine should not be null.", name));
   PADDLE_ENFORCE_EQ(
       true,
       itensor_map_.count(name),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Tensor named %s of TRT engine should not be null", name));
   itensor_map_.erase(name);
 }
@@ -538,12 +538,12 @@ void TensorRTEngine::SetITensor(const std::string &name,
                                 nvinfer1::ITensor *tensor) {
   PADDLE_ENFORCE_NOT_NULL(
       tensor,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Tensor named %s of TRT engine should not be null.", name));
   PADDLE_ENFORCE_EQ(
       0,
       itensor_map_.count(name),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Tensor named %s of TRT engine should not be duplicated", name));
   itensor_map_[name] = tensor;
 }
@@ -568,10 +568,10 @@ nvinfer1::ITensor *TensorRTEngine::ConvertWeight2ITensor(
   auto *var_v = scope_->FindVar(name);
   PADDLE_ENFORCE_NOT_NULL(
       var_v,
-      phi::errors::NotFound("You are converting a persistable weight to a "
-                            "tensor, but there is no "
-                            "persistable variable called %s in scope.",
-                            name));
+      common::errors::NotFound("You are converting a persistable weight to a "
+                               "tensor, but there is no "
+                               "persistable variable called %s in scope.",
+                               name));
   auto *var_t = var_v->GetMutable<phi::DenseTensor>();
   auto weight = this->GetTrtWeight(name, *var_t);
 
@@ -644,7 +644,7 @@ void TensorRTEngine::Deserialize(const std::string &engine_serialized_data) {
 
   PADDLE_ENFORCE_NOT_NULL(
       infer_engine_,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "Building TRT cuda engine failed when deserializing engine info. "
           "Please check:\n1. Your TRT serialization is generated and "
           "loaded "
@@ -679,7 +679,7 @@ TensorRTEngine::Weight TensorRTEngine::GetFp16TrtWeight(
   phi::CPUPlace cpu_place;
   PADDLE_ENFORCE_EQ(weight_map.count(name_with_suffix),
                     0,
-                    phi::errors::AlreadyExists(
+                    common::errors::AlreadyExists(
                         "The weight named %s is set into the weight map "
                         "twice in TRT OP converter.",
                         name_with_suffix));
@@ -752,7 +752,7 @@ TensorRTEngine::Weight TensorRTEngine::GetFp32TrtWeight(
   phi::CPUPlace cpu_place;
   PADDLE_ENFORCE_EQ(weight_map.count(name_with_suffix),
                     0,
-                    phi::errors::AlreadyExists(
+                    common::errors::AlreadyExists(
                         "The weight named %s is set into the weight map "
                         "twice in TRT OP converter.",
                         name_with_suffix));
@@ -824,7 +824,7 @@ TensorRTEngine::Weight TensorRTEngine::GetTrtWeight(
   phi::CPUPlace cpu_place;
   PADDLE_ENFORCE_EQ(weight_map.count(name_with_suffix),
                     0,
-                    phi::errors::AlreadyExists(
+                    common::errors::AlreadyExists(
                         "The weight named %s is set into the weight map "
                         "twice in TRT OP converter.",
                         name_with_suffix));
@@ -912,7 +912,7 @@ void TensorRTEngine::FreshDeviceId() {
   cudaGetDeviceCount(&count);
   PADDLE_ENFORCE_LT(device_id(),
                     count,
-                    phi::errors::OutOfRange(
+                    common::errors::OutOfRange(
                         "Device id %d exceeds the current device count: %d.",
                         device_id(),
                         count));

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -86,15 +86,15 @@ class TrtCudaGraph {
     // be used.
     const auto ret = cudaStreamEndCapture(stream, &cuda_graph_);
     if (ret == cudaErrorStreamCaptureInvalidated) {
-      PADDLE_ENFORCE_EQ(
-          cuda_graph_ == nullptr,
-          true,
-          phi::errors::PreconditionNotMet("CudaGraph capture stream failed."));
+      PADDLE_ENFORCE_EQ(cuda_graph_ == nullptr,
+                        true,
+                        common::errors::PreconditionNotMet(
+                            "CudaGraph capture stream failed."));
     } else {
       PADDLE_ENFORCE_GPU_SUCCESS(ret);
-      PADDLE_ENFORCE_NOT_NULL(
-          cuda_graph_,
-          phi::errors::PreconditionNotMet("CudaGraph capture stream failed."));
+      PADDLE_ENFORCE_NOT_NULL(cuda_graph_,
+                              common::errors::PreconditionNotMet(
+                                  "CudaGraph capture stream failed."));
       PADDLE_ENFORCE_GPU_SUCCESS(cudaGraphDestroy(cuda_graph_));
       cuda_graph_ = nullptr;
     }
@@ -243,7 +243,7 @@ class TensorRTEngine {
   void ResetContext() {
     PADDLE_ENFORCE_NOT_NULL(
         infer_engine_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "You should build engine first and then set the context."));
     std::unique_lock<std::mutex> lock(mutex_);
     infer_context_[predictor_id_per_thread].reset(nullptr);
@@ -254,14 +254,14 @@ class TensorRTEngine {
   nvinfer1::IHostMemory* Serialize() {
     PADDLE_ENFORCE_NOT_NULL(
         infer_engine_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The TensorRT engine must be built first before serialization"));
 #if IS_TRT_VERSION_LT(8000)
     ihost_memory_.reset(infer_engine_->serialize());
 #else
     PADDLE_ENFORCE_NOT_NULL(
         ihost_memory_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "TensorRT >= 8.0 requires that buildSerializedNetwork is called"));
 #endif
     return ihost_memory_.get();
@@ -345,7 +345,7 @@ class TensorRTEngine {
     std::string name_with_suffix = w_name + splitter + suffix;
     PADDLE_ENFORCE_EQ(weight_map.count(name_with_suffix),
                       0,
-                      phi::errors::AlreadyExists(
+                      common::errors::AlreadyExists(
                           "The weight named %s is set into the weight map "
                           "twice in TRT OP converter.",
                           name_with_suffix));
@@ -412,7 +412,7 @@ class TensorRTEngine {
       } else {
         PADDLE_ENFORCE_EQ(params_.min_input_shape[name].size(),
                           input_shape.size(),
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "TRT dynamic_shape min_input_shape %s size not "
                               "equal, the min_input_shape[%s].size()=%d"
                               ", but the runtime_input_shape[%s].size()=%d.",
@@ -464,7 +464,7 @@ class TensorRTEngine {
       } else {
         PADDLE_ENFORCE_EQ(params_.min_shape_tensor[name].size(),
                           shape_tensor.size(),
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "TRT dynamic_shape min_shape_tensor %s size not "
                               "equal, the min_shape_tensor[%s].size()=%d"
                               ", but the runtime_shape_tensor[%s].size()=%d.",

--- a/paddle/fluid/inference/tensorrt/helper.h
+++ b/paddle/fluid/inference/tensorrt/helper.h
@@ -228,8 +228,8 @@ static inline nvinfer1::DataType PhiType2NvType(phi::DataType type) {
       break;
 #endif
     default:
-      phi::errors::InvalidArgument("phi::DataType not supported data type %s.",
-                                   type);
+      common::errors::InvalidArgument(
+          "phi::DataType not supported data type %s.", type);
       break;
   }
   return nv_type;
@@ -253,7 +253,7 @@ static TRT_DT FluidDataType2TRT(FluidDT type) {
 
 #endif
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "unsupported datatype in TRT op converter, type: %s. "
           "Boolean type is supported as TRT input/output "
           "using TensorRT v8.4+.",
@@ -269,7 +269,7 @@ static nvinfer1::Dims Vec2TRT_Dims(const std::vector<T>& shape,
                                    bool with_dynamic_shape = false) {
   PADDLE_ENFORCE_GE(shape.size(),
                     0UL,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TensorRT's tensor input requires at least 0 "
                         "dimensions, but input %s has %d dims.",
                         input,
@@ -291,7 +291,7 @@ static nvinfer1::Dims Vec2TRT_Dims(const std::vector<T>& shape,
   if (!with_dynamic_shape) {
     if (shape.size() == 4UL) {
       if (shape[2] == -1 || shape[3] == -1) {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "The input [%s] shape of trt subgraph is %s, please enable "
             "trt dynamic_shape mode by SetTRTDynamicShapeInfo.",
             input,
@@ -300,7 +300,7 @@ static nvinfer1::Dims Vec2TRT_Dims(const std::vector<T>& shape,
       return nvinfer1::Dims3(shape[1], shape[2], shape[3]);
     } else if (shape.size() == 5UL) {
       if (shape[2] == -1 || shape[3] == -1 || shape[4] == -1) {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "The input [%s] shape of trt subgraph is %s, please enable "
             "trt dynamic_shape mode by SetTRTDynamicShapeInfo.",
             input,
@@ -309,7 +309,7 @@ static nvinfer1::Dims Vec2TRT_Dims(const std::vector<T>& shape,
       return nvinfer1::Dims4(shape[1], shape[2], shape[3], shape[4]);
     } else if (shape.size() == 3UL) {
       if (shape[1] == -1 || shape[2] == -1) {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "The input [%s] shape of trt subgraph is %s, please enable "
             "trt dynamic_shape mode by SetTRTDynamicShapeInfo.",
             input,
@@ -318,7 +318,7 @@ static nvinfer1::Dims Vec2TRT_Dims(const std::vector<T>& shape,
       return nvinfer1::Dims2(shape[1], shape[2]);
     } else if (shape.size() == 2UL) {
       if (shape[1] == -1) {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "The input [%s] shape of trt subgraph is %s, please enable "
             "trt dynamic_shape mode by SetTRTDynamicShapeInfo.",
             input,
@@ -332,7 +332,7 @@ static nvinfer1::Dims Vec2TRT_Dims(const std::vector<T>& shape,
     // static shape doesn't support 1D op so far.
     PADDLE_ENFORCE_NE(shape.size(),
                       1UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input [%s] shape of trt subgraph is %s."
                           "it's not supported by trt so far",
                           input,

--- a/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.cu
@@ -73,30 +73,30 @@ AnchorGeneratorPlugin::AnchorGeneratorPlugin(
   // anchors must be float32, which is the generator proposals' input
   PADDLE_ENFORCE_EQ(data_type_,
                     nvinfer1::DataType::kFLOAT,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TRT anchor generator plugin only accepts float32."));
   PADDLE_ENFORCE_GE(height_,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TRT anchor generator plugin only accepts height "
                         "greater than 0, but receive height = %d.",
                         height_));
   PADDLE_ENFORCE_GE(width_,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TRT anchor generator plugin only accepts width "
                         "greater than 0, but receive width = %d.",
                         width_));
   PADDLE_ENFORCE_GE(
       num_anchors_,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "TRT anchor generator plugin only accepts number of anchors greater "
           "than 0, but receive number of anchors = %d.",
           num_anchors_));
   PADDLE_ENFORCE_GE(box_num_,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TRT anchor generator plugin only accepts box_num "
                         "greater than 0, but receive box_num = %d.",
                         box_num_));
@@ -403,12 +403,12 @@ AnchorGeneratorPluginDynamic::AnchorGeneratorPluginDynamic(
   // height, width, num_anchors are calculated at configurePlugin
   PADDLE_ENFORCE_EQ(data_type_,
                     nvinfer1::DataType::kFLOAT,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TRT anchor generator plugin only accepts float32."));
   PADDLE_ENFORCE_GE(
       num_anchors_,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "TRT anchor generator plugin only accepts number of anchors greater "
           "than 0, but receive number of anchors = %d.",
           num_anchors_));

--- a/paddle/fluid/inference/tensorrt/plugin/c_allreduce_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/c_allreduce_op_plugin.cu
@@ -40,8 +40,8 @@ inline ncclDataType_t NvInferDtypeToNCCLDType(nvinfer1::DataType type) {
   } else if (type == nvinfer1::DataType::kINT32) {
     return ncclInt32;
   } else {
-    PADDLE_THROW(
-        phi::errors::Unimplemented("This datatype in nccl is not supported."));
+    PADDLE_THROW(common::errors::Unimplemented(
+        "This datatype in nccl is not supported."));
   }
 }
 #endif
@@ -93,16 +93,16 @@ bool CAllReducePluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of CAllReduce plugin shoule not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
 
   const nvinfer1::PluginTensorDesc& in = in_out[pos];
   if (pos == 0 || pos == 1) {
@@ -138,7 +138,7 @@ nvinfer1::DataType CAllReducePluginDynamic::getOutputDataType(
     int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The CAllReduce Plugin only has one input, so the "
                         "index value should be 0, but get %d.",
                         index));
@@ -179,15 +179,15 @@ int CAllReducePluginDynamic::enqueue(
       break;
 
     default:
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("Invalid reduce type: %d", red_type_));
+      PADDLE_THROW(common::errors::InvalidArgument("Invalid reduce type: %d",
+                                                   red_type_));
   }
   const auto& comm_context_manager =
       phi::distributed::CommContextManager::GetInstance();
   if (FLAGS_dynamic_static_unified_comm) {
     PADDLE_ENFORCE_EQ(comm_context_manager.Has(std::to_string(ring_id_)),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "You choose to use new communication library by "
                           "setting environment "
                           "variable FLAGS_dynamic_static_unified_comm True. "
@@ -198,7 +198,7 @@ int CAllReducePluginDynamic::enqueue(
         comm_context_manager.Get(std::to_string(ring_id_)));
     PADDLE_ENFORCE_NE(comm_ctx,
                       nullptr,
-                      phi::errors::Unavailable(
+                      common::errors::Unavailable(
                           "NCCLCommContext is nullptr, collective op should "
                           "has ring_id attr."));
     auto stream = comm_ctx->GetStream();

--- a/paddle/fluid/inference/tensorrt/plugin/common/common.cuh
+++ b/paddle/fluid/inference/tensorrt/plugin/common/common.cuh
@@ -208,7 +208,7 @@ inline void TransposeQKV(const int batch,
     // limit h * head_num to max block size(1024).
     PADDLE_ENFORCE_LE(h * head_num,
                       1024,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "head_num (%d) * head_size (%d) should <= %d",
                           head_num,
                           head_size,
@@ -222,7 +222,7 @@ inline void TransposeQKV(const int batch,
     // limit h * head_num to max block size(1024).
     PADDLE_ENFORCE_LE(h * head_num,
                       1024,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "head_num (%d) * head_size (%d) should <= %d",
                           head_num,
                           head_size,
@@ -233,7 +233,7 @@ inline void TransposeQKV(const int batch,
     // limit head_size * head_num to max block size(1024).
     PADDLE_ENFORCE_LE(head_size * head_num,
                       1024,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "head_num (%d) * head_size (%d) should <= %d",
                           head_num,
                           head_size,
@@ -260,7 +260,7 @@ inline void TransposeQKV(const int batch,
     // limit h * head_num to max block size(1024).
     PADDLE_ENFORCE_LE(h * head_num,
                       1024,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "head_num (%d) * head_size (%d) should <= %d",
                           head_num,
                           head_size,
@@ -274,7 +274,7 @@ inline void TransposeQKV(const int batch,
     // limit h * head_num to max block size(1024).
     PADDLE_ENFORCE_LE(h * head_num,
                       1024,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "head_num (%d) * head_size (%d) should <= %d",
                           head_num,
                           head_size,
@@ -285,7 +285,7 @@ inline void TransposeQKV(const int batch,
     // limit head_size * head_num to max block size(1024).
     PADDLE_ENFORCE_LE(head_size * head_num,
                       1024,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "head_num (%d) * head_size (%d) should <= %d",
                           head_num,
                           head_size,

--- a/paddle/fluid/inference/tensorrt/plugin/custom_generic_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/custom_generic_plugin.cu
@@ -46,7 +46,7 @@ void validate(const std::string& op_type,
   // https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#ipluginv2
   PADDLE_ENFORCE_GE(supports_dtypes.count(datatype),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "custorm op [%s] has unsupported datatype: [%s], "
                         "now only support: [float32, float16, int8, int32].",
                         op_type,
@@ -54,7 +54,7 @@ void validate(const std::string& op_type,
   PADDLE_ENFORCE_GE(
       supports_tensor_formats.count(tensor_format),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "custorm op [%s] has unsupported tensor format: [%s], "
           "now only support: [LINEAR, CHW32, CHW2, HWC8, CHW4, DHWC8(TensorRT "
           "7.2 and after), HWC16(TensorRT 8.0 and after)].",
@@ -66,7 +66,7 @@ void validate(const std::string& op_type,
     PADDLE_ENFORCE_GE(
         supports_formats_tmp.count(tensor_format),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "custorm op [%s]: float32 only supports [LINEAR, CHW32], "
             "but got tensor format: [%s], ",
             op_type,
@@ -83,7 +83,7 @@ void validate(const std::string& op_type,
 #endif
     PADDLE_ENFORCE_GE(supports_formats_tmp.count(tensor_format),
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "custorm op [%s]: float16 only supports [LINEAR, "
                           "CHW2, HWC8, CHW4, DHWC8(TensorRT 7.2 and after), "
                           "HWC16(TensorRT 8.0 and after)], "
@@ -97,7 +97,7 @@ void validate(const std::string& op_type,
     PADDLE_ENFORCE_GE(
         supports_formats_tmp.count(tensor_format),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "custorm op [%s]: int8 only supports [LINEAR, CHW32, CHW4], "
             "but got tensor format: [%s], ",
             op_type,
@@ -107,7 +107,7 @@ void validate(const std::string& op_type,
     std::unordered_set<std::string> supports_formats_tmp = {"LINEAR"};
     PADDLE_ENFORCE_GE(supports_formats_tmp.count(tensor_format),
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "custorm op [%s]: int32 only supports [LINEAR], "
                           "but got tensor format: [%s], ",
                           op_type,
@@ -164,7 +164,7 @@ nvinfer1::DataType getTrtDtype(std::string dtype) {
     return nvinfer1::DataType::kINT32;
   } else {
     PADDLE_THROW(
-        phi::errors::Unimplemented("Unsupported data type [%s]", dtype));
+        common::errors::Unimplemented("Unsupported data type [%s]", dtype));
   }
 }
 
@@ -188,8 +188,8 @@ nvinfer1::TensorFormat getTrtTensorFormat(std::string tensor_format) {
     return nvinfer1::TensorFormat::kHWC16;
 #endif
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented("Unsupported tensor format [%s]",
-                                            tensor_format));
+    PADDLE_THROW(common::errors::Unimplemented("Unsupported tensor format [%s]",
+                                               tensor_format));
   }
 }
 
@@ -225,7 +225,7 @@ ProtoTypeToGenerateCustomGenericPluginDataType(
     case VarType_Type::VarType_Type_COMPLEX128:
       return GenerateCustomGenericPluginDataType::PLUGIN_COMPLEX128;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "This data type is currently not supported"));
   }
 }
@@ -314,7 +314,7 @@ bool CustomGenericPlugin::supportsFormatCombination(
       OpMetaInfoHelper::GetTrtSupportsFormatConfig(op_info);
   PADDLE_ENFORCE_NE(supports_formate_config.empty(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The %s op has no tensorrt plugin "
                         "supportsFormatCombination config!"
                         "Please use SetTrtSupportsFormatConfig to set.",
@@ -328,7 +328,7 @@ bool CustomGenericPlugin::supportsFormatCombination(
     auto format_combination = parseConfig(op_desc_.Type(), config);
     PADDLE_ENFORCE_EQ(input_num + output_num,
                       format_combination.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Expexted %d format_combination, but got %d.",
                           input_num + output_num,
                           format_combination.size()));
@@ -375,7 +375,7 @@ nvinfer1::DataType CustomGenericPlugin::getOutputDataType(
   PADDLE_ENFORCE_NE(
       input_types,
       nullptr,
-      phi::errors::Unavailable("Input type should not be nullptr."));
+      common::errors::Unavailable("Input type should not be nullptr."));
   return input_types[0];
 }
 
@@ -399,7 +399,7 @@ nvinfer1::DimsExprs CustomGenericPlugin::getOutputDimensions(
   auto& infer_shape_fn = OpMetaInfoHelper::GetTrtInferShapeFn(op_info);
   PADDLE_ENFORCE_NE(infer_shape_fn,
                     nullptr,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The %s op has no getOutputDimensions function!"
                         "Please use SetTrtInferShapeFn to set.",
                         op_desc_.Type().c_str()));
@@ -434,7 +434,7 @@ nvinfer1::DimsExprs CustomGenericPlugin::getOutputDimensions(
       custom_attrs.emplace_back(
           PADDLE_GET_CONST(std::vector<std::string>, attrs.at(attr_name)));
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported `%s` type value as custom attribute now. "
           "Supported data types include `bool`, `int`, `float`, "
           "`int64_t`, `std::string`, `std::vector<int>`, "
@@ -588,7 +588,7 @@ int CustomGenericPlugin::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
       kernel_ctx.EmplaceBackAttr(
           PADDLE_GET_CONST(std::vector<std::string>, attrs.at(attr_name)));
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported `%s` type value as custom attribute now. "
           "Supported data types include `bool`, `int`, `float`, "
           "`int64_t`, `std::string`, `std::vector<int>`, "

--- a/paddle/fluid/inference/tensorrt/plugin/deformable_conv_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/deformable_conv_op_plugin.cu
@@ -98,16 +98,16 @@ DeformableConvPlugin::DeformableConvPlugin(const nvinfer1::DataType data_type,
   strides_.insert(strides_.end(), strides.cbegin(), strides.cend());
   paddings_.insert(paddings_.end(), paddings.cbegin(), paddings.cend());
   dilations_.insert(dilations_.end(), dilations.cbegin(), dilations.cend());
-  PADDLE_ENFORCE_EQ(
-      data_type_ == nvinfer1::DataType::kFLOAT ||
-          data_type_ == nvinfer1::DataType::kHALF,
-      true,
-      phi::errors::InvalidArgument("The DeformableConv TRT Plugin's input type "
-                                   "should be float or half."));
+  PADDLE_ENFORCE_EQ(data_type_ == nvinfer1::DataType::kFLOAT ||
+                        data_type_ == nvinfer1::DataType::kHALF,
+                    true,
+                    common::errors::InvalidArgument(
+                        "The DeformableConv TRT Plugin's input type "
+                        "should be float or half."));
   PADDLE_ENFORCE_EQ(
       paddings_.size(),
       strides_.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of paddings (%d) is not equal to the size of strides (%d).",
           paddings_.size(),
           strides_.size()));
@@ -143,16 +143,16 @@ DeformableConvPlugin::DeformableConvPlugin(const nvinfer1::DataType data_type,
   offset_dim_.insert(offset_dim_.end(), offset_dim.cbegin(), offset_dim.cend());
   mask_dim_.insert(mask_dim_.end(), mask_dim.cbegin(), mask_dim.cend());
   output_dim_.insert(output_dim_.end(), output_dim.cbegin(), output_dim.cend());
-  PADDLE_ENFORCE_EQ(
-      data_type_ == nvinfer1::DataType::kFLOAT ||
-          data_type_ == nvinfer1::DataType::kHALF,
-      true,
-      phi::errors::InvalidArgument("The DeformableConv TRT Plugin's input type "
-                                   "should be float or half."));
+  PADDLE_ENFORCE_EQ(data_type_ == nvinfer1::DataType::kFLOAT ||
+                        data_type_ == nvinfer1::DataType::kHALF,
+                    true,
+                    common::errors::InvalidArgument(
+                        "The DeformableConv TRT Plugin's input type "
+                        "should be float or half."));
   PADDLE_ENFORCE_EQ(
       paddings_.size(),
       strides_.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of paddings (%d) is not equal to the size of strides (%d).",
           paddings_.size(),
           strides_.size()));
@@ -198,7 +198,7 @@ nvinfer1::Dims DeformableConvPlugin::getOutputDimensions(
     int index, const nvinfer1::Dims* inputs, int nb_input_dims) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(nb_input_dims,
                     3,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The number of inputs should be equal to 3, but got %d",
                         nb_input_dims));
   nvinfer1::Dims ret;
@@ -260,11 +260,11 @@ int DeformableConvPlugin::enqueue(int batch_size,
 #if TRT_PLUGIN_FP16_AVALIABLE
     enqueue_impl<half>(batch_size, inputs, outputs, workspace, stream);
 #else
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Current CUDA arch dose not support fp16. Please use fp32 instead."));
 #endif
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The DeformableConv TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;
@@ -646,7 +646,7 @@ void gemm_impl<half>(cublasHandle_t handle,
   phi::dynload::cublasHgemm(
       handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
 #else
-  PADDLE_THROW(phi::errors::InvalidArgument(
+  PADDLE_THROW(common::errors::InvalidArgument(
       "Current CUDA arch dose not support fp16. Please use fp32 instead."));
 #endif
 }
@@ -833,12 +833,12 @@ void DeformableConvPlugin::configurePlugin(
   PADDLE_ENFORCE_EQ(
       nb_inputs,
       3,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of inputs should be equal to 3, but got %d", nb_inputs));
   PADDLE_ENFORCE_EQ(
       nb_outputs,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of inputs should be equal to 1, but got %d", nb_outputs));
 
   for (int i = 0; i < input_dims[0].nbDims; i++) {
@@ -939,7 +939,7 @@ nvinfer1::IPluginV2Ext* DeformableConvPluginCreator::createPlugin(
     } else if (field_name.compare("with_fp16")) {
       with_fp16 = *static_cast<const bool*>(fc->fields[i].data);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unknown plugin field name [%s] in the DeformableConv TRT Plugin.",
           field_name));
     }
@@ -991,16 +991,16 @@ DeformableConvPluginDynamic::DeformableConvPluginDynamic(
   strides_.insert(strides_.end(), strides.cbegin(), strides.cend());
   paddings_.insert(paddings_.end(), paddings.cbegin(), paddings.cend());
   dilations_.insert(dilations_.end(), dilations.cbegin(), dilations.cend());
-  PADDLE_ENFORCE_EQ(
-      data_type_ == nvinfer1::DataType::kFLOAT ||
-          data_type_ == nvinfer1::DataType::kHALF,
-      true,
-      phi::errors::InvalidArgument("The DeformableConv TRT Plugin's input type "
-                                   "should be float or half."));
+  PADDLE_ENFORCE_EQ(data_type_ == nvinfer1::DataType::kFLOAT ||
+                        data_type_ == nvinfer1::DataType::kHALF,
+                    true,
+                    common::errors::InvalidArgument(
+                        "The DeformableConv TRT Plugin's input type "
+                        "should be float or half."));
   PADDLE_ENFORCE_EQ(
       paddings_.size(),
       strides_.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of paddings (%d) is not equal to the size of strides (%d).",
           paddings_.size(),
           strides_.size()));
@@ -1099,12 +1099,12 @@ size_t DeformableConvPluginDynamic::getWorkspaceSize(
   PADDLE_ENFORCE_EQ(
       nbInputs,
       3,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of inputs should be equal to 3, but got %d", nbInputs));
   PADDLE_ENFORCE_EQ(
       nbOutputs,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of inputs should be equal to 1, but got %d", nbOutputs));
   int c_i = inputs[0].dims.d[1], h_i = inputs[0].dims.d[2],
       w_i = inputs[0].dims.d[3];
@@ -1125,7 +1125,7 @@ nvinfer1::DimsExprs DeformableConvPluginDynamic::getOutputDimensions(
   PADDLE_ENFORCE_EQ(
       nb_inputs,
       3,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of inputs should be equal to 3, but got %d", nb_inputs));
   nvinfer1::DimsExprs ret;
   ret.nbDims = inputDims[0].nbDims;
@@ -1171,15 +1171,15 @@ bool DeformableConvPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of groupnorm plugin shoule not be nullptr."));
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   const nvinfer1::PluginTensorDesc& in = in_out[pos];
   if (pos == 0) {
     if (with_fp16_) {
@@ -1202,7 +1202,7 @@ nvinfer1::DataType DeformableConvPluginDynamic::getOutputDataType(
     int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Elementwise Plugin only has one input, so the "
                         "index value should be 0, but get %d.",
                         index));
@@ -1217,12 +1217,12 @@ void DeformableConvPluginDynamic::configurePlugin(
   PADDLE_ENFORCE_EQ(
       nbInputs,
       3,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of inputs should be equal to 3, but got %d", nbInputs));
   PADDLE_ENFORCE_EQ(
       nbOutputs,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of inputs should be equal to 1, but got %d", nbOutputs));
 }
 
@@ -1241,11 +1241,11 @@ int DeformableConvPluginDynamic::enqueue(
     enqueue_impl<half>(
         input_desc, output_desc, inputs, outputs, workspace, stream);
 #else
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Current CUDA arch dose not support fp16. Please use fp32 instead."));
 #endif
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The DeformableConv TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;
@@ -1386,7 +1386,7 @@ nvinfer1::IPluginV2Ext* DeformableConvPluginDynamicCreator::createPlugin(
     } else if (field_name.compare("with_fp16")) {
       with_fp16 = *static_cast<const bool*>(fc->fields[i].data);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unknown plugin field name [%s] in the DeformableConv TRT Plugin.",
           field_name));
     }

--- a/paddle/fluid/inference/tensorrt/plugin/elementwise_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/elementwise_op_plugin.cu
@@ -75,19 +75,19 @@ nvinfer1::Dims ElementWisePlugin::getOutputDimensions(
     int index, const nvinfer1::Dims *input_dims, int num_inputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "There is only one output in TRT elementwise "
                         "op plugin, but got output index: %d.",
                         index));
   PADDLE_ENFORCE_EQ(
       num_inputs,
       2,
-      phi::errors::InvalidArgument("There are 2 inputs in TRT elementwise "
-                                   "op plugin, but got input number: %d.",
-                                   num_inputs));
+      common::errors::InvalidArgument("There are 2 inputs in TRT elementwise "
+                                      "op plugin, but got input number: %d.",
+                                      num_inputs));
   PADDLE_ENFORCE_NOT_NULL(
       input_dims,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input dims of TRT elementwise op plugin should not be null."));
   return input_dims[0];
 }
@@ -104,7 +104,7 @@ int ElementWisePlugin::initialize() TRT_NOEXCEPT {
 
   PADDLE_ENFORCE_GE(dims_x_.nbDims,
                     dims_y_.nbDims + axis_,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "We expect [number of x dims] >= [number of y dims + "
                         "axis] in TRT elementwise op plugin, but got [number "
                         "of x dims] = %d, [number of y dims + axis] = %d.",
@@ -113,11 +113,11 @@ int ElementWisePlugin::initialize() TRT_NOEXCEPT {
   PADDLE_ENFORCE_LT(
       axis_,
       dims_x_.nbDims,
-      phi::errors::InvalidArgument("We expect [axis] < [number of x dims] "
-                                   "in TRT elementwise op plugin, but got "
-                                   "[axis] = %d, [number of x dims] = %d.",
-                                   axis_,
-                                   dims_x_.nbDims));
+      common::errors::InvalidArgument("We expect [axis] < [number of x dims] "
+                                      "in TRT elementwise op plugin, but got "
+                                      "[axis] = %d, [number of x dims] = %d.",
+                                      axis_,
+                                      dims_x_.nbDims));
 
   prev_size_ = 1;
   midd_size_ = 1;
@@ -129,7 +129,7 @@ int ElementWisePlugin::initialize() TRT_NOEXCEPT {
   for (int i = 0; i < dims_y_.nbDims; ++i) {
     PADDLE_ENFORCE_EQ(dims_x_.d[i + axis_],
                       dims_y_.d[i],
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Broadcast dimension mismatch. The dims of input Y "
                           "should be a subsequence of X."));
     midd_size_ *= dims_y_.d[i];
@@ -204,7 +204,7 @@ int ElementWisePlugin::enqueue(int batch_size,
                                                      post_size_,
                                                      details::Pow<float>());
   } else {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The %s type elementwise is not implemented in trt plugin.", type_));
   }
 
@@ -240,16 +240,16 @@ bool ElementwisePluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of swish plugin shoule not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   (in_out && pos < (nb_inputs + nb_outputs));
 
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
@@ -268,7 +268,7 @@ nvinfer1::DataType ElementwisePluginDynamic::getOutputDataType(
     int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Elementwise Plugin only has one input, so the "
                         "index value should be 0, but get %d.",
                         index));
@@ -304,7 +304,7 @@ int ElementwisePluginDynamic::enqueue(
   for (int i = 0; i < trimed_nb_dims; ++i) {
     PADDLE_ENFORCE_EQ(x_dims.d[i + axis],
                       y_dims.d[i],
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Broadcast dimension mismatch found in trt "
                           "elementwise plugin's x and y input."));
     midd_size *= y_dims.d[i];
@@ -338,7 +338,7 @@ int ElementwisePluginDynamic::enqueue(
     elementwise_kernel<<<block, thread, 0, stream>>>(
         num, x, y, out, prev_size, midd_size, post_size, details::Pow<float>());
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Paddle-TRT only support elementwise "
         "operation: {add, mul, div, sub, pow} currently, "
         "but got %s.",

--- a/paddle/fluid/inference/tensorrt/plugin/elementwiseadd_transpose_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/elementwiseadd_transpose_op_plugin.cu
@@ -61,16 +61,16 @@ bool ElementwiseAddTransposePluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument("The input of elementwiseadd_transpose "
-                                   "plugin shoule not be nullptr."));
+      common::errors::InvalidArgument("The input of elementwiseadd_transpose "
+                                      "plugin shoule not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   // (in_out && pos < (nb_inputs + nb_outputs));
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   // input 0
@@ -162,7 +162,7 @@ nvinfer1::DataType ElementwiseAddTransposePluginDynamic::getOutputDataType(
     int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Elementwise Plugin only has one input, so the "
                         "index value should be 0, but get %d.",
                         index));

--- a/paddle/fluid/inference/tensorrt/plugin/fused_token_prune_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/fused_token_prune_op_plugin.cu
@@ -236,16 +236,16 @@ bool FusedTokenPrunePluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of swish plugin shoule not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
 
   const nvinfer1::PluginTensorDesc& in = in_out[pos];
   if (flag_varseqlen_) {
@@ -255,8 +255,8 @@ bool FusedTokenPrunePluginDynamic::supportsFormatCombination(
                (in.format == nvinfer1::TensorFormat::kLINEAR);
       } else {
         PADDLE_THROW(
-            phi::errors::Fatal("The FusedTokenPrune TRT Plugin's input type "
-                               "should be half for varseqlen."));
+            common::errors::Fatal("The FusedTokenPrune TRT Plugin's input type "
+                                  "should be half for varseqlen."));
       }
     } else if (pos == 6 || pos == 11) {  // mask_id, mask_id_out
       return (in.type == nvinfer1::DataType::kHALF) &&
@@ -340,7 +340,7 @@ int FusedTokenPrunePluginDynamic::enqueue(
   if (flag_varseqlen_) {
     if (!(input_desc[0].type == nvinfer1::DataType::kHALF &&
           input_desc[1].type == nvinfer1::DataType::kHALF)) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Token_prune'type must half for varseqlen"));
     }
     float scale =
@@ -367,8 +367,8 @@ int FusedTokenPrunePluginDynamic::enqueue(
     } else if (max_sequnce_length <= 512) {
       padding_token_length = 512;
     } else {
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("Token_prune'token_length must <= 512"));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Token_prune'token_length must <= 512"));
     }
 
     // 1. Compute the token length after pruning.
@@ -475,7 +475,7 @@ int FusedTokenPrunePluginDynamic::enqueue(
       } else if (pre_sequnce_length <= 512) {
         padding_token_length = 512;
       } else {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "Token_prune'token_length must <= 512"));
       }
 
@@ -568,7 +568,7 @@ int FusedTokenPrunePluginDynamic::enqueue(
       } else if (pre_sequnce_length <= 512) {
         padding_token_length = 512;
       } else {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "Token_prune'token_length must <= 512"));
       }
 
@@ -645,8 +645,8 @@ int FusedTokenPrunePluginDynamic::enqueue(
       }
     } else {
       PADDLE_THROW(
-          phi::errors::Fatal("The FusedTokenPrune TRT Plugin's input type "
-                             "should be float or half."));
+          common::errors::Fatal("The FusedTokenPrune TRT Plugin's input type "
+                                "should be float or half."));
     }
   }
   return cudaGetLastError() != cudaSuccess;

--- a/paddle/fluid/inference/tensorrt/plugin/fused_token_prune_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/fused_token_prune_op_plugin.h
@@ -106,7 +106,7 @@ class FusedTokenPrunePluginDynamic : public DynamicPluginTensorRT {
       padding_token_length = 512;
     } else {
       try {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "Token_prune'token_length(max) must <= 512"));
       } catch (std::exception& e) {
       }

--- a/paddle/fluid/inference/tensorrt/plugin/gather_nd_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/gather_nd_op_plugin.cu
@@ -81,13 +81,13 @@ nvinfer1::DimsExprs GatherNdPluginDynamic::getOutputDimensions(
   PADDLE_ENFORCE_EQ(
       nb_inputs,
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The gather_nd plugin should have 2 input, but got %d.", nb_inputs));
   PADDLE_ENFORCE_EQ(
       output_index,
       0,
-      phi::errors::InvalidArgument("When GetOutputDimensions in gather_nd "
-                                   "plugin, the output_index should be 0."));
+      common::errors::InvalidArgument("When GetOutputDimensions in gather_nd "
+                                      "plugin, the output_index should be 0."));
 
   nvinfer1::DimsExprs x_dims = inputs[0];
   nvinfer1::DimsExprs index_dims = inputs[1];
@@ -114,16 +114,16 @@ bool GatherNdPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of gather_nd plugin should not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   (in_out && pos < (nb_inputs + nb_outputs));
 
   const nvinfer1::PluginTensorDesc& in = in_out[pos];

--- a/paddle/fluid/inference/tensorrt/plugin/gelu_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/gelu_op_plugin.cu
@@ -127,7 +127,7 @@ int GeluPlugin::enqueue(int batch_size,
         <<<grid_size, block_size, 0, stream>>>(
             kAT, kBT, kCT, num, input, output);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The Gelu TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;
@@ -151,16 +151,16 @@ bool GeluPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of swish plugin shoule not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   (in_out && pos < (nb_inputs + nb_outputs));
 
   const nvinfer1::PluginTensorDesc& in = in_out[pos];
@@ -183,12 +183,12 @@ nvinfer1::DataType GeluPluginDynamic::getOutputDataType(
     int index,
     const nvinfer1::DataType* input_types,
     int nb_inputs) const TRT_NOEXCEPT {
-  PADDLE_ENFORCE_EQ(
-      index,
-      0,
-      phi::errors::InvalidArgument("The Gelu Plugin only has one input, so the "
-                                   "index value should be 0, but get %d.",
-                                   index));
+  PADDLE_ENFORCE_EQ(index,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The Gelu Plugin only has one input, so the "
+                        "index value should be 0, but get %d.",
+                        index));
   return input_types[0];
 }
 
@@ -218,7 +218,7 @@ int GeluPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
         <<<grid_size, block_size, 0, stream>>>(
             kAT, kBT, kCT, num, input, output);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The Gelu TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;

--- a/paddle/fluid/inference/tensorrt/plugin/generic_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/generic_plugin.cu
@@ -62,7 +62,7 @@ GeneratePluginDataType ProtoTypeToGeneratePluginDataType(
     case VarType_Type::VarType_Type_COMPLEX128:
       return GeneratePluginDataType::PLUGIN_COMPLEX128;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "This data type is currently not supported"));
   }
 }
@@ -81,7 +81,7 @@ void BuildPhiKernelContextAttr(const framework::OpDesc& op_desc,
   PADDLE_ENFORCE_EQ(
       attr_names.size(),
       attr_defs.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The attr_names.size() should be equal to attr_defs.size()."));
 
   framework::AttrReader attr_reader(op_desc.GetAttrMap());
@@ -119,7 +119,7 @@ void BuildPhiKernelContextAttr(const framework::OpDesc& op_desc,
                   PADDLE_GET_CONST(paddle::experimental::Scalar, attr)));
               break;
             default:
-              PADDLE_THROW(phi::errors::Unimplemented(
+              PADDLE_THROW(common::errors::Unimplemented(
                   "Unsupported cast op attribute `%s` to Scalar when "
                   "ProtoAttr2PhiAttr.",
                   attr_name));
@@ -142,7 +142,7 @@ void BuildPhiKernelContextAttr(const framework::OpDesc& op_desc,
                   phi::IntArray({PADDLE_GET_CONST(int, attr)}));
               break;
             default:
-              PADDLE_THROW(phi::errors::Unimplemented(
+              PADDLE_THROW(common::errors::Unimplemented(
                   "Unsupported cast op attribute `%s` to IntArray when "
                   "ProtoAttr2PhiAttr.",
                   attr_name));
@@ -199,7 +199,7 @@ void BuildPhiKernelContextAttr(const framework::OpDesc& op_desc,
               kernel_context->EmplaceBackAttr(std::move(scalar_list));
             } break;
             default:
-              PADDLE_THROW(phi::errors::Unimplemented(
+              PADDLE_THROW(common::errors::Unimplemented(
                   "Unsupported cast op attribute `%s` to vector<Scalar> when "
                   "ProtoAttr2PhiAttr.",
                   attr_name));
@@ -252,7 +252,7 @@ void BuildPhiKernelContextAttr(const framework::OpDesc& op_desc,
                   kernel_context->EmplaceBackAttr(vector_int64_attr);
                 } break;
                 default:
-                  PADDLE_THROW(phi::errors::Unimplemented(
+                  PADDLE_THROW(common::errors::Unimplemented(
                       "Unsupported cast op attribute `%s` to vector<int64_t> "
                       "when ProtoAttr2PhiAttr.",
                       attr_name));
@@ -275,7 +275,7 @@ void BuildPhiKernelContextAttr(const framework::OpDesc& op_desc,
                   PADDLE_GET_CONST(std::vector<double>, attr));
               break;
             default:
-              PADDLE_THROW(phi::errors::Unimplemented(
+              PADDLE_THROW(common::errors::Unimplemented(
                   "Unsupported cast op attribute `%s` when construct "
                   "ProtoAttr2PhiAttr.",
                   attr_name));
@@ -491,7 +491,8 @@ int GenericPlugin::initialize() TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(
       phi::KernelFactory::Instance().HasCompatiblePhiKernel(op_type),
       true,
-      phi::errors::Fatal("%s has no compatible phi kernel!", op_type.c_str()));
+      common::errors::Fatal("%s has no compatible phi kernel!",
+                            op_type.c_str()));
 
   phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
   phi::GPUPlace place(platform::GetCurrentDeviceId());
@@ -521,8 +522,8 @@ int GenericPlugin::initialize() TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(phi_kernels_[nvinfer1::DataType::kFLOAT]->IsValid() ||
                         phi_kernels_[nvinfer1::DataType::kHALF]->IsValid(),
                     true,
-                    phi::errors::Fatal("%s phi kernel is invalid!.",
-                                       phi_kernel_signature.name));
+                    common::errors::Fatal("%s phi kernel is invalid!.",
+                                          phi_kernel_signature.name));
 
   if (!dense_tensor_inputs_)
     dense_tensor_inputs_ = new std::vector<phi::DenseTensor>(getNbInputs());
@@ -541,7 +542,7 @@ nvinfer1::DimsExprs GenericPlugin::getOutputDimensions(
   auto& dynamic_infermeta_factory = tensorrt::DynamicMetaFnFactory::Instance();
   PADDLE_ENFORCE_EQ(dynamic_infermeta_factory.Contains(op_desc_.Type()),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The %s op has no dynamic plugin infershape function!",
                         op_desc_.Type().c_str()));
 

--- a/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
@@ -319,8 +319,8 @@ void groupNormNCHW32ScaleQDQ(const GroupNormNDHWCParams<__half> &params,
       break;
     default:
       PADDLE_THROW(
-          phi::errors::Fatal("The function groupNormNCHW32ScaleQDQ of "
-                             "GroupNorm TRT Plugin encounter error"));
+          common::errors::Fatal("The function groupNormNCHW32ScaleQDQ of "
+                                "GroupNorm TRT Plugin encounter error"));
   }
 }
 
@@ -402,7 +402,7 @@ int GroupNormPlugin::enqueue(int batch_size,
   PADDLE_ENFORCE_EQ(
       C,
       scale_.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "scale's size should be equal to the channel number in groupnorm,"
           "but got channel number:%d, scale's size:%d.",
           C,
@@ -410,7 +410,7 @@ int GroupNormPlugin::enqueue(int batch_size,
   PADDLE_ENFORCE_EQ(
       C,
       bias_.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "bias's size should be equal to the channel number in groupnorm,"
           "but got channel number:%d, bias's size:%d.",
           C,
@@ -454,7 +454,7 @@ int GroupNormPlugin::enqueue(int batch_size,
                variance_d,
                DataLayout::kNCHW);
   } else {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The GroupNorm TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;
@@ -474,15 +474,15 @@ bool GroupNormPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of groupnorm plugin shoule not be nullptr."));
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
 
   bool int8_support = in.type == nvinfer1::DataType::kINT8 &&
@@ -513,15 +513,15 @@ nvinfer1::DataType GroupNormPluginDynamic::getOutputDataType(
     int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The groupnorm Plugin only has one input, so the "
                         "index value should be 0, but get %d.",
                         index));
-  PADDLE_ENFORCE_EQ(
-      (input_types[0] == nvinfer1::DataType::kFLOAT ||
-       input_types[0] == nvinfer1::DataType::kHALF),
-      true,
-      phi::errors::InvalidArgument("The input type should be half or float"));
+  PADDLE_ENFORCE_EQ((input_types[0] == nvinfer1::DataType::kFLOAT ||
+                     input_types[0] == nvinfer1::DataType::kHALF),
+                    true,
+                    common::errors::InvalidArgument(
+                        "The input type should be half or float"));
 
   return input_types[0];
 }
@@ -587,7 +587,7 @@ int GroupNormPluginDynamic::enqueue(
   PADDLE_ENFORCE_EQ(
       C,
       scale_.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "scale's size should be equal to the channel number in groupnorm,"
           "but got feature_size:%d, scale's size:%d.",
           C,
@@ -595,7 +595,7 @@ int GroupNormPluginDynamic::enqueue(
   PADDLE_ENFORCE_EQ(
       C,
       bias_.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "bias's size should be equal to the channel number in groupnorm,"
           "but got feature_size:%d, bias's size:%d.",
           C,
@@ -715,7 +715,7 @@ int GroupNormPluginDynamic::enqueue(
       phi::groupNormNDHWCScale<half> ndhwc_scale;
       ndhwc_scale(params_, stream);
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "The Groupnorm TRT Plugin's only support nchw or nhwc8 input"));
     }
   } else if (input_type == nvinfer1::DataType::kINT8) {
@@ -801,12 +801,12 @@ int GroupNormPluginDynamic::enqueue(
       groupNormNCHW32SumQDQ(params_, stream);
       groupNormNCHW32ScaleQDQ(params_, stream);
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "The Groupnorm TRT Plugin only support nchw32 input"));
     }
   } else {
     // input not float
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The Groupnorm TRT Plugin's only support fp32, fp16 or int8 input"));
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/hard_swish_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/hard_swish_op_plugin.cu
@@ -127,7 +127,7 @@ nvinfer1::DataType HardSwishPluginDynamic::getOutputDataType(
     int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Elementwise Plugin only has one input, so the "
                         "index value should be 0, but get %d.",
                         index));
@@ -141,16 +141,16 @@ bool HardSwishPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of swish plugin shoule not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   (in_out && pos < (nb_inputs + nb_outputs));
 
   const nvinfer1::PluginTensorDesc &in = in_out[pos];

--- a/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.h
@@ -60,7 +60,7 @@ class InstanceNormPlugin : public PluginTensorRT {
       : eps_(eps), scale_(scale), bias_(bias) {
     PADDLE_ENFORCE_EQ(scale.size(),
                       bias.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The instanceNorm's scale and bias should be the "
                           "same size. Got scale size = %d, but bias size = %d",
                           scale.size(),
@@ -170,7 +170,7 @@ class InstanceNormPluginDynamic : public DynamicPluginTensorRT {
       : eps_(eps), scale_(scale), bias_(bias) {
     PADDLE_ENFORCE_EQ(scale.size(),
                       bias.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The instanceNorm's scale and bias should be the "
                           "same size. Got scale size = %d, but bias size = %d",
                           scale.size(),

--- a/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.cu
@@ -88,13 +88,13 @@ int LayerNormPlugin::enqueue(int batch_size,
 
   PADDLE_ENFORCE_EQ(1,
                     mean_shape_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Size of mean_shape vector should be equal to 1,"
                         "but got Size of mean_shape vector:%d",
                         mean_shape_.size()));
   PADDLE_ENFORCE_EQ(1,
                     variance_shape_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Size of variance_shape vector should be equal to 1,"
                         "but got Size of mean_shape vector:%d",
                         mean_shape_.size()));
@@ -112,14 +112,14 @@ int LayerNormPlugin::enqueue(int batch_size,
   int feature_size = static_cast<int>(matrix_dim[1]);
   PADDLE_ENFORCE_EQ(feature_size,
                     scale_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "scale's size should be equal to the feature_size,"
                         "but got feature_size:%d, scale's size:%d.",
                         feature_size,
                         scale_.size()));
   PADDLE_ENFORCE_EQ(feature_size,
                     bias_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "bias's size should be equal to the feature_size,"
                         "but got feature_size:%d, bias's size:%d.",
                         feature_size,
@@ -163,7 +163,7 @@ int LayerNormPlugin::enqueue(int batch_size,
                begin_norm_axis,
                eps);
   } else {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The LayerNorm TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;
@@ -209,15 +209,15 @@ bool LayerNormPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of layernorm plugin shoule not be nullptr."));
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   if (pos == 0) {
     if (with_fp16_) {
@@ -254,15 +254,15 @@ nvinfer1::DataType LayerNormPluginDynamic::getOutputDataType(
     int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The LayerNormPlugin only has one input, so the "
                         "index value should be 0, but get %d.",
                         index));
-  PADDLE_ENFORCE_EQ(
-      (input_types[0] == nvinfer1::DataType::kFLOAT ||
-       input_types[0] == nvinfer1::DataType::kHALF),
-      true,
-      phi::errors::InvalidArgument("The input type should be half or float"));
+  PADDLE_ENFORCE_EQ((input_types[0] == nvinfer1::DataType::kFLOAT ||
+                     input_types[0] == nvinfer1::DataType::kHALF),
+                    true,
+                    common::errors::InvalidArgument(
+                        "The input type should be half or float"));
   return input_types[0];
 }
 
@@ -285,42 +285,42 @@ int LayerNormPluginDynamic::enqueue(
   // the batch num should be involved in mean/variance shape
   PADDLE_ENFORCE_EQ(1,
                     mean_shape_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Size of mean_shape vector should be equal to 1,"
                         "but got Size of mean_shape vector:%d",
                         mean_shape_.size()));
   PADDLE_ENFORCE_EQ(1,
                     variance_shape_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Size of variance_shape vector should be equal to 1,"
                         "but got Size of mean_shape vector:%d",
                         mean_shape_.size()));
-  PADDLE_ENFORCE_GE(
-      mean_shape_[0],
-      0,
-      phi::errors::InvalidArgument("The size of mean vector should be positive,"
-                                   "but got:%d",
-                                   mean_shape_[0]));
-  PADDLE_ENFORCE_GE(
-      variance_shape_[0],
-      0,
-      phi::errors::InvalidArgument("The size of mean vector should be positive,"
-                                   "but got:%d",
-                                   variance_shape_[0]));
+  PADDLE_ENFORCE_GE(mean_shape_[0],
+                    0,
+                    common::errors::InvalidArgument(
+                        "The size of mean vector should be positive,"
+                        "but got:%d",
+                        mean_shape_[0]));
+  PADDLE_ENFORCE_GE(variance_shape_[0],
+                    0,
+                    common::errors::InvalidArgument(
+                        "The size of mean vector should be positive,"
+                        "but got:%d",
+                        variance_shape_[0]));
 
   const auto input_ddim = common::make_ddim(input_shape);
   auto matrix_dim = common::flatten_to_2d(input_ddim, begin_norm_axis);
   int feature_size = static_cast<int>(matrix_dim[1]);
   PADDLE_ENFORCE_EQ(feature_size,
                     scale_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "scale's size should be equal to the feature_size,"
                         "but got feature_size:%d, scale's size:%d.",
                         feature_size,
                         scale_.size()));
   PADDLE_ENFORCE_EQ(feature_size,
                     bias_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "bias's size should be equal to the feature_size,"
                         "but got feature_size:%d, bias's size:%d.",
                         feature_size,
@@ -364,7 +364,7 @@ int LayerNormPluginDynamic::enqueue(
                begin_norm_axis,
                eps);
   } else {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The LayerNorm TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;

--- a/paddle/fluid/inference/tensorrt/plugin/layernorm_shift_partition_op.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/layernorm_shift_partition_op.cu
@@ -553,15 +553,15 @@ bool LayernormShiftPartitionPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument("The input of LayernormShiftPartition "
-                                   "plugin shoule not be nullptr."));
+      common::errors::InvalidArgument("The input of LayernormShiftPartition "
+                                      "plugin shoule not be nullptr."));
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   if (pos == 0) {
     if (with_fp16_) {
@@ -584,7 +584,7 @@ nvinfer1::DataType LayernormShiftPartitionPluginDynamic::getOutputDataType(
   PADDLE_ENFORCE_EQ(
       index,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The LayernormShiftPartition only has one input, so the "
           "index value should be 0, but get %d.",
           index));
@@ -599,7 +599,7 @@ nvinfer1::DimsExprs LayernormShiftPartitionPluginDynamic::getOutputDimensions(
   PADDLE_ENFORCE_EQ(
       output_index,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "There is only one output of the LayernormShiftPartition, "
           "so the index should be zero,"
           "but it's (%d)",
@@ -607,7 +607,7 @@ nvinfer1::DimsExprs LayernormShiftPartitionPluginDynamic::getOutputDimensions(
   PADDLE_ENFORCE_EQ(
       nb_inputs,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The Input of the LayernormShiftPartition should be 1, but we found "
           "it has (%d) inputs",
           nb_inputs));
@@ -639,7 +639,7 @@ int LayernormShiftPartitionPluginDynamic::enqueue(
   PADDLE_ENFORCE_EQ(
       input_resolution_ * input_resolution_,
       input_dims.d[1],
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The LayernormShiftPartition‘s input_resolution is wrong (%d)",
           input_dims.d[1]));
   if (input_type == nvinfer1::DataType::kFLOAT) {
@@ -673,7 +673,7 @@ int LayernormShiftPartitionPluginDynamic::enqueue(
         eps_,
         stream);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The LayerNorm TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;

--- a/paddle/fluid/inference/tensorrt/plugin/many_emb_layernorm_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/many_emb_layernorm_plugin.cu
@@ -191,7 +191,7 @@ int32_t EmbLayerNormPlugin::enqueue(
   int32_t batchSize = inputDesc[0].dims.d[0];
   int32_t const maxSeqlen = inputDesc[0].dims.d[1];
   if (maxSeqlen > 512) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "EmbLayerNormPlugin support maxSeqlen is 512"));
   }
   const float* beta = mBetaDev.get();
@@ -256,7 +256,7 @@ int32_t EmbLayerNormPlugin::enqueue(
           mIdsVocabSize[3],
           output);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Only support 2,3,4 lookup_tables fused "));
     }
   } else if (mType == nvinfer1::DataType::kHALF) {
@@ -316,11 +316,11 @@ int32_t EmbLayerNormPlugin::enqueue(
                                       mIdsVocabSize[3],
                                       output);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Only support 2,3,4 lookup_tables fused "));
     }
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Unsupported type error, expected [kHALF,kFLOAT]"));
   }
   return STATUS_SUCCESS;

--- a/paddle/fluid/inference/tensorrt/plugin/many_emb_layernorm_varseqlen_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/many_emb_layernorm_varseqlen_plugin.cu
@@ -432,7 +432,7 @@ int32_t EmbLayerNormVarSeqlenPluginHFace::enqueue(
           mIdsVocabSize[3],
           output);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Only support 2,3,4 lookup_tables fused "));
     }
   } else if (mType == nvinfer1::DataType::kHALF) {
@@ -495,11 +495,11 @@ int32_t EmbLayerNormVarSeqlenPluginHFace::enqueue(
           mIdsVocabSize[3],
           output);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Only support 2,3,4 lookup_tables fused "));
     }
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Unsupported type error, expected [kHALF,kFLOAT]"));
   }
   return STATUS_SUCCESS;
@@ -598,7 +598,7 @@ int32_t EmbLayerNormVarSeqlenPluginMTron::enqueue(
           output,
           skip);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Only support 2,3,4 lookup_tables fused "));
     }
   } else if (mType == nvinfer1::DataType::kHALF) {
@@ -665,11 +665,11 @@ int32_t EmbLayerNormVarSeqlenPluginMTron::enqueue(
           output,
           skip);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Only support 2,3,4 lookup_tables fused "));
     }
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Unsupported type error, expected [kHALF,kFLOAT]"));
   }
   return STATUS_SUCCESS;

--- a/paddle/fluid/inference/tensorrt/plugin/matmul_op_int8_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/matmul_op_int8_plugin.cu
@@ -229,14 +229,14 @@ bool MatmulPlugin::supportsFormatCombination(
     int32_t nbOutputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(nbInputs,
                     2,
-                    phi::errors::InvalidArgument("Must have 2 inputs, "
-                                                 "but got %d input(s). ",
-                                                 nbInputs));
+                    common::errors::InvalidArgument("Must have 2 inputs, "
+                                                    "but got %d input(s). ",
+                                                    nbInputs));
   PADDLE_ENFORCE_EQ(nbOutputs,
                     getNbOutputs(),
-                    phi::errors::InvalidArgument("Must have 1 output, "
-                                                 "but got %d output(s). ",
-                                                 nbOutputs));
+                    common::errors::InvalidArgument("Must have 1 output, "
+                                                    "but got %d output(s). ",
+                                                    nbOutputs));
   if (pos == 0) {
     return (inOut[pos].type == nvinfer1::DataType::kHALF ||
             inOut[pos].type == nvinfer1::DataType::kFLOAT ||
@@ -771,8 +771,8 @@ int MatmulPlugin::enqueue(int batchSize,
                        workspace,
                        stream);
   } else {
-    PADDLE_THROW(
-        phi::errors::InvalidArgument("VarMessageToVarType:Unsupported type"));
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "VarMessageToVarType:Unsupported type"));
   }
   return cudaGetLastError() != cudaSuccess;
 }
@@ -810,14 +810,14 @@ bool MatmulPluginDynamic::supportsFormatCombination(
     int nbOutputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(nbInputs,
                     2,
-                    phi::errors::InvalidArgument("Must have 2 inputs, "
-                                                 "but got %d input(s). ",
-                                                 nbInputs));
+                    common::errors::InvalidArgument("Must have 2 inputs, "
+                                                    "but got %d input(s). ",
+                                                    nbInputs));
   PADDLE_ENFORCE_EQ(nbOutputs,
                     getNbOutputs(),
-                    phi::errors::InvalidArgument("Must have 1 output, "
-                                                 "but got %d output(s). ",
-                                                 nbOutputs));
+                    common::errors::InvalidArgument("Must have 1 output, "
+                                                    "but got %d output(s). ",
+                                                    nbOutputs));
   if (pos == 0) {
     return (inOut[pos].type == nvinfer1::DataType::kHALF ||
             inOut[pos].type == nvinfer1::DataType::kFLOAT ||

--- a/paddle/fluid/inference/tensorrt/plugin/merge_layernorm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/merge_layernorm_op_plugin.cu
@@ -116,7 +116,7 @@ void invokeMergeLayernorm(T *output,
                           int n,
                           cudaStream_t stream) {
   if ((W % 2 != 0) || (H % 2 != 0)) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "H(W) of merge layernorm should be a multiple of 2."));
   }
   dim3 grid(W / 2, H / 2, batch);
@@ -213,15 +213,15 @@ bool MergeLayernormPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument("The input of MergeLayernorm "
-                                   "plugin shoule not be nullptr."));
+      common::errors::InvalidArgument("The input of MergeLayernorm "
+                                      "plugin shoule not be nullptr."));
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   if (pos == 0) {
     if (with_fp16_) {
@@ -243,7 +243,7 @@ nvinfer1::DataType MergeLayernormPluginDynamic::getOutputDataType(
     int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The MergeLayernorm only has one input, so the "
                         "index value should be 0, but get %d.",
                         index));
@@ -282,7 +282,7 @@ int MergeLayernormPluginDynamic::enqueue(
   PADDLE_ENFORCE_EQ(
       input_resolution * input_resolution,
       input_dims.d[1],
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The MergeLayernorm TRT Plugin get invalid input_resolution %d",
           input_resolution));
 
@@ -313,7 +313,7 @@ int MergeLayernormPluginDynamic::enqueue(
         dim,
         stream);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The MergeLayernorm TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;

--- a/paddle/fluid/inference/tensorrt/plugin/mish_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/mish_op_plugin.cu
@@ -42,18 +42,18 @@ nvinfer1::Dims MishPlugin::getOutputDimensions(int index,
   PADDLE_ENFORCE_EQ(
       nb_inputs,
       1,
-      phi::errors::InvalidArgument("We expect [number of inputs] == 1"
-                                   "in TRT Mish op plugin, but got "
-                                   "[number of inputs] = %d.",
-                                   nb_inputs));
+      common::errors::InvalidArgument("We expect [number of inputs] == 1"
+                                      "in TRT Mish op plugin, but got "
+                                      "[number of inputs] = %d.",
+                                      nb_inputs));
   PADDLE_ENFORCE_LT(
       index,
       this->getNbOutputs(),
-      phi::errors::InvalidArgument("We expect [index] < [number of outputs]"
-                                   "in TRT Mish op plugin, but got "
-                                   "[index] = %d, [number of outputs] = %d.",
-                                   index,
-                                   this->getNbOutputs()));
+      common::errors::InvalidArgument("We expect [index] < [number of outputs]"
+                                      "in TRT Mish op plugin, but got "
+                                      "[index] = %d, [number of outputs] = %d.",
+                                      index,
+                                      this->getNbOutputs()));
   nvinfer1::Dims const& input_dims = in_dims[0];
   nvinfer1::Dims output_dims = input_dims;
   return output_dims;
@@ -142,7 +142,7 @@ int MishPlugin::enqueue(int batchSize,
     mish_kernel<half>
         <<<grid_size, block_size, 0, stream>>>(threshold_, num, input, output);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The Mish TRT Plugin's input type should be float or half."));
   }
 
@@ -179,16 +179,16 @@ bool MishPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of mish plugin shoule not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
 
   const nvinfer1::PluginTensorDesc& in = in_out[pos];
   if (pos == 0) {
@@ -210,12 +210,12 @@ nvinfer1::DataType MishPluginDynamic::getOutputDataType(
     int index,
     const nvinfer1::DataType* input_types,
     int nb_inputs) const TRT_NOEXCEPT {
-  PADDLE_ENFORCE_EQ(
-      index,
-      0,
-      phi::errors::InvalidArgument("The Mish Plugin only has one input, so the "
-                                   "index value should be 0, but get %d.",
-                                   index));
+  PADDLE_ENFORCE_EQ(index,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The Mish Plugin only has one input, so the "
+                        "index value should be 0, but get %d.",
+                        index));
   return input_types[0];
 }
 
@@ -244,7 +244,7 @@ int MishPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
     mish_kernel<half>
         <<<grid_size, block_size, 0, stream>>>(threshold_, num, input, output);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The Mish TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;

--- a/paddle/fluid/inference/tensorrt/plugin/multihead_matmul_roformer_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/multihead_matmul_roformer_plugin.cu
@@ -46,7 +46,7 @@ nvinfer1::DimsExprs MultiheadMatmulRoformerPlugin::getOutputDimensions(
   // output, (B, seq_len, hidden)
   PADDLE_ENFORCE_EQ(output_index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "There is only one output of the EmbEltwiseLayernorm, "
                         "so the index should be zero,"
                         "but it's (%d)",
@@ -54,7 +54,7 @@ nvinfer1::DimsExprs MultiheadMatmulRoformerPlugin::getOutputDimensions(
   PADDLE_ENFORCE_EQ(
       nb_inputs,
       4,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The Input of the EmbEltwiseLayernorm should be 3, but we found "
           "it has (%d) inputs",
           nb_inputs));
@@ -73,16 +73,16 @@ bool MultiheadMatmulRoformerPlugin::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of swish plugin shoule not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
 
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   if (pos == 0) {
@@ -117,7 +117,7 @@ nvinfer1::DataType MultiheadMatmulRoformerPlugin::getOutputDataType(
   PADDLE_ENFORCE_EQ(
       index,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The EmbEltwiseLayernorm Plugin only has one input, so the "
           "index value should be 0, but get %d.",
           index));
@@ -154,7 +154,7 @@ inline int round_up(int seq_len, int multiple = 32) {
   PADDLE_ENFORCE_GT(
       multiple,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "multiple should be a positive number, but it's (%d)", multiple));
   return ((seq_len + multiple - 1) / multiple) * multiple;
 }
@@ -357,7 +357,7 @@ int MultiheadMatmulRoformerPlugin::enqueue(
     transpose<half><<<grid, block, 0, stream>>>(
         tptr, output, batch, seq_len, head_number_, head_size_);
 #else
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The Ernie(Bert) TensorRT Plugin should be "
         "complied with CUDA version >= 10.0 when running with fp16. "
         "Please recomplie it or try to use fp32 by set "
@@ -365,7 +365,7 @@ int MultiheadMatmulRoformerPlugin::enqueue(
         "max_input_shape, opt_input_shape, true"));
 #endif
   } else {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The QKV TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;

--- a/paddle/fluid/inference/tensorrt/plugin/pool3d_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/pool3d_op_plugin.cu
@@ -73,19 +73,19 @@ nvinfer1::Dims Pool3DPlugin::getOutputDimensions(
     int index, const nvinfer1::Dims *inputDims, int nbInputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(nbInputs,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Pool3D Plugin only has one input, so the nbInputs "
                         "value should be 1, but get %d.",
                         nbInputs));
-  PADDLE_ENFORCE_EQ(
-      index,
-      0,
-      phi::errors::InvalidArgument("The Pool3D Plugin only has one input, so "
-                                   "the index value should be 0, but get %d.",
-                                   index));
+  PADDLE_ENFORCE_EQ(index,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The Pool3D Plugin only has one input, so "
+                        "the index value should be 0, but get %d.",
+                        index));
   PADDLE_ENFORCE_EQ(inputDims[0].nbDims,
                     4,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Pool3D Plugin only has four Dimensions, so the "
                         "nbDims value should be 4, but get %d.",
                         inputDims[0].nbDims));
@@ -225,14 +225,14 @@ nvinfer1::DimsExprs Pool3DPluginDynamic::getOutputDimensions(
     nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(nb_inputs,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Split plugin should be only one input."));
 
   PADDLE_ENFORCE_EQ(
       inputs[0].d[1]->isConstant(),
       true,
-      phi::errors::InvalidArgument("The channel dimension should be "
-                                   "static, but we found it's dynamic."));
+      common::errors::InvalidArgument("The channel dimension should be "
+                                      "static, but we found it's dynamic."));
   nvinfer1::DimsExprs output(inputs[0]);
   if (is_global_) {
     output.d[2] = expr_builder.constant(1);
@@ -328,16 +328,16 @@ bool Pool3DPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of swish plugin shoule not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   (in_out && pos < (nb_inputs + nb_outputs));
 
   return ((in_out[pos].type == nvinfer1::DataType::kFLOAT) &&
@@ -350,14 +350,14 @@ nvinfer1::DataType Pool3DPluginDynamic::getOutputDataType(
     int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Pool3D Plugin only has one input, so the "
                         "index value should be 0, but get %d.",
                         index));
   PADDLE_ENFORCE_EQ(
       (input_types[0] == nvinfer1::DataType::kFLOAT),
       true,
-      phi::errors::InvalidArgument("The input type should be float"));
+      common::errors::InvalidArgument("The input type should be float"));
   return input_types[0];
 }
 

--- a/paddle/fluid/inference/tensorrt/plugin/pool_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/pool_op_plugin.cu
@@ -181,7 +181,7 @@ nvinfer1::DimsExprs PoolPluginDynamic::getOutputDimensions(
     nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(nb_inputs,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Split plugin should be only one input."));
 
   nvinfer1::DimsExprs output(inputs[0]);
@@ -259,16 +259,16 @@ bool PoolPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of swish plugin shoule not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   (in_out && pos < (nb_inputs + nb_outputs));
 
   return ((in_out[pos].type == nvinfer1::DataType::kFLOAT) &&
@@ -279,16 +279,16 @@ nvinfer1::DataType PoolPluginDynamic::getOutputDataType(
     int index,
     const nvinfer1::DataType *input_types,
     int nb_inputs) const TRT_NOEXCEPT {
-  PADDLE_ENFORCE_EQ(
-      index,
-      0,
-      phi::errors::InvalidArgument("The Pool Plugin only has one input, so the "
-                                   "index value should be 0, but get %d.",
-                                   index));
+  PADDLE_ENFORCE_EQ(index,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The Pool Plugin only has one input, so the "
+                        "index value should be 0, but get %d.",
+                        index));
   PADDLE_ENFORCE_EQ(
       (input_types[0] == nvinfer1::DataType::kFLOAT),
       true,
-      phi::errors::InvalidArgument("The input type should be float"));
+      common::errors::InvalidArgument("The input type should be float"));
   return input_types[0];
 }
 

--- a/paddle/fluid/inference/tensorrt/plugin/preln_groupnorm_act_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/preln_groupnorm_act_op_plugin.cu
@@ -39,22 +39,22 @@ bool PrelnGroupnormActPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of prelnGroupnormAct plugin shoule not be nullptr."));
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   if (pos == 0) {
     if (with_fp16_) {
       return ((in.type == nvinfer1::DataType::kHALF) &&
               (in.format == nvinfer1::PluginFormat::kHWC8));
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "PrelnGroupnormAct TRT Plugin is fp16 only so far"));
 
       return (in.type == nvinfer1::DataType::kFLOAT) &&
@@ -218,7 +218,7 @@ void prelnGroupNormNDHWCSum(GroupNormNDHWCParams<__half> const &params,
   // Make sure the values are as we expect.
   PADDLE_ENFORCE_EQ(params.c % params.cPerBlock,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The groupNormNDHWCSum of prelnGroupnormAct Plugin got "
                         "wrong parameters"
                         "params.c %% params.cPerBlock should be 0, but get %d.",
@@ -226,7 +226,7 @@ void prelnGroupNormNDHWCSum(GroupNormNDHWCParams<__half> const &params,
   PADDLE_ENFORCE_EQ(
       params.dhw % params.dhwPerBlock,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The groupNormNDHWCSum of prelnGroupnormAct Plugin got wrong "
           "parameters"
           "params.dhw  %% params.dhwPerBlock should be 0, but get %d.",
@@ -235,7 +235,7 @@ void prelnGroupNormNDHWCSum(GroupNormNDHWCParams<__half> const &params,
   PADDLE_ENFORCE_EQ(
       params.cPerBlock % params.cPerGroup,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The groupNormNDHWCSum of prelnGroupnormAct Plugin got wrong "
           "parameters"
           "params.cPerBlock %% params.cPerGroup should be 0, but get %d.",
@@ -266,7 +266,7 @@ void prelnGroupNormNDHWCSum(GroupNormNDHWCParams<__half> const &params,
       prelnGroupNormNDHWCSumKernel<4><<<grid, 4, 0, stream>>>(params);
       break;
     default:
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "The function groupNormNDHWCSum of prelnGroupnormAct TRT Plugin "
           "encounter error"));
   }
@@ -351,7 +351,7 @@ void prelnGroupNormNDHWCScale(GroupNormNDHWCParams<__half> const &params,
   PADDLE_ENFORCE_EQ(
       params.c % params.cPerBlock,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The groupNormNDHWCScale of prelnGroupnormAct Plugin got "
           "wrong parameters"
           "params.c %% params.cPerBlock should be 0, but get %d.",
@@ -360,7 +360,7 @@ void prelnGroupNormNDHWCScale(GroupNormNDHWCParams<__half> const &params,
   PADDLE_ENFORCE_EQ(
       params.cPerBlock % params.cPerGroup,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The groupNormNDHWCScale of prelnGroupnormAct Plugin got wrong "
           "parameters"
           "params.cPerBlock %% params.cPerGroup should be 0, but get %d.",
@@ -391,7 +391,7 @@ void prelnGroupNormNDHWCScale(GroupNormNDHWCParams<__half> const &params,
       prelnGroupNormNDHWCScaleKernel<4><<<grid, 4, 0, stream>>>(params);
       break;
     default:
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "The function groupNormNDHWCSum of prelnGroupnormAct TRT Plugin "
           "encounter error"));
   }
@@ -407,7 +407,7 @@ int PrelnGroupnormActPluginDynamic::enqueue(
   auto input_type = input_desc[0].type;
   if (input_type == nvinfer1::DataType::kFLOAT) {
     VLOG(1) << "TRT Plugin DataType selected. prelnGroupnormAct-->fp32";
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The prelnGroupnormAct TRT Plugin's only support fp16 input"));
   } else if (input_type == nvinfer1::DataType::kHALF) {
     VLOG(1) << "TRT Plugin DataType selected. prelnGroupnormAct-->fp16";
@@ -481,7 +481,7 @@ int PrelnGroupnormActPluginDynamic::enqueue(
 
   } else {
     // input not fp16
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The PrelnGroupnormAct TRT Plugin's only support fp16 input"));
   }
   return cudaGetLastError() != cudaSuccess;

--- a/paddle/fluid/inference/tensorrt/plugin/preln_residual_bias_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/preln_residual_bias_plugin.cu
@@ -290,16 +290,16 @@ bool PrelnResidualBiasPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of swish plugin shoule not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
 
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   if (pos == 0) {
@@ -309,8 +309,8 @@ bool PrelnResidualBiasPluginDynamic::supportsFormatCombination(
              (in.format == nvinfer1::TensorFormat::kLINEAR);
 #else
       PADDLE_THROW(
-          phi::errors::Fatal("TRT plugin supported FP16 is not available "
-                             "while with_fp16 is set true."));
+          common::errors::Fatal("TRT plugin supported FP16 is not available "
+                                "while with_fp16 is set true."));
 #endif
     } else {
       return (in.type == nvinfer1::DataType::kFLOAT) &&
@@ -370,7 +370,7 @@ int PrelnResidualBiasPluginDynamic::enqueue(
     rows_temp = input_dims.d[0] * input_dims.d[1] * input_dims.d[2];
     cols_temp = input_dims.d[3];
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "fused_bias_dropout_residual_layer_norm op only support 3-D or 4-D "
         "input, but get `%d`-D.",
         input_dims.nbDims));
@@ -477,7 +477,7 @@ int PrelnResidualBiasPluginDynamic::enqueue(
             HALF2_ADD_BIAS_RESIDUAL_LAYERNORM_OPT2(8);
             break;
           default:
-            PADDLE_THROW(phi::errors::Fatal(
+            PADDLE_THROW(common::errors::Fatal(
                 "Invalid UNROLL_FACTOR in preln_residual_bias trt plugin."));
         }
       } else {
@@ -534,7 +534,7 @@ int PrelnResidualBiasPluginDynamic::enqueue(
           stream);
     }
 #else
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The Ernie(Bert) tensorRT plugin should be "
         "complied with CUDA version >= 10.0 when running with fp16. "
         "Please recomplie it or try to use fp32 by set "
@@ -543,8 +543,8 @@ int PrelnResidualBiasPluginDynamic::enqueue(
 #endif
   } else {
     PADDLE_THROW(
-        phi::errors::Fatal("The PrelnResidualBias TRT Plugin's input type "
-                           "should be float or half."));
+        common::errors::Fatal("The PrelnResidualBias TRT Plugin's input type "
+                              "should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;
 }

--- a/paddle/fluid/inference/tensorrt/plugin/prompt_tuning_emb_layernorm_varseqlen_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/prompt_tuning_emb_layernorm_varseqlen_plugin.cu
@@ -325,7 +325,7 @@ int32_t TrtPromptTuningEmbLayerNormVarSeqlenPluginHFace::enqueue(
   } else if (maxSeqlen <= 512) {
     S = 512;
   } else {
-    PADDLE_THROW(phi::errors::Fatal("The max seqlenth is 512."));
+    PADDLE_THROW(common::errors::Fatal("The max seqlenth is 512."));
   }
   const float* beta = mBetaDev.get();
   const float* gamma = mGammaDev.get();

--- a/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.cu
@@ -40,7 +40,7 @@ inline int round_up(int seq_len, int multiple = 32) {
   PADDLE_ENFORCE_GT(
       multiple,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "multiple should be a positive number, but it's (%d)", multiple));
   return ((seq_len + multiple - 1) / multiple) * multiple;
 }
@@ -166,7 +166,7 @@ nvinfer1::DimsExprs QkvToContextPluginDynamic::getOutputDimensions(
   // output, (B, seq_len, hidden)
   PADDLE_ENFORCE_EQ(output_index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "There is only one output of the EmbEltwiseLayernorm, "
                         "so the index should be zero,"
                         "but it's (%d)",
@@ -174,7 +174,7 @@ nvinfer1::DimsExprs QkvToContextPluginDynamic::getOutputDimensions(
   PADDLE_ENFORCE_EQ(
       nb_inputs,
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The Input of the EmbEltwiseLayernorm should be 3, but we found "
           "it has (%d) inputs",
           nb_inputs));
@@ -222,7 +222,7 @@ void QkvToContextPluginDynamic::configurePlugin(
           cudaMemsetAsync(fake_qk_bias_, 0, size, dev_ctx.stream()));
 #endif
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "The QKV TRT Plugin's input type should be float or half."));
     }
   }
@@ -235,16 +235,16 @@ bool QkvToContextPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of swish plugin shoule not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
 
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   if (pos == 0) {
@@ -279,7 +279,7 @@ nvinfer1::DataType QkvToContextPluginDynamic::getOutputDataType(
   PADDLE_ENFORCE_EQ(
       index,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The EmbEltwiseLayernorm Plugin only has one input, so the "
           "index value should be 0, but get %d.",
           index));
@@ -530,7 +530,7 @@ int QkvToContextPluginDynamic::enqueue(
           tptr, output, batch, seq_len, head_number_, head_size_);
     }
 #else
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The Ernie(Bert) TensorRT Plugin should be "
         "complied with CUDA version >= 10.0 when running with fp16. "
         "Please recomplie it or try to use fp32 by set "
@@ -538,7 +538,7 @@ int QkvToContextPluginDynamic::enqueue(
         "max_input_shape, opt_input_shape, true"));
 #endif
   } else {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The QKV TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;

--- a/paddle/fluid/inference/tensorrt/plugin/recover_padding_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/recover_padding_plugin.cu
@@ -64,14 +64,14 @@ bool RecoverPaddingPlugin::supportsFormatCombination(
     int nbOutputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(nbInputs,
                     3,
-                    phi::errors::InvalidArgument("Must have 3 inputs, "
-                                                 "but got %d input(s). ",
-                                                 nbInputs));
+                    common::errors::InvalidArgument("Must have 3 inputs, "
+                                                    "but got %d input(s). ",
+                                                    nbInputs));
   PADDLE_ENFORCE_EQ(nbOutputs,
                     getNbOutputs(),
-                    phi::errors::InvalidArgument("Must have 1 output, "
-                                                 "but got %d output(s). ",
-                                                 nbOutputs));
+                    common::errors::InvalidArgument("Must have 1 output, "
+                                                    "but got %d output(s). ",
+                                                    nbOutputs));
   if (pos == 1) {  // PosId
     return inOut[pos].type == nvinfer1::DataType::kINT32 &&
            inOut[pos].format == nvinfer1::TensorFormat::kLINEAR;

--- a/paddle/fluid/inference/tensorrt/plugin/remove_padding_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/remove_padding_plugin.cu
@@ -61,14 +61,14 @@ bool RemovePaddingPlugin::supportsFormatCombination(
     int nbOutputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(nbInputs,
                     3,
-                    phi::errors::InvalidArgument("Must have 3 inputs, "
-                                                 "but got %d input(s). ",
-                                                 nbInputs));
+                    common::errors::InvalidArgument("Must have 3 inputs, "
+                                                    "but got %d input(s). ",
+                                                    nbInputs));
   PADDLE_ENFORCE_EQ(nbOutputs,
                     getNbOutputs(),
-                    phi::errors::InvalidArgument("Must have 1 output, "
-                                                 "but got %d output(s). ",
-                                                 nbOutputs));
+                    common::errors::InvalidArgument("Must have 1 output, "
+                                                    "but got %d output(s). ",
+                                                    nbOutputs));
   if (pos == 1 || pos == 2) {  // pos_id, work_id
     return inOut[pos].type == nvinfer1::DataType::kINT32 &&
            inOut[pos].format == nvinfer1::TensorFormat::kLINEAR;

--- a/paddle/fluid/inference/tensorrt/plugin/reverse_roll_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/reverse_roll_op_plugin.cu
@@ -142,15 +142,15 @@ bool ReverseRollPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument("The input of ReverseRoll "
-                                   "plugin shoule not be nullptr."));
+      common::errors::InvalidArgument("The input of ReverseRoll "
+                                      "plugin shoule not be nullptr."));
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   if (pos == 0) {
     if (with_fp16_) {
@@ -170,12 +170,12 @@ nvinfer1::DataType ReverseRollPluginDynamic::getOutputDataType(
     int index,
     const nvinfer1::DataType *input_types,
     int nb_inputs) const TRT_NOEXCEPT {
-  PADDLE_ENFORCE_EQ(
-      index,
-      0,
-      phi::errors::InvalidArgument("The ReverseRoll only has one input, so the "
-                                   "index value should be 0, but get %d.",
-                                   index));
+  PADDLE_ENFORCE_EQ(index,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The ReverseRoll only has one input, so the "
+                        "index value should be 0, but get %d.",
+                        index));
   return input_types[0];
 }
 
@@ -186,7 +186,7 @@ nvinfer1::DimsExprs ReverseRollPluginDynamic::getOutputDimensions(
     nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(output_index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "There is only one output of the ReverseRoll, "
                         "so the index should be zero,"
                         "but it's (%d)",
@@ -194,7 +194,7 @@ nvinfer1::DimsExprs ReverseRollPluginDynamic::getOutputDimensions(
   PADDLE_ENFORCE_EQ(
       nb_inputs,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The Input of the ReverseRoll should be 1, but we found "
           "it has (%d) inputs",
           nb_inputs));
@@ -248,7 +248,7 @@ int ReverseRollPluginDynamic::enqueue(
                       shift_size_,
                       stream);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The ReverseRoll TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;

--- a/paddle/fluid/inference/tensorrt/plugin/roi_align_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/roi_align_op_plugin.cu
@@ -156,7 +156,7 @@ RoiAlignPluginDynamic::RoiAlignPluginDynamic(const nvinfer1::DataType data_type,
                             data_type_ == nvinfer1::DataType::kHALF;
   PADDLE_ENFORCE_EQ(data_type_is_valid,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TRT RoiAlign plugin only accepts kFLOAT(%d) or "
                         "kHALF(%d) data type, but the received data type = %d",
                         static_cast<int>(nvinfer1::DataType::kFLOAT),
@@ -165,7 +165,7 @@ RoiAlignPluginDynamic::RoiAlignPluginDynamic(const nvinfer1::DataType data_type,
 
   PADDLE_ENFORCE_GT(pooled_height_,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TRT RoiAlign plugin only accepts pooled_height "
                         "greater than %d, but the received pooled_height = %d",
                         0,
@@ -173,7 +173,7 @@ RoiAlignPluginDynamic::RoiAlignPluginDynamic(const nvinfer1::DataType data_type,
 
   PADDLE_ENFORCE_GT(pooled_width_,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TRT RoiAlign plugin only accepts pooled_width greater "
                         "than %d, but the received pooled_width = %d",
                         0,
@@ -181,7 +181,7 @@ RoiAlignPluginDynamic::RoiAlignPluginDynamic(const nvinfer1::DataType data_type,
 
   PADDLE_ENFORCE_GT(spatial_scale_,
                     0.f,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TRT RoiAlign plugin only accepts spatial_scale "
                         "greater than %f, but the received spatial_scale = %f",
                         0,
@@ -194,7 +194,7 @@ RoiAlignPluginDynamic::RoiAlignPluginDynamic(const nvinfer1::DataType data_type,
   PADDLE_ENFORCE_GE(
       device,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The cuda device ID should be greater than %d, but device ID is %d",
           0,
           device));
@@ -217,7 +217,7 @@ RoiAlignPluginDynamic::RoiAlignPluginDynamic(void const* data, size_t length) {
   PADDLE_ENFORCE_GE(
       device,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The cuda device ID should be greater than %d, but device ID is %d",
           0,
           device));
@@ -350,7 +350,7 @@ int RoiAlignPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
                                    cudaStream_t stream) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(outputDesc[0].type,
                     data_type_,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TRT RoiAlignPluginDynamic expects outputDesc[0].type "
                         "equal to data_type_"));
 

--- a/paddle/fluid/inference/tensorrt/plugin/skip_groupnorm_act_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/skip_groupnorm_act_op_plugin.cu
@@ -39,22 +39,22 @@ bool SkipGroupnormActPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of SkipGroupnormAct plugin shoule not be nullptr."));
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   if (pos == 0) {
     if (with_fp16_) {
       return ((in.type == nvinfer1::DataType::kHALF) &&
               (in.format == nvinfer1::PluginFormat::kHWC8));
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "SkipGroupnormAct TRT Plugin is fp16 only so far"));
       return (in.type == nvinfer1::DataType::kFLOAT) &&
              (in.format == nvinfer1::TensorFormat::kLINEAR);
@@ -72,15 +72,15 @@ nvinfer1::DataType SkipGroupnormActPluginDynamic::getOutputDataType(
   PADDLE_ENFORCE_EQ(
       index,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The SkipGroupnormAct Plugin only has one input, so the "
           "index value should be 0, but get %d.",
           index));
-  PADDLE_ENFORCE_EQ(
-      (input_types[0] == nvinfer1::DataType::kFLOAT ||
-       input_types[0] == nvinfer1::DataType::kHALF),
-      true,
-      phi::errors::InvalidArgument("The input type should be half or float"));
+  PADDLE_ENFORCE_EQ((input_types[0] == nvinfer1::DataType::kFLOAT ||
+                     input_types[0] == nvinfer1::DataType::kHALF),
+                    true,
+                    common::errors::InvalidArgument(
+                        "The input type should be half or float"));
 
   return input_types[0];
 }
@@ -230,7 +230,7 @@ void skipGroupNormNDHWCSum(GroupNormNDHWCParams<__half> const &params,
   // Make sure the values are as we expect.
   PADDLE_ENFORCE_EQ(params.c % params.cPerBlock,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The groupNormNDHWCSum of SkipGroupnormAct Plugin got "
                         "wrong parameters"
                         "params.c %% params.cPerBlock should be 0, but get %d.",
@@ -238,7 +238,7 @@ void skipGroupNormNDHWCSum(GroupNormNDHWCParams<__half> const &params,
   PADDLE_ENFORCE_EQ(
       params.dhw % params.dhwPerBlock,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The groupNormNDHWCSum of SkipGroupnormAct Plugin got wrong "
           "parameters"
           "params.dhw  %% params.dhwPerBlock should be 0, but get %d.",
@@ -247,7 +247,7 @@ void skipGroupNormNDHWCSum(GroupNormNDHWCParams<__half> const &params,
   PADDLE_ENFORCE_EQ(
       params.cPerBlock % params.cPerGroup,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The groupNormNDHWCSum of SkipGroupnormAct Plugin got wrong "
           "parameters"
           "params.cPerBlock %% params.cPerGroup should be 0, but get %d.",
@@ -278,7 +278,7 @@ void skipGroupNormNDHWCSum(GroupNormNDHWCParams<__half> const &params,
       skipGroupNormNDHWCSumKernel<4><<<grid, 4, 0, stream>>>(params);
       break;
     default:
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "The function groupNormNDHWCSum of SkipGroupnormAct TRT Plugin "
           "encounter error"));
   }
@@ -363,7 +363,7 @@ void skipGroupNormNDHWCScale(GroupNormNDHWCParams<__half> const &params,
   PADDLE_ENFORCE_EQ(
       params.c % params.cPerBlock,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The groupNormNDHWCScale of SkipGroupnormAct Plugin got "
           "wrong parameters"
           "params.c %% params.cPerBlock should be 0, but get %d.",
@@ -372,7 +372,7 @@ void skipGroupNormNDHWCScale(GroupNormNDHWCParams<__half> const &params,
   PADDLE_ENFORCE_EQ(
       params.cPerBlock % params.cPerGroup,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The groupNormNDHWCScale of SkipGroupnormAct Plugin got wrong "
           "parameters"
           "params.cPerBlock %% params.cPerGroup should be 0, but get %d.",
@@ -403,7 +403,7 @@ void skipGroupNormNDHWCScale(GroupNormNDHWCParams<__half> const &params,
       skipGroupNormNDHWCScaleKernel<4><<<grid, 4, 0, stream>>>(params);
       break;
     default:
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "The function groupNormNDHWCSum of SkipGroupnormAct TRT Plugin "
           "encounter error"));
   }
@@ -419,7 +419,7 @@ int SkipGroupnormActPluginDynamic::enqueue(
   auto input_type = input_desc[0].type;
   if (input_type == nvinfer1::DataType::kFLOAT) {
     VLOG(1) << "TRT Plugin DataType selected. SkipGroupnormAct-->fp32";
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The SkipGroupnormAct TRT Plugin's only support fp16 input"));
   } else if (input_type == nvinfer1::DataType::kHALF) {
     VLOG(1) << "TRT Plugin DataType selected. SkipGroupnormAct-->fp16";
@@ -491,7 +491,7 @@ int SkipGroupnormActPluginDynamic::enqueue(
 
   } else {
     // input not fp16
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The SkipGroupnormAct TRT Plugin's only support fp16 input"));
   }
   return cudaGetLastError() != cudaSuccess;

--- a/paddle/fluid/inference/tensorrt/plugin/skip_merge_layernorm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/skip_merge_layernorm_op_plugin.cu
@@ -119,7 +119,7 @@ void invokeMergeLayernorm(T *output,
                           int n,
                           cudaStream_t stream) {
   if ((W % 2 != 0) || (H % 2 != 0)) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "H(W) of merge layernorm should be a multiple of 2."));
   }
   dim3 grid(W / 2, H / 2, batch);
@@ -226,15 +226,15 @@ bool SkipMergeLayernormPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument("The input of MergeLayernorm "
-                                   "plugin shoule not be nullptr."));
+      common::errors::InvalidArgument("The input of MergeLayernorm "
+                                      "plugin shoule not be nullptr."));
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   if (pos == 0) {
     if (with_fp16_) {
@@ -256,7 +256,7 @@ nvinfer1::DataType SkipMergeLayernormPluginDynamic::getOutputDataType(
     int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The MergeLayernorm only has one input, so the "
                         "index value should be 0, but get %d.",
                         index));
@@ -295,7 +295,7 @@ int SkipMergeLayernormPluginDynamic::enqueue(
   PADDLE_ENFORCE_EQ(
       input_resolution * input_resolution,
       input_dims.d[1],
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The MergeLayernorm TRT Plugin get invalid input_resolution %d",
           input_resolution));
 
@@ -328,7 +328,7 @@ int SkipMergeLayernormPluginDynamic::enqueue(
         dim,
         stream);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The MergeLayernorm TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;

--- a/paddle/fluid/inference/tensorrt/plugin/split_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/split_op_plugin.cu
@@ -44,14 +44,14 @@ nvinfer1::Dims SplitPlugin::getOutputDimensions(
     int index, const nvinfer1::Dims* input_dims, int num_inputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(num_inputs,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Invalid number of inputs of split TRT plugin. "
                         "Expected 1, received %d.",
                         num_inputs));
   PADDLE_ENFORCE_LT(
       index,
       this->getNbOutputs(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Index of output should be less than the total number of outputs in "
           "split TensorRT plugin. Received index = %d >= total outputs = %d",
           index,
@@ -73,7 +73,7 @@ void SplitPlugin::shareData(const SplitPlugin* another) {
 int SplitPlugin::initialize() TRT_NOEXCEPT {
   PADDLE_ENFORCE_LE(axis_,
                     nvinfer1::Dims::MAX_DIMS,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Axis dimension exceeds max dimension in TensorRT. "
                         "Received axis = %d > MAX_DIMS = %d",
                         axis_,
@@ -198,11 +198,11 @@ nvinfer1::DimsExprs SplitPluginDynamic::getOutputDimensions(
     nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(nb_inputs,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Split plugin should be only one input."));
   PADDLE_ENFORCE_LT(output_index,
                     output_length_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "When GetOutputDimensions, the index(%d) should not "
                         "greater the num(%d) of the outpus.",
                         output_index,
@@ -221,16 +221,16 @@ bool SplitPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of split plugin should not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   (in_out && pos < (nb_inputs + nb_outputs));
 
   const nvinfer1::PluginTensorDesc& in = in_out[pos];

--- a/paddle/fluid/inference/tensorrt/plugin/spmm_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/spmm_plugin.cu
@@ -33,8 +33,8 @@ inline int getElementSize(nvinfer1::DataType type) {
     case nvinfer1::DataType::kINT8:
       return 1;
     default:
-      PADDLE_THROW(
-          phi::errors::Fatal("getElementSize only supports [FLOAT|HALF|INT8]"));
+      PADDLE_THROW(common::errors::Fatal(
+          "getElementSize only supports [FLOAT|HALF|INT8]"));
   }
 }
 
@@ -47,8 +47,8 @@ inline cudaDataType_t convertTrtType(nvinfer1::DataType type) {
     case nvinfer1::DataType::kINT8:
       return CUDA_R_8I;
     default:
-      PADDLE_THROW(
-          phi::errors::Fatal("getElementSize only supports [FLOAT|HALF|INT8]"));
+      PADDLE_THROW(common::errors::Fatal(
+          "getElementSize only supports [FLOAT|HALF|INT8]"));
   }
 }
 
@@ -59,7 +59,7 @@ inline void deserialize_value_size(void const** buffer,
   PADDLE_ENFORCE_GE(
       *buffer_size,
       value_size,
-      phi::errors::InvalidArgument("buffer_size must >= value_size"));
+      common::errors::InvalidArgument("buffer_size must >= value_size"));
   memcpy(value, *buffer, value_size);
   reinterpret_cast<char const*&>(*buffer) += value_size;
   *buffer_size -= value_size;
@@ -79,12 +79,12 @@ inline void convertAndCopy(const nvinfer1::Weights& src,
   PADDLE_ENFORCE_EQ(src.type == nvinfer1::DataType::kFLOAT ||
                         src.type == nvinfer1::DataType::kHALF,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "convertAndCopy only supports src type [FLOAT|HALF]"));
   PADDLE_ENFORCE_EQ(
       type == nvinfer1::DataType::kFLOAT || type == nvinfer1::DataType::kHALF,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "convertAndCopy only supports src type [FLOAT|HALF]"));
 
   if (type == nvinfer1::DataType::kFLOAT) {
@@ -137,7 +137,7 @@ void SpmmPluginDynamic::cusparseLtContext::init(
   PADDLE_ENFORCE_EQ(
       is_initialized,
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Descriptor should be destroyed before calling create"));
   constexpr int alignment = 16;
   cusparseComputeType compute_type;
@@ -153,8 +153,8 @@ void SpmmPluginDynamic::cusparseLtContext::init(
       break;
     default:
       PADDLE_THROW(
-          phi::errors::Fatal("cusparLtContext only supports data type"
-                             "[CUDA_R_32F|CUDA_R_16F|CUDA_R_8I]"));
+          common::errors::Fatal("cusparLtContext only supports data type"
+                                "[CUDA_R_32F|CUDA_R_16F|CUDA_R_8I]"));
   }
   phi::dynload::cusparseLtDenseDescriptorInit(
       &handle, &matA, m, k, k, alignment, type, CUSPARSE_ORDER_ROW);
@@ -213,7 +213,7 @@ void SpmmPluginDynamic::cusparseLtContext::init(
     PADDLE_ENFORCE_EQ(
         activation,
         SpmmPluginDynamic::Activation::kNone,
-        phi::errors::InvalidArgument("Received unknown activation"));
+        common::errors::InvalidArgument("Received unknown activation"));
   }
   if (bias_ptr != nullptr) {
     phi::dynload::cusparseLtMatmulDescSetAttribute(
@@ -239,7 +239,7 @@ void SpmmPluginDynamic::cusparseLtContext::setAlgo(int alg) {
   PADDLE_ENFORCE_EQ(
       is_initialized,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Descriptor should be initialized before setting algorithm"));
   phi::dynload::cusparseLtMatmulAlgSetAttribute(
       &handle, &alg_sel, CUSPARSELT_MATMUL_ALG_CONFIG_ID, &alg, sizeof(alg));
@@ -251,10 +251,10 @@ void SpmmPluginDynamic::cusparseLtContext::setAlgo(int alg) {
 }
 
 void SpmmPluginDynamic::cusparseLtContext::destroy() {
-  PADDLE_ENFORCE_EQ(
-      is_initialized,
-      true,
-      phi::errors::InvalidArgument("cusparseLtContext is destroy before init"));
+  PADDLE_ENFORCE_EQ(is_initialized,
+                    true,
+                    common::errors::InvalidArgument(
+                        "cusparseLtContext is destroy before init"));
   phi::dynload::cusparseLtMatmulPlanDestroy(&plan);
   phi::dynload::cusparseLtMatDescriptorDestroy(&matC);
   phi::dynload::cusparseLtMatDescriptorDestroy(&matB);
@@ -272,11 +272,11 @@ void SpmmPluginDynamic::cusparseLtContext::compressMatB(
   PADDLE_ENFORCE_EQ(
       is_initialized,
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cusparseLtContext should not initialized before compressMatB"));
   PADDLE_ENFORCE_EQ(*dest,
                     nullptr,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "before compressMatB *dest must be nullptr"));
   constexpr int alignment = 16;
   phi::dynload::cusparseLtStructuredDescriptorInit(
@@ -337,14 +337,14 @@ SpmmPluginDynamic::SpmmPluginDynamic(const std::string& layer_name,
   PADDLE_ENFORCE_EQ(
       weight.count % out_dim,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of weight should be divided by output dimension."));
   k_ = weight.count / out_dim;
   PADDLE_ENFORCE_EQ(
       weight.type == nvinfer1::DataType::kFLOAT ||
           weight.type == nvinfer1::DataType::kHALF,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "SpmmPluginDynamic only supports weight of type [FLOAT|HALF]"));
   nvinfer1::DataType weight_type;
   if (precision_ == nvinfer1::DataType::kINT8) {
@@ -396,7 +396,7 @@ SpmmPluginDynamic::SpmmPluginDynamic(const std::string& layer_name,
   has_bias_ = (bias.count != 0);
   if (has_bias_) {
     if (bias.count != out_dim) {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "The dimension of bias should be equal to output dimension"));
     }
     if (precision_ == nvinfer1::DataType::kHALF) {
@@ -501,7 +501,7 @@ SpmmPluginDynamic::SpmmPluginDynamic(const std::string name,
   PADDLE_ENFORCE_EQ(
       is_configured_,
       true,
-      phi::errors::InvalidArgument("Deserialize data should be configured"));
+      common::errors::InvalidArgument("Deserialize data should be configured"));
   weight_compressed_ = new char[compressed_size_];
   deserialize_value_size(&data, &length, weight_compressed_, compressed_size_);
   cudaMalloc(reinterpret_cast<void**>(&weight_compressed_dev_),
@@ -559,22 +559,22 @@ nvinfer1::DimsExprs SpmmPluginDynamic::getOutputDimensions(
   try {
     PADDLE_ENFORCE_EQ(nbInputs,
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "SpmmPluginDynamic's nbInputs is invalid"));
     PADDLE_ENFORCE_EQ(outputIndex,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "SpmmPluginDynamic's outputIndex is invalid"));
     if (nbDims == 5) {
       int nbDims = inputs[0].nbDims;
       PADDLE_ENFORCE_EQ(
           inputs[0].d[3]->getConstantValue(),
           1,
-          phi::errors::InvalidArgument("now the input d[3] should be 1"));
+          common::errors::InvalidArgument("now the input d[3] should be 1"));
       PADDLE_ENFORCE_EQ(
           inputs[0].d[4]->getConstantValue(),
           1,
-          phi::errors::InvalidArgument("now the input d[4] should be 1"));
+          common::errors::InvalidArgument("now the input d[4] should be 1"));
       nvinfer1::DimsExprs ret;
       ret.nbDims = nbDims;
       ret.d[0] = inputs[0].d[0];
@@ -588,11 +588,11 @@ nvinfer1::DimsExprs SpmmPluginDynamic::getOutputDimensions(
       PADDLE_ENFORCE_EQ(
           inputs[0].d[2]->getConstantValue(),
           1,
-          phi::errors::InvalidArgument("now the input d[2] should be 1"));
+          common::errors::InvalidArgument("now the input d[2] should be 1"));
       PADDLE_ENFORCE_EQ(
           inputs[0].d[3]->getConstantValue(),
           1,
-          phi::errors::InvalidArgument("now the input d[3] should be 1"));
+          common::errors::InvalidArgument("now the input d[3] should be 1"));
       nvinfer1::DimsExprs ret;
       ret.nbDims = nbDims;
       ret.d[0] = inputs[0].d[0];
@@ -602,7 +602,7 @@ nvinfer1::DimsExprs SpmmPluginDynamic::getOutputDimensions(
 
       return ret;
     } else {
-      PADDLE_THROW(phi::errors::Fatal("nbDims should be 4 or 5"));
+      PADDLE_THROW(common::errors::Fatal("nbDims should be 4 or 5"));
     }
   } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;
@@ -615,13 +615,13 @@ bool SpmmPluginDynamic::supportsFormatCombination(
     const nvinfer1::PluginTensorDesc* inOut,
     int nbInputs,
     int nbOutputs) noexcept {
-  PADDLE_ENFORCE_EQ(
-      nbInputs,
-      1,
-      phi::errors::InvalidArgument("SpmmPluginDynamic's nbInputs should be 1"));
+  PADDLE_ENFORCE_EQ(nbInputs,
+                    1,
+                    common::errors::InvalidArgument(
+                        "SpmmPluginDynamic's nbInputs should be 1"));
   PADDLE_ENFORCE_EQ(nbOutputs,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "SpmmPluginDynamic's nbOutputs should be 1"));
 
   const nvinfer1::PluginTensorDesc& in = inOut[pos];
@@ -648,34 +648,34 @@ void SpmmPluginDynamic::configurePlugin(
   try {
     PADDLE_ENFORCE_EQ(nbInputs,
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "SpmmPluginDynamic's nbInputs should be 1"));
     PADDLE_ENFORCE_EQ(nbOutputs,
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "SpmmPluginDynamic's nbOutputs should be 1"));
     PADDLE_ENFORCE_EQ(precision_,
                       inputs[0].desc.type,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "precision_ should be equal to inputs[0].desc.type"));
     const auto& inDims0 = inputs[0].desc.dims;
     if (inDims0.nbDims == 5) {
       PADDLE_ENFORCE_EQ(
           inDims0.nbDims,
           5,
-          phi::errors::InvalidArgument("inDims0.nbDims should be 5"));
-      PADDLE_ENFORCE_EQ(
-          k_,
-          inDims0.d[2],
-          phi::errors::InvalidArgument("inDims0.d[2] should be equals to k"));
+          common::errors::InvalidArgument("inDims0.nbDims should be 5"));
+      PADDLE_ENFORCE_EQ(k_,
+                        inDims0.d[2],
+                        common::errors::InvalidArgument(
+                            "inDims0.d[2] should be equals to k"));
       PADDLE_ENFORCE_EQ(
           inDims0.d[3],
           1,
-          phi::errors::InvalidArgument("inDims0.d[3] should be 1"));
+          common::errors::InvalidArgument("inDims0.d[3] should be 1"));
       PADDLE_ENFORCE_EQ(
           inDims0.d[4],
           1,
-          phi::errors::InvalidArgument("inDims0.d[4] should be 1"));
+          common::errors::InvalidArgument("inDims0.d[4] should be 1"));
       const int BS = inputs->max.d[0];
       const int Seq = inputs->max.d[1];
       m_max_ = BS * Seq;
@@ -683,19 +683,19 @@ void SpmmPluginDynamic::configurePlugin(
       PADDLE_ENFORCE_EQ(
           inDims0.nbDims,
           4,
-          phi::errors::InvalidArgument("inDims0.nbDims should be 4"));
-      PADDLE_ENFORCE_EQ(
-          k_,
-          inDims0.d[1],
-          phi::errors::InvalidArgument("inDims0.d[1] should be equals to k"));
+          common::errors::InvalidArgument("inDims0.nbDims should be 4"));
+      PADDLE_ENFORCE_EQ(k_,
+                        inDims0.d[1],
+                        common::errors::InvalidArgument(
+                            "inDims0.d[1] should be equals to k"));
       PADDLE_ENFORCE_EQ(
           inDims0.d[2],
           1,
-          phi::errors::InvalidArgument("inDims0.d[2] should be 1"));
+          common::errors::InvalidArgument("inDims0.d[2] should be 1"));
       PADDLE_ENFORCE_EQ(
           inDims0.d[3],
           1,
-          phi::errors::InvalidArgument("inDims0.d[3] should be 1"));
+          common::errors::InvalidArgument("inDims0.d[3] should be 1"));
       const int BS_Seq = inputs->max.d[0];
       m_max_ = BS_Seq;
     }
@@ -775,18 +775,18 @@ int SpmmPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
   try {
     PADDLE_ENFORCE_EQ(is_configured_,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The plugin is not configured before enqueue"));
     if (inputDesc->dims.nbDims == 5) {
       PADDLE_ENFORCE_EQ(
           k_,
           inputDesc->dims.d[2],
-          phi::errors::InvalidArgument("k_ == inputDesc->dims.d[2]"));
+          common::errors::InvalidArgument("k_ == inputDesc->dims.d[2]"));
     } else if (inputDesc->dims.nbDims == 4) {
       PADDLE_ENFORCE_EQ(
           k_,
           inputDesc->dims.d[1],
-          phi::errors::InvalidArgument("k_ == inputDesc->dims.d[1]"));
+          common::errors::InvalidArgument("k_ == inputDesc->dims.d[1]"));
     }
     float alpha = 1.0f;
     float beta = 0.0f;
@@ -843,7 +843,7 @@ int SpmmPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
                                          1);
       return status != CUSPARSE_STATUS_SUCCESS;
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "Unsupported type error, expected [kHALF,kFLOAT], but received %d",
           static_cast<int>(precision_)));
     }
@@ -860,16 +860,16 @@ nvinfer1::DataType SpmmPluginDynamic::getOutputDataType(
   PADDLE_ENFORCE_EQ(
       index,
       0,
-      phi::errors::InvalidArgument("SpmmPluginDynamic's index should be 0"));
-  PADDLE_ENFORCE_EQ(
-      nbInputs,
-      1,
-      phi::errors::InvalidArgument("SpmmPluginDynamic's nbInputs should be 1"));
+      common::errors::InvalidArgument("SpmmPluginDynamic's index should be 0"));
+  PADDLE_ENFORCE_EQ(nbInputs,
+                    1,
+                    common::errors::InvalidArgument(
+                        "SpmmPluginDynamic's nbInputs should be 1"));
   PADDLE_ENFORCE_EQ(inputTypes[0] == nvinfer1::DataType::kFLOAT ||
                         inputTypes[0] == nvinfer1::DataType::kHALF ||
                         inputTypes[0] == nvinfer1::DataType::kINT8,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "SpmmPluginDynamic is not support this format now"));
 
   return inputTypes[0];
@@ -952,7 +952,7 @@ inline nvinfer1::DataType fieldTypeToDataType(
     case nvinfer1::PluginFieldType::kINT8:
       return nvinfer1::DataType::kINT8;
     default:
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "No corresponding datatype for plugin field type"));
   }
 }
@@ -1012,29 +1012,29 @@ nvinfer1::IPluginV2* SpmmPluginDynamicCreator::createPlugin(
       } else if (field_name.compare("activation_id") == 0) {
         activation_id = static_cast<const int*>(fc->fields[i].data)[0];
       } else {
-        PADDLE_THROW(phi::errors::Fatal("Unsupport plugin field"));
+        PADDLE_THROW(common::errors::Fatal("Unsupport plugin field"));
       }
     }
 
     PADDLE_ENFORCE_NE(
         type_id,
         -1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "SpmmPluginDynamicCreator's type_id should not be -1"));
     PADDLE_ENFORCE_NE(
         out_dim,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "SpmmPluginDynamicCreator's out_dim should not be 0"));
     PADDLE_ENFORCE_NE(
         weight.count,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "SpmmPluginDynamicCreator's weight size should not be 0"));
     PADDLE_ENFORCE_NE(
         activation_id,
         -1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "SpmmPluginDynamicCreator's activation_id should not be -1"));
     nvinfer1::DataType type = static_cast<nvinfer1::DataType>(type_id);
     SpmmPluginDynamic::Activation activation =

--- a/paddle/fluid/inference/tensorrt/plugin/stack_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/stack_op_plugin.cu
@@ -104,16 +104,16 @@ bool StackPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of stack plugin should not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
 
   const nvinfer1::PluginTensorDesc& in = in_out[pos];
   if (pos == 0) {
@@ -141,7 +141,9 @@ nvinfer1::DataType StackPluginDynamic::getOutputDataType(
     const nvinfer1::DataType* input_types,
     int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(
-      index, 0, phi::errors::InvalidArgument("The index should be equal to 0"));
+      index,
+      0,
+      common::errors::InvalidArgument("The index should be equal to 0"));
   return input_types[0];
 }
 
@@ -173,7 +175,7 @@ int StackPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
   for (int i = axis_ + 1; i < out_num_dims; ++i) {
     PADDLE_ENFORCE_GT(out_dims.d[i],
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input dimensions should be greater than 0"));
     base_unit *= out_dims.d[i];
   }
@@ -182,7 +184,7 @@ int StackPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
   for (int i = 0; i < axis_; ++i) {
     PADDLE_ENFORCE_GT(out_dims.d[i],
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input dimensions should be greater than 0"));
     lead_unit *= out_dims.d[i];
   }
@@ -190,7 +192,7 @@ int StackPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
   PADDLE_ENFORCE_EQ(
       out_dims.d[axis_],
       num_stack_,
-      phi::errors::InvalidArgument("number of stack axis should be same"));
+      common::errors::InvalidArgument("number of stack axis should be same"));
 
   cudaMemcpyAsync(workspace,
                   reinterpret_cast<const void* const>(inputs),
@@ -222,8 +224,8 @@ int StackPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
         base_unit);
   } else {
     PADDLE_THROW(
-        phi::errors::Fatal("The Stack TRT Plugin's input type only "
-                           "support float or half currently."));
+        common::errors::Fatal("The Stack TRT Plugin's input type only "
+                              "support float or half currently."));
   }
   return cudaGetLastError() != cudaSuccess;
 }
@@ -258,8 +260,9 @@ nvinfer1::IPluginV2* StackPluginDynamicCreator::createPlugin(
     } else if (name == "with_fp16") {
       with_fp16 = static_cast<const bool*>(fc->fields[i].data)[0];
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Meet an unknown plugin field '" + name +
-                                      "' when creating stack op plugin."));
+      PADDLE_THROW(common::errors::Fatal("Meet an unknown plugin field '" +
+                                         name +
+                                         "' when creating stack op plugin."));
     }
   }
   return new StackPluginDynamic(axis, num_stack, with_fp16);

--- a/paddle/fluid/inference/tensorrt/plugin/swish_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/swish_op_plugin.cu
@@ -125,7 +125,7 @@ int SwishPlugin::enqueue(int batch_size,
     swish_kernel<<<blocks, threads, 0, stream>>>(
         num, input, output, (half)beta_);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The Swish TRT Plugin's input type should be float or half."));
   }
 
@@ -164,16 +164,16 @@ bool SwishPluginDynamic::supportsFormatCombination(
     int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of swish plugin shoule not be nullptr."));
 
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   (in_out && pos < (nb_inputs + nb_outputs));
 
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
@@ -199,7 +199,7 @@ nvinfer1::DataType SwishPluginDynamic::getOutputDataType(
     int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Swish Plugin only has one input, so the "
                         "index value should be 0, but get %d.",
                         index));
@@ -231,7 +231,7 @@ int SwishPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc *input_desc,
     swish_kernel<half><<<blocks, threads, 0, stream>>>(
         num, input, output, static_cast<half>(beta_));
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The Swish TRT Plugin's input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;

--- a/paddle/fluid/inference/tensorrt/plugin/trans_layernorm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/trans_layernorm_op_plugin.cu
@@ -198,22 +198,22 @@ bool TransLayerNormPluginDynamic::supportsFormatCombination(
   PADDLE_ENFORCE_GE(
       feature_size,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The feature size of layernorm feature_size must be positive,"
           "but got:%d",
           feature_size));
 
   PADDLE_ENFORCE_NOT_NULL(
       in_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of layernorm plugin shoule not be nullptr."));
   PADDLE_ENFORCE_LT(
       pos,
       nb_inputs + nb_outputs,
-      phi::errors::InvalidArgument("The pos(%d) should be less than the "
-                                   "num(%d) of the input and the output.",
-                                   pos,
-                                   nb_inputs + nb_outputs));
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   if (pos == 0) {
     if (with_fp16_) {
@@ -259,7 +259,7 @@ void TransLayerNormPluginDynamic::configurePlugin(
   PADDLE_ENFORCE_EQ(
       begin_norm_axis_,
       3,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The transpose_LayerNorm Plugin only has begin_norm_axis_ = 3"
           "but get %d.",
           begin_norm_axis_));
@@ -276,15 +276,15 @@ nvinfer1::DataType TransLayerNormPluginDynamic::getOutputDataType(
   PADDLE_ENFORCE_EQ(
       nb_inputs,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The transpose_LayerNorm Plugin only has one input, so the "
           "nb_inputs value should be 1, but get %d.",
           nb_inputs));
-  PADDLE_ENFORCE_EQ(
-      (input_types[0] == nvinfer1::DataType::kFLOAT ||
-       input_types[0] == nvinfer1::DataType::kHALF),
-      true,
-      phi::errors::InvalidArgument("The input type should be half or float"));
+  PADDLE_ENFORCE_EQ((input_types[0] == nvinfer1::DataType::kFLOAT ||
+                     input_types[0] == nvinfer1::DataType::kHALF),
+                    true,
+                    common::errors::InvalidArgument(
+                        "The input type should be half or float"));
   return input_types[0];
 }
 
@@ -309,28 +309,28 @@ int TransLayerNormPluginDynamic::enqueue(
   }
   PADDLE_ENFORCE_EQ(1,
                     mean_shape_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Size of mean_shape vector should be equal to 1,"
                         "but got Size of mean_shape vector:%d",
                         mean_shape_.size()));
   PADDLE_ENFORCE_EQ(1,
                     variance_shape_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Size of variance_shape vector should be equal to 1,"
                         "but got Size of mean_shape vector:%d",
                         mean_shape_.size()));
-  PADDLE_ENFORCE_GE(
-      mean_shape_[0],
-      0,
-      phi::errors::InvalidArgument("The size of mean vector should be positive,"
-                                   "but got:%d",
-                                   mean_shape_[0]));
-  PADDLE_ENFORCE_GE(
-      variance_shape_[0],
-      0,
-      phi::errors::InvalidArgument("The size of mean vector should be positive,"
-                                   "but got:%d",
-                                   variance_shape_[0]));
+  PADDLE_ENFORCE_GE(mean_shape_[0],
+                    0,
+                    common::errors::InvalidArgument(
+                        "The size of mean vector should be positive,"
+                        "but got:%d",
+                        mean_shape_[0]));
+  PADDLE_ENFORCE_GE(variance_shape_[0],
+                    0,
+                    common::errors::InvalidArgument(
+                        "The size of mean vector should be positive,"
+                        "but got:%d",
+                        variance_shape_[0]));
 
   // transpose do not change numel
   int trans_result_numel = input_numel;
@@ -341,14 +341,14 @@ int TransLayerNormPluginDynamic::enqueue(
   int feature_size = static_cast<int>(input_ddim[1]);
   PADDLE_ENFORCE_EQ(feature_size,
                     scale_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "scale's size should be equal to the feature_size,"
                         "but got feature_size:%d, scale's size:%d.",
                         feature_size,
                         scale_.size()));
   PADDLE_ENFORCE_EQ(feature_size,
                     bias_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "bias's size should be equal to the feature_size,"
                         "but got feature_size:%d, bias's size:%d.",
                         feature_size,
@@ -356,11 +356,12 @@ int TransLayerNormPluginDynamic::enqueue(
 
   int device_id = -1;
   cudaGetDevice(&device_id);
-  PADDLE_ENFORCE_GE(device_id,
-                    0,
-                    phi::errors::InvalidArgument("device_id should be positive,"
-                                                 "but got:%d",
-                                                 device_id));
+  PADDLE_ENFORCE_GE(
+      device_id,
+      0,
+      common::errors::InvalidArgument("device_id should be positive,"
+                                      "but got:%d",
+                                      device_id));
 
   auto input_type = input_desc[0].type;
 
@@ -507,7 +508,7 @@ int TransLayerNormPluginDynamic::enqueue(
               HALF2_RESIDUAL_LAYERNORM_OPT2(8);
               break;
             default:
-              PADDLE_THROW(phi::errors::Fatal(
+              PADDLE_THROW(common::errors::Fatal(
                   "Invalid UNROLL_FACTOR in transpose_layernorm trt plugin."));
           }
         } else {
@@ -543,8 +544,8 @@ int TransLayerNormPluginDynamic::enqueue(
     }
   } else {
     PADDLE_THROW(
-        phi::errors::Fatal("The TransLayerNormPluginDynamic TRT Plugin's "
-                           "input type should be float or half."));
+        common::errors::Fatal("The TransLayerNormPluginDynamic TRT Plugin's "
+                              "input type should be float or half."));
   }
   return cudaGetLastError() != cudaSuccess;
 }

--- a/paddle/fluid/inference/tensorrt/plugin/transformer_input_output_convert_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/transformer_input_output_convert_plugin.cu
@@ -116,13 +116,13 @@ bool TransformerInputConvertPlugin::supportsFormatCombination(
     int nbOutputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(nbInputs,
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TransformerInputConvertPlugin must have 2 inputs, "
                         "but got %d input(s). ",
                         nbInputs));
   PADDLE_ENFORCE_EQ(nbOutputs,
                     4,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TransformerInputConvertPlugin must have 4 outputs, "
                         "but got %d output(s). ",
                         nbOutputs));
@@ -256,13 +256,13 @@ bool TransformerOutputConvertPlugin::supportsFormatCombination(
     int nbOutputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(nbInputs,
                     3,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TransformerOutputConvertPlugin must have 3 inputs, "
                         "but got %d input(s). ",
                         nbInputs));
   PADDLE_ENFORCE_EQ(nbOutputs,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TransformerOutputConvertPlugin must have 1 output, "
                         "but got %d output(s). ",
                         nbOutputs));

--- a/paddle/fluid/inference/tensorrt/plugin/trt_plugin_utils.h
+++ b/paddle/fluid/inference/tensorrt/plugin/trt_plugin_utils.h
@@ -113,7 +113,7 @@ struct Serializer<
     size_t nbyte = value->size() * sizeof(T);
     PADDLE_ENFORCE_GE(*buffer_size,
                       nbyte,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Insufficient data in buffer, expect contains %d "
                           "byte, but actually only contains %d byte.",
                           *buffer_size,

--- a/paddle/fluid/inference/tensorrt/plugin_arg_mapping_context.cc
+++ b/paddle/fluid/inference/tensorrt/plugin_arg_mapping_context.cc
@@ -101,7 +101,7 @@ bool PluginArgumentMappingContext::IsDenseTensorInputs(
 
 bool PluginArgumentMappingContext::IsDenseTensorVectorInput(
     const std::string& name) const {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Not supported for input vector of DenseTensor."));
   return false;
 }
@@ -113,48 +113,48 @@ bool PluginArgumentMappingContext::IsDenseTensorOutput(
 
 bool PluginArgumentMappingContext::IsSelectedRowsInput(
     const std::string& name) const {
-  PADDLE_THROW(
-      phi::errors::Unimplemented("Not supported for input of SelectedRows."));
+  PADDLE_THROW(common::errors::Unimplemented(
+      "Not supported for input of SelectedRows."));
   return false;
 }
 
 bool PluginArgumentMappingContext::IsSelectedRowsInputs(
     const std::string& name) const {
-  PADDLE_THROW(
-      phi::errors::Unimplemented("Not supported for inputs of SelectedRows."));
+  PADDLE_THROW(common::errors::Unimplemented(
+      "Not supported for inputs of SelectedRows."));
   return false;
 }
 
 bool PluginArgumentMappingContext::IsSelectedRowsOutput(
     const std::string& name) const {
-  PADDLE_THROW(
-      phi::errors::Unimplemented("Not supported for output of SelectedRows."));
+  PADDLE_THROW(common::errors::Unimplemented(
+      "Not supported for output of SelectedRows."));
   return false;
 }
 
 bool PluginArgumentMappingContext::IsSparseCooTensorInput(
     const std::string& name) const {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Not supported for input of SparseCooTensor."));
   return false;
 }
 
 bool PluginArgumentMappingContext::IsSparseCooTensorOutput(
     const std::string& name) const {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Not supported for output of SparseCooTensor."));
   return false;
 }
 
 bool PluginArgumentMappingContext::IsSparseCsrTensorInput(
     const std::string& name) const {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Not supported for input of SparseCsrTensor."));
   return false;
 }
 
 bool PluginArgumentMappingContext::IsForInferShape() const {
-  PADDLE_THROW(phi::errors::Unimplemented("Not supported for InferShape."));
+  PADDLE_THROW(common::errors::Unimplemented("Not supported for InferShape."));
   return false;
 }
 

--- a/paddle/fluid/inference/tensorrt/test_dynamic_engine.cc
+++ b/paddle/fluid/inference/tensorrt/test_dynamic_engine.cc
@@ -119,7 +119,7 @@ TEST_F(TensorRTDynamicShapeValueEngineTest, test_trt_dynamic_shape_value) {
   layer->setInput(1, *shape);
   PADDLE_ENFORCE_NOT_NULL(
       layer,
-      phi::errors::InvalidArgument("TRT shuffle layer building failed."));
+      common::errors::InvalidArgument("TRT shuffle layer building failed."));
   engine_->DeclareOutput(layer, 0, "y");
   engine_->FreezeNetwork();
 #if IS_TRT_VERSION_GE(8600)
@@ -302,7 +302,7 @@ TEST_F(TensorRTDynamicEngineTest, test_spmm) {
   LOG(INFO) << "create weights";
   PADDLE_ENFORCE_NOT_NULL(
       fc_layer,
-      phi::errors::InvalidArgument("TRT SPMM layer building failed."));
+      common::errors::InvalidArgument("TRT SPMM layer building failed."));
 
   engine_->DeclareOutput(fc_layer, 0, "y");
   engine_->FreezeNetwork();
@@ -441,7 +441,7 @@ TEST_F(TensorRTDynamicTestFusedTokenPrune, test_fused_token_prune) {
   std::vector<nvinfer1::ITensor *> itensors = {attn, x, mask, new_mask};
   auto *layer = engine_->AddDynamicPlugin(itensors.data(), 4, plugin);
   PADDLE_ENFORCE_NOT_NULL(layer,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "TRT fused_token_prune layer building failed."));
   std::vector<std::string> output_tensor_names{"out_slimmed_x", "out_cls_inds"};
   for (size_t i = 0; i < 2; i++) {
@@ -643,7 +643,7 @@ TEST_F(TensorRTDynamicTestFusedTokenPruneHalf, test_fused_token_prune) {
   std::vector<nvinfer1::ITensor *> itensors = {attn, x, mask, new_mask};
   auto *layer = engine_->AddDynamicPlugin(itensors.data(), 4, plugin);
   PADDLE_ENFORCE_NOT_NULL(layer,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "TRT fused_token_prune layer building failed."));
   std::vector<std::string> output_tensor_names{"out_slimmed_x", "out_cls_inds"};
   for (size_t i = 0; i < 2; i++) {
@@ -988,7 +988,7 @@ TEST_F(TensorRTDynamicShapeGNTest, test_trt_dynamic_shape_groupnorm) {
   dq_layer->setAxis(1);
 
   PADDLE_ENFORCE_NOT_NULL(groupnorm_layer,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "TRT GN plugin layer building failed."));
 
   engine_->DeclareOutput(dq_layer, 0, "y");

--- a/paddle/fluid/inference/tensorrt/test_engine.cc
+++ b/paddle/fluid/inference/tensorrt/test_engine.cc
@@ -100,7 +100,7 @@ TEST_F(TensorRTEngineTest, add_layer) {
                            nvinfer1::MatrixOperation::kTRANSPOSE);
   PADDLE_ENFORCE_NOT_NULL(
       matmul_layer,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The TRT MatrixMultiply layer cannot be null. There is something "
           "wrong with the TRT network building and layer creation."));
   auto *add_layer = TRT_ENGINE_ADD_LAYER(engine_,
@@ -110,7 +110,7 @@ TEST_F(TensorRTEngineTest, add_layer) {
                                          nvinfer1::ElementWiseOperation::kSUM);
   PADDLE_ENFORCE_NOT_NULL(
       add_layer,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The TRT elementwise layer cannot be null. There is something wrong "
           "with the TRT network building and layer creation."));
 
@@ -170,7 +170,7 @@ TEST_F(TensorRTEngineTest, add_layer_multi_dim) {
                            nvinfer1::MatrixOperation::kTRANSPOSE);
   PADDLE_ENFORCE_NOT_NULL(
       matmul_layer,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The TRT MatrixMultiply layer cannot be null. There is something "
           "wrong with the TRT network building and layer creation."));
   auto *add_layer = TRT_ENGINE_ADD_LAYER(engine_,
@@ -180,7 +180,7 @@ TEST_F(TensorRTEngineTest, add_layer_multi_dim) {
                                          nvinfer1::ElementWiseOperation::kSUM);
   PADDLE_ENFORCE_NOT_NULL(
       add_layer,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The TRT elementwise layer cannot be null. There is something wrong "
           "with the TRT network building and layer creation."));
 
@@ -236,9 +236,9 @@ TEST_F(TensorRTEngineTest, test_conv2d) {
                                           nvinfer1::DimsHW{3, 3},
                                           weight.get(),
                                           bias.get());
-  PADDLE_ENFORCE_NOT_NULL(
-      conv_layer,
-      phi::errors::InvalidArgument("TRT convolution layer building failed."));
+  PADDLE_ENFORCE_NOT_NULL(conv_layer,
+                          common::errors::InvalidArgument(
+                              "TRT convolution layer building failed."));
   conv_layer->setStrideNd(nvinfer1::Dims2{1, 1});
   conv_layer->setPaddingNd(nvinfer1::Dims2{1, 1});
 
@@ -299,7 +299,7 @@ TEST_F(TensorRTEngineTest, test_pool2d) {
 
   PADDLE_ENFORCE_NOT_NULL(
       pool_layer,
-      phi::errors::InvalidArgument("TRT pooling layer building failed."));
+      common::errors::InvalidArgument("TRT pooling layer building failed."));
   pool_layer->setStrideNd(nvinfer1::Dims2{1, 1});
   pool_layer->setPaddingNd(nvinfer1::Dims2{0, 0});
 

--- a/paddle/fluid/inference/tensorrt/trt_int8_calibrator.cc
+++ b/paddle/fluid/inference/tensorrt/trt_int8_calibrator.cc
@@ -85,7 +85,7 @@ bool TRTInt8Calibrator::setBatch(
   for (const auto& it : data) {
     auto dataptr = data_buffers_.find(it.first);
     if (dataptr == data_buffers_.end()) {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "%s input name '%s' does not match with the buffer names.",
           engine_name_,
           it.first));
@@ -120,10 +120,10 @@ bool TRTInt8Calibrator::getBatch(void** bindings,
     if (it == data_buffers_.end()) {
       try {
         PADDLE_THROW(
-            phi::errors::Fatal("Calibration engine asked for unknown tensor "
-                               "name '%s' at position %d.",
-                               names[i],
-                               i));
+            common::errors::Fatal("Calibration engine asked for unknown tensor "
+                                  "name '%s' at position %d.",
+                                  names[i],
+                                  i));
       } catch (std::exception& e) {
       }
     }

--- a/paddle/fluid/inference/utils/io_utils.cc
+++ b/paddle/fluid/inference/utils/io_utils.cc
@@ -163,7 +163,7 @@ void DeserializePDTensorsToFile(const std::string &path,
   PADDLE_ENFORCE_EQ(
       is_present,
       true,
-      phi::errors::InvalidArgument("Cannot open %s to read", path));
+      common::errors::InvalidArgument("Cannot open %s to read", path));
   std::ifstream fin(path, std::ios::binary);
   DeserializePDTensorsToStream(fin, tensors);
   fin.close();
@@ -213,7 +213,7 @@ void DeserializeShapeRangeInfo(
     const std::string &path, paddle::inference::proto::ShapeRangeInfos *info) {
   int fd = open(path.c_str(), O_RDONLY);
   if (fd == -1) {
-    PADDLE_THROW(phi::errors::NotFound("File [%s] is not found.", path));
+    PADDLE_THROW(common::errors::NotFound("File [%s] is not found.", path));
   }
   google::protobuf::io::FileInputStream *is =
       new google::protobuf::io::FileInputStream(fd);

--- a/paddle/fluid/inference/utils/model_utils.cc
+++ b/paddle/fluid/inference/utils/model_utils.cc
@@ -46,7 +46,7 @@ phi::DataType GetModelPrecision(const framework::ProgramDesc& program) {
 
       if (t == VarType::FP16) {
         if (ret != phi::DataType::FLOAT32 && ret != phi::DataType::FLOAT16) {
-          PADDLE_THROW(phi::errors::PreconditionNotMet(
+          PADDLE_THROW(common::errors::PreconditionNotMet(
               "The model's weights already has been set %s type, but also has "
               "%s type, which is an error, please check the model.",
               ret,
@@ -55,7 +55,7 @@ phi::DataType GetModelPrecision(const framework::ProgramDesc& program) {
         ret = phi::DataType::FLOAT16;
       } else if (t == VarType::BF16) {
         if (ret != phi::DataType::FLOAT32 && ret != phi::DataType::BFLOAT16) {
-          PADDLE_THROW(phi::errors::PreconditionNotMet(
+          PADDLE_THROW(common::errors::PreconditionNotMet(
               "The model's weights already has been set %s type, but also has "
               "%s type, which is an error, please check the model.",
               ret,

--- a/paddle/fluid/inference/utils/singleton.h
+++ b/paddle/fluid/inference/utils/singleton.h
@@ -50,7 +50,7 @@ struct Registry {
     PADDLE_ENFORCE_EQ(
         items_.count(name),
         0,
-        phi::errors::AlreadyExists("Item `%s` has beed registered.", name));
+        common::errors::AlreadyExists("Item `%s` has beed registered.", name));
     items_[name] = new ItemChild;
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/66145#issuecomment-2249572051

Replace phi::errors to common::errors in paddle/fluid