### PR TITLE
fix add infermata

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -1692,17 +1692,8 @@ void ElementwiseRawInferMeta(const MetaTensor& x,
     std::vector<int> x_dims_array(max_dim);
     std::vector<int> y_dims_array(max_dim);
     std::vector<int> out_dims_array(max_dim);
-    std::cout << "x_dims1 = " << x_dims << std::endl;
-    std::cout << "y_dims1 = " << y_dims << std::endl;
 
 #ifdef PADDLE_WITH_DNNL
-    std::cout << "config.is_run_mkldnn_kernel = " << config.is_run_mkldnn_kernel
-              << std::endl;
-    std::cout << "phi::OneDNNContext::tls().get_cur_paddle_data_layout() = "
-              << phi::OneDNNContext::tls().get_cur_paddle_data_layout()
-              << std::endl;
-    std::cout << "x_dims.size() = " << x_dims.size() << std::endl;
-    std::cout << "y_dims.size() = " << y_dims.size() << std::endl;
     bool should_rotate =
         config.is_run_mkldnn_kernel &&
         (phi::OneDNNContext::tls().get_cur_paddle_data_layout() ==
@@ -1710,7 +1701,7 @@ void ElementwiseRawInferMeta(const MetaTensor& x,
         (x_dims.size() >= 3 || y_dims.size() >= 3);
     if (should_rotate) {
       // Pick bigger shape and rotate this one
-      bool x_over_y = (x_dims.size() > y_dims.size());
+      bool x_over_y = (common::product(x_dims) > common::product(y_dims));
       auto vdims = x_over_y ? common::vectorize<int>(x_dims)
                             : common::vectorize<int>(y_dims);
       std::rotate(vdims.begin() + 1, vdims.begin() + 2, vdims.end());
@@ -1721,8 +1712,6 @@ void ElementwiseRawInferMeta(const MetaTensor& x,
       }
     }
 #endif
-    std::cout << "x_dims2 = " << x_dims << std::endl;
-    std::cout << "y_dims2 = " << y_dims << std::endl;
     funcs::GetBroadcastDimsArrays(x_dims,
                                   y_dims,
                                   x_dims_array.data(),

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -1647,8 +1647,9 @@ void DotInferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out) {
 
 void ElementwiseInferMeta(const MetaTensor& x,
                           const MetaTensor& y,
-                          MetaTensor* out) {
-  return ElementwiseRawInferMeta(x, y, -1, out);
+                          MetaTensor* out,
+                          MetaConfig config) {
+  return ElementwiseRawInferMeta(x, y, -1, out, config);
 }
 
 void BitwiseShiftInferMeta(const MetaTensor& x,
@@ -1691,7 +1692,17 @@ void ElementwiseRawInferMeta(const MetaTensor& x,
     std::vector<int> x_dims_array(max_dim);
     std::vector<int> y_dims_array(max_dim);
     std::vector<int> out_dims_array(max_dim);
+    std::cout << "x_dims1 = " << x_dims << std::endl;
+    std::cout << "y_dims1 = " << y_dims << std::endl;
+
 #ifdef PADDLE_WITH_DNNL
+    std::cout << "config.is_run_mkldnn_kernel = " << config.is_run_mkldnn_kernel
+              << std::endl;
+    std::cout << "phi::OneDNNContext::tls().get_cur_paddle_data_layout() = "
+              << phi::OneDNNContext::tls().get_cur_paddle_data_layout()
+              << std::endl;
+    std::cout << "x_dims.size() = " << x_dims.size() << std::endl;
+    std::cout << "y_dims.size() = " << y_dims.size() << std::endl;
     bool should_rotate =
         config.is_run_mkldnn_kernel &&
         (phi::OneDNNContext::tls().get_cur_paddle_data_layout() ==
@@ -1710,6 +1721,8 @@ void ElementwiseRawInferMeta(const MetaTensor& x,
       }
     }
 #endif
+    std::cout << "x_dims2 = " << x_dims << std::endl;
+    std::cout << "y_dims2 = " << y_dims << std::endl;
     funcs::GetBroadcastDimsArrays(x_dims,
                                   y_dims,
                                   x_dims_array.data(),

--- a/paddle/phi/infermeta/binary.h
+++ b/paddle/phi/infermeta/binary.h
@@ -324,7 +324,8 @@ void DropoutNdInferMeta(const MetaTensor& x,
 
 TEST_API void ElementwiseInferMeta(const MetaTensor& x,
                                    const MetaTensor& y,
-                                   MetaTensor* out);
+                                   MetaTensor* out,
+                                   MetaConfig config = MetaConfig());
 
 void ElementwiseRawInferMeta(const MetaTensor& x_meta,
                              const MetaTensor& y_meta,

--- a/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
@@ -7,7 +7,7 @@
   args : (Tensor x, Tensor y)
   output : Tensor(out)
   infer_meta :
-    func : ElementwiseInferMeta
+    func : ElementwiseRawInferMeta
     spmd_rule : ElementwiseBinaryInferSpmd
   kernel :
     func : add

--- a/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
@@ -7,7 +7,7 @@
   args : (Tensor x, Tensor y)
   output : Tensor(out)
   infer_meta :
-    func : ElementwiseRawInferMeta
+    func : ElementwiseInferMeta
     spmd_rule : ElementwiseBinaryInferSpmd
   kernel :
     func : add


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
add ElementwiseInferMeta。ElementwiseInferMeta不支持MetaConfig的传入，因此使用了MetaConfig的默认值。在OneDNN下需要MetaConfig传递is_run_mkldnn_kernel，会出问题。
为ElementwiseInferMeta添加MetaConfig参数。

此外，对于[1, 6, 6, 3] add [1, 1, 1, 3]这种场景，代码中的rotate逻辑写的有bug，进行修复。

Pcard-67164