### PR TITLE
Replace gloo [fluid_ops] c_scatter_op.h

### DIFF
--- a/paddle/fluid/operators/collective/c_scatter_op.h
+++ b/paddle/fluid/operators/collective/c_scatter_op.h
@@ -23,9 +23,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_registry.h"
 
 #if defined(PADDLE_WITH_GLOO)
-#include <gloo/scatter.h>
-
-#include "paddle/fluid/framework/fleet/gloo_wrapper.h"
+#include "paddle/phi/core/distributed/gloo_comm_context.h"
 #endif
 
 namespace paddle {
@@ -36,35 +34,19 @@ class CScatterOpCPUKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
 #if defined(PADDLE_WITH_GLOO)
+    auto& dev_ctx = ctx.device_context<phi::CPUContext>();
     auto in = ctx.Input<phi::DenseTensor>("X");
     auto out = ctx.Output<phi::DenseTensor>("Out");
     auto root_id = ctx.Attr<int>("root");
 
-    auto gloo = paddle::framework::GlooWrapper::GetInstance();
-    PADDLE_ENFORCE_EQ(
-        gloo->IsInitialized(),
-        true,
-        phi::errors::PreconditionNotMet(
-            "You must initialize the gloo environment first to use it."));
-
-    int64_t send_numel = out->numel();
-    auto nranks = gloo->Size();
-    auto rank = gloo->Rank();
-    T* recv_buff = out->data<T>();
-    gloo::ScatterOptions opts(gloo->GetContext());
-    if (root_id == rank) {
-      T* send_buff = const_cast<T*>(in->data<T>());
-      std::vector<T*> ptrs(nranks);
-      for (int i = 0; i < nranks; ++i) {
-        ptrs[i] = send_buff;
-        send_buff += send_numel;
-      }
-      opts.setInputs(ptrs, send_numel);
-    }
-    opts.setOutput(recv_buff, send_numel);
-    opts.setRoot(root_id);
-
-    gloo::scatter(opts);
+    auto comm_ctx = static_cast<phi::distributed::GlooCommContext*>(
+        dev_ctx.GetCommContext());
+    PADDLE_ENFORCE_NE(comm_ctx,
+                      nullptr,
+                      ::common::errors::Unavailable(
+                          "NCCLCommContext is nullptr, collective op should "
+                          "has ring_id attr."));
+    comm_ctx->Scatter(out, *in, root_id);
 #else
     PADDLE_THROW(phi::errors::Unavailable(
         "PaddlePaddle should compile with GLOO by setting WITH_GLOO=ON"));

--- a/paddle/phi/core/distributed/gloo_comm_context.cc
+++ b/paddle/phi/core/distributed/gloo_comm_context.cc
@@ -128,6 +128,9 @@ void GlooCommContext::Scatter(phi::DenseTensor* out_tensor,
   gloo::ScatterOptions opts(gloo_context_);
   const auto& dtype = in_tensor.dtype();
   if (rank_ == src) {
+    if (size == 0) {
+      size = size_;
+    }
     GENERATE_FUNC(dtype, SetInputForScatter, &opts, in_tensor, size);
   }
   GENERATE_FUNC(dtype, SetOutput, &opts, out_tensor);

--- a/paddle/phi/core/distributed/gloo_comm_context.h
+++ b/paddle/phi/core/distributed/gloo_comm_context.h
@@ -61,7 +61,7 @@ class GlooCommContext final : public CommContext {
   void Scatter(phi::DenseTensor* out_tensor,
                const phi::DenseTensor& in_tensor,
                int src,
-               int size,
+               int size = 0,
                uint32_t tag = 0);
 
   void Barrier();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
修改 c_scatter_op 中 gloo 为 phi调用方式