### PR TITLE
Replace phi::errors in fluid/pir/dialect [fluid_ops] part20

### DIFF
--- a/paddle/fluid/pir/dialect/distributed/ir/dist_attribute.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_attribute.cc
@@ -77,13 +77,13 @@ phi::distributed::Placements TensorDistAttribute::placements() const {
     if (mesh_id >= 0) {
       auto& p = placements[mesh_id];
       if (p->is_shard()) {
-        PADDLE_THROW(phi::errors::PreconditionNotMet(
+        PADDLE_THROW(common::errors::PreconditionNotMet(
             "ProcessMesh dimension cann't be mapped to two  dimension of the "
             "same tensor: {%d} and {%d}",
             i,
             dynamic_cast<phi::distributed::Shard&>(*p).get_dim()));
       } else if (p->is_partial()) {
-        PADDLE_THROW(phi::errors::PreconditionNotMet(
+        PADDLE_THROW(common::errors::PreconditionNotMet(
             "ProcessMesh dimension {%d} cannot be both shard and partial!",
             mesh_id));
       }

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_op.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_op.cc
@@ -85,16 +85,16 @@ void ShardTensorOp::VerifySig() {
             "op_dist_attr");
     PADDLE_ENFORCE_EQ(op_dist_attr.num_operands(),
                       0u,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The op_dist_attr input size must be equal to 0."));
 
-    PADDLE_ENFORCE_EQ(
-        op_dist_attr.num_results(),
-        num_results(),
-        phi::errors::PreconditionNotMet("The op_dist_attr output size %d must "
-                                        "be equal to op output size %d.",
-                                        op_dist_attr.num_results(),
-                                        num_results()));
+    PADDLE_ENFORCE_EQ(op_dist_attr.num_results(),
+                      num_results(),
+                      common::errors::PreconditionNotMet(
+                          "The op_dist_attr output size %d must "
+                          "be equal to op output size %d.",
+                          op_dist_attr.num_results(),
+                          num_results()));
   }
   VLOG(4) << "End Verifying for: ShardTensorOp.";
 }
@@ -271,7 +271,7 @@ void ReshardOp::VerifySig() {
 
     PADDLE_ENFORCE_EQ(op_dist_attr.num_results(),
                       num_results(),
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The op_dist_attr output size of reshard op must be "
                           "equal to op output size."));
   }

--- a/paddle/fluid/pir/dialect/distributed/transforms/dist_to_dense_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/dist_to_dense_pass.cc
@@ -93,7 +93,7 @@ void ProcessDistBlock(pir::Block* block) {
       auto array_attr = prev_op->attribute<pir::ArrayAttribute>("value");
       PADDLE_ENFORCE_EQ(array_attr.size(),
                         local_dims.size(),
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "The reshape's shape inputs element's size must "
                             "equal to result's dim size."));
       std::vector<pir::Attribute> new_dims;
@@ -134,7 +134,7 @@ void VerifyDenseBlock(pir::Block* block) {
       PADDLE_ENFORCE_EQ(
           IsDistType(result.type()),
           false,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "Block op [%s] still contain dist type.", op_item->name()));
     }
 

--- a/paddle/fluid/pir/dialect/kernel/ir/kernel_op.cc
+++ b/paddle/fluid/pir/dialect/kernel/ir/kernel_op.cc
@@ -33,17 +33,17 @@ void PhiKernelOp::VerifySig() {
 
   PADDLE_ENFORCE(attributes.count("op_name") > 0 &&
                      attributes.at("op_name").isa<pir::StrAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: op_name is not right."));
 
   PADDLE_ENFORCE(attributes.count("kernel_name") > 0 &&
                      attributes.at("kernel_name").isa<pir::StrAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: kernel_name is not right."));
 
   PADDLE_ENFORCE(attributes.count("kernel_key") > 0 &&
                      attributes.at("kernel_key").isa<KernelAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: kernel_key is not right."));
 }
 
@@ -72,17 +72,17 @@ void LegacyKernelOp::VerifySig() {
 
   PADDLE_ENFORCE(attributes.count("op_name") > 0 &&
                      attributes.at("op_name").isa<pir::StrAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: op_name is not right."));
 
   PADDLE_ENFORCE(attributes.count("kernel_name") > 0 &&
                      attributes.at("kernel_name").isa<pir::StrAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: kernel_name is not right."));
 
   PADDLE_ENFORCE(attributes.count("kernel_key") > 0 &&
                      attributes.at("kernel_key").isa<KernelAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: kernel_key is not right."));
 }
 
@@ -110,17 +110,17 @@ void CustomKernelOp::VerifySig() {
 
   PADDLE_ENFORCE(attributes.count("op_name") > 0 &&
                      attributes.at("op_name").isa<pir::StrAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: op_name is not right."));
 
   PADDLE_ENFORCE(attributes.count("kernel_name") > 0 &&
                      attributes.at("kernel_name").isa<pir::StrAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: kernel_name is not right."));
 
   PADDLE_ENFORCE(attributes.count("kernel_key") > 0 &&
                      attributes.at("kernel_key").isa<KernelAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: kernel_key is not right."));
 }
 
@@ -152,17 +152,17 @@ void OneDNNPhiKernelOp::VerifySig() {
 
   PADDLE_ENFORCE(attributes.count("op_name") > 0 &&
                      attributes.at("op_name").isa<pir::StrAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: op_name is not right."));
 
   PADDLE_ENFORCE(attributes.count("kernel_name") > 0 &&
                      attributes.at("kernel_name").isa<pir::StrAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: kernel_name is not right."));
 
   PADDLE_ENFORCE(attributes.count("kernel_key") > 0 &&
                      attributes.at("kernel_key").isa<KernelAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: kernel_key is not right."));
 }
 
@@ -191,17 +191,17 @@ void OneDNNMixedPhiKernelOp::VerifySig() {
 
   PADDLE_ENFORCE(attributes.count("op_name") > 0 &&
                      attributes.at("op_name").isa<pir::StrAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: op_name is not right."));
 
   PADDLE_ENFORCE(attributes.count("kernel_name") > 0 &&
                      attributes.at("kernel_name").isa<pir::StrAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: kernel_name is not right."));
 
   PADDLE_ENFORCE(attributes.count("kernel_key") > 0 &&
                      attributes.at("kernel_key").isa<KernelAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: kernel_key is not right."));
 }
 
@@ -231,17 +231,17 @@ void OneDNNLegacyKernelOp::VerifySig() {
 
   PADDLE_ENFORCE(attributes.count("op_name") > 0 &&
                      attributes.at("op_name").isa<pir::StrAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: op_name is not right."));
 
   PADDLE_ENFORCE(attributes.count("kernel_name") > 0 &&
                      attributes.at("kernel_name").isa<pir::StrAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: kernel_name is not right."));
 
   PADDLE_ENFORCE(attributes.count("kernel_key") > 0 &&
                      attributes.at("kernel_key").isa<KernelAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Type of attribute: kernel_key is not right."));
 }
 

--- a/paddle/fluid/pir/dialect/op_generator/api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/api_gen.py
@@ -126,7 +126,7 @@ OP_DISPATCH_TEMPLATE = """
     }}"""
 
 OP_DISPATCH_ERROR_TEMPLATE = """
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "The kernel of ({op_name}) for input Value is unimplemented, please check the type of input Value."));"""
 
 

--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -498,7 +498,7 @@ def GenBuildOutputs(
     {name} = phi::IntArray(std::vector<int64_t>({name}_size, -1));
     {name}.SetFromTensor(true);
   }} else {{
-    PADDLE_THROW(phi::errors::Unimplemented("Only support VectorType or DenseTensorType"));
+    PADDLE_THROW(common::errors::Unimplemented("Only support VectorType or DenseTensorType"));
   }}\n"""
 
     CREATE_VECTOR_INT_MUTABLE_ATTRIBUTE_WITH_UNKNOWN_DATA_TEMPLATE = """  std::vector<int64_t> {name};
@@ -518,7 +518,7 @@ def GenBuildOutputs(
     }}
     {name} = std::vector<int64_t>({name}_size, -1);
   }} else {{
-    PADDLE_THROW(phi::errors::Unimplemented("Only support VectorType or DenseTensorType"));
+    PADDLE_THROW(common::errors::Unimplemented("Only support VectorType or DenseTensorType"));
   }}\n"""
 
     CREATE_SCALAR_MUTABLE_ATTRIBUTE_WITH_UNKNOWN_DATA_TEMPLATE = """  phi::Scalar {name};
@@ -829,7 +829,7 @@ def gen_build_func_str(
   PADDLE_ENFORCE_NE(
       attributes.find("{attribute_name}"),
       attributes.end(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<{attr_ir_type}>().data();
 """
@@ -837,7 +837,7 @@ def gen_build_func_str(
   PADDLE_ENFORCE_NE(
       attributes.find("{attribute_name}"),
       attributes.end(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<pir::StrAttribute>().AsString();
 """
@@ -845,7 +845,7 @@ def gen_build_func_str(
   PADDLE_ENFORCE_NE(
       attributes.find("{attribute_name}"),
       attributes.end(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name};
   for (size_t i = 0; i < attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().size(); i++) {{
@@ -856,7 +856,7 @@ def gen_build_func_str(
   PADDLE_ENFORCE_NE(
       attributes.find("{attribute_name}"),
       attributes.end(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData();
 """
@@ -864,7 +864,7 @@ def gen_build_func_str(
   PADDLE_ENFORCE_NE(
       attributes.find("{attribute_name}"),
       attributes.end(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::ScalarAttribute>().data().to<{attr_type}>();
 """

--- a/paddle/fluid/pir/dialect/op_generator/op_infermeta_func_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_infermeta_func_gen.py
@@ -52,7 +52,7 @@ CREATE_INPUT_VALUE_TEMPLATE = """
   pir::Value {input_name}_ = input_values[{index}]; (void){input_name}_;"""
 
 ENFORCE_INPUT_NUM_TEMPLATE = """
-  PADDLE_ENFORCE_EQ(input_values.size() == {op_input_name_list_size}, true, phi::errors::InvalidArgument(
+  PADDLE_ENFORCE_EQ(input_values.size() == {op_input_name_list_size}, true, common::errors::InvalidArgument(
       "Num of inputs is expected to be {op_input_name_list_size} but got %d.", input_values.size()));
 """
 
@@ -61,7 +61,7 @@ GET_INPUT_TYPE_TEMPLATE = """
   if ({name}_.type().isa<{type}>()) {{
     {name} = {name}_.type().dyn_cast<{type}>(); (void){name};
   }} else {{
-    PADDLE_THROW(phi::errors::Unimplemented("Only support {type} or {allocated_type}"));
+    PADDLE_THROW(common::errors::Unimplemented("Only support {type} or {allocated_type}"));
   }}
 """
 
@@ -195,7 +195,7 @@ def GenBuildOutputsPart2(
     if ({name}_.type().isa<{type}>()) {{
       {name} = {name}_.type().dyn_cast<{type}>();
     }} else {{
-      PADDLE_THROW(phi::errors::Unimplemented("Only support {type} or {allocated_type}"));
+      PADDLE_THROW(common::errors::Unimplemented("Only support {type} or {allocated_type}"));
     }}
     ir_tensor_{name} = paddle::dialect::IrTensor(paddle::dialect::TransToPhiDataType({name}.dtype()),
                                                         {name}.dims(),
@@ -217,7 +217,7 @@ def GenBuildOutputsPart2(
     if ({name}_.type().isa<{type}>()) {{
       {name} = {name}_.type().dyn_cast<{type}>();
     }} else {{
-      PADDLE_THROW(phi::errors::Unimplemented("Only support {type}"));
+      PADDLE_THROW(common::errors::Unimplemented("Only support {type}"));
     }}
     ir_tensor_{name} = paddle::dialect::IrSparseCooTensor(paddle::dialect::TransToPhiDataType({name}.dtype()),
                                                         {name}.dims(),
@@ -239,7 +239,7 @@ def GenBuildOutputsPart2(
     if ({name}_.type().isa<{type}>()) {{
       {name} = {name}_.type().dyn_cast<{type}>();
     }} else {{
-      PADDLE_THROW(phi::errors::Unimplemented("Only support {type}"));
+      PADDLE_THROW(common::errors::Unimplemented("Only support {type}"));
     }}
     ir_tensor_{name} = paddle::dialect::IrSparseCsrTensor(paddle::dialect::TransToPhiDataType({name}.dtype()),
                                                         {name}.dims(),
@@ -262,7 +262,7 @@ def GenBuildOutputsPart2(
                                                                     {name}_type.lod(),
                                                                     {name}_type.offset()));
     }} else {{
-        PADDLE_THROW(phi::errors::Unimplemented("Only support DenseTensorType or AllocatedDenseTensorType"));
+        PADDLE_THROW(common::errors::Unimplemented("Only support DenseTensorType or AllocatedDenseTensorType"));
     }}
   }}
   std::vector<paddle::dialect::IrMetaTensor> vec_meta_{name};
@@ -289,7 +289,7 @@ def GenBuildOutputsPart2(
                                                                         {name}_type.lod(),
                                                                         {name}_type.offset()));
         }} else {{
-            PADDLE_THROW(phi::errors::Unimplemented("Only support DenseTensorType or AllocatedDenseTensorType"));
+            PADDLE_THROW(common::errors::Unimplemented("Only support DenseTensorType or AllocatedDenseTensorType"));
         }}
     }}
   }}
@@ -341,7 +341,7 @@ def GenBuildOutputsPart2(
     }}
     {name} = std::vector<int64_t>({name}_size, -1);
   }}else {{
-    PADDLE_THROW(phi::errors::Unimplemented("Only support VectorType or DenseTensorType or AllocatedDenseTensorType"));
+    PADDLE_THROW(common::errors::Unimplemented("Only support VectorType or DenseTensorType or AllocatedDenseTensorType"));
   }}\n"""
 
     CREATE_SCALAR_MUTABLE_ATTRIBUTE_WITH_UNKNOWN_DATA_TEMPLATE = """  phi::Scalar {name};
@@ -669,7 +669,7 @@ def GetAttributes(
   PADDLE_ENFORCE_NE(
       attributes.find("{attribute_name}"),
       attributes.end(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<{attr_ir_type}>().data();
 """
@@ -677,7 +677,7 @@ def GetAttributes(
   PADDLE_ENFORCE_NE(
       attributes.find("{attribute_name}"),
       attributes.end(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<pir::StrAttribute>().AsString();
 """
@@ -685,7 +685,7 @@ def GetAttributes(
   PADDLE_ENFORCE_NE(
       attributes.find("{attribute_name}"),
       attributes.end(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name};
   for (size_t i = 0; i < attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().size(); i++) {{
@@ -696,7 +696,7 @@ def GetAttributes(
   PADDLE_ENFORCE_NE(
       attributes.find("{attribute_name}"),
       attributes.end(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData();
 """
@@ -704,7 +704,7 @@ def GetAttributes(
   PADDLE_ENFORCE_NE(
       attributes.find("{attribute_name}"),
       attributes.end(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::ScalarAttribute>().data().to<{attr_type}>();
 """

--- a/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
@@ -26,11 +26,11 @@ CHECK_INPUT_TEMPLATE = """
     PADDLE_ENFORCE_EQ(
       inputs_.size(),
       {inputs_size},
-      phi::errors::InvalidArgument("{op_name} op's inputs size should be {inputs_size}, but now is %d.", inputs_.size()));
+      common::errors::InvalidArgument("{op_name} op's inputs size should be {inputs_size}, but now is %d.", inputs_.size()));
     PADDLE_ENFORCE_EQ(
       outputs.size(),
       {outputs_size},
-      phi::errors::InvalidArgument("{op_name} op's outputs size should be {outputs_size}, but now is %d.", outputs.size()));
+      common::errors::InvalidArgument("{op_name} op's outputs size should be {outputs_size}, but now is %d.", outputs.size()));
 """
 
 OP_VJP_FORWARD_INPUT_OR_OUTPUT_TEMPLATE = """

--- a/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
@@ -41,81 +41,81 @@ void {op_name}::VerifySig() {{}}
 
 INPUT_TYPE_CHECK_TEMPLATE = """
   PADDLE_ENFORCE_EQ((*this)->operand_source({index}).type().isa<{standard}>(), true,
-                  phi::errors::InvalidArgument("Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type()));"""
+                  common::errors::InvalidArgument("Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type()));"""
 INPUT_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto vec_type = (*this)->operand_source({index}).type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        PADDLE_ENFORCE_EQ(vec_type[i].isa<{standard}>(), true, phi::errors::InvalidArgument(
+        PADDLE_ENFORCE_EQ(vec_type[i].isa<{standard}>(), true, common::errors::InvalidArgument(
                        "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type()));
       }}
   }}
   else {{
-    PADDLE_ENFORCE_EQ((*this)->operand_source({index}).type().isa<{standard}>(), true, phi::errors::InvalidArgument(
+    PADDLE_ENFORCE_EQ((*this)->operand_source({index}).type().isa<{standard}>(), true, common::errors::InvalidArgument(
                    "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type()));
   }}"""
 INPUT_OPTIONAL_TYPE_CHECK_TEMPLATE = """
   if (auto val = (*this)->operand({index})) {{
-    PADDLE_ENFORCE_EQ(val.type().isa<{standard}>(), true, phi::errors::InvalidArgument(
+    PADDLE_ENFORCE_EQ(val.type().isa<{standard}>(), true, common::errors::InvalidArgument(
                    "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type()));
   }}"""
 INPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto val =  (*this)->operand({index})) {{
     if (auto vec_type = val.type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); i++) {{
-        PADDLE_ENFORCE_EQ(vec_type[i].isa<{standard}>(), true, phi::errors::InvalidArgument(
+        PADDLE_ENFORCE_EQ(vec_type[i].isa<{standard}>(), true, common::errors::InvalidArgument(
                           "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type()));
       }}
     }}
     else {{
-      PADDLE_ENFORCE_EQ(val.type().isa<{standard}>(), true, phi::errors::InvalidArgument(
+      PADDLE_ENFORCE_EQ(val.type().isa<{standard}>(), true, common::errors::InvalidArgument(
                         "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type()));
     }}
   }}"""
 ATTRIBUTE_CHECK_TEMPLATE = """
-  PADDLE_ENFORCE_GT(attributes.count("{attribute_name}"), 0, phi::errors::InvalidArgument(
+  PADDLE_ENFORCE_GT(attributes.count("{attribute_name}"), 0, common::errors::InvalidArgument(
                  "{attribute_name} does not exist."));
-  PADDLE_ENFORCE_EQ(attributes.at("{attribute_name}").isa<{standard}>(), true, phi::errors::InvalidArgument(
+  PADDLE_ENFORCE_EQ(attributes.at("{attribute_name}").isa<{standard}>(), true, common::errors::InvalidArgument(
                  "Type of attribute: {attribute_name} is not {standard}."));
 """
 ATTRIBUTE_VECTOR_CHECK_TEMPLATE = """
-  PADDLE_ENFORCE_GT(attributes.count("{attribute_name}"), 0, phi::errors::InvalidArgument(
+  PADDLE_ENFORCE_GT(attributes.count("{attribute_name}"), 0, common::errors::InvalidArgument(
                  "{attribute_name} does not exist."));
-  PADDLE_ENFORCE_EQ(attributes.at("{attribute_name}").isa<pir::ArrayAttribute>(), true, phi::errors::InvalidArgument(
+  PADDLE_ENFORCE_EQ(attributes.at("{attribute_name}").isa<pir::ArrayAttribute>(), true, common::errors::InvalidArgument(
                  "Type of attribute: {attribute_name} is not pir::ArrayAttribute."));
   for (size_t i = 0; i < attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().size(); i++) {{
-    PADDLE_ENFORCE_EQ(attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().at(i).isa<{standard}>(), true, phi::errors::InvalidArgument(
+    PADDLE_ENFORCE_EQ(attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().at(i).isa<{standard}>(), true, common::errors::InvalidArgument(
                    "Type of attribute: {attribute_name} is not right."));
   }}"""
 OUTPUT_TYPE_CHECK_TEMPLATE = """
-  PADDLE_ENFORCE_EQ((*this)->result({index}).type().isa<{standard}>(), true, phi::errors::InvalidArgument(
+  PADDLE_ENFORCE_EQ((*this)->result({index}).type().isa<{standard}>(), true, common::errors::InvalidArgument(
                  "Type validation failed for the {index}th output."));"""
 OUTPUT_VECTORTYPE_CHECK_TEMPLATE = """
   auto output_{index}_type = (*this)->result({index}).type();
   if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
     for (size_t i = 0; i < vec_type.size(); i++) {{
-      PADDLE_ENFORCE_EQ(vec_type[i].isa<{standard}>(), true, phi::errors::InvalidArgument(
+      PADDLE_ENFORCE_EQ(vec_type[i].isa<{standard}>(), true, common::errors::InvalidArgument(
                      "Type validation failed for the {index}th output."));
     }}
   }}
   else {{
-    PADDLE_ENFORCE_EQ(output_{index}_type.isa<{standard}>(), true, phi::errors::InvalidArgument(
+    PADDLE_ENFORCE_EQ(output_{index}_type.isa<{standard}>(), true, common::errors::InvalidArgument(
                    "Type validation failed for the {index}th output."));
   }}"""
 OUTPUT_OPTIONAL_TYPE_CHECK_TEMPLATE = """
   if (auto output_{index}_type = (*this)->result({index}).type()) {{
-    PADDLE_ENFORCE_EQ(output_{index}_type.isa<{standard}>(),true, phi::errors::InvalidArgument(
+    PADDLE_ENFORCE_EQ(output_{index}_type.isa<{standard}>(),true, common::errors::InvalidArgument(
                    "Type validation failed for the {index}th output."));
   }}"""
 OUTPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto output_{index}_type = (*this)->result({index}).type()) {{
     if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        PADDLE_ENFORCE_EQ(vec_type[i].isa<{standard}>(), true, phi::errors::InvalidArgument(
+        PADDLE_ENFORCE_EQ(vec_type[i].isa<{standard}>(), true, common::errors::InvalidArgument(
                        "Type validation failed for the {index}th output."));
       }}
     }}
     else {{
-      PADDLE_ENFORCE_EQ(output_{index}_type.isa<{standard}>(), true, phi::errors::InvalidArgument(
+      PADDLE_ENFORCE_EQ(output_{index}_type.isa<{standard}>(), true, common::errors::InvalidArgument(
                      "Type validation failed for the {index}th output."));
     }}
   }}"""

--- a/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
@@ -40,10 +40,10 @@ static PyMethodDef OpsAPI[] = {{
 
 void BindOpsAPI(pybind11::module *module) {{
   if (PyModule_AddFunctions(module->ptr(), OpsAPI) < 0) {{
-    PADDLE_THROW(phi::errors::Fatal("Add C++ api to core.ops failed!"));
+    PADDLE_THROW(common::errors::Fatal("Add C++ api to core.ops failed!"));
   }}
   if (PyModule_AddFunctions(module->ptr(), ManualOpsAPI) < 0) {{
-    PADDLE_THROW(phi::errors::Fatal("Add C++ api to core.ops failed!"));
+    PADDLE_THROW(common::errors::Fatal("Add C++ api to core.ops failed!"));
   }}
 }}
 """

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
@@ -261,7 +261,7 @@ bool EmbeddingOpInferSymbolicShape(
 
 bool SparseWeightEmbeddingOpInferSymbolicShape(
     pir::Operation *op, pir::InferSymbolicShapeContext *infer_context) {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       op->name() + " 's InferSymbolicShape interface is NOT implemented now."));
   return true;
 }
@@ -330,7 +330,7 @@ bool GatherOpInferSymbolicShape(pir::Operation *op,
     PADDLE_ENFORCE_EQ(
         op->num_operands() == 3,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "in GatherOpInferSymbolicShape: The number of operands should be "
             "3 when the axis is not set."));
     const auto &axis_shape_or_data =
@@ -410,7 +410,7 @@ bool GatherNdOpInferSymbolicShape(
   PADDLE_ENFORCE_EQ(
       index_sym_shape[index_dims_size - 1].Has<std::int64_t>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "in GatherNdOpInferSymbolicShape: index[-1] should be unknown"));
 
   for (int i = static_cast<int>(

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
@@ -91,7 +91,7 @@ inline void CheckAndUpdateSliceAttrs(
     } else if (start_positive_end_negative) {
       starts.at(i) = starts.at(i) - in_dims.at(axis);
     } else {
-      PADDLE_THROW(phi::errors::Fatal("Dead code"));
+      PADDLE_THROW(common::errors::Fatal("Dead code"));
     }
   }
 }
@@ -105,7 +105,7 @@ inline ExprVec GetSliceDims(const ExprVec &in_dims,
   PADDLE_ENFORCE_EQ(
       (axes.size() == starts.size() && axes.size() == ends.size()),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of axes must equal size of starts and ends."));
   for (size_t i = 0; i < axes.size(); ++i) {
     int64_t axis = axes.at(i);
@@ -199,7 +199,7 @@ inline ShapeOrData SliceRawInferSymbolicShape(
     PADDLE_ENFORCE_EQ(
         vec_int64.has_value(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "for slice op, all the elements in `starts` must be int64_t"));
     std::vector<int64_t> starts_int = vec_int64.value();
 
@@ -207,7 +207,7 @@ inline ShapeOrData SliceRawInferSymbolicShape(
     PADDLE_ENFORCE_EQ(
         vec_int64.has_value(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "for slice op, all the elements in `ends` must be int64_t"));
     std::vector<int64_t> ends_int = vec_int64.value();
 

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
@@ -22,7 +22,7 @@ inline bool GetBoolAttr(const pir::Operation *op, const std::string &str) {
   const auto &attr_map = op->attributes();
   PADDLE_ENFORCE(
       attr_map.count(str),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "attr [%s] MUST in attribute map for [%s] op", str, op->name()));
   return attr_map.at(str).dyn_cast<pir::BoolAttribute>().data();
 }
@@ -60,19 +60,19 @@ std::vector<T> GetVectorAttr(const ::pir::Operation *op,
   const auto &attr_map = op->attributes();
   PADDLE_ENFORCE(
       attr_map.count(name),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "attr [%s] MUST in attribute map for [%s] op", name, op->name()));
   const auto &val = attr_map.at(name);
 
   PADDLE_ENFORCE(val.isa<::pir::ArrayAttribute>(),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "axis Type MUST ArrayAttribute for [%s] op", op->name()));
   auto array_list = val.dyn_cast<::pir::ArrayAttribute>().AsVector();
   std::vector<T> vec_res;
   if (array_list.size() > 0) {
     PADDLE_ENFORCE_EQ(array_list[0].isa<value_type>(),
                       true,
-                      phi::errors::Unimplemented(
+                      common::errors::Unimplemented(
                           "the 0th elementwise MUST be ir::Int64Attribute"));
     for (size_t i = 0; i < array_list.size(); ++i) {
       vec_res.push_back(array_list[i].dyn_cast<value_type>().data());
@@ -106,8 +106,8 @@ inline ExprVec GetExprVecFromData(const ShapeOrData &shapeordata) {
   PADDLE_ENFORCE_EQ(
       HasCompleteData(shapeordata),
       true,
-      phi::errors::Fatal("ShapeOrDataDimExprs must have complete data info "
-                         "when calling GetExprVecFromData"));
+      common::errors::Fatal("ShapeOrDataDimExprs must have complete data info "
+                            "when calling GetExprVecFromData"));
   ExprVec result;
   shapeordata.Match(
       [&](const symbol::TensorShapeOrDataDimExprs &impl) {

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -542,7 +542,8 @@ bool BicubicInterpOpInferSymbolicShape(
     infer_context->SetShapeOrDataForValue(op->result(0), shape_data);
     return true;
   } else {
-    PADDLE_THROW(phi::errors::Fatal("Input(X) dimension must be 3, 4 or 5!"));
+    PADDLE_THROW(
+        common::errors::Fatal("Input(X) dimension must be 3, 4 or 5!"));
   }
 
   return true;
@@ -617,7 +618,7 @@ bool CrossEntropyWithSoftmaxOpInferSymbolicShape(
   bool soft_label =
       attributes.at("soft_label").dyn_cast<pir::BoolAttribute>().data();
   PADDLE_ENFORCE(!soft_label || input_dim.size() == index_dim.size(),
-                 phi::errors::InvalidArgument(
+                 common::errors::InvalidArgument(
                      "The input and index should have the same rank when "
                      "soft_label is true. But received input rank(%d) and "
                      "index rank(%d)",
@@ -687,7 +688,7 @@ bool ConcatOpInferSymbolicShape(pir::Operation *op,
 
       return true;
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           op->name() +
           " 's InferSymbolicShape can NOT deal with rank > 1 now."));
     }
@@ -759,7 +760,7 @@ bool FlashAttnOpInferSymbolicShape(
 
   PADDLE_ENFORCE_EQ(q.shape().size(),
                     4,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "flash_attn receive input with dim "
                         "[batch_size, seq_len, num_heads, head_dim]"));
 
@@ -932,21 +933,21 @@ bool MemoryEfficientAttentionOpInferSymbolicShape(
   PADDLE_ENFORCE_EQ(
       q_shape.size(),
       4,
-      phi::errors::InvalidArgument("Query should be a 4-D tensor"
-                                   "But received Query dimension(%d)",
-                                   q_shape.size()));
+      common::errors::InvalidArgument("Query should be a 4-D tensor"
+                                      "But received Query dimension(%d)",
+                                      q_shape.size()));
   PADDLE_ENFORCE_EQ(
       k_shape.size(),
       4,
-      phi::errors::InvalidArgument("Key should be a 4-D tensor"
-                                   "But received Key dimension(%d)",
-                                   k_shape.size()));
+      common::errors::InvalidArgument("Key should be a 4-D tensor"
+                                      "But received Key dimension(%d)",
+                                      k_shape.size()));
   PADDLE_ENFORCE_EQ(
       v_shape.size(),
       4,
-      phi::errors::InvalidArgument("Value should be a 4-D tensor"
-                                   "But received Value dimension(%d)",
-                                   v_shape.size()));
+      common::errors::InvalidArgument("Value should be a 4-D tensor"
+                                      "But received Value dimension(%d)",
+                                      v_shape.size()));
 
   const auto &query_batch_size = q_shape[0];
   const auto &query_seq_length = q_shape[1];
@@ -1075,7 +1076,7 @@ bool StackOpInferSymbolicShape(pir::Operation *op,
           result_data.emplace_back(shape_data.data().value().at(0));
         }
       } else {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             op->name() +
             " 's InferSymbolicShape can NOT deal with data size > 1 now."));
       }

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
@@ -341,7 +341,7 @@ bool RandintOpInferSymbolicShape(
     return true;
 
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Currently shape must comes from FullIntArrayOp in RandintOp's "
         "InferSymbolicShape."));
     return true;

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -716,13 +716,13 @@ bool FlattenOpInferSymbolicShape(
     PADDLE_ENFORCE_EQ(
         start_axis == 0 || start_axis == -1,
         true,
-        phi::errors::InvalidArgument("The start_axis should be 0 or -1 when "
-                                     "the input tensor is a 0D-Tensor"));
-    PADDLE_ENFORCE_EQ(
-        stop_axis == 0 || stop_axis == -1,
-        true,
-        phi::errors::InvalidArgument("The stop_axis should be 0 or -1 when the "
-                                     "input tensor is a 0D-Tensor"));
+        common::errors::InvalidArgument("The start_axis should be 0 or -1 when "
+                                        "the input tensor is a 0D-Tensor"));
+    PADDLE_ENFORCE_EQ(stop_axis == 0 || stop_axis == -1,
+                      true,
+                      common::errors::InvalidArgument(
+                          "The stop_axis should be 0 or -1 when the "
+                          "input tensor is a 0D-Tensor"));
     // this can ensure out shape {1}
     start_axis = 0;
     stop_axis = -1;
@@ -738,8 +738,8 @@ bool FlattenOpInferSymbolicShape(
     PADDLE_ENFORCE_GE(
         stop_axis,
         start_axis,
-        phi::errors::InvalidArgument("The stop_axis should be greater"
-                                     "than or equal to start_axis."));
+        common::errors::InvalidArgument("The stop_axis should be greater"
+                                        "than or equal to start_axis."));
   }
 
   symbol::DimExpr outer{1};
@@ -850,9 +850,9 @@ bool MaxOpInferSymbolicShape(pir::Operation *op,
       // TODO(lanxianghit): there's other source: pir::VectorType,
       // paddle::dialect::DenseTensorType, but after PRIM, maybe always
       // FullIntArrayOp, to be confirmed
-      PADDLE_THROW(
-          phi::errors::Unimplemented("MaxOpInferSymbolicShape: 'axis' only "
-                                     "support FullIntArrayOp's result now."));
+      PADDLE_THROW(common::errors::Unimplemented(
+          "MaxOpInferSymbolicShape: 'axis' only "
+          "support FullIntArrayOp's result now."));
     }
     return axis_vec;
   }();
@@ -922,7 +922,7 @@ bool NonzeroOpInferSymbolicShape(
   PADDLE_ENFORCE_GE(
       rank,
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input(x) should have number of dimension at least 1."));
 
   std::string sym_name = infer_context->GetNextSymName();
@@ -953,7 +953,7 @@ bool PadOpInferSymbolicShape(pir::Operation *op,
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   PADDLE_ENFORCE_EQ(x_shape_or_data.data().has_value(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "InferSymbolicShape of PadOp only support input with "
                         "value now."));
   const auto &x_dims_sym = x_shape_or_data.shape();
@@ -964,7 +964,7 @@ bool PadOpInferSymbolicShape(pir::Operation *op,
       paddle::dialect::details::GetVectorAttr<int>(op, "paddings");
   PADDLE_ENFORCE_EQ(rank * 2,
                     paddings.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of paddings should be 2 * input's rank. But "
                         "got paddings.size() = %d, input's rank = %d.",
                         paddings.size(),
@@ -1066,8 +1066,8 @@ bool ProdOpInferSymbolicShape(pir::Operation *op,
     // TODO(lanxianghit): deal with other source: pir::VectorType,
     // paddle::dialect::DenseTensorType
     PADDLE_THROW(
-        phi::errors::Unimplemented("ProdOpInferSymbolicShape: 'axis' only "
-                                   "support FullIntArrayOp's result now."));
+        common::errors::Unimplemented("ProdOpInferSymbolicShape: 'axis' only "
+                                      "support FullIntArrayOp's result now."));
   }
 
   return true;
@@ -1262,7 +1262,7 @@ bool SplitOpInferSymbolicShape(pir::Operation *op,
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   PADDLE_ENFORCE_EQ(x_shape_or_data.data().has_value(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "InferSymbolicShape of SplitOp only support input with "
                         "value now."));
   const auto &x_dims_sym = x_shape_or_data.shape();
@@ -1353,14 +1353,14 @@ bool SplitWithNumOpInferSymbolicShape(
   PADDLE_ENFORCE_EQ(
       axis_shape_data.data().has_value(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "In InferSymbolicShape, axis of SplitWithNumOp is null"));
   const std::vector<symbol::DimExpr> &axis_data =
       axis_shape_data.data().value();
   PADDLE_ENFORCE_EQ(
       axis_data.size() == 1,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "In SplitWithNumOp, data of axis should be one dimension"));
 
   const auto &attributes = op->attributes();
@@ -1405,7 +1405,7 @@ bool SplitWithNumOpInferSymbolicShape(
         }
       } else {
         PADDLE_THROW(
-            phi::errors::InvalidArgument("The type of X must be int64_t."));
+            common::errors::InvalidArgument("The type of X must be int64_t."));
       }
     }
     if (count == 1) {
@@ -1431,7 +1431,7 @@ bool SplitWithNumOpInferSymbolicShape(
           op->result(0), symbol::ShapeOrDataDimExprs{res_list_s_d});
     }
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The type of axis must be int64_t or string."));
   }
   return true;
@@ -1455,8 +1455,8 @@ bool SumOpInferSymbolicShape(pir::Operation *op,
     // TODO(lanxianghit): deal with other source: pir::VectorType,
     // paddle::dialect::DenseTensorType
     PADDLE_THROW(
-        phi::errors::Unimplemented("SumOpInferSymbolicShape: 'axis' only "
-                                   "support FullIntArrayOp's result now."));
+        common::errors::Unimplemented("SumOpInferSymbolicShape: 'axis' only "
+                                      "support FullIntArrayOp's result now."));
   }
 
   return true;
@@ -1618,7 +1618,7 @@ bool SqueezeOpInferSymbolicShape(
   PADDLE_ENFORCE_EQ(
       op->num_operands(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "SqueezeOpInferSymbolicShape ONLY support num_operands() == 2 "
           "now, but got %d operands",
           op->num_operands()));
@@ -1647,7 +1647,7 @@ bool SqueezeOpInferSymbolicShape(
     PADDLE_ENFORCE_EQ(
         squeeze_dim.Has<std::int64_t>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "in SqueezeOpInferSymbolicShape, axes must be known int type, "
             "but got: %s",
             symbol::ToString(squeeze_dim)));
@@ -1720,7 +1720,7 @@ bool UnbindOpInferSymbolicShape(pir::Operation *op,
   PADDLE_ENFORCE_EQ(
       x_shape_or_data.data().has_value(),
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "InferSymbolicShape of UnbindOp only support input with "
           "value now."));
   const auto &x_dims_sym = x_shape_or_data.shape();
@@ -1738,7 +1738,7 @@ bool UnbindOpInferSymbolicShape(pir::Operation *op,
     const symbol::DimExpr &unbound_dim = x_dims_sym.at(axis);
     PADDLE_ENFORCE_EQ(unbound_dim.isa<int64_t>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "InferSymbolicShape of UnbindOp only support unbound "
                           "dim with constant length!"));
     output_dims_sym.erase(output_dims_sym.begin() + axis);
@@ -1764,7 +1764,7 @@ bool UniqueOpInferSymbolicShape(pir::Operation *op,
   PADDLE_ENFORCE_EQ(
       x_shape_or_data.data().has_value(),
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "InferSymbolicShape of UniqueOp only support input with "
           "value now."));
   const auto &x_dims_sym = x_shape_or_data.shape();
@@ -1838,7 +1838,7 @@ bool UniqueConsecutiveOpInferSymbolicShape(
   PADDLE_ENFORCE_EQ(
       x_shape_or_data.data().has_value(),
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "InferSymbolicShape of UniqueConsecutiveOp only support input with "
           "value now."));
   const auto &x_dims_sym = x_shape_or_data.shape();
@@ -1904,7 +1904,7 @@ bool UnsqueezeOpInferSymbolicShape(
   PADDLE_ENFORCE_EQ(
       op->num_operands(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "UnsqueezeOp InferSymbolicShape ONLY support num_operands() == 2 "
           "now, but got %d operands",
           op->num_operands()));
@@ -1939,7 +1939,7 @@ bool UnsqueezeOpInferSymbolicShape(
     PADDLE_ENFORCE_EQ(
         axis_expr.Has<std::int64_t>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "in UnsqueezeOpInferSymbolicShape, axes must be known int type, "
             "but got: %s",
             symbol::ToString(axis_expr)));

--- a/paddle/fluid/pir/dialect/operator/interface/layout_transformation.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/layout_transformation.cc
@@ -80,7 +80,7 @@ template <>
 common::DataLayout PreferLayoutImpl<Conv2dOp>(pir::Operation* op) {
   auto data_format_attr = op->attribute<pir::StrAttribute>("data_format");
   if (!data_format_attr) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "op (%s) should have attribute `data_format`, but got %s",
         op,
         data_format_attr));
@@ -121,7 +121,7 @@ template <>
 common::DataLayout PreferLayoutImpl<FusedConv2dAddActOp>(pir::Operation* op) {
   auto data_format_attr = op->attribute<pir::StrAttribute>("data_format");
   if (!data_format_attr) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "op (%s) should have attribute `data_format`, but got %s",
         op,
         data_format_attr));
@@ -188,7 +188,7 @@ template <>
 bool CanBeModifiedImpl<FusedConv2dAddActOp>(pir::Operation* op) {
   auto data_format_attr = op->attribute<pir::StrAttribute>("data_format");
   if (!data_format_attr) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "op (%s) should have attribute `data_format`, but got %s",
         op,
         data_format_attr));

--- a/paddle/fluid/pir/dialect/operator/ir/api_builder.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/api_builder.cc
@@ -25,14 +25,14 @@ ApiBuilder::ApiBuilder()
   PADDLE_ENFORCE_NE(
       builder_,
       nullptr,
-      phi::errors::InvalidArgument("api builder construct error!"));
+      common::errors::InvalidArgument("api builder construct error!"));
 }
 
 void ApiBuilder::SetProgram(pir::Program* program) {
   PADDLE_ENFORCE_NE(
       program,
       nullptr,
-      phi::errors::InvalidArgument("argument of program is nullptr"));
+      common::errors::InvalidArgument("argument of program is nullptr"));
   builder_->SetInsertionPointToBlockEnd(program->block());
 }
 
@@ -59,7 +59,7 @@ void ApiBuilder::LoadInsertionPoint() {
   PADDLE_ENFORCE_EQ(
       !insertion_point_stack_.empty(),
       true,
-      phi::errors::InvalidArgument("insertion_point_stack_ is empty."));
+      common::errors::InvalidArgument("insertion_point_stack_ is empty."));
   builder_->set_insertion_point(insertion_point_stack_.top());
   insertion_point_stack_.pop();
 }

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -83,7 +83,7 @@ void IfOp::Build(pir::Builder &builder,             // NOLINT
     auto size = op.num_operands();
     PADDLE_ENFORCE_EQ(size,
                       argument.output_types.size(),
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The output size of true block and false block must "
                           "be equal. but they are %u and %u, respectively",
                           argument.output_types.size(),
@@ -94,13 +94,13 @@ void IfOp::Build(pir::Builder &builder,             // NOLINT
         auto r_type = argument.output_types[i].dyn_cast<pir::DenseTensorType>();
         PADDLE_ENFORCE_EQ(l_type && r_type,
                           true,
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "The output[%d] of true_block&false_block must "
                               "be dense tensor type.",
                               i));
         PADDLE_ENFORCE_EQ(l_type.dtype(),
                           r_type.dtype(),
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "The dtype in output[%d] of "
                               "true_block&false_block must be equal.",
                               i));
@@ -109,7 +109,7 @@ void IfOp::Build(pir::Builder &builder,             // NOLINT
           PADDLE_ENFORCE_EQ(
               l_type.data_layout(),
               r_type.data_layout(),
-              phi::errors::PreconditionNotMet(
+              common::errors::PreconditionNotMet(
                   "The data_layout in output[%d] of "
                   "true_block (%s) & false_block (%s) must be equal.",
                   i,
@@ -118,13 +118,13 @@ void IfOp::Build(pir::Builder &builder,             // NOLINT
         }
         PADDLE_ENFORCE_EQ(l_type.lod(),
                           r_type.lod(),
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "The lod in output[%d] of true_block&false_block "
                               "must be equal.",
                               i));
         PADDLE_ENFORCE_EQ(l_type.offset(),
                           r_type.offset(),
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "The offset in output[%d] of "
                               "true_block&false_block must be equal.",
                               i));
@@ -140,7 +140,7 @@ void IfOp::Build(pir::Builder &builder,             // NOLINT
     }
   } else {
     PADDLE_ENFORCE(argument.output_types.empty(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "The output size of true block and false block must be "
                        "equal. but they are %u and 0, respectively",
                        argument.output_types.size()));
@@ -194,7 +194,7 @@ void IfOp::VerifySig() {
   PADDLE_ENFORCE_EQ(
       input_size,
       1u,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The size %d of inputs must be equal to 1.", input_size));
 
   if ((*this)->operand_source(0).type().isa<pir::DenseTensorType>()) {
@@ -205,14 +205,14 @@ void IfOp::VerifySig() {
             .dyn_cast<pir::DenseTensorType>()
             .dtype()
             .isa<pir::BoolType>(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 1th input, it should be a "
             "bool DenseTensorType."));
   }
 
   PADDLE_ENFORCE_EQ((*this)->num_regions(),
                     2u,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The size %d of regions must be equal to 2.",
                         (*this)->num_regions()));
 }
@@ -223,45 +223,45 @@ void IfOp::VerifyRegion() {
   PADDLE_ENFORCE_EQ(
       (*this)->region(0).size(),
       1u,
-      phi::errors::PreconditionNotMet("The size %d of true_region must be 1.",
-                                      (*this)->region(0).size()));
+      common::errors::PreconditionNotMet(
+          "The size %d of true_region must be 1.", (*this)->region(0).size()));
   if ((*this)->num_results() != 0) {
     auto &true_block = (*this)->region(0).front();
     PADDLE_ENFORCE_GT(
         true_block.size(),
         0u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The true block must have at least one op yield op."));
     auto &true_last_op = true_block.back();
     PADDLE_ENFORCE_EQ(true,
                       true_last_op.isa<pir::YieldOp>(),
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The last of true block must be YieldOp"));
     PADDLE_ENFORCE_EQ(true_last_op.num_operands(),
                       (*this)->num_results(),
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The size of last of true block op's input must be "
                           "equal to IfOp's outputs num."));
     VLOG(4) << "Start Verifying false branch.";
     PADDLE_ENFORCE_EQ((*this)->region(1).size(),
                       1u,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The size %d of false_region must be 1.",
                           (*this)->region(0).size()));
     auto &false_block = (*this)->region(1).front();
     PADDLE_ENFORCE_GT(
         false_block.size(),
         0u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The false block must have at least one op yield op."));
     auto &false_last_op = false_block.back();
     PADDLE_ENFORCE_EQ(true,
                       false_last_op.isa<pir::YieldOp>(),
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The last of false block must be YieldOp"));
     PADDLE_ENFORCE_EQ(false_last_op.num_operands(),
                       (*this)->num_results(),
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The size of last of false block op's input must be "
                           "equal to IfOp's outputs num."));
   }
@@ -273,14 +273,14 @@ std::vector<std::vector<pir::Value>> IfOp::Vjp(
     const std::vector<std::vector<pir::Value>> &outputs,
     const std::vector<std::vector<pir::Value>> &out_grads,
     const std::vector<std::vector<bool>> &stop_gradients) {
-  PADDLE_ENFORCE_EQ(
-      inputs_.size() >= 1u,
-      true,
-      phi::errors::InvalidArgument("if op's inputs' size should greater_equal "
-                                   "to 1, and all the inputs[i] "
-                                   "should be 1 size. "
-                                   "Now the inputs's size is %d .",
-                                   inputs_.size()));
+  PADDLE_ENFORCE_EQ(inputs_.size() >= 1u,
+                    true,
+                    common::errors::InvalidArgument(
+                        "if op's inputs' size should greater_equal "
+                        "to 1, and all the inputs[i] "
+                        "should be 1 size. "
+                        "Now the inputs's size is %d .",
+                        inputs_.size()));
 
   VLOG(6) << "Prepare inputs for if_grad";
   auto cond_val = inputs_[0][0];
@@ -346,7 +346,7 @@ bool IfOp::InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context) {
         // now only support results of true and false block have same rank.
         PADDLE_ENFORCE_EQ(true_dims.size(),
                           false_dims.size(),
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "The true and false block should have same rank, "
                               "but got true_rank(%d) and false_rank(%d)",
                               true_dims.size(),
@@ -367,8 +367,8 @@ bool IfOp::InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context) {
     return true;
   } else {
     PADDLE_THROW(
-        phi::errors::Unimplemented("IfOp::InferSymbolicShape: now only "
-                                   "support num_results() == 1."));
+        common::errors::Unimplemented("IfOp::InferSymbolicShape: now only "
+                                      "support num_results() == 1."));
   }
 }
 
@@ -451,30 +451,30 @@ void WhileOp::VerifySig() {
   PADDLE_ENFORCE_GE(
       input_size,
       1u,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The size %d of inputs must be greater or equal to 1.", input_size));
 
   if (auto cond_type = operand_type(0).dyn_cast<pir::DenseTensorType>()) {
     PADDLE_ENFORCE_EQ(
         cond_type.dtype().isa<pir::BoolType>(),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 0th input, it should be a "
             "bool DenseTensorType."));
   } else {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "Currently,  the while op cond input only support bool dense_tensor "
         "and bool allocated_dense_tensor."));
   }
   PADDLE_ENFORCE_EQ((*this)->num_regions(),
                     1u,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The size %d of regions must be equal to 1.",
                         (*this)->num_regions()));
   auto output_size = num_results();
   PADDLE_ENFORCE_EQ(output_size + 1,
                     input_size,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The result size (%d) not equal to input size(%d) + 1.",
                         num_results(),
                         input_size));
@@ -505,13 +505,13 @@ void WhileOp::VerifySig() {
       PADDLE_ENFORCE_EQ(
           new_input_tensor_type,
           output_tensor_type,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "The (%d) result and operand type is not equal.", index));
     } else {
       PADDLE_ENFORCE_EQ(
           input_type,
           output_type,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "The (%d) result and operand type is not equal.", index));
     }
   }
@@ -522,14 +522,14 @@ void WhileOp::VerifyRegion() {
   PADDLE_ENFORCE_EQ(
       (*this)->region(0).size(),
       1u,
-      phi::errors::PreconditionNotMet("The size %d of body_region must be 1.",
-                                      (*this)->region(0).size()));
+      common::errors::PreconditionNotMet(
+          "The size %d of body_region must be 1.", (*this)->region(0).size()));
   auto &body_block = body();
   auto output_size = num_results();
   PADDLE_ENFORCE_EQ(
       body_block.args_size(),
       output_size,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The result size (%d) not equal to block args size(%d) + 1.",
           output_size,
           body_block.args_size()));
@@ -537,21 +537,21 @@ void WhileOp::VerifyRegion() {
   PADDLE_ENFORCE_EQ(
       body_block.empty(),
       false,
-      phi::errors::PreconditionNotMet("The body block is empty."));
+      common::errors::PreconditionNotMet("The body block is empty."));
 
   auto yield_op = body_block.back().dyn_cast<pir::YieldOp>();
   auto input_size = num_operands();
   PADDLE_ENFORCE_EQ(
       yield_op && yield_op.num_operands() == input_size,
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The body block yield size not equal to operands size."));
   // Todo: fix other bugs and make the following code work.
   // for (size_t index = 0; index < input_size; ++index) {
   //   PADDLE_ENFORCE_EQ(
   //       operand_type(index),
   //       yield_op.operand_type(index),
-  //       phi::errors::PreconditionNotMet(
+  //       common::errors::PreconditionNotMet(
   //           "The (%d) operand and block yield type is not equal.", index));
   // }
   VLOG(4) << "Successful end verifying sub regions for: WhileOp.";
@@ -564,11 +564,11 @@ std::vector<std::vector<pir::Value>> WhileOp::Vjp(
     const std::vector<std::vector<pir::Value>> &out_grads,
     const std::vector<std::vector<bool>> &stop_gradients) {
   auto fwd_op = WhileOp::dyn_cast(op);
-  PADDLE_ENFORCE_NE(
-      fwd_op,
-      nullptr,
-      phi::errors::InvalidArgument("The input op used to called WhileOp::vjp "
-                                   "must be non-nullptr while_op"));
+  PADDLE_ENFORCE_NE(fwd_op,
+                    nullptr,
+                    common::errors::InvalidArgument(
+                        "The input op used to called WhileOp::vjp "
+                        "must be non-nullptr while_op"));
   TuplePushOp push_op;
   for (auto iter = fwd_op.body().rbegin(); iter != fwd_op.body().rend();
        ++iter) {
@@ -576,7 +576,7 @@ std::vector<std::vector<pir::Value>> WhileOp::Vjp(
       push_op = iter->dyn_cast<TuplePushOp>();
       PADDLE_ENFORCE_EQ(push_op.container().use_empty(),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The last container in forward while op must used "
                             "empty while construct while_grad op"));
       break;
@@ -584,13 +584,13 @@ std::vector<std::vector<pir::Value>> WhileOp::Vjp(
   }
   PADDLE_ENFORCE_NE(push_op,
                     nullptr,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The forward WhileOp must include TuplePushOp, denying "
                         "that we can't construct a reverse loop condition."));
 
   PADDLE_ENFORCE_GT(inputs.size(),
                     outputs.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "while op's inputs' size should greater than "
                         "outputs' size, Now the inputs's size is %d ."
                         "the outputs size is %d.",
@@ -598,7 +598,7 @@ std::vector<std::vector<pir::Value>> WhileOp::Vjp(
                         outputs.size()));
   PADDLE_ENFORCE_EQ(inputs.size(),
                     out_grads.size() + 1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "while op's inputs' size should equal to "
                         "output_grads' size + 1, Now the inputs's size is %d ."
                         "the output_grads size is %d.",
@@ -606,7 +606,7 @@ std::vector<std::vector<pir::Value>> WhileOp::Vjp(
                         out_grads.size()));
   PADDLE_ENFORCE_EQ(stop_gradients[0][0],
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The stop_gradient of condition input must be true."));
 
   auto &builder = *ApiBuilder::Instance().GetBuilder();
@@ -670,7 +670,7 @@ void InitBlockArgSymbolicShape(const pir::Value &origin_input,
         }
       },
       [&](const symbol::TensorListShapeOrDataDimExprs &impl) {
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "Dead code, TensorList should not be handled in while args."));
       },
       [&](const symbol::RankedTensorArrayShapeOrDataDimExprs &impl) {
@@ -686,7 +686,7 @@ void InitBlockArgSymbolicShape(const pir::Value &origin_input,
                     block_arg_shape_hint)));
       },
       [&](const symbol::NullShapeOrDataDimExpr &impl) {
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "Dead code, Null value should not be handled in while args."));
       });
 }
@@ -707,7 +707,7 @@ void AddCstrForArgs(const pir::Value &origin_input,
             infer_context->GetShapeOrDataForValue(yield_value).shape();
         PADDLE_ENFORCE_EQ(block_arg_shape.size(),
                           yield_value_shape.size(),
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "while op's input[%d] rank should equal to "
                               "output[%d]'s rank, Now the rank of input is %d,"
                               "the rank of output is %d.",
@@ -757,7 +757,7 @@ void AddCstrForArgs(const pir::Value &origin_input,
         }
       },
       [&](const symbol::TensorListShapeOrDataDimExprs &impl) {
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "Dead code, TensorList should not be handled in while args."));
       },
       [&](const symbol::RankedTensorArrayShapeOrDataDimExprs &impl) {
@@ -765,7 +765,7 @@ void AddCstrForArgs(const pir::Value &origin_input,
         return;
       },
       [&](const symbol::NullShapeOrDataDimExpr &impl) {
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "Dead code, Null value should not be handled in while args."));
       });
 }
@@ -795,7 +795,7 @@ void AddCstrForOutputs(const pir::Value &origin_input,
         }
       },
       [&](const symbol::TensorListShapeOrDataDimExprs &impl) {
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "Dead code, TensorList should not be handled in while args."));
       },
       [&](const symbol::RankedTensorArrayShapeOrDataDimExprs &impl) {
@@ -803,7 +803,7 @@ void AddCstrForOutputs(const pir::Value &origin_input,
         return;
       },
       [&](const symbol::NullShapeOrDataDimExpr &impl) {
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "Dead code, Null value should not be handled in while args."));
       });
 }
@@ -813,7 +813,7 @@ bool WhileOp::InferSymbolicShape(
   const auto &body_args = block_args();
   PADDLE_ENFORCE_EQ(num_operands() - 1,
                     body_args.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The num_operands-1 and body_args.size is not equal"));
   for (size_t i = 0; i < body_args.size(); ++i) {
     InitBlockArgSymbolicShape(
@@ -840,7 +840,7 @@ bool WhileOp::InferSymbolicShape(
 
   PADDLE_ENFORCE_EQ(body_args.size(),
                     num_results(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The body_args.size and num_results is not equal"));
   for (size_t i = 0; i < num_results(); ++i) {
     AddCstrForOutputs(
@@ -859,11 +859,11 @@ std::vector<std::vector<pir::Value>> TuplePushOpVjpInterfaceModel::Vjp(
   PADDLE_ENFORCE_EQ(
       inputs.size() >= 1u,
       true,
-      phi::errors::InvalidArgument("tuple_push op's inputs' size should be "
-                                   "greater_equal than 1, and the "
-                                   "inputs[i] should be non-empty. "
-                                   "Now the inputs's size is %d.",
-                                   inputs.size()));
+      common::errors::InvalidArgument("tuple_push op's inputs' size should be "
+                                      "greater_equal than 1, and the "
+                                      "inputs[i] should be non-empty. "
+                                      "Now the inputs's size is %d.",
+                                      inputs.size()));
   auto pop_op = ApiBuilder::Instance().GetBuilder()->Build<TuplePopOp>(
       TuplePushOp::dyn_cast(op).outlet());
   std::vector<std::vector<pir::Value>> res{inputs.size()};
@@ -892,23 +892,23 @@ void HasElementsOp::VerifySig() {
   PADDLE_ENFORCE_EQ(
       num_operands(),
       1u,
-      phi::errors::InvalidArgument("The size of inputs must equal to 1."));
+      common::errors::InvalidArgument("The size of inputs must equal to 1."));
   PADDLE_ENFORCE_EQ(
       operand_type(0).isa<pir::ContainerType>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The first input of cf.has_elements must be container type."));
 
   // No attributes should be verify.
 
   // Verify outputs:
-  PADDLE_ENFORCE_EQ(
-      num_results(),
-      1u,
-      phi::errors::InvalidArgument("The size of outputs must be equal to 1."));
+  PADDLE_ENFORCE_EQ(num_results(),
+                    1u,
+                    common::errors::InvalidArgument(
+                        "The size of outputs must be equal to 1."));
   PADDLE_ENFORCE_EQ((*this)->result_type(0).isa<DenseTensorType>(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The type of cf.has_elements' output is not correct."));
 }
 
@@ -963,7 +963,7 @@ void AssertOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         2u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of inputs must be equal to 2.", input_size));
 
     if ((*this)->operand_source(0).type().isa<pir::DenseTensorType>()) {
@@ -975,7 +975,7 @@ void AssertOp::VerifySig() {
               .dtype()
               .isa<pir::BoolType>(),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Type validation failed for the 0th input, it should be a "
               "bool DenseTensorType."));
     }
@@ -987,7 +987,7 @@ void AssertOp::VerifySig() {
             vec_type[i].isa<paddle::dialect::DenseTensorType>() ||
                 vec_type[i].isa<paddle::dialect::SelectedRowsType>(),
             true,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Type validation failed for the 1th input."));
       }
     } else {
@@ -998,7 +998,7 @@ void AssertOp::VerifySig() {
                   .type()
                   .isa<paddle::dialect::SelectedRowsType>(),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Type validation failed for the 1th input."));
     }
   }
@@ -1008,11 +1008,11 @@ void AssertOp::VerifySig() {
     PADDLE_ENFORCE_GT(
         attributes.count("summarize"),
         0,
-        phi::errors::InvalidArgument("summarize does not exist."));
+        common::errors::InvalidArgument("summarize does not exist."));
     PADDLE_ENFORCE_EQ(
         attributes.at("summarize").isa<pir::Int64Attribute>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type of attribute: summarize is not pir::Int64Attribute."));
   }
   VLOG(4) << "Verifying outputs:";
@@ -1021,7 +1021,7 @@ void AssertOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         0u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of outputs must be equal to 0.", output_size));
     // Outputs num is 0, not need to check outputs type.
   }
@@ -1033,10 +1033,10 @@ void SelectInputOp::VerifySig() {
   VLOG(4) << "Verifying inputs:";
   {
     auto in_size = num_operands();
-    PADDLE_ENFORCE_EQ(
-        in_size,
-        3u,
-        phi::errors::InvalidArgument("Size %d of inputs must be 3.", in_size));
+    PADDLE_ENFORCE_EQ(in_size,
+                      3u,
+                      common::errors::InvalidArgument(
+                          "Size %d of inputs must be 3.", in_size));
     auto input1 = (*this)->operand_source(1).type();
     auto input2 = (*this)->operand_source(2).type();
     if (input1.isa<paddle::dialect::DenseTensorType>() &&
@@ -1046,14 +1046,14 @@ void SelectInputOp::VerifySig() {
       PADDLE_ENFORCE_EQ(
           tensor1.dtype(),
           tensor2.dtype(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input dtype %s should be equal to 2ed input dtype %s.",
               tensor1.dtype(),
               tensor2.dtype()));
       PADDLE_ENFORCE_EQ(
           tensor1.data_layout(),
           tensor2.data_layout(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input data_layout %s should be equal to 2ed input "
               "data_layout %s.",
               tensor1.data_layout(),
@@ -1061,14 +1061,14 @@ void SelectInputOp::VerifySig() {
       PADDLE_ENFORCE_EQ(
           tensor1.lod(),
           tensor2.lod(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input lod %s should be equal to 2ed input lod %s.",
               tensor1.lod(),
               tensor2.lod()));
       PADDLE_ENFORCE_EQ(
           tensor1.offset(),
           tensor2.offset(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input offset %s should be equal to 2ed input offset %s.",
               tensor1.offset(),
               tensor2.offset()));
@@ -1081,14 +1081,14 @@ void SelectInputOp::VerifySig() {
       PADDLE_ENFORCE_EQ(
           tensor1.dtype(),
           tensor2.dtype(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input dtype %s should be equal to 2ed input dtype %s.",
               tensor1.dtype(),
               tensor2.dtype()));
       PADDLE_ENFORCE_EQ(
           tensor1.data_layout(),
           tensor2.data_layout(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input data_layout %s should be equal to 2ed input "
               "data_layout %s.",
               tensor1.data_layout(),
@@ -1096,21 +1096,21 @@ void SelectInputOp::VerifySig() {
       PADDLE_ENFORCE_EQ(
           tensor1.lod(),
           tensor2.lod(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input lod %s should be equal to 2ed input lod %s.",
               tensor1.lod(),
               tensor2.lod()));
       PADDLE_ENFORCE_EQ(
           tensor1.offset(),
           tensor2.offset(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input offset %s should be equal to 2ed input offset %s.",
               tensor1.offset(),
               tensor2.offset()));
       PADDLE_ENFORCE_EQ(
           tensor1.place(),
           tensor2.place(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input place %s should be equal to 2ed input place %s.",
               tensor1.place(),
               tensor2.place()));
@@ -1118,7 +1118,7 @@ void SelectInputOp::VerifySig() {
       PADDLE_ENFORCE_EQ(
           input1,
           input2,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input type %s should be equal to 2ed input type %s.",
               input1,
               input2));
@@ -1129,7 +1129,7 @@ void SelectInputOp::VerifySig() {
     auto out_size = num_results();
     PADDLE_ENFORCE_EQ(out_size,
                       1u,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Size %d of outputs must be equal to 1.", out_size));
   }
   VLOG(4) << "End Verifying for: AssignArray_Op.";
@@ -1175,17 +1175,17 @@ void SelectOutputOp::VerifySig() {
   VLOG(4) << "Verifying inputs:";
   {
     auto in_size = num_operands();
-    PADDLE_ENFORCE_EQ(
-        in_size,
-        2u,
-        phi::errors::InvalidArgument("Size %d of inputs must be 2.", in_size));
+    PADDLE_ENFORCE_EQ(in_size,
+                      2u,
+                      common::errors::InvalidArgument(
+                          "Size %d of inputs must be 2.", in_size));
   }
   VLOG(4) << "Verifying outputs:";
   {
     auto out_size = num_results();
     PADDLE_ENFORCE_EQ(out_size,
                       2u,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Size %d of outputs must be equal to 2.", out_size));
 
     auto out1 = (*this)->result(0).type();
@@ -1197,14 +1197,14 @@ void SelectOutputOp::VerifySig() {
       PADDLE_ENFORCE_EQ(
           tensor1.dtype(),
           tensor2.dtype(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input dtype %s should be equal to 2ed input dtype %s.",
               tensor1.dtype(),
               tensor2.dtype()));
       PADDLE_ENFORCE_EQ(
           tensor1.data_layout(),
           tensor2.data_layout(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input data_layout %s should be equal to 2ed input "
               "data_layout %s.",
               tensor1.data_layout(),
@@ -1212,14 +1212,14 @@ void SelectOutputOp::VerifySig() {
       PADDLE_ENFORCE_EQ(
           tensor1.lod(),
           tensor2.lod(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input lod %s should be equal to 2ed input lod %s.",
               tensor1.lod(),
               tensor2.lod()));
       PADDLE_ENFORCE_EQ(
           tensor1.offset(),
           tensor2.offset(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input offset %s should be equal to 2ed input offset %s.",
               tensor1.offset(),
               tensor2.offset()));
@@ -1230,14 +1230,14 @@ void SelectOutputOp::VerifySig() {
       PADDLE_ENFORCE_EQ(
           tensor1.dtype(),
           tensor2.dtype(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input dtype %s should be equal to 2ed input dtype %s.",
               tensor1.dtype(),
               tensor2.dtype()));
       PADDLE_ENFORCE_EQ(
           tensor1.data_layout(),
           tensor2.data_layout(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input data_layout %s should be equal to 2ed input "
               "data_layout %s.",
               tensor1.data_layout(),
@@ -1245,21 +1245,21 @@ void SelectOutputOp::VerifySig() {
       PADDLE_ENFORCE_EQ(
           tensor1.lod(),
           tensor2.lod(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input lod %s should be equal to 2ed input lod %s.",
               tensor1.lod(),
               tensor2.lod()));
       PADDLE_ENFORCE_EQ(
           tensor1.offset(),
           tensor2.offset(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input offset %s should be equal to 2ed input offset %s.",
               tensor1.offset(),
               tensor2.offset()));
       PADDLE_ENFORCE_EQ(
           tensor1.place(),
           tensor2.place(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input place %s should be equal to 2ed input place %s.",
               tensor1.place(),
               tensor2.place()));
@@ -1267,7 +1267,7 @@ void SelectOutputOp::VerifySig() {
       PADDLE_ENFORCE_EQ(
           out1,
           out2,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The 1st input type %s should be equal to 2ed input type %s.",
               out1,
               out2));

--- a/paddle/fluid/pir/dialect/operator/ir/ir_meta_tensor.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/ir_meta_tensor.cc
@@ -21,7 +21,7 @@ namespace paddle::dialect {
 static inline void ValidCheck(const IrMetaTensor& meta_tensor) {
   PADDLE_ENFORCE_EQ(meta_tensor.initialized(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The current MetaTensor is not initialized."));
 }
 
@@ -60,7 +60,7 @@ void IrMetaTensor::set_dims(const phi::DDim& dims) {
   } else if (paddle::dialect::IrSparseCsrTensor::classof(tensor_)) {
     static_cast<paddle::dialect::IrSparseCsrTensor*>(tensor_)->SetDims(dims);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "The current MetaTensor is not initialized."));
   }
 }
@@ -75,7 +75,7 @@ void IrMetaTensor::set_dtype(phi::DataType dtype) {
   } else if (paddle::dialect::IrSparseCsrTensor::classof(tensor_)) {
     static_cast<paddle::dialect::IrSparseCsrTensor*>(tensor_)->SetDtype(dtype);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "The current MetaTensor is not initialized."));
   }
 }
@@ -92,7 +92,7 @@ void IrMetaTensor::set_layout(phi::DataLayout layout) {
     static_cast<paddle::dialect::IrSparseCsrTensor*>(tensor_)->SetLayout(
         layout);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "The current MetaTensor is not initialized."));
   }
 }

--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
@@ -60,7 +60,7 @@ void set_parameter(const pir::Value& parameter, const std::string& name) {
   if (param) {
     PADDLE_ENFORCE_EQ(param->type(),
                       parameter.type(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Duplicate parameter %s with different type.", name));
   } else {
     std::unique_ptr<pir::Parameter> param_new(
@@ -74,7 +74,7 @@ void set_parameter(const pir::Value& parameter, const std::string& name) {
 void update_parameter(const pir::Value& parameter, const std::string& name) {
   pir::Parameter* param = ApiBuilder::Instance().GetParameter(name);
   PADDLE_ENFORCE_NOT_NULL(param,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Parameter %s not exist, can not update.", name));
   std::unique_ptr<pir::Parameter> param_new(
       new pir::Parameter(nullptr, 0, parameter.type()));
@@ -118,7 +118,7 @@ pir::Value embedding_grad(const pir::Value& x,
       return embedding_grad_op.weight_grad();
     }
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Now we do not support sparse weight embedding_grad."));
   }
 }
@@ -261,7 +261,7 @@ pir::Value assign(const pir::Value& x) {
             ->Build<paddle::dialect::AssignArrayOp>(x);
     return assign_array_op.result(0);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Currently, assign only supports DenseTensorType and "
         "DenseTensorArrayType."));
   }
@@ -294,7 +294,7 @@ pir::Value array_pop(pir::Value input, int index) {
             input, index);
     return array_pop_op.result(1);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "pop only supports DenseTensorArrayType."));
   }
 }

--- a/paddle/fluid/pir/dialect/operator/ir/manual_onednn_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_onednn_op.cc
@@ -126,7 +126,7 @@ void ExpandOp::Build(pir::Builder& builder,
 
   PADDLE_ENFORCE_NE(attributes.find("shape"),
                     attributes.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "'shape' Attribute is expected for ExpandOp. "));
   std::vector<int64_t> shape =
       attributes.at("shape")
@@ -137,7 +137,7 @@ void ExpandOp::Build(pir::Builder& builder,
   PADDLE_ENFORCE_NE(
       attributes.find("mkldnn_data_type"),
       attributes.end(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "'mkldnn_data_type' Attribute is expected for ExpandOp. "));
   std::string mkldnn_data_type = attributes.at("mkldnn_data_type")
                                      .dyn_cast<pir::StrAttribute>()
@@ -198,14 +198,14 @@ void ExpandOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         2u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of inputs must be equal to 2.", input_size));
     PADDLE_ENFORCE_EQ((*this)
                           ->operand_source(0)
                           .type()
                           .isa<paddle::dialect::DenseTensorType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 0th input, got %s.",
                           (*this)->operand_source(0).type()));
     if (auto vec_type =
@@ -214,7 +214,7 @@ void ExpandOp::VerifySig() {
         PADDLE_ENFORCE_EQ(
             vec_type[i].isa<paddle::dialect::DenseTensorType>(),
             true,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Type validation failed for the 1th input, got %s.",
                 (*this)->operand_source(1).type()));
       }
@@ -224,7 +224,7 @@ void ExpandOp::VerifySig() {
                             .type()
                             .isa<paddle::dialect::DenseTensorType>(),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Type validation failed for the 1th input, got %s.",
                             (*this)->operand_source(1).type()));
     }
@@ -235,11 +235,11 @@ void ExpandOp::VerifySig() {
     PADDLE_ENFORCE_GT(
         attributes.count("mkldnn_data_type"),
         0,
-        phi::errors::InvalidArgument("mkldnn_data_type does not exist."));
+        common::errors::InvalidArgument("mkldnn_data_type does not exist."));
     PADDLE_ENFORCE_EQ(
         attributes.at("mkldnn_data_type").isa<pir::StrAttribute>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type of attribute: mkldnn_data_type is not pir::StrAttribute."));
   }
   VLOG(4) << "Verifying outputs:";
@@ -248,12 +248,12 @@ void ExpandOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE_EQ(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: ExpandOp.";
@@ -273,7 +273,7 @@ std::vector<pir::Type> ExpandOp::InferMeta(
           "AttributeMap pointer in InferMeta function is nullptr."));
   PADDLE_ENFORCE_EQ(input_values.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 2 but got %d.",
                         input_values.size()));
 
@@ -285,7 +285,7 @@ std::vector<pir::Type> ExpandOp::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorType>()) {
     x = x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -310,7 +310,7 @@ std::vector<pir::Type> ExpandOp::InferMeta(
     shape = phi::IntArray(std::vector<int64_t>(shape_size, -2));
     shape.SetFromTensor(true);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support VectorType or DenseTensorType"));
   }
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -75,7 +75,7 @@ std::vector<pir::Type> FetchOp::InferMeta(
 
   PADDLE_ENFORCE_EQ(input_values.size() == 1,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 1 but got %d.",
                         input_values.size()));
 
@@ -176,14 +176,14 @@ void FetchOp::Build(pir::Builder &builder,
 
   PADDLE_ENFORCE_NE(attributes.find("name"),
                     attributes.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "'name' Attribute is expected for FetchOp. "));
   std::string name =
       attributes.at("name").dyn_cast<pir::StrAttribute>().AsString();
 
   PADDLE_ENFORCE_NE(attributes.find("col"),
                     attributes.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "'col' Attribute is expected for FetchOp. "));
   int col = attributes.at("col").dyn_cast<pir::Int32Attribute>().data();
 
@@ -224,7 +224,7 @@ void FetchOp::VerifySig() {
                               .type()
                               .isa<paddle::dialect::DenseTensorArrayType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 0th input, got %s.",
                           (*this)->operand_source(0).type()));
   }
@@ -233,19 +233,19 @@ void FetchOp::VerifySig() {
     auto &attributes = this->attributes();
     PADDLE_ENFORCE_GT(attributes.count("name"),
                       0,
-                      phi::errors::InvalidArgument("name does not exist."));
+                      common::errors::InvalidArgument("name does not exist."));
     PADDLE_ENFORCE_EQ(attributes.at("name").isa<pir::StrAttribute>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type of attribute: name is not pir::StrAttribute."));
 
     PADDLE_ENFORCE_GT(attributes.count("col"),
                       0,
-                      phi::errors::InvalidArgument("col does not exist."));
+                      common::errors::InvalidArgument("col does not exist."));
     PADDLE_ENFORCE_EQ(
         attributes.at("col").isa<pir::Int32Attribute>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type of attribute: col is not pir::Int32Attribute."));
   }
   VLOG(4) << "Verifying outputs:";
@@ -262,7 +262,7 @@ void FetchOp::VerifySig() {
                 .type()
                 .isa<paddle::dialect::DenseTensorArrayType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: FetchOp.";
@@ -326,14 +326,14 @@ void AddN_Op::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of inputs must be equal to 1.", input_size));
     if (auto vec_type =
             (*this)->operand_source(0).type().dyn_cast<pir::VectorType>()) {
       for (size_t i = 0; i < vec_type.size(); ++i) {
         PADDLE_ENFORCE(vec_type[i].isa<paddle::dialect::DenseTensorType>() ||
                            vec_type[i].isa<paddle::dialect::SelectedRowsType>(),
-                       phi::errors::PreconditionNotMet(
+                       common::errors::PreconditionNotMet(
                            "Type validation failed for the 0th input."));
       }
     } else {
@@ -344,7 +344,7 @@ void AddN_Op::VerifySig() {
                              ->operand_source(0)
                              .type()
                              .isa<paddle::dialect::SelectedRowsType>(),
-                     phi::errors::PreconditionNotMet(
+                     common::errors::PreconditionNotMet(
                          "Type validation failed for the 0th input."));
     }
   }
@@ -358,12 +358,12 @@ void AddN_Op::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorType>() ||
             (*this)->result(0).type().isa<paddle::dialect::SelectedRowsType>(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: AddN_Op.";
@@ -380,7 +380,7 @@ std::vector<pir::Type> AddN_Op::InferMeta(
   VLOG(4) << "Start infermeta AddN_Op";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 1 but got %d.",
                         input_values.size()));
   pir::Value inputs_ = input_values[0];
@@ -398,7 +398,7 @@ std::vector<pir::Type> AddN_Op::InferMeta(
           inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
           inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().offset()));
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Only support paddle::dialect::DenseTensorType or "
           "paddle::dialect::AllocatedDenseTensorType"));
     }
@@ -469,13 +469,13 @@ void AddNArrayOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of inputs must be equal to 1.", input_size));
     if (auto vec_type =
             (*this)->operand(0).type().dyn_cast<pir::VectorType>()) {
       for (size_t i = 0; i < vec_type.size(); ++i) {
         PADDLE_ENFORCE(vec_type[i].isa<paddle::dialect::DenseTensorArrayType>(),
-                       phi::errors::PreconditionNotMet(
+                       common::errors::PreconditionNotMet(
                            "Type validation failed for the 0th input."));
       }
     } else {
@@ -483,7 +483,7 @@ void AddNArrayOp::VerifySig() {
                          ->operand(0)
                          .type()
                          .isa<paddle::dialect::DenseTensorArrayType>(),
-                     phi::errors::PreconditionNotMet(
+                     common::errors::PreconditionNotMet(
                          "Type validation failed for the 0th input."));
     }
   }
@@ -497,11 +497,11 @@ void AddNArrayOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorArrayType>(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: AddNArrayOp.";
@@ -537,7 +537,7 @@ std::vector<pir::Type> AddNArrayOp::InferMeta(
   VLOG(4) << "Start infermeta AddNArrayOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 1 but got %d.",
                         input_values.size()));
   pir::Value inputs_ = input_values[0];
@@ -558,7 +558,7 @@ std::vector<pir::Type> AddNArrayOp::InferMeta(
               .data_layout(),
           {}));
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Only support paddle::dialect::DenseTensorArrayType or "
           "paddle::dialect::AllocatedDenseTensorArrayType"));
     }
@@ -641,19 +641,19 @@ void FusedGemmEpilogueOp::Build(pir::Builder &builder,
 
   PADDLE_ENFORCE(
       attributes.find("trans_x") != attributes.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "'trans_x' Attribute is expected for FusedGemmEpilogueOp"));
   bool trans_x = attributes.at("trans_x").dyn_cast<pir::BoolAttribute>().data();
 
   PADDLE_ENFORCE(
       attributes.find("trans_y") != attributes.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "'trans_y' Attribute is expected for FusedGemmEpilogueOp"));
   bool trans_y = attributes.at("trans_y").dyn_cast<pir::BoolAttribute>().data();
 
   PADDLE_ENFORCE(
       attributes.find("activation") != attributes.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "'activation' Attribute is expected for FusedGemmEpilogueOp"));
   std::string activation =
       attributes.at("activation").dyn_cast<pir::StrAttribute>().AsString();
@@ -691,25 +691,25 @@ void FusedGemmEpilogueOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         3u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of inputs must be equal to 3.", input_size));
     PADDLE_ENFORCE((*this)
                        ->operand_source(0)
                        .type()
                        .isa<paddle::dialect::DenseTensorType>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type validation failed for the 0th input."));
     PADDLE_ENFORCE((*this)
                        ->operand_source(1)
                        .type()
                        .isa<paddle::dialect::DenseTensorType>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type validation failed for the 1th input."));
     PADDLE_ENFORCE((*this)
                        ->operand_source(2)
                        .type()
                        .isa<paddle::dialect::DenseTensorType>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type validation failed for the 2th input."));
   }
   VLOG(4) << "Verifying attributes:";
@@ -717,15 +717,15 @@ void FusedGemmEpilogueOp::VerifySig() {
     auto &attributes = this->attributes();
     PADDLE_ENFORCE(attributes.count("trans_x") > 0 &&
                        attributes.at("trans_x").isa<pir::BoolAttribute>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type of attribute: trans_x is not right."));
     PADDLE_ENFORCE(attributes.count("trans_y") > 0 &&
                        attributes.at("trans_y").isa<pir::BoolAttribute>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type of attribute: trans_y is not right."));
     PADDLE_ENFORCE(attributes.count("activation") > 0 &&
                        attributes.at("activation").isa<pir::StrAttribute>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type of attribute: activation is not right."));
   }
   VLOG(4) << "Verifying outputs:";
@@ -734,15 +734,15 @@ void FusedGemmEpilogueOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         2u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of outputs must be equal to 2.", output_size));
     PADDLE_ENFORCE(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorType>(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 0th output."));
     if (auto output_1_type = (*this)->result(1).type()) {
       PADDLE_ENFORCE(output_1_type.isa<paddle::dialect::DenseTensorType>(),
-                     phi::errors::PreconditionNotMet(
+                     common::errors::PreconditionNotMet(
                          "Type validation failed for the 1th output."));
     }
   }
@@ -765,7 +765,7 @@ std::vector<pir::Type> FusedGemmEpilogueOp::InferMeta(
   VLOG(4) << "Start infermeta FusedGemmEpilogueOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     3,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 3 but got %d.",
                         input_values.size()));
   pir::Value x_ = input_values[0];
@@ -774,19 +774,19 @@ std::vector<pir::Type> FusedGemmEpilogueOp::InferMeta(
 
   PADDLE_ENFORCE(
       attributes.find("trans_x") != attributes.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "'trans_x' Attribute is expected for FusedGemmEpilogueOp"));
   bool trans_x = attributes.at("trans_x").dyn_cast<pir::BoolAttribute>().data();
 
   PADDLE_ENFORCE(
       attributes.find("trans_y") != attributes.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "'trans_y' Attribute is expected for FusedGemmEpilogueOp"));
   bool trans_y = attributes.at("trans_y").dyn_cast<pir::BoolAttribute>().data();
 
   PADDLE_ENFORCE(
       attributes.find("activation") != attributes.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "'activation' Attribute is expected for FusedGemmEpilogueOp"));
   std::string activation =
       attributes.at("activation").dyn_cast<pir::StrAttribute>().AsString();
@@ -796,7 +796,7 @@ std::vector<pir::Type> FusedGemmEpilogueOp::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorType>()) {
     x = x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -805,7 +805,7 @@ std::vector<pir::Type> FusedGemmEpilogueOp::InferMeta(
   if (y_.type().isa<paddle::dialect::DenseTensorType>()) {
     y = y_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -814,7 +814,7 @@ std::vector<pir::Type> FusedGemmEpilogueOp::InferMeta(
   if (bias_.type().isa<paddle::dialect::DenseTensorType>()) {
     bias = bias_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -958,20 +958,20 @@ void FusedGemmEpilogueGradOp::Build(pir::Builder &builder,
 
   PADDLE_ENFORCE(
       attributes.find("trans_x") != attributes.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "'trans_x' Attribute is expected for FusedGemmEpilogueGradOp"));
   bool trans_x = attributes.at("trans_x").dyn_cast<pir::BoolAttribute>().data();
 
   PADDLE_ENFORCE(
       attributes.find("trans_y") != attributes.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "'trans_y' Attribute is expected for FusedGemmEpilogueGradOp"));
   bool trans_y = attributes.at("trans_y").dyn_cast<pir::BoolAttribute>().data();
 
   PADDLE_ENFORCE(
       attributes.find("activation_grad") != attributes.end(),
-      phi::errors::NotFound("'activation_grad' Attribute is expected for"
-                            "FusedGemmEpilogueGradOp"));
+      common::errors::NotFound("'activation_grad' Attribute is expected for"
+                               "FusedGemmEpilogueGradOp"));
   std::string activation_grad =
       attributes.at("activation_grad").dyn_cast<pir::StrAttribute>().AsString();
 
@@ -1016,7 +1016,7 @@ std::vector<pir::Type> FusedGemmEpilogueGradOp::InferMeta(
   auto &attributes = *p_attributes;
   PADDLE_ENFORCE_EQ(input_values.size(),
                     4UL,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 4 but got %d.",
                         input_values.size()));
 
@@ -1028,20 +1028,20 @@ std::vector<pir::Type> FusedGemmEpilogueGradOp::InferMeta(
 
   PADDLE_ENFORCE(
       attributes.find("trans_x") != attributes.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "'trans_x' Attribute is expected for FusedGemmEpilogueGradOp"));
   bool trans_x = attributes.at("trans_x").dyn_cast<pir::BoolAttribute>().data();
 
   PADDLE_ENFORCE(
       attributes.find("trans_y") != attributes.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "'trans_y' Attribute is expected for FusedGemmEpilogueGradOp"));
   bool trans_y = attributes.at("trans_y").dyn_cast<pir::BoolAttribute>().data();
 
   PADDLE_ENFORCE(
       attributes.find("activation_grad") != attributes.end(),
-      phi::errors::NotFound("'activation_grad' Attribute is expected for"
-                            "FusedGemmEpilogueGradOp"));
+      common::errors::NotFound("'activation_grad' Attribute is expected for"
+                               "FusedGemmEpilogueGradOp"));
   std::string activation_grad =
       attributes.at("activation_grad").dyn_cast<pir::StrAttribute>().AsString();
 
@@ -1050,7 +1050,7 @@ std::vector<pir::Type> FusedGemmEpilogueGradOp::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorType>()) {
     x = x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -1059,7 +1059,7 @@ std::vector<pir::Type> FusedGemmEpilogueGradOp::InferMeta(
   if (y_.type().isa<paddle::dialect::DenseTensorType>()) {
     y = y_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -1070,7 +1070,7 @@ std::vector<pir::Type> FusedGemmEpilogueGradOp::InferMeta(
       reserve_space =
           reserve_space_.type().dyn_cast<paddle::dialect::DenseTensorType>();
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Only support paddle::dialect::DenseTensorType or "
           "paddle::dialect::AllocatedDenseTensorType"));
     }
@@ -1082,7 +1082,7 @@ std::vector<pir::Type> FusedGemmEpilogueGradOp::InferMeta(
   if (out_grad_.type().isa<paddle::dialect::DenseTensorType>()) {
     out_grad = out_grad_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -1261,13 +1261,13 @@ void SplitGradOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         2u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of inputs must be equal to 2.", input_size));
     if (auto vec_type =
             (*this)->operand_source(0).type().dyn_cast<pir::VectorType>()) {
       for (size_t i = 0; i < vec_type.size(); ++i) {
         PADDLE_ENFORCE(vec_type[i].isa<paddle::dialect::DenseTensorType>(),
-                       phi::errors::PreconditionNotMet(
+                       common::errors::PreconditionNotMet(
                            "Type validation failed for the 0th input."));
       }
     } else {
@@ -1275,14 +1275,14 @@ void SplitGradOp::VerifySig() {
                          ->operand_source(0)
                          .type()
                          .isa<paddle::dialect::DenseTensorType>(),
-                     phi::errors::PreconditionNotMet(
+                     common::errors::PreconditionNotMet(
                          "Type validation failed for the 0th input."));
     }
     PADDLE_ENFORCE((*this)
                        ->operand_source(1)
                        .type()
                        .isa<paddle::dialect::DenseTensorType>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type validation failed for the 1th input."));
   }
   VLOG(4) << "Verifying attributes:";
@@ -1295,11 +1295,11 @@ void SplitGradOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorType>(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: SplitGradOp.";
@@ -1317,7 +1317,7 @@ std::vector<pir::Type> SplitGradOp::InferMeta(
 
   PADDLE_ENFORCE_EQ(input_values.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 2 but got %d.",
                         input_values.size()));
   pir::Value out_grad_ = input_values[0];
@@ -1422,7 +1422,7 @@ void CreateArrayOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         0u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of inputs must be equal to 1.", input_size));
   }
   VLOG(4) << "Verifying attributes:";
@@ -1436,11 +1436,11 @@ void CreateArrayOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorArrayType>(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: CreateArrayOp.";
@@ -1461,9 +1461,9 @@ std::vector<pir::Type> CreateArrayOp::InferMeta(
   auto &attributes = *p_attributes;
   VLOG(4) << "Start infermeta CreateArrayOp";
 
-  PADDLE_ENFORCE(
-      attributes.find("dtype") != attributes.end(),
-      phi::errors::NotFound("'dtype' Attribute is expected for CreateArrayOp"));
+  PADDLE_ENFORCE(attributes.find("dtype") != attributes.end(),
+                 common::errors::NotFound(
+                     "'dtype' Attribute is expected for CreateArrayOp"));
   phi::DataType dtype = attributes.at("dtype")
                             .dyn_cast<paddle::dialect::DataTypeAttribute>()
                             .data();
@@ -1555,7 +1555,7 @@ void CreateArrayLikeOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of inputs must be equal to 1.", input_size));
   }
   VLOG(4) << "Verifying attributes:";
@@ -1569,11 +1569,11 @@ void CreateArrayLikeOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorArrayType>(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: CreateArrayLikeOp.";
@@ -1590,7 +1590,7 @@ std::vector<pir::Type> CreateArrayLikeOp::InferMeta(
   VLOG(4) << "Start infermeta CreateArrayLikeOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 1 but got %d.",
                         input_values.size()));
   pir::Value input_ = input_values[0];
@@ -1601,7 +1601,7 @@ std::vector<pir::Type> CreateArrayLikeOp::InferMeta(
     input_type =
         input_.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorArrayType or "
         "paddle::dialect::AllocatedDenseTensorArrayType"));
   }
@@ -1675,14 +1675,14 @@ void ArrayLengthOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of inputs must be equal to 1.", input_size));
 
     PADDLE_ENFORCE((*this)
                        ->operand_source(0)
                        .type()
                        .isa<paddle::dialect::DenseTensorArrayType>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type validation failed for the 0th input."));
   }
   VLOG(4) << "Verifying attributes:";
@@ -1692,11 +1692,11 @@ void ArrayLengthOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorType>(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: ArrayLengthOp.";
@@ -1713,7 +1713,7 @@ std::vector<pir::Type> ArrayLengthOp::InferMeta(
   VLOG(4) << "Start infermeta ArrayLengthOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 1 but got %d.",
                         input_values.size()));
   pir::Value x_ = input_values[0];
@@ -1722,7 +1722,7 @@ std::vector<pir::Type> ArrayLengthOp::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorArrayType>()) {
     x_type = x_.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorArrayType or "
         "paddle::dialect::AllocatedDenseTensorArrayType"));
   }
@@ -1837,20 +1837,20 @@ void ArrayReadOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         2u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of inputs must be equal to 3.", input_size));
 
     PADDLE_ENFORCE((*this)
                        ->operand_source(0)
                        .type()
                        .isa<paddle::dialect::DenseTensorArrayType>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type validation failed for the 0th input."));
     PADDLE_ENFORCE((*this)
                        ->operand_source(1)
                        .type()
                        .isa<paddle::dialect::DenseTensorType>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type validation failed for the 1th input."));
   }
   VLOG(4) << "Verifying attributes:";
@@ -1860,11 +1860,11 @@ void ArrayReadOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorType>(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: ArrayReadOp.";
@@ -1881,7 +1881,7 @@ std::vector<pir::Type> ArrayReadOp::InferMeta(
   VLOG(4) << "Start infermeta ArrayLengthOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 2 but got %d.",
                         input_values.size()));
   pir::Value array_ = input_values[0];
@@ -1893,7 +1893,7 @@ std::vector<pir::Type> ArrayReadOp::InferMeta(
     array_type =
         array_.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorArrayType or "
         "paddle::dialect::AllocatedDenseTensorArrayType"));
   }
@@ -2001,26 +2001,26 @@ void ArrayWrite_Op::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         3u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of inputs must be equal to 3.", input_size));
 
     PADDLE_ENFORCE((*this)
                        ->operand_source(0)
                        .type()
                        .isa<paddle::dialect::DenseTensorArrayType>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type validation failed for the 0th input."));
     PADDLE_ENFORCE((*this)
                        ->operand_source(1)
                        .type()
                        .isa<paddle::dialect::DenseTensorType>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type validation failed for the 1th input."));
     PADDLE_ENFORCE((*this)
                        ->operand_source(2)
                        .type()
                        .isa<paddle::dialect::DenseTensorType>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type validation failed for the 2th input."));
   }
   VLOG(4) << "Verifying attributes:";
@@ -2030,11 +2030,11 @@ void ArrayWrite_Op::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorArrayType>(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: ArrayWrite_Op.";
@@ -2051,7 +2051,7 @@ std::vector<pir::Type> ArrayWrite_Op::InferMeta(
   VLOG(4) << "Start infermeta ArrayWrite_Op";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     3,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 3 but got %d.",
                         input_values.size()));
   pir::Value array_ = input_values[0];
@@ -2063,7 +2063,7 @@ std::vector<pir::Type> ArrayWrite_Op::InferMeta(
     array_type =
         array_.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorArrayType or "
         "paddle::dialect::AllocatedDenseTensorArrayType"));
   }
@@ -2080,7 +2080,7 @@ std::vector<pir::Type> ArrayWrite_Op::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorType>()) {
     x_type = x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -2207,14 +2207,14 @@ void ArrayToTensorOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of inputs must be equal to 1.", input_size));
 
     PADDLE_ENFORCE((*this)
                        ->operand_source(0)
                        .type()
                        .isa<paddle::dialect::DenseTensorArrayType>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type validation failed for the 0th input."));
   }
 
@@ -2232,15 +2232,15 @@ void ArrayToTensorOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         2u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorType>(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 0th output."));
     PADDLE_ENFORCE(
         (*this)->result(1).type().isa<paddle::dialect::DenseTensorType>(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: ArrayToTensorOp.";
@@ -2262,20 +2262,20 @@ std::vector<pir::Type> ArrayToTensorOp::InferMeta(
   VLOG(4) << "Start infermeta ArrayToTensorOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 1 but got %d.",
                         input_values.size()));
   pir::Value x_ = input_values[0];
 
   PADDLE_ENFORCE_NE(attributes.find("axis"),
                     attributes.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "'value' Attribute is expected for IncrementOp. "));
   int32_t axis = attributes.at("axis").dyn_cast<pir::Int32Attribute>().data();
 
   PADDLE_ENFORCE_NE(attributes.find("use_stack"),
                     attributes.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "'value' Attribute is expected for IncrementOp. "));
   bool use_stack =
       attributes.at("use_stack").dyn_cast<pir::BoolAttribute>().data();
@@ -2285,7 +2285,7 @@ std::vector<pir::Type> ArrayToTensorOp::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorArrayType>()) {
     x_type = x_.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorArrayType or "
         "paddle::dialect::AllocatedDenseTensorArrayType"));
   }
@@ -2445,20 +2445,20 @@ void TensorToArrayOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         2u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of inputs must be equal to 2.", input_size));
 
     PADDLE_ENFORCE((*this)
                        ->operand_source(0)
                        .type()
                        .isa<paddle::dialect::DenseTensorArrayType>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type validation failed for the 0th input."));
     PADDLE_ENFORCE((*this)
                        ->operand_source(1)
                        .type()
                        .isa<paddle::dialect::DenseTensorType>(),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "Type validation failed for the 1th input."));
   }
 
@@ -2476,11 +2476,11 @@ void TensorToArrayOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorArrayType>(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: TensorToArrayOp.";
@@ -2502,7 +2502,7 @@ std::vector<pir::Type> TensorToArrayOp::InferMeta(
   VLOG(4) << "Start infermeta TensorToArrayOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 2 but got %d.",
                         input_values.size()));
   pir::Value x_ = input_values[0];
@@ -2513,13 +2513,13 @@ std::vector<pir::Type> TensorToArrayOp::InferMeta(
 
   PADDLE_ENFORCE_NE(attributes.find("axis"),
                     attributes.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "'value' Attribute is expected for IncrementOp. "));
   int32_t axis = attributes.at("axis").dyn_cast<pir::Int32Attribute>().data();
 
   PADDLE_ENFORCE_NE(attributes.find("use_stack"),
                     attributes.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "'value' Attribute is expected for IncrementOp. "));
   bool use_stack =
       attributes.at("use_stack").dyn_cast<pir::BoolAttribute>().data();
@@ -2530,7 +2530,7 @@ std::vector<pir::Type> TensorToArrayOp::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorArrayType>()) {
     x = x_.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorArrayType or "
         "paddle::dialect::AllocatedDenseTensorArrayType"));
   }
@@ -2545,7 +2545,7 @@ std::vector<pir::Type> TensorToArrayOp::InferMeta(
   if (out_grad_.type().isa<paddle::dialect::DenseTensorType>()) {
     out_grad = out_grad_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -2624,14 +2624,14 @@ void SliceArrayOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         3u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of inputs must be equal to 3.", input_size));
     PADDLE_ENFORCE_EQ((*this)
                           ->operand_source(0)
                           .type()
                           .isa<paddle::dialect::DenseTensorArrayType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 0th input, got %s.",
                           (*this)->operand_source(0).type()));
     PADDLE_ENFORCE_EQ(
@@ -2641,7 +2641,7 @@ void SliceArrayOp::VerifySig() {
                 .type()
                 .isa<paddle::dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 1st input, got %s.",
             (*this)->operand_source(1).type()));
     PADDLE_ENFORCE_EQ(
@@ -2651,7 +2651,7 @@ void SliceArrayOp::VerifySig() {
                 .type()
                 .isa<paddle::dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 1st input, got %s.",
             (*this)->operand_source(2).type()));
   }
@@ -2661,12 +2661,12 @@ void SliceArrayOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE_EQ(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorArrayType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: SliceArrayOp.";
@@ -2698,9 +2698,9 @@ phi::IntArray CalcSliceBoundsFromValue(pir::Value starts_or_ends) {
         phi::IntArray(std::vector<int64_t>(starts_or_ends_size, -1));
     starts_or_ends_list.SetFromTensor(true);
   } else {
-    PADDLE_THROW(
-        phi::errors::Unimplemented("Only support VectorType or DenseTensorType "
-                                   "or AllocatedDenseTensorType"));
+    PADDLE_THROW(common::errors::Unimplemented(
+        "Only support VectorType or DenseTensorType "
+        "or AllocatedDenseTensorType"));
   }
   return starts_or_ends_list;
 }
@@ -2734,7 +2734,7 @@ std::vector<pir::Type> SliceArrayOp::InferMeta(
   VLOG(4) << "Start infermeta SliceArrayOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     3,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 3 but got %d.",
                         input_values.size()));
   pir::Value input = input_values[0];
@@ -2746,7 +2746,7 @@ std::vector<pir::Type> SliceArrayOp::InferMeta(
   if (input.type().isa<paddle::dialect::DenseTensorArrayType>()) {
     input_type = input.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::AllocatedDenseTensorArrayType or "
         "paddle::dialect::AllocatedDenseTensorArrayType"));
   }
@@ -2832,14 +2832,14 @@ void SliceArrayDenseOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         2u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of inputs must be equal to 2.", input_size));
     PADDLE_ENFORCE_EQ((*this)
                           ->operand_source(0)
                           .type()
                           .isa<paddle::dialect::DenseTensorArrayType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 0th input, got %s.",
                           (*this)->operand_source(0).type()));
     PADDLE_ENFORCE_EQ(
@@ -2849,7 +2849,7 @@ void SliceArrayDenseOp::VerifySig() {
                 .type()
                 .isa<paddle::dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 1st input, got %s.",
             (*this)->operand_source(1).type()));
   }
@@ -2859,12 +2859,12 @@ void SliceArrayDenseOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE_EQ(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: SliceArrayOp.";
@@ -2898,7 +2898,7 @@ std::vector<pir::Type> SliceArrayDenseOp::InferMeta(
   VLOG(4) << "Start infermeta SliceArrayDenseOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 2 but got %d.",
                         input_values.size()));
   pir::Value input = input_values[0];
@@ -2909,7 +2909,7 @@ std::vector<pir::Type> SliceArrayDenseOp::InferMeta(
   if (input.type().isa<paddle::dialect::DenseTensorArrayType>()) {
     input_type = input.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorArrayType or "
         "paddle::dialect::AllocatedDenseTensorArrayType"));
   }
@@ -2995,14 +2995,14 @@ void AssignArrayOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of inputs must be equal to 1.", input_size));
     PADDLE_ENFORCE_EQ((*this)
                           ->operand_source(0)
                           .type()
                           .isa<paddle::dialect::DenseTensorArrayType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 0th input, got %s.",
                           (*this)->operand_source(0).type()));
   }
@@ -3016,12 +3016,12 @@ void AssignArrayOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE_EQ(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorArrayType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: AssignArrayOp.";
@@ -3047,7 +3047,7 @@ std::vector<pir::Type> AssignArrayOp::InferMeta(
   VLOG(4) << "Start infermeta AssignArrayOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 1 but got %d.",
                         input_values.size()));
   pir::Value x_ = input_values[0];
@@ -3057,7 +3057,7 @@ std::vector<pir::Type> AssignArrayOp::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorArrayType>()) {
     x_type = x_.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorArrayType or "
         "paddle::dialect::AllocatedDenseTensorArrayType"));
   }
@@ -3118,7 +3118,7 @@ void AssignArray_Op::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of inputs must be equal to 1.", input_size));
     PADDLE_ENFORCE_EQ(
         (*this)
@@ -3126,7 +3126,7 @@ void AssignArray_Op::VerifySig() {
             .type()
             .isa<paddle::dialect::DenseTensorArrayType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 0th input, but got %s.",
             (*this)->operand_source(0).type()));
   }
@@ -3137,12 +3137,12 @@ void AssignArray_Op::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE_EQ(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorArrayType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: AssignArray_Op.";
@@ -3159,7 +3159,7 @@ std::vector<pir::Type> AssignArray_Op::InferMeta(
   VLOG(4) << "Start infermeta AssignArray_Op";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 1 but got %d.",
                         input_values.size()));
   pir::Value x_ = input_values[0];
@@ -3169,7 +3169,7 @@ std::vector<pir::Type> AssignArray_Op::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorArrayType>()) {
     x_type = x_.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorArrayType or "
         "paddle::dialect::AllocatedDenseTensorArrayType"));
   }
@@ -3265,7 +3265,7 @@ void ExpandOp::Build(pir::Builder &builder,
 
   PADDLE_ENFORCE_NE(attributes.find("shape"),
                     attributes.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "'shape' Attribute is expected for ExpandOp. "));
   std::vector<int64_t> shape =
       attributes.at("shape")
@@ -3329,13 +3329,13 @@ bool ExpandOp::InferSymbolicShape(
           if (expand_shape[i] == symbol::DimExpr{-1}) {  // copy the dim from x
             // the shape is right aligned
             int index = i - (expand_shape.size() - x_dims.size());
-            PADDLE_ENFORCE_GE(
-                index,
-                0,
-                phi::errors::InvalidArgument("in ExpandOpInferSymbolicShape, "
-                                             "the dim to copy must >= 0, "
-                                             "but got %d",
-                                             index));
+            PADDLE_ENFORCE_GE(index,
+                              0,
+                              common::errors::InvalidArgument(
+                                  "in ExpandOpInferSymbolicShape, "
+                                  "the dim to copy must >= 0, "
+                                  "but got %d",
+                                  index));
 
             result_shape[i] = x_dims[index];
           }
@@ -3359,21 +3359,21 @@ void ExpandOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         2u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of inputs must be equal to 2.", input_size));
     PADDLE_ENFORCE_EQ((*this)
                           ->operand_source(0)
                           .type()
                           .isa<paddle::dialect::DenseTensorType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 0th input."));
     if (auto vec_type =
             (*this)->operand_source(1).type().dyn_cast<pir::VectorType>()) {
       for (size_t i = 0; i < vec_type.size(); ++i) {
         PADDLE_ENFORCE_EQ(vec_type[i].isa<paddle::dialect::DenseTensorType>(),
                           true,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Type validation failed for the 1th input."));
       }
     } else {
@@ -3382,7 +3382,7 @@ void ExpandOp::VerifySig() {
                             .type()
                             .isa<paddle::dialect::DenseTensorType>(),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Type validation failed for the 1th input."));
     }
   }
@@ -3396,12 +3396,12 @@ void ExpandOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE_EQ(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: ExpandOp.";
@@ -3418,7 +3418,7 @@ std::vector<pir::Type> ExpandOp::InferMeta(
   VLOG(4) << "Start infermeta ExpandOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 2 but got %d.",
                         input_values.size()));
   pir::Value x_ = input_values[0];
@@ -3430,7 +3430,7 @@ std::vector<pir::Type> ExpandOp::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorType>()) {
     x = x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -3528,7 +3528,7 @@ std::vector<pir::Type> ExpandOp::InferMeta(
       vec_shape = std::vector<int64_t>(shape_size, -2);
       *is_from_tensor = true;
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Only support VectorType or DenseTensorType "
           "or AllocatedDenseTensorType"));
     }
@@ -3628,7 +3628,7 @@ void IncrementOp::Build(pir::Builder &builder,
 
   PADDLE_ENFORCE_NE(attributes.find("value"),
                     attributes.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "'value' Attribute is expected for IncrementOp. "));
   float value = attributes.at("value").dyn_cast<pir::FloatAttribute>().data();
 
@@ -3657,14 +3657,14 @@ void IncrementOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of inputs must be equal to 1.", input_size));
     PADDLE_ENFORCE_EQ((*this)
                           ->operand_source(0)
                           .type()
                           .isa<paddle::dialect::DenseTensorType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 0th input, got %s.",
                           (*this)->operand_source(0).type()));
   }
@@ -3673,11 +3673,11 @@ void IncrementOp::VerifySig() {
     auto &attributes = this->attributes();
     PADDLE_ENFORCE_GT(attributes.count("value"),
                       0,
-                      phi::errors::InvalidArgument("value does not exist."));
+                      common::errors::InvalidArgument("value does not exist."));
     PADDLE_ENFORCE_EQ(
         attributes.at("value").isa<pir::FloatAttribute>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type of attribute: value is not pir::FloatAttribute."));
   }
   VLOG(4) << "Verifying outputs:";
@@ -3686,12 +3686,12 @@ void IncrementOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE_EQ(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: IncrementOp.";
@@ -3713,14 +3713,14 @@ std::vector<pir::Type> IncrementOp::InferMeta(
   VLOG(4) << "Start infermeta IncrementOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 1 but got %d.",
                         input_values.size()));
   pir::Value x_ = input_values[0];
 
   PADDLE_ENFORCE_NE(attributes.find("value"),
                     attributes.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "'value' Attribute is expected for IncrementOp. "));
   float value = attributes.at("value").dyn_cast<pir::FloatAttribute>().data();
 
@@ -3729,7 +3729,7 @@ std::vector<pir::Type> IncrementOp::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorType>()) {
     x = x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -3832,7 +3832,7 @@ void Increment_Op::Build(pir::Builder &builder,
 
   PADDLE_ENFORCE_NE(attributes.find("value"),
                     attributes.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "'value' Attribute is expected for Increment_Op. "));
   float value = attributes.at("value").dyn_cast<pir::FloatAttribute>().data();
 
@@ -3862,14 +3862,14 @@ void Increment_Op::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of inputs must be equal to 1.", input_size));
     PADDLE_ENFORCE_EQ((*this)
                           ->operand_source(0)
                           .type()
                           .isa<paddle::dialect::DenseTensorType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 0th input, got %s.",
                           (*this)->operand_source(0).type()));
   }
@@ -3878,11 +3878,11 @@ void Increment_Op::VerifySig() {
     auto &attributes = this->attributes();
     PADDLE_ENFORCE_GT(attributes.count("value"),
                       0,
-                      phi::errors::InvalidArgument("value does not exist."));
+                      common::errors::InvalidArgument("value does not exist."));
     PADDLE_ENFORCE_EQ(
         attributes.at("value").isa<pir::FloatAttribute>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type of attribute: value is not pir::FloatAttribute."));
   }
   VLOG(4) << "Verifying outputs:";
@@ -3891,12 +3891,12 @@ void Increment_Op::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE_EQ(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: Increment_Op.";
@@ -3918,14 +3918,14 @@ std::vector<pir::Type> Increment_Op::InferMeta(
   VLOG(4) << "Start infermeta Increment_Op";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 1 but got %d.",
                         input_values.size()));
   pir::Value x_ = input_values[0];
 
   PADDLE_ENFORCE_NE(attributes.find("value"),
                     attributes.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "'value' Attribute is expected for Increment_Op. "));
   float value = attributes.at("value").dyn_cast<pir::FloatAttribute>().data();
 
@@ -3934,7 +3934,7 @@ std::vector<pir::Type> Increment_Op::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorType>()) {
     x = x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -4042,14 +4042,14 @@ void AssignOut_Op::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         2u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of inputs must be equal to 2.", input_size));
     PADDLE_ENFORCE_EQ((*this)
                           ->operand_source(0)
                           .type()
                           .isa<paddle::dialect::DenseTensorType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 0th input, got %s.",
                           (*this)->operand_source(0).type()));
     PADDLE_ENFORCE_EQ((*this)
@@ -4057,7 +4057,7 @@ void AssignOut_Op::VerifySig() {
                           .type()
                           .isa<paddle::dialect::DenseTensorType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 1th input, got %s.",
                           (*this)->operand_source(1).type()));
   }
@@ -4071,12 +4071,12 @@ void AssignOut_Op::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of outputs must be equal to 1.", output_size));
     PADDLE_ENFORCE_EQ(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: AssignOut_Op.";
@@ -4092,7 +4092,7 @@ std::vector<pir::Type> AssignOut_Op::InferMeta(
     pir::AttributeMap *p_attributes) {
   PADDLE_ENFORCE_EQ(input_values.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 2 but got %d.",
                         input_values.size()));
 
@@ -4103,7 +4103,7 @@ std::vector<pir::Type> AssignOut_Op::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorType>()) {
     x = x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -4229,7 +4229,7 @@ std::vector<pir::Type> ShapeBroadcastOp::InferMeta(
   VLOG(4) << "Start infermeta ShapeBroadcastOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 2 but got %d.",
                         input_values.size()));
   pir::Value x_ = input_values[0];
@@ -4240,7 +4240,7 @@ std::vector<pir::Type> ShapeBroadcastOp::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorType>()) {
     x = x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -4249,7 +4249,7 @@ std::vector<pir::Type> ShapeBroadcastOp::InferMeta(
   if (y_.type().isa<paddle::dialect::DenseTensorType>()) {
     y = y_.type().dyn_cast<paddle::dialect::DenseTensorType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorType or "
         "paddle::dialect::AllocatedDenseTensorType"));
   }
@@ -4304,7 +4304,7 @@ symbol::DimExpr GetBroadcastDimExpr(const symbol::DimExpr &lhs,
     return symbol::SimplifyDimExpr(symbol::Broadcast<symbol::DimExpr>{
         symbol::List<symbol::DimExpr>{lhs, rhs}});
   }
-  PADDLE_THROW(phi::errors::Fatal("Dead code"));
+  PADDLE_THROW(common::errors::Fatal("Dead code"));
 }
 
 }  // namespace
@@ -4315,7 +4315,7 @@ std::vector<symbol::DimExpr> ComputeBroadcastShape(
   PADDLE_ENFORCE_GE(
       large_shape.size(),
       small_shape.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Size of large_shape is expected to be greater or equal size of "
           "small_shape, but got [%d] >= [%d].",
           large_shape.size(),
@@ -4341,11 +4341,11 @@ bool ShapeBroadcastOp::InferSymbolicShape(
   const auto &y_data_shape = infer_context->GetShapeOrDataForValue(y);
   PADDLE_ENFORCE_EQ(x_data_shape.data().has_value(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Value x comes from ShapeOp, it must have data"));
   PADDLE_ENFORCE_EQ(y_data_shape.data().has_value(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Value y comes from ShapeOp, it must have data"));
   const auto &x_data = x_data_shape.data().value();
   const auto &y_data = y_data_shape.data().value();
@@ -4401,14 +4401,14 @@ void MemcpyD2hMultiIoOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of inputs must be equal to 1.", input_size));
     PADDLE_ENFORCE_EQ((*this)
                           ->operand_source(0)
                           .type()
                           .isa<paddle::dialect::DenseTensorArrayType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 0th input, got %s.",
                           (*this)->operand_source(0).type()));
   }
@@ -4418,11 +4418,11 @@ void MemcpyD2hMultiIoOp::VerifySig() {
     PADDLE_ENFORCE_GT(
         attributes.count("dst_place_type"),
         0,
-        phi::errors::InvalidArgument("dst_place_type does not exist."));
+        common::errors::InvalidArgument("dst_place_type does not exist."));
     PADDLE_ENFORCE_EQ(
         attributes.at("dst_place_type").isa<pir::Int32Attribute>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type of attribute: dst_place_type is not pir::Int32Attribute."));
   }
   VLOG(4) << "Verifying outputs:";
@@ -4431,14 +4431,14 @@ void MemcpyD2hMultiIoOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of outputs must be equal to 1.", output_size));
     auto output_0_type = (*this)->result(0).type();
 
     PADDLE_ENFORCE_EQ(
         output_0_type.isa<paddle::dialect::DenseTensorArrayType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: MemcpyD2hMultiIoOp.";
@@ -4454,7 +4454,7 @@ std::vector<pir::Type> MemcpyD2hMultiIoOp::InferMeta(
     pir::AttributeMap *p_attributes) {
   PADDLE_ENFORCE_EQ(input_values.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 1 but got %d.",
                         input_values.size()));
 
@@ -4464,7 +4464,7 @@ std::vector<pir::Type> MemcpyD2hMultiIoOp::InferMeta(
   if (x_.type().isa<paddle::dialect::DenseTensorArrayType>()) {
     x_type = x_.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorArrayType or "
         "paddle::dialect::AllocatedDenseTensorArrayType"));
   }
@@ -4542,14 +4542,14 @@ void ArrayPopOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         input_size,
         1u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of inputs must be equal to 1.", input_size));
     PADDLE_ENFORCE_EQ((*this)
                           ->operand_source(0)
                           .type()
                           .isa<paddle::dialect::DenseTensorArrayType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 0th input, got %s.",
                           (*this)->operand_source(0).type()));
   }
@@ -4558,11 +4558,11 @@ void ArrayPopOp::VerifySig() {
     auto &attributes = this->attributes();
     PADDLE_ENFORCE_GT(attributes.count("index"),
                       0,
-                      phi::errors::InvalidArgument("index does not exist."));
+                      common::errors::InvalidArgument("index does not exist."));
     PADDLE_ENFORCE_EQ(
         attributes.at("index").isa<pir::Int32Attribute>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type of attribute: index is not pir::Int32Attribute."));
   }
   VLOG(4) << "Verifying outputs:";
@@ -4571,17 +4571,17 @@ void ArrayPopOp::VerifySig() {
     PADDLE_ENFORCE_EQ(
         output_size,
         2u,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size %d of outputs must be equal to 2.", output_size));
     PADDLE_ENFORCE_EQ(
         (*this)->result(0).type().isa<paddle::dialect::DenseTensorArrayType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 0th output."));
     PADDLE_ENFORCE_EQ(
         (*this)->result(1).type().isa<paddle::dialect::DenseTensorType>(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Type validation failed for the 1st output."));
   }
   VLOG(4) << "End Verifying for: ArrayPopOp.";
@@ -4624,7 +4624,7 @@ std::vector<pir::Type> ArrayPopOp::InferMeta(
   VLOG(4) << "Start infermeta ArrayPopOp";
   PADDLE_ENFORCE_EQ(input_values.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Num of inputs is expected to be 1 but got %d.",
                         input_values.size()));
   pir::Value input = input_values[0];
@@ -4634,14 +4634,14 @@ std::vector<pir::Type> ArrayPopOp::InferMeta(
   if (input.type().isa<paddle::dialect::DenseTensorArrayType>()) {
     input_type = input.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support paddle::dialect::DenseTensorArrayType or "
         "paddle::dialect::AllocatedDenseTensorArrayType"));
   }
 
   PADDLE_ENFORCE_NE(attributes.find("index"),
                     attributes.end(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "'index' Attribute is expected for ArrayPopOp. "));
   int index = attributes.at("index").dyn_cast<pir::Int32Attribute>().data();
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op_decomp_vjp.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op_decomp_vjp.cc
@@ -135,7 +135,7 @@ std::vector<std::vector<pir::Value>> ConcatGradOp::DecompVjp(
           ->value()
           .defining_op();
   if (axis_define_op->name() != "pd_op.full") {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "We don't support dynamic tensors "
         "attribute axis for concat_grad decomposition "
         "for now. "));
@@ -230,7 +230,7 @@ std::vector<std::vector<pir::Value>> SliceGradOp::DecompVjp(
       }
 
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "attr is not vector of pir::Int64Attribute "));
     }
   }
@@ -242,7 +242,7 @@ std::vector<std::vector<pir::Value>> SliceGradOp::DecompVjp(
           ->value()
           .defining_op();
   if (starts_define_op->name() != "pd_op.full_int_array") {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "We don't support dynamic tensors "
         "attribute starts for slice_grad decomposition "
         "for now. "));
@@ -257,7 +257,7 @@ std::vector<std::vector<pir::Value>> SliceGradOp::DecompVjp(
           ->value()
           .defining_op();
   if (ends_define_op->name() != "pd_op.full_int_array") {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "We don't support dynamic tensors "
         "attribute ends for slice_grad decomposition "
         "for now. "));
@@ -276,7 +276,7 @@ std::vector<std::vector<pir::Value>> SliceGradOp::DecompVjp(
       }
 
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "attr is not vector of pir::Int64Attribute "));
     }
   }
@@ -291,7 +291,7 @@ std::vector<std::vector<pir::Value>> SliceGradOp::DecompVjp(
       }
 
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "attr is not vector of pir::Int64Attribute "));
     }
   }

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op_vjp.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op_vjp.cc
@@ -36,12 +36,12 @@ std::vector<std::vector<pir::Value>> ExpandOp::Vjp(
     const std::vector<std::vector<bool>>& stop_gradients) {
   PADDLE_ENFORCE_EQ(inputs_.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "expand op's inputs size should be 2, but now is %d.",
                         inputs_.size()));
   PADDLE_ENFORCE_EQ(outputs.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "expand op's outputs size should be 1, but now is %d.",
                         outputs.size()));
 
@@ -84,13 +84,13 @@ std::vector<std::vector<pir::Value>> IncrementOp::Vjp(
   PADDLE_ENFORCE_EQ(
       inputs_.size(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Increment op's inputs size should be 2, but now is %d.",
           inputs_.size()));
   PADDLE_ENFORCE_EQ(
       outputs.size(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Increment op's outputs size should be 1, but now is %d.",
           outputs.size()));
 
@@ -114,13 +114,13 @@ std::vector<std::vector<pir::Value>> Increment_Op::Vjp(
   PADDLE_ENFORCE_EQ(
       inputs_.size(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Increment_ op's inputs size should be 1, but now is %d.",
           inputs_.size()));
   PADDLE_ENFORCE_EQ(
       outputs.size(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Increment_ op's outputs size should be 1, but now is %d.",
           outputs.size()));
 
@@ -145,13 +145,13 @@ std::vector<std::vector<pir::Value>> AssignOut_Op::Vjp(
   PADDLE_ENFORCE_EQ(
       inputs_.size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "assign_out_ op's inputs size should be 2, but now is %d.",
           inputs_.size()));
   PADDLE_ENFORCE_EQ(
       outputs.size(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "assign_out_ op's outputs size should be 1, but now is %d.",
           outputs.size()));
 
@@ -186,20 +186,20 @@ std::vector<std::vector<pir::Value>> ArrayWrite_Op::Vjp(
   PADDLE_ENFORCE_EQ(
       inputs_.size(),
       3,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "ArrayWrite_ op's inputs size should be 3, but now is %d.",
           inputs_.size()));
   PADDLE_ENFORCE_EQ(
       outputs.size(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "ArrayWrite_ op's outputs size should be 1, but now is %d.",
           outputs.size()));
 
   PADDLE_ENFORCE_EQ(
       in_grads.size(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "ArrayWrite_ op's outputs size should be 1, but now is %d.",
           outputs.size()));
 
@@ -225,13 +225,13 @@ std::vector<std::vector<pir::Value>> ArrayReadOp::Vjp(
   PADDLE_ENFORCE_EQ(
       inputs_.size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Array_read op's inputs size should be 2, but now is %d.",
           inputs_.size()));
   PADDLE_ENFORCE_EQ(
       outputs.size(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Array_read op's outputs size should be 1, but now is %d.",
           outputs.size()));
   // x = array_read(input, i)
@@ -240,7 +240,7 @@ std::vector<std::vector<pir::Value>> ArrayReadOp::Vjp(
   PADDLE_ENFORCE_EQ(
       out_grads.size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Array_read op's outputs size should be 1, but now is %d.",
           out_grads.size()));
 
@@ -265,20 +265,20 @@ std::vector<std::vector<pir::Value>> ArrayToTensorOp::Vjp(
   PADDLE_ENFORCE_EQ(
       inputs_.size(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Array_read op's inputs size should be 1, but now is %d.",
           inputs_.size()));
   PADDLE_ENFORCE_EQ(
       outputs.size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Array_read op's outputs size should be 2, but now is %d.",
           outputs.size()));
 
   PADDLE_ENFORCE_EQ(
       out_grads.size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Array_read op's outputs size should be 2, but now is %d.",
           out_grads.size()));
 

--- a/paddle/fluid/pir/dialect/operator/ir/op_attribute.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_attribute.cc
@@ -49,7 +49,7 @@ phi::Scalar ScalarAttribute::data() const {
   } else if (isa<pir::Complex128Attribute>()) {
     return phi::Scalar(dyn_cast<pir::Complex128Attribute>().data());
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Unsupported ir attribute when casting it into "
         "phi scalar."));
   }

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -50,7 +50,7 @@ struct CombineOpInferSymbolicShapeInterfaceModel
       for (size_t i = 0; i < op->num_operands(); ++i) {
         PADDLE_ENFORCE_NOT_NULL(
             op->operand(i).type().dyn_cast<DenseTensorType>(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Currently InferSymbolicShape of CombineOp only support "
                 "DenseTensorType."));
 
@@ -76,7 +76,7 @@ struct ConstantOpInferSymbolicShapeInterfaceModel
       pir::Operation* op, pir::InferSymbolicShapeContext* infer_context) {
     PADDLE_ENFORCE_NOT_NULL(
         op->result(0).type().dyn_cast<DenseTensorType>(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Currently InferSymbolicShape of ConstantOp only support "
             "DenseTensorType result."));
 
@@ -554,7 +554,7 @@ struct CustomOpInfoInterfaceModel : public OpYamlInfoInterface::Concept {
       auto attr_type_str = attr_name_and_type[1];
       param_names.push_back(attr_name);
       if (CppTypeToAttrTypeMap().count(attr_type_str) == 0) {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Unsupported `%s` type value as custom attribute now. "
             "Supported data types include `bool`, `int`, `float`, "
             "`int64_t`, `std::string`, `std::vector<int>`, "
@@ -647,7 +647,7 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
     PADDLE_ENFORCE_EQ(
         inputs.size(),
         fwd_inputs_name.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Custom op: %s inputs size should be %d, but now is %d.",
             pir_op_name,
             fwd_inputs_name.size(),
@@ -655,7 +655,7 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
     PADDLE_ENFORCE_EQ(
         outputs.size(),
         fwd_outputs_name.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Custom op: %s outputs size should be %d, but now is %d.",
             pir_op_name,
             fwd_outputs_name.size(),
@@ -664,7 +664,7 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
     PADDLE_ENFORCE_EQ(
         out_grads.size(),
         fwd_outputs_name.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Custom op: %s outputs grad size should be %d, but now is %d.",
             pir_op_name,
             fwd_outputs_name.size(),
@@ -713,13 +713,13 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
               std::distance(fwd_outputs_name.begin(), fwd_outputs_name_iter);
           return std::make_pair(2, index);
         } else {
-          PADDLE_THROW(phi::errors::NotFound(
+          PADDLE_THROW(common::errors::NotFound(
               "Can't find the grad op input:%s, please check your register "
               "grad op whether has correct input name",
               grad_op_input_name));
         }
       } else {
-        PADDLE_THROW(phi::errors::NotFound(
+        PADDLE_THROW(common::errors::NotFound(
             "Can't find the grad op input:%s, please check your register grad "
             "op whether has correct input name",
             grad_op_input_name));
@@ -832,7 +832,7 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
     PADDLE_ENFORCE_EQ(
         output_shapes.size(),
         all_values_num,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The number of output shapes after running custom operator's "
             "InferShapeFunc is wrong, "
             "expected contains %d Tensors' shape, but actually contains %d "
@@ -843,7 +843,7 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
     PADDLE_ENFORCE_EQ(
         output_dtypes.size(),
         all_values_num,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The number of output dtypes after running custom operator's "
             "InferDtypeFunc is wrong, "
             "expected contains %d Tensors' dtype, but actually contains %d "
@@ -956,7 +956,7 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
         PADDLE_ENFORCE_NE(
             fwd_inputs_name_iter,
             fwd_inputs_name.end(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Custom op: %s output %s is a Vec output. It should have the "
                 "forward input that need calculate gradients.",
                 pir_op_name,

--- a/paddle/fluid/pir/dialect/operator/ir/tensorrt_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/tensorrt_op.cc
@@ -98,14 +98,15 @@ OpInfoTuple TensorRTEngineOp::GetOpInfo() {
       pir::ArrayAttribute::get(pir::IrContext::Instance(), name##_tmp); \
   argument.AddAttribute(#name, attr_##name)
 
-#define VERIFY_ATTRIBUTE(type, name)                                         \
-  PADDLE_ENFORCE_GT(attributes.count(#name),                                 \
-                    0,                                                       \
-                    phi::errors::InvalidArgument(#name " does not exist.")); \
-  PADDLE_ENFORCE_EQ(attributes.at(#name).isa<type>(),                        \
-                    true,                                                    \
-                    phi::errors::InvalidArgument("Type of attribute: " #name \
-                                                 " is not " #type))
+#define VERIFY_ATTRIBUTE(type, name)                              \
+  PADDLE_ENFORCE_GT(                                              \
+      attributes.count(#name),                                    \
+      0,                                                          \
+      common::errors::InvalidArgument(#name " does not exist.")); \
+  PADDLE_ENFORCE_EQ(attributes.at(#name).isa<type>(),             \
+                    true,                                         \
+                    common::errors::InvalidArgument(              \
+                        "Type of attribute: " #name " is not " #type))
 
 void TensorRTEngineOp::Build(pir::Builder &builder,             // NOLINT
                              pir::OperationArgument &argument,  // NOLINT
@@ -212,7 +213,7 @@ void TensorRTEngineOp::VerifySig() {
                           "The size of inputs must be equal to 1."));
     PADDLE_ENFORCE_EQ((*this)->operand_source(0).type().isa<pir::VectorType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 0th input, got %s.",
                           (*this)->operand_source(0).type()));
     if (auto vec_type =
@@ -221,7 +222,7 @@ void TensorRTEngineOp::VerifySig() {
         PADDLE_ENFORCE_EQ(
             vec_type[i].isa<pir::DenseTensorType>(),
             true,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Type validation failed for the 0th input, got %s.",
                 (*this)->operand_source(0).type()));
       }
@@ -256,13 +257,13 @@ void TensorRTEngineOp::VerifySig() {
 
     PADDLE_ENFORCE_EQ(output_type.isa<pir::VectorType>(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Type validation failed for the 0th output."));
     if (auto vec_type = output_type.dyn_cast<pir::VectorType>()) {
       for (size_t i = 0; i < vec_type.size(); i++) {
         PADDLE_ENFORCE_EQ(vec_type[i].isa<pir::DenseTensorType>(),
                           true,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Type validation failed for the 0th output."));
       }
     }

--- a/paddle/fluid/pir/dialect/operator/utils/op_yaml_info_parser.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/op_yaml_info_parser.cc
@@ -25,12 +25,12 @@ OpYamlInfoParser::OpYamlInfoParser(OpInfoTuple op_info_tuple, bool is_legacy_op)
 }
 
 bool OpYamlInfoParser::IsTensorAttribute(size_t index) const {
-  PADDLE_ENFORCE_LT(
-      index,
-      InputInfo().size(),
-      phi::errors::OutOfRange("Input index [%d] large than op input size [%d]",
-                              index,
-                              InputInfo().size()));
+  PADDLE_ENFORCE_LT(index,
+                    InputInfo().size(),
+                    common::errors::OutOfRange(
+                        "Input index [%d] large than op input size [%d]",
+                        index,
+                        InputInfo().size()));
 
   return InputInfo()[index].is_mutable_attribute;
 }
@@ -46,7 +46,7 @@ const std::string& OpYamlInfoParser::AttrTypeName(
   PADDLE_ENFORCE_NE(
       it,
       attr_info_.end(),
-      phi::errors::NotFound("Not found [%s] in attribute map", name));
+      common::errors::NotFound("Not found [%s] in attribute map", name));
   return it->second.type_name;
 }
 
@@ -54,14 +54,15 @@ const std::string& OpYamlInfoParser::TensorAttrTypeName(
     const std::string& name) const {
   auto it = input_info_.find(name);
 
-  PADDLE_ENFORCE_NE(it,
-                    input_info_.end(),
-                    phi::errors::NotFound("Not found [%s] in input map", name));
+  PADDLE_ENFORCE_NE(
+      it,
+      input_info_.end(),
+      common::errors::NotFound("Not found [%s] in input map", name));
 
-  PADDLE_ENFORCE_EQ(
-      it->second.is_mutable_attribute,
-      true,
-      phi::errors::PreconditionNotMet("[%s] MUST be a tensor attribute", name));
+  PADDLE_ENFORCE_EQ(it->second.is_mutable_attribute,
+                    true,
+                    common::errors::PreconditionNotMet(
+                        "[%s] MUST be a tensor attribute", name));
   return it->second.type_name;
 }
 
@@ -97,8 +98,8 @@ const std::map<std::string, uint32_t>& OpYamlInfoParser::OutputName2Id() const {
 const std::string& OpYamlInfoParser::GetInputType(uint32_t input_id) const {
   PADDLE_ENFORCE_EQ(input_id < input_name_list_.size(),
                     true,
-                    phi::errors::NotFound("Exceeding maximum input id %d",
-                                          input_name_list_.size()));
+                    common::errors::NotFound("Exceeding maximum input id %d",
+                                             input_name_list_.size()));
   std::string input_name = input_name_list_[input_id];
   auto it = input_info_.find(input_name);
   return it->second.type_name;
@@ -107,8 +108,8 @@ const std::string& OpYamlInfoParser::GetInputType(uint32_t input_id) const {
 const std::string& OpYamlInfoParser::GetOutputType(uint32_t output_id) const {
   PADDLE_ENFORCE_EQ(output_id < output_name_list_.size(),
                     true,
-                    phi::errors::NotFound("Exceeding maximum output id %d",
-                                          output_name_list_.size()));
+                    common::errors::NotFound("Exceeding maximum output id %d",
+                                             output_name_list_.size()));
   std::string output_name = output_name_list_[output_id];
   auto it = output_info_.find(output_name);
   return it->second.type_name;
@@ -136,7 +137,7 @@ const std::string& OpYamlInfoParser::InplaceName(
       return info.second;
     }
   }
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "Can not find inplace input of [%s].", out_name));
 }
 
@@ -169,7 +170,7 @@ const std::string& OpYamlInfoParser::ViewName(
       return i.second;
     }
   }
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "Can not find inplace input of [%s].", out_name));
 }
 

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -120,7 +120,7 @@ static inline AttrType GetAttributeType(const pir::Attribute& attr) {
   } else if (attr.isa<paddle::dialect::PlaceAttribute>()) {
     return AttrType::PLACE;
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Unsupported ir Attribute type when casting it into "
         "AttrType."));
   }
@@ -227,7 +227,7 @@ static std::function<T(const pir::Attribute& attr)> GetAttrCast(
                }
                return T{vec_string};
              } else {
-               PADDLE_THROW(phi::errors::Unimplemented(
+               PADDLE_THROW(common::errors::Unimplemented(
                    "Unsupported ir Attribute type when casting it into "
                    "vector."));
              }
@@ -255,7 +255,7 @@ bool IsEmptyValue(const pir::Value& value) {
 std::vector<int64_t> GetInt64Vector(const pir::Attribute& attr) {
   PADDLE_ENFORCE_EQ(attr.isa<pir::ArrayAttribute>(),
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "attribute MUST be a pir::ArrayAttribute"));
   auto attr_vec = attr.dyn_cast<pir::ArrayAttribute>().AsVector();
 
@@ -264,7 +264,7 @@ std::vector<int64_t> GetInt64Vector(const pir::Attribute& attr) {
     PADDLE_ENFORCE_EQ(
         vec_element.isa<pir::Int64Attribute>(),
         true,
-        phi::errors::PreconditionNotMet("element MUST be a Int64Attribute"));
+        common::errors::PreconditionNotMet("element MUST be a Int64Attribute"));
     vec_int64.push_back(vec_element.dyn_cast<pir::Int64Attribute>().data());
   }
 
@@ -320,11 +320,11 @@ phi::DataType GetValueDataType(const pir::Type& type) {
       return phi::DataType::UNDEFINED;
     }
   } else {
-    PADDLE_THROW(phi::errors::InvalidType(
+    PADDLE_THROW(common::errors::InvalidType(
         "Not support op type %s in ConvertOpTypeToKernelType.", type));
     PADDLE_THROW(
-        phi::errors::InvalidType("Currently, we can only get dtype for "
-                                 "DenseTensorType and SelectedRowsType."));
+        common::errors::InvalidType("Currently, we can only get dtype for "
+                                    "DenseTensorType and SelectedRowsType."));
   }
 }
 
@@ -345,7 +345,7 @@ void DoValueCheck(const pir::Value& value,
     std::copy(expected_dtype.begin(),
               expected_dtype.end(),
               std::ostream_iterator<std::string>(joined, ", "));
-    PADDLE_THROW(phi::errors::InvalidType(
+    PADDLE_THROW(common::errors::InvalidType(
         "Check data type error for op: %s, input: %s, %s.dtype: %s, and "
         "expected_dtype: %s",
         op_name,
@@ -386,7 +386,7 @@ void CheckVectorOfValueDataType(const std::vector<pir::Value>& vector_value,
     return;
   }
   if (!IsSameDataTypeForValues(vector_value)) {
-    PADDLE_THROW(phi::errors::InvalidType(
+    PADDLE_THROW(common::errors::InvalidType(
         "All the Values in the input must have the same data type."));
   }
   std::set<std::string> expected_dtype = GetRegisterDataType(op_name);
@@ -405,7 +405,7 @@ void CheckDataType(const phi::DataType& dtype,
     std::copy(expected_dtype.begin(),
               expected_dtype.end(),
               std::ostream_iterator<std::string>(joined, ", "));
-    PADDLE_THROW(phi::errors::InvalidType(
+    PADDLE_THROW(common::errors::InvalidType(
         "Check data type error for op: %s, dtype: %s, and "
         "expected_dtype: %s",
         op_name,
@@ -488,9 +488,9 @@ std::vector<int64_t> ParseValueShape(const pir::Value& shape,
     vec_shape = std::vector<int64_t>(shape_size, -1);
     *is_from_tensor = true;
   } else {
-    PADDLE_THROW(
-        phi::errors::Unimplemented("Only support VectorType or DenseTensorType "
-                                   "or AllocatedDenseTensorType"));
+    PADDLE_THROW(common::errors::Unimplemented(
+        "Only support VectorType or DenseTensorType "
+        "or AllocatedDenseTensorType"));
   }
   return vec_shape;
 }

--- a/paddle/fluid/pir/dialect/operator/utils/utils.h
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.h
@@ -62,7 +62,7 @@ static inline phi::DataType TransToPhiDataType(pir::Type dtype) {
   } else if (dtype.isa<pir::Float8E5M2Type>()) {
     return phi::DataType::FLOAT8_E5M2;
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Unsupported ir data type when casting it into "
         "phi data type."));
   }
@@ -105,7 +105,7 @@ static inline pir::Type TransToIrDataType(phi::DataType dtype,
     case phi::DataType::FLOAT8_E5M2:
       return pir::Float8E5M2Type::get(ctx);
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported phi data type `%s` when casting it into "
           "ir data type.",
           dtype));
@@ -135,7 +135,7 @@ static inline pir::Attribute TransToIrAttribute(phi::Scalar scalar,
       return pir::Complex128Attribute::get(
           ctx, scalar.to<phi::dtype::complex<double>>());
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported phi data type `%s` when casting it into "
           "ir attribute.",
           scalar.dtype()));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/66145#issuecomment-2249572051

Replace phi::errors to common::errors in fluid/pir/dialect
