### PR TITLE
[PIR Unittest] fix pir ut   (`test_custom_relu_op_setup,test_weight_decay,test_sync_batch_norm_op`

### DIFF
--- a/test/custom_op/test_custom_relu_op_setup.py
+++ b/test/custom_op/test_custom_relu_op_setup.py
@@ -259,33 +259,34 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
 
     def _test_static_save_and_run_inference_predictor(self):
         paddle.enable_static()
-        np_data = np.random.random((1, 1, 28, 28)).astype("float32")
-        np_label = np.random.random((1, 1)).astype("int64")
-        path_prefix = "custom_op_inference/custom_relu"
-        from paddle.inference import Config, create_predictor
+        with paddle.pir_utils.OldIrGuard():
+            np_data = np.random.random((1, 1, 28, 28)).astype("float32")
+            np_label = np.random.random((1, 1)).astype("int64")
+            path_prefix = "custom_op_inference/custom_relu"
+            from paddle.inference import Config, create_predictor
 
-        for device in self.devices:
-            predict = custom_relu_static_inference(
-                self.custom_ops[0], device, np_data, np_label, path_prefix
-            )
-            # load inference model
-            config = Config(
-                path_prefix + ".pdmodel", path_prefix + ".pdiparams"
-            )
-            predictor = create_predictor(config)
-            input_tensor = predictor.get_input_handle(
-                predictor.get_input_names()[0]
-            )
-            input_tensor.reshape(np_data.shape)
-            input_tensor.copy_from_cpu(np_data.copy())
-            predictor.run()
-            output_tensor = predictor.get_output_handle(
-                predictor.get_output_names()[0]
-            )
-            predict_infer = output_tensor.copy_to_cpu()
-            predict = np.array(predict).flatten()
-            predict_infer = np.array(predict_infer).flatten()
-            check_output_allclose(predict, predict_infer, "predict")
+            for device in self.devices:
+                predict = custom_relu_static_inference(
+                    self.custom_ops[0], device, np_data, np_label, path_prefix
+                )
+                # load inference model
+                config = Config(
+                    path_prefix + ".pdmodel", path_prefix + ".pdiparams"
+                )
+                predictor = create_predictor(config)
+                input_tensor = predictor.get_input_handle(
+                    predictor.get_input_names()[0]
+                )
+                input_tensor.reshape(np_data.shape)
+                input_tensor.copy_from_cpu(np_data.copy())
+                predictor.run()
+                output_tensor = predictor.get_output_handle(
+                    predictor.get_output_names()[0]
+                )
+                predict_infer = output_tensor.copy_to_cpu()
+                predict = np.array(predict).flatten()
+                predict_infer = np.array(predict_infer).flatten()
+                check_output_allclose(predict, predict_infer, "predict")
         paddle.disable_static()
 
     def _test_double_grad_dynamic(self):

--- a/test/legacy_test/test_sync_batch_norm_op.py
+++ b/test/legacy_test/test_sync_batch_norm_op.py
@@ -31,6 +31,7 @@ from op_test import OpTest, _set_use_system_allocator, convert_float_to_uint16
 import paddle
 from paddle import base, nn
 from paddle.base import core
+from paddle.base.data_feeder import convert_dtype
 from paddle.base.framework import in_dygraph_mode
 from paddle.pir_utils import test_with_pir_api
 
@@ -110,10 +111,13 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
         self.atol = 5e-3
         self.data_dir = tempfile.TemporaryDirectory()
         self.fleet_log_dir = tempfile.TemporaryDirectory()
+        self.pre_dtype = paddle.get_default_dtype()
+        paddle.set_default_dtype(self.dtype)
 
     def tearDown(self) -> None:
         self.data_dir.cleanup()
         self.fleet_log_dir.cleanup()
+        paddle.set_default_dtype(self.pre_dtype)
 
     def multi_device_run(self, layout, fetch_list, only_forward=False):
         cmds = [
@@ -158,24 +162,32 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
                     shape=self.dshape,
                     dtype=self.dtype,
                 )
-                data.desc.set_need_check_feed(False)
-                conv = paddle.static.nn.conv2d(
-                    input=data,
-                    num_filters=32,
-                    filter_size=1,
-                    param_attr=base.ParamAttr(name='conv2d_weight'),
+                if not paddle.framework.use_pir_api():
+                    data.desc.set_need_check_feed(False)
+                conv_layer = paddle.nn.Conv2D(
+                    in_channels=data.shape[1],
+                    out_channels=32,
+                    kernel_size=1,
+                    weight_attr=base.ParamAttr(name='conv2d_weight'),
                     bias_attr=False,
-                    use_cudnn=use_cudnn,
                 )
-                bn = paddle.static.nn.batch_norm(
-                    conv,
+                conv_layer._use_cudnn = use_cudnn
+                conv = conv_layer(data)
+                print(self.dtype)
+                bn = paddle.nn.BatchNorm(
+                    num_channels=conv.shape[1]
+                    if layout == "NCHW"
+                    else conv.shape[3],
                     param_attr=base.ParamAttr(name='bn_scale'),
                     bias_attr=base.ParamAttr(name='bn_bias'),
                     moving_mean_name='bn_moving_mean',
                     moving_variance_name='bn_moving_variance',
                     data_layout=layout,
                     is_test=only_forward,
-                )
+                    dtype=convert_dtype(self.dtype)
+                    if self.dtype != np.uint16
+                    else "bfloat16",
+                )(conv)
                 if core.is_compiled_with_rocm():
                     bn = paddle.cast(bn, 'float32')
                 else:
@@ -184,10 +196,12 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
                 out = paddle.sum(sigmoid)
                 if not sync_bn:
                     out = out / core.get_cuda_device_count()
+                ops = base.default_main_program().global_block().ops
                 if not only_forward:
                     sgd_opt = paddle.optimizer.SGD(learning_rate=0.0)
                     sgd_opt.backward(out)
-        return main, startup, [out, conv, bn]
+                    ops = base.default_main_program().global_block().ops
+        return main, startup, [out, conv, bn, ops]
 
     @prog_scope()
     def _compare(self, place, layout, only_forward):
@@ -230,21 +244,35 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
         )
         exe = base.Executor(place)
         exe.run(startup)
-        fetch_names = [v.name for v in outs] + [
-            'bn_moving_mean',
-            'bn_moving_variance',
-            'bn_scale',
-            'bn_bias',
-        ]
-        if not only_forward:
-            others = [
-                'batch_norm_0.tmp_0',
-                'batch_norm_0.tmp_1',
-                'bn_scale@GRAD',
-                'bn_bias@GRAD',
-                'batch_norm_0.tmp_3@GRAD',
-                'conv2d_0.tmp_0@GRAD',
+        (out, conv, bn, ops) = outs
+        fetch_names = [out, conv, bn]
+        if not paddle.framework.use_pir_api():
+            fetch_names = fetch_names + [
+                'bn_moving_mean',
+                'bn_moving_variance',
+                'bn_scale',
+                'bn_bias',
             ]
+        if not only_forward:
+            if paddle.framework.in_pir_mode():
+                # print(1,ops)
+                others = [
+                    ops[7].result(0),
+                    ops[7].result(1),
+                    ops[-2].result(0),
+                    ops[-2].result(1),
+                    ops[-2].result(2),
+                    ops[-1].result(1),
+                ]
+            else:
+                others = [
+                    'batch_norm_0.tmp_0',
+                    'batch_norm_0.tmp_1',
+                    'bn_scale@GRAD',
+                    'bn_bias@GRAD',
+                    'batch_norm_0.tmp_3@GRAD',
+                    'conv2d_0.tmp_0@GRAD',
+                ]
             fetch_names += others
         bn_fetches = exe.run(
             program=main, feed={'input': data}, fetch_list=fetch_names
@@ -254,28 +282,41 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
         # Multi-GPUs, self.N / core.get_cuda_device_count() per GPU
         assert core.get_cuda_device_count() > 1
 
-        fetch_names = [
-            'bn_moving_mean',
-            'bn_moving_variance',
-            'bn_scale',
-            'bn_bias',
-        ]
-        if not only_forward:
-            others = [
-                'batch_norm_0.tmp_0',
-                'batch_norm_0.tmp_1',
-                'bn_scale@GRAD',
-                'bn_bias@GRAD',
-                'batch_norm_0.tmp_3@GRAD',
-                'conv2d_0.tmp_0@GRAD',
+        if paddle.framework.in_pir_mode():
+            fetch_names = []
+        else:
+            fetch_names = [
+                'bn_moving_mean',
+                'bn_moving_variance',
+                'bn_scale',
+                'bn_bias',
             ]
+        if not only_forward:
+            if paddle.framework.in_pir_mode():
+                others = [
+                    ops[7].result(0),
+                    ops[7].result(1),
+                    ops[-2].result(0),
+                    ops[-2].result(1),
+                    ops[-2].result(2),
+                    ops[-1].result(1),
+                ]
+            else:
+                others = [
+                    'batch_norm_0.tmp_0',
+                    'batch_norm_0.tmp_1',
+                    'bn_scale@GRAD',
+                    'bn_bias@GRAD',
+                    'batch_norm_0.tmp_3@GRAD',
+                    'conv2d_0.tmp_0@GRAD',
+                ]
             fetch_names += others
 
         self.multi_device_run(
             layout, fetch_list=fetch_names, only_forward=only_forward
         )
 
-        fetch_names = [v.name for v in outs] + fetch_names
+        fetch_names = [out, conv, bn] + fetch_names
 
         for i in range(1, len(bn_fetches)):
             bn_val = bn_fetches[i]
@@ -301,6 +342,7 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
                 + str(sync_bn_val),
             )
 
+    @test_with_pir_api
     def test_train(self):
         """Test training."""
         if not core.is_compiled_with_cuda():
@@ -311,6 +353,7 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
             for layout in ["NHWC", "NCHW"]:
                 self._compare(place, layout, False)
 
+    @test_with_pir_api
     def test_infer(self):
         """Test inference."""
         if not core.is_compiled_with_cuda():
@@ -336,6 +379,8 @@ class TestFP16SyncBatchNormOpTraining(TestSyncBatchNormOpTraining):
         self.atol = 5e-3
         self.data_dir = tempfile.TemporaryDirectory()
         self.fleet_log_dir = tempfile.TemporaryDirectory()
+        self.pre_dtype = paddle.get_default_dtype()
+        paddle.set_default_dtype(self.dtype)
 
 
 @unittest.skipIf(
@@ -357,6 +402,8 @@ class TestBF16SyncBatchNormOpTraining(TestSyncBatchNormOpTraining):
         self.atol = 1e-2
         self.data_dir = tempfile.TemporaryDirectory()
         self.fleet_log_dir = tempfile.TemporaryDirectory()
+        self.pre_dtype = paddle.get_default_dtype()
+        paddle.set_default_dtype(self.dtype)
 
 
 class TestDygraphSyncBatchNormAPIError(unittest.TestCase):
@@ -379,7 +426,8 @@ class TestDygraphSyncBatchNormAPIError(unittest.TestCase):
             x2 = paddle.static.data(
                 name='x2', shape=[-1, 3, 4, 5, 6], dtype="int32"
             )
-            x2.desc.set_need_check_feed(False)
+            if not paddle.framework.use_pir_api():
+                x2.desc.set_need_check_feed(False)
             self.assertRaises(TypeError, my_sync_batch_norm, x2)
         cleanup()
 
@@ -446,6 +494,7 @@ class TestConvertSyncBatchNormCast1(unittest.TestCase):
 
 
 class TestDygraphSyncBatchNormDataFormatError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         if not core.is_compiled_with_cuda():
             return

--- a/test/legacy_test/test_sync_batch_norm_op.py
+++ b/test/legacy_test/test_sync_batch_norm_op.py
@@ -111,6 +111,7 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
         self.atol = 5e-3
         self.data_dir = tempfile.TemporaryDirectory()
         self.fleet_log_dir = tempfile.TemporaryDirectory()
+        # nn.Conv2d don't have dtype args to set the dtype of weight and bias
         self.pre_dtype = paddle.get_default_dtype()
         paddle.set_default_dtype(self.dtype)
 
@@ -288,6 +289,7 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
         assert core.get_cuda_device_count() > 1
 
         if paddle.framework.in_pir_mode():
+            # may be not like this in dist
             fetch_names = [
                 ops[1].result(0),
                 ops[0].result(0),
@@ -352,7 +354,7 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
                 + str(sync_bn_val),
             )
 
-    @test_with_pir_api
+    # @test_with_pir_api
     def test_train(self):
         """Test training."""
         if not core.is_compiled_with_cuda():
@@ -363,7 +365,7 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
             for layout in ["NHWC", "NCHW"]:
                 self._compare(place, layout, False)
 
-    @test_with_pir_api
+    # @test_with_pir_api
     def test_infer(self):
         """Test inference."""
         if not core.is_compiled_with_cuda():
@@ -417,6 +419,7 @@ class TestBF16SyncBatchNormOpTraining(TestSyncBatchNormOpTraining):
 
 
 class TestDygraphSyncBatchNormAPIError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         if not core.is_compiled_with_cuda():
             return
@@ -504,7 +507,6 @@ class TestConvertSyncBatchNormCast1(unittest.TestCase):
 
 
 class TestDygraphSyncBatchNormDataFormatError(unittest.TestCase):
-    @test_with_pir_api
     def test_errors(self):
         if not core.is_compiled_with_cuda():
             return

--- a/test/legacy_test/test_sync_batch_norm_op.py
+++ b/test/legacy_test/test_sync_batch_norm_op.py
@@ -344,14 +344,7 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
                 convert_numpy_array(sync_bn_val),
                 rtol=1e-04,
                 atol=self.atol,
-                err_msg='Output ('
-                + fetch_names[i]
-                + ') has diff. \n'
-                + '\nBN     '
-                + str(bn_val)
-                + '\n'
-                + 'Sync BN '
-                + str(sync_bn_val),
+                err_msg=f"Output ({fetch_names[i]}) has diff. \n\nBN     {bn_val}\nSync BN {sync_bn_val}",
             )
 
     # @test_with_pir_api


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
修复单测
- `test/custom_op/test_custom_relu_op_setup.py`。涉及 inference 加载模型和权重，测试失败，加上了 OldIrGuard暂时没有适配
- `test/legacy_test/test_sync_batch_norm_op.py`。
    - 替换 `static.nn.conv2d`,`static.nn.batch_norm`由于 Conv2d 并没有设置 dtype 参数的选项，这里通过 default_type 来设置 parameter dtype。本地没有通过测试，都出错在 `assert core.get_cuda_device_count() > 1` 需要多卡环境。**涉及分布式所以没有打开 test_with_pir_api**
    - 适配 fetch_list
    - 
- `test/legacy_test/test_weight_decay.py`。
    - 其中使用了 `paddle.static.nn.sequence_lod.sequence_pool` ，此 api 不适配 PIR ，加上 OldIrGuard
    - 将 `base.framework.Program()` 替换成 `base.Program()` 