### PR TITLE
[CINN]Fix InferSymbolicShape for expand_as

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
@@ -246,9 +246,10 @@ bool ExpandAsOpInferSymbolicShape(
   std::vector<int> target_shape =
       paddle::dialect::details::GetVectorAttr<int>(op, "target_shape");
   const std::vector<symbol::DimExpr> &output_dims = [&] {
-    if (op->operand_source(0)) {
-      return infer_context->GetShapeOrDataForValue(op->operand_source(1))
-          .shape();
+    const auto &input_shape_or_data =
+        infer_context->GetShapeOrDataForValue(op->operand_source(1));
+    if (!input_shape_or_data.isa<symbol::NullShapeOrDataDimExpr>()) {
+      return input_shape_or_data.shape();
     }
     std::vector<symbol::DimExpr> output_dims;
     output_dims.reserve(target_shape.size());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR fixes InferSymbolicShape for expand_as.