### PR TITLE
[Paddle.incubate.jit.inference] allow repeate call `my_layer = paddle.incubate.jit.inference(my_layer)`

### DIFF
--- a/python/paddle/incubate/jit/inference_decorator.py
+++ b/python/paddle/incubate/jit/inference_decorator.py
@@ -236,6 +236,14 @@ class InferenceEngine:
                     )
                 input_specs.append(None)
 
+        for i in range(len(input_specs)):
+            if input_specs[i] is not None:
+                if isinstance(input_specs[i], list):
+                    for j in range(len(input_specs[i])):
+                        input_specs[i][j].stop_gradient = True
+                else:
+                    input_specs[i].stop_gradient = True
+
         # update the input_spec's shape for doing d2s
         d2s_shapes_id = 0
         # initial the self.d2s_input_names!
@@ -547,6 +555,15 @@ def inference(
             >>> decorator_result = mylayer(x)
 
     """
+    # if function has already been decorated by @paddle.incubate.jit.inference(), then we just return it.
+    if (
+        hasattr(function, "__name__")
+        and function.__name__ == "innermost_decorator"
+    ):
+        return function
+    elif isinstance(function, Layer):
+        if function.forward.__name__ == "innermost_decorator":
+            return function
 
     used_as_at_decorator = function is None
 

--- a/test/dygraph_to_static/test_incubate_jit_inference.py
+++ b/test/dygraph_to_static/test_incubate_jit_inference.py
@@ -102,6 +102,7 @@ class TestToStaticInfenrenceFunc(Dy2StTestBase):
         result_y0 = my_layer(y).numpy()
 
         my_layer.func = paddle.incubate.jit.inference(my_layer.func)
+        my_layer.func = paddle.incubate.jit.inference(my_layer.func)
 
         result_x1 = my_layer(x).numpy()
         result_y1 = my_layer(y).numpy()

--- a/test/dygraph_to_static/test_incubate_jit_inference.py
+++ b/test/dygraph_to_static/test_incubate_jit_inference.py
@@ -119,6 +119,7 @@ class TestToStaticInputListModel(Dy2StTestBase):
         my_layer = TestLayer2(hidd)
         result0 = my_layer([x, x]).numpy()
         my_static_layer = paddle.incubate.jit.inference(my_layer)
+        my_static_layer = paddle.incubate.jit.inference(my_layer)
 
         result1 = my_layer([x, x]).numpy()
         np.testing.assert_allclose(result0, result1, rtol=0.001, atol=1e-05)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

Pcard-71500

- allow repeate invloke `my_layer = paddle.incubate.jit.inference(my_layer)`
- set `input_specs[i].stop_gradient = True`
