### PR TITLE
[Bug fixes] fix top_p_sampling_kernel mode name

### DIFF
--- a/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
+++ b/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
@@ -585,7 +585,7 @@ void DispatchKeMatrixTopPBeamTopK(const Context& dev_ctx,
                                   const bool need_batch_random,
                                   const std::string& mode) {
   int BlockSize = GetBlockSize(vocab_size);
-  if (mode == "truncate") {
+  if (mode == "truncated") {
     switch (BlockSize) {
       FIXED_BLOCK_DIM(
           KeMatrixTopPBeamTopKFt<T, TopKMaxLength, TopPBeamTopK, kBlockDim>
@@ -972,7 +972,7 @@ void DispatchTopPSampling(const Context& dev_ctx,
                           int* count_iter_begin,
                           const std::string& mode) {
   int BlockSize = GetBlockSize(vocab_size);
-  if (mode == "truncate") {
+  if (mode == "truncated") {
     switch (BlockSize) {
       FIXED_BLOCK_DIM(
           topp_sampling_ft<T, kBlockDim>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-71500
fix top_p_sampling_kernel mode name, truncate -> truncated