### PR TITLE
[CINN] Fix bug of infer symbol shape for conv2d

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
@@ -14,7 +14,10 @@
 
 #include "paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.h"
 #include "paddle/common/ddim.h"
+#include "paddle/common/flags.h"
 #include "paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h"
+
+COMMON_DECLARE_bool(manually_trans_conv_filter);
 
 namespace {
 
@@ -152,8 +155,7 @@ bool Conv2dOpInferSymbolicShape(pir::Operation *op,
                                                   in_s_or_d.shape().end());
 
   const std::vector<symbol::DimExpr> filter_data_dims = [&]() {
-    if (filter_s_or_d.shape().size() == 4 &&
-        filter_s_or_d.shape().at(1) == filter_s_or_d.shape().at(2)) {  // NHWC
+    if (channel_last && FLAGS_manually_trans_conv_filter) {  // NHWC
       return std::vector<symbol::DimExpr>(filter_s_or_d.shape().begin() + 1,
                                           filter_s_or_d.shape().end() - 1);
     } else {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复conv2d算子符号推导接口layout处理不完备的问题。