### PR TITLE
Replace platform::GpuStreamSync in fluid/operators [fluid_ops]

### DIFF
--- a/paddle/fluid/operators/class_center_sample_op.cu
+++ b/paddle/fluid/operators/class_center_sample_op.cu
@@ -398,7 +398,7 @@ void ClassCenterSampleKernel(const Context& dev_ctx,
       if (comm_ctx) {
         comm_ctx->AllReduce(
             &num_classes_per_device, num_classes_per_device, ncclSum, stream);
-        paddle::platform::GpuStreamSync(stream);
+        phi::backends::gpu::GpuStreamSync(stream);
       } else {
         PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclAllReduce(
             num_classes_per_device_ptr,

--- a/paddle/fluid/operators/collective/barrier_op.cu.cc
+++ b/paddle/fluid/operators/collective/barrier_op.cu.cc
@@ -64,7 +64,7 @@ class BarrierOpCUDAKernel : public framework::OpKernel<T> {
       auto stream = comm_ctx->GetStream();
       ncclRedOp_t nccl_red_type = ncclSum;
       comm_ctx->AllReduce(out, *in, nccl_red_type, stream);
-      platform::GpuStreamSync(stream);
+      phi::backends::gpu::GpuStreamSync(stream);
       VLOG(3) << "new NCCLCommContext has rid " << rid;
     } else {
       auto comm = platform::NCCLCommContext::Instance().Get(rid, place);
@@ -78,7 +78,7 @@ class BarrierOpCUDAKernel : public framework::OpKernel<T> {
                                                              nccl_red_type,
                                                              comm->comm(),
                                                              stream));
-      platform::GpuStreamSync(stream);
+      phi::backends::gpu::GpuStreamSync(stream);
       VLOG(3) << "old NCCLCommContext has rid " << rid;
     }
 #else

--- a/paddle/fluid/operators/collective/c_sync_calc_stream_op.h
+++ b/paddle/fluid/operators/collective/c_sync_calc_stream_op.h
@@ -45,7 +45,7 @@ class CSyncCalcStreamKernel : public framework::OpKernel<T> {
     auto dev_ctx = static_cast<phi::GPUContext*>(
         phi::DeviceContextPool::Instance().Get(place));
 
-    platform::GpuStreamSync(dev_ctx->stream());
+    phi::backends::gpu::GpuStreamSync(dev_ctx->stream());
 
 #elif defined(PADDLE_WITH_XPU_BKCL)
     auto place = ctx.GetPlace();

--- a/paddle/fluid/operators/collective/c_sync_comm_stream_op.h
+++ b/paddle/fluid/operators/collective/c_sync_comm_stream_op.h
@@ -67,7 +67,7 @@ class CSyncCommStreamKernel : public framework::OpKernel<T> {
       VLOG(3) << "old NCCLCommContext has rid " << ring_id;
     }
 
-    platform::GpuStreamSync(stream);
+    phi::backends::gpu::GpuStreamSync(stream);
 
 #elif defined(PADDLE_WITH_XPU_BKCL)
     auto place = ctx.GetPlace();

--- a/paddle/fluid/operators/data_norm_op.cu
+++ b/paddle/fluid/operators/data_norm_op.cu
@@ -303,7 +303,7 @@ class DataNormGradKernel<T, phi::GPUContext> : public framework::OpKernel<T> {
             comm->comm(),
             stream));
       }
-      platform::GpuStreamSync(stream);
+      phi::backends::gpu::GpuStreamSync(stream);
 #else
       PADDLE_THROW(phi::errors::PreconditionNotMet(
           "PaddlePaddle should compile with GPU, and need_sync_stats connot be "

--- a/paddle/fluid/operators/reader/buffered_reader.cc
+++ b/paddle/fluid/operators/reader/buffered_reader.cc
@@ -237,11 +237,11 @@ void BufferedReader::ReadAsync(size_t i) {
                                     size,
                                     stream_.get());
 
-            platform::GpuStreamSync(stream_.get());
+            phi::backends::gpu::GpuStreamSync(stream_.get());
           }
           cuda[i].set_lod(cpu[i].lod());
         }
-        platform::GpuStreamSync(stream_.get());
+        phi::backends::gpu::GpuStreamSync(stream_.get());
       }
     }
 #endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Replace platform::GpuStreamSync in fluid/operators :
paddle::platform::GpuStreamSync to phi::backends::gpu::GpuStreamSync