### PR TITLE
[Typing][C-121,C-122,C-123,C-124] Add type annotations for `python/paddle/quantization/{base_observer,factory,ptq,qat}.py`

### DIFF
--- a/python/paddle/quantization/base_observer.py
+++ b/python/paddle/quantization/base_observer.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import abc
 
@@ -24,9 +25,9 @@ class BaseObserver(BaseQuanter, metaclass=abc.ABCMeta):
     and implement abstract methods.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     @abc.abstractmethod
-    def cal_thresholds(self):
+    def cal_thresholds(self) -> None:
         pass

--- a/python/paddle/quantization/factory.py
+++ b/python/paddle/quantization/factory.py
@@ -11,19 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from __future__ import annotations
 
 import abc
 import inspect
 from functools import partial
+from typing import TYPE_CHECKING, Any
 
-from paddle.nn import Layer
+if TYPE_CHECKING:
+    from paddle.nn import Layer
 
-from .base_quanter import BaseQuanter
+    from .base_quanter import BaseQuanter
 
 
 class ClassWithArguments(metaclass=abc.ABCMeta):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._args = args
         self._kwargs = kwargs
 
@@ -55,7 +57,7 @@ class QuanterFactory(ClassWithArguments):
     the arguments used to create quanter instance.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.partial_class = None
 

--- a/python/paddle/quantization/factory.py
+++ b/python/paddle/quantization/factory.py
@@ -16,12 +16,17 @@ from __future__ import annotations
 import abc
 import inspect
 from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
+
+from typing_extensions import ParamSpec
 
 if TYPE_CHECKING:
     from paddle.nn import Layer
 
     from .base_quanter import BaseQuanter
+
+_InputT = ParamSpec("_InputT")
+_RetT = TypeVar("_RetT")
 
 
 class ClassWithArguments(metaclass=abc.ABCMeta):
@@ -75,7 +80,7 @@ class QuanterFactory(ClassWithArguments):
 ObserverFactory = QuanterFactory
 
 
-def quanter(class_name):
+def quanter(class_name: str) -> BaseQuanter:
     r"""
     Annotation to declare a factory class for quanter.
 
@@ -104,7 +109,9 @@ def quanter(class_name):
 
     """
 
-    def wrapper(target_class):
+    def wrapper(
+        target_class: Callable[_InputT, _RetT]
+    ) -> Callable[_InputT, _RetT]:
         init_function_str = f"""
 def init_function(self, *args, **kwargs):
     super(type(self), self).__init__(*args, **kwargs)

--- a/python/paddle/quantization/factory.py
+++ b/python/paddle/quantization/factory.py
@@ -16,17 +16,12 @@ from __future__ import annotations
 import abc
 import inspect
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
-
-from typing_extensions import ParamSpec
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from paddle.nn import Layer
 
     from .base_quanter import BaseQuanter
-
-_InputT = ParamSpec("_InputT")
-_RetT = TypeVar("_RetT")
 
 
 class ClassWithArguments(metaclass=abc.ABCMeta):
@@ -80,7 +75,9 @@ class QuanterFactory(ClassWithArguments):
 ObserverFactory = QuanterFactory
 
 
-def quanter(class_name: str) -> BaseQuanter:
+def quanter(
+    class_name: str,
+) -> Callable[[type[BaseQuanter]], type[BaseQuanter]]:
     r"""
     Annotation to declare a factory class for quanter.
 
@@ -90,6 +87,7 @@ def quanter(class_name: str) -> BaseQuanter:
     Examples:
         .. code-block:: python
 
+            >>> # type: ignore
             >>> # doctest: +SKIP('need 2 file to run example')
             >>> # Given codes in ./customized_quanter.py
             >>> from paddle.quantization import quanter
@@ -109,9 +107,7 @@ def quanter(class_name: str) -> BaseQuanter:
 
     """
 
-    def wrapper(
-        target_class: Callable[_InputT, _RetT]
-    ) -> Callable[_InputT, _RetT]:
+    def wrapper(target_class: type[BaseQuanter]) -> type[BaseQuanter]:
         init_function_str = f"""
 def init_function(self, *args, **kwargs):
     super(type(self), self).__init__(*args, **kwargs)

--- a/python/paddle/quantization/ptq.py
+++ b/python/paddle/quantization/ptq.py
@@ -11,14 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import copy
+from typing import TYPE_CHECKING
 
 from paddle.distributed import fleet
-from paddle.nn import Layer
 
-from .config import QuantConfig
 from .quantize import Quantization
+
+if TYPE_CHECKING:
+    from paddle.nn import Layer
+
+    from .config import QuantConfig
 
 
 class PTQ(Quantization):
@@ -26,7 +31,7 @@ class PTQ(Quantization):
     Applying post training quantization to the model.
     """
 
-    def __init__(self, config: QuantConfig):
+    def __init__(self, config: QuantConfig) -> None:
         super().__init__(config)
 
     def _is_parallel_training(self):
@@ -38,7 +43,7 @@ class PTQ(Quantization):
         except Exception:  # fleet is not initialized
             return False
 
-    def quantize(self, model: Layer, inplace=False):
+    def quantize(self, model: Layer, inplace: bool = False) -> Layer:
         r"""
         Create a model for post-training quantization.
 

--- a/python/paddle/quantization/qat.py
+++ b/python/paddle/quantization/qat.py
@@ -11,13 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import copy
+from typing import TYPE_CHECKING
 
-from paddle.nn import Layer
-
-from .config import QuantConfig
 from .quantize import Quantization
+
+if TYPE_CHECKING:
+    from paddle.nn import Layer
+
+    from .config import QuantConfig
 
 
 class QAT(Quantization):
@@ -36,10 +40,10 @@ class QAT(Quantization):
             >>> qat = QAT(q_config)
     """
 
-    def __init__(self, config: QuantConfig):
+    def __init__(self, config: QuantConfig) -> None:
         super().__init__(config)
 
-    def quantize(self, model: Layer, inplace=False):
+    def quantize(self, model: Layer, inplace: bool = False) -> Layer:
         r"""
         Create a model for quantization-aware training.
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
- https://github.com/PaddlePaddle/Paddle/issues/65008
C-121,C-122,C-123,C-124