### PR TITLE
[CINN] Fix bug of infer_symbol_shape for slice

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_pass.cc
@@ -199,9 +199,10 @@ class BlockDimExprsAsserter {
     auto opt_shape_tensor_from_dim_exprs =
         BuildShapeTensorFromDataDimExprs(inputs, output, OpDimExprs4Value);
     if (!opt_shape_tensor_from_dim_exprs.has_value()) return;
+    const auto& output_dims =
+        output.type().dyn_cast<paddle::dialect::DenseTensorType>().dims();
+    if (::common::contain_unknown_dim(output_dims)) return;
     pir::Value flatten_output = [&] {
-      const auto& output_dims =
-          output.type().dyn_cast<paddle::dialect::DenseTensorType>().dims();
       if (output_dims.size() > 1) {
         return builder_
             .Build<paddle::dialect::FlattenOp>(

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
@@ -218,6 +218,7 @@ bool SliceOpInferSymbolicShape(pir::Operation *op,
       op->result(0),
       paddle::dialect::slice_utils::SliceRawInferSymbolicShape(
           op->operand_source(0),
+          op->result(0),
           starts,
           ends,
           axes_raw,

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
@@ -64,12 +64,15 @@ inline void CheckAndUpdateSliceAttrs(
     int64_t end_i = 0;
     if (ends.at(i).isa<int64_t>()) {
       if (in_dims.at(axis).isa<int64_t>()) {
-        ends.at(i) =
-            (ends.at(i).Get<int64_t>() > in_dims.at(axis).Get<int64_t>())
-                ? in_dims.at(axis)
-                : ends.at(i);
+        ends[i] = std::min(ends.at(i).Get<int64_t>(),
+                           in_dims.at(axis).Get<int64_t>());
       }
-      end_i = ends.at(i).Get<int64_t>();
+      if (ends.at(i).Get<int64_t>() < 0) {
+        ends[i] = ends.at(i) + in_dims.at(axis);
+      }
+      if (ends.at(i).isa<int64_t>()) {
+        end_i = ends.at(i).Get<int64_t>();
+      }
     }
 
     // For both start and end can be negative or positive, we need to handle the

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
@@ -210,10 +210,16 @@ inline ShapeOrData SliceRawInferSymbolicShape(
     const int64_t start =
         starts_int[0] < 0 ? starts_int[0] + in_shapeordata.data().value().size()
                           : starts_int[0];
-    const int64_t end =
-        static_cast<int64_t>(std::numeric_limits<int>::max()) == ends_int[0]
-            ? in_shapeordata.data().value().size()
-            : ends_int[0];
+    const int64_t end = [&] -> int64_t {
+      if (ends_int[0] < 0) {
+        return ends_int[0] + in_shapeordata.data().value().size();
+      }
+      if (ends_int[0] ==
+          static_cast<int64_t>(std::numeric_limits<int>::max())) {
+        return in_shapeordata.data().value().size();
+      }
+      return ends_int[0];
+    }();
 
     for (int64_t i = start; i < end; i++) {
       out_data.push_back(in_shapeordata.data().value().at(i));

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -804,6 +804,7 @@ bool SliceOpInferSymbolicShape(pir::Operation *op,
   infer_context->SetShapeOrDataForValue(
       res,
       slice_utils::SliceRawInferSymbolicShape(operand_source,
+                                              res,
                                               starts,
                                               ends,
                                               axes_vec,

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -504,7 +504,7 @@ ShapeConstraintIRAnalysis::GetShapeOrDataForValue(Value val) {
       SetSymbolForValueByStaticShape(val);
     } else {
       VLOG(3) << "InferShapeOrDataForValue,  defining_op: "
-              << val.defining_op()->name();
+              << val.defining_op()->name() << " id:" << val.defining_op()->id();
       InferShapeOrDataForValue(val);
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复Slice算子符号推导实现中end为负数的处理bug。