### PR TITLE
Fix amp bf16 error in dygraph with pir

### DIFF
--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -2014,5 +2014,6 @@ class Optimizer:
             )
         else:
             return (
-                dtype == core.DataType.FLOAT16 or dtype == core.DataType.UINT16
+                dtype == core.DataType.FLOAT16
+                or dtype == core.DataType.BFLOAT16
             )

--- a/test/amp/test_pir_amp.py
+++ b/test/amp/test_pir_amp.py
@@ -64,6 +64,32 @@ class TestPirAMPProgram(unittest.TestCase):
             np.testing.assert_equal(len(_white_list), 0)
             np.testing.assert_equal(len(_black_list), 0)
 
+    def test_linear_amp_bf16_o1(self):
+        if not core.is_compiled_with_cuda():
+            return
+        with paddle.pir_utils.IrGuard():
+            startup = paddle.static.Program()
+            main = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                x = paddle.static.data('x', [3, 4], 'float32')
+                linear = paddle.nn.Linear(4, 5)
+                with paddle.amp.auto_cast(
+                    level='O1', dtype='bfloat16', use_promote=True
+                ):
+                    out1 = linear(x)
+                    out2 = paddle.mean(out1)
+
+            cast_op_count = 0
+            for op in main.global_block().ops:
+                if op.name() == 'pd_op.cast':
+                    cast_op_count += 1
+            np.testing.assert_equal(out1.dtype, core.DataType.FLOAT32)
+            np.testing.assert_equal(out2.dtype, core.DataType.FLOAT32)
+            np.testing.assert_equal(cast_op_count, 3)
+            _white_list, _black_list = core._get_amp_op_list()
+            np.testing.assert_equal(len(_white_list), 0)
+            np.testing.assert_equal(len(_black_list), 0)
+
     def test_linear_amp_o2_without_scaler(self):
         if not core.is_compiled_with_cuda():
             return
@@ -139,6 +165,47 @@ class TestPirAMPProgram(unittest.TestCase):
                 if op.name() == 'pd_op.cast':
                     cast_op_count += 1
             np.testing.assert_equal(cast_op_count, 5)
+            place = paddle.CUDAPlace(0)
+            exe = paddle.static.Executor(place)
+            exe.run(startup)
+            result = exe.run(
+                main,
+                feed={'x': np.random.rand(3, 4).astype('float32')},
+                fetch_list=[loss],
+            )
+
+    def test_linear_amp_bf16_o2_without_scaler(self):
+        if not core.is_compiled_with_cuda():
+            return
+        with paddle.pir_utils.IrGuard():
+            startup = paddle.static.Program()
+            main = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                x = paddle.static.data('x', [3, 4], 'float32')
+                linear = paddle.nn.Linear(4, 5)
+                optimizer = paddle.optimizer.Adam(
+                    learning_rate=0.001, parameters=linear.parameters()
+                )
+                linear, optimizer = paddle.amp.decorate(
+                    models=linear,
+                    optimizers=optimizer,
+                    level='O2',
+                    dtype='bfloat16',
+                    master_weight=True,
+                    master_grad=True,
+                )
+
+                with paddle.amp.auto_cast(
+                    level='O2', dtype='bfloat16', use_promote=True
+                ):
+                    out = linear(x)
+                    loss = paddle.mean(out)
+                optimizer.minimize(loss)
+            cast_op_count = 0
+            for op in main.global_block().ops:
+                if op.name() == 'pd_op.cast':
+                    cast_op_count += 1
+            np.testing.assert_equal(cast_op_count, 3)
             place = paddle.CUDAPlace(0)
             exe = paddle.static.Executor(place)
             exe.run(startup)

--- a/test/amp/test_pir_amp.py
+++ b/test/amp/test_pir_amp.py
@@ -37,6 +37,11 @@ class TestAmpAttrs(unittest.TestCase):
             amp_attrs._amp_dtype = 'float32'
 
 
+@unittest.skipIf(
+    not paddle.is_compiled_with_cuda()
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "only support device's compute capability is at least 8.0",
+)
 class TestPirAMPProgram(unittest.TestCase):
     def test_linear_amp_o1(self):
         if not core.is_compiled_with_cuda():

--- a/tools/gpups_test.sh
+++ b/tools/gpups_test.sh
@@ -129,7 +129,8 @@ parallel_list="^init_phi_test$|\
 ^test_roll_op$|\
 ^test_switch_autotune$|\
 ^test_to_tensor$|\
-^test_top_k_v2_op$"
+^test_top_k_v2_op$|\
+^test_pir_amp$"
 
 cd ${work_dir}/build
 tmp_dir=`mktemp -d`


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Bug fixes

### Description
pcard-85872
when use AMP(**BF16** dtype, FP16 is fine) training in dygraph with pir will report an error: `ValueError: (InvalidArgument) The type of data we are trying to retrieve (float32) does not match the type of data (bfloat16) currently contained in the container.`

The reason is that when with pir(`FLAGS_enable_pir_api=True`) the method of `_is_dtype_fp16_or_bf16 ` in the optimizer base class `Optimizer` incorrectly judges data type of BF16 (FP16 is fine). so when data type is actually BF16 , but it judges that not. 

this further leads to issues of judgment logic of the method `_add_moments_pows`、`_create_accumulators` and `_append_optimize_op` in the optimizer. `_add_moments_pows` creates tensors of `moment1`, `moment2`, `beta1_pow`, and `beta2_pow` with dtype of BF16  (which should be FP32), which leads to an type mismatch error above when executing `beta1_pow.data<MPDType()` in the kernel of `adam/adamw` (adamw_kernel.cu).
