### PR TITLE
【Comm】switch alltoall in fluid to all_to_all in phi

### DIFF
--- a/paddle/fluid/framework/new_executor/pir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.cc
@@ -542,7 +542,7 @@ void PirInterpreter::UpdateNcclOpNum() {
       "pd_op.send_v2",
       "pd_op.mp_allreduce_sum",
       "pd_op.barrier",
-      "pd_op.alltoall",
+      "pd_op.all_to_all",
       "pd_op.global_gather",
       "pd_op.distributed_fused_lamb",
       "pd_op.margin_cross_entropy",

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -17,16 +17,6 @@
     func : all_reduce
     param: [x, reduce_type]
 
-- op : all_to_all
-  args : (Tensor x, int ring_id = 0)
-  output : Tensor(out)
-  infer_meta :
-    func : AllToAllInferMeta
-    param: [x]
-  kernel :
-    func : all_to_all
-    param: [x]
-
 - op : amax
   args : (Tensor x, IntArray axis={0}, bool keepdim=false, bool reduce_all=false, int in_dtype=-1, int out_dtype=-1)
   output : Tensor(out)

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -192,6 +192,16 @@
     func : all_gather
     param: [x, nranks]
 
+- op : all_to_all
+  args : (Tensor x, int ring_id = 0)
+  output : Tensor(out)
+  infer_meta :
+    func : AllToAllInferMeta
+    param: [x]
+  kernel :
+    func : all_to_all
+    param: [x]
+
 - op : allclose
   args : (Tensor x, Tensor y, Scalar(double) rtol=1e-5, Scalar(double) atol=1e-8, bool equal_nan=false)
   output : Tensor(out)

--- a/python/paddle/distributed/communication/stream/all_to_all.py
+++ b/python/paddle/distributed/communication/stream/all_to_all.py
@@ -87,7 +87,7 @@ def _all_to_all_in_static_mode(
     sync_op: bool,
     use_calc_stream: bool,
 ) -> None:
-    op_type = 'alltoall'
+    op_type = 'all_to_all'
     ring_id = 0 if group is None else group.id
     nranks = dist.get_world_size()
     helper = framework.LayerHelper(op_type, **locals())
@@ -118,15 +118,16 @@ def _all_to_all_in_static_mode(
         ['float16', 'float32', 'float64', 'int32', 'int64', 'uint16'],
         'all_to_all',
     )
-    helper.append_op(
+    op = helper.append_op(
         type=op_type,
-        inputs={'X': [in_tensor]},
-        outputs={'Out': [out_tensor]},
+        inputs={'x': [in_tensor]},
+        outputs={'out': [out_tensor]},
         attrs={
             'ring_id': ring_id,
-            'use_calc_stream': sync_op,
         },
     )
+    if sync_op:
+        op.dist_attr.execution_stream = "default"
     # NOTE(liyurui): If the argument `out_tensor_or_tensor_list` is a tensor_list,
     # we need to split the result. So we should wait the result of all_to_all
     # before split if the communication is not on calc stream.

--- a/test/collective/test_collective_alltoall_api.py
+++ b/test/collective/test_collective_alltoall_api.py
@@ -25,21 +25,6 @@ class TestCollectiveAllToAllAPI(TestDistBase):
     def _setup_config(self):
         pass
 
-    def test_alltoall_nccl_with_comm_context(self):
-        dtypes_to_test = [
-            "float32",
-        ]
-        if self._nccl_version >= 21000:
-            dtypes_to_test.append("bfloat16")
-        for dtype in dtypes_to_test:
-            self.check_with_place(
-                "collective_alltoall_api.py",
-                "alltoall",
-                "nccl",
-                dtype=dtype,
-                need_envs={"USE_COMM_CONTEXT": "1"},
-            )
-
     def test_alltoall_nccl_with_new_comm(self):
         dtypes_to_test = [
             "float16",
@@ -54,6 +39,27 @@ class TestCollectiveAllToAllAPI(TestDistBase):
                 "alltoall",
                 "nccl",
                 dtype=dtype,
+                need_envs={"FLAGS_dynamic_static_unified_comm": "true"},
+            )
+
+    def test_alltoall_nccl_with_new_comm_pir(self):
+        dtypes_to_test = [
+            "float16",
+            "float32",
+            "float64",
+            "int32",
+            "int64",
+        ]
+        for dtype in dtypes_to_test:
+            self.check_with_place(
+                "collective_alltoall_api.py",
+                "alltoall",
+                "nccl",
+                dtype=dtype,
+                need_envs={
+                    "FLAGS_dynamic_static_unified_comm": "true",
+                    "FLAGS_enable_pir_in_executor": "1",
+                },
             )
 
     def test_alltoall_nccl_dygraph(self):

--- a/test/legacy_test/test_collective_api_base.py
+++ b/test/legacy_test/test_collective_api_base.py
@@ -508,7 +508,7 @@ class TestDistBase(unittest.TestCase):
             np.testing.assert_allclose(
                 result_data, need_result, rtol=1e-05, atol=1e-05
             )
-        elif col_type == "alltoall":
+        elif col_type == "all_to_all":
             need_result1 = np.vstack(
                 (
                     input1[0 : input1.shape[0] // 2, :],

--- a/test/xpu/test_collective_api_base.py
+++ b/test/xpu/test_collective_api_base.py
@@ -501,7 +501,7 @@ class TestDistBase(unittest.TestCase):
             np.testing.assert_allclose(
                 result_data, need_result, rtol=1e-05, atol=1e-05
             )
-        elif col_type == "alltoall":
+        elif col_type == "all_to_all":
             need_result1 = np.vstack(
                 (
                     input1[0 : input1.shape[0] // 2, :],


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
replace `alltoall`  with `all_to_all`  in python api

PCard-85618