### PR TITLE
Replace phi::errors [fluid_ops] part10

### DIFF
--- a/paddle/fluid/framework/archive.h
+++ b/paddle/fluid/framework/archive.h
@@ -46,7 +46,7 @@ class ArchiveBase {
   // Archive is not copyable. But to allow move capture by function objects,
   // check it at runtime rather than at compile time.
   ArchiveBase(const ArchiveBase&) {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "ArchiveBase class does not support copy construction."));
   }
 
@@ -67,7 +67,7 @@ class ArchiveBase {
 
  public:
   ArchiveBase& operator=(const ArchiveBase&) {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "ArchiveBase class does not support assignment construction."));
     return *this;
   }

--- a/paddle/fluid/framework/attribute.cc
+++ b/paddle/fluid/framework/attribute.cc
@@ -59,7 +59,7 @@ paddle::any GetAttrValue(const Attribute& attr) {
     case proto::AttrType::SCALARS:
       return PADDLE_GET_CONST(std::vector<paddle::experimental::Scalar>, attr);
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported Attribute value type `%s` for phi.",
           platform::demangle(attr.type().name())));
   }
@@ -142,8 +142,8 @@ Attribute GetAttrValue(const proto::OpDesc::Attr& attr_desc) {
     }
 
     default:
-      PADDLE_THROW(phi::errors::Unavailable("Unsupported attribute type %d.",
-                                            attr_desc.type()));
+      PADDLE_THROW(common::errors::Unavailable("Unsupported attribute type %d.",
+                                               attr_desc.type()));
   }
   return paddle::blank();
 }
@@ -164,8 +164,8 @@ Attribute GetAttrValue(const proto::VarDesc::Attr& attr_desc) {
       return val;
     }
     default:
-      PADDLE_THROW(phi::errors::Unavailable("Unsupported attribute type %d.",
-                                            attr_desc.type()));
+      PADDLE_THROW(common::errors::Unavailable("Unsupported attribute type %d.",
+                                               attr_desc.type()));
   }
   return paddle::blank();
 }
@@ -184,9 +184,9 @@ paddle::experimental::Scalar MakeScalarFromProto(const proto::Scalar& v) {
       return paddle::experimental::Scalar(value);
     }
     default:
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("Expected scalar of type boolean, "
-                                       "integer, floating point or complex."));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Expected scalar of type boolean, "
+          "integer, floating point or complex."));
       break;
   }
   return paddle::experimental::Scalar();
@@ -230,14 +230,14 @@ proto::Scalar MakeScalarProto(const paddle::experimental::Scalar& v) {
     case phi::DataType::UNDEFINED:
     case phi::DataType::PSTRING:
     case phi::DataType::NUM_DATA_TYPES:
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("Expected scalar of type boolean, "
-                                       "integer, floating point or complex."));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Expected scalar of type boolean, "
+          "integer, floating point or complex."));
       break;
     default:
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("Expected scalar of type boolean, "
-                                       "integer, floating point or complex."));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Expected scalar of type boolean, "
+          "integer, floating point or complex."));
       break;
   }
   return s;
@@ -260,7 +260,7 @@ paddle::experimental::Scalar MakeScalarFromAttribute(const Attribute& v) {
     case proto::AttrType::FLOAT64:
       return paddle::experimental::Scalar(PADDLE_GET_CONST(double, v));
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unable to construct Scalar from given Attribute of type %s",
           attr_type));
   }
@@ -287,7 +287,7 @@ std::vector<paddle::experimental::Scalar> MakeScalarsFromAttribute(
       return experimental::WrapAsScalars(
           PADDLE_GET_CONST(std::vector<double>, v));
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unable to construct Scalars from given Attribute of type %s",
           attr_type));
   }
@@ -296,7 +296,7 @@ std::vector<paddle::experimental::Scalar> MakeScalarsFromAttribute(
 void CanonicalizeScalarAttrs(const proto::OpProto& op_proto,
                              AttributeMap* attrs) {
   PADDLE_ENFORCE_NOT_NULL(
-      attrs, phi::errors::InvalidArgument("attrs can not be nullptr"));
+      attrs, common::errors::InvalidArgument("attrs can not be nullptr"));
   for (auto& attr : op_proto.attrs()) {
     proto::AttrType attr_type = attr.type();
     const std::string& attr_name = attr.name();

--- a/paddle/fluid/framework/attribute.h
+++ b/paddle/fluid/framework/attribute.h
@@ -50,7 +50,7 @@ struct ExtractAttribute {
     try {
       attr_value = &paddle::get<T>(attr);
     } catch (paddle::bad_variant_access const& bad_get) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Cannot get attribute (%s) by type %s, its type is %s.",
           attr_name_,
           paddle::platform::demangle(typeid(T).name()),
@@ -85,7 +85,7 @@ struct ExtractAttribute<bool> {
     try {
       attr_value = &paddle::get<bool>(attr);
     } catch (paddle::bad_variant_access const& bad_get) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Cannot get attribute (%s) by type bool, its type is %s.",
           attr_name_,
           paddle::platform::demangle(attr.type().name())));
@@ -113,7 +113,7 @@ struct ExtractAttribute<int64_t> {
     try {
       attr_value = &paddle::get<int64_t>(attr);
     } catch (paddle::bad_variant_access const& bad_get) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Cannot get attribute (%s) by type int64_t, its type is %s.",
           attr_name_,
           paddle::platform::demangle(attr.type().name())));
@@ -143,7 +143,7 @@ struct ExtractAttribute<std::vector<int64_t>> {
     try {
       attr_value = &paddle::get<std::vector<int64_t>>(attr);
     } catch (paddle::bad_variant_access const& bad_get) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Cannot get attribute (%s) by type std::vector<int64_t>, its type is "
           "%s.",
           attr_name_,
@@ -172,7 +172,7 @@ struct ExtractAttribute<float> {
     try {
       attr_value = &paddle::get<float>(attr);
     } catch (paddle::bad_variant_access const& bad_get) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Cannot get attribute (%s) by type float, its type is %s.",
           attr_name_,
           paddle::platform::demangle(attr.type().name())));
@@ -203,7 +203,7 @@ struct ExtractAttribute<double> {
     try {
       attr_value = &paddle::get<double>(attr);
     } catch (paddle::bad_variant_access const& bad_get) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Cannot get attribute (%s) by type double, its type is %s.",
           attr_name_,
           paddle::platform::demangle(attr.type().name())));
@@ -233,7 +233,7 @@ struct ExtractAttribute<std::vector<double>> {
     try {
       attr_value = &paddle::get<std::vector<double>>(attr);
     } catch (paddle::bad_variant_access const& bad_get) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Cannot get attribute (%s) by type std::vector<double>, its type is "
           "%s.",
           attr_name_,
@@ -255,7 +255,7 @@ struct ExtractAttribute<paddle::experimental::Scalar> {
     try {
       attr_value = &paddle::get<paddle::experimental::Scalar>(attr);
     } catch (paddle::bad_variant_access const& bad_get) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Cannot get attribute (%s) by type Scalar, its type is %s, index is "
           "%d",
           attr_name_,
@@ -320,7 +320,7 @@ class AttrReader {
     }
     PADDLE_ENFORCE_EQ(found,
                       true,
-                      phi::errors::NotFound(
+                      common::errors::NotFound(
                           "Attribute (%s) should be in AttributeMap.", name));
 
     Attribute& attr = const_cast<Attribute&>(it->second);

--- a/paddle/fluid/framework/attribute_checker.h
+++ b/paddle/fluid/framework/attribute_checker.h
@@ -28,8 +28,8 @@ class GreaterThanChecker {
     PADDLE_ENFORCE_GT(
         value,
         lower_bound_,
-        phi::errors::OutOfRange("Check for attribute value greater than "
-                                "a certain value failed."));
+        common::errors::OutOfRange("Check for attribute value greater than "
+                                   "a certain value failed."));
   }
 
  private:
@@ -44,8 +44,8 @@ class EqualGreaterThanChecker {
     PADDLE_ENFORCE_GE(
         value,
         lower_bound_,
-        phi::errors::OutOfRange("Check for attribute value equal or "
-                                "greater than a certain value failed."));
+        common::errors::OutOfRange("Check for attribute value equal or "
+                                   "greater than a certain value failed."));
   }
 
  private:
@@ -70,12 +70,12 @@ class TypedAttrVarInfoChecker {
   void check(const VarDesc* var_desc) const {
     PADDLE_ENFORCE_NOT_NULL(
         var_desc,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Required Attribute with Variable type shall not be nullptr."));
     auto shape = var_desc->GetShape();
     PADDLE_ENFORCE_LE(shape.size(),
                       1U,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Required shape rank of Attribute(%s) <= 1, "
                           "but received rank == %s",
                           var_desc->Name(),
@@ -90,7 +90,7 @@ class TypedAttrVarInfoChecker {
                      dtype == proto::VarType::Type::VarType_Type_INT64);
       PADDLE_ENFORCE_EQ(is_int,
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Required dtype of Attribute(%s) shall be "
                             "int32|int64, but received %s.",
                             var_desc->Name(),
@@ -102,12 +102,12 @@ class TypedAttrVarInfoChecker {
     for (auto& var_desc : var_descs) {
       PADDLE_ENFORCE_NOT_NULL(
           var_desc,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Required Attribute with Variable type shall not be nullptr."));
       auto shape = var_desc->GetShape();
       PADDLE_ENFORCE_LE(shape.size(),
                         1U,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Required shape rank of Attribute(%s) <= 1, "
                             "but received rank == %s",
                             var_desc->Name(),
@@ -115,7 +115,7 @@ class TypedAttrVarInfoChecker {
       PADDLE_ENFORCE_EQ(
           shape.size() == 0U || shape[0] == 1U || shape[0] == -1,
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Required shape is (), or shape[0] of Attribute(%s) == 1 or -1, "
               "but received shape[0] == %s",
               var_desc->Name(),
@@ -146,9 +146,9 @@ class EnumInContainer {
     PADDLE_ENFORCE_NE(
         container_.find(val),
         container_.end(),
-        phi::errors::NotFound("Value %s is not in enum container %s.",
-                              val,
-                              ContainerDebugString()));
+        common::errors::NotFound("Value %s is not in enum container %s.",
+                                 val,
+                                 ContainerDebugString()));
   }
 
  private:
@@ -218,9 +218,9 @@ class TypedAttrChecker {
     PADDLE_ENFORCE_EQ(
         default_value_setter_.empty(),
         true,
-        phi::errors::AlreadyExists("Attribute (%s) has a default value "
-                                   "and cannot be set repeatedly.",
-                                   attr_name_));
+        common::errors::AlreadyExists("Attribute (%s) has a default value "
+                                      "and cannot be set repeatedly.",
+                                      attr_name_));
     default_value_setter_.push_back(DefaultValueSetter<T>(default_value));
     return *this;
   }
@@ -245,7 +245,7 @@ class TypedAttrChecker {
     if (it != attr_map->end() && HasAttrVar(it->second)) {
       PADDLE_ENFORCE_EQ(attr_->support_tensor(),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Found Attribute('%s') with type(Variable), but it "
                             "doesn't support phi::DenseTensor type.",
                             attr_name_));
@@ -269,8 +269,8 @@ class TypedAttrChecker {
         PADDLE_ENFORCE_EQ(
             default_value_setter_.empty(),
             false,
-            phi::errors::InvalidArgument("Attribute (%s) is not set correctly.",
-                                         attr_name_));
+            common::errors::InvalidArgument(
+                "Attribute (%s) is not set correctly.", attr_name_));
         // default_value_setter_ has no more than one element
         auto tmp = attr_map->emplace(attr_name_, default_value_setter_[0]());
         it = tmp.first;

--- a/paddle/fluid/framework/block_desc.cc
+++ b/paddle/fluid/framework/block_desc.cc
@@ -269,7 +269,7 @@ void BlockDesc::SetForwardBlockID(int32_t forward_block_id) {
   PADDLE_ENFORCE_EQ(
       desc_->has_forward_block_idx(),
       false,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Block %d's parent block ID has been set to %d, cannot be set to %d.",
           desc_->idx(),
           desc_->forward_block_idx(),
@@ -283,7 +283,7 @@ BlockDesc *BlockDesc::ForwardBlock() const {
 
 void BlockDesc::MoveFrom(BlockDesc *block) {
   PADDLE_ENFORCE_NOT_NULL(
-      block, phi::errors::InvalidArgument("Block must be provided."));
+      block, common::errors::InvalidArgument("Block must be provided."));
   if (this == block) {
     return;
   }

--- a/paddle/fluid/framework/compiled_program.cc
+++ b/paddle/fluid/framework/compiled_program.cc
@@ -111,7 +111,7 @@ class CompiledProgramPrivate {
         PADDLE_ENFORCE_EQ(
             phi::dynload::ncclGetUniqueId(nccl_id),
             ncclSuccess,
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "PaddlePaddle failed to get NCCL unique ID. It may due to your "
                 "system settings or NCCL library error, please debug on NCCL"));
         VLOG(10) << "can't find nccl_id_var:" << var_name
@@ -138,7 +138,7 @@ class CompiledProgramPrivate {
       auto nccl_id_var = scope->FindVar(var_name);
       PADDLE_ENFORCE_NOT_NULL(
           nccl_id_var,
-          phi::errors::NotFound("Can't find nccl_id_var '%s'.", var_name));
+          common::errors::NotFound("Can't find nccl_id_var '%s'.", var_name));
       auto nccl_id = nccl_id_var->GetMutable<ncclUniqueId>();
       flat_nccl_ids.push_back(nccl_id);
     }
@@ -153,7 +153,7 @@ class CompiledProgramPrivate {
         auto nccl_id_var = scope->FindVar(var_name);
         PADDLE_ENFORCE_NOT_NULL(
             nccl_id_var,
-            phi::errors::NotFound("Can't find nccl_id_var '%s'.", var_name));
+            common::errors::NotFound("Can't find nccl_id_var '%s'.", var_name));
         auto inter_nccl_id = nccl_id_var->GetMutable<ncclUniqueId>();
         inter_nccl_ids.push_back(inter_nccl_id);
       }
@@ -164,7 +164,7 @@ class CompiledProgramPrivate {
         auto nccl_id_var = scope->FindVar(var_name);
         PADDLE_ENFORCE_NOT_NULL(
             nccl_id_var,
-            phi::errors::NotFound("Can't find nccl_id_var '%s'.", var_name));
+            common::errors::NotFound("Can't find nccl_id_var '%s'.", var_name));
         auto nccl_id = nccl_id_var->GetMutable<ncclUniqueId>();
         exter_nccl_ids.push_back(nccl_id);
       }
@@ -186,7 +186,7 @@ class CompiledProgramPrivate {
     if (var != nullptr) {
       PADDLE_ENFORCE_EQ(var->IsInitialized(),
                         true,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "if %s exists, it must be initialized", var_name));
       VLOG(1) << "find " << var_name
               << " in scope, so use it and does not recreate!";
@@ -198,19 +198,19 @@ class CompiledProgramPrivate {
       PADDLE_ENFORCE_GT(
           bst->num_trainers_,
           1,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "The num_trainers should be greater than 1, but received %llu.",
               bst->num_trainers_));
       PADDLE_ENFORCE_GT(
           bst->hierarchical_allreduce_inter_nranks_,
           1,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "The inter_nranks should be greater than 1, but received %d.",
               bst->hierarchical_allreduce_inter_nranks_));
       PADDLE_ENFORCE_EQ(
           bst->num_trainers_ % bst->hierarchical_allreduce_inter_nranks_,
           0,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "num_trainers:%llu mod inter_nranks:%d != 0",
               bst->num_trainers_,
               bst->hierarchical_allreduce_inter_nranks_));
@@ -233,7 +233,7 @@ class CompiledProgramPrivate {
 
     PADDLE_ENFORCE_EQ(bst.use_hierarchical_allreduce_,
                       false,
-                      phi::errors::Unimplemented(
+                      common::errors::Unimplemented(
                           "xpu doesn't support use_hierarchical_allreduce"));
 
     std::vector<BKCLUniqueId *> flat_bkcl_ids;
@@ -258,7 +258,7 @@ class CompiledProgramPrivate {
         PADDLE_ENFORCE_EQ(
             bkcl_get_unique_id(id.get()),
             BKCL_SUCCESS,
-            phi::errors::Unavailable("bkcl get unique id failed"));
+            common::errors::Unavailable("bkcl get unique id failed"));
         bkcl_id = id.get();
       }
 
@@ -282,7 +282,7 @@ class CompiledProgramPrivate {
       auto bkcl_id_var = scope->FindVar(var_name);
       PADDLE_ENFORCE_NOT_NULL(
           bkcl_id_var,
-          phi::errors::NotFound("can't find %s bkcl_id_var", var_name));
+          common::errors::NotFound("can't find %s bkcl_id_var", var_name));
       auto bkcl_id = bkcl_id_var->GetMutable<BKCLUniqueId>();
       flat_bkcl_ids.push_back(bkcl_id);
     }
@@ -298,7 +298,7 @@ class CompiledProgramPrivate {
     if (var != nullptr) {
       PADDLE_ENFORCE_EQ(var->IsInitialized(),
                         true,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "if %s exists, it must be initialized", var_name));
       VLOG(1) << "find " << var_name
               << " in scope, so use it and does not recreate!";
@@ -426,7 +426,7 @@ ir::Graph *CompiledProgramPrivate::ApplyMemoryOptimizePass(ir::Graph *graph) {
       }
       VLOG(10) << "Created " << i << "-th GarbageCollector at " << place;
 #else
-      PADDLE_THROW(phi::errors::PermissionDenied(
+      PADDLE_THROW(common::errors::PermissionDenied(
           "Paddle can't use CUDA device since it's not compiled with CUDA,"
           "Please recompile or reinstall Paddle with GPU support."));
 #endif
@@ -435,7 +435,7 @@ ir::Graph *CompiledProgramPrivate::ApplyMemoryOptimizePass(ir::Graph *graph) {
       gc = std::make_unique<XPUGarbageCollector>(place, max_memory_size);
       VLOG(10) << "Created " << i << "-th GarbageCollector at " << place;
 #else
-      PADDLE_THROW(phi::errors::PermissionDenied(
+      PADDLE_THROW(common::errors::PermissionDenied(
           "Paddle can't use XPU device since it's not compiled with XPU,"
           "Please recompile or reinstall Paddle with XPU support."));
 #endif
@@ -444,7 +444,7 @@ ir::Graph *CompiledProgramPrivate::ApplyMemoryOptimizePass(ir::Graph *graph) {
       gc = std::make_unique<IPUGarbageCollector>(place, max_memory_size);
       VLOG(10) << "Created " << i << "-th GarbageCollector at " << place;
 #else
-      PADDLE_THROW(phi::errors::PermissionDenied(
+      PADDLE_THROW(common::errors::PermissionDenied(
           "Paddle can't use IPU device since it's not compiled with IPU,"
           "Please recompile or reinstall Paddle with IPU support."));
 #endif
@@ -459,7 +459,7 @@ ir::Graph *CompiledProgramPrivate::ApplyMemoryOptimizePass(ir::Graph *graph) {
       }
       VLOG(10) << "Created " << i << "-th GarbageCollector at " << place;
 #else
-      PADDLE_THROW(phi::errors::PermissionDenied(
+      PADDLE_THROW(common::errors::PermissionDenied(
           "Paddle can't use custom device since it's not compiled with "
           "CustomDevice,"
           "Please recompile or reinstall Paddle with CustomDevice support."));
@@ -468,7 +468,7 @@ ir::Graph *CompiledProgramPrivate::ApplyMemoryOptimizePass(ir::Graph *graph) {
       gc = std::make_unique<CPUGarbageCollector>(place, max_memory_size);
       VLOG(10) << "Created GarbageCollector at " << place;
     } else {
-      PADDLE_THROW(phi::errors::PreconditionNotMet(
+      PADDLE_THROW(common::errors::PreconditionNotMet(
           "Unsupported place for garbage collection"));
     }
     gcs_.emplace(place, std::move(gc));
@@ -551,7 +551,7 @@ CompiledProgram::CompiledProgram(const std::vector<phi::Place> &places,
   PADDLE_ENFORCE_EQ(
       !places.empty(),
       true,
-      phi::errors::Unavailable("NPU is not supported in CompiledProgram."));
+      common::errors::Unavailable("NPU is not supported in CompiledProgram."));
   InitP2P(places);
   InitReaderQueueDeviceCount(
       graph, *(member_->global_scope_), member_->places_.size());
@@ -626,7 +626,7 @@ void CompiledProgram::BCastParamsToDevices(const std::vector<std::string> &vars,
 
       PADDLE_ENFORCE_EQ(member_->places_.size(),
                         buffers.size(),
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "variables' buffer size to bcast is %d, which is "
                             "NOT equal to places size %d",
                             buffers.size(),
@@ -690,7 +690,7 @@ void CompiledProgram::BCastParamsToDevices(const std::vector<std::string> &vars,
 
       PADDLE_ENFORCE_EQ(member_->places_.size(),
                         buffers.size(),
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "variables' buffer size to bcast is %d, which is "
                             "NOT equal to places size %d",
                             buffers.size(),
@@ -700,20 +700,22 @@ void CompiledProgram::BCastParamsToDevices(const std::vector<std::string> &vars,
         platform::BKCLGroupGuard guard;
         for (size_t i = 0; i < member_->places_.size(); ++i) {
           auto &bkcl_ctx = bkcl_ctxs->at(member_->places_[i]);
-          PADDLE_ENFORCE_EQ(bkcl_broadcast(bkcl_ctx.comm(),
-                                           buffers[i],
-                                           buffers[i],
-                                           numel,
-                                           data_type,
-                                           0,
-                                           NULL),
-                            BKCL_SUCCESS,
-                            phi::errors::Unavailable("bkcl_broadcast failed"));
+          PADDLE_ENFORCE_EQ(
+              bkcl_broadcast(bkcl_ctx.comm(),
+                             buffers[i],
+                             buffers[i],
+                             numel,
+                             data_type,
+                             0,
+                             NULL),
+              BKCL_SUCCESS,
+              common::errors::Unavailable("bkcl_broadcast failed"));
         }
         bkcl_ctxs->WaitAll();
       }
 #else
-      PADDLE_THROW(phi::errors::PreconditionNotMet("Not compiled with BKCL."));
+      PADDLE_THROW(
+          common::errors::PreconditionNotMet("Not compiled with BKCL."));
 #endif
     } else {
       phi::CPUPlace cpu;
@@ -767,7 +769,7 @@ void CompiledProgram::InitProgramPrivateMemberInfo(
     PADDLE_ENFORCE_EQ(
         device_count,
         1,
-        phi::errors::Unavailable("Windows can support Single GPU only."));
+        common::errors::Unavailable("Windows can support Single GPU only."));
   }
 #endif
 
@@ -777,7 +779,7 @@ void CompiledProgram::InitProgramPrivateMemberInfo(
     PADDLE_ENFORCE_EQ(
         device_count,
         1,
-        phi::errors::PermissionDenied(
+        common::errors::PermissionDenied(
             "Your machine has multiple cards, "
             "but the WITH_NCCL option is not turned on during compilation, "
             "and you cannot use multi-card training or prediction. "
@@ -794,8 +796,8 @@ void CompiledProgram::InitProgramPrivateMemberInfo(
     device_name = "XPU";
   } else {
     PADDLE_THROW(
-        phi::errors::Unavailable("Only CPU/CUDA/XPU is supported. "
-                                 "please use CPU/CUDA/XPU backend."));
+        common::errors::Unavailable("Only CPU/CUDA/XPU is supported. "
+                                    "please use CPU/CUDA/XPU backend."));
   }
 }
 
@@ -834,7 +836,7 @@ void CompiledProgram::CreateLocalScopes(
     member_->own_local_scope_ = false;
     PADDLE_ENFORCE_EQ(member_->places_.size(),
                       local_scopes.size(),
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "member_->places_.size() = %d is not equal to "
                           "local_scopes.size() = %d",
                           member_->places_.size(),
@@ -854,10 +856,10 @@ std::vector<ir::Graph *> CompiledProgram::CloneGraphToMultiDevices(
     ir::Graph *graph) {
   std::vector<ir::Graph *> graphs;
   if (member_->build_strategy_.async_mode_) {
-    PADDLE_ENFORCE_EQ(
-        member_->IsUseCUDA(member_->use_device_),
-        false,
-        phi::errors::Unavailable("gpu mode does not support async_mode_ now!"));
+    PADDLE_ENFORCE_EQ(member_->IsUseCUDA(member_->use_device_),
+                      false,
+                      common::errors::Unavailable(
+                          "gpu mode does not support async_mode_ now!"));
     graphs.push_back(graph);
     for (size_t i = 1; i < member_->places_.size(); ++i) {
       auto *tmp_graph = new ir::Graph(graph->OriginProgram());
@@ -894,7 +896,7 @@ void CompiledProgram::PrepareNCCLCommunicator(Scope *global_scope) {
       dev_ctx->set_nccl_comm(nccl_ctx.comm());
     }
 #else
-    PADDLE_THROW(phi::errors::PreconditionNotMet("Not compiled with CUDA."));
+    PADDLE_THROW(common::errors::PreconditionNotMet("Not compiled with CUDA."));
 #endif
   }
   if (member_->use_device_ == p::kXPU && member_->nranks_ > 1) {
@@ -911,7 +913,7 @@ void CompiledProgram::PrepareNCCLCommunicator(Scope *global_scope) {
       dev_ctx->SetBkclContext(bkcl_ctx.comm());
     }
 #else
-    PADDLE_THROW(phi::errors::PreconditionNotMet("Not compiled with XPU."));
+    PADDLE_THROW(common::errors::PreconditionNotMet("Not compiled with XPU."));
 #endif
   }
 }
@@ -928,7 +930,7 @@ std::vector<ir::Graph *> CompiledProgram::CompileGraphWithBuildStrategy(
   if (member_->build_strategy_.async_mode_) {
     PADDLE_ENFORCE_EQ(graphs.size(),
                       device_count,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "graphs.size() should be %d, but received %d",
                           device_count,
                           graphs.size()));
@@ -963,7 +965,7 @@ std::vector<ir::Graph *> CompiledProgram::CompileGraphWithBuildStrategy(
   if (member_->build_strategy_.async_mode_) {
     PADDLE_ENFORCE_EQ(graphs.size(),
                       device_count,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "graphs.size() should be %d, but received %d",
                           device_count,
                           graphs.size()));

--- a/paddle/fluid/framework/custom_operator.cc
+++ b/paddle/fluid/framework/custom_operator.cc
@@ -77,19 +77,19 @@ static void RunKernelFunc(
         auto vec_x = ctx.MultiInput<phi::DenseTensor>(in_name);
         PADDLE_ENFORCE_NE(vec_x.empty(),
                           true,
-                          phi::errors::NotFound(
+                          common::errors::NotFound(
                               "Input vector<tensor> (%s) is empty.", in_name));
         for (size_t i = 0; i < vec_x.size(); ++i) {
           auto* x = vec_x[i];
           PADDLE_ENFORCE_NOT_NULL(
               x,
-              phi::errors::NotFound(
+              common::errors::NotFound(
                   "The %d-th tensor in input vector<tensor> (%s) is nullptr.",
                   i,
                   in_name));
           PADDLE_ENFORCE_EQ(x->IsInitialized(),
                             true,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "The %d-th tensor in input vector<tensor> (%s) "
                                 "is not initialized.",
                                 i,
@@ -101,9 +101,9 @@ static void RunKernelFunc(
       } else {  // optional vector<Tensor> inputs.
         PADDLE_ENFORCE(
             detail::IsOptionalVar(in_name),
-            phi::errors::NotFound("Your custom operator's KernelFunc cannot "
-                                  "find input parameter `%s`",
-                                  in_name));
+            common::errors::NotFound("Your custom operator's KernelFunc cannot "
+                                     "find input parameter `%s`",
+                                     in_name));
         VLOG(3) << "Custom Operator: KernelFunc's vector input " << in_name
                 << " is optional dtype with None input";
         // NOTE(HongyuJia): In dygraph mode, we can not distinguish Tensor and
@@ -118,11 +118,12 @@ static void RunKernelFunc(
       if (ctx.HasInput(in_name)) {  // general Tensor inputs
         auto* x = ctx.Input<phi::DenseTensor>(in_name);
         PADDLE_ENFORCE_NOT_NULL(
-            x, phi::errors::NotFound("Input tensor (%s) is nullptr.", in_name));
+            x,
+            common::errors::NotFound("Input tensor (%s) is nullptr.", in_name));
         PADDLE_ENFORCE_EQ(
             x->IsInitialized(),
             true,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Input tensor (%s) is not initialized.", in_name));
         paddle::Tensor custom_in;
         custom_in.set_impl(std::make_shared<phi::DenseTensor>(*x));
@@ -141,9 +142,9 @@ static void RunKernelFunc(
       } else {  // optional Tensor inputs
         PADDLE_ENFORCE(
             detail::IsOptionalVar(in_name),
-            phi::errors::NotFound("Your custom operator's KernelFunc cannot "
-                                  "find input parameter `%s`",
-                                  in_name));
+            common::errors::NotFound("Your custom operator's KernelFunc cannot "
+                                     "find input parameter `%s`",
+                                     in_name));
         VLOG(3) << "Custom Operator: KernelFunc's input " << in_name
                 << " is optional dtype with None input";
         kernel_ctx.EmplaceBackInput(paddle::Tensor());
@@ -174,7 +175,7 @@ static void RunKernelFunc(
     } else if (attr_type_str == "std::vector<std::string>") {
       kernel_ctx.EmplaceBackAttr(ctx.Attr<std::vector<std::string>>(attr_name));
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported `%s` type value as custom attribute now. "
           "Supported data types include `bool`, `int`, `float`, "
           "`int64_t`, `std::string`, `std::vector<int>`, "
@@ -194,7 +195,7 @@ static void RunKernelFunc(
             out_name)) {  // general/inplace vector<Tensor> outputs
       PADDLE_ENFORCE(
           !inplace_map.empty() || (i == 0UL && outputs.size() == 1UL),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "If custom operator's outputs contains `paddle::Vec()` type "
               "without setting InplaceMap, it only can hold one output."));
       auto vec_out = ctx.MultiOutput<phi::DenseTensor>(out_name);
@@ -202,7 +203,7 @@ static void RunKernelFunc(
       if (vec_out.empty()) {
         PADDLE_ENFORCE(
             detail::IsOptionalVar(out_name) && !inplace_map.empty(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Custom operator couldn't find custom output for name %s. If "
                 "you "
                 "are using inplace optional inputs & outputs, please check "
@@ -223,7 +224,7 @@ static void RunKernelFunc(
         auto* out = vec_out[j];
         PADDLE_ENFORCE_NOT_NULL(
             out,
-            phi::errors::NotFound(
+            common::errors::NotFound(
                 "The %d-th tensor in output vector<tensor> (%s) is nullptr.",
                 j,
                 out_name));
@@ -239,7 +240,7 @@ static void RunKernelFunc(
       if (!ctx.HasOutput(out_name)) {
         PADDLE_ENFORCE(
             detail::IsOptionalVar(out_name) && !inplace_map.empty(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Custom operator couldn't find custom output for name %s. If "
                 "you "
                 "are using inplace optional inputs & outputs, please check "
@@ -258,7 +259,7 @@ static void RunKernelFunc(
       auto* out = ctx.Output<phi::DenseTensor>(out_name);
       PADDLE_ENFORCE_NOT_NULL(
           out,
-          phi::errors::NotFound("Output tensor (%s) is nullptr.", out_name));
+          common::errors::NotFound("Output tensor (%s) is nullptr.", out_name));
       true_out_ptrs.emplace_back(out);
       paddle::Tensor custom_out;
       // here only can copy the output tensor into context
@@ -287,7 +288,7 @@ static void RunKernelFunc(
     PADDLE_ENFORCE_EQ(
         true_out_ptrs.size(),
         calc_outs->size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The number of element in custom operator outputs is wrong, "
             "expected contains %d Tensors, but actually contains %d "
             "Tensors.",
@@ -301,7 +302,7 @@ static void RunKernelFunc(
       }
       PADDLE_ENFORCE(
           true_out != nullptr && calc_outs->at(i).defined(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The returned Tensor is not defined in the KernelFn or custom "
               "operator passes wrong output in static mode."));
       auto calc_out =
@@ -322,9 +323,9 @@ static void RunKernelFunc(
   } catch (platform::EnforceNotMet& exception) {
     throw exception;
   } catch (std::exception& ex) {
-    PADDLE_THROW(phi::errors::External("%s", ex.what()));
+    PADDLE_THROW(common::errors::External("%s", ex.what()));
   } catch (...) {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "Custom operator raises an unknown exception in runtime."));
   }
 }
@@ -338,7 +339,7 @@ static void RunDefaultInferShapeFunc(
     PADDLE_ENFORCE_EQ(
         inputs.size(),
         1UL,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator contains multiple inputs. "
             "We only allow a custom operator that contains only one input "
             "and only one output without setting the InferShapeFn. "
@@ -349,7 +350,7 @@ static void RunDefaultInferShapeFunc(
     PADDLE_ENFORCE_EQ(
         outputs.size(),
         1UL,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator contains multiple outputs. "
             "We only allow a custom operator that contains only one input "
             "and only one output without setting the InferShapeFn. "
@@ -364,7 +365,7 @@ static void RunDefaultInferShapeFunc(
     PADDLE_ENFORCE_EQ(
         inplace_map.size(),
         outputs.size(),
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator uses `SetInplaceMap` without setting the "
             "InferShapeFn. However, `Outputs` size = %d does not match the "
             "`InplaceMap` size = %d. Please check `SetInplaceMap` again or set "
@@ -378,7 +379,7 @@ static void RunDefaultInferShapeFunc(
         if (!ctx->HasOutputs(pair.second)) {
           PADDLE_ENFORCE(
               detail::IsOptionalVar(pair.second),
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "Custom operator couldn't find custom output name for %s. If "
                   "you are using inplace optional inputs & outputs, please "
                   "check "
@@ -396,7 +397,7 @@ static void RunDefaultInferShapeFunc(
         if (!ctx->HasOutput(pair.second)) {
           PADDLE_ENFORCE(
               detail::IsOptionalVar(pair.second),
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "Custom operator couldn't find custom output name for %s. If "
                   "you are using inplace optional inputs & outputs, please "
                   "check "
@@ -442,9 +443,9 @@ static void RunInferShapeFunc(
       } else {  // optional inputs, `vec_shape` is empty
         PADDLE_ENFORCE(
             detail::IsOptionalVar(in_name),
-            phi::errors::NotFound("Your custom operator's InferShapeFunc "
-                                  "cannot find input parameter `%s`",
-                                  in_name));
+            common::errors::NotFound("Your custom operator's InferShapeFunc "
+                                     "cannot find input parameter `%s`",
+                                     in_name));
         VLOG(3) << "Custom Operator: InferShapeFunc's vector input " << in_name
                 << " is optional dtype with None input";
       }
@@ -456,9 +457,9 @@ static void RunInferShapeFunc(
       } else {  // optional inputs
         PADDLE_ENFORCE(
             detail::IsOptionalVar(in_name),
-            phi::errors::NotFound("Your custom operator's InferShapeFunc "
-                                  "cannot find input parameter `%s`",
-                                  in_name));
+            common::errors::NotFound("Your custom operator's InferShapeFunc "
+                                     "cannot find input parameter `%s`",
+                                     in_name));
         input_shapes.emplace_back(std::vector<int64_t>());
         VLOG(3) << "Custom Operator: InferShapeFunc's input " << in_name
                 << " is optional dtype with None input";
@@ -495,7 +496,7 @@ static void RunInferShapeFunc(
       custom_attrs.emplace_back(
           ctx->Attrs().Get<std::vector<std::string>>(attr_name));
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported `%s` type value as custom attribute now. "
           "Supported data types include `bool`, `int`, `float`, "
           "`int64_t`, `std::string`, `std::vector<int>`, "
@@ -511,7 +512,7 @@ static void RunInferShapeFunc(
   if (inplace_map.empty()) {
     PADDLE_ENFORCE_EQ(outputs.size(),
                       output_shapes.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Your custom operator has set the InferShapeFn. "
                           "However, `Outputs` size = %d does not match the "
                           "returned vector size of InferShapeFn = %d. Please "
@@ -522,7 +523,7 @@ static void RunInferShapeFunc(
     PADDLE_ENFORCE_EQ(
         outputs.size(),
         output_shapes.size() + inplace_map.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Your custom operator uses `SetInplaceMap` and sets the "
             "InferShapeFn. However, `Outputs` size = %d does not match the "
             "`InplaceMap size + InferShapeFn output size` = %d. Please check "
@@ -540,7 +541,7 @@ static void RunInferShapeFunc(
     if (detail::IsDuplicableVar(out_name)) {
       PADDLE_ENFORCE(
           inplace_reverse_map.find(out_name) != inplace_reverse_map.end(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Custom operator only supports `paddle::Vec(...)` inputs and "
               "cannot support `paddle::Vec(...)` output without setting "
               "InplaceMap. If you have to use `paddle::Vec(...)` output, "
@@ -552,7 +553,7 @@ static void RunInferShapeFunc(
       } else {
         PADDLE_ENFORCE(
             detail::IsOptionalVar(out_name),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Custom operator couldn't find custom output name for %s. If "
                 "you are using inplace optional inputs & outputs, please check "
                 "your InplaceMap and `Outputs` again and make sure %s is "
@@ -571,7 +572,7 @@ static void RunInferShapeFunc(
         } else {
           PADDLE_ENFORCE(
               detail::IsOptionalVar(out_name),
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "Custom operator couldn't find custom output name for %s. If "
                   "you are using inplace optional inputs & outputs, please "
                   "check your InplaceMap and `Outputs` again and make sure %s "
@@ -599,7 +600,7 @@ static void RunDefaultInferDtypeFunc(
     PADDLE_ENFORCE_EQ(
         inputs.size(),
         1UL,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator contains multiple inputs. "
             "We only allow a custom operator that contains only one input "
             "and only one output without setting the InferDtypeFn. "
@@ -610,7 +611,7 @@ static void RunDefaultInferDtypeFunc(
     PADDLE_ENFORCE_EQ(
         outputs.size(),
         1UL,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator contains multiple outputs. "
             "We only allow a custom operator that contains only one input "
             "and only one output without setting the InferDtypeFn. "
@@ -626,7 +627,7 @@ static void RunDefaultInferDtypeFunc(
     PADDLE_ENFORCE_EQ(
         inplace_map.size(),
         outputs.size(),
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator uses `SetInplaceMap` without setting the "
             "InferDtypeFn. However, `Outputs` size = %d does not match the "
             "`InplaceMap` size = %d. Please check `SetInplaceMap` again or set "
@@ -641,7 +642,7 @@ static void RunDefaultInferDtypeFunc(
       if (!ctx->HasOutput(pair.second)) {
         PADDLE_ENFORCE(
             detail::IsOptionalVar(pair.second),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Custom operator couldn't find custom output name for %s. If "
                 "you are using inplace optional inputs & outputs, please check "
                 "your InplaceMap and `Outputs` again and make sure %s is "
@@ -690,9 +691,9 @@ static void RunInferDtypeFunc(
       } else {  // optional inputs, `vec_custom_dtype` is empty
         PADDLE_ENFORCE(
             detail::IsOptionalVar(in_name),
-            phi::errors::NotFound("Your custom operator's InferDtypeFn "
-                                  "cannot find input parameter `%s`",
-                                  in_name));
+            common::errors::NotFound("Your custom operator's InferDtypeFn "
+                                     "cannot find input parameter `%s`",
+                                     in_name));
         VLOG(3) << "Custom Operator: InferDtypeFn's vector input " << in_name
                 << " is optional dtype with None input";
       }
@@ -704,9 +705,9 @@ static void RunInferDtypeFunc(
       } else {  // optional inputs
         PADDLE_ENFORCE(
             detail::IsOptionalVar(in_name),
-            phi::errors::NotFound("Your custom operator's InferDtypeFn "
-                                  "cannot find input parameter `%s`",
-                                  in_name));
+            common::errors::NotFound("Your custom operator's InferDtypeFn "
+                                     "cannot find input parameter `%s`",
+                                     in_name));
         input_dtypes.emplace_back(DataType::UNDEFINED);
         VLOG(3) << "Custom Operator: InferDtypeFn's input " << in_name
                 << " is optional dtype with None input";
@@ -746,7 +747,7 @@ static void RunInferDtypeFunc(
       custom_attrs.emplace_back(
           PADDLE_GET_CONST(std::vector<std::string>, ctx->GetAttr(attr_name)));
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported `%s` type value as custom attribute now. "
           "Supported data types include `bool`, `int`, `float`, "
           "`int64_t`, `std::string`, `std::vector<int>`, "
@@ -762,7 +763,7 @@ static void RunInferDtypeFunc(
   if (inplace_map.empty()) {
     PADDLE_ENFORCE_EQ(outputs.size(),
                       output_dtypes.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Your custom operator has set the InferDtypeFn. "
                           "However, `Outputs` size = %d does not match the "
                           "returned vector size of InferDtypeFn = %d. Please "
@@ -773,7 +774,7 @@ static void RunInferDtypeFunc(
     PADDLE_ENFORCE_EQ(
         outputs.size(),
         output_dtypes.size() + inplace_map.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Your custom operator uses `SetInplaceMap` and sets the "
             "InferDtypeFn. However, `Outputs` size = %d does not match the "
             "`InplaceMap size + InferDtypeFn output size` = %d. Please check "
@@ -791,7 +792,7 @@ static void RunInferDtypeFunc(
     if (detail::IsDuplicableVar(out_name)) {
       PADDLE_ENFORCE(
           inplace_reverse_map.find(out_name) != inplace_reverse_map.end(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Custom operator only supports `paddle::Vec(...)` inputs and "
               "cannot support `paddle::Vec(...)` output without setting "
               "InplaceMap. If you have to use `paddle::Vec(...)` output, "
@@ -807,7 +808,7 @@ static void RunInferDtypeFunc(
       } else {
         PADDLE_ENFORCE(
             detail::IsOptionalVar(out_name),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Custom operator couldn't find custom output name for %s. If "
                 "you are using inplace optional inputs & outputs, please check "
                 "your InplaceMap and `Outputs` again and make sure %s is "
@@ -827,7 +828,7 @@ static void RunInferDtypeFunc(
         } else {
           PADDLE_ENFORCE(
               out_name.find(paddle::kOptionalSuffix) != std::string::npos,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "Custom operator couldn't find custom output name for %s. If "
                   "you are using inplace optional inputs & outputs, please "
                   "check your InplaceMap and `Outputs` again and make sure %s "
@@ -929,7 +930,7 @@ static void RegisterOperatorKernel(
             << " with raw op kernel func";
     PADDLE_ENFORCE_NOT_NULL(
         dso_handle,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The dso handle must be provided if kernel_func is nullptr."));
     using OpKernelFuncPtr = void(const framework::ExecutionContext&);
     auto symbol_name = "PD_" + name + "_raw_op_kernel_func";
@@ -1011,7 +1012,7 @@ void RegisterOperatorWithMetaInfo(const std::vector<OpMetaInfo>& op_meta_infos,
   PADDLE_ENFORCE_EQ(
       info.proto_->IsInitialized(),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Fail to initialize %s's OpProto, because %s is not initialized.",
           op_name,
           info.proto_->InitializationErrorString()));
@@ -1202,7 +1203,7 @@ void RegisterOperatorWithMetaInfo(const std::vector<OpMetaInfo>& op_meta_infos,
               PADDLE_ENFORCE_EQ(
                   grad_op_inputs.size() == 1UL && grad_op_outputs.size() == 1UL,
                   true,
-                  phi::errors::Unavailable(
+                  common::errors::Unavailable(
                       "Custom grad operator infershape error. "
                       "If a custom grad operator contains only one input and "
                       "only one output, the input shape will be directly set "
@@ -1409,7 +1410,7 @@ void PD_RegisterOperator(const char* kernel_name_cstr,
     PADDLE_ENFORCE_EQ(
         info.proto_->IsInitialized(),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Fail to initialize %s's OpProto, because %s is not initialized.",
             kernel_name,
             info.proto_->InitializationErrorString()));

--- a/paddle/fluid/framework/custom_operator.h
+++ b/paddle/fluid/framework/custom_operator.h
@@ -87,7 +87,7 @@ class CustomOpMaker : public OpProtoAndCheckerMaker {
             attr_name, "custom operator std::vector<std::string> attribute.")
             .SetDefault({});
       } else {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Unsupported `%s` type value as custom attribute now. "
             "Supported data types include `bool`, `int`, `float`, "
             "`int64_t`, `std::string`, `std::vector<int>`, "
@@ -150,7 +150,7 @@ class CustomGradOpMaker<OpDesc> : public SingleGradOpMaker<OpDesc> {
         } else if (detail::IsMemberOf(fwd_op_outputs, in_name)) {
           grad_op->SetInput(in_name, this->Output(in_name));
         } else {
-          PADDLE_THROW(phi::errors::InvalidArgument(
+          PADDLE_THROW(common::errors::InvalidArgument(
               "The input tensor name `%s` is invalid, expected it is the input "
               "or output of forward operator.",
               in_name));
@@ -162,7 +162,7 @@ class CustomGradOpMaker<OpDesc> : public SingleGradOpMaker<OpDesc> {
           // Maybe visit here! handle inplace optional case
           PADDLE_ENFORCE(
               in_name.find(paddle::kOptionalSuffix) != std::string::npos,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "Custom operator couldn't find grad operator input name for "
                   "%s. If you are using inplace optional inputs & outputs, "
                   "please check your InplaceMap and `Outputs` again and make "
@@ -179,7 +179,7 @@ class CustomGradOpMaker<OpDesc> : public SingleGradOpMaker<OpDesc> {
       if (!this->HasInput(detail::NoGrad(out_name, is_double_grad_))) {
         PADDLE_ENFORCE(
             out_name.find(paddle::kOptionalSuffix) != std::string::npos,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Custom operator couldn't find grad operator output name for "
                 "%s. If you are using inplace optional inputs & outputs, "
                 "please check your InplaceMap and `Outputs` again and make "
@@ -253,7 +253,7 @@ class CustomGradOpMaker<imperative::OpBase>
         } else if (detail::IsMemberOf(fwd_op_outputs, in_name)) {
           grad_op->SetInput(in_name, this->Output(in_name));
         } else {
-          PADDLE_THROW(phi::errors::InvalidArgument(
+          PADDLE_THROW(common::errors::InvalidArgument(
               "The input tensor name `%s` is invalid, expected it is the input "
               "or output of forward operator.",
               in_name));
@@ -265,7 +265,7 @@ class CustomGradOpMaker<imperative::OpBase>
         } else {
           PADDLE_ENFORCE(
               in_name.find(paddle::kOptionalSuffix) != std::string::npos,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "Custom operator couldn't find grad operator input name for "
                   "%s. If you are using inplace optional inputs & outputs, "
                   "please check your InplaceMap and `Outputs` again and make "
@@ -282,7 +282,7 @@ class CustomGradOpMaker<imperative::OpBase>
       if (!this->HasInput(detail::NoGrad(out_name, is_double_grad_))) {
         PADDLE_ENFORCE(
             out_name.find(paddle::kOptionalSuffix) != std::string::npos,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Custom operator couldn't find grad operator output name for "
                 "%s. If you are using inplace optional inputs & outputs, "
                 "please check your InplaceMap and `Outputs` again and make "

--- a/paddle/fluid/framework/custom_operator_utils.h
+++ b/paddle/fluid/framework/custom_operator_utils.h
@@ -40,7 +40,7 @@ static T* DynLoad(void* handle, std::string name) {
 #endif  // !_WIN32
   PADDLE_ENFORCE_NOT_NULL(
       func,
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Failed to load dynamic operator library, error message(%s).",
           errorno));
   return func;
@@ -203,7 +203,7 @@ static void CheckDefaultInferShapeDtype(
     PADDLE_ENFORCE_EQ(
         OpMetaInfoHelper::GetInputs(custom_op_meta).size(),
         1UL,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator contains multiple inputs. "
             "We only allow a custom operator that contains only one input "
             "and only one output without setting the "
@@ -216,7 +216,7 @@ static void CheckDefaultInferShapeDtype(
     PADDLE_ENFORCE_EQ(
         OpMetaInfoHelper::GetOutputs(custom_op_meta).size(),
         1UL,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator contains multiple outputs. "
             "We only allow a custom operator that contains only one input "
             "and only one output without setting the "
@@ -230,7 +230,7 @@ static void CheckDefaultInferShapeDtype(
     PADDLE_ENFORCE_EQ(
         inplace_map.size(),
         OpMetaInfoHelper::GetOutputs(custom_op_meta).size(),
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator uses `SetInplaceMap` without setting the "
             "InferShapeFn/InferDtypeFn. However, `Outputs` size = %d does not "
             "match the "
@@ -291,7 +291,7 @@ static std::vector<std::vector<int64_t>> RunDefaultInferShape(
           PADDLE_ENFORCE_EQ(
               bwd_inputs_name.size() == 1UL && bwd_outputs_name.size() == 1UL,
               true,
-              phi::errors::Unavailable(
+              common::errors::Unavailable(
                   "Custom grad operator infershape error. "
                   "If a custom grad operator contains only one input and "
                   "only one output, the input shape will be directly set "
@@ -315,7 +315,7 @@ static std::vector<std::vector<int64_t>> RunDefaultInferShape(
     } else if (vec_input_shapes.size() == 1) {
       output_shapes = vec_input_shapes[0];
     } else {
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "We only allow a custom operator that contains only one input "
           "and only one output without setting the InferShapeFn. "));
     }
@@ -396,7 +396,7 @@ static std::vector<DataType> RunDefaultInferDtype(
     } else if (vec_input_dtypes.size() == 1) {
       output_dtypes = vec_input_dtypes[0];
     } else {
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "We only allow a custom operator that contains only one input "
           "and only one output without setting the InferDtypeFn. "));
     }
@@ -447,7 +447,7 @@ static std::vector<std::vector<int64_t>> RunInferShape(
       if (paddle::framework::detail::IsDuplicableVar(out_name)) {
         PADDLE_ENFORCE(
             inplace_reverse_map.find(out_name) != inplace_reverse_map.end(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Custom operator only supports `paddle::Vec(...)` inputs and "
                 "cannot support `paddle::Vec(...)` output without setting "
                 "InplaceMap. If you have to use `paddle::Vec(...)` output, "
@@ -516,7 +516,7 @@ static std::vector<DataType> RunInferDtype(
       if (paddle::framework::detail::IsDuplicableVar(out_name)) {
         PADDLE_ENFORCE(
             inplace_reverse_map.find(out_name) != inplace_reverse_map.end(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Custom operator only supports `paddle::Vec(...)` inputs and "
                 "cannot support `paddle::Vec(...)` output without setting "
                 "InplaceMap. If you have to use `paddle::Vec(...)` output, "

--- a/paddle/fluid/framework/data_device_transform.cc
+++ b/paddle/fluid/framework/data_device_transform.cc
@@ -25,8 +25,8 @@ void TransDataDevice(const phi::DenseTensor &in,
   PADDLE_ENFORCE_NE(
       in.place().GetType(),
       dst_place.GetType(),
-      phi::errors::Unavailable("Currently, model parallelism is only "
-                               "supported between CPU and CUDA."));
+      common::errors::Unavailable("Currently, model parallelism is only "
+                                  "supported between CPU and CUDA."));
 
   // NOTE(zhiqiu): Special case for CPU->NPU, avoid stream sync.
   if (phi::is_cpu_place(in.place())) {

--- a/paddle/fluid/framework/data_feed.cc
+++ b/paddle/fluid/framework/data_feed.cc
@@ -210,18 +210,18 @@ void DataFeed::SetBatchSize(int batch_size) {
   PADDLE_ENFORCE_GT(
       batch_size,
       0,
-      phi::errors::InvalidArgument("Batch size %d is illegal.", batch_size));
+      common::errors::InvalidArgument("Batch size %d is illegal.", batch_size));
   default_batch_size_ = batch_size;
 }
 
 bool DataFeed::PickOneFile(std::string* filename) {
   PADDLE_ENFORCE_NOT_NULL(
       mutex_for_pick_file_,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "You should call SetFileListMutex before PickOneFile"));
   PADDLE_ENFORCE_NOT_NULL(
       file_idx_,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "You should call SetFileListIndex before PickOneFile"));
   std::unique_lock<std::mutex> lock(*mutex_for_pick_file_);
   VLOG(4) << "filelist_ size: " << filelist_.size();
@@ -238,21 +238,21 @@ void DataFeed::CheckInit() {
   PADDLE_ENFORCE_EQ(
       finish_init_,
       true,
-      phi::errors::PreconditionNotMet("DataFeed initialization failed."));
+      common::errors::PreconditionNotMet("DataFeed initialization failed."));
 }
 
 void DataFeed::CheckSetFileList() {
   PADDLE_ENFORCE_EQ(
       finish_set_filelist_,
       true,
-      phi::errors::PreconditionNotMet("DataFeed set filelist failed."));
+      common::errors::PreconditionNotMet("DataFeed set filelist failed."));
 }
 
 void DataFeed::CheckStart() {
-  PADDLE_ENFORCE_EQ(
-      finish_start_,
-      true,
-      phi::errors::PreconditionNotMet("Datafeed has not started running yet."));
+  PADDLE_ENFORCE_EQ(finish_start_,
+                    true,
+                    common::errors::PreconditionNotMet(
+                        "Datafeed has not started running yet."));
 }
 
 void DataFeed::AssignFeedVar(const Scope& scope) {
@@ -273,7 +273,7 @@ void DataFeed::CopyToFeedTensor(void* dst, const void* src, size_t size) {
 #elif defined(PADDLE_WITH_XPU_KP)
     xpu_memcpy(dst, src, size, XPUMemcpyKind::XPU_HOST_TO_DEVICE);
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Not supported GPU/ROCM, please compile with option WITH_GPU=ON or "
         "WITH_ROCM=ON."));
 #endif
@@ -285,7 +285,7 @@ void PrivateQueueDataFeed<T>::SetQueueSize(int queue_size) {
   PADDLE_ENFORCE_GT(
       queue_size,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Queue size %d is illegal in PrivateQueueDataFeed.", queue_size));
   queue_size_ = queue_size;
   queue_ = paddle::framework::MakeChannel<T>();
@@ -647,7 +647,7 @@ void MultiSlotDataFeed::Init(
   PADDLE_ENFORCE_EQ(
       data_feed_desc.has_multi_slot_desc(),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Multi_slot_desc has not been set in MultiSlotDataFeed."));
   const paddle::framework::MultiSlotDesc& multi_slot_desc =
       data_feed_desc.multi_slot_desc();
@@ -892,7 +892,7 @@ bool MultiSlotDataFeed::ParseOneInstanceFromPipe(
            << " which is illegal.\n";
         ss << "\n";
 
-        PADDLE_THROW(phi::errors::InvalidArgument(ss.str()));
+        PADDLE_THROW(common::errors::InvalidArgument(ss.str()));
       }
 
       if (idx != -1) {
@@ -941,7 +941,7 @@ bool MultiSlotDataFeed::ParseOneInstance(std::vector<MultiSlotType>* instance) {
       PADDLE_ENFORCE_NE(
           num,
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The number of ids can not be zero, you need padding "
               "it in data generator; or if there is something wrong with "
               "the data, please check if the data contains unresolvable "
@@ -1053,7 +1053,7 @@ void MultiSlotInMemoryDataFeed::Init(
   PADDLE_ENFORCE_EQ(
       data_feed_desc.has_multi_slot_desc(),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Multi_slot_desc has not been set in MultiSlotInMemoryDataFeed."));
   const paddle::framework::MultiSlotDesc& multi_slot_desc =
       data_feed_desc.multi_slot_desc();
@@ -1208,7 +1208,7 @@ bool MultiSlotInMemoryDataFeed::ParseOneInstanceFromPipe(Record* instance) {
       PADDLE_ENFORCE_NE(
           num,
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The number of ids can not be zero, you need padding "
               "it in data generator; or if there is something wrong with "
               "the data, please check if the data contains unresolvable "
@@ -1224,7 +1224,7 @@ bool MultiSlotInMemoryDataFeed::ParseOneInstanceFromPipe(Record* instance) {
 #ifdef PADDLE_WITH_PSLIB
       if (parse_uid_ && all_slots_[i] == uid_slot_) {
         PADDLE_ENFORCE(num == 1 && all_slots_type_[i][0] == 'u',
-                       phi::errors::PreconditionNotMet(
+                       common::errors::PreconditionNotMet(
                            "The uid has to be uint64 and single.\n"
                            "please check this error line: %s",
                            str));
@@ -1295,7 +1295,7 @@ bool MultiSlotInMemoryDataFeed::ParseOneInstance(Record* instance) {
       PADDLE_ENFORCE_NE(
           num,
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The number of ids can not be zero, you need padding "
               "it in data generator; or if there is something wrong with "
               "the data, please check if the data contains unresolvable "
@@ -1421,7 +1421,7 @@ void MultiSlotInMemoryDataFeed::PutToFeedVec(const Record* ins_vec, int num) {
         std::vector<size_t> tmp_offset;
         PADDLE_ENFORCE_EQ(slot_offset.size(),
                           2,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "In batch reader, the sparse tensor lod size "
                               "must be 2, but received %d.",
                               slot_offset.size()));
@@ -1521,7 +1521,7 @@ void MultiSlotInMemoryDataFeed::PutToFeedVec(
         std::vector<size_t> tmp_offset;
         PADDLE_ENFORCE_EQ(slot_offset.size(),
                           2,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "In batch reader, the sparse tensor lod size "
                               "must be 2, but received %d.",
                               slot_offset.size()));
@@ -1578,7 +1578,7 @@ void PrivateInstantDataFeed<T>::PutToFeedVec() {
       PADDLE_ENFORCE_EQ(
           total_dims,
           total_instance,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The actual data size of slot[%s] doesn't match its declaration. "
               "The actual data size of slot is %lld"
               ", and its declaration is %lld.",
@@ -1609,7 +1609,7 @@ int PrivateInstantDataFeed<T>::Next() {
   PADDLE_ENFORCE_EQ(
       true,
       ParseOneMiniBatch(),
-      phi::errors::InvalidArgument("Fail to parse mini-batch data."));
+      common::errors::InvalidArgument("Fail to parse mini-batch data."));
   PutToFeedVec();
   return ins_vec_[0].GetBatchSize();
 }
@@ -1623,7 +1623,7 @@ void PrivateInstantDataFeed<T>::Init(const DataFeedDesc& data_feed_desc) {
   PADDLE_ENFORCE_EQ(
       data_feed_desc.has_multi_slot_desc(),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Multi_slot_desc has not been set in PrivateInstantDataFeed."));
   const paddle::framework::MultiSlotDesc& multi_slot_desc =
       data_feed_desc.multi_slot_desc();
@@ -1670,7 +1670,7 @@ bool MultiSlotFileInstantDataFeed::Preprocess(const std::string& filename) {
   PADDLE_ENFORCE_NE(
       fd_,
       -1,
-      phi::errors::Unavailable(
+      common::errors::Unavailable(
           "Fail to open file: %s in MultiSlotFileInstantDataFeed.",
           filename.c_str()));
 
@@ -1683,7 +1683,7 @@ bool MultiSlotFileInstantDataFeed::Preprocess(const std::string& filename) {
   PADDLE_ENFORCE_NE(
       buffer_,
       MAP_FAILED,
-      phi::errors::Unavailable(
+      common::errors::Unavailable(
           "Memory map failed when create shared memory, error number is %s.",
           strerror(errno)));
 
@@ -1720,7 +1720,7 @@ bool MultiSlotFileInstantDataFeed::ParseOneMiniBatch() {
       PADDLE_ENFORCE_NE(
           num,
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The number of ids can not be zero, you need padding "
               "it in data generator; or if there is something wrong with "
               "the data, please check if the data contains unresolvable "
@@ -1766,7 +1766,7 @@ bool MultiSlotFileInstantDataFeed::ParseOneMiniBatch() {
   }
 
   PADDLE_ENFORCE(batch_size_ == default_batch_size_ || offset_ == end_,
-                 phi::errors::InvalidArgument(
+                 common::errors::InvalidArgument(
                      "The batch size id not equal to default batch size, or "
                      "the offset is not equal to end index."
                      "The batch size is %d, default batcch size is %d, offset "
@@ -2041,7 +2041,7 @@ void SlotRecordInMemoryDataFeed::Init(const DataFeedDesc& data_feed_desc) {
   finish_set_filelist_ = false;
   finish_start_ = false;
   PADDLE_ENFORCE(data_feed_desc.has_multi_slot_desc(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Multi_slot_desc has not been set in data_feed_desc"));
   const paddle::framework::MultiSlotDesc& multi_slot_desc =
       data_feed_desc.multi_slot_desc();

--- a/paddle/fluid/framework/data_feed.cu
+++ b/paddle/fluid/framework/data_feed.cu
@@ -4784,7 +4784,7 @@ void GraphDataGenerator::AllocResource(
       PADDLE_ENFORCE_NE(
           iter,
           node_to_id.end(),
-          phi::errors::NotFound("(%s) is not found in node_to_id.", type));
+          common::errors::NotFound("(%s) is not found in node_to_id.", type));
       int node_type = iter->second;
       int type_index = type_to_index[node_type];
       VLOG(2) << "add node[" << type
@@ -4887,12 +4887,12 @@ void GraphDataGenerator::DumpWalkPath(std::string dump_path, size_t dump_rate) {
   PADDLE_ENFORCE_LE(
       dump_rate,
       10000000,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "dump_rate can't be large than 10000000. Please check the dump "
           "rate[1, 10000000]"));
   PADDLE_ENFORCE_GE(dump_rate,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "dump_rate can't be less than 1. Please check the dump "
                         "rate[1, 10000000]"));
   int err_no = 0;

--- a/paddle/fluid/framework/data_feed.h
+++ b/paddle/fluid/framework/data_feed.h
@@ -1144,7 +1144,7 @@ class DataFeed {
   virtual ~DataFeed() {}
   virtual void Init(const DataFeedDesc& data_feed_desc) = 0;
   virtual bool CheckFile(const char* filename UNUSED) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "This function(CheckFile) is not implemented."));
   }
   // Set filelist for DataFeed.
@@ -1368,7 +1368,7 @@ class DataFeed {
   }
 
   virtual void DoWalkandSage() {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "This function(DoWalkandSage) is not implemented."));
   }
 
@@ -1384,7 +1384,7 @@ class DataFeed {
 
   virtual bool IsTrainMode() { return train_mode_; }
   virtual void LoadIntoMemory() {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "This function(LoadIntoMemory) is not implemented."));
   }
   virtual void SetPlace(const phi::Place& place) { place_ = place; }
@@ -1396,7 +1396,7 @@ class DataFeed {
   }
 
   virtual void PackToScope(MiniBatchGpuPack* pack, const Scope* scope) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "This function(PackToScope) is not implemented."));
   }
   virtual void SetInsIdVec(MiniBatchGpuPack* pack) {}
@@ -1404,11 +1404,11 @@ class DataFeed {
 
   virtual void DumpWalkPath(std::string dump_path UNUSED,
                             size_t dump_rate UNUSED) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "This function(DumpWalkPath) is not implemented."));
   }
   virtual void DumpSampleNeighbors(std::string dump_path) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "This function(DumpSampleNeighbors) is not implemented"));
   }
 
@@ -1704,7 +1704,7 @@ class MultiSlotType {
   void CheckType(const std::string& type) const {
     PADDLE_ENFORCE_EQ((type == "uint64" || type == "float"),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "MultiSlotType error, expect type is uint64 or "
                           "float, but received type is %s.",
                           type));
@@ -1713,14 +1713,14 @@ class MultiSlotType {
     PADDLE_ENFORCE_EQ(
         type_[0],
         'f',
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "MultiSlotType error, add %s value to float slot.", type_));
   }
   void CheckUint64() const {
     PADDLE_ENFORCE_EQ(
         type_[0],
         'u',
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "MultiSlotType error, add %s value to uint64 slot.", type_));
   }
   std::vector<float> float_feasign_;
@@ -1840,10 +1840,10 @@ class RecordCandidateList {
     PADDLE_ENFORCE_LT(
         index,
         candidate_list_.size(),
-        phi::errors::OutOfRange("Your index [%lu] exceeds the number of "
-                                "elements in candidate_list[%lu].",
-                                index,
-                                candidate_list_.size()));
+        common::errors::OutOfRange("Your index [%lu] exceeds the number of "
+                                   "elements in candidate_list[%lu].",
+                                   index,
+                                   candidate_list_.size()));
     return candidate_list_[index];
   }
   void SetSlotIndexToReplace(

--- a/paddle/fluid/framework/data_layout_transform.cc
+++ b/paddle/fluid/framework/data_layout_transform.cc
@@ -25,14 +25,15 @@ std::vector<int> GetAxis(const DataLayout& from, const DataLayout& to) {
   PADDLE_ENFORCE_NE(
       from,
       to,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Layout transform should transform between different layout."));
   if (from == DataLayout::kNCHW && to == DataLayout::kNHWC) {
     return {0, 2, 3, 1};
   } else if (from == DataLayout::kNHWC && to == DataLayout::kNCHW) {
     return {0, 3, 1, 2};
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument("Unsupported layout transform."));
+    PADDLE_THROW(
+        common::errors::InvalidArgument("Unsupported layout transform."));
   }
 }
 
@@ -45,7 +46,7 @@ void CastDataLayout::apply() {
     auto* context = static_cast<const phi::CPUContext*>(ctx_);
     trans4(*context, in_, out_, axis_);
   } else {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "Unsupported data layout cast from CPU to GPU."));
   }
 }
@@ -58,7 +59,7 @@ void TransDataLayout(const phi::KernelKey& kernel_type_for_var,
   PADDLE_ENFORCE(
       backends_are_same_class(kernel_type_for_var.backend(),
                               expected_kernel_type.backend()),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "TransDataLayout only support DataLayout transform on same place."));
 
   TransDataLayout(kernel_type_for_var.layout(),
@@ -76,7 +77,7 @@ void TransDataLayout(DataLayout from_layout,
   PADDLE_ENFORCE_EQ(
       arity(in.dims()),
       4,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input dimension arity only can be 4, the input dimension is %s.",
           in.dims()));
 

--- a/paddle/fluid/framework/data_set.cc
+++ b/paddle/fluid/framework/data_set.cc
@@ -394,7 +394,7 @@ static int compute_thread_batch_nccl(
     int need_ins_num = thread_max_batch_num * thr_num;
     // data is too less
     if ((int64_t)need_ins_num > total_instance_num) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "error instance num:[%d] less need ins num:[%d]",
           total_instance_num,
           need_ins_num));
@@ -428,7 +428,7 @@ static int compute_thread_batch_nccl(
                  << ", thread avg batch num " << thread_avg_batch_num;
   }
 #else
-  PADDLE_THROW(phi::errors::Unavailable(
+  PADDLE_THROW(common::errors::Unavailable(
       "dataset compute nccl batch number need compile with GLOO"));
 #endif
   return thread_avg_batch_num;
@@ -466,8 +466,8 @@ void MultiSlotDataset::PrepareTrain() {
     }
   }
 #else
-  PADDLE_THROW(
-      phi::errors::Unavailable("dataset set heterps need compile with GLOO"));
+  PADDLE_THROW(common::errors::Unavailable(
+      "dataset set heterps need compile with GLOO"));
 #endif
   return;
 }
@@ -1853,7 +1853,7 @@ void MultiSlotDataset::SlotsShuffle(
     const std::set<std::string>& slots_to_replace) {
   PADDLE_ENFORCE_EQ(slots_shuffle_fea_eval_,
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "fea eval mode off, need to set on for slots shuffle"));
   platform::Timer timeline;
   timeline.Start();
@@ -2013,8 +2013,8 @@ void SlotRecordDataset::PrepareTrain() {
     }
   }
 #else
-  PADDLE_THROW(
-      phi::errors::Unavailable("dataset set heterps need compile with GLOO"));
+  PADDLE_THROW(common::errors::Unavailable(
+      "dataset set heterps need compile with GLOO"));
 #endif
   return;
 }

--- a/paddle/fluid/framework/data_transform.cc
+++ b/paddle/fluid/framework/data_transform.cc
@@ -62,7 +62,7 @@ void TransformData(const phi::KernelKey &expected_kernel_type,
       PADDLE_ENFORCE_EQ(
           !(lin == DataLayout::ONEDNN && lout == DataLayout::ONEDNN),
           true,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "No layout transform needed between two oneDNN OPKernels."));
 
       if (lin != DataLayout::ONEDNN && lout == DataLayout::ONEDNN) {
@@ -85,7 +85,7 @@ void TransformData(const phi::KernelKey &expected_kernel_type,
         // Case2 - transform from ONEDNN OPKernel to Non-ONEDNN OPKernel
         // Do transform via ONEDNN lib
         PADDLE_ENFORCE(lin == DataLayout::ONEDNN && lout != DataLayout::ONEDNN,
-                       phi::errors::InvalidArgument(
+                       common::errors::InvalidArgument(
                            "TransDataLayoutFromOneDNN only supports "
                            "transform from ONEDNN to non-ONEDNN"));
 
@@ -127,7 +127,7 @@ void TransformData(const phi::KernelKey &expected_kernel_type,
   PADDLE_ENFORCE_EQ(
       transformed,
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "No transform is applied for the data needs to be transformed."));
   // get output data
   output_tensor->ShareDataWith(in);
@@ -152,7 +152,7 @@ void SetTensorToVariable(const Variable &in_var,
     trans_selected_rows->set_rows(in_selected_rows.rows());
     trans_selected_rows->mutable_value()->ShareDataWith(tensor);
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Unsupported variable type, only supports phi::DenseTensor or "
         "SelectedRows, "
         "but the input variable type is %s.",

--- a/paddle/fluid/framework/data_type.cc
+++ b/paddle/fluid/framework/data_type.cc
@@ -72,8 +72,8 @@ proto::VarType::Type ToDataType(std::type_index type) {
   if (it != gDataTypeMap().cpp_to_proto_.end()) {
     return it->second;
   }
-  PADDLE_THROW(phi::errors::Unimplemented("Not support %s as tensor data type.",
-                                          platform::demangle(type.name())));
+  PADDLE_THROW(common::errors::Unimplemented(
+      "Not support %s as tensor data type.", platform::demangle(type.name())));
 }
 
 std::type_index ToTypeIndex(proto::VarType::Type type) {
@@ -81,7 +81,7 @@ std::type_index ToTypeIndex(proto::VarType::Type type) {
   if (it != gDataTypeMap().proto_to_cpp_.end()) {
     return it->second;
   }
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Not support proto::VarType::Type(%d) as tensor type.",
       static_cast<int>(type)));
 }
@@ -95,7 +95,7 @@ std::string DataTypeToString(const proto::VarType::Type type) {
   if (type == proto::VarType::RAW) {
     return "RAW(runtime decided type)";
   }
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Not support proto::VarType::Type(%d) as tensor type.",
       static_cast<int>(type)));
 }
@@ -105,8 +105,8 @@ size_t SizeOfType(proto::VarType::Type type) {
   if (it != gDataTypeMap().proto_to_size_.end()) {
     return it->second;
   }
-  PADDLE_THROW(phi::errors::Unimplemented("Not support %s as tensor type.",
-                                          DataTypeToString(type)));
+  PADDLE_THROW(common::errors::Unimplemented("Not support %s as tensor type.",
+                                             DataTypeToString(type)));
 }
 
 // Now only supports promotion of complex type
@@ -123,7 +123,7 @@ int DataTypeNumAlign(const proto::VarType::Type t) {
              t == proto::VarType::COMPLEX128) {
     cast_type_num = static_cast<int>(t) - 21;
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Only supports to align data type include float32, float64, complex64 "
         "and complex128, but received data type is `s`.",
         DataTypeToString(t)));

--- a/paddle/fluid/framework/data_type.h
+++ b/paddle/fluid/framework/data_type.h
@@ -137,7 +137,7 @@ inline void VisitDataType(proto::VarType::Type type, Visitor visitor) {
 
   _ForEachDataType_(VisitDataTypeCallback);
 #undef VisitDataTypeCallback
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Not supported proto::VarType::Type(%d) as data type.",
       static_cast<int>(type)));
 }
@@ -183,7 +183,7 @@ inline void VisitIntDataType(proto::VarType::Type type, Visitor visitor) {
 
   _ForEachIntDataType_(VisitIntDataTypeCallback);
 
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Expected integral data type, but got %s", DataTypeToString(type)));
 
 #undef VisitIntDataTypeCallback
@@ -243,7 +243,7 @@ extern inline proto::VarType::Type ToComplexType(proto::VarType::Type t) {
     case proto::VarType::FP64:
       return proto::VarType::COMPLEX128;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unknown real value data type (%s), now only support float32 and "
           "float64.",
           DataTypeToString(t)));
@@ -257,7 +257,7 @@ extern inline proto::VarType::Type ToRealType(proto::VarType::Type t) {
     case proto::VarType::COMPLEX128:
       return proto::VarType::FP64;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unknown complex value data type (%s), now only support complex64 "
           "and "
           "complex128.",

--- a/paddle/fluid/framework/data_type_transform.cc
+++ b/paddle/fluid/framework/data_type_transform.cc
@@ -69,7 +69,7 @@ static void XPUTransDataType(
       dst_type == proto::VarType::INT32 && dst_type == proto::VarType::INT64) {
     _ForEachDataType_(XPUCastCallback);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Data type (%s) is not supported in XPU when casting data type.",
         DataTypeToString(dst_type)));
   }
@@ -123,7 +123,7 @@ struct CastDataType {
             CastDataTypeFunctor<InType, OutType>());
 #endif
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Place type is not supported when casting data type."));
     }
   }
@@ -135,7 +135,7 @@ void TransDataType(const phi::KernelKey& kernel_type_for_var,
                    phi::DenseTensor* out) {
   PADDLE_ENFORCE_EQ(in.dtype(),
                     kernel_type_for_var.dtype(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The src dtype(%s) of input tensor and kernel_type(%s) "
                         "are not consistent.",
                         DataTypeToString(in.dtype()),
@@ -175,7 +175,7 @@ void TransDataType(const phi::DenseTensor& in,
       XPUTransDataType<int64_t>(in, out, dst_type, ctx);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported in XPU when casting data type.",
           DataTypeToString(src_type)));
   }
@@ -221,7 +221,7 @@ void TransDataType(const phi::DenseTensor& in,
       framework::VisitDataType(dst_type, CastDataType<uint8_t>(in, out, ctx));
       break;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported when casting data type.",
           DataTypeToString(src_type)));
   }
@@ -246,7 +246,7 @@ void TransComplexToReal(const proto::VarType::Type& dst_type,
           dst_type, CastDataType<phi::dtype::complex<double>>(in, out, ctx));
       break;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported when casting complex tensor to real "
           "data type.",
           DataTypeToString(src_type)));

--- a/paddle/fluid/framework/details/build_strategy.cc
+++ b/paddle/fluid/framework/details/build_strategy.cc
@@ -174,7 +174,7 @@ class ParallelExecutorPassBuilder : public ir::PassBuilder {
             AppendPass("all_reduce_mode_multi_devices_pass").get();
         break;
       default:
-        PADDLE_THROW(phi::errors::Unimplemented("Unknown reduce strategy."));
+        PADDLE_THROW(common::errors::Unimplemented("Unknown reduce strategy."));
     }
     multi_devices_pass->SetNotOwned<const BuildStrategy>("strategy",
                                                          &strategy_);
@@ -215,7 +215,7 @@ class ParallelExecutorPassBuilder : public ir::PassBuilder {
 #else
     PADDLE_ENFORCE_NE(FLAGS_use_mkldnn,
                       true,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "FLAGS_use_mkldnn has been set to True, but "
                           "PaddlePaddle is compiled without MKLDNN. "
                           "Please compile PaddlePaddle with MKLDNN first."));
@@ -261,7 +261,7 @@ ir::Graph *BuildStrategy::Apply(ir::Graph *graph,
     PADDLE_ENFORCE_EQ(
         graph->IsMainGraph(),
         true,
-        phi::errors::InvalidArgument("This graph is not main_graph"));
+        common::errors::InvalidArgument("This graph is not main_graph"));
   }
   // Create a default one if not finalized by user.
   CreatePassesFromStrategy(false);

--- a/paddle/fluid/framework/details/eager_deletion_op_handle.cc
+++ b/paddle/fluid/framework/details/eager_deletion_op_handle.cc
@@ -56,18 +56,18 @@ EagerDeletionOpHandle::EagerDeletionOpHandle(
 #endif
       PADDLE_ENFORCE_NOT_NULL(
           event_,
-          phi::errors::InvalidArgument("The cuda event created is NULL."));
+          common::errors::InvalidArgument("The cuda event created is NULL."));
     }
   }
 #endif
-  PADDLE_ENFORCE_NE(
-      vars.empty(),
-      true,
-      phi::errors::InvalidArgument("The variables to be deleted are empty."));
+  PADDLE_ENFORCE_NE(vars.empty(),
+                    true,
+                    common::errors::InvalidArgument(
+                        "The variables to be deleted are empty."));
   for (auto *var : var_infos_) {
-    PADDLE_ENFORCE_NOT_NULL(
-        var,
-        phi::errors::InvalidArgument("The memory optimization info is NULL."));
+    PADDLE_ENFORCE_NOT_NULL(var,
+                            common::errors::InvalidArgument(
+                                "The memory optimization info is NULL."));
   }
 }
 
@@ -96,14 +96,14 @@ void EagerDeletionOpHandle::CallOnce() {
   PADDLE_ENFORCE_EQ(
       vars_.empty(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The variables to be deleted should be initialized here."));
   Scope *exec_scope = local_exec_scopes_[0];
   for (auto *var_info : var_infos_) {
     auto *var = exec_scope->FindVar(var_info->Name());
     PADDLE_ENFORCE_NOT_NULL(
         var,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "The variable(%s) to be inplaced is not found in scope.",
             var_info->Name()));
     vars_.emplace_back(var);
@@ -160,7 +160,7 @@ void EagerDeletionOpHandle::RunImpl() {
         garbages.emplace_back(t.MoveMemoryHolder());
       }
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "The variable(%s) of type %s is not supported in eager deletion.",
           framework::ToTypeName(var->Type()),
           var_info->Name()));

--- a/paddle/fluid/framework/details/exception_holder.h
+++ b/paddle/fluid/framework/details/exception_holder.h
@@ -41,7 +41,7 @@ class ExceptionHolder {
     } catch (std::exception& ex) {
       Catch(ex);
     } catch (...) {
-      PADDLE_THROW(phi::errors::Fatal("Unknown exception caught."));
+      PADDLE_THROW(common::errors::Fatal("Unknown exception caught."));
     }
   }
 

--- a/paddle/fluid/framework/details/multi_devices_helper.h
+++ b/paddle/fluid/framework/details/multi_devices_helper.h
@@ -106,7 +106,7 @@ inline std::vector<std::string> GetOpRoleVarsOrEmpty(const OpDesc &op) {
   PADDLE_ENFORCE_EQ(
       ret.size() % 2,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of attribute %s must be an even number, but got %d",
           OpProtoAndCheckerMaker::OpRoleVarAttrName(),
           ret.size()));

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cc
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cc
@@ -128,7 +128,7 @@ void InitWhiteListFormEnv() {
     while (std::getline(ss, op_role, ',')) {
       PADDLE_ENFORCE_EQ(role_str2int().find(op_role) != role_str2int().end(),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Skip role must be one of "
                             "{forward,backward,optimize,rpc,dist,lrsched,loss,"
                             "default}, instead of %s",
@@ -145,7 +145,7 @@ void InitWhiteListFormEnv() {
       PADDLE_ENFORCE_EQ(
           pos != std::string::npos,
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Skip var format must be op:var, instead of %s", op_var));
       std::string op = op_var.substr(0, pos);
       std::string var = op_var.substr(pos + 1);
@@ -161,7 +161,7 @@ void CheckVarHasNanOrInf(const std::string& op_type,
                          const phi::Place& place) {
   PADDLE_ENFORCE_NOT_NULL(
       var,
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Cannot find var: `%s` in op `%s`.", var_name, op_type));
 
   const phi::DenseTensor* tensor{nullptr};
@@ -186,7 +186,7 @@ void CheckVarHasNanOrInf(const std::string& op_type,
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     tensor_check<phi::GPUContext>(op_type, var_name, *tensor, place);
 #else
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "phi::DenseTensor[%s] use gpu place. PaddlePaddle must compile "
         "with GPU.",
         var_name));
@@ -216,12 +216,12 @@ void CheckVarHasNanOrInf(const std::string& op_type,
     PADDLE_ENFORCE_NE(
         flag,
         true,
-        phi::errors::Fatal(
+        common::errors::Fatal(
             "Operator %s output phi::DenseTensor %s contains Inf.",
             op_type,
             var_name));
 #else
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "phi::DenseTensor[%s] use xpu place. PaddlePaddle must compile "
         "with XPU.",
         var_name));

--- a/paddle/fluid/framework/details/nccl_op_handle.h
+++ b/paddle/fluid/framework/details/nccl_op_handle.h
@@ -76,15 +76,16 @@ class NCCLOpHandleBase : public OpHandleBase {
     PADDLE_ENFORCE_EQ(
         places_.size(),
         1,
-        phi::errors::Unimplemented(
+        common::errors::Unimplemented(
             "Only supported for single place now, but got %d", places_.size()));
     PADDLE_ENFORCE_EQ(use_hierarchical_allreduce_,
                       0,
-                      phi::errors::Unimplemented(
+                      common::errors::Unimplemented(
                           "Not supported use_hierarchical_allreduce_ now"));
     PADDLE_ENFORCE_NOT_NULL(
         nccl_ctxs_,
-        phi::errors::NotFound("Can't get flat %d nccl contexts.", run_order_));
+        common::errors::NotFound("Can't get flat %d nccl contexts.",
+                                 run_order_));
     auto flat_nccl_ctxs = nccl_ctxs_->GetFlatCtx(run_order_);
     int dev_id = places_[0].device;
     auto& nccl_ctx = flat_nccl_ctxs->at(dev_id);
@@ -96,7 +97,7 @@ class NCCLOpHandleBase : public OpHandleBase {
     PADDLE_ENFORCE_GE(
         run_order,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The argument run_order must be >= 0, but got %d.", run_order));
     run_order_ = run_order;
     use_hierarchical_allreduce_ = use_hierarchical_allreduce;
@@ -120,7 +121,7 @@ class NCCLOpHandleBase : public OpHandleBase {
 
     PADDLE_ENFORCE_EQ(places_.size(),
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "HierarchicalAllReduce can only run "
                           "one proccess with one card mode, but got %d cards.",
                           places_.size()));
@@ -163,7 +164,7 @@ class NCCLOpHandleBase : public OpHandleBase {
     PADDLE_ENFORCE_GE(
         run_order_,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The argument run_order_ must be >= 0, but got %d.", run_order_));
     auto flat_nccl_ctxs = nccl_ctxs_->GetFlatCtx(run_order_);
     int dev_id = place.device;
@@ -188,7 +189,7 @@ class NCCLOpHandleBase : public OpHandleBase {
     PADDLE_ENFORCE_GE(
         run_order_,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The argument run_order_ must be >= 0, but got %d.", run_order_));
     if (!use_hierarchical_allreduce_) {
       FlatNCCLAllReduce(place, sendbuff, recvbuff, count, datatype, op);
@@ -207,7 +208,7 @@ class NCCLOpHandleBase : public OpHandleBase {
     PADDLE_ENFORCE_GE(
         run_order_,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The argument run_order_ must be >= 0, but got %d.", run_order_));
     InterReduce(place, sendbuff, recvbuff, count, datatype, op);
     // When a trainer is not in exter allreduce ring
@@ -260,7 +261,8 @@ class NCCLOpHandleBase : public OpHandleBase {
     auto nccl_ctxs = nccl_ctxs_->GetHierarchicalExterCtx(run_order_);
     PADDLE_ENFORCE_NOT_NULL(
         nccl_ctxs_,
-        phi::errors::NotFound("Can't get exter %d nccl contexts.", run_order_));
+        common::errors::NotFound("Can't get exter %d nccl contexts.",
+                                 run_order_));
     int dev_id = place.device;
     auto& nccl_ctx = nccl_ctxs->at(dev_id);
     auto stream = nccl_ctx.stream();

--- a/paddle/fluid/framework/details/op_handle_base.cc
+++ b/paddle/fluid/framework/details/op_handle_base.cc
@@ -69,7 +69,7 @@ void OpHandleBase::InitCUDA() {
     PADDLE_ENFORCE_EQ(
         dev_ctxes_.size(),
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Operator %s should have only one dev_ctx, but got %d.",
             Name(),
             dev_ctxes_.size()));
@@ -81,7 +81,7 @@ void OpHandleBase::InitCUDA() {
         PADDLE_ENFORCE_EQ(
             phi::is_same_place(place, out_var_handle->place()),
             true,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The place of output(%s) is not consistent with the "
                 "place of current op(%s).",
                 out_var_handle->Name(),
@@ -91,7 +91,7 @@ void OpHandleBase::InitCUDA() {
     }
   }
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "Paddle can't use CUDA device since it's not compiled with CUDA,"
       "Please recompile or reinstall Paddle with GPU support."));
 #endif
@@ -109,7 +109,7 @@ void OpHandleBase::InitXPU() {
   } else {
     PADDLE_ENFORCE_EQ(dev_ctxes_.size(),
                       1UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "%s should have only one dev_ctx.", Name()));
     auto &place = dev_ctxes_.begin()->first;
     int dev_id = place.device;
@@ -120,7 +120,7 @@ void OpHandleBase::InitXPU() {
         PADDLE_ENFORCE_EQ(
             phi::is_same_place(place, out_var_handle->place()),
             true,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The place of output(%s) is not consistent with the "
                 "place of current op(%s).",
                 out_var_handle->Name(),
@@ -129,7 +129,7 @@ void OpHandleBase::InitXPU() {
     }
   }
 #else
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "Paddle can't use XPU device since it's not compiled with XPU,"
       "Please recompile or reinstall Paddle with XPU support."));
 #endif
@@ -144,7 +144,7 @@ void OpHandleBase::Run(DeviceType use_device) {
   PADDLE_ENFORCE_NE(
       use_device,
       p::kCUDA,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Argument use_device should not be kCUDA when Paddle is not "
           "compiled with CUDA."));
 #endif
@@ -156,7 +156,7 @@ void OpHandleBase::Run(DeviceType use_device) {
     PADDLE_ENFORCE_NE(
         use_device,
         p::kXPU,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Argument use_device should not be kXPU when Paddle is not "
             "compiled with XPU."));
 #endif
@@ -174,12 +174,13 @@ void OpHandleBase::Run(DeviceType use_device) {
 void OpHandleBase::RecordWaitEventOnCtx(phi::DeviceContext *waited_ctx) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   PADDLE_ENFORCE_NOT_NULL(
-      waited_ctx, phi::errors::InvalidArgument("Argument waited_ctx is NULL."));
+      waited_ctx,
+      common::errors::InvalidArgument("Argument waited_ctx is NULL."));
   if (phi::is_cpu_place(waited_ctx->GetPlace()) || events_.empty()) {
     for (auto &dev_ctx : dev_ctxes_) {
       PADDLE_ENFORCE_NOT_NULL(
           dev_ctx.second,
-          phi::errors::InvalidArgument("The device context is NULL."));
+          common::errors::InvalidArgument("The device context is NULL."));
       dev_ctx.second->Wait();
     }
   } else {
@@ -232,7 +233,7 @@ void OpHandleBase::WaitInputVarGenerated(const phi::Place &place) {
 #endif
 #else
           PADDLE_THROW(
-              phi::errors::PreconditionNotMet("Not compiled with CUDA."));
+              common::errors::PreconditionNotMet("Not compiled with CUDA."));
 #endif
         }
         // There are nothing to do when the place is CPUPlace.
@@ -309,7 +310,7 @@ void OpHandleBase::SetLocalExecScopes(
     PADDLE_ENFORCE_NE(
         iter,
         scope_map.end(),
-        phi::errors::NotFound("Local scope not found in scope map."));
+        common::errors::NotFound("Local scope not found in scope map."));
     local_exec_scopes_.emplace_back(iter->second);
   }
 }

--- a/paddle/fluid/framework/details/op_registry.h
+++ b/paddle/fluid/framework/details/op_registry.h
@@ -170,7 +170,7 @@ struct OpInfoFiller<T, kOperator> {
   void operator()(const char* op_type, OpInfo* info) const {
     PADDLE_ENFORCE_EQ(info->creator_,
                       nullptr,
-                      phi::errors::AlreadyExists(
+                      common::errors::AlreadyExists(
                           "OpCreator of %s has been registered", op_type));
     info->creator_ = [](const std::string& type,
                         const VariableNameMap& inputs,
@@ -183,13 +183,14 @@ struct OpInfoFiller<T, kOperator> {
       PADDLE_ENFORCE_EQ(
           info->infer_shape_,
           nullptr,
-          phi::errors::AlreadyExists(
+          common::errors::AlreadyExists(
               "Duplicate InferShapeFN of %s has been registered", op_type));
 
       OperatorWithKernel* op = dynamic_cast<OperatorWithKernel*>(info->creator_(
           std::string{}, VariableNameMap{}, VariableNameMap{}, AttributeMap{}));
       PADDLE_ENFORCE_NOT_NULL(
-          op, phi::errors::InvalidArgument("%s should have kernels", op_type));
+          op,
+          common::errors::InvalidArgument("%s should have kernels", op_type));
       info->infer_shape_ = [op](InferShapeContext* ctx) {
         op->InferShape(ctx);
       };
@@ -202,11 +203,11 @@ struct OpInfoFiller<T, kOpProtoAndCheckerMaker> {
   void operator()(const char* op_type, OpInfo* info) const {
     PADDLE_ENFORCE_EQ(info->proto_,
                       nullptr,
-                      phi::errors::AlreadyExists(
+                      common::errors::AlreadyExists(
                           "OpProto of %s has been registered.", op_type));
     PADDLE_ENFORCE_EQ(info->checker_,
                       nullptr,
-                      phi::errors::AlreadyExists(
+                      common::errors::AlreadyExists(
                           "OpAttrChecker of %s has been registered.", op_type));
     info->proto_ = new proto::OpProto;
     info->checker_ = new OpAttrChecker();
@@ -216,7 +217,7 @@ struct OpInfoFiller<T, kOpProtoAndCheckerMaker> {
     PADDLE_ENFORCE_EQ(
         info->proto_->IsInitialized(),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Fail to initialize %s's OpProto, because %s is not initialized.",
             op_type,
             info->proto_->InitializationErrorString()));
@@ -229,8 +230,8 @@ struct OpInfoFiller<T, kGradOpDescMaker> {
     PADDLE_ENFORCE_EQ(
         info->grad_op_maker_,
         nullptr,
-        phi::errors::AlreadyExists("GradOpDescMaker of %s has been registered",
-                                   op_type));
+        common::errors::AlreadyExists(
+            "GradOpDescMaker of %s has been registered", op_type));
 
     info->grad_op_maker_ =
         [](const OpDesc& fwd_op,
@@ -261,7 +262,7 @@ struct OpInfoFiller<T, kGradCompOpDescMaker> {
     PADDLE_ENFORCE_EQ(
         info->grad_comp_op_maker_,
         nullptr,
-        phi::errors::AlreadyExists(
+        common::errors::AlreadyExists(
             "CompositeGradOpMakerBase of %s has been registered", op_type));
 
     info->grad_comp_op_maker_ =
@@ -285,8 +286,8 @@ struct OpInfoFiller<T, kGradOpBaseMaker> {
     PADDLE_ENFORCE_EQ(
         info->dygraph_grad_op_maker_,
         nullptr,
-        phi::errors::AlreadyExists("GradOpBaseMaker of %s has been registered",
-                                   op_type));
+        common::errors::AlreadyExists(
+            "GradOpBaseMaker of %s has been registered", op_type));
 
     info->dygraph_grad_op_maker_ =
         [](const std::string& type,
@@ -308,8 +309,8 @@ struct OpInfoFiller<T, kVarTypeInference> {
     PADDLE_ENFORCE_EQ(
         info->infer_var_type_,
         nullptr,
-        phi::errors::AlreadyExists("VarTypeInference of %s has been registered",
-                                   op_type));
+        common::errors::AlreadyExists(
+            "VarTypeInference of %s has been registered", op_type));
     info->infer_var_type_ = [](InferVarTypeContext* context) {
       T inference;
       inference(context);
@@ -358,7 +359,7 @@ struct OpInfoFiller<T, kInplaceOpInference> {
     PADDLE_ENFORCE_EQ(
         info->infer_inplace_,
         nullptr,
-        phi::errors::AlreadyExists(
+        common::errors::AlreadyExists(
             "InplaceOpInference of %s has been registered", op_type));
     info->infer_inplace_ = [](bool use_cuda) {
       T infer;
@@ -373,7 +374,7 @@ struct OpInfoFiller<T, kNoNeedBufferVarsInference> {
     PADDLE_ENFORCE_EQ(
         info->infer_no_need_buffer_vars_,
         nullptr,
-        phi::errors::AlreadyExists(
+        common::errors::AlreadyExists(
             "NoNeedBufferVarsInference of %s has been registered", op_type));
     info->infer_no_need_buffer_vars_.Reset(std::make_shared<T>());
   }

--- a/paddle/fluid/framework/details/share_tensor_buffer_functor.cc
+++ b/paddle/fluid/framework/details/share_tensor_buffer_functor.cc
@@ -56,7 +56,7 @@ ShareTensorBufferFunctor::ShareTensorBufferFunctor(
       share_dims_and_dtype_(share_dims_and_dtype) {
   PADDLE_ENFORCE_EQ(in_var_infos_.size(),
                     out_var_names_.size(),
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The number of input variables and output variables "
                         "should be equal, but got number of input variables is "
                         "%d and number of output variables is %d.",
@@ -80,11 +80,11 @@ void ShareTensorBufferFunctor::AddReuseVarPair(
     const ir::MemOptVarInfo *in_var_info, const std::string &out_var_name) {
   PADDLE_ENFORCE_NOT_NULL(
       in_var_info,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input variables to be inplaced should not be NULL."));
   PADDLE_ENFORCE_NE(in_var_info->Name(),
                     out_var_name,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The input variable and output variable to be inplaced "
                         "cannot have the same name: %s.",
                         out_var_name));
@@ -95,25 +95,25 @@ void ShareTensorBufferFunctor::AddReuseVarPair(
 void ShareTensorBufferFunctor::CallOnce() {
   PADDLE_ENFORCE(
       in_out_vars_.empty(),
-      phi::errors::InvalidArgument("The input-output variable pairs to be "
-                                   "inplaced should be initialized here."));
+      common::errors::InvalidArgument("The input-output variable pairs to be "
+                                      "inplaced should be initialized here."));
   for (size_t i = 0; i < in_var_infos_.size(); ++i) {
     auto *in_var = exec_scope_->FindVar(in_var_infos_[i]->Name());
     auto *out_var = exec_scope_->FindVar(out_var_names_[i]);
     PADDLE_ENFORCE_NOT_NULL(
         in_var,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "The variable(%s) to be inplaced is not found in scope.",
             in_var_infos_[i]->Name()));
     PADDLE_ENFORCE_NOT_NULL(
         out_var,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "The variable(%s) to be inplaced is not found in scope.",
             out_var_names_[i]));
     PADDLE_ENFORCE_NE(
         in_var,
         out_var,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The input variable and output variable to be inplaced "
             "cannot be the same variable(%s).",
             out_var_names_[i]));
@@ -124,7 +124,7 @@ void ShareTensorBufferFunctor::CallOnce() {
 void ShareTensorBufferFunctor::operator()(Scope *exec_scope) {
   if (!exec_scope_ || is_variant_scope_) {
     PADDLE_ENFORCE_NOT_NULL(exec_scope,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "The given execution scope should not be NULL "
                                 "if the cached scope is NULL."));
     exec_scope_ = exec_scope;
@@ -133,7 +133,7 @@ void ShareTensorBufferFunctor::operator()(Scope *exec_scope) {
   } else {
     PADDLE_ENFORCE_EQ(exec_scope_,
                       exec_scope,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The given execution scope and the cached execution "
                           "scope should be the same."));
   }

--- a/paddle/fluid/framework/details/share_tensor_buffer_functor.h
+++ b/paddle/fluid/framework/details/share_tensor_buffer_functor.h
@@ -44,7 +44,7 @@ static inline const phi::DenseTensor &GetTensorFromVar(const Variable *var) {
   if (var->IsType<phi::DenseTensor>()) {
     return var->Get<phi::DenseTensor>();
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Variable must be type of phi::DenseTensor, but received %s.",
         framework::ToTypeName(var->Type())));
   }
@@ -54,7 +54,7 @@ static inline phi::DenseTensor *GetMutableTensorFromVar(Variable *var) {
   if (var->IsType<phi::DenseTensor>()) {
     return var->GetMutable<phi::DenseTensor>();
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Variable must be type of phi::DenseTensor, but received %s.",
         framework::ToTypeName(var->Type())));
   }

--- a/paddle/fluid/framework/details/share_tensor_buffer_op_handle.cc
+++ b/paddle/fluid/framework/details/share_tensor_buffer_op_handle.cc
@@ -35,7 +35,7 @@ ComputationOpHandle *GetUniquePendingComputationOpHandle(
       auto *compute_op = dynamic_cast<ComputationOpHandle *>(&op);
       PADDLE_ENFORCE_NOT_NULL(
           compute_op,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "The pending OpHandle should be ComputationOpHandle."));
 
       if (result_op == nullptr) {
@@ -44,14 +44,14 @@ ComputationOpHandle *GetUniquePendingComputationOpHandle(
         PADDLE_ENFORCE_EQ(
             result_op,
             compute_op,
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "The pending OpHandle should be the unique one."));
       }
     }
   }
 
   PADDLE_ENFORCE_NOT_NULL(result_op,
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "The pending OpHandle should not be NULL."));
   return result_op;
 }

--- a/paddle/fluid/framework/details/var_handle.h
+++ b/paddle/fluid/framework/details/var_handle.h
@@ -63,7 +63,7 @@ struct VarHandleBase {
   void AddOutput(OpHandleBase* out, ir::Node* node) {
     if (pending_ops_.find(out) == pending_ops_.end()) {
       PADDLE_ENFORCE_NOT_NULL(out,
-                              phi::errors::InvalidArgument(
+                              common::errors::InvalidArgument(
                                   "The output added to VarHandle %s is NULL.",
                                   this->Node()->Name()));
       pending_ops_.insert(out);
@@ -136,7 +136,7 @@ struct VarHandle : public VarHandleBase {
     PADDLE_ENFORCE_EQ(
         HasEvent(),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The cuda event is not set, maybe InitCUDA() is not called."));
     return event_;
   }

--- a/paddle/fluid/framework/dlpack_tensor.cc
+++ b/paddle/fluid/framework/dlpack_tensor.cc
@@ -38,7 +38,7 @@ static ::DLDataType GetDLDataTypeCode() {
   } else if (std::is_integral<T>::value) {
     dtype.code = kDLInt;
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Unsupported data type (%s), only supports float16, float, unsigned "
         "int and int.",
         platform::demangle(typeid(T).name())));
@@ -65,8 +65,8 @@ static DLDataType GetDLDataTypeFromTypeIndex(proto::VarType::Type type) {
   auto it = type_to_dtype_map.find(static_cast<int>(type));
   PADDLE_ENFORCE_NE(it,
                     type_to_dtype_map_end_it,
-                    phi::errors::InvalidArgument("Unsupported data type (%s).",
-                                                 DataTypeToString(type)));
+                    common::errors::InvalidArgument(
+                        "Unsupported data type (%s).", DataTypeToString(type)));
   return it->second;
 #undef REG_DL_DATA_TYPE
 }
@@ -82,16 +82,18 @@ struct DLDeviceVisitor {
   }
 
   inline ::DLDevice operator()(const phi::IPUPlace &place) const {
-    PADDLE_THROW(phi::errors::Unimplemented("phi::IPUPlace is not supported"));
+    PADDLE_THROW(
+        common::errors::Unimplemented("phi::IPUPlace is not supported"));
   }
 
   inline ::DLDevice operator()(const phi::XPUPlace &place) const {
-    PADDLE_THROW(phi::errors::Unimplemented("phi::XPUPlace is not supported"));
+    PADDLE_THROW(
+        common::errors::Unimplemented("phi::XPUPlace is not supported"));
   }
 
   inline ::DLDevice operator()(const phi::CustomPlace &place) const {
     PADDLE_THROW(
-        phi::errors::Unimplemented("phi::CustomPlace is not supported"));
+        common::errors::Unimplemented("phi::CustomPlace is not supported"));
   }
 
   inline ::DLDevice operator()(const phi::GPUPlace &place) const {
@@ -101,7 +103,7 @@ struct DLDeviceVisitor {
     device.device_id = place.device;  // NOLINT
     return device;
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "phi::GPUPlace is not supported in CPU only version."));
 #endif
   }
@@ -113,7 +115,7 @@ struct DLDeviceVisitor {
     device.device_id = 0;
     return device;
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "phi::GPUPinnedPlace is not supported in CPU only version."));
 #endif
   }

--- a/paddle/fluid/framework/downpour_lite_worker.cc
+++ b/paddle/fluid/framework/downpour_lite_worker.cc
@@ -313,11 +313,11 @@ void DownpourLiteWorker::TrainFilesWithProfiler() {
       }
       PADDLE_ENFORCE_EQ(framework::TensorContainsInf(*tensor),
                         false,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "phi::DenseTensor %s contains Inf.", var_name));
       PADDLE_ENFORCE_EQ(framework::TensorContainsNAN(*tensor),
                         false,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "phi::DenseTensor %s contains NAN.", var_name));
     }
 
@@ -534,11 +534,11 @@ void DownpourLiteWorker::TrainFiles() {
       }
       PADDLE_ENFORCE_EQ(framework::TensorContainsInf(*tensor),
                         false,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "phi::DenseTensor %s contains Inf.", var_name));
       PADDLE_ENFORCE_EQ(framework::TensorContainsNAN(*tensor),
                         false,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "phi::DenseTensor %s contains NAN.", var_name));
     }
 

--- a/paddle/fluid/framework/downpour_worker.cc
+++ b/paddle/fluid/framework/downpour_worker.cc
@@ -586,11 +586,11 @@ void DownpourWorker::TrainFilesWithProfiler() {
       }
       PADDLE_ENFORCE_EQ(framework::TensorContainsInf(*tensor),
                         false,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "phi::DenseTensor %s contains Inf.", var_name));
       PADDLE_ENFORCE_EQ(framework::TensorContainsNAN(*tensor),
                         false,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "phi::DenseTensor %s contains NAN.", var_name));
     }
 
@@ -922,11 +922,11 @@ void DownpourWorker::TrainFiles() {
       }
       PADDLE_ENFORCE_EQ(framework::TensorContainsInf(*tensor),
                         false,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "phi::DenseTensor %s contains Inf.", var_name));
       PADDLE_ENFORCE_EQ(framework::TensorContainsNAN(*tensor),
                         false,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "phi::DenseTensor %s contains NAN.", var_name));
     }
 

--- a/paddle/fluid/framework/downpour_worker_opt.cc
+++ b/paddle/fluid/framework/downpour_worker_opt.cc
@@ -437,15 +437,15 @@ void DownpourWorkerOpt::TrainFiles() {
       PADDLE_ENFORCE_EQ(
           framework::TensorContainsInf(*tensor),
           false,
-          phi::errors::InvalidArgument("The target tensor %s contains Inf "
-                                       "should check some layers output.",
-                                       var_name));
+          common::errors::InvalidArgument("The target tensor %s contains Inf "
+                                          "should check some layers output.",
+                                          var_name));
       PADDLE_ENFORCE_EQ(
           framework::TensorContainsNAN(*tensor),
           false,
-          phi::errors::InvalidArgument("The target tensor %s contains Nan "
-                                       "should check some layers output.",
-                                       var_name));
+          common::errors::InvalidArgument("The target tensor %s contains Nan "
+                                          "should check some layers output.",
+                                          var_name));
     }
 
     if (need_to_push_sparse_) {

--- a/paddle/fluid/framework/eigen.h
+++ b/paddle/fluid/framework/eigen.h
@@ -31,7 +31,7 @@ struct EigenDim {
   static Type From(const DDim& dims) {
     PADDLE_ENFORCE_EQ(arity(dims),
                       D,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input dimension size should be equal to %d, but "
                           "received dimension size is %d.",
                           arity(dims),
@@ -83,7 +83,7 @@ struct EigenMatrix : public EigenTensor<T, 2, MajorType, IndexType> {
     int rank = tensor.dims().size();
     PADDLE_ENFORCE_EQ((num_col_dims > 0 && num_col_dims < rank),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input dimension number(num_col_dims) must be "
                           "between 0 and %d, but received number is %d.",
                           rank,
@@ -97,7 +97,7 @@ struct EigenMatrix : public EigenTensor<T, 2, MajorType, IndexType> {
     int rank = tensor.dims().size();
     PADDLE_ENFORCE_EQ((num_col_dims > 0 && num_col_dims < rank),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input dimension number(num_col_dims) must be "
                           "between 0 and %d, but received number is %d.",
                           rank,

--- a/paddle/fluid/framework/executor.cc
+++ b/paddle/fluid/framework/executor.cc
@@ -137,7 +137,7 @@ std::shared_ptr<TrainerBase> Executor::InitForDataset(
   bool success = trainer_desc.ParseFromString(trainer_desc_str);
   PADDLE_ENFORCE_EQ(success,
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Fail to parse TrainerDesc from string:\n%s",
                         trainer_desc_str.c_str()));
   VLOG(3) << "Going to create trainer, trainer class is "
@@ -160,7 +160,7 @@ std::shared_ptr<TrainerBase> Executor::InitForDataset(
 void Executor::RunFromDataset(std::shared_ptr<TrainerBase> trainer) {
   PADDLE_ENFORCE_NOT_NULL(
       trainer,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Trainer is nullptr, invoke InitForDataset first"));
   // training and finalize training
   VLOG(3) << "Trainer starts to run";
@@ -212,14 +212,14 @@ static bool has_feed_operators(
       PADDLE_ENFORCE_EQ(
           op->Input("X")[0],
           feed_holder_name,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "Input to feed op should be '%s', but received '%s'.",
               feed_holder_name,
               op->Input("X")[0]));
       std::string feed_target_name = op->Output("Out")[0];
       PADDLE_ENFORCE_NE(feed_targets.find(feed_target_name),
                         feed_targets.end(),
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "Feed operator output name '%s' cannot be found in "
                             "'feed_targets'",
                             feed_target_name));
@@ -230,7 +230,7 @@ static bool has_feed_operators(
     PADDLE_ENFORCE_EQ(
         feed_count,
         feed_targets.size(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The number of feed operators should match 'feed_targets', but "
             "received feed_count: %zu, required feed_targets.size(): %zu.",
             feed_count,
@@ -241,12 +241,12 @@ static bool has_feed_operators(
       auto var = block.FindVar(feed_holder_name);
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "Block should already have a '%s' variable", feed_holder_name));
       PADDLE_ENFORCE_EQ(
           var->GetType(),
           proto::VarType::FEED_MINIBATCH,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "'%s' variable should be 'FEED_MINIBATCH' type, but received "
               "'%s'.",
               feed_holder_name,
@@ -275,14 +275,14 @@ static bool has_fetch_operators(
       PADDLE_ENFORCE_EQ(
           op->Output("Out")[0],
           fetch_holder_name,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "Output of fetch op should be '%s', but received '%s'.",
               fetch_holder_name,
               op->Output("Out")[0]));
       std::string fetch_target_name = op->Input("X")[0];
       PADDLE_ENFORCE_NE(fetch_targets.find(fetch_target_name),
                         fetch_targets.end(),
-                        phi::errors::NotFound(
+                        common::errors::NotFound(
                             "Fetch operator input name '%s' cannot be found in "
                             "'fetch_targets'.",
                             fetch_target_name));
@@ -293,7 +293,7 @@ static bool has_fetch_operators(
     PADDLE_ENFORCE_EQ(
         fetch_count,
         fetch_targets.size(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The number of fetch operators should match 'fetch_targets', but "
             "received fetch_count: %zu, required fetch_targets.size(): %zu.",
             fetch_count,
@@ -304,12 +304,12 @@ static bool has_fetch_operators(
       auto var = block.FindVar(fetch_holder_name);
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "Block should already have a '%s' variable.", fetch_holder_name));
       PADDLE_ENFORCE_EQ(
           var->GetType(),
           proto::VarType::FETCH_LIST,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "'%s' variable should be 'FETCH_LIST' type, but received '%s'.",
               fetch_holder_name,
               DataTypeToString(var->GetType())));
@@ -413,7 +413,7 @@ std::unique_ptr<ExecutorPrepareContext> Executor::Prepare(
       new ExecutorPrepareContext(program, block_id));
   PADDLE_ENFORCE_LT(static_cast<size_t>(block_id),
                     program.Size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input block id = %d, but it should be less than "
                         "program.size() which is %d",
                         static_cast<size_t>(block_id),
@@ -434,15 +434,15 @@ std::vector<std::shared_ptr<ExecutorPrepareContext>> Executor::Prepare(
   PADDLE_ENFORCE_EQ(
       skip_ref_cnt_vars.empty() || skip_ref_cnt_vars.size() == block_ids.size(),
       true,
-      phi::errors::InvalidArgument("skip_ref_cnt_vars should be either "
-                                   "empty or equals to block number %d",
-                                   block_ids.size()));
+      common::errors::InvalidArgument("skip_ref_cnt_vars should be either "
+                                      "empty or equals to block number %d",
+                                      block_ids.size()));
   std::vector<std::shared_ptr<ExecutorPrepareContext>> result;
   size_t idx = 0;
   for (auto& bid : block_ids) {
     PADDLE_ENFORCE_LT(static_cast<size_t>(bid),
                       program.Size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input block id = %zu, but it should be less than "
                           "program.size() which is %zu",
                           static_cast<size_t>(bid),
@@ -475,7 +475,7 @@ void Executor::RunPartialPreparedContext(ExecutorPrepareContext* ctx,
                                    1);
   platform::RecordBlock b(kProgramId);
   PADDLE_ENFORCE_NOT_NULL(
-      scope, phi::errors::InvalidArgument("Scope shouldn't be null"));
+      scope, common::errors::InvalidArgument("Scope shouldn't be null"));
   Scope* local_scope = scope;
   if (create_vars) {
     if (create_local_scope) {
@@ -562,12 +562,12 @@ void Executor::RunPreparedContext(
   PADDLE_ENFORCE_EQ(
       has_feed_operators(global_block, *feed_targets, feed_holder_name),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Program in ExecutorPrepareContext should has feed_ops."));
   PADDLE_ENFORCE_EQ(
       has_fetch_operators(global_block, *fetch_targets, fetch_holder_name),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Program in the prepared context should has fetch_ops."));
 
   // map the data of feed_targets to feed_holder

--- a/paddle/fluid/framework/executor_cache.cc
+++ b/paddle/fluid/framework/executor_cache.cc
@@ -118,7 +118,7 @@ std::shared_ptr<InterpreterCore> CreateProgramInterpreterCoreInfoToCache(
     const int64_t &place_hash_key) {
   auto &cache = framework::InterpreterCoreInfoCache::Instance();
   if (cache.Size() > 256000u /* max_cached_size*/) {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The cached info size has exceeded max_cached_size: 256000, "
         "which will cause error. "));
   }
@@ -146,7 +146,7 @@ std::shared_ptr<InterpreterCore> CreatePirInterpreterCoreInfoToCache(
     const int64_t &place_hash_key) {
   auto &cache = framework::InterpreterCoreInfoCache::Instance();
   if (cache.Size() > 256000u /* max_cached_size*/) {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "The cached info size has exceeded max_cached_size: 256000, "
         "which will cause error. "));
   }

--- a/paddle/fluid/framework/executor_gc_helper.cc
+++ b/paddle/fluid/framework/executor_gc_helper.cc
@@ -203,7 +203,7 @@ void DeleteUnusedTensors(const Scope &scope,
       lod_tensor_arr->clear();
     } else if (var->IsType<Strings>()) {
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Type %s of variable %s is not supported eager deletion.",
           framework::ToTypeName(var->Type()),
           var_name));
@@ -253,10 +253,10 @@ GetEagerDeletionCleanVarsForPartial(const ProgramDesc &origin_program,
                                     const bool &for_partial_block) {
   ProgramDesc program{origin_program};
   size_t block_num = program.Size();
-  PADDLE_ENFORCE_GE(
-      block_num,
-      1,
-      phi::errors::PermissionDenied("Program should have at least one block"));
+  PADDLE_ENFORCE_GE(block_num,
+                    1,
+                    common::errors::PermissionDenied(
+                        "Program should have at least one block"));
   // Note(zhangbo): For dygraph2static inplace policy, origin_program is a
   // partial program(only include forward or backward), and control flow op's
   // attr skip_eager_deletion_vars has been updated at graph->program before
@@ -309,16 +309,16 @@ GetEagerDeletionCleanVarsForPartial(const ProgramDesc &origin_program,
       for (auto sub_block_id : sub_block_ids) {
         PADDLE_ENFORCE_GE(sub_block_id,
                           0,
-                          phi::errors::PermissionDenied(
+                          common::errors::PermissionDenied(
                               "sub_block id must be non-negative number"));
         PADDLE_ENFORCE_LT(sub_block_id,
                           block_num,
-                          phi::errors::PermissionDenied(
+                          common::errors::PermissionDenied(
                               "sub_block id exceeds max block num"));
         PADDLE_ENFORCE_EQ(
             found_skip_vars[sub_block_id],
             false,
-            phi::errors::PermissionDenied(
+            common::errors::PermissionDenied(
                 "there are 2 ops which refer to the same sub_block %d",
                 sub_block_id));
 

--- a/paddle/fluid/framework/feed_fetch_method.cc
+++ b/paddle/fluid/framework/feed_fetch_method.cc
@@ -34,7 +34,7 @@ void SetVariable(Scope* scope,
                  const std::string& var_name) {
   Variable* target_var = scope->FindVar(var_name);
   if (target_var && !target_var->IsType<phi::DenseTensor>()) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The variable you want to set is not a phi::DenseTensor, but here "
         "you tried to convert its type to phi::DenseTensor."));
   }
@@ -100,19 +100,19 @@ FetchType& GetFetchVariable(const Scope& scope,
   Variable* g_fetch_value = scope.FindVar(var_name);
   PADDLE_ENFORCE_NOT_NULL(
       g_fetch_value,
-      phi::errors::NotFound("Variable %s is not found in scope.", var_name));
-  PADDLE_ENFORCE_EQ(
-      g_fetch_value->IsType<FetchList>(),
-      true,
-      phi::errors::InvalidArgument("Only %s can be invoked by GetFetchVariable",
-                                   typeid(FetchList).name()));
+      common::errors::NotFound("Variable %s is not found in scope.", var_name));
+  PADDLE_ENFORCE_EQ(g_fetch_value->IsType<FetchList>(),
+                    true,
+                    common::errors::InvalidArgument(
+                        "Only %s can be invoked by GetFetchVariable",
+                        typeid(FetchList).name()));
   auto& fetch_outputs = *g_fetch_value->GetMutable<FetchList>();
   auto& tensor = fetch_outputs[index];
   VLOG(3) << "Fetch " << var_name << " with index " << index;
-  PADDLE_ENFORCE_LT(
-      index,
-      fetch_outputs.size(),
-      phi::errors::InvalidArgument("index must less than fetch_outputs size."));
+  PADDLE_ENFORCE_LT(index,
+                    fetch_outputs.size(),
+                    common::errors::InvalidArgument(
+                        "index must less than fetch_outputs size."));
   return tensor;
 }
 
@@ -121,10 +121,10 @@ phi::DenseTensor& GetVariableTensor(const Scope& scope,
   Variable* var = scope.FindVar(var_name);
   PADDLE_ENFORCE_NOT_NULL(
       var,
-      phi::errors::NotFound("Variable %s is not found in scope.", var_name));
+      common::errors::NotFound("Variable %s is not found in scope.", var_name));
   PADDLE_ENFORCE_EQ(var->IsType<phi::DenseTensor>(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Only support DenseTensor in GetVariableTensor now."));
   return *var->GetMutable<phi::DenseTensor>();
 }

--- a/paddle/fluid/framework/fleet/box_wrapper.cc
+++ b/paddle/fluid/framework/fleet/box_wrapper.cc
@@ -65,13 +65,13 @@ void BoxWrapper::CheckEmbedSizeIsValid(int embedx_dim, int expand_embed_dim) {
   PADDLE_ENFORCE_EQ(
       embedx_dim_,
       embedx_dim,
-      phi::errors::InvalidArgument("SetInstance(): invalid embedx_dim. "
-                                   "When embedx_dim = %d, but got %d.",
-                                   embedx_dim_,
-                                   embedx_dim));
+      common::errors::InvalidArgument("SetInstance(): invalid embedx_dim. "
+                                      "When embedx_dim = %d, but got %d.",
+                                      embedx_dim_,
+                                      embedx_dim));
   PADDLE_ENFORCE_EQ(expand_embed_dim_,
                     expand_embed_dim,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "SetInstance(): invalid expand_embed_dim. When "
                         "expand_embed_dim = %d, but got %d.",
                         expand_embed_dim_,
@@ -90,7 +90,7 @@ void BoxWrapper::PullSparse(const phi::Place& place,
     switch (expand_embed_dim) {                                              \
       __VA_ARGS__                                                            \
       default:                                                               \
-        PADDLE_THROW(phi::errors::InvalidArgument(                           \
+        PADDLE_THROW(common::errors::InvalidArgument(                        \
             "Unsupport this expand embedding size [%d]", expand_embed_dim)); \
     }                                                                        \
   } break
@@ -108,7 +108,7 @@ void BoxWrapper::PullSparse(const phi::Place& place,
                 PULLSPARSE_CASE(64););
     EMBEDX_CASE(16, PULLSPARSE_CASE(0););
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupport this embedding size [%d]", hidden_size - 3));
   }
 #undef PULLSPARSE_CASE
@@ -128,7 +128,7 @@ void BoxWrapper::PushSparseGrad(const phi::Place& place,
     switch (expand_embed_dim) {                                              \
       __VA_ARGS__                                                            \
       default:                                                               \
-        PADDLE_THROW(phi::errors::InvalidArgument(                           \
+        PADDLE_THROW(common::errors::InvalidArgument(                        \
             "Unsupport this expand embedding size [%d]", expand_embed_dim)); \
     }                                                                        \
   } break
@@ -151,7 +151,7 @@ void BoxWrapper::PushSparseGrad(const phi::Place& place,
                 PUSHSPARSE_CASE(64););
     EMBEDX_CASE(16, PUSHSPARSE_CASE(0););
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupport this embedding size [%d]", hidden_size - 3));
   }
 #undef PUSHSPARSE_CASE
@@ -198,7 +198,7 @@ void BoxWrapper::FeedPass(int date,
                           const std::vector<uint64_t>& feasign_to_box) const {
   int ret = boxps_ptr_->FeedPass(date, feasign_to_box);
   PADDLE_ENFORCE_EQ(
-      ret, 0, phi::errors::PreconditionNotMet("FeedPass failed in BoxPS."));
+      ret, 0, common::errors::PreconditionNotMet("FeedPass failed in BoxPS."));
 }
 
 void BoxWrapper::BeginFeedPass(int date, boxps::PSAgentBase** agent) const {
@@ -206,19 +206,21 @@ void BoxWrapper::BeginFeedPass(int date, boxps::PSAgentBase** agent) const {
   PADDLE_ENFORCE_EQ(
       ret,
       0,
-      phi::errors::PreconditionNotMet("BeginFeedPass failed in BoxPS."));
+      common::errors::PreconditionNotMet("BeginFeedPass failed in BoxPS."));
 }
 
 void BoxWrapper::EndFeedPass(boxps::PSAgentBase* agent) const {
   int ret = boxps_ptr_->EndFeedPass(agent);
   PADDLE_ENFORCE_EQ(
-      ret, 0, phi::errors::PreconditionNotMet("EndFeedPass failed in BoxPS."));
+      ret,
+      0,
+      common::errors::PreconditionNotMet("EndFeedPass failed in BoxPS."));
 }
 
 void BoxWrapper::BeginPass() const {
   int ret = boxps_ptr_->BeginPass();
   PADDLE_ENFORCE_EQ(
-      ret, 0, phi::errors::PreconditionNotMet("BeginPass failed in BoxPS."));
+      ret, 0, common::errors::PreconditionNotMet("BeginPass failed in BoxPS."));
 }
 
 void BoxWrapper::SetTestMode(bool is_test) const {
@@ -228,7 +230,7 @@ void BoxWrapper::SetTestMode(bool is_test) const {
 void BoxWrapper::EndPass(bool need_save_delta) const {
   int ret = boxps_ptr_->EndPass(need_save_delta);
   PADDLE_ENFORCE_EQ(
-      ret, 0, phi::errors::PreconditionNotMet("EndPass failed in BoxPS."));
+      ret, 0, common::errors::PreconditionNotMet("EndPass failed in BoxPS."));
 }
 
 void BoxWrapper::GetRandomReplace(const std::vector<Record>& pass_data) {

--- a/paddle/fluid/framework/fleet/box_wrapper.cu
+++ b/paddle/fluid/framework/fleet/box_wrapper.cu
@@ -173,7 +173,7 @@ void BoxWrapper::CopyForPull(const phi::Place& place,
     switch (expand_embed_dim) {                                              \
       __VA_ARGS__                                                            \
       default:                                                               \
-        PADDLE_THROW(phi::errors::InvalidArgument(                           \
+        PADDLE_THROW(common::errors::InvalidArgument(                        \
             "Unsupport this expand embedding size [%d]", expand_embed_dim)); \
     }                                                                        \
   } break
@@ -221,7 +221,7 @@ void BoxWrapper::CopyForPull(const phi::Place& place,
                 EXPAND_EMBED_PULL_CASE(64););
     EMBEDX_CASE(16, EXPAND_EMBED_PULL_CASE(0););
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupport this embedding size [%d]", hidden_size - 3));
   }
   cudaStreamSynchronize(stream);
@@ -316,7 +316,7 @@ void BoxWrapper::CopyForPush(const phi::Place& place,
     switch (expand_embed_dim) {                                              \
       __VA_ARGS__                                                            \
       default:                                                               \
-        PADDLE_THROW(phi::errors::InvalidArgument(                           \
+        PADDLE_THROW(common::errors::InvalidArgument(                        \
             "Unsupport this expand embedding size [%d]", expand_embed_dim)); \
     }                                                                        \
   } break
@@ -356,7 +356,7 @@ void BoxWrapper::CopyForPush(const phi::Place& place,
                 EXPAND_EMBED_PUSH_CASE(64););
     EMBEDX_CASE(16, EXPAND_EMBED_PUSH_CASE(0););
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupport this embedding size [%d]", hidden_size - 3));
   }
 

--- a/paddle/fluid/framework/fleet/box_wrapper.h
+++ b/paddle/fluid/framework/fleet/box_wrapper.h
@@ -70,26 +70,26 @@ class BasicAucCalculator {
     PADDLE_ENFORCE_GE(
         pred,
         0.0,
-        phi::errors::PreconditionNotMet("pred should be greater than 0"));
+        common::errors::PreconditionNotMet("pred should be greater than 0"));
     PADDLE_ENFORCE_LE(
         pred,
         1.0,
-        phi::errors::PreconditionNotMet("pred should be lower than 1"));
+        common::errors::PreconditionNotMet("pred should be lower than 1"));
     PADDLE_ENFORCE_EQ(
         label * label,
         label,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "label must be equal to 0 or 1, but its value is: %d", label));
     int pos = std::min(static_cast<int>(pred * _table_size), _table_size - 1);
     PADDLE_ENFORCE_GE(
         pos,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "pos must be equal or greater than 0, but its value is: %d", pos));
     PADDLE_ENFORCE_LT(
         pos,
         _table_size,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "pos must be less than table_size, but its value is: %d", pos));
     std::lock_guard<std::mutex> lock(_table_mutex);
     _local_abserr += fabs(pred - label);
@@ -157,7 +157,7 @@ class AfsStreamFile {
     reader_ = afsfile_->OpenReader(path);
     PADDLE_ENFORCE_NE(reader_,
                       nullptr,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "OpenReader for file[%s] failed.", path));
     return 0;
   }
@@ -185,14 +185,14 @@ class AfsManager {
     int ret = _afshandler->Init(true, (com_logstatus() == 0));
     PADDLE_ENFORCE_EQ(ret,
                       0,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Called AFSAPI Init Interface Failed."));
     // Too high level will hurt the performance
     comlog_set_log_level(4);
     ret = _afshandler->Connect();
     PADDLE_ENFORCE_EQ(ret,
                       0,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Called AFSAPI Connect Interface Failed"));
   }
   virtual ~AfsManager() {
@@ -210,7 +210,7 @@ class AfsManager {
     int ret = read_stream->Open(path.c_str());
     PADDLE_ENFORCE_EQ(ret,
                       0,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Called AFSAPI Open file %s Failed.", path.c_str()));
     char* _buff = static_cast<char*>(calloc(BUF_SIZE + 2, sizeof(char)));
     int size = 0;
@@ -235,26 +235,26 @@ class AfsManager {
       PADDLE_ENFORCE_EQ(
           pipe(fd_read),
           0,
-          phi::errors::External("Create read pipe failed in AfsManager."));
+          common::errors::External("Create read pipe failed in AfsManager."));
     }
     if (write) {
       PADDLE_ENFORCE_EQ(
           pipe(fd_write),
           0,
-          phi::errors::External("Create write pipe failed in AfsManager."));
+          common::errors::External("Create write pipe failed in AfsManager."));
     }
     pid = vfork();
     PADDLE_ENFORCE_GE(
         pid,
         0,
-        phi::errors::External(
+        common::errors::External(
             "Failed to create a child process via fork in AfsManager."));
     if (pid == 0) {
       if (read) {
         PADDLE_ENFORCE_NE(
             dup2(fd_read[1], STDOUT_FILENO),
             -1,
-            phi::errors::External(
+            common::errors::External(
                 "Failed to duplicate file descriptor via dup2 in AfsManager."));
         close(fd_read[1]);
         close(fd_read[0]);
@@ -264,7 +264,7 @@ class AfsManager {
         PADDLE_ENFORCE_NE(
             dup2(fd_write[0], STDIN_FILENO),
             -1,
-            phi::errors::External(
+            common::errors::External(
                 "Failed to duplicate file descriptor via dup2 in AfsManager."));
         close(fd_write[0]);
         close(fd_write[1]);
@@ -291,7 +291,7 @@ class AfsManager {
         PADDLE_ENFORCE_NE(
             fp_read,
             nullptr,
-            phi::errors::External(
+            common::errors::External(
                 "Failed to open file descriptor via fdopen in AfsManager."));
       }
 
@@ -302,7 +302,7 @@ class AfsManager {
         PADDLE_ENFORCE_NE(
             fp_write,
             nullptr,
-            phi::errors::External(
+            common::errors::External(
                 "Failed to open file descriptor via fdopen in AfsManager."));
       }
       return 0;
@@ -321,7 +321,7 @@ class AfsManager {
 
     PADDLE_ENFORCE_EQ(ret,
                       0,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Called PopenBidirectionalInternal Failed"));
     std::string filename(path);
     if (strncmp(filename.c_str(), "afs:", 4) == 0) {
@@ -475,7 +475,7 @@ class BoxWrapper {
     PADDLE_ENFORCE_EQ(
         date.length(),
         8,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "date[%s] is invalid, correct example is 20190817", date.c_str()));
     int year = std::stoi(date.substr(0, 4));
     int month = std::stoi(date.substr(4, 2));
@@ -492,7 +492,9 @@ class BoxWrapper {
     int ret = boxps_ptr_->SaveBase(
         batch_model_path, xbox_model_path, ret_str, seconds_from_1970 / 86400);
     PADDLE_ENFORCE_EQ(
-        ret, 0, phi::errors::PreconditionNotMet("SaveBase failed in BoxPS."));
+        ret,
+        0,
+        common::errors::PreconditionNotMet("SaveBase failed in BoxPS."));
     return ret_str;
   }
 
@@ -501,7 +503,9 @@ class BoxWrapper {
     std::string ret_str;
     int ret = boxps_ptr_->SaveDelta(xbox_model_path, ret_str);
     PADDLE_ENFORCE_EQ(
-        ret, 0, phi::errors::PreconditionNotMet("SaveDelta failed in BoxPS."));
+        ret,
+        0,
+        common::errors::PreconditionNotMet("SaveDelta failed in BoxPS."));
     return ret_str;
   }
 
@@ -509,7 +513,7 @@ class BoxWrapper {
     PADDLE_ENFORCE_EQ(
         s_instance_ == nullptr,
         false,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "GetInstance failed in BoxPs, you should use SetInstance firstly"));
     return s_instance_;
   }
@@ -582,8 +586,8 @@ class BoxWrapper {
       auto* var = exe_scope->FindVar(varname.c_str());
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::NotFound("Error: var %s is not found in scope.",
-                                varname.c_str()));
+          common::errors::NotFound("Error: var %s is not found in scope.",
+                                   varname.c_str()));
       auto& gpu_tensor = var->Get<phi::DenseTensor>();
       auto* gpu_data = gpu_tensor.data<T>();
       auto len = gpu_tensor.numel();
@@ -627,8 +631,8 @@ class BoxWrapper {
         PADDLE_ENFORCE_EQ(
             cur_cmatch_rank.size(),
             2,
-            phi::errors::PreconditionNotMet("illegal multitask auc spec: %s",
-                                            cmatch_rank.c_str()));
+            common::errors::PreconditionNotMet("illegal multitask auc spec: %s",
+                                               cmatch_rank.c_str()));
         cmatch_rank_v.emplace_back(atoi(cur_cmatch_rank[0].c_str()),
                                    atoi(cur_cmatch_rank[1].c_str()));
       }
@@ -637,7 +641,7 @@ class BoxWrapper {
       }
       PADDLE_ENFORCE_EQ(cmatch_rank_v.size(),
                         pred_v.size(),
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "cmatch_rank's size [%lu] should be equal to pred "
                             "list's size [%lu], but ther are not equal",
                             cmatch_rank_v.size(),
@@ -653,7 +657,7 @@ class BoxWrapper {
       PADDLE_ENFORCE_EQ(
           batch_size,
           label_data.size(),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "illegal batch size: batch_size[%lu] and label_data[%lu]",
               batch_size,
               label_data.size()));
@@ -666,7 +670,7 @@ class BoxWrapper {
         PADDLE_ENFORCE_EQ(
             batch_size,
             pred_data_list[i].size(),
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "illegal batch size: batch_size[%lu] and pred_data[%lu]",
                 batch_size,
                 pred_data_list[i].size()));
@@ -715,8 +719,8 @@ class BoxWrapper {
         PADDLE_ENFORCE_EQ(
             cur_cmatch_rank.size(),
             2,
-            phi::errors::PreconditionNotMet("illegal cmatch_rank auc spec: %s",
-                                            cmatch_rank.c_str()));
+            common::errors::PreconditionNotMet(
+                "illegal cmatch_rank auc spec: %s", cmatch_rank.c_str()));
         cmatch_rank_v.emplace_back(atoi(cur_cmatch_rank[0].c_str()),
                                    atoi(cur_cmatch_rank[1].c_str()));
       }
@@ -733,14 +737,14 @@ class BoxWrapper {
       PADDLE_ENFORCE_EQ(
           batch_size,
           label_data.size(),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "illegal batch size: cmatch_rank[%lu] and label_data[%lu]",
               batch_size,
               label_data.size()));
       PADDLE_ENFORCE_EQ(
           batch_size,
           pred_data.size(),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "illegal batch size: cmatch_rank[%lu] and pred_data[%lu]",
               batch_size,
               pred_data.size()));
@@ -813,7 +817,7 @@ class BoxWrapper {
         PADDLE_ENFORCE_NE(
             iter,
             metric_lists_.end(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The metric name you provided is not registered."));
 
         if (iter->second->MetricPhase() == metric_phase) {
@@ -872,7 +876,7 @@ class BoxWrapper {
                                               mask_varname,
                                               bucket_size));
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "PaddleBox only support AucCalculator, MultiTaskAucCalculator "
           "CmatchRankAucCalculator and MaskAucCalculator"));
     }
@@ -883,7 +887,7 @@ class BoxWrapper {
     const auto iter = metric_lists_.find(name);
     PADDLE_ENFORCE_NE(iter,
                       metric_lists_.end(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The metric name you provided is not registered."));
     std::vector<float> metric_return_values_(8, 0.0);
     auto* auc_cal_ = iter->second->GetCalculator();
@@ -1028,10 +1032,10 @@ class BoxHelper {
   void SlotsShuffle(const std::set<std::string>& slots_to_replace) {
 #ifdef PADDLE_WITH_BOX_PS
     auto box_ptr = BoxWrapper::GetInstance();
-    PADDLE_ENFORCE_EQ(
-        box_ptr->Mode(),
-        1,
-        phi::errors::PreconditionNotMet("Should call InitForAucRunner first."));
+    PADDLE_ENFORCE_EQ(box_ptr->Mode(),
+                      1,
+                      common::errors::PreconditionNotMet(
+                          "Should call InitForAucRunner first."));
     box_ptr->FlipPhase();
 
     std::unordered_set<uint16_t> index_slots;
@@ -1099,7 +1103,7 @@ class BoxHelper {
     const auto& all_readers = dataset_->GetReaders();
     PADDLE_ENFORCE_GT(all_readers.size(),
                       0,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Readers number must be greater than 0."));
     const auto& all_slots_name = all_readers[0]->GetAllSlotAlias();
     for (size_t i = 0; i < all_slots_name.size(); ++i) {

--- a/paddle/fluid/framework/fleet/box_wrapper_impl.h
+++ b/paddle/fluid/framework/fleet/box_wrapper_impl.h
@@ -41,7 +41,7 @@ void BoxWrapper::PullSparseCase(const phi::Place& place,
           buf->ptr());
 
   if (phi::is_cpu_place(place)) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Warning:: CPUPlace is not supported in PaddleBox now."));
   } else if (phi::is_gpu_place(place)) {
 #if (defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)) && !defined(_WIN32)
@@ -96,7 +96,7 @@ void BoxWrapper::PullSparseCase(const phi::Place& place,
     PADDLE_ENFORCE_EQ(
         ret,
         0,
-        phi::errors::PreconditionNotMet("PullSparseGPU failed in BoxPS."));
+        common::errors::PreconditionNotMet("PullSparseGPU failed in BoxPS."));
     pull_boxps_timer.Pause();
 
     VLOG(3) << "Begin Copy result to tensor, total_length[" << total_length
@@ -111,12 +111,12 @@ void BoxWrapper::PullSparseCase(const phi::Place& place,
                       expand_embed_dim,
                       total_length);
 #else
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "Please compile WITH_GPU option, because NCCL doesn't support "
         "windows."));
 #endif
   } else {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "PaddleBox: PullSparse Only Support CPUPlace or CUDAPlace Now."));
   }
   all_timer.Pause();
@@ -150,7 +150,7 @@ void BoxWrapper::PushSparseGradCase(
           boxps::FeaturePushValueGpu<EMBEDX_DIM, EXPAND_EMBED_DIM>*>(
           buf->ptr());
   if (phi::is_cpu_place(place)) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Warning:: CPUPlace is not supported in PaddleBox now."));
   } else if (phi::is_gpu_place(place)) {
 #if (defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)) && !defined(_WIN32)
@@ -178,15 +178,15 @@ void BoxWrapper::PushSparseGradCase(
     PADDLE_ENFORCE_EQ(
         ret,
         0,
-        phi::errors::PreconditionNotMet("PushSparseGPU failed in BoxPS."));
+        common::errors::PreconditionNotMet("PushSparseGPU failed in BoxPS."));
     push_boxps_timer.Pause();
 #else
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "Please compile WITH_GPU option, because NCCL doesn't support "
         "windows."));
 #endif
   } else {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "PaddleBox: PushSparseGrad Only Support CPUPlace or CUDAPlace Now."));
   }
   all_timer.Pause();

--- a/paddle/fluid/framework/fleet/fleet_wrapper.cc
+++ b/paddle/fluid/framework/fleet/fleet_wrapper.cc
@@ -1001,12 +1001,12 @@ void FleetWrapper::PushSparseVarsWithLabelAsync(
       try {
         slot = std::stoi(sparse_key_names[i]);
       } catch (std::invalid_argument const& e) {
-        PADDLE_THROW(phi::errors::PreconditionNotMet(
+        PADDLE_THROW(common::errors::PreconditionNotMet(
             "sparse var's name: %s, doesn't support non-integer type name when "
             "dump_slot=True",
             sparse_key_names[i]));
       } catch (std::out_of_range const& e) {
-        PADDLE_THROW(phi::errors::PreconditionNotMet(
+        PADDLE_THROW(common::errors::PreconditionNotMet(
             "sparse var's name: %s, integer type name out of range when "
             "dump_slot=True",
             sparse_key_names[i]));
@@ -1654,7 +1654,7 @@ void FleetWrapper::ShrinkDenseTable(int table_id,
   push_status.wait();
   auto status = push_status.get();
   if (status != 0) {
-    // PADDLE_THORW(phi::errors::Fatal(
+    // PADDLE_THORW(common::errors::Fatal(
     //    "push shrink dense param failed, status is [%d].", status));
     sleep(sleep_seconds_before_fail_exit_);
     exit(-1);

--- a/paddle/fluid/framework/fleet/gloo_wrapper.cc
+++ b/paddle/fluid/framework/fleet/gloo_wrapper.cc
@@ -63,7 +63,7 @@ void HdfsStore::set(const std::string& key, const std::vector<char>& data) {
       paddle::framework::fs_remove(tmp);
       if (i == retry_times_) {
         VLOG(0) << "fs_open_write failed, retry times reaches limit";
-        PADDLE_THROW(phi::errors::PreconditionNotMet(
+        PADDLE_THROW(common::errors::PreconditionNotMet(
             "fs_open_write failed, retry times reaches %d limit.",
             retry_times_));
       }
@@ -79,7 +79,7 @@ void HdfsStore::set(const std::string& key, const std::vector<char>& data) {
     auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
         std::chrono::steady_clock::now() - start);
     if (wait_timeout_ != gloo::kNoTimeout && elapsed > wait_timeout_) {
-      PADDLE_THROW(phi::errors::ExecutionTimeout(
+      PADDLE_THROW(common::errors::ExecutionTimeout(
           "fs_mv failed, tmp: %s, path: %s", tmp, path));
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(wait_sleep_ms_));
@@ -117,7 +117,7 @@ std::vector<char> HdfsStore::get(const std::string& key) {
   PADDLE_ENFORCE_EQ(
       is_exists,
       true,
-      phi::errors::NotFound("HdfsStore::get, path not exists: " + path));
+      common::errors::NotFound("HdfsStore::get, path not exists: " + path));
 
   int read_status = retry_do_func(
       [&path, &result]() {
@@ -141,7 +141,7 @@ std::vector<char> HdfsStore::get(const std::string& key) {
   PADDLE_ENFORCE_EQ(
       read_status,
       0,
-      phi::errors::Fatal("HdfsStore::get, path read failed: " + path));
+      common::errors::Fatal("HdfsStore::get, path read failed: " + path));
 #endif
   return result;
 }
@@ -169,10 +169,10 @@ void HdfsStore::wait(const std::vector<std::string>& keys,
           break;
         }
       }
-      PADDLE_THROW(
-          phi::errors::ExecutionTimeout("TIMEOUT self_rank = %d pair_rank = %d",
-                                        self_rank_,
-                                        last_check_rank));
+      PADDLE_THROW(common::errors::ExecutionTimeout(
+          "TIMEOUT self_rank = %d pair_rank = %d",
+          self_rank_,
+          last_check_rank));
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(wait_sleep_ms_));
   }

--- a/paddle/fluid/framework/fleet/gloo_wrapper.h
+++ b/paddle/fluid/framework/fleet/gloo_wrapper.h
@@ -238,7 +238,7 @@ class GlooWrapper {
       PADDLE_ENFORCE_EQ(
           0,
           1,
-          phi::errors::InvalidArgument("AllReduce mode not known: " + mode));
+          common::errors::InvalidArgument("AllReduce mode not known: " + mode));
     }
     gloo::allreduce(opts);
 #else

--- a/paddle/fluid/framework/fleet/heter_ps/gpu_graph_node.h
+++ b/paddle/fluid/framework/fleet/heter_ps/gpu_graph_node.h
@@ -505,7 +505,7 @@ struct GpuPsCommGraphFea {
     PADDLE_ENFORCE_LE(
         slot_num,
         255,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The number of slot_num should not be greater than 255 "
             ", but the slot_num is %d ",
             slot_num));
@@ -583,7 +583,7 @@ struct GpuPsCommGraphFloatFea {
     PADDLE_ENFORCE_LE(
         slot_num,
         255,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The number of slot_num should not be greater than 255 "
             ", but the slot_num is %d ",
             slot_num));

--- a/paddle/fluid/framework/fleet/heter_ps/gpu_graph_utils.h
+++ b/paddle/fluid/framework/fleet/heter_ps/gpu_graph_utils.h
@@ -92,8 +92,9 @@ inline void debug_gpu_memory_info(int gpu_id, const char* desc) {
   size_t total{0};
   cudaSetDevice(gpu_id);
   auto err = cudaMemGetInfo(&avail, &total);
-  PADDLE_ENFORCE_EQ(
-      err, cudaSuccess, phi::errors::InvalidArgument("cudaMemGetInfo failed!"));
+  PADDLE_ENFORCE_EQ(err,
+                    cudaSuccess,
+                    common::errors::InvalidArgument("cudaMemGetInfo failed!"));
   VLOG(0) << "update gpu memory on device " << gpu_id << ", "
           << "avail=" << avail / 1024.0 / 1024.0 / 1024.0 << "g, "
           << "total=" << total / 1024.0 / 1024.0 / 1024.0 << "g, "
@@ -110,18 +111,20 @@ inline void debug_gpu_memory_info(const char* desc) {
 
   int device_num = 0;
   auto err = cudaGetDeviceCount(&device_num);
-  PADDLE_ENFORCE_EQ(err,
-                    cudaSuccess,
-                    phi::errors::InvalidArgument("cudaGetDeviceCount failed!"));
+  PADDLE_ENFORCE_EQ(
+      err,
+      cudaSuccess,
+      common::errors::InvalidArgument("cudaGetDeviceCount failed!"));
 
   size_t avail{0};
   size_t total{0};
   for (int i = 0; i < device_num; ++i) {
     cudaSetDevice(i);
     auto err = cudaMemGetInfo(&avail, &total);
-    PADDLE_ENFORCE_EQ(err,
-                      cudaSuccess,
-                      phi::errors::InvalidArgument("cudaMemGetInfo failed!"));
+    PADDLE_ENFORCE_EQ(
+        err,
+        cudaSuccess,
+        common::errors::InvalidArgument("cudaMemGetInfo failed!"));
     VLOG(0) << "update gpu memory on device " << i << ", "
             << "avail=" << avail / 1024.0 / 1024.0 / 1024.0 << "g, "
             << "total=" << total / 1024.0 / 1024.0 / 1024.0 << "g, "
@@ -136,18 +139,20 @@ inline void show_gpu_mem(const char* desc) {
 
   int device_num = 0;
   auto err = cudaGetDeviceCount(&device_num);
-  PADDLE_ENFORCE_EQ(err,
-                    cudaSuccess,
-                    phi::errors::InvalidArgument("cudaGetDeviceCount failed!"));
+  PADDLE_ENFORCE_EQ(
+      err,
+      cudaSuccess,
+      common::errors::InvalidArgument("cudaGetDeviceCount failed!"));
 
   size_t avail{0};
   size_t total{0};
   for (int i = 0; i < device_num; ++i) {
     cudaSetDevice(i);
     auto err = cudaMemGetInfo(&avail, &total);
-    PADDLE_ENFORCE_EQ(err,
-                      cudaSuccess,
-                      phi::errors::InvalidArgument("cudaMemGetInfo failed!"));
+    PADDLE_ENFORCE_EQ(
+        err,
+        cudaSuccess,
+        common::errors::InvalidArgument("cudaMemGetInfo failed!"));
     VLOG(0) << "[" << desc << "] hbm on device " << i << ", "
             << "avail=" << avail / 1024.0 / 1024.0 / 1024.0 << "g, "
             << "total=" << total / 1024.0 / 1024.0 / 1024.0 << "g";

--- a/paddle/fluid/framework/fleet/heter_ps/graph_gpu_ps_table_inl.cu
+++ b/paddle/fluid/framework/fleet/heter_ps/graph_gpu_ps_table_inl.cu
@@ -1888,7 +1888,7 @@ void GpuPsGraphTable::build_graph_on_single_gpu(const GpuPsCommGraph& g,
     }
     PADDLE_ENFORCE_EQ(cudaStatus,
                       cudaSuccess,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "failed to allocate memory for graph on gpu %d",
                           resource_->dev_id(gpu_id)));
     VLOG(0) << "successfully allocate " << g.neighbor_size * sizeof(uint64_t)
@@ -1907,7 +1907,7 @@ void GpuPsGraphTable::build_graph_on_single_gpu(const GpuPsCommGraph& g,
       PADDLE_ENFORCE_EQ(
           cudaStatus,
           cudaSuccess,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "failed to allocate memory for graph edge weight on gpu %d",
               resource_->dev_id(gpu_id)));
       VLOG(0) << "successfully allocate " << g.neighbor_size * sizeof(float)
@@ -1938,8 +1938,8 @@ void GpuPsGraphTable::build_graph_from_cpu(
   PADDLE_ENFORCE_EQ(
       cpu_graph_list.size(),
       resource_->total_device(),
-      phi::errors::InvalidArgument("the cpu node list size doesn't match "
-                                   "the number of gpu on your machine."));
+      common::errors::InvalidArgument("the cpu node list size doesn't match "
+                                      "the number of gpu on your machine."));
   clear_graph_info(edge_idx);
   for (int i = 0; i < cpu_graph_list.size(); i++) {
     int table_offset =
@@ -2367,7 +2367,7 @@ NeighborSampleResult GpuPsGraphTable::graph_neighbor_sample_v2(
 
       PADDLE_ENFORCE_GT(sample_size,
                         0,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "sample_size should be greater than 0."));
       weighted_sample(graph,
                       node_info_list,
@@ -2931,10 +2931,10 @@ NeighborSampleResultV2 GpuPsGraphTable::graph_neighbor_sample_all_edge_type(
     thread_local std::mt19937 gen(rd());
     thread_local std::uniform_int_distribution<uint64_t> distrib;
     uint64_t random_seed = distrib(gen);
-    PADDLE_ENFORCE_GT(
-        sample_size,
-        0,
-        phi::errors::InvalidArgument("sample_size should be greater than 0."));
+    PADDLE_ENFORCE_GT(sample_size,
+                      0,
+                      common::errors::InvalidArgument(
+                          "sample_size should be greater than 0."));
 
     if (!weighted) {
       /*int grid_size_ = (shard_len * edge_type_len - 1) / block_size_ + 1;

--- a/paddle/fluid/framework/fleet/heter_ps/heter_comm_inl.h
+++ b/paddle/fluid/framework/fleet/heter_ps/heter_comm_inl.h
@@ -273,7 +273,7 @@ void HeterComm<KeyType, ValType, GradType, GPUAccessor>::reset_table(
   PADDLE_ENFORCE_LT(
       dev_id,
       device_num_,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "dev id %d more than device num %d", dev_id, device_num_));
 #if defined(PADDLE_WITH_CUDA)
   platform::CUDADeviceGuard guard(resource_->dev_id(dev_id));
@@ -1515,16 +1515,16 @@ void HeterComm<KeyType, ValType, GradType, GPUAccessor>::pull_merge_sparse(
   PADDLE_ENFORCE_EQ(
       r,
       XPU_SUCCESS,
-      phi::errors::External("XPU constant kernel return wrong value[%d %s]",
-                            r,
-                            XPUAPIErrorMsg[r]));
+      common::errors::External("XPU constant kernel return wrong value[%d %s]",
+                               r,
+                               XPUAPIErrorMsg[r]));
   int r2 = xpu::constant<int>(xpu_context, d_right_ptr, total_device, -1);
   PADDLE_ENFORCE_EQ(
       r2,
       XPU_SUCCESS,
-      phi::errors::External("XPU constant kernel return wrong value[%d %s]",
-                            r2,
-                            XPUAPIErrorMsg[r2]));
+      common::errors::External("XPU constant kernel return wrong value[%d %s]",
+                               r2,
+                               XPUAPIErrorMsg[r2]));
 #endif
 
   auto accessor_wrapper_ptr =
@@ -1695,16 +1695,16 @@ void HeterComm<KeyType, ValType, GradType, GPUAccessor>::pull_normal_sparse(
   PADDLE_ENFORCE_EQ(
       r,
       XPU_SUCCESS,
-      phi::errors::External("XPU constant kernel return wrong value[%d %s]",
-                            r,
-                            XPUAPIErrorMsg[r]));
+      common::errors::External("XPU constant kernel return wrong value[%d %s]",
+                               r,
+                               XPUAPIErrorMsg[r]));
   int r2 = xpu::constant<int>(xpu_context, d_right_ptr, total_device, -1);
   PADDLE_ENFORCE_EQ(
       r2,
       XPU_SUCCESS,
-      phi::errors::External("XPU constant kernel return wrong value[%d %s]",
-                            r2,
-                            XPUAPIErrorMsg[r2]));
+      common::errors::External("XPU constant kernel return wrong value[%d %s]",
+                               r2,
+                               XPUAPIErrorMsg[r2]));
 #endif
 
   auto d_idx = MemoryAlloc(place, len * sizeof(int));
@@ -1898,16 +1898,16 @@ void HeterComm<KeyType, ValType, GradType, GPUAccessor>::push_normal_sparse(
   PADDLE_ENFORCE_EQ(
       r,
       XPU_SUCCESS,
-      phi::errors::External("XPU constant kernel return wrong value[%d %s]",
-                            r,
-                            XPUAPIErrorMsg[r]));
+      common::errors::External("XPU constant kernel return wrong value[%d %s]",
+                               r,
+                               XPUAPIErrorMsg[r]));
   int r2 = xpu::constant<int>(xpu_context, d_right_ptr, total_device, -1);
   PADDLE_ENFORCE_EQ(
       r2,
       XPU_SUCCESS,
-      phi::errors::External("XPU constant kernel return wrong value[%d %s]",
-                            r2,
-                            XPUAPIErrorMsg[r2]));
+      common::errors::External("XPU constant kernel return wrong value[%d %s]",
+                               r2,
+                               XPUAPIErrorMsg[r2]));
 #endif
 
   auto d_idx = MemoryAlloc(place, len * sizeof(int));
@@ -2073,16 +2073,16 @@ void HeterComm<KeyType, ValType, GradType, GPUAccessor>::push_sparse(
   PADDLE_ENFORCE_EQ(
       r,
       XPU_SUCCESS,
-      phi::errors::External("XPU constant kernel return wrong value[%d %s]",
-                            r,
-                            XPUAPIErrorMsg[r]));
+      common::errors::External("XPU constant kernel return wrong value[%d %s]",
+                               r,
+                               XPUAPIErrorMsg[r]));
   int r2 = xpu::constant<int>(xpu_context, d_right_ptr, total_device, -1);
   PADDLE_ENFORCE_EQ(
       r2,
       XPU_SUCCESS,
-      phi::errors::External("XPU constant kernel return wrong value[%d %s]",
-                            r2,
-                            XPUAPIErrorMsg[r2]));
+      common::errors::External("XPU constant kernel return wrong value[%d %s]",
+                               r2,
+                               XPUAPIErrorMsg[r2]));
 #endif
 
   auto d_idx = MemoryAlloc(place, len * sizeof(int));

--- a/paddle/fluid/framework/fleet/heter_wrapper.cc
+++ b/paddle/fluid/framework/fleet/heter_wrapper.cc
@@ -243,8 +243,8 @@ framework::proto::VarType::Type HeterWrapper::ToVarType(
     case VariableMessage::BOOL:
       return framework::proto::VarType::BOOL;  // NOLINT
     default:
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("ToVarType:Unsupported type %d", type));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "ToVarType:Unsupported type %d", type));
   }
 }
 

--- a/paddle/fluid/framework/fleet/metrics.cc
+++ b/paddle/fluid/framework/fleet/metrics.cc
@@ -68,26 +68,26 @@ void BasicAucCalculator::add_unlock_data(double pred, int label) {
   PADDLE_ENFORCE_GE(
       pred,
       0.0,
-      phi::errors::PreconditionNotMet("pred should be greater than 0"));
+      common::errors::PreconditionNotMet("pred should be greater than 0"));
   PADDLE_ENFORCE_LE(
       pred,
       1.0,
-      phi::errors::PreconditionNotMet("pred should be lower than 1"));
+      common::errors::PreconditionNotMet("pred should be lower than 1"));
   PADDLE_ENFORCE_EQ(
       label * label,
       label,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "label must be equal to 0 or 1, but its value is: %d", label));
   int pos = std::min(static_cast<int>(pred * _table_size), _table_size - 1);
   PADDLE_ENFORCE_GE(
       pos,
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "pos must be equal or greater than 0, but its value is: %d", pos));
   PADDLE_ENFORCE_LT(
       pos,
       _table_size,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "pos must be less than table_size, but its value is: %d", pos));
   _local_abserr += fabs(pred - label);
   _local_sqrerr += (pred - label) * (pred - label);
@@ -287,15 +287,15 @@ void BasicAucCalculator::add_uid_unlock_data(double pred,
   PADDLE_ENFORCE_GE(
       pred,
       0.0,
-      phi::errors::PreconditionNotMet("pred should be greater than 0"));
+      common::errors::PreconditionNotMet("pred should be greater than 0"));
   PADDLE_ENFORCE_LE(
       pred,
       1.0,
-      phi::errors::PreconditionNotMet("pred should be lower than 1"));
+      common::errors::PreconditionNotMet("pred should be lower than 1"));
   PADDLE_ENFORCE_EQ(
       label * label,
       label,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "label must be equal to 0 or 1, but its value is: %d", label));
 
   WuaucRecord record = {0, 0, 0};

--- a/paddle/fluid/framework/fleet/metrics.h
+++ b/paddle/fluid/framework/fleet/metrics.h
@@ -165,7 +165,7 @@ class Metric {
       get_data<float>(exe_scope, pred_varname_, &pred_data, &pred_len);
       PADDLE_ENFORCE_EQ(label_len,
                         pred_len,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "the predict data length should be consistent with "
                             "the label data length"));
       calculator->add_data(pred_data, label_data, label_len, place);
@@ -180,8 +180,8 @@ class Metric {
       auto* var = exe_scope->FindVar(varname.c_str());
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::NotFound("Error: var %s is not found in scope.",
-                                varname.c_str()));
+          common::errors::NotFound("Error: var %s is not found in scope.",
+                                   varname.c_str()));
       auto& cpu_tensor = var->Get<phi::DenseTensor>();
       *data = cpu_tensor.data<T>();
       *len = cpu_tensor.numel();
@@ -194,8 +194,8 @@ class Metric {
       auto* var = exe_scope->FindVar(varname.c_str());
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::NotFound("Error: var %s is not found in scope.",
-                                varname.c_str()));
+          common::errors::NotFound("Error: var %s is not found in scope.",
+                                   varname.c_str()));
       auto& cpu_tensor = var->Get<phi::DenseTensor>();
       auto* cpu_data = cpu_tensor.data<T>();
       auto len = cpu_tensor.numel();
@@ -247,7 +247,7 @@ class Metric {
       get_data<int64_t>(exe_scope, uid_varname_, &uid_data, &uid_len);
       PADDLE_ENFORCE_EQ(label_len,
                         uid_len,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "the predict data length should be consistent with "
                             "the label data length"));
       auto cal = GetCalculator();
@@ -277,8 +277,8 @@ class Metric {
         PADDLE_ENFORCE_EQ(
             cur_cmatch_rank.size(),
             2,
-            phi::errors::PreconditionNotMet("illegal multitask auc spec: %s",
-                                            cmatch_rank.c_str()));
+            common::errors::PreconditionNotMet("illegal multitask auc spec: %s",
+                                               cmatch_rank.c_str()));
         cmatch_rank_v.emplace_back(atoi(cur_cmatch_rank[0].c_str()),
                                    atoi(cur_cmatch_rank[1].c_str()));
       }
@@ -287,7 +287,7 @@ class Metric {
       }
       PADDLE_ENFORCE_EQ(cmatch_rank_v.size(),
                         pred_v.size(),
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "cmatch_rank's size [%lu] should be equal to pred "
                             "list's size [%lu], but ther are not equal",
                             cmatch_rank_v.size(),
@@ -304,7 +304,7 @@ class Metric {
       PADDLE_ENFORCE_EQ(
           batch_size,
           label_data.size(),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "illegal batch size: batch_size[%lu] and label_data[%lu]",
               batch_size,
               label_data.size()));
@@ -317,7 +317,7 @@ class Metric {
         PADDLE_ENFORCE_EQ(
             batch_size,
             pred_data_list[i].size(),
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "illegal batch size: batch_size[%lu] and pred_data[%lu]",
                 batch_size,
                 pred_data_list[i].size()));
@@ -368,8 +368,8 @@ class Metric {
         PADDLE_ENFORCE_EQ(
             cur_cmatch_rank.size(),
             2,
-            phi::errors::PreconditionNotMet("illegal cmatch_rank auc spec: %s",
-                                            cmatch_rank.c_str()));
+            common::errors::PreconditionNotMet(
+                "illegal cmatch_rank auc spec: %s", cmatch_rank.c_str()));
         cmatch_rank_v.emplace_back(atoi(cur_cmatch_rank[0].c_str()),
                                    atoi(cur_cmatch_rank[1].c_str()));
       }
@@ -387,14 +387,14 @@ class Metric {
       PADDLE_ENFORCE_EQ(
           batch_size,
           label_data.size(),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "illegal batch size: cmatch_rank[%lu] and label_data[%lu]",
               batch_size,
               label_data.size()));
       PADDLE_ENFORCE_EQ(
           batch_size,
           pred_data.size(),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "illegal batch size: cmatch_rank[%lu] and pred_data[%lu]",
               batch_size,
               pred_data.size()));
@@ -452,7 +452,7 @@ class Metric {
       get_data<int64_t>(exe_scope, mask_varname_, &mask_data, &mask_len);
       PADDLE_ENFORCE_EQ(label_len,
                         mask_len,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "the predict data length should be consistent with "
                             "the label data length"));
       auto cal = GetCalculator();
@@ -491,8 +491,8 @@ class Metric {
         PADDLE_ENFORCE_EQ(
             cur_cmatch_rank.size(),
             2,
-            phi::errors::PreconditionNotMet("illegal cmatch_rank auc spec: %s",
-                                            cmatch_rank.c_str()));
+            common::errors::PreconditionNotMet(
+                "illegal cmatch_rank auc spec: %s", cmatch_rank.c_str()));
         cmatch_rank_v.emplace_back(atoi(cur_cmatch_rank[0].c_str()),
                                    atoi(cur_cmatch_rank[1].c_str()));
       }
@@ -510,14 +510,14 @@ class Metric {
       PADDLE_ENFORCE_EQ(
           batch_size,
           label_data.size(),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "illegal batch size: cmatch_rank[%lu] and label_data[%lu]",
               batch_size,
               label_data.size()));
       PADDLE_ENFORCE_EQ(
           batch_size,
           pred_data.size(),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "illegal batch size: cmatch_rank[%lu] and pred_data[%lu]",
               batch_size,
               pred_data.size()));
@@ -528,7 +528,7 @@ class Metric {
         PADDLE_ENFORCE_EQ(
             batch_size,
             mask_data.size(),
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "illegal batch size: cmatch_rank[%lu] and mask_data[%lu]",
                 batch_size,
                 mask_data.size()));
@@ -566,7 +566,7 @@ class Metric {
   static std::shared_ptr<Metric> GetInstance() {
     // PADDLE_ENFORCE_EQ(
     //     s_instance_ == nullptr, false,
-    //     phi::errors::PreconditionNotMet(
+    //     common::errors::PreconditionNotMet(
     //         "GetInstance failed in Metric, you should use SetInstance
     //         firstly"));
     return s_instance_;
@@ -596,7 +596,7 @@ class Metric {
         PADDLE_ENFORCE_NE(
             iter,
             metric_lists_.end(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The metric name you provided is not registered."));
 
         if (iter->second->MetricPhase() == metric_phase) {
@@ -674,7 +674,7 @@ class Metric {
                                                metric_phase,
                                                bucket_size));
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "PSLIB Metrics only support AucCalculator, MultiTaskAucCalculator, "
           "CmatchRankAucCalculator, MaskAucCalculator, WuAucCalculator and "
           "CmatchRankMaskAucCalculator"));
@@ -686,7 +686,7 @@ class Metric {
     const auto iter = metric_lists_.find(name);
     PADDLE_ENFORCE_NE(iter,
                       metric_lists_.end(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The metric name you provided is not registered."));
     std::vector<float> metric_return_values_(8, 0.0);
     auto* auc_cal_ = iter->second->GetCalculator();
@@ -708,7 +708,7 @@ class Metric {
     const auto iter = metric_lists_.find(name);
     PADDLE_ENFORCE_NE(iter,
                       metric_lists_.end(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The metric name you provided is not registered."));
     VLOG(0) << "begin GetWuAucMetricMsg";
     std::vector<float> metric_return_values_(6, 0.0);

--- a/paddle/fluid/framework/fleet/ps_gpu_wrapper.cc
+++ b/paddle/fluid/framework/fleet/ps_gpu_wrapper.cc
@@ -582,10 +582,10 @@ void PSGPUWrapper::add_slot_feature(std::shared_ptr<HeterContext> gpu_task) {
                                                     slot_num,
                                                     d_slot_feature_num_map,
                                                     fea_num_per_node);
-            PADDLE_ENFORCE_EQ(
-                ret,
-                0,
-                phi::errors::PreconditionNotMet("Get_feature_of_nodes error."));
+            PADDLE_ENFORCE_EQ(ret,
+                              0,
+                              common::errors::PreconditionNotMet(
+                                  "Get_feature_of_nodes error."));
 
             CUDA_CHECK(cudaMemcpyAsync(
                 feature_ids[i].data() + pos * fea_num_per_node,
@@ -1228,7 +1228,7 @@ void PSGPUWrapper::MergePull(std::shared_ptr<HeterContext> gpu_task) {
                   if (pos == -1) {
                     PADDLE_ENFORCE_EQ((k == merge_num),
                                       true,
-                                      phi::errors::InvalidArgument(
+                                      common::errors::InvalidArgument(
                                           "shardid=%d, k=%d, merge_num=%d.",
                                           shard_id,
                                           k,
@@ -1275,7 +1275,7 @@ void PSGPUWrapper::MergePull(std::shared_ptr<HeterContext> gpu_task) {
                   if (pos == -1) {
                     PADDLE_ENFORCE_EQ((k == merge_num),
                                       true,
-                                      phi::errors::InvalidArgument(
+                                      common::errors::InvalidArgument(
                                           "shardid=%d, k=%d, merge_num=%d.",
                                           shard_id,
                                           k,
@@ -1432,7 +1432,7 @@ void PSGPUWrapper::MergeKeys(std::shared_ptr<HeterContext> gpu_task) {
                   if (pos == -1) {
                     PADDLE_ENFORCE_EQ((k == merge_num),
                                       true,
-                                      phi::errors::InvalidArgument(
+                                      common::errors::InvalidArgument(
                                           "shardid=%d, k=%d, merge_num=%d.",
                                           shard_id,
                                           k,
@@ -1477,7 +1477,7 @@ void PSGPUWrapper::MergeKeys(std::shared_ptr<HeterContext> gpu_task) {
                   if (pos == -1) {
                     PADDLE_ENFORCE_EQ((k == merge_num),
                                       true,
-                                      phi::errors::InvalidArgument(
+                                      common::errors::InvalidArgument(
                                           "shardid=%d, k=%d, merge_num=%d.",
                                           shard_id,
                                           k,
@@ -2080,7 +2080,8 @@ void PSGPUWrapper::BeginPass() {
 #endif
   timer.Start();
   if (current_task_) {
-    PADDLE_THROW(phi::errors::Fatal("[BeginPass] current task is not ended."));
+    PADDLE_THROW(
+        common::errors::Fatal("[BeginPass] current task is not ended."));
   }
 
   debug_gpu_memory_info("befor build task");
@@ -2089,7 +2090,7 @@ void PSGPUWrapper::BeginPass() {
   timer.Pause();
 
   if (current_task_ == nullptr) {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "[BeginPass] after build_task, current task is not null."));
   }
   if (FLAGS_gpugraph_dedup_pull_push_mode) {
@@ -2175,7 +2176,8 @@ void PSGPUWrapper::HbmToSparseTable() {
   grad_push_count_ = 0;
 
   if (!current_task_) {
-    PADDLE_THROW(phi::errors::Fatal("[EndPass] current task has been ended."));
+    PADDLE_THROW(
+        common::errors::Fatal("[EndPass] current task has been ended."));
   }
   size_t keysize_max = 0;
   // in case of feasign_num = 0, skip dump_to_cpu
@@ -2353,7 +2355,7 @@ void PSGPUWrapper::PullSparse(const phi::Place& place,
           << " pull_feature_value_size:" << pull_type_size_;
 
   if (phi::is_cpu_place(place)) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Warning:: CPUPlace is not supported in GpuPs now."));
   } else if (phi::is_gpu_place(place)) {
 #ifdef PADDLE_WITH_CUDA
@@ -2469,7 +2471,7 @@ void PSGPUWrapper::PullSparse(const phi::Place& place,
 
       PADDLE_ENFORCE_GT(dedup_size,
                         0,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "dedup keys need more than zero failed in BoxPS."));
       dev.dedup_key_length = dedup_size;
 
@@ -2644,7 +2646,7 @@ void PSGPUWrapper::PullSparse(const phi::Place& place,
                                       feature_value_size);
 #endif
   } else {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "GpuPs/XpuPs: PullSparse Only Support CUDAPlace or XPUPlace Now."));
   }
   all_timer.Pause();
@@ -2670,7 +2672,7 @@ void PSGPUWrapper::PushSparseGrad(const phi::Place& place,
   size_t grad_value_size = accessor_wrapper_ptr->GetPushValueSize(max_mf_dim_);
 
   if (phi::is_cpu_place(place)) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Warning:: CPUPlace is not supported in GPUPS now."));
   } else if (phi::is_gpu_place(place)) {
 #ifdef PADDLE_WITH_CUDA
@@ -2833,7 +2835,7 @@ void PSGPUWrapper::PushSparseGrad(const phi::Place& place,
     push_gpups_timer.Pause();
 #endif
   } else {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "GPUPS: PushSparseGrad Only Support CUDAPlace Now."));
   }
   all_timer.Pause();

--- a/paddle/fluid/framework/fleet/ps_gpu_wrapper.h
+++ b/paddle/fluid/framework/fleet/ps_gpu_wrapper.h
@@ -299,7 +299,8 @@ class PSGPUWrapper {
         VLOG(0) << "init single node gpu server";
       }
 #else
-      PADDLE_THROW(phi::errors::Unavailable("heter ps need compile with GLOO"));
+      PADDLE_THROW(
+          common::errors::Unavailable("heter ps need compile with GLOO"));
 #endif
 #ifdef PADDLE_WITH_CUDA
       if (multi_node_) {
@@ -321,7 +322,7 @@ class PSGPUWrapper {
         PADDLE_ENFORCE_EQ(
             gloo->IsInitialized(),
             true,
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "You must initialize the gloo environment first to use it."));
         gloo::BroadcastOptions opts(gloo->GetContext());
         opts.setOutput(&inter_ncclids_[0], dev_size);
@@ -340,7 +341,7 @@ class PSGPUWrapper {
         node_size_ = gloo->Size();
 #else
         PADDLE_THROW(
-            phi::errors::Unavailable("heter ps need compile with GLOO"));
+            common::errors::Unavailable("heter ps need compile with GLOO"));
 #endif
       }
 #endif

--- a/paddle/fluid/framework/garbage_collector.cc
+++ b/paddle/fluid/framework/garbage_collector.cc
@@ -212,7 +212,7 @@ std::unique_ptr<GarbageCollector> CreateGarbageCollector(
     }
 #else
     PADDLE_THROW(
-        phi::errors::Unimplemented("No GPU gc found in CPU/XPU paddle"));
+        common::errors::Unimplemented("No GPU gc found in CPU/XPU paddle"));
 #endif
   } else if (phi::is_cpu_place(place)) {
     gc = std::make_unique<CPUGarbageCollector>(place, max_memory_size);
@@ -221,14 +221,14 @@ std::unique_ptr<GarbageCollector> CreateGarbageCollector(
     gc = std::make_unique<XPUGarbageCollector>(place, max_memory_size);
 #else
     PADDLE_THROW(
-        phi::errors::Unimplemented("No XPU gc found in CPU/GPU paddle"));
+        common::errors::Unimplemented("No XPU gc found in CPU/GPU paddle"));
 #endif
   } else if (phi::is_ipu_place(place)) {
 #ifdef PADDLE_WITH_IPU
     gc = std::make_unique<IPUGarbageCollector>(place, max_memory_size);
 #else
     PADDLE_THROW(
-        phi::errors::Unimplemented("No IPU gc found in CPU/IPU paddle"));
+        common::errors::Unimplemented("No IPU gc found in CPU/IPU paddle"));
 #endif
   } else if (phi::is_custom_place(place)) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
@@ -242,7 +242,7 @@ std::unique_ptr<GarbageCollector> CreateGarbageCollector(
           place, max_memory_size);
     }
 #else
-    PADDLE_THROW(phi::errors::Unimplemented("No CustomDevice gc found"));
+    PADDLE_THROW(common::errors::Unimplemented("No CustomDevice gc found"));
 #endif
   }
   return std::unique_ptr<GarbageCollector>(gc.release());

--- a/paddle/fluid/framework/grad_op_desc_maker.h
+++ b/paddle/fluid/framework/grad_op_desc_maker.h
@@ -102,7 +102,7 @@ class GradOpDescMakerBase {
     PADDLE_ENFORCE_LE(
         var_names.size(),
         1UL,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "BUG from operator developer:"
             " for input argument with a list of variables, "
             " drop_empty_grad is not allowed because it makes"
@@ -171,7 +171,7 @@ class GradOpDescMakerBase {
     PADDLE_ENFORCE_NE(
         it,
         map.end(),
-        phi::errors::NotFound("Cannot find attribute (%s).", name));
+        common::errors::NotFound("Cannot find attribute (%s).", name));
     return it->second;
   }
 
@@ -238,12 +238,12 @@ class SingleGradOpMaker<imperative::OpBase>
     auto it = Attrs().find(name);
     if (it == Attrs().end()) {
       it = this->DefaultAttrsMap().find(name);
-      PADDLE_ENFORCE_EQ(
-          it != this->DefaultAttrsMap().end(),
-          true,
-          phi::errors::NotFound("Cannot find attribute [%s] in operator [%s]",
-                                name,
-                                this->ForwardOpType()));
+      PADDLE_ENFORCE_EQ(it != this->DefaultAttrsMap().end(),
+                        true,
+                        common::errors::NotFound(
+                            "Cannot find attribute [%s] in operator [%s]",
+                            name,
+                            this->ForwardOpType()));
     }
 
     return it->second;

--- a/paddle/fluid/framework/heter_pipeline_trainer.cc
+++ b/paddle/fluid/framework/heter_pipeline_trainer.cc
@@ -43,7 +43,7 @@ void HeterPipelineTrainer::ResetDataset(Dataset* dataset) {
     // change thread num is not supported
     PADDLE_ENFORCE_EQ(thread_num_,
                       readers.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "change Dataset thread_num is not supported"));
     int cnt = -1;
     for (auto& worker_pair : workers_) {
@@ -163,7 +163,7 @@ void HeterPipelineTrainer::InitTrainerEnv(const ProgramDesc& main_program,
   place_ = place;
   PADDLE_ENFORCE_NOT_NULL(
       root_scope_,
-      phi::errors::InvalidArgument("root_scope_ can not be nullptr"));
+      common::errors::InvalidArgument("root_scope_ can not be nullptr"));
   // initialize mini_scopes & micro_scopes
   mini_scopes_.reset(new MiniScope{});
   micro_scopes_.reset(new MicroScope{});

--- a/paddle/fluid/framework/heter_section_worker.cc
+++ b/paddle/fluid/framework/heter_section_worker.cc
@@ -35,7 +35,7 @@ void SetMicroId(paddle::framework::Scope* scope,
   PADDLE_ENFORCE_EQ(
       var->IsType<phi::DenseTensor>(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "the type of microbatch_id  should be phi::DenseTensor"));
   auto* tensor = var->GetMutable<phi::DenseTensor>();
   std::vector<int> dims{1};
@@ -207,13 +207,13 @@ void HeterSectionWorker::MiniBatchBarrier() {
     auto micro_id = task.second;
     PADDLE_ENFORCE_EQ(message_name.find("backward") != std::string::npos,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "cpu trainers only receive backward data"));
     PADDLE_ENFORCE_EQ(
         micro_ids.find(micro_id) == micro_ids.end(),
         true,
-        phi::errors::InvalidArgument("minibatch_scope_ can not be nullptr "
-                                     "when create MicroBatch Scope"));
+        common::errors::InvalidArgument("minibatch_scope_ can not be nullptr "
+                                        "when create MicroBatch Scope"));
     micro_ids.insert(micro_id);
     // backward data has been deserialized to micro scope
     // now run backward computation
@@ -302,7 +302,7 @@ void HeterSectionWorker::BindingDataFeedMemory(int micro_id) {
 void HeterSectionWorker::CreateMicrobatchScopes() {
   PADDLE_ENFORCE_NOT_NULL(
       minibatch_scope_,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "minibatch_scope_ can not be nullptr when create MicroBatch Scopes"));
   if (microbatch_scopes_.get() == nullptr) {
     microbatch_scopes_.reset(new std::vector<paddle::framework::Scope*>{});
@@ -412,7 +412,7 @@ void HeterSectionWorker::Run() {
       if (is_last_stage) {
         PADDLE_ENFORCE_EQ(message_name.find("forward") != std::string::npos,
                           1,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "last stage only receive forward data"));
         RunForward(micro_id);
         RunBackward(micro_id);

--- a/paddle/fluid/framework/hogwild_worker.cc
+++ b/paddle/fluid/framework/hogwild_worker.cc
@@ -178,14 +178,14 @@ void HogwildWorker::OffLoadVarInfo::CopyInputs(const Scope *root,
       PADDLE_ENFORCE_NE(
           src_var,
           nullptr,
-          phi::errors::NotFound("root scope not found var name=%s",
-                                obj.second.c_str()));
+          common::errors::NotFound("root scope not found var name=%s",
+                                   obj.second.c_str()));
       auto &src_tensor = src_var->Get<phi::DenseTensor>();
       auto dest_var = scope->FindLocalVar(obj.first);
-      PADDLE_ENFORCE_NE(
-          dest_var,
-          nullptr,
-          phi::errors::NotFound("dest name=%s is nullptr", obj.first.c_str()));
+      PADDLE_ENFORCE_NE(dest_var,
+                        nullptr,
+                        common::errors::NotFound("dest name=%s is nullptr",
+                                                 obj.first.c_str()));
       auto *dest_tensor = dest_var->GetMutable<phi::DenseTensor>();
       auto dtype = framework::TransToProtoVarType(dest_tensor->dtype());
       framework::TransDataType(src_tensor, dtype, dest_tensor);
@@ -199,14 +199,14 @@ void HogwildWorker::OffLoadVarInfo::CopyInputs(const Scope *root,
     auto src_var = root->FindLocalVar(name);
     PADDLE_ENFORCE_NE(src_var,
                       nullptr,
-                      phi::errors::NotFound("root scope not found var name=%s",
-                                            name.c_str()));
+                      common::errors::NotFound(
+                          "root scope not found var name=%s", name.c_str()));
     auto &src_tensor = src_var->Get<phi::DenseTensor>();
     auto dest_var = scope->FindLocalVar(name);
     PADDLE_ENFORCE_NE(
         dest_var,
         nullptr,
-        phi::errors::NotFound("dest name=%s is nullptr", name.c_str()));
+        common::errors::NotFound("dest name=%s is nullptr", name.c_str()));
     auto *dest_tensor = dest_var->GetMutable<phi::DenseTensor>();
     copyer->Copy(src_tensor, place, dest_tensor);
   }
@@ -564,8 +564,8 @@ size_t HogwildWorker::AdjustOffloadOps(const ProgramDesc &program) {
         auto dest_var = thread_scope_->Var(name);  // init local var
         PADDLE_ENFORCE_NE(dest_var,
                           nullptr,
-                          phi::errors::InvalidArgument("init var error name=%s",
-                                                       name.c_str()));
+                          common::errors::InvalidArgument(
+                              "init var error name=%s", name.c_str()));
         offload_vars_[op.get()].copy_vars.push_back(name);
         // nccl broadcast param
         if (is_offload_communication_) {
@@ -964,7 +964,7 @@ void HogwildWorker::CreateThreadScope(const ProgramDesc &program) {
 
   PADDLE_ENFORCE_NOT_NULL(
       root_scope_,
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Root scope should be set before creating thread scope."));
 
   thread_scope_ = &root_scope_->NewScope();
@@ -1199,7 +1199,7 @@ bool HogwildWorker::CheckBatchNum(int flag) {
     if (FLAGS_dynamic_static_unified_comm) {
       PADDLE_ENFORCE_EQ(comm_context_manager.Has(std::to_string(ring_id)),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "You choose to use new communication library by "
                             "setting environment "
                             "variable FLAGS_dynamic_static_unified_comm True. "
@@ -1210,7 +1210,7 @@ bool HogwildWorker::CheckBatchNum(int flag) {
           comm_context_manager.Get(std::to_string(ring_id)));
       PADDLE_ENFORCE_NE(comm_ctx,
                         nullptr,
-                        phi::errors::Unavailable(
+                        common::errors::Unavailable(
                             "NCCLCommContext is nullptr, collective op should "
                             "has ring_id attr."));
     } else {

--- a/paddle/fluid/framework/infershape_utils.cc
+++ b/paddle/fluid/framework/infershape_utils.cc
@@ -57,8 +57,8 @@ class InferShapeArgumentMappingContext : public phi::ArgumentMappingContext {
     auto* attr = ctx_.Attrs().GetAttr(name);
     PADDLE_ENFORCE_NOT_NULL(
         attr,
-        phi::errors::NotFound("Attribute (%s) should be in AttributeMap.",
-                              name));
+        common::errors::NotFound("Attribute (%s) should be in AttributeMap.",
+                                 name));
     return GetAttrValue(*attr);
   }
 
@@ -160,7 +160,7 @@ class InferShapeArgumentMappingContext : public phi::ArgumentMappingContext {
 static inline void ValidCheck(const phi::MetaTensor& meta_tensor) {
   PADDLE_ENFORCE_EQ(meta_tensor.initialized(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The current CompatMetaTensor is not initialized."));
 }
 
@@ -220,7 +220,7 @@ DDim CompatMetaTensor::dims() const {
       auto& tensor_array = var->Get<framework::LoDTensorArray>();
       return common::make_ddim({static_cast<int64_t>(tensor_array.size())});
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Currently, only can get dims from DenseTensor or SelectedRows or "
           "DenseTensorArray."));
     }
@@ -248,7 +248,7 @@ phi::DataType CompatMetaTensor::dtype() const {
       // Unsupported get dtype from LoDTensorArray now
       return phi::DataType::UNDEFINED;
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Currently, only can get dtype from DenseTensor or SelectedRows."));
     }
   } else {
@@ -272,7 +272,7 @@ DataLayout CompatMetaTensor::layout() const {
       // Unsupported get layout from LoDTensorArray now
       return phi::DataLayout::UNDEFINED;
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Currently, only can get layout from DenseTensor or "
           "SelectedRows."));
     }
@@ -305,12 +305,12 @@ void CompatMetaTensor::set_dims(const DDim& dims) {
       // `test_list` contains this behavior
       PADDLE_ENFORCE_EQ(dims.size(),
                         1UL,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "LoDTensorArray can only have one dimension."));
       // only set the array size for LoDTensorArray input
       tensor_array->resize(dims[0]);
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Currently, only can set dims from DenseTensor or SelectedRows."));
     }
   } else {
@@ -339,7 +339,7 @@ void CompatMetaTensor::set_dtype(phi::DataType dtype) {
       // NOTE(chenweihang): do nothing
       // Unsupported set dtype for LoDTensorArray now
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Currently, only can set dtype from DenseTensor or SelectedRows."));
     }
   } else {
@@ -370,7 +370,7 @@ void CompatMetaTensor::set_layout(DataLayout layout) {
       // NOTE(chenweihang): do nothing
       // Unsupported set dtype for LoDTensorArray now
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Currently, only can set layout from DenseTensor or "
           "SelectedRows."));
     }
@@ -623,7 +623,7 @@ CompatInferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
                   PADDLE_GET_CONST(paddle::experimental::Scalar, attr)));
               break;
             default:
-              PADDLE_THROW(phi::errors::Unimplemented(
+              PADDLE_THROW(common::errors::Unimplemented(
                   "Unsupported cast op attribute `%s` to Scalar when construct "
                   "InferMetaContext.",
                   attr_name));
@@ -641,7 +641,7 @@ CompatInferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
               infer_meta_context.EmplaceBackAttr(tensor_scalar);
             }
           } else {
-            PADDLE_THROW(phi::errors::InvalidArgument(
+            PADDLE_THROW(common::errors::InvalidArgument(
                 "Invalid input.size() when cast op attribute `%s` to Scalar, "
                 "expected 1, but actually is %d .",
                 attr_name,
@@ -669,7 +669,7 @@ CompatInferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
                   phi::IntArray({PADDLE_GET_CONST(int, attr)}));
               break;
             default:
-              PADDLE_THROW(phi::errors::Unimplemented(
+              PADDLE_THROW(common::errors::Unimplemented(
                   "Unsupported cast op attribute `%s` to IntArray when "
                   "construct InferMetaContext.",
                   attr_name));
@@ -769,7 +769,7 @@ CompatInferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
               infer_meta_context.EmplaceBackAttr(std::move(scalar_list));
             } break;
             default:
-              PADDLE_THROW(phi::errors::Unimplemented(
+              PADDLE_THROW(common::errors::Unimplemented(
                   "Unsupported cast op attribute `%s` to vector<Scalar> when "
                   "construct KernelContext.",
                   attr_names[i]));
@@ -827,7 +827,7 @@ CompatInferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
                   infer_meta_context.EmplaceBackAttr(vector_int64_attr);
                 } break;
                 default:
-                  PADDLE_THROW(phi::errors::Unimplemented(
+                  PADDLE_THROW(common::errors::Unimplemented(
                       "Unsupported cast op attribute `%s` to vector<int64_t> "
                       "when "
                       "construct KernelContext.",
@@ -851,7 +851,7 @@ CompatInferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
                   PADDLE_GET_CONST(std::vector<double>, attr));
               break;
             default:
-              PADDLE_THROW(phi::errors::Unimplemented(
+              PADDLE_THROW(common::errors::Unimplemented(
                   "Unsupported cast op attribute `%s` when construct "
                   "KernelContext in dygraph.",
                   attr_names[i]));

--- a/paddle/fluid/framework/infershape_utils.h
+++ b/paddle/fluid/framework/infershape_utils.h
@@ -84,13 +84,13 @@ class CompatMetaTensor : public phi::MetaTensor {
     PADDLE_ENFORCE_EQ(
         is_runtime_,
         true,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Only can get phi::DenseTensor from MetaTensor in runtime."));
     auto* var = PADDLE_GET_CONST(Variable*, var_);
     PADDLE_ENFORCE_EQ(
         var->IsType<phi::SelectedRows>(),
         true,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "The phi::DenseTensor in MetaTensor is not SelectedRows."));
     return var->Get<phi::SelectedRows>();
   }

--- a/paddle/fluid/framework/io/crypto/aes_cipher.cc
+++ b/paddle/fluid/framework/io/crypto/aes_cipher.cc
@@ -152,10 +152,11 @@ std::string AESCipher::AuthenticatedDecryptInternal(
   CryptoPP::Redirector* filter_redirector = new CryptoPP::Redirector(*m_filter);
   CryptoPP::StringSource ss(
       ciphertext.substr(ciphertext_beg), true, filter_redirector);
-  PADDLE_ENFORCE_EQ(m_filter->GetLastResult(),
-                    true,
-                    phi::errors::InvalidArgument("Integrity check failed. "
-                                                 "Invalid ciphertext input."));
+  PADDLE_ENFORCE_EQ(
+      m_filter->GetLastResult(),
+      true,
+      common::errors::InvalidArgument("Integrity check failed. "
+                                      "Invalid ciphertext input."));
   return plaintext;
 }
 
@@ -193,7 +194,7 @@ void AESCipher::BuildCipher(
     m_filter->reset(new CryptoPP::StreamTransformationFilter(
         **m_cipher, nullptr, CryptoPP::BlockPaddingSchemeDef::NO_PADDING));
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Create cipher error. "
         "Cipher name %s is error, or has not been implemented.",
         aes_cipher_name_));
@@ -215,7 +216,7 @@ void AESCipher::BuildAuthEncCipher(
         CryptoPP::DEFAULT_CHANNEL,
         CryptoPP::BlockPaddingSchemeDef::NO_PADDING));
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Create cipher error. "
         "Cipher name %s is error, or has not been implemented.",
         aes_cipher_name_));
@@ -236,7 +237,7 @@ void AESCipher::BuildAuthDecCipher(
         tag_size_ / 8,
         CryptoPP::BlockPaddingSchemeDef::NO_PADDING));
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Create cipher error. "
         "Cipher name %s is error, or has not been implemented.",
         aes_cipher_name_));

--- a/paddle/fluid/framework/io/crypto/cipher.cc
+++ b/paddle/fluid/framework/io/crypto/cipher.cc
@@ -48,7 +48,7 @@ std::shared_ptr<Cipher> CipherFactory::CreateCipher(
     ret->Init(cipher_name, iv_size, tag_size);
     return ret;
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Invalid cipher name is specified. "
         "Please check you have specified valid cipher"
         " name in CryptoProperties."));

--- a/paddle/fluid/framework/io/crypto/cipher_utils.cc
+++ b/paddle/fluid/framework/io/crypto/cipher_utils.cc
@@ -46,9 +46,9 @@ std::string CipherUtils::GenKeyToFile(int length, const std::string& filename) {
   PADDLE_ENFORCE_EQ(
       fout.is_open(),
       true,
-      phi::errors::Unavailable("Failed to open file : %s, "
-                               "make sure input filename is available.",
-                               filename));
+      common::errors::Unavailable("Failed to open file : %s, "
+                                  "make sure input filename is available.",
+                                  filename));
   fout.write(rng.c_str(), rng.size());  // NOLINT
   fout.close();
   return rng;
@@ -68,9 +68,9 @@ std::unordered_map<std::string, std::string> CipherUtils::LoadConfig(
   PADDLE_ENFORCE_EQ(
       fin.is_open(),
       true,
-      phi::errors::Unavailable("Failed to open file : %s, "
-                               "make sure input filename is available.",
-                               config_file));
+      common::errors::Unavailable("Failed to open file : %s, "
+                                  "make sure input filename is available.",
+                                  config_file));
   std::unordered_map<std::string, std::string> ret;
   char c = 0;
   std::string line;
@@ -84,7 +84,7 @@ std::unordered_map<std::string, std::string> CipherUtils::LoadConfig(
     std::string key;
     std::string value;
     if (!(iss >> key >> c >> value) && (c == ':')) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Parse config file error, "
           "check the format of configure in file %s.",
           config_file));

--- a/paddle/fluid/framework/io/fs.cc
+++ b/paddle/fluid/framework/io/fs.cc
@@ -149,8 +149,8 @@ std::shared_ptr<FILE> localfs_open_append_write(std::string path,
 int64_t localfs_file_size(const std::string& path) {
   struct stat buf = {};
   if (0 != stat(path.c_str(), &buf)) {
-    PADDLE_THROW(
-        phi::errors::External("Failed to get file status via stat function."));
+    PADDLE_THROW(common::errors::External(
+        "Failed to get file status via stat function."));
     return -1;
   }
   return (int64_t)buf.st_size;
@@ -419,7 +419,7 @@ std::shared_ptr<FILE> fs_open_read(const std::string& path,
       return hdfs_open_read(path, err_no, converter, read_data);
 
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupport file system. Now only supports local file system and "
           "HDFS."));
   }
@@ -438,7 +438,7 @@ std::shared_ptr<FILE> fs_open_write(const std::string& path,
       return hdfs_open_write(path, err_no, converter);
 
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupport file system. Now only supports local file system and "
           "HDFS."));
   }
@@ -457,7 +457,7 @@ std::shared_ptr<FILE> fs_open_append_write(const std::string& path,
       return hdfs_open_write(path, err_no, converter);
 
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupport file system. Now only supports local file system and "
           "HDFS."));
   }
@@ -477,7 +477,7 @@ std::shared_ptr<FILE> fs_open(const std::string& path,
     return fs_open_write(path, err_no, converter);
   }
 
-  PADDLE_THROW(phi::errors::Unavailable(
+  PADDLE_THROW(common::errors::Unavailable(
       "Unsupport file open mode: %s. Only supports 'r', 'rb', 'w' or 'wb'.",
       mode));
   return {};
@@ -489,7 +489,7 @@ int64_t fs_file_size(const std::string& path) {
       return localfs_file_size(path);
 
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupport file system. Now only supports local file system."));
   }
 
@@ -505,7 +505,7 @@ void fs_remove(const std::string& path) {
       return hdfs_remove(path);
 
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupport file system. Now only supports local file system and "
           "HDFS."));
   }
@@ -520,7 +520,7 @@ std::vector<std::string> fs_list(const std::string& path) {
       return hdfs_list(path);
 
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupport file system. Now only supports local file system and "
           "HDFS."));
   }
@@ -537,7 +537,7 @@ std::string fs_tail(const std::string& path) {
       return hdfs_tail(path);
 
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupport file system. Now only supports local file system and "
           "HDFS."));
   }
@@ -554,7 +554,7 @@ bool fs_exists(const std::string& path) {
       return hdfs_exists(path);
 
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupport file system. Now only supports local file system and "
           "HDFS."));
   }
@@ -571,7 +571,7 @@ void fs_mkdir(const std::string& path) {
       return hdfs_mkdir(path);
 
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupport file system. Now only supports local file system and "
           "HDFS."));
   }

--- a/paddle/fluid/framework/io/save_load_tensor.cc
+++ b/paddle/fluid/framework/io/save_load_tensor.cc
@@ -30,10 +30,10 @@ void SaveTensor(const phi::DenseTensor& x,
   MkDirRecursively(DirName(new_path).c_str());
 
   std::ofstream fout(new_path, std::ios::binary);
-  PADDLE_ENFORCE_EQ(
-      static_cast<bool>(fout),
-      true,
-      phi::errors::Unavailable("Cannot open %s to save variables.", new_path));
+  PADDLE_ENFORCE_EQ(static_cast<bool>(fout),
+                    true,
+                    common::errors::Unavailable(
+                        "Cannot open %s to save variables.", new_path));
   framework::SerializeToStream(fout, x);
 
   fout.close();
@@ -43,12 +43,12 @@ void LoadTensor(const std::string& file_path, phi::DenseTensor* out) {
   std::ifstream fin(file_path, std::ios::binary);
   PADDLE_ENFORCE_EQ(static_cast<bool>(fin),
                     true,
-                    phi::errors::Unavailable(
+                    common::errors::Unavailable(
                         "Load operator fail to open file %s, please check "
                         "whether the model file is complete or damaged.",
                         file_path));
   PADDLE_ENFORCE_NOT_NULL(out,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The variable to be loaded cannot be found."));
 
   framework::DeserializeFromStream(fin, out);

--- a/paddle/fluid/framework/io/save_paddle2cinn_varmap.cc
+++ b/paddle/fluid/framework/io/save_paddle2cinn_varmap.cc
@@ -36,10 +36,10 @@ void save_paddle2cinn_varmap(
   MkDirRecursively(DirName(save_path).c_str());
   // set append mode to write all paddle var to cinn var map
   std::ofstream outfile(save_path, std::ios::app);
-  PADDLE_ENFORCE_EQ(
-      static_cast<bool>(outfile),
-      true,
-      phi::errors::Unavailable("Cannot open %s to save variables.", save_path));
+  PADDLE_ENFORCE_EQ(static_cast<bool>(outfile),
+                    true,
+                    common::errors::Unavailable(
+                        "Cannot open %s to save variables.", save_path));
   outfile << mapAsString;
   outfile.close();
 }

--- a/paddle/fluid/framework/io/save_runtime_graph.cc
+++ b/paddle/fluid/framework/io/save_runtime_graph.cc
@@ -30,7 +30,7 @@ void save_string(std::string content,
   PADDLE_ENFORCE_EQ(
       static_cast<bool>(fout),
       true,
-      phi::errors::Unavailable("Cannot open %s to save ", saved_path));
+      common::errors::Unavailable("Cannot open %s to save ", saved_path));
   fout << content;
   fout.close();
 }
@@ -45,7 +45,7 @@ void save_graph_compilation_key(int64_t graph_compilation_key,
   PADDLE_ENFORCE_EQ(
       static_cast<bool>(fout),
       true,
-      phi::errors::Unavailable("Cannot open %s to save ", saved_path));
+      common::errors::Unavailable("Cannot open %s to save ", saved_path));
   fout << std::to_string(graph_compilation_key);
   fout.close();
 }
@@ -67,7 +67,7 @@ void save_graph(const ir::Graph& graph,
   PADDLE_ENFORCE_EQ(
       static_cast<bool>(fout),
       true,
-      phi::errors::Unavailable("Cannot open %s to save ", saved_path));
+      common::errors::Unavailable("Cannot open %s to save ", saved_path));
   // record all nodes[var, op]
   // format
   int index = 0;

--- a/paddle/fluid/framework/io/shell.cc
+++ b/paddle/fluid/framework/io/shell.cc
@@ -32,7 +32,7 @@ std::shared_ptr<FILE> shell_fopen(const std::string& path,
   }
   FILE* fp = fopen(path.c_str(), mode.c_str());
   if (!fp) {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Failed to open file, path[%s], mode[%s].", path, mode));
   }
   return {fp, [path](FILE* fp) {
@@ -40,7 +40,7 @@ std::shared_ptr<FILE> shell_fopen(const std::string& path,
               LOG(INFO) << "Closing file[" << path << "]";
             }
             if (0 != fclose(fp)) {
-              PADDLE_THROW(phi::errors::Unavailable(
+              PADDLE_THROW(common::errors::Unavailable(
                   "Failed to close file, path[%s].", path));
             }
           }};
@@ -64,7 +64,7 @@ static int close_open_fds_internal() {
 
   int dir_fd = open("/proc/self/fd", O_RDONLY);
   if (dir_fd < 0) {
-    PADDLE_THROW(phi::errors::Unavailable("Failed to open proc/self/fd."));
+    PADDLE_THROW(common::errors::Unavailable("Failed to open proc/self/fd."));
     return -1;
   }
   char buffer[sizeof(linux_dirent)];  // NOLINT
@@ -75,8 +75,8 @@ static int close_open_fds_internal() {
                          dir_fd,
                          reinterpret_cast<linux_dirent*>(buffer),
                          sizeof(buffer))) < 0) {
-      PADDLE_THROW(
-          phi::errors::Unavailable("System call failed via syscall function."));
+      PADDLE_THROW(common::errors::Unavailable(
+          "System call failed via syscall function."));
       return -1;
     }
 
@@ -241,7 +241,7 @@ std::shared_ptr<FILE> shell_popen(const std::string& cmd,
               PADDLE_ENFORCE_NE(
                   errno,
                   ECHILD,
-                  phi::errors::Fatal("Must not be ECHILD errno here!"));
+                  common::errors::Fatal("Must not be ECHILD errno here!"));
               *err_no = -1;
             }
 
@@ -370,7 +370,7 @@ static int _shell_execute_cmd(const std::string& cmd,
                               int sleep_inter,
                               bool redirect_stderr = false) {
 #if defined(_WIN32) || defined(__APPLE__) || defined(PADDLE_ARM)
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "This function(shell_get_command_output) is not implemented under _WIN32 "
       "or __APPLE__."));
 #else

--- a/paddle/fluid/framework/ir/adaptive_pool2d_convert_global_pass_tester.cc
+++ b/paddle/fluid/framework/ir/adaptive_pool2d_convert_global_pass_tester.cc
@@ -53,7 +53,7 @@ TEST(AdaptivePool2dConvertGlobalPass, basic) {
   PADDLE_ENFORCE_EQ(
       global_pooling,
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The attribute of pool2d global_pooling should be true after fuse"));
 }
 

--- a/paddle/fluid/framework/ir/attention_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/attention_lstm_fuse_pass.cc
@@ -163,8 +163,9 @@ void AttentionLSTMFusePass::FindWhileOp(Graph* graph) const {
   GraphSafeRemoveNodes(graph, marked_nodes);
 }
 
-#define CHECK_P1(x) \
-  PADDLE_ENFORCE_NOT_NULL(x, phi::errors::NotFound("%s is a null pointer.", #x))
+#define CHECK_P1(x)        \
+  PADDLE_ENFORCE_NOT_NULL( \
+      x, common::errors::NotFound("%s is a null pointer.", #x))
 #define CHECK_P2(x0, x1) \
   CHECK_P1(x0);          \
   CHECK_P1(x1);
@@ -198,7 +199,7 @@ void PrepareParameters(Graph* graph, const Param& param, ir::Node* lstm_op) {
   // Check parameters
   PADDLE_ENFORCE_EQ(graph->Has(kParamScopeAttr),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Graph have no attribute: kParamScopeAttr."));
   auto& scope = graph->Get<Scope>(kParamScopeAttr);
 
@@ -260,7 +261,7 @@ void PrepareParameters(Graph* graph, const Param& param, ir::Node* lstm_op) {
   PADDLE_ENFORCE_EQ(
       attention_bias_t->dims().size(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "phi::DenseTensor attention bias dimension size(%d) must be 1.",
           attention_bias_t->dims().size()));
   attention_bias_t->Resize(common::make_ddim({1, attention_bias_t->dims()[0]}));
@@ -338,7 +339,7 @@ void PrepareLSTMBias(const phi::DenseTensor& B_forget,
   PADDLE_ENFORCE_EQ(
       B_forget.dims().size(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "phi::DenseTensor B forget dimension size(%d) must be 1.",
           B_forget.dims().size()));
   int D = static_cast<int>(B_forget.dims()[0]);

--- a/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
@@ -54,7 +54,7 @@ static phi::Backend ConvertPlaceToBackend(const phi::Place& place) {
     case phi::AllocationType::XPU:
       return phi::Backend::XPU;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Cannot convert place(%d).", static_cast<int>(place.GetType())));
   }
   return phi::Backend::UNDEFINED;
@@ -228,8 +228,8 @@ void AutoMixedPrecisionPass::Init(Graph* graph) const {
             .GetOrRegisterGlobalDeviceTypeId(device_type));
 #else
     PADDLE_THROW(
-        phi::errors::Unavailable("Paddle is not compiled with CustomDevice. "
-                                 "Cannot enable custom_device_mixed."));
+        common::errors::Unavailable("Paddle is not compiled with CustomDevice. "
+                                    "Cannot enable custom_device_mixed."));
 #endif
   }
 
@@ -283,12 +283,12 @@ void AutoMixedPrecisionPass::Init(Graph* graph) const {
 
 void AutoMixedPrecisionPass::ApplyImpl(Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(graph,
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "During the auto_mixed_precision_pass, the graph "
                               "should not be nullptr."));
   PADDLE_ENFORCE_EQ(graph->IsMainGraph(),
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "During the auto_mixed_precision_pass, the graph "
                         "should be main graph."));
 
@@ -782,7 +782,7 @@ bool AutoMixedPrecisionPass::OutputVarsNotConvert(
 void AutoMixedPrecisionPass::SetVarPrecision() const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(scope,
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "During the auto_mixed_precision_pass, the scope "
                               "should not be null."));
   for (const auto& nodes : all_op_nodes_) {
@@ -878,7 +878,7 @@ void AutoMixedPrecisionPass::SetVarPrecision() const {
 void AutoMixedPrecisionPass::ConvertWeightsData() const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(scope,
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "During the auto_mixed_precision_pass, the scope "
                               "should not be null."));
 

--- a/paddle/fluid/framework/ir/coalesce_grad_tensor_pass.cc
+++ b/paddle/fluid/framework/ir/coalesce_grad_tensor_pass.cc
@@ -122,7 +122,7 @@ class CoalesceGradTensorPass : public ir::Pass {
     }
     PADDLE_ENFORCE_EQ(p_g_dense_grad.size(),
                       num_of_p_g_dense_grad,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The number of dense grads is not consistent with "
                           "previous. Previous(%d), now(%d).",
                           p_g_dense_grad.size(),
@@ -139,9 +139,9 @@ class CoalesceGradTensorPass : public ir::Pass {
         PADDLE_ENFORCE_EQ(
             IsUnifiedDtype(sub_param_grad, vars_info),
             true,
-            phi::errors::InvalidArgument("All gradient variable in "
-                                         "kGroupParamsAndDenseGrads, must "
-                                         "have same type."));
+            common::errors::InvalidArgument("All gradient variable in "
+                                            "kGroupParamsAndDenseGrads, must "
+                                            "have same type."));
         CoalesceTensors(vars_info, sub_param_grad, &result);
       }
     }
@@ -154,19 +154,19 @@ class CoalesceGradTensorPass : public ir::Pass {
     // The Gradients should not be reused during memory optimization.
     for (auto &p_g : sub_param_grad) {
       auto iter = vars_info.find(p_g.second);
-      PADDLE_ENFORCE_EQ(
-          iter != vars_info.end(),
-          true,
-          phi::errors::NotFound("Parameter@Grad %s is not found.", p_g.second));
+      PADDLE_ENFORCE_EQ(iter != vars_info.end(),
+                        true,
+                        common::errors::NotFound(
+                            "Parameter@Grad %s is not found.", p_g.second));
       PADDLE_ENFORCE_EQ(
           !iter->second.empty(),
           true,
-          phi::errors::InvalidArgument("Parameter@Grad %s's var node is empty.",
-                                       p_g.second));
+          common::errors::InvalidArgument(
+              "Parameter@Grad %s's var node is empty.", p_g.second));
       for (auto it : iter->second) {
         PADDLE_ENFORCE_NOT_NULL(
             it->Var(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "A node of Parameter@Grad %s does not hold variable.",
                 p_g.second));
         pinned_var_set->insert(it->Var()->Name());
@@ -174,7 +174,7 @@ class CoalesceGradTensorPass : public ir::Pass {
       PADDLE_ENFORCE_EQ(
           IsLoDTensorType(GetTypeOfVar(vars_info, p_g.second)),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Parameter@Grad %s is not phi::DenseTensor.", p_g.second));
     }
   }
@@ -240,8 +240,8 @@ class CoalesceGradTensorPass : public ir::Pass {
     PADDLE_ENFORCE_EQ(
         fused_var_set.count(fused_grad_var_name),
         0,
-        phi::errors::AlreadyExists("Var(%s) is duplicate in FusedVars.",
-                                   fused_grad_var_name));
+        common::errors::AlreadyExists("Var(%s) is duplicate in FusedVars.",
+                                      fused_grad_var_name));
     fused_var_set.insert({fused_grad_var_name, var_info});
 
     result->Get<details::FusedGrads>(details::kFusedGrads)
@@ -489,15 +489,15 @@ class CoalesceGradTensorPass : public ir::Pass {
     PADDLE_ENFORCE_EQ(
         grad_iter != vars_info.end(),
         true,
-        phi::errors::NotFound("Variable %s is not found.", var_name));
-    PADDLE_ENFORCE_EQ(
-        !grad_iter->second.empty(),
-        true,
-        phi::errors::InvalidArgument("Variable %s's node is empty.", var_name));
+        common::errors::NotFound("Variable %s is not found.", var_name));
+    PADDLE_ENFORCE_EQ(!grad_iter->second.empty(),
+                      true,
+                      common::errors::InvalidArgument(
+                          "Variable %s's node is empty.", var_name));
     PADDLE_ENFORCE_NOT_NULL(
         grad_iter->second.front()->Var(),
-        phi::errors::InvalidArgument("A node of %s does not hold variable.",
-                                     var_name));
+        common::errors::InvalidArgument("A node of %s does not hold variable.",
+                                        var_name));
     return grad_iter->second.front()->Var();
   }
 
@@ -540,7 +540,7 @@ class CoalesceGradTensorPass : public ir::Pass {
       auto next_dtype = GetDtypeOfVar(vars_info, p_g.second);
       PADDLE_ENFORCE_EQ(next_dtype,
                         dtype,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "All Parameter@Grad should have same dtype, but "
                             "there are two different type: %s, %s.",
                             DataTypeToString(next_dtype),

--- a/paddle/fluid/framework/ir/constant_folding_pass.cc
+++ b/paddle/fluid/framework/ir/constant_folding_pass.cc
@@ -88,13 +88,13 @@ ConstantFoldingPass::ConstantFoldingPass() = default;
 
 void ConstantFoldingPass::ApplyImpl(ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("constant_folding", graph);
   auto *scope = param_scope();
 
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "scope must not be null when applying constant folding."));
 
   std::vector<std::string> blacklist{"feed",

--- a/paddle/fluid/framework/ir/conv2d_trans_filter_dilations_nxn_to_1x1_pass.cc
+++ b/paddle/fluid/framework/ir/conv2d_trans_filter_dilations_nxn_to_1x1_pass.cc
@@ -63,7 +63,7 @@ namespace paddle::framework::ir {
 
 void Conv2dTransFilterDilationsNxNTo1x1Pass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   conv2d_dilation_trans(graph);
 }

--- a/paddle/fluid/framework/ir/conv_bn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_bn_fuse_pass.cc
@@ -91,7 +91,7 @@ void recompute_bias_and_weights(const Scope* scope,
   // Re-compute bias of conv2d from BN
   PADDLE_ENFORCE_EQ(eltwise_y_in_tensor->dims(),
                     bn_bias_tensor.dims(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "phi::DenseTensor elementwise y(%d) and batch "
                         "norm bias(%d) must have same dims.",
                         eltwise_y_in_tensor->dims().size(),
@@ -122,7 +122,7 @@ void recompute_bias_and_weights(const Scope* scope,
   for (int i = 0; i < variance_tensor->numel(); i++) {
     PADDLE_ENFORCE_EQ(std::isfinite(variance_array[i]),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The inverse of Fused batch norm variance "
                           "should be finite. Found nonfinite values! "
                           "Please check %s ",
@@ -136,13 +136,13 @@ void recompute_bias_and_weights(const Scope* scope,
   eltwise_y_in_array =
       ((eltwise_y_in_array - mean_array) * variance_array) + bn_bias_array;
   for (int i = 0; i < eltwise_y_in_tensor->numel(); i++) {
-    PADDLE_ENFORCE_EQ(
-        std::isfinite(eltwise_y_in_array[i]),
-        true,
-        phi::errors::InvalidArgument("Fused batch norm bias should be "
-                                     "finite. Found nonfinite values! "
-                                     "Please check %s and related variables.",
-                                     bn_variance.Name()));
+    PADDLE_ENFORCE_EQ(std::isfinite(eltwise_y_in_array[i]),
+                      true,
+                      common::errors::InvalidArgument(
+                          "Fused batch norm bias should be "
+                          "finite. Found nonfinite values! "
+                          "Please check %s and related variables.",
+                          bn_variance.Name()));
   }
 
   // Re-compute weight of conv2d from BN
@@ -304,7 +304,7 @@ ConvBNFusePass::ConvBNFusePass() {
 
 void ConvBNFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(name_scope_, graph);
 
   VLOG(3) << "Running conv_bn_fuse_pass.";
@@ -317,7 +317,7 @@ void ConvBNFusePass::ApplyImpl(ir::Graph* graph) const {
 
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
-      scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+      scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
   GraphPatternDetector gpd;
   auto* conv_input =
@@ -425,12 +425,12 @@ void ConvBNFusePass::ApplyImpl(ir::Graph* graph) const {
         PADDLE_ENFORCE_EQ(
             conv_bias_names.size(),
             1UL,
-            phi::errors::InvalidArgument("Find input var Bias error."));
+            common::errors::InvalidArgument("Find input var Bias error."));
         auto* conv_bias_var = scope->FindVar(conv_bias_names[0]);
         auto* conv_bias_tensor = conv_bias_var->GetMutable<phi::DenseTensor>();
         PADDLE_ENFORCE_EQ(conv_bias_tensor->dims(),
                           bn_bias_tensor->dims(),
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "phi::DenseTensor convolution bias(%d) and batch "
                               "normalization bias (%d) "
                               "must have same dims.",
@@ -612,7 +612,7 @@ ConvEltwiseAddBNFusePass::ConvEltwiseAddBNFusePass() {
 
 void ConvEltwiseAddBNFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(name_scope_, graph);
 
   VLOG(3) << "Running conv_eltwiseadd_bn_fuse_pass.";
@@ -626,7 +626,7 @@ void ConvEltwiseAddBNFusePass::ApplyImpl(ir::Graph* graph) const {
 
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
-      scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+      scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
   GraphPatternDetector gpd;
   auto* conv_input =

--- a/paddle/fluid/framework/ir/conv_bn_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/conv_bn_fuse_pass_tester.cc
@@ -85,13 +85,13 @@ void TestMain(const std::string& conv_type) {
   PADDLE_ENFORCE_EQ(
       num_bn_nodes_before,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Before conv_bn_fuse_pass, number of batch norm op(%d) must be 1.",
           num_bn_nodes_before));
   PADDLE_ENFORCE_EQ(
       num_bn_nodes_after,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After conv_bn_fuse_pass, number of batch norm op(%d) must be 0.",
           num_bn_nodes_after));
 }

--- a/paddle/fluid/framework/ir/conv_elementwise_add2_act_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_elementwise_add2_act_fuse_pass.cc
@@ -210,7 +210,7 @@ void ConvElementwiseAdd2ActFusePass::ApplyImpl(ir::Graph* graph) const {
     PADDLE_ENFORCE_NE(
         subgraph.count(x),
         0,
-        phi::errors::NotFound("Detector did not find input x of conv2d."));
+        common::errors::NotFound("Detector did not find input x of conv2d."));
     auto* conv_in_node = subgraph.at(x);
 
     IR_NODE_LINK_TO(conv_in_node, new_conv_op);            // Input

--- a/paddle/fluid/framework/ir/conv_elementwise_add_act_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_elementwise_add_act_fuse_pass.cc
@@ -233,7 +233,7 @@ void ConvElementwiseAddActFusePass::ApplyImpl(ir::Graph* graph) const {
     PADDLE_ENFORCE_NE(
         subgraph.count(x),
         0,
-        phi::errors::NotFound("Detector did not find input x of conv2d."));
+        common::errors::NotFound("Detector did not find input x of conv2d."));
     auto* conv_in_node = subgraph.at(x);
 
     IR_NODE_LINK_TO(conv_in_node, new_conv_op);          // Input

--- a/paddle/fluid/framework/ir/conv_elementwise_add_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_elementwise_add_fuse_pass.cc
@@ -153,7 +153,7 @@ void ConvElementwiseAddFusePass::ApplyImpl(ir::Graph* graph) const {
     PADDLE_ENFORCE_NE(
         subgraph.count(x),
         0,
-        phi::errors::NotFound("Detector did not find input x of conv2d."));
+        common::errors::NotFound("Detector did not find input x of conv2d."));
     auto* conv_in_node = subgraph.at(x);
 
     IR_NODE_LINK_TO(conv_in_node, new_conv_op);          // Input

--- a/paddle/fluid/framework/ir/cost_model.cc
+++ b/paddle/fluid/framework/ir/cost_model.cc
@@ -232,8 +232,8 @@ CostData CostModel::ProfileMeasure(
     profiler_state = platform::ProfilerState::kAll;
     place = phi::GPUPlace();
   } else {
-    PADDLE_THROW(
-        phi::errors::Unimplemented("Not support %s in CostModel now", device));
+    PADDLE_THROW(common::errors::Unimplemented(
+        "Not support %s in CostModel now", device));
   }
 
   Executor executor(place);

--- a/paddle/fluid/framework/ir/cutlass_teller.h
+++ b/paddle/fluid/framework/ir/cutlass_teller.h
@@ -44,13 +44,13 @@ class CutlassTeller {
     auto dilations = op_desc->GetAttrIfExists<std::vector<int>>("dilations");
     PADDLE_ENFORCE_EQ(strides.size(),
                       2UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The 'strides' attribute in conv2d should be a "
                           "vector of size 2, but received size %d.",
                           strides.size()));
     PADDLE_ENFORCE_EQ(dilations.size(),
                       2UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The 'dilations' attribute in conv2d should be a "
                           "vector of size 2, but received size %d.",
                           dilations.size()));
@@ -66,7 +66,7 @@ class CutlassTeller {
       const auto &filter_tensor = filter_var->Get<phi::DenseTensor>();
       PADDLE_ENFORCE_EQ(filter_tensor.dims().size(),
                         4UL,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The 'Filter' tensor in conv2d should have 4 "
                             "dimensions, but received dimensions %d.",
                             filter_tensor.dims().size()));
@@ -112,13 +112,13 @@ class CutlassTeller {
     auto dilations = op_desc->GetAttrIfExists<std::vector<int>>("dilations");
     PADDLE_ENFORCE_EQ(strides.size(),
                       2UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The 'strides' attribute in conv2d should be a "
                           "vector of size 2, but received size %d.",
                           strides.size()));
     PADDLE_ENFORCE_EQ(dilations.size(),
                       2UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The 'dilations' attribute in conv2d should be a "
                           "vector of size 2, but received size %d.",
                           dilations.size()));
@@ -134,7 +134,7 @@ class CutlassTeller {
       const auto &filter_tensor = filter_var->Get<phi::DenseTensor>();
       PADDLE_ENFORCE_EQ(filter_tensor.dims().size(),
                         4UL,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The 'Filter' tensor in conv2d should have 4 "
                             "dimensions, but received dimensions %d.",
                             filter_tensor.dims().size()));
@@ -182,13 +182,13 @@ class CutlassTeller {
     auto dilations = op_desc->GetAttrIfExists<std::vector<int>>("dilations");
     PADDLE_ENFORCE_EQ(strides.size(),
                       2UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The 'strides' attribute in conv2d should be a "
                           "vector of size 2, but received size %d.",
                           strides.size()));
     PADDLE_ENFORCE_EQ(dilations.size(),
                       2UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The 'dilations' attribute in conv2d should be a "
                           "vector of size 2, but received size %d.",
                           dilations.size()));
@@ -210,7 +210,7 @@ class CutlassTeller {
       const auto &filter_tensor = filter_var->Get<phi::DenseTensor>();
       PADDLE_ENFORCE_EQ(filter_tensor.dims().size(),
                         4UL,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The 'Filter' tensor in conv2d should have 4 "
                             "dimensions, but received dimensions %d.",
                             filter_tensor.dims().size()));

--- a/paddle/fluid/framework/ir/delete_assign_op_pass.cc
+++ b/paddle/fluid/framework/ir/delete_assign_op_pass.cc
@@ -69,7 +69,7 @@ class DeleteAssignOpPass : public FusePassBase {
 
 void DeleteAssignOpPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   GraphPatternDetector gpd;
   patterns::AssignWithSameInputOutputNamePattern pattern(gpd.mutable_pattern(),

--- a/paddle/fluid/framework/ir/delete_assign_op_pass_test.cc
+++ b/paddle/fluid/framework/ir/delete_assign_op_pass_test.cc
@@ -35,7 +35,7 @@ TEST(delete_assign_op_pass, basic) {
   PADDLE_ENFORCE_EQ(
       assign_num,
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "graph should have 0 assign after delete_assign_op_pass, "
           "but actually has %d.",
           assign_num));

--- a/paddle/fluid/framework/ir/delete_cast_op_pass.cc
+++ b/paddle/fluid/framework/ir/delete_cast_op_pass.cc
@@ -775,7 +775,7 @@ int DeleteCastOpPass::ApplyCastPass(ir::Graph* graph) const {
 
 void DeleteCastOpPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   if (!graph->IsMainGraph()) {
     VLOG(3) << "'delete_cast_op_pass' needs info in all graphs, so it "
                "should be applied in the main graph.";

--- a/paddle/fluid/framework/ir/delete_cast_op_pass_test.cc
+++ b/paddle/fluid/framework/ir/delete_cast_op_pass_test.cc
@@ -149,14 +149,14 @@ TEST(ApplyCastWriteReadPass, basic) {
   int cast_num_in_graph1 = GetOpNum(graph->GetSubGraph(1), "cast");
   PADDLE_ENFORCE_EQ(cast_num_in_graph1,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "graph1 should have 0 cast after delete_cast_op_pass, "
                         "but actually has %d.",
                         cast_num_in_graph1));
   int cast_num_in_graph0 = GetOpNum(graph.get(), "cast");
   PADDLE_ENFORCE_EQ(cast_num_in_graph0,
                     1,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "graph0 should have 1 cast after delete_cast_op_pass, "
                         "but actually has %d.",
                         cast_num_in_graph0));
@@ -196,14 +196,14 @@ TEST(ApplyCastLodResetWriteReadPass, basic) {
   int cast_num_in_graph1 = GetOpNum(graph->GetSubGraph(1), "cast");
   PADDLE_ENFORCE_EQ(cast_num_in_graph1,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "graph1 should have 0 cast after delete_cast_op_pass, "
                         "but actually has %d.",
                         cast_num_in_graph1));
   int cast_num_in_graph0 = GetOpNum(graph.get(), "cast");
   PADDLE_ENFORCE_EQ(cast_num_in_graph0,
                     2,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "graph0 should have 2 cast after delete_cast_op_pass, "
                         "but actually has %d.",
                         cast_num_in_graph0));
@@ -229,7 +229,7 @@ TEST(ApplyCastIndexSamplePass, basic) {
   int cast_num_in_graph = GetOpNum(graph->GetSubGraph(0), "cast");
   PADDLE_ENFORCE_EQ(GetOpNum(graph->GetSubGraph(0), "cast"),
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "graph should have 0 cast after delete_cast_op_pass, "
                         "but actually has %d.",
                         cast_num_in_graph));
@@ -258,7 +258,7 @@ TEST(ApplyCastScatterPass, basic) {
   int cast_num_in_graph = GetOpNum(graph->GetSubGraph(0), "cast");
   PADDLE_ENFORCE_EQ(GetOpNum(graph->GetSubGraph(0), "cast"),
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "graph should have 0 cast after delete_cast_op_pass, "
                         "but actually has %d.",
                         cast_num_in_graph));
@@ -288,7 +288,7 @@ TEST(ApplyCastLookupTablePass, basic) {
   int cast_num_in_graph = GetOpNum(graph->GetSubGraph(0), "cast");
   PADDLE_ENFORCE_EQ(GetOpNum(graph->GetSubGraph(0), "cast"),
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "graph should have 0 cast after delete_cast_op_pass, "
                         "but actually has %d.",
                         cast_num_in_graph));
@@ -307,7 +307,7 @@ TEST(ApplyCastPass, basic) {
   int cast_num_in_graph = GetOpNum(graph->GetSubGraph(0), "cast");
   PADDLE_ENFORCE_EQ(GetOpNum(graph->GetSubGraph(0), "cast"),
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "graph should have 0 cast after delete_cast_op_pass, "
                         "but actually has %d.",
                         cast_num_in_graph));

--- a/paddle/fluid/framework/ir/delete_concat_op_pass.cc
+++ b/paddle/fluid/framework/ir/delete_concat_op_pass.cc
@@ -79,7 +79,7 @@ class DeleteConcatOpPass : public FusePassBase {
 
 void DeleteConcatOpPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   GraphPatternDetector gpd;
   patterns::ConcatPattern pattern(gpd.mutable_pattern(), name_scope_);

--- a/paddle/fluid/framework/ir/delete_dropout_op_pass_test.cc
+++ b/paddle/fluid/framework/ir/delete_dropout_op_pass_test.cc
@@ -61,14 +61,14 @@ TEST(DeleteDropoutOpsPass, dropout) {
       PADDLE_ENFORCE_EQ(
           num_dropout_nodes_after,
           0,
-          phi::errors::InvalidArgument("num_dropout_nodes_after = %d.",
-                                       num_dropout_nodes_after));
+          common::errors::InvalidArgument("num_dropout_nodes_after = %d.",
+                                          num_dropout_nodes_after));
 
       if (dropout_implementation == "downgrade_in_infer") {
         PADDLE_ENFORCE_EQ(
             num_dropout_nodes_before,
             num_scale_nodes_after - num_scale_nodes_before,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "num_dropout_nodes_before = %d, num_scale_nodes_after = %d, "
                 "num_scale_nodes_before = %d.",
                 num_dropout_nodes_before,
@@ -78,7 +78,7 @@ TEST(DeleteDropoutOpsPass, dropout) {
         PADDLE_ENFORCE_EQ(
             num_scale_nodes_after - num_scale_nodes_before,
             0,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "num_scale_nodes_after = %d, num_scale_nodes_before = %d.",
                 num_scale_nodes_after,
                 num_scale_nodes_before));

--- a/paddle/fluid/framework/ir/delete_elementwise_mul_op_pass.cc
+++ b/paddle/fluid/framework/ir/delete_elementwise_mul_op_pass.cc
@@ -83,7 +83,7 @@ class DeleteElementwiseMulOpPass : public FusePassBase {
 
 void DeleteElementwiseMulOpPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   GraphPatternDetector gpd;
   patterns::FillMulPattern pattern(gpd.mutable_pattern(), name_scope_);

--- a/paddle/fluid/framework/ir/delete_op_device_pass.cc
+++ b/paddle/fluid/framework/ir/delete_op_device_pass.cc
@@ -34,7 +34,7 @@ class DeleteOpDevicePass : public Pass {
 
 void DeleteOpDevicePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   int delete_counts = 0;
   for (auto* node : graph->Nodes()) {
     if (!node->IsOp() || !node->Op()->HasAttr("op_device")) continue;

--- a/paddle/fluid/framework/ir/delete_op_device_pass_test.cc
+++ b/paddle/fluid/framework/ir/delete_op_device_pass_test.cc
@@ -35,7 +35,7 @@ TEST(delete_op_device_pass, relu) {
     if (!node->IsOp()) continue;
     if (node->Op()->Type() == "relu") {
       PADDLE_ENFORCE(!node->Op()->HasAttr("op_device"),
-                     phi::errors::InvalidArgument(
+                     common::errors::InvalidArgument(
                          "Run delete_op_device_pass failed. Relu op still has "
                          "'op_device' attr."));
     }

--- a/paddle/fluid/framework/ir/delete_quant_dequant_filter_op_pass.cc
+++ b/paddle/fluid/framework/ir/delete_quant_dequant_filter_op_pass.cc
@@ -111,10 +111,11 @@ void DeleteQuantDequantFilterOpPass::ApplyImpl(ir::Graph* graph) const {
         break;
       }
     }
-    PADDLE_ENFORCE_GT(arg_name.size(),
-                      0,
-                      phi::errors::InvalidArgument("can not find the input %s.",
-                                                   quant_dequant_op_out_name));
+    PADDLE_ENFORCE_GT(
+        arg_name.size(),
+        0,
+        common::errors::InvalidArgument("can not find the input %s.",
+                                        quant_dequant_op_out_name));
     // any_op2_desc->SetAttr("enable_int8", true);
     any_op2_desc->SetAttr("bit_length", bit_length);
 
@@ -136,14 +137,14 @@ void DeleteQuantDequantFilterOpPass::ApplyImpl(ir::Graph* graph) const {
       PADDLE_ENFORCE_EQ(
           quant_axis == 0 || quant_axis == 1,
           true,
-          phi::errors::InvalidArgument("'quant_axis' should be 0 or 1, but "
-                                       "the received is %d",
-                                       quant_axis));
+          common::errors::InvalidArgument("'quant_axis' should be 0 or 1, but "
+                                          "the received is %d",
+                                          quant_axis));
 
       // To Do @Wangzheee: use "OutScale" to quant_dequant
       /*auto scales_name = quant_dequant_op->Op()->Output("OutScale");
       PADDLE_ENFORCE_EQ(scales_name.size(), 1,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Scales size in channel-wise quant dequantize op "
                             "should be 1, got %d.",
                             scales_name.size()));
@@ -151,7 +152,7 @@ void DeleteQuantDequantFilterOpPass::ApplyImpl(ir::Graph* graph) const {
           scope->FindVar(scales_name[0])->Get<phi::DenseTensor>();
       PADDLE_ENFORCE(
           phi::is_cpu_place(channel_scale_tensor.place()),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Channel scale tensor's place should be CPU."));
       // compute the channel wise abs max of the weight tensor
 
@@ -189,7 +190,7 @@ void DeleteQuantDequantFilterOpPass::ApplyImpl(ir::Graph* graph) const {
       for (int i = 0; i < channel; i++) {
         PADDLE_ENFORCE_NE(weight_scale[i],
                           0,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Weight scale should be nonzero, but get zero."));
         weight_scale[i] = weight_scale[i] / static_cast<float>(range);
       }
@@ -202,11 +203,11 @@ void DeleteQuantDequantFilterOpPass::ApplyImpl(ir::Graph* graph) const {
       }
       PADDLE_ENFORCE_NE(abs_max_weight,
                         0,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Weight scale should be nonzero, but get zero"));
       weight_scale.push_back(abs_max_weight / static_cast<float>(range));
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupported quantize_dequantize op type: %s", dequant_type));
     }
 

--- a/paddle/fluid/framework/ir/delete_quant_dequant_linear_op_pass.cc
+++ b/paddle/fluid/framework/ir/delete_quant_dequant_linear_op_pass.cc
@@ -91,7 +91,7 @@ void DeleteQuantDequantLinearOpPass::ApplyImpl(ir::Graph* graph) const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Scope in DeleteQuantDequantLinearOpPass should not be null."));
 
   VLOG(3) << "Running delete_quant_dequant_linear_op_pass.";
@@ -141,7 +141,7 @@ void DeleteQuantDequantLinearOpPass::ApplyImpl(ir::Graph* graph) const {
             ->Get<phi::DenseTensor>();
     PADDLE_ENFORCE_EQ(phi::is_cpu_place(input_scale_tensor.place()),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input scale tensor's place should be CPU."));
 
     float input_scale = NAN;
@@ -153,8 +153,8 @@ void DeleteQuantDequantLinearOpPass::ApplyImpl(ir::Graph* graph) const {
           input_scale_tensor.data<phi::dtype::float16>();
       input_scale = static_cast<float>(input_scale_data[0]);
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented("%d is not supported.",
-                                              input_scale_tensor.dtype()));
+      PADDLE_THROW(common::errors::Unimplemented("%d is not supported.",
+                                                 input_scale_tensor.dtype()));
     }
 
     int nums_any_ops =

--- a/paddle/fluid/framework/ir/delete_quant_dequant_op_pass.cc
+++ b/paddle/fluid/framework/ir/delete_quant_dequant_op_pass.cc
@@ -53,7 +53,7 @@ void DeleteQuantDequantOpPass::ApplyImpl(ir::Graph* graph) const {
     PADDLE_ENFORCE_EQ(
         subgraph.count(input_node),
         true,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Input act node(%s) not found in QuantDequantFuse pass.",
             input_node->name()));
     Node* input = subgraph.at(input_node);
@@ -66,13 +66,13 @@ void DeleteQuantDequantOpPass::ApplyImpl(ir::Graph* graph) const {
         quant_dequant_op->Op()->Input("InScale").front();
     PADDLE_ENFORCE_NOT_NULL(
         scope,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Scope in DeleteQuantDequantOpPass should not be null."));
     const phi::DenseTensor& input_scale_tensor =
         scope->FindVar(input_scale_var_name)->Get<phi::DenseTensor>();
     PADDLE_ENFORCE_EQ(phi::is_cpu_place(input_scale_tensor.place()),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input scale tensor's place should be CPU."));
     const float* input_scale_data = input_scale_tensor.data<float>();
     float input_scale = input_scale_data[0];

--- a/paddle/fluid/framework/ir/delete_remove_padding_recover_padding_pass.cc
+++ b/paddle/fluid/framework/ir/delete_remove_padding_recover_padding_pass.cc
@@ -42,7 +42,7 @@ void RecoverPadding::operator()() {
 
 void DeleteRemovePaddingRecoverPaddingPass::ApplyImpl(ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init(name_scope_, graph);
   int found_subgraph_count = 0;
 

--- a/paddle/fluid/framework/ir/delete_repeated_ops_pass.cc
+++ b/paddle/fluid/framework/ir/delete_repeated_ops_pass.cc
@@ -273,7 +273,7 @@ std::string GenSqueeze2AttrKey(Node* squeeze2_op_node) {
 
 void DeleteRepeatedOpsPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   int repeat_time = 0;
   int total_delete_op_count = 0;

--- a/paddle/fluid/framework/ir/delete_weight_dequant_linear_op_pass.cc
+++ b/paddle/fluid/framework/ir/delete_weight_dequant_linear_op_pass.cc
@@ -32,7 +32,7 @@ void DeleteWeightDequantLinearOpPass::ApplyImpl(ir::Graph* graph) const {
                                              "conv2d_transpose"};
   PADDLE_ENFORCE_EQ(graph->Has(kParamScopeAttr),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Graph must have kParamScopeAttr attribute."));
 
   VLOG(3) << "Running delete_weight_dequant_linear_op_pass.";
@@ -119,7 +119,7 @@ void DeleteWeightDequantLinearOpPass::ApplyImpl(ir::Graph* graph) const {
                           static_cast<float>(weight_scale_data[i]));
                     }
                   } else {
-                    PADDLE_THROW(phi::errors::Unimplemented(
+                    PADDLE_THROW(common::errors::Unimplemented(
                         "The dtype of quantization scale must be FP32/FP16, "
                         "but received %d, which is not supported.",
                         weight_scale_tensor->dtype()));
@@ -131,7 +131,7 @@ void DeleteWeightDequantLinearOpPass::ApplyImpl(ir::Graph* graph) const {
                     PADDLE_ENFORCE_EQ(
                         weight_scale_nums,
                         1,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "When quant_axis == -1, it means using per_layer "
                             "dequantization. In this situation, the number of "
                             "weight_scale should be 1, but received %d.",
@@ -147,7 +147,7 @@ void DeleteWeightDequantLinearOpPass::ApplyImpl(ir::Graph* graph) const {
                     PADDLE_ENFORCE_EQ(
                         weight_scale_nums,
                         weights_shape[quant_axis],
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "When quant_axis != -1, it means using per_channel "
                             "dequantization. In this situation, the number of "
                             "weight_scale should be equal with "

--- a/paddle/fluid/framework/ir/delete_weight_dequant_linear_op_pass_tester.cc
+++ b/paddle/fluid/framework/ir/delete_weight_dequant_linear_op_pass_tester.cc
@@ -74,17 +74,17 @@ TEST(DeleteWeightDequantLinearOpPass, basic) {
   PADDLE_ENFORCE_EQ(
       num_nodes_before,
       num_nodes_after + 3,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After pass, the number of nodes should be reduced by 3, but the "
           "number before pass is %d, after pass is %d.",
           num_nodes_before,
           num_nodes_after));
-  PADDLE_ENFORCE_EQ(
-      num_dequant_nodes_after,
-      0,
-      phi::errors::InvalidArgument("After pass, the number of nodes of type "
-                                   "'dequantize_linear' should be 1, not %d.",
-                                   num_dequant_nodes_after));
+  PADDLE_ENFORCE_EQ(num_dequant_nodes_after,
+                    0,
+                    common::errors::InvalidArgument(
+                        "After pass, the number of nodes of type "
+                        "'dequantize_linear' should be 1, not %d.",
+                        num_dequant_nodes_after));
 }
 
 TEST(DeleteWeightDequantLinearOpPass, basic_fp16) {
@@ -121,17 +121,17 @@ TEST(DeleteWeightDequantLinearOpPass, basic_fp16) {
   PADDLE_ENFORCE_EQ(
       num_nodes_before,
       num_nodes_after + 3,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After pass, the number of nodes should be reduced by 3, but the "
           "number before pass is %d, after pass is %d.",
           num_nodes_before,
           num_nodes_after));
-  PADDLE_ENFORCE_EQ(
-      num_dequant_nodes_after,
-      0,
-      phi::errors::InvalidArgument("After pass, the number of nodes of type "
-                                   "'dequantize_linear' should be 1, not %d.",
-                                   num_dequant_nodes_after));
+  PADDLE_ENFORCE_EQ(num_dequant_nodes_after,
+                    0,
+                    common::errors::InvalidArgument(
+                        "After pass, the number of nodes of type "
+                        "'dequantize_linear' should be 1, not %d.",
+                        num_dequant_nodes_after));
 }
 
 }  // namespace ir

--- a/paddle/fluid/framework/ir/dense_fc_to_sparse_pass.cc
+++ b/paddle/fluid/framework/ir/dense_fc_to_sparse_pass.cc
@@ -67,7 +67,7 @@ DenseFCToSparsePass::DenseFCToSparsePass() {
 
 void DenseFCToSparsePass::ApplyImpl(Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
 
   std::string name_scope = "dense_fc_to_sparse_pass";
   FusePassBase::Init(name_scope, graph);

--- a/paddle/fluid/framework/ir/dense_fc_to_sparse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/dense_fc_to_sparse_pass_tester.cc
@@ -83,19 +83,19 @@ TEST(FCFusePass, basic) {
   int num_sparse_fc_nodes_after = GetNumOpNodes(graph, "sparse_fc");
   VLOG(3) << DebugString(graph);
 
-  PADDLE_ENFORCE_EQ(
-      num_nodes_before,
-      num_nodes_after + 6,
-      phi::errors::InvalidArgument("num_nodes_before=%d, num_nodes_after=%d.",
-                                   num_nodes_before,
-                                   num_nodes_after));
+  PADDLE_ENFORCE_EQ(num_nodes_before,
+                    num_nodes_after + 6,
+                    common::errors::InvalidArgument(
+                        "num_nodes_before=%d, num_nodes_after=%d.",
+                        num_nodes_before,
+                        num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fc_nodes_after,
                     1,
-                    phi::errors::InvalidArgument("num_fc_nodes_after=%d.",
-                                                 num_fc_nodes_after));
+                    common::errors::InvalidArgument("num_fc_nodes_after=%d.",
+                                                    num_fc_nodes_after));
   PADDLE_ENFORCE_EQ(num_mul_nodes_before,
                     num_fc_nodes_after + num_sparse_fc_nodes_after,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "num_mul_nodes_before=%d, num_fc_nodes_after=%d + "
                         "num_sparse_fc_nodes_after=%d.",
                         num_mul_nodes_before,

--- a/paddle/fluid/framework/ir/dense_multihead_matmul_to_sparse_pass.cc
+++ b/paddle/fluid/framework/ir/dense_multihead_matmul_to_sparse_pass.cc
@@ -81,7 +81,7 @@ DenseMultiheadMatmulToSparsePass::DenseMultiheadMatmulToSparsePass() {
 
 void DenseMultiheadMatmulToSparsePass::ApplyImpl(Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
 
   std::string name_scope = "dense_multihead_matmul_to_sparse_pass";
   FusePassBase::Init(name_scope, graph);

--- a/paddle/fluid/framework/ir/dense_multihead_matmul_to_sparse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/dense_multihead_matmul_to_sparse_pass_tester.cc
@@ -132,7 +132,7 @@ TEST(DenseMultiHeadMatmulToSparsePass, basic) {
 
   PADDLE_ENFORCE_EQ(num_nodes_before,
                     num_nodes_after + 39,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After the multihead_matmul pass and sparse pass, The "
                         "node num in graph "
                         "should be %d, but the result is %d",
@@ -140,7 +140,7 @@ TEST(DenseMultiHeadMatmulToSparsePass, basic) {
                         num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fused_nodes_after,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After the multihead_matmul pass and sparse pass, "
                         "there should be one "
                         "sparse_multihead_matmul op, but the result is %d",

--- a/paddle/fluid/framework/ir/elementwise_groupnorm_act_pass.cc
+++ b/paddle/fluid/framework/ir/elementwise_groupnorm_act_pass.cc
@@ -97,7 +97,7 @@ void SkipGroupNormAct::operator()(PDNode *x, PDNode *y) {
 
 int SkipGroupNormActFusePass::ApplyGNSiluPattern(ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("skip_groupnorm_silu_fuse", graph);
 
   int found_subgraph_count = 0;

--- a/paddle/fluid/framework/ir/elementwiseadd_transpose_pass.cc
+++ b/paddle/fluid/framework/ir/elementwiseadd_transpose_pass.cc
@@ -78,7 +78,7 @@ namespace paddle::framework::ir {
 int ElementwiseAddTransposeFusePass::ApplyEleTransPattern(
     ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("eleadd_transpose_fuse", graph);
   int found_subgraph_count = 0;
   GraphPatternDetector gpd;
@@ -183,7 +183,7 @@ int ElementwiseAddTransposeFusePass::ApplyEleTransPattern(
 }
 void ElementwiseAddTransposeFusePass::ApplyImpl(ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(graph,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Pointer to graph argument should not be NULL."));
   FusePassBase::Init("elementwiseadd_transpose_fuse_pass", graph);
   int found_subgraph_count = ApplyEleTransPattern(graph);

--- a/paddle/fluid/framework/ir/embedding_eltwise_layernorm_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/embedding_eltwise_layernorm_fuse_pass_tester.cc
@@ -84,13 +84,13 @@ TEST(EmbeddingElewiseLayernormFusePass, basic) {
 
   PADDLE_ENFORCE_EQ(num_nodes_before,
                     num_nodes_after + 28,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The number of nodes before and after the fuse does "
                         "not meet expectations"));
   PADDLE_ENFORCE_EQ(
       num_fused_nodes_after,
       2,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The number of fusion nodes does not meet expectations after fuse"));
 }
 

--- a/paddle/fluid/framework/ir/embedding_fc_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/embedding_fc_lstm_fuse_pass.cc
@@ -70,12 +70,12 @@ static int BuildFusion(Graph* graph,
 
     // Multiply embeddings with Weights
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
     const std::string& embeddings = patterns::UniqueKey("Embeddings");
     auto* embeddings_var = scope->Var(embeddings);
     PADDLE_ENFORCE_NOT_NULL(
         embeddings_var,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Embeddings variable's pointer cannot be nullptr."));
     auto* embeddings_tensor = embeddings_var->GetMutable<phi::DenseTensor>();
     // Get WeightX size: [single_embedding, fc_size]
@@ -84,7 +84,7 @@ static int BuildFusion(Graph* graph,
     auto* embedding_var = scope->FindVar(W->Name());
     PADDLE_ENFORCE_NOT_NULL(
         embedding_var,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Embedding variable's pointer cannot be nullptr."));
     const auto& embedding_tensor = embedding_var->Get<phi::DenseTensor>();
 
@@ -101,9 +101,9 @@ static int BuildFusion(Graph* graph,
 
     // Adding biases to GEMM result to be
     auto* lstm_bias_var = scope->FindVar(bias->Name());
-    PADDLE_ENFORCE_NOT_NULL(
-        lstm_bias_var,
-        phi::errors::InvalidArgument("Lstm bias var ptr cannot be nullptr."));
+    PADDLE_ENFORCE_NOT_NULL(lstm_bias_var,
+                            common::errors::InvalidArgument(
+                                "Lstm bias var ptr cannot be nullptr."));
     const auto& lstm_bias_tensor = lstm_bias_var->Get<phi::DenseTensor>();
 
     auto alpha = 1.0f;

--- a/paddle/fluid/framework/ir/fc_elementwise_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_elementwise_layernorm_fuse_pass.cc
@@ -203,7 +203,7 @@ FCElementwiseLayerNormFusePass::FCElementwiseLayerNormFusePass() {
 
 void FCElementwiseLayerNormFusePass::ApplyImpl(ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(graph,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Pointer to graph argument should not be NULL."));
   FusePassBase::Init("fc_elementwise_layernorm_fuse", graph);
   int found_subgraph_count = 0;

--- a/paddle/fluid/framework/ir/fc_elementwise_layernorm_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/fc_elementwise_layernorm_fuse_pass_tester.cc
@@ -57,14 +57,14 @@ TEST(FCElementwiseLayerNormFusePass, basic) {
   PADDLE_ENFORCE_EQ(
       num_nodes_before,
       num_nodes_after + 6,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After pass, the number of nodes should be reduced by 6, but the "
           "number before pass is %d, after pass is %d.",
           num_nodes_before,
           num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fused_nodes_after,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After pass, the number of nodes of type "
                         "'fused_fc_elementwise_layernorm' should be 1, not %d.",
                         num_fused_nodes_after));

--- a/paddle/fluid/framework/ir/fc_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_fuse_pass.cc
@@ -89,7 +89,7 @@ FCFusePass::FCFusePass() {
 
 void FCFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init("fc_fuse", graph);
 
   int found_fc_count = 0;

--- a/paddle/fluid/framework/ir/fc_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/fc_fuse_pass_tester.cc
@@ -80,19 +80,19 @@ TEST(FCFusePass, basic) {
   int num_fc_nodes_after = GetNumOpNodes(graph, "fc");
   VLOG(3) << DebugString(graph);
 
-  PADDLE_ENFORCE_EQ(
-      num_nodes_before,
-      num_nodes_after + 6,
-      phi::errors::InvalidArgument("num_nodes_before=%d, num_nodes_after=%d.",
-                                   num_nodes_before,
-                                   num_nodes_after));
+  PADDLE_ENFORCE_EQ(num_nodes_before,
+                    num_nodes_after + 6,
+                    common::errors::InvalidArgument(
+                        "num_nodes_before=%d, num_nodes_after=%d.",
+                        num_nodes_before,
+                        num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fc_nodes_after,
                     2,
-                    phi::errors::InvalidArgument("num_fc_nodes_after=%d.",
-                                                 num_fc_nodes_after));
+                    common::errors::InvalidArgument("num_fc_nodes_after=%d.",
+                                                    num_fc_nodes_after));
   PADDLE_ENFORCE_EQ(num_mul_nodes_before,
                     num_fc_nodes_after,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "num_mul_nodes_before=%d, num_fc_nodes_after=%d.",
                         num_mul_nodes_before,
                         num_fc_nodes_after));

--- a/paddle/fluid/framework/ir/fc_gru_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_gru_fuse_pass.cc
@@ -222,18 +222,18 @@ int FCGRUFusePass::BuildFusion(Graph* graph,
       PADDLE_ENFORCE_NE(
           gru_bias_var,
           nullptr,
-          phi::errors::NotFound("GRU bias var has not been found."));
+          common::errors::NotFound("GRU bias var has not been found."));
       PADDLE_ENFORCE_NE(
           fc_bias_var,
           nullptr,
-          phi::errors::NotFound("FC bias var has not been found."));
+          common::errors::NotFound("FC bias var has not been found."));
 
       auto* gru_bias_tensor = gru_bias_var->GetMutable<phi::DenseTensor>();
       auto* fc_bias_tensor = fc_bias_var->GetMutable<phi::DenseTensor>();
       PADDLE_ENFORCE_EQ(
           gru_bias_tensor->numel(),
           fc_bias_tensor->numel(),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "GRU and FC biases have to have equal number of elements."));
 
       auto gru_bias_data =

--- a/paddle/fluid/framework/ir/fc_gru_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/fc_gru_fuse_pass_tester.cc
@@ -33,19 +33,19 @@ TEST(FcGruFusePass, basic) {
   int num_fuse_gru_nodes_after = GetNumOpNodes(graph, "fusion_gru");
   VLOG(3) << DebugString(graph);
 
-  PADDLE_ENFORCE_EQ(
-      num_nodes_before,
-      num_nodes_after + 6,
-      phi::errors::PreconditionNotMet("The number of nodes before and after "
-                                      "the fuse does not meet expectations"));
+  PADDLE_ENFORCE_EQ(num_nodes_before,
+                    num_nodes_after + 6,
+                    common::errors::PreconditionNotMet(
+                        "The number of nodes before and after "
+                        "the fuse does not meet expectations"));
   PADDLE_ENFORCE_EQ(
       num_fuse_gru_nodes_after,
       2,
-      phi::errors::PreconditionNotMet("The number of gru nodes before the "
-                                      "fuse does not meet expectations"));
+      common::errors::PreconditionNotMet("The number of gru nodes before the "
+                                         "fuse does not meet expectations"));
   PADDLE_ENFORCE_EQ(num_gru_nodes_before,
                     num_fuse_gru_nodes_after,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The number of fusion_gru nodes does not meet "
                         "expectations after fuse"));
 }

--- a/paddle/fluid/framework/ir/fc_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_lstm_fuse_pass.cc
@@ -207,15 +207,15 @@ int FCLstmFusePass::BuildFusion(Graph* graph,
     if (with_fc_bias) {
       // Add FC-bias with LSTM-bias and create a new weight
       PADDLE_ENFORCE_NOT_NULL(
-          scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+          scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
       auto* lstm_bias_var = scope->FindVar(bias->Name());
       auto* fc_bias_var = scope->FindVar(fc_bias->Name());
-      PADDLE_ENFORCE_NOT_NULL(
-          lstm_bias_var,
-          phi::errors::InvalidArgument("Lstm bias var ptr cannot be nullptr."));
-      PADDLE_ENFORCE_NOT_NULL(
-          fc_bias_var,
-          phi::errors::InvalidArgument("FC bias var ptr cannot be nullptr."));
+      PADDLE_ENFORCE_NOT_NULL(lstm_bias_var,
+                              common::errors::InvalidArgument(
+                                  "Lstm bias var ptr cannot be nullptr."));
+      PADDLE_ENFORCE_NOT_NULL(fc_bias_var,
+                              common::errors::InvalidArgument(
+                                  "FC bias var ptr cannot be nullptr."));
       auto* lstm_bias_tensor = lstm_bias_var->GetMutable<phi::DenseTensor>();
       const auto& fc_bias_tensor = fc_bias_var->Get<phi::DenseTensor>();
 

--- a/paddle/fluid/framework/ir/fc_lstm_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/fc_lstm_fuse_pass_tester.cc
@@ -30,21 +30,21 @@ TEST(FcLstmFusePass, basic) {
   int num_fusion_lstm_nodes_after = GetNumOpNodes(graph, "fusion_lstm");
   VLOG(3) << DebugString(graph);
 
-  PADDLE_ENFORCE_EQ(
-      num_nodes_before,
-      num_nodes_after - 6,
-      phi::errors::PreconditionNotMet("The number of nodes before and after "
-                                      "the fuse does not meet expectations"));
+  PADDLE_ENFORCE_EQ(num_nodes_before,
+                    num_nodes_after - 6,
+                    common::errors::PreconditionNotMet(
+                        "The number of nodes before and after "
+                        "the fuse does not meet expectations"));
   PADDLE_ENFORCE_EQ(
       num_fusion_lstm_nodes_after,
       2,
-      phi::errors::PreconditionNotMet("The number of lstm nodes before the "
-                                      "fuse does not meet expectations"));
+      common::errors::PreconditionNotMet("The number of lstm nodes before the "
+                                         "fuse does not meet expectations"));
   PADDLE_ENFORCE_EQ(
       num_lstm_nodes_before,
       num_fusion_lstm_nodes_after,
-      phi::errors::PreconditionNotMet("The number of fusion_gru nodes does "
-                                      "not meet expectations after fuse"));
+      common::errors::PreconditionNotMet("The number of fusion_gru nodes does "
+                                         "not meet expectations after fuse"));
 }
 }  // namespace paddle::framework::ir::fc_lstm_test
 

--- a/paddle/fluid/framework/ir/fuse_adamw_op_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_adamw_op_pass.cc
@@ -42,7 +42,7 @@ Node *GetInputNode(const Node *op, const std::string &name) {
   }
 
   PADDLE_ENFORCE_NOT_NULL(
-      out, phi::errors::InvalidArgument("Input's name cannot be found."));
+      out, common::errors::InvalidArgument("Input's name cannot be found."));
 
   return out;
 }
@@ -58,7 +58,7 @@ Node *GetOutputNode(const Node *op, const std::string &name) {
   }
 
   PADDLE_ENFORCE_NOT_NULL(
-      out, phi::errors::InvalidArgument("Output's name cannot be found."));
+      out, common::errors::InvalidArgument("Output's name cannot be found."));
 
   return out;
 }
@@ -254,7 +254,7 @@ ir::Graph *FuseAdamWPass::FuseAdamWFun(ir::Graph *graph,
                                        const bool with_decay,
                                        const bool multi_precision) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
 
   VLOG(4) << "handle fuse AdadW";
 

--- a/paddle/fluid/framework/ir/fuse_bn_act_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_bn_act_pass.cc
@@ -51,7 +51,7 @@ ir::Graph *FuseBatchNormActPass::FuseBatchNormAct(
     ir::Graph *graph, const std::unordered_set<std::string> &act_types) const {
   PADDLE_ENFORCE_NOT_NULL(
       graph,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input graph of FuseBatchNormAct should not be nullptr."));
   FusePassBase::Init("bn_act", graph);
 
@@ -191,7 +191,7 @@ ir::Graph *FuseBatchNormActPass::FuseBatchNormActGrad(
     const std::unordered_set<std::string> &act_grad_types) const {
   PADDLE_ENFORCE_NOT_NULL(
       graph,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input graph of FuseBatchNormActGrad should not be nullptr."));
   FusePassBase::Init("bn_act_grad", graph);
 
@@ -346,8 +346,8 @@ std::vector<Node *> FuseBatchNormActPass::ReplaceNode(
       });
   PADDLE_ENFORCE_EQ(has_replaced,
                     true,
-                    phi::errors::NotFound("Not found %s in the node list.",
-                                          cur_node->Name()));
+                    common::errors::NotFound("Not found %s in the node list.",
+                                             cur_node->Name()));
   return new_list;
 }
 

--- a/paddle/fluid/framework/ir/fuse_bn_add_act_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_bn_add_act_pass.cc
@@ -43,7 +43,7 @@ ir::Graph *FuseBatchNormAddActPass::FuseBatchNormAddAct(
   PADDLE_ENFORCE_NE(
       graph,
       nullptr,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input graph of FuseBatchNormAddAct should not be nullptr."));
   FusePassBase::Init("bn_add_act", graph);
 
@@ -190,7 +190,7 @@ ir::Graph *FuseBatchNormAddActPass::FuseBatchNormAddActGrad(
   PADDLE_ENFORCE_NE(
       graph,
       nullptr,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input graph of FuseBatchNormAddActGrad should not be nullptr."));
   FusePassBase::Init("bn_add_act_grad", graph);
 
@@ -380,8 +380,8 @@ std::vector<Node *> FuseBatchNormAddActPass::ReplaceNode(
       });
   PADDLE_ENFORCE_EQ(has_replaced,
                     true,
-                    phi::errors::NotFound("Not found %s in the node list.",
-                                          cur_node->Name()));
+                    common::errors::NotFound("Not found %s in the node list.",
+                                             cur_node->Name()));
   return new_list;
 }
 

--- a/paddle/fluid/framework/ir/fuse_dot_product_attention_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_dot_product_attention_pass.cc
@@ -50,7 +50,7 @@ ir::Graph *FuseDotProductAttentionPass::FuseDotProductAttentionFwd(
     OutputCache *output_cache,
     std::unordered_set<const Node *> *nodes_to_remove) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   const std::string scope_name("dot_product_attention");
   FusePassBase::Init(scope_name, graph);
 
@@ -264,7 +264,7 @@ ir::Graph *FuseDotProductAttentionPass::FuseDotProductAttentionBwd(
     OutputCache *output_cache,
     std::unordered_set<const Node *> *nodes_to_remove) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   const std::string scope_name("dot_product_attention");
   FusePassBase::Init(scope_name, graph);
 

--- a/paddle/fluid/framework/ir/fuse_elewise_add_act_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_elewise_add_act_pass.cc
@@ -42,7 +42,7 @@ void FuseElewiseAddActPass::ApplyImpl(ir::Graph *graph) const {
 ir::Graph *FuseElewiseAddActPass::FuseElewiseAddAct(
     ir::Graph *graph, const std::unordered_set<std::string> &act_types) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init("elewise_add_act", graph);
 
   GraphPatternDetector gpd;
@@ -94,7 +94,7 @@ ir::Graph *FuseElewiseAddActPass::FuseElewiseAddAct(
 ir::Graph *FuseElewiseAddActPass::FuseActElewiseAdd(
     ir::Graph *graph, const std::unordered_set<std::string> &act_types) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init("act_elewise_add", graph);
 
   GraphPatternDetector gpd;
@@ -147,7 +147,7 @@ ir::Graph *FuseElewiseAddActPass::FuseActElewiseAdd(
 ir::Graph *FuseElewiseAddActPass::FuseElewiseAddActInplaceGrad(
     ir::Graph *graph, const std::unordered_set<std::string> &act_types) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init("elewise_add_act_grad", graph);
 
   GraphPatternDetector gpd;
@@ -229,7 +229,7 @@ ir::Graph *FuseElewiseAddActPass::FuseElewiseAddActInplaceGrad(
 ir::Graph *FuseElewiseAddActPass::FuseActElewiseAddInplaceGrad(
     ir::Graph *graph, const std::unordered_set<std::string> &act_types) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init("act_elewise_add_grad", graph);
   GraphPatternDetector gpd;
   auto *d_out_var =
@@ -348,7 +348,7 @@ void FuseElewiseAddActPass::RemoveIntermediateOut(Graph *graph) const {
       PADDLE_ENFORCE_EQ(
           (save_intermediate_out && !intermediate_out_args.empty()),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The %s should save the intermediate out in the fusing stage.",
               cur_node->Name()));
 
@@ -369,7 +369,7 @@ void FuseElewiseAddActPass::RemoveIntermediateOut(Graph *graph) const {
       PADDLE_ENFORCE_EQ(
           intermediate_out_grad_args.empty(),
           false,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The %s should save the intermediate out in the fusing stage.",
               cur_node->Name()));
       auto cur_node_outputs = cur_node->outputs;
@@ -391,7 +391,7 @@ void FuseElewiseAddActPass::RemoveIntermediateOut(Graph *graph) const {
     // RemovedVars.
     PADDLE_ENFORCE_EQ(graph->Has(details::kRemovedVars),
                       false,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Removed nodes are only saved for "
                           "fuse_elewise_add_act_pass in temporary."));
     graph->Set(details::kRemovedVars, saved_removed_nodes);
@@ -424,7 +424,7 @@ void FuseElewiseAddActPass::ReLinkNodes(Graph *graph,
     } else {
       PADDLE_ENFORCE_EQ(out,
                         intermediate_out,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Output of op(%s) must be %s, but not %s.",
                             op_1->Name(),
                             intermediate_out->Name(),
@@ -511,8 +511,8 @@ std::vector<Node *> FuseElewiseAddActPass::ReplaceNode(
       });
   PADDLE_ENFORCE_EQ(has_replaced,
                     true,
-                    phi::errors::NotFound("Not found %s in the node list.",
-                                          cur_node->Name()));
+                    common::errors::NotFound("Not found %s in the node list.",
+                                             cur_node->Name()));
   return new_list;
 }
 

--- a/paddle/fluid/framework/ir/fuse_gemm_epilogue_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_gemm_epilogue_pass.cc
@@ -48,7 +48,7 @@ void FuseGemmEpiloguePass::ApplyImpl(ir::Graph *graph) const {
 ir::Graph *FuseGemmEpiloguePass::FuseLinearFwd(ir::Graph *graph,
                                                bool is_training) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   const std::string scope_name("gemm_epilogue");
   FusePassBase::Init(scope_name, graph);
 
@@ -128,7 +128,7 @@ ir::Graph *FuseGemmEpiloguePass::FuseLinearActFwd(
     bool is_act_grad_x_from_act,
     EpiloguePassActivationCache *cache) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
 
   const std::string scope_name("gemm_epilogue");
   FusePassBase::Init(scope_name, graph);
@@ -237,7 +237,7 @@ ir::Graph *FuseGemmEpiloguePass::FuseLinearActFwd(
 ir::Graph *FuseGemmEpiloguePass::FuseLinearBwd(ir::Graph *graph,
                                                bool without_x_gradient) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   const std::string scope_name("gemm_epilogue");
   FusePassBase::Init(scope_name, graph);
 
@@ -369,7 +369,7 @@ ir::Graph *FuseGemmEpiloguePass::FuseLinearActBwd(
     bool is_act_grad_x_from_act,
     EpiloguePassActivationCache *cache) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   const std::string scope_name("gemm_epilogue");
   FusePassBase::Init(scope_name, graph);
 

--- a/paddle/fluid/framework/ir/fuse_gemm_epilogue_pass.h
+++ b/paddle/fluid/framework/ir/fuse_gemm_epilogue_pass.h
@@ -51,7 +51,7 @@ class EpiloguePassActivationCache {
     if (HasFusedActivation(key)) {
       return fused_activation_space_map_.find(key)->second;
     }
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The key (%d) of EpiloguePassActivationCache does not exist.", key));
   }
 
@@ -61,7 +61,7 @@ class EpiloguePassActivationCache {
       fused_activation_space_map_.insert({key, value});
       mtx_.unlock();
     } else {
-      PADDLE_THROW(phi::errors::AlreadyExists(
+      PADDLE_THROW(common::errors::AlreadyExists(
           "The key (%d) of EpiloguePassActivationCache already exist.", key));
     }
   }

--- a/paddle/fluid/framework/ir/fuse_multi_transformer_layer_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_multi_transformer_layer_pass.cc
@@ -289,8 +289,8 @@ void FuseMultiTransformerLayerPass::ApplyImpl(Graph* graph) const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal("During the fuse_multi_transformer_layer pass, "
-                         "The scope should not be null."));
+      common::errors::Fatal("During the fuse_multi_transformer_layer pass, "
+                            "The scope should not be null."));
 
   VLOG(3) << "Running fuse_multi_transformer_layer_pass.";
   if (graph->IsMainGraph()) {

--- a/paddle/fluid/framework/ir/fuse_multi_transformer_layer_pass_tester.cc
+++ b/paddle/fluid/framework/ir/fuse_multi_transformer_layer_pass_tester.cc
@@ -108,7 +108,7 @@ TEST(FuseMultiTransformerLayerPass, encoder_fp) {
   PADDLE_ENFORCE_EQ(
       num_nodes_after,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After the fuse_multi_transformer_layer_pass, "
           "The node num in graph should be 1, but the result is %d",
           num_nodes_after));
@@ -162,7 +162,7 @@ TEST(FuseMultiTransformerLayerPass, decoder_fp) {
   PADDLE_ENFORCE_EQ(
       num_nodes_after,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After the fuse_multi_transformer_layer_pass, "
           "The node num in graph should be 1, but the result is %d",
           num_nodes_after));

--- a/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_adam_op_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_adam_op_pass.cc
@@ -56,7 +56,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
       if (fused_scale2_in_nodes.count(out_node)) {
         PADDLE_ENFORCE_EQ(out_node->IsCtrlVar(),
                           true,
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "In adam op pass, the dependency var(%s) only "
                               "should be ctrl var.",
                               out_node->Name()));
@@ -69,12 +69,12 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
       PADDLE_ENFORCE_EQ(
           node->inputs.empty(),
           false,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "Node(%s)'s input should not be empty here.", node->Name()));
       auto op_node = node->inputs.front();
       PADDLE_ENFORCE_EQ(op_node->IsOp(),
                         true,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "Node(%s) should be an OP node.", op_node->Name()));
       op_node->outputs.erase(remove_if(op_node->outputs.begin(),
                                        op_node->outputs.end(),
@@ -102,9 +102,10 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
       const std::unordered_map<std::string, std::string> &fused_vars_name,
       const std::vector<ir::Node *> &adam_ops,
       ir::Graph *graph) const {
-    PADDLE_ENFORCE_GT(adam_ops.size(),
-                      static_cast<size_t>(0),
-                      phi::errors::InvalidArgument("No adam op in the graph."));
+    PADDLE_ENFORCE_GT(
+        adam_ops.size(),
+        static_cast<size_t>(0),
+        common::errors::InvalidArgument("No adam op in the graph."));
 
     // Check attributions
     // NOTE: If new attribution is added, the following code maybe need change.
@@ -123,7 +124,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
       PADDLE_ENFORCE_EQ(
           beta1,
           PADDLE_GET_CONST(float, adam_op->Op()->GetAttr("beta1")),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "All adam Op's attr(beta1) must be same, but there are two "
               "different "
               "value: %f, %f.",
@@ -132,7 +133,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
       PADDLE_ENFORCE_EQ(
           beta2,
           PADDLE_GET_CONST(float, adam_op->Op()->GetAttr("beta2")),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "All adam Op's attr(beta2) must be same, but there are two "
               "different "
               "value: %f, %f.",
@@ -141,7 +142,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
       PADDLE_ENFORCE_EQ(
           epsilon,
           PADDLE_GET_CONST(float, adam_op->Op()->GetAttr("epsilon")),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "All adam Op's attr(epsilon) must be same, but there are two "
               "different "
               "value: %f, %f.",
@@ -150,7 +151,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
       PADDLE_ENFORCE_EQ(
           lazy_mode,
           PADDLE_GET_CONST(bool, adam_op->Op()->GetAttr("lazy_mode")),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "All adam Op's attr(lazy_mode) must be same, but there are two "
               "different "
               "value: %d, %d.",
@@ -161,7 +162,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
           PADDLE_GET_CONST(
               int64_t,
               adam_op->Op()->GetAttr("min_row_size_to_use_multithread")),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "All adam Op's attr(min_row_size_to_use_multithread) must be "
               "same, but there are two different value: %I64, %I64.",
               min_row_size_to_use_multithread,
@@ -173,7 +174,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
           PADDLE_GET_CONST(
               int,
               adam_op->Op()->GetAttr(OpProtoAndCheckerMaker::OpRoleAttrName())),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "All adam Op's attr(op_role) must be same, but there are two "
               "different "
               "value: %d, %d.",
@@ -219,7 +220,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
                          ir::Graph *graph) const {
     PADDLE_ENFORCE_EQ(beta_name.size(),
                       adam_ops.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Beta name size(%d) must equal to adam op size(%d).",
                           beta_name.size(),
                           adam_ops.size()));
@@ -239,8 +240,8 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
                        });
       PADDLE_ENFORCE_NE(beta_pow_iter,
                         adam_ops[i]->inputs.end(),
-                        phi::errors::NotFound("Can not find %s in adam ops.",
-                                              beta_1_pow_name));
+                        common::errors::NotFound("Can not find %s in adam ops.",
+                                                 beta_1_pow_name));
 
       auto beta_pow_node = *beta_pow_iter;
       auto scale_op_iter = std::find_if(
@@ -252,15 +253,15 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
       PADDLE_ENFORCE_NE(
           scale_op_iter,
           beta_pow_node->outputs.end(),
-          phi::errors::NotFound("Can not find %s in beta pow node.",
-                                scale_op_name));
+          common::errors::NotFound("Can not find %s in beta pow node.",
+                                   scale_op_name));
 
       scale_ops.emplace_back(*scale_op_iter);
     }
     PADDLE_ENFORCE_EQ(
         scale_ops.size(),
         beta_name.size(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Beta name size(%d) must equal to scale ops size(%d).",
             beta_name.size(),
             scale_ops.size()));
@@ -278,7 +279,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
       PADDLE_ENFORCE_EQ(
           scale,
           PADDLE_GET_CONST(float, scale_op->Op()->GetAttr("scale")),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "All scale Op's attr(scale) must be same, but there are two "
               "different "
               "value: %f, %f.",
@@ -287,7 +288,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
       PADDLE_ENFORCE_EQ(
           bias,
           PADDLE_GET_CONST(float, scale_op->Op()->GetAttr("bias")),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "All scale Op's attr(bias) must be same, but there are two "
               "different "
               "value: %f, %f.",
@@ -296,7 +297,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
       PADDLE_ENFORCE_EQ(
           bias_after_scale,
           PADDLE_GET_CONST(bool, scale_op->Op()->GetAttr("bias_after_scale")),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "All scale Op's attr(bias_after_scale) must be same, but there "
               "are two different value: %d, %d.",
               bias_after_scale,
@@ -307,7 +308,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
           PADDLE_GET_CONST(int,
                            scale_op->Op()->GetAttr(
                                OpProtoAndCheckerMaker::OpRoleAttrName())),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "All scale Op's attr(op_role) must be same, but there are two "
               "different "
               "value: %d, %d.",

--- a/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_momentum_op_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_momentum_op_pass.cc
@@ -42,7 +42,7 @@ class FuseMomentumOpPass : public FuseOptimizerOpPass {
     PADDLE_ENFORCE_GT(
         momentum_ops.size(),
         static_cast<size_t>(0),
-        phi::errors::InvalidArgument("Momentum ops must not be empty."));
+        common::errors::InvalidArgument("Momentum ops must not be empty."));
 
     // Check attributions
     // NOTE: If new attribution is added, the following code maybe need change.
@@ -58,7 +58,7 @@ class FuseMomentumOpPass : public FuseOptimizerOpPass {
       PADDLE_ENFORCE_EQ(
           mu,
           PADDLE_GET_CONST(float, momentum_op->Op()->GetAttr("mu")),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "All momentum Op's attr(mu) must be same, but there are two "
               "different "
               "value: %f, %f.",
@@ -67,7 +67,7 @@ class FuseMomentumOpPass : public FuseOptimizerOpPass {
       PADDLE_ENFORCE_EQ(
           use_nesterov,
           PADDLE_GET_CONST(bool, momentum_op->Op()->GetAttr("use_nesterov")),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "All momentum Op's attr(use_nesterov) must be same, but there "
               "are two different value: %d, %d.",
               use_nesterov,
@@ -78,7 +78,7 @@ class FuseMomentumOpPass : public FuseOptimizerOpPass {
           PADDLE_GET_CONST(int,
                            momentum_op->Op()->GetAttr(
                                OpProtoAndCheckerMaker::OpRoleAttrName())),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "All momentum Op's attr(op_role) must be same, but there are two "
               "different "
               "value: %d, %d.",

--- a/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_optimizer_op_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_optimizer_op_pass.cc
@@ -40,7 +40,7 @@ void FuseOptimizerOpPass::ApplyImpl(ir::Graph *graph) const {
       PADDLE_ENFORCE_EQ(
           grad_name.size(),
           static_cast<size_t>(1),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The %s operator has multiple gradient input. Expected "
               "it to only have one gradient input.",
               fuse_op_type));
@@ -105,8 +105,8 @@ void FuseOptimizerOpPass::ApplyImpl(ir::Graph *graph) const {
     PADDLE_ENFORCE_EQ(
         fused_var_set.count(fused_var_name),
         0,
-        phi::errors::AlreadyExists("The fused variable(%s) already exists.",
-                                   fused_var_name));
+        common::errors::AlreadyExists("The fused variable(%s) already exists.",
+                                      fused_var_name));
     // FIXME(wangxi). update persistable
     details::VariableInfo var_info;
     var_info.name_ = fused_var_name;
@@ -125,7 +125,7 @@ void FuseOptimizerOpPass::ApplyImpl(ir::Graph *graph) const {
         result.Get<details::ParamsAndGrads>(details::kParamsAndDenseGrads);
     PADDLE_ENFORCE_LE(params_and_dense_grads.size(),
                       aux_var_map.at(kGrad).size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The number of dense gradients(%d) should be "
                           "little than optimizer ops(%d).",
                           params_and_dense_grads.size(),
@@ -149,7 +149,7 @@ void FuseOptimizerOpPass::ApplyImpl(ir::Graph *graph) const {
     // some gradient's name maybe changed.
     if (new_grad_idx.empty()) {
       if (!result.Has(details::kFusedGrads)) {
-        PADDLE_THROW(phi::errors::PreconditionNotMet(
+        PADDLE_THROW(common::errors::PreconditionNotMet(
             "The coalesce_grad_tensor_pass should "
             "be called before this pass."));
       }
@@ -157,7 +157,7 @@ void FuseOptimizerOpPass::ApplyImpl(ir::Graph *graph) const {
       PADDLE_ENFORCE_NE(
           fused_grad.size(),
           0,
-          phi::errors::NotFound("The fused gradient should not be empty."));
+          common::errors::NotFound("The fused gradient should not be empty."));
       if (fused_grad.size() > 1) {
         // Note(chenweihang): Because the dtype of those gradients is not
         //   unified,so the number of fused gradients is more than one,
@@ -170,7 +170,7 @@ void FuseOptimizerOpPass::ApplyImpl(ir::Graph *graph) const {
       PADDLE_ENFORCE_EQ(
           iter != fused_vars.end(),
           true,
-          phi::errors::NotFound("Not found the fused gradient variable."));
+          common::errors::NotFound("Not found the fused gradient variable."));
       fused_vars_name[kGrad] = fused_grad.front();
 
       // Sort the parameters and auxiliary variables according
@@ -386,20 +386,20 @@ void FuseOptimizerOpPass::FuseGradientsToContinuousSpace(
     PADDLE_ENFORCE_EQ(
         iter != vars_info.end(),
         true,
-        phi::errors::NotFound("The gradient variable %s is not found.",
-                              grad_var_name));
+        common::errors::NotFound("The gradient variable %s is not found.",
+                                 grad_var_name));
     PADDLE_ENFORCE_EQ(
         !iter->second.empty(),
         true,
-        phi::errors::NotFound("The gradient var node %s is not found.",
-                              grad_var_name));
+        common::errors::NotFound("The gradient var node %s is not found.",
+                                 grad_var_name));
     PADDLE_ENFORCE_NOT_NULL(
         iter->second.front()->Var(),
-        phi::errors::InvalidArgument("The gradient var(%s) node is null.",
-                                     grad_var_name));
+        common::errors::InvalidArgument("The gradient var(%s) node is null.",
+                                        grad_var_name));
     PADDLE_ENFORCE_EQ(IsLoDTensorType(iter->second.front()->Var()->GetType()),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Currently the gradient(%s) type only should be "
                           "phi::DenseTensor when "
                           "fusing optimizer ops.",
@@ -443,14 +443,14 @@ const VarDesc *FuseOptimizerOpPass::GetVarDescFromVarsInfo(
   auto grad_iter = vars_info.find(var_name);
   PADDLE_ENFORCE_EQ(grad_iter != vars_info.end(),
                     true,
-                    phi::errors::NotFound(
+                    common::errors::NotFound(
                         "The gradient variable %s is not found.", var_name));
   PADDLE_ENFORCE_EQ(!grad_iter->second.empty(),
                     true,
-                    phi::errors::NotFound(
+                    common::errors::NotFound(
                         "The gradient var node %s is not found.", var_name));
   PADDLE_ENFORCE_NOT_NULL(grad_iter->second.front()->Var(),
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The gradient var(%s) node is null.", var_name));
   return grad_iter->second.front()->Var();
 }
@@ -500,7 +500,7 @@ void FuseOptimizerOpPass::SortParametersAndAuxVars(
   PADDLE_ENFORCE_NE(
       aux_var_map->count(kGrad),
       static_cast<size_t>(0),
-      phi::errors::NotFound("The gradient variable doesn‘t exist."));
+      common::errors::NotFound("The gradient variable doesn‘t exist."));
   auto &grad_vec = aux_var_map->at(kGrad);
 
   std::vector<size_t> grad_sort_idx;
@@ -511,7 +511,7 @@ void FuseOptimizerOpPass::SortParametersAndAuxVars(
     PADDLE_ENFORCE_EQ(
         iter != grad_vec.end(),
         true,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Parameter@Grad(%s) is not found in gradient vector.", p_g.second));
     auto idx = std::distance(grad_vec.begin(), iter);
     grad_sort_idx.emplace_back(idx);
@@ -552,7 +552,7 @@ void FuseOptimizerOpPass::GetFusingVarNamesMap(
       auto arg_names = node->Op()->Input(var_n);
       PADDLE_ENFORCE_EQ(arg_names.size(),
                         static_cast<size_t>(1),
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The input variable of optimizer to be fused is "
                             "invalid. Excepted %s only has one %s input.",
                             node->Op()->Type(),
@@ -607,14 +607,14 @@ void FuseOptimizerOpPass::InsertInputAndOutputForFusedOpNode(
                                  ir::Node *ctr_var_node) {
     PADDLE_ENFORCE_EQ(ctr_var_node->inputs.size(),
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The control var(%s) node has multiple inputs.",
                           ctr_var_node->Name()));
     if (ctr_var_node->inputs.front() == fused_opt_node) {
       PADDLE_ENFORCE_GT(
           ctr_var_node->outputs.size(),
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The control var(%s) node has no output.", ctr_var_node->Name()));
       auto output_ops = ctr_var_node->outputs;
       output_ops.erase(std::remove_if(output_ops.begin(),

--- a/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_sgd_op_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_sgd_op_pass.cc
@@ -41,7 +41,7 @@ class FuseSgdOpPass : public FuseOptimizerOpPass {
     PADDLE_ENFORCE_GT(
         sgd_ops.size(),
         static_cast<size_t>(0),
-        phi::errors::InvalidArgument("SGD ops must not be empty."));
+        common::errors::InvalidArgument("SGD ops must not be empty."));
 
     // NOTE: fused_var is only exist in scope, so the graph doesn't have
     // fused_var node.

--- a/paddle/fluid/framework/ir/fuse_pass_base.cc
+++ b/paddle/fluid/framework/ir/fuse_pass_base.cc
@@ -36,7 +36,7 @@ void FusePassBase::Init(const std::string& repr, Graph* graph) const {
 Scope* FusePassBase::param_scope() const {
   PADDLE_ENFORCE_EQ(graph_->Has(kParamScopeAttr),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Graph must have kParamScopeAttr attribute."));
   auto& scope = graph_->Get<framework::Scope>(kParamScopeAttr);
   return &scope;
@@ -44,10 +44,10 @@ Scope* FusePassBase::param_scope() const {
 
 void FusePassBase::AddStatis(int count_of_fused) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph_, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph_, common::errors::InvalidArgument("Graph cannot be nullptr."));
   PADDLE_ENFORCE_EQ(repr_.empty(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Fuse pass must be initialized with a name."));
   if (!graph_->Has(kFuseStatisAttr)) {
     graph_->Set(kFuseStatisAttr, new std::unordered_map<std::string, int>);

--- a/paddle/fluid/framework/ir/fuse_relu_depthwise_conv_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_relu_depthwise_conv_pass.cc
@@ -32,7 +32,7 @@ void FuseReluDepthwiseConvPass::ApplyImpl(ir::Graph *graph) const {
 ir::Graph *FuseReluDepthwiseConvPass::FuseReluDepthwiseConv(
     ir::Graph *graph, bool only_forward) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   if (only_forward)
     FusePassBase::Init("relu_depthwise_conv_only_forward", graph);
   else
@@ -114,16 +114,16 @@ ir::Graph *FuseReluDepthwiseConvPass::FuseReluDepthwiseConv(
     PADDLE_ENFORCE_EQ(
         layer_op->Input("Input").size(),
         1UL,
-        phi::errors::InvalidArgument("Op(%s)'s input size(%d) must be 1.",
-                                     layer_op->Type(),
-                                     layer_op->Input("Input").size()));
+        common::errors::InvalidArgument("Op(%s)'s input size(%d) must be 1.",
+                                        layer_op->Type(),
+                                        layer_op->Input("Input").size()));
     PADDLE_ENFORCE_EQ(
         layer_op->Input("Input")[0],
         y_var->Name(),
-        phi::errors::InvalidArgument("Op(%s)'s input name(%s) must be %s.",
-                                     layer_op->Type(),
-                                     layer_op->Input("Input")[0],
-                                     y_var->Name()));
+        common::errors::InvalidArgument("Op(%s)'s input name(%s) must be %s.",
+                                        layer_op->Type(),
+                                        layer_op->Input("Input")[0],
+                                        y_var->Name()));
     layer_op->SetInput("Input", {x_var->Name()});
     subgraph.at(layer)->inputs.push_back(subgraph.at(x));
     subgraph.at(x)->outputs.push_back(subgraph.at(layer));
@@ -133,29 +133,29 @@ ir::Graph *FuseReluDepthwiseConvPass::FuseReluDepthwiseConv(
       PADDLE_ENFORCE_EQ(
           layer_g_op->Input("Input").size(),
           1UL,
-          phi::errors::InvalidArgument("Op(%s)'s input size(%d) must be 1.",
-                                       layer_g_op->Type(),
-                                       layer_g_op->Input("Input").size()));
+          common::errors::InvalidArgument("Op(%s)'s input size(%d) must be 1.",
+                                          layer_g_op->Type(),
+                                          layer_g_op->Input("Input").size()));
       PADDLE_ENFORCE_EQ(
           layer_g_op->Input("Input")[0],
           y_var->Name(),
-          phi::errors::InvalidArgument("Op(%s)'s input name(%s) must be %s.",
-                                       layer_g_op->Type(),
-                                       layer_g_op->Input("Input")[0],
-                                       y_var->Name()));
+          common::errors::InvalidArgument("Op(%s)'s input name(%s) must be %s.",
+                                          layer_g_op->Type(),
+                                          layer_g_op->Input("Input")[0],
+                                          y_var->Name()));
       layer_g_op->SetInput("Input", {x_var->Name()});
       subgraph.at(layer_g)->inputs.push_back(subgraph.at(x));
       subgraph.at(x)->outputs.push_back(subgraph.at(layer_g));
 
       PADDLE_ENFORCE_EQ(layer_g_op->Output(GradVarName("Input")).size(),
                         1UL,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Op(%s)'s input size(%d) must be 1.",
                             layer_g_op->Type(),
                             layer_g_op->Output(GradVarName("Input")).size()));
       PADDLE_ENFORCE_EQ(layer_g_op->Output(GradVarName("Input"))[0],
                         yg_var->Name(),
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Op(%s)'s input name(%s) must be %s.",
                             layer_g_op->Type(),
                             layer_g_op->Output(GradVarName("Input"))[0],

--- a/paddle/fluid/framework/ir/fuse_resunit_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_resunit_pass.cc
@@ -415,7 +415,7 @@ ir::Node *RetrieveForwardNode(ir::Graph *graph,
   PADDLE_ENFORCE_NE(
       pos,
       std::string::npos,
-      phi::errors::InvalidArgument("expect @GRAD in name, got (%s)", name));
+      common::errors::InvalidArgument("expect @GRAD in name, got (%s)", name));
   std::string fwd_name = name.substr(0, pos);
   for (auto *node : graph->Nodes()) {
     if (node->Name() == fwd_name) {
@@ -426,8 +426,8 @@ ir::Node *RetrieveForwardNode(ir::Graph *graph,
       }
     }
   }
-  PADDLE_THROW(
-      phi::errors::InvalidArgument("The node (%d) does not exist.", fwd_name));
+  PADDLE_THROW(common::errors::InvalidArgument("The node (%d) does not exist.",
+                                               fwd_name));
   return nullptr;
 }
 
@@ -472,7 +472,7 @@ ir::Graph *FuseResUnitPass::FuseConvBNAddActFwd(
     bool shortcut,
     bool is_training) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   const std::string scope_name("conv_bn_add_act");
   FusePassBase::Init(scope_name, graph);
 
@@ -601,7 +601,7 @@ ir::Graph *FuseResUnitPass::FuseConvBNActConvBNstats(
     int *found_pattern_count_output,
     ResUnitPassCache *cache) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   const std::string scope_name("conv_bn_act_conv_bnstats");
   FusePassBase::Init(scope_name, graph);
 
@@ -689,7 +689,7 @@ ir::Graph *FuseResUnitPass::FuseBNActConvBwd(
     const std::unordered_set<std::string> &act_grad_types,
     ResUnitPassCache *cache) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   VLOG(4) << "Applying FuseBNActConvBwd";
   const std::string scope_name("bn_act_conv_bwd");
   FusePassBase::Init(scope_name, graph);
@@ -714,7 +714,7 @@ ir::Graph *FuseResUnitPass::FuseBNActConvBwd(
     auto *bn_eqbias =
         cache->Get(GetCacheKey(bn_saved_mean->Var()->Name(), g->GetBlockId()));
     if (bn_eqscale == nullptr || bn_eqbias == nullptr) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "The bn_eqscale and bn_eqbias do not exist in the cache. "
           "The forward fusion pass may not be successful."));
     }
@@ -769,7 +769,7 @@ ir::Graph *FuseResUnitPass::FuseBNAddActConvBwd(
     bool shortcut,
     bool with_sum) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   VLOG(4) << "Applying FuseBNAddActConvBwd, shortcut=" << shortcut
           << ", with_sum=" << with_sum;
   const std::string scope_name("bn_add_act_conv_bwd");

--- a/paddle/fluid/framework/ir/fuse_resunit_pass.h
+++ b/paddle/fluid/framework/ir/fuse_resunit_pass.h
@@ -52,7 +52,7 @@ class ResUnitPassCache {
       var_map_.insert({key, value});
       mtx.unlock();
     } else {
-      PADDLE_THROW(phi::errors::AlreadyExists(
+      PADDLE_THROW(common::errors::AlreadyExists(
           "The key (%d) of ResUnitPassCache already exist.", key));
     }
   }

--- a/paddle/fluid/framework/ir/fused_attention_pass.h
+++ b/paddle/fluid/framework/ir/fused_attention_pass.h
@@ -278,7 +278,7 @@ class FusedAttentionPassCache {
     if (var_name_to_ir_node_cache_.count(name)) {
       return var_name_to_ir_node_cache_.find(name)->second;
     }
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The key (%d) of FusedAttentionCache does not exist.", name));
   }
 
@@ -286,7 +286,7 @@ class FusedAttentionPassCache {
     if (!var_name_to_ir_node_cache_.count(name)) {
       var_name_to_ir_node_cache_.insert({name, node});
     } else {
-      PADDLE_THROW(phi::errors::AlreadyExists(
+      PADDLE_THROW(common::errors::AlreadyExists(
           "The key (%d) of FusedAttentionCache already exist.", name));
     }
   }

--- a/paddle/fluid/framework/ir/fused_continuous_same_ops_pass.cc
+++ b/paddle/fluid/framework/ir/fused_continuous_same_ops_pass.cc
@@ -200,7 +200,7 @@ void FusedContinuousSameOpsPass::FusedUnsqueezeOps(ir::Graph* graph) const {
 }
 void FusedContinuousSameOpsPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   int repeat_time = 0;
   int total_delete_op_count = 0;

--- a/paddle/fluid/framework/ir/fused_feedforward_pass.cc
+++ b/paddle/fluid/framework/ir/fused_feedforward_pass.cc
@@ -65,7 +65,7 @@ ir::Graph *FusedFeedForwardPass::FusedFeedForwardFwd(
     bool use_dropout_2,
     Cache *dropout_nodes_map) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   const std::string scope_name("fused_feed_forward_fwd_pattern");
   GraphPatternDetector gpd;
   auto *x = gpd.mutable_pattern()
@@ -405,7 +405,7 @@ ir::Graph *FusedFeedForwardPass::FusedFeedForwardBwd(
     bool use_dropout_2,
     Cache *dropout_nodes_map) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   const std::string scope_name("fused_feed_forward_bwd_pattern");
 
   // 1. residual_add_grad -> dropout2_grad -> linear2_grad -> dropout1_grad ->

--- a/paddle/fluid/framework/ir/fused_multi_transformer_decoder_pass.cc
+++ b/paddle/fluid/framework/ir/fused_multi_transformer_decoder_pass.cc
@@ -1664,8 +1664,8 @@ void FusedMultiTransformerDecoderPass::ApplyImpl(Graph* graph) const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal("During the multi_transformer pass, "
-                         "The scope should not be null."));
+      common::errors::Fatal("During the multi_transformer pass, "
+                            "The scope should not be null."));
 
   VLOG(3) << "Running fused_multi_transformer_decoder_pass.";
   if (graph->IsMainGraph()) {
@@ -2379,8 +2379,8 @@ void FusedMultiTransformerDecoderFuseQKVPass::ApplyImpl(Graph* graph) const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal("During the fused_multi_transformer_decoder "
-                         "pass, The scope should not be null."));
+      common::errors::Fatal("During the fused_multi_transformer_decoder "
+                            "pass, The scope should not be null."));
 
   VLOG(3) << "Running fused_multi_transformer_decoder_fuse_qkv_pass.";
   if (graph->IsMainGraph()) {
@@ -3160,8 +3160,8 @@ void MultiDevicesFusedMultiTransformerDecoderFuseQKVPass::ApplyImpl(
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal("During the fused_multi_transformer_decoder "
-                         "pass, The scope should not be null."));
+      common::errors::Fatal("During the fused_multi_transformer_decoder "
+                            "pass, The scope should not be null."));
 
   VLOG(3)
       << "Running multi_devices_fused_multi_transformer_decoder_fuse_qkv_pass.";

--- a/paddle/fluid/framework/ir/fused_multi_transformer_decoder_pass_tester.cc
+++ b/paddle/fluid/framework/ir/fused_multi_transformer_decoder_pass_tester.cc
@@ -207,7 +207,7 @@ TEST(FusedMultiTransformerDecoderPass, basic) {
 
   PADDLE_ENFORCE_EQ(num_nodes_before,
                     num_nodes_after + 60,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After the fused_multi_transformer_decoder_pass, The "
                         "node num in graph "
                         "should be %d, but the result is %d",
@@ -215,7 +215,7 @@ TEST(FusedMultiTransformerDecoderPass, basic) {
                         num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fused_nodes_after,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After the fused_multi_transformer_decoder pass, "
                         "there should be one fused_multi_transformer op, "
                         "but the result is %d",
@@ -362,14 +362,14 @@ TEST(FusedMultiTransformerDecoderFuseQKVPass, basic) {
   PADDLE_ENFORCE_EQ(
       num_nodes_before,
       num_nodes_after + 52,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After the fused_multi_transformer_decoder_fuse_qkv_pass, "
           "The node num in graph should be %d, but the result is %d",
           num_nodes_before - 52,
           num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fused_nodes_after,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After the fused_multi_transformer_decoder_fuse_qkv "
                         "pass, there should be one fused_multi_transformer "
                         "op, but the result is %d",
@@ -526,14 +526,14 @@ TEST(MultiDevicesFusedMultiTransformerDecoderFuseQKVPass, basic) {
   PADDLE_ENFORCE_EQ(
       num_nodes_before,
       num_nodes_after + 60,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After the fused_multi_transformer_decoder_fuse_qkv_pass, "
           "The node num in graph should be %d, but the result is %d",
           num_nodes_before - 60,
           num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fused_nodes_after,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After the fused_multi_transformer_decoder_fuse_qkv "
                         "multi-devices pass, there should be one "
                         "fused_multi_transformer op, but the result is %d",

--- a/paddle/fluid/framework/ir/fused_multi_transformer_encoder_pass.cc
+++ b/paddle/fluid/framework/ir/fused_multi_transformer_encoder_pass.cc
@@ -1556,7 +1556,7 @@ inline void QKVWeightsBiasProcess(phi::DenseTensor* wq_tensor,
           wq_tensor, wk_tensor, wv_tensor, num_head, dim_head, dim_embed);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "fused_multi_transformer not supported weight dtype. "
           "we now only support fp32/fp16/int8."));
       break;
@@ -1571,7 +1571,7 @@ inline void QKVWeightsBiasProcess(phi::DenseTensor* wq_tensor,
           bq_tensor, bk_tensor, bv_tensor, num_head, dim_head, dim_embed);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "fused_multi_transformer not supported bias dtype. "
           "we now only support fp32/fp16."));
       break;
@@ -1669,7 +1669,7 @@ inline void QKVWeightsBiasProcessFuseQKV(phi::DenseTensor* qkv_w_tensor,
           qkv_w_tensor, num_head, dim_head, dim_embed);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "fused_multi_transformer not supported weight dtype. "
           "we now only support fp32/fp16/int8."));
       break;
@@ -1683,7 +1683,7 @@ inline void QKVWeightsBiasProcessFuseQKV(phi::DenseTensor* qkv_w_tensor,
       QKVBiasProcessFuseQKV<float>(qkv_b_tensor, num_head, dim_head, dim_embed);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "fused_multi_transformer not supported bias dtype. "
           "we now only support fp32/fp16."));
       break;
@@ -2393,7 +2393,7 @@ void FusedMultiTransformerEncoderPass::ApplyImpl(Graph* graph) const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "During the multi_transformer pass, The scope should not be null."));
 
   VLOG(3) << "Running fused_multi_transformer_encoder_pass.";
@@ -3213,8 +3213,8 @@ void FusedMultiTransformerEncoderFuseQKVPass::ApplyImpl(Graph* graph) const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal("During the fused_multi_transformer_encoder pass, "
-                         "The scope should not be null."));
+      common::errors::Fatal("During the fused_multi_transformer_encoder pass, "
+                            "The scope should not be null."));
 
   VLOG(3) << "Running fused_multi_transformer_encoder_fuse_qkv_pass.";
   if (graph->IsMainGraph()) {
@@ -4026,7 +4026,7 @@ void MultiDevicesFusedMultiTransformerEncoderPass::ApplyImpl(
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "During the multi_transformer pass, The scope should not be null."));
 
   VLOG(3) << "Running multi_devices_fused_multi_transformer_encoder_pass.";
@@ -4895,8 +4895,8 @@ void MultiDevicesFusedMultiTransformerEncoderFuseQKVPass::ApplyImpl(
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal("During the fused_multi_transformer_encoder pass, "
-                         "The scope should not be null."));
+      common::errors::Fatal("During the fused_multi_transformer_encoder pass, "
+                            "The scope should not be null."));
 
   VLOG(3)
       << "Running multi_devices_fused_multi_transformer_encoder_fuse_qkv_pass.";

--- a/paddle/fluid/framework/ir/fused_multi_transformer_encoder_pass_tester.cc
+++ b/paddle/fluid/framework/ir/fused_multi_transformer_encoder_pass_tester.cc
@@ -200,7 +200,7 @@ TEST(FusedMultiTransformerEncoderPass, basic) {
 
   PADDLE_ENFORCE_EQ(num_nodes_before,
                     num_nodes_after + 58,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After the fused_multi_transformer_encoder_pass, The "
                         "node num in graph "
                         "should be %d, but the result is %d",
@@ -208,7 +208,7 @@ TEST(FusedMultiTransformerEncoderPass, basic) {
                         num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fused_nodes_after,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After the fused_multi_transformer_encoder pass, "
                         "there should be one fused_multi_transformer op, "
                         "but the result is %d",
@@ -376,7 +376,7 @@ TEST(MultiDevicesFusedMultiTransformerEncoderPass, basic) {
 
   PADDLE_ENFORCE_EQ(num_nodes_before,
                     num_nodes_after + 70,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After the fused_multi_transformer_encoder_pass, The "
                         "node num in graph "
                         "should be %d, but the result is %d",
@@ -384,7 +384,7 @@ TEST(MultiDevicesFusedMultiTransformerEncoderPass, basic) {
                         num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fused_nodes_after,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After the fused_multi_transformer_encoder pass, "
                         "there should be one fused_multi_transformer op, "
                         "but the result is %d",
@@ -527,14 +527,14 @@ TEST(FusedMultiTransformerEncoderFuseQKVPass, basic) {
   PADDLE_ENFORCE_EQ(
       num_nodes_before,
       num_nodes_after + 46,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After the fused_multi_transformer_encoder_fuse_qkv_pass, "
           "The node num in graph should be %d, but the result is %d",
           num_nodes_before - 46,
           num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fused_nodes_after,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After the fused_multi_transformer_encoder_fuse_qkv "
                         "pass, there should be one fused_multi_transformer "
                         "op, but the result is %d",
@@ -687,14 +687,14 @@ TEST(MultiDevicesFusedMultiTransformerEncoderFuseQKVPass, basic) {
   PADDLE_ENFORCE_EQ(
       num_nodes_before,
       num_nodes_after + 54,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After the fused_multi_transformer_encoder_fuse_qkv_pass, "
           "The node num in graph should be %d, but the result is %d",
           num_nodes_before - 54,
           num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fused_nodes_after,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After the fused_multi_transformer_encoder_fuse_qkv "
                         "multi-devices pass, there should be one "
                         "fused_multi_transformer op, but the result is %d",

--- a/paddle/fluid/framework/ir/fusion_group/code_generator.cc
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator.cc
@@ -56,7 +56,7 @@ std::string CodeGenerator::Generate(SubGraph* subgraph) {
 static bool HasInput(Node* n, std::string name) {
   PADDLE_ENFORCE_EQ(n && n->IsOp() && n->Op(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Expected node %p to be an operator node.", n));
   std::vector<std::string> input_names = n->Op()->InputNames();
   std::unordered_set<std::string> input_names_set(input_names.begin(),
@@ -67,7 +67,7 @@ static bool HasInput(Node* n, std::string name) {
 static Node* GetInputVar(Node* n, const std::string& name) {
   PADDLE_ENFORCE_EQ(n && n->IsOp() && n->Op(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Expected node %p to be an operator node.", n));
   for (auto* in : n->inputs) {
     if (in->Name() == name) {
@@ -80,7 +80,7 @@ static Node* GetInputVar(Node* n, const std::string& name) {
 static Node* GetOutputVar(Node* n, const std::string& name) {
   PADDLE_ENFORCE_EQ(n && n->IsOp() && n->Op(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Expected node %p to be an operator node.", n));
   for (auto* out : n->outputs) {
     if (out->Name() == name) {
@@ -118,7 +118,7 @@ std::vector<OperationExpression> CodeGenerator::ConvertToExpressions(
             PADDLE_ENFORCE_NE(
                 var_ids.find(input_var),
                 var_ids.end(),
-                phi::errors::InvalidArgument(
+                common::errors::InvalidArgument(
                     "Input(%s) of operation %s is not set.", name, op->Type()));
             input_ids.push_back(var_ids[input_var]);
           }
@@ -139,7 +139,7 @@ std::vector<OperationExpression> CodeGenerator::ConvertToExpressions(
         PADDLE_ENFORCE_NE(
             var_ids.find(output_var),
             var_ids.end(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Output(%s) of operation %s is not set.", name, op->Type()));
         output_ids.push_back(var_ids[output_var]);
         if (!subgraph->SaveIntermediateOut() &&
@@ -252,7 +252,7 @@ std::unordered_map<int, std::string> CodeGenerator::DistilDtypes(
         PADDLE_ENFORCE_EQ(
             dtypes[id],
             dtype,
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "In fusion group, Same Node id must have same date type"));
       }
     }
@@ -264,7 +264,7 @@ std::unordered_map<int, std::string> CodeGenerator::DistilDtypes(
         PADDLE_ENFORCE_EQ(
             dtypes[id],
             dtype,
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "In fusion group, Same Node id must have same date type"));
       }
     }

--- a/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
@@ -138,7 +138,7 @@ std::string OperationExpression::GetRHS(std::unordered_set<int>* used,
         int index = StringTo<int>(index_str);
         PADDLE_ENFORCE_LT(index,
                           input_ids_.size(),
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Only %d inputs are provided, but need %d for "
                               "operation < %s >.",
                               input_ids_.size(),
@@ -146,7 +146,7 @@ std::string OperationExpression::GetRHS(std::unordered_set<int>* used,
                               op_type_));
         PADDLE_ENFORCE_GE(input_ids_[index],
                           0,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Expected %d-th input id > 0 for operation < %s "
                               ">. Received %d.",
                               index,

--- a/paddle/fluid/framework/ir/fusion_group/code_generator_helper.h
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator_helper.h
@@ -142,7 +142,7 @@ class CodeTemplate {
     for (auto iter : template_var.Get()) {
       PADDLE_ENFORCE_NE(found.find(iter.first),
                         found.end(),
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "Keyword %s in template is not set.", iter.first));
     }
 

--- a/paddle/fluid/framework/ir/fusion_group/elementwise_group_detector.cc
+++ b/paddle/fluid/framework/ir/fusion_group/elementwise_group_detector.cc
@@ -47,7 +47,7 @@ static bool IsSpecifiedOp(const std::unordered_set<std::string>& op_types,
 static bool IsGradOp(const Node* n) {
   PADDLE_ENFORCE_EQ(n && n->IsOp() && n->Op(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Expected node %p to be an operator node.", n));
   std::string suffix = "_grad";
   std::string op_type = n->Op()->Type();

--- a/paddle/fluid/framework/ir/fusion_group/operation.cc
+++ b/paddle/fluid/framework/ir/fusion_group/operation.cc
@@ -46,7 +46,7 @@ void OperationMap::Insert(int type,
   Operation op(type, num_operands, op_type, {expr}, input_names, output_names);
   PADDLE_ENFORCE_EQ(op.IsValid(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Operation %s is invalid. Please set correct "
                         "expression for forward calculation.",
                         op_type));
@@ -76,7 +76,7 @@ void OperationMap::Insert(int type,
                       grad_output_names);
     PADDLE_ENFORCE_EQ(grad_op.IsValid(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Operation %s is invalid. Please set correct "
                           "expression for backward calculation.",
                           grad_op_type));

--- a/paddle/fluid/framework/ir/fusion_group/operation.h
+++ b/paddle/fluid/framework/ir/fusion_group/operation.h
@@ -77,7 +77,7 @@ class OperationMap {
   static OperationMap& Instance() {
     PADDLE_ENFORCE_NOT_NULL(
         map,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Please initialize OperationMap first, by calling "
             "framework::fusion_group::OperationMap::Init()!"));
     return *map;
@@ -100,7 +100,7 @@ class OperationMap {
     auto iter = operations_.find(op_type);
     PADDLE_ENFORCE_NE(iter,
                       operations_.end(),
-                      phi::errors::Unimplemented(
+                      common::errors::Unimplemented(
                           "Operation %s is not supported yet.", op_type));
     return iter->second;
   }

--- a/paddle/fluid/framework/ir/generate_pass.cc
+++ b/paddle/fluid/framework/ir/generate_pass.cc
@@ -27,7 +27,7 @@ class element_visitor {
 
   template <typename T>
   Attribute operator()(const T& attr UNUSED) const {
-    PADDLE_THROW(phi::errors::Unimplemented("Unimplemented operand."));
+    PADDLE_THROW(common::errors::Unimplemented("Unimplemented operand."));
   }
 
   template <typename T>
@@ -50,7 +50,7 @@ class element_visitor {
 template <>
 Attribute element_visitor::operator()(
     const std::vector<::pir::Value>& attr UNUSED) const {
-  PADDLE_THROW(phi::errors::Unimplemented("Unimplemented operand."));
+  PADDLE_THROW(common::errors::Unimplemented("Unimplemented operand."));
 }
 
 class operation_visitor {
@@ -61,7 +61,7 @@ class operation_visitor {
   template <typename T1, typename T2>
   Attribute operator()(const T1& attr UNUSED,
                        const T2& operation UNUSED) const {
-    PADDLE_THROW(phi::errors::Unimplemented("Unimplemented operand."));
+    PADDLE_THROW(common::errors::Unimplemented("Unimplemented operand."));
   }
 
   template <typename T, std::enable_if_t<std::is_integral<T>::value>* = nullptr>
@@ -77,7 +77,7 @@ class operation_visitor {
 
       default:
         PADDLE_THROW(
-            phi::errors::Unimplemented("Unimplemented operation type."));
+            common::errors::Unimplemented("Unimplemented operation type."));
     }
   }
 
@@ -221,7 +221,7 @@ void InitGeneratePattern(const proto::PassDesc& pass_desc, PDPattern* pattern) {
 
           default:
             PADDLE_THROW(
-                phi::errors::Unimplemented("Unimplemented condition type."));
+                common::errors::Unimplemented("Unimplemented condition type."));
         }
       });
     }
@@ -232,8 +232,8 @@ void InitGeneratePattern(const proto::PassDesc& pass_desc, PDPattern* pattern) {
     PDNode* var_pdnode = pattern->RetrieveNode(var_map.pattern_var());
     PADDLE_ENFORCE_NOT_NULL(
         var_pdnode,
-        phi::errors::NotFound("Not found the var %s in the pattern.",
-                              var_map.pattern_var()));
+        common::errors::NotFound("Not found the var %s in the pattern.",
+                                 var_map.pattern_var()));
     var_pdnode->AsOutput();
   }
 }
@@ -313,8 +313,8 @@ GraphPatternDetector::handle_t GetGenerateRewrite(
               condition_attr = GetVarAttrValue(condition_node->Var(),
                                                condition.condition_attr());
             } else {
-              PADDLE_THROW(
-                  phi::errors::Unimplemented("Unimplemented for operation."));
+              PADDLE_THROW(common::errors::Unimplemented(
+                  "Unimplemented for operation."));
             }
             bool check_failed = false;
             if (condition.type() == proto::PassDesc_ConditionType_kEQ) {
@@ -497,7 +497,7 @@ void GeneratePass::VerifyDesc() const {
   PADDLE_ENFORCE_NE(
       multi_pass_desc_.pass_descs_size(),
       0,
-      phi::errors::InvalidArgument("Size of PassDesc should not be empty."));
+      common::errors::InvalidArgument("Size of PassDesc should not be empty."));
 }
 
 bool GeneratePass::VerifyGraph(const Graph& graph) {
@@ -594,7 +594,7 @@ void PassPairs::AddPassDesc(const SubgraphType& pattern,
   pass_desc->mutable_replace()->CopyFrom(replace.ProgramDesc().blocks(0).ops());
   PADDLE_ENFORCE_EQ(pattern.InputVars().size(),
                     replace.InputVars().size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Size of lambda expression arguments is not equal "
                         "between pattern/replace subgraph."));
   for (size_t i = 0; i < pattern.InputVars().size(); i++) {
@@ -604,7 +604,7 @@ void PassPairs::AddPassDesc(const SubgraphType& pattern,
   }
   PADDLE_ENFORCE_EQ(pattern.OutputVars().size(),
                     replace.OutputVars().size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Size of lambda expression returns is not equal "
                         "between pattern/replace subgraph."));
   for (size_t i = 0; i < pattern.OutputVars().size(); i++) {

--- a/paddle/fluid/framework/ir/generate_pass_tester.cc
+++ b/paddle/fluid/framework/ir/generate_pass_tester.cc
@@ -121,19 +121,19 @@ TEST(GeneratePass, generate_fc_fuse) {
   int num_fc_nodes_after = GetNumOpNodes(graph, "fc");
   VLOG(3) << DebugString(graph);
 
-  PADDLE_ENFORCE_EQ(
-      num_nodes_before,
-      num_nodes_after + 6,
-      phi::errors::InvalidArgument("num_nodes_before=%d, num_nodes_after=%d.",
-                                   num_nodes_before,
-                                   num_nodes_after));
+  PADDLE_ENFORCE_EQ(num_nodes_before,
+                    num_nodes_after + 6,
+                    common::errors::InvalidArgument(
+                        "num_nodes_before=%d, num_nodes_after=%d.",
+                        num_nodes_before,
+                        num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fc_nodes_after,
                     2,
-                    phi::errors::InvalidArgument("num_fc_nodes_after=%d.",
-                                                 num_fc_nodes_after));
+                    common::errors::InvalidArgument("num_fc_nodes_after=%d.",
+                                                    num_fc_nodes_after));
   PADDLE_ENFORCE_EQ(num_mul_nodes_before,
                     num_fc_nodes_after,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "num_mul_nodes_before=%d, num_fc_nodes_after=%d.",
                         num_mul_nodes_before,
                         num_fc_nodes_after));
@@ -162,19 +162,19 @@ TEST(GeneratePass, generate_multi_add_to_addn) {
   int num_addn_nodes_after = GetNumOpNodes(graph, "sum");
   VLOG(3) << DebugString(graph);
 
-  PADDLE_ENFORCE_EQ(
-      num_nodes_before,
-      num_nodes_after + 2,
-      phi::errors::InvalidArgument("num_nodes_before=%d, num_nodes_after=%d.",
-                                   num_nodes_before,
-                                   num_nodes_after));
+  PADDLE_ENFORCE_EQ(num_nodes_before,
+                    num_nodes_after + 2,
+                    common::errors::InvalidArgument(
+                        "num_nodes_before=%d, num_nodes_after=%d.",
+                        num_nodes_before,
+                        num_nodes_after));
   PADDLE_ENFORCE_EQ(num_addn_nodes_after,
                     1,
-                    phi::errors::InvalidArgument("num_addn_nodes_after=%d.",
-                                                 num_addn_nodes_after));
+                    common::errors::InvalidArgument("num_addn_nodes_after=%d.",
+                                                    num_addn_nodes_after));
   PADDLE_ENFORCE_EQ(num_add_nodes_before,
                     num_addn_nodes_after + 1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "num_add_nodes_before=%d, num_addn_nodes_after=%d.",
                         num_add_nodes_before,
                         num_addn_nodes_after));
@@ -203,20 +203,20 @@ TEST(GeneratePass, generate_combine_matmul) {
   int num_matmul_nodes_after = GetNumOpNodes(graph, "matmul");
   VLOG(3) << DebugString(graph);
 
-  PADDLE_ENFORCE_EQ(
-      num_nodes_before,
-      num_nodes_after - 4,
-      phi::errors::InvalidArgument("num_nodes_before=%d, num_nodes_after=%d.",
-                                   num_nodes_before,
-                                   num_nodes_after));
+  PADDLE_ENFORCE_EQ(num_nodes_before,
+                    num_nodes_after - 4,
+                    common::errors::InvalidArgument(
+                        "num_nodes_before=%d, num_nodes_after=%d.",
+                        num_nodes_before,
+                        num_nodes_after));
   PADDLE_ENFORCE_EQ(num_matmul_nodes_after,
                     1,
-                    phi::errors::InvalidArgument("num_matmul_nodes_after=%d.",
-                                                 num_matmul_nodes_after));
+                    common::errors::InvalidArgument(
+                        "num_matmul_nodes_after=%d.", num_matmul_nodes_after));
   PADDLE_ENFORCE_EQ(
       num_matmul_nodes_before,
       num_matmul_nodes_after + 1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "num_matmul_nodes_before=%d, num_matmul_nodes_after=%d.",
           num_matmul_nodes_before,
           num_matmul_nodes_after));

--- a/paddle/fluid/framework/ir/gpu_cpu_map_matmul_to_mul_pass.cc
+++ b/paddle/fluid/framework/ir/gpu_cpu_map_matmul_to_mul_pass.cc
@@ -253,7 +253,7 @@ GpuCpuSqueeze2MatmulFusePass::GpuCpuSqueeze2MatmulFusePass() {
 
 void GpuCpuMapMatmul2MulPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   std::string name_scope = "gpu_cpu_map_matmul_to_mul_pass";
   FusePassBase::Init(name_scope, graph);
 
@@ -322,7 +322,7 @@ void GpuCpuMapMatmul2MulPass::ApplyImpl(ir::Graph* graph) const {
 
 void GpuCpuMapMatmulV2ToMulPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   std::string name_scope = "gpu_cpu_map_matmul_v2_to_mul_pass";
   FusePassBase::Init(name_scope, graph);
 
@@ -396,7 +396,7 @@ void GpuCpuMapMatmulV2ToMulPass::ApplyImpl(ir::Graph* graph) const {
 
 void GpuCpuMapMatmulV2ToMatmulPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   std::string name_scope = "gpu_cpu_map_matmul_v2_to_matmul_pass";
   FusePassBase::Init(name_scope, graph);
 
@@ -472,7 +472,7 @@ void GpuCpuMapMatmulV2ToMatmulPass::ApplyImpl(ir::Graph* graph) const {
 
 void GpuCpuSqueeze2MatmulFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   std::string name_scope = "gpu_cpu_squeeze2_matmul_fuse_pass";
   FusePassBase::Init(name_scope, graph);
 
@@ -614,7 +614,7 @@ GpuCpuReshape2MatmulFusePass::GpuCpuReshape2MatmulFusePass() {
 
 void GpuCpuReshape2MatmulFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   std::string name_scope = "gpu_cpu_reshape2_matmul_fuse_pass";
   FusePassBase::Init(name_scope, graph);
 
@@ -696,7 +696,7 @@ void GpuCpuReshape2MatmulFusePass::ApplyImpl(ir::Graph* graph) const {
 
 void GpuCpuFlatten2MatmulFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   std::string name_scope = "gpu_cpu_flatten2_matmul_fuse_pass";
   FusePassBase::Init(name_scope, graph);
 

--- a/paddle/fluid/framework/ir/graph.h
+++ b/paddle/fluid/framework/ir/graph.h
@@ -152,12 +152,12 @@ class Graph {
     PADDLE_ENFORCE_EQ(
         Has(attr_name),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "%s attribute not registered for current graph.", attr_name));
     try {
       return *paddle::any_cast<AttrType *>(attrs_.at(attr_name));
     } catch (paddle::bad_any_cast &) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Invalid attribute type of %s, expected: %s, received: %s.",
           attr_name,
           platform::demangle(typeid(AttrType *).name()),  // NOLINT
@@ -175,7 +175,7 @@ class Graph {
     PADDLE_ENFORCE_EQ(
         attrs_.count(attr_name),
         0,
-        phi::errors::AlreadyExists(
+        common::errors::AlreadyExists(
             "The attribute %s to be set already exists in the graph.",
             attr_name));
     attrs_[attr_name] = attr;
@@ -195,9 +195,9 @@ class Graph {
     PADDLE_ENFORCE_EQ(
         attrs_.count(attr_name),
         0,
-        phi::errors::AlreadyExists("The attribute %s to be set(not owned) "
-                                   "already exists in the graph.",
-                                   attr_name));
+        common::errors::AlreadyExists("The attribute %s to be set(not owned) "
+                                      "already exists in the graph.",
+                                      attr_name));
     attrs_[attr_name] = attr;
     attr_dels_[attr_name] = []() {};
   }
@@ -211,7 +211,7 @@ class Graph {
     PADDLE_ENFORCE_NE(
         attrs_.count(attr_name),
         0,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "The attribute %s to be erased does not exist in the graph.",
             attr_name));
     attr_dels_[attr_name]();
@@ -237,7 +237,7 @@ class Graph {
     }
     PADDLE_ENFORCE_NOT_NULL(
         var_desc,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The VarDesc used to create variable node is null."));
     auto *x =
         AddNode(new ir::Node(var_desc, block_id == -1 ? block_id_ : block_id));
@@ -255,7 +255,7 @@ class Graph {
     }
     PADDLE_ENFORCE_NOT_NULL(
         op_desc,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The OpDesc used to create operator node is null."));
     auto *x = AddNode(new ir::Node(op_desc));
     x->SetId(num_node_created_++);
@@ -322,7 +322,7 @@ class Graph {
     }
     PADDLE_ENFORCE_EQ(node_set_.find(node) != node_set_.end(),
                       true,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The node to be removed does not exist."));
     std::unique_ptr<ir::Node> ret;
     ret.reset(nodes_.at(node).release());
@@ -368,7 +368,7 @@ class Graph {
     }
     PADDLE_ENFORCE_EQ(node_set_.find(node) == node_set_.end(),
                       true,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The node to be added already exists."));
     nodes_[node].reset(node);
     node_set_.insert(node);
@@ -390,10 +390,11 @@ class Graph {
     PADDLE_ENFORCE_EQ(
         this->IsMainGraph(),
         true,
-        phi::errors::InvalidArgument("This graph is not main_graph"));
-    PADDLE_ENFORCE_LT(idx,
-                      sub_graphs_.size(),
-                      phi::errors::InvalidArgument("Invalid sub_graph index"));
+        common::errors::InvalidArgument("This graph is not main_graph"));
+    PADDLE_ENFORCE_LT(
+        idx,
+        sub_graphs_.size(),
+        common::errors::InvalidArgument("Invalid sub_graph index"));
     return sub_graphs_.at(idx).get();
   }
 
@@ -410,7 +411,7 @@ class Graph {
     PADDLE_ENFORCE_EQ(
         this->IsMainGraph(),
         true,
-        phi::errors::InvalidArgument("This graph is not main_graph"));
+        common::errors::InvalidArgument("This graph is not main_graph"));
     return sub_graphs_.size();
   }
 
@@ -445,7 +446,7 @@ class Graph {
     PADDLE_ENFORCE_EQ(
         this->IsMainGraph(),
         true,
-        phi::errors::InvalidArgument("This graph is not main_graph"));
+        common::errors::InvalidArgument("This graph is not main_graph"));
     sub_graphs_.clear();
   }
 
@@ -453,10 +454,10 @@ class Graph {
     PADDLE_ENFORCE_EQ(
         this->IsMainGraph(),
         true,
-        phi::errors::InvalidArgument("This graph is not main_graph"));
+        common::errors::InvalidArgument("This graph is not main_graph"));
     PADDLE_ENFORCE_EQ(sub_graphs_.size(),
                       sub_graph->block_id_,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "sub_graph idx is not equal to block_id_"));
     sub_graphs_.push_back(std::move(sub_graph));
   }

--- a/paddle/fluid/framework/ir/graph_helper.cc
+++ b/paddle/fluid/framework/ir/graph_helper.cc
@@ -153,10 +153,10 @@ bool FindCircleSubGraph(const Graph &graph,
 std::vector<ir::Node *> TopologySortOperations(const Graph &graph) {
   std::map<ir::Node *, std::set<ir::Node *, ir::NodeComp>, ir::NodeComp>
       adj_list = BuildOperationAdjList(graph);
-  PADDLE_ENFORCE_EQ(
-      HasCircleInternal(adj_list, nullptr),
-      false,
-      phi::errors::InvalidArgument("Generated graph shouldn't contain cycle."));
+  PADDLE_ENFORCE_EQ(HasCircleInternal(adj_list, nullptr),
+                    false,
+                    common::errors::InvalidArgument(
+                        "Generated graph shouldn't contain cycle."));
   std::unordered_set<ir::Node *> visited;
   std::vector<ir::Node *> ret;
   for (auto const &adj : adj_list) {
@@ -208,7 +208,7 @@ std::map<ir::Node *, std::unordered_set<ir::Node *>> BuildOperationOutAdjList(
       for (auto &adj_n : var->outputs) {
         PADDLE_ENFORCE_EQ(adj_n->NodeType(),
                           ir::Node::Type::kOperation,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Node(%s)'s type(%d) must be kOperation type.",
                               adj_n->Name(),
                               static_cast<int>(adj_n->NodeType())));
@@ -385,7 +385,7 @@ size_t GraphNum(const Graph &graph) {
           new std::ofstream(FLAGS_print_sub_graph_dir));
       PADDLE_ENFORCE_EQ(fout->good(),
                         true,
-                        phi::errors::Unavailable(
+                        common::errors::Unavailable(
                             "Can not open file %s for printing the graph.",
                             FLAGS_print_sub_graph_dir));
       *fout << out.str();
@@ -436,10 +436,10 @@ std::vector<ir::Node *> TopologySortGraphByDescOrder(const Graph &graph) {
            std::set<ir::Node *, DescOrderComparator>,
            DescOrderComparator>
       adj_list = BuildOperationAdjList<DescOrderComparator>(graph);
-  PADDLE_ENFORCE_EQ(
-      HasCircleInternal<DescOrderComparator>(adj_list, nullptr),
-      false,
-      phi::errors::InvalidArgument("Generated graph shouldn't contain cycle."));
+  PADDLE_ENFORCE_EQ(HasCircleInternal<DescOrderComparator>(adj_list, nullptr),
+                    false,
+                    common::errors::InvalidArgument(
+                        "Generated graph shouldn't contain cycle."));
   std::unordered_set<ir::Node *> visited;
   std::vector<ir::Node *> ret;
   for (auto const &adj : adj_list) {
@@ -575,8 +575,8 @@ void ReplaceAllReduceOp(const Node &node,
   }
 #else
   PADDLE_THROW(
-      phi::errors::Unimplemented("ReplaceAllReduceOp is only implemented "
-                                 "for paddle compiled with NCCL/RCCL."));
+      common::errors::Unimplemented("ReplaceAllReduceOp is only implemented "
+                                    "for paddle compiled with NCCL/RCCL."));
 #endif
 }
 
@@ -753,12 +753,12 @@ void GraphToProgram(const Graph &graph,
                     const SortKind *sort_kind) {
   PADDLE_ENFORCE_EQ(graph.IsMainGraph(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "This graph is a sub_graph, "
                         "and can't convert to program individually"));
   PADDLE_ENFORCE_NOT_NULL(
       program,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "program must not be nullptr when converting graph to program"));
 
   proto::ProgramDesc program_pb(*(program->Proto()));
@@ -865,8 +865,8 @@ static std::vector<std::vector<ir::Node::Dep>> GetOpDependencies(
     PADDLE_ENFORCE_EQ(
         op_id_to_idx.emplace(op_desc->OriginalId(), op_idx).second,
         true,
-        phi::errors::InvalidArgument("There should not be duplicate op id: %d",
-                                     op_desc->OriginalId()));
+        common::errors::InvalidArgument(
+            "There should not be duplicate op id: %d", op_desc->OriginalId()));
   }
 
   std::vector<std::vector<ir::Node::Dep>> dep_matrix(op_num);
@@ -877,10 +877,10 @@ static std::vector<std::vector<ir::Node::Dep>> GetOpDependencies(
 
   auto get_op_idx_by_id = [&op_id_to_idx](uint64_t op_id) {
     auto iter = op_id_to_idx.find(op_id);
-    PADDLE_ENFORCE_NE(
-        iter,
-        op_id_to_idx.end(),
-        phi::errors::InvalidArgument("Cannot find OpDesc with id %d", op_id));
+    PADDLE_ENFORCE_NE(iter,
+                      op_id_to_idx.end(),
+                      common::errors::InvalidArgument(
+                          "Cannot find OpDesc with id %d", op_id));
     return iter->second;
   };
 

--- a/paddle/fluid/framework/ir/graph_helper.h
+++ b/paddle/fluid/framework/ir/graph_helper.h
@@ -97,7 +97,7 @@ BuildOperationAdjList(const Graph &graph) {
       for (auto &adj_n : var->inputs) {
         PADDLE_ENFORCE_EQ(adj_n->NodeType(),
                           ir::Node::Type::kOperation,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Node(%s)'s type(%d) must be kOperation type.",
                               adj_n->Name(),
                               static_cast<int>(adj_n->NodeType())));

--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -35,7 +35,7 @@ PDNode *PDPattern::NewNode(const std::string &name) {
     PADDLE_ENFORCE_EQ(
         node_map_.count(name),
         0UL,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "PDNode's name should be unique, get duplicate [%s]", name));
   }
 
@@ -50,7 +50,7 @@ PDNode *PDPattern::NewNode(PDNode::teller_t &&teller, const std::string &name) {
     PADDLE_ENFORCE_EQ(
         node_map_.count(name),
         0UL,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "PDNode's name should be unique, get duplicate [%s]", name));
   }
 
@@ -71,14 +71,14 @@ PDNode *PDPattern::RetrieveNode(const std::string &id) const {
 
 void PDPattern::AddEdge(PDNode *a, PDNode *b) {
   PADDLE_ENFORCE_NOT_NULL(a,
-                          phi::errors::NotFound("PDNode %s is not found.",
-                                                a->name()));  // NOLINT
+                          common::errors::NotFound("PDNode %s is not found.",
+                                                   a->name()));  // NOLINT
   PADDLE_ENFORCE_NOT_NULL(b,
-                          phi::errors::NotFound("PDNode %s is not found.",
-                                                b->name()));  // NOLINT
+                          common::errors::NotFound("PDNode %s is not found.",
+                                                   b->name()));  // NOLINT
   PADDLE_ENFORCE_NE(a,
                     b,
-                    phi::errors::PermissionDenied(
+                    common::errors::PermissionDenied(
                         "Cannot connect the same node in the graph."));
   edges_.emplace_back(a, b);
 }
@@ -720,12 +720,12 @@ bool IsNthInput(Node *var, Node *op, const std::string &argument, size_t nth) {
   PADDLE_ENFORCE_EQ(
       var->IsVar(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "First parameter of function IsNthInput must be Node::Var"));
   PADDLE_ENFORCE_EQ(
       op->IsOp(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Second parameter of function IsNthInput must be Node::Op"));
   if (!HasInput(op, argument) || op->Op()->Input(argument).size() <= nth)
     return false;
@@ -736,7 +736,7 @@ bool HasInput(Node *op, const std::string &argument) {
   PADDLE_ENFORCE_EQ(
       op->IsOp(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "First parameter of function HasInput must be Node::Op"));
   auto const &names = op->Op()->InputNames();
   if (std::find(names.begin(), names.end(), argument) == names.end())
@@ -748,7 +748,7 @@ bool HasOutput(Node *op, const std::string &argument) {
   PADDLE_ENFORCE_EQ(
       op->IsOp(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "First parameter of function HasOutput must be Node::Op"));
   auto const &names = op->Op()->OutputNames();
   if (std::find(names.begin(), names.end(), argument) == names.end())
@@ -760,12 +760,12 @@ bool IsNthOutput(Node *var, Node *op, const std::string &argument, size_t nth) {
   PADDLE_ENFORCE_EQ(
       var->IsVar(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "First parameter of function IsNthOutput must be Node::Var"));
   PADDLE_ENFORCE_EQ(
       op->IsOp(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Second parameter of function IsNthOutput must be Node::Op"));
   if (!HasOutput(op, argument) || op->Op()->Output(argument).size() <= nth)
     return false;

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -183,7 +183,7 @@ struct PDNode {
         type_(type) {
     PADDLE_ENFORCE_NOT_NULL(
         teller_,
-        phi::errors::NotFound("invalid teller is set, teller is null"));
+        common::errors::NotFound("invalid teller is set, teller is null"));
   }
 
   PDNode(PDNode&& other) = default;
@@ -458,15 +458,15 @@ static std::string UniqueKey(const std::string& repr) {
 // var: variable.
 // arg: the argument declared by PATTERN_DECL_NODE in a pattern definition.
 // pat: the pattern object.
-#define GET_IR_NODE_FROM_SUBGRAPH(var, arg, pat)                          \
-  PADDLE_ENFORCE_NE(subgraph.count(pat.arg##_n()),                        \
-                    0UL,                                                  \
-                    phi::errors::NotFound("Node not found for PDNode %s", \
-                                          pat.arg##_repr()));             \
-  Node* var = subgraph.at(pat.arg##_n());                                 \
-  PADDLE_ENFORCE_NOT_NULL(                                                \
-      var,                                                                \
-      phi::errors::NotFound("node %s not exists in the sub-graph", #arg));
+#define GET_IR_NODE_FROM_SUBGRAPH(var, arg, pat)                             \
+  PADDLE_ENFORCE_NE(subgraph.count(pat.arg##_n()),                           \
+                    0UL,                                                     \
+                    common::errors::NotFound("Node not found for PDNode %s", \
+                                             pat.arg##_repr()));             \
+  Node* var = subgraph.at(pat.arg##_n());                                    \
+  PADDLE_ENFORCE_NOT_NULL(                                                   \
+      var,                                                                   \
+      common::errors::NotFound("node %s not exists in the sub-graph", #arg));
 
 // The base class of all the patterns.
 struct PatternBase {

--- a/paddle/fluid/framework/ir/graph_traits.cc
+++ b/paddle/fluid/framework/ir/graph_traits.cc
@@ -84,14 +84,14 @@ NodesDFSIterator::NodesDFSIterator(const NodesDFSIterator &other)
 Node &NodesDFSIterator::operator*() {
   PADDLE_ENFORCE_EQ(stack_.empty(),
                     false,
-                    phi::errors::OutOfRange("The iterator exceeds range."));
+                    common::errors::OutOfRange("The iterator exceeds range."));
   return *stack_.top();
 }
 
 NodesDFSIterator &NodesDFSIterator::operator++() {
   PADDLE_ENFORCE_EQ(stack_.empty(),
                     false,
-                    phi::errors::OutOfRange("The iterator exceeds range."));
+                    common::errors::OutOfRange("The iterator exceeds range."));
   visited_.insert(stack_.top());
   auto *cur = stack_.top();
   stack_.pop();
@@ -125,14 +125,14 @@ NodesTSIterator::NodesTSIterator(const std::vector<Node *> &source) {
   PADDLE_ENFORCE_EQ(
       source.empty(),
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Start points of topological sorting should not be empty!"));
   // CHECK all the inputs' in-degree is 0
   for (auto *node : source) {
     PADDLE_ENFORCE_EQ(
         CheckNodeIndegreeEquals(*node, 0),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "In start points of topological sorting, the indegree of each "
             "point should be 0. Node(%s)'s indegree is not 0.",
             node->Name()));
@@ -169,7 +169,7 @@ Node &NodesTSIterator::operator*() {
   PADDLE_ENFORCE_LT(
       cursor_,
       sorted_.size(),
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "The iterator exceeds range. Container size is %d, but index is %d.",
           sorted_.size(),
           cursor_));
@@ -197,7 +197,7 @@ Node *NodesTSIterator::operator->() {
   PADDLE_ENFORCE_LT(
       cursor_,
       sorted_.size(),
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "The iterator exceeds range. Container size is %d, but index is %d.",
           sorted_.size(),
           cursor_));

--- a/paddle/fluid/framework/ir/graph_traits.h
+++ b/paddle/fluid/framework/ir/graph_traits.h
@@ -115,7 +115,7 @@ struct GraphTraits {
     PADDLE_ENFORCE_EQ(
         start_points.empty(),
         false,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Start points of topological sorting should not be empty!"));
     NodesTSIterator x(start_points);
     return iterator_range<NodesTSIterator>(NodesTSIterator(start_points),

--- a/paddle/fluid/framework/ir/graph_viz_pass.cc
+++ b/paddle/fluid/framework/ir/graph_viz_pass.cc
@@ -56,8 +56,8 @@ void GraphVizPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_EQ(
       fout->good(),
       true,
-      phi::errors::Unavailable("Can not open file %s for printing the graph.",
-                               graph_viz_path));
+      common::errors::Unavailable(
+          "Can not open file %s for printing the graph.", graph_viz_path));
   std::ostream& sout = *fout;
 
   // serialize only model file.

--- a/paddle/fluid/framework/ir/groupnorm_act_pass.cc
+++ b/paddle/fluid/framework/ir/groupnorm_act_pass.cc
@@ -78,7 +78,7 @@ namespace paddle::framework::ir {
 
 int GroupNormActFusePass::ApplyGNSiluPattern(ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("groupnorm_silu_fuse", graph);
 
   int found_subgraph_count = 0;

--- a/paddle/fluid/framework/ir/identity_op_clean_pass_test.cc
+++ b/paddle/fluid/framework/ir/identity_op_clean_pass_test.cc
@@ -37,7 +37,7 @@ TEST(identity_op_clean_pass, assign) {
   PADDLE_ENFORCE_EQ(
       assign_num,
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "graph should have 0 assign after identity_op_clean_pass, "
           "but actually has %d.",
           assign_num));
@@ -61,7 +61,7 @@ TEST(identity_op_clean_pass, scale) {
   PADDLE_ENFORCE_EQ(
       scale_num,
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "graph should have 0 scale op after identity_op_clean_pass, "
           "but actually has %d.",
           scale_num));
@@ -85,7 +85,7 @@ TEST(identity_op_clean_pass, cast) {
   PADDLE_ENFORCE_EQ(
       cast_num,
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "graph should have 0 cast after identity_op_clean_pass, "
           "but actually has %d.",
           cast_num));
@@ -107,7 +107,7 @@ TEST(identity_op_clean_pass, concat) {
   PADDLE_ENFORCE_EQ(
       concat_num,
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "graph should have 0 concat after identity_op_clean_pass, "
           "but actually has %d.",
           concat_num));

--- a/paddle/fluid/framework/ir/ipu/inference_process_pass.cc
+++ b/paddle/fluid/framework/ir/ipu/inference_process_pass.cc
@@ -71,8 +71,8 @@ void InferenceProcessPass::ApplyImpl(ir::Graph* graph) const {
     PADDLE_ENFORCE_GE(
         batches_per_step,
         num_ipus,
-        phi::errors::InvalidArgument("Batched per step should be equal or "
-                                     "greater than the number of IPUs"));
+        common::errors::InvalidArgument("Batched per step should be equal or "
+                                        "greater than the number of IPUs"));
     ipu_strategy_instance_->batches_per_step = batches_per_step;
   }
 

--- a/paddle/fluid/framework/ir/ipu/optimizer_extract_pass.cc
+++ b/paddle/fluid/framework/ir/ipu/optimizer_extract_pass.cc
@@ -115,27 +115,27 @@ void IpuOptimizerExtractPass::ApplyImpl(ir::Graph* graph) const {
         auto type = std::string{"sgd"};
         // auto LearningRate = op->Input("LearningRate");
         auto use_nesterov = PADDLE_GET_CONST(bool, op->GetAttr("use_nesterov"));
-        PADDLE_ENFORCE_EQ(
-            use_nesterov,
-            false,
-            phi::errors::Unimplemented("ipu does not support nesterov mode."));
+        PADDLE_ENFORCE_EQ(use_nesterov,
+                          false,
+                          common::errors::Unimplemented(
+                              "ipu does not support nesterov mode."));
         auto regularization_method =
             PADDLE_GET_CONST(std::string, op->GetAttr("regularization_method"));
-        PADDLE_ENFORCE_NE(
-            regularization_method,
-            "l1_decay",
-            phi::errors::Unimplemented("ipu does not support l1_decay mode."));
+        PADDLE_ENFORCE_NE(regularization_method,
+                          "l1_decay",
+                          common::errors::Unimplemented(
+                              "ipu does not support l1_decay mode."));
         auto multi_precision =
             PADDLE_GET_CONST(bool, op->GetAttr("multi_precision"));
         PADDLE_ENFORCE_EQ(multi_precision,
                           false,
-                          phi::errors::Unimplemented(
+                          common::errors::Unimplemented(
                               "ipu does not support multi_precision mode."));
         auto rescale_grad =
             PADDLE_GET_CONST(float, op->GetAttr("rescale_grad"));
         PADDLE_ENFORCE_EQ(rescale_grad,
                           1.0,
-                          phi::errors::Unimplemented(
+                          common::errors::Unimplemented(
                               "ipu does not support rescale_grad mode."));
         auto regularization_coeff =
             PADDLE_GET_CONST(float, op->GetAttr("regularization_coeff"));
@@ -155,13 +155,13 @@ void IpuOptimizerExtractPass::ApplyImpl(ir::Graph* graph) const {
         auto lazy_mode = PADDLE_GET_CONST(bool, op->GetAttr("lazy_mode"));
         auto multi_precision =
             PADDLE_GET_CONST(bool, op->GetAttr("multi_precision"));
-        PADDLE_ENFORCE_EQ(
-            lazy_mode,
-            false,
-            phi::errors::Unimplemented("ipu does not support lazy_mode mode."));
+        PADDLE_ENFORCE_EQ(lazy_mode,
+                          false,
+                          common::errors::Unimplemented(
+                              "ipu does not support lazy_mode mode."));
         PADDLE_ENFORCE_EQ(multi_precision,
                           false,
-                          phi::errors::Unimplemented(
+                          common::errors::Unimplemented(
                               "ipu does not support multi_precision mode."));
         new_op.SetAttr("type", type);
         new_op.SetAttr("lr_var", lr_var);
@@ -269,7 +269,7 @@ void IpuOptimizerExtractPass::ApplyImpl(ir::Graph* graph) const {
       } else if (ignored_ops.count(op_type)) {
         VLOG(10) << "Ignore optimizer related op: " << op_type;
       } else {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "Unknown optimizer related op_type: %s", op_type));
       }
     } else if (op_role == OpRole::kLoss) {
@@ -278,12 +278,12 @@ void IpuOptimizerExtractPass::ApplyImpl(ir::Graph* graph) const {
       PADDLE_ENFORCE_EQ(
           outputs.size(),
           1,
-          phi::errors::InvalidArgument("Can only support one loss key"));
+          common::errors::InvalidArgument("Can only support one loss key"));
       auto losses = outputs.begin()->second;
       PADDLE_ENFORCE_EQ(
           losses.size(),
           1,
-          phi::errors::InvalidArgument("Can only support one loss name"));
+          common::errors::InvalidArgument("Can only support one loss name"));
       auto loss_var = losses.front();
       new_op.SetAttr("loss_var", loss_var);
     } else if (op_role == OpRole::kLRSched) {
@@ -305,7 +305,7 @@ void IpuOptimizerExtractPass::ApplyImpl(ir::Graph* graph) const {
       // L1Decay
       // sign + scale + sum
       PADDLE_THROW(
-          phi::errors::Unimplemented("Unsupported L1Decay regularizer"));
+          common::errors::Unimplemented("Unsupported L1Decay regularizer"));
     } else {
       // L2Decay
       // scale + sum
@@ -318,10 +318,10 @@ void IpuOptimizerExtractPass::ApplyImpl(ir::Graph* graph) const {
   // setup grad clip
   if (set_ops.count("clip")) {
     // ClipGradByValue
-    PADDLE_THROW(phi::errors::Unimplemented("Unsupported ClipGradByValue"));
+    PADDLE_THROW(common::errors::Unimplemented("Unsupported ClipGradByValue"));
   } else if (set_ops.count("clip_by_norm")) {
     // ClipGradByNorm
-    PADDLE_THROW(phi::errors::Unimplemented("Unsupported ClipGradByNorm"));
+    PADDLE_THROW(common::errors::Unimplemented("Unsupported ClipGradByNorm"));
   }
 
   // ClipGradByGlobalNorm
@@ -335,7 +335,7 @@ void IpuOptimizerExtractPass::ApplyImpl(ir::Graph* graph) const {
     VLOG(10) << "New Optimizer Node:";
     VLOG(10) << DebugString(new_node);
   } else {
-    PADDLE_THROW(phi::errors::NotFound(
+    PADDLE_THROW(common::errors::NotFound(
         "No optimizer found, optimizer must be one of these types: sgd, "
         "momentum, adam, adamw, adamax, lamb, adadelta, adagrad or rmsprop"));
   }

--- a/paddle/fluid/framework/ir/ipu/popart_canonicalization_pass.cc
+++ b/paddle/fluid/framework/ir/ipu/popart_canonicalization_pass.cc
@@ -68,7 +68,7 @@ void PopartCanonicalizationPass::ApplyImpl(ir::Graph* graph) const {
     for (auto& op_type : missing_ops) {
       LOG(ERROR) << op_type;
     }
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Found unimplemented op_handler(s) for IPU"));
   }
 

--- a/paddle/fluid/framework/ir/layer_norm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/layer_norm_fuse_pass.cc
@@ -215,15 +215,15 @@ LayerNormFusePass::LayerNormFusePass() {
 }
 
 void LayerNormFusePass::ApplyImpl(Graph* graph) const {
-  PADDLE_ENFORCE_NOT_NULL(
-      graph,
-      phi::errors::InvalidArgument("The input graph of "
-                                   "LayerNormFusePass should not be nullptr."));
+  PADDLE_ENFORCE_NOT_NULL(graph,
+                          common::errors::InvalidArgument(
+                              "The input graph of "
+                              "LayerNormFusePass should not be nullptr."));
   FusePassBase::Init(scope_name_, graph);
 
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
-      scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+      scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
   GraphPatternDetector gpd;
   patterns::LayerNorm layer_norm_pattern(gpd.mutable_pattern(), scope_name_);

--- a/paddle/fluid/framework/ir/layernorm_shift_partition_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/layernorm_shift_partition_fuse_pass.cc
@@ -105,7 +105,7 @@ int LayerNormShiftPartitionFusePass::ApplyPattern(ir::Graph* graph,
                                                   bool with_roll) const {
   PADDLE_ENFORCE_NOT_NULL(
       graph,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input graph of LayerNormShiftPartitionFusePass should not be "
           "nullptr."));
   FusePassBase::Init(scope_name_, graph);

--- a/paddle/fluid/framework/ir/lock_free_optimize_pass.cc
+++ b/paddle/fluid/framework/ir/lock_free_optimize_pass.cc
@@ -32,7 +32,7 @@ const char kOptimizerType[] = "sgd";  // NOLINT
 
 void LockFreeOptimizePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
 
   // We could collect all weights' name from SGD, where
   // W1 <- SGD(W0, Grad0)
@@ -43,7 +43,7 @@ void LockFreeOptimizePass::ApplyImpl(ir::Graph* graph) const {
       PADDLE_ENFORCE_EQ(
           param_out_vars.size(),
           1u,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "In op(%s), find output(ParamOut) failed.", node->Name()));
       weight_var_set.insert(param_out_vars[0]);
     }
@@ -100,7 +100,7 @@ void LockFreeOptimizePass::ApplyImpl(ir::Graph* graph) const {
 
             PADDLE_ENFORCE_NOT_NULL(
                 forward_op,
-                phi::errors::NotFound(
+                common::errors::NotFound(
                     "Can not find forward op for backward op(%s).",
                     backward_op->Name()));
 
@@ -109,7 +109,7 @@ void LockFreeOptimizePass::ApplyImpl(ir::Graph* graph) const {
 
             PADDLE_ENFORCE_NOT_NULL(
                 new_optimizer_node,
-                phi::errors::InvalidArgument(
+                common::errors::InvalidArgument(
                     "Create new SGD node failed, backward op is %s.",
                     backward_op->Name()));
           }
@@ -158,24 +158,24 @@ ir::Node* LockFreeOptimizePass::CreateNewSGDNode(
     ir::Node* backward_node,
     ir::Node* grad_sum_node,
     ir::Node* optimize_node) const {
-  PADDLE_ENFORCE_NOT_NULL(
-      graph,
-      phi::errors::InvalidArgument("Input argument graph cannot be nullptr."));
+  PADDLE_ENFORCE_NOT_NULL(graph,
+                          common::errors::InvalidArgument(
+                              "Input argument graph cannot be nullptr."));
   PADDLE_ENFORCE_NOT_NULL(
       forward_node,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input argument forward_node cannot be nullptr."));
   PADDLE_ENFORCE_NOT_NULL(
       backward_node,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input argument backward_node cannot be nullptr."));
   PADDLE_ENFORCE_NOT_NULL(
       grad_sum_node,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input argument grad_sum_node cannot be nullptr."));
   PADDLE_ENFORCE_NOT_NULL(
       optimize_node,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input argument optimize_node cannot be nullptr."));
 
   // find the grad var node between the grad sum node and backward_node
@@ -188,7 +188,8 @@ ir::Node* LockFreeOptimizePass::CreateNewSGDNode(
     }
   }
   PADDLE_ENFORCE_NOT_NULL(
-      grad_node, phi::errors::NotFound("Can not find control dep variable."));
+      grad_node,
+      common::errors::NotFound("Can not find control dep variable."));
 
   // create a new SGD node
   OpDesc* old_desc = optimize_node->Op();
@@ -244,13 +245,13 @@ ir::Node* LockFreeOptimizePass::CreateNewSGDNode(
   PADDLE_ENFORCE_EQ(
       old_desc->Input("LearningRate").size(),
       1u,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "In op(%s), find input(LearningRate) failed.", old_desc->Type()));
   PADDLE_ENFORCE_EQ(
       old_desc->Input("Param").size(),
       1u,
-      phi::errors::InvalidArgument("In op(%s), find input(Param) failed.",
-                                   old_desc->Type()));
+      common::errors::InvalidArgument("In op(%s), find input(Param) failed.",
+                                      old_desc->Type()));
 
   // LR and weight nodes should be copied
   for (Node* upstream_node : optimize_node->inputs) {
@@ -285,15 +286,15 @@ void LockFreeOptimizePass::ReplaceUpstreamNode(
     ir::Node* new_optimizer_node) const {
   PADDLE_ENFORCE_NOT_NULL(
       upstream_node,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input argument upstream_node cannot be nullptr."));
   PADDLE_ENFORCE_NOT_NULL(
       old_optimizer_node,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input argument old_optimizer_node cannot be nullptr."));
   PADDLE_ENFORCE_NOT_NULL(
       new_optimizer_node,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input argument new_optimizer_node cannot be nullptr."));
 
   // Remove the old_optimizer_node from upstream_node's outputs vector
@@ -317,11 +318,11 @@ void LockFreeOptimizePass::ReplaceAllDownstreamNode(
     ir::Node* old_optimizer_node, ir::Node* new_optimizer_node) const {
   PADDLE_ENFORCE_NOT_NULL(
       old_optimizer_node,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input argument old_optimizer_node cannot be nullptr."));
   PADDLE_ENFORCE_NOT_NULL(
       new_optimizer_node,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input argument new_optimizer_node cannot be nullptr."));
 
   for (ir::Node* downstream_node : old_optimizer_node->outputs) {
@@ -345,12 +346,12 @@ void LockFreeOptimizePass::ReplaceAllDownstreamNode(
 
 ir::Node* LockFreeOptimizePass::FindForwardOpViaBackwardOp(
     ir::Graph* graph, ir::Node* backward_node) const {
-  PADDLE_ENFORCE_NOT_NULL(
-      graph,
-      phi::errors::InvalidArgument("Input argument graph cannot be nullptr."));
+  PADDLE_ENFORCE_NOT_NULL(graph,
+                          common::errors::InvalidArgument(
+                              "Input argument graph cannot be nullptr."));
   PADDLE_ENFORCE_NOT_NULL(
       backward_node,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input argument backward_node cannot be nullptr."));
 
   // strip the suffix _grad of backward_node's name

--- a/paddle/fluid/framework/ir/lock_free_optimize_pass.h
+++ b/paddle/fluid/framework/ir/lock_free_optimize_pass.h
@@ -89,34 +89,34 @@ class LockFreeOptimizePass : public Pass {
                                            ir::Node* downstream_node) const;
 
   inline bool IsOpNamed(ir::Node* node, const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(
-        node,
-        phi::errors::InvalidArgument("Input argument node cannot be nullptr."));
+    PADDLE_ENFORCE_NOT_NULL(node,
+                            common::errors::InvalidArgument(
+                                "Input argument node cannot be nullptr."));
 
     return node->NodeType() == Node::Type::kOperation && node->Name() == name;
   }
 
   inline bool IsVarNamed(ir::Node* node, const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(
-        node,
-        phi::errors::InvalidArgument("Input argument node cannot be nullptr."));
+    PADDLE_ENFORCE_NOT_NULL(node,
+                            common::errors::InvalidArgument(
+                                "Input argument node cannot be nullptr."));
 
     return node->NodeType() == Node::Type::kVariable && node->Name() == name;
   }
 
   inline bool IsVarNameEndsWith(ir::Node* node, const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(
-        node,
-        phi::errors::InvalidArgument("Input argument node cannot be nullptr."));
+    PADDLE_ENFORCE_NOT_NULL(node,
+                            common::errors::InvalidArgument(
+                                "Input argument node cannot be nullptr."));
 
     return node->NodeType() == Node::Type::kVariable &&
            paddle::string::ends_with(node->Name(), name);
   }
 
   inline bool IsVarNameContains(ir::Node* node, const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(
-        node,
-        phi::errors::InvalidArgument("Input argument node cannot be nullptr."));
+    PADDLE_ENFORCE_NOT_NULL(node,
+                            common::errors::InvalidArgument(
+                                "Input argument node cannot be nullptr."));
 
     return node->NodeType() == Node::Type::kVariable &&
            node->Name().find(name) != std::string::npos;
@@ -125,11 +125,11 @@ class LockFreeOptimizePass : public Pass {
   inline bool IsControlDepFrom(ir::Node* ctrl_dep_node, ir::Node* node) const {
     PADDLE_ENFORCE_NOT_NULL(
         ctrl_dep_node,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input argument ctrl_dep_node cannot be nullptr."));
-    PADDLE_ENFORCE_NOT_NULL(
-        node,
-        phi::errors::InvalidArgument("Input argument node cannot be nullptr."));
+    PADDLE_ENFORCE_NOT_NULL(node,
+                            common::errors::InvalidArgument(
+                                "Input argument node cannot be nullptr."));
 
     return IsControlDepVar(*ctrl_dep_node) &&
            ctrl_dep_node->inputs.size() >= 1u &&

--- a/paddle/fluid/framework/ir/map_op_to_another_pass.cc
+++ b/paddle/fluid/framework/ir/map_op_to_another_pass.cc
@@ -25,7 +25,7 @@ namespace ir {
 
 void MapOp2AnotherPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init("map_op_to_another_pass", graph);
 
   int found_count = 0;

--- a/paddle/fluid/framework/ir/matmul_scale_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/matmul_scale_fuse_pass.cc
@@ -109,7 +109,7 @@ MatmulV2ScaleFusePass::MatmulV2ScaleFusePass() {
 
 void MatmulScaleFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   std::string name_scope = "matmul_scale_fuse";
   FusePassBase::Init(name_scope, graph);
 
@@ -169,7 +169,7 @@ void MatmulScaleFusePass::ApplyImpl(ir::Graph* graph) const {
 
 void MatmulV2ScaleFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   std::string name_scope = "matmul_v2_scale_fuse";
   FusePassBase::Init(name_scope, graph);
 

--- a/paddle/fluid/framework/ir/memory_optimize_pass/buffer_shared_inplace_op_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/buffer_shared_inplace_op_pass.cc
@@ -60,7 +60,7 @@ void BufferSharedInplaceOpPass::Run(Graph *graph) const {
       const framework::OpDesc *op_desc = op->Node()->Op();
       PADDLE_ENFORCE_NOT_NULL(
           op_desc,
-          phi::errors::NotFound("Op(%s) can not find opdesc.", op->Name()));
+          common::errors::NotFound("Op(%s) can not find opdesc.", op->Name()));
 
       auto &infer_inplace = OpInfoMap::Instance().Get(op_type).infer_inplace_;
       if (!infer_inplace) {
@@ -172,15 +172,15 @@ GetInplaceVars(const BlockDesc &block,
   PADDLE_ENFORCE_EQ(
       block.ID(),
       0,
-      phi::errors::Unimplemented("Inplace can only perform in block 0."));
+      common::errors::Unimplemented("Inplace can only perform in block 0."));
   // only take block 0 gc_vars
   const auto op_gc_vars = GetEagerDeletionCleanVarsForPartial(
       *block.Program(), skip_vars, for_partial_block)[0];
   const auto all_ops = block.AllOps();
-  PADDLE_ENFORCE_EQ(
-      op_gc_vars.size(),
-      all_ops.size(),
-      phi::errors::PermissionDenied("GC analysis error: op number not match."));
+  PADDLE_ENFORCE_EQ(op_gc_vars.size(),
+                    all_ops.size(),
+                    common::errors::PermissionDenied(
+                        "GC analysis error: op number not match."));
   size_t n = all_ops.size();
   std::unordered_set<std::string> visited_vars;
   std::unordered_set<std::string> reused_in_vars(skip_vars.begin(),
@@ -278,7 +278,7 @@ void BufferSharedInplaceOpPass::ApplyImpl(ProgramDesc *main_program,
       GetInplaceVars(*block, use_cuda, skip_vars, for_partial_block);
   PADDLE_ENFORCE_EQ(inplace_vars.size(),
                     block->OpSize(),
-                    phi::errors::PermissionDenied(
+                    common::errors::PermissionDenied(
                         "Inplace analysis error: op number not match."));
   int64_t n = static_cast<int64_t>(inplace_vars.size());
   for (int64_t i = n - 1; i >= 0; --i) {

--- a/paddle/fluid/framework/ir/memory_optimize_pass/conditional_block_op_eager_deletion_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/conditional_block_op_eager_deletion_pass.cc
@@ -48,7 +48,7 @@ class ConditionalOpEagerDeletionPass : public Pass {
     if (graph->IsConstructedByPartialProgram()) {
       PADDLE_ENFORCE_LE(target_ops.size(),
                         1,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Unsupported multi devices if graph is constructed "
                             "with partial program."));
       size_t scope_idx = 0;

--- a/paddle/fluid/framework/ir/memory_optimize_pass/eager_deletion_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/eager_deletion_pass.cc
@@ -60,10 +60,10 @@ static int64_t GetMemorySize(
   auto *var_desc = TryGetLatestVarDesc(vars.at(var_name));
   PADDLE_ENFORCE_NOT_NULL(
       var_desc,
-      phi::errors::NotFound("Var(%s) can not find VarDesc.", var_name));
+      common::errors::NotFound("Var(%s) can not find VarDesc.", var_name));
   PADDLE_ENFORCE_EQ(IsLoDTensor(var_desc),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Var(%s) must be phi::DenseTensor.", var_name));
   auto dims = var_desc->GetShape();
   return static_cast<int64_t>(

--- a/paddle/fluid/framework/ir/memory_optimize_pass/inplace_addto_op_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/inplace_addto_op_pass.cc
@@ -66,7 +66,7 @@ class InplaceAddToOpPass : public MemoryReusePass {
       PADDLE_ENFORCE_EQ(
           out_var_op_iter->second.ops().empty(),
           false,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Var(%s)'s last live op should not empty.", out_var->Name()));
       last_live_op_of_in_var = *(out_var_op_iter->second.ops().begin());
     }
@@ -80,7 +80,7 @@ class InplaceAddToOpPass : public MemoryReusePass {
     PADDLE_ENFORCE_NE(
         in_var_info_iter,
         (*var_infos_)[scope_idx].end(),
-        phi::errors::NotFound("Cannot find variable %s.", in_var->Name()));
+        common::errors::NotFound("Cannot find variable %s.", in_var->Name()));
 
     in_var_info_iter->second->SetRefCnt(2);  // before inplace, it is 1
   }
@@ -115,7 +115,7 @@ void InplaceAddToOpPass::Run(Graph *graph) const {
       const framework::OpDesc *op_desc = op->Node()->Op();
       PADDLE_ENFORCE_NOT_NULL(
           op_desc,
-          phi::errors::NotFound("Op(%s) can not find opdesc.", op->Name()));
+          common::errors::NotFound("Op(%s) can not find opdesc.", op->Name()));
 
       // only grad op should be processed.
       if (op_type != "grad_add") {
@@ -151,14 +151,14 @@ void InplaceAddToOpPass::Run(Graph *graph) const {
 
     PADDLE_ENFORCE_EQ(op->Node()->inputs.size(),
                       2,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The size of inputs of %s should be 2, but got %d",
                           op_type,
                           op->Node()->inputs.size()));
 
     PADDLE_ENFORCE_EQ(op->Node()->outputs.size(),
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The size of outputs of %s should be 1, but got %d",
                           op_type,
                           op->Node()->outputs.size()));
@@ -348,7 +348,7 @@ GetAllVersionVarsMap(const Graph &graph) {
   PADDLE_ENFORCE_EQ(
       sorted_nodes.size(),
       nodes.size(),
-      phi::errors::PermissionDenied("Wrong toplogical sort algorithm."));
+      common::errors::PermissionDenied("Wrong toplogical sort algorithm."));
   std::unordered_map<std::string, std::vector<Node *>> result;
   for (auto *node : sorted_nodes) {
     if (node->IsVar() && !node->IsCtrlVar()) {
@@ -385,7 +385,7 @@ void InplaceAddToOpPass::ApplyImpl(ProgramDesc *main_program,
       }
       PADDLE_ENFORCE_LT(input_vars.size(),
                         2,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The size of inputs of grad_add should be 2."));
       input_vars.push_back(in);
     }
@@ -411,19 +411,19 @@ void InplaceAddToOpPass::ApplyImpl(ProgramDesc *main_program,
     // Step 2: find the unique output var
     Node *output_var = nullptr;
     std::string output_var_name = node->Op()->Output("Out")[0];
-    PADDLE_ENFORCE_NE(
-        output_var_name,
-        kEmptyVarName,
-        phi::errors::InvalidArgument("Output of grad_add should be provided."));
+    PADDLE_ENFORCE_NE(output_var_name,
+                      kEmptyVarName,
+                      common::errors::InvalidArgument(
+                          "Output of grad_add should be provided."));
     for (auto *out : node->outputs) {
       if (output_var_name == out->Name()) {
         output_var = out;
         break;
       }
     }
-    PADDLE_ENFORCE_NOT_NULL(
-        output_var,
-        phi::errors::InvalidArgument("Output of grad_add should be provided."));
+    PADDLE_ENFORCE_NOT_NULL(output_var,
+                            common::errors::InvalidArgument(
+                                "Output of grad_add should be provided."));
 
     VLOG(10) << "Check inplace chain: " << input_vars[0]->Name() << " -> "
              << input_vars[1]->Name() << " -> " << output_var->Name();
@@ -453,16 +453,16 @@ void InplaceAddToOpPass::ApplyImpl(ProgramDesc *main_program,
     auto iter = all_ver_vars.find(input_vars[0]->Name());
     PADDLE_ENFORCE_EQ(iter != all_ver_vars.end(),
                       true,
-                      phi::errors::InvalidArgument("Variable %s not found.",
-                                                   input_vars[0]->Name()));
+                      common::errors::InvalidArgument("Variable %s not found.",
+                                                      input_vars[0]->Name()));
     if (iter->second[iter->second.size() - 1] != input_vars[0]) continue;
 
     iter = all_ver_vars.find(input_vars[1]->Name());
     if (iter->second.size() != 1) continue;
     PADDLE_ENFORCE_EQ(iter->second[0],
                       input_vars[1],
-                      phi::errors::InvalidArgument("Variable %s not found.",
-                                                   input_vars[1]->Name()));
+                      common::errors::InvalidArgument("Variable %s not found.",
+                                                      input_vars[1]->Name()));
     iter = all_ver_vars.find(output_var->Name());
     if (iter->second[0] != output_var) continue;
 

--- a/paddle/fluid/framework/ir/memory_optimize_pass/memory_optimization_var_info.h
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/memory_optimization_var_info.h
@@ -46,7 +46,7 @@ class MemOptVarInfo {
     PADDLE_ENFORCE_GE(
         ref_cnt,
         1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Reference count(%d) must be larger than or equal to 1.", ref_cnt));
     ref_cnt_ = ref_cnt;
     runtime_ref_cnt_ = ref_cnt;

--- a/paddle/fluid/framework/ir/memory_optimize_pass/memory_reuse_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/memory_reuse_pass.cc
@@ -71,7 +71,7 @@ bool MemoryReusePass::TryReuseVar(details::VarHandle *in_var,
       dynamic_cast<details::ComputationOpHandle *>(out_var->GeneratedOp());
   PADDLE_ENFORCE_NOT_NULL(
       op,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Var(%s) have no GeneratedOp, or it's op is not ComputationOpHandle.",
           out_var->Name()));
   if (IsVarPairReusable(*in_var, *out_var)) {
@@ -102,10 +102,11 @@ VarDesc *MemoryReusePass::GetVarDesc(const details::VarHandle &var) const {
     PADDLE_ENFORCE_NE(
         (*all_vars_)[scope_idx].count(var_name),
         0,
-        phi::errors::NotFound("Variable %s not found.", var_name));
+        common::errors::NotFound("Variable %s not found.", var_name));
     auto *desc = TryGetLatestVarDesc((*all_vars_)[scope_idx].at(var_name));
     PADDLE_ENFORCE_NOT_NULL(
-        desc, phi::errors::NotFound("Var(%s) can not find VarDesc.", var_name));
+        desc,
+        common::errors::NotFound("Var(%s) can not find VarDesc.", var_name));
     var_descs_[scope_idx].emplace(var_name, desc);
     return desc;
   } else {
@@ -135,7 +136,7 @@ void MemoryReusePass::CollectShareTensorBufferOpHandles() const {
       PADDLE_ENFORCE_EQ(
           ops_.count(compute_op),
           0,
-          phi::errors::AlreadyExists("Compute op already exists."));
+          common::errors::AlreadyExists("Compute op already exists."));
       ops_.emplace(compute_op, share_buffer_op);
     }
   }
@@ -247,7 +248,7 @@ bool MemoryReusePass::IsOutVarReusable(
     const details::VarHandle &out_var) const {
   PADDLE_ENFORCE_NOT_NULL(
       dynamic_cast<const details::ComputationOpHandle *>(out_var.GeneratedOp()),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Var(%s) have no GeneratedOp, or it's op is not ComputationOpHandle.",
           out_var.Name()));
   const auto out_name = out_var.Name();
@@ -261,7 +262,7 @@ bool MemoryReusePass::IsOutVarReusable(
       (out_var_iter != (*all_vars_)[out_var.scope_idx()].end() &&
        !out_var_iter->second.empty()),
       true,
-      phi::errors::NotFound("Cannot find variable %s.", out_name));
+      common::errors::NotFound("Cannot find variable %s.", out_name));
 
   if (out_var_iter->second[0] != &out_var) {
     return false;
@@ -307,7 +308,7 @@ bool MemoryReusePass::IsVarPairReusable(
       dynamic_cast<const details::ComputationOpHandle *>(out_var.GeneratedOp());
   PADDLE_ENFORCE_NOT_NULL(
       op,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Var(%s) have no GeneratedOp, or it's op is not ComputationOpHandle.",
           out_var.Name()));
 
@@ -339,8 +340,8 @@ void MemoryReusePass::AddReuseVar(details::ComputationOpHandle *op,
   PADDLE_ENFORCE_GT(
       (*var_infos_)[op->GetScopeIdx()].count(in_var->Name()),
       0,
-      phi::errors::NotFound("Var(%s) does not in mem opt var infos.",
-                            in_var->Name()));
+      common::errors::NotFound("Var(%s) does not in mem opt var infos.",
+                               in_var->Name()));
 
   if (ops_.count(op) == 0) {
     InsertShareTensorBufferOpHandleToGraph(op);
@@ -386,8 +387,8 @@ void MemoryReusePass::UpdateLastLiveOpOfVar(details::ComputationOpHandle *op,
     PADDLE_ENFORCE_EQ(
         out_var_op_iter->second.ops().empty(),
         false,
-        phi::errors::InvalidArgument("Var(%s)'s last live op should not empty.",
-                                     out_var->Name()));
+        common::errors::InvalidArgument(
+            "Var(%s)'s last live op should not empty.", out_var->Name()));
     last_live_op_of_in_var = *(out_var_op_iter->second.ops().begin());
   }
 
@@ -400,7 +401,7 @@ void MemoryReusePass::UpdateLastLiveOpOfVar(details::ComputationOpHandle *op,
   PADDLE_ENFORCE_NE(
       in_var_info_iter,
       (*var_infos_)[scope_idx].end(),
-      phi::errors::NotFound("Cannot find variable %s.", in_var->Name()));
+      common::errors::NotFound("Cannot find variable %s.", in_var->Name()));
 
   in_var_info_iter->second->SetRefCnt(1);
 }

--- a/paddle/fluid/framework/ir/memory_optimize_pass/op_graph_view.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/op_graph_view.cc
@@ -40,7 +40,7 @@ void OpGraphView::Build(const std::vector<details::OpHandleBase *> &ops) {
   }
   PADDLE_ENFORCE(
       preceding_ops_.size() == ops.size() && pending_ops_.size() == ops.size(),
-      phi::errors::InvalidArgument("There are duplicate ops in graph."));
+      common::errors::InvalidArgument("There are duplicate ops in graph."));
 }
 
 std::unordered_set<details::OpHandleBase *> OpGraphView::AllOps() const {
@@ -60,8 +60,8 @@ void OpGraphView::EnforceHasOp(details::OpHandleBase *op) const {
   PADDLE_ENFORCE_EQ(
       HasOp(op),
       true,
-      phi::errors::NotFound("Cannot find op %s in OpGraphView.",
-                            op == nullptr ? "nullptr" : op->DebugString()));
+      common::errors::NotFound("Cannot find op %s in OpGraphView.",
+                               op == nullptr ? "nullptr" : op->DebugString()));
 }
 
 const std::unordered_set<details::OpHandleBase *> &OpGraphView::PendingOps(

--- a/paddle/fluid/framework/ir/memory_optimize_pass/op_graph_view.h
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/op_graph_view.h
@@ -136,15 +136,18 @@ void OpGraphView::BreadthFirstVisit(Callback &&callback) const {
     }
   }
 
-  PADDLE_ENFORCE_EQ(num_calls,
-                    op_num,
-                    phi::errors::InvalidArgument("There are unvisited ops."));
-  PADDLE_ENFORCE_EQ(visited_ops.size(),
-                    op_num,
-                    phi::errors::InvalidArgument("There are unvisited ops."));
-  PADDLE_ENFORCE_EQ(op_deps.empty(),
-                    true,
-                    phi::errors::InvalidArgument("There are unvisited ops."));
+  PADDLE_ENFORCE_EQ(
+      num_calls,
+      op_num,
+      common::errors::InvalidArgument("There are unvisited ops."));
+  PADDLE_ENFORCE_EQ(
+      visited_ops.size(),
+      op_num,
+      common::errors::InvalidArgument("There are unvisited ops."));
+  PADDLE_ENFORCE_EQ(
+      op_deps.empty(),
+      true,
+      common::errors::InvalidArgument("There are unvisited ops."));
 }
 
 }  // namespace ir

--- a/paddle/fluid/framework/ir/memory_optimize_pass/pylayer_op_eager_deletion_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/pylayer_op_eager_deletion_pass.cc
@@ -50,7 +50,7 @@ class PyLayerOpEagerDeletionPass : public Pass {
     if (graph->IsConstructedByPartialProgram()) {
       PADDLE_ENFORCE_LE(target_ops.size(),
                         1,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Unsupported multi devices if graph is constructed "
                             "with partial program."));
       size_t scope_idx = 0;

--- a/paddle/fluid/framework/ir/memory_optimize_pass/reference_count_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/reference_count_pass.cc
@@ -74,14 +74,14 @@ class ShrinkDepsOpFunctor {
       PADDLE_ENFORCE_EQ(
           graph_.HasOp(ops[i]),
           true,
-          phi::errors::InvalidArgument("Op does not exist in graph."));
+          common::errors::InvalidArgument("Op does not exist in graph."));
       op_to_idx[ops[i]] = i;
     }
 
     PADDLE_ENFORCE_EQ(
         op_to_idx.size(),
         ops.size(),
-        phi::errors::InvalidArgument("Graph may have duplicate ops."));
+        common::errors::InvalidArgument("Graph may have duplicate ops."));
 
     std::vector<std::vector<RelationShip>> ret(ops.size());
     for (auto &e : ret) {
@@ -251,7 +251,7 @@ ExtractComputationOpFromLastLivedVar(details::VarHandle *var,
   PADDLE_ENFORCE_EQ(
       computation_ops.empty(),
       false,
-      phi::errors::InvalidArgument("Computation ops should not be empty."));
+      common::errors::InvalidArgument("Computation ops should not be empty."));
 
   // stage four. Try to shrink computation op if they depend on each other.
   // Get the smallest set of the most ops.
@@ -265,7 +265,7 @@ void ReferenceCountPass::ApplyImpl(ir::Graph *graph) const {
       Get<std::vector<LastLiveOpsOfVars>>(kLastLiveOpsOfVars);
 
   PADDLE_ENFORCE(last_live_ops_of_vars.empty() && var_infos.empty(),
-                 phi::errors::InvalidArgument(
+                 common::errors::InvalidArgument(
                      "Last live ops and reference counts of vars should be "
                      "initialized at here."));
 
@@ -310,7 +310,7 @@ void ReferenceCountPass::ApplyImpl(ir::Graph *graph) const {
       PADDLE_ENFORCE_EQ(
           var_desc->Name(),
           var_name,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "A Var, it's VarName(%s) and DescName(%s) not same.",
               var_name,
               var_desc->Name()));
@@ -318,7 +318,7 @@ void ReferenceCountPass::ApplyImpl(ir::Graph *graph) const {
       PADDLE_ENFORCE_EQ(
           var_handles.empty(),
           false,
-          phi::errors::InvalidArgument("Variable %s not found.", var_name));
+          common::errors::InvalidArgument("Variable %s not found.", var_name));
       auto last_ver_var = var_handles.back();
 
       if (last_ver_var->Node()->IsCtrlVar()) {
@@ -337,15 +337,15 @@ void ReferenceCountPass::ApplyImpl(ir::Graph *graph) const {
         continue;
       }
 
-      PADDLE_ENFORCE_EQ(
-          status,
-          LastLiveOpSearchStatus::kSuccess,
-          phi::errors::InvalidArgument("Status(%d) must be success.", status));
+      PADDLE_ENFORCE_EQ(status,
+                        LastLiveOpSearchStatus::kSuccess,
+                        common::errors::InvalidArgument(
+                            "Status(%d) must be success.", status));
       PADDLE_ENFORCE_EQ(
           result.empty(),
           false,
-          phi::errors::NotFound("Last living ops of %s cannot be empty.",
-                                var_name));
+          common::errors::NotFound("Last living ops of %s cannot be empty.",
+                                   var_name));
 
       std::string last_live_ops_log_str;
       for (auto &each_ret : result) {

--- a/paddle/fluid/framework/ir/memory_optimize_pass/while_op_eager_deletion_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/while_op_eager_deletion_pass.cc
@@ -59,7 +59,7 @@ class WhileOpEagerDeletionPass : public ir::Pass {
       PADDLE_ENFORCE_LE(
           target_ops.size(),
           1,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Unsupported multi device if graph is constructed by "
               "partial program."));
       size_t scope_idx = 0;

--- a/paddle/fluid/framework/ir/multi_batch_merge_pass.cc
+++ b/paddle/fluid/framework/ir/multi_batch_merge_pass.cc
@@ -83,8 +83,8 @@ void BatchMergePass::ApplyImpl(ir::Graph* graph) const {
     if (!node->IsOp()) continue;
     PADDLE_ENFORCE_NOT_NULL(
         node->Op(),
-        phi::errors::InvalidArgument("Node(%s) must hold op description.",
-                                     node->Name()));
+        common::errors::InvalidArgument("Node(%s) must hold op description.",
+                                        node->Name()));
     int op_role = PADDLE_GET_CONST(
         int,
         node->Op()->GetAttr(
@@ -109,9 +109,9 @@ void BatchMergePass::ApplyImpl(ir::Graph* graph) const {
       lr_ops.push_back(node);
     } else {  // NOLINT
       PADDLE_THROW(
-          phi::errors::InvalidArgument("Invalid op role(%d), in node(%s).",
-                                       static_cast<int>(op_role),
-                                       node->Name()));
+          common::errors::InvalidArgument("Invalid op role(%d), in node(%s).",
+                                          static_cast<int>(op_role),
+                                          node->Name()));
     }
   }
 

--- a/paddle/fluid/framework/ir/multi_devices_graph_pass/multi_devices_graph_pass.cc
+++ b/paddle/fluid/framework/ir/multi_devices_graph_pass/multi_devices_graph_pass.cc
@@ -110,7 +110,7 @@ void MultiDevSSAGraphBuilderBase::Init() const {
   PADDLE_ENFORCE_EQ(
       places_.size(),
       local_scopes_.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Places size and LocalScopes not equal "
           "Places size(%d), LocalScopes size(%d) "
           "If use multi devices, Places size must equas to LocalScopes size.",

--- a/paddle/fluid/framework/ir/multihead_matmul_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/multihead_matmul_fuse_pass.cc
@@ -911,7 +911,7 @@ int MultiHeadMatmulV2FusePass::BuildFusionV2(Graph* graph,
       QKVWeightsProcess<phi::dtype::float16>(
           wq_tensor, wk_tensor, wv_tensor, bq_tensor, bk_tensor, bv_tensor);
     } else {
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "multihead_matmul not supported weight dtype. we now only support "
           "fp32 and fp16."));
     }
@@ -1160,7 +1160,7 @@ void MultiHeadMatmulV2FusePass::ApplyImpl(Graph* graph) const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "During the multiheadMatmul pass, The scope should not be null."));
 
   int fusion_count = BuildFusionV2(graph, name_scope_, scope);
@@ -1599,7 +1599,7 @@ void MultiHeadMatmulV3FusePass::ApplyImpl(Graph* graph) const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "During the multiheadMatmul pass, The scope should not be null."));
 
   int fusion_count = BuildFusionV3(graph, name_scope_, scope);

--- a/paddle/fluid/framework/ir/multihead_matmul_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/multihead_matmul_fuse_pass_tester.cc
@@ -126,14 +126,14 @@ TEST(MultiHeadMatmulFusePass, basic) {
   PADDLE_ENFORCE_EQ(
       num_nodes_before,
       num_nodes_after + 39,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After the multihead_matmul pass, The node num in graph "
           "should be %d, but the result is %d",
           num_nodes_before - 39,
           num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fused_nodes_after,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "After the multihead_matmul pass, there should be one "
                         "multihead_matmul op, but the result is %d",
                         num_fused_nodes_after));

--- a/paddle/fluid/framework/ir/multihead_matmul_roformer_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/multihead_matmul_roformer_fuse_pass.cc
@@ -745,7 +745,7 @@ void MultiHeadMatmulRoformerFusePass::ApplyImpl(Graph* graph) const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "During the multiheadMatmul pass, The scope should not be null."));
 
   int fusion_count = BuildFusion(graph, name_scope_, scope);

--- a/paddle/fluid/framework/ir/node.h
+++ b/paddle/fluid/framework/ir/node.h
@@ -81,7 +81,7 @@ class Node {
   VarDesc* Var() const {
     PADDLE_ENFORCE_EQ(IsVar(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Node(%s) must be kVariable type, but not %d.",
                           name_,
                           static_cast<int>(type_)));
@@ -91,7 +91,7 @@ class Node {
   OpDesc* Op() const {
     PADDLE_ENFORCE_EQ(IsOp(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Node(%s) must be kOperation type, but not %d.",
                           name_,
                           static_cast<int>(type_)));
@@ -115,7 +115,7 @@ class Node {
     try {
       return *paddle::any_cast<T*>(wrapper_);
     } catch (paddle::bad_any_cast&) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Invalid wrapper type error, expected %s, actual %s.",
           typeid(T).name(),
           wrapper_type_.name()));
@@ -147,7 +147,7 @@ class Node {
     PADDLE_ENFORCE_EQ(
         type_ == Type::kVariable && var_desc_,
         true,
-        phi::errors::InvalidArgument("Node must be type of variable."));
+        common::errors::InvalidArgument("Node must be type of variable."));
     name_ = new_name;
     var_desc_->SetName(new_name);
   }
@@ -156,7 +156,7 @@ class Node {
     PADDLE_ENFORCE_EQ(
         type_ == Type::kOperation && op_desc_,
         true,
-        phi::errors::InvalidArgument("Node must be type of variable."));
+        common::errors::InvalidArgument("Node must be type of variable."));
     name_ = new_name;
     op_desc_->SetType(new_name);
   }
@@ -167,7 +167,7 @@ class Node {
     PADDLE_ENFORCE_EQ(
         type_ == Type::kVariable && var_desc_,
         true,
-        phi::errors::InvalidArgument("Node must be type of variable."));
+        common::errors::InvalidArgument("Node must be type of variable."));
     return block_id_;
   }
 

--- a/paddle/fluid/framework/ir/onednn/activation_onednn_fuse_pass.h
+++ b/paddle/fluid/framework/ir/onednn/activation_onednn_fuse_pass.h
@@ -61,7 +61,7 @@ inline void SetActivationAttrs(paddle::framework::OpDesc* fused_op,
                                const std::string& act_type) {
   if (fused_op->HasAttr("use_mkldnn")) {
     PADDLE_ENFORCE(PADDLE_GET_CONST(bool, fused_op->GetAttr("use_mkldnn")),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "oneDNN activation fuses require use_mkldnn=True"));
   }
   fused_op->SetAttr("use_mkldnn", true);

--- a/paddle/fluid/framework/ir/onednn/batch_norm_act_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/batch_norm_act_fuse_pass.cc
@@ -81,7 +81,7 @@ void FuseBatchNormActOneDNNPass::FuseBatchNormAct(
     Graph *graph, const std::string &act_type) const {
   PADDLE_ENFORCE_NOT_NULL(
       graph,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input graph of "
           "FuseBatchNormActOneDNNPass should not be nullptr."));
   FusePassBase::Init("bn_act", graph);
@@ -111,7 +111,7 @@ void FuseBatchNormActOneDNNPass::FuseBatchNormAct(
     if (bn_op->HasAttr("trainable_statistics")) {
       PADDLE_ENFORCE(
           !PADDLE_GET_CONST(bool, bn_op->GetAttr("trainable_statistics")),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "The BatchNorm+Act fusion may happen only when mean and variance "
               "are not calculated by current batch statistics."));
     }
@@ -119,7 +119,7 @@ void FuseBatchNormActOneDNNPass::FuseBatchNormAct(
     if (bn_op->HasAttr("is_test")) {
       PADDLE_ENFORCE(
           PADDLE_GET_CONST(bool, bn_op->GetAttr("is_test")),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "The BatchNorm+Act fusion may happen only during inference."));
     }
 

--- a/paddle/fluid/framework/ir/onednn/compute_propagate_scales_onednn_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/compute_propagate_scales_onednn_pass.cc
@@ -49,13 +49,13 @@ std::vector<float> ComputePropagateScalesMkldnnPass::GetScales(
     phi::DenseTensor* tensor, int axis) const {
   PADDLE_ENFORCE_LT(axis,
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The input axis is required to be less than 2."));
   auto* data = tensor->data<float>();
   const auto dims = tensor->dims();
   PADDLE_ENFORCE_EQ(dims.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The input tensor's rank is required to be 2."));
 
   const int rows = static_cast<int>(dims.at(0));
@@ -106,7 +106,7 @@ void ComputePropagateScalesMkldnnPass::ComputeVarScales(
       auto* var = scope->FindVar(var_name);
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::NotFound(
+          common::errors::NotFound(
               "The input persistable var [%s] of [%s] op is not found.",
               var_name,
               op_desc->Type()));
@@ -143,13 +143,13 @@ void ComputePropagateScalesMkldnnPass::ComputeSingleGruWeightScales(
   auto* wx_var = scope->FindVar(wx_var_name);
   PADDLE_ENFORCE_NOT_NULL(
       wx_var,
-      phi::errors::NotFound("The input persistable var [%s] is not found.",
-                            wx_var_name));
+      common::errors::NotFound("The input persistable var [%s] is not found.",
+                               wx_var_name));
   auto* wh_var = scope->FindVar(wh_var_name);
   PADDLE_ENFORCE_NOT_NULL(
       wh_var,
-      phi::errors::NotFound("The input persistable var [%s] is not found.",
-                            wh_var_name));
+      common::errors::NotFound("The input persistable var [%s] is not found.",
+                               wh_var_name));
 
   const auto* wx_tensor = wx_var->GetMutable<phi::DenseTensor>();
   const auto* wh_tensor = wh_var->GetMutable<phi::DenseTensor>();
@@ -218,10 +218,10 @@ void ComputePropagateScalesMkldnnPass::ComputeGruWeightScales(
       PADDLE_ENFORCE_EQ(
           wx_names_size,
           wh_names_size,
-          phi::errors::Fatal("Mismatch in number of weights inputs (%d "
-                             "for WeightX vs. %d for WeightH).",
-                             wx_names_size,
-                             wh_names_size));
+          common::errors::Fatal("Mismatch in number of weights inputs (%d "
+                                "for WeightX vs. %d for WeightH).",
+                                wx_names_size,
+                                wh_names_size));
       for (int i = 0; i < wx_names_size; i++) {
         auto wh_var_name = wh_var_names[i];
         auto wx_var_name = wx_var_names[i];
@@ -242,13 +242,13 @@ void ComputePropagateScalesMkldnnPass::ComputeSingleLstmWeightScales(
   auto* wx_var = scope->FindVar(wx_var_name);
   PADDLE_ENFORCE_NOT_NULL(
       wx_var,
-      phi::errors::NotFound("The input persistable var [%s] is not found.",
-                            wx_var_name));
+      common::errors::NotFound("The input persistable var [%s] is not found.",
+                               wx_var_name));
   auto* wh_var = scope->FindVar(wh_var_name);
   PADDLE_ENFORCE_NOT_NULL(
       wh_var,
-      phi::errors::NotFound("The input persistable var [%s] is not found.",
-                            wh_var_name));
+      common::errors::NotFound("The input persistable var [%s] is not found.",
+                               wh_var_name));
 
   const auto* wx_tensor = wx_var->GetMutable<phi::DenseTensor>();
   const auto* wh_tensor = wh_var->GetMutable<phi::DenseTensor>();
@@ -296,10 +296,10 @@ void ComputePropagateScalesMkldnnPass::ComputeLstmWeightScales(
       PADDLE_ENFORCE_EQ(
           wx_names_size,
           wh_names_size,
-          phi::errors::Fatal("Mismatch in number of weights inputs (%d "
-                             "for WeightX vs. %d for WeightH).",
-                             wx_names_size,
-                             wh_names_size));
+          common::errors::Fatal("Mismatch in number of weights inputs (%d "
+                                "for WeightX vs. %d for WeightH).",
+                                wx_names_size,
+                                wh_names_size));
 
       for (int i = 0; i < wx_names_size; i++) {
         auto wh_var_name = wh_var_names[i];

--- a/paddle/fluid/framework/ir/onednn/conv_activation_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/conv_activation_onednn_fuse_pass.cc
@@ -39,7 +39,7 @@ void ConvActivationMkldnnFusePass::FuseConvAct(Graph* graph,
                                                const std::string& conv_type,
                                                std::string& act_type) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(conv_type + "_" + act_type + "_onednn_fuse_pass", graph);
 
   GraphPatternDetector gpd;
@@ -89,7 +89,7 @@ void ConvActivationMkldnnFusePass::FuseConvAct(Graph* graph,
 void ConvActivationMkldnnFusePass::FuseConvConcatAct(
     Graph* graph, std::string& act_type) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init("conv2d_concat_" + act_type + "_onednn_fuse_pass", graph);
 
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/onednn/conv_affine_channel_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/conv_affine_channel_onednn_fuse_pass.cc
@@ -60,7 +60,7 @@ void recompute_bias_and_weights(const Scope* scope,
   // Re-compute bias of conv2d from AffineChannel
   PADDLE_ENFORCE_EQ(eltwise_y_in_tensor->dims(),
                     ac_bias_tensor.dims(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "phi::DenseTensor elementwise y(%d) and activation "
                         "bias(%d) must have same "
                         "dimension.",
@@ -218,12 +218,12 @@ void ConvAffineChannelFusePass::ApplyImpl(ir::Graph* graph) const {
 void ConvAffineChannelFusePass::FuseConvAffineChannel(
     ir::Graph* graph, const std::string& conv_type) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(name_scope_, graph);
 
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
-      scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+      scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
   GraphPatternDetector gpd;
   auto* conv_input =

--- a/paddle/fluid/framework/ir/onednn/conv_bias_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/conv_bias_onednn_fuse_pass.cc
@@ -294,7 +294,7 @@ phi::DenseTensor tensor_apply_eltwise(const phi::DenseTensor& vec_a,
                                       BinaryOperation f) {
   PADDLE_ENFORCE_EQ(vec_a.dims(),
                     vec_b.dims(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input two tensors must have same shape, but they are "
                         "different: %s, %s.",
                         vec_a.dims(),
@@ -322,12 +322,12 @@ void ConvBiasFusePass::FuseConvBias(ir::Graph* graph,
                                     const std::string& conv_type,
                                     const std::string& fused_conv) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(name_scope_, graph);
 
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
-      scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+      scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
   GraphPatternDetector gpd;
   auto* conv_input =
@@ -356,7 +356,7 @@ void ConvBiasFusePass::FuseConvBias(ir::Graph* graph,
     PADDLE_ENFORCE_NE(
         subgraph.count(conv_input),
         0,
-        phi::errors::NotFound("Detector did not find conv input."));
+        common::errors::NotFound("Detector did not find conv input."));
 
     // check compat
     if (!IsCompat(subgraph, g)) {
@@ -383,13 +383,13 @@ void ConvBiasFusePass::FuseConvBias(ir::Graph* graph,
       // add eltwise bias to existing conv bias
       PADDLE_ENFORCE_EQ(conv_bias_names.size(),
                         1,
-                        phi::errors::NotFound("Can not find var Bias."));
+                        common::errors::NotFound("Can not find var Bias."));
       auto* conv_bias_var = scope->FindVar(conv_bias_names[0]);
       auto* conv_bias_tensor = conv_bias_var->GetMutable<phi::DenseTensor>();
       PADDLE_ENFORCE_EQ(
           conv_bias_tensor->dims(),
           eltwise_bias_tensor->dims(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Conv bias tensor and eltwise bias tensor "
               "must have same shape, but they are different: %s, %s.",
               conv_bias_tensor->dims(),

--- a/paddle/fluid/framework/ir/onednn/cpu_bfloat16_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/cpu_bfloat16_pass.cc
@@ -128,7 +128,7 @@ class Quantizer final : public Quanter {
     PADDLE_ENFORCE_GE(
         inputs.size(),
         1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "OP(%s)'s inputs(%d) must be equal or greater than 1.",
             op->Name(),
             inputs.size()));
@@ -180,7 +180,7 @@ class DeQuantizer final : public Quanter {
     PADDLE_ENFORCE_GE(
         outputs.size(),
         1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "OP(%s)'s outputs(%d) must be equal or greater than 1.",
             op->Name(),
             outputs.size()));

--- a/paddle/fluid/framework/ir/onednn/cpu_quantize_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/cpu_quantize_pass.cc
@@ -88,7 +88,7 @@ void CPUQuantizePass::QuantizeInput(Graph* g,
       std::find(inputs.begin(), inputs.end(), input_name) != inputs.end();
   PADDLE_ENFORCE_EQ(name_found,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Var(%s) isn't the input of the %s operator.",
                         input_name,
                         op->Op()->Type()));
@@ -154,16 +154,16 @@ void CPUQuantizePass::QuantizeInputs(Graph* g,
   auto output = op->outputs[0];
   PADDLE_ENFORCE_GE(inputs.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "OP(%s)'s inputs(%d) must be equal or greater than 1.",
                         op->Name(),
                         inputs.size()));
-  PADDLE_ENFORCE_EQ(
-      op->outputs.size(),
-      1,
-      phi::errors::InvalidArgument("OP(%s)'s outputs(%d) must be equal to 1.",
-                                   op->Name(),
-                                   op->outputs.size()));
+  PADDLE_ENFORCE_EQ(op->outputs.size(),
+                    1,
+                    common::errors::InvalidArgument(
+                        "OP(%s)'s outputs(%d) must be equal to 1.",
+                        op->Name(),
+                        op->outputs.size()));
 
   // create a quantize op desc prototype
   OpDesc q_desc;
@@ -185,7 +185,7 @@ void CPUQuantizePass::QuantizeInputs(Graph* g,
     if (index == -1) {
       PADDLE_ENFORCE_NE(index,
                         -1,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Var(%s) isn't the input of the %s operator.",
                             unique_var_names[var_id],
                             op->Op()->Type()));
@@ -243,7 +243,7 @@ void CPUQuantizePass::DequantizeOutput(Graph* g,
       std::find(outputs.begin(), outputs.end(), output_name) != outputs.end();
   PADDLE_ENFORCE_EQ(name_found,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Var(%s) isn't the output of the %s operator.",
                         output_name,
                         op->Op()->Type()));
@@ -288,7 +288,7 @@ void CPUQuantizePass::DequantizeOutputs(Graph* g,
 
   PADDLE_ENFORCE_GE(outputs.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "OP(%s)'s outputs(%d) must be equal or greater than 1.",
                         op->Name(),
                         outputs.size()));
@@ -309,7 +309,7 @@ void CPUQuantizePass::DequantizeOutputs(Graph* g,
     if (index == -1) {
       PADDLE_ENFORCE_NE(index,
                         -1,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Var(%s) isn't the input of the %s operator.",
                             var_names[var_id],
                             op->Op()->Type()));
@@ -906,14 +906,14 @@ void CPUQuantizePass::QuantizeMatmul(Graph* graph, bool with_residual) const {
     bool is_x_unsigned{false}, is_y_unsigned{false};
     auto input_x_scale = GetScaleValueForNode(matmul_in_x, &is_x_unsigned);
     auto input_y_scale = GetScaleValueForNode(matmul_in_y, &is_y_unsigned);
-    PADDLE_ENFORCE_EQ(
-        is_x_unsigned,
-        is_y_unsigned,
-        phi::errors::InvalidArgument("Matmul inputs should have the same "
-                                     "attribute of signed/unsigned, but they "
-                                     "are different: x(%d), y(%d).",
-                                     is_x_unsigned,
-                                     is_y_unsigned));
+    PADDLE_ENFORCE_EQ(is_x_unsigned,
+                      is_y_unsigned,
+                      common::errors::InvalidArgument(
+                          "Matmul inputs should have the same "
+                          "attribute of signed/unsigned, but they "
+                          "are different: x(%d), y(%d).",
+                          is_x_unsigned,
+                          is_y_unsigned));
 
     if (with_residual) {
       GET_IR_NODE_FROM_SUBGRAPH(
@@ -1278,11 +1278,12 @@ void CPUQuantizePass::QuantizeFusionLSTM(Graph* graph) const {
 void CPUQuantizePass::ApplyImpl(ir::Graph* graph) const {
   VLOG(3) << "Quantizing the graph.";
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(name_scope_, graph);
 
   PADDLE_ENFORCE_NOT_NULL(
-      param_scope(), phi::errors::InvalidArgument("Scope cannot be nullptr."));
+      param_scope(),
+      common::errors::InvalidArgument("Scope cannot be nullptr."));
 
   GetQuantInfo(graph);
   QuantizeConv(graph, "fused_conv2d", false /* with_residual_data */);

--- a/paddle/fluid/framework/ir/onednn/cpu_quantize_placement_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/cpu_quantize_placement_pass.cc
@@ -64,7 +64,7 @@ void CPUQuantizePlacementPass::ApplyImpl(ir::Graph* graph) const {
       PADDLE_ENFORCE_NE(
           supported_op_types.count(op),
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Pass attribute quantize_enabled_op_types contains operator %s "
               "that is not supported by OneDNN quantization.",
               op));

--- a/paddle/fluid/framework/ir/onednn/cpu_quantize_squash_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/cpu_quantize_squash_pass.cc
@@ -194,7 +194,7 @@ void CPUQuantizeSquashPass::DequantQuantSquash(
     PADDLE_ENFORCE_NE(
         nodes_keep_counter->find(dequant_out),
         nodes_keep_counter->end(),
-        phi::errors::NotFound("The dequant output node is not found."));
+        common::errors::NotFound("The dequant output node is not found."));
 
     // check if dequantize op should be kept or removed, decrease the counter
     bool keep_dequant = (*nodes_keep_counter)[dequant_out]-- > 1;
@@ -274,9 +274,9 @@ void CPUQuantizeSquashPass::OpRequantSquash(Graph* graph) const {
       PADDLE_ENFORCE_NE(
           any_op_output_name.empty(),
           true,
-          phi::errors::NotFound("Operator before requantize operator(%s) "
-                                "should have requantize input as output.",
-                                requant_in->Name()));
+          common::errors::NotFound("Operator before requantize operator(%s) "
+                                   "should have requantize input as output.",
+                                   requant_in->Name()));
 
       float requant_scale_out =
           PADDLE_GET_CONST(float, requant_op->Op()->GetAttr("Scale_out"));
@@ -318,9 +318,9 @@ void CPUQuantizeSquashPass::RequantOpSquash(Graph* graph) const {
       PADDLE_ENFORCE_NE(
           any_op_input_name.empty(),
           true,
-          phi::errors::NotFound("The operator after requantize operator(%s) "
-                                "should have requantize output as input.",
-                                requant_out->Name()));
+          common::errors::NotFound("The operator after requantize operator(%s) "
+                                   "should have requantize output as input.",
+                                   requant_out->Name()));
       float requant_scale_in =
           paddle::get<float>(requant_op->Op()->GetAttr("Scale_in"));
 
@@ -331,7 +331,7 @@ void CPUQuantizeSquashPass::RequantOpSquash(Graph* graph) const {
       PADDLE_ENFORCE_EQ(
           requant_op->Op()->GetAttrIfExists<float>("Scale_out"),
           any_op->Op()->GetAttrIfExists<float>(scale_name),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The operator after requantize should have input "
               "scale(%f) equal to requantize output scale(%f).",
               any_op->Op()->GetAttrIfExists<float>(scale_name),
@@ -423,7 +423,7 @@ void CPUQuantizeSquashPass::MultipleQuantizeSquash(Graph* graph) const {
 
     PADDLE_ENFORCE_NE(scale,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Quantize scale(%f) should not be equal 0.", scale));
 
     for (int iter = static_cast<int>(prev_out->outputs.size()) - 1; iter >= 0;
@@ -443,9 +443,9 @@ void CPUQuantizeSquashPass::MultipleQuantizeSquash(Graph* graph) const {
         PADDLE_ENFORCE_NE(
             last_op_input_name.empty(),
             true,
-            phi::errors::NotFound("Operator after quantize operator(%s) "
-                                  "should have quantize output as input.",
-                                  quant_out->Name()));
+            common::errors::NotFound("Operator after quantize operator(%s) "
+                                     "should have quantize output as input.",
+                                     quant_out->Name()));
 
         // update the next operator input,
         // by replacing quant_out with first_quant_out
@@ -498,14 +498,14 @@ void CPUQuantizeSquashPass::DequantScaleSquash(Graph* graph) const {
 
       PADDLE_ENFORCE_GT(dequant_scale,
                         0.0f,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Dequantize scale(%f) should have positive value.",
                             dequant_scale));
       PADDLE_ENFORCE_NE(
           scale_scale,
           0.0f,
-          phi::errors::InvalidArgument("Scale(%f) should have a non-zero value",
-                                       scale_scale));
+          common::errors::InvalidArgument(
+              "Scale(%f) should have a non-zero value", scale_scale));
 
       dequant_op->Op()->SetAttr("Scale", dequant_scale / scale_scale);
       dequant_op->Op()->SetOutput(
@@ -551,13 +551,13 @@ void CPUQuantizeSquashPass::ScaleQuantSquash(Graph* graph) const {
       PADDLE_ENFORCE_GT(
           quant_scale,
           0.0f,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Quantize scale(%f) should have positive value.", quant_scale));
       PADDLE_ENFORCE_NE(
           scale_scale,
           0.0f,
-          phi::errors::InvalidArgument("Scale(%f) should have a non-zero value",
-                                       scale_scale));
+          common::errors::InvalidArgument(
+              "Scale(%f) should have a non-zero value", scale_scale));
 
       quant_op->Op()->SetAttr("Scale", quant_scale * scale_scale);
       quant_op->Op()->SetInput("Input",
@@ -619,7 +619,7 @@ void CPUQuantizeSquashPass::QuantizeBf16ConvImpl(
 void CPUQuantizeSquashPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
       graph,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The graph in function CPUQuantizeSquashPass::ApplyImpl is null."));
   FusePassBase::Init("cpu_quantize_squash_pass", graph);
 

--- a/paddle/fluid/framework/ir/onednn/cpu_quantize_squash_pass_tester.cc
+++ b/paddle/fluid/framework/ir/onednn/cpu_quantize_squash_pass_tester.cc
@@ -85,7 +85,7 @@ void SetOp(ProgramDesc* prog,
     op->SetInput("Input", {inputs[0]});
     PADDLE_ENFORCE_EQ(inputs.size(),
                       2UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The fc inputs should contain input and weights, but "
                           "now the size of inputs is %d.",
                           inputs.size()));

--- a/paddle/fluid/framework/ir/onednn/depthwise_conv_onednn_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/depthwise_conv_onednn_pass.cc
@@ -23,14 +23,14 @@ namespace ir {
 
 class Graph;
 
-#define GET_NODE(id, pattern)                                               \
-  PADDLE_ENFORCE_NE(                                                        \
-      subgraph.count(pattern.RetrieveNode(#id)),                            \
-      0,                                                                    \
-      phi::errors::InvalidArgument("Pattern has no Node called %s.", #id)); \
-  auto* id = subgraph.at(pattern.RetrieveNode(#id));                        \
-  PADDLE_ENFORCE_NOT_NULL(                                                  \
-      id, phi::errors::InvalidArgument("Subgraph has no node %s.", #id));
+#define GET_NODE(id, pattern)                                                  \
+  PADDLE_ENFORCE_NE(                                                           \
+      subgraph.count(pattern.RetrieveNode(#id)),                               \
+      0,                                                                       \
+      common::errors::InvalidArgument("Pattern has no Node called %s.", #id)); \
+  auto* id = subgraph.at(pattern.RetrieveNode(#id));                           \
+  PADDLE_ENFORCE_NOT_NULL(                                                     \
+      id, common::errors::InvalidArgument("Subgraph has no node %s.", #id));
 
 DepthwiseConvMKLDNNPass::DepthwiseConvMKLDNNPass() {  // NOLINT
   AddOpCompat(OpCompat("depthwise_conv2d"))
@@ -75,7 +75,7 @@ DepthwiseConvMKLDNNPass::DepthwiseConvMKLDNNPass() {  // NOLINT
 
 void DepthwiseConvMKLDNNPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init("depthwise_conv_onednn_pass", graph);
   GraphPatternDetector gpd;
 

--- a/paddle/fluid/framework/ir/onednn/elementwise_act_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/elementwise_act_onednn_fuse_pass.cc
@@ -40,7 +40,7 @@ void ElementwiseActivationOneDNNPass::FuseElementwiseAct(
     const std::string &elt_type,
     const std::string &act_type) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(elt_type + "_" + act_type + "_onednn_fuse_pass", graph);
 
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/onednn/fc_act_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/fc_act_onednn_fuse_pass.cc
@@ -33,7 +33,7 @@ void FuseFCActOneDNNPass::ApplyImpl(Graph *graph) const {
 void FuseFCActOneDNNPass::FuseFCAct(Graph *graph,
                                     const std::string &act_type) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init("fc_" + act_type + "_onednn_fuse_pass", graph);
 
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/onednn/fc_onednn_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/fc_onednn_pass.cc
@@ -31,7 +31,7 @@ class Graph;
 
 void FCMKLDNNPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(graph,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Pointer to graph argument should not be NULL."));
   Init("fc_onednn_pass", graph);
 

--- a/paddle/fluid/framework/ir/onednn/int8_scale_calculation_onednn_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/int8_scale_calculation_onednn_pass.cc
@@ -106,7 +106,7 @@ void Int8ScaleCalculationMkldnnPass::ApplyImpl(ir::Graph* graph) const {
 void Int8ScaleCalculationMkldnnPass::Int8ScaleImpl(
     ir::Graph* graph, const std::string& conv_type) const {
   PADDLE_ENFORCE_NOT_NULL(graph,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Pointer to graph argument should not be NULL."));
   FusePassBase::Init("int8_scale_calculation_onednn_pass", graph);
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/onednn/interpolate_onednn_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/interpolate_onednn_pass.cc
@@ -29,7 +29,7 @@ class Graph;
 
 void InterpolateOneDNNPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(graph,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Pointer to graph argument should not be NULL."));
   if (!(graph->Has("use_mkldnn") && graph->Get<bool>("use_mkldnn"))) {
     VLOG(3) << "Do not handle interpolate_onednn_pass";

--- a/paddle/fluid/framework/ir/onednn/matmul_activation_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/matmul_activation_onednn_fuse_pass.cc
@@ -38,7 +38,7 @@ void MatmulActivationMkldnnFusePass::ApplyImpl(Graph* graph) const {
 void MatmulActivationMkldnnFusePass::FuseMatmulAct(
     Graph* graph, const std::string& matmul_type, std::string& act_type) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(matmul_type + "_" + act_type + "_onednn_fuse_pass", graph);
 
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/onednn/matmul_transpose_reshape_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/matmul_transpose_reshape_onednn_fuse_pass.cc
@@ -35,7 +35,7 @@ void MatmulTransposeReshapeMKLDNNPass::ApplyImpl(Graph *graph) const {
 void MatmulTransposeReshapeMKLDNNPass::Fuse(
     Graph *graph, const std::string &matmul_type) const {
   PADDLE_ENFORCE_NOT_NULL(graph,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Pointer to graph argument should not be NULL."));
   FusePassBase::Init(matmul_type + "_transpose_reshape_onednn_fuse_pass",
                      graph);

--- a/paddle/fluid/framework/ir/onednn/multi_gru_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/multi_gru_fuse_pass.cc
@@ -45,11 +45,12 @@ std::vector<std::string> JoinInputs(Node* op1,
 void MultiGRUFusePass::ApplyImpl(ir::Graph* graph) const {
   VLOG(3) << "Fusing two concatenated multi_gru ops.";
   PADDLE_ENFORCE_NOT_NULL(graph,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Pointer to graph argument cannot be NULL."));
   FusePassBase::Init(name_scope_, graph);
   PADDLE_ENFORCE_NOT_NULL(
-      param_scope(), phi::errors::InvalidArgument("Scope cannot be nullptr."));
+      param_scope(),
+      common::errors::InvalidArgument("Scope cannot be nullptr."));
 
   GraphPatternDetector gpd;
   patterns::TwoFusionGruConcat pattern{gpd.mutable_pattern(), name_scope_};

--- a/paddle/fluid/framework/ir/onednn/multi_gru_seq_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/multi_gru_seq_fuse_pass.cc
@@ -47,11 +47,12 @@ std::vector<std::string> JoinInputs(Node* op1,
 void MultiGruSeqFusePass::ApplyImpl(ir::Graph* graph) const {
   VLOG(3) << "Fusing two consecutive multi_gru ops.";
   PADDLE_ENFORCE_NOT_NULL(graph,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Pointer to graph argument cannot be NULL."));
   FusePassBase::Init(name_scope_, graph);
   PADDLE_ENFORCE_NOT_NULL(
-      param_scope(), phi::errors::InvalidArgument("Scope cannot be nullptr."));
+      param_scope(),
+      common::errors::InvalidArgument("Scope cannot be nullptr."));
 
   GraphPatternDetector gpd;
   patterns::MultiGruSeq pattern{gpd.mutable_pattern(), name_scope_};

--- a/paddle/fluid/framework/ir/onednn/operator_reshape2_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/operator_reshape2_onednn_fuse_pass.cc
@@ -37,7 +37,7 @@ void FuseOperatorReshape2OneDNNPass::FuseReshape2(Graph *graph,
                                                   const std::string &op_type,
                                                   int num_of_outputs) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(op_type + "_reshape2_onednn_fuse_pass", graph);
 
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/onednn/operator_scale_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/operator_scale_onednn_fuse_pass.cc
@@ -44,7 +44,7 @@ void FuseOperatorScaleOneDNNPass::ApplyImpl(Graph *graph) const {
 void FuseOperatorScaleOneDNNPass::FuseScale(Graph *graph,
                                             const std::string &op_type) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(op_type + "_scale_onednn_fuse_pass", graph);
 
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/onednn/operator_unsqueeze2_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/operator_unsqueeze2_onednn_fuse_pass.cc
@@ -38,7 +38,7 @@ void FuseOperatorUnsqueeze2OneDNNPass::ApplyImpl(Graph *graph) const {
 void FuseOperatorUnsqueeze2OneDNNPass::FuseUnsqueeze2(
     Graph *graph, const std::string &op_type, int num_of_outputs) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(op_type + "_unsqueeze2_onednn_fuse_pass", graph);
 
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/onednn/params_quantization_onednn_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/params_quantization_onednn_pass.cc
@@ -138,7 +138,7 @@ void ParamsQuantizationMkldnnPass::QuantizeConv(ir::Graph* graph,
     // get scope to interact with tensors
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
     // If not a quantized OP
     if (!platform::HasOpINT8DataType(conv_op->Op())) {
@@ -166,7 +166,7 @@ void ParamsQuantizationMkldnnPass::QuantizeConv(ir::Graph* graph,
 
 void ParamsQuantizationMkldnnPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(graph,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Pointer to graph argument should not be NULL."));
   FusePassBase::Init(name_scope_, graph);
   QuantizeConv(graph, "fused_conv2d", true /*with_residual_data*/);

--- a/paddle/fluid/framework/ir/onednn/params_quantization_onednn_pass_tester.cc
+++ b/paddle/fluid/framework/ir/onednn/params_quantization_onednn_pass_tester.cc
@@ -30,7 +30,7 @@ struct Data {
     PADDLE_ENFORCE_EQ(
         size_from_shape,
         data.size(),
-        phi::errors::InvalidArgument("Shape size doesn't match data size."));
+        common::errors::InvalidArgument("Shape size doesn't match data size."));
   }
 
   const std::vector<int64_t>& getShape() const { return shape; }

--- a/paddle/fluid/framework/ir/onednn/quant_dequant_onednn_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/quant_dequant_onednn_pass.cc
@@ -80,7 +80,7 @@ void QuantDequantMkldnnPass::CollectInfoFromFake(
         auto* var = scope->FindVar(scale_name);
         PADDLE_ENFORCE_NOT_NULL(
             var,
-            phi::errors::NotFound(
+            common::errors::NotFound(
                 "The Scales variable [%s] of dequantize op is not found.",
                 var));
 
@@ -114,7 +114,7 @@ void QuantDequantMkldnnPass::CollectWeightScalesInfoFromONNXFormatDequantize(
       auto* var = scope->FindVar(scale_name);
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::NotFound(
+          common::errors::NotFound(
               "The Scales variable [%s] of dequantize op is not found.", var));
 
       auto* scale_tensor = var->GetMutable<phi::DenseTensor>();
@@ -165,9 +165,9 @@ void QuantDequantMkldnnPass::CollectInputScalesFromQuantize(
       PADDLE_ENFORCE_EQ(
           bit_length,
           8,
-          phi::errors::InvalidArgument("Unsupported number quantization "
-                                       "bits: %d, only 8 is supported now.",
-                                       bit_length));
+          common::errors::InvalidArgument("Unsupported number quantization "
+                                          "bits: %d, only 8 is supported now.",
+                                          bit_length));
 
       std::string scale_name = "InScale";
       std::string out_name = "Out";
@@ -182,7 +182,7 @@ void QuantDequantMkldnnPass::CollectInputScalesFromQuantize(
       auto* var = scope->FindVar(scale_var_name);
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::NotFound(
+          common::errors::NotFound(
               "The InScale variable [%s] of quantize op is not found.", var));
 
       auto* scale_tensor = var->GetMutable<phi::DenseTensor>();
@@ -264,12 +264,12 @@ void QuantDequantMkldnnPass::CollectFakeQuantizeOps(
 
   PADDLE_ENFORCE_NOT_NULL(
       fake_quant_in,
-      phi::errors::NotFound("The input var [%s] of quantize op is not found.",
-                            x_var_name));
+      common::errors::NotFound(
+          "The input var [%s] of quantize op is not found.", x_var_name));
   PADDLE_ENFORCE_NOT_NULL(
       fake_quant_out,
-      phi::errors::NotFound("The output var [%s] of quantize op is not found.",
-                            out_var_name));
+      common::errors::NotFound(
+          "The output var [%s] of quantize op is not found.", out_var_name));
 
   std::string input_act_name = fake_quant_in->Var()->Name();
   std::string output_act_name = fake_quant_out->Var()->Name();
@@ -312,11 +312,11 @@ void QuantDequantMkldnnPass::CollectFakeDequantizeOps(
 
   PADDLE_ENFORCE_NOT_NULL(
       fake_dequant_in,
-      phi::errors::NotFound("The input var [%s] of dequantize op is not found.",
-                            x_var_name));
+      common::errors::NotFound(
+          "The input var [%s] of dequantize op is not found.", x_var_name));
   PADDLE_ENFORCE_NOT_NULL(
       fake_dequant_out,
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "The output var [%s] of dequantize op is not found.", out_var_name));
 
   std::string input_act_name = fake_dequant_in->Var()->Name();
@@ -360,16 +360,16 @@ void QuantDequantMkldnnPass::CollectQuantizeDequantizeOpsFromONNXFormat(
 
   PADDLE_ENFORCE_NOT_NULL(
       fake_quant_in,
-      phi::errors::NotFound("The input var [%s] of quantize op is not found.",
-                            x_var_name));
+      common::errors::NotFound(
+          "The input var [%s] of quantize op is not found.", x_var_name));
   PADDLE_ENFORCE_NOT_NULL(
       fake_quant_in_scale,
-      phi::errors::NotFound("The scale var [%s] of quantize op is not found.",
-                            in_scale_name));
+      common::errors::NotFound(
+          "The scale var [%s] of quantize op is not found.", in_scale_name));
   PADDLE_ENFORCE_NOT_NULL(
       fake_quant_out,
-      phi::errors::NotFound("The output var [%s] of quantize op is not found.",
-                            out_var_name));
+      common::errors::NotFound(
+          "The output var [%s] of quantize op is not found.", out_var_name));
 
   std::string input_act_name = fake_quant_in->Var()->Name();
   std::string output_act_name = fake_quant_out->Var()->Name();
@@ -538,7 +538,7 @@ void QuantDequantMkldnnPass::ConvertFromINT8ToFP32(
            weight_data.data(),
            weight_tensor->numel() * sizeof(float));
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The size of weight scales vector (%d) does not "
         "match the dimensions (%d) of the weights tensor %s.",
         size,
@@ -564,7 +564,7 @@ void QuantDequantMkldnnPass::DequantizeOpWeights(
   if (iter != weight_thresholds.end()) {
     scales = iter->second;
   } else {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "Could not find threshold information for [%s] var, please check if "
         "the model is correct.",
         output_var_name));
@@ -573,7 +573,7 @@ void QuantDequantMkldnnPass::DequantizeOpWeights(
   auto* var = scope->FindVar(weight_var_name);
   PADDLE_ENFORCE_NOT_NULL(
       var,
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "The input persistable [%s] var of [%s] op is not found.",
           weight_var_name,
           op_desc->Type()));
@@ -608,7 +608,7 @@ void QuantDequantMkldnnPass::DequantizeOpWeightsFromONNXFormat(
     if (!IsInt8Weight(op_node, scope, weight_name)) {
       return;
     }
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "Could not find threshold information for [%s] var, please check if "
         "the model is correct.",
         weight_var_name));
@@ -617,7 +617,7 @@ void QuantDequantMkldnnPass::DequantizeOpWeightsFromONNXFormat(
   auto* var = scope->FindVar(weight_var_name);
   PADDLE_ENFORCE_NOT_NULL(
       var,
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "The input persistable [%s] var of [%s] op is not found.",
           weight_var_name,
           op_desc->Type()));

--- a/paddle/fluid/framework/ir/onednn/quant_transpose2_dequant_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/quant_transpose2_dequant_onednn_fuse_pass.cc
@@ -24,7 +24,7 @@ namespace ir {
 void FuseQuantTranspose2DequantOneDNNPass::FuseQuantizeTranspose2(
     Graph *graph, const std::string &transpose_type) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(name_scope, graph);
 
   GraphPatternDetector gpd;
@@ -102,7 +102,7 @@ void FuseQuantTranspose2DequantOneDNNPass::FuseQuantizeTranspose2(
 void FuseQuantTranspose2DequantOneDNNPass::FuseTranspose2Dequantize(
     Graph *graph, const std::string &transpose_type) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(name_scope, graph);
 
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/onednn/reshape_transpose_matmul_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/reshape_transpose_matmul_onednn_fuse_pass.cc
@@ -49,7 +49,7 @@ void ReshapeTransposeMatmulMkldnnFusePass::Fuse(
     bool with_reshape_xshape,
     bool with_transpose_xshape) const {
   PADDLE_ENFORCE_NOT_NULL(graph,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Pointer to graph argument should not be NULL."));
   FusePassBase::Init("reshape_transpose_" + matmul_type + "_onednn_fuse_pass",
                      graph);
@@ -97,7 +97,7 @@ void ReshapeTransposeMatmulMkldnnFusePass::Fuse(
     } else if (matmul_desc->Inputs().at("Y").at(0) == input_var_name) {
       matmul_input_name = "Y";
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unexpected input to %s encountered.", matmul_type));
     }
 

--- a/paddle/fluid/framework/ir/onednn/scale_matmul_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/scale_matmul_fuse_pass.cc
@@ -69,7 +69,7 @@ ScaleMatmulFusePass::ScaleMatmulFusePass() {
 
 void ScaleMatmulFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(graph,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Pointer to graph argument should not be NULL."));
 
   FusePassBase::Init("scale_matmul_fuse_pass", graph);
@@ -100,12 +100,12 @@ void ScaleMatmulFusePass::ApplyImpl(ir::Graph* graph) const {
       PADDLE_ENFORCE_GT(
           matmul_alpha,
           0.0f,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Alpha(%f) of matmul op should have positive value.",
               matmul_alpha));
       PADDLE_ENFORCE_GT(scale_scale,
                         0.0f,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Scale(%f) of scale op should have positive value.",
                             scale_scale));
 
@@ -115,9 +115,9 @@ void ScaleMatmulFusePass::ApplyImpl(ir::Graph* graph) const {
       PADDLE_ENFORCE_NE(
           matmul_op_input_name.empty(),
           true,
-          phi::errors::NotFound("Operator after scale operator(%s) "
-                                "should have scale output as input.",
-                                scale_out->Name()));
+          common::errors::NotFound("Operator after scale operator(%s) "
+                                   "should have scale output as input.",
+                                   scale_out->Name()));
       matmul_op->Op()->SetAttr("alpha", matmul_alpha * scale_scale);
       matmul_op->Op()->SetInput(matmul_op_input_name,
                                 std::vector<std::string>({scale_in->Name()}));

--- a/paddle/fluid/framework/ir/onednn/self_attention_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/self_attention_fuse_pass.cc
@@ -100,7 +100,7 @@ void SelfAttentionFusePass::ApplyImpl(ir::Graph* graph) const {
     // Link inputs and outputs.
     PADDLE_ENFORCE_NE(subgraph.count(x),
                       0,
-                      phi::errors::NotFound(
+                      common::errors::NotFound(
                           "Detector did not find input x of self attention."));
 
     IR_NODE_LINK_TO(subgraph.at(x), self_attention_node);    // Input

--- a/paddle/fluid/framework/ir/onednn/shuffle_channel_onednn_detect_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/shuffle_channel_onednn_detect_pass.cc
@@ -87,9 +87,10 @@ void ShuffleChannelMKLDNNDetectPass::ApplyImpl(ir::Graph* graph) const {
       LOG(WARNING) << "The Pass in op compat failed.";
       return;
     }
-    PADDLE_ENFORCE_GT(subgraph.count(x),
-                      0,
-                      phi::errors::NotFound("Detector did not find input X."));
+    PADDLE_ENFORCE_GT(
+        subgraph.count(x),
+        0,
+        common::errors::NotFound("Detector did not find input X."));
     auto* input_node = subgraph.at(x);
     auto reshape1_desc = reshape1_op->Op();
     auto reshape2_desc = reshape2_op->Op();

--- a/paddle/fluid/framework/ir/onednn/softplus_activation_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/softplus_activation_onednn_fuse_pass.cc
@@ -36,7 +36,7 @@ void SoftplusActivationOneDNNPass::ApplyImpl(Graph *graph) const {
 void SoftplusActivationOneDNNPass::FuseSoftplusActivation(
     Graph *graph, const std::string &act_type) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init("softplus_activation", graph);
 
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/onednn/squeeze2_transpose2_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/squeeze2_transpose2_onednn_fuse_pass.cc
@@ -24,7 +24,7 @@ using string::PrettyLogDetail;
 void FuseSqueeze2Transpose2OneDNNPass::ApplyImpl(Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
       graph,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input graph pointer argument should not be nullptr."));
 
   FusePassBase::Init("squeeze2_transpose2_onednn_fuse_pass", graph);

--- a/paddle/fluid/framework/ir/op_compat_sensible_pass.cc
+++ b/paddle/fluid/framework/ir/op_compat_sensible_pass.cc
@@ -166,7 +166,7 @@ AttrCompat& OpCompat::AddAttr(const std::string& attr_name) {
   PADDLE_ENFORCE_EQ(
       attr_compats_.find(attr_name),
       attr_compats_.end(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The attribute compat with the same name has been added"));
   attr_compats_.emplace(attr_name, AttrCompat(attr_name, this));
   return attr_compats_.at(attr_name);
@@ -175,7 +175,7 @@ AttrCompat& OpCompat::AddAttr(const std::string& attr_name) {
 InputOrOutputCompat& OpCompat::AddInput(const std::string& name) {
   PADDLE_ENFORCE_EQ(input_compats_.find(name),
                     input_compats_.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The input with the same name has been added"));
   input_compats_.emplace(name, InputOrOutputCompat(name, this));
   return input_compats_.at(name);
@@ -184,7 +184,7 @@ InputOrOutputCompat& OpCompat::AddInput(const std::string& name) {
 InputOrOutputCompat& OpCompat::AddOutput(const std::string& name) {
   PADDLE_ENFORCE_EQ(output_compats_.find(name),
                     output_compats_.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The output with the same name has been added"));
   output_compats_.emplace(name, InputOrOutputCompat(name, this));
   return output_compats_.at(name);
@@ -303,7 +303,7 @@ bool OpCompatSensiblePass::IsCompat(
     const GraphPatternDetector::subgraph_t& subgraph, Graph*) const {
   PADDLE_ENFORCE_EQ(op_compat_judgers_.empty(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "At least one OpCompat instance should be added"));
   // Check the all the ops in the subgraph are contained in the
   // op_compat.

--- a/paddle/fluid/framework/ir/pass.cc
+++ b/paddle/fluid/framework/ir/pass.cc
@@ -100,18 +100,18 @@ Graph *Pass::Apply(Graph *graph) const {
   VLOG(10) << "start to apply pass " << Type() << " to graph";
   CheckPrevPass();
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   for (const std::string &attr : required_pass_attrs_) {
     PADDLE_ENFORCE_NE(
         attrs_.find(attr),
         attrs_.end(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Required atrribute %s for pass < %s > is not set.", attr, Type()));
   }
   for (const std::string &attr : required_graph_attrs_) {
     PADDLE_ENFORCE_EQ(graph->Has(attr),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Required atrribute %s for graph is not set.", attr));
   }
   ApplyImpl(graph);
@@ -119,12 +119,12 @@ Graph *Pass::Apply(Graph *graph) const {
   PADDLE_ENFORCE_EQ(
       HasCircle(*graph),
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Illegal pass %s. Generated graph shouldn't contain cycle.", Type()));
   PADDLE_ENFORCE_EQ(
       VarDescIsConsistency(*graph),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The VarDescs of persistable variable are not consistency."));
   if (!graph->Has(kPassRecorder)) {
     graph->Set<PassRecorder>(kPassRecorder, new PassRecorder);
@@ -163,13 +163,13 @@ Graph *Pass::Apply(Graph *graph) const {
       PADDLE_ENFORCE_EQ(
           HasCircle(*sub_graph),
           false,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Illegal pass %s. Generated graph shouldn't contain cycle.",
               Type()));
       PADDLE_ENFORCE_EQ(
           VarDescIsConsistency(*sub_graph),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The VarDescs of persistable variable are not consistency."));
       if (!sub_graph->Has(kPassRecorder)) {
         sub_graph->Set<PassRecorder>(kPassRecorder, new PassRecorder);
@@ -226,21 +226,21 @@ void Pass::ApplyPassesToProgram(const std::vector<const Pass *> &passes,
   VLOG(10) << "ApplyPassesToProgram is called";
   PADDLE_ENFORCE_NOT_NULL(
       main_program,
-      phi::errors::InvalidArgument("The main program must be provided."));
+      common::errors::InvalidArgument("The main program must be provided."));
 
   PADDLE_ENFORCE_NOT_NULL(
       startup_program,
-      phi::errors::InvalidArgument("The startup program must be provided."));
+      common::errors::InvalidArgument("The startup program must be provided."));
 
   for (auto *p : passes) {
-    PADDLE_ENFORCE_NOT_NULL(
-        p,
-        phi::errors::InvalidArgument("The provided pass cannot be nullptr."));
+    PADDLE_ENFORCE_NOT_NULL(p,
+                            common::errors::InvalidArgument(
+                                "The provided pass cannot be nullptr."));
     VLOG(10) << "Pass " << p->Type();
     if (passes.size() > 1) {
       PADDLE_ENFORCE_EQ(p->SupportApplyProgramViaGraph(),
                         true,
-                        phi::errors::PermissionDenied(
+                        common::errors::PermissionDenied(
                             "Each pass must support to be applied via Graph if "
                             "multi-passes are applied."));
     }
@@ -264,7 +264,7 @@ void Pass::ApplyPassesToProgram(const std::vector<const Pass *> &passes,
 
 void Pass::ApplyImpl(ProgramDesc *main_program,
                      ProgramDesc *startup_program) const {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "The pass %s does not support to apply ProgramDesc directly", Type()));
 }
 

--- a/paddle/fluid/framework/ir/pass.h
+++ b/paddle/fluid/framework/ir/pass.h
@@ -88,7 +88,7 @@ class Pass {
   AttrType &Get(const std::string &attr_name) const {
     PADDLE_ENFORCE_NE(attrs_.find(attr_name),
                       attrs_.end(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Attribute %s not registered for pass.", attr_name));
     try {
       return *paddle::any_cast<AttrType *>(attrs_.at(attr_name));
@@ -108,7 +108,7 @@ class Pass {
         return info.name();
       };
 
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Invalid type for attritube %s, expected: %s, actual: %s.",
           attr_name,
           TypeToString(typeid(AttrType *)),
@@ -138,8 +138,8 @@ class Pass {
       PADDLE_ENFORCE_EQ(
           attrs_.count(attr_name),
           0,
-          phi::errors::AlreadyExists("Attribute %s already set in the pass.",
-                                     attr_name));
+          common::errors::AlreadyExists("Attribute %s already set in the pass.",
+                                        attr_name));
     } else {
       VLOG(3) << "Setting the attribute " << attr_name << " for the pass "
               << type_;
@@ -157,7 +157,7 @@ class Pass {
   void SetNotOwned(const std::string &attr_name, AttrType *attr) {
     PADDLE_ENFORCE_EQ(attrs_.count(attr_name),
                       0,
-                      phi::errors::AlreadyExists(
+                      common::errors::AlreadyExists(
                           "Attribute %s already set in the pass.", attr_name));
     attrs_[attr_name] = attr;
   }
@@ -172,7 +172,7 @@ class Pass {
 
  protected:
   virtual void ApplyImpl(Graph *graph UNUSED) const {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "The virtual pass called is not implemented."));
   }
 
@@ -245,10 +245,10 @@ class PassRegistry {
   }
 
   void Insert(const std::string &pass_type, const PassCreator &pass_creator) {
-    PADDLE_ENFORCE_NE(
-        Has(pass_type),
-        true,
-        phi::errors::AlreadyExists("Pass %s has been registered.", pass_type));
+    PADDLE_ENFORCE_NE(Has(pass_type),
+                      true,
+                      common::errors::AlreadyExists(
+                          "Pass %s has been registered.", pass_type));
     map_.insert({pass_type, pass_creator});
   }
 
@@ -256,7 +256,7 @@ class PassRegistry {
     if (pass_type == "tensorrt_subgraph_pass") {
       PADDLE_ENFORCE_EQ(Has(pass_type),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Pass %s has not been registered. Please "
                             "use the paddle inference library "
                             "compiled with tensorrt or disable "
@@ -265,7 +265,7 @@ class PassRegistry {
     } else {
       PADDLE_ENFORCE_EQ(Has(pass_type),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Pass %s has not been registered.", pass_type));
     }
     return map_.at(pass_type)();
@@ -284,8 +284,8 @@ struct PassRegistrar : public Registrar {
     PADDLE_ENFORCE_EQ(
         PassRegistry::Instance().Has(pass_type),
         false,
-        phi::errors::AlreadyExists("Pass '%s' is registered more than once.",
-                                   pass_type));
+        common::errors::AlreadyExists("Pass '%s' is registered more than once.",
+                                      pass_type));
     PassRegistry::Instance().Insert(
         pass_type, [this, pass_type]() -> std::unique_ptr<Pass> {
           std::unique_ptr<Pass> pass(new PassType());

--- a/paddle/fluid/framework/ir/pass_builder.cc
+++ b/paddle/fluid/framework/ir/pass_builder.cc
@@ -36,7 +36,7 @@ void PassBuilder::RemovePass(size_t idx) {
   PADDLE_ENFORCE_GT(
       passes_.size(),
       idx,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Passes size is %d, %d is not a valid index.", passes_.size(), idx));
   passes_.erase(passes_.begin() + idx);  // NOLINT
 }
@@ -46,7 +46,7 @@ std::shared_ptr<Pass> PassBuilder::InsertPass(size_t idx,
   PADDLE_ENFORCE_GE(
       passes_.size(),
       idx,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Passes size is %d, %d is not a valid index.", passes_.size(), idx));
   std::shared_ptr<Pass> pass(
       ir::PassRegistry::Instance().Get(pass_type).release());

--- a/paddle/fluid/framework/ir/preln_elementwise_groupnorm_act_pass.cc
+++ b/paddle/fluid/framework/ir/preln_elementwise_groupnorm_act_pass.cc
@@ -91,7 +91,7 @@ namespace paddle::framework::ir {
 int PrelnGroupNormActFusePass::ApplyAddGNPattern(ir::Graph *graph,
                                                  bool with_act) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("preln_groupnorm_silu_fuse", graph);
 
   int found_subgraph_count = 0;

--- a/paddle/fluid/framework/ir/preln_layernorm_x_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/preln_layernorm_x_fuse_pass.cc
@@ -91,7 +91,7 @@ void PrelnLayerNormX::operator()(PDNode *x,
 int PrelnLayerNormXFusePass::ApplyLayerNormShiftPattern(
     ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("preln_layernorm_x_fuse", graph);
 
   int found_subgraph_count = 0;
@@ -171,7 +171,7 @@ int PrelnLayerNormXFusePass::ApplyLayerNormShiftPattern(
 int PrelnLayerNormXFusePass::ApplyMergeLayerNormPattern(
     ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("preln_layernorm_x_fuse", graph);
 
   int found_subgraph_count = 0;

--- a/paddle/fluid/framework/ir/preln_residual_bias_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/preln_residual_bias_fuse_pass.cc
@@ -144,7 +144,7 @@ void addIntermediateOut(Node *op_node,
 int PrelnResidualBiasFusePass::ApplyPattern(ir::Graph *graph,
                                             bool with_bias) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("preln_residual_bias_fuse", graph);
 
   int found_subgraph_count = 0;
@@ -285,7 +285,7 @@ void PrelnResidualBiasFusePass::ApplyImpl(ir::Graph *graph) const {
   VLOG(1) << "Fuse PrelnResidualBias into "
              "fused_bias_dropout_residual_layer_norm op with dropout rate = 0";
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("preln_residual_bias_fuse", graph);
 
   int found_subgraph_count = 0;

--- a/paddle/fluid/framework/ir/preln_skip_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/preln_skip_layernorm_fuse_pass.cc
@@ -100,7 +100,7 @@ namespace paddle::framework::ir {
 
 void PrelnSkipLayerNormFusePass::ApplyImpl(ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("preln_skip_layernorm_fuse", graph);
   bool enable_int8 = Get<bool>("enable_int8");
   bool use_varseqlen = Get<bool>("use_varseqlen");

--- a/paddle/fluid/framework/ir/quant_linear_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/quant_linear_fuse_pass.cc
@@ -156,7 +156,7 @@ QuantLinearFusePass::QuantLinearFusePass() {
 // if have relu after elementwise_add, then fuse relu into quant_linear op.
 void QuantLinearFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
 
   FusePassBase::Init("quant_linear_fuse_pattern", graph);
 
@@ -174,10 +174,10 @@ int QuantLinearFusePass::ApplyQuantLinearFusePattern(Graph* graph,
   GraphPatternDetector gpd;
 
   auto* scope = param_scope();
-  PADDLE_ENFORCE_NOT_NULL(
-      scope,
-      phi::errors::InvalidArgument("Scope in QuantLinearFusePass should not be "
-                                   "null."));
+  PADDLE_ENFORCE_NOT_NULL(scope,
+                          common::errors::InvalidArgument(
+                              "Scope in QuantLinearFusePass should not be "
+                              "null."));
 
   patterns::QuantLinearFusePattern pattern(gpd.mutable_pattern(),
                                            "quant_linear_fuse_pattern");
@@ -198,7 +198,7 @@ int QuantLinearFusePass::ApplyQuantLinearFusePattern(Graph* graph,
             ->Get<phi::DenseTensor>();
     PADDLE_ENFORCE_EQ(phi::is_cpu_place(input_scale_tensor.place()),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input scale tensor's place should be CPU."));
 
     float input_scale = NAN;
@@ -210,7 +210,7 @@ int QuantLinearFusePass::ApplyQuantLinearFusePattern(Graph* graph,
           input_scale_tensor.data<phi::dtype::float16>();
       input_scale = static_cast<float>(input_scale_data[0]);
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupport type. The type of 'Scale' in quantize_linear op is "
           "expected to be float32 or float16, but the current type is %d",
           input_scale_tensor.dtype()));
@@ -230,7 +230,7 @@ int QuantLinearFusePass::ApplyQuantLinearFusePattern(Graph* graph,
             ->Get<phi::DenseTensor>();
     PADDLE_ENFORCE_EQ(phi::is_cpu_place(weight_scale_tensor.place()),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "weight_scale tensor's place should be CPU."));
     const float* weight_scale_data = weight_scale_tensor.data<float>();
 

--- a/paddle/fluid/framework/ir/relu6_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/relu6_fuse_pass.cc
@@ -70,7 +70,7 @@ void Relu6FusePass::ApplyImpl(ir::Graph* graph) const {
 
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
     const auto& clip_max_t =
         scope->GetVar(clip_max_node->Name())->Get<phi::DenseTensor>();
@@ -78,18 +78,18 @@ void Relu6FusePass::ApplyImpl(ir::Graph* graph) const {
     PADDLE_ENFORCE_EQ(
         clip_max_t_dims.size(),
         1,
-        phi::errors::InvalidArgument("the size(%d) of clip max tensor "
-                                     "must equal 1",
-                                     clip_max_t_dims.size()));
+        common::errors::InvalidArgument("the size(%d) of clip max tensor "
+                                        "must equal 1",
+                                        clip_max_t_dims.size()));
     const auto& clip_min_t =
         scope->GetVar(clip_min_node->Name())->Get<phi::DenseTensor>();
     auto clip_min_t_dims = clip_min_t.dims();
     PADDLE_ENFORCE_EQ(
         clip_min_t_dims.size(),
         1,
-        phi::errors::InvalidArgument("the size(%d) of clip max tensor "
-                                     "must equal 1",
-                                     clip_min_t_dims.size()));
+        common::errors::InvalidArgument("the size(%d) of clip max tensor "
+                                        "must equal 1",
+                                        clip_min_t_dims.size()));
     auto tensor_type = clip_max_t.dtype();
     float max_val_ = 0.f;
     float min_val_ = 1.f;
@@ -104,7 +104,7 @@ void Relu6FusePass::ApplyImpl(ir::Graph* graph) const {
       max_val_ = clip_max_t_fp32_ptr[0];
       min_val_ = clip_min_t_fp32_ptr[0];
     } else {
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "relu6_fuse_pass do not supported weight dtype. "
           "we now only support fp32/fp16."));
     }

--- a/paddle/fluid/framework/ir/relu6_fuse_pass_test.cc
+++ b/paddle/fluid/framework/ir/relu6_fuse_pass_test.cc
@@ -59,7 +59,7 @@ TEST(Relu6FusePass, basic) {
   auto clip_num = GetNumOpNodes(graph, "clip");
   PADDLE_ENFORCE_EQ(clip_num,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "clip should be mapped to relu6 after pass."));
 }
 

--- a/paddle/fluid/framework/ir/remove_padding_recover_padding_pass.cc
+++ b/paddle/fluid/framework/ir/remove_padding_recover_padding_pass.cc
@@ -187,7 +187,7 @@ void RemovePaddingRecoverPaddingPass::ApplyImpl(ir::Graph* graph) const {
   }
 
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init(name_scope_, graph);
   auto* scope = param_scope();
   int found_subgraph_count = 0;

--- a/paddle/fluid/framework/ir/repeated_fc_relu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/repeated_fc_relu_fuse_pass.cc
@@ -328,13 +328,13 @@ int RepeatedFCReluFusePass::BuildFusion(Graph* graph,
   auto retrieve_node = [](const std::string& name,
                           const GraphPatternDetector::subgraph_t& subgraph,
                           const PDPattern& pat) -> Node* {
-    PADDLE_ENFORCE_GT(
-        subgraph.count(pat.RetrieveNode(name)),
-        0,
-        phi::errors::NotFound("Pattern has no node called %s.", name.c_str()));
+    PADDLE_ENFORCE_GT(subgraph.count(pat.RetrieveNode(name)),
+                      0,
+                      common::errors::NotFound("Pattern has no node called %s.",
+                                               name.c_str()));
     Node* p = subgraph.at(pat.RetrieveNode(name));
     PADDLE_ENFORCE_NOT_NULL(
-        p, phi::errors::NotFound("Subgraph has no node %s.", name.c_str()));
+        p, common::errors::NotFound("Subgraph has no node %s.", name.c_str()));
     return p;
   };
 
@@ -426,7 +426,7 @@ int RepeatedFCReluFusePass::BuildFusion(Graph* graph,
 
 void RepeatedFCReluFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(name_scope_, graph);
 
   int fusion_count = 0;

--- a/paddle/fluid/framework/ir/repeated_fc_relu_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/repeated_fc_relu_fuse_pass_tester.cc
@@ -64,7 +64,7 @@ void TestMain(int num_fc) {
   PADDLE_ENFORCE_EQ(
       num_nodes_before - (num_fc_nodes_before - 1) + 1,
       num_nodes_after,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "num_nodes_before = %d, num_fc_nodes_before = %d, num_nodes_after = "
           "%d.",
           num_nodes_before,
@@ -72,8 +72,8 @@ void TestMain(int num_fc) {
           num_nodes_after));
   PADDLE_ENFORCE_EQ(num_fused_nodes_after,
                     1,
-                    phi::errors::InvalidArgument("num_fused_nodes_after = %d.",
-                                                 num_fused_nodes_after));
+                    common::errors::InvalidArgument(
+                        "num_fused_nodes_after = %d.", num_fused_nodes_after));
 }
 
 TEST(RepeatedFCReluFusePass, basic_3) { TestMain(3); }

--- a/paddle/fluid/framework/ir/reverse_roll_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/reverse_roll_fuse_pass.cc
@@ -83,7 +83,7 @@ ReverseRollFusePass::ReverseRollFusePass() {  // NOLINT
 int ReverseRollFusePass::ApplyPattern(ir::Graph* graph, bool with_roll) const {
   PADDLE_ENFORCE_NOT_NULL(
       graph,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input graph of ReverseRollFusePass should not be "
           "nullptr."));
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/seq_concat_fc_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/seq_concat_fc_fuse_pass.cc
@@ -266,14 +266,14 @@ void SeqConcatFcFusePass::ApplyImpl(ir::Graph* graph) const {
   auto* concat_out = BuildSeqExpandConcatPattern(pattern);
   BuildFCPattern(pattern, concat_out);
 
-#define GET_NODE(id, pattern)                                        \
-  PADDLE_ENFORCE_GT(                                                 \
-      subgraph.count(pattern.RetrieveNode(#id)),                     \
-      0,                                                             \
-      phi::errors::NotFound("Pattern has no node called %s.", #id)); \
-  auto* id = subgraph.at(pattern.RetrieveNode(#id));                 \
-  PADDLE_ENFORCE_NOT_NULL(                                           \
-      id, phi::errors::NotFound("Subgraph has no node %s.", #id));
+#define GET_NODE(id, pattern)                                           \
+  PADDLE_ENFORCE_GT(                                                    \
+      subgraph.count(pattern.RetrieveNode(#id)),                        \
+      0,                                                                \
+      common::errors::NotFound("Pattern has no node called %s.", #id)); \
+  auto* id = subgraph.at(pattern.RetrieveNode(#id));                    \
+  PADDLE_ENFORCE_NOT_NULL(                                              \
+      id, common::errors::NotFound("Subgraph has no node %s.", #id));
 
   int fuse_count{0};
 

--- a/paddle/fluid/framework/ir/seqpool_concat_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/seqpool_concat_fuse_pass.cc
@@ -146,13 +146,13 @@ static int BuildFusion(Graph* graph,
   auto retrieve_node = [](const std::string& name,
                           const GraphPatternDetector::subgraph_t& subgraph,
                           const PDPattern& pat) -> Node* {
-    PADDLE_ENFORCE_GT(
-        subgraph.count(pat.RetrieveNode(name)),
-        0,
-        phi::errors::NotFound("Pattern has no node called %s.", name.c_str()));
+    PADDLE_ENFORCE_GT(subgraph.count(pat.RetrieveNode(name)),
+                      0,
+                      common::errors::NotFound("Pattern has no node called %s.",
+                                               name.c_str()));
     Node* p = subgraph.at(pat.RetrieveNode(name));
     PADDLE_ENFORCE_NOT_NULL(
-        p, phi::errors::NotFound("Subgraph has no node %s.", name.c_str()));
+        p, common::errors::NotFound("Subgraph has no node %s.", name.c_str()));
     return p;
   };
 

--- a/paddle/fluid/framework/ir/set_subgraph_edge_pass.cc
+++ b/paddle/fluid/framework/ir/set_subgraph_edge_pass.cc
@@ -36,7 +36,7 @@ void SetSubgraphEdge::ApplyImpl(Graph *graph) const {
   }
 
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
 
   VLOG(3) << "Running set_subgraph_edge_pass.";
   if (graph->IsMainGraph()) {
@@ -54,8 +54,8 @@ void SetSubgraphEdge::ApplyImpl(Graph *graph) const {
   auto *scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::InvalidArgument("Scope in SetSubgraphEdge should not be "
-                                   "null."));
+      common::errors::InvalidArgument("Scope in SetSubgraphEdge should not be "
+                                      "null."));
   // Create pattern
   patterns::SubgraphEdgePattern pattern(gpd.mutable_pattern(), pattern_name);
 
@@ -123,7 +123,7 @@ void SetSubgraphEdge::ApplyImpl(Graph *graph) const {
       if (subgraph_node) {
         subgraph_node->SetSubgraphOutput();
       } else {
-        PADDLE_THROW(phi::errors::Fatal("Subgraph don't have block node."));
+        PADDLE_THROW(common::errors::Fatal("Subgraph don't have block node."));
       }
     }
     found_count++;

--- a/paddle/fluid/framework/ir/set_transformer_input_convert_pass.cc
+++ b/paddle/fluid/framework/ir/set_transformer_input_convert_pass.cc
@@ -63,7 +63,7 @@ void SetTransformerInputConvertPass::ApplyImpl(ir::Graph *graph) const {
     return;
   }
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init(name_scope_, graph);
   int found_subgraph_count = 0;
   Node *transformer_input_convert_out0_node;

--- a/paddle/fluid/framework/ir/shuffle_channel_detect_pass.cc
+++ b/paddle/fluid/framework/ir/shuffle_channel_detect_pass.cc
@@ -87,9 +87,10 @@ void ShuffleChannelDetectPass::ApplyImpl(ir::Graph* graph) const {
       LOG(WARNING) << "The Pass in op compat failed.";
       return;
     }
-    PADDLE_ENFORCE_GT(subgraph.count(x),
-                      0,
-                      phi::errors::NotFound("Detector did not find input X."));
+    PADDLE_ENFORCE_GT(
+        subgraph.count(x),
+        0,
+        common::errors::NotFound("Detector did not find input X."));
     auto* input_node = subgraph.at(x);
     auto reshape1_desc = reshape1_op->Op();
     auto reshape2_desc = reshape2_op->Op();

--- a/paddle/fluid/framework/ir/sigmoid_elementmul_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/sigmoid_elementmul_fuse_pass.cc
@@ -71,7 +71,7 @@ SigmoidElementmulFusePass::SigmoidElementmulFusePass() = default;
 
 void SigmoidElementmulFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/simplify_with_basic_ops_pass_tester.cc
+++ b/paddle/fluid/framework/ir/simplify_with_basic_ops_pass_tester.cc
@@ -62,13 +62,13 @@ TEST(SimplifyWithBasicOpsPass, dropout) {
       PADDLE_ENFORCE_EQ(
           num_dropout_nodes_after,
           0,
-          phi::errors::InvalidArgument("num_dropout_nodes_after = %d.",
-                                       num_dropout_nodes_after));
+          common::errors::InvalidArgument("num_dropout_nodes_after = %d.",
+                                          num_dropout_nodes_after));
       if (dropout_implementation == "downgrade_in_infer") {
         PADDLE_ENFORCE_EQ(
             num_dropout_nodes_before,
             num_scale_nodes_after - num_scale_nodes_before,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "num_dropout_nodes_before = %d, num_scale_nodes_after = %d, "
                 "num_scale_nodes_before = %d.",
                 num_dropout_nodes_before,
@@ -78,7 +78,7 @@ TEST(SimplifyWithBasicOpsPass, dropout) {
         PADDLE_ENFORCE_EQ(
             num_scale_nodes_after - num_scale_nodes_before,
             0,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "num_scale_nodes_after = %d, num_scale_nodes_before = %d.",
                 num_scale_nodes_after,
                 num_scale_nodes_before));

--- a/paddle/fluid/framework/ir/skip_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/skip_layernorm_fuse_pass.cc
@@ -97,7 +97,7 @@ namespace paddle::framework::ir {
 
 void SkipLayerNormFusePass::ApplyImpl(ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("skip_layernorm_fuse", graph);
   int found_subgraph_count = 0;
 

--- a/paddle/fluid/framework/ir/skip_layernorm_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/skip_layernorm_fuse_pass_tester.cc
@@ -47,13 +47,13 @@ TEST(SkipLayerNormFusePass, basic) {
 
   PADDLE_ENFORCE_EQ(num_nodes_before,
                     num_nodes_after + 4,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The number of nodes before and after the fuse does "
                         "not meet expectations"));
   PADDLE_ENFORCE_EQ(
       num_fused_nodes_after,
       1,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The number of fusion nodes does not meet expectations after fuse"));
 }
 

--- a/paddle/fluid/framework/ir/sparse_conv_optim_pass.cc
+++ b/paddle/fluid/framework/ir/sparse_conv_optim_pass.cc
@@ -67,7 +67,7 @@ void SparseConvOptimPass::ApplyImpl(ir::Graph* graph) const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Scope in SparseConvOptimPass should not be null."));
   // Create pattern
   patterns::SparseConvOptimPartern pattern(gpd.mutable_pattern(), pattern_name);
@@ -99,7 +99,7 @@ void SparseConvOptimPass::ApplyImpl(ir::Graph* graph) const {
     PADDLE_ENFORCE_EQ((dilations.size() == paddings.size() &&
                        paddings.size() == strides.size()),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dilations, paddings, strides must have the same "
                           "rank, but received %d, %d, %d.",
                           dilations.size(),

--- a/paddle/fluid/framework/ir/squared_mat_sub_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/squared_mat_sub_fuse_pass.cc
@@ -310,13 +310,13 @@ static int BuildFusion(Graph* graph,
   auto retrieve_node = [](const std::string& name,
                           const GraphPatternDetector::subgraph_t& subgraph,
                           const PDPattern& pat) -> Node* {
-    PADDLE_ENFORCE_GT(
-        subgraph.count(pat.RetrieveNode(name)),
-        0,
-        phi::errors::NotFound("Pattern has no node called %s.", name.c_str()));
+    PADDLE_ENFORCE_GT(subgraph.count(pat.RetrieveNode(name)),
+                      0,
+                      common::errors::NotFound("Pattern has no node called %s.",
+                                               name.c_str()));
     Node* p = subgraph.at(pat.RetrieveNode(name));
     PADDLE_ENFORCE_NOT_NULL(
-        p, phi::errors::NotFound("Subgraph has no node %s.", name.c_str()));
+        p, common::errors::NotFound("Subgraph has no node %s.", name.c_str()));
     return p;
   };
 

--- a/paddle/fluid/framework/ir/subgraph_detector.h
+++ b/paddle/fluid/framework/ir/subgraph_detector.h
@@ -151,7 +151,7 @@ static iterator_range<NodesTSIterator> TopologicalSort(const Graph &g) {
   PADDLE_ENFORCE_GT(
       start_points.size(),
       0U,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Expected the number of graph's start points >= 1. Expected %d.",
           start_points.size()));
   NodesTSIterator x(start_points);

--- a/paddle/fluid/framework/ir/trans_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/trans_layernorm_fuse_pass.cc
@@ -95,7 +95,7 @@ void TransLayernormPattern::operator()(PDNode *x) {
 int TransLayernormFusePass::ApplyConvTransLayernormPattern(
     ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("trans_layernorm_fuse", graph);
   int found_subgraph_count = 0;
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/transfer_layout_pass.cc
+++ b/paddle/fluid/framework/ir/transfer_layout_pass.cc
@@ -105,7 +105,8 @@ void InsertLayoutTransOp(ir::Graph *graph,
 
 void TransferLayoutPass::ApplyImpl(ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be nullptr."));
+      graph,
+      common::errors::PreconditionNotMet("graph should not be nullptr."));
   FusePassBase::Init("fused_conv2d_add_act_layout_transfer", graph);
   auto *scope = param_scope();
 
@@ -123,14 +124,14 @@ void TransferLayoutPass::ApplyImpl(ir::Graph *graph) const {
 
   PADDLE_ENFORCE_EQ(graph->IsMainGraph(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "the graph should be main graph when applying "
                         "transfer_layout_pass"));
 
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal("scope must not be nullptr when applying "
-                         "transfer_layout_pass"));
+      common::errors::Fatal("scope must not be nullptr when applying "
+                            "transfer_layout_pass"));
 
   // Not support multiple block now.
   std::unordered_map<ir::Node *, ir::Node *> cache;

--- a/paddle/fluid/framework/ir/transpose_flatten_concat_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/transpose_flatten_concat_fuse_pass.cc
@@ -97,21 +97,22 @@ void TransposeFlattenConcatFusePass::RunTransposeFlattenConcatFuse(
     for (int i = 0; i < times; i++) {
       PADDLE_ENFORCE_NOT_NULL(
           subgraph.at(pattern.GetPDNode("transpose" + std::to_string(i))),
-          phi::errors::NotFound("Can not find transpose%d in subgraph.", i));
+          common::errors::NotFound("Can not find transpose%d in subgraph.", i));
       PADDLE_ENFORCE_NOT_NULL(
           subgraph.at(pattern.GetPDNode("transpose_out" + std::to_string(i))),
-          phi::errors::NotFound("Can not find transpose_out%d in subgraph.",
-                                i));
+          common::errors::NotFound("Can not find transpose_out%d in subgraph.",
+                                   i));
       PADDLE_ENFORCE_NOT_NULL(
           subgraph.at(pattern.GetPDNode("flatten" + std::to_string(i))),
-          phi::errors::NotFound("Can not find flatten%d in subgraph.", i));
+          common::errors::NotFound("Can not find flatten%d in subgraph.", i));
       PADDLE_ENFORCE_NOT_NULL(
           subgraph.at(pattern.GetPDNode("flatten_out" + std::to_string(i))),
-          phi::errors::NotFound("Can not find flatten_out%d in subgraph.", i));
+          common::errors::NotFound("Can not find flatten_out%d in subgraph.",
+                                   i));
       PADDLE_ENFORCE_NOT_NULL(
           subgraph.at(input_nodes[i]),
-          phi::errors::NotFound("Can not find %s in subgraph.",
-                                input_nodes[i]->name()));
+          common::errors::NotFound("Can not find %s in subgraph.",
+                                   input_nodes[i]->name()));
 
       if (i == 0) {
         trans_axis0 = PADDLE_GET_CONST(

--- a/paddle/fluid/framework/ir/trt_delete_weight_dequant_linear_op_pass.cc
+++ b/paddle/fluid/framework/ir/trt_delete_weight_dequant_linear_op_pass.cc
@@ -206,7 +206,7 @@ void TrtDeleteWeightQuantDequantLinearOpPass::ApplyImpl(
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Scope in TrtDeleteWeightQuantDequantLinearOpPass should not be "
           "null."));
   // Create pattern
@@ -274,7 +274,7 @@ void TrtDeleteWeightQuantDequantLinearOpPass::ApplyImpl(
     if (quant_axis == -1) {  // per_layer quant_dequant: all OP
       PADDLE_ENFORCE_EQ(weight_scale_nums,
                         1,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "When quant_axis == -1 means use per_layer "
                             "quant_dequant, weight_scale'number should be 1."));
 
@@ -288,13 +288,13 @@ void TrtDeleteWeightQuantDequantLinearOpPass::ApplyImpl(
       PADDLE_ENFORCE_EQ(
           weight_scale_nums,
           w_dims[quant_axis],
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "When quant_axis == 0 means use per_channel quant_dequant, "
               "weight_scale'numbers should be equal channels."));
       PADDLE_ENFORCE_EQ(
           w_dims.size(),
           4,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "When quant_axis == 0 means use per_channel "
               "quant_dequant, (conv2d, depthwise_conv2d, "
               "fused_conv2d_add_act)'s weight dims should be 4."));
@@ -308,7 +308,7 @@ void TrtDeleteWeightQuantDequantLinearOpPass::ApplyImpl(
       PADDLE_ENFORCE_EQ(
           weight_scale_nums,
           w_dims[quant_axis],
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "When quant_axis == 1 means use per_channel quant_dequant, "
               "weight_scale'numbers should be equal channels."));
 
@@ -319,7 +319,7 @@ void TrtDeleteWeightQuantDequantLinearOpPass::ApplyImpl(
           PADDLE_ENFORCE_EQ(
               quantized_op_type,
               "conv2d_transpose",
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "When quant_axis == 1 means use per_channel quant_dequant, "
                   "only conv2d_transpose weight dims equal 4."));
         }
@@ -334,12 +334,12 @@ void TrtDeleteWeightQuantDequantLinearOpPass::ApplyImpl(
                                weight_scale[i % w_dims[1]];
         }
       } else {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "When quant_axis == 1 , weight dims should be 2 or 4, please check "
             "your model "));
       }
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "quant_axis should be -1 or 0 or 1, please check your model "
           "OP'attribute "));
     }

--- a/paddle/fluid/framework/ir/trt_embedding_eltwise_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/trt_embedding_eltwise_layernorm_fuse_pass.cc
@@ -474,11 +474,11 @@ void TrtEmbeddingEltwiseLayerNormFusePass::ApplyImpl(Graph* graph) const {
       VLOG(3) << "start trt_embedding_eltwise_layernorm_fuse_pass";
     } else {
       PADDLE_THROW(
-          phi::errors::Fatal("Use transformer'varseqlen need config: "
-                             "use_varseqlen, set pos_id, set "
-                             "mask_id. Or not use varseqlen, do not set "
-                             "pos_id. Please "
-                             "reconfig"));
+          common::errors::Fatal("Use transformer'varseqlen need config: "
+                                "use_varseqlen, set pos_id, set "
+                                "mask_id. Or not use varseqlen, do not set "
+                                "pos_id. Please "
+                                "reconfig"));
     }
     graph->Set(kEmbEltwiseLayernormPass, new bool(true));
   }

--- a/paddle/fluid/framework/ir/trt_map_ops_to_matrix_multiply_pass.cc
+++ b/paddle/fluid/framework/ir/trt_map_ops_to_matrix_multiply_pass.cc
@@ -30,7 +30,7 @@ TrtMapOpsToMatrixMultiplyPass::TrtMapOpsToMatrixMultiplyPass() = default;
 
 void TrtMapOpsToMatrixMultiplyPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   std::string name_scope = "trt_map_ops_to_matrix_multiply_pass";
   FusePassBase::Init(name_scope, graph);
 

--- a/paddle/fluid/framework/ir/trt_multihead_matmul_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/trt_multihead_matmul_fuse_pass.cc
@@ -1080,7 +1080,7 @@ void TrtMultiHeadMatmulV2FusePass::ApplyImpl(Graph* graph) const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "During the multiheadMatmul pass, The scope should not be null."));
 
   int fusion_count = BuildFusionV2(graph, name_scope_, scope);
@@ -1101,20 +1101,20 @@ void TrtMultiHeadMatmulV2FusePass::ApplyImpl(Graph* graph) const {
         }
       } else {
         PADDLE_THROW(
-            phi::errors::Fatal("Use transformer'varseqlen need "
-                               "embedding_eltwise_layernorm_fuse_pass or "
-                               "preln_embedding_eltwise_layernorm_fuse_"
-                               "pass. please use no_varseqlen"));
+            common::errors::Fatal("Use transformer'varseqlen need "
+                                  "embedding_eltwise_layernorm_fuse_pass or "
+                                  "preln_embedding_eltwise_layernorm_fuse_"
+                                  "pass. please use no_varseqlen"));
       }
     } else if (!use_varseqlen && pos_id.empty()) {
       VLOG(3) << "start no_varseqlen_trt_multihead_matmul_fuse_pass";
     } else {
       PADDLE_THROW(
-          phi::errors::Fatal("Use transformer'varseqlen need config: "
-                             "use_varseqlen, set pos_id, set "
-                             "mask_id. Or not use varseqlen, do not set "
-                             "pos_id. Please "
-                             "reconfig"));
+          common::errors::Fatal("Use transformer'varseqlen need config: "
+                                "use_varseqlen, set pos_id, set "
+                                "mask_id. Or not use varseqlen, do not set "
+                                "pos_id. Please "
+                                "reconfig"));
     }
     graph->Set(kMultiheadMatmulPass, new bool(true));
   }
@@ -1494,7 +1494,7 @@ void TrtMultiHeadMatmulV3FusePass::ApplyImpl(Graph* graph) const {
   auto* scope = param_scope();
   PADDLE_ENFORCE_NOT_NULL(
       scope,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "During the multiheadMatmul pass, The scope should not be null."));
 
   int fusion_count = BuildFusionV3(graph, name_scope_, scope);
@@ -1515,20 +1515,20 @@ void TrtMultiHeadMatmulV3FusePass::ApplyImpl(Graph* graph) const {
         }
       } else {
         PADDLE_THROW(
-            phi::errors::Fatal("Use transformer'varseqlen need "
-                               "embedding_eltwise_layernorm_fuse_pass or "
-                               "preln_embedding_eltwise_layernorm_fuse_"
-                               "pass. please use no_varseqlen"));
+            common::errors::Fatal("Use transformer'varseqlen need "
+                                  "embedding_eltwise_layernorm_fuse_pass or "
+                                  "preln_embedding_eltwise_layernorm_fuse_"
+                                  "pass. please use no_varseqlen"));
       }
     } else if (!use_varseqlen && pos_id.empty()) {
       VLOG(3) << "start no_varseqlen_trt_multihead_matmul_fuse_pass";
     } else {
       PADDLE_THROW(
-          phi::errors::Fatal("Use transformer'varseqlen need config: "
-                             "use_varseqlen, set pos_id, set "
-                             "mask_id. Or not use varseqlen, do not set "
-                             "pos_id. Please "
-                             "reconfig"));
+          common::errors::Fatal("Use transformer'varseqlen need config: "
+                                "use_varseqlen, set pos_id, set "
+                                "mask_id. Or not use varseqlen, do not set "
+                                "pos_id. Please "
+                                "reconfig"));
     }
     graph->Set(kMultiheadMatmulPass, new bool(true));
   }

--- a/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
+++ b/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
@@ -50,7 +50,7 @@ void CastDataTypeInplace(phi::DenseTensor *tensor) {
 void TrtRemoveAMPStrategyOpPass::ApplyImpl(Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
       graph,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "During the trt_remove_strategy_op_pass, the graph "
           "should not be null."));
   FusePassBase::Init("trt_remove_strategy_op_pass", graph);
@@ -143,8 +143,8 @@ void TrtRemoveAMPStrategyOpPass::ApplyImpl(Graph *graph) const {
       auto output_dtype = op_node->outputs[0]->Var()->GetDataType();
       if ((input_dtype == DataType::FP32 && output_dtype == DataType::FP16) ||
           (input_dtype == DataType::FP16 && output_dtype == DataType::FP32)) {
-        PADDLE_THROW(
-            phi::errors::Fatal("There are cast OPs remaining in the graph."));
+        PADDLE_THROW(common::errors::Fatal(
+            "There are cast OPs remaining in the graph."));
       }
     }
   }

--- a/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
@@ -100,7 +100,7 @@ namespace paddle::framework::ir {
 
 void TrtSkipLayerNormFusePass::ApplyImpl(ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("skip_layernorm_fuse", graph);
 
 #ifdef PADDLE_WITH_TENSORRT
@@ -246,7 +246,7 @@ void TrtSkipLayerNormFusePass::ApplyImpl(ir::Graph *graph) const {
           graph->Has(framework::ir::kMultiheadMatmulPass)) {
         VLOG(3) << "start varseqlen trt_skip_layernorm_fuse_pass";
       } else {
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "Use transformer'varseqlen need "
             "trt_embedding_eltwise_layernorm_fuse_pass, "
             "trt_multihead_matmul_fuse_pass. please use no_varseqlen"));
@@ -255,11 +255,11 @@ void TrtSkipLayerNormFusePass::ApplyImpl(ir::Graph *graph) const {
       VLOG(3) << "start no_varseqlen trt_skip_layernorm_fuse_pass";
     } else {
       PADDLE_THROW(
-          phi::errors::Fatal("Use transformer'varseqlen need config: "
-                             "use_varseqlen, set pos_id, set "
-                             "mask_id. Or not use varseqlen, do not set "
-                             "pos_id. Please "
-                             "reconfig"));
+          common::errors::Fatal("Use transformer'varseqlen need config: "
+                                "use_varseqlen, set pos_id, set "
+                                "mask_id. Or not use varseqlen, do not set "
+                                "pos_id. Please "
+                                "reconfig"));
     }
   }
   AddStatis(found_subgraph_count);

--- a/paddle/fluid/framework/ir/trt_support_nhwc_pass.cc
+++ b/paddle/fluid/framework/ir/trt_support_nhwc_pass.cc
@@ -148,7 +148,7 @@ bool IsWeight(ir::Node *op_node,
 
 void TrtSupportNHWCPass::ApplyImpl(Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(graph,
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "During the trt_support_nhwc_pass, the graph "
                               "should not be null."));
   FusePassBase::Init("trt_support_nhwc_pass", graph);
@@ -299,7 +299,7 @@ void TrtSupportNHWCPass::ApplyImpl(Graph *graph) const {
       UpdateWeightVars();
       UpdateOutputVars();
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "During the trt_support_nhwc_pass, %s op not supported. Please "
           "update the supported op lists.",
           op_desc->Type()));

--- a/paddle/fluid/framework/ir/vit_attention_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/vit_attention_fuse_pass.cc
@@ -134,7 +134,7 @@ void VitAttentionFusePass::ApplyImpl(ir::Graph* graph) const {
     PADDLE_ENFORCE_NE(
         subgraph.count(x),
         0,
-        phi::errors::NotFound("Detector did not find input x of conv2d."));
+        common::errors::NotFound("Detector did not find input x of conv2d."));
 
     IR_NODE_LINK_TO(subgraph.at(x), vit_attention_node);  // Input
     IR_NODE_LINK_TO(matmul0_in_y, vit_attention_node);

--- a/paddle/fluid/framework/ir/xpu/add_activation_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/add_activation_xpu_fuse_pass.cc
@@ -121,7 +121,7 @@ class AddActXPUFusePass : public FusePassBase {
 
 void AddActXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   int found_subgraph_count = 0;
@@ -151,7 +151,7 @@ int AddActXPUFusePass::ApplyImpl(ir::Graph* graph,
     auto* block = ele_add->Op()->Block();
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
     std::string fused_op_out_name;
     fused_op_out_name = act_out->Name();
     std::string fused_op_out_max_name = fused_op_out_name + "_max";

--- a/paddle/fluid/framework/ir/xpu/add_layernorm_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/add_layernorm_xpu_fuse_pass.cc
@@ -153,7 +153,7 @@ class AddLayernormXPUFusePass : public FusePassBase {
 
 void AddLayernormXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   FuseAddLayernorm(graph);
@@ -183,7 +183,7 @@ void AddLayernormXPUFusePass::FuseAddLayernorm(ir::Graph* graph) const {
     auto* block = l_norm->Op()->Block();
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
     auto x_shape = add_x->Var()->GetShape();
     auto x_rank = x_shape.size();
     auto y_shape = add_y->Var()->GetShape();

--- a/paddle/fluid/framework/ir/xpu/block_multihead_attention_xpu_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/block_multihead_attention_xpu_pass.cc
@@ -50,7 +50,7 @@ class BlockMultiHeadAttentionXPUPass : public FusePassBase {
 
 void BlockMultiHeadAttentionXPUPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   InplaceBlockMultiHeadAttentionXPU(graph);

--- a/paddle/fluid/framework/ir/xpu/bn_act_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/bn_act_xpu_fuse_pass.cc
@@ -113,7 +113,7 @@ class BNActXPUFusePass : public FusePassBase {
 
 void BNActXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   int found_subgraph_count = 0;
@@ -146,7 +146,7 @@ int BNActXPUFusePass::ApplyImpl(ir::Graph* graph,
     auto* block = bn->Op()->Block();
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
     std::string fused_op_out_name;
     fused_op_out_name = act_out->Name();
     // Generate fused op

--- a/paddle/fluid/framework/ir/xpu/cast_embedding_trans_ids_to_int32_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/cast_embedding_trans_ids_to_int32_pass.cc
@@ -86,7 +86,7 @@ class CastEmbeddingTransIdsToInt32Pass : public FusePassBase {
 };
 void CastEmbeddingTransIdsToInt32Pass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/xpu/cast_mixed_precision_op_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/cast_mixed_precision_op_fuse_pass.cc
@@ -222,7 +222,7 @@ int CastMixedPrecisionOpFusePass::ApplyCastAfterPass(
 
 void CastMixedPrecisionOpFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   int count = 0;

--- a/paddle/fluid/framework/ir/xpu/cast_mixed_precision_op_fuse_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/cast_mixed_precision_op_fuse_pass_test.cc
@@ -37,7 +37,7 @@ TEST(CastMixedPrecisionOpFusePass, cast_before) {
   PADDLE_ENFORCE_EQ(
       num,
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "cast op should be removed from graph, but graph still has %d ops.",
           num));
 }
@@ -59,7 +59,7 @@ TEST(CastMixedPrecisionOpFusePass, cast_after) {
   PADDLE_ENFORCE_EQ(
       num,
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "cast op should be removed from graph, but graph still has %d ops.",
           num));
 }

--- a/paddle/fluid/framework/ir/xpu/conv1d_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/conv1d_xpu_fuse_pass.cc
@@ -375,7 +375,7 @@ class Conv1dXPUFusePass : public FusePassBase {
 
 void Conv1dXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   int found_subgraph_count = 0;
@@ -464,7 +464,7 @@ int Conv1dXPUFusePass::ApplyImpl(ir::Graph* graph,
     auto* block = conv->Op()->Block();
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
     // recompute bias and weight for conv1d_xpu op
     // update shape of conv_filter
@@ -489,25 +489,25 @@ int Conv1dXPUFusePass::ApplyImpl(ir::Graph* graph,
         auto* ew_bias_add_y_t = scope->GetVar(ew_bias_add_y->Name())
                                     ->GetMutable<phi::DenseTensor>();
         auto ew_bias_add_y_dims = ew_bias_add_y_t->dims();
-        PADDLE_ENFORCE_EQ(
-            filter_dims[0],
-            ew_bias_add_y_dims[0],
-            phi::errors::InvalidArgument("the shape[%d] of elewise bias tensor "
-                                         "must equal out_channel[%d] of conv",
-                                         ew_bias_add_y_dims[0],
-                                         filter_dims[0]));
+        PADDLE_ENFORCE_EQ(filter_dims[0],
+                          ew_bias_add_y_dims[0],
+                          common::errors::InvalidArgument(
+                              "the shape[%d] of elewise bias tensor "
+                              "must equal out_channel[%d] of conv",
+                              ew_bias_add_y_dims[0],
+                              filter_dims[0]));
         PrepareBias(graph, scope, block, ew_bias_add_y, &fusion_bias_node);
       }
       if (with_bn) {
         auto bn_bias_t =
             scope->Var(bn_bias->Name())->GetMutable<phi::DenseTensor>();
-        PADDLE_ENFORCE_EQ(
-            filter_dims[0],
-            bn_bias_t->dims()[0],
-            phi::errors::InvalidArgument("the shape[%d] of bn bias tensor "
-                                         "must equal out_channel[%d] of conv",
-                                         bn_bias_t->dims()[0],
-                                         filter_dims[0]));
+        PADDLE_ENFORCE_EQ(filter_dims[0],
+                          bn_bias_t->dims()[0],
+                          common::errors::InvalidArgument(
+                              "the shape[%d] of bn bias tensor "
+                              "must equal out_channel[%d] of conv",
+                              bn_bias_t->dims()[0],
+                              filter_dims[0]));
         auto bn_scale_t =
             scope->Var(bn_scale->Name())->GetMutable<phi::DenseTensor>();
         auto bn_mean_t =

--- a/paddle/fluid/framework/ir/xpu/conv2d_bias_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/conv2d_bias_fuse_pass.cc
@@ -162,7 +162,7 @@ ScaleFusePattern::ScaleFusePattern(PDPattern* pattern,
 void Conv2dBiasFusePass::TransFcBias(ir::Graph* graph,
                                      const std::string& mul_type) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   GraphPatternDetector gpd;
   patterns::FcBiasPattern pattern(gpd.mutable_pattern(), name_scope_, mul_type);
@@ -199,7 +199,7 @@ void Conv2dBiasFusePass::TransFcBias(ir::Graph* graph,
 
 void Conv2dBiasFusePass::FoldConv2dBias(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   GraphPatternDetector gpd;
   patterns::Conv2dBiasPattern pattern(gpd.mutable_pattern(), name_scope_);
@@ -254,7 +254,7 @@ void Conv2dBiasFusePass::FuseScaleOps(ir::Graph* graph) const {
 
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
     // get attrs of scale from ele_mul && ele_add
     const auto& ele_mul_y_t =
         scope->GetVar(ele_mul_y->Name())->GetMutable<phi::DenseTensor>();
@@ -262,18 +262,18 @@ void Conv2dBiasFusePass::FuseScaleOps(ir::Graph* graph) const {
     PADDLE_ENFORCE_EQ(
         ele_mul_y_t_len,
         1,
-        phi::errors::InvalidArgument("the size(%ld) of ele_mul y tensor "
-                                     "must equal 1",
-                                     ele_mul_y_t_len));
+        common::errors::InvalidArgument("the size(%ld) of ele_mul y tensor "
+                                        "must equal 1",
+                                        ele_mul_y_t_len));
     const auto& ele_add_y_t =
         scope->GetVar(ele_add_y->Name())->GetMutable<phi::DenseTensor>();
     auto ele_add_y_t_len = ele_add_y_t->numel();
     PADDLE_ENFORCE_EQ(
         ele_add_y_t_len,
         1,
-        phi::errors::InvalidArgument("the size(%ld) of ele_add y tensor "
-                                     "must equal 1",
-                                     ele_mul_y_t_len));
+        common::errors::InvalidArgument("the size(%ld) of ele_add y tensor "
+                                        "must equal 1",
+                                        ele_mul_y_t_len));
     auto tensor_type = ele_mul_y_t->dtype();
     float scale_val_ = 1.f;
     float bias_val_ = 0.f;
@@ -311,7 +311,7 @@ void Conv2dBiasFusePass::FuseScaleOps(ir::Graph* graph) const {
 
 void Conv2dBiasFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   // for conv2d + scale fuse
   FuseScaleOps(graph);

--- a/paddle/fluid/framework/ir/xpu/conv2d_transpose_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/conv2d_transpose_xpu_fuse_pass.cc
@@ -232,7 +232,7 @@ class Conv2dTransposeXPUFusePass : public FusePassBase {
 
 void Conv2dTransposeXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   int found_subgraph_count = 0;
@@ -282,7 +282,7 @@ int Conv2dTransposeXPUFusePass::ApplyImpl(ir::Graph* graph,
     auto* block = conv->Op()->Block();
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
     // recompute bias and weight for conv2d_transpose_xpu op
     auto* filter_t =
@@ -303,13 +303,13 @@ int Conv2dTransposeXPUFusePass::ApplyImpl(ir::Graph* graph,
       auto* ew_bias_add_y_t =
           scope->FindVar(ew_bias_add_y->Name())->GetMutable<phi::DenseTensor>();
       auto ew_bias_add_y_dims = ew_bias_add_y_t->dims();
-      PADDLE_ENFORCE_EQ(
-          out_c,
-          ew_bias_add_y_dims[0],
-          phi::errors::InvalidArgument("the shape[%d] of elewise bias tensor "
-                                       "must equal out_channel[%d] of conv",
-                                       ew_bias_add_y_dims[0],
-                                       out_c));
+      PADDLE_ENFORCE_EQ(out_c,
+                        ew_bias_add_y_dims[0],
+                        common::errors::InvalidArgument(
+                            "the shape[%d] of elewise bias tensor "
+                            "must equal out_channel[%d] of conv",
+                            ew_bias_add_y_dims[0],
+                            out_c));
       PrepareBias(graph, scope, block, ew_bias_add_y, &fusion_bias_node);
     }
     // bn
@@ -319,10 +319,10 @@ int Conv2dTransposeXPUFusePass::ApplyImpl(ir::Graph* graph,
       PADDLE_ENFORCE_EQ(
           out_c,
           bn_bias_t->dims()[0],
-          phi::errors::InvalidArgument("the shape[%d] of bn bias tensor "
-                                       "must equal out_channel[%d] of conv",
-                                       bn_bias_t->dims()[0],
-                                       out_c));
+          common::errors::InvalidArgument("the shape[%d] of bn bias tensor "
+                                          "must equal out_channel[%d] of conv",
+                                          bn_bias_t->dims()[0],
+                                          out_c));
       auto bn_scale_t =
           scope->Var(bn_scale->Name())->GetMutable<phi::DenseTensor>();
       auto bn_mean_t =

--- a/paddle/fluid/framework/ir/xpu/cross_attention_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/cross_attention_xpu_fuse_pass.cc
@@ -324,7 +324,7 @@ void CrossAttentionXPUFusePass::PrepareQKVWeight(Graph* graph,
       // Share the same variable
       PADDLE_ENFORCE_NOT_NULL(
           scope->FindVar(w_max_name),
-          phi::errors::Fatal(
+          common::errors::Fatal(
               "w_max(%s) variable should not be nullptr if real_w(%s) "
               "variable is exist.",
               w_max_name,
@@ -334,7 +334,7 @@ void CrossAttentionXPUFusePass::PrepareQKVWeight(Graph* graph,
     *w_max = FindNodeWithName(graph, w_max_name);
     PADDLE_ENFORCE_NOT_NULL(
         *w_max,
-        phi::errors::Fatal(
+        common::errors::Fatal(
             "w_max(%s) variable should not be nullptr if real_w(%s) "
             "variable is exist.",
             w_max_name,
@@ -645,7 +645,7 @@ void CrossAttentionXPUFusePass::ApplyCrossAttentionXPUFuse(
 
 void CrossAttentionXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   for (auto with_q_scale : {true, false}) {

--- a/paddle/fluid/framework/ir/xpu/decoder_attention_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/decoder_attention_xpu_fuse_pass.cc
@@ -343,7 +343,7 @@ void DecoderAttentionXPUFusePass::ApplyDecoderAttentionXPUFuse(
 
 void DecoderAttentionXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   ApplyDecoderAttentionXPUFuse(graph);

--- a/paddle/fluid/framework/ir/xpu/delete_isolated_node_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/delete_isolated_node_pass.cc
@@ -62,7 +62,7 @@ class DeleteIsolatedNodePass : public Pass {
 
 void DeleteIsolatedNodePass::ApplyImpl(Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   if (!graph->IsMainGraph()) {
     VLOG(3) << "Pass(apply in main graph) will delete isolated nodes in all "
                "subgraphs.";

--- a/paddle/fluid/framework/ir/xpu/delete_isolated_node_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/delete_isolated_node_pass_test.cc
@@ -122,12 +122,12 @@ TEST(delete_isolated_node_pass, basic) {
   pass0->Apply(graph->GetSubGraph(1));
   int weight_node_num =
       WeightNodeNum(graph.get()) + WeightNodeNum(graph->GetSubGraph(1));
-  PADDLE_ENFORCE_EQ(
-      weight_node_num,
-      6,
-      phi::errors::PreconditionNotMet("Graph should have 6 weight node after "
-                                      "fc_xpu_fuse_pass, but actually has %d.",
-                                      weight_node_num));
+  PADDLE_ENFORCE_EQ(weight_node_num,
+                    6,
+                    common::errors::PreconditionNotMet(
+                        "Graph should have 6 weight node after "
+                        "fc_xpu_fuse_pass, but actually has %d.",
+                        weight_node_num));
 
   auto pass1 = PassRegistry::Instance().Get("delete_isolated_node_pass");
   pass1->Apply(graph.get());
@@ -135,14 +135,14 @@ TEST(delete_isolated_node_pass, basic) {
       WeightNodeNum(graph.get()) + WeightNodeNum(graph->GetSubGraph(1));
   PADDLE_ENFORCE_EQ(weight_node_num,
                     4,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Graph should have 4 weight node after "
                         "delete_isolated_node_pass, but actually has %d.",
                         weight_node_num));
   int weight_tensor_num = WeightTensorNum(scope);
   PADDLE_ENFORCE_EQ(weight_tensor_num,
                     2,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Scope should have 2 weight tensor after "
                         "delete_isolated_node_pass, but actually has %d.",
                         weight_tensor_num));
@@ -152,7 +152,7 @@ TEST(delete_isolated_node_pass, basic) {
       auto while_in_names = node->Op()->Inputs().at("X");
       PADDLE_ENFORCE_EQ(while_in_names.size(),
                         3,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "While op should have 3 input after "
                             "delete_isolated_node_pass, but actually has %d.",
                             while_in_names.size()));
@@ -169,7 +169,7 @@ TEST(delete_isolated_node_pass, basic) {
     auto* var1 = scope1.FindVar(name);
     PADDLE_ENFORCE(
         var0 == var1,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Variables with the same name in two scopes is different."));
   }
 }

--- a/paddle/fluid/framework/ir/xpu/duplicated_transpose_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/duplicated_transpose_fuse_pass.cc
@@ -118,7 +118,7 @@ void DuplicatedTransposeFusePass::DuplicatedTranspose(ir::Graph* graph) const {
 
 void DuplicatedTransposeFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   int repeat_time = 0;
   int total_delete_op_count = 0;

--- a/paddle/fluid/framework/ir/xpu/elementwise_mul_add_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/elementwise_mul_add_fuse_pass.cc
@@ -179,7 +179,7 @@ class ElementwiseMulAddFusePass : public FusePassBase {
 
 void ElementwiseMulAddFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   FuseElementwiseMulAdd(graph);

--- a/paddle/fluid/framework/ir/xpu/embedding_with_eltwise_add_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/embedding_with_eltwise_add_xpu_fuse_pass.cc
@@ -190,7 +190,7 @@ class EmbeddingWithEltwiseAddXPUFusePass : public FusePassBase {
 
 void EmbeddingWithEltwiseAddXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init(name_scope_, graph);
   std::vector<std::string> pre_op_types{"reshape2", "squeeze2", ""};
   std::vector<std::string> op_types{"lookup_table", "lookup_table_v2"};
@@ -216,11 +216,12 @@ void EmbeddingWithEltwiseAddXPUFusePass::ApplyImpl(
   PADDLE_ENFORCE_NE(                                                         \
       subgraph.count(pat.PatternBase::pattern->RetrieveNode(name)),          \
       0UL,                                                                   \
-      phi::errors::NotFound("Node not found for PDNode %s", name));          \
+      common::errors::NotFound("Node not found for PDNode %s", name));       \
   Node* rt_node = subgraph.at(pat.PatternBase::pattern->RetrieveNode(name)); \
   PADDLE_ENFORCE_NOT_NULL(                                                   \
       rt_node,                                                               \
-      phi::errors::NotFound("node %s not exists in the sub-graph", #rt_node));
+      common::errors::NotFound("node %s not exists in the sub-graph",        \
+                               #rt_node));
 
   auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
                      Graph* graph) {

--- a/paddle/fluid/framework/ir/xpu/fast_layernorm_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fast_layernorm_xpu_fuse_pass.cc
@@ -113,7 +113,7 @@ class FastLayernormXPUFusePass : public FusePassBase {
 
 void FastLayernormXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   FuseFastLayernorm(graph);
@@ -140,7 +140,7 @@ void FastLayernormXPUFusePass::FuseFastLayernorm(ir::Graph* graph) const {
     auto* block = l_norm->Op()->Block();
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
     // delete useless node
     std::unordered_set<const Node*> delete_nodes;

--- a/paddle/fluid/framework/ir/xpu/fast_where_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fast_where_xpu_fuse_pass.cc
@@ -317,7 +317,7 @@ OneFastWhereXPUPattern::OneFastWhereXPUPattern(PDPattern* pattern,
   PADDLE_ENFORCE_LE(
       mode,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "one_fast_where_xpu_fuse_pass mode(%d) is not supported.", mode));
   if (mode == 0) {
     mul0->LinksFrom({x, scale_out}).LinksTo({mul0_out});
@@ -455,7 +455,7 @@ CascadeFastWhereXPUPattern::CascadeFastWhereXPUPattern(
   PADDLE_ENFORCE_LE(
       mode,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cascade_fast_where_xpu_fuse_pass mode(%d) is not supported.", mode));
   if (mode == 0) {
     fast_where_xpu0_out->assert_is_op_input("fast_where_xpu", "y");
@@ -537,7 +537,7 @@ int OneFastWhereXPUFusePass::ApplySubgraph(ir::Graph* graph, int mode) const {
 
 void OneFastWhereXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   int found_subgraph_count = 0;
   for (auto mode : {0, 1}) {
@@ -615,7 +615,7 @@ int CascadeFastWhereXPUFusePass::ApplySubgraph(ir::Graph* graph,
 
 void CascadeFastWhereXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   int total_found_subgraph_count = 0;
   int cur_found_subgraph_count = 0;

--- a/paddle/fluid/framework/ir/xpu/fast_where_xpu_fuse_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/fast_where_xpu_fuse_pass_test.cc
@@ -30,20 +30,20 @@ namespace ir {
   PADDLE_ENFORCE_EQ(                                                          \
       num_op_nodes,                                                           \
       1,                                                                      \
-      phi::errors::PreconditionNotMet(                                        \
+      common::errors::PreconditionNotMet(                                     \
           "The graph contains only one op node, but %d op nodes found.",      \
           num_op_nodes));                                                     \
   auto fast_where_xpu_op_nodes = GetOpNodes(graph, "fast_where_xpu");         \
   PADDLE_ENFORCE_EQ(fast_where_xpu_op_nodes.size(),                           \
                     1,                                                        \
-                    phi::errors::PreconditionNotMet(                          \
+                    common::errors::PreconditionNotMet(                       \
                         "The graph contains only a fast_where_xpu op node, "  \
                         "but %d op nodes found.",                             \
                         fast_where_xpu_op_nodes.size()));                     \
   const auto& x_name = fast_where_xpu_op_nodes[0]->Op()->Input("x")[0];       \
   PADDLE_ENFORCE_EQ(x_name,                                                   \
                     #x,                                                       \
-                    phi::errors::PreconditionNotMet(                          \
+                    common::errors::PreconditionNotMet(                       \
                         "The input 'x' of fast_where_xpu op should be '%s', " \
                         "but receive '%s'.",                                  \
                         #x,                                                   \
@@ -51,7 +51,7 @@ namespace ir {
   const auto& y_name = fast_where_xpu_op_nodes[0]->Op()->Input("y")[0];       \
   PADDLE_ENFORCE_EQ(y_name,                                                   \
                     #y,                                                       \
-                    phi::errors::PreconditionNotMet(                          \
+                    common::errors::PreconditionNotMet(                       \
                         "The input 'y' of fast_where_xpu op should be '%s', " \
                         "but receive '%s'.",                                  \
                         #y,                                                   \
@@ -189,28 +189,28 @@ TEST(FastWhereXPUFusePass, one_case5) {
   PADDLE_ENFORCE_EQ(                                                          \
       num_op_nodes,                                                           \
       2,                                                                      \
-      phi::errors::PreconditionNotMet(                                        \
+      common::errors::PreconditionNotMet(                                     \
           "The graph contains only two op nodes, but %d op nodes found.",     \
           num_op_nodes));                                                     \
   auto logical_op_nodes = GetOpNodes(graph, #logical_op);                     \
   PADDLE_ENFORCE_EQ(                                                          \
       logical_op_nodes.size(),                                                \
       1,                                                                      \
-      phi::errors::PreconditionNotMet(                                        \
+      common::errors::PreconditionNotMet(                                     \
           "The graph contains only a '%s' op node, but %d op nodes found.",   \
           #logical_op,                                                        \
           logical_op_nodes.size()));                                          \
   auto fast_where_xpu_op_nodes = GetOpNodes(graph, "fast_where_xpu");         \
   PADDLE_ENFORCE_EQ(fast_where_xpu_op_nodes.size(),                           \
                     1,                                                        \
-                    phi::errors::PreconditionNotMet(                          \
+                    common::errors::PreconditionNotMet(                       \
                         "The graph contains only a fast_where_xpu op node, "  \
                         "but %d op nodes found.",                             \
                         fast_where_xpu_op_nodes.size()));                     \
   const auto& x_name = fast_where_xpu_op_nodes[0]->Op()->Input("x")[0];       \
   PADDLE_ENFORCE_EQ(x_name,                                                   \
                     #x,                                                       \
-                    phi::errors::PreconditionNotMet(                          \
+                    common::errors::PreconditionNotMet(                       \
                         "The input 'x' of fast_where_xpu op should be '%s', " \
                         "but receive '%s'.",                                  \
                         #x,                                                   \
@@ -218,7 +218,7 @@ TEST(FastWhereXPUFusePass, one_case5) {
   const auto& y_name = fast_where_xpu_op_nodes[0]->Op()->Input("y")[0];       \
   PADDLE_ENFORCE_EQ(y_name,                                                   \
                     #y,                                                       \
-                    phi::errors::PreconditionNotMet(                          \
+                    common::errors::PreconditionNotMet(                       \
                         "The input 'y' of fast_where_xpu op should be '%s', " \
                         "but receive '%s'.",                                  \
                         #y,                                                   \

--- a/paddle/fluid/framework/ir/xpu/fc_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fc_xpu_fuse_pass.cc
@@ -297,7 +297,7 @@ void FcXPUFusePass::CreateTheReplicatedWeights(
   PADDLE_ENFORCE_EQ(
       mul != nullptr,
       true,
-      phi::errors::InvalidArgument("mul node ptr can not be null"));
+      common::errors::InvalidArgument("mul node ptr can not be null"));
   auto mul_w_name = mul->Op()->Input("Y")[0];
   std::string replicated_w_name = mul_w_name + "_copy_" +
                                   std::to_string(block->ID()) + "_" +
@@ -335,22 +335,22 @@ Node* FcXPUFusePass::GetNodeFromNodesMap(
   PADDLE_ENFORCE_EQ(
       iter != nodes_map.end(),
       true,
-      phi::errors::InvalidArgument("nodes_map[%s] not found in nodes_map",
-                                   pattern_node_name.c_str()));
+      common::errors::InvalidArgument("nodes_map[%s] not found in nodes_map",
+                                      pattern_node_name.c_str()));
   auto node_map = iter->second;
   auto node_iter = node_map.find(node_name);
-  PADDLE_ENFORCE_EQ(
-      node_iter != node_map.end(),
-      true,
-      phi::errors::InvalidArgument("nodes_map[%s][%s] not found in nodes_map",
-                                   pattern_node_name.c_str(),
-                                   node_name.c_str()));
+  PADDLE_ENFORCE_EQ(node_iter != node_map.end(),
+                    true,
+                    common::errors::InvalidArgument(
+                        "nodes_map[%s][%s] not found in nodes_map",
+                        pattern_node_name.c_str(),
+                        node_name.c_str()));
   return node_iter->second;
 }
 
 void FcXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   int found_subgraph_count = 0;
@@ -393,7 +393,7 @@ void FcXPUFusePass::CreateFusionWeightsAndBias(
   PADDLE_ENFORCE_EQ(
       mul != nullptr,
       true,
-      phi::errors::InvalidArgument("mul node ptr can not be null"));
+      common::errors::InvalidArgument("mul node ptr can not be null"));
   auto mul_w_name = mul->Op()->Input("Y")[0];
   Node* mul_w = FindNodeWithName(graph, mul_w_name);
   CreateTheReplicatedWeights(graph, scope, block, nodes_map);
@@ -427,7 +427,7 @@ void FcXPUFusePass::CreateFusionWeightsAndBias(
         GetNodeFromNodesMap(nodes_map, "ew_bias_add", "ew_bias_add_bias");
     PADDLE_ENFORCE_EQ(ew_bias_add_bias != nullptr,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "ew_bias_add_bias node ptr can not be null"));
     PrepareBias(graph, scope, block, ew_bias_add_bias, &fusion_bias_node);
   }
@@ -437,27 +437,27 @@ void FcXPUFusePass::CreateFusionWeightsAndBias(
     PADDLE_ENFORCE_EQ(
         bn != nullptr,
         true,
-        phi::errors::InvalidArgument("bn node ptr can not be null"));
+        common::errors::InvalidArgument("bn node ptr can not be null"));
     auto* bn_bias = GetNodeFromNodesMap(nodes_map, "bn", "bn_bias");
     PADDLE_ENFORCE_EQ(
         bn_bias != nullptr,
         true,
-        phi::errors::InvalidArgument("bn_bias node ptr can not be null"));
+        common::errors::InvalidArgument("bn_bias node ptr can not be null"));
     auto* bn_scale = GetNodeFromNodesMap(nodes_map, "bn", "bn_scale");
     PADDLE_ENFORCE_EQ(
         bn_scale != nullptr,
         true,
-        phi::errors::InvalidArgument("bn_scale node ptr can not be null"));
+        common::errors::InvalidArgument("bn_scale node ptr can not be null"));
     auto* bn_var = GetNodeFromNodesMap(nodes_map, "bn", "bn_var");
     PADDLE_ENFORCE_EQ(
         bn_var != nullptr,
         true,
-        phi::errors::InvalidArgument("bn_var node ptr can not be null"));
+        common::errors::InvalidArgument("bn_var node ptr can not be null"));
     auto* bn_mean = GetNodeFromNodesMap(nodes_map, "bn", "bn_mean");
     PADDLE_ENFORCE_EQ(
         bn_mean != nullptr,
         true,
-        phi::errors::InvalidArgument("bn_mean node ptr can not be null"));
+        common::errors::InvalidArgument("bn_mean node ptr can not be null"));
 
     auto bn_bias_t =
         scope->Var(bn_bias->Name())->GetMutable<phi::DenseTensor>();
@@ -498,7 +498,7 @@ void FcXPUFusePass::CreateFusionWeightsAndBias(
       PADDLE_ENFORCE_EQ(
           weight_scale.size(),
           mean_len,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Weight max_scale size must equal batch_norm scale/mean size."));
       for (int i = 0; i < mean_len; i++) {
         weight_scale[i] *= fabs(bn_scale_ptr[i]);
@@ -625,7 +625,7 @@ void FcXPUFusePass::CreateFusionOutputs(
   PADDLE_ENFORCE_EQ(
       mul != nullptr,
       true,
-      phi::errors::InvalidArgument("mul node ptr can not be null"));
+      common::errors::InvalidArgument("mul node ptr can not be null"));
   // output && output max
   std::string fc_xpu_out_name;
   Node* fc_out_var_node = nullptr;
@@ -639,7 +639,7 @@ void FcXPUFusePass::CreateFusionOutputs(
     PADDLE_ENFORCE_EQ(
         act_out != nullptr,
         true,
-        phi::errors::InvalidArgument("act_out node ptr can not be null"));
+        common::errors::InvalidArgument("act_out node ptr can not be null"));
     fc_xpu_out_name = act_out->Name();
     fc_out_var_node = act_out;
   } else if (bn) {
@@ -647,7 +647,7 @@ void FcXPUFusePass::CreateFusionOutputs(
     PADDLE_ENFORCE_EQ(
         bn_out != nullptr,
         true,
-        phi::errors::InvalidArgument("bn_out node ptr can not be null"));
+        common::errors::InvalidArgument("bn_out node ptr can not be null"));
     fc_xpu_out_name = bn_out->Name();
     fc_out_var_node = bn_out;
   } else if (ew_bias_add) {
@@ -655,7 +655,7 @@ void FcXPUFusePass::CreateFusionOutputs(
         GetNodeFromNodesMap(nodes_map, "ew_bias_add", "ew_bias_add_out");
     PADDLE_ENFORCE_EQ(ew_bias_add_out != nullptr,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "ew_bias_add_out node ptr can not be null"));
     fc_xpu_out_name = ew_bias_add_out->Name();
     fc_out_var_node = ew_bias_add_out;
@@ -664,7 +664,7 @@ void FcXPUFusePass::CreateFusionOutputs(
     PADDLE_ENFORCE_EQ(
         mul_out != nullptr,
         true,
-        phi::errors::InvalidArgument("mul_out node ptr can not be null"));
+        common::errors::InvalidArgument("mul_out node ptr can not be null"));
     fc_xpu_out_name = mul_out->Name();
     fc_out_var_node = mul_out;
   }
@@ -722,19 +722,19 @@ void FcXPUFusePass::CreateFusionInputs(
   PADDLE_ENFORCE_EQ(
       mul != nullptr,
       true,
-      phi::errors::InvalidArgument("mul node ptr can not be null"));
+      common::errors::InvalidArgument("mul node ptr can not be null"));
   auto* mul_x = GetNodeFromNodesMap(nodes_map, "mul", "mul_x");
   PADDLE_ENFORCE_EQ(
       mul_x != nullptr,
       true,
-      phi::errors::InvalidArgument("mul_x node ptr can not be null"));
+      common::errors::InvalidArgument("mul_x node ptr can not be null"));
   // x max
   std::string mul_x_max_name = mul_x->Name() + "_input_max";
   Node* mul_x_max = nullptr;
   if (op_weights_precision == "int8") {
     PADDLE_ENFORCE_EQ(AreScalesPresentForNodes(var_quant_scales, {mul_x}),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "When fc op is running in int8 precision, the scales "
                           "of input var should be present in!"));
     float input_scale = GetScaleValueForNode(var_quant_scales, mul_x);
@@ -847,7 +847,7 @@ int FcXPUFusePass::ApplyImpl(ir::Graph* graph,
       auto* var = scope->FindVar(mul_w_name);
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::NotFound(
+          common::errors::NotFound(
               "The input persistable [%s] var of [%s] op is not found.",
               mul_w_name));
       auto* weight_tensor = var->GetMutable<phi::DenseTensor>();

--- a/paddle/fluid/framework/ir/xpu/fold_interp_outsize_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fold_interp_outsize_fuse_pass.cc
@@ -165,7 +165,7 @@ void FoldInterpOutsizeFusePass::FoldInterpOutsize(ir::Graph* graph) const {
 
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
     auto* concat_y_t =
         scope->GetVar(concat_y->Name())->GetMutable<phi::DenseTensor>();
@@ -202,7 +202,7 @@ void FoldInterpOutsizeFusePass::FoldInterpOutsize(ir::Graph* graph) const {
 
 void FoldInterpOutsizeFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   FoldInterpOutsize(graph);

--- a/paddle/fluid/framework/ir/xpu/fold_interp_outsize_fuse_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/fold_interp_outsize_fuse_pass_test.cc
@@ -47,7 +47,7 @@ TEST(FoldInterpOutsizeFusePass, basic) {
   PADDLE_ENFORCE_EQ(
       ops_num,
       1,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "graph should only have 2 op nodes, but received %d.", ops_num));
 }
 

--- a/paddle/fluid/framework/ir/xpu/fold_two_squeeze2_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fold_two_squeeze2_fuse_pass.cc
@@ -122,7 +122,7 @@ void FoldTwoSqueeze2FusePass::FoldTwoSqueeze2(ir::Graph* graph) const {
 
 void FoldTwoSqueeze2FusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   FoldTwoSqueeze2(graph);

--- a/paddle/fluid/framework/ir/xpu/fold_two_squeeze2_fuse_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/fold_two_squeeze2_fuse_pass_test.cc
@@ -34,7 +34,7 @@ TEST(FoldTwoSqueeze2FusePass, basic) {
   PADDLE_ENFORCE_EQ(
       ops_num,
       1,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "graph should only have 2 op nodes, but received %d.", ops_num));
 }
 

--- a/paddle/fluid/framework/ir/xpu/fused_multi_transformer_cachekv_layout_trans_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fused_multi_transformer_cachekv_layout_trans_pass.cc
@@ -92,7 +92,7 @@ FusedMultiTransformerGatherPattern::FusedMultiTransformerGatherPattern(
 void FusedMultiTransformerCacheKVLayoutTransPass::FillConstantReshapePass(
     ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   GraphPatternDetector gpd;
   patterns::FusedMultiTransformerFillConstantPattern pattern(
       gpd.mutable_pattern(), name_scope_);
@@ -141,7 +141,7 @@ void FusedMultiTransformerCacheKVLayoutTransPass::FillConstantReshapePass(
 int FusedMultiTransformerCacheKVLayoutTransPass::
     CountFillConstantReshapePattern(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   GraphPatternDetector gpd;
   patterns::FusedMultiTransformerFillConstantPattern pattern(
       gpd.mutable_pattern(), name_scope_);
@@ -166,7 +166,7 @@ int FusedMultiTransformerCacheKVLayoutTransPass::
 void FusedMultiTransformerCacheKVLayoutTransPass::GatherReshapePass(
     ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   GraphPatternDetector gpd;
   patterns::FusedMultiTransformerGatherPattern pattern(gpd.mutable_pattern(),
                                                        name_scope_);
@@ -211,7 +211,7 @@ void FusedMultiTransformerCacheKVLayoutTransPass::GatherReshapePass(
 int FusedMultiTransformerCacheKVLayoutTransPass::CountGatherReshapePattern(
     ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   GraphPatternDetector gpd;
   patterns::FusedMultiTransformerGatherPattern pattern(gpd.mutable_pattern(),
                                                        name_scope_);
@@ -238,7 +238,7 @@ int FusedMultiTransformerCacheKVLayoutTransPass::CountGatherReshapePattern(
 void FusedMultiTransformerCacheKVLayoutTransPass::ApplyImpl(
     ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   if (!graph->IsMainGraph()) {
     VLOG(3) << "'fused_multi_transformer_cachekv_layout_pass' needs info in "
                "all graphs, so it should be applied in the main graph.";

--- a/paddle/fluid/framework/ir/xpu/fused_multi_transformer_cachekv_layout_trans_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/fused_multi_transformer_cachekv_layout_trans_pass_test.cc
@@ -79,12 +79,12 @@ TEST(FillConstantReshapePass, basic) {
       "shape0", "shape1", "shape2", "shape3", "shape4"};
   PADDLE_ENFORCE_EQ(fill0_in_names,
                     expect_fill0_out_names,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "fill_constant name should not be updated."));
   auto fill1_in_names = fills[1]->Op()->Input("ShapeTensorList");
   PADDLE_ENFORCE_EQ(fill1_in_names,
                     expect_fill1_out_names,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "fill_constant name should not be updated."));
 }
 
@@ -112,7 +112,7 @@ TEST(GatherReshapePass, basic) {
   for (auto* gather : gathers) {
     PADDLE_ENFORCE_EQ(gather->Op()->GetAttrIfExists<int>("axis"),
                       1,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "gather's axis attr should not be updated by pass."));
   }
 }
@@ -162,21 +162,21 @@ TEST(FillConstantAndGatherReshapePass, basic) {
       "shape0", "shape3", "shape1", "shape2", "shape4"};
   std::vector<std::string> expect_fill1_out_names{
       "shape5", "shape8", "shape6", "shape7", "shape9"};
-  PADDLE_ENFORCE_EQ(
-      fill0_in_names,
-      expect_fill0_out_names,
-      phi::errors::PreconditionNotMet("fill_constant name should be updated."));
+  PADDLE_ENFORCE_EQ(fill0_in_names,
+                    expect_fill0_out_names,
+                    common::errors::PreconditionNotMet(
+                        "fill_constant name should be updated."));
   auto fill1_in_names = fills[1]->Op()->Input("ShapeTensorList");
-  PADDLE_ENFORCE_EQ(
-      fill1_in_names,
-      expect_fill1_out_names,
-      phi::errors::PreconditionNotMet("fill_constant name should be updated."));
+  PADDLE_ENFORCE_EQ(fill1_in_names,
+                    expect_fill1_out_names,
+                    common::errors::PreconditionNotMet(
+                        "fill_constant name should be updated."));
   auto gathers = GetOpNodes(graph, "gather");
   for (auto* gather : gathers) {
     PADDLE_ENFORCE_EQ(
         gather->Op()->GetAttrIfExists<int>("axis"),
         2,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "gather's axis attr should be updated to 2 by pass."));
   }
 }

--- a/paddle/fluid/framework/ir/xpu/fused_multi_transformer_int8_cachekv_layout_trans_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fused_multi_transformer_int8_cachekv_layout_trans_pass.cc
@@ -92,7 +92,7 @@ FusedMultiTransformerIng8GatherPattern::FusedMultiTransformerIng8GatherPattern(
 void FusedMultiTransformerInt8CacheKVLayoutTransPass::FillConstantReshapePass(
     ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   GraphPatternDetector gpd;
   patterns::FusedMultiTransformerInt8FillConstantPattern pattern(
       gpd.mutable_pattern(), name_scope_);
@@ -141,7 +141,7 @@ void FusedMultiTransformerInt8CacheKVLayoutTransPass::FillConstantReshapePass(
 int FusedMultiTransformerInt8CacheKVLayoutTransPass::
     CountFillConstantReshapePattern(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   GraphPatternDetector gpd;
   patterns::FusedMultiTransformerInt8FillConstantPattern pattern(
       gpd.mutable_pattern(), name_scope_);
@@ -166,7 +166,7 @@ int FusedMultiTransformerInt8CacheKVLayoutTransPass::
 void FusedMultiTransformerInt8CacheKVLayoutTransPass::GatherReshapePass(
     ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   GraphPatternDetector gpd;
   patterns::FusedMultiTransformerIng8GatherPattern pattern(
       gpd.mutable_pattern(), name_scope_);
@@ -211,7 +211,7 @@ void FusedMultiTransformerInt8CacheKVLayoutTransPass::GatherReshapePass(
 int FusedMultiTransformerInt8CacheKVLayoutTransPass::CountGatherReshapePattern(
     ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   GraphPatternDetector gpd;
   patterns::FusedMultiTransformerIng8GatherPattern pattern(
       gpd.mutable_pattern(), name_scope_);
@@ -238,7 +238,7 @@ int FusedMultiTransformerInt8CacheKVLayoutTransPass::CountGatherReshapePattern(
 void FusedMultiTransformerInt8CacheKVLayoutTransPass::ApplyImpl(
     ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   if (!graph->IsMainGraph()) {
     VLOG(3) << "'fused_multi_transformer_cachekv_layout_pass' needs info in "
                "all graphs, so it should be applied in the main graph.";

--- a/paddle/fluid/framework/ir/xpu/fused_multi_transformer_int8_cachekv_layout_trans_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/fused_multi_transformer_int8_cachekv_layout_trans_pass_test.cc
@@ -80,12 +80,12 @@ TEST(FillConstantReshapePass, basic) {
       "shape0", "shape1", "shape2", "shape3", "shape4"};
   PADDLE_ENFORCE_EQ(fill0_in_names,
                     expect_fill0_out_names,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "fill_constant name should not be updated."));
   auto fill1_in_names = fills[1]->Op()->Input("ShapeTensorList");
   PADDLE_ENFORCE_EQ(fill1_in_names,
                     expect_fill1_out_names,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "fill_constant name should not be updated."));
 }
 
@@ -113,7 +113,7 @@ TEST(GatherReshapePass, basic) {
   for (auto* gather : gathers) {
     PADDLE_ENFORCE_EQ(gather->Op()->GetAttrIfExists<int>("axis"),
                       1,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "gather's axis attr should not be updated by pass."));
   }
 }
@@ -164,21 +164,21 @@ TEST(FillConstantAndGatherReshapePass, basic) {
       "shape0", "shape3", "shape1", "shape2", "shape4"};
   std::vector<std::string> expect_fill1_out_names{
       "shape5", "shape8", "shape6", "shape7", "shape9"};
-  PADDLE_ENFORCE_EQ(
-      fill0_in_names,
-      expect_fill0_out_names,
-      phi::errors::PreconditionNotMet("fill_constant name should be updated."));
+  PADDLE_ENFORCE_EQ(fill0_in_names,
+                    expect_fill0_out_names,
+                    common::errors::PreconditionNotMet(
+                        "fill_constant name should be updated."));
   auto fill1_in_names = fills[1]->Op()->Input("ShapeTensorList");
-  PADDLE_ENFORCE_EQ(
-      fill1_in_names,
-      expect_fill1_out_names,
-      phi::errors::PreconditionNotMet("fill_constant name should be updated."));
+  PADDLE_ENFORCE_EQ(fill1_in_names,
+                    expect_fill1_out_names,
+                    common::errors::PreconditionNotMet(
+                        "fill_constant name should be updated."));
   auto gathers = GetOpNodes(graph, "gather");
   for (auto* gather : gathers) {
     PADDLE_ENFORCE_EQ(
         gather->Op()->GetAttrIfExists<int>("axis"),
         2,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "gather's axis attr should be updated to 2 by pass."));
   }
 }

--- a/paddle/fluid/framework/ir/xpu/fused_multi_transformer_int8_xpu_quant_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fused_multi_transformer_int8_xpu_quant_pass.cc
@@ -295,7 +295,7 @@ class FusedMultiTransformerInt8XPUQuantPass : public FusePassBase {
 
 void FusedMultiTransformerInt8XPUQuantPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   VLOG(3) << "in FusedMultiTransformerInt8XPUQuantPass::ApplyImpl";
 
@@ -488,7 +488,7 @@ int FusedMultiTransformerInt8XPUQuantPass::FusedMultiTransformerInt8(
           PADDLE_ENFORCE_NE(
               curr_tensor,
               nullptr,
-              phi::errors::Fatal("tensor node should not be nullptr"));
+              common::errors::Fatal("tensor node should not be nullptr"));
           // Create dst node
           // Update dst var_desc in block
           VarDesc dst_desc(dst_name);
@@ -545,7 +545,7 @@ int FusedMultiTransformerInt8XPUQuantPass::FusedMultiTransformerInt8(
         PADDLE_ENFORCE_NE(
             curr_tensor,
             nullptr,
-            phi::errors::Fatal("tensor node should not be nullptr"));
+            common::errors::Fatal("tensor node should not be nullptr"));
         CastToFp32(curr_tensor);
 
         Node* curr_node = FindNodeWithName(graph, name);

--- a/paddle/fluid/framework/ir/xpu/fused_multi_transformer_int8_xpu_quant_pass_tester.cc
+++ b/paddle/fluid/framework/ir/xpu/fused_multi_transformer_int8_xpu_quant_pass_tester.cc
@@ -126,11 +126,11 @@ TEST(RemoveAssignGather, basic) {
   auto gather_num = GetNumOpNodes(graph, "gather");
   PADDLE_ENFORCE_EQ(assign_num,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "assign op should be removed from the graph."));
   PADDLE_ENFORCE_EQ(gather_num,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "gather op should be removed from the graph."));
 }
 
@@ -190,7 +190,7 @@ TEST(FusedMultiTransformerInt8XPUQuantPass, context_stage) {
   PADDLE_ENFORCE_EQ(
       num_nodes_after,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After the fused_multi_transformer_int8_xpu_quant_pass, "
           "The node num in graph should be 1, but the result is %d",
           num_nodes_after));
@@ -252,7 +252,7 @@ TEST(FusedMultiTransformerInt8XPUQuantPass, decoder_stage) {
   PADDLE_ENFORCE_EQ(
       num_nodes_after,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After the fused_multi_transformer_int8_xpu_quant_pass, "
           "The node num in graph should be 1, but the result is %d",
           num_nodes_after));

--- a/paddle/fluid/framework/ir/xpu/fused_multi_transformer_xpu_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fused_multi_transformer_xpu_pass.cc
@@ -300,7 +300,7 @@ class FusedMultiTransformerXPUPass : public FusePassBase {
 
 void FusedMultiTransformerXPUPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   VLOG(3) << "in FusedMultiTransformerXPUPass::ApplyImpl";
 
@@ -420,9 +420,10 @@ int FusedMultiTransformerXPUPass::FusedMultiTransformerXPUQuant(
         Node* w_intx = nullptr;
         Node* w_max = nullptr;
         Node* scale_max = nullptr;
-        PADDLE_ENFORCE_NE(w_node,
-                          nullptr,
-                          phi::errors::Fatal("w node should not be nullptr"));
+        PADDLE_ENFORCE_NE(
+            w_node,
+            nullptr,
+            common::errors::Fatal("w node should not be nullptr"));
         if (quant_post_dynamic_weight_precision == 0) {
           PrepareWeight<float, int8_t>(graph,
                                        scope,
@@ -455,35 +456,35 @@ int FusedMultiTransformerXPUPass::FusedMultiTransformerXPUQuant(
       PADDLE_ENFORCE_EQ(
           w_names.size(),
           w_nodes->size(),
-          phi::errors::Fatal(
+          common::errors::Fatal(
               "The size of w_names(%d) should be equal to w_nodes(%d)",
               static_cast<int>(w_names.size()),
               static_cast<int>(w_nodes->size())));
       PADDLE_ENFORCE_EQ(
           w_names.size(),
           w_intx_nodes->size(),
-          phi::errors::Fatal(
+          common::errors::Fatal(
               "The size of w_names(%d) should be equal to w_intx_nodes(%d)",
               static_cast<int>(w_names.size()),
               static_cast<int>(w_intx_nodes->size())));
       PADDLE_ENFORCE_EQ(
           w_names.size(),
           w_max_nodes->size(),
-          phi::errors::Fatal(
+          common::errors::Fatal(
               "The size of w_names(%d) should be equal to w_max_nodes(%d)",
               static_cast<int>(w_names.size()),
               static_cast<int>(w_max_nodes->size())));
       PADDLE_ENFORCE_EQ(
           w_names.size(),
           w_intx_names->size(),
-          phi::errors::Fatal(
+          common::errors::Fatal(
               "The size of w_names(%d) should be equal to w_intx_names(%d)",
               static_cast<int>(w_names.size()),
               static_cast<int>(w_intx_names->size())));
       PADDLE_ENFORCE_EQ(
           w_names.size(),
           w_max_names->size(),
-          phi::errors::Fatal(
+          common::errors::Fatal(
               "The size of w_names(%d) should be equal to w_max_names(%d)",
               static_cast<int>(w_names.size()),
               static_cast<int>(w_max_names->size())));
@@ -526,7 +527,7 @@ int FusedMultiTransformerXPUPass::FusedMultiTransformerXPUQuant(
         PADDLE_ENFORCE_NE(
             curr_tensor,
             nullptr,
-            phi::errors::Fatal("tensor node should not be nullptr"));
+            common::errors::Fatal("tensor node should not be nullptr"));
         CastToFp32(curr_tensor);
 
         Node* curr_node = FindNodeWithName(graph, name);

--- a/paddle/fluid/framework/ir/xpu/fused_multi_transformer_xpu_pass_tester.cc
+++ b/paddle/fluid/framework/ir/xpu/fused_multi_transformer_xpu_pass_tester.cc
@@ -111,11 +111,11 @@ TEST(RemoveAssignGather, basic) {
   auto gather_num = GetNumOpNodes(graph, "gather");
   PADDLE_ENFORCE_EQ(assign_num,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "assign op should be removed from the graph."));
   PADDLE_ENFORCE_EQ(gather_num,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "gather op should be removed from the graph."));
 }
 
@@ -162,7 +162,7 @@ TEST(FusedMultiTransformerXPUPass, context_stage) {
   PADDLE_ENFORCE_EQ(
       num_nodes_after,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After the fuse_multi_transformer_layer_pass, "
           "The node num in graph should be 1, but the result is %d",
           num_nodes_after));
@@ -212,7 +212,7 @@ TEST(FusedMultiTransformerXPUPass, decoder_stage) {
   PADDLE_ENFORCE_EQ(
       num_nodes_after,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "After the fuse_multi_transformer_layer_pass, "
           "The node num in graph should be 1, but the result is %d",
           num_nodes_after));

--- a/paddle/fluid/framework/ir/xpu/gather_squeeze_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/gather_squeeze_pass.cc
@@ -72,7 +72,7 @@ GatherSqueeze::GatherSqueeze(PDPattern* pattern, const std::string& name_scope)
 
 void GatherSqueezePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   AddTranspose(graph);
@@ -80,7 +80,7 @@ void GatherSqueezePass::ApplyImpl(ir::Graph* graph) const {
 
 void GatherSqueezePass::AddTranspose(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   GraphPatternDetector gpd;
   patterns::GatherSqueeze pattern(gpd.mutable_pattern(), name_scope_);
 

--- a/paddle/fluid/framework/ir/xpu/generate_sequence_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/generate_sequence_xpu_fuse_pass.cc
@@ -131,7 +131,7 @@ class GenerateSequenceXPUFusePass : public FusePassBase {
 
 void GenerateSequenceXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   GraphPatternDetector gpd;
   patterns::GenerateSequenceXPUPattern pattern(gpd.mutable_pattern(),

--- a/paddle/fluid/framework/ir/xpu/group_norm_silu_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/group_norm_silu_xpu_fuse_pass.cc
@@ -128,7 +128,7 @@ class GroupNormalizeSiluXPUFusePass : public FusePassBase {
 
 void GroupNormalizeSiluXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   FuseGroupNormalizeSilu(graph);
@@ -159,7 +159,7 @@ void GroupNormalizeSiluXPUFusePass::FuseGroupNormalizeSilu(
     auto* block = gn->Op()->Block();
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
     // delete useless node
     std::unordered_set<const Node*> delete_nodes;
 

--- a/paddle/fluid/framework/ir/xpu/layer_norm_act_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/layer_norm_act_xpu_fuse_pass.cc
@@ -123,7 +123,7 @@ class LayerNormActXPUFusePass : public FusePassBase {
 
 void LayerNormActXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   int found_subgraph_count = 0;
@@ -154,7 +154,7 @@ int LayerNormActXPUFusePass::ApplyImpl(ir::Graph* graph,
     auto* block = layer_norm->Op()->Block();
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
     // delete useless node
     std::unordered_set<const Node*> delete_nodes;
 

--- a/paddle/fluid/framework/ir/xpu/link_xpu_op_max_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/link_xpu_op_max_pass.cc
@@ -268,7 +268,7 @@ void LinkXPUOpMaxPass::LinkFcMax(ir::Graph* graph) const {
 
 void LinkXPUOpMaxPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   LinkFcMax(graph);

--- a/paddle/fluid/framework/ir/xpu/matmul_weight_trans_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/matmul_weight_trans_pass.cc
@@ -145,7 +145,7 @@ void MatmulWeightTransPass::TransMatmulV2Weight(ir::Graph* graph) const {
 
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
     auto* matmul_y_t =
         scope->GetVar(matmul_y->Name())->GetMutable<phi::DenseTensor>();
@@ -182,7 +182,7 @@ void MatmulWeightTransPass::FuseTranspose2MatmulV2(ir::Graph* graph) const {
 
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
     matmul->Op()->RenameInput(matmul_y->Name(), transpose2_in->Name());
     matmul->Op()->SetAttr("trans_y", true);
@@ -202,7 +202,7 @@ void MatmulWeightTransPass::FuseTranspose2MatmulV2(ir::Graph* graph) const {
 
 void MatmulWeightTransPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   TransMatmulV2Weight(graph);

--- a/paddle/fluid/framework/ir/xpu/matmul_weight_trans_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/matmul_weight_trans_pass_test.cc
@@ -45,7 +45,7 @@ TEST(MatMulWeightTransPass, basic) {
   PADDLE_ENFORCE_EQ(
       trans_y,
       false,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The attribute of matmul_v2 trans_y should be false after pass"));
 }
 

--- a/paddle/fluid/framework/ir/xpu/multi_encoder_xpu_adaptive_seqlen_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/multi_encoder_xpu_adaptive_seqlen_fuse_pass.cc
@@ -458,7 +458,7 @@ int MultiEncoderXPUAdaptiveSeqlenFusePass::ApplyAdaptiveSeqlenPassV3(
 
 void MultiEncoderXPUAdaptiveSeqlenFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   std::vector<std::string> matmul_types{"matmul", "matmul_v2"};
   int found_subgraph_count = 0;

--- a/paddle/fluid/framework/ir/xpu/multi_encoder_xpu_adaptive_seqlen_fuse_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/multi_encoder_xpu_adaptive_seqlen_fuse_pass_test.cc
@@ -49,7 +49,7 @@ TEST(MultiEncoderXPUAdaptiveSeqlenFusePass, V1) {
   PADDLE_ENFORCE_EQ(
       num,
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "matmul/scale/stack ops should be removed from graph, but graph "
           "still has %d ops.",
           num));
@@ -91,7 +91,7 @@ TEST(MultiEncoderXPUAdaptiveSeqlenFusePass, V2) {
              GetNumOpNodes(graph, "tile");
   PADDLE_ENFORCE_EQ(num,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "not_equal/cast/unsqueeze2/matmul_v2/scale ops should "
                         "be removed from graph, but graph "
                         "still has %d ops.",

--- a/paddle/fluid/framework/ir/xpu/multi_encoder_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/multi_encoder_xpu_fuse_pass.cc
@@ -620,7 +620,7 @@ SingleEncoderXPUPattern::SingleEncoderXPUPattern(
 
 void MultiEncoderXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   int single_encoder_fused_counts = 0;
@@ -703,7 +703,7 @@ void MultiEncoderXPUFusePass::PrepareInputMax(
       PADDLE_ENFORCE_GT(
           gelu_out_threshold,
           0.f,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "QUANT_GELU_OUT_THRESHOLD should be an positive float value: %f",
               gelu_out_threshold));
     }
@@ -920,7 +920,7 @@ void MultiEncoderXPUFusePass::PrepareQKVWeight(
       // Share the same variable
       PADDLE_ENFORCE_NOT_NULL(
           scope->FindVar(qkv_w_max_name),
-          phi::errors::Fatal(
+          common::errors::Fatal(
               "qkv_w_max(%s) variable should not be nullptr if qkv_w_intx(%s) "
               "variable is exist.",
               qkv_w_max_name,
@@ -928,18 +928,18 @@ void MultiEncoderXPUFusePass::PrepareQKVWeight(
       if (is_per_channel) {
         PADDLE_ENFORCE_NOT_NULL(
             scope->FindVar(qkv_scale_max_name),
-            phi::errors::Fatal("qkv_scale_max(%s) variable should not be "
-                               "nullptr if qkv_w_intx(%s) "
-                               "variable is exist.",
-                               qkv_scale_max_name,
-                               qkv_w_intx_name));
+            common::errors::Fatal("qkv_scale_max(%s) variable should not be "
+                                  "nullptr if qkv_w_intx(%s) "
+                                  "variable is exist.",
+                                  qkv_scale_max_name,
+                                  qkv_w_intx_name));
       }
     }
   } else {
     *qkv_w_max = FindNodeWithName(graph, qkv_w_max_name);
     PADDLE_ENFORCE_NOT_NULL(
         *qkv_w_max,
-        phi::errors::Fatal(
+        common::errors::Fatal(
             "qkv_w_max(%s) variable should not be nullptr if qkv_w_intx(%s) "
             "variable is exist.",
             qkv_w_max_name,

--- a/paddle/fluid/framework/ir/xpu/multi_encoder_xpu_slice_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/multi_encoder_xpu_slice_fuse_pass.cc
@@ -110,7 +110,7 @@ class MultiEncoderXPUSliceFusePass : public FusePassBase {
 
 void MultiEncoderXPUSliceFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   GraphPatternDetector gpd;
   patterns::MultiEncoderXPUSlicePattern pattern(gpd.mutable_pattern(),

--- a/paddle/fluid/framework/ir/xpu/one_beam_size_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/one_beam_size_fuse_pass.cc
@@ -572,7 +572,7 @@ void OneBeamSizeFusePass::RemoveGatherOps(ir::Graph* graph) const {
 
 void OneBeamSizeFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   if (!OnlyOneBeamSearchAndOneBeamSize(graph)) return;

--- a/paddle/fluid/framework/ir/xpu/one_beam_size_fuse_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/one_beam_size_fuse_pass_test.cc
@@ -83,11 +83,11 @@ TEST(RemoveAssignGather, basic) {
   auto gather_num = GetNumOpNodes(graph, "gather");
   PADDLE_ENFORCE_EQ(assign_num,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "assign op should be removed from the graph."));
   PADDLE_ENFORCE_EQ(gather_num,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "gather op should be removed from the graph."));
 }
 
@@ -121,7 +121,7 @@ TEST(FoldShapeAssociatedOps, basic) {
   PADDLE_ENFORCE_EQ(
       ops_num,
       2,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "graph should only have 2 op nodes, but received %d.", ops_num));
 }
 
@@ -158,7 +158,7 @@ TEST(RemoveBeamSearchAssociatedOps, basic) {
   auto beam_search_num = GetNumOpNodes(graph, "beam_search");
   PADDLE_ENFORCE_EQ(beam_search_num,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "beam_search op should be removed from the graph."));
 }
 
@@ -185,7 +185,7 @@ TEST(RemoveWriteReadArrayOps, basic) {
                         GetNumOpNodes(graph, "read_from_array");
   PADDLE_ENFORCE_EQ(write_read_num,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "write_to_array and read_from_array ops should be "
                         "removed from the graph."));
 }
@@ -210,7 +210,7 @@ TEST(RemoveGatherOps, basic) {
   auto gather_num = GetNumOpNodes(graph, "gather");
   PADDLE_ENFORCE_EQ(gather_num,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "gather op should be removed from the graph."));
 }
 

--- a/paddle/fluid/framework/ir/xpu/pad2d_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/pad2d_xpu_fuse_pass.cc
@@ -151,7 +151,7 @@ class Pad2dXpuFusePattern : public FusePassBase {
 
 void Pad2dXpuFusePattern::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   int found_subgraph_count = 0;
   found_subgraph_count += FusedUnsqueezePadOps(graph);
@@ -176,7 +176,7 @@ int Pad2dXpuFusePattern::FusedUnsqueezePadOps(ir::Graph* graph) const {
 
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
     // pad2d
     auto* block = pad3d->Op()->Block();

--- a/paddle/fluid/framework/ir/xpu/pass_utils.cc
+++ b/paddle/fluid/framework/ir/xpu/pass_utils.cc
@@ -57,7 +57,7 @@ int ConvertActivationType(std::string act_type) {
   } else if (act_type == "relu6") {
     return static_cast<int>(xpu::Activation_t::RELU6);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Not support convert activation_type(%s).", act_type));
   }
   return -1;
@@ -91,7 +91,7 @@ std::vector<Node*> FindOpNodeByInputName(Graph* graph,
 
 template <typename T>
 std::string IntTypeToString() {
-  PADDLE_THROW(phi::errors::InvalidArgument("Not support type."));
+  PADDLE_THROW(common::errors::InvalidArgument("Not support type."));
   return "";
 }
 
@@ -257,23 +257,23 @@ void PrepareWeight(Graph* graph,
       // Share the same variable
       PADDLE_ENFORCE_NOT_NULL(
           scope->FindVar(dst_weight_max_name),
-          phi::errors::Fatal("dst_weight_max(%s) variable should not be "
-                             "nullptr if dst_weight(%s) "
-                             "variable is exist. (weight_name is %s)",
-                             dst_weight_max_name,
-                             dst_weight_name,
-                             weight_name));
+          common::errors::Fatal("dst_weight_max(%s) variable should not be "
+                                "nullptr if dst_weight(%s) "
+                                "variable is exist. (weight_name is %s)",
+                                dst_weight_max_name,
+                                dst_weight_name,
+                                weight_name));
     }
   } else {
     *dst_weight_max = FindNodeWithName(graph, dst_weight_max_name);
     PADDLE_ENFORCE_NOT_NULL(
         *dst_weight_max,
-        phi::errors::Fatal("dst_weight_max(%s) variable should not be "
-                           "nullptr if dst_weight(%s) "
-                           "variable is exist. (weight_name is %s)",
-                           dst_weight_max_name,
-                           dst_weight_name,
-                           weight_name));
+        common::errors::Fatal("dst_weight_max(%s) variable should not be "
+                              "nullptr if dst_weight(%s) "
+                              "variable is exist. (weight_name is %s)",
+                              dst_weight_max_name,
+                              dst_weight_name,
+                              weight_name));
   }
 
   if (dst_scale_max_tensor.initialized()) {
@@ -303,12 +303,12 @@ void PrepareWeight(Graph* graph,
         // Share the same variable
         PADDLE_ENFORCE_NOT_NULL(
             scope->FindVar(dst_scale_max_name),
-            phi::errors::Fatal("dst_scale_max(%s) variable should not be "
-                               "nullptr if dst_weight(%s) "
-                               "variable is exist. (weight_name is %s)",
-                               dst_scale_max_name,
-                               dst_weight_name,
-                               weight_name));
+            common::errors::Fatal("dst_scale_max(%s) variable should not be "
+                                  "nullptr if dst_weight(%s) "
+                                  "variable is exist. (weight_name is %s)",
+                                  dst_scale_max_name,
+                                  dst_weight_name,
+                                  weight_name));
       }
     }
   }

--- a/paddle/fluid/framework/ir/xpu/pass_utils.h
+++ b/paddle/fluid/framework/ir/xpu/pass_utils.h
@@ -29,17 +29,17 @@ namespace ir {
 // var: variable.
 // arg: the argument declared by PATTERN_DECL_NODE in a pattern definition.
 // pat: the pattern object.
-#define SAFE_GET_IR_NODE_FROM_SUBGRAPH(var, arg, pat)                        \
-  Node* var = nullptr;                                                       \
-  if (pat.arg##_n()) {                                                       \
-    PADDLE_ENFORCE_NE(subgraph.count(pat.arg##_n()),                         \
-                      0UL,                                                   \
-                      phi::errors::NotFound("Node not found for PDNode %s",  \
-                                            pat.arg##_repr()));              \
-    var = subgraph.at(pat.arg##_n());                                        \
-    PADDLE_ENFORCE_NOT_NULL(                                                 \
-        var,                                                                 \
-        phi::errors::NotFound("node %s not exists in the sub-graph", #arg)); \
+#define SAFE_GET_IR_NODE_FROM_SUBGRAPH(var, arg, pat)                          \
+  Node* var = nullptr;                                                         \
+  if (pat.arg##_n()) {                                                         \
+    PADDLE_ENFORCE_NE(subgraph.count(pat.arg##_n()),                           \
+                      0UL,                                                     \
+                      common::errors::NotFound("Node not found for PDNode %s", \
+                                               pat.arg##_repr()));             \
+    var = subgraph.at(pat.arg##_n());                                          \
+    PADDLE_ENFORCE_NOT_NULL(var,                                               \
+                            common::errors::NotFound(                          \
+                                "node %s not exists in the sub-graph", #arg)); \
   }
 
 #define SAFE_IR_NODE_LINK_TO(a, b)    \

--- a/paddle/fluid/framework/ir/xpu/qk_qkv_attention_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/qk_qkv_attention_xpu_fuse_pass.cc
@@ -338,7 +338,7 @@ void QkQkvAttentionXPUFusePass::ApplyQkQkvAttentionXPUFuse(
 
 void QkQkvAttentionXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   for (auto with_q_scale : {true, false}) {

--- a/paddle/fluid/framework/ir/xpu/quant_dequant_xpu_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/quant_dequant_xpu_pass.cc
@@ -66,7 +66,7 @@ void QuantDequantXPUPass::CollectWeightScalesInfoFromDequantize(
         auto* var = scope->FindVar(scale_name);
         PADDLE_ENFORCE_NOT_NULL(
             var,
-            phi::errors::NotFound(
+            common::errors::NotFound(
                 "The Scales variable [%s] of dequantize op is not found.",
                 var));
 
@@ -100,7 +100,7 @@ void QuantDequantXPUPass::CollectWeightScalesInfoFromONNXFormatDequantize(
       auto* var = scope->FindVar(scale_name);
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::NotFound(
+          common::errors::NotFound(
               "The Scales variable [%s] of dequantize op is not found.", var));
 
       auto* scale_tensor = var->GetMutable<phi::DenseTensor>();
@@ -150,9 +150,9 @@ void QuantDequantXPUPass::CollectInputScalesFromQuantize(
       PADDLE_ENFORCE_EQ(
           bit_length,
           8,
-          phi::errors::InvalidArgument("Unsupported number quantization "
-                                       "bits: %d, only 8 is supported now.",
-                                       bit_length));
+          common::errors::InvalidArgument("Unsupported number quantization "
+                                          "bits: %d, only 8 is supported now.",
+                                          bit_length));
 
       std::string scale_name = "InScale";
       std::string out_name = "Out";
@@ -167,7 +167,7 @@ void QuantDequantXPUPass::CollectInputScalesFromQuantize(
       auto* var = scope->FindVar(scale_var_name);
       PADDLE_ENFORCE_NOT_NULL(
           var,
-          phi::errors::NotFound(
+          common::errors::NotFound(
               "The InScale variable [%s] of quantize op is not found.", var));
 
       auto* scale_tensor = var->GetMutable<phi::DenseTensor>();
@@ -259,12 +259,12 @@ void QuantDequantXPUPass::CollectFakeQuantizeOps(
 
   PADDLE_ENFORCE_NOT_NULL(
       fake_quant_in,
-      phi::errors::NotFound("The input var [%s] of quantize op is not found.",
-                            x_var_name));
+      common::errors::NotFound(
+          "The input var [%s] of quantize op is not found.", x_var_name));
   PADDLE_ENFORCE_NOT_NULL(
       fake_quant_out,
-      phi::errors::NotFound("The output var [%s] of quantize op is not found.",
-                            out_var_name));
+      common::errors::NotFound(
+          "The output var [%s] of quantize op is not found.", out_var_name));
 
   std::string input_act_name = fake_quant_in->Var()->Name();
   std::string output_act_name = fake_quant_out->Var()->Name();
@@ -307,11 +307,11 @@ void QuantDequantXPUPass::CollectFakeDequantizeOps(
 
   PADDLE_ENFORCE_NOT_NULL(
       fake_dequant_in,
-      phi::errors::NotFound("The input var [%s] of dequantize op is not found.",
-                            x_var_name));
+      common::errors::NotFound(
+          "The input var [%s] of dequantize op is not found.", x_var_name));
   PADDLE_ENFORCE_NOT_NULL(
       fake_dequant_out,
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "The output var [%s] of dequantize op is not found.", out_var_name));
 
   std::string input_act_name = fake_dequant_in->Var()->Name();
@@ -355,16 +355,16 @@ void QuantDequantXPUPass::CollectQuantizeDequantizeOpsFromONNXFormat(
 
   PADDLE_ENFORCE_NOT_NULL(
       fake_quant_in,
-      phi::errors::NotFound("The input var [%s] of quantize op is not found.",
-                            x_var_name));
+      common::errors::NotFound(
+          "The input var [%s] of quantize op is not found.", x_var_name));
   PADDLE_ENFORCE_NOT_NULL(
       fake_quant_in_scale,
-      phi::errors::NotFound("The scale var [%s] of quantize op is not found.",
-                            in_scale_name));
+      common::errors::NotFound(
+          "The scale var [%s] of quantize op is not found.", in_scale_name));
   PADDLE_ENFORCE_NOT_NULL(
       fake_quant_out,
-      phi::errors::NotFound("The output var [%s] of quantize op is not found.",
-                            out_var_name));
+      common::errors::NotFound(
+          "The output var [%s] of quantize op is not found.", out_var_name));
 
   std::string input_act_name = fake_quant_in->Var()->Name();
   std::string output_act_name = fake_quant_out->Var()->Name();
@@ -416,7 +416,7 @@ void QuantDequantXPUPass::RestoreWeightsToInt8(
     auto* var = scope->FindVar(weight_var_name);
     PADDLE_ENFORCE_NOT_NULL(
         var,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "The input persistable [%s] var of [%s] op is not found.",
             weight_var_name));
     auto* weight_tensor = var->GetMutable<phi::DenseTensor>();

--- a/paddle/fluid/framework/ir/xpu/quant_utils.cc
+++ b/paddle/fluid/framework/ir/xpu/quant_utils.cc
@@ -45,7 +45,7 @@ void Transpose2D(phi::DenseTensor* in, phi::DenseTensor* out) {
   PADDLE_ENFORCE_EQ(
       in_dims.size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "In dims rank should be 2, but received in dims size is [%d].",
           in_dims.size()));
 
@@ -72,7 +72,7 @@ void Transpose2D(phi::DenseTensor* in, phi::DenseTensor* out) {
       phi::TransposeKernel<int8_t>(*cpu_ctx, *in, axis, out_ptr);
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Only support fp16/fp32/int16/int8, but received dtype is %s.",
           phi::DataTypeToString(in->dtype())));
       break;
@@ -105,7 +105,7 @@ void CastToInt32(phi::DenseTensor* in, phi::DenseTensor* out) {
       }
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Only support int64 and int32, but received dtype is %s.",
           phi::DataTypeToString(in->dtype())));
       break;
@@ -121,7 +121,7 @@ void CastTo(phi::DenseTensor* in, phi::DenseTensor* out, DataType out_dtype) {
 
   if (in->dtype() != phi::DataType::FLOAT16 &&
       in->dtype() != phi::DataType::FLOAT32) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Only support fp16 and fp32, but received dtype is %s.",
         phi::DataTypeToString(in->dtype())));
   }
@@ -248,7 +248,7 @@ static void QuantFP32ToIntX(const float* src_ptr,
                             T* dst_ptr,
                             float max_val,
                             int numel) {
-  PADDLE_THROW(phi::errors::Unimplemented("Not support."));
+  PADDLE_THROW(common::errors::Unimplemented("Not support."));
 }
 
 template <>
@@ -292,7 +292,7 @@ void ConvertWithQuant(phi::DenseTensor* weight,
                       bool per_channel_quant) {
   std::stringstream ss;
   ss << "Not support for Tcpu is " << phi::CppTypeToDataType<Tcpu>::Type();
-  PADDLE_THROW(phi::errors::Fatal(ss.str()));
+  PADDLE_THROW(common::errors::Fatal(ss.str()));
 }
 
 template <
@@ -389,7 +389,7 @@ void ConvertWithoutQuant(phi::DenseTensor* weight,
     PADDLE_ENFORCE_EQ(
         weight_scales.empty(),
         false,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "ConvertWithoutQuant is not allowed weight scales is empty!"));
     auto* cpu_ctx = static_cast<phi::CPUContext*>(
         phi::DeviceContextPool::Instance().Get(phi::CPUPlace()));
@@ -441,7 +441,7 @@ void ConvertWithoutQuant(phi::DenseTensor* weight,
     QuantFP32ToIntX<float>(
         weight_data, cpu_ctx->Alloc<float>(weight), max_val, size);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Only support float<->int31, int8<->int8 and int16<->int16 convert."));
   }
 }
@@ -477,7 +477,7 @@ bool IsPerTensorQuant(const std::vector<float>& weight_max) {
   PADDLE_ENFORCE_GT(
       weight_max.size(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op's channel size: [%d] should great than zero", weight_max.size()));
   auto first = weight_max[0];
   for (size_t i = 1; i < weight_max.size(); ++i) {

--- a/paddle/fluid/framework/ir/xpu/reduce_ops_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/reduce_ops_fuse_pass.cc
@@ -317,7 +317,7 @@ void ReduceOpsFusePass::FuseReduceMean(ir::Graph* graph) const {
 
 void ReduceOpsFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   FuseReduceMax(graph);

--- a/paddle/fluid/framework/ir/xpu/redundant_squeeze_unsqueeze_elimination_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/redundant_squeeze_unsqueeze_elimination_pass.cc
@@ -283,7 +283,7 @@ class SqueezeActivationUnsqueezeEliminationPass : public FusePassBase {
 void SqueezeActivationUnsqueezeEliminationPass::ApplyImpl(
     ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   std::vector<std::string> support_act_type{"relu",
                                             "sigmoid",
@@ -322,7 +322,7 @@ int SqueezeActivationUnsqueezeEliminationPass::ApplyImpl(
 
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
     // Judge squeeze1 && squeeze2 op shape is same or not, if axes is same, the
     // shape is same too.
     std::vector<int> squeeze_axes =
@@ -372,7 +372,7 @@ class CustomSqueezeUnsqueezeEliminationPass : public FusePassBase {
 
 void CustomSqueezeUnsqueezeEliminationPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   std::vector<std::string> support_act_type{"relu",
                                             "sigmoid",
@@ -436,7 +436,7 @@ int CustomSqueezeUnsqueezeEliminationPass::ApplyImpl(
 
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
     std::unordered_set<const Node*> delete_nodes;
     // Judge squeeze1 && squeeze2 op shape is same or not, if axes is same, the
     // shape is same too.

--- a/paddle/fluid/framework/ir/xpu/redundant_unsqueeze_squeeze_elimination_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/redundant_unsqueeze_squeeze_elimination_pass.cc
@@ -468,7 +468,7 @@ void RedundantUnsqueeze2EliminationPass::FoldGatherSqueeze2Ops(
 
 void RedundantUnsqueeze2EliminationPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   for (auto act_type : {"relu"}) {
     FoldTranspose2Ops(graph, act_type);

--- a/paddle/fluid/framework/ir/xpu/reshape2_matmul_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/reshape2_matmul_xpu_fuse_pass.cc
@@ -247,7 +247,7 @@ void Reshape2MatmulXPUFusePass::FuseReshape2Matmul(ir::Graph* graph) const {
 
 void Reshape2MatmulXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   FuseReshape2Matmul(graph);
@@ -300,7 +300,7 @@ void MapMatmulV2ToMatmulXPUPass::MapMatmulV2ToMatmul(ir::Graph* graph) const {
 
 void MapMatmulV2ToMatmulXPUPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   MapMatmulV2ToMatmul(graph);
@@ -353,7 +353,7 @@ void Squeeze2MatmulXPUFusePass::FuseSqueeze2Matmul(ir::Graph* graph) const {
 
 void Squeeze2MatmulXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   FuseSqueeze2Matmul(graph);

--- a/paddle/fluid/framework/ir/xpu/reshape2_matmul_xpu_fuse_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/reshape2_matmul_xpu_fuse_pass_test.cc
@@ -44,7 +44,7 @@ TEST(Squeeze2MatmulXPUFusePass, basic) {
   PADDLE_ENFORCE_EQ(
       ops_num,
       3,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "graph should only have 2 op nodes, but received %d.", ops_num));
 }
 
@@ -70,7 +70,7 @@ TEST(ReShape2MatmulXPUFusePass, basic) {
   PADDLE_ENFORCE_EQ(
       ops_num,
       3,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "graph should only have 2 op nodes, but received %d.", ops_num));
 }
 
@@ -93,7 +93,7 @@ TEST(MapMatmulV2ToMatmulXPUPass, basic) {
     PADDLE_ENFORCE_EQ(
         std::abs(matmul->Op()->GetAttrIfExists<float>("alpha") - 1.f) < 1e-5f,
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "matmul_v2 is mapped to matmul by pass."));
   }
 }

--- a/paddle/fluid/framework/ir/xpu/reshape_unstack_concat_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/reshape_unstack_concat_fuse_pass.cc
@@ -156,7 +156,7 @@ Optimized subgraph:
 // clang-format on
 void ReshapeUnstackConcatFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   GraphPatternDetector gpd;
   patterns::ReshapeUnstackConcatPattern pattern(gpd.mutable_pattern(),

--- a/paddle/fluid/framework/ir/xpu/roformer_relative_pos_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/roformer_relative_pos_fuse_pass.cc
@@ -200,7 +200,7 @@ class RoformerRelativePosFusePass : public FusePassBase {
 
 void RoformerRelativePosFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   GraphPatternDetector gpd;
@@ -240,7 +240,7 @@ void RoformerRelativePosFusePass::ApplyImpl(ir::Graph* graph) const {
     auto* block = add->Op()->Block();
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
     // Generate roformer_relative_embedding_xpu fused op
     framework::OpDesc fused_op_desc(block);
     fused_op_desc.SetType("roformer_relative_embedding_xpu");

--- a/paddle/fluid/framework/ir/xpu/sine_pos_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/sine_pos_fuse_pass.cc
@@ -206,7 +206,7 @@ class SinePosFusePass : public FusePassBase {
 
 void SinePosFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   GraphPatternDetector gpd;
@@ -237,7 +237,7 @@ void SinePosFusePass::ApplyImpl(ir::Graph* graph) const {
     auto* block = flatten->Op()->Block();
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
     // Generate sine_pos_xpu fused op
     framework::OpDesc fused_op_desc(block);
     fused_op_desc.SetType("sine_pos_xpu");

--- a/paddle/fluid/framework/ir/xpu/spatial_transformer_resblock_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/spatial_transformer_resblock_xpu_fuse_pass.cc
@@ -329,7 +329,7 @@ class SpatialTransformerResBlockXPUFusePass : public FusePassBase {
 
 void SpatialTransformerResBlockXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   int found_subgraph_count = 0;
   for (auto conv_fix : {false, true}) {
@@ -411,7 +411,7 @@ int SpatialTransformerResBlockXPUFusePass::FuseSpatialTransformerResBlock(
     auto* block = gn_silu_1->Op()->Block();
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
     // delete useless node
     std::unordered_set<const Node*> delete_nodes;
 

--- a/paddle/fluid/framework/ir/xpu/squeeze_excitation_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/squeeze_excitation_fuse_pass.cc
@@ -220,7 +220,7 @@ SqueezeExcitationFusePattern::SqueezeExcitationFusePattern(
 
 void SqueezeExcitationFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null. "));
+      graph, common::errors::PreconditionNotMet("graph should not be null. "));
   Init(name_scope_, graph);
 
   int found_subgraph_count = 0;
@@ -286,7 +286,7 @@ int SqueezeExcitationFusePass::ApplyImpl(ir::Graph* graph,
     auto* block = pool2d->Op()->Block();
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
     framework::OpDesc fused_op_desc(block);
     fused_op_desc.SetType("squeeze_excitation_block");
@@ -312,14 +312,14 @@ int SqueezeExcitationFusePass::ApplyImpl(ir::Graph* graph,
       std::stringstream ss;
       ss << "Error: Dims of excitation mul1 weight is: " << mul_1_w_dims
          << ", but get dims of excitation mul2 weight is: " << mul_2_w_dims;
-      PADDLE_THROW(phi::errors::InvalidArgument(ss.str()));
+      PADDLE_THROW(common::errors::InvalidArgument(ss.str()));
     }
     std::vector<int16_t> encode_filter_int16;
     encode_filter_int16.resize(mul_1_w_len + mul_2_w_len);
 
     PADDLE_ENFORCE_EQ(mul_1_w_dims[1] % mul_1_w_dims[0] == 0,
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Reduction ratio of excitation is not an integer."
                           "Received mul_1_w_dims[1]: %d, mul_1_w_dims[0]: %d",
                           mul_1_w_dims[1],

--- a/paddle/fluid/framework/ir/xpu/squeeze_excitation_fuse_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/squeeze_excitation_fuse_pass_test.cc
@@ -49,7 +49,7 @@ TEST(SqueezeExcitationFusePass, V1) {
              GetNumOpNodes(graph, "elementwise_mul");
   PADDLE_ENFORCE_EQ(num,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "pool2d/conv2d_xpu/elementwise_mul ops should be "
                         "removed from graph, but graph "
                         "still has %d ops. ",

--- a/paddle/fluid/framework/ir/xpu/stack_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/stack_fuse_pass.cc
@@ -100,7 +100,7 @@ class StackFusePass : public FusePassBase {
 
 void StackFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   GraphPatternDetector gpd;
   patterns::StackPattern pattern(gpd.mutable_pattern(), name_scope_);

--- a/paddle/fluid/framework/ir/xpu/stack_fuse_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/stack_fuse_pass_test.cc
@@ -40,7 +40,7 @@ TEST(StackFusePass, basic) {
   auto stack_num = GetNumOpNodes(graph, "stack");
   PADDLE_ENFORCE_EQ(stack_num,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "stack op should be removed from graph, but graph "
                         "still has %d stack op.",
                         stack_num));

--- a/paddle/fluid/framework/ir/xpu/weight_only_linear_xpu_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/weight_only_linear_xpu_pass.cc
@@ -119,7 +119,7 @@ void PermuteINT8WeightOnlyPass::ApplyPermuteINT8WeightOnly(
             scope->Var(scale_names[id])->GetMutable<phi::DenseTensor>();
         PADDLE_ENFORCE_NOT_NULL(
             scale_tensor,
-            phi::errors::Fatal(
+            common::errors::Fatal(
                 "weight_scale tensor node should not be nullptr"));
 
         size_t dst_hash = HashTensor<phi::dtype::float16>(*scale_tensor);
@@ -131,7 +131,7 @@ void PermuteINT8WeightOnlyPass::ApplyPermuteINT8WeightOnly(
               scope->Var(name)->GetMutable<phi::DenseTensor>();
           PADDLE_ENFORCE_NOT_NULL(
               curr_tensor,
-              phi::errors::Fatal("tensor node should not be nullptr"));
+              common::errors::Fatal("tensor node should not be nullptr"));
           // Create dst node
           // Update dst var_desc in block
           VarDesc dst_desc(dst_name);
@@ -220,7 +220,7 @@ void PermuteINT8WeightOnlyPass::ApplyPermuteINT8WeightOnly(
 
 void PermuteINT8WeightOnlyPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   ApplyPermuteINT8WeightOnly(graph);

--- a/paddle/fluid/framework/ir/xpu/xpu_delete_cast_op_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/xpu_delete_cast_op_pass.cc
@@ -390,7 +390,7 @@ int XpuDeleteCastOpPass::ApplyCastCacheKVInitializationPass(
 
 void XpuDeleteCastOpPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   if (!graph->IsMainGraph()) {
     VLOG(3) << "'xpu_delete_cast_op_pass' needs info in all "
                "graphs, so it "

--- a/paddle/fluid/framework/ir/xpu/xpu_delete_cast_op_pass_test.cc
+++ b/paddle/fluid/framework/ir/xpu/xpu_delete_cast_op_pass_test.cc
@@ -79,7 +79,7 @@ TEST(ApplyCastSoftmaxPass, basic) {
   PADDLE_ENFORCE_EQ(
       GetOpNum(graph->GetSubGraph(0), "cast"),
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "graph should have 0 cast after xpu_delete_cast_op_pass, "
           "but actually has %d.",
           cast_num_in_graph));
@@ -106,7 +106,7 @@ TEST(ApplyCastLayerNormPass, basic) {
   PADDLE_ENFORCE_EQ(
       GetOpNum(graph->GetSubGraph(0), "cast"),
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "graph should have 0 cast after xpu_delete_cast_op_pass, "
           "but actually has %d.",
           cast_num_in_graph));
@@ -188,18 +188,18 @@ TEST(ApplyCastCacheKVInitializationPass, basic) {
   PADDLE_ENFORCE_EQ(
       GetOpNum(graph->GetSubGraph(0), "shape"),
       1,
-      phi::errors::PreconditionNotMet("graph should have 1 shape after "
-                                      "xpu_delete_cast_op_pass, "
-                                      "but actually has %d.",
-                                      shape_num_in_graph));
+      common::errors::PreconditionNotMet("graph should have 1 shape after "
+                                         "xpu_delete_cast_op_pass, "
+                                         "but actually has %d.",
+                                         shape_num_in_graph));
   int cast_num_in_graph = GetOpNum(graph->GetSubGraph(0), "cast");
   PADDLE_ENFORCE_EQ(
       GetOpNum(graph->GetSubGraph(0), "cast"),
       1,
-      phi::errors::PreconditionNotMet("graph should have 1 cast after "
-                                      "xpu_delete_cast_op_pass, "
-                                      "but actually has %d.",
-                                      cast_num_in_graph));
+      common::errors::PreconditionNotMet("graph should have 1 cast after "
+                                         "xpu_delete_cast_op_pass, "
+                                         "but actually has %d.",
+                                         cast_num_in_graph));
 }
 
 }  // namespace ir

--- a/paddle/fluid/framework/ir/xpu/xpu_quantize_op_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/xpu_quantize_op_pass.cc
@@ -54,7 +54,7 @@ void XPUQuantizeOpPass::QuantizeInput(Graph* g,
       std::find(inputs.begin(), inputs.end(), input_arg_name) != inputs.end();
   PADDLE_ENFORCE_EQ(name_found,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Var(%s) isn't the input of the %s operator.",
                         input_arg_name,
                         op->Op()->Type()));
@@ -97,7 +97,7 @@ void XPUQuantizeOpPass::DequantizeOutput(Graph* g,
       outputs.end();
   PADDLE_ENFORCE_EQ(name_found,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Var(%s) isn't the output of the %s operator.",
                         output_arg_name,
                         op->Op()->Type()));
@@ -332,10 +332,11 @@ void XPUQuantizeOpPass::QuantizeQkvAttention(ir::Graph* graph) const {
 void XPUQuantizeOpPass::ApplyImpl(ir::Graph* graph) const {
   VLOG(3) << "Insert quantize/dequantize op to the graph.";
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::InvalidArgument("Graph cannot be nullptr."));
+      graph, common::errors::InvalidArgument("Graph cannot be nullptr."));
   FusePassBase::Init(name_scope_, graph);
   PADDLE_ENFORCE_NOT_NULL(
-      param_scope(), phi::errors::InvalidArgument("Scope cannot be nullptr."));
+      param_scope(),
+      common::errors::InvalidArgument("Scope cannot be nullptr."));
 
   GetQuantInfo(graph);
   QuantizeConv(graph);

--- a/paddle/fluid/framework/ir/xpu/xpu_quantize_squash_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/xpu_quantize_squash_pass.cc
@@ -82,7 +82,7 @@ void XPUQuantizeSquashPass::DequantQuantSquash(
     PADDLE_ENFORCE_NE(
         nodes_keep_counter->find(dequant_out),
         nodes_keep_counter->end(),
-        phi::errors::NotFound("The dequant output node is not found."));
+        common::errors::NotFound("The dequant output node is not found."));
 
     // check if dequantize op should be kept or removed, decrease the counter
     bool keep_dequant = (*nodes_keep_counter)[dequant_out]-- > 1;
@@ -276,7 +276,7 @@ void XPUQuantizeSquashPass::MultipleQuantizeSquash(Graph* graph) const {
 
     PADDLE_ENFORCE_NE(scale,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Quantize scale(%f) should not be equal 0.", scale));
 
     for (int iter = prev_out->outputs.size() - 1; iter >= 0; iter--) {
@@ -294,9 +294,9 @@ void XPUQuantizeSquashPass::MultipleQuantizeSquash(Graph* graph) const {
         PADDLE_ENFORCE_NE(
             last_op_input_name.empty(),
             true,
-            phi::errors::NotFound("Operator after quantize operator(%s) "
-                                  "should have quantize output as input.",
-                                  quant_out->Name()));
+            common::errors::NotFound("Operator after quantize operator(%s) "
+                                     "should have quantize output as input.",
+                                     quant_out->Name()));
 
         // update the next operator input,
         // by replacing quant_out with first_quant_out
@@ -323,7 +323,7 @@ void XPUQuantizeSquashPass::MultipleQuantizeSquash(Graph* graph) const {
 void XPUQuantizeSquashPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
       graph,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The graph in function XPUQuantizeSquashPass::ApplyImpl is null."));
   FusePassBase::Init("xpu_quantize_squash_pass", graph);
 

--- a/paddle/fluid/framework/ir/xpu/yolo_box_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/yolo_box_xpu_fuse_pass.cc
@@ -283,7 +283,7 @@ class YoloBoxXPUFusePass : public FusePassBase {
 
 void YoloBoxXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
 
   int found_subgraph_count = 0;
@@ -335,7 +335,7 @@ int YoloBoxXPUFusePass::ApplyImpl(ir::Graph* graph,
     auto* block = concat->Op()->Block();
     auto* scope = param_scope();
     PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("Scope cannot be nullptr."));
+        scope, common::errors::InvalidArgument("Scope cannot be nullptr."));
 
     std::string fused_op_out_name;
     fused_op_out_name = concat_out->Name();
@@ -357,7 +357,7 @@ int YoloBoxXPUFusePass::ApplyImpl(ir::Graph* graph,
       auto left_ew_sub_y_dims = left_ew_sub_y_t.dims();
       PADDLE_ENFORCE_EQ(left_ew_sub_y_dims.size(),
                         1,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "the size(%d) of left elementwise sub tensor "
                             "must equal 1",
                             left_ew_sub_y_dims.size()));
@@ -369,7 +369,7 @@ int YoloBoxXPUFusePass::ApplyImpl(ir::Graph* graph,
         auto* sub_t_fp32_ptr = left_ew_sub_y_t.data<float>();
         offset_ = sub_t_fp32_ptr[0];
       } else {
-        PADDLE_THROW(phi::errors::Unavailable(
+        PADDLE_THROW(common::errors::Unavailable(
             "yolo_box_fuse_xpu_pass not supported weight dtype. "
             "we now only support fp32/fp16."));
       }

--- a/paddle/fluid/framework/ir/yolo_box_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/yolo_box_fuse_pass.cc
@@ -153,7 +153,7 @@ YoloBoxFusePass::YoloBoxFusePass() = default;
 
 void YoloBoxFusePass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
-      graph, phi::errors::PreconditionNotMet("graph should not be null."));
+      graph, common::errors::PreconditionNotMet("graph should not be null."));
   Init(name_scope_, graph);
   GraphPatternDetector gpd;
   patterns::YoloBoxPattern yolo_box_pattern(gpd.mutable_pattern(), name_scope_);

--- a/paddle/fluid/framework/library_type.h
+++ b/paddle/fluid/framework/library_type.h
@@ -40,7 +40,7 @@ inline std::string LibraryTypeToString(const LibraryType& library_type) {
     case LibraryType::kKP:
       return "KP";
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unknown LibraryType code (%d), only supports library type include "
           "PLAIN(0), MKLDNN(1), CUDNN(2), KP(3).",
           static_cast<int>(library_type)));
@@ -71,7 +71,7 @@ inline LibraryType StringToLibraryType(const char* ctype) {
   } else if (s == std::string("CUDA")) {
     return LibraryType::kPlain;
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Unknown LibraryType string (%s), only support library type string "
         "include PLAIN, MKLDNN, CUDNN, CPU, CUDA and IPU.",
         s.c_str()));

--- a/paddle/fluid/framework/lod_rank_table.cc
+++ b/paddle/fluid/framework/lod_rank_table.cc
@@ -25,7 +25,7 @@ void LoDRankTable::Reset(const LoD& lod, size_t level) {
   PADDLE_ENFORCE_LT(
       level,
       lod.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Cannot reset LoD since the level %d is less than lod size %d.",
           level,
           lod.size()));

--- a/paddle/fluid/framework/lod_tensor.cc
+++ b/paddle/fluid/framework/lod_tensor.cc
@@ -34,7 +34,7 @@ LoD SliceInLevel(const LoD &in,
   PADDLE_ENFORCE_LT(
       level,
       in.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input phi::DenseTensor's lod level should be less than "
           "the LoD size, but received level is %d, LoD is %s.",
           level,
@@ -42,7 +42,7 @@ LoD SliceInLevel(const LoD &in,
   PADDLE_ENFORCE_LT(
       elem_begin,
       elem_end,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The index to start slicing should be less than the index to end "
           "slicing, but received start index is %d, end index is %d.",
           elem_begin,
@@ -50,7 +50,7 @@ LoD SliceInLevel(const LoD &in,
   PADDLE_ENFORCE_LT(
       elem_end,
       in[level].size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The index to end slicing should be less than the input LoD size, "
           "but received end index is %d, LoD size is %d.",
           elem_end,
@@ -177,7 +177,7 @@ LoDAndOffset GetSubLoDAndAbsoluteOffset(const LoD &lod,
   for (size_t level_idx = start_level; level_idx < lod.size(); ++level_idx) {
     PADDLE_ENFORCE_LE(start_idx,
                       end_idx,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The start index should be less than the end index, "
                           "but received start index is %d, end index is %d.",
                           start_idx,
@@ -185,7 +185,7 @@ LoDAndOffset GetSubLoDAndAbsoluteOffset(const LoD &lod,
     PADDLE_ENFORCE_LT(
         end_idx,
         lod[level_idx].size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The end index should be less than the LoD level size, but "
             "received end index is %d, LoD level size is %d.",
             end_idx,
@@ -258,12 +258,12 @@ void DeserializeFromStream(std::istream &is,
     is.read(reinterpret_cast<char *>(&version), sizeof(version));
     PADDLE_ENFORCE_EQ(paddle::framework::IsTensorVersionSupported(version),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Tensor version %u is not supported.", version));
     PADDLE_ENFORCE_EQ(
         version,
         0U,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Deserialize to tensor failed, maybe the loaded file is "
             "not a paddle model(expected file format: 0, but %u found).",
             version));
@@ -289,12 +289,12 @@ void DeserializeFromStream(std::istream &is,
     is.read(reinterpret_cast<char *>(&version), sizeof(version));
     PADDLE_ENFORCE_EQ(paddle::framework::IsTensorVersionSupported(version),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Tensor version %u is not supported.", version));
     PADDLE_ENFORCE_EQ(
         version,
         0U,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Deserialize to tensor failed, maybe the loaded file is "
             "not a paddle model(expected file format: 0, but %u found).",
             version));
@@ -340,7 +340,7 @@ std::vector<phi::DenseTensor> SplitLoDTensor(
     const phi::DenseTensor &src, const std::vector<phi::Place> places) {
   PADDLE_ENFORCE_GT(places.size(),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Place number cannot be empty when splitting."));
   src.check_memory_size();
   auto rank = src.dims().size();
@@ -383,7 +383,7 @@ std::vector<phi::DenseTensor> SplitLoDTensor(
     auto end = std::min<size_t>((i + 1) * step_width, batch_size);
     PADDLE_ENFORCE_LT(begin,
                       end,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The begin index must be less than the end index, "
                           "but received begin index is %d, end index is %d.",
                           begin,
@@ -424,10 +424,10 @@ std::vector<phi::DenseTensor> SplitLoDTensor(
 void MergeLoDTensor(phi::DenseTensor *target,
                     const std::vector<const phi::DenseTensor *> &lod_tensors,
                     phi::Place dst_place) {
-  PADDLE_ENFORCE_EQ(
-      lod_tensors.empty(),
-      false,
-      phi::errors::InvalidArgument("The LoDTensors to be merged are empty."));
+  PADDLE_ENFORCE_EQ(lod_tensors.empty(),
+                    false,
+                    common::errors::InvalidArgument(
+                        "The LoDTensors to be merged are empty."));
 
   phi::DDim new_dim = lod_tensors[0]->dims();
   proto::VarType::Type new_type = proto::VarType::FP32;
@@ -450,7 +450,7 @@ void MergeLoDTensor(phi::DenseTensor *target,
       PADDLE_ENFORCE_EQ(
           new_type,
           framework::TransToProtoVarType(t->dtype()),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "phi::DenseTensor data type does not match, expected type is %s, "
               "actual "
               "type is %s.",
@@ -459,7 +459,7 @@ void MergeLoDTensor(phi::DenseTensor *target,
       PADDLE_ENFORCE_EQ(
           new_layout,
           t->layout(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "phi::DenseTensor layout does not match, expected layout is %s, "
               "actual layout is %s.",
               common::DataLayoutToString(new_layout),
@@ -467,13 +467,13 @@ void MergeLoDTensor(phi::DenseTensor *target,
       auto tensor_dims = t->dims();
       PADDLE_ENFORCE_EQ(tensor_dims.size(),
                         new_dim.size(),
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "dimensions of DenseTensor does not match"));
       for (int j = 1; j < t->dims().size(); j++) {
         PADDLE_ENFORCE_EQ(
             tensor_dims[j],
             new_dim[j],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "DenseTensor.ddim[%d] should equal to %d, but is %d",
                 j,
                 new_dim[j],
@@ -488,7 +488,7 @@ void MergeLoDTensor(phi::DenseTensor *target,
     PADDLE_ENFORCE_EQ(
         new_lod.size(),
         lod.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The LoD information of phi::DenseTensor does not match, "
             "expected LoD is %s, actual LoD is %s.",
             new_lod,

--- a/paddle/fluid/framework/lod_tensor.h
+++ b/paddle/fluid/framework/lod_tensor.h
@@ -133,7 +133,7 @@ phi::DenseTensor LodExpand(const phi::DenseTensor& source,
   PADDLE_ENFORCE_EQ(
       num_instances,
       lod_level.size() - 1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input phi::DenseTensor instance number should be equal to the "
           "LoD "
           "level size minus 1."

--- a/paddle/fluid/framework/multi_trainer.cc
+++ b/paddle/fluid/framework/multi_trainer.cc
@@ -375,7 +375,7 @@ void MultiTrainer::ResetDataset(Dataset* dataset) {
   // change thread num is not supported
   PADDLE_ENFORCE_EQ(thread_num_,
                     readers.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "change Dataset thread_num is not supported"));
   for (int i = 0; i < thread_num_; ++i) {
     workers_[i]->SetDataFeed(readers[i]);

--- a/paddle/fluid/framework/naive_executor.cc
+++ b/paddle/fluid/framework/naive_executor.cc
@@ -160,9 +160,9 @@ void NaiveExecutor::CreateVariables(const ProgramDesc &desc,
                                     int block_id,
                                     bool persistable,
                                     Scope *scope) {
-  PADDLE_ENFORCE_NOT_NULL(
-      scope,
-      phi::errors::InvalidArgument("The Scope to hold variables is nullptr."));
+  PADDLE_ENFORCE_NOT_NULL(scope,
+                          common::errors::InvalidArgument(
+                              "The Scope to hold variables is nullptr."));
 
   auto &global_block = desc.Block(block_id);
 
@@ -170,7 +170,7 @@ void NaiveExecutor::CreateVariables(const ProgramDesc &desc,
   PADDLE_ENFORCE_NE(
       anc->parent(),
       anc,
-      phi::errors::InvalidArgument("Input scope should be child scope."));
+      common::errors::InvalidArgument("Input scope should be child scope."));
   while (anc->parent()) {
     anc = anc->parent();
   }
@@ -214,11 +214,12 @@ void NaiveExecutor::CreateOps(const ProgramDesc &desc, int block_id) {
 
 phi::DenseTensor *NaiveExecutor::FindTensor(const std::string &name) {
   PADDLE_ENFORCE_NOT_NULL(scope_,
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "Need to init scope in NaiveExecutor firstly."));
   auto *var = scope_->FindVar(name);
   PADDLE_ENFORCE_NOT_NULL(
-      var, phi::errors::NotFound("No variable [%s] in current scope.", name));
+      var,
+      common::errors::NotFound("No variable [%s] in current scope.", name));
   auto *tensor = const_cast<phi::DenseTensor *>(&var->Get<phi::DenseTensor>());
   return tensor;
 }

--- a/paddle/fluid/framework/new_executor/collect_shape_manager.cc
+++ b/paddle/fluid/framework/new_executor/collect_shape_manager.cc
@@ -56,7 +56,7 @@ void CollectShapeManager::CollectShapeInfo(
       // This must be a zero dimension tensor.
       PADDLE_ENFORCE_EQ(tensor.numel(),
                         1UL,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "This tensor must have one element, but got %ld.",
                             tensor.numel()));
       std::vector<int32_t> zero_shape(1, 1);
@@ -224,7 +224,7 @@ std::vector<int32_t> CollectShapeManager::GetValueShapeRangeInfo(
       return opt_shapes_[kernel_val];
     }
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "We only support ShapeMode::kMIN, ShapeMode::kMax and ShapeMode::kOpt "
         "when GetValueShapeRangeInfo"));
   }

--- a/paddle/fluid/framework/new_executor/feed_fetch_utils.cc
+++ b/paddle/fluid/framework/new_executor/feed_fetch_utils.cc
@@ -35,7 +35,7 @@ void SetColAttrForFeedFetchOps(std::shared_ptr<ProgramDesc> program_desc,
       PADDLE_ENFORCE_GE(
           col,
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Expected the column index (the attribute 'col' of "
               "operator 'Fetch') of current fetching variable to be "
               "no less than 0. But received column index = %d.",
@@ -58,8 +58,8 @@ void SplitFeedTensors(const std::vector<std::string>& feed_names,
     auto feed_var = scope->GetVar(feed_name);
     PADDLE_ENFORCE_NOT_NULL(
         feed_var,
-        phi::errors::NotFound("Variable %s should not be nullptr.",
-                              feed_names[i]));
+        common::errors::NotFound("Variable %s should not be nullptr.",
+                                 feed_names[i]));
     feed_tensors.push_back(feed_var->Get<phi::DenseTensor>());
   }
 
@@ -74,7 +74,7 @@ void SplitFeedTensors(const std::vector<std::string>& feed_names,
     int64_t numel_size = feed_tensor.dims()[0];
     PADDLE_ENFORCE_EQ(numel_size % micro_batch_num,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Split expects feed data (%s)'s dim[0] (%d) is "
                           "divisible by micro_batch_num (%d).",
                           feed_names[i],
@@ -96,13 +96,13 @@ void FetchTensors(const std::vector<std::string>& job_fetch_names,
                   const int64_t micro_batch_id,
                   Scope* scope,
                   FetchUnmergedList* fetch_list) {
-  PADDLE_ENFORCE_GT(
-      fetch_list->size(),
-      micro_batch_id,
-      phi::errors::Unavailable("The fetch list size (%lld) should be greater "
-                               "than micro_batch_id (%lld)",
-                               fetch_list->size(),
-                               micro_batch_id));
+  PADDLE_ENFORCE_GT(fetch_list->size(),
+                    micro_batch_id,
+                    common::errors::Unavailable(
+                        "The fetch list size (%lld) should be greater "
+                        "than micro_batch_id (%lld)",
+                        fetch_list->size(),
+                        micro_batch_id));
 
   fetch_list->at(micro_batch_id).resize(fetch_var_names.size());
   for (auto& var_name : job_fetch_names) {
@@ -141,13 +141,13 @@ void MergeFetchTensors(const FetchUnmergedList& fetch_list,
                        FetchList* out) {
   if (fetch_list.size() == 0) return;
 
-  PADDLE_ENFORCE_EQ(
-      fetch_list.size(),
-      micro_batch_num,
-      phi::errors::Unavailable("The fetch_list size (%lld) should be equal to "
-                               "the micro_batch_num (%lld)",
-                               fetch_list.size(),
-                               micro_batch_num));
+  PADDLE_ENFORCE_EQ(fetch_list.size(),
+                    micro_batch_num,
+                    common::errors::Unavailable(
+                        "The fetch_list size (%lld) should be equal to "
+                        "the micro_batch_num (%lld)",
+                        fetch_list.size(),
+                        micro_batch_num));
 
   if (micro_batch_num < 2) {
     *out = std::move(fetch_list[0]);
@@ -174,7 +174,7 @@ void MergeTensors(const std::vector<const phi::DenseTensor*>& tensors,
   PADDLE_ENFORCE_EQ(
       tensors.empty(),
       false,
-      phi::errors::InvalidArgument("The tensors to be merged are empty."));
+      common::errors::InvalidArgument("The tensors to be merged are empty."));
 
   DDim new_dim = tensors[0]->dims();
   proto::VarType::Type new_type = proto::VarType::FP32;
@@ -200,7 +200,7 @@ void MergeTensors(const std::vector<const phi::DenseTensor*>& tensors,
       PADDLE_ENFORCE_EQ(
           new_type,
           framework::TransToProtoVarType(t->dtype()),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "phi::DenseTensor data type does not match, expected type is %s, "
               "actual "
               "type is %s.",
@@ -209,7 +209,7 @@ void MergeTensors(const std::vector<const phi::DenseTensor*>& tensors,
       PADDLE_ENFORCE_EQ(
           new_layout,
           t->layout(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "phi::DenseTensor layout does not match, expected layout is %s, "
               "actual layout is %s.",
               common::DataLayoutToString(new_layout),
@@ -218,13 +218,13 @@ void MergeTensors(const std::vector<const phi::DenseTensor*>& tensors,
         auto tensor_dims = t->dims();
         PADDLE_ENFORCE_EQ(tensor_dims.size(),
                           new_dim.size(),
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "dimensions of DenseTensor does not match"));
         for (int j = 1; j < t->dims().size(); j++) {
           PADDLE_ENFORCE_EQ(
               tensor_dims[j],
               new_dim[j],
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "DenseTensor.ddim[%d] should equal to %d, but is %d",
                   j,
                   new_dim[j],
@@ -235,11 +235,11 @@ void MergeTensors(const std::vector<const phi::DenseTensor*>& tensors,
         auto tensor_dims = t->dims();
         PADDLE_ENFORCE_EQ(tensor_dims.size(),
                           0,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "dimensions of DenseTensor does not match"));
         PADDLE_ENFORCE_EQ(new_dim.size(),
                           1,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "dimensions of DenseTensor does not match"));
         new_dim[0] += 1;
       }

--- a/paddle/fluid/framework/new_executor/garbage_collector/event_garbage_collector.cc
+++ b/paddle/fluid/framework/new_executor/garbage_collector/event_garbage_collector.cc
@@ -60,7 +60,7 @@ void InterpreterCoreEventGarbageCollector::Add(Variable* var,
                                                const Instruction& instr) {
   PADDLE_ENFORCE_LT(instr.Id(),
                     gc_event_.size(),
-                    phi::errors::OutOfRange(
+                    common::errors::OutOfRange(
                         "The index should be less than the size of gc event "
                         ", but got index is %d and size is %d",
                         instr.Id(),
@@ -72,7 +72,7 @@ void InterpreterCoreEventGarbageCollector::Add(Variable* var,
                                                const InstructionBase* instr) {
   PADDLE_ENFORCE_LT(instr->Id(),
                     gc_event_.size(),
-                    phi::errors::OutOfRange(
+                    common::errors::OutOfRange(
                         "The index should be less than the size of gc event "
                         ", but got index is %d and size is %d",
                         instr->Id(),
@@ -141,7 +141,7 @@ void InterpreterCoreEventGarbageCollector::Add(Variable* var,
     // refer to executor.cc to see what old garbage collector does.
     // do nothing, because the sub scope will be deleted by sub-executor.
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "The variable(%s) is not supported in eager deletion.",
         framework::ToTypeName(var->Type())));
   }

--- a/paddle/fluid/framework/new_executor/garbage_collector/fast_garbage_collector.cc
+++ b/paddle/fluid/framework/new_executor/garbage_collector/fast_garbage_collector.cc
@@ -75,7 +75,7 @@ void InterpreterCoreFastGarbageCollector::Add(Variable* var) {
     // refer to executor.cc to see what old garbage collector does.
     // do nothing, because the sub scope will be deleted by sub-executor.
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "The variable(%s) is not supported in eager deletion.",
         framework::ToTypeName(var->Type())));
   }

--- a/paddle/fluid/framework/new_executor/garbage_collector/garbage_collector.h
+++ b/paddle/fluid/framework/new_executor/garbage_collector/garbage_collector.h
@@ -58,7 +58,7 @@ inline bool IsInterpretercoreFastGCEnabled() {
                         memory::allocation::AllocatorFacade::Instance()
                                 .IsCUDAMallocAsyncAllocatorUsed() == true,
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "StreamSafeAllocator and AsyncAllocator shouldn't be "
                         "True together."));
   PADDLE_ENFORCE_EQ(memory::allocation::AllocatorFacade::Instance()
@@ -67,7 +67,7 @@ inline bool IsInterpretercoreFastGCEnabled() {
                                 .IsCUDAMallocAsyncAllocatorUsed() == false &&
                         FLAGS_new_executor_use_cuda_graph,
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "When FLAGS_new_executor_use_cuda_graph is true, "
                         "Either IsStreamSafeCUDAAllocatorUsed or "
                         "IsCUDAMallocAsyncAllocatorUsed must be true, but "

--- a/paddle/fluid/framework/new_executor/garbage_collector/no_event_garbage_collector.cc
+++ b/paddle/fluid/framework/new_executor/garbage_collector/no_event_garbage_collector.cc
@@ -101,7 +101,7 @@ void InterpreterCoreNoEventGarbageCollector::Add(
     // refer to executor.cc to see what old garbage collector does.
     // do nothing, because the sub scope will be deleted by sub-executor.
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "The variable(%s) is not supported in eager deletion.",
         framework::ToTypeName(var->Type())));
   }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/assert_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/assert_instruction.cc
@@ -29,7 +29,7 @@ AssertInstruction::AssertInstruction(size_t id,
       type_(OpFuncType::kCpuSync),
       value_exe_info_(value_exe_info) {
   PADDLE_ENFORCE(op->isa<paddle::dialect::AssertOp>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Assert instruction only support assert op"));
 
   auto assert_op = op->dyn_cast<paddle::dialect::AssertOp>();
@@ -60,7 +60,7 @@ void AssertInstruction::Run() {
   PADDLE_ENFORCE_EQ(
       cond.numel(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The numel of Input(Condition) of AssertOp must be 1. But now "
           "the Condition's shape is %s.",
           cond.dims().to_str()));
@@ -94,7 +94,7 @@ void AssertInstruction::Run() {
     }
     return {};
   }();
-  PADDLE_THROW(phi::errors::InvalidArgument(
+  PADDLE_THROW(common::errors::InvalidArgument(
       "The condition variable '%s' of AssertOp must be "
       "true, but received false. %s",
       value_exe_info_->GetVarName(cond_var_),

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
@@ -58,9 +58,9 @@ IfInstruction::IfInstruction(size_t id,
       false_branch_inter_(nullptr),
       true_skip_gc_names_(),
       false_skip_gc_names_() {
-  PADDLE_ENFORCE(
-      op->isa<paddle::dialect::IfOp>(),
-      phi::errors::PreconditionNotMet("Cond instruction only support if op"));
+  PADDLE_ENFORCE(op->isa<paddle::dialect::IfOp>(),
+                 common::errors::PreconditionNotMet(
+                     "Cond instruction only support if op"));
   auto if_op = op->dyn_cast<paddle::dialect::IfOp>();
   op_ = op;
 
@@ -111,7 +111,7 @@ IfInstruction::IfInstruction(size_t id,
       PADDLE_ENFORCE_EQ(
           value_exec_info->HasValue(value),
           true,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "input should in name map, [%d] 'th input of [%s] op",
               i,
               "if op"));
@@ -232,7 +232,7 @@ void IfInstruction::Run() {
           cond_tensor, phi::CPUPlace(), &cpu_cond);
       cond = cpu_cond.data<bool>()[0];
 #else
-      PADDLE_THROW(phi::errors::PreconditionNotMet(
+      PADDLE_THROW(common::errors::PreconditionNotMet(
           "This version of PaddlePaddle does NOT support GPU/XPU but got "
           "GPU/XPU tensor Cond in WhileOp. Please compile WITH_GPU or "
           "WITH_XPU option."));

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/pylayer_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/pylayer_instruction.cc
@@ -51,7 +51,7 @@ PyLayerInstruction::PyLayerInstruction(
     interpreter::ExecutionConfig execution_config)
     : InstructionBase(id, place), output_vars_(), fwd_skip_gc_names_() {
   PADDLE_ENFORCE(op->isa<paddle::dialect::PyLayerOp>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Cond instruction only support pylayer op"));
   auto pylayer_op = op->dyn_cast<paddle::dialect::PyLayerOp>();
   op_ = op;
@@ -95,7 +95,7 @@ PyLayerInstruction::PyLayerInstruction(
       PADDLE_ENFORCE_EQ(
           value_exec_info->HasValue(value),
           true,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "output should in name map, [%d] 'th output of [%s] op",
               i,
               "pylayer op"));

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/select_input_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/select_input_instruction.cc
@@ -53,11 +53,11 @@ inline int GetBranchNumber(const phi::DenseTensor &mask) {
   PADDLE_ENFORCE_EQ(
       mask.numel(),
       1,
-      phi::errors::Fatal("The numel of Input(Mask) in SelectInputOp or "
-                         "SelectOutputOp must be 1. "
-                         "But received %d, and it's shape is [%s].",
-                         mask.numel(),
-                         mask.dims()));
+      common::errors::Fatal("The numel of Input(Mask) in SelectInputOp or "
+                            "SelectOutputOp must be 1. "
+                            "But received %d, and it's shape is [%s].",
+                            mask.numel(),
+                            mask.dims()));
   if (phi::is_cpu_place(mask.place())) {
     return mask.data<int>()[0];
   }
@@ -67,7 +67,7 @@ inline int GetBranchNumber(const phi::DenseTensor &mask) {
     defined(PADDLE_WITH_CUSTOM_DEVICE) || defined(PADDLE_WITH_XPU)
   framework::TensorCopySync(mask, phi::CPUPlace(), cpu_mask.get());
 #else
-  PADDLE_THROW(phi::errors::Fatal(
+  PADDLE_THROW(common::errors::Fatal(
       "This version of PaddlePaddle does NOT support GPU, "
       "but got GPU tensor 'Mask' in SelectInputOp or SelectOutputOp. "
       "Please compile PaddlePaddle WITH_GPU first."));
@@ -106,7 +106,7 @@ class AssignFunctor {
     PADDLE_ENFORCE_EQ(
         true,
         false,
-        phi::errors::PermissionDenied(
+        common::errors::PermissionDenied(
             "Not support type for assign op with type %s", typeid(T).name()));
   }
 
@@ -129,7 +129,7 @@ void SelectInputInstruction::Run() {
   PADDLE_ENFORCE_LT(
       output_branch,
       inputs_.size(),
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "Input 'Mask' in SelectInputOp is invalid. "
           "'Mask' must be less than the size of input vector 'X'. "
           "But received Mask = %d, X's size = %d.",

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/select_output_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/select_output_instruction.cc
@@ -52,11 +52,11 @@ inline int GetBranchNumber(const phi::DenseTensor &mask) {
   PADDLE_ENFORCE_EQ(
       mask.numel(),
       1,
-      phi::errors::Fatal("The numel of Input(Mask) in SelectInputOp or "
-                         "SelectOutputOp must be 1. "
-                         "But received %d, and it's shape is [%s].",
-                         mask.numel(),
-                         mask.dims()));
+      common::errors::Fatal("The numel of Input(Mask) in SelectInputOp or "
+                            "SelectOutputOp must be 1. "
+                            "But received %d, and it's shape is [%s].",
+                            mask.numel(),
+                            mask.dims()));
   if (phi::is_cpu_place(mask.place())) {
     return mask.data<int>()[0];
   }
@@ -66,7 +66,7 @@ inline int GetBranchNumber(const phi::DenseTensor &mask) {
     defined(PADDLE_WITH_CUSTOM_DEVICE) || defined(PADDLE_WITH_XPU)
   framework::TensorCopySync(mask, phi::CPUPlace(), cpu_mask.get());
 #else
-  PADDLE_THROW(phi::errors::Fatal(
+  PADDLE_THROW(common::errors::Fatal(
       "This version of PaddlePaddle does NOT support GPU, "
       "but got GPU tensor 'Mask' in SelectInputOp or SelectOutputOp. "
       "Please compile PaddlePaddle WITH_GPU first."));
@@ -105,7 +105,7 @@ class AssignFunctor {
     PADDLE_ENFORCE_EQ(
         true,
         false,
-        phi::errors::PermissionDenied(
+        common::errors::PermissionDenied(
             "Not support type for assign op with type %s", typeid(T).name()));
   }
 
@@ -128,7 +128,7 @@ void SelectOutputInstruction::Run() {
   PADDLE_ENFORCE_LE(
       output_branch,
       outputs_.size(),
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "Input 'Mask' in SelectInputOp is invalid. "
           "'Mask' must be less than the size of output vector 'X'. "
           "But received Mask = %d, Out's size = %d.",

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
@@ -113,7 +113,7 @@ void ShareVarData(const Variable* src_var, Variable* dst_var) {
       ShareVarData(src_var_array.at(i), copy_var);
     }
   } else {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "Output only support DenseTensorType "
         "or SelectedRowsType or TensorArrayType"));
   }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_push_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_push_instruction.cc
@@ -43,7 +43,7 @@ bool ParsePlace(const pir::Type& type, OpFuncType* type_) {
       }
     }
   } else {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "Only support AllocatedDenseTensorType and "
         "AllocatedDenseTensorArrayType in vectortype now, but get: %s",
         type));

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/while_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/while_instruction.cc
@@ -57,7 +57,7 @@ WhileInstruction::WhileInstruction(
       body_inter_(nullptr),
       external_input_names_() {
   PADDLE_ENFORCE(op->isa<paddle::dialect::WhileOp>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "While instruction only support While op"));
   op_ = op;
   auto while_op = op->dyn_cast<paddle::dialect::WhileOp>();
@@ -103,7 +103,7 @@ WhileInstruction::WhileInstruction(
       PADDLE_ENFORCE_NE(
           parent_exe_info->GetValue2VarName().find(value),
           parent_exe_info->GetValue2VarName().end(),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "output should in name map, [%d] 'th output of [%s] op",
               i,
               "while op"));
@@ -164,8 +164,8 @@ void WhileInstruction::ShareInputsToOutputs() {
       auto* output_array = outputs_[i]->GetMutable<phi::TensorArray>();
       *output_array = input_array;
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented("unsupported type %d",
-                                              inputs_[i]->Type()));
+      PADDLE_THROW(common::errors::Unimplemented("unsupported type %d",
+                                                 inputs_[i]->Type()));
     }
   }
 }
@@ -186,8 +186,8 @@ void WhileInstruction::ShareOutputsToBlockArgs() {
       VLOG(10) << inner_var
                << " should be created: " << inner_var->IsInitialized();
     } else {
-      PADDLE_THROW(
-          phi::errors::Unimplemented("unsupported type %d", inner_var->Type()));
+      PADDLE_THROW(common::errors::Unimplemented("unsupported type %d",
+                                                 inner_var->Type()));
     }
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/yield_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/yield_instruction.cc
@@ -50,11 +50,11 @@ YieldInstruction::YieldInstruction(size_t id,
   PADDLE_ENFORCE_EQ(
       input_vars_.size(),
       output_vars_.size(),
-      phi::errors::InvalidArgument("The number of inputs in YieldOp and "
-                                   "outputs of parent op must be equal."
-                                   "But received %d and %d.",
-                                   input_vars_.size(),
-                                   output_vars_.size()));
+      common::errors::InvalidArgument("The number of inputs in YieldOp and "
+                                      "outputs of parent op must be equal."
+                                      "But received %d and %d.",
+                                      input_vars_.size(),
+                                      output_vars_.size()));
 }
 
 void YieldInstruction::Run() {
@@ -67,8 +67,8 @@ void YieldInstruction::Run() {
       auto *output_array = output_vars_[i]->GetMutable<phi::TensorArray>();
       *output_array = inner_array;
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented("unsupported type %d",
-                                              input_vars_[i]->Type()));
+      PADDLE_THROW(common::errors::Unimplemented("unsupported type %d",
+                                                 input_vars_[i]->Type()));
     }
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/custom_kernel_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/custom_kernel_instruction.cc
@@ -36,7 +36,7 @@ void CustomKernelInstruction::BuildCustomContext(
       // make sure ctx has valid inplace optional outputs
       PADDLE_ENFORCE(
           paddle::framework::detail::IsOptionalVar(pair.second),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Custom operator couldn't find custom output name for %s. If "
               "you are using inplace optional inputs & outputs, please "
               "check "
@@ -63,7 +63,7 @@ void CustomKernelInstruction::BuildCustomContext(
     PADDLE_ENFORCE_EQ(
         name2id.count(t),
         true,
-        phi::errors::NotFound("param [%s] MUST in name2id map", t));
+        common::errors::NotFound("param [%s] MUST in name2id map", t));
 
     pir::Value ptr = op_->operand_source(op_yaml_info.InputName2Id().at(t));
     if (!IsInvalid(ptr)) {
@@ -94,7 +94,7 @@ void CustomKernelInstruction::BuildCustomContext(
     VLOG(6) << "ctx->EmplaceBackInput: " << t << "\t" << in_var_name;
 
     PADDLE_ENFORCE_NOT_NULL(inner_scope->FindVar(in_var_name),
-                            phi::errors::PreconditionNotMet(
+                            common::errors::PreconditionNotMet(
                                 "can not find var[%s] in scope", in_var_name));
     auto var = inner_scope->FindVar(in_var_name);
     if (var->IsType<phi::DenseTensor>()) {
@@ -127,7 +127,7 @@ void CustomKernelInstruction::BuildCustomContext(
           custom_in.set_impl(tensor_in);
           vec_custom_in.push_back(std::move(custom_in));
         } else {
-          PADDLE_THROW(phi::errors::Unimplemented(
+          PADDLE_THROW(common::errors::Unimplemented(
               "Only support Vector<DenseTensor> and vector<SelectedRows> now, "
               "not support vector<%d>.",
               variable_array[i]->Type()));
@@ -138,19 +138,19 @@ void CustomKernelInstruction::BuildCustomContext(
       vec_input_ptrs_.push_back(vec_input_ptrs);
       custom_kernel_ctx_.EmplaceBackInputs(vec_custom_in);
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented("Not support var type [%d] ",
-                                              var->Type()));
+      PADDLE_THROW(common::errors::Unimplemented("Not support var type [%d] ",
+                                                 var->Type()));
     }
   }
   // EmplaceBackAttributes
   auto& vec_attr_params = op_yaml_info.AttrParams(true);
   for (auto& t : vec_attr_params) {
-    PADDLE_ENFORCE_NE(
-        attr_map.find(t),
-        attr_map.end(),
-        phi::errors::NotFound("Not found %s in attr_map, it maybe need mapping "
-                              "it in OpTranslator.",
-                              t));
+    PADDLE_ENFORCE_NE(attr_map.find(t),
+                      attr_map.end(),
+                      common::errors::NotFound(
+                          "Not found %s in attr_map, it maybe need mapping "
+                          "it in OpTranslator.",
+                          t));
     auto& attr_type_name = op_yaml_info.AttrTypeName(t);
     if (attr_type_name == "pir::Int32Attribute") {
       custom_attrs_.push_back(
@@ -189,7 +189,7 @@ void CustomKernelInstruction::BuildCustomContext(
         PADDLE_ENFORCE_EQ(
             array_list[0].isa<pir::Int32Attribute>(),
             true,
-            phi::errors::Unimplemented(
+            common::errors::Unimplemented(
                 "the 0th elementwise MUST be pir::Int32Attribute"));
         for (size_t i = 0; i < array_list.size(); ++i) {
           vec_res.push_back(
@@ -209,8 +209,8 @@ void CustomKernelInstruction::BuildCustomContext(
           }
 
         } else {
-          PADDLE_THROW(phi::errors::Unimplemented("attr type not support [%s] ",
-                                                  attr_type_name));
+          PADDLE_THROW(common::errors::Unimplemented(
+              "attr type not support [%s] ", attr_type_name));
         }
       }
       custom_attrs_.push_back(vec_res);
@@ -223,7 +223,7 @@ void CustomKernelInstruction::BuildCustomContext(
         PADDLE_ENFORCE_EQ(
             array_list[0].isa<pir::Int64Attribute>(),
             true,
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "Element in array list MUST be pir::Int64Attribute "));
 
         for (size_t i = 0; i < array_list.size(); ++i) {
@@ -241,7 +241,7 @@ void CustomKernelInstruction::BuildCustomContext(
         PADDLE_ENFORCE_EQ(
             array_list[0].isa<pir::StrAttribute>(),
             true,
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "Element in array list MUST be pir::StrAttribute "));
 
         for (size_t i = 0; i < array_list.size(); ++i) {
@@ -253,8 +253,8 @@ void CustomKernelInstruction::BuildCustomContext(
       custom_kernel_ctx_.EmplaceBackAttr(vec_res);
 
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented("attr type not support [%s] ",
-                                              attr_type_name));
+      PADDLE_THROW(common::errors::Unimplemented("attr type not support [%s] ",
+                                                 attr_type_name));
     }
     VLOG(6) << "ctx->EmplaceBackAttr: " << t;
   }
@@ -268,7 +268,7 @@ void CustomKernelInstruction::BuildCustomContext(
       PADDLE_ENFORCE(
           paddle::framework::detail::IsOptionalVar(out_name) &&
               !inplace_id_map.empty(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Custom operator couldn't find custom output for name %s. If "
               "you "
               "are using inplace optional inputs & outputs, please check "
@@ -309,7 +309,7 @@ void CustomKernelInstruction::BuildCustomContext(
       std::vector<paddle::Tensor> custom_vec_out;
       PADDLE_ENFORCE(
           !inplace_id_map.empty() || (i == 0UL && op_->num_results() == 1UL),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "If custom operator's outputs contains `paddle::Vec()` type "
               "without setting InplaceMap, it only can hold one output."));
       for (size_t j = 0; j < variable_array.size(); ++j) {
@@ -325,7 +325,7 @@ void CustomKernelInstruction::BuildCustomContext(
           custom_out.set_impl(tensor_out);
           custom_vec_out.push_back(std::move(custom_out));
         } else {
-          PADDLE_THROW(phi::errors::Unimplemented(
+          PADDLE_THROW(common::errors::Unimplemented(
               "Only support Vector<DenseTensor> now, "
               "not support vector<%d>.",
               variable_array[j]->Type()));
@@ -335,8 +335,8 @@ void CustomKernelInstruction::BuildCustomContext(
               << value_exec_info_.GetVarName(out_ptr);
       custom_kernel_ctx_.EmplaceBackOutputs(custom_vec_out);
     } else {
-      PADDLE_THROW(
-          phi::errors::Unimplemented("only support DenseTensor and vector "));
+      PADDLE_THROW(common::errors::Unimplemented(
+          "only support DenseTensor and vector "));
     }
   }
 
@@ -383,7 +383,7 @@ CustomKernelInstruction::CustomKernelInstruction(
       op_info.GetInterfaceImpl<paddle::dialect::OpYamlInfoInterface>();
   PADDLE_ENFORCE_NOT_NULL(
       yaml_interface,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "can not find OpYamlInfoInterface from [%s]", custom_op_name_));
   paddle::dialect::OpYamlInfoParser yaml_info_parser(
       yaml_interface->get_op_info_(custom_op_name_),
@@ -440,7 +440,7 @@ void CustomKernelInstruction::UpdateOutputMeta(
   PADDLE_ENFORCE_EQ(
       output_shapes.size(),
       cache_out_ptrs_.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of output shapes after running custom operator's "
           "InferShapeFunc is wrong, "
           "expected contains %d Tensors' shape, but actually contains %d "
@@ -451,7 +451,7 @@ void CustomKernelInstruction::UpdateOutputMeta(
   PADDLE_ENFORCE_EQ(
       output_dtypes.size(),
       cache_out_ptrs_.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of output dtypes after running custom operator's "
           "InferDtypeFunc is wrong, "
           "expected contains %d Tensors' dtype, but actually contains %d "

--- a/paddle/fluid/framework/new_executor/instruction/instruction_base.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_base.cc
@@ -205,7 +205,7 @@ InstructionBase::InstructionBase(size_t id, const phi::Place& place)
     PADDLE_ENFORCE_EQ(
         interpreter::IsSupportedHeterPlace(place),
         true,
-        phi::errors::Fatal("Unsupported current place %s", place));
+        common::errors::Fatal("Unsupported current place %s", place));
     type_ = OpFuncType::kGpuAsync;
   }
 
@@ -308,7 +308,7 @@ void InstructionBase::InitInputsOutputsIds(
       PADDLE_ENFORCE_EQ(
           value_exec_info.HasValue(value),
           true,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "input should in name map, [%d] 'th input of [%s] op",
               i,
               op_name));
@@ -325,7 +325,7 @@ void InstructionBase::InitInputsOutputsIds(
       PADDLE_ENFORCE_EQ(
           value_exec_info.HasValue(value),
           true,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "input should in name map, [%d] 'th input of [%s] op",
               i,
               op_name));

--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
@@ -169,9 +169,10 @@ OpFuncType AnalyseOpFuncType(pir::Operation* op, const phi::Place& place) {
     return OpFuncType::kCpuSync;
   }
 
-  PADDLE_ENFORCE_EQ(interpreter::IsSupportedHeterPlace(place),
-                    true,
-                    phi::errors::Fatal("Unsupported current place %s", place));
+  PADDLE_ENFORCE_EQ(
+      interpreter::IsSupportedHeterPlace(place),
+      true,
+      common::errors::Fatal("Unsupported current place %s", place));
 
   auto& op_attributes = op->attributes();
 
@@ -224,7 +225,7 @@ void GetInputIds(pir::Operation* op,
       PADDLE_ENFORCE_EQ(
           value_exec_info.HasValue(value),
           true,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "input should in name map, [%d] 'th input of [%s] op",
               i,
               "if op"));
@@ -314,7 +315,7 @@ std::vector<pir::Value> GetExternalInputs(
     if (value && (!inner_outputs.count(value))) {
       PADDLE_ENFORCE_EQ(value_exec_info.HasValue(value),
                         true,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "input %s should be in name map", value.impl()));
       input_ids->emplace(value, GetValueIds(value, value_exec_info));
       outside_op_inputs.push_back(value);
@@ -418,7 +419,7 @@ bool GetCondData(const phi::DenseTensor& cond) {
     defined(PADDLE_WITH_XPU) || defined(PADDLE_WITH_CUSTOM_DEVICE)
   paddle::framework::TensorCopySync(cond, phi::CPUPlace(), cpu_cond.get());
 #else
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "This version of PaddlePaddle does NOT support GPU/XPU but got "
       "GPU/XPU tensor Cond in WhileOp. Please compile WITH_GPU or "
       "WITH_XPU option."));
@@ -465,11 +466,11 @@ void HandleForInplaceOp(pir::Operation* op,
       std::string output_var_name = value_exe_info->GetVarName(value);
       PADDLE_ENFORCE_NE(input_var_name,
                         "",
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The input var name of inplace op is empty."));
       PADDLE_ENFORCE_NE(output_var_name,
                         "",
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The output var name of inplace op is empty."));
       VLOG(4) << "inplace: " << value_name << " -> " << inplace_name
               << " (var: " << input_var_name << ")";
@@ -485,11 +486,11 @@ void HandleForInplaceOp(pir::Operation* op,
 
       PADDLE_ENFORCE_NE(input_var_name,
                         "",
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The input var name of view op is empty."));
       PADDLE_ENFORCE_NE(output_var_name,
                         "",
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The output var name of view op is empty."));
       VLOG(4) << "view: " << value_name << " -> " << view_name
               << " (var: " << input_var_name << ")";
@@ -521,7 +522,7 @@ void ShareVarBuffer(const Variable* src_var, Variable* dst_var) {
     }
     return;
   } else {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "Output only support DenseTensorType "
         "or SelectedRowsType or VariableRefArray"));
   }

--- a/paddle/fluid/framework/new_executor/instruction/legacy_kernel_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/legacy_kernel_instruction.cc
@@ -105,7 +105,7 @@ LegacyKernelInstruction::LegacyKernelInstruction(
       op_info.GetInterfaceImpl<paddle::dialect::OpYamlInfoInterface>();
   PADDLE_ENFORCE_NOT_NULL(
       yaml_interface,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "can not find OpYamlInfoInterface from [%s]", legacy_op_name_));
   paddle::dialect::OpYamlInfoParser yaml_info_parser(
       yaml_interface->get_op_info_(op_name),

--- a/paddle/fluid/framework/new_executor/instruction/onednn/onednn_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/onednn/onednn_instruction.cc
@@ -62,7 +62,7 @@ static phi::Attribute ConvertPirAttribute2RuntimeAttribute(
     if (array_list.size() > 0) {
       PADDLE_ENFORCE_EQ(array_list[0].isa<pir::Int32Attribute>(),
                         true,
-                        phi::errors::Unimplemented(
+                        common::errors::Unimplemented(
                             "the 0th elementwise MUST be pir::Int32Attribute"));
       for (size_t i = 0; i < array_list.size(); ++i) {
         vec_res.push_back(array_list[i].dyn_cast<pir::Int32Attribute>().data());
@@ -75,7 +75,7 @@ static phi::Attribute ConvertPirAttribute2RuntimeAttribute(
     if (array_list.size() > 0) {
       PADDLE_ENFORCE_EQ(array_list[0].isa<pir::Int64Attribute>(),
                         true,
-                        phi::errors::Unimplemented(
+                        common::errors::Unimplemented(
                             "the 0th elementwise MUST be pir::Int64Attribute"));
       for (size_t i = 0; i < array_list.size(); ++i) {
         vec_res.push_back(array_list[i].dyn_cast<pir::Int64Attribute>().data());
@@ -93,7 +93,7 @@ static phi::Attribute ConvertPirAttribute2RuntimeAttribute(
         }
 
       } else {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "ConvertPirAttribute2RuntimeAttribute not support [%s] ",
             attr_type_name));
       }
@@ -110,7 +110,7 @@ static phi::Attribute ConvertPirAttribute2RuntimeAttribute(
   } else if (attr_type_name == "paddle::dialect::ScalarAttribute") {
     return attr.dyn_cast<dialect::ScalarAttribute>().data();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ConvertPirAttribute2RuntimeAttribute not support [%s] ",
         attr_type_name));
   }
@@ -140,7 +140,7 @@ void TensorNameMap(pir::Operation* op,
     PADDLE_ENFORCE_EQ(
         name2id.count(name),
         true,
-        phi::errors::NotFound("param [%s] MUST in name2id map", name));
+        common::errors::NotFound("param [%s] MUST in name2id map", name));
     auto index = name2id.at(name);
     pir::Value ptr = op->operand_source(index);
 
@@ -151,7 +151,7 @@ void TensorNameMap(pir::Operation* op,
     auto legacy_arg_name = op_normalizer.GetLegacyArgName(fluid_op_name, name);
     auto in_var_name = value_exec_info.GetVarName(ptr);
     PADDLE_ENFORCE_NOT_NULL(inner_scope->FindVar(in_var_name),
-                            phi::errors::PreconditionNotMet(
+                            common::errors::PreconditionNotMet(
                                 "can not find var[%s] in scope", in_var_name));
 
     auto type = ptr.type();
@@ -170,7 +170,7 @@ void TensorNameMap(pir::Operation* op,
       }
       inputs_tensor_name_map[legacy_arg_name] = vec_tmp;
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "only support AllocatedDenseTensor, AllocatedSelectedRowsType  and "
           "pir::vector type"));
     }
@@ -189,7 +189,7 @@ void TensorNameMap(pir::Operation* op,
     auto out_var_name = value_exec_info.GetVarName(ptr);
 
     PADDLE_ENFORCE_NOT_NULL(inner_scope->FindVar(out_var_name),
-                            phi::errors::PreconditionNotMet(
+                            common::errors::PreconditionNotMet(
                                 "can not find var[%s] in scope", out_var_name));
 
     auto type = ptr.type();
@@ -208,7 +208,7 @@ void TensorNameMap(pir::Operation* op,
       }
       outputs_tensor_name_map[legacy_arg_name] = vec_tmp;
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "only support AllocatedDenseTensor, AllocatedSelectedRowsType  and "
           "pir::vector type"));
     }
@@ -242,7 +242,7 @@ OneDNNPhiKernelInstruction::OneDNNPhiKernelInstruction(
       op_info.GetInterfaceImpl<paddle::dialect::OpYamlInfoInterface>();
   PADDLE_ENFORCE_NOT_NULL(
       yaml_interface,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "can not find OpYamlInfoInterface from [%s]", phi_op_name_));
   paddle::dialect::OpYamlInfoParser yaml_info_parser(
       yaml_interface->get_op_info_(op_name),

--- a/paddle/fluid/framework/new_executor/instruction/onednn/onednn_legacy_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/onednn/onednn_legacy_instruction.cc
@@ -59,7 +59,7 @@ static paddle::framework::Attribute ConvertPirAttribute2FrameworkAttribute(
     if (array_list.size() > 0) {
       PADDLE_ENFORCE_EQ(array_list[0].isa<pir::Int32Attribute>(),
                         true,
-                        phi::errors::Unimplemented(
+                        common::errors::Unimplemented(
                             "the 0th elementwise MUST be pir::Int32Attribute"));
       for (size_t i = 0; i < array_list.size(); ++i) {
         vec_res.push_back(array_list[i].dyn_cast<pir::Int32Attribute>().data());
@@ -77,14 +77,14 @@ static paddle::framework::Attribute ConvertPirAttribute2FrameworkAttribute(
         }
 
       } else {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "ConvertPirAttribute2RuntimeAttribute not support [%s] ",
             attr_type_name));
       }
     }
     return vec_res;
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ConvertPirAttribute2RuntimeAttribute not support [%s] ",
         attr_type_name));
   }
@@ -117,7 +117,7 @@ OneDNNLegacyKernelInstruction::OneDNNLegacyKernelInstruction(
       op_info.GetInterfaceImpl<paddle::dialect::OpYamlInfoInterface>();
   PADDLE_ENFORCE_NOT_NULL(
       yaml_interface,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "can not find OpYamlInfoInterface from [%s]", legacy_op_name_));
   paddle::dialect::OpYamlInfoParser yaml_info_parser(
       yaml_interface->get_op_info_(op_name),

--- a/paddle/fluid/framework/new_executor/instruction/phi_kernel_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/phi_kernel_instruction.cc
@@ -110,7 +110,7 @@ PhiKernelInstruction::PhiKernelInstruction(
       op_info.GetInterfaceImpl<paddle::dialect::OpYamlInfoInterface>();
   PADDLE_ENFORCE_NOT_NULL(
       yaml_interface,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "can not find OpYamlInfoInterface from [%s]", phi_op_name_));
   paddle::dialect::OpYamlInfoParser yaml_info_parser(
       yaml_interface->get_op_info_(op_name),

--- a/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
@@ -200,7 +200,7 @@ static void RuntimeDynamicShapeCheck(
   PADDLE_ENFORCE_EQ(is_input_shape_valid(
                         runtime_input_shape, min_input_shape, max_input_shape),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "TRT runtime input shape of %s is invalid. Expect "
                         "runtime input shape to be within min/max input shape "
                         "configured in SetTRTDynamicShapeInfo(),"
@@ -227,7 +227,7 @@ static phi::DataType TRT2PaddleDataType(nvinfer1::DataType type) {
       return phi::DataType::BOOL;
 #endif
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "unknown fluid datatype in Fluid op converter"));
       return phi::DataType::FLOAT32;
   }
@@ -242,13 +242,13 @@ void TensorRTEngineInstruction::PrepareDynamicShape() {
   auto in_var_name = value_exec_info_->GetVarName(source_value);
 
   PADDLE_ENFORCE_NOT_NULL(scope.FindVar(in_var_name),
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "can not find var[%s] in scope", in_var_name));
   auto var = scope.FindVar(in_var_name);
   auto &variable_array = var->Get<VariableRefArray>();
   PADDLE_ENFORCE_EQ(variable_array.size(),
                     input_names_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input tensor num(%d) is not equal with the input "
                         "names num(%d) in TensorRTEngineInstruction",
                         variable_array.size(),
@@ -256,9 +256,9 @@ void TensorRTEngineInstruction::PrepareDynamicShape() {
   for (size_t i = 0; i < variable_array.size(); ++i) {
     if (!variable_array[i]->IsType<phi::DenseTensor>()) {
       PADDLE_THROW(
-          phi::errors::Unimplemented("Only support Vector<DenseTensor> now "
-                                     "not support vector<%d>.",
-                                     variable_array[i]->Type()));
+          common::errors::Unimplemented("Only support Vector<DenseTensor> now "
+                                        "not support vector<%d>.",
+                                        variable_array[i]->Type()));
     }
     auto input_tensor = variable_array[i]->Get<phi::DenseTensor>();
     auto name = input_names_[i];
@@ -352,12 +352,12 @@ void TensorRTEngineInstruction::PrepareDynamicShape() {
       PADDLE_ENFORCE_EQ(
           min_input_shape.count(x),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Input %s not found in TRT engine min_input_shape.", x));
       PADDLE_ENFORCE_EQ(
           max_input_shape.count(x),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Input %s not found in TRT engine max_input_shape.", x));
       RuntimeDynamicShapeCheck(
           x, runtime_input_shape[x], min_input_shape[x], max_input_shape[x]);
@@ -416,7 +416,7 @@ void TensorRTEngineInstruction::BindInputTensor(
   PADDLE_ENFORCE_GT(
       input_tensor.numel(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input tensor named %s of trt-subgraph must "
           "have >0 elements, but now have %d elements. "
           "It's likely that this tensor is connected to a Concat op inside "
@@ -438,7 +438,7 @@ void TensorRTEngineInstruction::BindInputTensor(
   if (input_shape.empty()) {
     PADDLE_ENFORCE_EQ(input_tensor.numel(),
                       1UL,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "This tensor must have one element, but got %ld.",
                           input_tensor.numel()));
     input_shape.push_back(1);
@@ -450,7 +450,7 @@ void TensorRTEngineInstruction::BindInputTensor(
       binding_offset;
   PADDLE_ENFORCE_LT(bind_index,
                     num_bindings,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Wrong TRT engine input binding index. Expected The "
                         "binding index of TRT engine input to be less than "
                         "the number of inputs and outputs. Received binding "
@@ -537,7 +537,7 @@ void TensorRTEngineInstruction::BindInputTensor(
   auto intrt_type = trt_engine_->engine()->getBindingDataType(intrt_index);
   PADDLE_ENFORCE_EQ(indata_type,
                     intrt_type,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The TRT Engine OP's input type [%d] should equal "
                         "to the input data type [%d].",
                         static_cast<int>(intrt_type),
@@ -579,9 +579,9 @@ void TensorRTEngineInstruction::BindInputTensor(
         static_cast<void *>(const_cast<bool *>(input_tensor.data<bool>()));
 #endif
   } else {
-    PADDLE_THROW(
-        phi::errors::Fatal("The TRT Engine OP only support "
-                           "float/double/int32_t/int64_t/float16/bool input."));
+    PADDLE_THROW(common::errors::Fatal(
+        "The TRT Engine OP only support "
+        "float/double/int32_t/int64_t/float16/bool input."));
   }
 }
 
@@ -633,7 +633,7 @@ void TensorRTEngineInstruction::BindOutputTensor(
 
   PADDLE_ENFORCE_LT(bind_index,
                     num_bindings,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The binding index in TRT engine should be less "
                         "than the number of bindings, but got binding "
                         "index = %d, number of bindings = %d.",
@@ -661,7 +661,7 @@ void TensorRTEngineInstruction::RunTrt() {
   auto in_var_name = value_exec_info_->GetVarName(source_value);
 
   PADDLE_ENFORCE_NOT_NULL(scope.FindVar(in_var_name),
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "can not find var[%s] in scope", in_var_name));
   auto in_var = scope.FindVar(in_var_name);
   auto &in_variable_array = in_var->Get<VariableRefArray>();
@@ -680,9 +680,9 @@ void TensorRTEngineInstruction::RunTrt() {
                       &runtime_batch);
     } else {
       PADDLE_THROW(
-          phi::errors::Unimplemented("Only support Vector<DenseTensor> now "
-                                     "not support vector<%d>.",
-                                     in_variable_array[i]->Type()));
+          common::errors::Unimplemented("Only support Vector<DenseTensor> now "
+                                        "not support vector<%d>.",
+                                        in_variable_array[i]->Type()));
     }
   }
 
@@ -692,7 +692,7 @@ void TensorRTEngineInstruction::RunTrt() {
   auto out_var_name = value_exec_info_->GetVarName(result_value);
 
   PADDLE_ENFORCE_NOT_NULL(scope.FindVar(out_var_name),
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "can not find var[%s] in scope", out_var_name));
   auto out_var = scope.FindVar(out_var_name);
   auto *out_variable_array = out_var->GetMutable<VariableRefArray>();
@@ -705,9 +705,9 @@ void TensorRTEngineInstruction::RunTrt() {
           output_names_[i], output_tensor, i, buffers, &runtime_batch);
     } else {
       PADDLE_THROW(
-          phi::errors::Unimplemented("Only support Vector<DenseTensor> now "
-                                     "not support vector<%d>.",
-                                     out_variable_array->at(i)->Type()));
+          common::errors::Unimplemented("Only support Vector<DenseTensor> now "
+                                        "not support vector<%d>.",
+                                        out_variable_array->at(i)->Type()));
     }
   }
 

--- a/paddle/fluid/framework/new_executor/interpreter/data_transfer.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/data_transfer.cc
@@ -137,7 +137,7 @@ void DataTransferHelper::RunAndConstructOpFuncNode(
   // prepare a ptr to OperatorWithKernel
   OperatorBase* op_ptr = op.get();
   if (dynamic_cast<framework::OperatorWithKernel*>(op_ptr) == nullptr) {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "%s should be OperatorWithKernel type.", op_ptr->Type()));
   }
   auto op_with_kernel = static_cast<framework::OperatorWithKernel*>(op_ptr);
@@ -409,7 +409,7 @@ std::shared_ptr<OperatorBase> TransferDevice(const std::string& var_name,
   AttributeMap attr_map;
   PADDLE_ENFORCE_EQ(phi::is_same_place(src_place, dst_place),
                     false,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Required src_place shall be different with dst_place, "
                         "but received same place: %s",
                         src_place));
@@ -428,7 +428,7 @@ std::shared_ptr<OperatorBase> TransferDevice(const std::string& var_name,
                                                                 : -1;
     attr_map = {{"dst_place_type", dst_place_type}};
   } else {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "Not support Memcpy typ : %s -> %s", src_place, dst_place));
   }
 
@@ -460,8 +460,8 @@ void ApplyDataTransform(const OpKernelType& expected_kernel_key,
   auto op_base = op_func_node->operator_base_.get();
   PADDLE_ENFORCE_NOT_NULL(
       op_base,
-      phi::errors::PreconditionNotMet("op_base is null, please pass a valid "
-                                      "op_base in apply_data_transform."));
+      common::errors::PreconditionNotMet("op_base is null, please pass a valid "
+                                         "op_base in apply_data_transform."));
 
   VariableNameMap new_ins(op_base->Inputs());
   VariableNameMap new_outs(op_base->Outputs());
@@ -497,7 +497,7 @@ void ApplyDataTransform(const OpKernelType& expected_kernel_key,
           std::vector<Variable*>* arguments) {
         PADDLE_ENFORCE_EQ(argument_names.size(),
                           arguments->size(),
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The size of argument_names (%d) should equal to "
                               "the size of arguments (%d).",
                               argument_names.size(),
@@ -660,16 +660,16 @@ void ApplyDataTransform(const OpKernelType& expected_kernel_key,
           phi::KernelRegisteredType::FUNCTION) {
     framework::OperatorWithKernel* op_with_kernel =
         dynamic_cast<framework::OperatorWithKernel*>(op_base);
-    PADDLE_ENFORCE_NOT_NULL(
-        op_with_kernel,
-        phi::errors::Unavailable("Failed to cast op_base (%p) from Operator* "
-                                 "to OperatorWithKernel*.",
-                                 op_base));
+    PADDLE_ENFORCE_NOT_NULL(op_with_kernel,
+                            common::errors::Unavailable(
+                                "Failed to cast op_base (%p) from Operator* "
+                                "to OperatorWithKernel*.",
+                                op_base));
     const auto& input_names = op_with_kernel->PhiKernelSignature()->input_names;
     const auto& input_defs = phi_kernel->args_def().input_defs();
     PADDLE_ENFORCE_EQ(input_names.size(),
                       input_defs.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The size of inputs_args names (%d) must be equal to "
                           "the size of kernel input_defs (%d).",
                           input_names.size(),
@@ -803,7 +803,7 @@ void HandleComplexGradToRealGrad(const OpFuncNode& op_func_node,
           framework::GetLoDTensorOrSelectedRowsValueFromVar(*var);
       PADDLE_ENFORCE_NOT_NULL(
           tensor,
-          phi::errors::Unavailable(
+          common::errors::Unavailable(
               "Forward tensor is nullptr when handle complex data to real."));
       // only need record type, the allocation may have been released
       auto dst_type = framework::TransToProtoVarType(tensor->dtype());

--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
@@ -151,7 +151,7 @@ const std::map<size_t, std::set<size_t>>& DependencyBuilder::OpDownstreamMap()
   PADDLE_ENFORCE_EQ(
       is_build_,
       true,
-      phi::errors::Unavailable(
+      common::errors::Unavailable(
           "DependencyBuilder is not yet built, call Build() firstly."));
   return *op_downstream_map_;
 }
@@ -361,7 +361,7 @@ void DependencyBuilder::AddDownstreamOp(size_t prior_op_idx,
   PADDLE_ENFORCE_EQ(
       OpHappensBefore(posterior_op_idx, prior_op_idx),
       false,
-      phi::errors::Unavailable(
+      common::errors::Unavailable(
           "Can not add dependency %d->%d because %d is run before %d",
           prior_op_idx,
           posterior_op_idx,
@@ -796,7 +796,7 @@ const std::map<size_t, std::set<size_t>>& DependencyBuilderSimplify::Build(
   PADDLE_ENFORCE_EQ(
       is_build_,
       false,
-      phi::errors::AlreadyExists("The op dependency has been built"));
+      common::errors::AlreadyExists("The op dependency has been built"));
   start_index_ = start_index;
   is_sharding_mode_ = is_sharding_mode;
   _ops_ptr = &ops;
@@ -1300,7 +1300,7 @@ std::vector<size_t> DependencyBuilderSimplify::get_new_executor_order() {
   PADDLE_ENFORCE_EQ(
       is_build_,
       true,
-      phi::errors::AlreadyExists("The op dependency has not been built"));
+      common::errors::AlreadyExists("The op dependency has not been built"));
   std::vector<size_t> new_order;
   std::vector<bool> is_visit(op_num_, false);
   std::vector<size_t> adam_vector;
@@ -1393,7 +1393,7 @@ std::vector<size_t> DependencyBuilderSimplify::get_new_executor_order() {
   PADDLE_ENFORCE_EQ(
       new_order.size(),
       op_num_ - not_usefull_op.size(),
-      phi::errors::AlreadyExists("new_order size not equal op num"));
+      common::errors::AlreadyExists("new_order size not equal op num"));
   if (FLAGS_enable_dependency_builder_debug_info) {
     std::stringstream ss;
     ss << " new order [ ";
@@ -1432,7 +1432,7 @@ void DependencyBuilderSimplify::AddDownstreamOp(size_t prior_op_idx,
   PADDLE_ENFORCE_EQ(
       OpHappensBefore(posterior_op_idx, prior_op_idx),
       false,
-      phi::errors::Unavailable(
+      common::errors::Unavailable(
           "Can not add dependency %d->%d because %d is run before %d",
           prior_op_idx,
           posterior_op_idx,

--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
@@ -52,7 +52,7 @@ class DependencyBuilder {
     PADDLE_ENFORCE_GE(
         op_happens_before_->size(),
         0,
-        phi::errors::Unavailable("op_happen_before is not yet built"));
+        common::errors::Unavailable("op_happen_before is not yet built"));
     return op_happens_before_->at(prior_op_idx).at(posterior_op_idx);
   }
 
@@ -160,7 +160,7 @@ class DependencyBuilderSimplify {
     PADDLE_ENFORCE_GE(
         op_happens_before_.size(),
         0,
-        phi::errors::Unavailable("op_happen_before is not yet built"));
+        common::errors::Unavailable("op_happen_before is not yet built"));
     return op_happens_before_.at(prior_op_idx).at(posterior_op_idx);
   }
   std::vector<size_t> get_new_executor_order();

--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -311,9 +311,10 @@ OpFuncType AnalyseOpFuncType(const OpFuncNode& op_func_node,
     return OpFuncType::kCpuSync;
   }
 
-  PADDLE_ENFORCE_EQ(IsSupportedHeterPlace(place),
-                    true,
-                    phi::errors::Fatal("Unsupported current place %s", place));
+  PADDLE_ENFORCE_EQ(
+      IsSupportedHeterPlace(place),
+      true,
+      common::errors::Fatal("Unsupported current place %s", place));
 
   // Some GPU OPs do not launch CUDA Kernel, but spend a lot of time on CPU
   // computing. They execute serially in device thread and block CUDA kernel
@@ -469,7 +470,7 @@ void ApplyDeviceGuard(const OperatorBase* op_base,
       PADDLE_ENFORCE_EQ(
           is_custom_device_op,
           true,
-          phi::errors::Unimplemented(
+          common::errors::Unimplemented(
               "Unsupported current device %s with Paddle CustomDevice ",
               op_device));
 #else
@@ -492,7 +493,7 @@ void ApplyDeviceGuard(const OperatorBase* op_base,
               << " by device_guard.";
     } else {
       PADDLE_THROW(
-          phi::errors::Fatal("Unsupported current place %s", op_device));
+          common::errors::Fatal("Unsupported current place %s", op_device));
     }
   }
 }
@@ -1267,7 +1268,7 @@ void BuildId2VarName(const std::map<std::string, int>& var_name_2_id,
                      std::unordered_map<int, std::string>* id_2_var_name) {
   PADDLE_ENFORCE_NOT_NULL(
       id_2_var_name,
-      phi::errors::InvalidArgument("id2_var_name can not be null"));
+      common::errors::InvalidArgument("id2_var_name can not be null"));
   for (auto [var_name, id] : var_name_2_id) {
     id_2_var_name->insert({id, var_name});
   }
@@ -1447,14 +1448,14 @@ const std::vector<std::string> GetInstructionCallStack(
     auto attr = iter->second;
     PADDLE_ENFORCE(
         attr.isa<pir::ArrayAttribute>(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "%s: Callstack attributes of %s is not ArrayAttribute type", type));
     pir::ArrayAttribute array_attribute = attr.dyn_cast<pir::ArrayAttribute>();
     std::vector<pir::Attribute> vec_attr = array_attribute.AsVector();
     for (auto value : vec_attr) {
       PADDLE_ENFORCE(
           value.isa<pir::StrAttribute>(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "%s: Callstack attributes of %s is not StrAttribute type", type));
       vec_str.emplace_back(value.dyn_cast<pir::StrAttribute>().AsString());
     }

--- a/paddle/fluid/framework/new_executor/interpreter/job.h
+++ b/paddle/fluid/framework/new_executor/interpreter/job.h
@@ -39,7 +39,7 @@ class Job final {
     PADDLE_ENFORCE_GE(
         micro_batch_id,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The micro_batch_id should be greater or equal to 0."));
     micro_batch_id_ = micro_batch_id;
   }
@@ -47,7 +47,7 @@ class Job final {
   void SetSkipGcVars(const std::set<std::string>& skip_gc_vars) {
     PADDLE_ENFORCE_EQ(skip_gc_vars_.empty(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "skip_gc_vars_ can only be initialized once, now "
                           "skip_gc_vars_ is not empty, "
                           "do not call SetSkipGcVars method repeatedly."));

--- a/paddle/fluid/framework/new_executor/interpreter/plan.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/plan.cc
@@ -29,7 +29,7 @@ Plan::Plan(const std::vector<std::shared_ptr<Job>>& job_list,
   for (size_t i = 0; i < job_list_.size(); ++i) {
     const auto& job = job_list_[i];
     PADDLE_ENFORCE(type_to_program_.find(job->Type()) != type_to_program_.end(),
-                   phi::errors::InvalidArgument(
+                   common::errors::InvalidArgument(
                        "The %d-th job (type:%s, micro_batch_id:%d) has no "
                        "corresponding Program.",
                        i,
@@ -51,7 +51,7 @@ Plan::Plan(
     const auto& job = job_list_[i];
     PADDLE_ENFORCE(
         type_to_ir_program_.find(job->Type()) != type_to_ir_program_.end(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The %d-th job (type:%s, micro_batch_id:%d) has no "
             "corresponding Program.",
             i,

--- a/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.cc
@@ -134,7 +134,7 @@ void StreamAnalyzer::ConstructEvents(std::vector<Instruction>* instructions) {
         PADDLE_ENFORCE_NE(
             op_func_node->event_to_record_,
             "default",
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "If the attribute 'force_record_event_' of one "
                 "operator is 'true', the 'event_to_record_' of this "
                 "operator can not be 'default'. But the "
@@ -144,7 +144,7 @@ void StreamAnalyzer::ConstructEvents(std::vector<Instruction>* instructions) {
             (*program_force_events_to_wait_)
                 .find(op_func_node->event_to_record_),
             (*program_force_events_to_wait_).end(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The program_force_events_to_wait_ had the event "
                 "that belongs to the operator : %s before the operator create "
                 "the event, "
@@ -166,7 +166,7 @@ void StreamAnalyzer::ConstructEvents(std::vector<Instruction>* instructions) {
         PADDLE_ENFORCE_NE(
             (*program_force_events_to_wait_).find(event_name),
             (*program_force_events_to_wait_).end(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The program_force_events_to_wait_ don't have the event %s "
                 "for the operator: %s to wait. The event should had been "
                 "created by the operator "
@@ -774,7 +774,7 @@ void PirStreamAnalyzer::ConstructEvents(
         PADDLE_ENFORCE_NE(
             instr->EventToRecordInfo(),
             "default",
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "If the attribute 'force_record_event_' of one "
                 "operator is 'true', the 'event_to_record_' of this "
                 "operator can not be 'default'. But the "
@@ -783,7 +783,7 @@ void PirStreamAnalyzer::ConstructEvents(
         PADDLE_ENFORCE_EQ(
             (*program_force_events_to_wait_).find(instr->EventToRecordInfo()),
             (*program_force_events_to_wait_).end(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The program_force_events_to_wait_ had the event "
                 "that belongs to the operator : %s before the operator create "
                 "the event, "
@@ -805,7 +805,7 @@ void PirStreamAnalyzer::ConstructEvents(
         PADDLE_ENFORCE_NE(
             (*program_force_events_to_wait_).find(event_name),
             (*program_force_events_to_wait_).end(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The program_force_events_to_wait_ don't have the event %s "
                 "for the operator: %s to wait. The event should had been "
                 "created by the operator "

--- a/paddle/fluid/framework/new_executor/interpreter_base_impl.h
+++ b/paddle/fluid/framework/new_executor/interpreter_base_impl.h
@@ -127,7 +127,7 @@ inline void SetDeviceId(const phi::Place& place) {
   // TODO(zhiqiu): reduce the cost
   if (phi::is_gpu_place(place)) {
 #if !defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP)
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Cannot run operator on place %s, please recompile paddle or "
         "reinstall Paddle with CUDA support.",
         place));
@@ -137,7 +137,7 @@ inline void SetDeviceId(const phi::Place& place) {
 #endif
   } else if (phi::is_xpu_place(place)) {
 #ifndef PADDLE_WITH_XPU
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Cannot run operator on place %s, please recompile paddle or "
         "reinstall Paddle with XPU support.",
         place));
@@ -147,7 +147,7 @@ inline void SetDeviceId(const phi::Place& place) {
 #endif
   } else if (phi::is_custom_place(place)) {
 #ifndef PADDLE_WITH_CUSTOM_DEVICE
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Cannot run operator on place %s, please recompile paddle or "
         "reinstall Paddle with CustomDevice support.",
         place));

--- a/paddle/fluid/framework/new_executor/nan_inf_utils.cc
+++ b/paddle/fluid/framework/new_executor/nan_inf_utils.cc
@@ -83,7 +83,7 @@ void CheckTensorHasNanOrInf(InstructionBase* instruction,
         paddle::framework::details::tensor_check<phi::GPUContext>(
             api_name, tensor_name, *dense_tensor, place);
 #else
-        PADDLE_THROW(phi::errors::PreconditionNotMet(
+        PADDLE_THROW(common::errors::PreconditionNotMet(
             "Tensor[%s] use gpu place. PaddlePaddle must compile with GPU.",
             tensor_name));
 #endif

--- a/paddle/fluid/framework/new_executor/new_executor_defs.cc
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.cc
@@ -35,7 +35,7 @@ VariableScope::VariableScope(Scope* scope)
   PADDLE_ENFORCE_NE(
       scope,
       nullptr,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "You have passed a nullptr to construct VariableScope."));
 }
 
@@ -102,7 +102,7 @@ void VariableScope::AddVar(const std::string& name,
     PADDLE_ENFORCE_EQ(
         var_list_.size(),
         name2id_.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size of var_list and name2id map should be equal"));
   }
 }
@@ -136,7 +136,7 @@ bool VariableScope::GetVarSkipInplace(int id) const {
 void VariableScope::CheckExist(int id) const {
   PADDLE_ENFORCE_LT(id,
                     name2id_.size(),
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Required var_id < %d, but received var_id = %d.",
                         name2id_.size(),
                         id));
@@ -145,7 +145,7 @@ void VariableScope::CheckExist(int id) const {
 void VariableScope::CheckExist(const std::string& name) const {
   PADDLE_ENFORCE_EQ(HasVar(name),
                     true,
-                    phi::errors::NotFound("%s not in VariableScope.", name));
+                    common::errors::NotFound("%s not in VariableScope.", name));
 }
 
 Instruction::Instruction(size_t id,
@@ -170,7 +170,7 @@ Instruction::Instruction(size_t id,
   }
   PADDLE_ENFORCE_GE(id,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Required id >= 0, but received id = %d", id));
 }
 
@@ -226,7 +226,7 @@ OperatorBase* Instruction::OpBase() const {
   auto op_base = op_func_node_.operator_base_;
   PADDLE_ENFORCE_NOT_NULL(
       op_base,
-      phi::errors::PreconditionNotMet("op_base shall not be nullptr."));
+      common::errors::PreconditionNotMet("op_base shall not be nullptr."));
   return op_base.get();
 }
 

--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h
@@ -180,7 +180,7 @@ void BuildPhiContext(pir::Operation* op,
     PADDLE_ENFORCE_EQ(
         name2id.count(t),
         true,
-        phi::errors::NotFound("param [%s] MUST in name2id map", t));
+        common::errors::NotFound("param [%s] MUST in name2id map", t));
 
     pir::Value ptr = op->operand_source(op_yaml_info.InputName2Id().at(t));
 
@@ -203,7 +203,7 @@ void BuildPhiContext(pir::Operation* op,
     VLOG(6) << "ctx->EmplaceBackInput: " << t << "\t" << in_var_name;
 
     PADDLE_ENFORCE_NOT_NULL(inner_scope->FindVar(in_var_name),
-                            phi::errors::PreconditionNotMet(
+                            common::errors::PreconditionNotMet(
                                 "can not find var[%s] in scope", in_var_name));
     auto var = inner_scope->FindVar(in_var_name);
     if (var->IsType<phi::DenseTensor>()) {
@@ -226,7 +226,7 @@ void BuildPhiContext(pir::Operation* op,
           inputs.emplace_back(InType(const_cast<phi::TensorArray*>(
               &(variable_array[i]->Get<phi::TensorArray>()))));
         } else {
-          PADDLE_THROW(phi::errors::Unimplemented(
+          PADDLE_THROW(common::errors::Unimplemented(
               "Only support Vector<DenseTensor> and vector<SelectedRows> "
               "and vector<TensorArray> now "
               "not support vector<%d>.",
@@ -244,8 +244,8 @@ void BuildPhiContext(pir::Operation* op,
       const phi::TensorBase* tensor_in = &(var->Get<phi::SparseCsrTensor>());
       ctx->EmplaceBackInput(InType(tensor_in));
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented("Not support var type [%d] ",
-                                              var->Type()));
+      PADDLE_THROW(common::errors::Unimplemented("Not support var type [%d] ",
+                                                 var->Type()));
     }
   }
   VLOG(8) << "EmplaceBackInput done";
@@ -281,7 +281,7 @@ void BuildPhiContext(pir::Operation* op,
             ctx->EmplaceBackAttr(vec_ref);
           }
         } else {
-          PADDLE_THROW(phi::errors::Unimplemented(
+          PADDLE_THROW(common::errors::Unimplemented(
               " [%s] only support dense tensor and vector type  ",
               tensor_attr_type));
         }
@@ -291,18 +291,18 @@ void BuildPhiContext(pir::Operation* op,
 
         ctx->EmplaceBackAttr(attr);
       } else {
-        PADDLE_THROW(phi::errors::Unimplemented("attr type not support [%s] ",
-                                                tensor_attr_type));
+        PADDLE_THROW(common::errors::Unimplemented(
+            "attr type not support [%s] ", tensor_attr_type));
       }
 
       continue;
     }
-    PADDLE_ENFORCE_NE(
-        attr_map.find(t),
-        attr_map.end(),
-        phi::errors::NotFound("Not found %s in attr_map, it maybe need mapping "
-                              "it in OpTranslator.",
-                              t));
+    PADDLE_ENFORCE_NE(attr_map.find(t),
+                      attr_map.end(),
+                      common::errors::NotFound(
+                          "Not found %s in attr_map, it maybe need mapping "
+                          "it in OpTranslator.",
+                          t));
     auto& attr_type_name = op_yaml_info.AttrTypeName(t);
     if (attr_type_name == "paddle::dialect::IntArrayAttribute") {
       ctx->EmplaceBackAttr(
@@ -331,7 +331,7 @@ void BuildPhiContext(pir::Operation* op,
         PADDLE_ENFORCE_EQ(
             array_list[0].isa<paddle::dialect::ScalarAttribute>(),
             true,
-            phi::errors::Unimplemented(
+            common::errors::Unimplemented(
                 "the 0th elementwise MUST be dialect::ScalarAttribute"));
         for (size_t i = 0; i < array_list.size(); ++i) {
           vec_res.push_back(array_list[i]
@@ -347,7 +347,7 @@ void BuildPhiContext(pir::Operation* op,
         PADDLE_ENFORCE_EQ(
             array_list[0].isa<pir::Int32Attribute>(),
             true,
-            phi::errors::Unimplemented(
+            common::errors::Unimplemented(
                 "the 0th elementwise MUST be pir::Int32Attribute"));
         for (size_t i = 0; i < array_list.size(); ++i) {
           vec_res.push_back(
@@ -366,8 +366,8 @@ void BuildPhiContext(pir::Operation* op,
           }
 
         } else {
-          PADDLE_THROW(phi::errors::Unimplemented("attr type not support [%s] ",
-                                                  attr_type_name));
+          PADDLE_THROW(common::errors::Unimplemented(
+              "attr type not support [%s] ", attr_type_name));
         }
       }
       ctx->EmplaceBackAttr(vec_res);
@@ -379,7 +379,7 @@ void BuildPhiContext(pir::Operation* op,
         PADDLE_ENFORCE_EQ(
             array_list[0].isa<pir::Int64Attribute>(),
             true,
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "Element in array list MUST be pir::Int64Attribute "));
 
         for (size_t i = 0; i < array_list.size(); ++i) {
@@ -396,7 +396,7 @@ void BuildPhiContext(pir::Operation* op,
         PADDLE_ENFORCE_EQ(
             array_list[0].isa<pir::Int64Attribute>(),
             true,
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "Element in array list MUST be pir::Int64Attribute "));
 
         for (size_t i = 0; i < array_list.size(); ++i) {
@@ -414,7 +414,7 @@ void BuildPhiContext(pir::Operation* op,
         PADDLE_ENFORCE_EQ(
             array_list[0].isa<pir::StrAttribute>(),
             true,
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "Element in array list MUST be pir::StrAttribute "));
 
         for (size_t i = 0; i < array_list.size(); ++i) {
@@ -431,8 +431,8 @@ void BuildPhiContext(pir::Operation* op,
       ctx->EmplaceBackAttr(
           attr_map[t].dyn_cast<paddle::dialect::ScalarAttribute>().data());
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented("attr type not support [%s] ",
-                                              attr_type_name));
+      PADDLE_THROW(common::errors::Unimplemented("attr type not support [%s] ",
+                                                 attr_type_name));
     }
     VLOG(6) << "ctx->EmplaceBackAttr: " << t;
   }
@@ -503,7 +503,7 @@ void BuildPhiContext(pir::Operation* op,
           outputs.emplace_back(OutType(const_cast<phi::SelectedRows*>(
               &(variable_array[i]->Get<phi::SelectedRows>()))));
         } else {
-          PADDLE_THROW(phi::errors::Unimplemented(
+          PADDLE_THROW(common::errors::Unimplemented(
               "Only support Vector<DenseTensor> and vector<SelectedRows> now, "
               "not support vector<%d>.",
               variable_array[i]->Type()));
@@ -513,7 +513,7 @@ void BuildPhiContext(pir::Operation* op,
               << value_exec_info.GetVarName(out_ptr);
       ctx->EmplaceBackOutputs(outputs);
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "only support DenseTensor, SparseCooTensor, SparseCsrTensor, and "
           "vector "));
     }

--- a/paddle/fluid/framework/new_executor/program_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/program_interpreter.cc
@@ -217,7 +217,7 @@ FetchList ProgramInterpreter::Run(const std::vector<std::string>& feed_names,
       if (platform::IsCUDAGraphCapturing()) {
         PADDLE_ENFORCE_EQ(fetch_list.empty(),
                           true,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Cannot fetch data when using CUDA Graph."));
       }
 #endif
@@ -296,7 +296,7 @@ FetchList ProgramInterpreter::Run(
       if (platform::IsCUDAGraphCapturing()) {
         PADDLE_ENFORCE_EQ(fetch_list.empty(),
                           true,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Cannot fetch data when using CUDA Graph."));
       }
 #endif
@@ -316,7 +316,7 @@ void ProgramInterpreter::SetSkipGcVars(
   PADDLE_ENFORCE_EQ(
       execution_config_.skip_gc_vars.empty(),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "execution_config_.skip_gc_vars can only be initialized once, now "
           "execution_config_.skip_gc_vars is "
           "not empty, do not call SetSkipGcVars method repeatedly."));
@@ -328,7 +328,7 @@ void ProgramInterpreter::SetJitInputVars(
   PADDLE_ENFORCE_EQ(
       execution_config_.jit_input_vars.empty(),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "execution_config_.jit_input_vars can only be initialized once, now "
           "execution_config_.jit_input_vars is "
           "not empty, do not call SetJitInputVars method repeatedly."));
@@ -560,17 +560,17 @@ void ProgramInterpreter::PrepareForCUDAGraphCapture() {
   PADDLE_ENFORCE_EQ(
       platform::IsCUDAGraphCapturing(),
       false,
-      phi::errors::PermissionDenied("CUDA Graph is not allowed to capture "
-                                    "before prepare."));
+      common::errors::PermissionDenied("CUDA Graph is not allowed to capture "
+                                       "before prepare."));
   PADDLE_ENFORCE_EQ(phi::is_gpu_place(place_),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "CUDA Graph is only supported on NVIDIA GPU device."));
   // If set true, will call `cudaStreamSynchronize(nccl_stream)`after allreduce.
   // which may cause error in cuda graph. This behavior is consistent with PE.
   PADDLE_ENFORCE_EQ(FLAGS_sync_nccl_allreduce,
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "FLAGS_sync_nccl_allreduce must be False to support "
                         "CUDA Graph capturing."));
 
@@ -595,7 +595,7 @@ void ProgramInterpreter::PrepareForCUDAGraphCapture() {
     }
   }
 #else
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "CUDA Graph is only supported on NVIDIA GPU device."));
 #endif
 }
@@ -607,19 +607,19 @@ void ProgramInterpreter::CheckCUDAGraphBeforeRun(
     PADDLE_ENFORCE_EQ(
         feed_names.empty(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Feeding data is not permitted when capturing CUDA Graph."));
     PADDLE_ENFORCE_EQ(
         FLAGS_new_executor_use_cuda_graph,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "You must turn on FLAGS_new_executor_use_cuda_graph to True "
             "to enable CUDA Graph capturing."));
     PADDLE_ENFORCE_EQ(
         place_,
         platform::CUDAGraphCapturingPlace(),
-        phi::errors::InvalidArgument("The place to capture CUDAGraph is "
-                                     "not the same as the place to run."));
+        common::errors::InvalidArgument("The place to capture CUDAGraph is "
+                                        "not the same as the place to run."));
   }
 #endif
 }
@@ -715,12 +715,12 @@ void ProgramInterpreter::Convert(
       auto& op_type = op->Type();
       if (op_type == interpreter::kMemcpyD2H ||
           op_type == interpreter::kMemcpyH2D) {
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "Cuda memory copy d2h/h2d is not allowed while using cuda graph."));
       }
       PADDLE_ENFORCE_EQ(typeid(*dev_ctx_) == typeid(phi::GPUContext),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Device context of op %s must be [%s] while using "
                             "cuda graph, but got [%s].",
                             op_type,
@@ -1326,7 +1326,7 @@ void ProgramInterpreter::ExecuteInstructionList(
     PADDLE_ENFORCE_EQ(
         main_thread_blocker_.Clear(),
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "main_thread_blocker_.Clear() return -1, clear failed"));
     VLOG(4) << "clear ok";
     exception_holder_.ReThrow();
@@ -1395,7 +1395,7 @@ void ProgramInterpreter::RunInstructionAsync(size_t instr_id) {
 
 void ProgramInterpreter::RecordStreamForGC(const Instruction& instr) {
 #if !defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP)
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "RecordStreamForGC is only implemented when compiled with GPU."));
 #else
   platform::RecordEvent record(
@@ -1491,7 +1491,7 @@ void ProgramInterpreter::RecordStreamForGC(const Instruction& instr) {
     } else if (var->IsType<std::vector<Scope*>>()) {
       // do nothing
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "The variable(%s) is not supported in eager deletion.",
           framework::ToTypeName(var->Type())));
     }
@@ -1528,7 +1528,7 @@ void ProgramInterpreter::Prepare(
     bool switch_stream) {
   PADDLE_ENFORCE_EQ(feed_names.size(),
                     feed_tensors.size(),
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Required feed_names.size() == feed_tensors.size(), "
                         "but received %d != %d",
                         feed_names.size(),
@@ -1539,8 +1539,8 @@ void ProgramInterpreter::Prepare(
       auto* feed_var = local_scope_->FindVar(feed_names[i]);
       PADDLE_ENFORCE_NOT_NULL(
           feed_var,
-          phi::errors::NotFound("Variable %s should not be nullptr.",
-                                feed_names[i]));
+          common::errors::NotFound("Variable %s should not be nullptr.",
+                                   feed_names[i]));
 
       auto feed_tensor = feed_var->GetMutable<phi::DenseTensor>();
       feed_tensor->ShareDataWith(feed_tensors[i]);
@@ -1649,7 +1649,7 @@ void ProgramInterpreter::TraceInstructionList(
     PADDLE_ENFORCE_EQ(
         main_thread_blocker_.Clear(),
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "main_thread_blocker_.Clear() return -1, clear failed"));
     VLOG(4) << "clear ok";
     exception_holder_.ReThrow();
@@ -1727,7 +1727,7 @@ void ProgramInterpreter::AnalyseExecuteOrderForTrace() {
   PADDLE_ENFORCE_EQ(
       trace_order.size(),
       dependency_count_->size(),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "trace_order size should be equal to dependency_count_."));
 
   trace_execute_order_ = trace_order;
@@ -1748,7 +1748,7 @@ void ProgramInterpreter::AnalyseExecuteOrderForTrace() {
 }
 
 Variable* ProgramInterpreter::DebugVar(const std::string& name) const {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "DebugVar is not implemented in ProgramInterpreter."));
 }
 }  // namespace framework

--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -73,12 +73,12 @@ StandaloneExecutor::StandaloneExecutor(const phi::Place& place,
     }
 
     int64_t micro_batch_id = job->MicroBatchId();
-    PADDLE_ENFORCE(
-        micro_batch_id >= 0 && micro_batch_id < micro_batch_num,
-        phi::errors::Unavailable("The micro batch id (%lld) out of bound, "
-                                 "which should be in the range of [0, %lld].",
-                                 micro_batch_id,
-                                 micro_batch_num));
+    PADDLE_ENFORCE(micro_batch_id >= 0 && micro_batch_id < micro_batch_num,
+                   common::errors::Unavailable(
+                       "The micro batch id (%lld) out of bound, "
+                       "which should be in the range of [0, %lld].",
+                       micro_batch_id,
+                       micro_batch_num));
 
     if (!FLAGS_enable_pir_api && !FLAGS_enable_pir_in_executor) {
       SetColAttrForFeedFetchOps(program, micro_batch_num, micro_batch_id);
@@ -154,7 +154,7 @@ StandaloneExecutor::StandaloneExecutor(const phi::Place& place,
                               interpretercores_.back()->Impl())
                               ->IsStaticBuild(),
                           true,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "When using pipeline strategy in auto "
                               "prarallelism with new executor, "
                               "the backward subprogram must be builded in real "

--- a/paddle/fluid/framework/new_executor/workqueue/events_waiter.cc
+++ b/paddle/fluid/framework/new_executor/workqueue/events_waiter.cc
@@ -103,7 +103,8 @@ std::string EventsWaiter::WaitEvent() {
                                         true,
                                         std::memory_order_seq_cst,
                                         std::memory_order_relaxed)) {
-    PADDLE_THROW(phi::errors::ResourceExhausted("Another thread is waiting."));
+    PADDLE_THROW(
+        common::errors::ResourceExhausted("Another thread is waiting."));
   }
 
   auto w = cv_.GetWaiter(0);

--- a/paddle/fluid/framework/new_executor/workqueue/workqueue.cc
+++ b/paddle/fluid/framework/new_executor/workqueue/workqueue.cc
@@ -15,20 +15,20 @@ namespace paddle {
 namespace framework {
 
 void WorkQueueOptions::Validate() const {
-  PADDLE_ENFORCE_GT(
-      name.size(),
-      0,
-      phi::errors::InvalidArgument("WorkQueueOptions.name must be nonempty"));
+  PADDLE_ENFORCE_GT(name.size(),
+                    0,
+                    common::errors::InvalidArgument(
+                        "WorkQueueOptions.name must be nonempty"));
   PADDLE_ENFORCE_EQ(
       name.find('_'),
       std::string::npos,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "WorkQueueOptions.name shouldn't contain an underline"));
   PADDLE_ENFORCE_EQ(
       allow_spinning == false && always_spinning == true,
       false,
-      phi::errors::InvalidArgument("WorkQueueOptions.allow_spinning must "
-                                   "be true when always_spinning is set"));
+      common::errors::InvalidArgument("WorkQueueOptions.allow_spinning must "
+                                      "be true when always_spinning is set"));
 }
 
 namespace {
@@ -170,8 +170,8 @@ void WorkQueueGroupImpl::AddTask(size_t queue_idx, std::function<void()> fn) {
   assert(queue_idx < queues_.size());
   PADDLE_ENFORCE_NOT_NULL(
       queues_.at(queue_idx),
-      phi::errors::NotFound("Workqueue of index %d is not initialized.",
-                            queue_idx));
+      common::errors::NotFound("Workqueue of index %d is not initialized.",
+                               queue_idx));
   if (queues_options_.at(queue_idx).track_task) {
     fn = [task = std::move(fn),
           raii = CounterGuard<TaskTracker>(tracker_)]() mutable { task(); };
@@ -216,7 +216,7 @@ std::unique_ptr<WorkQueue> CreateSingleThreadedWorkQueue(
   // extra check
   PADDLE_ENFORCE_EQ(options.num_threads,
                     1u,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "For a SingleThreadedWorkQueue, "
                         "WorkQueueOptions.num_threads must equals to 1."));
   std::unique_ptr<WorkQueue> ptr(new WorkQueueImpl(options));
@@ -230,9 +230,9 @@ std::unique_ptr<WorkQueue> CreateMultiThreadedWorkQueue(
   PADDLE_ENFORCE_GT(
       options.num_threads,
       1u,
-      phi::errors::InvalidArgument("For a MultiThreadedWorkQueue, "
-                                   "WorkQueueOptions.num_threads must be "
-                                   "greater than 1."));
+      common::errors::InvalidArgument("For a MultiThreadedWorkQueue, "
+                                      "WorkQueueOptions.num_threads must be "
+                                      "greater than 1."));
   std::unique_ptr<WorkQueue> ptr(new WorkQueueImpl(options));
   return ptr;
 }
@@ -241,7 +241,7 @@ std::unique_ptr<WorkQueueGroup> CreateWorkQueueGroup(
     const std::vector<WorkQueueOptions>& queues_options) {
   PADDLE_ENFORCE_GT(queues_options.size(),
                     1u,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "For a WorkQueueGroup, the number of WorkQueueOptions "
                         "must be greater than 1."));
   for (const auto& opts : queues_options) {

--- a/paddle/fluid/framework/new_executor/workqueue/workqueue.h
+++ b/paddle/fluid/framework/new_executor/workqueue/workqueue.h
@@ -42,7 +42,7 @@ class FakeCopyable {
   FakeCopyable(FakeCopyable&& other) : obj_(std::move(other.obj_)) {}
 
   FakeCopyable(const FakeCopyable& other) {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Never use the copy constructor of FakeCopyable."));
   }
 

--- a/paddle/fluid/framework/new_executor/workqueue/workqueue_utils.h
+++ b/paddle/fluid/framework/new_executor/workqueue/workqueue_utils.h
@@ -55,7 +55,7 @@ class CounterGuard {
   // copy constructor deleted, we define this for std::function
   // never use it directly
   CounterGuard(const CounterGuard& other) {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Never use the copy constructor of CounterGuard."));
   }
 

--- a/paddle/fluid/framework/no_need_buffer_vars_inference.cc
+++ b/paddle/fluid/framework/no_need_buffer_vars_inference.cc
@@ -25,9 +25,10 @@ namespace framework {
 const Attribute &InferNoNeedBufferVarsContext::GetAttr(
     const std::string &name) const {
   auto iter = attrs_.find(name);
-  PADDLE_ENFORCE_NE(iter,
-                    attrs_.end(),
-                    phi::errors::NotFound("Cannot find attribute (%s).", name));
+  PADDLE_ENFORCE_NE(
+      iter,
+      attrs_.end(),
+      common::errors::NotFound("Cannot find attribute (%s).", name));
   return iter->second;
 }
 

--- a/paddle/fluid/framework/no_need_buffer_vars_inference.h
+++ b/paddle/fluid/framework/no_need_buffer_vars_inference.h
@@ -107,7 +107,7 @@ class InferNoNeedBufferVarsFN {
       const AttributeMap &attrs) const {
     PADDLE_ENFORCE_NOT_NULL(
         inferer_,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The `inferer_` of InferNoNeedBufferVarsFN is not initialized."));
     StaticGraphInferNoNeedBufferVarsContext ctx(inputs, outputs, attrs);
     return (*inferer_)(ctx);
@@ -119,7 +119,7 @@ class InferNoNeedBufferVarsFN {
       const AttributeMap &attrs) const {
     PADDLE_ENFORCE_NOT_NULL(
         inferer_,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The `inferer_` of InferNoNeedBufferVarsFN is not initialized."));
     DyGraphInferNoNeedBufferVarsContext ctx(inputs, outputs, attrs);
     return (*inferer_)(ctx);
@@ -132,13 +132,13 @@ class InferNoNeedBufferVarsFN {
   inline void Reset(const std::shared_ptr<NoNeedBufferVarsInference> &inferer) {
     PADDLE_ENFORCE_NOT_NULL(
         inferer,
-        phi::errors::InvalidArgument("The input inferer of "
-                                     "InferNoNeedBufferVarsFN::"
-                                     "Reset is nullptr."));
+        common::errors::InvalidArgument("The input inferer of "
+                                        "InferNoNeedBufferVarsFN::"
+                                        "Reset is nullptr."));
     PADDLE_ENFORCE_EQ(
         inferer_,
         nullptr,
-        phi::errors::AlreadyExists(
+        common::errors::AlreadyExists(
             "The `inferer_` of InferNoNeedBufferVarsFN has been initialized."));
     inferer_ = inferer;
   }

--- a/paddle/fluid/framework/op_compatible_info.cc
+++ b/paddle/fluid/framework/op_compatible_info.cc
@@ -26,7 +26,7 @@ inline std::vector<int> ConvertStr2Int(const std::string& str_text) {
   auto vec_text = string::split_string<std::string>(str_text, ".");
   PADDLE_ENFORCE(
       (vec_text.size() == 2 || vec_text.size() == 3),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input[%s] is not a right version format [1.6 or 1.6.0].", str_text));
 
   std::vector<int> vec_res;
@@ -52,7 +52,7 @@ inline bool CompareVersion(const std::string& str_first,
   // first version id
   PADDLE_ENFORCE_EQ(vec_first_version.size(),
                     vec_second_version.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Version information size is not equal, the first is "
                         "[%d], the second is [%d].",
                         vec_first_version.size(),

--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -58,7 +58,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
         paddle::framework::OpInfoMap::Instance().Get(op_.Type()).proto_;
     PADDLE_ENFORCE_LT(idx,
                       op_proto->inputs().size(),
-                      phi::errors::OutOfRange(
+                      common::errors::OutOfRange(
                           "The index should be less than the size of inputs of "
                           "operator %s, but got index is %d and size is %d",
                           op_.Type(),
@@ -73,7 +73,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
     PADDLE_ENFORCE_LT(
         idx,
         op_proto->outputs().size(),
-        phi::errors::OutOfRange(
+        common::errors::OutOfRange(
             "The index should be less than the size of outputs of "
             "operator %s, but got index is %d and size is %d",
             op_.Type(),
@@ -88,14 +88,14 @@ class CompileTimeInferShapeContext : public InferShapeContext {
                 size_t j = 0) override {
     PADDLE_ENFORCE_LT(i,
                       Inputs(in).size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input variable index is out of range, expected "
                           "index less than %d, but received index is %d.",
                           Inputs(in).size(),
                           i));
     PADDLE_ENFORCE_LT(j,
                       Outputs(out).size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The output variable index is out of range, expected "
                           "index less than %d, but received index is %d.",
                           Outputs(out).size(),
@@ -106,11 +106,11 @@ class CompileTimeInferShapeContext : public InferShapeContext {
 
     PADDLE_ENFORCE_NE(input_n,
                       framework::kEmptyVarName,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input variable %s[%d] is empty.", in, i));
     PADDLE_ENFORCE_NE(output_n,
                       framework::kEmptyVarName,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The output variable %s[%d] is empty.", out, j));
 
     auto *in_var = block_.FindVarRecursive(input_n);
@@ -119,7 +119,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
     PADDLE_ENFORCE_EQ(
         in_var->GetType(),
         out_var->GetType(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The type of input %s and output %s do not match. The input type "
             "is %s, output type is %s.",
             input_n,
@@ -138,7 +138,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
     PADDLE_ENFORCE_EQ(
         in_var_names.size(),
         out_var_names.size(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Op [%s]:  Input var number should be equal with output var number",
             op_.Type()));
 
@@ -165,25 +165,25 @@ class CompileTimeInferShapeContext : public InferShapeContext {
                 size_t j = 0) const override {
     PADDLE_ENFORCE_LT(i,
                       Inputs(in).size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input variable index is out of range, expected "
                           "index less than %d, but received index is %d.",
                           Inputs(in).size(),
                           i));
     PADDLE_ENFORCE_LT(j,
                       Outputs(out).size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The output variable index is out of range, expected "
                           "index less than %d, but received index is %d.",
                           Outputs(out).size(),
                           j));
     PADDLE_ENFORCE_NE(Inputs(in)[i],
                       framework::kEmptyVarName,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input variable %s[%d] is empty.", in, i));
     PADDLE_ENFORCE_NE(Outputs(out)[j],
                       framework::kEmptyVarName,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The output variable %s[%d] is empty.", out, j));
     auto *in_var = block_.FindVarRecursive(Inputs(in)[i]);
     auto *out_var = block_.FindVarRecursive(Outputs(out)[j]);
@@ -199,7 +199,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
   int32_t GetLoDLevel(const std::string &in, size_t i = 0) const override {
     PADDLE_ENFORCE_LT(i,
                       Inputs(in).size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input variable index is out of range, input "
                           "variable %s of operator %s only has %d elements.",
                           in,
@@ -207,7 +207,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
                           Inputs(in).size()));
     PADDLE_ENFORCE_NE(Inputs(in)[i],
                       framework::kEmptyVarName,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input variable %s[%d] of operator %s is empty.",
                           in,
                           i,
@@ -215,7 +215,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
     auto *in_var = block_.FindVarRecursive(Inputs(in)[i]);
     PADDLE_ENFORCE_NOT_NULL(
         in_var,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "The input variable %s[%d] of operator %s is not found.",
             in,
             i,
@@ -228,7 +228,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
                    size_t j = 0) const override {
     PADDLE_ENFORCE_LT(j,
                       Outputs(out).size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The output variable index is out of range, output "
                           "variable %s of operator %s only has %d elements.",
                           out,
@@ -236,7 +236,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
                           Outputs(out).size()));
     PADDLE_ENFORCE_NE(Outputs(out)[j],
                       framework::kEmptyVarName,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The output variable %s[%d] of operator %s is empty.",
                           out,
                           j,
@@ -244,7 +244,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
     auto *out_var = block_.FindVarRecursive(Outputs(out)[j]);
     PADDLE_ENFORCE_NOT_NULL(
         out_var,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "The output variable %s[%d] of operator %s is not found.",
             out,
             j,
@@ -286,7 +286,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
     const std::vector<std::string> &arg_names = Inputs(name);
     PADDLE_ENFORCE_EQ(arg_names.size(),
                       1UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input(%s) should hold only one element, but now "
                           "it holds %d elements.",
                           name,
@@ -321,7 +321,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
     auto arg_names = Outputs(name);
     PADDLE_ENFORCE_EQ(arg_names.size(),
                       1UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input(%s) should hold only one element, but "
                           "now it holds %d elements.",
                           name,
@@ -363,7 +363,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
   DDim GetDim(const std::string &name) const {
     auto var = block_.FindVarRecursive(name);
     PADDLE_ENFORCE_NOT_NULL(
-        var, phi::errors::NotFound("Variable %s is not found.", name));
+        var, common::errors::NotFound("Variable %s is not found.", name));
     DDim res;
     try {
       auto shape = var->GetShape();
@@ -393,7 +393,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
     size_t length = names.size();
     PADDLE_ENFORCE_EQ(length,
                       dims.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input variables number(%d) and input dimensions "
                           "number(%d) do not match.",
                           length,
@@ -538,7 +538,7 @@ const std::vector<std::string> &OpDesc::Input(const std::string &name) const {
   PADDLE_ENFORCE_NE(
       it,
       inputs_.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Input %s cannot be found in operator %s.", name, Type()));
   return it->second;
 }
@@ -584,7 +584,7 @@ const std::vector<std::string> &OpDesc::Output(const std::string &name) const {
   PADDLE_ENFORCE_NE(
       it,
       outputs_.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Output %s cannot be found in operator %s.", name, Type()));
   return it->second;
 }
@@ -753,7 +753,7 @@ void OpDesc::SetAttr(const std::string &name, const Attribute &v) {
         return;
       }
       default:
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Unsupported attribute type (code %d).", attr_type));
     }
     need_update_ = true;
@@ -823,13 +823,13 @@ Attribute OpDesc::GetAttr(const std::string &name, bool with_attr_var) const {
     PADDLE_ENFORCE_NE(
         it,
         runtime_attrs_.end(),
-        phi::errors::NotFound("Attribute %s is not found.", name));
+        common::errors::NotFound("Attribute %s is not found.", name));
   }
   if (!with_attr_var) {
     PADDLE_ENFORCE_EQ(
         HasAttrVar(it->second),
         false,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Attribute %s with constant value is not found, but found it with "
             "Variable(s) type, which maybe not supported in some scenarios "
             "currently, such as TensorRT et.al",
@@ -848,7 +848,7 @@ const proto::OpProto::Attr &OpDesc::GetProtoAttr(
     }
   }
 
-  PADDLE_THROW(phi::errors::NotFound(
+  PADDLE_THROW(common::errors::NotFound(
       "Attribute %s is not found in proto %s.", name, proto.type()));
 }
 
@@ -866,7 +866,7 @@ std::vector<int> OpDesc::GetBlocksAttrIds(const std::string &name) const {
   PADDLE_ENFORCE_NE(
       it,
       attrs_.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Attribute `%s` is not found in operator `%s`.", name, desc_.type()));
   auto blocks = PADDLE_GET_CONST(std::vector<BlockDesc *>, it->second);
 
@@ -883,7 +883,7 @@ int OpDesc::GetBlockAttrId(const std::string &name) const {
   PADDLE_ENFORCE_NE(
       it,
       attrs_.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Attribute `%s` is not found in operator `%s`.", name, desc_.type()));
   return PADDLE_GET_CONST(BlockDesc *, it->second)->ID();
 }
@@ -1022,7 +1022,7 @@ struct SetAttrDescVisitor {
   }
 
   void operator()(paddle::blank) const {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Unsupported calling method of SetAttrDescVisitor object for "
         "`boost::blank` type."));
   }
@@ -1087,7 +1087,7 @@ void OpDesc::Flush() {
 void OpDesc::CheckAttrs() {
   PADDLE_ENFORCE_EQ(Type().empty(),
                     false,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "CheckAttrs() can not be called before type is set."));
   auto *checker = OpInfoMap::Instance().Get(Type()).Checker();
   if (checker == nullptr) {
@@ -1115,8 +1115,8 @@ void OpDesc::InferShape(const BlockDesc &block) {
     PADDLE_ENFORCE_EQ(
         static_cast<bool>(infer_shape),
         true,
-        phi::errors::NotFound("Operator %s's infer_shape is not registered.",
-                              this->Type()));
+        common::errors::NotFound("Operator %s's infer_shape is not registered.",
+                                 this->Type()));
     CompileTimeInferShapeContext ctx(*this, block);
     if (VLOG_IS_ON(10)) {
       std::ostringstream sout;
@@ -1180,7 +1180,7 @@ void OpDesc::UpdateVarAttr(const std::string &name, const Attribute &attr) {
     PADDLE_ENFORCE_EQ(
         attr_type,
         type,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Required attr.type == proto::AttrType::VAR, but received %s",
             attr_type));
     auto *var_desc = PADDLE_GET_CONST(VarDesc *, attr);
@@ -1190,7 +1190,7 @@ void OpDesc::UpdateVarAttr(const std::string &name, const Attribute &attr) {
     PADDLE_ENFORCE_EQ(
         attr_type,
         type,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Required attr.type == proto::AttrType::VARS, but received %s",
             attr_type));
     auto vars_desc = PADDLE_GET_CONST(std::vector<VarDesc *>, attr);
@@ -1212,7 +1212,7 @@ VarDesc *OpDesc::FindVarRecursive(const std::string &name) {
     }
     cur_block = cur_block->ParentBlock();
   }
-  PADDLE_THROW(phi::errors::NotFound(
+  PADDLE_THROW(common::errors::NotFound(
       "Not found Var(%s) from Block(%d) back into global Block.",
       name,
       block_->ID()));  // NOLINT
@@ -1236,10 +1236,10 @@ bool CompileTimeInferShapeContext::HasInput(const std::string &name) const {
   PADDLE_ENFORCE_EQ(
       length,
       1UL,
-      phi::errors::InvalidArgument("Input(%s) should have only one value, "
-                                   "but it has %d values now.",
-                                   name,
-                                   length));
+      common::errors::InvalidArgument("Input(%s) should have only one value, "
+                                      "but it has %d values now.",
+                                      name,
+                                      length));
   return block_.HasVarRecursive(input_names[0]);
 }
 
@@ -1255,10 +1255,10 @@ bool CompileTimeInferShapeContext::HasOutput(const std::string &name) const {
   PADDLE_ENFORCE_EQ(
       length,
       1UL,
-      phi::errors::InvalidArgument("Output(%s) should have only one value, "
-                                   "but it has %d values now.",
-                                   name,
-                                   length));
+      common::errors::InvalidArgument("Output(%s) should have only one value, "
+                                      "but it has %d values now.",
+                                      name,
+                                      length));
   return block_.HasVarRecursive(output_names[0]);
 }
 
@@ -1317,7 +1317,7 @@ std::vector<DDim> CompileTimeInferShapeContext::GetRepeatedDims(
     const std::string &name) const {
   auto var = block_.FindVarRecursive(name);
   PADDLE_ENFORCE_NOT_NULL(
-      var, phi::errors::NotFound("Variable %s is not found.", name));
+      var, common::errors::NotFound("Variable %s is not found.", name));
   std::vector<DDim> res;
   try {
     auto shapes = var->GetShapes();
@@ -1340,7 +1340,7 @@ void CompileTimeInferShapeContext::SetRepeatedDims(
     const std::string &name, const std::vector<DDim> &dims) {
   auto var = block_.FindVarRecursive(name);
   PADDLE_ENFORCE_NOT_NULL(
-      var, phi::errors::NotFound("Variable %s is not found.", name));
+      var, common::errors::NotFound("Variable %s is not found.", name));
   std::vector<std::vector<int64_t>> dim_vec(dims.size());
   std::transform(
       dims.begin(), dims.end(), dim_vec.begin(), common::vectorize<>);
@@ -1365,7 +1365,7 @@ std::vector<std::string> AttrVarNames(const Attribute &attr) {
       vars_name.emplace_back(iter->Name());
     }
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Unsupported Attribute value type `%s` for AttrVarNames",
         platform::demangle(attr.type().name())));
   }

--- a/paddle/fluid/framework/op_info.h
+++ b/paddle/fluid/framework/op_info.h
@@ -68,18 +68,18 @@ class OpInfo {
   const proto::OpProto& Proto() const {
     PADDLE_ENFORCE_NOT_NULL(
         proto_,
-        phi::errors::NotFound("Operator's Proto has not been registered"));
+        common::errors::NotFound("Operator's Proto has not been registered"));
     PADDLE_ENFORCE_EQ(proto_->IsInitialized(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Operator's Proto in op info is not initialized."));
     return *proto_;
   }
 
   const OpCreator& Creator() const {
-    PADDLE_ENFORCE_NOT_NULL(
-        creator_,
-        phi::errors::NotFound("Operator's Creator has not been registered."));
+    PADDLE_ENFORCE_NOT_NULL(creator_,
+                            common::errors::NotFound(
+                                "Operator's Creator has not been registered."));
     return creator_;
   }
 
@@ -106,7 +106,7 @@ class OpInfo {
     std::string type = proto_ ? proto_->type() : "unknown";
     PADDLE_ENFORCE_NOT_NULL(
         dygraph_grad_op_maker_,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Operator %s's DygraphGradOpMaker has not been "
             "registered.\nPlease check whether (%s) operator has "
             "gradient operator.\nIf not, please set stop_gradient to be True "
@@ -138,10 +138,10 @@ class TEST_API OpInfoMap {
   }
 
   void Insert(const std::string& type, const OpInfo& info) {
-    PADDLE_ENFORCE_NE(
-        Has(type),
-        true,
-        phi::errors::AlreadyExists("Operator (%s) has been registered.", type));
+    PADDLE_ENFORCE_NE(Has(type),
+                      true,
+                      common::errors::AlreadyExists(
+                          "Operator (%s) has been registered.", type));
     map_.insert({type, info});
   }
 
@@ -149,7 +149,7 @@ class TEST_API OpInfoMap {
     auto op_info_ptr = GetNullable(type);
     PADDLE_ENFORCE_NOT_NULL(
         op_info_ptr,
-        phi::errors::NotFound("Operator (%s) is not registered.", type));
+        common::errors::NotFound("Operator (%s) is not registered.", type));
     return *op_info_ptr;
   }
 

--- a/paddle/fluid/framework/op_kernel_type.cc
+++ b/paddle/fluid/framework/op_kernel_type.cc
@@ -36,7 +36,7 @@ size_t OpKernelType::Hash::operator()(const OpKernelType& key) const {
   int customized_value = key.customized_type_value_;
   PADDLE_ENFORCE_LT(customized_value,
                     (1 << OpKernelType::kCustomizeBits),
-                    phi::errors::Unavailable(
+                    common::errors::Unavailable(
                         "Too many custom OpKernel attribute values, expected "
                         "maximum value is %d, received value is %d.",
                         (1 << OpKernelType::kCustomizeBits),
@@ -45,7 +45,7 @@ size_t OpKernelType::Hash::operator()(const OpKernelType& key) const {
   cur_loc += OpKernelType::kCustomizeBits;
   PADDLE_ENFORCE_LT(cur_loc,
                     64,
-                    phi::errors::Unavailable(
+                    common::errors::Unavailable(
                         "Too many OpKernel attribute values, expected maximum "
                         "value is 64, received value is %d.",
                         cur_loc));

--- a/paddle/fluid/framework/op_proto_maker.cc
+++ b/paddle/fluid/framework/op_proto_maker.cc
@@ -46,7 +46,7 @@ void OpProtoAndCheckerMaker::CheckNoDuplicatedInOutAttrs() {
     PADDLE_ENFORCE_EQ(
         names.count(name),
         0,
-        phi::errors::AlreadyExists("Attribute [%s] is duplicated.", name));
+        common::errors::AlreadyExists("Attribute [%s] is duplicated.", name));
     names.insert(name);
   };
   for (auto& attr : proto_->attrs()) {

--- a/paddle/fluid/framework/op_registry.h
+++ b/paddle/fluid/framework/op_registry.h
@@ -95,7 +95,7 @@ struct OperatorRegistrar : public Registrar {
     PADDLE_ENFORCE_EQ(
         OpInfoMap::Instance().Has(op_type),
         false,
-        phi::errors::AlreadyExists(
+        common::errors::AlreadyExists(
             "Operator '%s' is registered more than once.", op_type));
     static_assert(sizeof...(ARGS) != 0,
                   "OperatorRegistrar should be invoked at least by OpClass");

--- a/paddle/fluid/framework/op_version_registry.cc
+++ b/paddle/fluid/framework/op_version_registry.cc
@@ -79,7 +79,7 @@ OpVersion& OpVersionRegistrar::Register(const std::string& op_type) {
   PADDLE_ENFORCE_EQ(
       op_version_map_.find(op_type),
       op_version_map_.end(),
-      phi::errors::AlreadyExists(
+      common::errors::AlreadyExists(
           "'%s' is registered in operator version more than once.", op_type));
   op_version_map_.insert(
       std::pair<std::string, OpVersion>{op_type, OpVersion()});
@@ -89,7 +89,7 @@ uint32_t OpVersionRegistrar::version_id(const std::string& op_type) const {
   PADDLE_ENFORCE_NE(
       op_version_map_.count(op_type),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The version of operator type %s has not been registered.", op_type));
   return op_version_map_.find(op_type)->second.version_id();
 }

--- a/paddle/fluid/framework/op_version_registry.h
+++ b/paddle/fluid/framework/op_version_registry.h
@@ -142,7 +142,7 @@ OpAttrVariantT op_attr_wrapper(const char (&val)[N]) {
   PADDLE_ENFORCE_EQ(
       val[N - 1],
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The argument of operator register %c is illegal.", val[N - 1]));
   return OpAttrVariantT{std::string{val}};
 }
@@ -381,7 +381,7 @@ class PassVersionCheckerRegistrar {
     PADDLE_ENFORCE_EQ(
         pass_version_checkers_map_.find(pass_name),
         pass_version_checkers_map_.end(),
-        phi::errors::AlreadyExists(
+        common::errors::AlreadyExists(
             "PassVersionCheckers(%s) has already been registered.",
             pass_name.c_str()));
     return pass_version_checkers_map_[pass_name];

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -244,7 +244,7 @@ bool RuntimeInferShapeContext::HasInput(const std::string& name) const {
   PADDLE_ENFORCE_EQ(
       in.size(),
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input %s should not contain more than one inputs.", name));
   return in[0] != nullptr;
 }
@@ -263,7 +263,7 @@ bool RuntimeInferShapeContext::HasOutput(const std::string& name) const {
   PADDLE_ENFORCE_EQ(
       out.size(),
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Output %s should not contain more than one outputs.", name));
   return out[0] != nullptr;
 }
@@ -320,7 +320,7 @@ std::string RuntimeInferShapeContext::GetInputNameByIdx(size_t idx) const {
       paddle::framework::OpInfoMap::Instance().Get(op_.Type()).proto_;
   PADDLE_ENFORCE_LT(idx,
                     op_proto->inputs().size(),
-                    phi::errors::OutOfRange(
+                    common::errors::OutOfRange(
                         "The index should be less than the size of inputs of "
                         "operator %s, but got index is %d and size is %d",
                         op_.Type(),
@@ -334,7 +334,7 @@ std::string RuntimeInferShapeContext::GetOutputNameByIdx(size_t idx) const {
       paddle::framework::OpInfoMap::Instance().Get(op_.Type()).proto_;
   PADDLE_ENFORCE_LT(idx,
                     op_proto->outputs().size(),
-                    phi::errors::OutOfRange(
+                    common::errors::OutOfRange(
                         "The index should be less than the size of outputs of "
                         "operator %s, but got index is %d and size is %d",
                         op_.Type(),
@@ -351,20 +351,20 @@ void RuntimeInferShapeContext::ShareDim(const std::string& in,
   auto out_it = ctx_.outputs.find(out);
   PADDLE_ENFORCE_NE(in_it,
                     ctx_.inputs.end(),
-                    phi::errors::NotFound("Input %s does not exist.", in));
+                    common::errors::NotFound("Input %s does not exist.", in));
   PADDLE_ENFORCE_NE(out_it,
                     ctx_.outputs.end(),
-                    phi::errors::NotFound("Output %s does not exist.", out));
+                    common::errors::NotFound("Output %s does not exist.", out));
   PADDLE_ENFORCE_LT(i,
                     in_it->second.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The index of input dimension is out of range, "
                         "excepted index less than %zu, but received %zu.",
                         in_it->second.size(),
                         i));
   PADDLE_ENFORCE_LT(j,
                     out_it->second.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The index of output dimension is out of range, "
                         "excepted index less than %zu, but received %zu.",
                         out_it->second.size(),
@@ -376,7 +376,7 @@ void RuntimeInferShapeContext::ShareDim(const std::string& in,
   PADDLE_ENFORCE_EQ(
       in_var->Type(),
       out_var->Type(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The type of input (%s) and output (%s) are inconsistent.", in, out));
 
   if (in_var->IsType<phi::SelectedRows>()) {
@@ -390,7 +390,7 @@ void RuntimeInferShapeContext::ShareDim(const std::string& in,
     auto* out_lod_tensor = out_var->GetMutable<phi::DenseTensor>();
     out_lod_tensor->Resize(in_lod_tensor.dims());
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Currently, the input type of ShareDim only can be phi::DenseTensor "
         "or SelectedRows."));
   }
@@ -402,11 +402,11 @@ void RuntimeInferShapeContext::ShareAllLoD(const std::string& in,
   auto out_it = ctx_.outputs.find(out);
   PADDLE_ENFORCE_NE(in_it,
                     ctx_.inputs.end(),
-                    phi::errors::NotFound(
+                    common::errors::NotFound(
                         "Input [%s] found error in Op [%s]", in, op_.Type()));
   PADDLE_ENFORCE_NE(out_it,
                     ctx_.outputs.end(),
-                    phi::errors::NotFound(
+                    common::errors::NotFound(
                         "Output [%s] found error in Op [%s]", out, op_.Type()));
 
   auto& in_var_list = in_it->second;
@@ -415,7 +415,7 @@ void RuntimeInferShapeContext::ShareAllLoD(const std::string& in,
   PADDLE_ENFORCE_EQ(
       in_var_list.size(),
       out_var_list.size(),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Op [%s]: Input var size should be equal with output var size",
           op_.Type()));
 
@@ -432,7 +432,7 @@ void RuntimeInferShapeContext::ShareAllLoD(const std::string& in,
     PADDLE_ENFORCE_EQ(
         out_var->IsType<phi::DenseTensor>(),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The %d-th output of Output(%s) must be phi::DenseTensor.",
             i,
             out_var_names[i]));
@@ -457,20 +457,20 @@ void RuntimeInferShapeContext::ShareLoD(const std::string& in,
   auto out_it = ctx_.outputs.find(out);
   PADDLE_ENFORCE_NE(in_it,
                     ctx_.inputs.end(),
-                    phi::errors::NotFound("Input %s does not exist.", in));
+                    common::errors::NotFound("Input %s does not exist.", in));
   PADDLE_ENFORCE_NE(out_it,
                     ctx_.outputs.end(),
-                    phi::errors::NotFound("Output %s does not exist.", out));
+                    common::errors::NotFound("Output %s does not exist.", out));
   PADDLE_ENFORCE_LT(i,
                     in_it->second.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The index of input dimension is out of range, "
                         "excepted index less than %zu, but received %zu.",
                         in_it->second.size(),
                         i));
   PADDLE_ENFORCE_LT(j,
                     out_it->second.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The index of output dimension is out of range, "
                         "excepted index less than %zu, but received %zu.",
                         out_it->second.size(),
@@ -482,7 +482,7 @@ void RuntimeInferShapeContext::ShareLoD(const std::string& in,
   PADDLE_ENFORCE_EQ(
       out_var->IsType<phi::DenseTensor>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The %zu-th output of Output(%s) must be phi::DenseTensor.", j, out));
   auto& in_tensor = in_var->Get<phi::DenseTensor>();
   auto* out_tensor = out_var->GetMutable<phi::DenseTensor>();
@@ -511,7 +511,7 @@ void RuntimeInferShapeContext::ShareLoD(const std::string& in,
 
 int32_t RuntimeInferShapeContext::GetLoDLevel(const std::string& in,
                                               size_t i) const {
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "GetLoDLevel is only used in compile time. The calculation of "
       "output's actual lod is different among operators so that should be "
       "set in the runtime kernel."));
@@ -520,7 +520,7 @@ int32_t RuntimeInferShapeContext::GetLoDLevel(const std::string& in,
 void RuntimeInferShapeContext::SetLoDLevel(const std::string& out,
                                            int32_t lod_level,
                                            size_t j) const {
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "SetLoDLevel is only used in compile time. The calculation of "
       "output's actual lod is different among operators so that should be "
       "set in the runtime kernel."));
@@ -563,7 +563,7 @@ DDim RuntimeInferShapeContext::GetInputDim(const std::string& name) const {
   PADDLE_ENFORCE_EQ(
       vars.size(),
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input(%s) should hold one element, but now it holds %zu elements.",
           name,
           vars.size()));
@@ -597,10 +597,10 @@ void RuntimeInferShapeContext::SetOutputDim(const std::string& name,
   PADDLE_ENFORCE_EQ(
       vars.size(),
       1UL,
-      phi::errors::InvalidArgument("Output(%s) should hold one element, "
-                                   "but now it holds %zu elements.",
-                                   name,
-                                   vars.size()));
+      common::errors::InvalidArgument("Output(%s) should hold one element, "
+                                      "but now it holds %zu elements.",
+                                      name,
+                                      vars.size()));
   SetDim(vars[0], dim);
 }
 
@@ -673,13 +673,13 @@ std::vector<DDim> RuntimeInferShapeContext::GetOutputsDim(
 
 DDim RuntimeInferShapeContext::GetDim(Variable* var) const {
   PADDLE_ENFORCE_NOT_NULL(
-      var, phi::errors::InvalidArgument("Input variable is nullptr."));
+      var, common::errors::InvalidArgument("Input variable is nullptr."));
   if (var->IsType<phi::DenseTensor>()) {
     return var->Get<phi::DenseTensor>().dims();
   } else if (var->IsType<phi::SelectedRows>()) {
     return var->Get<phi::SelectedRows>().GetCompleteDims();
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Only phi::DenseTensor or SelectedRows support 'GetDim', but input "
         "Variable's type is %s.",
         ToTypeName(var->Type())));
@@ -699,7 +699,7 @@ std::vector<DDim> RuntimeInferShapeContext::GetDims(
 
 std::vector<DDim> RuntimeInferShapeContext::GetRepeatedDims(
     const std::string& name) const {
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "GetRepeatedDims method only ban be used in compile time."));
 }
 
@@ -709,7 +709,7 @@ void RuntimeInferShapeContext::SetDim(Variable* var, const DDim& dim) {
   } else if (var->IsType<phi::SelectedRows>()) {
     var->GetMutable<phi::SelectedRows>()->set_height(dim[0]);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Variable type error, expect phi::DenseTensor or SelectedRows, but "
         "received "
         "(%s).",
@@ -722,7 +722,7 @@ void RuntimeInferShapeContext::SetDims(const std::vector<Variable*>& vars,
   size_t length = vars.size();
   PADDLE_ENFORCE_EQ(length,
                     dims.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The number of input variables do not match the "
                         "number of input dimensions, the number of variables "
                         "is %zu, the number of dimensions is %zu.",
@@ -738,7 +738,7 @@ void RuntimeInferShapeContext::SetDims(const std::vector<Variable*>& vars,
 
 void RuntimeInferShapeContext::SetRepeatedDims(const std::string& name,
                                                const std::vector<DDim>& dims) {
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "SetRepeatedDims method only can be used in compile time."));
 }
 
@@ -766,7 +766,7 @@ const std::vector<Variable*>& RuntimeInferShapeContext::InputVars(
   PADDLE_ENFORCE_NE(
       it,
       ctx_.inputs.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Operator (%s) does not have the input (%s).", op_.Type(), name));
   return it->second;
 }
@@ -777,7 +777,7 @@ const std::vector<Variable*>& RuntimeInferShapeContext::OutputVars(
   PADDLE_ENFORCE_NE(
       it,
       ctx_.outputs.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Operator (%s) does not have the outputs (%s).", op_.Type(), name));
   return it->second;
 }
@@ -787,7 +787,7 @@ void OperatorBase::Run(const Scope& scope, const phi::Place& place) {
     VLOG(4) << place << " " << DebugStringEx(&scope);
     if (phi::is_gpu_place(place)) {
 #if !defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP)
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Cannot run operator on place %s, please recompile paddle or "
           "reinstall Paddle with CUDA support.",
           place));
@@ -797,7 +797,7 @@ void OperatorBase::Run(const Scope& scope, const phi::Place& place) {
 #endif
     } else if (phi::is_xpu_place(place)) {
 #ifndef PADDLE_WITH_XPU
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Cannot run operator on place %s, please recompile paddle or "
           "reinstall Paddle with XPU support.",
           place));
@@ -807,7 +807,7 @@ void OperatorBase::Run(const Scope& scope, const phi::Place& place) {
 #endif
     } else if (phi::is_custom_place(place)) {
 #ifndef PADDLE_WITH_CUSTOM_DEVICE
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Cannot run operator on place %s, please recompile paddle or "
           "reinstall Paddle with CustomDevice support.",
           place));
@@ -856,7 +856,7 @@ std::string OperatorBase::Input(const std::string& name) const {
   PADDLE_ENFORCE_LE(
       ins.size(),
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Operator %s's input %s should contain only one variable.",
           type_,
           name));
@@ -869,7 +869,7 @@ const std::vector<std::string>& OperatorBase::Inputs(
   PADDLE_ENFORCE_NE(
       it,
       inputs_.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Operator %s does not have the input %s.", type_, name));
   return it->second;
 }
@@ -887,7 +887,7 @@ std::string OperatorBase::Output(const std::string& name) const {
   PADDLE_ENFORCE_LE(
       outs.size(),
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Operator %s's output %s should contain only one variable.",
           type_,
           name));
@@ -900,7 +900,7 @@ const std::vector<std::string>& OperatorBase::Outputs(
   PADDLE_ENFORCE_NE(
       it,
       outputs_.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Operator %s does not have an output called %s.", type_, name));
   return it->second;
 }
@@ -1066,7 +1066,7 @@ void OperatorBase::CheckAllInputOutputSet() const {
       PADDLE_ENFORCE_NE(
           inputs_.find(in.name()),
           inputs_.end(),
-          phi::errors::NotFound(
+          common::errors::NotFound(
               "Operator %s's input (%s) is not set.", Type(), in.name()));
     }
   }
@@ -1076,7 +1076,7 @@ void OperatorBase::CheckAllInputOutputSet() const {
       PADDLE_ENFORCE_NE(
           outputs_.find(out.name()),
           outputs_.end(),
-          phi::errors::NotFound(
+          common::errors::NotFound(
               "Operator %s's output (%s) is not set.", Type(), out.name()));
     }
   }
@@ -1102,7 +1102,7 @@ const phi::DenseTensor* GetLoDTensorOrSelectedRowsValueFromVar(
   } else if (var.IsType<phi::SelectedRows>()) {
     return &(var.Get<phi::SelectedRows>().value());
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Variable type is %s, expect phi::DenseTensor or SelectedRows.",
         ToTypeName(var.Type())));
   }
@@ -1114,7 +1114,7 @@ phi::DenseTensor* GetMutableLoDTensorOrSelectedRowsValueFromVar(Variable* var) {
   } else if (var->IsType<phi::SelectedRows>()) {
     return var->GetMutable<phi::SelectedRows>()->mutable_value();
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Variable type is %s, expect phi::DenseTensor or SelectedRows.",
         ToTypeName(var->Type())));
   }
@@ -1161,7 +1161,7 @@ const Variable* ExecutionContext::InputVar(const std::string& name) const {
   PADDLE_ENFORCE_LE(
       it->second.size(),
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Operator %s's input %s should contain only one variable.",
           op_.Type(),
           name));
@@ -1175,7 +1175,7 @@ Variable* ExecutionContext::OutputVar(const std::string& name) const {
   PADDLE_ENFORCE_LE(
       it->second.size(),
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Operator %s's output %s should contain only one variable.",
           op_.Type(),
           name));
@@ -1201,7 +1201,7 @@ ExecutionContext::MultiInput<phi::DenseTensor>(const std::string& name) const {
                    PADDLE_ENFORCE_EQ(
                        var->IsType<phi::DenseTensor>(),
                        true,
-                       phi::errors::InvalidArgument(
+                       common::errors::InvalidArgument(
                            "Input variable should be phi::DenseTensor, "
                            "but the received type is %s.",
                            ToTypeName(var->Type())));
@@ -1327,18 +1327,18 @@ static void CheckTensorNANOrInf(const std::string& op_type,
       framework::TransToProtoVarType(tensor.dtype()) != proto::VarType::FP64) {
     return;
   }
-  PADDLE_ENFORCE_NE(
-      framework::TensorContainsInf(tensor),
-      true,
-      phi::errors::Fatal("Operator %s output phi::DenseTensor %s contains Inf.",
-                         op_type,
-                         name));
-  PADDLE_ENFORCE_NE(
-      framework::TensorContainsNAN(tensor),
-      true,
-      phi::errors::Fatal("Operator %s output phi::DenseTensor %s contains NAN.",
-                         op_type,
-                         name));
+  PADDLE_ENFORCE_NE(framework::TensorContainsInf(tensor),
+                    true,
+                    common::errors::Fatal(
+                        "Operator %s output phi::DenseTensor %s contains Inf.",
+                        op_type,
+                        name));
+  PADDLE_ENFORCE_NE(framework::TensorContainsNAN(tensor),
+                    true,
+                    common::errors::Fatal(
+                        "Operator %s output phi::DenseTensor %s contains NAN.",
+                        op_type,
+                        name));
 }
 
 bool OperatorWithKernel::SupportGPU() const {
@@ -1397,7 +1397,7 @@ bool OperatorWithKernel::SupportXPU() const {
     }
   }
 #else
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "should not call OperatorWithKernel::SupportXPU() when not compiled with "
       "XPU support."));
   return false;
@@ -1431,7 +1431,7 @@ bool OperatorWithKernel::SupportCustomDevice() const {
     }
   }
 #else
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "should not call OperatorWithKernel::SupportCustomDevice() when not "
       "compiled with "
       "CustomDevice support."));
@@ -1623,7 +1623,7 @@ bool OperatorWithKernel::CanCUDNNBeUsed(const framework::ExecutionContext& ctx,
     PADDLE_ENFORCE_GE(
         platform::DnnVersion(),
         8100,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "bfloat16 can only be used when CUDNN_VERSION >= 8100"));
   }
 #endif  // PADDLE_WITH_CUDA
@@ -1637,7 +1637,7 @@ bool OperatorWithKernel::CanCUDNNBeUsed(const framework::ExecutionContext& ctx,
 }
 
 void OperatorWithKernel::InferShape(InferShapeContext* ctx) const {
-  PADDLE_THROW(phi::errors::PermissionDenied(
+  PADDLE_THROW(common::errors::PermissionDenied(
       "The default InferShape function of OperatorWithKernel is not allowed to "
       "be called, please override corresponding InferShape function in the "
       "specific operator."));
@@ -2330,7 +2330,7 @@ void OperatorWithKernel::ChooseKernel(const ExecutionContext& ctx) const {
   PADDLE_ENFORCE_NE(
       kernels_iter,
       all_op_kernels.end(),
-      phi::errors::Unimplemented(
+      common::errors::Unimplemented(
           "There are no kernels which are registered in the %s operator.",
           type_));
 
@@ -2437,9 +2437,9 @@ void OperatorWithKernel::ChooseKernel(const ExecutionContext& ctx) const {
   PADDLE_ENFORCE_NE(
       kernel_iter,
       kernels.end(),
-      phi::errors::NotFound("Operator (%s) does not have kernel for %s.",
-                            type_,
-                            KernelTypeToString(expected_kernel_key)));
+      common::errors::NotFound("Operator (%s) does not have kernel for %s.",
+                               type_,
+                               KernelTypeToString(expected_kernel_key)));
 
   std::lock_guard<std::mutex> lock(cache_update_mutex_);
   if (kernel_type_.get() == nullptr || kernel_func_.get() == nullptr) {
@@ -2455,15 +2455,15 @@ void OperatorWithKernel::TransferInplaceVarsBack(
   for (auto& var_name : inplace_vars) {
     VLOG(3) << "share inplace var " + var_name + " back to it's original scope";
     auto* origin_var = scope.FindVar(var_name);
-    PADDLE_ENFORCE_NOT_NULL(
-        origin_var,
-        phi::errors::InvalidArgument("The variable[%s] is nullptr.", var_name));
+    PADDLE_ENFORCE_NOT_NULL(origin_var,
+                            common::errors::InvalidArgument(
+                                "The variable[%s] is nullptr.", var_name));
     auto* original_tensor =
         GetMutableLoDTensorOrSelectedRowsValueFromVar(origin_var);
     auto* var = transfer_scope.FindVar(var_name);
-    PADDLE_ENFORCE_NOT_NULL(
-        var,
-        phi::errors::InvalidArgument("The variable[%s] is nullptr.", var_name));
+    PADDLE_ENFORCE_NOT_NULL(var,
+                            common::errors::InvalidArgument(
+                                "The variable[%s] is nullptr.", var_name));
     auto* transformed_tensor = GetLoDTensorOrSelectedRowsValueFromVar(*var);
     original_tensor->ShareDataWith(*transformed_tensor);
   }
@@ -2515,7 +2515,7 @@ void OperatorWithKernel::HandleComplexGradToRealGrad(
       const auto* tensor = GetLoDTensorOrSelectedRowsValueFromVar(*var);
       PADDLE_ENFORCE_NOT_NULL(
           tensor,
-          phi::errors::Unavailable(
+          common::errors::Unavailable(
               "Forward tensor is nullptr when handle complex data to real."));
       // only need record type, the allocation may have been released
       auto dst_type = framework::TransToProtoVarType(tensor->dtype());
@@ -2783,7 +2783,7 @@ Scope* OperatorWithKernel::PrepareData(
     const auto& input_defs = phi_kernel_->args_def().input_defs();
     PADDLE_ENFORCE_EQ(input_names.size(),
                       input_defs.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The size of inputs_args names (%d) must be equal to "
                           "the size of kernel input_defs (%d).",
                           input_names.size(),
@@ -2899,14 +2899,14 @@ void OperatorWithKernel::ParseMultiInputDataType(
         PADDLE_ENFORCE_EQ(
             sp_t->initialized(),
             true,
-            phi::errors::InvalidArgument("The %s Op's Input Variable `%s` "
-                                         "contains uninitialized Tensor.",
-                                         Type(),
-                                         name));
+            common::errors::InvalidArgument("The %s Op's Input Variable `%s` "
+                                            "contains uninitialized Tensor.",
+                                            Type(),
+                                            name));
         proto::VarType::Type tmp =
             paddle::framework::TransToProtoVarType(sp_t->dtype());
         PADDLE_ENFORCE(tmp == *data_type || *data_type == default_data_type,
-                       phi::errors::InvalidArgument(
+                       common::errors::InvalidArgument(
                            "The DataType of %s Op's duplicable or different "
                            "slot Variable %s must be "
                            "consistent or register GetExpectedKernelType. The "
@@ -2928,7 +2928,7 @@ void OperatorWithKernel::ParseMultiInputDataType(
       if (t != nullptr) {
         PADDLE_ENFORCE_EQ(t->IsInitialized(),
                           true,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The %s Op's Input Variable `%s` "
                               "contains uninitialized phi::DenseTensor.",
                               Type(),
@@ -2936,7 +2936,7 @@ void OperatorWithKernel::ParseMultiInputDataType(
         proto::VarType::Type tmp =
             paddle::framework::TransToProtoVarType(t->dtype());
         PADDLE_ENFORCE(tmp == *data_type || *data_type == default_data_type,
-                       phi::errors::InvalidArgument(
+                       common::errors::InvalidArgument(
                            "The DataType of %s Op's duplicable or different "
                            "slot Variable %s must be "
                            "consistent or register GetExpectedKernelType. The "
@@ -2968,7 +2968,7 @@ proto::VarType::Type OperatorWithKernel::IndicateDataType(
   PADDLE_ENFORCE_NE(
       data_type,
       default_data_type,
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "DataType should be indicated by input Variable at %s.", Type()));
   return data_type;
 }
@@ -2986,7 +2986,7 @@ proto::VarType::Type OperatorWithKernel::IndicateVarDataType(
   PADDLE_ENFORCE_NE(
       data_type,
       default_data_type,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The Input Variable(%s) of (%s) Operator used to determine kernel "
           "data type is empty or not phi::DenseTensor or SelectedRows or "
           "LoDTensorArray.",
@@ -3005,7 +3005,7 @@ phi::DenseTensor* OperatorWithKernel::GetTensorFormInputSafely(
   Variable* var = const_cast<Variable*>(ctx.InputVar(name));
   PADDLE_ENFORCE_NOT_NULL(
       var,
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "The variable %s is not found when promote complex types.", name));
   // 2. get tensor and check
   phi::DenseTensor* t = nullptr;
@@ -3014,17 +3014,17 @@ phi::DenseTensor* OperatorWithKernel::GetTensorFormInputSafely(
   } else if (var->IsType<phi::SelectedRows>()) {
     t = var->GetMutable<phi::SelectedRows>()->mutable_value();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Unsupported input variable type in complex type promotion."));
   }
   PADDLE_ENFORCE_NOT_NULL(t,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The phi::DenseTensor of variable %s is nullptr "
                               "when promote complex types."));
   PADDLE_ENFORCE_EQ(
       t->IsInitialized(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The phi::DenseTensor in the %s Op's Input Variable %s(%s) is "
           "not initialized.",
           Type(),
@@ -3134,7 +3134,7 @@ static void SetDnnAttrIntoDeviceContext(
         one_dnn_ctx->SetDnnAttr(attr_name, PADDLE_GET_CONST(bool, attr));
         break;
       default:
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Unsupported Attribute value type `%s` for phi.",
             platform::demangle(attr.type().name())));
     }
@@ -3153,7 +3153,7 @@ static void SetDnnAttrIntoDeviceContext(
         gpu_dnn_ctx->SetDnnAttr(attr_name, PADDLE_GET_CONST(bool, attr));
         break;
       default:
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Unsupported Attribute value type `%s` for phi.",
             platform::demangle(attr.type().name())));
     }
@@ -3186,7 +3186,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
 
   PADDLE_ENFORCE_EQ(input_names.size(),
                     input_defs.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of inputs_args names (%d) must be equal to "
                         "the size of kernel input_defs (%d).",
                         input_names.size(),
@@ -3194,7 +3194,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
 
   PADDLE_ENFORCE_EQ(output_names.size(),
                     output_defs.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of outputs_args names (%d) must be equal to "
                         "the size of kernel output_defs (%d).",
                         output_names.size(),
@@ -3202,7 +3202,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
 
   PADDLE_ENFORCE_EQ(attr_names.size(),
                     attr_defs.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of attribute_args names (%d) must be equal "
                         "to the size of kernel attribute_defs (%d).",
                         attr_names.size(),
@@ -3253,7 +3253,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
         tensor_in = &(var->Get<framework::FeedList>());
         phi_kernel_context->EmplaceBackInputWithoutSetRange(tensor_in);
       } else {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Unsupported input `%s` type when call pt kernel.",
             framework::ToTypeName(var->Type())));
       }
@@ -3308,7 +3308,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
           tensor_out = var->template GetMutable<paddle::framework::RawTensor>();
           phi_kernel_context->EmplaceBackOutputWithoutSetRange(tensor_out);
         } else {
-          PADDLE_THROW(phi::errors::Unimplemented(
+          PADDLE_THROW(common::errors::Unimplemented(
               "Unsupported output `%s` type when call pt kernel.",
               framework::ToTypeName(var->Type())));
         }
@@ -3361,7 +3361,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
                   paddle::experimental::Scalar, attr_iter->second)));
               break;
             default:
-              PADDLE_THROW(phi::errors::Unimplemented(
+              PADDLE_THROW(common::errors::Unimplemented(
                   "Unsupported cast op attribute `%s` to Scalar when construct "
                   "KernelContext in dygraph.",
                   attr_names[i]));
@@ -3393,7 +3393,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
                   &PADDLE_GET_CONST(int64_t, attr_iter->second), 1));
               break;
             default:
-              PADDLE_THROW(phi::errors::Unimplemented(
+              PADDLE_THROW(common::errors::Unimplemented(
                   "Unsupported cast op attribute `%s` to IntArray when "
                   "construct KernelContext.",
                   attr_names[i]));
@@ -3415,9 +3415,9 @@ void OperatorWithKernel::BuildPhiKernelContext(
         PADDLE_ENFORCE_NE(
             attr_iter,
             Attrs().end(),
-            phi::errors::NotFound("(%s) is not found in AttributeMap when "
-                                  "building static KernelContext.",
-                                  attr_names[i]));
+            common::errors::NotFound("(%s) is not found in AttributeMap when "
+                                     "building static KernelContext.",
+                                     attr_names[i]));
         switch (AttrTypeID(attr_iter->second)) {
           case proto::AttrType::INTS: {
             const auto& vec =
@@ -3476,7 +3476,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
             phi_kernel_context->EmplaceBackAttr(std::move(scalar_list));
           } break;
           default:
-            PADDLE_THROW(phi::errors::Unimplemented(
+            PADDLE_THROW(common::errors::Unimplemented(
                 "Unsupported cast op attribute `%s` to vector<Scalar> when "
                 "construct KernelContext.",
                 attr_names[i]));
@@ -3489,9 +3489,9 @@ void OperatorWithKernel::BuildPhiKernelContext(
           PADDLE_ENFORCE_NE(
               attr_iter,
               RuntimeAttrs().end(),
-              phi::errors::NotFound("(%s) is not found in AttributeMap when "
-                                    "building static KernelContext.",
-                                    attr_names[i]));
+              common::errors::NotFound("(%s) is not found in AttributeMap when "
+                                       "building static KernelContext.",
+                                       attr_names[i]));
         }
 
         switch (attr_defs[i].type_index) {
@@ -3547,7 +3547,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
                 phi_kernel_context->EmplaceBackAttr(vector_int64_attr);
               } break;
               default:
-                PADDLE_THROW(phi::errors::Unimplemented(
+                PADDLE_THROW(common::errors::Unimplemented(
                     "Unsupported cast op attribute `%s` to vector<int64_t> "
                     "when "
                     "construct KernelContext.",
@@ -3563,7 +3563,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
                 PADDLE_GET_CONST(std::vector<std::string>, attr_iter->second));
             break;
           default:
-            PADDLE_THROW(phi::errors::Unimplemented(
+            PADDLE_THROW(common::errors::Unimplemented(
                 "Unsupported cast op attribute `%s` when construct "
                 "KernelContext in dygraph.",
                 attr_names[i]));
@@ -3640,12 +3640,12 @@ void OperatorWithKernel::BuildPhiKernelContext(
         PADDLE_ENFORCE_EQ(
             ins_vector.size(),
             1UL,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "OneDNN's extra input only allows one input tensor."));
         auto* var = ins_vector[0];
         PADDLE_ENFORCE_EQ(var->IsType<phi::DenseTensor>(),
                           true,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "OneDNN's extra input only can be DenseTensor."));
         one_dnn_ctx->SetDnnInput(input_name, &(var->Get<phi::DenseTensor>()));
       }

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -308,7 +308,7 @@ class TEST_API OperatorBase {
       PADDLE_ENFORCE_NE(
           it,
           runtime_attrs_.end(),
-          phi::errors::NotFound(
+          common::errors::NotFound(
               "(%s) is not found in AttributeMap and RuntimeAttributeMap.",
               name));
     }
@@ -318,7 +318,7 @@ class TEST_API OperatorBase {
     PADDLE_ENFORCE_EQ(
         HasAttr(name),
         true,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "The attribute %s is not found in operator %s", name, Type()));
 
     attrs_[name] = v;
@@ -337,7 +337,8 @@ class TEST_API OperatorBase {
   const OpInfo& Info() const {
     PADDLE_ENFORCE_NOT_NULL(
         info_,
-        phi::errors::NotFound("OpInfo of operator (%s) is not found.", type_));
+        common::errors::NotFound("OpInfo of operator (%s) is not found.",
+                                 type_));
     return *info_;
   }
 
@@ -463,10 +464,10 @@ class ExecutionContext : public phi::KernelContext {
       PADDLE_ENFORCE_NE(
           iter,
           op_.RuntimeAttrs().end(),
-          phi::errors::NotFound("(%s) is not found in AttributeMap and "
-                                "RuntimeAttributeMap of (%s) operator.",
-                                name,
-                                op_.Type()));
+          common::errors::NotFound("(%s) is not found in AttributeMap and "
+                                   "RuntimeAttributeMap of (%s) operator.",
+                                   name,
+                                   op_.Type()));
     }
     return iter->second;
   }
@@ -583,7 +584,7 @@ class ExecutionContext : public phi::KernelContext {
   const inline phi::GPUContext& cuda_device_context() const {
     PADDLE_ENFORCE_EQ(phi::is_gpu_place(device_context_.GetPlace()),
                       true,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Current device context place is not GPUPlace."));
     return *reinterpret_cast<const phi::GPUContext*>(&device_context_);
   }

--- a/paddle/fluid/framework/phi_utils.cc
+++ b/paddle/fluid/framework/phi_utils.cc
@@ -36,7 +36,8 @@ class KernelArgsNameMakerByOpProto : public KernelArgsNameMaker {
       const framework::proto::OpProto* op_proto)
       : op_proto_(op_proto), input_names_(), output_names_(), attr_names_() {
     PADDLE_ENFORCE_NOT_NULL(
-        op_proto_, phi::errors::InvalidArgument("Op proto cannot be nullptr."));
+        op_proto_,
+        common::errors::InvalidArgument("Op proto cannot be nullptr."));
   }
 
   ~KernelArgsNameMakerByOpProto() override = default;
@@ -137,10 +138,10 @@ phi::KernelKey FallBackToCpu(const phi::KernelKey& kernel_key,
   if (kernel_key.backend() == phi::Backend::GPU ||
       kernel_key.backend() == phi::Backend::GPUDNN) {
     PADDLE_THROW(
-        phi::errors::NotFound("The kernel (%s) with key %s is not found and "
-                              "GPU kernel cannot fallback to CPU one.",
-                              op.Type(),
-                              kernel_key));
+        common::errors::NotFound("The kernel (%s) with key %s is not found and "
+                                 "GPU kernel cannot fallback to CPU one.",
+                                 op.Type(),
+                                 kernel_key));
   }
 #endif
 
@@ -271,10 +272,10 @@ phi::Scalar MakePhiScalarFromVar(const framework::Variable& variable) {
     PADDLE_ENFORCE_EQ(
         tensor.numel(),
         1UL,
-        phi::errors::InvalidArgument("The DenseTensor used to construct "
-                                     "the Scalar contains more than 1 "
-                                     "value, it contains `%d` values.",
-                                     tensor.numel()));
+        common::errors::InvalidArgument("The DenseTensor used to construct "
+                                        "the Scalar contains more than 1 "
+                                        "value, it contains `%d` values.",
+                                        tensor.numel()));
     if (!phi::is_same_place(tensor.place(), expected_place)) {
       phi::DenseTensor tmp_tensor;
       framework::TensorCopySync(tensor, expected_place, &tmp_tensor);
@@ -283,7 +284,7 @@ phi::Scalar MakePhiScalarFromVar(const framework::Variable& variable) {
       return {tensor};
     }
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Unsupport casting input `%s` type to Scalar when call pt "
         "kernel.",
         framework::ToTypeName(variable.Type())));
@@ -295,7 +296,7 @@ phi::IntArray MakePhiIntArrayFromVar(const framework::Variable& variable) {
     const auto& tensor = variable.Get<phi::DenseTensor>();
     return phi::IntArray(tensor);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Unsupport casting input `%s` type to IntArray when call pt "
         "kernel.",
         framework::ToTypeName(variable.Type())));
@@ -339,14 +340,14 @@ phi::IntArray MakePhiIntArrayFromVarList(
           vector_data.push_back(*tensor.data<int32_t>());
         }
       } else {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "Data type error. When cast a LoDTensor to VectorTensor, "
             "the data type of LoDTensor must be int32 or int64, "
             "but now data type is %s.",
             data_type));
       }
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupport casting input `%s` type to VectorTensor when call pt "
           "kernel.",
           framework::ToTypeName(var->Type())));

--- a/paddle/fluid/framework/pipeline_trainer.cc
+++ b/paddle/fluid/framework/pipeline_trainer.cc
@@ -92,7 +92,7 @@ void PipelineTrainer::InitTrainerEnv(const ProgramDesc& main_program,
                                      const phi::Place& place) {
   PADDLE_ENFORCE_NOT_NULL(
       root_scope_,
-      phi::errors::InvalidArgument("root_scope_ can not be nullptr"));
+      common::errors::InvalidArgument("root_scope_ can not be nullptr"));
   microbatch_scopes_.resize(num_microbatches_);
 
   VLOG(3) << "Create minibatch and microbatch scopes...";

--- a/paddle/fluid/framework/program_converter.cc
+++ b/paddle/fluid/framework/program_converter.cc
@@ -158,7 +158,7 @@ void ConvertAssignValueOp(OpDesc* op) {
 
 void ConvertProgram(ProgramDesc* program) {
   PADDLE_ENFORCE_NOT_NULL(
-      program, phi::errors::InvalidArgument("program should not be null"));
+      program, common::errors::InvalidArgument("program should not be null"));
 
   VLOG(3) << "Setting Program Version and OpVersionMap to Legacy "
              "settings(a.k.a 2.4.2)";
@@ -286,7 +286,7 @@ void ConvertAssignValueOp(OpDesc* op) {
 
 void ConvertProgram(ProgramDesc* program) {
   PADDLE_ENFORCE_NOT_NULL(
-      program, phi::errors::InvalidArgument("program should not be null"));
+      program, common::errors::InvalidArgument("program should not be null"));
 
   auto legacy_op_results = DetectLegacyOps(program);
   bool is_legacy_program = legacy_op_results.first;

--- a/paddle/fluid/framework/program_desc.cc
+++ b/paddle/fluid/framework/program_desc.cc
@@ -148,7 +148,7 @@ void ProgramDesc::CopyFrom(const proto::ProgramDesc &desc) {
 ProgramDesc::ProgramDesc(const std::string &binary_str) {
   PADDLE_ENFORCE_EQ(desc_.ParseFromString(binary_str),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Failed to parse program_desc from binary string."));
   InitFromProto();
   scalar::ConvertProgram(this);

--- a/paddle/fluid/framework/program_utils.cc
+++ b/paddle/fluid/framework/program_utils.cc
@@ -34,15 +34,15 @@ void MergePrograms(ProgramDesc *dst,
                    const std::vector<ProgramDesc> &srcs,
                    bool append) {
   PADDLE_ENFORCE_NOT_NULL(
-      dst, phi::errors::InvalidArgument("Dst program must be provided."));
+      dst, common::errors::InvalidArgument("Dst program must be provided."));
   bool reverse = !append;
 
   auto create_var_visitor = [dst](const ProgramDesc &src) {
     PADDLE_ENFORCE_EQ(
         src.Size(),
         1,
-        phi::errors::Unimplemented("MergePrograms can only support to "
-                                   "merge program with only one block."));
+        common::errors::Unimplemented("MergePrograms can only support to "
+                                      "merge program with only one block."));
     const auto &src_block = src.Block(0);
     auto *dst_block = dst->MutableBlock(0);
     for (const auto *src_new_var : src_block.AllVars()) {

--- a/paddle/fluid/framework/prune.cc
+++ b/paddle/fluid/framework/prune.cc
@@ -79,7 +79,7 @@ int GetSubBlockIndex(const proto::OpDesc& op_desc) {
     if (attr.type() == proto::AttrType::BLOCK) {
       PADDLE_ENFORCE_EQ(attr.has_block_idx(),
                         true,
-                        phi::errors::NotFound(
+                        common::errors::NotFound(
                             "Attribute sub_block is not found in operator %s",
                             op_desc.type()));
       return attr.block_idx();
@@ -95,8 +95,8 @@ void GetSubBlocksIndices(const proto::OpDesc& op_desc,
       PADDLE_ENFORCE_GT(
           attr.blocks_idx_size(),
           0,
-          phi::errors::NotFound("Attribute blocks is not found in operator %s",
-                                op_desc.type()));
+          common::errors::NotFound(
+              "Attribute blocks is not found in operator %s", op_desc.type()));
       indices->resize(attr.blocks_idx_size());
       for (int i = 0; i < attr.blocks_idx_size(); i++) {
         (*indices)[i] = attr.blocks_idx(i);
@@ -110,7 +110,7 @@ void SetSubBlockIndex(proto::OpDesc* op_desc, int sub_idx) {
     if (attr.type() == proto::AttrType::BLOCK) {
       PADDLE_ENFORCE_EQ(attr.has_block_idx(),
                         true,
-                        phi::errors::NotFound(
+                        common::errors::NotFound(
                             "Attribute sub_block is not found in operator %s",
                             op_desc->type()));
       attr.set_block_idx(sub_idx);
@@ -125,8 +125,8 @@ void SetSubBlocksIndices(proto::OpDesc* op_desc,
       PADDLE_ENFORCE_GT(
           attr.blocks_idx_size(),
           0,
-          phi::errors::NotFound("Attribute blocks is not found in operator %s",
-                                op_desc->type()));
+          common::errors::NotFound(
+              "Attribute blocks is not found in operator %s", op_desc->type()));
       attr.clear_blocks_idx();
       for (auto idx : sub_indices) {
         attr.add_blocks_idx(idx);
@@ -146,8 +146,8 @@ bool HasSubBlocks(const proto::OpDesc& op_desc) {
       PADDLE_ENFORCE_GT(
           attr.blocks_idx_size(),
           0,
-          phi::errors::NotFound("Attribute blocks is not found in operator %s",
-                                op_desc.type()));
+          common::errors::NotFound(
+              "Attribute blocks is not found in operator %s", op_desc.type()));
       return true;
     }
   }
@@ -161,9 +161,9 @@ int GetOpRole(const proto::OpDesc& op_desc) {
       PADDLE_ENFORCE_EQ(
           attr.has_i(),
           true,
-          phi::errors::NotFound("Attribute %s is empty in operator %s",
-                                OpProtoAndCheckerMaker::OpRoleAttrName(),
-                                op_desc.type()));
+          common::errors::NotFound("Attribute %s is empty in operator %s",
+                                   OpProtoAndCheckerMaker::OpRoleAttrName(),
+                                   op_desc.type()));
       return attr.i();
     }
   }
@@ -242,7 +242,7 @@ void prune_impl(const proto::ProgramDesc& input,
     PADDLE_ENFORCE_EQ(
         op_desc.type() != kFeedOpType || expect_feed,
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "All FeedOps are at the beginning of the ProgramDesc"));
     expect_feed = (op_desc.type() == kFeedOpType);
   }
@@ -252,7 +252,7 @@ void prune_impl(const proto::ProgramDesc& input,
     auto& op_desc = *op_iter;
     PADDLE_ENFORCE_EQ(op_desc.type() != kFetchOpType || expect_fetch,
                       true,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "All FetchOps must at the end of the ProgramDesc"));
     expect_fetch = (op_desc.type() == kFetchOpType);
   }
@@ -405,7 +405,7 @@ void prune_impl(const proto::ProgramDesc& input,
           }
         } else {
           PADDLE_ENFORCE(false,
-                         phi::errors::PreconditionNotMet(
+                         common::errors::PreconditionNotMet(
                              "Attr Block or Blocks must exist when recursively "
                              "calling prune_impl"));
         }
@@ -484,7 +484,7 @@ std::map<int, int> Prune(const proto::ProgramDesc& input,
         PADDLE_ENFORCE_NE(
             sub_idx,
             -1,
-            phi::errors::NotFound(
+            common::errors::NotFound(
                 "The origin sub block id should be found in "
                 "pruned_progin_block_id_map when the op has sub_block"));
         SetSubBlockIndex(&op_desc, sub_idx);
@@ -497,7 +497,7 @@ std::map<int, int> Prune(const proto::ProgramDesc& input,
           PADDLE_ENFORCE_NE(
               sub_idx,
               -1,
-              phi::errors::NotFound(
+              common::errors::NotFound(
                   "The origin sub block id should be found in "
                   "pruned_progin_block_id_map when the op has sub_blocks"));
           sub_indices.push_back(sub_idx);
@@ -636,11 +636,11 @@ std::tuple<framework::ProgramDesc, std::map<int, int>> PruneBackward(
       } else {
         auto parent_idx =
             FindMapByValue(pruned_progin_block_id_map, origin->parent_idx());
-        PADDLE_ENFORCE_NE(
-            parent_idx,
-            -1,
-            phi::errors::NotFound("The origin parent block id is not found in "
-                                  "pruned_progin_block_id_map"));
+        PADDLE_ENFORCE_NE(parent_idx,
+                          -1,
+                          common::errors::NotFound(
+                              "The origin parent block id is not found in "
+                              "pruned_progin_block_id_map"));
         pruned_block->set_parent_idx(parent_idx);
       }
     }
@@ -659,7 +659,7 @@ std::tuple<framework::ProgramDesc, std::map<int, int>> PruneBackward(
         PADDLE_ENFORCE_NE(
             sub_idx,
             -1,
-            phi::errors::NotFound(
+            common::errors::NotFound(
                 "The origin sub block id is not found in "
                 "pruned_progin_block_id_map when the op has sub_block"));
         SetSubBlockIndex(&op_desc, sub_idx);
@@ -672,7 +672,7 @@ std::tuple<framework::ProgramDesc, std::map<int, int>> PruneBackward(
           PADDLE_ENFORCE_NE(
               sub_idx,
               -1,
-              phi::errors::NotFound(
+              common::errors::NotFound(
                   "The origin sub block id should be found in "
                   "pruned_progin_block_id_map when the op has sub_blocks"));
           sub_indices.push_back(sub_idx);

--- a/paddle/fluid/framework/ps_gpu_worker.cc
+++ b/paddle/fluid/framework/ps_gpu_worker.cc
@@ -72,10 +72,10 @@ void PSGPUWorker::CreateDeviceResource(const ProgramDesc& main_prog) {
             continue;
           }
           auto* ptr = scope->FindLocalVar(var->Name());
-          PADDLE_ENFORCE_NE(
-              ptr,
-              nullptr,
-              phi::errors::NotFound("The var %s is not found.", var->Name()));
+          PADDLE_ENFORCE_NE(ptr,
+                            nullptr,
+                            common::errors::NotFound("The var %s is not found.",
+                                                     var->Name()));
           need_reuse.push_back(ptr);
         }
       }
@@ -90,10 +90,10 @@ void PSGPUWorker::CreateDeviceResource(const ProgramDesc& main_prog) {
             continue;
           }
           auto* ptr = thread_scope_->FindLocalVar(var->Name());
-          PADDLE_ENFORCE_NE(
-              ptr,
-              nullptr,
-              phi::errors::NotFound("The var %s is not found.", var->Name()));
+          PADDLE_ENFORCE_NE(ptr,
+                            nullptr,
+                            common::errors::NotFound("The var %s is not found.",
+                                                     var->Name()));
           need_reuse_var_.push_back(ptr);
         }
       }
@@ -240,12 +240,12 @@ int PSGPUWorker::OpRunAndShapeCheck(OperatorBase& op,
       op_name = op.Info().Proto().type();
     }
 
-#define SHAPE_CHECK_EQ(__VAL0, __VAL1)                                 \
-  PADDLE_ENFORCE_EQ(                                                   \
-      __VAL0,                                                          \
-      __VAL1,                                                          \
-      phi::errors::Fatal("Shape check dims/lods error, op name: %s .", \
-                         op_name))
+#define SHAPE_CHECK_EQ(__VAL0, __VAL1)                                    \
+  PADDLE_ENFORCE_EQ(                                                      \
+      __VAL0,                                                             \
+      __VAL1,                                                             \
+      common::errors::Fatal("Shape check dims/lods error, op name: %s .", \
+                            op_name))
 
     SHAPE_CHECK_EQ(pre_dims.size(), after_dims.size());
     for (size_t i = 0; i < pre_dims.size(); i++) {
@@ -373,7 +373,7 @@ void PSGPUWorker::TrainFiles() {
           need_reuse_var_vec_[thread_scope];
       PADDLE_ENFORCE_EQ(cur_scope_vars.size(),
                         need_reuse_var_.size(),
-                        phi::errors::Fatal("reuse vars size must be same."));
+                        common::errors::Fatal("reuse vars size must be same."));
       for (size_t i = 0; i < need_reuse_var_.size(); i++) {
         Variable* child = cur_scope_vars[i];
         Variable* parent = need_reuse_var_[i];
@@ -456,7 +456,7 @@ void PSGPUWorker::TrainFiles() {
           need_reuse_var_vec_[thread_scope];
       PADDLE_ENFORCE_EQ(cur_scope_vars.size(),
                         need_reuse_var_.size(),
-                        phi::errors::Fatal("reuse vars size must be same."));
+                        common::errors::Fatal("reuse vars size must be same."));
       for (size_t i = 0; i < need_reuse_var_.size(); i++) {
         Variable* child = cur_scope_vars[i];
         Variable* parent = need_reuse_var_[i];

--- a/paddle/fluid/framework/pull_dense_worker.cc
+++ b/paddle/fluid/framework/pull_dense_worker.cc
@@ -118,8 +118,8 @@ void PullDenseWorker::Wait(std::vector<::std::future<int32_t>>* status_vec) {
 
   size_t MAX_FAIL_NUM = 20;
   if (pull_dense_fail_times_ > MAX_FAIL_NUM) {
-    PADDLE_THROW(phi::errors::Fatal("Pull dense failed more than %d times.",
-                                    MAX_FAIL_NUM));
+    PADDLE_THROW(common::errors::Fatal("Pull dense failed more than %d times.",
+                                       MAX_FAIL_NUM));
     exit(-1);
   }
   status_vec->resize(0);

--- a/paddle/fluid/framework/raw_tensor.h
+++ b/paddle/fluid/framework/raw_tensor.h
@@ -53,14 +53,14 @@ class RawTensor : public phi::ExtendedTensor,
   T& Get() const {
     PADDLE_ENFORCE_EQ(data_.empty(),
                       false,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The data in RawTensor is empty. Please set data "
                           "before using it."));
 
     try {
       return *(paddle::any_cast<T*>(data_));
     } catch (paddle::bad_any_cast&) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Invalid data type error, expected %s, actual %s.",
           typeid(T).name(),
           data_type_.name()));
@@ -73,7 +73,7 @@ class RawTensor : public phi::ExtendedTensor,
       try {
         return paddle::any_cast<T*>(data_);
       } catch (paddle::bad_any_cast&) {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "Invalid data type error, expected %s, actual %s.",
             typeid(T).name(),
             data_type_.name()));

--- a/paddle/fluid/framework/reader.cc
+++ b/paddle/fluid/framework/reader.cc
@@ -23,7 +23,7 @@ void ReaderBase::ReadNext(paddle::framework::LoDTensorArray *out) {
   std::lock_guard<std::mutex> lock(mu_);
   PADDLE_ENFORCE_EQ(status_,
                     ReaderStatus::kRunning,
-                    phi::errors::Unavailable(
+                    common::errors::Unavailable(
                         "The current reader has stopped running and cannot "
                         "continue to read the next batch of data."));
   ReadNextImpl(out);

--- a/paddle/fluid/framework/reader.h
+++ b/paddle/fluid/framework/reader.h
@@ -37,13 +37,13 @@ class ReaderBase {
     PADDLE_ENFORCE_EQ(
         shapes_.size(),
         need_check_feed_.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Construct ReaderBase with mismatched sizes of shapes "
             "and need_check_feed"));
     PADDLE_ENFORCE_EQ(
         var_types_.size(),
         need_check_feed_.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Construct ReaderBase with mismatched sizes of var_types "
             "and need_check_feed"));
   }
@@ -113,7 +113,7 @@ class DecoratedReader : public ReaderBase,
         reader_(reader) {
     PADDLE_ENFORCE_NOT_NULL(
         reader_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The underlying reader of DecoratedReader should not be null"));
   }
 
@@ -156,7 +156,7 @@ class ReaderHolder {
     auto reader_base = std::dynamic_pointer_cast<ReaderBase>(reader);
     PADDLE_ENFORCE_NOT_NULL(
         reader_base,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The underlying reader of ReaderHolder should not be null"));
     reader_ = reader_base;
   }
@@ -168,7 +168,7 @@ class ReaderHolder {
   void ReadNext(paddle::framework::LoDTensorArray* out) {
     PADDLE_ENFORCE_NOT_NULL(
         reader_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The underlying reader of ReaderHolder should not be null"));
     reader_->ReadNext(out);
   }
@@ -188,7 +188,7 @@ class ReaderHolder {
     VLOG(1) << "Shutdown";
     PADDLE_ENFORCE_NOT_NULL(
         reader_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The underlying reader of ReaderHolder should not be null"));
     reader_->Shutdown();
   }
@@ -197,7 +197,7 @@ class ReaderHolder {
     VLOG(1) << "start";
     PADDLE_ENFORCE_NOT_NULL(
         reader_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The underlying reader of ReaderHolder should not be null"));
     reader_->Start();
   }

--- a/paddle/fluid/framework/scope.cc
+++ b/paddle/fluid/framework/scope.cc
@@ -77,7 +77,7 @@ Variable* Scope::FindVar(const std::string& name) const {
 Variable* Scope::GetVar(const std::string& name) const {
   auto* var = FindVar(name);
   PADDLE_ENFORCE_NOT_NULL(
-      var, phi::errors::NotFound("Cannot find %s in scope.", name));
+      var, common::errors::NotFound("Cannot find %s in scope.", name));
   return var;
 }
 
@@ -151,7 +151,7 @@ void Scope::DeleteScope(Scope* scope) const {
     auto it = std::find(this->kids_.begin(), this->kids_.end(), scope);
     PADDLE_ENFORCE_NE(it,
                       this->kids_.end(),
-                      phi::errors::NotFound(
+                      common::errors::NotFound(
                           "%p is not found in %p as kid scope", scope, this));
     this->kids_.erase(it);
     // When making memory benchmark on Fluid, we have to delete scope sync.
@@ -225,14 +225,14 @@ void Scope::RenameInternal(const std::string& origin_name,
   PADDLE_ENFORCE_NE(
       origin_it,
       vars_.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Original variable with name %s is not found in the scope.",
           origin_name));
   auto new_it = vars_.find(new_name);
   PADDLE_ENFORCE_EQ(
       new_it,
       vars_.end(),
-      phi::errors::AlreadyExists(
+      common::errors::AlreadyExists(
           "The variable with name %s already exists in the scope.", new_name));
   vars_[new_name].reset(origin_it->second.release());
   vars_.erase(origin_it);

--- a/paddle/fluid/framework/scope_pool.cc
+++ b/paddle/fluid/framework/scope_pool.cc
@@ -37,9 +37,9 @@ void ScopePool::Remove(Scope *s) {
   PADDLE_ENFORCE_GT(
       has_scope,
       0,
-      phi::errors::NotFound("Global scope %p is not found in ScopePool. "
-                            "Deleting a nonexistent scope is not allowed.",
-                            s));
+      common::errors::NotFound("Global scope %p is not found in ScopePool. "
+                               "Deleting a nonexistent scope is not allowed.",
+                               s));
   DeleteScope(s);
 }
 

--- a/paddle/fluid/framework/section_worker.cc
+++ b/paddle/fluid/framework/section_worker.cc
@@ -51,7 +51,7 @@ void SectionWorker::Initialize(const TrainerDesc &desc) {
     } else if (op_role == static_cast<int>(OpRole::kOptimize)) {
       optimizer_ops_.push_back(op.get());
     } else {
-      PADDLE_THROW(phi::errors::PreconditionNotMet(
+      PADDLE_THROW(common::errors::PreconditionNotMet(
           "The op %s is None of LRSched, Forward, Backward or Optimize.",
           op->Type()));
     }
@@ -74,7 +74,7 @@ void SectionWorker::Initialize(const TrainerDesc &desc) {
     VLOG(3) << "Pipeline backward send var " << var_name;
     PADDLE_ENFORCE_NE(is_first_stage,
                       true,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The first pipeline stage must do not have a "
                           "backward send var, please check var %s",
                           var_name));
@@ -167,7 +167,7 @@ void SectionWorker::Run1F1B(std::unique_ptr<GarbageCollector> &gc) {
   PADDLE_ENFORCE_GT(
       num_microbatches_,
       startup_steps,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "To use pipeline with 1F1B scheduler, please make sure number of "
           "microbatches (%d) is than startup steps (%d).",
           num_microbatches_,

--- a/paddle/fluid/framework/selected_rows_utils.cc
+++ b/paddle/fluid/framework/selected_rows_utils.cc
@@ -66,7 +66,7 @@ void DeserializeFromStream(std::istream& is,
     is.read(reinterpret_cast<char*>(&version), sizeof(version));
     PADDLE_ENFORCE_EQ(version,
                       0U,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Only version 0 SelectedRows is supported."));
   }
   {
@@ -76,7 +76,7 @@ void DeserializeFromStream(std::istream& is,
     PADDLE_ENFORCE_EQ(
         is.good(),
         true,
-        phi::errors::Unavailable("Cannot read the number of rows."));
+        common::errors::Unavailable("Cannot read the number of rows."));
     auto& rows = *selected_rows->mutable_rows();
     rows.resize(size);
     for (uint64_t i = 0; i < size; ++i) {

--- a/paddle/fluid/framework/shape_inference.cc
+++ b/paddle/fluid/framework/shape_inference.cc
@@ -23,7 +23,7 @@ std::vector<DDim> InferShapeContext::GetReaderDims(
   const std::vector<std::string> &arg_names = Inputs(name);
   PADDLE_ENFORCE_EQ(arg_names.size(),
                     1UL,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Reader input '%s' should hold one element, but now it "
                         "holds %d elements.",
                         name,
@@ -36,7 +36,7 @@ void InferShapeContext::SetReaderDims(const std::string &name,
   const std::vector<std::string> &arg_names = Outputs(name);
   PADDLE_ENFORCE_EQ(arg_names.size(),
                     1UL,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Reader output '%s' should hold one element, but now "
                         "it holds %d elements.",
                         name,

--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -119,7 +119,7 @@ void TensorCopyImpl(const TENSOR& src,
     }
     memory::Copy(dst_place, dst_ptr, src_place, src_ptr, size);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Copy from %s to %s is not supported.", src_place, dst_place));
   }
 #endif
@@ -144,13 +144,13 @@ void TensorCopyImpl(const TENSOR& src,
     PADDLE_ENFORCE_EQ(
         phi::is_gpu_place(ctx_place),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Context place error, excepted GPUPlace, but actually %s.",
             ctx_place));
     auto ctx_gpu_place = ctx_place;
     PADDLE_ENFORCE_EQ(src_gpu_place,
                       ctx_gpu_place,
-                      phi::errors::Unavailable(
+                      common::errors::Unavailable(
                           "Source place and context place do not match, source "
                           "place is %s, context place is %s.",
                           src_gpu_place,
@@ -166,13 +166,13 @@ void TensorCopyImpl(const TENSOR& src,
     PADDLE_ENFORCE_EQ(
         phi::is_gpu_place(ctx_place),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Context place error, excepted GPUPlace, but actually %s.",
             ctx_place));
     auto ctx_gpu_place = ctx_place;
     PADDLE_ENFORCE_EQ(dst_gpu_place,
                       ctx_gpu_place,
-                      phi::errors::Unavailable(
+                      common::errors::Unavailable(
                           "Destination place and context place do not match, "
                           "destination place is %s, context place is %s.",
                           dst_gpu_place,
@@ -188,14 +188,14 @@ void TensorCopyImpl(const TENSOR& src,
     PADDLE_ENFORCE_EQ(
         phi::is_gpu_place(ctx_place),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Device context place mismatch. When copying phi::DenseTensor "
             "data from GPU memory to CUDA Pinned memory, current "
             "device context place should be GPU."));
     auto ctx_gpu_place = ctx_place;
     PADDLE_ENFORCE_EQ(src_gpu_place,
                       ctx_gpu_place,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The source GPU device and current device context do "
                           "not match. The source GPU device number is %d, but "
                           "device context GPU number is %d.",
@@ -213,14 +213,14 @@ void TensorCopyImpl(const TENSOR& src,
     PADDLE_ENFORCE_EQ(
         phi::is_gpu_place(ctx_place),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Device context place mismatch. When copying phi::DenseTensor "
             "data from CUDA Pinned memory to GPU memory, current "
             "device context place should be GPU."));
     auto ctx_gpu_place = ctx_place;
     PADDLE_ENFORCE_EQ(dst_gpu_place,
                       ctx_gpu_place,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The target GPU device and current device context do "
                           "not match. The target GPU device number is %d, but "
                           "device context GPU number is %d.",
@@ -238,7 +238,7 @@ void TensorCopyImpl(const TENSOR& src,
     PADDLE_ENFORCE_EQ(
         phi::is_gpu_place(ctx_place),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Context place error, excepted GPUPlace, but actually %s.",
             ctx_place));
     auto stream = reinterpret_cast<const phi::GPUContext&>(ctx).stream();
@@ -255,13 +255,13 @@ void TensorCopyImpl(const TENSOR& src,
         memory::Copy(
             dst_gpu_place, dst_ptr, src_gpu_place, src_ptr, size, stream);
       } else {
-        PADDLE_THROW(phi::errors::Unavailable(
+        PADDLE_THROW(common::errors::Unavailable(
             "Context place dose not match the source and destination place."));
       }
     }
   }
   else {  // NOLINT
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Copying from %s to %s is not supported.", src_place, dst_place));
   }
 #endif
@@ -371,7 +371,7 @@ void TensorCopySync(const phi::DenseTensor& src,
     }
   }       // NOLINT
   else {  // NOLINT
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Copy from %s to %s is not supported.", src_place, dst_place));
   }
 #endif
@@ -418,7 +418,7 @@ void TensorCopySync(const phi::DenseTensor& src,
         dst_gpu_place, dst_ptr, src_pinned_place, src_ptr, size, nullptr);
   }
   else {  // NOLINT
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Copy from %s to %s is not supported.", src_place, dst_place));
   }
 #endif
@@ -441,7 +441,7 @@ void TensorCopySync(const phi::DenseTensor& src,
     memory::Copy(dst_place, dst_ptr, src_place, src_ptr, size);
   }
   else {  // NOLINT
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Copy from %s to %s is not supported.", src_place, dst_place));
   }
 #endif
@@ -484,7 +484,7 @@ void TensorToStream(std::ostream& os,
     auto* data_ptr = contiguous_tensor.data();
     PADDLE_ENFORCE_LT(size,
                       (std::numeric_limits<std::streamsize>::max)(),
-                      phi::errors::ResourceExhausted(
+                      common::errors::ResourceExhausted(
                           "tensor size %d overflow when writing tensor", size));
     if (phi::is_gpu_place(contiguous_tensor.place())) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
@@ -507,7 +507,7 @@ void TensorToStream(std::ostream& os,
         size -= size_to_write;
       }
 #else
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "CUDAPlace is not supported when not compiled with CUDA"));
 #endif
     } else if (phi::is_xpu_place(contiguous_tensor.place())) {
@@ -531,7 +531,7 @@ void TensorToStream(std::ostream& os,
         size -= size_to_write;
       }
 #else
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "XPUPlace is not supported when not compiled with XPU"));
 #endif
     } else if (phi::is_custom_place(contiguous_tensor.place())) {
@@ -556,7 +556,7 @@ void TensorToStream(std::ostream& os,
         size -= size_to_write;
       }
 #else
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "CustomPlace is not supported when not compiled with "
           "CustomDevice"));
 #endif
@@ -594,7 +594,7 @@ void TensorFromStream(std::istream& is,
   PADDLE_ENFORCE_EQ(
       version,
       0U,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "tensor version %u is not supported, Only version 0 is supported",
           version));
 
@@ -605,9 +605,10 @@ void TensorFromStream(std::istream& is,
     is.read(reinterpret_cast<char*>(&size), sizeof(size));
     std::unique_ptr<char[]> buf(new char[size]);  // NOLINT
     is.read(reinterpret_cast<char*>(buf.get()), size);
-    PADDLE_ENFORCE_EQ(desc.ParseFromArray(buf.get(), size),
-                      true,
-                      phi::errors::InvalidArgument("Cannot parse tensor desc"));
+    PADDLE_ENFORCE_EQ(
+        desc.ParseFromArray(buf.get(), size),
+        true,
+        common::errors::InvalidArgument("Cannot parse tensor desc"));
   }
   {  // read tensor
     tensor->Resize(common::make_ddim(shape));
@@ -635,10 +636,10 @@ void TensorFromStream(std::istream& is,
       }
 #else
       if (phi::is_gpu_place(dev_ctx.GetPlace())) {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "CUDAPlace is not supported when not compiled with CUDA"));
       } else if (phi::is_xpu_place(dev_ctx.GetPlace())) {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "XPUPlace is not supported when not compiled with XPU"));
       }
 #endif
@@ -659,7 +660,7 @@ void TensorFromStream(std::istream& is,
   PADDLE_ENFORCE_EQ(
       version,
       0U,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "tensor version %u is not supported, Only version 0 is supported",
           version));
   proto::VarType::TensorDesc desc;
@@ -667,18 +668,20 @@ void TensorFromStream(std::istream& is,
      // proto buffer
     int32_t size = -1;
     is.read(reinterpret_cast<char*>(&size), sizeof(size));
-    PADDLE_ENFORCE_EQ(is.good(),
-                      true,
-                      phi::errors::Unavailable("Cannot read tensor desc size"));
-    PADDLE_ENFORCE_GE(
-        size,
-        0,
-        phi::errors::InvalidArgument("phi::DenseTensor desc size should >= 0"));
+    PADDLE_ENFORCE_EQ(
+        is.good(),
+        true,
+        common::errors::Unavailable("Cannot read tensor desc size"));
+    PADDLE_ENFORCE_GE(size,
+                      0,
+                      common::errors::InvalidArgument(
+                          "phi::DenseTensor desc size should >= 0"));
     std::unique_ptr<char[]> buf(new char[size]);  // NOLINT
     is.read(reinterpret_cast<char*>(buf.get()), size);
-    PADDLE_ENFORCE_EQ(desc.ParseFromArray(buf.get(), size),
-                      true,
-                      phi::errors::InvalidArgument("Cannot parse tensor desc"));
+    PADDLE_ENFORCE_EQ(
+        desc.ParseFromArray(buf.get(), size),
+        true,
+        common::errors::InvalidArgument("Cannot parse tensor desc"));
   }
   {  // read tensor
     std::vector<int64_t> dims;
@@ -706,15 +709,15 @@ void TensorFromStream(std::istream& is,
       }
 #else
       if (phi::is_gpu_place(dev_ctx.GetPlace())) {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "CUDAPlace is not supported when not compiled with CUDA"));
       } else if (phi::is_xpu_place(dev_ctx.GetPlace())) {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "XPUPlace is not supported when not compiled with XPU"));
       } else {
         PADDLE_THROW(
-            phi::errors::Unimplemented("CustomPlace is not supported when "
-                                       "not compiled with CustomDevice"));
+            common::errors::Unimplemented("CustomPlace is not supported when "
+                                          "not compiled with CustomDevice"));
       }
 #endif
     } else {
@@ -734,7 +737,7 @@ void* GetDstPtrByDLDataType(DLDataType type,
   PADDLE_ENFORCE_LE(
       type.lanes,
       1,
-      phi::errors::Unimplemented("Vector type is not supported currently."));
+      common::errors::Unimplemented("Vector type is not supported currently."));
 
   switch (type.bits) {
     case 8:
@@ -742,7 +745,7 @@ void* GetDstPtrByDLDataType(DLDataType type,
         return static_cast<void*>(dst->mutable_data<int8_t>(dst_place));
       if (type.code == kDLUInt)
         return static_cast<void*>(dst->mutable_data<uint8_t>(dst_place));
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "DLDataType code <%d> is illegal when DLDataType.bits is <%d>.",
           type.code,
           type.bits));
@@ -755,7 +758,7 @@ void* GetDstPtrByDLDataType(DLDataType type,
       if (type.code == kDLBfloat)
         return static_cast<void*>(
             dst->mutable_data<phi::dtype::bfloat16>(dst_place));
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "DLDataType code <%d> is illegal when DLDataType.bits is <%d>.",
           type.code,
           type.bits));
@@ -764,7 +767,7 @@ void* GetDstPtrByDLDataType(DLDataType type,
         return static_cast<void*>(dst->mutable_data<int32_t>(dst_place));
       if (type.code == kDLFloat)
         return static_cast<void*>(dst->mutable_data<float>(dst_place));
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "DLDataType code <%d> is illegal when DLDataType.bits is <%d>.",
           type.code,
           type.bits));
@@ -776,7 +779,7 @@ void* GetDstPtrByDLDataType(DLDataType type,
       if (type.code == kDLComplex)
         return static_cast<void*>(
             dst->mutable_data<phi::dtype::complex<float>>(dst_place));
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "DLDataType code <%d> is illegal when DLDataType.bits is <%d>.",
           type.code,
           type.bits));
@@ -784,13 +787,13 @@ void* GetDstPtrByDLDataType(DLDataType type,
       if (type.code == kDLComplex)
         return static_cast<void*>(
             dst->mutable_data<phi::dtype::complex<double>>(dst_place));
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "DLDataType code <%d> is illegal when DLDataType.bits is <%d>.",
           type.code,
           type.bits));
     default:
-      PADDLE_THROW(phi::errors::Unimplemented("Unsupported DLDataType.bits %d.",
-                                              type.bits));
+      PADDLE_THROW(common::errors::Unimplemented(
+          "Unsupported DLDataType.bits %d.", type.bits));
   }
 }
 
@@ -830,7 +833,7 @@ void TensorFromDLPack(const ::DLTensor& dl_tensor, phi::DenseTensor* dst) {
   }
 #endif
 #ifdef PADDLE_WITH_XPU
-  PADDLE_THROW(phi::errors::Unimplemented("XPUPlace is not supported"));
+  PADDLE_THROW(common::errors::Unimplemented("XPUPlace is not supported"));
 #endif
 }
 
@@ -870,7 +873,7 @@ void TensorFromDLPack(const DLManagedTensor* src, phi::DenseTensor* dst) {
 #endif
   src->deleter(const_cast<DLManagedTensor*>(src));
 #ifdef PADDLE_WITH_XPU
-  PADDLE_THROW(phi::errors::Unimplemented("XPUPlace is not supported"));
+  PADDLE_THROW(common::errors::Unimplemented("XPUPlace is not supported"));
 #endif
 }
 

--- a/paddle/fluid/framework/tensor_util.h
+++ b/paddle/fluid/framework/tensor_util.h
@@ -157,7 +157,7 @@ void TensorFromArray(const T* src,
   }
 #endif
   else {  // NOLINT
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "TensorFromArray on %s is not supported.", dst_place));
   }
 }
@@ -203,7 +203,7 @@ void TensorFromVector(const std::vector<T>& src,
   }
 #endif
   else {  // NOLINT
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "TensorFromVector on %s is not supported.", dst_place));
   }
 }
@@ -255,7 +255,7 @@ inline void TensorFromVector(const std::vector<bool>& src,
   }
 #endif
   else {  // NOLINT
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "TensorFromVector on %s is not supported.", dst_place));
   }
   delete[] array;
@@ -326,7 +326,7 @@ void TensorToVector(const phi::DenseTensor& src,
   }
 #endif
   else {  // NOLINT
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "TensorToVector on %s is not supported.", src.place()));
   }
 }
@@ -385,7 +385,7 @@ void TensorToVector(const phi::DenseTensor& src, std::vector<T>* dst) {
   PADDLE_ENFORCE_EQ(
       phi::is_cpu_place(src.place()),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input tensor should be CPU device, but actually it is in %s.",
           src.place()));
 
@@ -407,7 +407,7 @@ inline void TensorToVector(const phi::DenseTensor& src,
   PADDLE_ENFORCE_EQ(
       phi::is_cpu_place(src.place()),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input tensor should be CPU device, but actually it is in %s.",
           src.place()));
 

--- a/paddle/fluid/framework/unused_var_check.cc
+++ b/paddle/fluid/framework/unused_var_check.cc
@@ -128,7 +128,7 @@ void CheckUnusedVar(const OperatorBase &op, const Scope &scope) {
         "OP-Should-Not-Have-Unused-Input]";
     PADDLE_ENFORCE_EQ(unsed_input_var_names.size(),
                       0,
-                      phi::errors::PermissionDenied(
+                      common::errors::PermissionDenied(
                           "Unused input variables check failed: %s", err_msg));
   }
 }

--- a/paddle/fluid/framework/var_desc.cc
+++ b/paddle/fluid/framework/var_desc.cc
@@ -68,9 +68,9 @@ void VarDesc::SetTensorDescNum(size_t num) {
     } break;
     default:
       PADDLE_THROW(
-          phi::errors::Unavailable("Setting 'sub_tensor_number' is not "
-                                   "supported by the %s type variable.",
-                                   this->Name()));
+          common::errors::Unavailable("Setting 'sub_tensor_number' is not "
+                                      "supported by the %s type variable.",
+                                      this->Name()));
   }
   need_updated_ = true;
 }
@@ -82,9 +82,9 @@ size_t VarDesc::GetTensorDescNum() const {
       break;
     default:
       PADDLE_THROW(
-          phi::errors::Unavailable("Getting 'sub_tensor_number' is not "
-                                   "supported by the %s type variable.",
-                                   this->Name()));
+          common::errors::Unavailable("Getting 'sub_tensor_number' is not "
+                                      "supported by the %s type variable.",
+                                      this->Name()));
   }
 }
 
@@ -168,7 +168,7 @@ void VarDesc::SetLoDLevel(int32_t lod_level) {
       desc_.mutable_type()->mutable_tensor_array()->set_lod_level(lod_level);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Setting 'lod_level' is not supported by the %s type variable.",
           this->Name()));
   }
@@ -193,7 +193,7 @@ void VarDesc::SetLoDLevels(const std::vector<int32_t> &multiple_lod_level) {
       }
     } break;
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Setting 'lod_levels' is not supported by the %s type variable",
           this->Name()));
   }
@@ -207,7 +207,7 @@ int32_t VarDesc::GetLoDLevel() const {
     case proto::VarType::LOD_TENSOR_ARRAY:
       return desc_.type().tensor_array().lod_level();
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Getting 'lod_level' is not supported by the %s type variable.",
           this->Name()));
   }
@@ -224,19 +224,21 @@ std::vector<int32_t> VarDesc::GetLoDLevels() const {
       return res;
       break;
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Getting 'lod_levels' is not supported by the %s type variable.",
           this->Name()));
   }
 }
 
 const proto::VarType::TensorDesc &VarDesc::tensor_desc() const {
-  PADDLE_ENFORCE_EQ(desc_.has_type(),
-                    true,
-                    phi::errors::NotFound("The variable's type was not set."));
-  PADDLE_ENFORCE_EQ(desc_.type().has_type(),
-                    true,
-                    phi::errors::NotFound("The variable's type was not set."));
+  PADDLE_ENFORCE_EQ(
+      desc_.has_type(),
+      true,
+      common::errors::NotFound("The variable's type was not set."));
+  PADDLE_ENFORCE_EQ(
+      desc_.type().has_type(),
+      true,
+      common::errors::NotFound("The variable's type was not set."));
   switch (desc_.type().type()) {
     case proto::VarType::SELECTED_ROWS:
       return desc_.type().selected_rows();
@@ -251,7 +253,7 @@ const proto::VarType::TensorDesc &VarDesc::tensor_desc() const {
     case proto::VarType::SPARSE_COO:
       return desc_.type().sparse_coo();
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Getting 'tensor_desc' is not supported by the %s type variable.",
           this->Name()));
   }
@@ -261,7 +263,7 @@ std::vector<proto::VarType::TensorDesc> VarDesc::tensor_descs() const {
   PADDLE_ENFORCE_EQ(
       desc_.has_type(),
       true,
-      phi::errors::NotFound("The variable's type was not be set."));
+      common::errors::NotFound("The variable's type was not be set."));
   std::vector<proto::VarType::TensorDesc> res;
   res.reserve(GetTensorDescNum());
   switch (desc_.type().type()) {
@@ -271,7 +273,7 @@ std::vector<proto::VarType::TensorDesc> VarDesc::tensor_descs() const {
       }
       return res;
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Getting 'tensor_descs' is not supported by the %s type variable.",
           this->Name()));
   }
@@ -281,11 +283,11 @@ proto::VarType::TensorDesc *VarDesc::mutable_tensor_desc() {
   PADDLE_ENFORCE_EQ(
       desc_.has_type(),
       true,
-      phi::errors::NotFound("The variable's type was not be set."));
+      common::errors::NotFound("The variable's type was not be set."));
   PADDLE_ENFORCE_EQ(
       desc_.type().has_type(),
       true,
-      phi::errors::NotFound("The variable's type was not be set."));
+      common::errors::NotFound("The variable's type was not be set."));
   switch (desc_.type().type()) {
     case proto::VarType::SELECTED_ROWS:
       return desc_.mutable_type()->mutable_selected_rows();
@@ -301,9 +303,9 @@ proto::VarType::TensorDesc *VarDesc::mutable_tensor_desc() {
       return desc_.mutable_type()->mutable_sparse_coo();
     default:
       PADDLE_THROW(
-          phi::errors::Unavailable("Getting 'mutable_tensor_desc' is not "
-                                   "supported by the %s type variable.",
-                                   this->Name()));
+          common::errors::Unavailable("Getting 'mutable_tensor_desc' is not "
+                                      "supported by the %s type variable.",
+                                      this->Name()));
   }
   need_updated_ = true;
 }
@@ -312,11 +314,11 @@ std::vector<proto::VarType::TensorDesc *> VarDesc::mutable_tensor_descs() {
   PADDLE_ENFORCE_EQ(
       desc_.has_type(),
       true,
-      phi::errors::NotFound("The variable's type was not be set."));
+      common::errors::NotFound("The variable's type was not be set."));
   PADDLE_ENFORCE_EQ(
       desc_.type().has_type(),
       true,
-      phi::errors::NotFound("The variable's type was not be set."));
+      common::errors::NotFound("The variable's type was not be set."));
   std::vector<proto::VarType::TensorDesc *> res;
   res.reserve(GetTensorDescNum());
   switch (desc_.type().type()) {
@@ -327,7 +329,7 @@ std::vector<proto::VarType::TensorDesc *> VarDesc::mutable_tensor_descs() {
       }
       return res;
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Getting 'tensor_descs' is not supported by the %s type variable.",
           this->Name()));
   }
@@ -359,12 +361,12 @@ void VarDesc::SetAttr(const std::string &name, const Attribute &v) {
   bool valid = attr_type == proto::AttrType::INT ||
                attr_type == proto::AttrType::STRING ||
                attr_type == proto::AttrType::INTS;
-  PADDLE_ENFORCE_EQ(
-      valid,
-      true,
-      phi::errors::InvalidArgument("The value for attr (%s) must be "
-                                   "one of int, string, list of int for now.",
-                                   name));
+  PADDLE_ENFORCE_EQ(valid,
+                    true,
+                    common::errors::InvalidArgument(
+                        "The value for attr (%s) must be "
+                        "one of int, string, list of int for now.",
+                        name));
 
   this->attrs_[name] = v;
   need_updated_ = true;
@@ -372,9 +374,10 @@ void VarDesc::SetAttr(const std::string &name, const Attribute &v) {
 
 Attribute VarDesc::GetAttr(const std::string &name) const {
   auto it = attrs_.find(name);
-  PADDLE_ENFORCE_NE(it,
-                    attrs_.end(),
-                    phi::errors::NotFound("Attribute %s is not found.", name));
+  PADDLE_ENFORCE_NE(
+      it,
+      attrs_.end(),
+      common::errors::NotFound("Attribute %s is not found.", name));
   return it->second;
 }
 
@@ -389,7 +392,7 @@ struct SetVarAttrDescVisitor {
         std::is_same<U, std::vector<int>>::value) {
       set_attr_value(v);
     } else {
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Unsupported calling method of SetAttrDescVisitor object."));
     }
   }

--- a/paddle/fluid/framework/var_type.h
+++ b/paddle/fluid/framework/var_type.h
@@ -40,7 +40,7 @@ inline proto::VarType::Type ToVarType(int type) {
     case proto::VarType::READER:
       return static_cast<proto::VarType::Type>(type);
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "ToVarType method Unsupported type %d.", type));
   }
 }
@@ -70,8 +70,8 @@ inline void VisitVarType(const framework::Variable& var, Visitor visitor) {
       visitor(var.Get<FetchList>());
       return;
     default:
-      PADDLE_THROW(phi::errors::Unavailable("Not supported visit type %s.",
-                                            ToTypeName(var.Type())));
+      PADDLE_THROW(common::errors::Unavailable("Not supported visit type %s.",
+                                               ToTypeName(var.Type())));
   }
 }
 

--- a/paddle/fluid/framework/var_type_inference.h
+++ b/paddle/fluid/framework/var_type_inference.h
@@ -43,13 +43,13 @@ class InferVarTypeContext {
 
   virtual Attribute GetAttr(const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     return op_->GetAttr(name);
   }
 
   virtual bool HasInput(const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     auto& inputs = op_->Inputs();
     auto input = inputs.find(name);
     return input != inputs.end() && !input->second.empty();
@@ -57,7 +57,7 @@ class InferVarTypeContext {
 
   virtual bool HasOutput(const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     auto& outputs = op_->Outputs();
     auto output = outputs.find(name);
     return output != outputs.end() && !output->second.empty();
@@ -65,27 +65,27 @@ class InferVarTypeContext {
 
   virtual size_t InputSize(const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     return op_->Inputs().at(name).size();
   }
 
   virtual size_t OutputSize(const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     return op_->Outputs().at(name).size();
   }
 
   virtual const std::string& InputVarName(const std::string& name,
                                           const int index = 0) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     return op_->Inputs().at(name)[index];
   }
 
   virtual bool InputTypeAnyOf(const std::string& name,
                               proto::VarType::Type type) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     auto& inputs = op_->Input(name);
     return std::any_of(
         inputs.begin(), inputs.end(), [this, &type](const std::string& name) {
@@ -96,7 +96,7 @@ class InferVarTypeContext {
   virtual bool InputTypeAllOf(const std::string& name,
                               proto::VarType::Type type) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     auto& inputs = op_->Input(name);
     return std::all_of(
         inputs.begin(), inputs.end(), [this, &type](const std::string& name) {
@@ -108,7 +108,7 @@ class InferVarTypeContext {
                                    const std::string& output_name,
                                    int index = 0) {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     auto& x_name = op_->Input(input_name).at(index);
     auto& out_name = op_->Output(output_name).at(index);
 
@@ -122,7 +122,7 @@ class InferVarTypeContext {
                              proto::VarType::Type type,
                              int index = 0) {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     if (ALL_ELEMENTS == index) {
       for (const auto& var_name : op_->Output(name)) {
         this->SetVarType(var_name, type);
@@ -136,21 +136,21 @@ class InferVarTypeContext {
   virtual proto::VarType::Type GetInputType(const std::string& name,
                                             const int& index = 0) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     return this->GetVarType(op_->Input(name).at(index));
   }
 
   virtual proto::VarType::Type GetOutputType(const std::string& name,
                                              const int& index = 0) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     return this->GetVarType(op_->Output(name).at(index));
   }
 
   virtual proto::VarType::Type GetInputDataType(const std::string& name,
                                                 const int& index = 0) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     return this->GetVarDataType(op_->Input(name).at(index));
   }
 
@@ -158,7 +158,7 @@ class InferVarTypeContext {
                                  proto::VarType::Type type,
                                  int index = 0) {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     if (ALL_ELEMENTS == index) {
       for (const auto& var_name : op_->Output(name)) {
         this->SetVarDataType(var_name, type);
@@ -172,7 +172,7 @@ class InferVarTypeContext {
   virtual std::vector<proto::VarType::Type> GetInputDataTypes(
       const std::string& name, const int& index = 0) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     return this->GetVarDataTypes(op_->Input(name).at(index));
   }
 
@@ -181,7 +181,7 @@ class InferVarTypeContext {
       const std::vector<proto::VarType::Type>& multiple_data_type,
       const int& index = 0) {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     auto& var_name = op_->Output(name).at(index);
     this->SetVarDataTypes(var_name, multiple_data_type);
   }
@@ -189,7 +189,7 @@ class InferVarTypeContext {
   virtual std::vector<int64_t> GetInputShape(const std::string& name,
                                              const int& index = 0) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     auto& var_name = op_->Input(name).at(index);
     return this->GetVarShape(var_name);
   }
@@ -198,7 +198,7 @@ class InferVarTypeContext {
                               const std::vector<int64_t>& dims,
                               const int& index = 0) {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     auto& var_name = op_->Output(name).at(index);
     this->SetVarShape(var_name, dims);
   }
@@ -206,7 +206,7 @@ class InferVarTypeContext {
   virtual int32_t GetInputLoDLevel(const std::string& name,
                                    const int& index = 0) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     auto& var_name = op_->Input(name).at(index);
     return this->GetVarLoDLevel(var_name);
   }
@@ -215,7 +215,7 @@ class InferVarTypeContext {
                                  int32_t lod_level,
                                  const int& index = 0) {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     auto& var_name = op_->Output(name).at(index);
     this->SetVarLoDLevel(var_name, lod_level);
   }
@@ -232,53 +232,58 @@ class InferVarTypeContext {
  protected:
   virtual bool HasVar(const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(
-        block_, phi::errors::PreconditionNotMet("block_ should not be null"));
+        block_,
+        common::errors::PreconditionNotMet("block_ should not be null"));
     return block_->FindVarRecursive(name) != nullptr;
   }
 
   virtual const std::vector<std::string>& InputVars(
       const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     return op_->Input(name);
   }
 
   virtual const std::vector<std::string>& OutputVars(
       const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(
-        op_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        op_, common::errors::PreconditionNotMet("op_ should not be null"));
     return op_->Output(name);
   }
 
   virtual proto::VarType::Type GetVarType(const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(
-        block_, phi::errors::PreconditionNotMet("block_ should not be null"));
+        block_,
+        common::errors::PreconditionNotMet("block_ should not be null"));
     return block_->FindRecursiveOrCreateVar(name).GetType();
   }
 
   virtual void SetVarType(const std::string& name, proto::VarType::Type type) {
     PADDLE_ENFORCE_NOT_NULL(
-        block_, phi::errors::PreconditionNotMet("op_ should not be null"));
+        block_, common::errors::PreconditionNotMet("op_ should not be null"));
     block_->FindRecursiveOrCreateVar(name).SetType(type);
   }
 
   virtual proto::VarType::Type GetVarDataType(const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(
-        block_, phi::errors::PreconditionNotMet("block_ should not be null"));
+        block_,
+        common::errors::PreconditionNotMet("block_ should not be null"));
     return block_->FindRecursiveOrCreateVar(name).GetDataType();
   }
 
   virtual void SetVarDataType(const std::string& name,
                               proto::VarType::Type type) {
     PADDLE_ENFORCE_NOT_NULL(
-        block_, phi::errors::PreconditionNotMet("block_ should not be null"));
+        block_,
+        common::errors::PreconditionNotMet("block_ should not be null"));
     block_->FindRecursiveOrCreateVar(name).SetDataType(type);
   }
 
   virtual std::vector<proto::VarType::Type> GetVarDataTypes(
       const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(
-        block_, phi::errors::PreconditionNotMet("block_ should not be null"));
+        block_,
+        common::errors::PreconditionNotMet("block_ should not be null"));
     return block_->FindRecursiveOrCreateVar(name).GetDataTypes();
   }
 
@@ -286,32 +291,37 @@ class InferVarTypeContext {
       const std::string& name,
       const std::vector<proto::VarType::Type>& multiple_data_type) {
     PADDLE_ENFORCE_NOT_NULL(
-        block_, phi::errors::PreconditionNotMet("block_ should not be null"));
+        block_,
+        common::errors::PreconditionNotMet("block_ should not be null"));
     block_->FindRecursiveOrCreateVar(name).SetDataTypes(multiple_data_type);
   }
 
   virtual std::vector<int64_t> GetVarShape(const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(
-        block_, phi::errors::PreconditionNotMet("block_ should not be null"));
+        block_,
+        common::errors::PreconditionNotMet("block_ should not be null"));
     return block_->FindRecursiveOrCreateVar(name).GetShape();
   }
 
   virtual void SetVarShape(const std::string& name,
                            const std::vector<int64_t>& dims) {
     PADDLE_ENFORCE_NOT_NULL(
-        block_, phi::errors::PreconditionNotMet("block_ should not be null"));
+        block_,
+        common::errors::PreconditionNotMet("block_ should not be null"));
     block_->FindRecursiveOrCreateVar(name).SetShape(dims);
   }
 
   virtual int32_t GetVarLoDLevel(const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(
-        block_, phi::errors::PreconditionNotMet("block_ should not be null"));
+        block_,
+        common::errors::PreconditionNotMet("block_ should not be null"));
     return block_->FindRecursiveOrCreateVar(name).GetLoDLevel();
   }
 
   virtual void SetVarLoDLevel(const std::string& name, int32_t lod_level) {
     PADDLE_ENFORCE_NOT_NULL(
-        block_, phi::errors::PreconditionNotMet("block_ should not be null"));
+        block_,
+        common::errors::PreconditionNotMet("block_ should not be null"));
     block_->FindRecursiveOrCreateVar(name).SetLoDLevel(lod_level);
   }
 

--- a/paddle/fluid/framework/var_type_traits.cc
+++ b/paddle/fluid/framework/var_type_traits.cc
@@ -62,12 +62,12 @@ struct VarIdToTypeIndexMapInitializerImpl {
     PADDLE_ENFORCE_EQ(
         id_to_type->count(kId),
         0,
-        phi::errors::AlreadyExists(
+        common::errors::AlreadyExists(
             "Registered duplicate type id %d for type %s.", kId, type.name()));
     PADDLE_ENFORCE_EQ(
         type_to_id->count(type),
         0,
-        phi::errors::AlreadyExists(
+        common::errors::AlreadyExists(
             "Registered duplicate type index %s for id %d.", type.name(), kId));
     id_to_type->emplace(kId, type);
     type_to_id->emplace(type, kId);
@@ -99,7 +99,7 @@ struct VarIdToTypeIndexMapHolder {
     PADDLE_ENFORCE_NE(
         it,
         Instance().id_to_type_map_.end(),
-        phi::errors::NotFound("Variable Id %d is not registered.", var_id));
+        common::errors::NotFound("Variable Id %d is not registered.", var_id));
     return it->second;
   }
 
@@ -107,7 +107,7 @@ struct VarIdToTypeIndexMapHolder {
     auto it = Instance().type_to_id_map_.find(type);
     PADDLE_ENFORCE_NE(it,
                       Instance().type_to_id_map_.end(),
-                      phi::errors::NotFound(
+                      common::errors::NotFound(
                           "Variable Type %s is not registered.", type.name()));
     return it->second;
   }

--- a/paddle/fluid/framework/variable.h
+++ b/paddle/fluid/framework/variable.h
@@ -31,11 +31,11 @@ class Variable {
         IsRegisteredVarType<T>(),
         "Not registered type. Please register T inside var_type_traits.h");
     PADDLE_ENFORCE_NOT_NULL(
-        holder_, phi::errors::NotFound("Variable is not initialized."));
+        holder_, common::errors::NotFound("Variable is not initialized."));
     PADDLE_ENFORCE_EQ(
         holder_->Type(),
         VarTypeTrait<T>::kId,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The Variable type must be %s, but the type it holds is %s.",
             ToTypeName(VarTypeTrait<T>::kId),
             ToTypeName(holder_->Type())));
@@ -52,7 +52,7 @@ class Variable {
       PADDLE_ENFORCE_EQ(
           holder_->Type(),
           VarTypeTrait<T>::kId,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The Variable type must be %s, but the type it holds is %s.",
               ToTypeName(VarTypeTrait<T>::kId),
               ToTypeName(holder_->Type())));
@@ -69,7 +69,7 @@ class Variable {
 
   int Type() const {
     PADDLE_ENFORCE_NOT_NULL(
-        holder_, phi::errors::NotFound("Variable is not initialized."));
+        holder_, common::errors::NotFound("Variable is not initialized."));
     return holder_->Type();
   }
 

--- a/paddle/fluid/framework/variable_helper.cc
+++ b/paddle/fluid/framework/variable_helper.cc
@@ -54,7 +54,7 @@ void InitializeVariable(Variable *var, proto::VarType::Type var_type) {
   } else if (var_type == proto::VarType::SPARSE_COO) {
     var->GetMutable<phi::SparseCooTensor>();
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Variable type %d is not in "
         "[LOD_TENSOR, SELECTED_ROWS, FEED_MINIBATCH, FETCH_LIST, "
         "LOD_RANK_TABLE, PLACE_LIST, READER, RAW].",
@@ -80,7 +80,7 @@ void CopyVariable(const Variable &src_var, Variable *dst_var) {
     auto *dst_t = tmp_grad_slr->mutable_value();
     framework::TensorCopy(src_t, cpu_place, dst_t);
   } else {
-    PADDLE_THROW(phi::errors::Unavailable("Unknown variable type to copy."));
+    PADDLE_THROW(common::errors::Unavailable("Unknown variable type to copy."));
   }
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/66145#issuecomment-2249572051

Replace phi::errors to common::errors in paddle/fluid