### PR TITLE
[CINN] fix accuracy_check_pass cannot find kernel name

### DIFF
--- a/paddle/cinn/hlir/framework/pir/compilation_cache.h
+++ b/paddle/cinn/hlir/framework/pir/compilation_cache.h
@@ -49,7 +49,7 @@ class BackendResource final {
     return backend_compiler_;
   }
   pir::CINNKernelInfo GenerateKernelInfo() const;
-  const std::string GetHostFuncName() const { return host_fn_name_; }
+  const std::string& GetHostFuncName() const { return host_fn_name_; }
 
  private:
   std::string host_fn_name_;
@@ -70,9 +70,12 @@ class CompilationResult final {
     backend_resource_ = other;
   }
 
-  const std::string GetHostFuncName() const {
-    if (GetBackendResource()) return GetBackendResource()->GetHostFuncName();
-    return "";
+  const std::string& GetHostFuncName() const {
+    PADDLE_ENFORCE_NOT_NULL(GetBackendResource(),
+                            ::common::errors::PreconditionNotMet(
+                                "Found backend_resource_ is nullptr, please "
+                                "call SetBackendResource first."));
+    return GetBackendResource()->GetHostFuncName();
   }
 
   pir::CINNKernelInfo GetKernelInfo() {

--- a/paddle/cinn/hlir/framework/pir/compilation_cache.h
+++ b/paddle/cinn/hlir/framework/pir/compilation_cache.h
@@ -49,6 +49,7 @@ class BackendResource final {
     return backend_compiler_;
   }
   pir::CINNKernelInfo GenerateKernelInfo() const;
+  const std::string GetHostFuncName() const { return host_fn_name_; }
 
  private:
   std::string host_fn_name_;
@@ -67,6 +68,11 @@ class CompilationResult final {
 
   void SetBackendResource(const std::shared_ptr<BackendResource>& other) {
     backend_resource_ = other;
+  }
+
+  const std::string GetHostFuncName() const {
+    if (GetBackendResource()) return GetBackendResource()->GetHostFuncName();
+    return "";
   }
 
   pir::CINNKernelInfo GetKernelInfo() {

--- a/paddle/cinn/hlir/framework/pir_compiler.cc
+++ b/paddle/cinn/hlir/framework/pir_compiler.cc
@@ -161,7 +161,7 @@ void CompilationContextMapper::Construct(
 
   for (size_t i = 0; i < groups.size(); ++i) {
     fusion_infos_.emplace_back(*groups[i]);
-    VLOG(5) << "Construct FusionInfo: " << fusion_infos_[i]
+    VLOG(4) << "Construct FusionInfo: " << fusion_infos_[i]
             << " for group: " << *groups[i];
     // If FLAGS_enable_cinn_compile_cache=False, Cache strategy will not take
     // effects.
@@ -211,8 +211,10 @@ void CompilationContextMapper::UpdateGlobalCache() {
                       ::common::errors::PreconditionNotMet(
                           "Required mapper_index < fusion_infos_.size()."));
     const auto& fusion_info = fusion_infos_[mapper_index_[i]];
-    VLOG(5) << "Insert new compiled result into cache, fusion_info: "
-            << fusion_info;
+    VLOG(4) << "============== Insert new compiled result into cache, "
+               "fusion_info: ==============\n"
+            << fusion_info << ", host func name: "
+            << compilation_results_[i]->GetHostFuncName();
     CompilationCache::Instance().Insert(fusion_info, compilation_results_[i]);
   }
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
修复 accuracy_check_pass 找不到 kernel name 的问题，错误原因是开编译缓存之后fn_name没对应上

修复方法：多打印了一些信息，使得能够手动二次查找 kernel name

查找方法：GLOG_vmodule=pir_compiler=4

先搜索报错 kernel name，找到打印信息：
![截屏2024-07-30 16 22 06](https://github.com/user-attachments/assets/0521799d-4179-4197-8499-1b069c6d3cb1)
![image](https://github.com/user-attachments/assets/6c6c01e8-1e94-4e35-a31b-b1db289c2d61)

然后向上找对应的fusion hash：
![截屏2024-07-30 16 22 31](https://github.com/user-attachments/assets/7ceb2001-5103-4ebf-a82c-20b1b7eb2e41)

搜索hash，可以看到对应 Insert new compiled result into cache 时的 kernel name
![截屏2024-07-30 16 22 43](https://github.com/user-attachments/assets/36faa458-5cc7-434d-bb39-553b726c7785)
![截屏2024-07-30 16 22 54](https://github.com/user-attachments/assets/0c976f9e-0bd0-4021-bf79-5f23dd9a60e0)

最后搜这个名字可以看到对应的 kernel
![截屏2024-07-30 16 23 04](https://github.com/user-attachments/assets/e91aa6f7-4085-442c-af45-2434d0bc4fed)


