### PR TITLE
Replace phi::errors [fluid_ops] part14

### DIFF
--- a/paddle/phi/kernels/xpu/accuracy_kernel.cc
+++ b/paddle/phi/kernels/xpu/accuracy_kernel.cc
@@ -36,7 +36,7 @@ void AccuracyRawKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       inference.dims().size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Rank(Input) of AccuracyOp must be 2, with shape "
           "[sample_number, class_dim], But received rank(Input) is %d",
           inference.dims().size()));

--- a/paddle/phi/kernels/xpu/add_n_kernel.cc
+++ b/paddle/phi/kernels/xpu/add_n_kernel.cc
@@ -62,7 +62,7 @@ void AddNKernel(const Context& dev_ctx,
       auto& in_t = *(static_cast<const SelectedRows*>(x[i]));
       functor(dev_ctx, in_t, out);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Expected type of Input(X) of %d-th must be Tensor, "
           "SelectedRows. But got "
           "unsupport type: %s.",
@@ -134,7 +134,7 @@ void AddNArrayKernel(const Context& dev_ctx,
           PADDLE_ENFORCE_EQ(
               out->at(j).lod(),
               in_array->at(j).lod(),
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "The lod message between inputs[%d] and"
                   " outputs[%d] must be same, but now is not same.",
                   j,

--- a/paddle/phi/kernels/xpu/affine_channel_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/affine_channel_grad_kernel.cc
@@ -77,37 +77,37 @@ void AffineChannelGradXPUKernel(const Context& dev_ctx,
   int r = 0;
   if (dscale_d && dbias_d) {
     r = xpu::reduce_sum<T>(dev_ctx.x_context(), dy_d, dbias_d, x_shape, rdims);
-    PADDLE_ENFORCE_EQ(
-        r,
-        xpu::Error_t::SUCCESS,
-        phi::errors::External("The reduce_sum XPU OP return wrong value[%d %s]",
-                              r,
-                              XPUAPIErrorMsg[r]));
+    PADDLE_ENFORCE_EQ(r,
+                      xpu::Error_t::SUCCESS,
+                      common::errors::External(
+                          "The reduce_sum XPU OP return wrong value[%d %s]",
+                          r,
+                          XPUAPIErrorMsg[r]));
     xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
     T* tmp = RAII_GUARD.alloc_l3_or_gm<T>(dy->numel());
-    PADDLE_ENFORCE_NOT_NULL(tmp,
-                            phi::errors::External("XPU has no enough memory"));
+    PADDLE_ENFORCE_NOT_NULL(
+        tmp, common::errors::External("XPU has no enough memory"));
 
     r = xpu::mul<T>(dev_ctx.x_context(), dy_d, x->data<T>(), tmp, dy->numel());
     PADDLE_ENFORCE_EQ(
         r,
         xpu::Error_t::SUCCESS,
-        phi::errors::External(
+        common::errors::External(
             "The mul XPU OP return wrong value[%d %s]", r, XPUAPIErrorMsg[r]));
     r = xpu::reduce_sum<T>(dev_ctx.x_context(), tmp, dscale_d, x_shape, rdims);
-    PADDLE_ENFORCE_EQ(
-        r,
-        xpu::Error_t::SUCCESS,
-        phi::errors::External("The reduce_sum XPU OP return wrong value[%d %s]",
-                              r,
-                              XPUAPIErrorMsg[r]));
+    PADDLE_ENFORCE_EQ(r,
+                      xpu::Error_t::SUCCESS,
+                      common::errors::External(
+                          "The reduce_sum XPU OP return wrong value[%d %s]",
+                          r,
+                          XPUAPIErrorMsg[r]));
   }
   if (dx_d) {
     r = xpu::broadcast_mul(
         dev_ctx.x_context(), dy_d, scale_d, dx_d, x_shape, b_shape);
     PADDLE_ENFORCE_EQ(r,
                       xpu::Error_t::SUCCESS,
-                      phi::errors::External(
+                      common::errors::External(
                           "The broadcast_mul XPU OP return wrong value[%d %s]",
                           r,
                           XPUAPIErrorMsg[r]));

--- a/paddle/phi/kernels/xpu/affine_channel_kernel.cc
+++ b/paddle/phi/kernels/xpu/affine_channel_kernel.cc
@@ -68,7 +68,7 @@ void AffineChannelXPUKernel(const Context& dev_ctx,
       dev_ctx.x_context(), x_d, scale_d, y_d, x_shape, b_shape);
   PADDLE_ENFORCE_EQ(r,
                     xpu::Error_t::SUCCESS,
-                    phi::errors::External(
+                    common::errors::External(
                         "The broadcast_mul XPU OP return wrong value[%d %s]",
                         r,
                         XPUAPIErrorMsg[r]));
@@ -76,7 +76,7 @@ void AffineChannelXPUKernel(const Context& dev_ctx,
       dev_ctx.x_context(), y_d, bias_d, y_d, x_shape, b_shape);
   PADDLE_ENFORCE_EQ(r,
                     xpu::Error_t::SUCCESS,
-                    phi::errors::External(
+                    common::errors::External(
                         "The broadcast_add XPU OP return wrong value[%d %s]",
                         r,
                         XPUAPIErrorMsg[r]));

--- a/paddle/phi/kernels/xpu/amp_kernel.cc
+++ b/paddle/phi/kernels/xpu/amp_kernel.cc
@@ -48,10 +48,10 @@ void UpdateLossScalingKernel(const Context& dev_ctx,
   using MPDType = typename phi::dtype::MPTypeTrait<T>::Type;
   using XPUTyp = typename XPUTypeTrait<T>::Type;
 
-  PADDLE_ENFORCE_EQ(
-      found_infinite.numel(),
-      1,
-      phi::errors::InvalidArgument("FoundInfinite must has only one element."));
+  PADDLE_ENFORCE_EQ(found_infinite.numel(),
+                    1,
+                    common::errors::InvalidArgument(
+                        "FoundInfinite must has only one element."));
   const bool* found_inf_data = found_infinite.data<bool>();
   bool cpu_found_inf_data = false;
   if (found_infinite.place().GetType() == phi::AllocationType::XPU) {

--- a/paddle/phi/kernels/xpu/arg_min_max_kernel.cc
+++ b/paddle/phi/kernels/xpu/arg_min_max_kernel.cc
@@ -33,7 +33,7 @@ void ArgMaxKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_GT(
       x.numel(),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "argmin/argmax input numel must > 0, bug got %d", x.numel()));
   using XPUType = typename XPUTypeTrait<T>::Type;
   PADDLE_ENFORCE_EQ(

--- a/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
@@ -34,7 +34,7 @@ static int CalculateInvBNY(xpu::Context *ctx,
                            const T *y) {
   PADDLE_ENFORCE_EQ(x,
                     y,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "X and Y should be inplaced in inplace mode"));
   std::vector<int> tensor_shape_vec({N, C, M});
   std::vector<int> array_shape_vec({1, C, 1});
@@ -94,7 +94,7 @@ void BatchNormGradKernel(const Context &dev_ctx,
   const auto *d_y = &y_grad;
   PADDLE_ENFORCE_EQ(data_layout == "NCHW" || data_layout == "NHWC",
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The 'data_layout' attribute must be NCHW or NHWC. "
                         "But received 'data_layout' is [%s].",
                         data_layout));
@@ -111,7 +111,7 @@ void BatchNormGradKernel(const Context &dev_ctx,
   if (x_grad) {
     PADDLE_ENFORCE_NE(x_grad,
                       d_y,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "X@GRAD and Y@GRAD inplaced in non-inplace mode"));
   }
 
@@ -119,7 +119,7 @@ void BatchNormGradKernel(const Context &dev_ctx,
   PADDLE_ENFORCE_EQ(
       x_dims.size() >= 2 && x_dims.size() <= 5,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of input's dimensions should be between 2 and 5. "
           "But received: the size of input's dimensions is [%d]",
           x_dims.size()));
@@ -172,7 +172,7 @@ void BatchNormGradKernel(const Context &dev_ctx,
   PADDLE_ENFORCE_EQ(
       new_scale.dims().size(),
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of scale's dimensions must equal to 1. But received: "
           "the size of scale's dimensions is [%d], the dimensions of scale "
           "is [%s].",
@@ -181,7 +181,7 @@ void BatchNormGradKernel(const Context &dev_ctx,
   PADDLE_ENFORCE_EQ(
       new_scale.dims()[0],
       C,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The first dimension of scale must equal to Channels[%d]. But "
           "received: the first dimension of scale is [%d]",
           C,

--- a/paddle/phi/kernels/xpu/batch_norm_kernel.cc
+++ b/paddle/phi/kernels/xpu/batch_norm_kernel.cc
@@ -46,7 +46,7 @@ void BatchNormKernel(const Context& dev_ctx,
   const auto data_layout = common::StringToDataLayout(data_layout_str);
   PADDLE_ENFORCE_EQ(data_layout_str == "NCHW" || data_layout_str == "NHWC",
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The 'data_layout' attribute must be NCHW or NHWC. "
                         "But received 'data_layout' is [%s].",
                         data_layout_str));
@@ -55,7 +55,7 @@ void BatchNormKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       x_dims.size() >= 2 && x_dims.size() <= 5,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of input's dimensions should be between 2 and 5"
           "But received: the size of input's dimensions is [%d]",
           x_dims.size()));
@@ -102,7 +102,7 @@ void BatchNormKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_LE(
       x_dims.size(),
       5,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of input X's dimensions should be less than 6."
           "But received: the size of input X's dimensions is [%d]",
           x_dims.size()));

--- a/paddle/phi/kernels/xpu/beam_search_decode_kernel.cc
+++ b/paddle/phi/kernels/xpu/beam_search_decode_kernel.cc
@@ -31,7 +31,7 @@ void BeamSearchDecodeXPUKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_GT(
       step_num,
       0UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "beam search steps, which is the"
           "size of Input(Ids) TensorArray. beam search steps should "
           "be larger than 0, but received %d. ",
@@ -41,7 +41,7 @@ void BeamSearchDecodeXPUKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_GT(
       source_num,
       0UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "source_num is the sequence number of the"
           "first decoding step, indicating by Input(Ids)[0].lod[0].size. "
           "The number of source_num should be larger than"
@@ -52,7 +52,7 @@ void BeamSearchDecodeXPUKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         ids->at(i).lod().size(),
         2UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "For the i step in beam search steps,"
             "the size of Input(Ids)[i].lod() should larger than 2,"
             "but received %d. ",
@@ -87,15 +87,15 @@ void BeamSearchDecodeXPUKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         r,
         xpu::Error_t::SUCCESS,
-        phi::errors::External("Execute function CopyTensorByXPU failed by [%d]",
-                              r));
+        common::errors::External(
+            "Execute function CopyTensorByXPU failed by [%d]", r));
 
     r = phi::funcs::CopyTensorByType(
         *sentenceScores, sentenceScores_temp, 1, ids->at(0).place());
     PADDLE_ENFORCE_EQ(
         r,
         xpu::Error_t::SUCCESS,
-        phi::errors::External(
+        common::errors::External(
             "Execute function CopyTensorByType failed by [%d]", r));
     sentenceIds_temp->set_lod(sentenceIds->lod());
     sentenceScores_temp->set_lod(sentenceScores->lod());

--- a/paddle/phi/kernels/xpu/bmm_kernel.cc
+++ b/paddle/phi/kernels/xpu/bmm_kernel.cc
@@ -33,20 +33,20 @@ void BmmKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_EQ(x_dims.size(),
                     3,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(X) of BmmOp must be 3-dimensional in BmmOp, "
                         "but received X's shape: [%s]",
                         x_dims));
   PADDLE_ENFORCE_EQ(y_dims.size(),
                     3,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Y) of BmmOp must be 3-dimensional in BmmOp, "
                         "but received Y's shape: [%s].",
                         y_dims));
   PADDLE_ENFORCE_EQ(
       x_dims[0],
       y_dims[0],
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input(X) and Input(Y) must have the same batch size in BmmOp, "
           "but received X's batch size: [%s],"
           "Y's batch size [%s]",
@@ -55,7 +55,7 @@ void BmmKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       x_dims[2],
       y_dims[1],
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input(X)'s width must be equal with Input(Y)'s height in BmmOp,"
           "but receive X's width: [%s],"
           "Y's height: [%s].",

--- a/paddle/phi/kernels/xpu/c_embedding_kernel.cc
+++ b/paddle/phi/kernels/xpu/c_embedding_kernel.cc
@@ -64,7 +64,7 @@ void CEmbeddingKernel(const Context& dev_ctx,
                            static_cast<int64_t>(start_index));
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "embedding");
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "XPU c_embedding ids only support int32 or int64."));
   }
 }

--- a/paddle/phi/kernels/xpu/c_embedding_kernel_grad.cc
+++ b/paddle/phi/kernels/xpu/c_embedding_kernel_grad.cc
@@ -73,7 +73,7 @@ void CEmbeddingGradKernel(const Context& dev_ctx,
                             -1,
                             static_cast<int64_t>(start_index));
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "XPU c_embedding ids only support int32 or int64."));
   }
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "embedding_grad");

--- a/paddle/phi/kernels/xpu/c_split_kernel.cc
+++ b/paddle/phi/kernels/xpu/c_split_kernel.cc
@@ -32,19 +32,19 @@ void CSplitKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_GE(rank,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The value of rank (%d) for c_split must be "
                         "greater than or equal to 0.",
                         rank));
   PADDLE_ENFORCE_GE(nranks,
                     2,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The value of nranks (%d) for c_split must be "
                         "greater than or equal to 2.",
                         nranks));
   PADDLE_ENFORCE_LT(rank,
                     nranks,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The value of rank (%d) for c_split must be "
                         "less than that of nranks (%d).",
                         rank,

--- a/paddle/phi/kernels/xpu/cast_kernel.cc
+++ b/paddle/phi/kernels/xpu/cast_kernel.cc
@@ -114,7 +114,7 @@ void CastKernel(const Context& dev_ctx,
       CastXPUKernelImpl<T, int16_t, Context>(dev_ctx, x, out);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Not supported cast %d -> %d", x.dtype(), out_dtype));
   }
 }

--- a/paddle/phi/kernels/xpu/clip_by_norm_kernel.cc
+++ b/paddle/phi/kernels/xpu/clip_by_norm_kernel.cc
@@ -29,7 +29,7 @@ void ClipByNormKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(output);
 
   PADDLE_ENFORCE_NOT_NULL(input,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Input(X) of ClipByNormOp should not be null. "
                               "Please check if it is created correctly."));
 

--- a/paddle/phi/kernels/xpu/clip_kernel.cc
+++ b/paddle/phi/kernels/xpu/clip_kernel.cc
@@ -41,10 +41,10 @@ void ClipKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_EQ(r,
                     XPU_SUCCESS,
-                    phi::errors::External("XPU API(clip_v2) return wrong "
-                                          "value[%d %s]",
-                                          r,
-                                          XPUAPIErrorMsg[r]));
+                    common::errors::External("XPU API(clip_v2) return wrong "
+                                             "value[%d %s]",
+                                             r,
+                                             XPUAPIErrorMsg[r]));
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/xpu/concat_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/concat_grad_kernel.cc
@@ -40,7 +40,7 @@ void ConcatGradKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_NE(
       x[0],
       nullptr,
-      phi::errors::InvalidArgument("The input should not be null."));
+      common::errors::InvalidArgument("The input should not be null."));
   auto axis = axis_scalar.to<int>();
   axis = phi::funcs::ComputeAxis(static_cast<int64_t>(axis),
                                  static_cast<int64_t>(x[0]->dims().size()));
@@ -54,15 +54,15 @@ void ConcatGradKernel(const Context& dev_ctx,
       ptrs[j] = nullptr;
     }
   }
-  PADDLE_ENFORCE_GE(
-      axis,
-      0,
-      phi::errors::InvalidArgument("concat_grad: axis should be larger than or "
-                                   "equal to 0, but received axis is %d.",
-                                   axis));
+  PADDLE_ENFORCE_GE(axis,
+                    0,
+                    common::errors::InvalidArgument(
+                        "concat_grad: axis should be larger than or "
+                        "equal to 0, but received axis is %d.",
+                        axis));
   PADDLE_ENFORCE_LT(axis,
                     out_grad.dims().size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "concat_grad: axis should be less than x[0]->dims()!"
                         "But received axis is %d, while x[0]->dims()"
                         "size is %d.",

--- a/paddle/phi/kernels/xpu/concat_kernel.cc
+++ b/paddle/phi/kernels/xpu/concat_kernel.cc
@@ -32,17 +32,17 @@ void ConcatKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_NE(
       x[0],
       nullptr,
-      phi::errors::InvalidArgument("The input should not be null."));
+      common::errors::InvalidArgument("The input should not be null."));
   axis = phi::funcs::ComputeAxis(axis, x[0]->dims().size());
   PADDLE_ENFORCE_GE(
       axis,
       0,
-      phi::errors::InvalidArgument("concat: axis should be larger than or "
-                                   "equal to 0, but received axis is %d.",
-                                   axis));
+      common::errors::InvalidArgument("concat: axis should be larger than or "
+                                      "equal to 0, but received axis is %d.",
+                                      axis));
   PADDLE_ENFORCE_LT(axis,
                     x[0]->dims().size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "concat: axis should be less than x[0]->dims()!"
                         "But received axis is %d, while x[0]->dims()"
                         "size is %d.",
@@ -68,7 +68,7 @@ void ConcatKernel(const Context& dev_ctx,
         PADDLE_ENFORCE_EQ(
             x[i]->lod().size(),
             lod_size_0,
-            phi::errors::Unimplemented(
+            common::errors::Unimplemented(
                 "The lod level of all input LoDTensors should be same. "
                 "Maybe different lod level of input LoDTensors can concat,"
                 "it is not supported currently. The lod level of %dth input "
@@ -106,7 +106,7 @@ void ConcatKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_GT(xdims_list.size(),
                     0,
-                    phi::errors::InvalidArgument("No tensor need concat"));
+                    common::errors::InvalidArgument("No tensor need concat"));
 
   int r = xpu::concat<XPUType>(dev_ctx.x_context(),
                                ptrs,

--- a/paddle/phi/kernels/xpu/contiguous_kernel.cc
+++ b/paddle/phi/kernels/xpu/contiguous_kernel.cc
@@ -178,7 +178,7 @@ void ContiguousKernel(const Context& dev_ctx,
                                 0);
     }
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Received unsupported dtype : %s.", input.dtype()));
   }
 

--- a/paddle/phi/kernels/xpu/conv_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/conv_grad_kernel.cc
@@ -44,7 +44,7 @@ void ConvGradKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       data_format == "NDHWC",
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           ("XPU doesn't support data_format is NDHWC in conv grad op.")));
 
   phi::DDim in_data_dims =

--- a/paddle/phi/kernels/xpu/conv_kernel.cc
+++ b/paddle/phi/kernels/xpu/conv_kernel.cc
@@ -43,7 +43,7 @@ void ConvKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       data_format == "NDHWC",
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           ("XPU does not support data_format is NDHWC in conv op.")));
 
   phi::DDim in_data_dims =

--- a/paddle/phi/kernels/xpu/cum_kernel.cc
+++ b/paddle/phi/kernels/xpu/cum_kernel.cc
@@ -55,7 +55,7 @@ void CumsumKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         axis_as_int < out_dims.size() && axis_as_int >= (0 - out_dims.size()),
         true,
-        phi::errors::OutOfRange(
+        common::errors::OutOfRange(
             "Attr(axis) is out of range, It's expected "
             "to be in range of [-%d, %d]. But received Attr(axis) = %d.",
             out_dims.size(),

--- a/paddle/phi/kernels/xpu/dequantization_kernel.cc
+++ b/paddle/phi/kernels/xpu/dequantization_kernel.cc
@@ -55,7 +55,7 @@ void DeQuantizeKernel(const Context& ctx,
       DeQuantizeKernelImpl<T, dtype::float16, Context>(ctx, x, scale, y);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Not supported dequantize data type from %d -> %d ",
           x.dtype(),
           out_dtype));

--- a/paddle/phi/kernels/xpu/dropout_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/dropout_grad_kernel.cc
@@ -33,7 +33,7 @@ void DropoutGradRawKernel(const Context& dev_ctx,
   using XPUType = typename XPUTypeTrait<T>::Type;
   PADDLE_ENFORCE_EQ(!is_test,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "GradOp is only callable when is_test is false"));
   auto* grad_x = x_grad;
   auto* grad_y = &out_grad;

--- a/paddle/phi/kernels/xpu/embedding_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/embedding_grad_kernel.cc
@@ -44,7 +44,7 @@ void EmbeddingGradKernel(const Context& ctx,
   PADDLE_ENFORCE_EQ(
       ids_numel <= std::numeric_limits<int32_t>::max(),
       true,
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "Number of ids greater than int32_t::max , please check "
           "number of ids in LookupTableV2GradXPUKernel."));
 
@@ -112,7 +112,7 @@ void EmbeddingSparseGradKernel(const Context& ctx,
                        sizeof(int64_t) * input.numel());
     ids = CopyIdsToVector<int, int64_t>(ids_cpu);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "embedding input only support int32 and int64"));
   }
 
@@ -138,7 +138,7 @@ void EmbeddingSparseGradKernel(const Context& ctx,
       flatten_to_2d(d_output_dims, d_output_dims.size() - 1);
   PADDLE_ENFORCE_EQ(d_table_value->dims(),
                     d_output_dims_2d,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "ShapeError: The shape of lookup_table@Grad and "
                         "output@Grad should be same. "
                         "But received lookup_table@Grad's shape = [%s], "

--- a/paddle/phi/kernels/xpu/embedding_kernel.cc
+++ b/paddle/phi/kernels/xpu/embedding_kernel.cc
@@ -32,9 +32,9 @@ void EmbeddingKernel(const Context &ctx,
   PADDLE_ENFORCE_EQ(
       (std::is_same<Context, XPUContext>::value),
       true,
-      phi::errors::PreconditionNotMet("Unsupported place! only support "
-                                      "xpu place , please check your "
-                                      "place."));
+      common::errors::PreconditionNotMet("Unsupported place! only support "
+                                         "xpu place , please check your "
+                                         "place."));
 
   int64_t ids_numel = ids_t->numel();
 
@@ -47,7 +47,7 @@ void EmbeddingKernel(const Context &ctx,
   PADDLE_ENFORCE_EQ(
       ids_numel <= std::numeric_limits<int32_t>::max(),
       true,
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "Number of ids greater than int32_t::max , please check "
           "number of ids in LookupTableV2XPUKernel."));
 

--- a/paddle/phi/kernels/xpu/expand_as_kernel.cc
+++ b/paddle/phi/kernels/xpu/expand_as_kernel.cc
@@ -34,13 +34,13 @@ void ExpandAs(const Context& context,
   for (size_t i = 0; i < vec_in_dims.size(); ++i) {
     PADDLE_ENFORCE_NE(target_shape[i],
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The value of target shape cannot be zero."));
     if (vec_in_dims[i] != 1) {
       PADDLE_ENFORCE_EQ(
           vec_in_dims[i],
           target_shape[i],
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The value (%d) of the non-singleton dimension does not match"
               " the corresponding value (%d) in "
               "target tensor for expand_as_v2 op.",
@@ -83,10 +83,10 @@ void ExpandAs(const Context& context,
   PADDLE_ENFORCE_EQ(
       r,
       XPU_SUCCESS,
-      phi::errors::External("XPU API(broadcast) return wrong "
-                            "value[%d %s] in ExpandAsV2XPUKernel.",
-                            r,
-                            XPUAPIErrorMsg[r]));
+      common::errors::External("XPU API(broadcast) return wrong "
+                               "value[%d %s] in ExpandAsV2XPUKernel.",
+                               r,
+                               XPUAPIErrorMsg[r]));
 }
 
 template <typename T, typename Context>
@@ -99,7 +99,7 @@ void ExpandAsKernel(const Context& ctx,
   auto target_rank = target_shape.size();
   PADDLE_ENFORCE_GE(target_rank,
                     rank,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The rank (%d) of the input 'target_tensor' for "
                         "expand_as_v2 op must be greater than or equal to "
                         "the rank (%d) of the input 'x'.",
@@ -108,12 +108,12 @@ void ExpandAsKernel(const Context& ctx,
   PADDLE_ENFORCE_GE(
       rank,
       0,
-      phi::errors::InvalidArgument("The rank (%d) of the input 'x' for "
-                                   "expand_as_v2 op must be positive.",
-                                   rank));
+      common::errors::InvalidArgument("The rank (%d) of the input 'x' for "
+                                      "expand_as_v2 op must be positive.",
+                                      rank));
   PADDLE_ENFORCE_LE(target_rank,
                     MAX_RANK_SUPPORTED,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The rank (%d) of the input 'target_tensor' for "
                         "expand_as_v2 op must be less than or equal to %d.",
                         target_rank,

--- a/paddle/phi/kernels/xpu/expand_kernel.cc
+++ b/paddle/phi/kernels/xpu/expand_kernel.cc
@@ -35,13 +35,13 @@ void ExpandKernel(const Context& ctx,
     PADDLE_ENFORCE_NE(
         expand_shape[i],
         0,
-        phi::errors::InvalidArgument("The expanded size cannot be zero."));
+        common::errors::InvalidArgument("The expanded size cannot be zero."));
     if (i < diff) {  // expand_shape = [3,4,-1,-1], X = [10,2] -->
                      // final_expand_shape = [3,4,10,2]
       PADDLE_ENFORCE_GT(
           expand_shape[i],
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The expanded size (%d) for non-existing dimensions must be "
               "positive for expand_v2 op.",
               expand_shape[i]));
@@ -53,7 +53,7 @@ void ExpandKernel(const Context& ctx,
         PADDLE_ENFORCE_EQ(
             vec_in_dims[i],
             expand_shape[i],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The value (%d) of the non-singleton dimension does not match"
                 " the corresponding value (%d) in shape for expand_v2 op.",
                 vec_in_dims[i],
@@ -67,7 +67,7 @@ void ExpandKernel(const Context& ctx,
       PADDLE_ENFORCE_EQ(
           expand_shape[i],
           -1,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "When the value in shape is negative for expand_v2 op, "
               "only -1 is supported, but the value received is %d.",
               expand_shape[i]));
@@ -79,7 +79,7 @@ void ExpandKernel(const Context& ctx,
   PADDLE_ENFORCE_GE(
       rank,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The rank of the input 'X' for expand_v2_npu op must be positive, "
           "but the value received is %d.",
           rank));
@@ -87,7 +87,7 @@ void ExpandKernel(const Context& ctx,
   PADDLE_ENFORCE_GE(
       shape_size,
       rank,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The number (%d) of elements of 'shape' for expand_v2_npu op must "
           "be "
           "greater than or equal to the rank (%d) of the input 'X'.",
@@ -116,12 +116,13 @@ void ExpandKernel(const Context& ctx,
     r = xpu::broadcast<XPUType>(
         ctx.x_context(), x_data, out_data, x_shape, out_shape);
   }
-  PADDLE_ENFORCE_EQ(r,
-                    XPU_SUCCESS,
-                    phi::errors::External("XPU API(broadcast) return wrong "
-                                          "value[%d %s] in ExpandV2XPUKernel.",
-                                          r,
-                                          XPUAPIErrorMsg[r]));
+  PADDLE_ENFORCE_EQ(
+      r,
+      XPU_SUCCESS,
+      common::errors::External("XPU API(broadcast) return wrong "
+                               "value[%d %s] in ExpandV2XPUKernel.",
+                               r,
+                               XPUAPIErrorMsg[r]));
 }
 }  // namespace phi
 

--- a/paddle/phi/kernels/xpu/flash_attn_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/flash_attn_grad_kernel.cc
@@ -56,7 +56,7 @@ void FlashAttnGradKernel(const Context& ctx,
   PADDLE_ENFORCE_EQ(
       head_size_og,
       head_size,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "flash_attn_bwd receive input with head_size_og == head_size"));
 
   // raw pointers
@@ -77,11 +77,11 @@ void FlashAttnGradKernel(const Context& ctx,
     if (mask_dims.size() == 3 || (mask_dims[1] == 1 && mask_dims.size() == 4)) {
       fa_layout |= AttnQKVLayout_t::BIAS_BLL;
     } else {
-      PADDLE_ENFORCE_EQ(
-          mask_dims.size(),
-          4,
-          phi::errors::InvalidArgument("flash_attn_bwd requires mask's shape "
-                                       "like [b,l,l] or [b, h, l, l]"));
+      PADDLE_ENFORCE_EQ(mask_dims.size(),
+                        4,
+                        common::errors::InvalidArgument(
+                            "flash_attn_bwd requires mask's shape "
+                            "like [b,l,l] or [b, h, l, l]"));
     }
     if (attn_mask->dtype() == phi::DataType::FLOAT32) {
       bias_data = attn_mask->data<float>();
@@ -186,7 +186,7 @@ void FlashAttnGradKernel(const Context& ctx,
   );
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "mha_varlen_bwd");
 #else
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "re-compile using -DWITH_XPU_XRE5=ON to use FlashAttnGradKernel"));
 #endif
 }

--- a/paddle/phi/kernels/xpu/flash_attn_kernel.cc
+++ b/paddle/phi/kernels/xpu/flash_attn_kernel.cc
@@ -189,14 +189,15 @@ void FlashAttnKernel(const Context& ctx,
                      DenseTensor* seed_offset) {
 #ifdef PADDLE_WITH_XPU_XRE5
   if (return_softmax == true) {
-    PADDLE_THROW(phi::errors::Unimplemented("return_softmax should be false"));
+    PADDLE_THROW(
+        common::errors::Unimplemented("return_softmax should be false"));
   }
 
   // q, k, v [batch_size, seq_len, num_heads, head_dim]
   const auto& dims = q.dims();
   PADDLE_ENFORCE_EQ(dims.size(),
                     4,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "flash_attn receive input with dim "
                         "[batch_size, seq_len, num_heads, head_dim]"));
 
@@ -255,11 +256,11 @@ void FlashAttnKernel(const Context& ctx,
     if (mask_dims.size() == 3 || (mask_dims[1] == 1 && mask_dims.size() == 4)) {
       fa_layout |= AttnQKVLayout_t::BIAS_BLL;
     } else {
-      PADDLE_ENFORCE_EQ(
-          mask_dims.size(),
-          4,
-          phi::errors::InvalidArgument("flash_attn_fwd requires mask's shape "
-                                       "like [b,l,l] or [b, h, l, l]"));
+      PADDLE_ENFORCE_EQ(mask_dims.size(),
+                        4,
+                        common::errors::InvalidArgument(
+                            "flash_attn_fwd requires mask's shape "
+                            "like [b,l,l] or [b, h, l, l]"));
     }
     if (attn_mask->dtype() == phi::DataType::FLOAT32) {
       bias_data = attn_mask->data<float>();
@@ -333,7 +334,7 @@ void FlashAttnKernel(const Context& ctx,
       );
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "mha_varlen_fwd");
 #else
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "re-compile using -DWITH_XPU_XRE5=ON to use FlashAttnKernel"));
 #endif
 }

--- a/paddle/phi/kernels/xpu/full_kernel.cc
+++ b/paddle/phi/kernels/xpu/full_kernel.cc
@@ -77,7 +77,7 @@ void FullLikeKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       is_out_range,
       false,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The filled value is out of range for target type, "
           "current kernel type is %s, the range should between %f "
           "and %f, but now value is %f.",

--- a/paddle/phi/kernels/xpu/gather_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/gather_grad_kernel.cc
@@ -38,14 +38,14 @@ void GatherGradKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         index_dims[1],
         1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The last dim of index should be 1 when it is 2D, but we get %d",
             index_dims[1]));
   } else {
     PADDLE_ENFORCE_EQ(
         index_dims.size() == 1 || index_dims.size() == 0,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The index should be 0D or 1D, when it is not 2D, but we get %d",
             index_dims.size()));
   }

--- a/paddle/phi/kernels/xpu/gather_kernel.cc
+++ b/paddle/phi/kernels/xpu/gather_kernel.cc
@@ -36,14 +36,14 @@ void GatherKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         index_dims[1],
         1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The last dim of index should be 1 when it is 2D, but we get %d",
             index_dims[1]));
   } else {
     PADDLE_ENFORCE_EQ(
         index_dims.size() == 1 || index_dims.size() == 0,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The index should be 0D, 1D, when it is not 2D, but we get %d",
             index_dims.size()));
   }
@@ -77,7 +77,7 @@ void GatherKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       r,
       xpu::Error_t::SUCCESS,
-      phi::errors::External(
+      common::errors::External(
           "XPU gather kernel return wrong value[%d %s]", r, XPUAPIErrorMsg[r]));
 }
 

--- a/paddle/phi/kernels/xpu/gather_nd_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/gather_nd_grad_kernel.cc
@@ -47,7 +47,7 @@ void GatherNdGradKernel(const Context &ctx,
     PADDLE_ENFORCE_EQ(
         end_size,
         0,
-        phi::errors::InvalidArgument("end_size[%d] should be 0", end_size));
+        common::errors::InvalidArgument("end_size[%d] should be 0", end_size));
     // remain dim
     auto remain_ddim = common::slice_ddim(index_dims, 0, index_dims_size - 1);
     int64_t remain_numel = common::product(remain_ddim);
@@ -57,7 +57,7 @@ void GatherNdGradKernel(const Context &ctx,
     PADDLE_ENFORCE_EQ(
         x_numel * remain_numel,
         out_grad_numel,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "x_numel[%d] * remain_numel[%d] should match out_grad_numel[%d]",
             x_numel,
             remain_numel,
@@ -78,14 +78,14 @@ void GatherNdGradKernel(const Context &ctx,
   auto index_type = index.dtype();
   bool index_type_match =
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
-  PADDLE_ENFORCE_EQ(
-      index_type_match,
-      true,
-      phi::errors::InvalidArgument("Index holds the wrong type, it holds [%s],"
-                                   "but desires to be [%s] or [%s]",
-                                   index_type,
-                                   phi::DataType::INT32,
-                                   phi::DataType::INT64));
+  PADDLE_ENFORCE_EQ(index_type_match,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Index holds the wrong type, it holds [%s],"
+                        "but desires to be [%s] or [%s]",
+                        index_type,
+                        phi::DataType::INT32,
+                        phi::DataType::INT64));
 
   auto x_shape = common::vectorize<int64_t>(x_grad->dims());
   auto index_shape = common::vectorize<int64_t>(index.dims());

--- a/paddle/phi/kernels/xpu/gather_nd_kernel.cc
+++ b/paddle/phi/kernels/xpu/gather_nd_kernel.cc
@@ -39,7 +39,7 @@ void GatherNdKernel(const Context &ctx,
     PADDLE_ENFORCE_EQ(
         end_size,
         0,
-        phi::errors::InvalidArgument("end_size[%d] should be 0", end_size));
+        common::errors::InvalidArgument("end_size[%d] should be 0", end_size));
     // remain dim
     auto remain_ddim = common::slice_ddim(index_dims, 0, index_dims_size - 1);
     int64_t remain_numel = common::product(remain_ddim);
@@ -49,7 +49,7 @@ void GatherNdKernel(const Context &ctx,
     PADDLE_ENFORCE_EQ(
         x_numel * remain_numel,
         y_numel,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "x_numel[%d] * remain_numel[%d] should match y_numel[%d]",
             x_numel,
             remain_numel,
@@ -69,14 +69,14 @@ void GatherNdKernel(const Context &ctx,
   const auto &index_type = index.dtype();
   bool index_type_match =
       index_type == DataType::INT32 || index_type == DataType::INT64;
-  PADDLE_ENFORCE_EQ(
-      index_type_match,
-      true,
-      phi::errors::InvalidArgument("Index holds the wrong type, it holds [%s],"
-                                   "but desires to be [%s] or [%s]",
-                                   index_type,
-                                   DataType::INT32,
-                                   DataType::INT64));
+  PADDLE_ENFORCE_EQ(index_type_match,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Index holds the wrong type, it holds [%s],"
+                        "but desires to be [%s] or [%s]",
+                        index_type,
+                        DataType::INT32,
+                        DataType::INT64));
 
   auto x_shape = common::vectorize<int>(x.dims());
   auto index_shape = common::vectorize<int>(index.dims());

--- a/paddle/phi/kernels/xpu/generate_proposals_kernel.cc
+++ b/paddle/phi/kernels/xpu/generate_proposals_kernel.cc
@@ -289,7 +289,7 @@ void GenerateProposalsKernel(const Context& dev_ctx,
                              DenseTensor* rpn_rois_num) {
   PADDLE_ENFORCE_GE(eta,
                     1.,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Not support adaptive NMS. The attribute 'eta' "
                         "should not less than 1. But received eta=[%d]",
                         eta));

--- a/paddle/phi/kernels/xpu/grid_sample_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/grid_sample_grad_kernel.cc
@@ -32,7 +32,7 @@ void GridSampleGradKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       x.dims().size(),
       4,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           ("XPU is only support input_dims == 4 in grid_sample_grad op.")));
 
   const int64_t n = grid.dims()[0];

--- a/paddle/phi/kernels/xpu/increment_kernel.cc
+++ b/paddle/phi/kernels/xpu/increment_kernel.cc
@@ -28,7 +28,7 @@ void IncrementKernel(const Context& ctx,
   // check input
   PADDLE_ENFORCE_EQ(x.numel(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "input tensor x's numel should be EXACTLY 1."));
 
   const T* x_data = x.data<T>();

--- a/paddle/phi/kernels/xpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_put_kernel.cc
@@ -81,12 +81,13 @@ void IndexPutKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       x.dtype(),
       value.dtype(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The data type of tensor value must be same to the data type "
           "of tensor x."));
-  PADDLE_ENFORCE_EQ(indices.empty(),
-                    false,
-                    phi::errors::InvalidArgument("Indices cannot be empty."));
+  PADDLE_ENFORCE_EQ(
+      indices.empty(),
+      false,
+      common::errors::InvalidArgument("Indices cannot be empty."));
   const int64_t total_dims = x.dims().size();
   PADDLE_ENFORCE_LE(
       total_dims,

--- a/paddle/phi/kernels/xpu/index_sample_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_sample_grad_kernel.cc
@@ -32,7 +32,7 @@ void IndexSampleGradKernel(const Context& ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Index) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         index_type,

--- a/paddle/phi/kernels/xpu/index_select_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_select_grad_kernel.cc
@@ -35,7 +35,7 @@ void IndexSelectGradKernel(const Context& ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Index) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         index_type,

--- a/paddle/phi/kernels/xpu/index_select_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_select_kernel.cc
@@ -34,7 +34,7 @@ void IndexSelectKernel(const Context& ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Index) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         index_type,

--- a/paddle/phi/kernels/xpu/instance_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/instance_norm_grad_kernel.cc
@@ -37,7 +37,7 @@ void InstanceNormGradKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       x_dims.size() <= 5 && D == 1,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of input's dimensions should be less equal than 5",
           "and the dimension of D should be equal to 1",
           "But received: the size of input's dimensions is [%d]",
@@ -58,7 +58,7 @@ void InstanceNormGradKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         scale_ptr->dims().size(),
         1UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The `shape` in InstanceNormOp is invalid: "
             "the size of scale's dimensions must be equal to 1. But "
             "received: the size of scale's dimensions"
@@ -66,7 +66,7 @@ void InstanceNormGradKernel(const Context& dev_ctx,
             scale_ptr->dims().size()));
     PADDLE_ENFORCE_EQ(scale_ptr->dims()[0],
                       C,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The `shape` in InstanceNormOp is invalid: "
                           "the first dimension of scale must be equal to "
                           "Channels([%d]). But received: "

--- a/paddle/phi/kernels/xpu/inverse_kernel.cc
+++ b/paddle/phi/kernels/xpu/inverse_kernel.cc
@@ -31,7 +31,7 @@ void InverseKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_GT(
       x_dims_len,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Dimensions of input should be greater than 1, but got %d.",
           x_dims_len));
 
@@ -39,7 +39,7 @@ void InverseKernel(const Context& dev_ctx,
   int64_t batch = x_dims_len > 2 ? x.numel() / (n * n) : 1;
   PADDLE_ENFORCE_LE(n * n * sizeof(T),
                     8192,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of a single matrix (%d bytes) exceeds the "
                         "maximum numbers of bytes xpu supports (8192).",
                         n * n * sizeof(T)));

--- a/paddle/phi/kernels/xpu/kldiv_loss_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/kldiv_loss_grad_kernel.cc
@@ -62,7 +62,7 @@ void KLDivLossGradKernel(const Context& dev_ctx,
   }
 
   if ("none" != reduction) {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Not supported reduction [%s] in kldiv_loss_grad", reduction));
   }
 }

--- a/paddle/phi/kernels/xpu/kldiv_loss_kernel.cc
+++ b/paddle/phi/kernels/xpu/kldiv_loss_kernel.cc
@@ -61,7 +61,7 @@ void KLDivLossKernel(const Context& dev_ctx,
   }
 
   if ("none" != reduction) {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "Not supported reduction [%s] in kldiv_loss", reduction));
   }
 }

--- a/paddle/phi/kernels/xpu/label_smooth_kernel.cc
+++ b/paddle/phi/kernels/xpu/label_smooth_kernel.cc
@@ -26,7 +26,7 @@ void LabelSmoothKernel(const Context& ctx,
   auto ptr = ctx.template Alloc<T>(out);
   if (prior_dist.is_initialized()) {
     PADDLE_THROW(
-        phi::errors::External("XPU doesn't support dist label smooth"));
+        common::errors::External("XPU doesn't support dist label smooth"));
   } else {
     int r = xpu::label_smooth<T>(ctx.x_context(),
                                  label.data<T>(),
@@ -37,10 +37,10 @@ void LabelSmoothKernel(const Context& ctx,
     PADDLE_ENFORCE_EQ(
         r,
         XPU_SUCCESS,
-        phi::errors::External("XPU API(label_smooth) return wrong "
-                              "value[%d %s]",
-                              r,
-                              XPUAPIErrorMsg[r]));
+        common::errors::External("XPU API(label_smooth) return wrong "
+                                 "value[%d %s]",
+                                 r,
+                                 XPUAPIErrorMsg[r]));
   }
 }
 }  // namespace phi

--- a/paddle/phi/kernels/xpu/lamb_kernel.cc
+++ b/paddle/phi/kernels/xpu/lamb_kernel.cc
@@ -53,7 +53,7 @@ void LambKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(
         kIsSameType,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "When multi_precision=False, T and MT must be the same type."));
   }
   bool cpu_skip_update = false;

--- a/paddle/phi/kernels/xpu/lars_momentum_kernel.cc
+++ b/paddle/phi/kernels/xpu/lars_momentum_kernel.cc
@@ -63,11 +63,11 @@ void LarsMomentumKernel(
     PADDLE_ENFORCE_EQ(
         param_list[i],
         param_out_list[i],
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Input(Param) and Output(ParamOut) must be the same Tensors."));
     PADDLE_ENFORCE_EQ(velocity_list[i],
                       velocity_out_list[i],
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input(Velocity) and Output(VelocityOut) must be "
                           "the same Tensors."));
     if (multi_precision) {
@@ -77,7 +77,7 @@ void LarsMomentumKernel(
           dev_ctx.template Alloc<float>(master_param_out[i]));
       PADDLE_ENFORCE_EQ(master_param_list[i],
                         master_param_out_list[i],
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Input(MasterParam) and Output(MasterParamOut) "
                             "must be the same Tensors."));
     } else {

--- a/paddle/phi/kernels/xpu/layer_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/layer_norm_grad_kernel.cc
@@ -50,7 +50,7 @@ void LayerNormGradKernel(const Context& ctx,
   if (!is_scale_bias_same_dtype_with_x) {
     PADDLE_ENFORCE_EQ(scale_bias_dtype,
                       phi::CppTypeToDataType<float>::Type(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Unsupported data type of Scale and Bias"));
   }
   using XPUType = typename XPUTypeTrait<T>::Type;

--- a/paddle/phi/kernels/xpu/layer_norm_kernel.cc
+++ b/paddle/phi/kernels/xpu/layer_norm_kernel.cc
@@ -39,11 +39,11 @@ void LayerNormKernel(const Context& ctx,
   if (valid_scale) {
     scale_bias_dtype = scale->dtype();
     if (valid_bias) {
-      PADDLE_ENFORCE_EQ(
-          scale->dtype(),
-          bias->dtype(),
-          phi::errors::InvalidArgument("This Scale and Bias of layer_norm op "
-                                       "should have the same data type."));
+      PADDLE_ENFORCE_EQ(scale->dtype(),
+                        bias->dtype(),
+                        common::errors::InvalidArgument(
+                            "This Scale and Bias of layer_norm op "
+                            "should have the same data type."));
     }
   } else {
     scale_bias_dtype = valid_bias ? bias->dtype() : x_dtype;
@@ -53,7 +53,7 @@ void LayerNormKernel(const Context& ctx,
   if (!is_scale_bias_same_dtype_with_x) {
     PADDLE_ENFORCE_EQ(scale_bias_dtype,
                       phi::CppTypeToDataType<float>::Type(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Unsupported data type of Scale and Bias"));
   }
 

--- a/paddle/phi/kernels/xpu/linspace_kernel.cc
+++ b/paddle/phi/kernels/xpu/linspace_kernel.cc
@@ -42,7 +42,7 @@ T GetValueOfExpectedType(const Context& ctx, const DenseTensor& x) {
     case DataType::UINT8:
       return static_cast<T>(GetValue<uint8_t, Context>(ctx, x));
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported when casting data type.",
           x.dtype()));
   }
@@ -63,9 +63,9 @@ void LinspaceKernel(const Context& ctx,
   PADDLE_ENFORCE_GT(
       num,
       0,
-      phi::errors::InvalidArgument("The num of linspace op should be larger "
-                                   "than 0, but received num is %d",
-                                   num));
+      common::errors::InvalidArgument("The num of linspace op should be larger "
+                                      "than 0, but received num is %d",
+                                      num));
 
   out->Resize(common::make_ddim({num}));
   T* out_data = ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/xpu/masked_select_kernel.cc
+++ b/paddle/phi/kernels/xpu/masked_select_kernel.cc
@@ -36,7 +36,7 @@ void MaskedSelectKernel(const Context& dev_ctx,
   auto mask_dim = mask.dims();
   PADDLE_ENFORCE_EQ(input_dim,
                     mask_dim,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dim size of input and mask in OP(masked_selected) "
                         "must be equal, but got input dim:(%ld), mask dim: "
                         "(%ld). Please check input "

--- a/paddle/phi/kernels/xpu/mean_all_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/mean_all_grad_kernel.cc
@@ -32,7 +32,7 @@ void MeanAllGradKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       OG->numel(),
       1,
-      phi::errors::InvalidArgument("Mean Gradient should be scalar"));
+      common::errors::InvalidArgument("Mean Gradient should be scalar"));
   auto dev_version =
       phi::backends::xpu::get_xpu_version(dev_ctx.GetPlace().GetDeviceId());
   if (dev_version == phi::backends::xpu::XPUVersion::XPU3) {

--- a/paddle/phi/kernels/xpu/multiclass_nms3_kernel.cc
+++ b/paddle/phi/kernels/xpu/multiclass_nms3_kernel.cc
@@ -84,18 +84,18 @@ void MultiClassNMSKernel(const Context& ctx,
     }
     PADDLE_ENFORCE_EQ(boxes_count == bboxes.dims()[0],
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "boxes_count should equal boxes->dims()[0].",
                           "But received: (%d) and (%d)",
                           boxes_count,
                           bboxes.dims()[0]));
-    PADDLE_ENFORCE_EQ(
-        boxes_count == score_dims[0],
-        true,
-        phi::errors::InvalidArgument("boxes_count should equal score_dims[0].",
-                                     "But received: (%d) and (%d)",
-                                     boxes_count,
-                                     score_dims[0]));
+    PADDLE_ENFORCE_EQ(boxes_count == score_dims[0],
+                      true,
+                      common::errors::InvalidArgument(
+                          "boxes_count should equal score_dims[0].",
+                          "But received: (%d) and (%d)",
+                          boxes_count,
+                          score_dims[0]));
   } else {
     n = bboxes.dims()[0];
     b = bboxes.dims()[1];

--- a/paddle/phi/kernels/xpu/nll_loss_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/nll_loss_grad_kernel.cc
@@ -34,7 +34,7 @@ void NllLossGradKernel(const Context& dev_ctx,
       label_type == phi::DataType::INT32 || label_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(label_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Label) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         label_type,

--- a/paddle/phi/kernels/xpu/nll_loss_kernel.cc
+++ b/paddle/phi/kernels/xpu/nll_loss_kernel.cc
@@ -33,7 +33,7 @@ void NllLossRawKernel(const Context& dev_ctx,
       label_type == phi::DataType::INT32 || label_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(label_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Label) holds the wrong type, it holds %s, but "
                         "desires to be %s or %s",
                         label_type,

--- a/paddle/phi/kernels/xpu/norm_kernel.cc
+++ b/paddle/phi/kernels/xpu/norm_kernel.cc
@@ -44,12 +44,12 @@ void NormKernel(const Context& ctx,
   PADDLE_ENFORCE_GE(
       axis,
       0,
-      phi::errors::InvalidArgument("axis must be greater than or equal to 0."
-                                   "But received axis: %d.",
-                                   axis));
+      common::errors::InvalidArgument("axis must be greater than or equal to 0."
+                                      "But received axis: %d.",
+                                      axis));
   PADDLE_ENFORCE_LT(axis,
                     x_dims_size,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Attr(axis) value must be less than rank of Input(X)"
                         "But received axis: %d, rank: %d.",
                         axis,

--- a/paddle/phi/kernels/xpu/pad3d_kernel.cc
+++ b/paddle/phi/kernels/xpu/pad3d_kernel.cc
@@ -65,7 +65,7 @@ void Pad3dKernel(const Context& dev_ctx,
   }
 
   if (mode == "circular") {
-    PADDLE_THROW(phi::errors::External(
+    PADDLE_THROW(common::errors::External(
         "XPU is not support circular padding mode in pad3d"));
   }
 

--- a/paddle/phi/kernels/xpu/pool_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/pool_grad_kernel.cc
@@ -45,17 +45,17 @@ void Pool2dGradKernel(const Context& ctx,
   PADDLE_ENFORCE_EQ(
       data_format,
       "NCHW",
-      phi::errors::InvalidArgument("The Pool2d_grad XPU OP only support"
-                                   "data_format is 'NCHW', but received %s",
-                                   data_format));
+      common::errors::InvalidArgument("The Pool2d_grad XPU OP only support"
+                                      "data_format is 'NCHW', but received %s",
+                                      data_format));
 
   PADDLE_ENFORCE_EQ(
       kernel_size.size(),
       2,
-      phi::errors::InvalidArgument("The Pool2d XPU OP only support 2 "
-                                   "dimension pooling!, but received "
-                                   "%d-dimension pool kernel size",
-                                   kernel_size.size()));
+      common::errors::InvalidArgument("The Pool2d XPU OP only support 2 "
+                                      "dimension pooling!, but received "
+                                      "%d-dimension pool kernel size",
+                                      kernel_size.size()));
   if (global_pooling) {
     for (size_t i = 0; i < kernel_size.size(); ++i) {
       paddings[i] = 0;
@@ -124,7 +124,7 @@ void Pool2dGradKernel(const Context& ctx,
           out_w,
           true);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupported pooling type for kunlun ", pooling_type));
     }
 
@@ -170,7 +170,7 @@ void Pool2dGradKernel(const Context& ctx,
           !exclusive,
           true);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupported pooling type for kunlun ", pooling_type));
     }
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "pool2dgrad");
@@ -204,9 +204,9 @@ void Pool3dGradKernel(const Context& ctx,
   PADDLE_ENFORCE_EQ(
       data_format,
       "NCDHW",
-      phi::errors::InvalidArgument("The Pool3d_grad XPU OP only support"
-                                   "data_format is 'NCDHW', but received %s",
-                                   data_format));
+      common::errors::InvalidArgument("The Pool3d_grad XPU OP only support"
+                                      "data_format is 'NCDHW', but received %s",
+                                      data_format));
   if (!dx) {
     return;
   }
@@ -311,7 +311,7 @@ void Pool3dGradKernel(const Context& ctx,
           out_w,
           !channel_last);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupported pooling type for kunlun ", pooling_type));
     }
 
@@ -369,7 +369,7 @@ void Pool3dGradKernel(const Context& ctx,
           !exclusive,
           !channel_last);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupported pooling type for kunlun ", pooling_type));
     }
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "pool3dgrad");
@@ -402,10 +402,10 @@ void MaxPool2dWithIndexGradKernel(const Context& ctx,
   PADDLE_ENFORCE_EQ(
       ksize.size(),
       2,
-      phi::errors::InvalidArgument("The Pool2d XPU OP only support 2 "
-                                   "dimension pooling!, but received "
-                                   "%d-dimension pool kernel size",
-                                   ksize.size()));
+      common::errors::InvalidArgument("The Pool2d XPU OP only support 2 "
+                                      "dimension pooling!, but received "
+                                      "%d-dimension pool kernel size",
+                                      ksize.size()));
   global_pooling = global_pooling || (adaptive && (ksize[0] * ksize[1] == 1));
   if (global_pooling) {
     for (size_t i = 0; i < ksize.size(); ++i) {

--- a/paddle/phi/kernels/xpu/pool_kernel.cc
+++ b/paddle/phi/kernels/xpu/pool_kernel.cc
@@ -42,16 +42,16 @@ void Pool2dKernel(const Context& ctx,
 
   PADDLE_ENFORCE_EQ(kernel_size.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Pool2d XPU OP only support 2 dimension pooling!"));
 
   // old model's data_format maybe AnyLayout
   PADDLE_ENFORCE_NE(
       data_format,
       "NHWC",
-      phi::errors::InvalidArgument("The Pool2d XPU OP does not support "
-                                   "data_format is 'NHWC', but received %s",
-                                   data_format));
+      common::errors::InvalidArgument("The Pool2d XPU OP does not support "
+                                      "data_format is 'NHWC', but received %s",
+                                      data_format));
 
   if (global_pooling) {
     for (size_t i = 0; i < kernel_size.size(); ++i) {
@@ -126,7 +126,7 @@ void Pool2dKernel(const Context& ctx,
           !exclusive,
           true);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupported pooling type for kunlun ", pooling_type));
     }
   } else {
@@ -156,7 +156,7 @@ void Pool2dKernel(const Context& ctx,
           out_w,
           true);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupported pooling type for kunlun ", pooling_type));
     }
   }
@@ -260,7 +260,7 @@ void Pool3dKernel(const Context& ctx,
           !exclusive,
           data_format == "NCDHW");
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupported pooling type for kunlun ", pooling_type));
     }
   } else {
@@ -294,7 +294,7 @@ void Pool3dKernel(const Context& ctx,
           out_w,
           data_format == "NCDHW");
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupported pooling type for kunlun ", pooling_type));
     }
   }
@@ -323,11 +323,11 @@ void MaxPool2dWithIndexKernel(const Context& ctx,
 
   PADDLE_ENFORCE_EQ(ksize.size(),
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Pool2d XPU OP only support 2 dimension pooling!"));
   PADDLE_ENFORCE_EQ(!adaptive || (ksize[0] * ksize[1] == 1),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The Pool2d XPU OP does not support (adaptive == "
                         "true && output_size != 1)"));
   global_pooling = global_pooling || (adaptive && (ksize[0] * ksize[1] == 1));

--- a/paddle/phi/kernels/xpu/pow2_decay_with_linear_warmup_kernel.cc
+++ b/paddle/phi/kernels/xpu/pow2_decay_with_linear_warmup_kernel.cc
@@ -33,21 +33,21 @@ void Pow2DecayWithLinearWarmupKernel(const Context& dev_ctx,
                                      DenseTensor* step_out) {
   PADDLE_ENFORCE_EQ(&lr,
                     lr_out,
-                    phi::errors::InvalidArgument("Input(LearningRate) and "
-                                                 "Output(LearningRateOut) "
-                                                 "must be the same."));
+                    common::errors::InvalidArgument("Input(LearningRate) and "
+                                                    "Output(LearningRateOut) "
+                                                    "must be the same."));
   PADDLE_ENFORCE_EQ(&step,
                     step_out,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(Step) and Output(StepOut) must be the same."));
   PADDLE_ENFORCE_EQ(
       step.initialized(),
       true,
-      phi::errors::InvalidArgument("Input(Step) must be initialized."));
+      common::errors::InvalidArgument("Input(Step) must be initialized."));
 
   PADDLE_ENFORCE_LE(warmup_steps,
                     total_steps,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "warmup_steps must not be larger than total_steps."));
 
   auto* lr_data = lr_out->data<T>();

--- a/paddle/phi/kernels/xpu/quantization_kernel.cc
+++ b/paddle/phi/kernels/xpu/quantization_kernel.cc
@@ -55,7 +55,7 @@ void QuantizeKernel(const Context& ctx,
       QuantizeKernelImpl<T, int8_t, Context>(ctx, x, scale, y);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Not supported quantize data type from %d -> %d ",
           x.dtype(),
           out_dtype));

--- a/paddle/phi/kernels/xpu/rmsprop_kernel.cc
+++ b/paddle/phi/kernels/xpu/rmsprop_kernel.cc
@@ -60,13 +60,13 @@ void RmspropDenseKernel(const Context& dev_ctx,
       PADDLE_ENFORCE_EQ(
           mg_tensor->Holder(),
           mean_grad_out->Holder(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "MeanGrad and MeanGradOut must be the same Tensor"));
     } else {
       PADDLE_ENFORCE_EQ(
           mg_tensor,
           mean_grad_out,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "MeanGrad and MeanGradOut must be the same Tensor"));
     }
     int r = xpu::rmsprop(dev_ctx.x_context(),

--- a/paddle/phi/kernels/xpu/scale_kernel.cc
+++ b/paddle/phi/kernels/xpu/scale_kernel.cc
@@ -31,10 +31,10 @@ void ScaleKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       x.dims(),
       out->dims(),
-      phi::errors::InvalidArgument("In and out should have the same dim,"
-                                   " expected %s, but got %s.",
-                                   x.dims().to_str().c_str(),
-                                   out->dims().to_str().c_str()));
+      common::errors::InvalidArgument("In and out should have the same dim,"
+                                      " expected %s, but got %s.",
+                                      x.dims().to_str().c_str(),
+                                      out->dims().to_str().c_str()));
   if (x.numel() == 0 || !x.IsInitialized()) {
     return;
   }

--- a/paddle/phi/kernels/xpu/scatter_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/scatter_grad_kernel.cc
@@ -34,7 +34,7 @@ void ScatterGradKernel(const Context &ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "scatter_op index holds the wrong type, it holds [%s],"
                         "but desires to be [%s] or [%s]",
                         index_type,

--- a/paddle/phi/kernels/xpu/scatter_kernel.cc
+++ b/paddle/phi/kernels/xpu/scatter_kernel.cc
@@ -38,21 +38,21 @@ void ScatterKernel(const Context &ctx,
   const auto &index_type = index.dtype();
   bool index_type_match =
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
-  PADDLE_ENFORCE_EQ(
-      index_type_match,
-      true,
-      phi::errors::InvalidArgument("Index holds the wrong type, it holds [%s],"
-                                   "but desires to be [%s] or [%s].",
-                                   index_type,
-                                   phi::DataType::INT32,
-                                   phi::DataType::INT64));
+  PADDLE_ENFORCE_EQ(index_type_match,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Index holds the wrong type, it holds [%s],"
+                        "but desires to be [%s] or [%s].",
+                        index_type,
+                        phi::DataType::INT32,
+                        phi::DataType::INT64));
 
   // check index of shape 1-D
   PADDLE_ENFORCE_EQ(
       index.dims().size() == 1 || index.dims().size() == 0 ||
           (index.dims().size() == 2 && index.dims()[1] == 1),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "index's shape is error, "
           "expect index'dims shape is 0, 1, 2 (index.dims[1] should "
           "be 1), 0 but got index'dims shape is %d",
@@ -68,7 +68,7 @@ void ScatterKernel(const Context &ctx,
       PADDLE_ENFORCE_EQ(
           x_dims[i],
           update_dims[i],
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The dimensions of the source tensor and target tensor should"
               " match, but received source tensor's %d-th dimension is %d,"
               "target tensor's %d-th dimension is %d.",

--- a/paddle/phi/kernels/xpu/scatter_nd_add_kernel.cc
+++ b/paddle/phi/kernels/xpu/scatter_nd_add_kernel.cc
@@ -57,7 +57,7 @@ void ScatterNdAddKernel(const Context &ctx,
       index_type == phi::DataType::INT32 || index_type == phi::DataType::INT64;
   PADDLE_ENFORCE_EQ(index_type_match,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Index holds the wrong type, it holds [%s], but "
                         "desires to be [%s] or [%s].",
                         index_type,

--- a/paddle/phi/kernels/xpu/sequence_conv_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/sequence_conv_grad_kernel.cc
@@ -39,13 +39,13 @@ void SequenceConvGradXPUKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_EQ(in->lod().empty(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(X) phi::DenseTensor of SequenceConvOp "
                         "does not contain LoD information."));
   PADDLE_ENFORCE_EQ(
       in->lod().size(),
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Only support input sequence with lod level equal to 1 at "
           "present. But received: lod level %u.",
           in->lod().size()));
@@ -53,24 +53,26 @@ void SequenceConvGradXPUKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       padding_trainable,
       false,
-      phi::errors::InvalidArgument("Only support padding_trainable "
-                                   "equal false."));
+      common::errors::InvalidArgument("Only support padding_trainable "
+                                      "equal false."));
 
   int up_pad = std::max(0, -context_start);
   int down_pad = std::max(0, context_start + context_length - 1);
   PADDLE_ENFORCE_EQ(
-      up_pad, 2, phi::errors::InvalidArgument("Only support up_pad equal 2."));
+      up_pad,
+      2,
+      common::errors::InvalidArgument("Only support up_pad equal 2."));
   PADDLE_ENFORCE_EQ(
       down_pad,
       2,
-      phi::errors::InvalidArgument("Only support down_pad equal 2."));
+      common::errors::InvalidArgument("Only support down_pad equal 2."));
 
   auto lod_level_0 = in->lod()[0];
   int lod_size = lod_level_0.size();
   PADDLE_ENFORCE_LE(
       lod_size,
       257,
-      phi::errors::InvalidArgument("Only support batch size <= 256."));
+      common::errors::InvalidArgument("Only support batch size <= 256."));
 
   std::vector<int> cpu_lodx(lod_size);
   for (int i = 0; i < lod_size; i++) {
@@ -86,7 +88,7 @@ void SequenceConvGradXPUKernel(const Context& dev_ctx,
   int col_numel = col_shape[0] * col_shape[1];
   T* col_data = RAII_GUARD.alloc_l3_or_gm<T>(col_numel);
   PADDLE_ENFORCE_NOT_NULL(col_data,
-                          phi::errors::Fatal("XPU memory is not enough"));
+                          common::errors::Fatal("XPU memory is not enough"));
 
   if (in_g || filter_g) {
     bool trans_a = false;
@@ -97,7 +99,7 @@ void SequenceConvGradXPUKernel(const Context& dev_ctx,
     int k1 = filter_p->dims()[1];
     PADDLE_ENFORCE_EQ(k,
                       k1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The shape of FC in SequenceConvGradOp is invalid."
                           "The k of matrix A is %d, k1 of matrix B is %d."
                           "But expect k == k1",
@@ -138,7 +140,7 @@ void SequenceConvGradXPUKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_LT(
         sequence_width,
         512,
-        phi::errors::InvalidArgument("Only support sequence_width < 512."));
+        common::errors::InvalidArgument("Only support sequence_width < 512."));
 
     dev_ctx.template Alloc<T>(in_g);
     in_g->set_lod(in->lod());
@@ -179,7 +181,7 @@ void SequenceConvGradXPUKernel(const Context& dev_ctx,
     int n = out_g->dims()[1];
     PADDLE_ENFORCE_EQ(k,
                       k1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The shape of FC in SequenceConvGradOp is invalid."
                           "The k of matrix A is %d, k1 of matrix B is %d."
                           "But expect k == k1",

--- a/paddle/phi/kernels/xpu/sequence_conv_kernel.cc
+++ b/paddle/phi/kernels/xpu/sequence_conv_kernel.cc
@@ -33,13 +33,13 @@ void SequenceConvXPUKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_EQ(in->lod().empty(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input(X) phi::DenseTensor of SequenceConvOp "
                         "does not contain LoD information."));
   PADDLE_ENFORCE_EQ(
       in->lod().size(),
       1UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Only support input sequence with lod level equal to 1 at "
           "present. But received: lod level %u.",
           in->lod().size()));
@@ -47,17 +47,19 @@ void SequenceConvXPUKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       padding_trainable,
       false,
-      phi::errors::InvalidArgument("Only support padding_trainable "
-                                   "equal false."));
+      common::errors::InvalidArgument("Only support padding_trainable "
+                                      "equal false."));
 
   int up_pad = std::max(0, -context_start);
   int down_pad = std::max(0, context_start + context_length - 1);
   PADDLE_ENFORCE_EQ(
-      up_pad, 2, phi::errors::InvalidArgument("Only support up_pad equal 2."));
+      up_pad,
+      2,
+      common::errors::InvalidArgument("Only support up_pad equal 2."));
   PADDLE_ENFORCE_EQ(
       down_pad,
       2,
-      phi::errors::InvalidArgument("Only support down_pad equal 2."));
+      common::errors::InvalidArgument("Only support down_pad equal 2."));
 
   auto* xpu_context = dev_ctx.x_context();
   auto sequence_width = static_cast<int64_t>(in->dims()[1]);
@@ -66,7 +68,7 @@ void SequenceConvXPUKernel(const Context& dev_ctx,
   int col_numel = col_shape[0] * col_shape[1];
   T* col_data = RAII_GUARD.alloc_l3_or_gm<T>(col_numel);
   PADDLE_ENFORCE_NOT_NULL(col_data,
-                          phi::errors::Fatal("XPU memory is not enough"));
+                          common::errors::Fatal("XPU memory is not enough"));
 
   auto lod_level_0 = in->lod()[0];
   int lod_size = lod_level_0.size();
@@ -76,7 +78,7 @@ void SequenceConvXPUKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_LE(
       lod_size,
       257,
-      phi::errors::InvalidArgument("Only support batch size <= 256."));
+      common::errors::InvalidArgument("Only support batch size <= 256."));
 
   std::vector<int> cpu_lodx(lod_size);
   for (int i = 0; i < lod_size; i++) {
@@ -105,7 +107,7 @@ void SequenceConvXPUKernel(const Context& dev_ctx,
   int n = filter.dims()[1];
   PADDLE_ENFORCE_EQ(k,
                     k1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The shape of FC in SequenceConvOp is invalid."
                         "The k of matrix A is %d, k1 of matrix B is %d."
                         "But expect k == k1",

--- a/paddle/phi/kernels/xpu/set_value_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/set_value_grad_kernel.cc
@@ -390,7 +390,7 @@ void SetValueGradKernel(const Context& dev_ctx,
                                       value_grad);
       break;
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "The rank of set_value_grad's input should be less than 7, but "
           "received %d.",
           rank));

--- a/paddle/phi/kernels/xpu/sgd_kernel.cc
+++ b/paddle/phi/kernels/xpu/sgd_kernel.cc
@@ -95,7 +95,7 @@ void SGDDenseParamSparseGradKernel(
   PADDLE_ENFORCE_EQ(
       &param,
       param_out,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input tensor Param of SgdOp should be equal with ParamOut "
           "if variable's type is SelectedRows."));
 
@@ -103,7 +103,7 @@ void SGDDenseParamSparseGradKernel(
   auto out_dims = param_out->dims();
   PADDLE_ENFORCE_EQ(in_height,
                     out_dims[0],
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The input tensor Grad's height of SgdOp should be "
                         "equal with ParamOut's dims. But received Grad's "
                         "height [%s] and ParamOut's dims [%s]",
@@ -119,7 +119,7 @@ void SGDDenseParamSparseGradKernel(
   int64_t in_row_numel = in_value.numel() / in_rows.size();
   PADDLE_ENFORCE_EQ(in_row_numel,
                     param_out->numel() / in_height,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The in_row_numel of SgdOp should be equal with "
                         "param_out's numel / in_height."));
 

--- a/paddle/phi/kernels/xpu/slice_kernel.cc
+++ b/paddle/phi/kernels/xpu/slice_kernel.cc
@@ -37,11 +37,11 @@ void SliceKernel(const Context& ctx,
   PADDLE_ENFORCE_EQ(
       starts.size(),
       axes.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of starts must be equal to the size of axes."));
   PADDLE_ENFORCE_EQ(ends.size(),
                     axes.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of ends must be equal to the size of axes."));
 
   // Step 2: Compute output

--- a/paddle/phi/kernels/xpu/squared_l2_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/squared_l2_norm_grad_kernel.cc
@@ -31,7 +31,7 @@ void SquaredL2NormGradKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       dout.numel(),
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input(GRAD@Out) of SquaredL2NormGradOP should be a scalar."));
 
   xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());

--- a/paddle/phi/kernels/xpu/strided_copy_kernel.cc
+++ b/paddle/phi/kernels/xpu/strided_copy_kernel.cc
@@ -32,14 +32,14 @@ void StridedCopyKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_EQ(input.dims(),
                     out->dims(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input shape(%s) must be equal with out shape(%s).",
                         input.dims(),
                         out->dims()));
 
   PADDLE_ENFORCE_EQ(input.numel(),
                     out->numel(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Input numel(%d) must be equal with out numel(%d).",
                         input.numel(),
                         out->numel()));
@@ -50,7 +50,7 @@ void StridedCopyKernel(const Context& dev_ctx,
     auto input_data = reinterpret_cast<const float*>(input.data<T>());
     auto output_data = reinterpret_cast<float*>(out->data<T>());
     PADDLE_ENFORCE_NOT_NULL(output_data,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "StridedCopyKernel's out tensor must complete "
                                 "mutable data before call kernel."));
     if (input.numel() == 1) {
@@ -68,7 +68,7 @@ void StridedCopyKernel(const Context& dev_ctx,
     auto input_data = reinterpret_cast<const int64_t*>(input.data<T>());
     auto output_data = reinterpret_cast<int64_t*>(out->data<T>());
     PADDLE_ENFORCE_NOT_NULL(output_data,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "StridedCopyKernel's out tensor must complete "
                                 "mutable data before call kernel."));
     if (input.numel() == 1) {
@@ -88,7 +88,7 @@ void StridedCopyKernel(const Context& dev_ctx,
     auto input_data = reinterpret_cast<const XPUFLOAT16*>(input.data<T>());
     auto output_data = reinterpret_cast<XPUFLOAT16*>(out->data<T>());
     PADDLE_ENFORCE_NOT_NULL(output_data,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "StridedCopyKernel's out tensor must complete "
                                 "mutable data before call kernel."));
     if (input.numel() == 1) {
@@ -109,7 +109,7 @@ void StridedCopyKernel(const Context& dev_ctx,
     auto input_data = reinterpret_cast<const XPUFLOAT16*>(input.data<T>());
     auto output_data = reinterpret_cast<XPUFLOAT16*>(out->data<T>());
     PADDLE_ENFORCE_NOT_NULL(output_data,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "StridedCopyKernel's out tensor must complete "
                                 "mutable data before call kernel."));
     if (input.numel() == 1) {
@@ -130,7 +130,7 @@ void StridedCopyKernel(const Context& dev_ctx,
     auto input_data = reinterpret_cast<const XPUFLOAT16*>(input.data<T>());
     auto output_data = reinterpret_cast<XPUFLOAT16*>(out->data<T>());
     PADDLE_ENFORCE_NOT_NULL(output_data,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "StridedCopyKernel's out tensor must complete "
                                 "mutable data before call kernel."));
     if (input.numel() == 1) {
@@ -150,7 +150,7 @@ void StridedCopyKernel(const Context& dev_ctx,
     auto input_data = reinterpret_cast<const int8_t*>(input.data<T>());
     auto output_data = reinterpret_cast<int8_t*>(out->data<T>());
     PADDLE_ENFORCE_NOT_NULL(output_data,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "StridedCopyKernel's out tensor must complete "
                                 "mutable data before call kernel."));
     if (input.numel() == 1) {
@@ -168,7 +168,7 @@ void StridedCopyKernel(const Context& dev_ctx,
     auto input_data = reinterpret_cast<const int8_t*>(input.data<T>());
     auto output_data = reinterpret_cast<int8_t*>(out->data<T>());
     PADDLE_ENFORCE_NOT_NULL(output_data,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "StridedCopyKernel's out tensor must complete "
                                 "mutable data before call kernel."));
     if (input.numel() == 1) {
@@ -186,7 +186,7 @@ void StridedCopyKernel(const Context& dev_ctx,
     auto input_data = reinterpret_cast<const int32_t*>(input.data<T>());
     auto output_data = reinterpret_cast<int32_t*>(out->data<T>());
     PADDLE_ENFORCE_NOT_NULL(output_data,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "StridedCopyKernel's out tensor must complete "
                                 "mutable data before call kernel."));
     if (input.numel() == 1) {
@@ -205,7 +205,7 @@ void StridedCopyKernel(const Context& dev_ctx,
     auto input_data = reinterpret_cast<const int64_t*>(input.data<T>());
     auto output_data = reinterpret_cast<int64_t*>(out->data<T>());
     PADDLE_ENFORCE_NOT_NULL(output_data,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "StridedCopyKernel's out tensor must complete "
                                 "mutable data before call kernel."));
     if (input.numel() == 1) {
@@ -225,7 +225,7 @@ void StridedCopyKernel(const Context& dev_ctx,
     auto output_data = reinterpret_cast<bool*>(out->data<T>());
 
     PADDLE_ENFORCE_NOT_NULL(output_data,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "StridedCopyKernel's out tensor must complete "
                                 "mutable data before call kernel."));
     if (input.numel() == 1) {
@@ -240,7 +240,7 @@ void StridedCopyKernel(const Context& dev_ctx,
                                   common::vectorize<int64_t>(out->strides()));
     }
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Received unsupported dtype : %s.", input.dtype()));
   }
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "strided_copy");

--- a/paddle/phi/kernels/xpu/swiglu_kernel.cc
+++ b/paddle/phi/kernels/xpu/swiglu_kernel.cc
@@ -37,13 +37,13 @@ void SwiGluKernel(const Context& ctx,
     const auto& y_dims = y_tensor.dims();
     const auto* y_data = y_tensor.data<T>();
     y_ptr = reinterpret_cast<const XPUType*>(y_data);
-    PADDLE_ENFORCE_EQ(
-        y_dims,
-        dims,
-        phi::errors::InvalidArgument("The shape of Input(Y):[%s] must be equal "
-                                     "to the shape of Input(X):[%s].",
-                                     y_dims,
-                                     dims));
+    PADDLE_ENFORCE_EQ(y_dims,
+                      dims,
+                      common::errors::InvalidArgument(
+                          "The shape of Input(Y):[%s] must be equal "
+                          "to the shape of Input(X):[%s].",
+                          y_dims,
+                          dims));
   }
   int ret = xpu::swiglu(ctx.x_context(),
                         reinterpret_cast<const XPUType*>(x_data),

--- a/paddle/phi/kernels/xpu/swiglu_kernel_grad.cc
+++ b/paddle/phi/kernels/xpu/swiglu_kernel_grad.cc
@@ -50,13 +50,13 @@ void SwiGluGradKernel(const Context& ctx,
     auto* dy_data = ctx.template Alloc<T>(dy);
     y_ptr = reinterpret_cast<const XPUType*>(y_data);
     dy_ptr = reinterpret_cast<XPUType*>(dy_data);
-    PADDLE_ENFORCE_EQ(
-        y_dims,
-        dims,
-        phi::errors::InvalidArgument("The shape of Input(Y):[%s] must be equal "
-                                     "to the shape of Input(X):[%s].",
-                                     y_dims,
-                                     dims));
+    PADDLE_ENFORCE_EQ(y_dims,
+                      dims,
+                      common::errors::InvalidArgument(
+                          "The shape of Input(Y):[%s] must be equal "
+                          "to the shape of Input(X):[%s].",
+                          y_dims,
+                          dims));
   }
   int ret = xpu::swiglu_grad(ctx.x_context(),
                              reinterpret_cast<const XPUType*>(x_data),

--- a/paddle/phi/kernels/xpu/unfold_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/unfold_grad_kernel.cc
@@ -35,7 +35,7 @@ void UnfoldGradKernel(const Context& ctx,
   bool is_nchw = data_format == "NCHW";
   PADDLE_ENFORCE_EQ(is_nchw,
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Unfold grad op only supports datalayout == NCHW"));
 
   auto x_dims = x_grad->dims();

--- a/paddle/phi/kernels/xpu/unfold_kernel.cc
+++ b/paddle/phi/kernels/xpu/unfold_kernel.cc
@@ -34,7 +34,7 @@ void UnfoldKernel(const Context& ctx,
   bool is_nchw = data_format == "NCHW";
   PADDLE_ENFORCE_EQ(is_nchw,
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Unfold op only supports datalayout == NCHW"));
   auto x_dims = x.dims();
   int n = static_cast<int>(x_dims[0]);

--- a/paddle/phi/kernels/xpu/uniform_inplace_kernel.cc
+++ b/paddle/phi/kernels/xpu/uniform_inplace_kernel.cc
@@ -45,7 +45,7 @@ void XPUUniformRandomInplaceKernel(const Context& ctx,
     PADDLE_ENFORCE_GT(
         size,
         (diag_num - 1) * (diag_step + 1),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "ShapeInvalid: the diagonal's elements is equal (num-1) "
             "* (step-1) with num %d, step %d,"
             "It should be smaller than %d, but received %d",

--- a/paddle/phi/kernels/xpu/unique_kernel.cc
+++ b/paddle/phi/kernels/xpu/unique_kernel.cc
@@ -374,7 +374,7 @@ void UniqueRawKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_LE(
         x.numel(),
         INT_MAX,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The number of elements in Input(X) should be less than or "
             "equal to INT_MAX, but received num is %d. Please set `dtype` to "
             "int64.",

--- a/paddle/phi/kernels/xpu/warpctc_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/warpctc_grad_kernel.cc
@@ -33,8 +33,8 @@ void WarpctcGradKernel(const Context& dev_ctx,
 
   bool has_logits_length = logits_length.is_initialized();
   if (!has_logits_length) {
-    PADDLE_THROW(
-        phi::errors::External("XPU only support logits_length is_initialized"));
+    PADDLE_THROW(common::errors::External(
+        "XPU only support logits_length is_initialized"));
   }
 
   int max_seq_length = warpctcgrad.dims()[0];  // Tmax

--- a/paddle/phi/kernels/xpu/warpctc_kernel.cc
+++ b/paddle/phi/kernels/xpu/warpctc_kernel.cc
@@ -32,13 +32,13 @@ void WarpctcKernel(const Context& dev_ctx,
                    DenseTensor* warpctcgrad) {
   bool has_logits_length = logits_length.is_initialized();
   if (!has_logits_length) {
-    PADDLE_THROW(
-        phi::errors::External("XPU only support logits_length is_initialized"));
+    PADDLE_THROW(common::errors::External(
+        "XPU only support logits_length is_initialized"));
   }
   bool has_labels_length = labels_length.is_initialized();
   if (!has_labels_length) {
-    PADDLE_THROW(
-        phi::errors::External("XPU only support labels_length is_initialized"));
+    PADDLE_THROW(common::errors::External(
+        "XPU only support labels_length is_initialized"));
   }
 
   int max_sequence_length = logits.dims()[0];
@@ -48,50 +48,51 @@ void WarpctcKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_GT(max_sequence_length,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The first dimension of Input(Logits) should be "
                         "greater than zero "
                         "but received %d. ",
                         max_sequence_length));
   PADDLE_ENFORCE_GT(num_sequences,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The second dimension of Input(Logits) should be "
                         "greater than zero "
                         "but received %d. ",
                         num_sequences));
   PADDLE_ENFORCE_GT(sequence_width,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The third dimension of Input(Logits) should be "
                         "greater than zero "
                         "but received %d. ",
                         sequence_width));
-  PADDLE_ENFORCE_GE(blank,
-                    0,
-                    phi::errors::InvalidArgument("Input(blank) should be "
-                                                 "equal or greater than zero "
-                                                 "but received %d. ",
-                                                 blank));
+  PADDLE_ENFORCE_GE(
+      blank,
+      0,
+      common::errors::InvalidArgument("Input(blank) should be "
+                                      "equal or greater than zero "
+                                      "but received %d. ",
+                                      blank));
   PADDLE_ENFORCE_LT(blank,
                     sequence_width,
-                    phi::errors::InvalidArgument("Input(blank) should be "
-                                                 "less than %d "
-                                                 "but received %d. ",
-                                                 sequence_width,
-                                                 blank));
+                    common::errors::InvalidArgument("Input(blank) should be "
+                                                    "less than %d "
+                                                    "but received %d. ",
+                                                    sequence_width,
+                                                    blank));
 
   auto logits_length_dtype = logits_length.get_ptr()->dtype();
   auto labels_length_dtype = labels_length.get_ptr()->dtype();
-  PADDLE_ENFORCE_EQ(
-      logits_length_dtype == labels_length_dtype,
-      true,
-      phi::errors::InvalidArgument("The data type of Input(logits_length) and "
-                                   "Input(labels_length) should be equal. "));
+  PADDLE_ENFORCE_EQ(logits_length_dtype == labels_length_dtype,
+                    true,
+                    common::errors::InvalidArgument(
+                        "The data type of Input(logits_length) and "
+                        "Input(labels_length) should be equal. "));
   PADDLE_ENFORCE_EQ(logits_length_dtype == DataType::INT32 ||
                         logits_length_dtype == DataType::INT64,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The data type of Input(logits_length) should be "
                         "either %s or %s, "
                         "but received %s. ",
@@ -101,7 +102,7 @@ void WarpctcKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(labels_length_dtype == DataType::INT32 ||
                         labels_length_dtype == DataType::INT64,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The data type of Input(labels_length) should be "
                         "either %s or %s, "
                         "but received %s. ",
@@ -130,7 +131,7 @@ void WarpctcKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_LE(
       sm_workspace + lm_workspace,
       256 * 1024,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Input size should be equal or less than %d for xpu warpctc kernel, "
           "but size %d is received. ",
           256 * 1024,

--- a/paddle/phi/kernels/xpu/xpu_api_wrapper.h
+++ b/paddle/phi/kernels/xpu/xpu_api_wrapper.h
@@ -173,7 +173,7 @@ static void GetFCInfo(const phi::DDim& x_dims,
 
   PADDLE_ENFORCE_EQ(mat_dim_a.width_,
                     mat_dim_b.height_,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Shape mistake in matmul_op xdims = %s ydims = %s "
                         "x_trans = %d y_trans = %d",
                         x_dims.to_str(),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/66145#issuecomment-2249572051

Replace phi::errors to common::errors in paddle/phi