### PR TITLE
TensorInit support paddle::DataType

### DIFF
--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -365,14 +365,8 @@ def _recompute_without_reentrant(
                             inner_x.placements,
                         )
                     else:
-                        if isinstance(inner_x.dtype, paddle.base.core.DataType):
-                            inner_x_dtype = paddle.pir.core.datatype_to_vartype[
-                                inner_x.dtype
-                            ]
-                        else:
-                            inner_x_dtype = inner_x.dtype
                         tmp_tensor = core.eager.Tensor(
-                            inner_x_dtype,
+                            inner_x.dtype,
                             inner_x.shape,
                             inner_x.name + "cpy",
                             core.VarDesc.VarType.LOD_TENSOR,


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Bug fixes

### Description
pcard-85841
in dygraph mode, model will run error: "Incompatible constructor arguments, there are only 5 position args, but the first position args should be PyArray or dtype." when meets 2 conditions:
1. FLAGS_enable_pir_api=true
2. use the following interface to create Tensor (such as recompute)
```python
tmp_tensor = core.eager.Tensor(
                            inner_x.dtype,
                            inner_x.shape,
                            inner_x.name + "cpy",
                            core.VarDesc.VarType.LOD_TENSOR,
                            inner_x.persistable,
                        ) 
```
The root cause is: In the current situation (default `FLAGS_enable_pir_api=false`), `inner_x.dtype` returns `paddle.base.libpaddle.VarType` object, and after setting `FLAGS_deable_pir_mapi=true`, it will return `paddle.base.libpaddle.DataType` object. **But** `core.eager.Tensor` requires the data type to be the former, and if the data type is the latter, an error will be reported.

From the original purpose of the PIR design, the data type in the PaddlePaddle framework needs to be unified to the `paddle:: DataType` (that is the `paddle.base.libpaddle.DataType` object), so interface `core.eager.Tensor` should support `paddle:: DataType`. 

Of course, for compatibility, before the official update of PIR(default `FLAGS_deable_pir_mapi=True`) and during the transitional period, we also supports `paddle.base.libpaddle.VarType`.