### PR TITLE
Replace phi::errors [fluid_ops] part13

### DIFF
--- a/paddle/phi/kernels/gpu/accuracy_kernel.cu
+++ b/paddle/phi/kernels/gpu/accuracy_kernel.cu
@@ -88,7 +88,7 @@ void AccuracyKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       inference.dims().size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Rank(Input) of AccuracyOp must be 2, with shape "
           "[sample_number, class_dim], But received rank(Input) is %d",
           inference.dims().size()));
@@ -104,18 +104,18 @@ void AccuracyKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_GT(label.dims().size(),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Rank(Label) of AccuracyOp must greater than 0, "
                         "But received rank(Label) is %d",
                         label.dims().size()));
 
-  PADDLE_ENFORCE_GE(
-      label.dims()[0],
-      inference.dims()[0],
-      phi::errors::InvalidArgument("num_samples(%d) of Label should less than "
-                                   "or equal to num_samples(%d) of Input",
-                                   label.dims()[0],
-                                   num_samples));
+  PADDLE_ENFORCE_GE(label.dims()[0],
+                    inference.dims()[0],
+                    common::errors::InvalidArgument(
+                        "num_samples(%d) of Label should less than "
+                        "or equal to num_samples(%d) of Input",
+                        label.dims()[0],
+                        num_samples));
 
   if (num_samples == 0) {
     return;

--- a/paddle/phi/kernels/gpu/add_n_kernel.cu
+++ b/paddle/phi/kernels/gpu/add_n_kernel.cu
@@ -84,7 +84,7 @@ void AddNKernel(const Context &dev_ctx,
     PADDLE_ENFORCE_EQ(
         x[i]->initialized(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "This argument is invalid, %d-th tensor is uninitialized.", i));
   }
 

--- a/paddle/phi/kernels/gpu/all_to_all_kernel.cu
+++ b/paddle/phi/kernels/gpu/all_to_all_kernel.cu
@@ -73,7 +73,7 @@ void AllToAllKernel(const Context& dev_ctx,
   }
   comm_ctx->GroupEnd();
 #else
-  PADDLE_THROW(phi::errors::Unavailable("NCCL version >= 2.7.3 is needed."));
+  PADDLE_THROW(common::errors::Unavailable("NCCL version >= 2.7.3 is needed."));
 #endif
 #else
   PADDLE_THROW(

--- a/paddle/phi/kernels/gpu/allclose_kernel.cu
+++ b/paddle/phi/kernels/gpu/allclose_kernel.cu
@@ -63,7 +63,7 @@ void AllCloseKernel(const Context& dev_ctx,
   } else if (rtol.dtype() == DataType::FLOAT32) {
     rtol_v = rtol.to<float>();
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Input (Rtol) type must be double or float, but get %s.",
         rtol.dtype()));
   }
@@ -72,7 +72,7 @@ void AllCloseKernel(const Context& dev_ctx,
   } else if (atol.dtype() == DataType::FLOAT32) {
     atol_v = atol.to<float>();
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Input (Atol) type must be double or float, but get %s.",
         atol.dtype()));
   }

--- a/paddle/phi/kernels/gpu/arg_min_max_kernel.cu
+++ b/paddle/phi/kernels/gpu/arg_min_max_kernel.cu
@@ -214,7 +214,7 @@ void ArgMinMaxOpCUDAKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_GT(
       x.numel(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "argmin/argmax input numel must > 0, bug got %d", x.numel()));
   if (dtype == DataType::UNDEFINED) {
     phi::VisitDataTypeTiny(

--- a/paddle/phi/kernels/gpu/batch_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/batch_norm_grad_kernel.cu
@@ -148,7 +148,7 @@ class InplaceHelper {
                   const gpuStream_t &stream) {
     PADDLE_ENFORCE_EQ(x,
                       y,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "X and Y should be inplaced in inplace mode"));
     KeBNRestoreData<<<grid2, block, 0, stream>>>(
         layout, x, scale, bias, mean, variance, epsilon, C, M, num, y);
@@ -526,7 +526,7 @@ void BatchNormGradFunctor(const Context &ctx,
   PADDLE_ENFORCE_EQ(
       x_dims.size() >= 2 && x_dims.size() <= 5,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of input's dimensions should be between 2 and 5."
           "But received: the size of input's dimensions is [%d],"
           "the dimensions of input is [%s]",
@@ -536,7 +536,7 @@ void BatchNormGradFunctor(const Context &ctx,
   PADDLE_ENFORCE_EQ((d_scale == nullptr && d_bias == nullptr) ||
                         (d_scale != nullptr && d_bias != nullptr),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Weight and bias's stop_gradient of BatchNorm must be "
                         "True or False at the same time."));
 
@@ -574,7 +574,7 @@ void BatchNormGradFunctor(const Context &ctx,
   PADDLE_ENFORCE_EQ(
       new_scale.dims().size(),
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of scale's dimensions must equal to 1. But received: "
           "the size of scale's dimensions is [%d], the dimensions of scale "
           "is [%s].",
@@ -583,7 +583,7 @@ void BatchNormGradFunctor(const Context &ctx,
   PADDLE_ENFORCE_EQ(
       new_scale.dims()[0],
       C,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The first dimension of scale must equal to Channels[%d]. But "
           "received: the first dimension of scale is [%d]",
           C,
@@ -1374,7 +1374,7 @@ void BatchNormDoubleGradKernel(
     DenseTensor *y_grad_grad) {
   PADDLE_ENFORCE_EQ(is_test,
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "`is_test = True` CANNOT be used in train program. If "
                         "you want to use global status in pre_train model, "
                         "please set `use_global_stats = True`"));

--- a/paddle/phi/kernels/gpu/batch_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/batch_norm_kernel.cu
@@ -544,7 +544,7 @@ void BatchNormKernel(const Context &ctx,
   PADDLE_ENFORCE_EQ(
       x_dims.size() >= 2 && x_dims.size() <= 5,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of input's dimensions should be between 2 and 5"
           "But received: the size of input's dimensions is [%d]",
           x_dims.size()));
@@ -707,7 +707,7 @@ void BatchNormKernel(const Context &ctx,
     PADDLE_ENFORCE_EQ(
         est_mean->dims().size(),
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size of mean's dimensions must equal to 1."
             "But received: the size of mean's dimensions mean is [%d],"
             "the dimensions of mean is [%s].",
@@ -716,7 +716,7 @@ void BatchNormKernel(const Context &ctx,
     PADDLE_ENFORCE_EQ(
         est_var->dims().size(),
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size of variance's dimensions must equal to 1."
             "But received: the size of variance's dimensions is [%d],"
             "the dimensions of variance is [%s].",
@@ -725,7 +725,7 @@ void BatchNormKernel(const Context &ctx,
     PADDLE_ENFORCE_EQ(
         est_mean->dims()[0],
         C,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The first dimension of mean must equal to the number of "
             "Channels, which is [%d]. But received: the first dimension"
             "of mean is [%d], the dimensions of mean is [%s].",
@@ -735,7 +735,7 @@ void BatchNormKernel(const Context &ctx,
     PADDLE_ENFORCE_EQ(
         est_var->dims()[0],
         C,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The first dimension of variance must equal to the number"
             "of Channels, which is [%d]. But received: the first dimension of"
             "variance is [%d], the dimensions of variance is [%s].",
@@ -1156,7 +1156,7 @@ void BatchNormKernel(const Context &ctx,
         }
         PADDLE_ENFORCE_NOT_NULL(
             reserve_space,
-            phi::errors::NotFound(
+            common::errors::NotFound(
                 "The argument ReserveSpace of batch_norm op is not found."));
         // --------------- cudnn batchnorm workspace ---------------
         PADDLE_ENFORCE_GPU_SUCCESS(

--- a/paddle/phi/kernels/gpu/bincount_kernel.cu
+++ b/paddle/phi/kernels/gpu/bincount_kernel.cu
@@ -85,7 +85,7 @@ void BincountCUDAInner(const Context& dev_ctx,
   PADDLE_ENFORCE_GE(
       input_min,
       static_cast<InputT>(0),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The elements in input tensor must be non-negative ints"));
 
   int64_t output_size =
@@ -137,7 +137,7 @@ void BincountKernel(const Context& dev_ctx,
   int int_minlength = minlength.to<int>();
   PADDLE_ENFORCE_GE(int_minlength,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The minlength should be greater than or equal to 0."
                         "But received minlength is %d",
                         int_minlength));

--- a/paddle/phi/kernels/gpu/box_coder_kernel.cu
+++ b/paddle/phi/kernels/gpu/box_coder_kernel.cu
@@ -164,7 +164,7 @@ void BoxCoderKernel(const Context &dev_ctx,
   if (prior_box_var) {
     PADDLE_ENFORCE_EQ(variance.empty(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input 'PriorBoxVar' and attribute 'variance'"
                           " of BoxCoder operator should not be used at the "
                           "same time."));
@@ -174,7 +174,7 @@ void BoxCoderKernel(const Context &dev_ctx,
   if (!(variance.empty())) {
     PADDLE_ENFORCE_EQ(static_cast<int>(variance.size()),
                       4,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Size of attribute 'variance' in BoxCoder operator"
                           " should be 4. But received size is %d",
                           variance.size()));
@@ -183,7 +183,7 @@ void BoxCoderKernel(const Context &dev_ctx,
   if (target_box.lod().size()) {
     PADDLE_ENFORCE_EQ(target_box.lod().size(),
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input 'TargetBox' of BoxCoder operator only"
                           " supports LoD with one level."));
   }

--- a/paddle/phi/kernels/gpu/broadcast_kernel.cu
+++ b/paddle/phi/kernels/gpu/broadcast_kernel.cu
@@ -28,10 +28,10 @@ void BroadcastKernel(const Context& dev_ctx,
                      const DenseTensor& x,
                      int root,
                      DenseTensor* out) {
-  PADDLE_ENFORCE_GT(
-      x.numel(),
-      0,
-      phi::errors::InvalidArgument("Tensor need be broadcast must not empty."));
+  PADDLE_ENFORCE_GT(x.numel(),
+                    0,
+                    common::errors::InvalidArgument(
+                        "Tensor need be broadcast must not empty."));
 
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
   dev_ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/gpu/c_embedding_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/c_embedding_grad_kernel.cu
@@ -134,7 +134,7 @@ void CEmbeddingGradKernel(const Context& dev_ctx,
       return;
     }
   }
-  PADDLE_THROW(phi::errors::InvalidArgument(
+  PADDLE_THROW(common::errors::InvalidArgument(
       "The data type of Input(Ids) must be int32 or int64."));
 }
 

--- a/paddle/phi/kernels/gpu/c_embedding_kernel.cu
+++ b/paddle/phi/kernels/gpu/c_embedding_kernel.cu
@@ -107,7 +107,7 @@ void CEmbeddingKernel(const Context& ctx,
                                                limit,
                                                vocab_size);
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "GPU c_embedding ids only support int32 or int64."));
   }
 }

--- a/paddle/phi/kernels/gpu/c_split_kernel.cu
+++ b/paddle/phi/kernels/gpu/c_split_kernel.cu
@@ -62,19 +62,19 @@ void CSplitKernel(const Context& ctx,
 
   PADDLE_ENFORCE_GE(rank,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The value of rank (%d) for c_split must be "
                         "greater than or equal to 0.",
                         rank));
   PADDLE_ENFORCE_GE(nranks,
                     2,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The value of nranks (%d) for c_split must be "
                         "greater than or equal to 2.",
                         nranks));
   PADDLE_ENFORCE_LT(rank,
                     nranks,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The value of rank (%d) for c_split must be "
                         "less than that of nranks (%d).",
                         rank,

--- a/paddle/phi/kernels/gpu/calc_reduced_attn_kernel.cu
+++ b/paddle/phi/kernels/gpu/calc_reduced_attn_kernel.cu
@@ -58,13 +58,13 @@ void CalcReducedAttnScoresKernel(const Context& ctx,
 #if defined(PADDLE_WITH_FLASHATTN) && !defined(PADDLE_WITH_HIP)
   PADDLE_ENFORCE_EQ(q.dims().size(),
                     4,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "calc_reduced_attention receive input with dim "
                         "[batch_size, seq_len, num_heads, head_dim]"));
 
   PADDLE_ENFORCE_EQ(k.dims().size(),
                     4,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "calc_reduced_attention receive input with dim "
                         "[batch_size, seq_len, num_heads, head_dim]"));
 

--- a/paddle/phi/kernels/gpu/check_numerics_kernel.cu
+++ b/paddle/phi/kernels/gpu/check_numerics_kernel.cu
@@ -46,7 +46,7 @@ static void InitMultiGPUOpVarMap() {
   int dev_count = phi::backends::gpu::GetGPUDeviceCount();
   PADDLE_ENFORCE_GT(dev_count,
                     0,
-                    phi::errors::NotFound(
+                    common::errors::NotFound(
                         "cuda device must > 0, now dev_count=%d", dev_count));
 
   // https://stackoverflow.com/questions/16465633/how-can-i-use-something-like-stdvectorstdmutex
@@ -279,8 +279,8 @@ inline std::string GetHintString(const std::string& op_type,
   PADDLE_ENFORCE_EQ(
       (dev_id >= 0 && dev_id < multi_op_var2gpu_str_mutex().size()),
       true,
-      phi::errors::OutOfRange("GPU dev_id must >=0 and < dev_count=%d",
-                              multi_op_var2gpu_str_mutex().size()));
+      common::errors::OutOfRange("GPU dev_id must >=0 and < dev_count=%d",
+                                 multi_op_var2gpu_str_mutex().size()));
   return op_var;
 }
 
@@ -312,7 +312,7 @@ static char* GetGpuHintStringPtr(const phi::GPUContext& ctx,
       auto iter = op_var2gpu_str.find(op_var);
       PADDLE_ENFORCE_EQ(iter != op_var2gpu_str.end(),
                         true,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "op_var=%s should successed insert into "
                             "op_var2gpu_str, but now failed",
                             op_var));
@@ -334,7 +334,7 @@ static char* GetGpuHintStringPtr(const phi::GPUContext& ctx,
       auto iter = op_var2gpu_str.find(op_var);
       PADDLE_ENFORCE_EQ(iter != op_var2gpu_str.end(),
                         true,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "op_var=%s should be in the op_var2gpu_str, but "
                             "now can't find it",
                             op_var));

--- a/paddle/phi/kernels/gpu/clip_by_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/clip_by_norm_kernel.cu
@@ -37,7 +37,7 @@ void ClipByNormKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(output);
 
   PADDLE_ENFORCE_NOT_NULL(input,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Input(X) of ClipByNormOp should not be null. "
                               "Please check if it is created correctly."));
   std::vector<int> reduce_dims;

--- a/paddle/phi/kernels/gpu/concat_kernel.cu
+++ b/paddle/phi/kernels/gpu/concat_kernel.cu
@@ -54,7 +54,7 @@ void ConcatKernel(const Context& dev_ctx,
         PADDLE_ENFORCE_EQ(
             x[i]->lod().size(),
             lod_size_0,
-            phi::errors::Unimplemented(
+            common::errors::Unimplemented(
                 "The lod level of all input LoDTensors should be same. "
                 "Maybe different lod level of input LoDTensors can concat,"
                 "it is not supported currently. The lod level of %dth input "

--- a/paddle/phi/kernels/gpu/contiguous_kernel.cu
+++ b/paddle/phi/kernels/gpu/contiguous_kernel.cu
@@ -413,7 +413,7 @@ bool LaunchContiguousCazeOneKernel(
           input_dims[rank - 1] * input_dims[rank - 2] * input_dims[rank - 3]);
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "The rank of input should be less than 9, but received %d.", rank));
   }
 
@@ -470,7 +470,7 @@ void LaunchContiguousDefaultKernel(
           input_data, input_stride, input_dims, numel, output_data);
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "The rank of input should be less than 9, but received %d.", rank));
   }
 }

--- a/paddle/phi/kernels/gpu/correlation_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/correlation_grad_kernel.cu
@@ -221,7 +221,7 @@ void CorrelationCUDAGradKernel(const Context &dev_ctx,
   PADDLE_ENFORCE_EQ(
       is_gpu_place,
       true,
-      phi::errors::InvalidArgument("Correlation only supports GPU now."));
+      common::errors::InvalidArgument("Correlation only supports GPU now."));
   const auto *grad_output = &out_grad;
 
   auto *grad_input1 = input1_grad;

--- a/paddle/phi/kernels/gpu/correlation_kernel.cu
+++ b/paddle/phi/kernels/gpu/correlation_kernel.cu
@@ -107,7 +107,7 @@ void CorrelationCUDAKernel(const Context &dev_ctx,
   PADDLE_ENFORCE_EQ(
       is_gpu_place,
       true,
-      phi::errors::InvalidArgument("Correlation only supports GPU now."));
+      common::errors::InvalidArgument("Correlation only supports GPU now."));
 
   dev_ctx.template Alloc<T>(out);
 

--- a/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
@@ -152,8 +152,8 @@ void CrossEntropyWithSoftmaxGradGPUKernel(const GPUContext& dev_ctx,
   PADDLE_ENFORCE_EQ(
       dev_ctx.GetPlace().GetType(),
       phi::AllocationType::GPU,
-      phi::errors::Unavailable("softmax_with_cross_entropy operator's "
-                               "CUDA kernel only runs on GPU device."));
+      common::errors::Unavailable("softmax_with_cross_entropy operator's "
+                                  "CUDA kernel only runs on GPU device."));
   const T* loss_grad_data = loss_grad.data<T>();
   DenseTensor* logit_grad = logits_grad;
 
@@ -246,8 +246,8 @@ void CrossEntropyWithSoftmaxGradKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         dtype,
         phi::CppTypeToDataType<T>::Type(),
-        phi::errors::InvalidArgument("The Input(Label) should be with the "
-                                     "same data type as kernel data type."));
+        common::errors::InvalidArgument("The Input(Label) should be with the "
+                                        "same data type as kernel data type."));
     CrossEntropyWithSoftmaxGradGPUKernel<T, T>(dev_ctx,
                                                label,
                                                softmax,

--- a/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
@@ -1417,8 +1417,8 @@ void CrossEntropyWithSoftmaxKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         dtype,
         phi::CppTypeToDataType<T>::Type(),
-        phi::errors::InvalidArgument("The Input(Label) should be with the "
-                                     "same data type as Input(Logits)."));
+        common::errors::InvalidArgument("The Input(Label) should be with the "
+                                        "same data type as Input(Logits)."));
     CrossEntropyWithSoftmaxCUDAKernel<T, T>(dev_ctx,
                                             logits,
                                             label,

--- a/paddle/phi/kernels/gpu/cross_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_kernel.cu
@@ -68,7 +68,7 @@ void CrossKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         dim < input_x_dims.size() && dim >= (0 - input_x_dims.size()),
         true,
-        phi::errors::OutOfRange(
+        common::errors::OutOfRange(
             "Attr(dim) is out of range, It's expected "
             "to be in range of [-%d, %d]. But received Attr(dim) = %d.",
             input_x_dims.size(),
@@ -81,7 +81,7 @@ void CrossKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         input_x_dims[dim] == 3,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input(X/Y).dims[dim] must be equal to 3. But received: "
             "Input(X/Y).dims[dim] = [%d].",
             input_x_dims[dim]));
@@ -94,7 +94,7 @@ void CrossKernel(const Context& dev_ctx,
     }
     PADDLE_ENFORCE_EQ(dim == DDim::kMaxRank,
                       false,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "There must be at least one dimension 'd' so that "
                           "Input(X/Y).dims()[d] is equal to 3. "
                           "But received: Input(X/Y).dims() == [%s].",

--- a/paddle/phi/kernels/gpu/ctc_align_kernel.cu
+++ b/paddle/phi/kernels/gpu/ctc_align_kernel.cu
@@ -89,7 +89,7 @@ void CTCAlignOpCUDAKernel(const Context& dev_ctx,
                           DenseTensor* output_length) {
   PADDLE_ENFORCE_EQ(dev_ctx.GetPlace().GetType() == phi::AllocationType::GPU,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "CTCAlign operator CUDA kernel must use CUDAPlace "
                         "rather than CPUPlace."));
   const T* tokens = input.data<T>();

--- a/paddle/phi/kernels/gpu/cudnn_lstm_cache.h
+++ b/paddle/phi/kernels/gpu/cudnn_lstm_cache.h
@@ -181,7 +181,7 @@ class ScopedRNNBase {
     PADDLE_ENFORCE_EQ(
         weights_size_,
         sizeof(T) * weight_numel_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The cudnn lstm and setting weight size should be same."));
     // ------------------- cudnn weight descriptors ---------------------
     phi::backends::gpu::DataLayout layout =

--- a/paddle/phi/kernels/gpu/cudnn_lstm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cudnn_lstm_grad_kernel.cu
@@ -336,7 +336,7 @@ void CudnnLSTMGradKernel(
         const_cast<uint8_t *>(reserve_data),
         reserve_size));
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "The padded input of rnn is supported by cudnnRNNBackwardDataEx, "
         "cudnnRNNBackwardWeightsEx, but it only works when the version "
         "of cudnn is larger than 7.2.1"));

--- a/paddle/phi/kernels/gpu/cudnn_lstm_kernel.cu
+++ b/paddle/phi/kernels/gpu/cudnn_lstm_kernel.cu
@@ -144,7 +144,7 @@ void LSTMInferece(const bool &has_seq_length,
         workspace_size));
 #else
     // CUDNN VERSION has to >=7.2.1
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "The padded input is supported by "
         "cudnnRNNForwardInferenceEx, but it only works when "
         "the version of cudnn is larger than 7.2.1"));
@@ -400,7 +400,7 @@ void CudnnLSTMKernel(
           reserve_data,
           reserve_size));
 #else
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "The padded input is supported by "
           "cudnnRNNForwardTrainingEx, but it only works when "
           "the version of cudnn is larger than 7.2.1"));

--- a/paddle/phi/kernels/gpu/cum_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_kernel.cu
@@ -300,7 +300,7 @@ void ScanKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       axis < out_dims.size() && axis >= (0 - out_dims.size()),
       true,
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "Attr(axis) is out of range, It's expected "
           "to be in range of [-%d, %d]. But received Attr(axis) = %d.",
           out_dims.size(),

--- a/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
@@ -246,7 +246,7 @@ void ScanWithIndicesKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       axis < out_dims.size() && axis >= (0 - out_dims.size()),
       true,
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "Attr(axis) is out of range, It's expected "
           "to be in range of [-%d, %d]. But received Attr(axis) = %d.",
           out_dims.size(),

--- a/paddle/phi/kernels/gpu/cvm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cvm_grad_kernel.cu
@@ -102,7 +102,7 @@ void CVMGradCUDAKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         batch_size,
         lod[lod.size() - 1],
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Output(X@GRAD)'s dim[0] must be equal to last element of lod"));
     phi::MixVector<size_t> mixv_lod(&lod);
     CvmGradComputeKernel<<<(dx_numel + PADDLE_CUDA_NUM_THREADS - 1) /

--- a/paddle/phi/kernels/gpu/cvm_kernel.cu
+++ b/paddle/phi/kernels/gpu/cvm_kernel.cu
@@ -73,7 +73,7 @@ void CVMCUDAKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         batch_size,
         lod[lod.size() - 1],
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Input(X)'s dim[0] must be equal to last element of lod"));
     CvmComputeKernel<<<(numel + PADDLE_CUDA_NUM_THREADS - 1) /
                            PADDLE_CUDA_NUM_THREADS,

--- a/paddle/phi/kernels/gpu/depthwise_conv_kernel.cu
+++ b/paddle/phi/kernels/gpu/depthwise_conv_kernel.cu
@@ -54,7 +54,7 @@ void DepthwiseConvKernel(const Context& dev_ctx,
         output->dims()[output->dims().size() - 1] %
             input.dims()[input.dims().size() - 1],
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "ShapeError: The output channels must be a multiple of the "
             "input channels. But receivced output channel number is %d "
             "and input channel number is %d",
@@ -64,7 +64,7 @@ void DepthwiseConvKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         output->dims()[1] % input.dims()[1],
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "ShapeError: The output channels must be a multiple of the "
             "input channels. But receivced output channel number is %d "
             "and input channel number is %d",

--- a/paddle/phi/kernels/gpu/dgc_kernel.cu
+++ b/paddle/phi/kernels/gpu/dgc_kernel.cu
@@ -34,9 +34,9 @@ inline float get_period_sparcity(const std::vector<float>& sparsity,
   PADDLE_ENFORCE_GE(
       static_cast<int>(cur_step),
       0,
-      phi::errors::InvalidArgument("DGC current step=%d, but it must >= 0, "
-                                   "please submit issue in github",
-                                   static_cast<int>(cur_step)));
+      common::errors::InvalidArgument("DGC current step=%d, but it must >= 0, "
+                                      "please submit issue in github",
+                                      static_cast<int>(cur_step)));
 
   size_t idx = static_cast<int>(cur_step * sparsity.size() / rampup_steps);
   if (idx >= sparsity.size()) {
@@ -46,7 +46,7 @@ inline float get_period_sparcity(const std::vector<float>& sparsity,
   PADDLE_ENFORCE_LT(
       idx,
       sparsity.size(),
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "sparsity index out of bounds. idx=%d >= sparsity.size=%d",
           idx,
           sparsity.size()));
@@ -78,7 +78,7 @@ void DGCKernel(const Context& dev_ctx,
   const int nranks = static_cast<int>(*nranks_tensor.data<float>());
   PADDLE_ENFORCE_GT(nranks,
                     1,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "DGC is not useful when num_trainers <= 1. Please "
                         "use multi card or multi machine GPU"));
 
@@ -96,7 +96,7 @@ void DGCKernel(const Context& dev_ctx,
   // accuracy of coeff/nranks will be too low.
   PADDLE_ENFORCE_EQ(regular_type >= 0 && regular_type <= 2,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "DGC only support one of None|L1Decay|L2Decay "
                         "Regularization for now."));
   if (regular_type == 0) {
@@ -126,9 +126,13 @@ void DGCKernel(const Context& dev_ctx,
                         static_cast<float>(*current_step - rampup_begin_step),
                         rampup_step);
   PADDLE_ENFORCE_GE(
-      ratio, 0.0, phi::errors::InvalidArgument("DGC sparsity ratio must >= 0"));
+      ratio,
+      0.0,
+      common::errors::InvalidArgument("DGC sparsity ratio must >= 0"));
   PADDLE_ENFORCE_LT(
-      ratio, 1.0, phi::errors::InvalidArgument("DGC sparsity ratio must < 1"));
+      ratio,
+      1.0,
+      common::errors::InvalidArgument("DGC sparsity ratio must < 1"));
   int k = static_cast<int>(grad.numel() * ratio);
 
   VLOG(10) << "m:" << m << ", use_nesterov:" << use_nesterov
@@ -206,7 +210,7 @@ void DGCKernel(const Context& dev_ctx,
           dev_ctx.stream(),
           u_out_data)) {
     // TODO(weihang): owner should polish this error message
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "V_out numel error, V_out numel is %d.", v_out->numel()));
   }
 

--- a/paddle/phi/kernels/gpu/embedding_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/embedding_grad_kernel.cu
@@ -148,7 +148,7 @@ void EmbeddingGradKernel(const Context& ctx,
   } else if (input.dtype() == phi::DataType::INT16) {
     functor.template apply<int16_t>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "emebdding input only support int16, int32 and int64"));
   }
 }
@@ -212,7 +212,7 @@ struct EmbeddingSparseGradCUDAFunctor {
         common::flatten_to_2d(d_output_dims, d_output_dims.size() - 1);
     PADDLE_ENFORCE_EQ(d_table_value->dims(),
                       d_output_dims_2d,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "ShapeError: The shape of lookup_table@Grad and "
                           "output@Grad should be same. "
                           "But received lookup_table@Grad's shape = [%s], "
@@ -252,7 +252,7 @@ void EmbeddingSparseGradKernel(const Context& ctx,
     functor.template apply<int64_t>();
   } else if (input.dtype() == phi::DataType::INT16) {
     functor.template apply<int16_t>();
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "emebdding input only support int16, int32 and int64"));
   }
 }

--- a/paddle/phi/kernels/gpu/embedding_kernel.cu
+++ b/paddle/phi/kernels/gpu/embedding_kernel.cu
@@ -121,7 +121,7 @@ void EmbeddingKernel(const Context &ctx,
   } else if (input.dtype() == phi::DataType::INT16) {
     functor.template apply<int16_t>();
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "emebdding input only support int16, int32 and int64"));
   }
 }

--- a/paddle/phi/kernels/gpu/expand_kernel.cu
+++ b/paddle/phi/kernels/gpu/expand_kernel.cu
@@ -35,12 +35,12 @@ void ExpandKernel(const Context& ctx,
     PADDLE_ENFORCE_NE(
         expand_shape[i],
         0,
-        phi::errors::InvalidArgument("The expanded size cannot be zero."));
+        common::errors::InvalidArgument("The expanded size cannot be zero."));
     if (i < diff) {
       PADDLE_ENFORCE_GT(
           expand_shape[i],
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The expanded size (%d) for non-existing dimensions must be "
               "positive for expand kernel.",
               expand_shape[i]));
@@ -50,7 +50,7 @@ void ExpandKernel(const Context& ctx,
         PADDLE_ENFORCE_EQ(
             out_shape[i],
             expand_shape[i],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The value (%d) of the non-singleton dimension does not match"
                 " the corresponding value (%d) in shape for expand kernel.",
                 out_shape[i],
@@ -62,7 +62,7 @@ void ExpandKernel(const Context& ctx,
       PADDLE_ENFORCE_EQ(
           expand_shape[i],
           -1,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "When the value in shape is negative for expand_v2 op, "
               "only -1 is supported, but the value received is %d.",
               expand_shape[i]));

--- a/paddle/phi/kernels/gpu/flash_attn_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_grad_kernel.cu
@@ -109,14 +109,14 @@ template <typename T>
 static auto selectSumkernel(int64_t headdim) {
   PADDLE_ENFORCE_LE(headdim,
                     256,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "FlashAttention only support headdim <= 256"));
   PADDLE_ENFORCE_EQ(headdim % 32,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "FlashAttention only support headdim %% 32 == 0"));
   PADDLE_ENFORCE_NE(
-      headdim, 0, phi::errors::InvalidArgument("Headdim can't be zero"));
+      headdim, 0, common::errors::InvalidArgument("Headdim can't be zero"));
 #define CASEN(n) \
   case n:        \
     return SumStridedKV<T, n>;
@@ -141,11 +141,11 @@ static void kvReduceForGQA(const Context& ctx,
   PADDLE_ENFORCE_EQ(
       dk->strides()[2],
       1,
-      phi::errors::InvalidArgument("headdim dimention must be contiguous"));
+      common::errors::InvalidArgument("headdim dimention must be contiguous"));
   PADDLE_ENFORCE_EQ(
       dk_tmp.strides()[3],
       1,
-      phi::errors::InvalidArgument("headdim dimention must be contiguous"));
+      common::errors::InvalidArgument("headdim dimention must be contiguous"));
   const int64_t reduceDimSize = dk_tmp.dims()[2];
   const size_t blockNum =
       std::min((static_cast<int64_t>(dk_tmp.dims()[0] + 31) / 32),
@@ -175,19 +175,19 @@ static void kvReduceBatchedForGQA(const Context& ctx,
   PADDLE_ENFORCE_EQ(
       dk->strides()[3],
       1,
-      phi::errors::InvalidArgument("headdim dimention must be contiguous"));
+      common::errors::InvalidArgument("headdim dimention must be contiguous"));
   PADDLE_ENFORCE_EQ(
       dk_tmp.strides()[4],
       1,
-      phi::errors::InvalidArgument("headdim dimention must be contiguous"));
-  PADDLE_ENFORCE_EQ(
-      dk->strides()[0],
-      dk->strides()[1] * dk->dims()[1],
-      phi::errors::InvalidArgument("batchsize dimention must be contiguous"));
-  PADDLE_ENFORCE_EQ(
-      dk_tmp.strides()[0],
-      dk_tmp.strides()[1] * dk_tmp.dims()[1],
-      phi::errors::InvalidArgument("batchsize dimention must be contiguous"));
+      common::errors::InvalidArgument("headdim dimention must be contiguous"));
+  PADDLE_ENFORCE_EQ(dk->strides()[0],
+                    dk->strides()[1] * dk->dims()[1],
+                    common::errors::InvalidArgument(
+                        "batchsize dimention must be contiguous"));
+  PADDLE_ENFORCE_EQ(dk_tmp.strides()[0],
+                    dk_tmp.strides()[1] * dk_tmp.dims()[1],
+                    common::errors::InvalidArgument(
+                        "batchsize dimention must be contiguous"));
   const int64_t reduceDimSize = dk_tmp.dims()[3];
   const size_t blockNum = std::min(
       (static_cast<int64_t>(dk_tmp.dims()[0] * dk_tmp.dims()[1] + 31) / 32),
@@ -289,7 +289,7 @@ void FlashAttnUnpaddedGradBaseKernel(
   PADDLE_ENFORCE_EQ(
       head_size_og,
       head_size,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "flash_attn_bwd receive input with head_size_og == head_size"));
 
   FlashAttnBwdParamsV2 params =
@@ -528,7 +528,7 @@ static void sliceFlattenView(const DenseTensor& in,
   PADDLE_ENFORCE_LT(
       axis,
       in.dims().size(),
-      phi::errors::InvalidArgument("sliceView receive axis out of bound"));
+      common::errors::InvalidArgument("sliceView receive axis out of bound"));
   std::array<int64_t, DDim::kMaxRank> dimArr;
   std::array<int64_t, DDim::kMaxRank> strideArr;
   auto id = dimArr.begin(), is = strideArr.begin();
@@ -695,7 +695,7 @@ void FlashAttnGradBaseKernel(
   PADDLE_ENFORCE_EQ(
       head_size_og,
       head_size,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "flash_attn_bwd receive input with head_size_og == head_size"));
 
   const float softmax_scale = 1.0f / std::sqrt(head_size);

--- a/paddle/phi/kernels/gpu/flash_attn_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_kernel.cu
@@ -74,23 +74,23 @@ void FlashAttnUnpaddedBaseKernel(
   PADDLE_ENFORCE_EQ(
       dims.size(),
       3,
-      phi::errors::InvalidArgument("flash_attn_raw receive input with dim "
-                                   "[total_seq_len, num_heads, head_dim]"));
+      common::errors::InvalidArgument("flash_attn_raw receive input with dim "
+                                      "[total_seq_len, num_heads, head_dim]"));
   PADDLE_ENFORCE_EQ(
       k.dims().size(),
       3,
-      phi::errors::InvalidArgument("flash_attn_raw receive input with dim "
-                                   "[total_seq_len, num_heads, head_dim]"));
+      common::errors::InvalidArgument("flash_attn_raw receive input with dim "
+                                      "[total_seq_len, num_heads, head_dim]"));
   PADDLE_ENFORCE_EQ(
       v.dims().size(),
       3,
-      phi::errors::InvalidArgument("flash_attn_raw receive input with dim "
-                                   "[total_seq_len, num_heads, head_dim]"));
+      common::errors::InvalidArgument("flash_attn_raw receive input with dim "
+                                      "[total_seq_len, num_heads, head_dim]"));
   PADDLE_ENFORCE_EQ(
       out->dims().size(),
       3,
-      phi::errors::InvalidArgument("flash_attn_raw receive input with dim "
-                                   "[total_seq_len, num_heads, head_dim]"));
+      common::errors::InvalidArgument("flash_attn_raw receive input with dim "
+                                      "[total_seq_len, num_heads, head_dim]"));
 
   const int64_t batch_size = cu_seqlens_q.numel() - 1;
   const int64_t num_heads = dims[1];
@@ -263,7 +263,7 @@ static void sliceFlattenView(const DenseTensor& in,
   PADDLE_ENFORCE_LT(
       axis,
       in.dims().size(),
-      phi::errors::InvalidArgument("sliceView receive axis out of bound"));
+      common::errors::InvalidArgument("sliceView receive axis out of bound"));
   std::array<int64_t, DDim::kMaxRank> dimArr;
   std::array<int64_t, DDim::kMaxRank> strideArr;
   auto id = dimArr.begin(), is = strideArr.begin();
@@ -362,22 +362,22 @@ void FlashAttnBaseKernel(
   const auto& dims = q.dims();
   PADDLE_ENFORCE_EQ(dims.size(),
                     4,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "flash_attn receive input with dim "
                         "[batch_size, seq_len, num_heads, head_dim]"));
   PADDLE_ENFORCE_EQ(k.dims().size(),
                     4,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "flash_attn receive input with dim "
                         "[batch_size, seq_len, num_heads, head_dim]"));
   PADDLE_ENFORCE_EQ(v.dims().size(),
                     4,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "flash_attn receive input with dim "
                         "[batch_size, seq_len, num_heads, head_dim]"));
   PADDLE_ENFORCE_EQ(out->dims().size(),
                     4,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "flash_attn receive input with dim "
                         "[batch_size, seq_len, num_heads, head_dim]"));
   const int64_t batch_size = dims[0];

--- a/paddle/phi/kernels/gpu/flash_attn_utils.h
+++ b/paddle/phi/kernels/gpu/flash_attn_utils.h
@@ -60,7 +60,7 @@ static std::vector<int64_t> GetAttnMaskDims(const DenseTensor* attn_mask) {
     PADDLE_ENFORCE_GE(
         rank,
         4,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The number of dimensions of attn_mask is expected to be greater "
             "or equal to 4, but received %d. The shape of attn_mask is {%s}",
             rank,
@@ -89,14 +89,14 @@ static std::vector<int64_t> GetAttnSparseMaskDims(
     auto rank = origin_dims.size();
     PADDLE_ENFORCE_EQ(dtype,
                       DataType::INT32,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "dtype of attn_mask_start_row_indices must be "
                           "int32, but recieved %d",
                           dtype));
     PADDLE_ENFORCE_GE(
         rank,
         3,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The number of dimenstions of attn_mask_start_row_indices is "
             "expected to be greater or "
             "equal to 3, but recieved %d. The shape of "
@@ -105,7 +105,7 @@ static std::vector<int64_t> GetAttnSparseMaskDims(
             origin_dims));
     PADDLE_ENFORCE_EQ(origin_dims[rank - 1],
                       max_seqlen_q,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The sparse_mask_dims[%d] of "
                           "attn_mask_start_row_indices is expected to be "
                           "equal to %d, but recieved %d.",
@@ -114,7 +114,7 @@ static std::vector<int64_t> GetAttnSparseMaskDims(
                           origin_dims[2]));
     PADDLE_ENFORCE_GE(attn_mask_start_row,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "attn_mask_start_row should be greater or equal than "
                           "0 when using attn_mask_start_row_indices, "
                           "but recieved %d.",
@@ -193,13 +193,13 @@ struct FlashAttnParamsBase {
     if (attn_mask_tensor) {
       PADDLE_ENFORCE_NE(causal,
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "When attn_mask is set, causal can not be true."));
 
       PADDLE_ENFORCE_EQ(
           attn_mask->dtype(),
           q_dtype,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "attn_mask is expected to have the same data type with q."));
 
       mask_dims = GetAttnMaskDims(attn_mask_tensor);
@@ -210,7 +210,7 @@ struct FlashAttnParamsBase {
 
     PADDLE_ENFORCE_NE(attn_mask_tensor && attn_mask_start_row_indices,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "attn_mask and attn_mask_start_row_indices cannot be "
                           "set at same time."));
   }
@@ -289,7 +289,7 @@ struct FlashAttnFwdParamsV2 : public FlashAttnParamsBase {
       PADDLE_ENFORCE_EQ(
           dropout > 0.0f,
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "return_softmax is only supported when dropout > 0.0"));
 
       softmax->Resize(
@@ -355,16 +355,16 @@ struct FlashAttnBwdParamsV2 : public FlashAttnParamsBase {
 static void CheckFlashAttnStatus(const bool status) {
   PADDLE_ENFORCE_EQ(status,
                     true,
-                    phi::errors::External(
+                    common::errors::External(
                         "Error in Flash-Attention, detail information is: %s",
                         phi::dynload::flash_attn_error()));
 }
 #endif
 
 static void RaiseNotSupportedError() {
-  PADDLE_THROW(
-      phi::errors::Unimplemented("FlashAttention is unsupported, please check "
-                                 "the GPU compability and CUDA Version."));
+  PADDLE_THROW(common::errors::Unimplemented(
+      "FlashAttention is unsupported, please check "
+      "the GPU compability and CUDA Version."));
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/full_kernel.cu
+++ b/paddle/phi/kernels/gpu/full_kernel.cu
@@ -99,7 +99,7 @@ void FullLikeKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         is_out_range,
         false,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The filled value is out of range for target type, "
             "current kernel type is %s, the range should between %f "
             "and %f, but now value is %f.",

--- a/paddle/phi/kernels/gpu/fused_adam_kernel.cu
+++ b/paddle/phi/kernels/gpu/fused_adam_kernel.cu
@@ -295,18 +295,18 @@ void FusedAdamKernel(
   for (int i = 1; i < beta1_pows.size(); i++) {
     PADDLE_ENFORCE_EQ(beta1_pow_first->place(),
                       beta1_pows[i]->place(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "All Beta1Pow must be in the same place."));
     PADDLE_ENFORCE_EQ(beta2_pow_first->place(),
                       beta2_pows[i]->place(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "All Beta2Pow must be in the same place."));
   }
 
   PADDLE_ENFORCE_EQ(
       beta1_pow_first->place(),
       beta2_pow_first->place(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input(Beta1Pows) and Input(Beta2Pows) must be in the same place."));
 
   bool is_cpu_betapow = (beta1_pow_first->place() == CPUPlace());

--- a/paddle/phi/kernels/gpu/gather_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/gather_grad_kernel.cu
@@ -55,7 +55,7 @@ void GatherGradKernel(const Context& dev_ctx,
     phi::funcs::GPUScatterAssign<T, int64_t>(
         dev_ctx, out_grad, index, x_grad, false);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The data type of Input(Index) of gather_grad must be int32 or int64 "
         "on GPU."));
   }

--- a/paddle/phi/kernels/gpu/gather_kernel.cu
+++ b/paddle/phi/kernels/gpu/gather_kernel.cu
@@ -53,9 +53,9 @@ void GatherKernel(const Context& dev_ctx,
   } else if (index_type == phi::DataType::INT16) {
     phi::funcs::GPUGather<T, int16_t>(dev_ctx, x, index, out);
   } else {
-    PADDLE_THROW(
-        phi::errors::InvalidArgument("The data type of Input(Index) of gather "
-                                     "must be int16, int32 or int64 on GPU."));
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "The data type of Input(Index) of gather "
+        "must be int16, int32 or int64 on GPU."));
   }
 }
 

--- a/paddle/phi/kernels/gpu/gather_nd_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/gather_nd_grad_kernel.cu
@@ -38,14 +38,14 @@ void GatherNdGradKernel(const Context &ctx,
   bool index_type_match =
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
 
-  PADDLE_ENFORCE_EQ(
-      index_type_match,
-      true,
-      phi::errors::InvalidArgument("Index holds the wrong type, it holds [%s],"
-                                   "but desires to be [%s] or [%s].",
-                                   index_type,
-                                   phi::DataType::INT32,
-                                   phi::DataType::INT64));
+  PADDLE_ENFORCE_EQ(index_type_match,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Index holds the wrong type, it holds [%s],"
+                        "but desires to be [%s] or [%s].",
+                        index_type,
+                        phi::DataType::INT32,
+                        phi::DataType::INT64));
 
   if (index_type == phi::DataType::INT32) {
     phi::funcs::GPUScatterNdAdd<T, int>(ctx, out_grad, index, x_grad);

--- a/paddle/phi/kernels/gpu/gather_nd_kernel.cu
+++ b/paddle/phi/kernels/gpu/gather_nd_kernel.cu
@@ -34,7 +34,7 @@ void GatherNdKernel(const Context &ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Index holds the wrong type, it holds [%s], but "
                         "desires to be [%s] or [%s].",
                         index_type,

--- a/paddle/phi/kernels/gpu/gather_tree_kernel.cu
+++ b/paddle/phi/kernels/gpu/gather_tree_kernel.cu
@@ -65,12 +65,12 @@ void GatherTreeKernel(const Context &dev_ctx,
   T *out_data = dev_ctx.template Alloc<T>(out);
 
   PADDLE_ENFORCE_NOT_NULL(ids_data,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Input(Ids) of gather_tree should not be null."));
 
   PADDLE_ENFORCE_NOT_NULL(
       parents_data,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input(Parents) of gather_tree should not be null."));
 
   auto &ids_dims = ids.dims();

--- a/paddle/phi/kernels/gpu/graph_send_ue_recv_funcs.h
+++ b/paddle/phi/kernels/gpu/graph_send_ue_recv_funcs.h
@@ -57,7 +57,7 @@ inline void CopyBCastOff(const BroadCastInfo& bcast_info,
 inline int FindNumThreads(int dim, int max_num_threads) {
   PADDLE_ENFORCE_GE(dim,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Required dim >= 0, but received dim = %d", dim));
   int res = max_num_threads;
   if (dim == 0) res = 1;
@@ -82,7 +82,7 @@ inline int FindNumBlocks(char axis, int nblocks, int max_num_blocks = -1) {
       break;
     default:
       PADDLE_THROW(
-          phi::errors::InvalidArgument("%c axis is not recognized", axis));
+          common::errors::InvalidArgument("%c axis is not recognized", axis));
   }
   if (max_num_blocks == -1) {
     max_num_blocks = default_max_num_blocks;
@@ -90,9 +90,9 @@ inline int FindNumBlocks(char axis, int nblocks, int max_num_blocks = -1) {
   PADDLE_ENFORCE_GT(
       max_num_blocks,
       0,
-      phi::errors::InvalidArgument("max_num_blocks should be larger than 0, "
-                                   "but received %d",
-                                   max_num_blocks));
+      common::errors::InvalidArgument("max_num_blocks should be larger than 0, "
+                                      "but received %d",
+                                      max_num_blocks));
   if (nblocks < max_num_blocks) {
     return nblocks;
   }

--- a/paddle/phi/kernels/gpu/histogram_kernel.cu
+++ b/paddle/phi/kernels/gpu/histogram_kernel.cu
@@ -184,7 +184,7 @@ void HistogramKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_LT(
       range,
       static_cast<double>(std::numeric_limits<T>::max()),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The range of max - min is out of range for target type, "
           "current kernel type is %s, the range should less than %f "
           "but now min is %f, max is %f.",
@@ -193,16 +193,17 @@ void HistogramKernel(const Context& dev_ctx,
           output_min,
           output_max));
 
-  PADDLE_ENFORCE_EQ((std::isinf(static_cast<float>(output_min)) ||
-                     std::isnan(static_cast<float>(output_max)) ||
-                     std::isinf(static_cast<float>(output_min)) ||
-                     std::isnan(static_cast<float>(output_max))),
-                    false,
-                    phi::errors::OutOfRange("range of min, max is not finite"));
+  PADDLE_ENFORCE_EQ(
+      (std::isinf(static_cast<float>(output_min)) ||
+       std::isnan(static_cast<float>(output_max)) ||
+       std::isinf(static_cast<float>(output_min)) ||
+       std::isnan(static_cast<float>(output_max))),
+      false,
+      common::errors::OutOfRange("range of min, max is not finite"));
   PADDLE_ENFORCE_GE(
       output_max,
       output_min,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "max must be larger or equal to min. If min and max are both zero, "
           "the minimum and maximum values of the data are used. "
           "But received max is %d, min is %d",

--- a/paddle/phi/kernels/gpu/index_add_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_add_grad_kernel.cu
@@ -52,7 +52,7 @@ void IndexAddGradKernel(const Context& ctx,
       index_type == phi::DataType::INT64 || index_type == phi::DataType::INT32;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Index) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         index_type,

--- a/paddle/phi/kernels/gpu/index_put_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_grad_kernel.cu
@@ -233,7 +233,7 @@ void IndexPutGradKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       x.dtype(),
       value.dtype(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The data type of tensor value must be same to the data type "
           "of tensor x."));
   std::vector<DenseTensor> tmp_args;

--- a/paddle/phi/kernels/gpu/index_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_kernel.cu
@@ -117,12 +117,13 @@ void IndexPutKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       x.dtype(),
       value.dtype(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The data type of tensor value must be same to the data type "
           "of tensor x."));
-  PADDLE_ENFORCE_EQ(indices.empty(),
-                    false,
-                    phi::errors::InvalidArgument("Indices cannot be empty."));
+  PADDLE_ENFORCE_EQ(
+      indices.empty(),
+      false,
+      common::errors::InvalidArgument("Indices cannot be empty."));
   std::vector<DenseTensor> tmp_args;
   std::vector<const phi::DenseTensor*> int_indices_v =
       funcs::DealWithBoolIndices<T, Context>(dev_ctx, indices, &tmp_args);

--- a/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
@@ -70,7 +70,7 @@ void IndexSelectGradKernel(const Context& ctx,
       index_type == phi::DataType::INT64 || index_type == phi::DataType::INT32;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Index) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         index_type,

--- a/paddle/phi/kernels/gpu/index_select_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_select_kernel.cu
@@ -44,7 +44,7 @@ void IndexSelectKernel(const Context& ctx,
       index_type == phi::DataType::INT64 || index_type == phi::DataType::INT32;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Index) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         index_type,

--- a/paddle/phi/kernels/gpu/instance_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/instance_norm_grad_kernel.cu
@@ -335,7 +335,7 @@ void InstanceNormGradKernel(const Context &dev_ctx,
     PADDLE_ENFORCE_EQ(
         scale_ptr->dims().size(),
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The `shape` in InstanceNormOp is invalid: "
             "the size of scale's dimensions must be equal to 1. But "
             "received: the size of scale's dimensions"
@@ -343,7 +343,7 @@ void InstanceNormGradKernel(const Context &dev_ctx,
             scale_ptr->dims().size()));
     PADDLE_ENFORCE_EQ(scale_ptr->dims()[0],
                       C,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The `shape` in InstanceNormOp is invalid: "
                           "the first dimension of scale must be equal to "
                           "Channels([%d]). But received: "

--- a/paddle/phi/kernels/gpu/instance_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/instance_norm_kernel.cu
@@ -40,7 +40,7 @@ void InstanceNormKernel(const Context &dev_ctx,
   auto &x_dims = x.dims();
   PADDLE_ENFORCE_GE(x_dims.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The `shape` in InstanceNormOp is invalid: "
                         "the size of X's dimensions must greater than "
                         "or equal to 2. But received: "
@@ -48,7 +48,7 @@ void InstanceNormKernel(const Context &dev_ctx,
                         x_dims.size()));
   PADDLE_ENFORCE_LE(x_dims.size(),
                     5,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The `shape` in InstanceNormOp is invalid: "
                         "the size of X's dimensions must smaller than"
                         "or equal to 5. But received: "

--- a/paddle/phi/kernels/gpu/kthvalue_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_kernel.cu
@@ -170,7 +170,7 @@ void KthvalueKernel(const Context& dev_ctx,
   if (in_dims.size() == 0) {
     PADDLE_ENFORCE_EQ(k,
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "the k in the kthvalue must less equal than the "
                           "elemenents number of the input X, but received %d .",
                           k));
@@ -198,7 +198,7 @@ void KthvalueKernel(const Context& dev_ctx,
         SortKthvalue<T>(
             dev_ctx, &x, input_width, input_height, k, output, indices),
         true,
-        phi::errors::External("KthvalueOP: Error when use cub sorting"));
+        common::errors::External("KthvalueOP: Error when use cub sorting"));
 #endif
 
     return;
@@ -265,7 +265,7 @@ void KthvalueKernel(const Context& dev_ctx,
                         &trans_out,
                         &trans_ind),
         true,
-        phi::errors::External("KthvalueOP: Error when use cub sorting"));
+        common::errors::External("KthvalueOP: Error when use cub sorting"));
 #endif
     funcs::TransCompute<phi::GPUContext, int64_t>(
         ndims, dev_ctx, trans_ind, indices, trans);

--- a/paddle/phi/kernels/gpu/l1_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/l1_norm_grad_kernel.cu
@@ -36,7 +36,7 @@ void L1NormGradKernel(const Context& dev_ctx,
                       DenseTensor* x_grad) {
   PADDLE_ENFORCE_EQ(out_grad.numel(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(GRAD@Out) of L1NormGradOp should be a scalar."));
   dev_ctx.template Alloc<T>(x_grad);
   auto x_eigen = phi::EigenVector<T>::Flatten(x);

--- a/paddle/phi/kernels/gpu/l1_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/l1_norm_kernel.cu
@@ -36,7 +36,7 @@ void L1NormGradKernel(const Context& dev_ctx,
                       DenseTensor* x_grad) {
   PADDLE_ENFORCE_EQ(out_grad.numel(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(GRAD@Out) of L1NormGradOp should be a scalar."));
   dev_ctx.template Alloc<T>(x_grad);
   auto x_eigen = phi::EigenVector<T>::Flatten(x);

--- a/paddle/phi/kernels/gpu/layer_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_kernel.cu
@@ -473,7 +473,7 @@ void LayerNormDirectCUDAFunctor<T, U>::operator()(gpuStream_t stream,
         <<<batch_size, kBlockDim, 0, stream>>>(
             input, scale, bias, output, mean, variance, eps, feature_size));
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Product from begin_norm_axis to end in layer_norm must be larger "
           "than 1"));
       break;
@@ -516,11 +516,11 @@ void LayerNormKernel(const Context &dev_ctx,
   if (valid_scale) {
     scale_bias_dtype = scale->dtype();
     if (valid_bias) {
-      PADDLE_ENFORCE_EQ(
-          scale->dtype(),
-          bias->dtype(),
-          phi::errors::InvalidArgument("This Scale and Bias of layer_norm op "
-                                       "should have the same data type."));
+      PADDLE_ENFORCE_EQ(scale->dtype(),
+                        bias->dtype(),
+                        common::errors::InvalidArgument(
+                            "This Scale and Bias of layer_norm op "
+                            "should have the same data type."));
     }
   } else {
     scale_bias_dtype = valid_bias ? bias->dtype() : x_dtype;
@@ -530,7 +530,7 @@ void LayerNormKernel(const Context &dev_ctx,
   if (!is_scale_bias_same_dtype_with_x) {
     PADDLE_ENFORCE_EQ(scale_bias_dtype,
                       phi::CppTypeToDataType<U>::Type(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Unsupported data type of Scale and Bias"));
   }
 
@@ -555,7 +555,7 @@ void LayerNormKernel(const Context &dev_ctx,
               epsilon,                                                     \
               feature_size));                                              \
       default:                                                             \
-        PADDLE_THROW(phi::errors::InvalidArgument(                         \
+        PADDLE_THROW(common::errors::InvalidArgument(                      \
             "Product from begin_norm_axis to end must be larger than 1")); \
         break;                                                             \
     }                                                                      \
@@ -614,7 +614,7 @@ void LayerNormKernel(const Context &dev_ctx,
       switch (feature_size) {
         PADDLE_LAUNCH_FAST_LAYERNORM_FWD(T);
         default:
-          PADDLE_THROW(phi::errors::InvalidArgument(
+          PADDLE_THROW(common::errors::InvalidArgument(
               "Only when feature_size is from 256 to 4096 and is diviaible by "
               "256 is supported "
               "now"));
@@ -624,7 +624,7 @@ void LayerNormKernel(const Context &dev_ctx,
       switch (feature_size) {
         PADDLE_LAUNCH_FAST_LAYERNORM_FWD(U);
         default:
-          PADDLE_THROW(phi::errors::InvalidArgument(
+          PADDLE_THROW(common::errors::InvalidArgument(
               "Only when feature_size is from 256 to 4096 and is diviaible by "
               "is supported "
               "now"));

--- a/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
@@ -178,14 +178,14 @@ void LerpGradKernel(const Context& ctx,
   PADDLE_ENFORCE_GE(
       rank,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of dimensions for LerpGradOp must be "
           "greater than or equal to 0, but the value received is %d.",
           rank));
   PADDLE_ENFORCE_LE(
       rank,
       6,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of dimensions for LerpGradOp must be "
           "less than or equal to 6, but the value received is %d.",
           rank));

--- a/paddle/phi/kernels/gpu/lerp_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_kernel.cu
@@ -50,18 +50,18 @@ void LerpKernel(const Context &ctx,
   PADDLE_ENFORCE_GT(
       x.numel(),
       0,
-      phi::errors::InvalidArgument("LerpKernel's input x must not empty."));
+      common::errors::InvalidArgument("LerpKernel's input x must not empty."));
 
   PADDLE_ENFORCE_GT(
       y.numel(),
       0,
-      phi::errors::InvalidArgument("LerpKernel's input y must not empty."));
+      common::errors::InvalidArgument("LerpKernel's input y must not empty."));
 
   int rank = out->dims().size();
   PADDLE_ENFORCE_GE(
       rank,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number of dimensions for LerpOp must be "
           "greater than or equal to 0, but the value received is %d.",
           rank));

--- a/paddle/phi/kernels/gpu/linspace_kernel.cu
+++ b/paddle/phi/kernels/gpu/linspace_kernel.cu
@@ -64,7 +64,7 @@ T GetValueOfExpectedType(const Context& ctx, const DenseTensor& x) {
     case DataType::UINT8:
       return static_cast<T>(GetValue<uint8_t, Context>(ctx, x));
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported when casting data type.",
           x.dtype()));
   }
@@ -84,9 +84,9 @@ void LinspaceKernel(const Context& ctx,
   PADDLE_ENFORCE_GT(
       num,
       0,
-      phi::errors::InvalidArgument("The num of linspace op should be larger "
-                                   "than 0, but received num is %d",
-                                   num));
+      common::errors::InvalidArgument("The num of linspace op should be larger "
+                                      "than 0, but received num is %d",
+                                      num));
 
   out->Resize(common::make_ddim({num}));
   T* out_data = ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/gpu/llm_int8_linear_kernel.cu
+++ b/paddle/phi/kernels/gpu/llm_int8_linear_kernel.cu
@@ -58,7 +58,7 @@ void llm_int8_compute(const Context& dev_ctx,
     phi::AddKernel<T, Context>(dev_ctx, *out, bias.get(), out);
   }
 #else
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "llm_int8_linear op needs paddle with cuda and cuda version >= 11.2"));
 #endif
 }

--- a/paddle/phi/kernels/gpu/logspace_kernel.cu
+++ b/paddle/phi/kernels/gpu/logspace_kernel.cu
@@ -89,9 +89,9 @@ void LogspaceKernel(const Context& ctx,
   PADDLE_ENFORCE_GT(
       num,
       0,
-      phi::errors::InvalidArgument("The num of logspace op should be larger "
-                                   "than 0, but received num is %d",
-                                   num));
+      common::errors::InvalidArgument("The num of logspace op should be larger "
+                                      "than 0, but received num is %d",
+                                      num));
 
   out->Resize(common::make_ddim({num}));
   T* out_data = ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/gpu/masked_select_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_select_kernel.cu
@@ -75,7 +75,7 @@ void MaskedSelectKernel(const Context& dev_ctx,
   auto mask_dim = mask_expand.dims();
   PADDLE_ENFORCE_EQ(input_dim,
                     mask_dim,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dim size of input and mask in OP(masked_selected) "
                         "must be equal, but got input dim:(%ld), mask dim: "
                         "(%ld). Please check input "

--- a/paddle/phi/kernels/gpu/matrix_rank_tol_kernel.cu
+++ b/paddle/phi/kernels/gpu/matrix_rank_tol_kernel.cu
@@ -127,7 +127,7 @@ void GesvdjBatched<float>(const phi::GPUContext& dev_ctx,
     PADDLE_ENFORCE_EQ(
         error_info,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "For batch [%d]: CUSolver SVD is not zero. [%d]", i, error_info));
   }
   PADDLE_ENFORCE_GPU_SUCCESS(
@@ -207,7 +207,7 @@ void GesvdjBatched<double>(const phi::GPUContext& dev_ctx,
     PADDLE_ENFORCE_EQ(
         error_info,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "For batch [%d]: CUSolver SVD is not zero. [%d]", i, error_info));
   }
   PADDLE_ENFORCE_GPU_SUCCESS(
@@ -263,7 +263,7 @@ void SyevjBatched<float>(const phi::GPUContext& dev_ctx,
     PADDLE_ENFORCE_EQ(
         error_info,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "For batch [%d]: CUSolver eigenvalues is not zero. [%d]",
             i,
             error_info));
@@ -318,7 +318,7 @@ void SyevjBatched<double>(const phi::GPUContext& dev_ctx,
     PADDLE_ENFORCE_EQ(
         error_info,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "For batch [%d]: CUSolver eigenvalues is not zero. [%d]",
             i,
             error_info));
@@ -340,18 +340,18 @@ void MatrixRankTolKernel(const Context& dev_ctx,
   auto dim_out = out->dims();
   int rows = dim_x[dim_x.size() - 2];
   int cols = dim_x[dim_x.size() - 1];
-  PADDLE_ENFORCE_NE(
-      rows,
-      0,
-      phi::errors::InvalidArgument("The input Tensor x's shape[-2] should not "
-                                   "be 0, but shape is %s now.",
-                                   dim_x));
-  PADDLE_ENFORCE_NE(
-      cols,
-      0,
-      phi::errors::InvalidArgument("The input Tensor x's shape[-1] should not "
-                                   "be 0, but shape is %s now.",
-                                   dim_x));
+  PADDLE_ENFORCE_NE(rows,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The input Tensor x's shape[-2] should not "
+                        "be 0, but shape is %s now.",
+                        dim_x));
+  PADDLE_ENFORCE_NE(cols,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The input Tensor x's shape[-1] should not "
+                        "be 0, but shape is %s now.",
+                        dim_x));
   int k = std::min(rows, cols);
   auto numel = x.numel();
   int batches = numel / (rows * cols);

--- a/paddle/phi/kernels/gpu/mean_all_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/mean_all_grad_kernel.cu
@@ -35,7 +35,7 @@ void MeanAllGradKernel(const Context& dev_ctx,
                        DenseTensor* x_grad) {
   PADDLE_ENFORCE_EQ(out_grad.numel(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Mean Gradient Input Tensor len should be 1. But "
                         "received Out@Grad's elements num is %d.",
                         out_grad.numel()));

--- a/paddle/phi/kernels/gpu/miopen_lstm_cache.h
+++ b/paddle/phi/kernels/gpu/miopen_lstm_cache.h
@@ -114,7 +114,7 @@ class ScopedRNNBase {
     PADDLE_ENFORCE_EQ(
         weights_size_,
         sizeof(T) * weight_numel_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The miopen lstm and setting weight size should be same."));
     // ------------------- miopen weight descriptors ---------------------
     phi::backends::gpu::DataLayout layout =

--- a/paddle/phi/kernels/gpu/multiclass_nms3_kernel.cu
+++ b/paddle/phi/kernels/gpu/multiclass_nms3_kernel.cu
@@ -854,7 +854,7 @@ void InferNMS(gpuStream_t stream,
   PADDLE_ENFORCE_EQ(
       share_location,
       true,
-      phi::errors::Unimplemented("share_location=false is not supported."));
+      common::errors::Unimplemented("share_location=false is not supported."));
 
   // Prepare workspaces
   size_t bbox_data_size =
@@ -1058,16 +1058,16 @@ void MultiClassNMSGPUKernel(const Context& ctx,
   PADDLE_ENFORCE_LE(
       nms_top_k,
       num_priors,
-      phi::errors::InvalidArgument("Expect nms_top_k (%d)"
-                                   " <= num of boxes per batch (%d).",
-                                   nms_top_k,
-                                   num_priors));
+      common::errors::InvalidArgument("Expect nms_top_k (%d)"
+                                      " <= num of boxes per batch (%d).",
+                                      nms_top_k,
+                                      num_priors));
   PADDLE_ENFORCE_LE(keep_top_k,
                     nms_top_k,
-                    phi::errors::InvalidArgument("Expect keep_top_k (%d)"
-                                                 " <= nms_top_k (%d).",
-                                                 keep_top_k,
-                                                 nms_top_k));
+                    common::errors::InvalidArgument("Expect keep_top_k (%d)"
+                                                    " <= nms_top_k (%d).",
+                                                    keep_top_k,
+                                                    nms_top_k));
 
   // Transform the layout of bboxes and scores
   // bboxes: [N,M,4] -> [N,1,M,4]

--- a/paddle/phi/kernels/gpu/nanmedian_kernel.cu
+++ b/paddle/phi/kernels/gpu/nanmedian_kernel.cu
@@ -211,12 +211,12 @@ void ProcessMedianKernel(const Context& dev_ctx,
   int64_t x_rank = x_dim.size();
   int64_t stride = x_dim[x_rank - 1];
 
-  PADDLE_ENFORCE_NE(
-      stride,
-      0,
-      phi::errors::InvalidArgument("The input Tensor x's shape[-1] should not "
-                                   "be 0, but shape is %s now.",
-                                   x_dim));
+  PADDLE_ENFORCE_NE(stride,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The input Tensor x's shape[-1] should not "
+                        "be 0, but shape is %s now.",
+                        x_dim));
 
   int64_t pre_dim = numel / stride;
   int64_t i = 0;

--- a/paddle/phi/kernels/gpu/nms_kernel.cu
+++ b/paddle/phi/kernels/gpu/nms_kernel.cu
@@ -61,14 +61,14 @@ void NMSKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       boxes.dims().size(),
       2,
-      phi::errors::InvalidArgument("The shape [%s] of boxes must be (N, 4).",
-                                   boxes.dims()));
+      common::errors::InvalidArgument("The shape [%s] of boxes must be (N, 4).",
+                                      boxes.dims()));
 
   PADDLE_ENFORCE_EQ(
       boxes.dims()[1],
       4,
-      phi::errors::InvalidArgument("The shape [%s] of boxes must be (N, 4).",
-                                   boxes.dims()));
+      common::errors::InvalidArgument("The shape [%s] of boxes must be (N, 4).",
+                                      boxes.dims()));
 
   const int64_t num_boxes = boxes.dims()[0];
   const auto blocks_per_line = CeilDivide(num_boxes, threadsPerBlock);

--- a/paddle/phi/kernels/gpu/partial_concat_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/partial_concat_grad_kernel.cu
@@ -59,7 +59,7 @@ void PartialConcatGradOpCUDAKernel(const Context &dev_ctx,
 
   PADDLE_ENFORCE_EQ(ins[0] != nullptr,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The input of partial concat should not be null."));
   // all parameters
   auto batch_size = ins[0]->dims()[0];

--- a/paddle/phi/kernels/gpu/partial_concat_kernel.cu
+++ b/paddle/phi/kernels/gpu/partial_concat_kernel.cu
@@ -56,13 +56,13 @@ void PartialConcatOpCUDAKernel(const Context &dev_ctx,
   auto in_vars = x;
   PADDLE_ENFORCE_EQ(in_vars[0] != nullptr,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The input of partial concat should not be null."));
 
   auto input_dim = in_vars[0]->dims();
   PADDLE_ENFORCE_EQ(input_dim.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Only supports 2-D array with batch size in the 1st "
                         "dimension and data in the 2nd."));
   auto in_size = input_dim[1];

--- a/paddle/phi/kernels/gpu/partial_sum_kernel.cu
+++ b/paddle/phi/kernels/gpu/partial_sum_kernel.cu
@@ -81,7 +81,7 @@ void PartialSumOpCUDAKernel(const Context &dev_ctx,
   PADDLE_ENFORCE_EQ(
       x.size() > 0,
       true,
-      phi::errors::InvalidArgument("The input should not be null."));
+      common::errors::InvalidArgument("The input should not be null."));
 
   auto place = dev_ctx.GetPlace();  // GPUPlace only now
   auto batch_size = in_vars[0]->dims()[0];
@@ -153,7 +153,7 @@ void PartialSumGradOpCUDAKernel(const Context &dev_ctx,
   PADDLE_ENFORCE_EQ(
       ins.size() > 0,
       true,
-      phi::errors::InvalidArgument("The input should not be null."));
+      common::errors::InvalidArgument("The input should not be null."));
   if (length == -1) {
     length = ins[0]->dims()[1] - start_index;
   }

--- a/paddle/phi/kernels/gpu/prune_gate_by_capacity_kernel.cu
+++ b/paddle/phi/kernels/gpu/prune_gate_by_capacity_kernel.cu
@@ -86,7 +86,7 @@ static void VisitType(phi::DataType type, Visitor visitor) {
   if (type == phi::DataType::INT64) {
     visitor.template apply<int64_t>();
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The received values gate_id type %s can not meet input requirements. "
         "Because the given gate_id data type of operators must be "
         "int64. Please input appropriate gate_id again! ",

--- a/paddle/phi/kernels/gpu/qr_kernel.cu
+++ b/paddle/phi/kernels/gpu/qr_kernel.cu
@@ -227,7 +227,7 @@ void BatchedGeqrf<GPUContext, float>(const GPUContext& dev_ctx,
     PADDLE_ENFORCE_EQ(
         info_h,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "For batch [%d]: CUSolver geqrf is not zero. [%d]", i, info_h));
   }
 }
@@ -281,7 +281,7 @@ void BatchedGeqrf<GPUContext, double>(const GPUContext& dev_ctx,
     PADDLE_ENFORCE_EQ(
         info_h,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "For batch [%d]: CUSolver geqrf is not zero. [%d]", i, info_h));
   }
 }
@@ -337,7 +337,7 @@ void BatchedOrgqr<GPUContext, float>(const GPUContext& dev_ctx,
     PADDLE_ENFORCE_EQ(
         info_h,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "For batch [%d]: CUSolver QR is not zero. [%d]", i, info_h));
   }
 }
@@ -393,7 +393,7 @@ void BatchedOrgqr<GPUContext, double>(const GPUContext& dev_ctx,
     PADDLE_ENFORCE_EQ(
         info_h,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "For batch [%d]: CUSolver QR is not zero. [%d]", i, info_h));
   }
 }

--- a/paddle/phi/kernels/gpu/rank_attention_kernel.cu
+++ b/paddle/phi/kernels/gpu/rank_attention_kernel.cu
@@ -45,15 +45,15 @@ void RankAttentionCUDAKernel(const Context &dev_ctx,
   PADDLE_ENFORCE_EQ(
       rank_offset_dims[0],
       ins_num,
-      phi::errors::InvalidArgument("Input(RankOffset) has wrong rows."));
+      common::errors::InvalidArgument("Input(RankOffset) has wrong rows."));
   PADDLE_ENFORCE_EQ(
       (rank_offset_dims[1] - 1) / 2,
       max_rank,
-      phi::errors::InvalidArgument("Input(RankOffset) has wrong columns."));
+      common::errors::InvalidArgument("Input(RankOffset) has wrong columns."));
   PADDLE_ENFORCE_EQ(
       max_rank * max_rank * x_fea_dim,
       para_row,
-      phi::errors::InvalidArgument("Input(RankParam) has wrong rows."));
+      common::errors::InvalidArgument("Input(RankParam) has wrong rows."));
 
   int block_matrix_row = max_rank * x_fea_dim;
   int max_ins = std::max(ins_num, static_cast<int64_t>(max_size));

--- a/paddle/phi/kernels/gpu/reduce_kernel.cu
+++ b/paddle/phi/kernels/gpu/reduce_kernel.cu
@@ -237,10 +237,10 @@ void ReduceKernel(const Context& dev_ctx,
                   int root,
                   int reduce_type,
                   DenseTensor* out) {
-  PADDLE_ENFORCE_GT(
-      x.numel(),
-      0,
-      phi::errors::InvalidArgument("Tensor need be reduced must not empty."));
+  PADDLE_ENFORCE_GT(x.numel(),
+                    0,
+                    common::errors::InvalidArgument(
+                        "Tensor need be reduced must not empty."));
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
   out->Resize(x.dims());
   dev_ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/gpu/rms_norm_funcs.h
+++ b/paddle/phi/kernels/gpu/rms_norm_funcs.h
@@ -48,41 +48,41 @@ namespace {  // NOLINT
 #define DEFAULT_THROW(NAME, TYPE)                              \
   default:                                                     \
     do {                                                       \
-      PADDLE_THROW(phi::errors::Unimplemented(                 \
+      PADDLE_THROW(common::errors::Unimplemented(              \
           "(%s) is  not implemented for (%s).", #NAME, TYPE)); \
     } while (0);                                               \
     break
 
-#define DISPATCH_SCALE_TYPE(INPUT_TYPE, SCALE_DTYPE, NAME, ...)            \
-  do {                                                                     \
-    auto input_dtype = phi::CppTypeToDataType<INPUT_TYPE>::Type();         \
-    bool is_scale_same_dtype_with_x = input_dtype == SCALE_DTYPE;          \
-    using U = typename phi::backends::gpu::CudnnDataType<                  \
-        INPUT_TYPE>::BatchNormParamType;                                   \
-    if (!is_scale_same_dtype_with_x) {                                     \
-      PADDLE_ENFORCE_EQ(                                                   \
-          SCALE_DTYPE,                                                     \
-          phi::CppTypeToDataType<U>::Type(),                               \
-          phi::errors::InvalidArgument("Unsupported data type of Scale")); \
-    }                                                                      \
-    switch (SCALE_DTYPE) {                                                 \
-      case paddle::DataType::FLOAT32: {                                    \
-        using SCALE_TYPE = float;                                          \
-        __VA_ARGS__;                                                       \
-        break;                                                             \
-      }                                                                    \
-      case paddle::DataType::FLOAT16: {                                    \
-        using SCALE_TYPE = phi::dtype::float16;                            \
-        __VA_ARGS__;                                                       \
-        break;                                                             \
-      }                                                                    \
-      case paddle::DataType::BFLOAT16: {                                   \
-        using SCALE_TYPE = phi::dtype::bfloat16;                           \
-        __VA_ARGS__;                                                       \
-        break;                                                             \
-      }                                                                    \
-        DEFAULT_THROW(NAME, SCALE_DTYPE);                                  \
-    }                                                                      \
+#define DISPATCH_SCALE_TYPE(INPUT_TYPE, SCALE_DTYPE, NAME, ...)               \
+  do {                                                                        \
+    auto input_dtype = phi::CppTypeToDataType<INPUT_TYPE>::Type();            \
+    bool is_scale_same_dtype_with_x = input_dtype == SCALE_DTYPE;             \
+    using U = typename phi::backends::gpu::CudnnDataType<                     \
+        INPUT_TYPE>::BatchNormParamType;                                      \
+    if (!is_scale_same_dtype_with_x) {                                        \
+      PADDLE_ENFORCE_EQ(                                                      \
+          SCALE_DTYPE,                                                        \
+          phi::CppTypeToDataType<U>::Type(),                                  \
+          common::errors::InvalidArgument("Unsupported data type of Scale")); \
+    }                                                                         \
+    switch (SCALE_DTYPE) {                                                    \
+      case paddle::DataType::FLOAT32: {                                       \
+        using SCALE_TYPE = float;                                             \
+        __VA_ARGS__;                                                          \
+        break;                                                                \
+      }                                                                       \
+      case paddle::DataType::FLOAT16: {                                       \
+        using SCALE_TYPE = phi::dtype::float16;                               \
+        __VA_ARGS__;                                                          \
+        break;                                                                \
+      }                                                                       \
+      case paddle::DataType::BFLOAT16: {                                      \
+        using SCALE_TYPE = phi::dtype::bfloat16;                              \
+        __VA_ARGS__;                                                          \
+        break;                                                                \
+      }                                                                       \
+        DEFAULT_THROW(NAME, SCALE_DTYPE);                                     \
+    }                                                                         \
   } while (0)
 
 #ifdef PADDLE_WITH_HIP

--- a/paddle/phi/kernels/gpu/rms_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/rms_norm_grad_kernel.cu
@@ -169,11 +169,11 @@ void RmsNormGradKernel(const Context& dev_ctx,
                        DenseTensor* grad_x,
                        DenseTensor* grad_norm_weight) {
   if (bias || residual || norm_bias) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "bias or residual or norm_bias is not supported yet"));
   }
   if (quant_scale > 0.0f) {
-    PADDLE_THROW(phi::errors::Unimplemented("quant is not supported yet"));
+    PADDLE_THROW(common::errors::Unimplemented("quant is not supported yet"));
   }
   cuda_rms_norm_gradient<T, Context>(dev_ctx,
                                      x,

--- a/paddle/phi/kernels/gpu/rms_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/rms_norm_kernel.cu
@@ -1097,26 +1097,26 @@ void RmsNormKernel(const Context& dev_ctx,
       out->dtype() == phi::DataType::FLOAT8_E4M3FN) {
     PADDLE_ENFORCE_EQ(quant_scale != 0.0f,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Quant rms_norm'output, must has quant_scale, "
                           "quant_scale!=0, but quant_scale = %f ",
                           quant_scale));
     PADDLE_ENFORCE_EQ(quant_round_type == 0 || quant_round_type == 1,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Quant rms_norm'output, must has quant_round_type, "
                           "quant_round_type = 0 or quant_round_type = 1, but "
                           "quant_scale = %d ",
                           quant_scale));
     PADDLE_ENFORCE_EQ(quant_max_bound != 0.0f,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Quant rms_norm'output, must has quant_max_bound and "
                           "quant_max_bound!=0, but quant_max_bound = %f ",
                           quant_scale));
     PADDLE_ENFORCE_EQ(quant_min_bound != 0.0f,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Quant rms_norm'output, must has quant_min_bound and "
                           "quant_min_bound!=0, but quant_min_bound = %f ",
                           quant_scale));

--- a/paddle/phi/kernels/gpu/rmsprop_kernel.cu
+++ b/paddle/phi/kernels/gpu/rmsprop_kernel.cu
@@ -58,13 +58,13 @@ struct RmsFunctor<T, phi::GPUContext> {
         PADDLE_ENFORCE_EQ(
             mg_tensor->Holder(),
             mean_grad_out->Holder(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "MeanGrad and MeanGradOut must be the same Tensor"));
       } else {
         PADDLE_ENFORCE_EQ(
             mg_tensor,
             mean_grad_out,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "MeanGrad and MeanGradOut must be the same Tensor"));
       }
 

--- a/paddle/phi/kernels/gpu/rnn_functor.h
+++ b/paddle/phi/kernels/gpu/rnn_functor.h
@@ -235,7 +235,7 @@ class RNNDescriptors {
     PADDLE_ENFORCE_EQ(
         weights_size_,
         sizeof(T) * weight_numel_,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The cudnn rnn and setting weight size should be same."));
     // ------------------- cudnn weight descriptors ---------------------
     auto layout = phi::backends::gpu::DataLayout::kNCHW;

--- a/paddle/phi/kernels/gpu/rnn_grad_kernel.cu.cc
+++ b/paddle/phi/kernels/gpu/rnn_grad_kernel.cu.cc
@@ -117,7 +117,7 @@ void RnnGradKernel(const Context &dev_ctx,
     rnn_mode = CUDNN_RNN_TANH;
 #endif
   else
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "rnn_mode should be LSTM, GRU, RNN_RELU or RNN_TANH, but received: "
         "%s.",
         mode));
@@ -215,10 +215,10 @@ void RnnGradKernel(const Context &dev_ctx,
 
   bool has_seq_length = sequence_length.is_initialized();
 #ifdef PADDLE_WITH_HIP
-  PADDLE_ENFORCE_EQ(
-      has_seq_length,
-      false,
-      phi::errors::InvalidArgument("ROCm do not support SequenceLength yet."));
+  PADDLE_ENFORCE_EQ(has_seq_length,
+                    false,
+                    common::errors::InvalidArgument(
+                        "ROCm do not support SequenceLength yet."));
 #endif
   std::vector<int> SequenceLength;
   if (has_seq_length) {
@@ -464,7 +464,7 @@ void RnnGradKernel(const Context &dev_ctx,
           reserve_size));
     }
 #else
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "The padded input of rnn is supported by cudnnRNNBackwardDataEx, "
         "cudnnRNNBackwardWeightsEx, but it only works when the version "
         "of cudnn is larger than 7.2.1"));

--- a/paddle/phi/kernels/gpu/rnn_kernel.cu.cc
+++ b/paddle/phi/kernels/gpu/rnn_kernel.cu.cc
@@ -143,7 +143,7 @@ void RNNInferece(bool has_seq_length,
         workspace_size));
 #else
     // CUDNN VERSION has to >=7.2.1
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "The padded input is supported by "
         "cudnnRNNForwardInferenceEx, but it only works when "
         "the version of cudnn is larger than 7.2.1"));
@@ -193,7 +193,7 @@ void RnnKernel(const Context &dev_ctx,
     rnn_mode = CUDNN_RNN_TANH;
 #endif
   else
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "rnn_mode should be LSTM, GRU, RNN_RELU or RNN_TANH, but received: "
         "%s.",
         mode));
@@ -224,10 +224,10 @@ void RnnKernel(const Context &dev_ctx,
 
   bool has_seq_length = sequence_length.is_initialized();
 #ifdef PADDLE_WITH_HIP
-  PADDLE_ENFORCE_EQ(
-      has_seq_length,
-      false,
-      phi::errors::InvalidArgument("ROCm do not support SequenceLength yet."));
+  PADDLE_ENFORCE_EQ(has_seq_length,
+                    false,
+                    common::errors::InvalidArgument(
+                        "ROCm do not support SequenceLength yet."));
 #endif
   std::vector<int> SequenceLength;
   if (has_seq_length) {
@@ -440,7 +440,7 @@ void RnnKernel(const Context &dev_ctx,
           reserve_data,
           reserve_size));
 #else
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "The padded input is supported by "
           "cudnnRNNForwardTrainingEx, but it only works when "
           "the version of cudnn is larger than 7.2.1"));

--- a/paddle/phi/kernels/gpu/roi_pool_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_kernel.cu
@@ -137,7 +137,7 @@ void RoiPoolKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         boxes_batch_size,
         batch_size,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The batch size of input(ROIs) and input(X) must be the same but "
             "received batch size of input(ROIs) and input(X) is %d and %d "
             "respectively.",
@@ -163,7 +163,7 @@ void RoiPoolKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         boxes_batch_size,
         batch_size,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The batch size of input(ROIs) and input(X) must be the same but "
             "received batch size of input(ROIs) and input(X) is %d and %d "
             "respectively.",
@@ -173,7 +173,7 @@ void RoiPoolKernel(const Context& dev_ctx,
     int boxes_num_with_lod = boxes_lod[boxes_batch_size];
     PADDLE_ENFORCE_EQ(rois_num,
                       boxes_num_with_lod,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The number of rois from input(ROIs) and its LOD "
                           "must be the same. Received rois %d of input(ROIs) "
                           "but the number of rois %d from its LOD is %d",

--- a/paddle/phi/kernels/gpu/scatter_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/scatter_grad_kernel.cu
@@ -36,7 +36,7 @@ void ScatterGradKernel(const Context &ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "scatter_op index holds the wrong type, it holds [%s],"
                         "but desires to be [%s] or [%s]",
                         index_type,

--- a/paddle/phi/kernels/gpu/scatter_kernel.cu
+++ b/paddle/phi/kernels/gpu/scatter_kernel.cu
@@ -36,7 +36,7 @@ void ScatterKernel(const Context &ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "scatter_op Index holds the wrong type, it holds [%s],"
                         "but desires to be [%s] or [%s].",
                         index_type,

--- a/paddle/phi/kernels/gpu/scatter_nd_add_kernel.cu
+++ b/paddle/phi/kernels/gpu/scatter_nd_add_kernel.cu
@@ -34,7 +34,7 @@ void ScatterNdAddKernel(const Context &ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Index holds the wrong type, it holds [%s], but "
                         "desires to be [%s] or [%s].",
                         index_type,

--- a/paddle/phi/kernels/gpu/sgd_kernel.cu
+++ b/paddle/phi/kernels/gpu/sgd_kernel.cu
@@ -124,7 +124,7 @@ void SGDDenseParamSparseGradKernel(
   PADDLE_ENFORCE_EQ(
       &param,
       param_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input tensor Param of SgdOp should be equal with ParamOut "
           "if variable's type is SelectedRows."));
 
@@ -132,7 +132,7 @@ void SGDDenseParamSparseGradKernel(
   auto out_dims = param_out->dims();
   PADDLE_ENFORCE_EQ(in_height,
                     out_dims[0],
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The input tensor Grad's height of SgdOp should be "
                         "equal with ParamOut's dims. But received Grad's "
                         "height [%s] and ParamOut's dims [%s]",
@@ -145,7 +145,7 @@ void SGDDenseParamSparseGradKernel(
   int64_t in_row_numel = in_value.numel() / in_rows.size();
   PADDLE_ENFORCE_EQ(in_row_numel,
                     param_out->numel() / in_height,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The in_row_numel of SgdOp should be equal with "
                         "param_out's numel / in_height."));
 

--- a/paddle/phi/kernels/gpu/shard_index_kernel.cu
+++ b/paddle/phi/kernels/gpu/shard_index_kernel.cu
@@ -61,27 +61,27 @@ void ShardIndexKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_GT(
       index_num,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The value 'index_num' for Op(shard_index) must be greater than 0, "
           "but the value given is %d.",
           index_num));
   PADDLE_ENFORCE_GT(nshards,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The value 'nshard' for Op(shard_index) must be "
                         "greater than 0, but the value given is %d.",
                         nshards));
   PADDLE_ENFORCE_GE(
       shard_id,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The value 'shard_id' for Op(shard_index) must be greater or "
           "equal to 0, but the value given is %d.",
           shard_id));
   PADDLE_ENFORCE_LT(
       shard_id,
       nshards,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The value 'shard_id' for Op(shard_index) must be less than "
           "nshards (%d), but the value given is %d.",
           nshards,

--- a/paddle/phi/kernels/gpu/shuffle_batch_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/shuffle_batch_grad_kernel.cu
@@ -39,7 +39,7 @@ void ShuffleBatchGradKernel(const Context& dev_ctx,
                             int startup_seed,
                             DenseTensor* x_grad) {
 #ifdef _MSC_VER
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "GPU shuffle_batch_grad is not supported on Windows yet"));
 #else
   const auto* out_grad_data = out_grad.data<T>();

--- a/paddle/phi/kernels/gpu/shuffle_batch_kernel.cu
+++ b/paddle/phi/kernels/gpu/shuffle_batch_kernel.cu
@@ -41,7 +41,7 @@ void ShuffleBatchKernel(const Context& dev_ctx,
                         DenseTensor* shuffleidx,
                         DenseTensor* seed_out) {
 #ifdef _MSC_VER
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "GPU shuffle_batch is not supported on Windows yet"));
 #else
   int64_t x_embed_size = x.dims()[x.dims().size() - 1];

--- a/paddle/phi/kernels/gpu/squared_l2_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/squared_l2_norm_grad_kernel.cu
@@ -41,7 +41,7 @@ void SquaredL2NormGradKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       dout.numel(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input(GRAD@Out) of SquaredL2NormGradOP should be a scalar."));
   std::vector<const DenseTensor*> ins{&x, &dout};
   std::vector<DenseTensor*> outs{dx};

--- a/paddle/phi/kernels/gpu/stack_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/stack_grad_kernel.cu
@@ -31,7 +31,7 @@ void StackGradKernel(const Context& ctx,
   PADDLE_ENFORCE_EQ(
       split_dim,
       x_grad.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Output x_grad's size should be equal to the split_dim, but"
           " received split_dim is:%d x_grad's size is:%d.",
           split_dim,

--- a/paddle/phi/kernels/gpu/strided_copy_kernel.cu
+++ b/paddle/phi/kernels/gpu/strided_copy_kernel.cu
@@ -362,7 +362,7 @@ bool LaunchStridedCopyCazeOneKernel(
           dims[rank - 1] * dims[rank - 2] * dims[rank - 3]);
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "The rank of input should be less than 9, but received %d.", rank));
   }
 
@@ -449,7 +449,7 @@ void LaunchStridedCopyDefaultKernel(
           input_data, input_stride, output_data, output_stride, dims, numel);
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "The rank of input should be less than 9, but received %d.", rank));
   }
 }
@@ -785,7 +785,7 @@ bool LaunchStrided2ContiguousCazeOneKernel(
           dims[rank - 1] * dims[rank - 2] * dims[rank - 3]);
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "The rank of input should be less than 9, but received %d.", rank));
   }
 
@@ -863,7 +863,7 @@ void LaunchStrided2ContiguousDefaultKernel(
           input_data, input_stride, output_data, dims, numel);
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "The rank of input should be less than 9, but received %d.", rank));
   }
 }
@@ -1199,7 +1199,7 @@ bool LaunchContiguous2StridedCazeOneKernel(
           dims[rank - 1] * dims[rank - 2] * dims[rank - 3]);
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "The rank of input should be less than 9, but received %d.", rank));
   }
 
@@ -1277,7 +1277,7 @@ void LaunchContiguous2StridedDefaultKernel(
           input_data, output_data, output_stride, dims, numel);
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "The rank of input should be less than 9, but received %d.", rank));
   }
 }
@@ -1297,14 +1297,14 @@ void StridedCopyKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_EQ(input.dims(),
                     out->dims(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input shape(%s) must be equal with out shape(%s).",
                         input.dims(),
                         out->dims()));
 
   PADDLE_ENFORCE_EQ(input.numel(),
                     out->numel(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input numel(%d) must be equal with out numel(%d).",
                         input.numel(),
                         out->numel()));
@@ -1320,7 +1320,7 @@ void StridedCopyKernel(const Context& dev_ctx,
 
   T* output_data = out->data<T>();
   PADDLE_ENFORCE_NOT_NULL(output_data,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "StridedCopyKernel's out tensor must complete "
                               "mutable data before call kernel."));
 

--- a/paddle/phi/kernels/gpu/svd_kernel.cu
+++ b/paddle/phi/kernels/gpu/svd_kernel.cu
@@ -113,7 +113,7 @@ void GesvdjBatched<float>(const phi::GPUContext& dev_ctx,
     PADDLE_ENFORCE_EQ(
         error_info,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "For batch [%d]: CUSolver SVD is not zero. [%d]", i, error_info));
   }
   PADDLE_ENFORCE_GPU_SUCCESS(
@@ -194,7 +194,7 @@ void GesvdjBatched<double>(const phi::GPUContext& dev_ctx,
     PADDLE_ENFORCE_EQ(
         error_info,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "For batch [%d]: CUSolver SVD is not zero. [%d]", i, error_info));
   }
   PADDLE_ENFORCE_GPU_SUCCESS(

--- a/paddle/phi/kernels/gpu/swiglu_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/swiglu_grad_kernel.cu
@@ -146,7 +146,7 @@ void SwiGLUGradKernelImpl(const Context &ctx,
       PD_LAUNCH_SWIGLU_GRAD_CUDA_KERNEL_BASE(                               \
           VecSizeS, __is_combine, __has_dx, __has_dy);                      \
       default:                                                              \
-        PADDLE_THROW(phi::errors::Unimplemented(                            \
+        PADDLE_THROW(common::errors::Unimplemented(                         \
             "Unsupported vectorized size: %d !", vec_size));                \
         break;                                                              \
     }                                                                       \
@@ -164,14 +164,14 @@ void SwiGLUGradKernelImpl(const Context &ctx,
     } else {
       PADDLE_ENFORCE_NOT_NULL(
           dy,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Both gradients of Input(X) and Input(Y) is None."));
       PD_LAUNCH_SWIGLU_GRAD_CUDA_KERNEL(false, false, true);
     }
   } else {
     PADDLE_ENFORCE_NOT_NULL(
         dx,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Both gradients of Input(X) and Input(Y) is None."));
     while (n % vec_size != 0) {
       vec_size /= 2;

--- a/paddle/phi/kernels/gpu/swiglu_kernel.cu
+++ b/paddle/phi/kernels/gpu/swiglu_kernel.cu
@@ -98,7 +98,7 @@ void SwiGLUKernelImpl(
       PD_LAUNCH_SWIGLU_CUDA_KERNEL_BASE(VecSizeM, __is_combine); \
       PD_LAUNCH_SWIGLU_CUDA_KERNEL_BASE(VecSizeS, __is_combine); \
       default:                                                   \
-        PADDLE_THROW(phi::errors::Unimplemented(                 \
+        PADDLE_THROW(common::errors::Unimplemented(              \
             "Unsupported vectorized size: %d !", vec_size));     \
         break;                                                   \
     }                                                            \

--- a/paddle/phi/kernels/gpu/take_along_axis_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/take_along_axis_grad_kernel.cu
@@ -52,10 +52,10 @@ void TakeAlongAxisGradKernel(const Context& dev_ctx,
     phi::funcs::gpu_scatter_add_kernel<T, int64_t>(
         *x_grad, axis, index, out_grad, true, dev_ctx);
   } else {
-    PADDLE_THROW(
-        phi::errors::InvalidArgument("The data type of input index is expected "
-                                     "to be int32 or int64, but received %s.",
-                                     phi::DataTypeToString(index_type)));
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "The data type of input index is expected "
+        "to be int32 or int64, but received %s.",
+        phi::DataTypeToString(index_type)));
   }
 }
 

--- a/paddle/phi/kernels/gpu/take_along_axis_kernel.cu
+++ b/paddle/phi/kernels/gpu/take_along_axis_kernel.cu
@@ -39,10 +39,10 @@ void TakeAlongAxisKernel(const Context& dev_ctx,
     phi::funcs::gpu_gather_kernel<T, int64_t>(
         x, axis, index, *out, true, dev_ctx);
   } else {
-    PADDLE_THROW(
-        phi::errors::InvalidArgument("The data type of input index is expected "
-                                     "to be int32 or int64, but received %s.",
-                                     phi::DataTypeToString(index_type)));
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "The data type of input index is expected "
+        "to be int32 or int64, but received %s.",
+        phi::DataTypeToString(index_type)));
   }
 }
 

--- a/paddle/phi/kernels/gpu/unique_consecutive_functor.h
+++ b/paddle/phi/kernels/gpu/unique_consecutive_functor.h
@@ -299,7 +299,7 @@ void IndexSelect(const Context& context,
     PADDLE_ENFORCE_GE(
         index_vec[i],
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Variable value (index) of OP(index_select) "
             "expected >= 0 and < %ld, but got %ld. Please check input "
             "value.",
@@ -308,7 +308,7 @@ void IndexSelect(const Context& context,
     PADDLE_ENFORCE_LT(
         index_vec[i],
         input_dim[dim],
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Variable value (index) of OP(index_select) "
             "expected >= 0 and < %ld, but got %ld. Please check input "
             "value.",

--- a/paddle/phi/kernels/gpu/unique_consecutive_kernel.cu
+++ b/paddle/phi/kernels/gpu/unique_consecutive_kernel.cu
@@ -37,7 +37,7 @@ void UniqueConsecutiveKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_LE(
         x.numel() + 1,
         INT_MAX,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The number of elements in Input(X) should be less than or "
             "equal to INT_MAX, but received num is %d. Please set `dtype` to "
             "int64.",

--- a/paddle/phi/kernels/gpu/unique_kernel.cu
+++ b/paddle/phi/kernels/gpu/unique_kernel.cu
@@ -624,7 +624,7 @@ void UniqueRawKernel(const Context& context,
     PADDLE_ENFORCE_LE(
         x.numel() + 1,
         INT_MAX,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The number of elements in Input(X) should be less than or "
             "equal to INT_MAX, but received num is %d. Please set `dtype` to "
             "int64.",

--- a/paddle/phi/kernels/gpu/unstack_kernel.cu
+++ b/paddle/phi/kernels/gpu/unstack_kernel.cu
@@ -33,7 +33,7 @@ void UnStackKernel(const Context& ctx,
   PADDLE_ENFORCE_EQ(
       split_dim,
       outs.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Output outs's size should be equal to the split_dim, but"
           " received split_dim is:%d outs's size is:%d.",
           split_dim,

--- a/paddle/phi/kernels/gpu/weight_dequantize_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_dequantize_kernel.cu
@@ -470,7 +470,7 @@ void WeightDequantizeKernel(const Context& dev_ctx,
   out->ShareDataWith(out_tmp);
 #else
   PADDLE_THROW(
-      phi::errors::PreconditionNotMet("Not compiled with WITH_CUTLASS=ON"));
+      common::errors::PreconditionNotMet("Not compiled with WITH_CUTLASS=ON"));
 #endif
 }
 

--- a/paddle/phi/kernels/gpu/weight_only_linear_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_only_linear_grad_kernel.cu
@@ -39,13 +39,13 @@ void WeightOnlyLinearGradKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       ((arch == 80) || (arch == 86)),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Currently weightonly linear grad only support arch = 80 or 86. "));
 
   PADDLE_ENFORCE_EQ(
       group_size,
       -1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Currently weightonly linear grad only support per-channel mode. "));
 
   int n = weight_scale.dims()[0];
@@ -67,7 +67,7 @@ void WeightOnlyLinearGradKernel(const Context& dev_ctx,
       dev_ctx, out_grad, weight_dequantized, false, false, x_grad);
 #else
   PADDLE_THROW(
-      phi::errors::PreconditionNotMet("Not compiled with WITH_CUTLASS=ON"));
+      common::errors::PreconditionNotMet("Not compiled with WITH_CUTLASS=ON"));
 #endif
 }
 

--- a/paddle/phi/kernels/gpu/weight_only_linear_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_only_linear_kernel.cu
@@ -38,10 +38,10 @@ void WeightOnlyLinearKernel(const Context& dev_ctx,
       ((arch == 70) || (arch == 75) || (arch == 80) || (arch == 86) ||
        (arch == 89) || (arch == 90)),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Currently, arch only support 70, 75, 80, 86, 89, 90."));
 #else
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Please compile with cutlass to make cutlass available"));
 #endif
 
@@ -161,7 +161,7 @@ we havenot support sm70 weightonly gemv, because sm70 weight layout is RowMajor.
       }
     }
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Please compile with cutlass to make cutlass available"));
 #endif
   } else {  // m <= 3: gemv

--- a/paddle/phi/kernels/gpu/weight_quantize_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_quantize_kernel.cu
@@ -33,7 +33,7 @@ void WeightQuantizeKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       ((group_size == -1) || (group_size == 64) || (group_size == 128)),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Currently, group_size only support -1(per-channel), 64 or 128."));
 
   DenseTensor quanted_x;
@@ -49,7 +49,7 @@ void WeightQuantizeKernel(const Context& dev_ctx,
       ((arch == 70) || (arch == 75) || (arch == 80) || (arch == 86) ||
        (arch == 89) || (arch == 90)),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Currently, arch only support 70, 75, 80, 86, 89, 90."));
 #endif
   if (algo == "llm.int8") {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/66145#issuecomment-2249572051

Replace phi::errors to common::errors in paddle/phi
