### PR TITLE
[CINN] fix split symbolic loop

### DIFF
--- a/paddle/cinn/ir/schedule/impl/loop_transformation.cc
+++ b/paddle/cinn/ir/schedule/impl/loop_transformation.cc
@@ -116,8 +116,7 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
   bool is_positive = true;
   int num_minus1 = 0;
   std::vector<Expr> process_factors;
-  int64_t prod_size(-1);
-  int idx_neg1 = 1;
+  int prod_size(-1);
   bool exact_split = true;
   for (auto factor : factors) prod_size = prod_size * factor;
   Expr remaining_size = tot_extent / Expr(prod_size);

--- a/paddle/cinn/ir/schedule/impl/loop_transformation.cc
+++ b/paddle/cinn/ir/schedule/impl/loop_transformation.cc
@@ -116,31 +116,27 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
   bool is_positive = true;
   int num_minus1 = 0;
   std::vector<Expr> process_factors;
-  Expr prod_size(-1);
+  int64_t prod_size(-1);
   int idx_neg1 = 1;
-  for (auto factor : factors) prod_size = prod_size * Expr(factor);
+  bool exact_split = true;
+  for (auto factor : factors) prod_size = prod_size * factor;
+  Expr remaining_size = tot_extent / Expr(prod_size);
+  Expr total_size = remaining_size * Expr(prod_size);
+  common::cas_intervals_t var_intervals = {};
+  cinn::common::SymbolicExprAnalyzer analyzer(var_intervals);
+  if (!analyzer.ProveEQ(tot_extent, total_size).value_or(false)) {
+    remaining_size = (tot_extent + Expr(prod_size - 1)) / Expr(prod_size);
+    exact_split = false;
+  }
   std::for_each(factors.begin(), factors.end(), [&](int factor) {
     if (factor == -1) {
-      process_factors.push_back(
-          cinn::common::AutoSimplify(tot_extent / prod_size));
-      idx_neg1 = -idx_neg1;
+      process_factors.push_back(remaining_size);
     } else {
       process_factors.push_back(Expr(factor));
-      if (idx_neg1 > 0) idx_neg1++;
     }
     if (factor < 1 && factor != -1) is_positive = false;
     if (factor == -1) ++num_minus1;
   });
-
-  idx_neg1 = (-idx_neg1) - 1;
-
-  bool exact_split =
-      (tot_extent ==
-       cinn::common::AutoSimplify(process_factors[0] * process_factors[1]));
-  if (!exact_split) {
-    process_factors[idx_neg1] =
-        cinn::common::AutoSimplify(process_factors[idx_neg1] + Expr(1));
-  }
 
   if (num_minus1 > 1 || (!is_positive)) {
     os << "The params in factors of Split on dynamic shape should contains at "

--- a/test/cinn/ir/test_llir_schedule_fuse_split.py
+++ b/test/cinn/ir/test_llir_schedule_fuse_split.py
@@ -190,15 +190,15 @@ def test_split_dynamic():
             for i in range(128):
                 for j in range(128):
                     for k_7 in range(16):
-                        for k_8 in range((N / 16) + 1):
-                            if (((N / 16) * k_7) + (k_7 + k_8)) < N:
+                        for k_8 in range((N + 15) / 16):
+                            if ((((15 + N) / 16) * k_7) + k_8) < N:
                                 with ir.ScheduleBlockContext("Y") as Y_block:
                                     i1, j1, k1 = ir.AxisMap(
                                         "SSS",
                                         [
                                             i,
                                             j,
-                                            (((N / 16) * k_7) + (k_7 + k_8)),
+                                            ((((15 + N) / 16) * k_7) + k_8),
                                         ],
                                     )
                                     Y[i1, j1, k1] = X[i1, j1, k1] * 2.0


### PR DESCRIPTION
### PR Category
CINN


### PR Types
Bug fixes


### Description
Pcard-74042
Fix Split primitive on symbolic loop.
For example, when split a loop with extent S by factor=(-1, 4, 4), we will get a loop nest of (S / 4 + 1, 4).
This PR modify it to （(S - 3) / 4, 4）.
