### PR TITLE
fix bug in pir mode fp16.

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/optimizer.cc
+++ b/paddle/phi/infermeta/spmd_rules/optimizer.cc
@@ -98,11 +98,7 @@ SpmdInfo AdamInferSpmdDynamic(const DistMetaTensor& param,
         errors::InvalidArgument(
             "skip_update should be replicated, but got shard on mesh %d.",
             skip_update_dist_attr.dims_mapping()[0]));
-    PADDLE_ENFORCE_EQ(
-        skip_update_dist_attr.partial_status().size(),
-        0,
-        errors::InvalidArgument("skip_update should be replicated, but got "
-                                "patial status not empty"));
+    skip_update_dist_attr.clean_partial_status();
     if (skip_update_dist_attr.process_mesh().ndim() > 1 &&
         phi::distributed::IsSubMesh(skip_update_dist_attr.process_mesh(),
                                     param_dist_attr.process_mesh())) {

--- a/python/paddle/distributed/auto_parallel/static/pir_pass.py
+++ b/python/paddle/distributed/auto_parallel/static/pir_pass.py
@@ -264,7 +264,12 @@ def remove_other_rank_input_output_pass(dist_program):
 
 
 # Note: this is the pass in the dense program
-comm_ops = ["pd_op.c_allreduce_sum", "pd_op.all_gather"]
+comm_ops = [
+    "pd_op.c_allreduce_sum",
+    "pd_op.all_gather",
+    "pd_op.c_allreduce_max",
+    "pd_op.c_reducescatter",
+]
 
 
 def remove_unuseful_comm_op_pass(program):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

 Auto Parallel 
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes
### Description
<!-- Describe what you’ve done -->
fix some errors find in llama while in fp16 mode.
- A new function 'CvtValueToDist'  is added, which will add distributed to the value and all the values and ops it depends on.
- Fix the adamw inferspmd funtion to support the 'skip_update' is partial.
- Add  "pd_op.c_allreduce_max" and "pd_op.c_reducescatter" for communication list in remove_unuseful_comm_op_pass.

### Other
Pcard-67164
