### PR TITLE
[SOT][DynamicShape] Search symbolic inputs by use dict key

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/tracker.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/tracker.py
@@ -69,18 +69,6 @@ class Tracker:
         """
         raise NotImplementedError()
 
-    def match_expr(self, expr: str) -> bool:
-        """
-        Match the expression with the tracked variables.
-
-        Args:
-            expr (str): The expression to be matched.
-
-        Returns:
-            bool: True if the expression matches the tracked variables, False otherwise.
-        """
-        return self.trace_value_from_frame().inlined_expr == expr
-
     def is_traceable(self) -> bool:
         """
         Determine if all the tracked variables can be traced from the frame.

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -756,15 +756,15 @@ class SymbolicVariable(VariableBase):
     ):
         tracker_expr = tracker.trace_value_from_frame().inlined_expr
         symbolic_inputs.setdefault(tracker_expr, {})
-        for expr, symbolic_input in symbolic_inputs.items():
-            if tracker.match_expr(expr):
-                symbolic_input.setdefault(value, 0)
-                symbolic_input[value] += 1
-                if symbolic_input[value] >= STATIC_DIM_FREQ_THRESHOLD:
-                    return False
-                if len(symbolic_input.keys()) > 1:
-                    return True
+        if tracker_expr in symbolic_inputs:
+            symbolic_input = symbolic_inputs[tracker_expr]
+            symbolic_input.setdefault(value, 0)
+            symbolic_input[value] += 1
+            if symbolic_input[value] >= STATIC_DIM_FREQ_THRESHOLD:
                 return False
+            if len(symbolic_input.keys()) > 1:
+                return True
+            return False
         return False
 
     @staticmethod


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

直接使用 dict hash 访问 symbolic input，避免每次都从头遍历，这会导致越来越慢（`test_word2vec` 可复现，有一个非常多 Tensor 的全局变量）

PCard-66972