### PR TITLE
paddle.put_along_axis_ add attr `broadcast` 易用性提升

### DIFF
--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -899,8 +899,34 @@ class TestPutAlongAxisAPICase4(unittest.TestCase):
 
             paddle.enable_static()
 
+        def run_inplace(place):
+            paddle.disable_static(place)
+            x_tensor = paddle.to_tensor(self.x_np)
+            index_tensor1 = paddle.to_tensor(self.index_np1)
+            value_tensor = paddle.to_tensor(self.value)
+            x_tensor.put_along_axis(
+                index_tensor1, value_tensor, 0, 'assign', True, False
+            )
+            out_ref = copy.deepcopy(self.x_np)
+            for i in range(self.index1_shape[0]):
+                for j in range(self.index1_shape[1]):
+                    out_ref[self.index_np1[i, j], j] = self.value[i, j]
+            np.testing.assert_allclose(x_tensor.numpy(), out_ref, rtol=0.001)
+
+            x_tensor = paddle.to_tensor(self.x_np)
+            index_tensor2 = paddle.to_tensor(self.index_np2)
+            x_tensor.put_along_axis(index_tensor2, 10, 1, 'assign', True, False)
+            out_ref = copy.deepcopy(self.x_np)
+            for i in range(self.index2_shape[0]):
+                for j in range(self.index2_shape[1]):
+                    out_ref[i, self.index_np2[i, j]] = 10
+            np.testing.assert_allclose(x_tensor.numpy(), out_ref, rtol=0.001)
+
+            paddle.enable_static()
+
         for place in self.place:
             run(place)
+            run_inplace(place)
 
     @test_with_pir_api
     def test_api_static(self):
@@ -977,6 +1003,11 @@ class TestPutAlongAxisAPICase4(unittest.TestCase):
             )
         except Exception as error:
             self.assertIsInstance(error, ValueError)
+        # len(values.shape) != len(indices.shape)
+        try:
+            tensorx.put_along_axis(indices, values, 0, 'assign', True, False)
+        except Exception as error:
+            self.assertIsInstance(error, ValueError)
         indices = paddle.to_tensor(
             [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]
         ).astype("int32")
@@ -987,12 +1018,22 @@ class TestPutAlongAxisAPICase4(unittest.TestCase):
             )
         except Exception as error:
             self.assertIsInstance(error, RuntimeError)
+        # indices too large
+        try:
+            tensorx.put_along_axis(indices, 1.0, 0, 'assign', True, False)
+        except Exception as error:
+            self.assertIsInstance(error, RuntimeError)
         indices = paddle.to_tensor([[10]]).astype("int32")
         # the element of indices out of range
         try:
             res = paddle.put_along_axis(
                 tensorx, indices, 1.0, 0, 'assign', True, False
             )
+        except Exception as error:
+            self.assertIsInstance(error, RuntimeError)
+        # the element of indices out of range
+        try:
+            tensorx.put_along_axis(indices, 1.0, 0, 'assign', True, False)
         except Exception as error:
             self.assertIsInstance(error, RuntimeError)
 

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -904,7 +904,7 @@ class TestPutAlongAxisAPICase4(unittest.TestCase):
             x_tensor = paddle.to_tensor(self.x_np)
             index_tensor1 = paddle.to_tensor(self.index_np1)
             value_tensor = paddle.to_tensor(self.value)
-            x_tensor.put_along_axis(
+            x_tensor.put_along_axis_(
                 index_tensor1, value_tensor, 0, 'assign', True, False
             )
             out_ref = copy.deepcopy(self.x_np)
@@ -915,7 +915,9 @@ class TestPutAlongAxisAPICase4(unittest.TestCase):
 
             x_tensor = paddle.to_tensor(self.x_np)
             index_tensor2 = paddle.to_tensor(self.index_np2)
-            x_tensor.put_along_axis(index_tensor2, 10, 1, 'assign', True, False)
+            x_tensor.put_along_axis_(
+                index_tensor2, 10, 1, 'assign', True, False
+            )
             out_ref = copy.deepcopy(self.x_np)
             for i in range(self.index2_shape[0]):
                 for j in range(self.index2_shape[1]):
@@ -1005,7 +1007,7 @@ class TestPutAlongAxisAPICase4(unittest.TestCase):
             self.assertIsInstance(error, ValueError)
         # len(values.shape) != len(indices.shape)
         try:
-            tensorx.put_along_axis(indices, values, 0, 'assign', True, False)
+            tensorx.put_along_axis_(indices, values, 0, 'assign', True, False)
         except Exception as error:
             self.assertIsInstance(error, ValueError)
         indices = paddle.to_tensor(
@@ -1020,7 +1022,7 @@ class TestPutAlongAxisAPICase4(unittest.TestCase):
             self.assertIsInstance(error, RuntimeError)
         # indices too large
         try:
-            tensorx.put_along_axis(indices, 1.0, 0, 'assign', True, False)
+            tensorx.put_along_axis_(indices, 1.0, 0, 'assign', True, False)
         except Exception as error:
             self.assertIsInstance(error, RuntimeError)
         indices = paddle.to_tensor([[10]]).astype("int32")
@@ -1033,7 +1035,7 @@ class TestPutAlongAxisAPICase4(unittest.TestCase):
             self.assertIsInstance(error, RuntimeError)
         # the element of indices out of range
         try:
-            tensorx.put_along_axis(indices, 1.0, 0, 'assign', True, False)
+            tensorx.put_along_axis_(indices, 1.0, 0, 'assign', True, False)
         except Exception as error:
             self.assertIsInstance(error, RuntimeError)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
为 paddle.put_along_axis_ 添加 `broadcast` 参数，与非 inplace API 保持一致。