### PR TITLE
[CINN] Fix bug of infer_symbol_shape for controw flow op

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -318,13 +318,8 @@ bool IfOp::InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context) {
   auto GetSymExprForBlockResult =
       [infer_context](const pir::Operation &op,
                       uint32_t idx) -> const std::vector<symbol::DimExpr> & {
-    const auto &shape_or_data =
-        infer_context->GetShapeOrDataForValue(op.operand_source(idx));
-    if (shape_or_data.data().has_value()) {
-      return shape_or_data.data().value();
-    } else {
-      return shape_or_data.shape();
-    }
+    return infer_context->GetShapeOrDataForValue(op.operand_source(idx))
+        .shape();
   };
 
   // TODO(lanxianghit): for llama, `if` op's result num always > 0, but
@@ -1142,18 +1137,10 @@ void SelectInputOp::VerifySig() {
 
 bool SelectInputOp::InferSymbolicShape(
     pir::InferSymbolicShapeContext *infer_context) {
-  auto GetSymExprForValue =
-      [infer_context](pir::Value val) -> const std::vector<symbol::DimExpr> & {
-    const auto &shape_or_data = infer_context->GetShapeOrDataForValue(val);
-    if (shape_or_data.data().has_value()) {
-      return shape_or_data.data().value();
-    } else {
-      return shape_or_data.shape();
-    }
-  };
-
-  const auto &input1_dims = GetSymExprForValue(operand_source(0));
-  const auto &input2_dims = GetSymExprForValue(operand_source(1));
+  const auto &input1_dims =
+      infer_context->GetShapeOrDataForValue(operand_source(1)).shape();
+  const auto &input2_dims =
+      infer_context->GetShapeOrDataForValue(operand_source(2)).shape();
 
   // for compatibility, we just return second_shape.
   if (input1_dims.size() != input2_dims.size()) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复部分控制流算子符号推导实现问题。