### PR TITLE
Remove redundant traits

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_op.cu.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_op.cu.h
@@ -39,21 +39,6 @@ using float16 = phi::dtype::float16;
 #define MMHA_USE_FP32_ACUM_FOR_FMA
 // #define MMHA_USE_HMMA_FOR_REDUCTION
 
-template <typename D>
-class PDDataTypeTraits;
-
-template <>
-class PDDataTypeTraits<float> {
- public:
-  typedef float DataType;
-};
-
-template <>
-class PDDataTypeTraits<float16> {
- public:
-  typedef half DataType;
-};
-
 template <typename T>
 struct Masked_multihead_attention_params {
   // output buffer, [B, 1(seq_len), num_head * dim_head]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

Pcard-71501

移除了paddle/phi/kernels/fusion/gpu/fused_multi_transformer_op.cu.h中冗余的PDDataTypeTraits

其可能会和paddle/phi/common/datatype_traits.h中的PDDataTypeTraits在引用上发生冲突，在未指明命名空间的情况下会产生没有特化bfloat16的错误

