### PR TITLE
Replace phi::errors [fluid_ops] part12

### DIFF
--- a/paddle/phi/kernels/cpu/accuracy_kernel.cc
+++ b/paddle/phi/kernels/cpu/accuracy_kernel.cc
@@ -38,7 +38,7 @@ void AccuracyKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       inference.dims().size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Rank(Input) of AccuracyOp must be 2, with shape "
           "[sample_number, class_dim], But received rank(Input) is %d",
           inference.dims().size()));
@@ -49,18 +49,18 @@ void AccuracyKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_GT(label.dims().size(),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Rank(Label) of AccuracyOp must greater than 0, "
                         "But received rank(Label) is %d",
                         label.dims().size()));
 
-  PADDLE_ENFORCE_GE(
-      label.dims()[0],
-      inference.dims()[0],
-      phi::errors::InvalidArgument("num_samples(%d) of Label should less than "
-                                   "or equal to num_samples(%d) of Input",
-                                   label.dims()[0],
-                                   num_samples));
+  PADDLE_ENFORCE_GE(label.dims()[0],
+                    inference.dims()[0],
+                    common::errors::InvalidArgument(
+                        "num_samples(%d) of Label should less than "
+                        "or equal to num_samples(%d) of Input",
+                        label.dims()[0],
+                        num_samples));
 
   if (num_samples == 0) {
     return;
@@ -72,7 +72,7 @@ void AccuracyKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_GE(
         label_data[i],
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "label of AccuracyOp must >= 0, But received label[%d] is %d",
             i,
             label_data[i]));

--- a/paddle/phi/kernels/cpu/add_n_kernel.cc
+++ b/paddle/phi/kernels/cpu/add_n_kernel.cc
@@ -69,7 +69,7 @@ void AddNKernel(const Context& dev_ctx,
       auto& in_t = *(static_cast<const SelectedRows*>(x[i]));
       functor(dev_ctx, in_t, out);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Expected type of Input(X) of %d-th must be Tensor, "
           "SelectedRows. But got "
           "unsupport type: %s.",

--- a/paddle/phi/kernels/cpu/add_position_encoding_kernel.cc
+++ b/paddle/phi/kernels/cpu/add_position_encoding_kernel.cc
@@ -37,7 +37,7 @@ void AddPositionEncodingKernel(const Context& dev_ctx,
   if (x_lod.empty()) {
     PADDLE_ENFORCE_EQ(x_dim.size(),
                       3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input(X)'s dimension of AddPositionEncodingOp "
                           "should be equal to "
                           "3, but received %d. ",
@@ -48,14 +48,14 @@ void AddPositionEncodingKernel(const Context& dev_ctx,
   } else {
     PADDLE_ENFORCE_EQ(x_dim.size(),
                       2,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input(X)'s dimension of AddPositionEncodingOp "
                           "should be equal to "
                           "2, but received %d. ",
                           x_dim.size()));
     PADDLE_ENFORCE_EQ(x_lod.size(),
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The input(X)'s lod level of AddPositionEncodingOp "
                           "should be equal to "
                           "1, but received %d. ",
@@ -66,13 +66,13 @@ void AddPositionEncodingKernel(const Context& dev_ctx,
     enc_size = x_dim[1];
   }
 
-  PADDLE_ENFORCE_EQ(
-      enc_size % 2,
-      0,
-      phi::errors::InvalidArgument("The input(X)'s feature size of "
-                                   "AddPositionEncodingOp only support even, "
-                                   "but received an odd number: %d. ",
-                                   enc_size));
+  PADDLE_ENFORCE_EQ(enc_size % 2,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The input(X)'s feature size of "
+                        "AddPositionEncodingOp only support even, "
+                        "but received an odd number: %d. ",
+                        enc_size));
 
   const int half_size = enc_size / 2;
   for (int i = 0; i < batch_size; ++i) {

--- a/paddle/phi/kernels/cpu/allclose_kernel.cc
+++ b/paddle/phi/kernels/cpu/allclose_kernel.cc
@@ -36,7 +36,7 @@ void AllCloseKernel(const Context& dev_ctx,
   } else if (rtol.dtype() == DataType::FLOAT32) {
     rtol_v = rtol.to<float>();
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Input (Rtol) type must be double or float, but get %s.",
         rtol.dtype()));
   }
@@ -45,7 +45,7 @@ void AllCloseKernel(const Context& dev_ctx,
   } else if (atol.dtype() == DataType::FLOAT32) {
     atol_v = atol.to<float>();
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Input (Atol) type must be double or float, but get %s.",
         atol.dtype()));
   }

--- a/paddle/phi/kernels/cpu/amp_kernel.cc
+++ b/paddle/phi/kernels/cpu/amp_kernel.cc
@@ -46,7 +46,7 @@ class UpdateLossScalingFunctor<phi::CPUContext, T, IsFoundInfOnCPU> {
     PADDLE_ENFORCE_EQ(
         IsFoundInfOnCPU,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The Input(FoundInfinite) should be on the CPUPlace."));
     Update<T>(found_inf_data,
               pre_loss_scaling_data,

--- a/paddle/phi/kernels/cpu/arg_min_max_kernel.cc
+++ b/paddle/phi/kernels/cpu/arg_min_max_kernel.cc
@@ -135,7 +135,7 @@ struct VisitDataArgMinMaxFunctor {
         PADDLE_ENFORCE_LE(
             x_dims.size(),
             6,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "%s operator doesn't supports tensors whose ranks are greater "
                 "than 6.",
                 (EnumArgMinMaxValue == kArgMin ? "argmin" : "argmax")));
@@ -156,7 +156,7 @@ void ArgMinMaxKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_GT(
       x.numel(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "argmin/argmax input numel must > 0, bug got %d", x.numel()));
   if (dtype == DataType::UNDEFINED) {
     phi::VisitDataTypeTiny(

--- a/paddle/phi/kernels/cpu/assign_pos_kernel.cc
+++ b/paddle/phi/kernels/cpu/assign_pos_kernel.cc
@@ -24,7 +24,7 @@ void AssignPosKernel(const Context& dev_ctx,
                      const DenseTensor& cum_count,
                      const DenseTensor& eff_num_len,
                      DenseTensor* out) {
-  PADDLE_THROW(phi::errors::Unavailable(
+  PADDLE_THROW(common::errors::Unavailable(
       "Do not support assign pos op for cpu kernel now."));
 }
 

--- a/paddle/phi/kernels/cpu/attention_lstm_kernel.cc
+++ b/paddle/phi/kernels/cpu/attention_lstm_kernel.cc
@@ -106,11 +106,11 @@ void AttentionLSTMKernel(
   PADDLE_ENFORCE_EQ(
       x_lod.size(),
       1UL,
-      phi::errors::InvalidArgument("Input(X)'s lod size must be 1."));
+      common::errors::InvalidArgument("Input(X)'s lod size must be 1."));
   PADDLE_ENFORCE_EQ(
       c0->dims()[0],
       N,
-      phi::errors::InvalidArgument("C0 dims should be %d x %d.", N, D));
+      common::errors::InvalidArgument("C0 dims should be %d x %d.", N, D));
   fc_out->Resize({max_seq_len, 1});
 
   std::function<void(const int, const T*, T*)> act_gate, act_cell, act_cand;

--- a/paddle/phi/kernels/cpu/auc_kernel.cc
+++ b/paddle/phi/kernels/cpu/auc_kernel.cc
@@ -53,11 +53,11 @@ void statAuc(const DenseTensor &label,
           inference_data[i * inference_width + (inference_width - 1)];
       PADDLE_ENFORCE_LE(predict_data,
                         1,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "The predict data must less or equal 1."));
       PADDLE_ENFORCE_GE(predict_data,
                         0,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "The predict data must gather or equal 0."));
 
       uint32_t binIdx = static_cast<uint32_t>(predict_data * num_thresholds);
@@ -93,11 +93,11 @@ void statAuc(const DenseTensor &label,
         inference_data[i * inference_width + (inference_width - 1)];
     PADDLE_ENFORCE_LE(predict_data,
                       1,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The predict data must less or equal 1."));
     PADDLE_ENFORCE_GE(predict_data,
                       0,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The predict data must gather or equal 0."));
 
     uint32_t binIdx = static_cast<uint32_t>(predict_data * num_thresholds);
@@ -187,7 +187,7 @@ void AucKernel(const Context &dev_ctx,
         slide_steps);
     PADDLE_ENFORCE_LE(required_bytes,
                       max_bytes,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The number of bytes to be copied %d must be less "
                           "than or equal to the maximum number of bytes %d. ",
                           required_bytes,
@@ -206,7 +206,7 @@ void AucKernel(const Context &dev_ctx,
         slide_steps);
     PADDLE_ENFORCE_LE(required_bytes,
                       max_bytes,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The number of bytes to be copied %d must be less "
                           "than or equal to the maximum number of bytes %d. ",
                           required_bytes,

--- a/paddle/phi/kernels/cpu/batch_fc_kernel.cc
+++ b/paddle/phi/kernels/cpu/batch_fc_kernel.cc
@@ -25,7 +25,7 @@ void BatchFCKernel(const Context &dev_ctx,
   PADDLE_ENFORCE_EQ(
       dev_ctx.GetPlace().GetType() == phi::AllocationType::GPU,
       true,
-      phi::errors::Unimplemented("BatchFC only supports GPU now."));
+      common::errors::Unimplemented("BatchFC only supports GPU now."));
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/batch_norm_grad_kernel.cc
@@ -75,14 +75,14 @@ void BatchNormGradFunctor(const Context& ctx,
     if (d_x) {
       PADDLE_ENFORCE_EQ(d_x,
                         d_y,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "X@GRAD and Y@GRAD inplaced in non-inplace mode"));
     }
   } else {
     if (d_x) {
       PADDLE_ENFORCE_NE(d_x,
                         d_y,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "X@GRAD and Y@GRAD inplaced in non-inplace mode"));
     }
   }
@@ -93,14 +93,14 @@ void BatchNormGradFunctor(const Context& ctx,
   PADDLE_ENFORCE_GE(
       x_dims.size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of input X's dimensions should be larger than 1."
           "But received: the size of input X's dimensions is [%d]",
           x_dims.size()));
   PADDLE_ENFORCE_LE(
       x_dims.size(),
       5,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of input X's dimensions should be less than 6."
           "But received: the size of input X's dimensions is [%d]",
           x_dims.size()));
@@ -299,8 +299,8 @@ void BatchNormGradFunctor(const Context& ctx,
       break;
     }
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument("Unknown storage order: %s",
-                                                data_layout_str));
+      PADDLE_THROW(common::errors::InvalidArgument("Unknown storage order: %s",
+                                                   data_layout_str));
   }
 }
 
@@ -376,7 +376,7 @@ void BatchNormDoubleGradKernel(
 
   PADDLE_ENFORCE_EQ(is_test,
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "`is_test = True` CANNOT be used in train program. If "
                         "you want to use global status in pre_train model, "
                         "please set `use_global_stats = True`"));

--- a/paddle/phi/kernels/cpu/batch_norm_kernel.cc
+++ b/paddle/phi/kernels/cpu/batch_norm_kernel.cc
@@ -61,14 +61,14 @@ void BatchNormKernel(const Context& ctx,
   PADDLE_ENFORCE_GE(
       x_dims.size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of input X's dimensions should be larger than 1."
           "But received: the size of input X's dimensions is [%d]",
           x_dims.size()));
   PADDLE_ENFORCE_LE(
       x_dims.size(),
       5,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of input X's dimensions should be less than 6."
           "But received: the size of input X's dimensions is [%d]",
           x_dims.size()));
@@ -144,8 +144,8 @@ void BatchNormKernel(const Context& ctx,
         break;
       }
       default:
-        PADDLE_THROW(phi::errors::InvalidArgument("Unknown storage order: %s",
-                                                  data_layout_str));
+        PADDLE_THROW(common::errors::InvalidArgument(
+            "Unknown storage order: %s", data_layout_str));
     }
 
     // if MomentumTensor is set, use MomentumTensor value, momentum
@@ -214,8 +214,8 @@ void BatchNormKernel(const Context& ctx,
       break;
     }
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument("Unknown storage order: %d",
-                                                data_layout));
+      PADDLE_THROW(common::errors::InvalidArgument("Unknown storage order: %d",
+                                                   data_layout));
   }
 }
 

--- a/paddle/phi/kernels/cpu/bce_loss_kernel.cc
+++ b/paddle/phi/kernels/cpu/bce_loss_kernel.cc
@@ -38,12 +38,12 @@ void BCELossKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_GE(
         x_data[i],
         static_cast<T>(0),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Illegal input, input must be greater than  or equal to 0"));
     PADDLE_ENFORCE_LE(
         x_data[i],
         static_cast<T>(1),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Illegal input, input must be less than or equal to 1"));
     out_data[i] =
         (label_data[i] - static_cast<T>(1)) *

--- a/paddle/phi/kernels/cpu/bernoulli_kernel.cc
+++ b/paddle/phi/kernels/cpu/bernoulli_kernel.cc
@@ -23,14 +23,14 @@ namespace phi {
 
 template <typename T>
 inline T BernoulliFunctor(T p, T rand) {
-  PADDLE_ENFORCE_LE(
-      p,
-      1.0,
-      phi::errors::OutOfRange("The probability should be <= 1, but got %f", p));
-  PADDLE_ENFORCE_GE(
-      p,
-      0.0,
-      phi::errors::OutOfRange("The probability should be >= 0, but got %f", p));
+  PADDLE_ENFORCE_LE(p,
+                    1.0,
+                    common::errors::OutOfRange(
+                        "The probability should be <= 1, but got %f", p));
+  PADDLE_ENFORCE_GE(p,
+                    0.0,
+                    common::errors::OutOfRange(
+                        "The probability should be >= 0, but got %f", p));
   return static_cast<T>(rand < p);
 }
 

--- a/paddle/phi/kernels/cpu/bincount_kernel.cc
+++ b/paddle/phi/kernels/cpu/bincount_kernel.cc
@@ -42,7 +42,7 @@ void BincountInner(const Context& dev_ctx,
   PADDLE_ENFORCE_GE(
       *std::min_element(input_data, input_data + input_numel),
       static_cast<InputT>(0),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The elements in input tensor must be non-negative ints"));
 
   int64_t output_size = static_cast<int64_t>(*std::max_element(
@@ -92,7 +92,7 @@ void BincountKernel(const Context& dev_ctx,
   int int_minlength = minlength.to<int>();
   PADDLE_ENFORCE_GE(int_minlength,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The minlength should be greater than or equal to 0."
                         "But received minlength is %d",
                         int_minlength));

--- a/paddle/phi/kernels/cpu/bipartite_match_kernel.cc
+++ b/paddle/phi/kernels/cpu/bipartite_match_kernel.cc
@@ -32,7 +32,7 @@ void BipartiteMatch(const phi::DenseTensor& dist,
   PADDLE_ENFORCE_EQ(
       dist.dims().size(),
       2,
-      phi::errors::InvalidArgument("The rank of dist must be 2."));
+      common::errors::InvalidArgument("The rank of dist must be 2."));
   int64_t row = dist.dims()[0];
   int64_t col = dist.dims()[1];
   auto* dist_data = dist.data<T>();
@@ -97,7 +97,7 @@ void BipartiteMatch(const phi::DenseTensor& dist,
         PADDLE_ENFORCE_EQ(
             match_indices[max_idx],
             -1,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The match_indices must be initialized to -1 at [%d].",
                 max_idx));
         match_indices[max_idx] = max_row_idx;
@@ -141,7 +141,7 @@ void ArgMaxMatch(const phi::DenseTensor& dist,
       PADDLE_ENFORCE_EQ(
           match_indices[j],
           -1,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The match_indices must be initialized to -1 at [%d].", j));
       match_indices[j] = max_row_idx;
       match_dist[j] = max_dist;
@@ -169,7 +169,7 @@ void BipartiteMatchKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         dist_mat->lod().size(),
         1UL,
-        phi::errors::InvalidArgument("Only support 1 level of LoD."));
+        common::errors::InvalidArgument("Only support 1 level of LoD."));
   }
   match_indices->Resize({n, col});
   dev_ctx.template Alloc<int>(match_indices);

--- a/paddle/phi/kernels/cpu/box_coder_kernel.cc
+++ b/paddle/phi/kernels/cpu/box_coder_kernel.cc
@@ -182,7 +182,7 @@ void BoxCoderKernel(const Context &dev_ctx,
   if (!target_box.lod().empty()) {
     PADDLE_ENFORCE_EQ(target_box.lod().size(),
                       1UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input(TargetBox) of BoxCoder operator "
                           "supports LoD with only one level. But received "
                           "level = %d",
@@ -191,19 +191,19 @@ void BoxCoderKernel(const Context &dev_ctx,
   if (prior_box_var) {
     PADDLE_ENFORCE_EQ(variance.empty(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input 'PriorBoxVar' and attribute 'variance' "
                           "of BoxCoder operator should not be used at the "
                           "same time."));
   }
   if (!(variance.empty())) {
-    PADDLE_ENFORCE_EQ(
-        static_cast<int>(variance.size()),
-        4,
-        phi::errors::InvalidArgument("Size of attribute 'variance' of BoxCoder "
-                                     "operator should be 4. But received "
-                                     "size = %d",
-                                     variance.size()));
+    PADDLE_ENFORCE_EQ(static_cast<int>(variance.size()),
+                      4,
+                      common::errors::InvalidArgument(
+                          "Size of attribute 'variance' of BoxCoder "
+                          "operator should be 4. But received "
+                          "size = %d",
+                          variance.size()));
   }
 
   auto code_type = phi::funcs::GetBoxCodeType(code_type_str);

--- a/paddle/phi/kernels/cpu/broadcast_kernel.cc
+++ b/paddle/phi/kernels/cpu/broadcast_kernel.cc
@@ -28,10 +28,10 @@ void BroadcastKernel(const Context& dev_ctx,
                      const DenseTensor& x,
                      int root,
                      DenseTensor* out) {
-  PADDLE_ENFORCE_GT(
-      x.numel(),
-      0,
-      phi::errors::InvalidArgument("Tensor need be broadcast must not empty."));
+  PADDLE_ENFORCE_GT(x.numel(),
+                    0,
+                    common::errors::InvalidArgument(
+                        "Tensor need be broadcast must not empty."));
 
 #if defined(PADDLE_WITH_GLOO)
   dev_ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/cpu/c_embedding_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/c_embedding_grad_kernel.cc
@@ -83,7 +83,7 @@ void CEmbeddingGradKernel(const Context& dev_ctx,
                     width,
                     d_output_data);
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "CPU c_embedding ids only support int32 or int64."));
   }
 }

--- a/paddle/phi/kernels/cpu/c_embedding_kernel.cc
+++ b/paddle/phi/kernels/cpu/c_embedding_kernel.cc
@@ -73,7 +73,7 @@ void CEmbeddingKernel(const Context& ctx,
                     width,
                     output_data);
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "CPU c_embedding ids only support int32 or int64."));
   }
 }

--- a/paddle/phi/kernels/cpu/c_split_kernel.cc
+++ b/paddle/phi/kernels/cpu/c_split_kernel.cc
@@ -27,8 +27,8 @@ void CSplitKernel(const Context& ctx,
                   bool use_calc_stream,
                   bool use_model_parallel,
                   DenseTensor* out) {
-  PADDLE_THROW(
-      phi::errors::Unavailable("Do not support c_split for cpu kernel now."));
+  PADDLE_THROW(common::errors::Unavailable(
+      "Do not support c_split for cpu kernel now."));
 }
 }  // namespace phi
 

--- a/paddle/phi/kernels/cpu/concat_kernel.cc
+++ b/paddle/phi/kernels/cpu/concat_kernel.cc
@@ -55,7 +55,7 @@ void ConcatKernel(const Context& dev_ctx,
         PADDLE_ENFORCE_EQ(
             x[i]->lod().size(),
             lod_size_0,
-            phi::errors::Unimplemented(
+            common::errors::Unimplemented(
                 "The lod level of all input LoDTensors should be same. "
                 "Maybe different lod level of input LoDTensors can concat,"
                 "it is not supported currently. The lod level of %dth input "

--- a/paddle/phi/kernels/cpu/conv_util.h
+++ b/paddle/phi/kernels/cpu/conv_util.h
@@ -37,7 +37,7 @@ inline void UpdatePaddingAndDilation(std::vector<T>* paddings,
     PADDLE_ENFORCE_EQ(
         data_dims.size() * 2,
         paddings->size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Attribute padding's size should be the same or twice as the "
             "input's dimension. "
             "But received: padding's size is %d, padding is [%s]; input's "
@@ -84,7 +84,7 @@ inline int ConvOutSize(int input_size,
   PADDLE_ENFORCE_GT(
       output_size,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The output's size is expected to be greater than 0. "
           "But received: output's size is %d. The output's size is computed by "
           "((input_size + pad_left + pad_right - (dilation * (filter_size - "
@@ -121,7 +121,7 @@ inline std::vector<int64_t> ComputeOutputShape(
     PADDLE_ENFORCE_GT(
         dilations[i],
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The dilation of Op(Conv) should be larger than 0, but received "
             "dilation is %d.",
             dilations[i]));
@@ -130,7 +130,7 @@ inline std::vector<int64_t> ComputeOutputShape(
   PADDLE_ENFORCE_EQ(
       in_dims.size() == 4 || in_dims.size() == 5,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input of Op(Conv) should be a 4-D or 5-D Tensor. But "
           "received: input's dimension is %u, input's shape is [%s].",
           in_dims.size(),
@@ -139,7 +139,7 @@ inline std::vector<int64_t> ComputeOutputShape(
   PADDLE_ENFORCE_EQ(
       in_dims.size(),
       filter_dims.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input's dimension and filter's dimension of "
           "Op(Conv) should be equal. But received: the input's shape is "
           "[%s], "
@@ -155,7 +155,7 @@ inline std::vector<int64_t> ComputeOutputShape(
     PADDLE_ENFORCE_GT(
         strides[i],
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The stride of Op(Conv) should be larger than 0, but received "
             "stride is %d.",
             strides[i]));
@@ -164,7 +164,7 @@ inline std::vector<int64_t> ComputeOutputShape(
   PADDLE_ENFORCE_EQ(
       in_dims.size(),
       strides.size() + 2U,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The difference of input's dimension and Attr(strides)'s "
           "length must be equal to 2 for Op(Conv). "
           "But received: input's dimension is %d, input's shape is [%s]; "
@@ -183,7 +183,7 @@ inline std::vector<int64_t> ComputeOutputShape(
       input_channels,
       (channel_last ? filter_dims[filter_dims.size() - 1] : filter_dims[1]) *
           groups,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of input's channels should be equal to filter's "
           "channels "
           "* groups for Op(Conv). But received: the input's channels is %d, "
@@ -199,7 +199,7 @@ inline std::vector<int64_t> ComputeOutputShape(
   PADDLE_ENFORCE_EQ(
       filter_dims[0] % groups,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of output's channels (filter's first dimension) of "
           "Op(Conv) should be divided by groups. But received: "
           "the output channels is %d, the filter's shape is [%s], "
@@ -212,7 +212,7 @@ inline std::vector<int64_t> ComputeOutputShape(
     PADDLE_ENFORCE_GT(
         filter_dims[0],
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "the size of filter at axis 0 should be greater than 0"));
   }
 

--- a/paddle/phi/kernels/cpu/correlation_kernel.cc
+++ b/paddle/phi/kernels/cpu/correlation_kernel.cc
@@ -37,7 +37,7 @@ void CorrelationKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       is_gpu_place,
       true,
-      phi::errors::Unimplemented("Correlation only supports GPU now."));
+      common::errors::Unimplemented("Correlation only supports GPU now."));
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/crf_decoding_kernel.cc
+++ b/paddle/phi/kernels/cpu/crf_decoding_kernel.cc
@@ -119,7 +119,7 @@ void CRFDecodingOpKernel(const Context& dev_ctx,
   } else {
     PADDLE_ENFORCE_EQ(emission_weights->NumLevels(),
                       1UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The Input(Emission) should be a sequence with lod "
                           "level 1. But received: lod level %u.",
                           emission_weights->NumLevels()));
@@ -127,7 +127,7 @@ void CRFDecodingOpKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_GT(
         lod.size(),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input(Emission) must be a sequence. But received: lod level %u.",
             lod.size()));
     const size_t level = 0;
@@ -147,7 +147,7 @@ void CRFDecodingOpKernel(const Context& dev_ctx,
     if (label) {
       PADDLE_ENFORCE_EQ(label_p->NumLevels(),
                         1UL,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The Input(label) should be a sequence with lod "
                             "level 1. But received: lod level %u.",
                             label_p->NumLevels()));

--- a/paddle/phi/kernels/cpu/cross_entropy_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/cross_entropy_grad_kernel.cc
@@ -47,7 +47,7 @@ void CrossEntropyWithSoftmaxGradCPUKernel(const CPUContext& dev_ctx,
   PADDLE_ENFORCE_GT(
       axis_dim,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The axis dimension should be larger than 0, but received "
           "axis dimension is %d.",
           axis_dim));
@@ -56,7 +56,7 @@ void CrossEntropyWithSoftmaxGradCPUKernel(const CPUContext& dev_ctx,
   PADDLE_ENFORCE_GT(
       n,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of axis should be larger than 0, but received "
           "SizeToAxis of logit_grad is %d.",
           n));
@@ -185,8 +185,8 @@ void CrossEntropyWithSoftmaxGradKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         dtype,
         phi::CppTypeToDataType<T>::Type(),
-        phi::errors::InvalidArgument("The Input(Label) should be with the "
-                                     "same data type as kernel data type."));
+        common::errors::InvalidArgument("The Input(Label) should be with the "
+                                        "same data type as kernel data type."));
     CrossEntropyWithSoftmaxGradCPUKernel<T, T>(dev_ctx,
                                                label,
                                                softmax,

--- a/paddle/phi/kernels/cpu/cross_entropy_kernel.cc
+++ b/paddle/phi/kernels/cpu/cross_entropy_kernel.cc
@@ -39,7 +39,7 @@ void CrossEntropy(const CPUContext& dev_ctx,
   PADDLE_ENFORCE_GT(
       axis_dim,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The axis dimension should be larger than 0, but received "
           "axis dimension is %d.",
           axis_dim));
@@ -50,7 +50,7 @@ void CrossEntropy(const CPUContext& dev_ctx,
   PADDLE_ENFORCE_GT(
       n,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of axis should be larger than 0, but received "
           "SizeToAxis of softmax is %d.",
           n));

--- a/paddle/phi/kernels/cpu/cross_kernel.cc
+++ b/paddle/phi/kernels/cpu/cross_kernel.cc
@@ -38,7 +38,7 @@ void CrossKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         dim < input_x_dims.size() && dim >= (0 - input_x_dims.size()),
         true,
-        phi::errors::OutOfRange(
+        common::errors::OutOfRange(
             "Attr(dim) is out of range, It's expected "
             "to be in range of [-%d, %d]. But received Attr(dim) = %d.",
             input_x_dims.size(),
@@ -51,7 +51,7 @@ void CrossKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         input_x_dims[dim] == 3,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input(X/Y).dims[dim] must be equal to 3. But received: "
             "Input(X/Y).dims[dim] = [%d].",
             input_x_dims[dim]));
@@ -64,7 +64,7 @@ void CrossKernel(const Context& dev_ctx,
     }
     PADDLE_ENFORCE_EQ(dim == DDim::kMaxRank,
                       false,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "There must be at least one dimension 'd' so that "
                           "Input(X/Y).dims()[d] is equal to 3. "
                           "But received: Input(X/Y).dims() == [%s].",

--- a/paddle/phi/kernels/cpu/cudnn_lstm_kernel.cc
+++ b/paddle/phi/kernels/cpu/cudnn_lstm_kernel.cc
@@ -40,7 +40,7 @@ void CudnnLSTMKernel(
     DenseTensor* last_c,
     DenseTensor* reserve,
     DenseTensor* state_out) {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "CPU is not support for cudnn_lstm now. Will be add in the future"));
 }
 

--- a/paddle/phi/kernels/cpu/cum_kernel.cc
+++ b/paddle/phi/kernels/cpu/cum_kernel.cc
@@ -70,7 +70,7 @@ void ScanKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       axis < out_dims.size() && axis >= (0 - out_dims.size()),
       true,
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "Attr(axis) is out of range, It's expected "
           "to be in range of [-%d, %d]. But received Attr(axis) = %d.",
           out_dims.size(),

--- a/paddle/phi/kernels/cpu/cum_maxmin_kernel.cc
+++ b/paddle/phi/kernels/cpu/cum_maxmin_kernel.cc
@@ -132,7 +132,7 @@ void ScanWithIndicesKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       axis < out_dims.size() && axis >= (0 - out_dims.size()),
       true,
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "Attr(axis) is out of range, It's expected "
           "to be in range of [-%d, %d]. But received Attr(axis) = %d.",
           out_dims.size(),

--- a/paddle/phi/kernels/cpu/detection_map_kernel.cc
+++ b/paddle/phi/kernels/cpu/detection_map_kernel.cc
@@ -367,7 +367,7 @@ T CalcMAP(APType ap_type,
       mAP += average_precisions;
       ++count;
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unkown ap version %s. Now only supports integral and l1point.",
           ap_type));
     }
@@ -407,7 +407,7 @@ void GetBoxes(const phi::DenseTensor& input_label,
         PADDLE_ENFORCE_EQ(
             input_label.dims()[1],
             5,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The input label width"
                 " must be 5, but received %d, please check your input data",
                 input_label.dims()[1]));
@@ -465,12 +465,12 @@ void DetectionMAPOpKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       label_lod.size(),
       1UL,
-      phi::errors::InvalidArgument("Only support LodTensor of lod_level "
-                                   "with 1 in label, but received %d.",
-                                   label_lod.size()));
+      common::errors::InvalidArgument("Only support LodTensor of lod_level "
+                                      "with 1 in label, but received %d.",
+                                      label_lod.size()));
   PADDLE_ENFORCE_EQ(label_lod[0].size(),
                     detect_lod[0].size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The batch_size of input(Label) and input(Detection) "
                         "must be the same, but received %d:%d",
                         label_lod[0].size(),

--- a/paddle/phi/kernels/cpu/dpsgd_kernel.cc
+++ b/paddle/phi/kernels/cpu/dpsgd_kernel.cc
@@ -40,12 +40,12 @@ void DpsgdOpKernel(const Context &dev_ctx,
   auto sz = param_out->numel();
   PADDLE_ENFORCE_EQ(param->numel(),
                     sz,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input parameter's number of elements is error, "
                         "expected %zu, but received %zu."));
   PADDLE_ENFORCE_EQ(grad->numel(),
                     sz,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input gradient's number of elements is error, "
                         "expected %zu, but received %zu."));
 

--- a/paddle/phi/kernels/cpu/elementwise.h
+++ b/paddle/phi/kernels/cpu/elementwise.h
@@ -126,7 +126,7 @@ struct SameDimsDivideFunctor<
                   const DenseTensor& x UNUSED,
                   const DenseTensor& y UNUSED,
                   DenseTensor* z UNUSED) {
-    phi::errors::InvalidArgument(
+    common::errors::InvalidArgument(
         "If use SameDimsDivideFunctor, template args(T) must be floating "
         "point. ");
   }

--- a/paddle/phi/kernels/cpu/embedding_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/embedding_grad_kernel.cc
@@ -66,7 +66,7 @@ struct EmbeddingGradCPUFunctor {
           PADDLE_ENFORCE_LT(
               ids_data[i],
               N,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "Variable value (input) of "
                   "OP(paddle.nn.functional.embedding) "
                   "expected >= 0 and < %ld, but got %ld. Please check input "
@@ -76,7 +76,7 @@ struct EmbeddingGradCPUFunctor {
           PADDLE_ENFORCE_GE(
               ids_data[i],
               0,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "Variable value (input) of "
                   "OP(paddle.nn.functional.embedding) "
                   "expected >= 0 and < %ld, but got %ld. Please check input "
@@ -114,7 +114,7 @@ void EmbeddingGradKernel(const Context& ctx,
   } else if (input.dtype() == phi::DataType::INT64) {
     functor.template apply<int64_t>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "embedding input only support int32 and int64"));
   }
 }
@@ -162,7 +162,7 @@ struct EmbeddingSparseGradCPUFunctor {
         flatten_to_2d(d_output_dims, d_output_dims.size() - 1);
     PADDLE_ENFORCE_EQ(d_table_value->dims(),
                       d_output_dims_2d,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "ShapeError: The shape of lookup_table@Grad and "
                           "output@Grad should be same. "
                           "But received lookup_table@Grad's shape = [%s], "
@@ -195,7 +195,7 @@ void EmbeddingSparseGradKernel(const Context& ctx,
   } else if (input.dtype() == phi::DataType::INT64) {
     functor.template apply<int64_t>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "embedding input only support int32 and int64"));
   }
 }

--- a/paddle/phi/kernels/cpu/embedding_kernel.cc
+++ b/paddle/phi/kernels/cpu/embedding_kernel.cc
@@ -54,7 +54,7 @@ struct EmbeddingCPUFunctor {
         PADDLE_ENFORCE_LT(
             ids[i],
             row_number,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Variable value (input) of OP(fluid.layers.embedding) "
                 "expected >= 0 and < %ld, but got %ld. Please check input "
                 "value.",
@@ -63,7 +63,7 @@ struct EmbeddingCPUFunctor {
         PADDLE_ENFORCE_GE(
             ids[i],
             0,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Variable value (input) of OP(fluid.layers.embedding) "
                 "expected >= 0 and < %ld, but got %ld. Please check input "
                 "value.",
@@ -108,7 +108,7 @@ void EmbeddingKernel(const Context& ctx,
   } else if (input.dtype() == phi::DataType::INT64) {
     functor.template apply<int64_t>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "emebdding input only support int32 and int64, but get %s",
         input.dtype()));
   }

--- a/paddle/phi/kernels/cpu/full_kernel.cc
+++ b/paddle/phi/kernels/cpu/full_kernel.cc
@@ -72,7 +72,7 @@ void FullLikeKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         is_out_range,
         false,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The filled value is out of range for target type, "
             "current kernel type is %s, the range should between %f "
             "and %f, but now value is %f.",

--- a/paddle/phi/kernels/cpu/fusion_seqpool_concat_kernel.cc
+++ b/paddle/phi/kernels/cpu/fusion_seqpool_concat_kernel.cc
@@ -43,7 +43,7 @@ void FusionSeqPoolConcatKernel(const Context& dev_ctx,
   int w = static_cast<int>(ins[0]->numel() / x0_dims[0]);
   PADDLE_ENFORCE_EQ(y_dims[1] % w,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The output of dims[1] should be dividable of w, but "
                         "dims[1] is %d, w is %d.",
                         y_dims[1],
@@ -67,7 +67,7 @@ void FusionSeqPoolConcatKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         static_cast<int>(ins[i]->numel() / x_dims[0]),
         w,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Width of all inputs should be equal, but the width of the %d-th "
             "input %d is not equal to the previous %d",
             i,
@@ -76,7 +76,7 @@ void FusionSeqPoolConcatKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         x_lod.size(),
         bs + 1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Batchsize of all inputs should be equal, but the value of the "
             "%d-th %d is not equal to the previous %d.",
             i,

--- a/paddle/phi/kernels/cpu/gather_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/gather_grad_kernel.cc
@@ -55,7 +55,7 @@ void GatherGradKernel(const Context& dev_ctx,
   } else if (index_type == phi::DataType::INT64) {
     phi::funcs::ScatterAssignAdd<T, int64_t>(dev_ctx, out_grad, index, x_grad);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The data type of Input(Index) of gather_grad must be int32 or int64 "
         "on CPU."));
   }

--- a/paddle/phi/kernels/cpu/gather_kernel.cc
+++ b/paddle/phi/kernels/cpu/gather_kernel.cc
@@ -50,9 +50,9 @@ void GatherKernel(const Context& dev_ctx,
   } else if (index_type == phi::DataType::INT64) {
     phi::funcs::CPUGather<T, int64_t>(dev_ctx, x, index, out);
   } else {
-    PADDLE_THROW(
-        phi::errors::InvalidArgument("The data type of Input(Index) of gather "
-                                     "must be int32 or int64 on CPU."));
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "The data type of Input(Index) of gather "
+        "must be int32 or int64 on CPU."));
   }
 }
 

--- a/paddle/phi/kernels/cpu/gather_nd_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/gather_nd_grad_kernel.cc
@@ -36,14 +36,14 @@ void GatherNdGradKernel(const Context &ctx,
   auto index_type = index.dtype();
   bool index_type_match =
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
-  PADDLE_ENFORCE_EQ(
-      index_type_match,
-      true,
-      phi::errors::InvalidArgument("Index holds the wrong type, it holds [%s],"
-                                   "but desires to be [%s] or [%s]",
-                                   index_type,
-                                   phi::DataType::INT32,
-                                   phi::DataType::INT64));
+  PADDLE_ENFORCE_EQ(index_type_match,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Index holds the wrong type, it holds [%s],"
+                        "but desires to be [%s] or [%s]",
+                        index_type,
+                        phi::DataType::INT32,
+                        phi::DataType::INT64));
 
   if (index_type == phi::DataType::INT32) {
     phi::funcs::ScatterNdAdd<T, int32_t>(ctx, out_grad, index, x_grad);

--- a/paddle/phi/kernels/cpu/gather_nd_kernel.cc
+++ b/paddle/phi/kernels/cpu/gather_nd_kernel.cc
@@ -31,14 +31,14 @@ void GatherNdKernel(const Context &ctx,
   auto index_type = index.dtype();
   bool index_type_match =
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
-  PADDLE_ENFORCE_EQ(
-      index_type_match,
-      true,
-      phi::errors::InvalidArgument("Index holds the wrong type, it holds [%s],"
-                                   "but desires to be [%s] or [%s]",
-                                   index_type,
-                                   phi::DataType::INT32,
-                                   phi::DataType::INT64));
+  PADDLE_ENFORCE_EQ(index_type_match,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Index holds the wrong type, it holds [%s],"
+                        "but desires to be [%s] or [%s]",
+                        index_type,
+                        phi::DataType::INT32,
+                        phi::DataType::INT64));
   if (index_type == phi::DataType::INT32) {
     phi::funcs::CPUGatherNd<T, int>(ctx, x, index, out);
   } else if (index_type == phi::DataType::INT64) {

--- a/paddle/phi/kernels/cpu/gather_tree_kernel.cc
+++ b/paddle/phi/kernels/cpu/gather_tree_kernel.cc
@@ -35,12 +35,12 @@ void GatherTreeKernel(const Context &dev_ctx,
   auto beam_size = ids_dims[2];
 
   PADDLE_ENFORCE_NOT_NULL(ids_data,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Input(Ids) of gather_tree should not be null."));
 
   PADDLE_ENFORCE_NOT_NULL(
       parents_data,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input(Parents) of gather_tree should not be null."));
 
   for (int batch = 0; batch < batch_size; batch++) {
@@ -53,7 +53,7 @@ void GatherTreeKernel(const Context &dev_ctx,
         PADDLE_ENFORCE_LT(
             parent,
             beam_size,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The parents must be less than beam size, but received "
                 "parents %d is greater than or equal to beam size %d. ",
                 parent,
@@ -62,7 +62,7 @@ void GatherTreeKernel(const Context &dev_ctx,
         PADDLE_ENFORCE_GE(
             parent,
             0,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The parents must be greater than or equal to 0, but received "
                 "parents %d is less than 0. ",
                 parent));

--- a/paddle/phi/kernels/cpu/graph_khop_sampler_kernel.cc
+++ b/paddle/phi/kernels/cpu/graph_khop_sampler_kernel.cc
@@ -111,9 +111,9 @@ void SampleNeighbors(const T* src,
     PADDLE_ENFORCE_GT(
         total_neighbors,
         0,
-        phi::errors::InvalidArgument("The input nodes `X` should have at "
-                                     "least one neighbors, but none of the "
-                                     "input nodes have neighbors."));
+        common::errors::InvalidArgument("The input nodes `X` should have at "
+                                        "least one neighbors, but none of the "
+                                        "input nodes have neighbors."));
   }
   output_counts->resize(bs);
   outputs->resize(total_neighbors);
@@ -213,18 +213,18 @@ void GraphKhopSamplerKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_NE(
         row_dims[i],
         0,
-        phi::errors::InvalidArgument("The size of Row(X) should not be 0."));
+        common::errors::InvalidArgument("The size of Row(X) should not be 0."));
   }
   for (int i = 0; i < col_dims_lens; i++) {
     PADDLE_ENFORCE_NE(col_dims[i],
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The size of Col_Ptr(X) should not be 0."));
   }
   for (int i = 0; i < x_dims_lens; i++) {
     PADDLE_ENFORCE_NE(x_dims[i],
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The size of Input_Node(X) should not be 0."));
   }
 
@@ -370,7 +370,7 @@ void GraphKhopSamplerKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       src_merge.size(),
       num_sample_edges,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Number of sample edges dismatch, the sample kernel has error."));
 
   // 6. Reindex edges.

--- a/paddle/phi/kernels/cpu/gru_kernel.cc
+++ b/paddle/phi/kernels/cpu/gru_kernel.cc
@@ -110,8 +110,9 @@ void GRUCPUKernel(const Context &dev_ctx,
                                      frame_size /*height of height*/);
     PADDLE_ENFORCE_NOT_NULL(
         packed_gate,
-        phi::errors::NotFound("The calculation result of packed_gate by "
-                              "GEMM_ALLOC should not be null when using MKL."));
+        common::errors::NotFound(
+            "The calculation result of packed_gate by "
+            "GEMM_ALLOC should not be null when using MKL."));
     blas.GEMM_PACK(CblasBMatrix,
                    CblasNoTrans,
                    1 /*cur bs?*/,
@@ -127,8 +128,9 @@ void GRUCPUKernel(const Context &dev_ctx,
                                       frame_size /*height of height*/);
     PADDLE_ENFORCE_NOT_NULL(
         packed_state,
-        phi::errors::NotFound("The calculation result of packed_state by "
-                              "GEMM_ALLOC should not be null when using MKL."));
+        common::errors::NotFound(
+            "The calculation result of packed_state by "
+            "GEMM_ALLOC should not be null when using MKL."));
     blas.GEMM_PACK(CblasBMatrix,
                    CblasNoTrans,
                    1 /*cur bs?*/,

--- a/paddle/phi/kernels/cpu/histogram_kernel.cc
+++ b/paddle/phi/kernels/cpu/histogram_kernel.cc
@@ -57,7 +57,7 @@ void HistogramKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_LT(
       range,
       static_cast<double>(std::numeric_limits<T>::max()),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The range of max - min is out of range for target type, "
           "current kernel type is %s, the range should less than %f "
           "but now min is %f, max is %f.",
@@ -66,16 +66,17 @@ void HistogramKernel(const Context& dev_ctx,
           output_min,
           output_max));
 
-  PADDLE_ENFORCE_EQ((std::isinf(static_cast<float>(output_min)) ||
-                     std::isnan(static_cast<float>(output_max)) ||
-                     std::isinf(static_cast<float>(output_min)) ||
-                     std::isnan(static_cast<float>(output_max))),
-                    false,
-                    phi::errors::OutOfRange("range of min, max is not finite"));
+  PADDLE_ENFORCE_EQ(
+      (std::isinf(static_cast<float>(output_min)) ||
+       std::isnan(static_cast<float>(output_max)) ||
+       std::isinf(static_cast<float>(output_min)) ||
+       std::isnan(static_cast<float>(output_max))),
+      false,
+      common::errors::OutOfRange("range of min, max is not finite"));
   PADDLE_ENFORCE_GE(
       output_max,
       output_min,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "max must be larger or equal to min. If min and max are both zero, "
           "the minimum and maximum values of the data are used. "
           "But received max is %d, min is %d",

--- a/paddle/phi/kernels/cpu/identity_loss_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/identity_loss_grad_kernel.cc
@@ -44,7 +44,7 @@ void IdentityLossGradKernel(const Context& dev_ctx,
       break;
     default:
       // error
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "reduction should be 0, 1 and 2. But get %d", reduction));
   }
 }

--- a/paddle/phi/kernels/cpu/identity_loss_kernel.cc
+++ b/paddle/phi/kernels/cpu/identity_loss_kernel.cc
@@ -43,7 +43,7 @@ void IdentityLossKernel(const Context& dev_ctx,
       break;
     default:
       // error
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "reduction should be 0, 1 and 2. But get %d", reduction));
   }
 }

--- a/paddle/phi/kernels/cpu/index_add_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_add_grad_kernel.cc
@@ -37,7 +37,7 @@ void IndexAddGradKernel(const Context& ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Index) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         index_type,

--- a/paddle/phi/kernels/cpu/index_add_impl.h
+++ b/paddle/phi/kernels/cpu/index_add_impl.h
@@ -57,7 +57,7 @@ void IndexAddInner(const Context& ctx,
     PADDLE_ENFORCE_GE(
         index_data[i],
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Variable value (index) of OP(index_add) "
             "expected >= 0 and < %ld, but got %ld. Please check input "
             "value.",
@@ -66,7 +66,7 @@ void IndexAddInner(const Context& ctx,
     PADDLE_ENFORCE_LT(
         index_data[i],
         input_dim[axis],
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Variable value (index) of OP(index_add) "
             "expected >= 0 and < %ld, but got %ld. Please check input "
             "value.",

--- a/paddle/phi/kernels/cpu/index_put_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_grad_kernel.cc
@@ -185,7 +185,7 @@ void IndexPutGradKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       x.dtype(),
       value.dtype(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The data type of tensor value must be same to the data type "
           "of tensor x."));
   std::vector<DenseTensor> tmp_args;

--- a/paddle/phi/kernels/cpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_kernel.cc
@@ -108,17 +108,18 @@ void IndexPutKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       x.dtype(),
       value.dtype(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The data type of tensor value must be same to the data type "
           "of tensor x."));
-  PADDLE_ENFORCE_EQ(indices.empty(),
-                    false,
-                    phi::errors::InvalidArgument("Indices cannot be empty."));
+  PADDLE_ENFORCE_EQ(
+      indices.empty(),
+      false,
+      common::errors::InvalidArgument("Indices cannot be empty."));
 
   const size_t total_dims = x.dims().size();
   PADDLE_ENFORCE_LE(total_dims,
                     6,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Dims of input tensor should be less than 7."));
 
   std::vector<DenseTensor> tmp_args;

--- a/paddle/phi/kernels/cpu/index_select_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_select_grad_kernel.cc
@@ -36,7 +36,7 @@ void IndexSelectGradKernel(const Context& ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Index) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         index_type,

--- a/paddle/phi/kernels/cpu/index_select_impl.h
+++ b/paddle/phi/kernels/cpu/index_select_impl.h
@@ -86,7 +86,7 @@ void IndexSelectInner(const Context& ctx,
     PADDLE_ENFORCE_GE(
         index_data[i],
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Variable value (index) of OP(index_select) "
             "expected >= 0 and < %ld, but got %ld. Please check input "
             "value.",
@@ -95,7 +95,7 @@ void IndexSelectInner(const Context& ctx,
     PADDLE_ENFORCE_LT(
         index_data[i],
         input_dim[dim],
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Variable value (index) of OP(index_select) "
             "expected >= 0 and < %ld, but got %ld. Please check input "
             "value.",

--- a/paddle/phi/kernels/cpu/index_select_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_select_kernel.cc
@@ -36,7 +36,7 @@ void IndexSelectKernel(const Context& ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Index) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         index_type,

--- a/paddle/phi/kernels/cpu/kthvalue_kernel.cc
+++ b/paddle/phi/kernels/cpu/kthvalue_kernel.cc
@@ -89,7 +89,7 @@ void KthvalueKernel(const Context& dev_ctx,
   if (in_dims.size() == 0) {
     PADDLE_ENFORCE_EQ(k,
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "the k in the kthvalue must less equal than the "
                           "elemenents number of the input X, but received %d .",
                           k));

--- a/paddle/phi/kernels/cpu/l1_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/l1_norm_grad_kernel.cc
@@ -36,7 +36,7 @@ void L1NormGradKernel(const Context& dev_ctx,
                       DenseTensor* x_grad) {
   PADDLE_ENFORCE_EQ(out_grad.numel(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(GRAD@Out) of L1NormGradOp should be a scalar."));
   dev_ctx.template Alloc<T>(x_grad);
   auto x_eigen = phi::EigenVector<T>::Flatten(x);

--- a/paddle/phi/kernels/cpu/l1_norm_kernel.cc
+++ b/paddle/phi/kernels/cpu/l1_norm_kernel.cc
@@ -36,7 +36,7 @@ void L1NormGradKernel(const Context& dev_ctx,
                       DenseTensor* x_grad) {
   PADDLE_ENFORCE_EQ(out_grad.numel(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(GRAD@Out) of L1NormGradOp should be a scalar."));
   dev_ctx.template Alloc<T>(x_grad);
   auto x_eigen = phi::EigenVector<T>::Flatten(x);

--- a/paddle/phi/kernels/cpu/layer_norm_kernel.cc
+++ b/paddle/phi/kernels/cpu/layer_norm_kernel.cc
@@ -103,13 +103,13 @@ void LayerNormKernel(const Context& dev_ctx,
 #else
   PADDLE_ENFORCE_EQ(mean_tmp.numel(),
                     left,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "mean's length (%d) is not equal with expected (%d).",
                         mean_tmp.numel(),
                         left));
   PADDLE_ENFORCE_EQ(var_tmp.numel(),
                     left,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "var's length (%d) is not equal with expected (%d).",
                         var_tmp.numel(),
                         left));
@@ -117,7 +117,7 @@ void LayerNormKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         scale->numel(),
         right,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "scale's length (%d) is not equal with expected (%d).",
             scale->numel(),
             right));
@@ -125,7 +125,7 @@ void LayerNormKernel(const Context& dev_ctx,
   if (bias) {
     PADDLE_ENFORCE_EQ(bias->numel(),
                       right,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "bias's length (%d) is not equal with expected (%d).",
                           bias->numel(),
                           right));

--- a/paddle/phi/kernels/cpu/limit_by_capacity_kernel.cc
+++ b/paddle/phi/kernels/cpu/limit_by_capacity_kernel.cc
@@ -27,8 +27,8 @@ void LimitByCapacityKernel(const Context& dev_ctx,
                            const DenseTensor& capacity,
                            int n_worker,
                            DenseTensor* Out) {
-  PADDLE_THROW(
-      phi::errors::Unimplemented("limit_by_capacity is not supported on CPU."));
+  PADDLE_THROW(common::errors::Unimplemented(
+      "limit_by_capacity is not supported on CPU."));
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/linspace_kernel.cc
+++ b/paddle/phi/kernels/cpu/linspace_kernel.cc
@@ -36,9 +36,9 @@ void LinspaceKernel(const Context& ctx,
   PADDLE_ENFORCE_GT(
       num,
       0,
-      phi::errors::InvalidArgument("The num of linspace op should be larger "
-                                   "than 0, but received num is %d",
-                                   num));
+      common::errors::InvalidArgument("The num of linspace op should be larger "
+                                      "than 0, but received num is %d",
+                                      num));
 
   out->Resize(common::make_ddim({num}));
   T* out_data = ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/cpu/logspace_kernel.cc
+++ b/paddle/phi/kernels/cpu/logspace_kernel.cc
@@ -41,9 +41,9 @@ void LogspaceKernel(const Context& ctx,
   PADDLE_ENFORCE_GT(
       num,
       0,
-      phi::errors::InvalidArgument("The num of logspace op should be larger "
-                                   "than 0, but received num is %d",
-                                   num));
+      common::errors::InvalidArgument("The num of logspace op should be larger "
+                                      "than 0, but received num is %d",
+                                      num));
 
   out->Resize(common::make_ddim({num}));
   T* out_data = ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/cpu/lookup_table_dequant_kernel.cc
+++ b/paddle/phi/kernels/cpu/lookup_table_dequant_kernel.cc
@@ -65,7 +65,7 @@ void LookupTableDequantKernel(const Context &dev_ctx,
       PADDLE_ENFORCE_LT(
           ids[i],
           row_number,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Variable value (input) of OP(fluid.layers.embedding) "
               "expected >= 0 and < %ld, but got %ld. Please check input "
               "value.",
@@ -74,7 +74,7 @@ void LookupTableDequantKernel(const Context &dev_ctx,
       PADDLE_ENFORCE_GE(
           ids[i],
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Variable value (input) of OP(fluid.layers.embedding) "
               "expected >= 0 and < %ld, but got %ld. Please check input "
               "value.",

--- a/paddle/phi/kernels/cpu/lstsq_kernel.cc
+++ b/paddle/phi/kernels/cpu/lstsq_kernel.cc
@@ -272,7 +272,7 @@ void LstsqKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         info,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "For batch [%d]: Lapack info is not zero but [%d]", i, info));
 
     if (rank_working_ptr) *rank_working_ptr = static_cast<int>(rank_32);

--- a/paddle/phi/kernels/cpu/masked_select_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/masked_select_grad_kernel.cc
@@ -80,7 +80,7 @@ void MaskedSelectGradKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       index,
       out_grad_numel,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The dim size of input and x_grad in OP(masked_selected_grad) "
           "must be equal, but got mask with ones:(%ld), out_grad numel: "
           "(%ld). Please check input "

--- a/paddle/phi/kernels/cpu/masked_select_kernel.cc
+++ b/paddle/phi/kernels/cpu/masked_select_kernel.cc
@@ -49,7 +49,7 @@ void MaskedSelectKernel(const Context& dev_ctx,
   auto mask_dim = mask_expand.dims();
   PADDLE_ENFORCE_EQ(input_dim,
                     mask_dim,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dim size of input and mask in OP(masked_selected) "
                         "must be equal, but got input dim:(%ld), mask dim: "
                         "(%ld). Please check input "

--- a/paddle/phi/kernels/cpu/match_matrix_tensor_kernel.cc
+++ b/paddle/phi/kernels/cpu/match_matrix_tensor_kernel.cc
@@ -39,20 +39,20 @@ void CPUMatchMatrixTensorOPKernel(const Context& dev_ctx,
   const auto& x_lod = x->lod();
   PADDLE_ENFORCE_EQ(x_lod.empty(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Input(X) should hold LoD information, but "
                         "received Input(X).lod() is empty."));
   const auto& x_lod_0 = x_lod[0];
   PADDLE_ENFORCE_GE(x_lod_0.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dimensions of Input(X)'s LoD data should be "
                         "equal to 2, but received %d.",
                         x_lod_0.size()));
   auto x_dims = x->dims();
   PADDLE_ENFORCE_EQ(x_dims[0],
                     static_cast<int64_t>(x_lod_0.back()),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The last element of Input(X)'s LoD data should be "
                         "equal to the first dimension of Input(X). "
                         "But received the last element of Input(X)'s LoD "
@@ -62,20 +62,20 @@ void CPUMatchMatrixTensorOPKernel(const Context& dev_ctx,
   const auto& y_lod = y->lod();
   PADDLE_ENFORCE_EQ(y_lod.empty(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Input(Y) should hold LoD information, but "
                         "received Input(Y).lod() is empty."));
   const auto& y_lod_0 = y_lod[0];
   PADDLE_ENFORCE_GE(y_lod_0.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dimensions of Input(Y)'s LoD data should be "
                         "equal to 2, but received %d.",
                         y_lod_0.size()));
   auto y_dims = y->dims();
   PADDLE_ENFORCE_EQ(y_dims[0],
                     static_cast<int64_t>(y_lod_0.back()),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The last element of Input(Y)'s LoD data should be "
                         "equal to the first dimension of Input(Y). "
                         "But received the last element of Input(Y)'s LoD "
@@ -85,7 +85,7 @@ void CPUMatchMatrixTensorOPKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_EQ(x_lod_0.size(),
                     y_lod_0.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dimensions of Input(X)'s and Input(Y)'s LoD "
                         "data should be equal. "
                         "But received the dimensions of Input(X)'s LoD is "

--- a/paddle/phi/kernels/cpu/matrix_rank_tol_kernel.cc
+++ b/paddle/phi/kernels/cpu/matrix_rank_tol_kernel.cc
@@ -57,11 +57,11 @@ void LapackSVD(const T* x_data, T* eigenvalues_data, int rows, int cols) {
                            &info);
 
   if (info < 0) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "This %s-th argument has an illegal value", info));
   }
   if (info > 0) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "DBDSDC/SBDSDC did not converge, updating process failed. May be you "
         "passes a invalid matrix."));
   }

--- a/paddle/phi/kernels/cpu/mean_all_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/mean_all_grad_kernel.cc
@@ -26,7 +26,7 @@ void MeanAllGradKernel(const Context& dev_ctx,
                        DenseTensor* x_grad) {
   PADDLE_ENFORCE_EQ(out_grad.numel(),
                     1UL,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Mean Gradient should be scalar. But received "
                         "Out@Grad's elements num is %d.",
                         out_grad.numel()));

--- a/paddle/phi/kernels/cpu/nanmedian_kernel.cc
+++ b/paddle/phi/kernels/cpu/nanmedian_kernel.cc
@@ -148,12 +148,12 @@ void ProcessMedianKernel(const Context& dev_ctx,
   int64_t x_rank = x_dim.size();
   int64_t stride = x_dim[static_cast<int>(x_rank - 1)];
 
-  PADDLE_ENFORCE_NE(
-      stride,
-      0,
-      phi::errors::InvalidArgument("The input Tensor x's shape[-1] should not "
-                                   "be 0, but shape is %s now.",
-                                   x_dim));
+  PADDLE_ENFORCE_NE(stride,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The input Tensor x's shape[-1] should not "
+                        "be 0, but shape is %s now.",
+                        x_dim));
 
   int64_t pre_dim = numel / stride;
   int64_t i = 0;

--- a/paddle/phi/kernels/cpu/nll_loss_kernel.cc
+++ b/paddle/phi/kernels/cpu/nll_loss_kernel.cc
@@ -39,7 +39,7 @@ static void nll_loss_1D(T* out_data,
       }
       PADDLE_ENFORCE_EQ(cur_label >= 0 && cur_label < n_classes,
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Label value is out of range. "
                             "Expected label value in range of [0, %d), but "
                             "received value is %d.",
@@ -65,7 +65,7 @@ static void nll_loss_1D(T* out_data,
     PADDLE_ENFORCE_EQ(
         cur_label >= 0 && cur_label < n_classes,
         true,
-        phi::errors::InvalidArgument("label should not be out of bounds."));
+        common::errors::InvalidArgument("label should not be out of bounds."));
 
     const auto cur_weight =
         weight_data ? weight_data[cur_label] : static_cast<T>(1);
@@ -105,7 +105,7 @@ static void nll_loss_2D(T* out_data,
           }
           PADDLE_ENFORCE_EQ(cur_label >= 0 && cur_label < n_classes,
                             true,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "label should not be out of bounds."));
           const auto cur_weight =
               weight_data ? weight_data[cur_label] : static_cast<T>(1);
@@ -130,10 +130,10 @@ static void nll_loss_2D(T* out_data,
           out_data[index] = 0;
           continue;
         }
-        PADDLE_ENFORCE_EQ(
-            cur_label >= 0 && cur_label < n_classes,
-            true,
-            phi::errors::InvalidArgument("label should not be out of bounds."));
+        PADDLE_ENFORCE_EQ(cur_label >= 0 && cur_label < n_classes,
+                          true,
+                          common::errors::InvalidArgument(
+                              "label should not be out of bounds."));
         const auto cur_weight =
             weight_data ? weight_data[cur_label] : static_cast<T>(1);
         total_weight_val += cur_weight;

--- a/paddle/phi/kernels/cpu/nms_kernel.cc
+++ b/paddle/phi/kernels/cpu/nms_kernel.cc
@@ -73,14 +73,14 @@ void NMSKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       boxes.dims().size(),
       2,
-      phi::errors::InvalidArgument("The shape [%s] of boxes must be (N, 4).",
-                                   boxes.dims()));
+      common::errors::InvalidArgument("The shape [%s] of boxes must be (N, 4).",
+                                      boxes.dims()));
 
   PADDLE_ENFORCE_EQ(
       boxes.dims()[1],
       4,
-      phi::errors::InvalidArgument("The shape [%s] of boxes must be (N, 4).",
-                                   boxes.dims()));
+      common::errors::InvalidArgument("The shape [%s] of boxes must be (N, 4).",
+                                      boxes.dims()));
 
   int64_t num_boxes = boxes.dims()[0];
   DenseTensor output_tmp;

--- a/paddle/phi/kernels/cpu/number_count_kernel.cc
+++ b/paddle/phi/kernels/cpu/number_count_kernel.cc
@@ -23,7 +23,7 @@ void NumberCountKernel(const Context& dev_ctx,
                        const DenseTensor& numbers,
                        int upper_range,
                        DenseTensor* out) {
-  PADDLE_THROW(phi::errors::Unavailable(
+  PADDLE_THROW(common::errors::Unavailable(
       "Do not support expert count op for cpu kernel now."));
 }
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/one_hot_kernel.cc
+++ b/paddle/phi/kernels/cpu/one_hot_kernel.cc
@@ -44,14 +44,14 @@ struct OneHotV2OpFunctor {
       PADDLE_ENFORCE_GE(
           p_in_data[i],
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Illegal index value, Input(input) value should be at least 0, "
               "but received input (%d) less than 0",
               p_in_data[i]));
       PADDLE_ENFORCE_LT(
           p_in_data[i],
           depth_,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Illegal index value, Input(input) value should be less than "
               "Input(depth), "
               "but received input (%d) not less than depth (%d)",
@@ -83,14 +83,14 @@ void OneHotKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_GE(
         p_in_data[i],
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Illegal index value, Input(input) value should be at least 0, "
             "but received input (%d) less than 0",
             p_in_data[i]));
     PADDLE_ENFORCE_LT(
         p_in_data[i],
         depth_v,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Illegal index value, Input(input) value should be less than "
             "Input(depth), "
             "but received input (%d) not less than depth (%d)",

--- a/paddle/phi/kernels/cpu/prune_gate_by_capacity_kernel.cc
+++ b/paddle/phi/kernels/cpu/prune_gate_by_capacity_kernel.cc
@@ -25,7 +25,7 @@ void PruneGateByCapacityKernel(const Context& dev_ctx,
                                int64_t n_expert,
                                int64_t n_worker,
                                DenseTensor* new_gate_idx) {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "prune_gate_by_capacity is not supported on CPU."));
 }
 

--- a/paddle/phi/kernels/cpu/pyramid_hash_kernel.cc
+++ b/paddle/phi/kernels/cpu/pyramid_hash_kernel.cc
@@ -119,7 +119,7 @@ void CPUPyramidHashOPKernel(const Context& dev_ctx,
       PADDLE_ENFORCE_EQ(
           phi::math::bloomfilter_check(_filter),
           1,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "The white filter is not loaded successfully, please make sure "
               "'white_list_len': %d is valid for Input(WhiteList).",
               white_list_len));
@@ -129,7 +129,7 @@ void CPUPyramidHashOPKernel(const Context& dev_ctx,
       PADDLE_ENFORCE_EQ(
           phi::math::bloomfilter_check(_black_filter),
           1,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "The black filter is not loaded successfully, please make sure "
               "'black_list_len': %d is valid for Input(BlackList).",
               black_list_len));

--- a/paddle/phi/kernels/cpu/random_routing_kernel.cc
+++ b/paddle/phi/kernels/cpu/random_routing_kernel.cc
@@ -24,7 +24,7 @@ void RandomRoutingKernel(const Context& dev_ctx,
                          const DenseTensor& topk_value,
                          const DenseTensor& topk_idx,
                          DenseTensor* out) {
-  PADDLE_THROW(phi::errors::Unavailable(
+  PADDLE_THROW(common::errors::Unavailable(
       "Do not support expert count op for cpu kernel now."));
 }
 

--- a/paddle/phi/kernels/cpu/reduce_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_kernel.cc
@@ -32,10 +32,10 @@ void ReduceKernel(const Context& dev_ctx,
                   int root,
                   int reduce_type,
                   DenseTensor* out) {
-  PADDLE_ENFORCE_GT(
-      x.numel(),
-      0,
-      phi::errors::InvalidArgument("Tensor need be reduced must not empty."));
+  PADDLE_ENFORCE_GT(x.numel(),
+                    0,
+                    common::errors::InvalidArgument(
+                        "Tensor need be reduced must not empty."));
 #if defined(PADDLE_WITH_GLOO)
   out->Resize(x.dims());
   dev_ctx.template Alloc<T>(out);
@@ -61,10 +61,10 @@ void ReduceKernel(const phi::CustomContext& dev_ctx,
                   int root,
                   int reduce_type,
                   DenseTensor* out) {
-  PADDLE_ENFORCE_GT(
-      x.numel(),
-      0,
-      phi::errors::InvalidArgument("Tensor need be reduced must not empty."));
+  PADDLE_ENFORCE_GT(x.numel(),
+                    0,
+                    common::errors::InvalidArgument(
+                        "Tensor need be reduced must not empty."));
   out->Resize(x.dims());
   dev_ctx.template Alloc<T>(out);
 

--- a/paddle/phi/kernels/cpu/repeat_interleave_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/repeat_interleave_grad_kernel.cc
@@ -39,7 +39,7 @@ void RepeatInterleaveWithTensorIndexGradKernel(
   DenseTensor index;
   PADDLE_ENFORCE_EQ(repeats_tensor.dims()[0] == x_grad->dims()[dim],
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The length of Input(RepeatsTensor) must be the "
                         "same as length of Input(X) in axis. "
                         "But received: [%s], required: [%d].",
@@ -52,7 +52,7 @@ void RepeatInterleaveWithTensorIndexGradKernel(
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Repeats) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         DataTypeToString(index_type),

--- a/paddle/phi/kernels/cpu/rmsprop_kernel.cc
+++ b/paddle/phi/kernels/cpu/rmsprop_kernel.cc
@@ -49,16 +49,16 @@ struct RmsFunctor<T, phi::CPUContext> {
 
     PADDLE_ENFORCE_EQ(p_tensor.IsSharedBufferWith(*param_out),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Param and ParamOut must be the same Tensor"));
     PADDLE_ENFORCE_EQ(mom_tensor.IsSharedBufferWith(*moment_out),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Moment and MomentOut must be the same Tensor"));
     PADDLE_ENFORCE_EQ(
         ms_tensor.IsSharedBufferWith(*mean_square_out),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "MeanSquare and MeanSquareOut must be the same Tensor"));
 
     auto &grad_tensor = grad;
@@ -81,13 +81,13 @@ struct RmsFunctor<T, phi::CPUContext> {
         PADDLE_ENFORCE_EQ(
             mg_tensor->Holder(),
             mean_grad_out->Holder(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "MeanGrad and MeanGradOut must be the same Tensor"));
       } else {
         PADDLE_ENFORCE_EQ(
             mg_tensor,
             mean_grad_out,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "MeanGrad and MeanGradOut must be the same Tensor"));
       }
       auto mg = EigenVector<T>::Flatten(*mg_tensor);

--- a/paddle/phi/kernels/cpu/rnn_functor.h
+++ b/paddle/phi/kernels/cpu/rnn_functor.h
@@ -287,7 +287,7 @@ void RnnFunc(const Context& dev_ctx,
   const auto& init_h_dims = init_h->dims();
   PADDLE_ENFORCE_EQ(init_h_dims[0],
                     num_layers * direction_num,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The num_layers of in RNN layer must be the same as "
                         "first dim of init hidden, but received"
                         " num_layers:%d, dim:%d",
@@ -297,7 +297,7 @@ void RnnFunc(const Context& dev_ctx,
     const auto& init_c_dims = init_c->dims();  // NOLINT
     PADDLE_ENFORCE_EQ(init_c_dims[0],
                       num_layers * direction_num,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The num_layers of in RNN layer must be the same as "
                           "first dim of cell state hidden, but received"
                           " num_layers:%d, dim:%d",
@@ -345,9 +345,9 @@ void RnnFunc(const Context& dev_ctx,
   std::vector<DenseTensor> init_c_unbind, last_c_unbind;
   if (is_lstm(cell_type)) {
     PADDLE_ENFORCE_NOT_NULL(
-        init_c, phi::errors::InvalidArgument("init_c contains no data."));
+        init_c, common::errors::InvalidArgument("init_c contains no data."));
     PADDLE_ENFORCE_NOT_NULL(
-        last_c, phi::errors::InvalidArgument("last_c contains no data."));
+        last_c, common::errors::InvalidArgument("last_c contains no data."));
     init_c_unbind = Unbind(*init_c);
     last_c_unbind = Unbind(*last_c);
   }

--- a/paddle/phi/kernels/cpu/roi_pool_kernel.cc
+++ b/paddle/phi/kernels/cpu/roi_pool_kernel.cc
@@ -58,8 +58,8 @@ void RoiPoolKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         boxes_batch_size,
         batch_size,
-        phi::errors::InvalidArgument("The boxes_batch_size and imgs "
-                                     "batch_size must be the same."));
+        common::errors::InvalidArgument("The boxes_batch_size and imgs "
+                                        "batch_size must be the same."));
     auto* boxes_num_data = boxes_num->data<int>();
     int start = 0;
     for (int n = 0; n < boxes_batch_size; ++n) {
@@ -74,14 +74,14 @@ void RoiPoolKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         boxes_batch_size,
         batch_size,
-        phi::errors::InvalidArgument("The boxes_batch_size and imgs "
-                                     "batch_size must be the same."));
+        common::errors::InvalidArgument("The boxes_batch_size and imgs "
+                                        "batch_size must be the same."));
     int rois_num_with_lod = static_cast<int>(boxes_lod[boxes_batch_size]);
     PADDLE_ENFORCE_EQ(
         rois_num,
         rois_num_with_lod,
-        phi::errors::InvalidArgument("The rois_num from input "
-                                     "and lod must be the same."));
+        common::errors::InvalidArgument("The rois_num from input "
+                                        "and lod must be the same."));
     for (int n = 0; n < boxes_batch_size; ++n) {
       for (size_t i = boxes_lod[n]; i < boxes_lod[n + 1]; ++i) {
         box_batch_id_data[i] = n;

--- a/paddle/phi/kernels/cpu/roll_kernel.cc
+++ b/paddle/phi/kernels/cpu/roll_kernel.cc
@@ -46,7 +46,7 @@ void RollKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         dims[i] < input_dim.size() && dims[i] >= (0 - input_dim.size()),
         true,
-        phi::errors::OutOfRange(
+        common::errors::OutOfRange(
             "Attr(axis[%d]) is out of range, It's expected "
             "to be in range of [-%d, %d]. But received Attr(axis[%d]) = %d.",
             i,

--- a/paddle/phi/kernels/cpu/scatter_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/scatter_grad_kernel.cc
@@ -35,7 +35,7 @@ void ScatterGradKernel(const Context &ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "scatter_op index holds the wrong type, it holds [%s],"
                         "but desires to be [%s] or [%s]",
                         index_type,

--- a/paddle/phi/kernels/cpu/scatter_kernel.cc
+++ b/paddle/phi/kernels/cpu/scatter_kernel.cc
@@ -34,14 +34,14 @@ void ScatterKernel(const Context &ctx,
   const auto &index_type = index.dtype();
   bool index_type_match =
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
-  PADDLE_ENFORCE_EQ(
-      index_type_match,
-      true,
-      phi::errors::InvalidArgument("Index holds the wrong type, it holds [%s],"
-                                   "but desires to be [%s] or [%s].",
-                                   index_type,
-                                   phi::DataType::INT32,
-                                   phi::DataType::INT64));
+  PADDLE_ENFORCE_EQ(index_type_match,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Index holds the wrong type, it holds [%s],"
+                        "but desires to be [%s] or [%s].",
+                        index_type,
+                        phi::DataType::INT32,
+                        phi::DataType::INT64));
   if (overwrite) {
     if (index_type == phi::DataType::INT32) {
       phi::funcs::ScatterAssign<T, int32_t>(ctx, updates, index, out);

--- a/paddle/phi/kernels/cpu/scatter_nd_add_kernel.cc
+++ b/paddle/phi/kernels/cpu/scatter_nd_add_kernel.cc
@@ -34,7 +34,7 @@ void ScatterNdAddKernel(const Context &ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Index holds the wrong type, it holds [%s], but "
                         "desires to be [%s] or [%s].",
                         index_type,

--- a/paddle/phi/kernels/cpu/sgd_kernel.cc
+++ b/paddle/phi/kernels/cpu/sgd_kernel.cc
@@ -101,7 +101,7 @@ void sgd_dense_param_sparse_grad_impl<phi::dtype::bfloat16>(
     PADDLE_ENFORCE_LT(
         grad_rows[i],
         grad_height,
-        phi::errors::OutOfRange(
+        common::errors::OutOfRange(
             "Grad rows index value should be less than grad height."
             "Got [%s], but expected less than [%s]",
             grad_rows[i],
@@ -161,7 +161,7 @@ void SGDSparseParamSparseGradKernel(
   PADDLE_ENFORCE_EQ(
       param_row_width,
       grad_row_width,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The param_row in SgdOP should have the same size with grad_row. "
           "But received param_row's width is [%s], and grad_row's width is "
           "[%s]",
@@ -176,7 +176,7 @@ void SGDSparseParamSparseGradKernel(
     PADDLE_ENFORCE_GE(
         id_index,
         static_cast<int64_t>(0),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The id in SgdOp should be >= 0. But received id_index is [%s]",
             id_index));
     for (int64_t j = 0; j < grad_row_width; j++) {

--- a/paddle/phi/kernels/cpu/shape_broadcast_kernel.cc
+++ b/paddle/phi/kernels/cpu/shape_broadcast_kernel.cc
@@ -27,7 +27,7 @@ std::vector<T> ComputeBroadcastShape(const paddle::array_ref<T>& large_shape,
   PADDLE_ENFORCE_GE(
       large_shape.size(),
       small_shape.size(),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Size of large_shape is expected to be greater or equal size of "
           "small_shape, but got [%d] >= [%d].",
           large_shape.size(),
@@ -49,18 +49,18 @@ void ShapeBroadcastKernel(const Context& ctx,
                           const DenseTensor& x_shape,
                           const DenseTensor& y_shape,
                           DenseTensor* out) {
-  PADDLE_ENFORCE_EQ(
-      x_shape.dims().size(),
-      1,
-      phi::errors::InvalidArgument("Invalid input tensor. The rank of x_shape "
-                                   "should be equal 1, but now received [%d].",
-                                   x_shape.dims().size()));
-  PADDLE_ENFORCE_EQ(
-      y_shape.dims().size(),
-      1,
-      phi::errors::InvalidArgument("Invalid input tensor. The rank of y_shape "
-                                   "should be equal 1, but now received [%d].",
-                                   y_shape.dims().size()));
+  PADDLE_ENFORCE_EQ(x_shape.dims().size(),
+                    1,
+                    common::errors::InvalidArgument(
+                        "Invalid input tensor. The rank of x_shape "
+                        "should be equal 1, but now received [%d].",
+                        x_shape.dims().size()));
+  PADDLE_ENFORCE_EQ(y_shape.dims().size(),
+                    1,
+                    common::errors::InvalidArgument(
+                        "Invalid input tensor. The rank of y_shape "
+                        "should be equal 1, but now received [%d].",
+                        y_shape.dims().size()));
   paddle::array_ref<T> x_shape_data(x_shape.data<T>(), x_shape.numel());
   paddle::array_ref<T> y_shape_data(y_shape.data<T>(), y_shape.numel());
   const auto& output_data =

--- a/paddle/phi/kernels/cpu/sparse_weight_embedding_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/sparse_weight_embedding_grad_kernel.cc
@@ -69,7 +69,7 @@ struct SparseWeightEmbeddingGradCPUFunctor {
           PADDLE_ENFORCE_LT(
               ids_data[i],
               N,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "Variable value (input) of "
                   "OP(paddle.nn.functional.embedding) "
                   "expected >= 0 and < %ld, but got %ld. Please check input "
@@ -79,7 +79,7 @@ struct SparseWeightEmbeddingGradCPUFunctor {
           PADDLE_ENFORCE_GE(
               ids_data[i],
               0,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "Variable value (input) of "
                   "OP(paddle.nn.functional.embedding) "
                   "expected >= 0 and < %ld, but got %ld. Please check input "
@@ -146,7 +146,7 @@ struct SparseWeightEmbeddingSparseGradCPUFunctor {
         common::flatten_to_2d(d_output_dims, d_output_dims.size() - 1);
     PADDLE_ENFORCE_EQ(d_table_value->dims(),
                       d_output_dims_2d,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "ShapeError: The shape of lookup_table@Grad and "
                           "output@Grad should be same. "
                           "But received lookup_table@Grad's shape = [%s], "
@@ -180,7 +180,7 @@ void SparseWeightEmbeddingGradKernel(const Context& ctx,
   } else if (input.dtype() == phi::DataType::INT64) {
     functor.template apply<int64_t>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "emebdding input only support int32 and int64"));
   }
 }
@@ -200,7 +200,7 @@ void SparseWeightEmbeddingSparseGradKernel(const Context& ctx,
   } else if (input.dtype() == phi::DataType::INT64) {
     functor.template apply<int64_t>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "emebdding input only support int32 and int64"));
   }
 }

--- a/paddle/phi/kernels/cpu/sparse_weight_embedding_kernel.cc
+++ b/paddle/phi/kernels/cpu/sparse_weight_embedding_kernel.cc
@@ -54,7 +54,7 @@ struct EmbeddingCPUSparseFunctor {
         PADDLE_ENFORCE_GE(
             ids[i],
             0,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Variable value (input) of OP(fluid.layers.embedding) "
                 "expected >= 0. But received %ld",
                 ids[i]));
@@ -62,7 +62,7 @@ struct EmbeddingCPUSparseFunctor {
         PADDLE_ENFORCE_GE(
             id_index,
             0,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "the input key should be exists. But received %d.", id_index));
 
         if (input_data_type == phi::DataType::BFLOAT16) {
@@ -100,7 +100,7 @@ void SparseWeightEmbeddingKernel(const Context& ctx,
   } else if (input.dtype() == phi::DataType::INT64) {
     functor.template apply<int64_t>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "emebdding input only support int32 and int64"));
   }
 }

--- a/paddle/phi/kernels/cpu/stack_kernel.cc
+++ b/paddle/phi/kernels/cpu/stack_kernel.cc
@@ -31,7 +31,7 @@ void StackKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_GE(
         x_dims[i],
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The dims of Input(X) should be greater than or equal to 0"));
   }
   // zero sized tensor case

--- a/paddle/phi/kernels/cpu/strided_copy_kernel.cc
+++ b/paddle/phi/kernels/cpu/strided_copy_kernel.cc
@@ -36,14 +36,14 @@ void StridedCopyKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_EQ(input.dims(),
                     out->dims(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input shape(%s) must be equal with out shape(%s).",
                         input.dims(),
                         out->dims()));
 
   PADDLE_ENFORCE_EQ(input.numel(),
                     out->numel(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input numel(%d) must be equal with out numel(%d).",
                         input.numel(),
                         out->numel()));
@@ -59,7 +59,7 @@ void StridedCopyKernel(const Context& dev_ctx,
 
   T* output_data = out->data<T>();
   PADDLE_ENFORCE_NOT_NULL(output_data,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "StridedCopyKernel's out tensor must complete "
                               "mutable data before call kernel."));
   int output_rank = meta.dims.size();

--- a/paddle/phi/kernels/cpu/svd_kernel.cc
+++ b/paddle/phi/kernels/cpu/svd_kernel.cc
@@ -51,11 +51,11 @@ void LapackSvd(
                            iwork.data(),
                            &info);
   if (info < 0) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "This %s-th argument has an illegal value", info));
   }
   if (info > 0) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "DBDSDC/SBDSDC did not converge, updating process failed. May be you "
         "passes a invalid matrix."));
   }

--- a/paddle/phi/kernels/cpu/tdm_child_kernel.cc
+++ b/paddle/phi/kernels/cpu/tdm_child_kernel.cc
@@ -50,7 +50,7 @@ void TDMChildInner(const Context &dev_ctx,
     PADDLE_ENFORCE_LT(
         input_data[input_ids],
         node_nums,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input id of OP(paddle.incubate.layers.tdm_child) "
             "expected >= 0 and < %ld, but got %ld. Please check input "
             "value.",
@@ -59,7 +59,7 @@ void TDMChildInner(const Context &dev_ctx,
     PADDLE_ENFORCE_LE(
         0,
         input_data[input_ids],
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input id of OP(paddle.incubate.layers.tdm_child) "
             "expected >= 0 and < %ld, but got %ld. Please check input "
             "value.",
@@ -112,7 +112,7 @@ void TDMChildKernel(const Context &dev_ctx,
       input_type == DataType::INT32 || input_type == DataType::INT64;
   PADDLE_ENFORCE_EQ(input_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(X) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         DataTypeToString(input_type),
@@ -125,7 +125,7 @@ void TDMChildKernel(const Context &dev_ctx,
   PADDLE_ENFORCE_EQ(
       info_type_match,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input(TreeInfo) holds the wrong type, it holds %s, but "
           "desires to be %s or %s",
           DataTypeToString(info_type),
@@ -137,7 +137,7 @@ void TDMChildKernel(const Context &dev_ctx,
       output_type == DataType::INT32 || output_type == DataType::INT64;
   PADDLE_ENFORCE_EQ(out_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Output(Child) & Output(LeafMask) holds the wrong "
                         "type, it holds %s, but "
                         "desires to be %s or %s",

--- a/paddle/phi/kernels/cpu/tdm_sampler_kernel.cc
+++ b/paddle/phi/kernels/cpu/tdm_sampler_kernel.cc
@@ -87,7 +87,7 @@ void TDMSamplerInner(const Context &dev_ctx,
     PADDLE_ENFORCE_LT(
         -1,
         input_id,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Variable value (input) of OP(fluid.layers.tdm_sampler) "
             "expected >= 0 and < %ld, but got %ld. Please check input "
             "value.",
@@ -96,7 +96,7 @@ void TDMSamplerInner(const Context &dev_ctx,
     PADDLE_ENFORCE_LT(
         input_id,
         travel_dim[0],
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Variable value (input) of OP(fluid.layers.tdm_sampler) "
             "expected >= 0 and < %ld, but got %ld. Please check input "
             "value.",
@@ -120,7 +120,7 @@ void TDMSamplerInner(const Context &dev_ctx,
       PADDLE_ENFORCE_LE(
           sample_num,
           node_nums - 1,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Neg sample nums id of OP(fluid.layers.tdm_sampler) at layer %ld "
               "expected <= %ld - 1 (positive included), but got %ld. Please "
               "check neg_samples_num_list.",
@@ -157,7 +157,7 @@ void TDMSamplerInner(const Context &dev_ctx,
       PADDLE_ENFORCE_LE(
           positive_node_id,
           node_id_max,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Positive node id of OP(fluid.layers.tdm_sampler) at layer %ld "
               "expected >= %ld and <= %ld, but got %ld. Please check input "
               "value.",
@@ -168,7 +168,7 @@ void TDMSamplerInner(const Context &dev_ctx,
       PADDLE_ENFORCE_LE(
           node_id_min,
           positive_node_id,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Positive node id of OP(fluid.layers.tdm_sampler) at layer %ld "
               "expected >= %ld and <= %ld, but got %ld. Please check input "
               "value.",
@@ -218,7 +218,7 @@ void TDMSamplerInner(const Context &dev_ctx,
         PADDLE_ENFORCE_LE(
             layer_data[layer_offset_lod[layer_idx] + sample_res],
             node_id_max,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Negative node id of OP(fluid.layers.tdm_sampler) at layer %ld"
                 "expected >= %ld and <= %ld, but got %ld. Please check input "
                 "tdm tree structure and tdm travel info.",
@@ -263,7 +263,7 @@ void TDMSamplerKernel(const Context &dev_ctx,
       input_type == ProtoDataType::INT32 || input_type == ProtoDataType::INT64;
   PADDLE_ENFORCE_EQ(input_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(X) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         phi::DataTypeToString(x.dtype()),
@@ -275,7 +275,7 @@ void TDMSamplerKernel(const Context &dev_ctx,
                            travel_type == ProtoDataType::INT64;
   PADDLE_ENFORCE_EQ(travel_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Travel) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         phi::DataTypeToString(travel.dtype()),
@@ -287,7 +287,7 @@ void TDMSamplerKernel(const Context &dev_ctx,
       layer_type == ProtoDataType::INT32 || layer_type == ProtoDataType::INT64;
   PADDLE_ENFORCE_EQ(layer_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Layer) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         phi::DataTypeToString(layer.dtype()),
@@ -295,7 +295,7 @@ void TDMSamplerKernel(const Context &dev_ctx,
                         phi::DataTypeToString(DataType::INT64)));
   PADDLE_ENFORCE_EQ(travel_type,
                     layer_type,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Travel) must holds the same type with "
                         "Input(Layer), but Travel holds %s, and Layer holds %s",
                         phi::DataTypeToString(travel.dtype()),

--- a/paddle/phi/kernels/cpu/uniform_random_batch_size_like_kernel.cc
+++ b/paddle/phi/kernels/cpu/uniform_random_batch_size_like_kernel.cc
@@ -48,7 +48,7 @@ void CPUUniformRandomKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_GT(
         size,
         (diag_num_tmp - 1) * (diag_step_tmp + 1),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "ShapeInvalid: the diagonal's elements is equal (num-1) "
             "* (step-1) with num %d, step %d,"
             "It should be smaller than %d, but received %d",

--- a/paddle/phi/kernels/cpu/unique_consecutive_kernel.cc
+++ b/paddle/phi/kernels/cpu/unique_consecutive_kernel.cc
@@ -38,7 +38,7 @@ void UniqueConsecutiveKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_LE(
         x.numel(),
         INT_MAX,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The number of elements in Input(X) should be less than or "
             "equal to INT_MAX, but received num is %d. Please set `dtype` to "
             "int64.",

--- a/paddle/phi/kernels/cpu/unique_kernel.cc
+++ b/paddle/phi/kernels/cpu/unique_kernel.cc
@@ -67,7 +67,7 @@ void UniqueRawKernel(const Context& context,
     PADDLE_ENFORCE_LE(
         x.numel(),
         INT_MAX,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The number of elements in Input(X) should be less than or "
             "equal to INT_MAX, but received num is %d. Please set `dtype` to "
             "int64.",

--- a/paddle/phi/kernels/cpu/unpool_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/unpool_grad_kernel.cc
@@ -57,7 +57,7 @@ void UnpoolGradKernel(const Context& dev_ctx,
         PADDLE_ENFORCE_LT(
             index,
             output_feasize,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "index should less than output tensor height * output tensor "
                 "width. Expected %ld < %ld, but got "
                 "%ld >= %ld. Please check input value.",
@@ -110,7 +110,7 @@ void Unpool3dGradKernel(const Context& dev_ctx,
         PADDLE_ENFORCE_LT(
             index,
             output_feasize,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "index should less than output tensor depth * output tensor "
                 "height "
                 "* output tensor width. Expected %ld < %ld, but got "

--- a/paddle/phi/kernels/cpu/unpool_kernel.cc
+++ b/paddle/phi/kernels/cpu/unpool_kernel.cc
@@ -55,7 +55,7 @@ void UnpoolKernel(const Context& dev_ctx,
         PADDLE_ENFORCE_LT(
             index,
             output_feasize,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "index should less than output tensor height * output tensor "
                 "width. Expected %ld < %ld, but got "
                 "%ld >= %ld. Please check input value.",
@@ -106,7 +106,7 @@ void Unpool3dKernel(const Context& dev_ctx,
         PADDLE_ENFORCE_LT(
             index,
             output_feasize,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "index should less than output tensor depth * output tensor "
                 "height "
                 "* output tensor width. Expected %ld < %ld, but got "

--- a/paddle/phi/kernels/cpu/weight_quantize_kernel.cc
+++ b/paddle/phi/kernels/cpu/weight_quantize_kernel.cc
@@ -39,7 +39,7 @@ void quant_compute(const DeviceContext& dev_ctx,
       ((arch == 70) || (arch == 75) || (arch == 80) || (arch == 86) ||
        (arch == 89) || (arch == 90)),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Currently, arch only support 70, 75, 80, 86, 89, 90."));
 
 #endif
@@ -47,7 +47,7 @@ void quant_compute(const DeviceContext& dev_ctx,
   PADDLE_ENFORCE_EQ(
       x_dims.size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "the x tensor of quant op must be 2D, but got[%d]", x_dims.size()));
   size_t m = x_dims[0];
   size_t n = x_dims[1];
@@ -169,7 +169,7 @@ void WeightQuantizeKernel(const Context& dev_ctx,
     quant_compute<Context, T, int8_t, 4>(
         dev_ctx, x, out, scale, algo, arch, group_size);
   } else {
-    phi::errors::Unimplemented(
+    common::errors::Unimplemented(
         "The algo must be in ['weight_only_int8', 'weight_only_int4', "
         "'llm.int8'], but got[%s]",
         algo);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/66145#issuecomment-2249572051

Replace phi::errors to common::errors in paddle/phi