### PR TITLE
Reset epoch for custom sampler and fix add dependency bug for auto static

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
@@ -344,12 +344,13 @@ void DependencyBuilder::AddDependencyForSequentialRun() {
   for (size_t op_idx = 0; op_idx < op_num_; ++op_idx) {
     if (dependence_op_idx != ULLONG_MAX) {
       if (this->GetInstructionName(op_idx) == "pd_op.full_int_array") {
-      VLOG(8) << "Skip adding dependency for sequential run: "
-              << dependence_op_idx << "->" << op_idx << " "
-              << this->GetInstructionName(dependence_op_idx) << "->"
-              << this->GetInstructionName(op_idx);
-      continue;
-    }
+        VLOG(8) << "Skip adding dependency for sequential run: "
+                << dependence_op_idx << "->" << op_idx << " "
+                << this->GetInstructionName(dependence_op_idx) << "->"
+                << this->GetInstructionName(op_idx);
+        continue;
+      }
+
       AddDownstreamOp(dependence_op_idx, op_idx);
     }
     dependence_op_idx = op_idx;

--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
@@ -342,14 +342,14 @@ void DependencyBuilder::AddDependencyForReadOp() {
 void DependencyBuilder::AddDependencyForSequentialRun() {
   size_t dependence_op_idx = ULLONG_MAX;
   for (size_t op_idx = 0; op_idx < op_num_; ++op_idx) {
-    if (this->GetInstructionName(op_idx) == "pd_op.full_int_array") {
+    if (dependence_op_idx != ULLONG_MAX) {
+      if (this->GetInstructionName(op_idx) == "pd_op.full_int_array") {
       VLOG(8) << "Skip adding dependency for sequential run: "
               << dependence_op_idx << "->" << op_idx << " "
               << this->GetInstructionName(dependence_op_idx) << "->"
               << this->GetInstructionName(op_idx);
       continue;
     }
-    if (dependence_op_idx != ULLONG_MAX) {
       AddDownstreamOp(dependence_op_idx, op_idx);
     }
     dependence_op_idx = op_idx;

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -300,11 +300,13 @@ class Engine:
             batch_sampler = dataloader.batch_sampler
         else:
             batch_sampler = dataloader._dataloader.batch_sampler
+
         if hasattr(batch_sampler, "set_epoch"):
             # Get data from DataLoader iterator directly may affect data generation randomness
             # of BatchSampler when `Shuffle=True`. It may cause difference of data feeding
             # between dynamic and to_static mode.
             batch_sampler.set_epoch(0)
+
         if isinstance(data, dict):
             data = tuple(data.values())
             if len(data) != 2:
@@ -1045,7 +1047,9 @@ class Engine:
             self._json_config,
         )
         self._dist_contexts[mode].gradient_scale = self._strategy.gradient_scale
-        self._dist_contexts[mode].gradient_scale_using_allreduce_avg = (
+        self._dist_contexts[
+            mode
+        ].gradient_scale_using_allreduce_avg = (
             self._strategy.gradient_scale_using_allreduce_avg
         )
         self._fwd_main_progs[mode] = serial_main_prog.clone()
@@ -1078,9 +1082,9 @@ class Engine:
 
         if self._tuning.run_after_tuning:
             # update the strategy
-            self._dist_contexts[mode]._strategy = (
-                self._optimization_tuner.get_best_config()
-            )
+            self._dist_contexts[
+                mode
+            ]._strategy = self._optimization_tuner.get_best_config()
 
     def _plan(self, mode):
         if self._planned_mode is None:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复以下2个问题：
1. 自动并行动转静`to_static`接口中通过提前读取一次dataloader数据构造`input_spec`，从而导致sampler的epoch等状态改变。为了消除多load一次数据的影响，原本的逻辑在load结束后对状态进行回滚，但相关代码只适配了框架`paddle.io.DistributedBatchSampler`，无法处理业务自定义sampler的行为。本PR将回滚逻辑扩展到覆盖所有实现了set_epoch接口的sampler，以解决目前业务遇到的问题。后续针对业务自定义的sampler，需要更通用的用户设计。
2. 执行器`AddDependencyForSequentialRun`函数特殊处理了`full_int_array`算子，但该代码未考虑`full_int_array`为网络中第一个算子的情况，在此case下运行会出错异常退出，本PR对该问题进行了修复。

Pcard-76459
