### PR TITLE
[PIR Unittest] fix pir ut (`test_while_op,test_norm_nn_grad`)

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
@@ -213,7 +213,6 @@ NO_NEED_GEN_STATIC_ONLY_APIS = [
     'seed',
     'shadow_feed',
     'shadow_feed_tensors',
-    'shuffle_batch',
     'sparse_momentum',
     'tdm_sampler',
     'soft_relu',

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -3757,9 +3757,12 @@ void ShuffleBatchInferMeta(const MetaTensor& x,
 ) {
   out->share_dims(x);
   out->share_lod(x);
+  out->set_dtype(x.dtype());
   seed_out->share_dims(seed);
   seed_out->share_lod(seed);
+  seed_out->set_dtype(x.dtype());
   shuffle_idx->set_dims(phi::make_ddim({-1}));
+  shuffle_idx->set_dtype(x.dtype());
 }
 
 void SequenceMaskInferMeta(const MetaTensor& x,

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -3760,9 +3760,8 @@ void ShuffleBatchInferMeta(const MetaTensor& x,
   out->set_dtype(x.dtype());
   seed_out->share_dims(seed);
   seed_out->share_lod(seed);
-  seed_out->set_dtype(x.dtype());
+  seed_out->set_dtype(seed.dtype());
   shuffle_idx->set_dims(phi::make_ddim({-1}));
-  shuffle_idx->set_dtype(x.dtype());
 }
 
 void SequenceMaskInferMeta(const MetaTensor& x,

--- a/python/paddle/incubate/layers/nn.py
+++ b/python/paddle/incubate/layers/nn.py
@@ -532,7 +532,8 @@ def shuffle_batch(x: Tensor, seed: int | Tensor | None = None) -> Tensor:
         op_attrs["startup_seed"] = seed
         if paddle.framework.in_pir_mode():
             seed = paddle.full([], 0, "int64")
-            seed.persistable = False
+            out, _, _ = _C_ops.shuffle_batch(x, seed, op_attrs["startup_seed"])
+            return out
         else:
             seed = helper.create_variable(
                 name=unique_name.generate("shuffle_batch_seed"),
@@ -540,7 +541,7 @@ def shuffle_batch(x: Tensor, seed: int | Tensor | None = None) -> Tensor:
                 persistable=False,
             )
     if paddle.framework.in_pir_mode():
-        out, _, _ = _C_ops.shuffle_batch(x, seed, **op_attrs)
+        out, _, _ = _C_ops.shuffle_batch(x, seed, 0)
         return out
     helper.append_op(
         type='shuffle_batch',

--- a/python/paddle/incubate/layers/nn.py
+++ b/python/paddle/incubate/layers/nn.py
@@ -531,7 +531,7 @@ def shuffle_batch(x: Tensor, seed: int | Tensor | None = None) -> Tensor:
     if isinstance(seed, int):
         op_attrs["startup_seed"] = seed
         if paddle.framework.in_pir_mode():
-            seed = paddle.full([], 0, "int64")
+            seed = paddle.full([0], 0, "int64")
             out, _, _ = _C_ops.shuffle_batch(x, seed, op_attrs["startup_seed"])
             return out
         else:

--- a/test/legacy_test/test_norm_nn_grad.py
+++ b/test/legacy_test/test_norm_nn_grad.py
@@ -71,7 +71,8 @@ class TestInstanceNormDoubleGradCheck(unittest.TestCase):
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
-            self.func(p)
+            with paddle.pir_utils.OldIrGuard():
+                self.func(p)
             self.func_pir(p)
 
 
@@ -281,7 +282,8 @@ class TestBatchNormDoubleGradCheck(unittest.TestCase):
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
-            self.func(p)
+            with paddle.pir_utils.OldIrGuard():
+                self.func(p)
             self.func_pir(p)
 
 

--- a/test/legacy_test/test_shuffle_batch_op.py
+++ b/test/legacy_test/test_shuffle_batch_op.py
@@ -21,6 +21,7 @@ from op_test import OpTest
 
 import paddle
 from paddle import base
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestShuffleBatchOpBase(OpTest):
@@ -97,6 +98,7 @@ class TestShuffleBatchAPI(unittest.TestCase):
     def tearDown(self):
         paddle.disable_static()
 
+    @test_with_pir_api
     def test_seed_without_tensor(self):
         def api_run(seed, place=paddle.CPUPlace()):
             main_prog, startup_prog = (
@@ -115,6 +117,7 @@ class TestShuffleBatchAPI(unittest.TestCase):
             api_run(None, place=place)
             api_run(1, place=place)
 
+    @test_with_pir_api
     def test_seed_with_tensor(self):
         def api_run(place=paddle.CPUPlace()):
             main_prog, startup_prog = (

--- a/test/legacy_test/test_shuffle_batch_op.py
+++ b/test/legacy_test/test_shuffle_batch_op.py
@@ -19,6 +19,7 @@ import unittest
 import numpy as np
 from op_test import OpTest
 
+import paddle
 from paddle import base
 
 
@@ -38,6 +39,8 @@ class TestShuffleBatchOpBase(OpTest):
 
     def setUp(self):
         self.op_type = 'shuffle_batch'
+        self.python_api = paddle.incubate.layers.shuffle_batch
+        self.python_out_sig = ["Out"]
         self.dtype = np.float64
         self.shape = self.get_shape()
         x = self.gen_random_array(self.shape)
@@ -53,7 +56,7 @@ class TestShuffleBatchOpBase(OpTest):
         self.attrs = {'startup_seed': 1}
 
     def test_check_output(self):
-        self.check_output_customized(self.verify_output)
+        self.check_output_customized(self.verify_output, check_pir=True)
 
     def verify_output(self, outs):
         x = np.copy(self.inputs['X'])
@@ -76,12 +79,54 @@ class TestShuffleBatchOpBase(OpTest):
         return np.reshape(np.array(arr_list), shape)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', check_dygraph=False)
+        self.check_grad(['X'], 'Out', check_dygraph=False, check_pir=True)
 
 
 class TestShuffleBatchOp2(TestShuffleBatchOpBase):
     def get_shape(self):
         return (4, 30)
+
+
+class TestShuffleBatchAPI(unittest.TestCase):
+    def setUp(self):
+        paddle.enable_static()
+
+    def tearDown(self):
+        paddle.disable_static()
+
+    def test_seed_without_tensor(self):
+        def api_run(seed):
+            main_prog, startup_prog = (
+                paddle.static.Program(),
+                paddle.static.Program(),
+            )
+            with paddle.static.program_guard(main_prog, startup_prog):
+                x = paddle.static.data(name='x', shape=[-1, 4], dtype='float32')
+                out = paddle.incubate.layers.shuffle_batch(x, seed=seed)
+            exe = paddle.static.Executor()
+            feed = {'x': np.random.random((10, 4)).astype('float32')}
+            exe.run(startup_prog)
+            _ = exe.run(main_prog, feed=feed, fetch_list=[out])
+
+        api_run(seed=None)
+        api_run(seed=1)
+
+    def test_seed_with_tensor(self):
+        main_prog, startup_prog = (
+            paddle.static.Program(),
+            paddle.static.Program(),
+        )
+        with paddle.static.program_guard(main_prog, startup_prog):
+            x = paddle.static.data(name='x', shape=[-1, 4], dtype='float32')
+            seed = paddle.static.data(name='seed', shape=[1], dtype='int64')
+            out = paddle.incubate.layers.shuffle_batch(x, seed=seed)
+        exe = paddle.static.Executor()
+        feed = {
+            'x': np.random.random((10, 4)).astype('float32'),
+            'seed': np.array([1]).astype('int64'),
+        }
+        exe.run(startup_prog)
+        _ = exe.run(main_prog, feed=feed, fetch_list=[out])
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_while_op.py
+++ b/test/legacy_test/test_while_op.py
@@ -190,9 +190,11 @@ class TestIgnoreVarNameInWhile(unittest.TestCase):
         exe = base.Executor(base.CPUPlace())
         exe.run(base.default_startup_program())
 
-        input_x = numpy.array([[1, 2, 3, 4], [4, 5, 6, 7], [7, 8, 9, 10]])
+        input_x = numpy.array(
+            [[1.0, 2.0, 3.0, 4.0], [4.0, 5.0, 6.0, 7.0], [7.0, 8.0, 9.0, 10.0]]
+        ).astype('float32')
         input_x = input_x.reshape(3, 1, 4)
-        input_y = numpy.array([[10], [12], [33]])
+        input_y = numpy.array([[10.0], [12.0], [33.0]]).astype('float32')
         input_y = input_y.reshape(3, 1, 1)
 
         (res,) = exe.run(

--- a/test/legacy_test/test_while_op.py
+++ b/test/legacy_test/test_while_op.py
@@ -159,6 +159,7 @@ class BadInputTest(unittest.TestCase):
 
 
 class TestIgnoreVarNameInWhile(unittest.TestCase):
+    @test_with_pir_api
     def test_ignore_var(self):
         def cond(i, ten, temp, y):
             return i < ten


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
修复单测：
- test_while_op，
    - 适配 shuffle_batch API
    - 指定 feed 数据类型为所需的 float32
- test_norm_nn_grad，PIR 下不支持 feed parameter 的用法，加上 OldIrGuard