### PR TITLE
[Fix PIR Unittest] fix pir ut (`test_sequence_conv_op_xpu,test_while_op_xpu`)

### DIFF
--- a/test/xpu/test_sequence_conv_op_xpu.py
+++ b/test/xpu/test_sequence_conv_op_xpu.py
@@ -429,19 +429,22 @@ for stype in support_types:
 
 class TestSeqConvApi(unittest.TestCase):
     def test_api(self):
-        from paddle import base
+        with paddle.pir_utils.OldIrGuard():
+            from paddle import base
 
-        x = paddle.static.data('x', shape=[-1, 32], lod_level=1)
-        y = paddle.static.nn.sequence_lod.sequence_conv(
-            input=x, num_filters=2, filter_size=3, padding_start=None
-        )
-        place = base.CPUPlace()
-        x_tensor = base.create_lod_tensor(
-            np.random.rand(10, 32).astype("float32"), [[2, 3, 1, 4]], place
-        )
-        exe = base.Executor(place)
-        exe.run(base.default_startup_program())
-        ret = exe.run(feed={'x': x_tensor}, fetch_list=[y], return_numpy=False)
+            x = paddle.static.data('x', shape=[-1, 32], lod_level=1)
+            y = paddle.static.nn.sequence_lod.sequence_conv(
+                input=x, num_filters=2, filter_size=3, padding_start=None
+            )
+            place = base.CPUPlace()
+            x_tensor = base.create_lod_tensor(
+                np.random.rand(10, 32).astype("float32"), [[2, 3, 1, 4]], place
+            )
+            exe = base.Executor(place)
+            exe.run(base.default_startup_program())
+            ret = exe.run(
+                feed={'x': x_tensor}, fetch_list=[y], return_numpy=False
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
修复单测
- test_sequence_conv_op_xpu，使用了 `static.nn.sequence_lod.sequence_conv`，PIR 下不适配，加上 OldIrGuard
- test_while_op_xpu，使用了 `base.compiler.CompiledProgram`，加上 OldIrGuard