### PR TITLE
[CINN] Get strides of loop variables for the input of Reduce

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -95,7 +95,7 @@ std::shared_ptr<GroupInfo> OpLowererImpl::GetGroupInfo(
     const std::unordered_map<::pir::Value, ir::Tensor>& tensor_map) {
   std::shared_ptr<GroupInfo> group_info = std::make_shared<GroupInfo>();
   group_info->data_space = fusion_group_info.loop_ranges;
-  group_info->loop_transform_map = fusion_group_info.loop_transform_map;
+  group_info->loop_strides = fusion_group_info.loop_strides;
   group_info->reduce_axis = fusion_group_info.reduce_axis;
   group_info->reduce_var_names =
       std::set<std::string>(fusion_group_info.reduce_var_name.begin(),

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
@@ -50,7 +50,7 @@ typedef bool (OpLowererImpl::*ScheduleDetermineFunction)(::pir::Operation*);
 struct GroupInfo {
   std::vector<int64_t> data_space;
   std::vector<int64_t> reduce_axis;
-  std::vector<int64_t> loop_transform_map;
+  std::vector<int64_t> loop_strides;
   std::set<std::string> reduce_var_names;
   std::set<std::string> shared_var_names;
   std::set<std::string> direct_output_var_names;

--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
@@ -165,12 +165,13 @@ std::vector<ir::Var> GetAllForIters(const ir::Expr& expr);
 
 struct FusionGroupInfo {
   std::vector<int64_t> loop_ranges;
-  std::vector<int64_t> loop_transform_map;
+  std::vector<int64_t> loop_strides;
   std::vector<int64_t> reduce_axis;
   std::vector<std::string> reduce_var_name;
 
   std::string DebugPrint() {
     return "GroupInfo\nloop_ranges: " + cinn::utils::Join(loop_ranges, " ") +
+           "\nloop_strides: " + cinn::utils::Join(loop_strides, ", ") +
            "\nreduce_axis: " + cinn::utils::Join(reduce_axis, " ") +
            "\nreduce_var_name: " + cinn::utils::Join(reduce_var_name, " ");
   }

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -97,7 +97,7 @@ std::shared_ptr<ScheduleConfig::BaseInfo> InitBasicInfo(
   base_info->shared_var_names = group_info->shared_var_names;
   base_info->direct_output_var_names = group_info->direct_output_var_names;
   base_info->data_rank = group_info->data_space.size();
-  base_info->loop_transform_map = group_info->loop_transform_map;
+  base_info->loop_strides = group_info->loop_strides;
 
   std::set<int64_t> reduce_dim_loc;
   for (int64_t dim : group_info->reduce_axis) {

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.h
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.h
@@ -31,7 +31,7 @@ using IterSpaceType = std::vector<std::pair<std::string, std::string>>;
 struct ScheduleConfig {
   struct BaseInfo {
     std::vector<int64_t> reduce_axis;
-    std::vector<int64_t> loop_transform_map;
+    std::vector<int64_t> loop_strides;
     int64_t data_rank;
     int64_t reduce_numel;
     int64_t spatial_numel;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Improvements


### Description
CINN previously stored the relation between loops and input indices in `loop_transform_map`. However, this is unreliable as a loop variable may not be able to map to a single index.

This PR instead gets the strides of each loop variables, and stores them in `loop_strides`. The later tactics can reorder the loops based on their strides.

pcard-85711