### PR TITLE
Replace phi::errors [fluid_ops] part15

### DIFF
--- a/paddle/phi/kernels/funcs/beam_search_decode.h
+++ b/paddle/phi/kernels/funcs/beam_search_decode.h
@@ -91,7 +91,7 @@ void BeamSearchDecoder<T>::ConvertSentenceVectorToLodTensor(
   PADDLE_ENFORCE_NE(
       src_num,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "src_num is the sequence number of the first decoding step"
           ", indicating by Input(Ids)[0].lod[0].size."
           "src_num has wrong value."
@@ -161,12 +161,12 @@ void BeamSearchDecoder<T>::Backtrace(const TensorArray& step_ids,
   PADDLE_ENFORCE_NE(
       step_ids.empty(),
       true,
-      phi::errors::InvalidArgument("Input(Ids) should not be empty."
-                                   "But the Input(Ids) is empty."));
+      common::errors::InvalidArgument("Input(Ids) should not be empty."
+                                      "But the Input(Ids) is empty."));
   PADDLE_ENFORCE_EQ(
       step_ids.size(),
       step_scores.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of Input(Ids) and Input(Scores) should be "
           "the same. But the size of Input(Ids) and Input(Scores) "
           "are not equal."));

--- a/paddle/phi/kernels/funcs/beam_search_decode_xpu.h
+++ b/paddle/phi/kernels/funcs/beam_search_decode_xpu.h
@@ -48,7 +48,7 @@ inline int CopyTensorByXPU(const phi::DenseTensor& srcTensor,
   PADDLE_ENFORCE_EQ(
       r,
       xpu::Error_t::SUCCESS,
-      phi::errors::External("Execute function SetMeta failed by [%d]", r));
+      common::errors::External("Execute function SetMeta failed by [%d]", r));
 
   if (flag == 0) {
     auto cpu_place = phi::CPUPlace();
@@ -92,7 +92,7 @@ const int CopyTensorByType(const phi::DenseTensor& srcTensor,
 
   PADDLE_ENFORCE_EQ(r,
                     xpu::Error_t::SUCCESS,
-                    phi::errors::External(
+                    common::errors::External(
                         "Execute function CopyTensorByXPU failed by [%d]", r));
 
   return xpu::Error_t::SUCCESS;
@@ -121,7 +121,7 @@ struct BeamSearchDecodeXPUFunctor {
           PADDLE_ENFORCE_EQ(
               r,
               xpu::Error_t::SUCCESS,
-              phi::errors::External(
+              common::errors::External(
                   "Execute function CopyTensorByXPU failed by [%d]", r));
         }
 
@@ -139,7 +139,7 @@ struct BeamSearchDecodeXPUFunctor {
           PADDLE_ENFORCE_EQ(
               r,
               xpu::Error_t::SUCCESS,
-              phi::errors::External(
+              common::errors::External(
                   "Execute function CopyTensorByType failed by [%d]", r));
         }
 
@@ -152,7 +152,7 @@ struct BeamSearchDecodeXPUFunctor {
   template <typename T>
   void apply_xpu() const {
     if (std::is_same<bool, T>::value) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "beam search decode op does not support bool!"));
     } else {
       BeamSearchDecoder<T> beam_search_decoder(beam_size_, end_id_);

--- a/paddle/phi/kernels/funcs/blas/blas.cc
+++ b/paddle/phi/kernels/funcs/blas/blas.cc
@@ -22,9 +22,9 @@ MatDescriptor CreateMatrixDescriptor(const DDim &tensor_dim,
   PADDLE_ENFORCE_GT(
       tensor_dim.size(),
       1,
-      phi::errors::InvalidArgument("The tensor dim size should be greater "
-                                   "than 1, but reveived dim size is %d",
-                                   tensor_dim.size()));
+      common::errors::InvalidArgument("The tensor dim size should be greater "
+                                      "than 1, but reveived dim size is %d",
+                                      tensor_dim.size()));
   MatDescriptor retv;
   if (num_flatten_cols > 1) {
     auto flatten_dim = common::flatten_to_2d(tensor_dim, num_flatten_cols);

--- a/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
@@ -65,7 +65,7 @@ struct CUBlas<float> {
 #if CUDA_VERSION >= 8000
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasSgemmBatched(args...));
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "SgemmBatched is not supported on cuda <= 7.5"));
 #endif
   }
@@ -76,7 +76,7 @@ struct CUBlas<float> {
     PADDLE_ENFORCE_GPU_SUCCESS(
         phi::dynload::cublasSgemmStridedBatched(args...));
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "SgemmStridedBatched is not supported on cuda <= 7.5"));
 #endif
   }
@@ -127,7 +127,7 @@ struct CUBlas<float> {
                                                              ldc));
     });
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasSgemmEx is not supported on cuda <= 7.5"));
 #endif
   }
@@ -195,7 +195,7 @@ struct CUBlas<double> {
 #if CUDA_VERSION >= 8000
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasDgemmBatched(args...));
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "DgemmBatched is not supported on cuda <= 7.5"));
 #endif
   }
@@ -206,15 +206,15 @@ struct CUBlas<double> {
     PADDLE_ENFORCE_GPU_SUCCESS(
         phi::dynload::cublasDgemmStridedBatched(args...));
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "DgemmStridedBatched is not supported on cuda <= 7.5"));
 #endif
   }
 
   template <typename... ARGS>
   static void GEMM_EX(ARGS... args UNUSED) {
-    PADDLE_THROW(
-        phi::errors::Unimplemented("Currently there are not cublasDgemmEx."));
+    PADDLE_THROW(common::errors::Unimplemented(
+        "Currently there are not cublasDgemmEx."));
   }
 
   template <typename... ARGS>
@@ -340,7 +340,7 @@ struct CUBlas<phi::dtype::float16> {
                                             algo));
     });
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasGemmBatchedEx is not supported on cuda <= 7.5"));
 #endif
   }
@@ -385,7 +385,7 @@ struct CUBlas<phi::dtype::float16> {
         strideC,
         batchCount));
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "HgemmStridedBatched is not supported on cuda <= 7.5"));
 #endif
   }
@@ -444,7 +444,7 @@ struct CUBlas<phi::dtype::float16> {
                                                             algo));
     });
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasGemmEx is not supported on cuda <= 7.5"));
 #endif
   }
@@ -535,7 +535,7 @@ struct CUBlas<phi::dtype::complex<float>> {
         strideC,
         batchCount));
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "CgemmStridedBatched is not supported on cuda <= 7.5"));
 #endif
   }
@@ -652,7 +652,7 @@ struct CUBlas<phi::dtype::complex<float>> {
                                                             algo));
     });
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasGemmEx is not supported on cuda <= 7.5"));
 #endif
   }
@@ -830,7 +830,7 @@ struct CUBlas<phi::dtype::complex<double>> {
         strideC,
         batchCount));
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "CgemmStridedBatched is not supported on cuda <= 7.5"));
 #endif
   }
@@ -976,7 +976,7 @@ struct CUBlas<phi::dtype::complex<double>> {
                                                             algo));
     });
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasGemmEx is not supported on cuda <= 7.5"));
 #endif
   }
@@ -1129,7 +1129,7 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
   PADDLE_ENFORCE_GE(
       context_.GetComputeCapability(),
       53,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cublas fp16 gemm requires GPU compute capability >= 53,"
           "but received %d",
           context_.GetComputeCapability()));
@@ -1208,7 +1208,7 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
   PADDLE_ENFORCE_GE(
       context_.GetComputeCapability(),
       80,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cublas bf16 gemm requires GPU compute capability >= 80,"
           "but received %d",
           context_.GetComputeCapability()));
@@ -1246,7 +1246,7 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
   });
 #else
   // raise error
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "cublasGemmEx with bfloat16 is not supported on cuda <= 11"));
 
 #endif  // CUDA_VERSION >= 11000
@@ -1277,7 +1277,7 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
   PADDLE_ENFORCE_GE(
       context_.GetComputeCapability(),
       53,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cublas complex64 gemm requires GPU compute capability >= 53,"
           "but received %d",
           context_.GetComputeCapability()));
@@ -1357,7 +1357,7 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
   PADDLE_ENFORCE_GE(
       context_.GetComputeCapability(),
       53,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cublas complex128 gemm requires GPU compute capability >= 53,"
           "but received %d",
           context_.GetComputeCapability()));
@@ -1540,7 +1540,7 @@ inline void Blas<phi::GPUContext>::GEMM(bool transA,
   PADDLE_ENFORCE_GE(
       context_.GetComputeCapability(),
       80,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cublas bf16 gemm requires GPU compute capability >= 80,"
           "but received %d",
           context_.GetComputeCapability()));
@@ -1578,7 +1578,7 @@ inline void Blas<phi::GPUContext>::GEMM(bool transA,
   });
 #else
   // raise error
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "cublasGemmEx with bfloat16 is not supported on cuda <= 11"));
 
 #endif  // CUDA_VERSION >= 11000
@@ -1846,7 +1846,7 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   });
 #else
   // raise error
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "cublasGemmStridedBatchedEx with bfloat16 is not supported on cuda <= "
       "11"));
 #endif  // CUDA_VERSION >= 11000
@@ -1988,7 +1988,7 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   PADDLE_ENFORCE_GE(
       context_.GetComputeCapability(),
       53,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cublas fp16 gemm requires GPU compute capability >= 53,"
           "but received %d",
           context_.GetComputeCapability()));
@@ -2043,7 +2043,7 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   PADDLE_ENFORCE_GE(
       context_.GetComputeCapability(),
       80,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cublas bf16 gemm requires GPU compute capability >= 80,"
           "but received %d",
           context_.GetComputeCapability()));
@@ -2086,7 +2086,7 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   });
 #else
   // raise error
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "cublasGemmBatchedEx with bfloat16 is not supported on cuda <= 11"));
 
 #endif  // CUDA_VERSION >= 11000
@@ -2144,7 +2144,7 @@ void Blas<phi::GPUContext>::BatchedGETRI(int n,
   PADDLE_ENFORCE_NE(
       a_inv,
       a,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cuBLAS fuction 'cublas<S/D>getrfBatched' cannot be executed "
           "in-place. The memory space of output matrix (address: %p) cannot "
           "overlap memory space of input matrix (address: %p).",

--- a/paddle/phi/kernels/funcs/blas/blas_impl.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.h
@@ -49,7 +49,7 @@ template <>
 struct CBlas<int8_t> {
   template <typename... ARGS>
   static void VCOPY(ARGS... args) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Blas VCOPY do not supported on CPU, please check your code"));
   }
 };
@@ -58,7 +58,7 @@ template <>
 struct CBlas<int16_t> {
   template <typename... ARGS>
   static void VCOPY(ARGS... args) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Blas VCOPY do not supported on CPU, please check your code"));
   }
 };
@@ -72,7 +72,7 @@ struct CBlas<phi::dtype::bfloat16> {
 
   template <typename... ARGS>
   static void VCOPY(ARGS... args UNUSED) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Blas VCOPY do not supported on CPU with bfloat16,"
         " please check your code"));
   }
@@ -956,45 +956,45 @@ struct CBlas<phi::dtype::complex<double>> {
 template <>
 struct CBlas<phi::dtype::float16> {
   static void GEMM(...) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "float16 GEMM not supported on CPU, please check your code"));
   }
 
   static void SMM_GEMM(...) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "float16 SMM_GEMM not supported on CPU, please check your code"));
   }
   static void VMUL(...) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "float16 VMUL not supported on CPU, please check your code"));
   }
   static void VEXP(...) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "float16 VEXP not supported on CPU, please check your code"));
   }
   static void VSQUARE(...) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "float16 VSQUARE not supported on CPU, please check your code"));
   }
   static void VPOW(...) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "float16 VPOW not supported on CPU, please check your code"));
   }
   static void DOT(...) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "float16 DOT not supported on CPU, please check your code"));
   };
   static void SCAL(...) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "float16 SCAL not supported on CPU, please check your code"));
   };
   static void ASUM(...) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "float16 ASUM not supported on CPU, please check your code"));
   };
 #ifdef PADDLE_WITH_MKLML
   static void GEMM_BATCH(...) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "float16 GEMM_BATCH not supported on CPU, please check your code"));
   }
 #endif
@@ -1157,7 +1157,7 @@ void Blas<DeviceContext>::MatMul(const phi::DenseTensor &mat_a,
   PADDLE_ENFORCE_EQ(
       dim_a.size() == 2 && dim_b.size() == 2 && dim_out.size() == 2,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input and output of matmul should be matrix, the dim size must "
           "be 2,"
           "but received dim size input_a:%d, input_b:%d, output:%d",
@@ -1167,9 +1167,9 @@ void Blas<DeviceContext>::MatMul(const phi::DenseTensor &mat_a,
   PADDLE_ENFORCE_EQ(
       mat_a.place() == mat_b.place() && mat_a.place() == mat_out->place(),
       true,
-      phi::errors::InvalidArgument("The places of matrices in the matmul "
-                                   "should be same, please check your "
-                                   "code."));
+      common::errors::InvalidArgument("The places of matrices in the matmul "
+                                      "should be same, please check your "
+                                      "code."));
 
   int M = dim_out[0];
   int N = dim_out[1];
@@ -1366,11 +1366,11 @@ void Blas<phi::CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                         int64_t strideA,
                                         int64_t strideB) const {
   PADDLE_ENFORCE_NOT_NULL(
-      A, phi::errors::InvalidArgument("Pointer A should not be null."));
+      A, common::errors::InvalidArgument("Pointer A should not be null."));
   PADDLE_ENFORCE_NOT_NULL(
-      B, phi::errors::InvalidArgument("Pointer B should not be null."));
+      B, common::errors::InvalidArgument("Pointer B should not be null."));
   PADDLE_ENFORCE_NOT_NULL(
-      C, phi::errors::InvalidArgument("Pointer C should not be null."));
+      C, common::errors::InvalidArgument("Pointer C should not be null."));
 #ifdef PADDLE_WITH_MKLML
   int lda = (transA == CblasNoTrans) ? K : M;
   int ldb = (transB == CblasNoTrans) ? N : K;
@@ -1517,7 +1517,7 @@ void Blas<phi::CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
     PADDLE_ENFORCE_EQ(
         W1,
         H2,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The first matrix width should be same as second matrix height,"
             "but received first matrix width %d"
             ", second matrix height %d",
@@ -1649,7 +1649,7 @@ void Blas<DeviceContext>::MatMul(const T *mat_a,
   PADDLE_ENFORCE_EQ(
       dim_a.width_,
       dim_b.height_,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The first matrix width should be same as second matrix height,"
           "but received first matrix width %d"
           ", second matrix height %d",
@@ -1674,7 +1674,7 @@ void Blas<DeviceContext>::MatMul(const T *mat_a,
         dim_a.batch_size_ == dim_b.batch_size_ || dim_a.batch_size_ == 0 ||
             dim_b.batch_size_ == 0,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "dim_a.batch_size should be equal to dim_b.batch_size, or "
             "one of dim_a.batch_size and dim_b.batch_size should be 0. "
             "But got dim_a.batch_size = %d, dim_b.batch_size = %d.",
@@ -1731,22 +1731,22 @@ void Blas<DeviceContext>::MatMulWithHead(const phi::DenseTensor &mat_a,
   PADDLE_ENFORCE_EQ(
       dim_a.width_ % head_number,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The first input width must be some times the head number"
           "but received first input width %d"
           ",  head_number %d",
           dim_a.width_,
           head_number));
-  PADDLE_ENFORCE_GE(
-      head_number,
-      1,
-      phi::errors::InvalidArgument("The head number should be greater equal 1,"
-                                   "but received head number %d",
-                                   head_number));
+  PADDLE_ENFORCE_GE(head_number,
+                    1,
+                    common::errors::InvalidArgument(
+                        "The head number should be greater equal 1,"
+                        "but received head number %d",
+                        head_number));
   PADDLE_ENFORCE_LE(
       head_number,
       dim_a.width_,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The head number should be less equal first input width,"
           "but received first input width %d"
           ",  head_number %d",
@@ -1759,7 +1759,7 @@ void Blas<DeviceContext>::MatMulWithHead(const phi::DenseTensor &mat_a,
     PADDLE_ENFORCE_EQ(
         dim_b.height_,
         dim_a.width_ / head_number,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The second input height should be equal than first input width,"
             "but received second input height %d, first input width %d",
             dim_b.height_,
@@ -1767,7 +1767,7 @@ void Blas<DeviceContext>::MatMulWithHead(const phi::DenseTensor &mat_a,
     PADDLE_ENFORCE_EQ(
         dim_a.width_ % head_number,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The second input width should be some times the head number"
             "but received second input width %d"
             ",  head_number %d",
@@ -1831,7 +1831,7 @@ void Blas<DeviceContext>::MatMulWithHead(const phi::DenseTensor &mat_a,
         (dim_a.batch_size_ == dim_b.batch_size_ || dim_a.batch_size_ == 0 ||
          dim_b.batch_size_ == 0),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The first input batch size should be equal than second input,"
             "either two input batch size is 0, but received first input batch "
             "size"

--- a/paddle/phi/kernels/funcs/blas/blas_impl.hip.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.hip.h
@@ -66,7 +66,7 @@ struct CUBlas<float> {
   // https://github.com/ROCm-Developer-Tools/HIP/blob/roc-3.5.x/docs/markdown/CUBLAS_API_supported_by_HIP.md
   template <typename... ARGS>
   static void GEMM_EX(ARGS... args) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasSgemmEx is not supported on HIP platform."));
   }
 
@@ -77,25 +77,25 @@ struct CUBlas<float> {
 
   template <typename... ARGS>
   static void GETRF_BATCH(ARGS... args) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasSgetrfBatched is not supported on HIP platform."));
   }
 
   template <typename... ARGS>
   static void GETRI_BATCH(ARGS... args) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasSgetriBatched is not supported on HIP platform."));
   }
 
   template <typename... ARGS>
   static void MATINV_BATCH(ARGS... args) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasSmatinvBatched is not supported on HIP platform."));
   }
 
   template <typename... ARGS>
   static void TRSM_BATCH(ARGS... args) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasStrsmBatched is not supported on HIP platform."));
   }
 };
@@ -135,8 +135,8 @@ struct CUBlas<double> {
 
   template <typename... ARGS>
   static void GEMM_EX(ARGS... args) {
-    PADDLE_THROW(
-        phi::errors::Unimplemented("Currently there are not cublasDgemmEx."));
+    PADDLE_THROW(common::errors::Unimplemented(
+        "Currently there are not cublasDgemmEx."));
   }
 
   template <typename... ARGS>
@@ -146,25 +146,25 @@ struct CUBlas<double> {
 
   template <typename... ARGS>
   static void GETRF_BATCH(ARGS... args) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasDgetrfBatched is not supported on HIP platform."));
   }
 
   template <typename... ARGS>
   static void GETRI_BATCH(ARGS... args) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasDgetriBatched is not supported on HIP platform."));
   }
 
   template <typename... ARGS>
   static void MATINV_BATCH(ARGS... args) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasDmatinvBatched is not supported on HIP platform."));
   }
 
   template <typename... ARGS>
   static void TRSM_BATCH(ARGS... args) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "cublasDtrsmBatched is not supported on HIP platform."));
   }
 };
@@ -696,7 +696,7 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
   PADDLE_ENFORCE_GE(
       context_.GetComputeCapability(),
       53,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cublas fp16 gemm requires GPU compute capability >= 53,"
           "but received %d",
           context_.GetComputeCapability()));
@@ -758,7 +758,7 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
   PADDLE_ENFORCE_GE(
       context_.GetComputeCapability(),
       53,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "rocblas bf16 gemm requires GPU compute capability >= 53,"
           "but received %d",
           context_.GetComputeCapability()));
@@ -823,7 +823,7 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
   PADDLE_ENFORCE_GE(
       context_.GetComputeCapability(),
       53,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cublas complex64 gemm requires GPU compute capability >= 53,"
           "but received %d",
           context_.GetComputeCapability()));
@@ -880,7 +880,7 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
   PADDLE_ENFORCE_GE(
       context_.GetComputeCapability(),
       53,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cublas complex128 gemm requires GPU compute capability >= 53,"
           "but received %d",
           context_.GetComputeCapability()));
@@ -1014,7 +1014,7 @@ inline void Blas<phi::GPUContext>::GEMM(bool transA,
   PADDLE_ENFORCE_GE(
       context_.GetComputeCapability(),
       53,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "rocblas bf16 gemm requires GPU compute capability >= 53,"
           "but received %d",
           context_.GetComputeCapability()));
@@ -1505,7 +1505,7 @@ void Blas<phi::GPUContext>::BatchedGETRI(int n,
   PADDLE_ENFORCE_NE(
       a_inv,
       a,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "cuBLAS fuction 'cublas<S/D>getrfBatched' cannot be executed "
           "in-place. The memory space of output matrix (address: %p) cannot "
           "overlap memory space of input matrix (address: %p).",

--- a/paddle/phi/kernels/funcs/blas/blaslt_impl.cu.h
+++ b/paddle/phi/kernels/funcs/blas/blaslt_impl.cu.h
@@ -574,9 +574,10 @@ struct CublasLtBase {
                                                 requested_algo_count,
                                                 heuristic_results.data(),
                                                 &returned_results));
-    PADDLE_ENFORCE_GT(returned_results,
-                      0,
-                      phi::errors::Unavailable("No GEMM algorithm available."));
+    PADDLE_ENFORCE_GT(
+        returned_results,
+        0,
+        common::errors::Unavailable("No GEMM algorithm available."));
     int best_algo_idx = -1;
     if (returned_results == 1 || FLAGS_cublaslt_exhaustive_search_times <= 0) {
       best_algo_idx = 0;
@@ -689,9 +690,9 @@ struct CublasLtBase<int8_t, int32_t, MatmulDescriptor> {
     size_t workspace_size = static_cast<size_t>(4) * 1024 * 1024;
     phi::Allocator::AllocationPtr workspace = nullptr;
 
-    PADDLE_ENFORCE_NOT_NULL(
-        planner,
-        phi::errors::InvalidArgument("matmul planner should be initialized!"));
+    PADDLE_ENFORCE_NOT_NULL(planner,
+                            common::errors::InvalidArgument(
+                                "matmul planner should be initialized!"));
 
     if (FLAGS_enable_blaslt_global_search && !desc->is_cached) {
       SearchBestAlgoGlobal(ctx,
@@ -857,9 +858,10 @@ struct CublasLtBase<int8_t, int32_t, MatmulDescriptor> {
                                                 requested_algo_count,
                                                 heuristic_results.data(),
                                                 &returned_results));
-    PADDLE_ENFORCE_GT(returned_results,
-                      0,
-                      phi::errors::Unavailable("No GEMM algorithm available."));
+    PADDLE_ENFORCE_GT(
+        returned_results,
+        0,
+        common::errors::Unavailable("No GEMM algorithm available."));
     int best_algo_idx = -1;
     if (returned_results == 1 || FLAGS_cublaslt_exhaustive_search_times <= 0) {
       best_algo_idx = 0;
@@ -975,7 +977,7 @@ struct DescriptorSetter {
         PADDLE_ENFORCE_EQ(
             (N % 4 == 0 || N == 1),
             true,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The dimension size N used in int8 matmul must be 1 or a "
                 "multiple of 4 does not "
                 "match the size (%d) currently contained in the container.",
@@ -983,7 +985,7 @@ struct DescriptorSetter {
         PADDLE_ENFORCE_EQ(
             (K % 4 == 0),
             true,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The dimension size K used in int8 matmul must be a multiple "
                 "of 4 does not "
                 "match the size (%d) currently contained in the container.",
@@ -992,7 +994,7 @@ struct DescriptorSetter {
         PADDLE_ENFORCE_EQ(
             (K % 4 == 0),
             true,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The dimension size K used in int8 matmul must be a multiple "
                 "of 4 does not "
                 "match the size (%d) currently contained in the container.",
@@ -1001,7 +1003,7 @@ struct DescriptorSetter {
         PADDLE_ENFORCE_EQ(
             (M % 4 == 0 || M == 1),
             true,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The dimension size M used in int8 matmul must be 1 or a "
                 "multiple of 4 does not "
                 "match the size (%d) currently contained in the container.",
@@ -1009,7 +1011,7 @@ struct DescriptorSetter {
         PADDLE_ENFORCE_EQ(
             (N % 4 == 0 || N == 1),
             true,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The dimension size N used in int8 matmul must be 1 or a "
                 "multiple of 4 does not "
                 "match the size (%d) currently contained in the container.",
@@ -1018,7 +1020,7 @@ struct DescriptorSetter {
         PADDLE_ENFORCE_EQ(
             (M % 4 == 0 || M == 1),
             true,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The dimension size M used in int8 matmul must be 1 or a "
                 "multiple of 4 does not "
                 "match the size (%d) currently contained in the container.",
@@ -1026,7 +1028,7 @@ struct DescriptorSetter {
         PADDLE_ENFORCE_EQ(
             (K % 4 == 0),
             true,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The dimension size K used in int8 matmul must be a multiple "
                 "of 4 does not "
                 "match the size (%d) currently contained in the container.",

--- a/paddle/phi/kernels/funcs/broadcast_function.h
+++ b/paddle/phi/kernels/funcs/broadcast_function.h
@@ -559,7 +559,7 @@ BroadcastKernelForDifferentVecSize(const KPDevice &ctx,
       break;
     }
     default: {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported vectorized size: %d!", vec_size));
       break;
     }
@@ -770,36 +770,36 @@ void BroadcastKernel(const KPDevice &ctx,
   PADDLE_ENFORCE_EQ(
       ins.size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "XPU only support inputs is 2, but received %d", ins.size()));
 #endif
 
   PADDLE_ENFORCE_EQ(
       ins.size(),
       kArity,
-      phi::errors::InvalidArgument("The number of inputs is expected to be "
-                                   "equal to the "
-                                   "arity of functor. But received: the "
-                                   "number of inputs "
-                                   "is %d, the arity of functor is %d.",
-                                   ins.size(),
-                                   kArity));
+      common::errors::InvalidArgument("The number of inputs is expected to be "
+                                      "equal to the "
+                                      "arity of functor. But received: the "
+                                      "number of inputs "
+                                      "is %d, the arity of functor is %d.",
+                                      ins.size(),
+                                      kArity));
   PADDLE_ENFORCE_EQ(
       outs->size(),
       NumOuts,
-      phi::errors::InvalidArgument("Number of outputs shall equal to number "
-                                   "of functions, "
-                                   "but number of outputs is %d, of "
-                                   "functions is %d.",
-                                   outs->size(),
-                                   NumOuts));
+      common::errors::InvalidArgument("Number of outputs shall equal to number "
+                                      "of functions, "
+                                      "but number of outputs is %d, of "
+                                      "functions is %d.",
+                                      outs->size(),
+                                      NumOuts));
 
   for (auto i = 0; i < outs->size(); ++i) {
     if (i > 0) {
       PADDLE_ENFORCE_EQ(
           (*outs)[i]->dims(),
           (*outs)[0]->dims(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The shape of each output tensor shall be identical yet, but "
               "%d-th output tensor`s shape is not.",
               i));

--- a/paddle/phi/kernels/funcs/check_numerics_utils.h
+++ b/paddle/phi/kernels/funcs/check_numerics_utils.h
@@ -87,7 +87,7 @@ HOSTDEVICE static void PrintAndThrowError(const char* debug_info,
                                           int64_t num_inf,
                                           int64_t num_zero) {
 #if !defined(__HIPCC__) && !defined(__CUDA_ARCH__)
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "There are NAN or INF (num_nan=%lld, num_inf=%lld, num_zero=%lld) in "
       "%s.",
       static_cast<long long>(num_nan),   // NOLINT
@@ -150,13 +150,13 @@ void WriteToFileForDifferentLevel(const char* debug_info,
   MKDIR(output_dir.c_str());
   std::string filename = output_dir + "worker_" + log_name;
   std::ofstream outfile(filename, std::ios::app);
-  PADDLE_ENFORCE_EQ(
-      outfile.is_open(),
-      true,
-      phi::errors::Unavailable("Fail to open output file %s, please check the "
-                               "specified output_dir (%s).",
-                               filename,
-                               output_dir));
+  PADDLE_ENFORCE_EQ(outfile.is_open(),
+                    true,
+                    common::errors::Unavailable(
+                        "Fail to open output file %s, please check the "
+                        "specified output_dir (%s).",
+                        filename,
+                        output_dir));
 
   if (num_nan > 0 || num_inf > 0) {
     outfile << "[PRECISION] [ERROR] in " << debug_info
@@ -351,8 +351,8 @@ void CheckNumericsCpuImpl(const T* value_ptr,
       std::isinf(imag_sum)) {
     // hot fix for compile failed in gcc4.8
     // here also need print detail info of nan or inf later
-    PADDLE_THROW(phi::errors::PreconditionNotMet("There are NAN or INF in %s.",
-                                                 cpu_hint_str));
+    PADDLE_THROW(common::errors::PreconditionNotMet(
+        "There are NAN or INF in %s.", cpu_hint_str));
   }
 }
 

--- a/paddle/phi/kernels/funcs/common_shape.h
+++ b/paddle/phi/kernels/funcs/common_shape.h
@@ -42,13 +42,13 @@ inline void GetBroadcastDimsArrays(const DDim &x_dims,
   PADDLE_ENFORCE_GE(
       axis,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Axis should be great than or equal to 0, but received axis is %d.",
           axis));
   PADDLE_ENFORCE_LE(
       axis,
       max_dim,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Axis should be less than or equal to %d, but received axis is %d.",
           max_dim,
           axis));
@@ -72,7 +72,7 @@ inline void GetBroadcastDimsArrays(const DDim &x_dims,
         x_dims_array[i] == y_dims_array[i] || x_dims_array[i] <= 1 ||
             y_dims_array[i] <= 1,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Broadcast dimension mismatch. Operands could "
             "not be broadcast together with the shape of X = [%s] and "
             "the shape of Y = [%s]. Received [%d] in X is not equal to "
@@ -161,7 +161,7 @@ static inline std::vector<int64_t> MatrixGetBroadcastBatchPortion(
     PADDLE_ENFORCE_EQ(
         (x_size == y_size || x_size == 1 || y_size == 1),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The size of tensor x (%d) must match the size of tensor y "
             "(%d) at non-singleton dimension %d.",
             x_size,
@@ -309,7 +309,7 @@ inline void FCOutputSize(const DDim &in_dims,
   PADDLE_ENFORCE_EQ(
       in_mat_dims[1],
       w_dims0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input's second dimension and weight's first dimension is "
           "expected to be the same. But received input's second dimension is "
           "%d, input's shape is %s; weight's first dimension is %d, weight's "
@@ -342,7 +342,7 @@ inline std::vector<int64_t> GetReduceDims(const DenseTensor &in,
       PADDLE_ENFORCE_EQ(
           in_dims[i + diff],
           out_dims[i],
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "ReduceDims dimension mismatch. Operands could "
               "not be broadcast together with the shape of in_dims = [%s] and "
               "the shape of out_dims = [%s]. Received [%d] in X is not equal "

--- a/paddle/phi/kernels/funcs/concat_and_split_functor.cc
+++ b/paddle/phi/kernels/funcs/concat_and_split_functor.cc
@@ -39,7 +39,7 @@ struct ConcatFunctor<phi::CPUContext, T> {
     PADDLE_ENFORCE_NE(
         rows,
         0,
-        phi::errors::InvalidArgument("The input size should not be 0."));
+        common::errors::InvalidArgument("The input size should not be 0."));
 
     std::vector<int64_t> input_cols(input.size());
     for (size_t i = 0; i < num; ++i) {

--- a/paddle/phi/kernels/funcs/concat_funcs.h
+++ b/paddle/phi/kernels/funcs/concat_funcs.h
@@ -23,7 +23,7 @@ static inline int64_t ComputeAxis(int64_t axis, int64_t rank) {
   PADDLE_ENFORCE_EQ(
       axis >= -rank && axis < rank,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The axis is expected to be in range of [%d, %d), but got %d",
           -rank,
           rank,
@@ -45,14 +45,14 @@ static inline phi::DDim ComputeAndCheckShape(
     PADDLE_ENFORCE_EQ(
         inputs_dims[i].size(),
         out_dims.size(),
-        phi::errors::InvalidArgument("The shape of input[0] and input[%d] "
-                                     "is expected to be equal."
-                                     "But received input[0]'s shape = "
-                                     "[%s], input[%d]'s shape = [%s].",
-                                     i,
-                                     inputs_dims[0],
-                                     i,
-                                     inputs_dims[i]));
+        common::errors::InvalidArgument("The shape of input[0] and input[%d] "
+                                        "is expected to be equal."
+                                        "But received input[0]'s shape = "
+                                        "[%s], input[%d]'s shape = [%s].",
+                                        i,
+                                        inputs_dims[0],
+                                        i,
+                                        inputs_dims[i]));
     for (size_t j = 0; j < in_zero_dims_size; j++) {
       if (j == axis) {
         if (is_runtime) {
@@ -71,7 +71,7 @@ static inline phi::DDim ComputeAndCheckShape(
           // check all shape in run time
           PADDLE_ENFORCE_EQ(inputs_dims[0][j],
                             inputs_dims[i][j],
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "The %d-th dimension of input[0] and input[%d] "
                                 "is expected to be equal."
                                 "But received input[0]'s shape = "

--- a/paddle/phi/kernels/funcs/cpu_vec.h
+++ b/paddle/phi/kernels/funcs/cpu_vec.h
@@ -651,7 +651,7 @@ class VecActivations {
     } else if (type == "identity" || type == "") {
       return vec_identity<T, isa>;
     }
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Expected type should be one of sigmoid, relu, tanh, identity. But got "
         "not support type: %s.",
         type));

--- a/paddle/phi/kernels/funcs/cross_entropy.cc
+++ b/paddle/phi/kernels/funcs/cross_entropy.cc
@@ -53,17 +53,17 @@ struct HardLabelCrossEntropyCPUFunctorImpl {
       for (int j = 0; j < num_remain; j++) {
         int lbl = static_cast<int>(label_data[i * num_remain + j]);  // NOLINT
         if (lbl != ignore_index_) {
-          PADDLE_ENFORCE_GE(
-              lbl,
-              0,
-              phi::errors::OutOfRange("label value should >= 0 when label "
-                                      "value(%f) not equal to ignore_index(%f)",
-                                      lbl,
-                                      ignore_index_));
+          PADDLE_ENFORCE_GE(lbl,
+                            0,
+                            common::errors::OutOfRange(
+                                "label value should >= 0 when label "
+                                "value(%f) not equal to ignore_index(%f)",
+                                lbl,
+                                ignore_index_));
           PADDLE_ENFORCE_LT(
               lbl,
               axis_dim_,
-              phi::errors::OutOfRange(
+              common::errors::OutOfRange(
                   "label value should less than the shape of axis dimension "
                   "when label value(%f) not equal to ignore_index(%f), But "
                   "received label value as %ld and shape of axis dimension "

--- a/paddle/phi/kernels/funcs/cublaslt.h
+++ b/paddle/phi/kernels/funcs/cublaslt.h
@@ -60,7 +60,7 @@ class CublasLtHelper {
     PADDLE_ENFORCE_EQ(
         status,
         CUBLAS_STATUS_SUCCESS,
-        phi::errors::External(
+        common::errors::External(
             "cublasLtMatmulDescCreate execution error"
             "refer https://docs.nvidia.com/cuda/cublas/index.html to get more "
             "information"));
@@ -72,7 +72,7 @@ class CublasLtHelper {
     PADDLE_ENFORCE_EQ(
         status,
         CUBLAS_STATUS_SUCCESS,
-        phi::errors::External(
+        common::errors::External(
             "cublasLtMatmulDescSetAttribute execution error"
             "refer https://docs.nvidia.com/cuda/cublas/index.html to get more "
             "information"));
@@ -82,7 +82,7 @@ class CublasLtHelper {
     PADDLE_ENFORCE_EQ(
         status,
         CUBLAS_STATUS_SUCCESS,
-        phi::errors::External(
+        common::errors::External(
             "cublasLtMatrixLayoutCreate execution error"
             "refer https://docs.nvidia.com/cuda/cublas/index.html to get more "
             "information"));
@@ -91,7 +91,7 @@ class CublasLtHelper {
     PADDLE_ENFORCE_EQ(
         status,
         CUBLAS_STATUS_SUCCESS,
-        phi::errors::External(
+        common::errors::External(
             "cublasLtMatrixLayoutCreate execution error"
             "refer https://docs.nvidia.com/cuda/cublas/index.html to get more "
             "information"));
@@ -100,7 +100,7 @@ class CublasLtHelper {
     PADDLE_ENFORCE_EQ(
         status,
         CUBLAS_STATUS_SUCCESS,
-        phi::errors::External(
+        common::errors::External(
             "cublasLtMatrixLayoutCreate execution error"
             "refer https://docs.nvidia.com/cuda/cublas/index.html to get more "
             "information"));
@@ -203,7 +203,7 @@ class CublasLtHelper {
     PADDLE_ENFORCE_EQ(
         status,
         CUBLAS_STATUS_SUCCESS,
-        phi::errors::External(
+        common::errors::External(
             "cublasLtMatmul execution error"
             "refer https://docs.nvidia.com/cuda/cublas/index.html to get more "
             "information"));
@@ -303,10 +303,10 @@ void CublasLtMatmulFP8(const phi::GPUContext& dev_ctx,
                                                &heuristicResult,
                                                &returnedResults);
 
-  PADDLE_ENFORCE_NE(
-      returnedResults,
-      0,
-      phi::errors::NotFound("Unable to find suitable cuBLAS GEMM algorithm"));
+  PADDLE_ENFORCE_NE(returnedResults,
+                    0,
+                    common::errors::NotFound(
+                        "Unable to find suitable cuBLAS GEMM algorithm"));
 
   status =
       dyl::cublasLtMatmul(dev_ctx.cublaslt_handle(),

--- a/paddle/phi/kernels/funcs/cudnn_rnn_cache.h
+++ b/paddle/phi/kernels/funcs/cudnn_rnn_cache.h
@@ -267,7 +267,7 @@ class CudnnRNNCache {
     PADDLE_ENFORCE_EQ(
         weights_size_,
         cudnn_size * weight_numel,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The cudnn lstm and setting weight size should be same."));
 
     int dim_w[3];

--- a/paddle/phi/kernels/funcs/cufft_util.h
+++ b/paddle/phi/kernels/funcs/cufft_util.h
@@ -57,7 +57,7 @@ inline bool has_complex_input(FFTTransformType type) {
     case FFTTransformType::R2C:
       return false;
   }
-  PADDLE_THROW(phi::errors::InvalidArgument("Unknown FFTTransformType"));
+  PADDLE_THROW(common::errors::InvalidArgument("Unknown FFTTransformType"));
 }
 
 // Returns true if the transform type has complex output
@@ -70,7 +70,7 @@ inline bool has_complex_output(FFTTransformType type) {
     case FFTTransformType::C2R:
       return false;
   }
-  PADDLE_THROW(phi::errors::InvalidArgument("Unknown FFTTransformType"));
+  PADDLE_THROW(common::errors::InvalidArgument("Unknown FFTTransformType"));
 }
 
 class FFTConfig {
@@ -102,7 +102,7 @@ class FFTConfig {
       otype = complex_output ? CUDA_C_64F : CUDA_R_64F;
       exec_type = CUDA_C_64F;
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Only transforms of type float32 and float64 are supported."));
     }
 

--- a/paddle/phi/kernels/funcs/cumprod.h
+++ b/paddle/phi/kernels/funcs/cumprod.h
@@ -25,7 +25,7 @@ static void GetCumprodDimInfo(const DDim& dim,
   PADDLE_ENFORCE_GE(
       cumprod_dim,
       -dim.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The input dim of CumprodOp should be larger than the opposite "
           "rank of input x which is %d.But received dim=%d",
           -dim.size(),
@@ -34,7 +34,7 @@ static void GetCumprodDimInfo(const DDim& dim,
     PADDLE_ENFORCE_LE(
         cumprod_dim,
         dim.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input dim of CumprodOp should be smaller than the "
             "rank of input x which is %d.But received dim=%d",
             dim.size(),
@@ -44,7 +44,7 @@ static void GetCumprodDimInfo(const DDim& dim,
 
   PADDLE_ENFORCE_LT(cumprod_dim,
                     dim.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The input dim of CumprodOp should be smaller than the "
                         "rank of input x which is %d.But received dim=%d",
                         dim.size(),

--- a/paddle/phi/kernels/funcs/data_type_transform.h
+++ b/paddle/phi/kernels/funcs/data_type_transform.h
@@ -50,7 +50,7 @@ phi::DenseTensor TransDataType(const Context& dev_ctx,
     case DataType::UINT8:
       return phi::Cast<uint8_t>(dev_ctx, x, dtype);
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported when casting data type.",
           x.dtype()));
   }

--- a/paddle/phi/kernels/funcs/detail/strided_memcpy.h
+++ b/paddle/phi/kernels/funcs/detail/strided_memcpy.h
@@ -48,7 +48,7 @@ struct StridedMemcpyFunctor<T, 0> {
           gpu_place, dst, gpu_place, src, sizeof(T), cuda_ctx.stream());
 #else
       PADDLE_THROW(
-          phi::errors::Unavailable("Paddle is not compiled with GPU."));
+          common::errors::Unavailable("Paddle is not compiled with GPU."));
 #endif
     }
   }
@@ -79,7 +79,7 @@ struct StridedMemcpyFunctor<T, 1> {
                          cuda_ctx.stream());
 #else
       PADDLE_THROW(
-          phi::errors::Unavailable("Paddle is not compiled with GPU."));
+          common::errors::Unavailable("Paddle is not compiled with GPU."));
 #endif
     }
   }

--- a/paddle/phi/kernels/funcs/dims_simplifier.h
+++ b/paddle/phi/kernels/funcs/dims_simplifier.h
@@ -113,7 +113,7 @@ struct BroadcastDimsSimplifier {
             extended_in_dim[out_idx] = in_dim[in_idx];
             out_idx++;
           } else {
-            PADDLE_THROW(phi::errors::InvalidArgument(
+            PADDLE_THROW(common::errors::InvalidArgument(
                 "The %d-th dimension of input tensor is expected to be equal "
                 "with the %d-th dimension of output tensor %d or 1, but "
                 "received %d. The input's shape is {%s}, the output's shape is "
@@ -134,7 +134,7 @@ struct BroadcastDimsSimplifier {
           PADDLE_ENFORCE_EQ(
               in_dim[in_idx] == out_dims[in_idx] || in_dim[in_idx] == 1,
               true,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "The %d-th dimension of input tensor is expected to be equal "
                   "with the %d-th dimension of output tensor %d or 1, but "
                   "received %d.",

--- a/paddle/phi/kernels/funcs/eigen/common.h
+++ b/paddle/phi/kernels/funcs/eigen/common.h
@@ -30,7 +30,7 @@ struct EigenDim {
   static Type From(const DDim& dims) {
     PADDLE_ENFORCE_EQ(arity(dims),
                       D,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input dimension size should be equal to %d, but "
                           "received dimension size is %d.",
                           arity(dims),
@@ -87,7 +87,7 @@ struct EigenMatrix : public EigenTensor<T, 2, MajorType, IndexType> {
     int rank = tensor.dims().size();
     PADDLE_ENFORCE_EQ((num_col_dims > 0 && num_col_dims < rank),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input dimension number(num_col_dims) must be "
                           "between 0 and %d, but received number is %d.",
                           rank,
@@ -101,7 +101,7 @@ struct EigenMatrix : public EigenTensor<T, 2, MajorType, IndexType> {
     int rank = tensor.dims().size();
     PADDLE_ENFORCE_EQ((num_col_dims > 0 && num_col_dims < rank),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Input dimension number(num_col_dims) must be "
                           "between 0 and %d, but received number is %d.",
                           rank,

--- a/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
+++ b/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
@@ -1283,7 +1283,7 @@ void FusedElemwiseAndActGradComputeEx(const DeviceContext &dev_ctx,
   if (UseIntermediateOut) {
     PADDLE_ENFORCE_NOT_NULL(
         intermediate_out,
-        phi::errors::InvalidArgument("Intermediate out is null pointer."));
+        common::errors::InvalidArgument("Intermediate out is null pointer."));
   }
   if (x_dim == y_dim) {
     FusedElemwiseAndActGradComputeNoBroadcast<DeviceContext,
@@ -1387,7 +1387,7 @@ void FusedElemwiseAndActComputeEx(const DeviceContext &dev_ctx,
   if (KeepIntermediateOut) {
     PADDLE_ENFORCE_NOT_NULL(
         intermediate_out,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The save_intermediate_out is opened, intermediate "
             "out is null pointer."));
   }

--- a/paddle/phi/kernels/funcs/elementwise_base.h
+++ b/paddle/phi/kernels/funcs/elementwise_base.h
@@ -321,13 +321,13 @@ void CommonElementwiseBroadcastForward(const CPUContext &dev_ctx,
   PADDLE_ENFORCE_GE(
       axis,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Axis should be great than or equal to 0, but received axis is %d.",
           axis));
   PADDLE_ENFORCE_LE(
       axis,
       max_dim,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Axis should be less than or equal to %d, but received axis is %d.",
           max_dim,
           axis));
@@ -797,7 +797,7 @@ ElementwiseKernelForDifferentVecSize(
           ctx, ins, outs, func);
       break;
     default: {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported vectorized size: %d !", vec_size));
       break;
     }
@@ -813,7 +813,7 @@ void ElementwiseKernel(const KPDevice &ctx,
   const int kArity = Traits::arity;
   PADDLE_ENFORCE_EQ(ins.size(),
                     kArity,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The number of inputs is expected to be equal to the "
                         "arity of functor. But received: the number of inputs "
                         "is %d, the arity of functor is %d.",
@@ -821,7 +821,7 @@ void ElementwiseKernel(const KPDevice &ctx,
                         kArity));
   PADDLE_ENFORCE_EQ(outs->size(),
                     NumOuts,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Number of outputs shall equal to number of functions, "
                         "but number of outputs is %d, of functions is %d.",
                         outs->size(),
@@ -832,7 +832,7 @@ void ElementwiseKernel(const KPDevice &ctx,
       PADDLE_ENFORCE_EQ(
           (*outs)[i]->dims(),
           (*outs)[0]->dims(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The shape of each output tensor shall be identical yet, "
               "but %dth output tensor`s shape is not.",
               i));

--- a/paddle/phi/kernels/funcs/elementwise_utils.h
+++ b/paddle/phi/kernels/funcs/elementwise_utils.h
@@ -55,7 +55,7 @@ inline void GetMidDims(const DDim &x_dims,
     if (x_dims[i + axis] != y_dims[i]) {
       PADDLE_ENFORCE_EQ(y_dims[i] == 1 || x_dims[i + axis] == 1,
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Broadcast dimension mismatch. Operands "
                             "could not be broadcast together with the shape of "
                             "X = [%s] and the shape of Y = [%s]. Received [%d] "

--- a/paddle/phi/kernels/funcs/fake_quantize_functor.cc
+++ b/paddle/phi/kernels/funcs/fake_quantize_functor.cc
@@ -90,9 +90,9 @@ void FindChannelAbsMaxFunctor<Context, T>::operator()(
   PADDLE_ENFORCE_EQ(
       quant_axis == 0 || quant_axis == 1,
       true,
-      phi::errors::InvalidArgument("'quant_axis' should be 0 or 1, but "
-                                   "the received is %d",
-                                   quant_axis));
+      common::errors::InvalidArgument("'quant_axis' should be 0 or 1, but "
+                                      "the received is %d",
+                                      quant_axis));
   auto *in_data = in_tensor.data<T>();
   auto in_dims = in_tensor.dims();
   const int64_t channel = in_dims[quant_axis];
@@ -134,9 +134,9 @@ void ChannelClipAndFakeQuantFunctor<Context, T>::operator()(
   PADDLE_ENFORCE_EQ(
       quant_axis == 0 || quant_axis == 1,
       true,
-      phi::errors::InvalidArgument("'quant_axis' should be 0 or 1, but "
-                                   "the received is %d",
-                                   quant_axis));
+      common::errors::InvalidArgument("'quant_axis' should be 0 or 1, but "
+                                      "the received is %d",
+                                      quant_axis));
   auto *scale_data = scale.data<T>();
   auto *in_data = in.data<T>();
   auto *out_data = ctx.template Alloc<T>(out);
@@ -212,9 +212,9 @@ void ChannelClipFakeQuantDequantFunctor<Context, T>::operator()(
   PADDLE_ENFORCE_EQ(
       quant_axis == 0 || quant_axis == 1,
       true,
-      phi::errors::InvalidArgument("'quant_axis' should be 0 or 1, but "
-                                   "the received is %d",
-                                   quant_axis));
+      common::errors::InvalidArgument("'quant_axis' should be 0 or 1, but "
+                                      "the received is %d",
+                                      quant_axis));
 
   auto *scale_data = scale.data<T>();
   auto *in_data = in.data<T>();

--- a/paddle/phi/kernels/funcs/fake_quantize_functor.cu
+++ b/paddle/phi/kernels/funcs/fake_quantize_functor.cu
@@ -324,9 +324,9 @@ void FindChannelAbsMaxFunctor<Context, T>::operator()(
   PADDLE_ENFORCE_EQ(
       quant_axis == 0 || quant_axis == 1,
       true,
-      phi::errors::InvalidArgument("'quant_axis' should be 0 or 1, but "
-                                   "the received is %d",
-                                   quant_axis));
+      common::errors::InvalidArgument("'quant_axis' should be 0 or 1, but "
+                                      "the received is %d",
+                                      quant_axis));
   const int num = in_tensor.numel();
   auto in_dims = in_tensor.dims();
   const T *in_data = in_tensor.data<T>();

--- a/paddle/phi/kernels/funcs/fft.cc
+++ b/paddle/phi/kernels/funcs/fft.cc
@@ -206,7 +206,8 @@ static T compute_factor(size_t size, FFTNormMode normalization) {
     case FFTNormMode::by_sqrt_n:
       return one / std::sqrt(static_cast<T>(size));
   }
-  PADDLE_THROW(phi::errors::InvalidArgument("Unsupported normalization type"));
+  PADDLE_THROW(
+      common::errors::InvalidArgument("Unsupported normalization type"));
 }
 }  // namespace phi::funcs::detail
 namespace phi::funcs {

--- a/paddle/phi/kernels/funcs/fft.h
+++ b/paddle/phi/kernels/funcs/fft.h
@@ -41,7 +41,7 @@ inline FFTNormMode get_norm_from_string(const std::string& norm, bool forward) {
     return FFTNormMode::by_sqrt_n;
   }
 
-  PADDLE_THROW(phi::errors::InvalidArgument(
+  PADDLE_THROW(common::errors::InvalidArgument(
       "FFT norm string must be 'forward' or 'backward' or 'ortho', "
       "received %s",
       norm));
@@ -67,7 +67,7 @@ inline FFTTransformType GetFFTTransformType(DataType input_dtype,
     return FFTTransformType::R2C;
   }
   PADDLE_THROW(
-      phi::errors::InvalidArgument("Real to real FFTs are not supported"));
+      common::errors::InvalidArgument("Real to real FFTs are not supported"));
 }
 
 template <typename DeviceContext, typename Ti, typename To>

--- a/paddle/phi/kernels/funcs/fft_cache.h
+++ b/paddle/phi/kernels/funcs/fft_cache.h
@@ -85,7 +85,7 @@ class FFTConfigCache {
   FFTConfig& lookup(FFTConfigKey params) {
     PADDLE_ENFORCE_GT(_max_size,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The max size of FFTConfigCache must be great than 0,"
                           "But received is [%d]",
                           _max_size));
@@ -150,12 +150,12 @@ class FFTConfigCache {
     PADDLE_ENFORCE_GE(
         new_size,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "cuFFT plan cache size must be non-negative, But received is [%d]",
             new_size));
     PADDLE_ENFORCE_LE(new_size,
                       CUFFT_MAX_PLAN_NUM,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "cuFFT plan cache size can not be larger than [%d], "
                           "But received is [%d]",
                           CUFFT_MAX_PLAN_NUM,

--- a/paddle/phi/kernels/funcs/fused_elemwise_activation_functor.h
+++ b/paddle/phi/kernels/funcs/fused_elemwise_activation_functor.h
@@ -50,7 +50,7 @@ static inline bool IsUnaryCompound(
   PADDLE_ENFORCE_EQ(
       functor_list.size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Invalid functor list size %d, which should be equal to %d.",
           functor_list.size(),
           2));
@@ -70,7 +70,7 @@ static inline bool HasInPlaceUnary(
   PADDLE_ENFORCE_EQ(
       functor_list.size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Invalid functor list size %d, which should be equal to %d.",
           functor_list.size(),
           2));
@@ -90,7 +90,7 @@ static inline bool InputXCanBeAbsent(
   PADDLE_ENFORCE_EQ(
       functor_list.size(),
       2,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Invalid functor list size %d, which should be equal to %d.",
           functor_list.size(),
           2));
@@ -108,7 +108,7 @@ static bool IsSupportedCompound(const std::vector<std::string> &functors) {
   PADDLE_ENFORCE_EQ(
       functors.size(),
       2UL,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Invalid functor list size %d, which should be equal to %d.",
           functors.size(),
           2));
@@ -124,12 +124,12 @@ static bool IsSupportedCompound(const std::vector<std::string> &functors) {
   } else if (binary_fun.count(functors[1])) {
     unary_fun_str = functors[0];
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "%s and %s are not included in fused_list.", functors[0], functors[1]));
   }
   PADDLE_ENFORCE_EQ(unary_fun.count(unary_fun_str),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "%s is not included in fused_list.", unary_fun_str));
   return true;
 }
@@ -528,8 +528,8 @@ void RunFunctors(const DeviceContext &dev_ctx,
         axis,
         save_intermediate_out);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument("%s has not been implemented.",
-                                              funcs_str));
+    PADDLE_THROW(common::errors::InvalidArgument("%s has not been implemented.",
+                                                 funcs_str));
   }
 }
 
@@ -736,8 +736,8 @@ void RunGradFunctors(const DeviceContext &dev_ctx,
                                           d_intermediate_out,
                                           axis);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument("%s has not been implemented.",
-                                              funcs_str));
+    PADDLE_THROW(common::errors::InvalidArgument("%s has not been implemented.",
+                                                 funcs_str));
   }
 }
 

--- a/paddle/phi/kernels/funcs/fused_gemm_epilogue.h
+++ b/paddle/phi/kernels/funcs/fused_gemm_epilogue.h
@@ -116,7 +116,7 @@ class GemmEpilogueAlgoCache {
     PADDLE_ENFORCE_GT(
         returned_results,
         0,
-        phi::errors::Unavailable("No GEMM epilogue algorithm support!"));
+        common::errors::Unavailable("No GEMM epilogue algorithm support!"));
 
     PADDLE_ENFORCE_GPU_SUCCESS(
         phi::dynload::cublasLtMatmulPreferenceDestroy(preference));
@@ -148,8 +148,8 @@ class GemmEpilogueAlgoCache {
         t = -1;
         warmup_algo_idx += 1;
         if (warmup_algo_idx == requested_algo_count_) {
-          PADDLE_THROW(
-              phi::errors::Unavailable("No GEMM epilogue algorithm support!"));
+          PADDLE_THROW(common::errors::Unavailable(
+              "No GEMM epilogue algorithm support!"));
         }
       }
     }
@@ -205,7 +205,7 @@ class GemmEpilogueAlgoCache {
 
     if (best_algo_idx == -1) {
       PADDLE_THROW(
-          phi::errors::Unavailable("No GEMM epilogue algorithm support!"));
+          common::errors::Unavailable("No GEMM epilogue algorithm support!"));
     }
 
     ret = heuristic_results[best_algo_idx].algo;
@@ -325,7 +325,7 @@ static cublasLtEpilogue_t GetEpilogueType(const std::string& activation,
   } else if (activation == "none") {
     return CUBLASLT_EPILOGUE_BIAS;
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The activation attribute of fused_gemm_epilogue op should be"
         " one of {\"none\", \"relu\", \"gelu\"}. But received %s."
         "But received activation=%s.",
@@ -500,7 +500,7 @@ struct BwdFusedEpilogueSetter {
     } else if (activation_grad == "gelu_grad") {
       return kMatmulGeluGrad;
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Fued linear epilogue type should be one of {none, relu, gelu}."
           "But received activation is %s, please check",
           activation_grad));
@@ -603,7 +603,7 @@ static cublasLtEpilogue_t GetEpilogueGradType(
   } else if (activation_grad == "gelu_grad") {
     return CUBLASLT_EPILOGUE_DGELU;
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The activation_grad attribute of fused_gemm_epilogue op should "
         "be one of {\"none\", \"relu\", \"gelu\"}. But received %s."
         "But received activation_grad=%s.",

--- a/paddle/phi/kernels/funcs/gather.cu.h
+++ b/paddle/phi/kernels/funcs/gather.cu.h
@@ -89,8 +89,8 @@ void GPUGather(const phi::GPUContext& ctx,
     PADDLE_ENFORCE_EQ(
         index.dims()[1],
         1,
-        phi::errors::InvalidArgument("If the index's rank of gather_op is 2,"
-                                     " the second dimension should be 1."));
+        common::errors::InvalidArgument("If the index's rank of gather_op is 2,"
+                                        " the second dimension should be 1."));
   }
 
   // index size

--- a/paddle/phi/kernels/funcs/gather.h
+++ b/paddle/phi/kernels/funcs/gather.h
@@ -42,7 +42,7 @@ void CPUGather(const phi::CPUContext& ctx UNUSED,
     PADDLE_ENFORCE_EQ(
         index.dims()[1],
         1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "index.dims()[1] should be 1 when index.dims().size() = 2"
             "in gather_op, but received value is [%d].",
             index.dims()[1]));
@@ -50,7 +50,7 @@ void CPUGather(const phi::CPUContext& ctx UNUSED,
     PADDLE_ENFORCE_EQ(
         index.dims().size() == 1 || index.dims().size() == 0,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The index should be 0D or 1D, when it is not 2D, but we get %d",
             index.dims().size()));
   }
@@ -75,7 +75,7 @@ void CPUGather(const phi::CPUContext& ctx UNUSED,
     IndexT index_ = p_index[i];
     PADDLE_ENFORCE_LT(p_index[i],
                       input_size,
-                      phi::errors::OutOfRange(
+                      common::errors::OutOfRange(
                           "The element of Index must be less than the size of "
                           "input dim size of axis which is %d, but received "
                           "index element which is %d in the %d index.",
@@ -84,7 +84,7 @@ void CPUGather(const phi::CPUContext& ctx UNUSED,
                           i));
     PADDLE_ENFORCE_GE(p_index[i],
                       0,
-                      phi::errors::OutOfRange(
+                      common::errors::OutOfRange(
                           "The element of Index must be greater than or equal "
                           "to 0, but received index element which is %d in the "
                           "%d index.",
@@ -128,12 +128,12 @@ void CPUGatherNd(const phi::CPUContext& ctx UNUSED,
       PADDLE_ENFORCE_LT(
           index_value,
           input_dims[j],
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Input(index[-1)] has wrong value, it is [%d]", index_value));
       PADDLE_ENFORCE_GE(
           index_value,
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The value of Input(index) must be no less than 0"));
 
       index_ += (index_value * temp);
@@ -163,7 +163,7 @@ void GatherV2Function(const phi::CPUContext& ctx,
   for (int64_t i = 0; i < index_size; i++) {
     PADDLE_ENFORCE_LT(index_data[i],
                       input_index_dim_size,
-                      phi::errors::OutOfRange(
+                      common::errors::OutOfRange(
                           "The element of Index must be less than the size of "
                           "input dim size of axis which is %d, but received "
                           "index element which is %d in the %d index.",
@@ -172,7 +172,7 @@ void GatherV2Function(const phi::CPUContext& ctx,
                           i));
     PADDLE_ENFORCE_GE(index_data[i],
                       0,
-                      phi::errors::OutOfRange(
+                      common::errors::OutOfRange(
                           "The element of Index must be greater than or equal "
                           "to 0, but received index element which is %d in the "
                           "%d index.",

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cc
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cc
@@ -92,7 +92,7 @@ struct cpu_gather_scatter_functor {
     auto src_dims = src.dims();
     if (self_size == 0 || src_size == 0 || index_size == 0) {
       VLOG(3) << "zero size input found";
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "self_size, src_size, index_size cannot be 0");
       return;
     }

--- a/paddle/phi/kernels/funcs/get_pad_lse.cu.h
+++ b/paddle/phi/kernels/funcs/get_pad_lse.cu.h
@@ -54,11 +54,11 @@ phi::DenseTensor get_pad_lse(const phi::GPUContext& dev_ctx,
   PADDLE_ENFORCE_EQ(
       lse->dims().size(),
       3,
-      phi::errors::InvalidArgument("The lse should be a 3d tensor"));
-  PADDLE_ENFORCE_EQ(
-      (data_format == "NCHW" || data_format == "NHWC"),
-      true,
-      phi::errors::InvalidArgument("The data_format should be NCHW or NHWC"));
+      common::errors::InvalidArgument("The lse should be a 3d tensor"));
+  PADDLE_ENFORCE_EQ((data_format == "NCHW" || data_format == "NHWC"),
+                    true,
+                    common::errors::InvalidArgument(
+                        "The data_format should be NCHW or NHWC"));
   std::string pad3d_data_format = data_format == "NCHW" ? "NCDHW" : "NDHWC";
   if (pad_amount > 0) {
     phi::DenseTensor tmp = *lse;

--- a/paddle/phi/kernels/funcs/gpc.cc
+++ b/paddle/phi/kernels/funcs/gpc.cc
@@ -543,7 +543,7 @@ static int count_contours(polygon_node *polygon) {
 
 static void add_left(polygon_node *p, double x, double y) {
   PADDLE_ENFORCE_NOT_NULL(
-      p, phi::errors::InvalidArgument("Input polygon node is nullptr."));
+      p, common::errors::InvalidArgument("Input polygon node is nullptr."));
   vertex_node *nv = nullptr;
 
   /* Create a new vertex node and set its fields */
@@ -604,7 +604,7 @@ static void add_right(polygon_node *p, double x, double y) {
 
 static void merge_right(polygon_node *p, polygon_node *q, polygon_node *list) {
   PADDLE_ENFORCE_NOT_NULL(
-      p, phi::errors::InvalidArgument("Input polygon node is nullptr."));
+      p, common::errors::InvalidArgument("Input polygon node is nullptr."));
   polygon_node *target = nullptr;
 
   /* Label contour as external */
@@ -689,7 +689,7 @@ void add_vertex(vertex_node **t, double x, double y) {
 
 void gpc_vertex_create(edge_node *e, int p, int s, double x, double y) {
   PADDLE_ENFORCE_NOT_NULL(
-      e, phi::errors::InvalidArgument("Input edge node is nullptr."));
+      e, common::errors::InvalidArgument("Input edge node is nullptr."));
   add_vertex(&(e->outp[p]->v[s]), x, y);
   e->outp[p]->active++;
 }
@@ -724,7 +724,7 @@ static bbox *create_contour_bboxes(gpc_polygon *p) {
                    p->num_contours * static_cast<int>(sizeof(bbox)),
                    const_cast<char *>("Bounding box creation"));  // NOLINT
   PADDLE_ENFORCE_NOT_NULL(
-      box, phi::errors::ResourceExhausted("Failed to malloc box memory."));
+      box, common::errors::ResourceExhausted("Failed to malloc box memory."));
 
   /* Construct contour bounding boxes */
   for (c = 0; c < p->num_contours; c++) {
@@ -890,9 +890,9 @@ void gpc_add_contour(gpc_polygon *p, gpc_vertex_list *new_contour, int hole) {
   gpc_malloc<int>(extended_hole,
                   (p->num_contours + 1) * static_cast<int>(sizeof(int)),
                   const_cast<char *>("contour hole addition"));  // NOLINT
-  PADDLE_ENFORCE_NOT_NULL(
-      extended_hole,
-      phi::errors::ResourceExhausted("Failed to malloc extended hole memory."));
+  PADDLE_ENFORCE_NOT_NULL(extended_hole,
+                          common::errors::ResourceExhausted(
+                              "Failed to malloc extended hole memory."));
 
   /* Create an extended contour array */
   gpc_malloc<gpc_vertex_list>(
@@ -1016,7 +1016,7 @@ void gpc_polygon_clip(gpc_op op,
                      sbt_entries * static_cast<int>(sizeof(double)),
                      const_cast<char *>("sbt creation"));  // NOLINT
   PADDLE_ENFORCE_NOT_NULL(sbt,
-                          phi::errors::ResourceExhausted(
+                          common::errors::ResourceExhausted(
                               "Failed to malloc scanbeam table memory."));
 
   build_sbt(&scanbeam, sbt, sbtree);
@@ -1061,7 +1061,7 @@ void gpc_polygon_clip(gpc_op op,
     e1 = aet;  // NOLINT
     /* Set up bundle fields of first edge */
     PADDLE_ENFORCE_NOT_NULL(
-        aet, phi::errors::InvalidArgument("Edge node AET is nullptr."));
+        aet, common::errors::InvalidArgument("Edge node AET is nullptr."));
 
     aet->bundle[ABOVE][aet->type] = (aet->top.y != yb);
     aet->bundle[ABOVE][!aet->type] = 0;
@@ -1664,7 +1664,7 @@ void gpc_tristrip_clip(gpc_op op,
                      sbt_entries * static_cast<int>(sizeof(double)),
                      const_cast<char *>("sbt creation"));  // NOLINT
   PADDLE_ENFORCE_NOT_NULL(sbt,
-                          phi::errors::ResourceExhausted(
+                          common::errors::ResourceExhausted(
                               "Failed to malloc scanbeam table memory."));
   build_sbt(&scanbeam, sbt, sbtree);
   scanbeam = 0;
@@ -1704,7 +1704,7 @@ void gpc_tristrip_clip(gpc_op op,
 
     /* Set up bundle fields of first edge */
     PADDLE_ENFORCE_NOT_NULL(
-        aet, phi::errors::InvalidArgument("Edge node AET is nullptr."));
+        aet, common::errors::InvalidArgument("Edge node AET is nullptr."));
     aet->bundle[ABOVE][aet->type] = (aet->top.y != yb);
     aet->bundle[ABOVE][!aet->type] = 0;
     aet->bstate[ABOVE] = UNBUNDLED;

--- a/paddle/phi/kernels/funcs/hipfft_util.h
+++ b/paddle/phi/kernels/funcs/hipfft_util.h
@@ -82,7 +82,7 @@ class FFTConfig {
             return HIPFFT_Z2D;
         }
       }
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Only transforms of type float32 and float64 are supported."));
     }();
 
@@ -175,7 +175,7 @@ static void exec_plan(const FFTConfig& config,
       }
     }
   }
-  PADDLE_THROW(phi::errors::InvalidArgument(
+  PADDLE_THROW(common::errors::InvalidArgument(
       "hipFFT only support transforms of type float32 and float64"));
 }
 

--- a/paddle/phi/kernels/funcs/im2col.cc
+++ b/paddle/phi/kernels/funcs/im2col.cc
@@ -39,13 +39,13 @@ class Im2ColFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
                   const DataLayout data_layout) {
     PADDLE_ENFORCE_EQ(im.dims().size(),
                       3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'im' should be 3. But got "
                           "the dims of tensor 'im' is [%s].",
                           im.dims()));
     PADDLE_ENFORCE_EQ(col->dims().size(),
                       5,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'col' should be 5. But got "
                           "the dims of tensor 'col' is [%s].",
                           col->dims()));
@@ -84,13 +84,13 @@ class Col2ImFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
                   const DataLayout data_layout) {
     PADDLE_ENFORCE_EQ(im->dims().size(),
                       3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'im' should be 3. But got "
                           "the dims of tensor 'im' is [%s].",
                           im->dims()));
     PADDLE_ENFORCE_EQ(col.dims().size(),
                       5,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'col' should be 5. But got "
                           "the dims of tensor 'col' is [%s].",
                           col.dims()));
@@ -111,16 +111,16 @@ class Col2ImFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
                 stride[0] +
             1,
         col_height,
-        phi::errors::InvalidArgument("Output_height and padding(padding_up, "
-                                     "padding_down) are inconsistent."));
+        common::errors::InvalidArgument("Output_height and padding(padding_up, "
+                                        "padding_down) are inconsistent."));
     PADDLE_ENFORCE_EQ(
         (im_width + padding[1] + padding[3] -
          ((dilation[1] * (filter_width - 1) + 1))) /
                 stride[1] +
             1,
         col_width,
-        phi::errors::InvalidArgument("Output_height and padding(padding_up, "
-                                     "padding_down) are inconsistent."));
+        common::errors::InvalidArgument("Output_height and padding(padding_up, "
+                                        "padding_down) are inconsistent."));
 
     int channels_col = im_channels * filter_height * filter_width;
 
@@ -196,13 +196,13 @@ class Im2ColFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
                   const DataLayout data_layout UNUSED) {
     PADDLE_ENFORCE_EQ(im.dims().size(),
                       3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'im' should be 3. But got "
                           "the dims of tensor 'im' is [%s].",
                           im.dims()));
     PADDLE_ENFORCE_EQ(col->dims().size(),
                       5,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'col' should be 5. But got "
                           "the dims of tensor 'col' is [%s].",
                           col->dims()));
@@ -269,13 +269,13 @@ class Col2ImFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
                   const DataLayout data_layout UNUSED) {
     PADDLE_ENFORCE_EQ(im->dims().size(),
                       3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'im' should be 3. But got "
                           "the dims of tensor 'im' is [%s].",
                           im->dims()));
     PADDLE_ENFORCE_EQ(col.dims().size(),
                       5,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'col' should be 5. But got "
                           "the dims of tensor 'col' is [%s].",
                           col.dims()));
@@ -290,14 +290,14 @@ class Col2ImFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
     PADDLE_ENFORCE_EQ(
         (im_height + padding[0] + padding[2] - filter_height) / stride[0] + 1,
         col_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Output_height and padding(padding_up, padding_down) "
             "are inconsistent."));
     PADDLE_ENFORCE_EQ(
         (im_width + padding[1] + padding[3] - filter_width) / stride[1] + 1,
         col_width,
-        phi::errors::InvalidArgument("col_width and padding(padding_left, "
-                                     "padding_right) are inconsistent."));
+        common::errors::InvalidArgument("col_width and padding(padding_left, "
+                                        "padding_right) are inconsistent."));
 
     T* im_data = im->data<T>();
     const T* col_data = col.data<T>();

--- a/paddle/phi/kernels/funcs/im2col.cu
+++ b/paddle/phi/kernels/funcs/im2col.cu
@@ -97,13 +97,13 @@ class Im2ColFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
                   const DataLayout data_layout) {
     PADDLE_ENFORCE_EQ(im.dims().size(),
                       3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'im' should be 3. But got "
                           "the dims of tensor 'im' is [%s].",
                           im.dims()));
     PADDLE_ENFORCE_EQ(col->dims().size(),
                       5,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'col' should be 5. But got "
                           "the dims of tensor 'col' is [%s].",
                           col->dims()));
@@ -232,13 +232,13 @@ class Col2ImFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
                   const DataLayout data_layout) {
     PADDLE_ENFORCE_EQ(im->dims().size(),
                       3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'im' should be 3. But got "
                           "the dims of tensor 'im' is [%s].",
                           im->dims()));
     PADDLE_ENFORCE_EQ(col.dims().size(),
                       5,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'col' should be 5. But got "
                           "the dims of tensor 'col' is [%s].",
                           col.dims()));
@@ -260,16 +260,16 @@ class Col2ImFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
                 stride[0] +
             1,
         col_height,
-        phi::errors::InvalidArgument("Output_height and padding(padding_up, "
-                                     "padding_down) are inconsistent."));
+        common::errors::InvalidArgument("Output_height and padding(padding_up, "
+                                        "padding_down) are inconsistent."));
     PADDLE_ENFORCE_EQ(
         (im_width + padding[1] + padding[3] -
          (dilation[1] * (filter_width - 1) + 1)) /
                 stride[1] +
             1,
         col_width,
-        phi::errors::InvalidArgument("col_width and padding(padding_left, "
-                                     "padding_right) are inconsistent."));
+        common::errors::InvalidArgument("col_width and padding(padding_left, "
+                                        "padding_right) are inconsistent."));
 
     size_t num_kernels = im_channels * im_height * im_width;
 
@@ -398,13 +398,13 @@ class Im2ColFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
                   const DataLayout data_layout) {
     PADDLE_ENFORCE_EQ(im.dims().size(),
                       3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'im' should be 3. But got "
                           "the dims of tensor 'im' is [%s].",
                           im.dims()));
     PADDLE_ENFORCE_EQ(col->dims().size(),
                       5,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'col' should be 5. But got "
                           "the dims of tensor 'col' is [%s].",
                           col->dims()));
@@ -508,13 +508,13 @@ class Col2ImFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
                   const DataLayout data_layout) {
     PADDLE_ENFORCE_EQ(im->dims().size(),
                       3,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'im' should be 3. But got "
                           "the dims of tensor 'im' is [%s].",
                           im->dims()));
     PADDLE_ENFORCE_EQ(col.dims().size(),
                       5,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of tensor 'col' should be 5. But got "
                           "the dims of tensor 'col' is [%s].",
                           col.dims()));
@@ -533,16 +533,16 @@ class Col2ImFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
                 stride[0] +
             1,
         col_height,
-        phi::errors::InvalidArgument("Output_height and padding(padding_up, "
-                                     "padding_down) are inconsistent."));
+        common::errors::InvalidArgument("Output_height and padding(padding_up, "
+                                        "padding_down) are inconsistent."));
     PADDLE_ENFORCE_EQ(
         (im_width + padding[1] + padding[3] -
          (dilation[1] * (filter_width - 1) + 1)) /
                 stride[1] +
             1,
         col_width,
-        phi::errors::InvalidArgument("col_width and padding(padding_left, "
-                                     "padding_right) are inconsistent."));
+        common::errors::InvalidArgument("col_width and padding(padding_left, "
+                                        "padding_right) are inconsistent."));
 
     int block_dim_x = 0;
     int block_dim_y = 0;

--- a/paddle/phi/kernels/funcs/index_calculator.h
+++ b/paddle/phi/kernels/funcs/index_calculator.h
@@ -35,13 +35,13 @@ namespace details {
 // Convert dims from vector to array
 template <typename T, size_t ElementCount, typename VectorLikeType>
 static inline Array<T, ElementCount> VectorToArray(const VectorLikeType& vec) {
-  PADDLE_ENFORCE_LE(
-      vec.size(),
-      ElementCount,
-      phi::errors::InvalidArgument("Vector to Array: size not match. Received "
-                                   "vec.size() %d > ElementCount %d.",
-                                   vec.size(),
-                                   ElementCount));
+  PADDLE_ENFORCE_LE(vec.size(),
+                    ElementCount,
+                    common::errors::InvalidArgument(
+                        "Vector to Array: size not match. Received "
+                        "vec.size() %d > ElementCount %d.",
+                        vec.size(),
+                        ElementCount));
   size_t n = static_cast<size_t>(vec.size());
   Array<T, ElementCount> ret;
   for (size_t i = 0; i < n; ++i) {

--- a/paddle/phi/kernels/funcs/index_impl.cu.h
+++ b/paddle/phi/kernels/funcs/index_impl.cu.h
@@ -83,7 +83,7 @@ void IndexKernel(const KPDevice &dev_ctx, DenseTensor *out, Functor func) {
           <<<grid, block, 0, stream>>>(out_data, numel, main_offset, func);
       break;
     default: {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported vectorized size: %d !", vec_size));
       break;
     }

--- a/paddle/phi/kernels/funcs/index_put_utils.h
+++ b/paddle/phi/kernels/funcs/index_put_utils.h
@@ -89,7 +89,7 @@ std::vector<const phi::DenseTensor*> DealWithBoolIndices(
         int rank = indices_v[i]->dims().size();
         PADDLE_ENFORCE_GE(rank,
                           1UL,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "the only bool tensor in indices should "
                               "have number of dimension at least 1"));
         phi::DenseTensor nonzero_indices(phi::DataType::INT64);
@@ -128,7 +128,7 @@ std::vector<const phi::DenseTensor*> DealWithBoolIndices(
                  (indices_v[i]->dtype() == phi::DataType::INT32)) {
         tmp_indices_v->emplace_back(*indices_v[i]);
       } else {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "data type of tensor in indices must be int32, int64 or bool"));
       }
     }
@@ -276,7 +276,7 @@ static void CalCompressedDimsWith1AndWithout1(
   int i = static_cast<int>(after_dims->size()) - 1;
   int j = static_cast<int>(before_dims->size()) - 1;
   if (i < j) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "shape of value can't not be broadcast to shape of x[indices]"));
   }
 
@@ -291,7 +291,7 @@ static void CalCompressedDimsWith1AndWithout1(
       i--;
       j--;
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "shape of value can't not be broadcast to shape of x[indices]"));
     }
   }

--- a/paddle/phi/kernels/funcs/jit/benchmark.cc
+++ b/paddle/phi/kernels/funcs/jit/benchmark.cc
@@ -121,7 +121,7 @@ void BenchAllImpls(const typename KernelTuple::attr_type& attr, Args... args) {
   // Test result from Get function
   auto tgt = jit::KernelFuncs<KernelTuple, PlaceType>::Cache().At(attr);
   if (!tgt) {
-    PADDLE_THROW(phi::errors::Fatal("Benchmark target can not be empty."));
+    PADDLE_THROW(common::errors::Fatal("Benchmark target can not be empty."));
   }
   infos.push_back(std::make_pair("Target", benchmark(tgt, args...)));
 
@@ -312,7 +312,7 @@ void BenchKernelSgd() {
     PADDLE_ENFORCE_LE(
         static_cast<size_t>(upper - lower),
         n - 1,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The range of Sgd (upper - lower) should be equal to or lower "
             "than n-1 (Sgd size -1). But upper - lower is %d and n-1 is %d.",
             static_cast<size_t>(upper - lower),
@@ -320,7 +320,7 @@ void BenchKernelSgd() {
     PADDLE_ENFORCE_GT(
         n,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The Sgd size should be larger than 0. But the n is %d.", n));
     std::vector<int64_t> all, out;
     for (int i = 0; i < n; ++i) {

--- a/paddle/phi/kernels/funcs/jit/gen/act.h
+++ b/paddle/phi/kernels/funcs/jit/gen/act.h
@@ -265,7 +265,7 @@ class VActFunc : public JitCode {
         identity_jmm<JMM>(dst, src, 15);
         break;
       default:
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Do not support operand type code: %d.", type));
         break;
     }
@@ -282,7 +282,7 @@ class VActJitCode : public VActFunc {
     if (!(type_ == operand_type::RELU || type_ == operand_type::EXP ||
           type_ == operand_type::SIGMOID || type_ == operand_type::TANH ||
           type_ == operand_type::IDENTITY || type_ == operand_type::SQUARE)) {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Do not support operand type code: %d.", type));
     }
     this->genCode();

--- a/paddle/phi/kernels/funcs/jit/gen/blas.h
+++ b/paddle/phi/kernels/funcs/jit/gen/blas.h
@@ -40,7 +40,7 @@ class VXXJitCode : public JitCode {
         with_relu_(with_relu) {
     if (!(type_ == operand_type::MUL || type_ == operand_type::ADD ||
           type_ == operand_type::SUB)) {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Do not support operand type code: %d.", type));
     }
     this->genCode();

--- a/paddle/phi/kernels/funcs/jit/gen/embseqpool.cc
+++ b/paddle/phi/kernels/funcs/jit/gen/embseqpool.cc
@@ -132,31 +132,31 @@ class EmbSeqPoolCreator : public JitCodeCreator<emb_seq_pool_attr_t> {
       const emb_seq_pool_attr_t& attr) const override {
     PADDLE_ENFORCE_GT(attr.table_height,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The attribute table_height of EmbSeqPool should "
                           "be larger than 0. But it is %d.",
                           attr.table_height));
     PADDLE_ENFORCE_GT(attr.table_width,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The attribute table_width of EmbSeqPool should "
                           "be larger than 0. But it is %d.",
                           attr.table_width));
     PADDLE_ENFORCE_GT(attr.index_height,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The attribute index_height of EmbSeqPool should "
                           "be larger than 0. But it is %d.",
                           attr.index_height));
     PADDLE_ENFORCE_GT(attr.index_width,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The attribute index_width of EmbSeqPool should "
                           "be larger than 0. But it is %d.",
                           attr.index_width));
     PADDLE_ENFORCE_GT(attr.out_width,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The attribute out_width of EmbSeqPool should be "
                           "larger than 0. But it is %d.",
                           attr.out_width));

--- a/paddle/phi/kernels/funcs/jit/gen/embseqpool.h
+++ b/paddle/phi/kernels/funcs/jit/gen/embseqpool.h
@@ -33,7 +33,8 @@ class EmbSeqPoolJitCode : public JitCode {
         tbl_w_(attr.table_width),
         type_(attr.pool_type) {
     if (type_ != SeqPoolType::kSum) {
-      PADDLE_THROW(phi::errors::Unimplemented("Only supports sum pool yet."));
+      PADDLE_THROW(
+          common::errors::Unimplemented("Only supports sum pool yet."));
     }
     this->genCode();
   }

--- a/paddle/phi/kernels/funcs/jit/gen/gru.h
+++ b/paddle/phi/kernels/funcs/jit/gen/gru.h
@@ -41,7 +41,7 @@ class GRUJitCode : public VActFunc {
       } else if (type == KernelType::kVIdentity) {
         return operand_type::IDENTITY;
       } else {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Do not support jit::KernelType code: %d.", type));
       }
       return operand_type::IDENTITY;

--- a/paddle/phi/kernels/funcs/jit/gen/lstm.h
+++ b/paddle/phi/kernels/funcs/jit/gen/lstm.h
@@ -44,7 +44,7 @@ class LSTMJitCode : public VActFunc {
       } else if (type == KernelType::kVIdentity) {
         return operand_type::IDENTITY;
       } else {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Do not support jit::KernelType code: %d.", type));
       }
       return operand_type::IDENTITY;

--- a/paddle/phi/kernels/funcs/jit/gen/matmul.cc
+++ b/paddle/phi/kernels/funcs/jit/gen/matmul.cc
@@ -28,9 +28,9 @@ void MatMulJitCode::genCode() {
   PADDLE_ENFORCE_GT(
       groups.front(),
       0,
-      phi::errors::InvalidArgument("The number of rest registers should "
-                                   "be larger than 0. But it is %d.",
-                                   groups.front()));
+      common::errors::InvalidArgument("The number of rest registers should "
+                                      "be larger than 0. But it is %d.",
+                                      groups.front()));
 
   const int block_len = sizeof(float) * block;  // NOLINT
   const int x_reg_idx = (block == ZMM_FLOAT_BLOCK ? 32 : 16) - 1;
@@ -123,21 +123,21 @@ class MatMulCreator : public JitCodeCreator<matmul_attr_t> {
     PADDLE_ENFORCE_GT(
         attr.m,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The attribute m (first matrix's row) of MatMul should "
             "be larger than 0. But it is %d.",
             attr.m));
     PADDLE_ENFORCE_GT(
         attr.n,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The attribute n (first matrix's col) of MatMul should "
             "be larger than 0. But it is %d.",
             attr.n));
     PADDLE_ENFORCE_GT(
         attr.k,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The attribute k (second matrix's col) of MatMul should "
             "be larger than 0. But it is %d.",
             attr.k));

--- a/paddle/phi/kernels/funcs/jit/gen/matmul.h
+++ b/paddle/phi/kernels/funcs/jit/gen/matmul.h
@@ -33,12 +33,12 @@ class MatMulJitCode : public JitCode {
                          size_t code_size = 256 * 1024,
                          void* code_ptr = nullptr)
       : JitCode(code_size, code_ptr), m_(attr.m), n_(attr.n), k_(attr.k) {
-    PADDLE_ENFORCE_EQ(
-        m_,
-        1,
-        phi::errors::Unimplemented("Jitcode of matmul only support m==1 (first "
-                                   "matrix's row) now. But m is %d.",
-                                   m_));
+    PADDLE_ENFORCE_EQ(m_,
+                      1,
+                      common::errors::Unimplemented(
+                          "Jitcode of matmul only support m==1 (first "
+                          "matrix's row) now. But m is %d.",
+                          m_));
     this->genCode();
   }
 

--- a/paddle/phi/kernels/funcs/jit/gen/seqpool.cc
+++ b/paddle/phi/kernels/funcs/jit/gen/seqpool.cc
@@ -70,15 +70,15 @@ class SeqPoolCreator : public JitCodeCreator<seq_pool_attr_t> {
     PADDLE_ENFORCE_GT(
         attr.w,
         0,
-        phi::errors::InvalidArgument("The attribute width of SeqPool should "
-                                     "be larger than 0. But it is %d.",
-                                     attr.w));
-    PADDLE_ENFORCE_GT(
-        attr.h,
-        0,
-        phi::errors::InvalidArgument("The attribute height of SeqPool should "
-                                     "be larger than 0. But it is %d.",
-                                     attr.h));
+        common::errors::InvalidArgument("The attribute width of SeqPool should "
+                                        "be larger than 0. But it is %d.",
+                                        attr.w));
+    PADDLE_ENFORCE_GT(attr.h,
+                      0,
+                      common::errors::InvalidArgument(
+                          "The attribute height of SeqPool should "
+                          "be larger than 0. But it is %d.",
+                          attr.h));
     return make_unique<SeqPoolJitCode>(attr, CodeSize(attr));
   }
 };

--- a/paddle/phi/kernels/funcs/jit/gen/seqpool.h
+++ b/paddle/phi/kernels/funcs/jit/gen/seqpool.h
@@ -32,7 +32,7 @@ class SeqPoolJitCode : public JitCode {
       : JitCode(code_size, code_ptr), w_(attr.w), type_(attr.type) {
     if (!(type_ == SeqPoolType::kSum || type_ == SeqPoolType::kAvg ||
           type_ == SeqPoolType::kSqrt)) {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Only supports sum, average and sqrt pool type."));
     }
     fp_h_[0] = 1.f;
@@ -129,7 +129,7 @@ class SeqPoolJitCode : public JitCode {
       PADDLE_ENFORCE_EQ(
           reg_idx,
           rest_used_num_regs,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "All heights of SeqPool should use the same number of registers."
               "It equals to the numbr of rest registers. But use %d registers "
               "and the numbr of rest registers is %d.",

--- a/paddle/phi/kernels/funcs/jit/gen/sgd.cc
+++ b/paddle/phi/kernels/funcs/jit/gen/sgd.cc
@@ -116,7 +116,7 @@ class SgdCreator : public JitCodeCreator<sgd_attr_t> {
       const sgd_attr_t& attr) const override {
     PADDLE_ENFORCE_EQ(attr.param_width,
                       attr.grad_width,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The attribute param_width of Sgd should be "
                           "equal to the attribute grad_width. But param_width "
                           "is %d and grad_width is %d.",
@@ -124,7 +124,7 @@ class SgdCreator : public JitCodeCreator<sgd_attr_t> {
                           attr.grad_width));
     PADDLE_ENFORCE_LE(attr.selected_rows_size,
                       attr.grad_height,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The attribute selected_rows_size of Sgd should be "
                           "equal to or less than the attribute grad_height. "
                           "But selected_rows_size is %d and grad_height is %d.",
@@ -133,7 +133,7 @@ class SgdCreator : public JitCodeCreator<sgd_attr_t> {
     PADDLE_ENFORCE_GE(
         attr.selected_rows_size,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The attribute selected_rows_size of Sgd should be "
             "equal to or larger than 0. But selected_rows_size is %d.",
             attr.selected_rows_size));

--- a/paddle/phi/kernels/funcs/jit/gen/vbroadcast.cc
+++ b/paddle/phi/kernels/funcs/jit/gen/vbroadcast.cc
@@ -76,7 +76,7 @@ class VBroadcastCreator : public JitCodeCreator<int64_t> {
     PADDLE_ENFORCE_GT(
         w,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The width of VBroadcast should be larger than 0. But w is %d.",
             w));
     return make_unique<VBroadcastJitCode>(w, CodeSize(w));

--- a/paddle/phi/kernels/funcs/jit/gen_base.cc
+++ b/paddle/phi/kernels/funcs/jit/gen_base.cc
@@ -55,14 +55,14 @@ void* GenBase::operator new(size_t size) {
   PADDLE_ENFORCE_EQ(
       posix_memalign(&ptr, alignment, size),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Jitcode generator (GenBase) allocate %ld memory error!", size));
 #endif
   PADDLE_ENFORCE_NOT_NULL(
       ptr,
-      phi::errors::InvalidArgument("Fail to allocate jitcode generator "
-                                   "(GenBase) CPU memory: size = %d .",
-                                   size));
+      common::errors::InvalidArgument("Fail to allocate jitcode generator "
+                                      "(GenBase) CPU memory: size = %d .",
+                                      size));
   return ptr;
 }
 

--- a/paddle/phi/kernels/funcs/jit/helper.cc
+++ b/paddle/phi/kernels/funcs/jit/helper.cc
@@ -61,7 +61,7 @@ const char* to_string(KernelType kt) {
     ONE_CASE(kEmbSeqPool);
     ONE_CASE(kSgd);
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "JIT kernel do not support type: %d.", kt));
       return "NOT JITKernel";
   }
@@ -75,7 +75,7 @@ const char* to_string(SeqPoolType tp) {
     ONE_CASE(kAvg);
     ONE_CASE(kSqrt);
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "SeqPool JIT kernel do not support type: %d.", tp));
       return "NOT PoolType";
   }
@@ -97,7 +97,7 @@ KernelType to_kerneltype(const std::string& act) {
   } else if (lower == "tanh" || lower == "vtanh") {
     return kVTanh;
   }
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Act JIT kernel do not support type: %s.", act));
   return kNone;
 }
@@ -109,7 +109,7 @@ void pack_weights<float>(const float* src, float* dst, int n, int k) {
   std::for_each(groups.begin(), groups.end(), [&](int i) {
     PADDLE_ENFORCE_GT(i,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Each element of groups should be larger than "
                           "0. However the element: %d doesn't satisfy.",
                           i));
@@ -118,7 +118,7 @@ void pack_weights<float>(const float* src, float* dst, int n, int k) {
   std::memset(dst, 0, k * sum * block * sizeof(float));
   PADDLE_ENFORCE_GE(sum * block,
                     n,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The packed n (sum * block) should be equal to or "
                         "larger than n (matmul row size). "
                         "However, the packed n is %d and n is %d.",
@@ -145,7 +145,7 @@ void pack_weights<float>(const float* src, float* dst, int n, int k) {
 template <typename T>
 typename std::enable_if<!std::is_same<T, float>::value>::type pack_weights(
     const T* src, T* dst, int n, int k) {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Only supports pack weights with float type."));
 }
 

--- a/paddle/phi/kernels/funcs/jit/helper.h
+++ b/paddle/phi/kernels/funcs/jit/helper.h
@@ -88,7 +88,7 @@ inline const Kernel* GetReferKernel() {
   PADDLE_ENFORCE_NE(
       ref_iter,
       ref_pool.end(),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Every Refer Kernel of jitcode should have reference function."));
   auto& ref_impls = ref_iter->second;
   for (auto& impl : ref_impls) {
@@ -104,10 +104,10 @@ template <typename KernelTuple>
 inline typename KernelTuple::func_type GetReferFunc() {
   auto ker = GetReferKernel<KernelTuple>();
   auto p = dynamic_cast<const ReferKernel<KernelTuple>*>(ker);
-  PADDLE_ENFORCE_NOT_NULL(
-      p,
-      phi::errors::InvalidArgument("Get the reference code of kernel in CPU "
-                                   "failed. The Refer kernel should exist."));
+  PADDLE_ENFORCE_NOT_NULL(p,
+                          common::errors::InvalidArgument(
+                              "Get the reference code of kernel in CPU "
+                              "failed. The Refer kernel should exist."));
   return p->GetFunc();
 }
 
@@ -140,8 +140,8 @@ std::vector<const Kernel*> GetAllCandidateKernels(
   auto ref = GetReferKernel<KernelTuple>();
   PADDLE_ENFORCE_NOT_NULL(
       ref,
-      phi::errors::InvalidArgument("Get all candidate kernel in CPU failed. "
-                                   "The Refer Kernel can not be empty."));
+      common::errors::InvalidArgument("Get all candidate kernel in CPU failed. "
+                                      "The Refer Kernel can not be empty."));
   res.emplace_back(ref);
   return res;
 }
@@ -157,13 +157,14 @@ GetAllCandidateFuncsWithTypes(const typename KernelTuple::attr_type& attr) {
     if (name == "JitCode") {
       auto i = dynamic_cast<const GenBase*>(k);
       PADDLE_ENFORCE_NOT_NULL(i,
-                              phi::errors::InvalidArgument(
+                              common::errors::InvalidArgument(
                                   "Generate jitcode kernel (GenBase) failed."));
       res.emplace_back(std::make_pair(name, i->template getCode<Func>()));
     } else {
       auto i = dynamic_cast<const KernelMore<KernelTuple>*>(k);
       PADDLE_ENFORCE_NOT_NULL(
-          i, phi::errors::InvalidArgument("Kernel cast (KernelMore) failed."));
+          i,
+          common::errors::InvalidArgument("Kernel cast (KernelMore) failed."));
       res.emplace_back(std::make_pair(name, i->GetFunc()));
     }
   }
@@ -187,7 +188,7 @@ typename KernelTuple::func_type GetDefaultBestFunc(
   auto funcs = GetAllCandidateFuncs<KernelTuple, PlaceType>(attr);
   PADDLE_ENFORCE_GE(funcs.size(),
                     1UL,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The candidate jit kernel is at least one in CPU."));
   // Here could do some runtime benchmark of this attr and return the best one.
   // But yet just get the first one as the default best one,

--- a/paddle/phi/kernels/funcs/jit/more/mix/mix.cc
+++ b/paddle/phi/kernels/funcs/jit/more/mix/mix.cc
@@ -56,7 +56,7 @@ void (*getActFunc(KernelType type, int d))(const T*, T*, int) {  // NOLINT
   } else if (type == kVIdentity) {
     return KernelFuncs<VIdentityTuple<T>, CPUPlace>::Cache().At(d);
   }
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Act JIT kernel do not support type: %s", type));
   return nullptr;
 }

--- a/paddle/phi/kernels/funcs/jit/more/mkl/mkl.h
+++ b/paddle/phi/kernels/funcs/jit/more/mkl/mkl.h
@@ -107,7 +107,7 @@ void EmbSeqPool(const T* table,
   PADDLE_ENFORCE_EQ(
       attr->table_width * attr->index_width,
       attr->out_width,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The attribute table_width * index_width of EmbSeqPool should "
           "be equal to out_width. But table_width * index_width is %d, "
           "out_width is %d.",
@@ -117,7 +117,7 @@ void EmbSeqPool(const T* table,
     PADDLE_ENFORCE_LT(
         idx[i],
         attr->table_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The idx should be lower than the attribute table_height of "
             "EmbSeqPool. But %dth of idx is %d and table_height is %d.",
             i,
@@ -125,7 +125,7 @@ void EmbSeqPool(const T* table,
             attr->table_height));
     PADDLE_ENFORCE_GE(idx[i],
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The idx should be equal to or larger than "
                           "the 0. But %dth of idx is %d.",
                           i,
@@ -163,7 +163,7 @@ void Sgd(const T* lr,
          const sgd_attr_t* attr) {
   PADDLE_ENFORCE_EQ(attr->param_width,
                     attr->grad_width,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The attribute param_width of Sgd should be "
                         "equal to the attribute grad_width. But param_width "
                         "is %d and grad_width is %d.",
@@ -171,7 +171,7 @@ void Sgd(const T* lr,
                         attr->grad_width));
   PADDLE_ENFORCE_LE(attr->selected_rows_size,
                     attr->grad_height,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The attribute selected_rows_size of Sgd should be "
                         "equal to or less than the attribute grad_height. "
                         "But selected_rows_size is %d and grad_height is %d.",
@@ -184,7 +184,7 @@ void Sgd(const T* lr,
       auto h_idx = rows[i];
       PADDLE_ENFORCE_LT(h_idx,
                         attr->param_height,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The rows of Sgd should be "
                             "less than the attribute. But %dth of rows "
                             "is %d and grad_width is %d.",
@@ -194,11 +194,11 @@ void Sgd(const T* lr,
       PADDLE_ENFORCE_GE(
           h_idx,
           0,
-          phi::errors::InvalidArgument("The rows of Sgd should be "
-                                       "larger than 0. But %dth of rows "
-                                       "is %d.",
-                                       i,
-                                       h_idx));
+          common::errors::InvalidArgument("The rows of Sgd should be "
+                                          "larger than 0. But %dth of rows "
+                                          "is %d.",
+                                          i,
+                                          h_idx));
       VAXPY(scalar, grad + i * width, out + h_idx * width, width);
     }
   } else {
@@ -206,7 +206,7 @@ void Sgd(const T* lr,
       auto h_idx = rows[i];
       PADDLE_ENFORCE_LT(h_idx,
                         attr->param_height,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The rows of Sgd should be "
                             "less than the attribute. But %dth of rows "
                             "is %d and grad_width is %d.",
@@ -216,11 +216,11 @@ void Sgd(const T* lr,
       PADDLE_ENFORCE_GE(
           h_idx,
           0,
-          phi::errors::InvalidArgument("The rows of Sgd should be "
-                                       "larger than 0. But %dth of rows "
-                                       "is %d.",
-                                       i,
-                                       h_idx));
+          common::errors::InvalidArgument("The rows of Sgd should be "
+                                          "larger than 0. But %dth of rows "
+                                          "is %d.",
+                                          i,
+                                          h_idx));
       VScal(&scalar, grad + i * width, out + h_idx * width, width);
       VAdd(param + h_idx * width,
            out + h_idx * width,

--- a/paddle/phi/kernels/funcs/jit/refer/refer.h
+++ b/paddle/phi/kernels/funcs/jit/refer/refer.h
@@ -146,7 +146,7 @@ void (*getActFunc(KernelType type))(const T*, T*, int) {  // NOLINT
   } else if (type == kVIdentity) {
     return VIdentity<T>;
   }
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Act JIT kernel do not support type: %s.", type));
   return nullptr;
 }
@@ -406,7 +406,7 @@ void EmbSeqPool(const T* table,
   PADDLE_ENFORCE_EQ(
       attr->table_width * attr->index_width,
       attr->out_width,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The attribute table_width * index_width of EmbSeqPool should "
           "be equal to out_width. But table_width * index_width is %d and "
           "out_width is %d.",
@@ -417,7 +417,7 @@ void EmbSeqPool(const T* table,
     PADDLE_ENFORCE_LT(
         idx[i],
         attr->table_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The idx should be lower than the attribute table_height of "
             "EmbSeqPool. But %dth of idx is %d and table_height is %d.",
             i,
@@ -425,7 +425,7 @@ void EmbSeqPool(const T* table,
             attr->table_height));
     PADDLE_ENFORCE_GE(idx[i],
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The idx should be equal to or larger than "
                           "the 0. But %dth of idx is %d.",
                           i,
@@ -473,7 +473,7 @@ void Sgd(const T* lr,
          const sgd_attr_t* attr) {
   PADDLE_ENFORCE_EQ(attr->param_width,
                     attr->grad_width,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The attribute param_width of Sgd should be "
                         "equal to the attribute grad_width. But param_width "
                         "is %d and grad_width is %d.",
@@ -481,7 +481,7 @@ void Sgd(const T* lr,
                         attr->grad_width));
   PADDLE_ENFORCE_LE(attr->selected_rows_size,
                     attr->grad_height,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The attribute selected_rows_size of Sgd should be "
                         "equal to or less than the attribute grad_height. "
                         "But selected_rows_size is %d and grad_height is %d.",
@@ -491,7 +491,7 @@ void Sgd(const T* lr,
     auto h_idx = rows[i];
     PADDLE_ENFORCE_LT(h_idx,
                       attr->param_height,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The rows of Sgd should be "
                           "less than the attribute. But %dth of rows "
                           "is %d and grad_width is %d.",
@@ -501,11 +501,11 @@ void Sgd(const T* lr,
     PADDLE_ENFORCE_GE(
         h_idx,
         0,
-        phi::errors::InvalidArgument("The rows of Sgd should be "
-                                     "larger than 0. But %dth of rows "
-                                     "is %d.",
-                                     i,
-                                     h_idx));
+        common::errors::InvalidArgument("The rows of Sgd should be "
+                                        "larger than 0. But %dth of rows "
+                                        "is %d.",
+                                        i,
+                                        h_idx));
     for (int64_t j = 0; j < attr->grad_width; ++j) {
       out[h_idx * attr->grad_width + j] =
           param[h_idx * attr->grad_width + j] -

--- a/paddle/phi/kernels/funcs/jit/test.cc
+++ b/paddle/phi/kernels/funcs/jit/test.cc
@@ -920,7 +920,7 @@ void TestKernelSgd() {
                                   const int64_t upper) -> std::vector<int64_t> {
     PADDLE_ENFORCE_LE(static_cast<size_t>(upper - lower),
                       n - 1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The range of Sgd (upper - lower) should be lower "
                           "than n-1 (Sgd size -1). But the upper - lower is %d "
                           "and n-1 is %d.",
@@ -929,7 +929,7 @@ void TestKernelSgd() {
     PADDLE_ENFORCE_GT(
         n,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The Sgd size should be larger than 0. But the n is %d.", n));
     std::vector<int64_t> all, out;
     for (int i = 0; i < n; ++i) {

--- a/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
+++ b/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
@@ -1008,7 +1008,7 @@ void ln_bwd_fast_kernel_driver(const phi::GPUContext &dev_ctx,
 
     if (mask_ptr != nullptr) {
       if (d_dropout_src_ptr == nullptr) {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "To compute fused_dropout_residual_ln grad, d_dropout_src_ptr "
             "can't be null"));
       }
@@ -1121,7 +1121,7 @@ void ln_bwd_fast_kernel_driver(const phi::GPUContext &dev_ctx,
     // Note: it is not supported for double type.
     if (sizeof(U) > 4) {
       PADDLE_THROW(
-          phi::errors::InvalidArgument("Only support float and fp16 type"));
+          common::errors::InvalidArgument("Only support float and fp16 type"));
     } else {
       int gridx_2 = 0;
 
@@ -1154,7 +1154,7 @@ void ln_bwd_fast_kernel_driver(const phi::GPUContext &dev_ctx,
 #undef LAUNCH_LN_BWD_BETA_GAMMMA_KERNEL
     }
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Fast layer_norm kernel is only used when feature_size is 1024"));
   }
 }

--- a/paddle/phi/kernels/funcs/math/beam_search.cc
+++ b/paddle/phi/kernels/funcs/math/beam_search.cc
@@ -97,10 +97,10 @@ class BeamSearchFunctor<phi::CPUContext, T> {
     lod[0].assign(high_level.begin(), high_level.end());
     lod[1].assign(low_level.begin(), low_level.end());
     if (!CheckLoD(lod)) {
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("lod %s is not right in"
-                                       " beam_search, please check your code.",
-                                       LoDToString(lod)));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "lod %s is not right in"
+          " beam_search, please check your code.",
+          LoDToString(lod)));
     }
     selected_ids->set_lod(lod);
     selected_scores->set_lod(lod);

--- a/paddle/phi/kernels/funcs/math/beam_search.cu
+++ b/paddle/phi/kernels/funcs/math/beam_search.cu
@@ -505,17 +505,17 @@ class BeamSearchFunctor<phi::GPUContext, T> {
                 num_used_threads));
       }
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Not implemented other number of sequences yet."));
     }
 
     context.Wait();
     mix_vector.CopyToCPU();
     if (!CheckLoD(selected_lod)) {
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("lod %s is not right in"
-                                       " beam_search, please check your code.",
-                                       LoDToString(selected_lod)));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "lod %s is not right in"
+          " beam_search, please check your code.",
+          LoDToString(selected_lod)));
     }
 
     selected_ids->set_lod(selected_lod);

--- a/paddle/phi/kernels/funcs/math/beam_search_xpu.cc
+++ b/paddle/phi/kernels/funcs/math/beam_search_xpu.cc
@@ -41,7 +41,7 @@ void CopyDataByCondition(const T *x, T **y, int len, const Place &place) {
     PADDLE_ENFORCE_EQ(
         r,
         xpu::Error_t::SUCCESS,
-        phi::errors::External("Copy data form xpu to cpu failed"));
+        common::errors::External("Copy data form xpu to cpu failed"));
   }
 }
 
@@ -125,10 +125,10 @@ class BeamSearchFunctor<phi::XPUContext, T> {
     lod[0].assign(high_level.begin(), high_level.end());
     lod[1].assign(low_level.begin(), low_level.end());
     if (!CheckLoD(lod)) {
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("lod %s is not right in"
-                                       " beam_search, please check your code.",
-                                       LoDToString(lod)));
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "lod %s is not right in"
+          " beam_search, please check your code.",
+          LoDToString(lod)));
     }
     selected_ids->set_lod(lod);
     selected_scores->set_lod(lod);

--- a/paddle/phi/kernels/funcs/math/context_project.h
+++ b/paddle/phi/kernels/funcs/math/context_project.h
@@ -142,7 +142,7 @@ class ContextProjectFunctor {
     if (padding_trainable) {
       PADDLE_ENFORCE_NOT_NULL(
           padding_data,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The input tensor 'padding_data' should not be NULL."));
       for (int i = 0; i < static_cast<int>(lod_level_0.size()) - 1; ++i) {
         if (lod_level_0[i] == lod_level_0[i + 1]) continue;

--- a/paddle/phi/kernels/funcs/math/sampler.h
+++ b/paddle/phi/kernels/funcs/math/sampler.h
@@ -35,7 +35,7 @@ class Sampler {
     PADDLE_ENFORCE_GT(
         range,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Range should be greater than 0, but received %d.", range));
     if (seed == 0) {
       std::random_device r;

--- a/paddle/phi/kernels/funcs/math/tree2col.cc
+++ b/paddle/phi/kernels/funcs/math/tree2col.cc
@@ -57,7 +57,7 @@ void Tree2ColUtil::construct_tree(const phi::DenseTensor &EdgeSet,
   const auto &edge_set_dims = EdgeSet.dims();
   PADDLE_ENFORCE_EQ(edge_set_dims[1],
                     2,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The second dimension of the EdgeSet shall be 2, but "
                         "got %ld != 2. Please check the input value.",
                         edge_set_dims[1]));

--- a/paddle/phi/kernels/funcs/math/unpooling.cc
+++ b/paddle/phi/kernels/funcs/math/unpooling.cc
@@ -42,7 +42,7 @@ class Unpool2dMaxFunctor<phi::CPUContext, T> {
           PADDLE_ENFORCE_LT(
               index,
               output_feasize,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "index should less than output tensor height * output tensor "
                   "width. Expected %ld < %ld, but got "
                   "%ld >= %ld. Please check input value.",
@@ -87,7 +87,7 @@ class Unpool2dMaxGradFunctor<phi::CPUContext, T> {
           PADDLE_ENFORCE_LT(
               index,
               output_feasize,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "index should less than output tensor height * output tensor "
                   "width. Expected %ld < %ld, but got "
                   "%ld >= %ld. Please check input value.",
@@ -133,7 +133,7 @@ class Unpool3dMaxFunctor<phi::CPUContext, T> {
           PADDLE_ENFORCE_LT(
               index,
               output_feasize,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "index should less than output tensor depth * output tensor "
                   "height "
                   "* output tensor width. Expected %ld < %ld, but got "
@@ -181,7 +181,7 @@ class Unpool3dMaxGradFunctor<phi::CPUContext, T> {
           PADDLE_ENFORCE_LT(
               index,
               output_feasize,
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "index should less than output tensor depth * output tensor "
                   "height "
                   "* output tensor width. Expected %ld < %ld, but got "

--- a/paddle/phi/kernels/funcs/math_function.cc
+++ b/paddle/phi/kernels/funcs/math_function.cc
@@ -171,7 +171,7 @@ void set_constant_with_place<phi::XPUPlace>(const phi::DeviceContext& context,
       tensor->dtype(),
       TensorSetConstantXPU<float>(tensor, value, tensor->place()));
 #else
-  PADDLE_THROW(phi::errors::PreconditionNotMet("Not compiled with XPU!"));
+  PADDLE_THROW(common::errors::PreconditionNotMet("Not compiled with XPU!"));
 #endif
 }
 
@@ -179,7 +179,7 @@ template <>
 void set_constant_with_place<phi::IPUPlace>(const phi::DeviceContext& context,
                                             phi::DenseTensor* tensor,
                                             float value) {
-  PADDLE_THROW(phi::errors::Unimplemented("IPUPlace is not supported"));
+  PADDLE_THROW(common::errors::Unimplemented("IPUPlace is not supported"));
 }
 
 template <>
@@ -204,7 +204,7 @@ void set_constant_with_place<phi::CustomPlace>(
                tensor->dtype(),
                tensor);
 #else
-  PADDLE_THROW(phi::errors::Unimplemented("CustomPlace is not supported"));
+  PADDLE_THROW(common::errors::Unimplemented("CustomPlace is not supported"));
 #endif
 }
 
@@ -284,7 +284,7 @@ struct RowwiseAdd<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         vector.numel(),
         size,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input vector size"
             " should be equal to the size of each row of input tensor."
             " Expected vector size=%d, but received %d",
@@ -292,7 +292,7 @@ struct RowwiseAdd<phi::CPUContext, T> {
             vector.numel()));
     PADDLE_ENFORCE_EQ(out_dims,
                       in_dims,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The output tensor shape should be same as the input"
                           " tensor shape. Expected output tensor shape: %s,"
                           " but received %s",

--- a/paddle/phi/kernels/funcs/math_function.cu
+++ b/paddle/phi/kernels/funcs/math_function.cu
@@ -104,7 +104,7 @@ void BatchTranspose(T* output,
   int64_t input_num = batch * m * n;
 
   if (input_num >= std::numeric_limits<int>::max()) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Unsupported input size, batch: %ld,m: %ld, n: %ld", batch, m, n));
   }
 
@@ -389,7 +389,7 @@ struct RowwiseAdd<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         vector.numel(),
         size,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input vector size"
             " should be equal to the size of each row of input tensor."
             " Expected vector size=%d, but received %d",
@@ -400,7 +400,7 @@ struct RowwiseAdd<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         out_dims,
         in_dims,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The output tensor shape should be same as the input tensor"
             " shape. Expected output tensor shape: %s,"
             " but received %s",
@@ -435,7 +435,7 @@ void ColwiseSum<phi::GPUContext, double>::operator()(
   auto size = input.numel() / in_dims[0];
   PADDLE_ENFORCE_EQ(vector->numel(),
                     size,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of input vector"
                         " should be equal to the size of input tensor column"
                         " dimension. Expected vector size=%d, but received %d",
@@ -473,7 +473,7 @@ void RowwiseSum<phi::GPUContext, double>::operator()(
   auto size = input.numel() / in_dims[0];
   PADDLE_ENFORCE_EQ(vector->numel(),
                     in_dims[0],
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of input vector"
                         " should be equal to the size of input tensor row"
                         " dimension. Expected vector size=%d, but received %d",

--- a/paddle/phi/kernels/funcs/math_function.h
+++ b/paddle/phi/kernels/funcs/math_function.h
@@ -132,7 +132,7 @@ struct TensorSetConstantXPU {
                          numel * sizeof(T));
     } else if (std::is_same<T, phi::dtype::float8_e4m3fn>::value ||
                std::is_same<T, phi::dtype::float8_e5m2>::value) {
-      PADDLE_THROW(phi::errors::Fatal("XPU does not support fp8"));
+      PADDLE_THROW(common::errors::Fatal("XPU does not support fp8"));
     } else {
       auto* dev_ctx = static_cast<phi::XPUContext*>(ctx);
       using XPUType = typename XPUTypeTrait<T>::Type;

--- a/paddle/phi/kernels/funcs/math_function_impl.h
+++ b/paddle/phi/kernels/funcs/math_function_impl.h
@@ -75,7 +75,7 @@ void ColwiseSum<DeviceContext, T>::operator()(const DeviceContext& context,
   auto size = input.numel() / in_dims[0];
   PADDLE_ENFORCE_EQ(out->numel(),
                     size,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of output tensor "
                         "should be equal to the size of input tensor column"
                         " dimension. Expected output size=%d, but received %d",
@@ -103,7 +103,7 @@ class ColwiseSum<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         out->numel(),
         size,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size of output tensor "
             "should be equal to the size of input tensor column"
             " dimension. Expected output size=%d, but received %d",
@@ -130,14 +130,15 @@ void RowwiseMean<DeviceContext, T>::operator()(const DeviceContext& context,
                                                const phi::DenseTensor& input,
                                                phi::DenseTensor* out) {
   auto in_dims = input.dims();
-  PADDLE_ENFORCE_EQ(in_dims.size(),
-                    2U,
-                    phi::errors::InvalidArgument("The rank of input tensor "
-                                                 "should be 2, but received %d",
-                                                 in_dims.size()));
+  PADDLE_ENFORCE_EQ(
+      in_dims.size(),
+      2U,
+      common::errors::InvalidArgument("The rank of input tensor "
+                                      "should be 2, but received %d",
+                                      in_dims.size()));
   PADDLE_ENFORCE_EQ(out->numel(),
                     in_dims[0],
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of output tensor "
                         "should be equal to the size of input tensor row"
                         " dimension. Expected output size=%d, but received %d",
@@ -163,15 +164,15 @@ class RowwiseMean<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in_dims.size(),
         2U,
-        phi::errors::InvalidArgument("The rank of input tensor "
-                                     "should be 2, but received %d",
-                                     in_dims.size()));
+        common::errors::InvalidArgument("The rank of input tensor "
+                                        "should be 2, but received %d",
+                                        in_dims.size()));
     auto height = in_dims[0];
     auto size = in_dims[1];
     PADDLE_ENFORCE_EQ(
         out->numel(),
         height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size of output tensor "
             "should be equal to the size of input tensor row"
             " dimension. Expected output size=%d, but received %d",
@@ -196,14 +197,15 @@ void RowwiseSum<DeviceContext, T>::operator()(const DeviceContext& context,
                                               const phi::DenseTensor& input,
                                               phi::DenseTensor* out) {
   auto in_dims = input.dims();
-  PADDLE_ENFORCE_EQ(in_dims.size(),
-                    2U,
-                    phi::errors::InvalidArgument("The rank of input tensor "
-                                                 "should be 2, but received %d",
-                                                 in_dims.size()));
+  PADDLE_ENFORCE_EQ(
+      in_dims.size(),
+      2U,
+      common::errors::InvalidArgument("The rank of input tensor "
+                                      "should be 2, but received %d",
+                                      in_dims.size()));
   PADDLE_ENFORCE_EQ(out->numel(),
                     in_dims[0],
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The size of output tensor "
                         "should be equal to the size of input tensor row"
                         " dimension. Expected output size=%d, but received %d",
@@ -229,15 +231,15 @@ class RowwiseSum<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in_dims.size(),
         2U,
-        phi::errors::InvalidArgument("The rank of input tensor "
-                                     "should be 2, but received %d",
-                                     in_dims.size()));
+        common::errors::InvalidArgument("The rank of input tensor "
+                                        "should be 2, but received %d",
+                                        in_dims.size()));
     auto height = in_dims[0];
     auto size = in_dims[1];
     PADDLE_ENFORCE_EQ(
         out->numel(),
         height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The size of output tensor "
             "should be equal to the size of input tensor row"
             " dimension. Expected output size=%d, but received %d",

--- a/paddle/phi/kernels/funcs/matrix_inverse.cu
+++ b/paddle/phi/kernels/funcs/matrix_inverse.cu
@@ -116,7 +116,7 @@ void MatrixInverseFunctor<Context, T>::operator()(const Context& dev_ctx,
   for (int i = 0; i < batch_size; ++i) {
     PADDLE_ENFORCE_EQ(info[i],
                       0,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "For batch [%d]: U(%d, %d) is zero, singular U. "
                           "Please check the matrix value and change it to a "
                           "non-singular matrix",

--- a/paddle/phi/kernels/funcs/matrix_solve.cu
+++ b/paddle/phi/kernels/funcs/matrix_solve.cu
@@ -130,7 +130,7 @@ void MatrixSolveFunctor<Context, T>::operator()(const Context& context,
   for (int i = 0; i < batch_size; ++i) {
     PADDLE_ENFORCE_EQ(info[i],
                       0,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "For batch [%d]: U(%d, %d) is zero, singular U. "
                           "Please check the matrix value and change it to a "
                           "non-singular matrix",
@@ -158,7 +158,7 @@ void MatrixSolveFunctor<Context, T>::operator()(const Context& context,
   // check whether BatchedGETRS is executed successfully or not
   PADDLE_ENFORCE_EQ(host_info,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The [%d]'th argument to cublas*getrsBatched had "
                         "an illegal value.",
                         -host_info));

--- a/paddle/phi/kernels/funcs/matrix_solve.h
+++ b/paddle/phi/kernels/funcs/matrix_solve.h
@@ -80,7 +80,7 @@ static std::vector<int64_t> getNewDimsVec(const DDim& b_dims) {
   PADDLE_ENFORCE_NE(
       b_dims_vec.empty(),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The size of tensor b must not be %d after getting new dims", 0));
   // if b_dims_vec.size() == 1, just return original vec
   return b_dims_vec;
@@ -124,13 +124,13 @@ void compute_solve_eigen(const Context& context,
       PADDLE_ENFORCE_GT(
           min_abs_pivot,
           static_cast<T>(0),
-          phi::errors::InvalidArgument("Input is not invertible."));
+          common::errors::InvalidArgument("Input is not invertible."));
       out_mat.noalias() = lu.solve(b_mat);
     }
   } else {
     PADDLE_ENFORCE_EQ(a_batch_size,
                       b_batch_size,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "All input tensors must have the same rank."));
   }
 }
@@ -175,7 +175,7 @@ void SolveLinearSystem(T* matrix_data,
         lu_decomposition.matrixLU().diagonal().cwiseAbs().minCoeff();
     PADDLE_ENFORCE_GT(min_abs_piv,
                       Treal(0),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Something's wrong with SolveLinearSystem. "));
 
     output = lu_decomposition.solve(input_rhs);

--- a/paddle/phi/kernels/funcs/miopen_rnn_cache.h
+++ b/paddle/phi/kernels/funcs/miopen_rnn_cache.h
@@ -93,10 +93,10 @@ struct CudnnRNNCache {
 
     const auto numDirections = is_bidirec_ ? 2 : 1;
 
-    PADDLE_ENFORCE_EQ(
-        miopen_type,
-        miopenFloat,
-        phi::errors::InvalidArgument("MIOPEN do not support double datatype."));
+    PADDLE_ENFORCE_EQ(miopen_type,
+                      miopenFloat,
+                      common::errors::InvalidArgument(
+                          "MIOPEN do not support double datatype."));
     auto miopen_size = sizeof(float);
 
     x_desc_ = new miopenTensorDescriptor_t[seq_length_];
@@ -259,7 +259,7 @@ struct CudnnRNNCache {
     PADDLE_ENFORCE_EQ(
         weights_size_,
         miopen_size * weight_numel,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The miopen lstm and setting weight size should be same."));
 
     int dim_w[3];

--- a/paddle/phi/kernels/funcs/mkl_fft_utils.h
+++ b/paddle/phi/kernels/funcs/mkl_fft_utils.h
@@ -23,12 +23,12 @@ namespace phi {
 namespace funcs {
 namespace detail {
 
-#define MKL_DFTI_CHECK(expr)                                              \
-  do {                                                                    \
-    MKL_LONG status = (expr);                                             \
-    if (!phi::dynload::DftiErrorClass(status, DFTI_NO_ERROR))             \
-      PADDLE_THROW(                                                       \
-          phi::errors::External(phi::dynload::DftiErrorMessage(status))); \
+#define MKL_DFTI_CHECK(expr)                                                 \
+  do {                                                                       \
+    MKL_LONG status = (expr);                                                \
+    if (!phi::dynload::DftiErrorClass(status, DFTI_NO_ERROR))                \
+      PADDLE_THROW(                                                          \
+          common::errors::External(phi::dynload::DftiErrorMessage(status))); \
   } while (0);
 
 struct DftiDescriptorDeleter {
@@ -48,7 +48,7 @@ class DftiDescriptor {
             MKL_LONG* sizes) {
     PADDLE_ENFORCE_EQ(desc_.get(),
                       nullptr,
-                      phi::errors::AlreadyExists(
+                      common::errors::AlreadyExists(
                           "DftiDescriptor has already been initialized."));
 
     DFTI_DESCRIPTOR* raw_desc;
@@ -60,7 +60,7 @@ class DftiDescriptor {
   DFTI_DESCRIPTOR* get() const {
     DFTI_DESCRIPTOR* raw_desc = desc_.get();
     PADDLE_ENFORCE_NOT_NULL(raw_desc,
-                            phi::errors::PreconditionNotMet(
+                            common::errors::PreconditionNotMet(
                                 "DFTI DESCRIPTOR has not been initialized."));
     return raw_desc;
   }
@@ -87,7 +87,7 @@ static DftiDescriptor plan_mkl_fft(const DataType in_dtype,
       case DataType::COMPLEX128:
         return DFTI_DOUBLE;
       default:
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "Invalid input datatype (%s), input data type should be FP32, "
             "FP64, COMPLEX64 or COMPLEX128.",
             in_dtype));

--- a/paddle/phi/kernels/funcs/multihead_matmul_functor.cu
+++ b/paddle/phi/kernels/funcs/multihead_matmul_functor.cu
@@ -572,7 +572,7 @@ inline void MatmulWithHeadQK(const phi::GPUContext &context,
 #if defined(__HIPCC__) || (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700)
           PADDLE_ENFORCE_EQ(bias_is_mask,
                             false,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "QK_bias is mask can't be supported on rocm or "
                                 "cuda_arch<700"));
 #else
@@ -614,7 +614,7 @@ inline void MatmulWithHeadQK(const phi::GPUContext &context,
 #if defined(__HIPCC__) || (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700)
           PADDLE_ENFORCE_EQ(bias_is_mask,
                             false,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "QK_bias is mask can't be supported on rocm or "
                                 "cuda_arch<700"));
 #else
@@ -627,7 +627,7 @@ inline void MatmulWithHeadQK(const phi::GPUContext &context,
           } else if (block.x <= 4096) {
             SOFTMAX_KERNEL_WITH_MASK(4);
           } else {
-            PADDLE_THROW(phi::errors::InvalidArgument(
+            PADDLE_THROW(common::errors::InvalidArgument(
                 "Cannot support the length of attention > 8192."));
           }
 #endif

--- a/paddle/phi/kernels/funcs/padding.h
+++ b/paddle/phi/kernels/funcs/padding.h
@@ -96,9 +96,9 @@ void PaddingFunctor(int rank,
       PadFunction<DeviceContext, T, 6>(context, pads, src, pad_value, out);
       break;
     default:
-      PADDLE_THROW(
-          phi::errors::Unimplemented("PadOp only support tensors with no more"
-                                     " than 6 dimensions currently."));
+      PADDLE_THROW(common::errors::Unimplemented(
+          "PadOp only support tensors with no more"
+          " than 6 dimensions currently."));
   }
 }
 
@@ -128,9 +128,9 @@ void PaddingGradFunctor(int rank,
       PadGradFunction<DeviceContext, T, 6>(context, pads, src, out);
       break;
     default:
-      PADDLE_THROW(
-          phi::errors::Unimplemented("PadOp only support tensors with no more"
-                                     " than 6 dimensions currently."));
+      PADDLE_THROW(common::errors::Unimplemented(
+          "PadOp only support tensors with no more"
+          " than 6 dimensions currently."));
   }
 }
 

--- a/paddle/phi/kernels/funcs/partial_concat_funcs.h
+++ b/paddle/phi/kernels/funcs/partial_concat_funcs.h
@@ -22,7 +22,7 @@ static inline int64_t ComputeStartIndex(int64_t start_index, int64_t size) {
   PADDLE_ENFORCE_EQ(
       start_index >= -size && start_index < size,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The start_index is expected to be in range of [%d, %d), but got %d",
           -size,
           size,

--- a/paddle/phi/kernels/funcs/pooling.cc
+++ b/paddle/phi/kernels/funcs/pooling.cc
@@ -1878,14 +1878,14 @@ class FractionalMaxPool2dFunctor<CPUContext, T1, T2> {
     PADDLE_ENFORCE_GE(
         input_height,
         output_height - 1 + pool_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_height [%d] is less than valid output_height [%d]",
             input_height,
             output_height - 1 + pool_height));
     PADDLE_ENFORCE_GE(
         input_width,
         output_width - 1 + pool_width,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_width [%d] is less than valid output_width [%d]",
             input_width,
             output_width - 1 + pool_width));
@@ -2038,21 +2038,21 @@ class FractionalMaxPool3dFunctor<CPUContext, T1, T2> {
     PADDLE_ENFORCE_GE(
         input_depth,
         output_depth - 1 + pool_depth,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_depth [%d] is less than valid output_depth [%d]",
             input_depth,
             output_depth - 1 + pool_depth));
     PADDLE_ENFORCE_GE(
         input_height,
         output_height - 1 + pool_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_height [%d] is less than valid output_height [%d]",
             input_height,
             output_height - 1 + pool_height));
     PADDLE_ENFORCE_GE(
         input_width,
         output_width - 1 + pool_width,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_width [%d] is less than valid output_width [%d]",
             input_width,
             output_width - 1 + pool_width));

--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -2761,14 +2761,14 @@ class FractionalMaxPool2dFunctor<phi::GPUContext, T1, T2> {
     PADDLE_ENFORCE_GE(
         input_height,
         output_height - 1 + pool_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_height [%d] is less than valid output_height [%d]",
             input_height,
             output_height - 1 + pool_height));
     PADDLE_ENFORCE_GE(
         input_width,
         output_width - 1 + pool_width,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_width [%d] is less than valid output_width [%d]",
             input_width,
             output_width - 1 + pool_width));
@@ -3092,21 +3092,21 @@ class FractionalMaxPool3dFunctor<phi::GPUContext, T1, T2> {
     PADDLE_ENFORCE_GE(
         input_depth,
         output_depth - 1 + pool_depth,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_depth [%d] is less than valid output_depth [%d]",
             input_depth,
             output_depth - 1 + pool_depth));
     PADDLE_ENFORCE_GE(
         input_height,
         output_height - 1 + pool_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_height [%d] is less than valid output_height [%d]",
             input_height,
             output_height - 1 + pool_height));
     PADDLE_ENFORCE_GE(
         input_width,
         output_width - 1 + pool_width,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_width [%d] is less than valid output_width [%d]",
             input_width,
             output_width - 1 + pool_width));

--- a/paddle/phi/kernels/funcs/pooling.h
+++ b/paddle/phi/kernels/funcs/pooling.h
@@ -507,7 +507,7 @@ inline int PoolOutputSize(int input_size,
   PADDLE_ENFORCE_NE(
       stride,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The stride of PoolOutputSize shall not be 0, but received %d.",
           stride));
 
@@ -543,7 +543,7 @@ inline int MaxPoolOutputSize(
   PADDLE_ENFORCE_NE(
       stride,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The stride of MaxPool shall not be 0, but received %d.", stride));
   if (ceil_mode) {
     return (input_size - filter_size + 2 * padding + stride - 1) / stride + 1;

--- a/paddle/phi/kernels/funcs/range_function.h
+++ b/paddle/phi/kernels/funcs/range_function.h
@@ -23,20 +23,20 @@ void GetSize(T start, T end, T step, int64_t* size) {
   PADDLE_ENFORCE_NE(
       step,
       0,
-      phi::errors::InvalidArgument("The step of range op should not be 0."));
+      common::errors::InvalidArgument("The step of range op should not be 0."));
 
   if (start < end) {
     PADDLE_ENFORCE_GT(
         step,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The step should be greater than 0 while start < end."));
   }
 
   if (start > end) {
     PADDLE_ENFORCE_LT(step,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The step should be less than 0 while start > end."));
   }
 

--- a/paddle/phi/kernels/funcs/reduce_function.h
+++ b/paddle/phi/kernels/funcs/reduce_function.h
@@ -75,7 +75,7 @@ static inline void CheckReduceRank(int reduce_rank, int rank) {
   if (rank % 2 == 0) {
     PADDLE_ENFORCE_EQ(reduce_rank,
                       rank / 2,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "ReduceOp: invalid reduce rank. When rank = %d, "
                           "reduce_rank must be %d, but got %d.",
                           rank,
@@ -87,7 +87,7 @@ static inline void CheckReduceRank(int reduce_rank, int rank) {
     PADDLE_ENFORCE_EQ(
         reduce_rank == lower_rank || reduce_rank == upper_rank,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "ReduceOp: invalid reduce rank. When rank = %d, reduce_rank "
             "must be %d or %d, but got %d.",
             rank,
@@ -111,7 +111,7 @@ static inline std::vector<int> GetReduceDim(const std::vector<int64_t>& dims,
     for (auto e : dims) {
       PADDLE_ENFORCE_LT(e,
                         dim_size,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "ReduceOp: invalid axis, when x_dims is %d, "
                             "axis[i] should less than x_dims, but got %d.",
                             dim_size,
@@ -981,7 +981,7 @@ CubTensorReduceImpl(const Tx* x_data,
                     int reduce_num,
                     const KPDevice& dev_ctx,
                     KPStream stream) {
-  PADDLE_THROW(phi::errors::InvalidArgument(
+  PADDLE_THROW(common::errors::InvalidArgument(
       "Tx should not be float16 when using cub::DeviceReduce::Reduce()."));
 }
 template <typename Tx,
@@ -997,7 +997,7 @@ CubTensorReduceImpl(const Tx* x_data,
                     int reduce_num,
                     const KPDevice& dev_ctx,
                     KPStream stream) {
-  PADDLE_THROW(phi::errors::InvalidArgument(
+  PADDLE_THROW(common::errors::InvalidArgument(
       "Tx should not be bfloat16 when using cub::DeviceReduce::Reduce()."));
 }
 #endif  // PADDLE_WITH_XPU_KP
@@ -1049,10 +1049,10 @@ void ReduceKernel(const KPDevice& dev_ctx,
                   phi::DenseTensor* y,
                   const TransformOp& transform,
                   const std::vector<int>& origin_reduce_dims) {
-  PADDLE_ENFORCE_GT(
-      x.numel(),
-      0,
-      phi::errors::InvalidArgument("Tensor need be reduced must not empty."));
+  PADDLE_ENFORCE_GT(x.numel(),
+                    0,
+                    common::errors::InvalidArgument(
+                        "Tensor need be reduced must not empty."));
 #ifdef PADDLE_WITH_XPU_KP
   auto stream = dev_ctx.x_context()->xpu_stream;
 #else
@@ -1332,7 +1332,7 @@ void HandleLargeDim(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       unreduced * reduced,
       input_numel,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Reducing failed in HandleLargeDim, when try to transpose (%d) "
           "operands into 2D tensor with shape (%d, %d).",
           input_numel,
@@ -1357,10 +1357,10 @@ void ReduceKernelImpl(const Context& dev_ctx,
                       const std::vector<int64_t>& dims,
                       bool keep_dim,
                       bool reduce_all) {
-  PADDLE_ENFORCE_GT(
-      input.numel(),
-      0,
-      phi::errors::InvalidArgument("Tensor need be reduced must not empty."));
+  PADDLE_ENFORCE_GT(input.numel(),
+                    0,
+                    common::errors::InvalidArgument(
+                        "Tensor need be reduced must not empty."));
 
   dev_ctx.template Alloc<OutT>(output);
 

--- a/paddle/phi/kernels/funcs/reduce_grad_functions.h
+++ b/paddle/phi/kernels/funcs/reduce_grad_functions.h
@@ -94,7 +94,7 @@ void HandleLargeDimGrad(const Context& dev_ctx,
   PADDLE_ENFORCE_EQ(
       unreduced * reduced,
       x_numel,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Reducing failed in HandleLargeDimGrad, when try to transpose (%d) "
           "operands into 2D tensor with shape (%d, %d).",
           x_numel,

--- a/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.h
+++ b/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.h
@@ -34,7 +34,7 @@ void RepeatsTensor2IndexTensor(const Context& ctx,
   for (int i = 0; i < repeats.dims()[0]; i++) {
     PADDLE_ENFORCE_GE(repeats_data[i],
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "repeats must grater or equal than 0, but got %d",
                           repeats_data[i]));
     index_size += repeats_data[i];

--- a/paddle/phi/kernels/funcs/scatter.cu.h
+++ b/paddle/phi/kernels/funcs/scatter.cu.h
@@ -132,15 +132,15 @@ void GPUScatterAssign(const phi::GPUContext& ctx,
     PADDLE_ENFORCE_EQ(
         index.dims()[1],
         1,
-        phi::errors::InvalidArgument("index.dims()[1] should be 1 when "
-                                     "index.dims().size() = 2 in scatter_op."
-                                     "But received value is [%d]",
-                                     index.dims()[1]));
+        common::errors::InvalidArgument("index.dims()[1] should be 1 when "
+                                        "index.dims().size() = 2 in scatter_op."
+                                        "But received value is [%d]",
+                                        index.dims()[1]));
   } else {
     PADDLE_ENFORCE_EQ(
         index.dims().size() == 1 || index.dims().size() == 0,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "index.dims().size() should be 0, 1 or 2 in scatter_op."
             "But received value is [%d]",
             index.dims().size()));

--- a/paddle/phi/kernels/funcs/scatter.h
+++ b/paddle/phi/kernels/funcs/scatter.h
@@ -80,14 +80,14 @@ void ScatterAssign(const phi::CPUContext& ctx UNUSED,
     PADDLE_ENFORCE_EQ(
         index.dims()[1],
         1,
-        phi::errors::InvalidArgument("index.dims()[1] should be 1 when "
-                                     "index.dims().size() =2 in scatter_op."
-                                     "But received value is [%d]",
-                                     index.dims()[1]));
+        common::errors::InvalidArgument("index.dims()[1] should be 1 when "
+                                        "index.dims().size() =2 in scatter_op."
+                                        "But received value is [%d]",
+                                        index.dims()[1]));
   } else {
     PADDLE_ENFORCE_EQ(index.dims().size() == 1 || index.dims().size() == 0,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "index.dims().size() should be 0, 1 or 2 in "
                           "scatter_op. But received value is [%d]",
                           index.dims().size()));
@@ -109,7 +109,7 @@ void ScatterAssign(const phi::CPUContext& ctx UNUSED,
       PADDLE_ENFORCE_EQ(
           src_dims[i],
           dst_dims[i],
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The dimensions of the source tensor and target tensor should"
               " match, but received source tensor's %d-th dimension is %d,"
               "target tensor's %d-th dimension is %d.",
@@ -134,7 +134,7 @@ void ScatterAssign(const phi::CPUContext& ctx UNUSED,
 
     PADDLE_ENFORCE_GE(index_,
                       0,
-                      phi::errors::OutOfRange(
+                      common::errors::OutOfRange(
                           "The index is out of bounds, "
                           "please check whether the dimensions of index and "
                           "input meet the requirements. It should "
@@ -144,7 +144,7 @@ void ScatterAssign(const phi::CPUContext& ctx UNUSED,
     PADDLE_ENFORCE_LT(
         index_,
         dst_dims[0],
-        phi::errors::OutOfRange(
+        common::errors::OutOfRange(
             "The index is out of bounds, "
             "please check whether the values of index and "
             "dimensions of input meet the requirements. each index should "
@@ -165,7 +165,7 @@ void ScatterAssignAdd(const phi::CPUContext& ctx,
       index.dims().size() == 1 || index.dims().size() == 0 ||
           (index.dims().size() == 2 && index.dims()[1] == 1),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "index's shape is error, "
           "expect index'dims shape is 0, 1, 2 (index.dims[1] should "
           "be 1), but got index'dims shape is %d",
@@ -186,7 +186,7 @@ void ScatterAssignAdd(const phi::CPUContext& ctx,
       PADDLE_ENFORCE_EQ(
           src_dims[i],
           dst_dims[i],
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The dimensions of the source tensor and target tensor should"
               " match, but received source tensor's %d-th dimension is %d,"
               "target tensor's %d-th dimension is %d.",
@@ -212,7 +212,7 @@ void ScatterAssignAdd(const phi::CPUContext& ctx,
     const IndexT& index_val = p_index[i];
     PADDLE_ENFORCE_GE(index_val,
                       0,
-                      phi::errors::OutOfRange(
+                      common::errors::OutOfRange(
                           "The index is out of bounds, "
                           "please check whether the dimensions of index and "
                           "input meet the requirements. It should "
@@ -220,7 +220,7 @@ void ScatterAssignAdd(const phi::CPUContext& ctx,
                           index_val));
     PADDLE_ENFORCE_LT(index_val,
                       max_index,
-                      phi::errors::OutOfRange(
+                      common::errors::OutOfRange(
                           "The index is out of bounds, "
                           "please check whether the dimensions of index and "
                           "input meet the requirements. It should "
@@ -292,7 +292,7 @@ void ScatterNdAdd(const phi::CPUContext& ctx,
       PADDLE_ENFORCE_EQ(
           (index_value >= 0 && index_value < output_dims[j]),
           true,
-          phi::errors::OutOfRange(
+          common::errors::OutOfRange(
               "The index is out of bounds, "
               "please check whether the dimensions of index and "
               "input meet the requirements. It should "

--- a/paddle/phi/kernels/funcs/search_compute.h
+++ b/paddle/phi/kernels/funcs/search_compute.h
@@ -143,7 +143,7 @@ inline void axpy(const T* x, T* y, size_t len, const T alpha) {
   }
 #elif defined(PADDLE_WITH_ARM) || defined(PADDLE_WITH_SW) || \
     defined(PADDLE_WITH_MIPS) || defined(PADDLE_WITH_LOONGARCH)
-  PADDLE_THROW(phi::errors::Unimplemented("axpy is not supported"));
+  PADDLE_THROW(common::errors::Unimplemented("axpy is not supported"));
 #else
   lll = len & ~SSE_CUT_LEN_MASK;
   __m128x mm_alpha = _mm_load1_px(&alpha);
@@ -173,7 +173,7 @@ inline void axpy_noadd(const T* x, T* y, size_t len, const T alpha) {
   }
 #elif defined(PADDLE_WITH_ARM) || defined(PADDLE_WITH_SW) || \
     defined(PADDLE_WITH_MIPS) || defined(PADDLE_WITH_LOONGARCH)
-  PADDLE_THROW(phi::errors::Unimplemented("axpy_noadd is not supported"));
+  PADDLE_THROW(common::errors::Unimplemented("axpy_noadd is not supported"));
 #else
   lll = len & ~SSE_CUT_LEN_MASK;
   __m128x mm_alpha = _mm_load1_px(&alpha);
@@ -192,7 +192,7 @@ inline void axpy_noadd(const int8_t* x,
                        int8_t* y,
                        size_t len,
                        const float alpha) {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "int8_t input of axpy_noadd is not supported"));
 }
 

--- a/paddle/phi/kernels/funcs/segment_pooling.cc
+++ b/paddle/phi/kernels/funcs/segment_pooling.cc
@@ -42,7 +42,7 @@ class SegmentPoolFunctor<phi::CPUContext, T, IndexT> {
         if (segment_ids[idx] == curent_id) continue;
         PADDLE_ENFORCE_GE(segment_ids[idx],
                           curent_id,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The segment ids should be sorted, but got "
                               "segment_ids[%d]:%d > segment_ids[%d]:%d.",
                               idx - 1,
@@ -68,7 +68,7 @@ class SegmentPoolFunctor<phi::CPUContext, T, IndexT> {
       } else if (pooltype == "MIN") {
         out_e.device(place) = in_e.minimum(reduce_dim);
       } else {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "Unsupported segment pooling type, only MEAN, SUM, MAX, MIN "
             "available, but got %s.",
             pooltype));
@@ -101,7 +101,7 @@ class SegmentPoolGradFunctor<phi::CPUContext, T, IndexT> {
         if (segment_ids[idx] == curent_id) continue;
         PADDLE_ENFORCE_GE(segment_ids[idx],
                           curent_id,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The segment ids should be sorted, but got "
                               "segment_ids[%d]:%d > segment_ids[%d]:%d.",
                               idx - 1,
@@ -131,7 +131,7 @@ class SegmentPoolGradFunctor<phi::CPUContext, T, IndexT> {
             (in_e == out_e.broadcast(bcast)).template cast<T>() *
             out_g_e.broadcast(bcast);
       } else {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "Unsupported segment pooling type, only MEAN, SUM, MAX, MIN "
             "available, but got %s.",
             pooltype));

--- a/paddle/phi/kernels/funcs/segment_pooling.cu
+++ b/paddle/phi/kernels/funcs/segment_pooling.cu
@@ -292,7 +292,7 @@ void SegmentPoolCUDAGradFunctor(const phi::GPUContext& ctx,
                            in_grad->data<T>(),
                            h);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Unsupported segment pooling grad operation, Only MAX, MIN "
         "available, but got %s.",
         pooltype));
@@ -392,7 +392,7 @@ class SegmentPoolFunctor<phi::GPUContext, T, IndexT> {
                              h,
                              pool);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupported segment pooling operation, Only MEAN, SUM, MAX, MIN "
           "available, but got %s.",
           pooltype));
@@ -431,7 +431,7 @@ class SegmentPoolGradFunctor<phi::GPUContext, T, IndexT> {
     } else if (pooltype == "SUM") {
       phi::funcs::GPUGather<T, IndexT>(dev_ctx, out_grad, segments, in_grad);
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Unsupported segment pooling operation, Only MEAN, SUM, MAX, MIN "
           "available, but got %s.",
           pooltype));

--- a/paddle/phi/kernels/funcs/selected_rows_functor.cc
+++ b/paddle/phi/kernels/funcs/selected_rows_functor.cc
@@ -44,11 +44,11 @@ struct SelectedRowsAdd<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_height,
         input2.height(),
-        phi::errors::InvalidArgument("The two inputs height must be equal."
-                                     "But received first input height  = "
-                                     "[%d], second input height = [%d]",
-                                     in1_height,
-                                     input2.height()));
+        common::errors::InvalidArgument("The two inputs height must be equal."
+                                        "But received first input height  = "
+                                        "[%d], second input height = [%d]",
+                                        in1_height,
+                                        input2.height()));
     output->set_height(in1_height);
 
     auto& in1_rows = input1.rows();
@@ -69,7 +69,7 @@ struct SelectedRowsAdd<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_row_numel,
         in2_value.numel() / in2_rows.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The two inputs width must be equal."
             "But received first input width = [%d], second input width = [%d]",
             in1_row_numel,
@@ -77,7 +77,7 @@ struct SelectedRowsAdd<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_row_numel,
         out_value->numel() / out_rows.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input and output width must be equal."
             "But received input width = [%d], output width = [%d]",
             in1_row_numel,
@@ -86,17 +86,17 @@ struct SelectedRowsAdd<phi::CPUContext, T> {
     auto in1_place = input1.place();
     PADDLE_ENFORCE_EQ(in1_place.GetType() == phi::AllocationType::CPU,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The running environment is not on the CPU place."));
     auto in2_place = input2.place();
     PADDLE_ENFORCE_EQ(in2_place.GetType() == phi::AllocationType::CPU,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The running environment is not on the CPU place."));
     auto out_place = context.GetPlace();
     PADDLE_ENFORCE_EQ(out_place.GetType() == phi::AllocationType::CPU,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The running environment is not on the CPU place."));
 
     auto* out_data = out_value->data<T>();
@@ -131,15 +131,15 @@ struct SelectedRowsAddTensor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_height,
         in2_dims[0],
-        phi::errors::InvalidArgument("The two inputs height must be equal."
-                                     "But received first input height = "
-                                     "[%d], second input height = [%d]",
-                                     in1_height,
-                                     in2_dims[0]));
+        common::errors::InvalidArgument("The two inputs height must be equal."
+                                        "But received first input height = "
+                                        "[%d], second input height = [%d]",
+                                        in1_height,
+                                        in2_dims[0]));
     PADDLE_ENFORCE_EQ(
         in1_height,
         out_dims[0],
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input and output height must be equal."
             "But received input height = [%d], output height = [%d]",
             in1_height,
@@ -153,7 +153,7 @@ struct SelectedRowsAddTensor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_row_numel,
         input2.numel() / in1_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The two inputs width must be equal."
             "But received first input width = [%d], second input width = [%d]",
             in1_row_numel,
@@ -161,7 +161,7 @@ struct SelectedRowsAddTensor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_row_numel,
         output->numel() / in1_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input and output width must be equal."
             "But received input width = [%d], output width = [%d]",
             in1_row_numel,
@@ -199,11 +199,11 @@ struct SelectedRowsAddTo<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_height,
         input2->height(),
-        phi::errors::InvalidArgument("The two inputs height must be equal."
-                                     "But received first input height = "
-                                     "[%d], second input height = [%d]",
-                                     in1_height,
-                                     input2->height()));
+        common::errors::InvalidArgument("The two inputs height must be equal."
+                                        "But received first input height = "
+                                        "[%d], second input height = [%d]",
+                                        in1_height,
+                                        input2->height()));
 
     auto& in1_rows = input1.rows();
     auto& in2_rows = *(input2->mutable_rows());
@@ -218,12 +218,12 @@ struct SelectedRowsAddTo<phi::CPUContext, T> {
     auto in1_place = input1.place();
     PADDLE_ENFORCE_EQ(in1_place.GetType() == phi::AllocationType::CPU,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The running environment is not on the CPU place."));
     auto in2_place = input2->place();
     PADDLE_ENFORCE_EQ(in2_place.GetType() == phi::AllocationType::CPU,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The running environment is not on the CPU place."));
 
     auto* in1_data = in1_value.data<T>();
@@ -255,7 +255,7 @@ struct SelectedRowsSumTo<phi::CPUContext, T> {
       auto in1_height = item->height();
       PADDLE_ENFORCE_EQ(in1_height,
                         input2->height(),
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "The two inputs height must be equal."
                             "But received first input height = [%d], second "
                             "input height = [%d]",
@@ -301,11 +301,11 @@ struct SelectedRowsAddToTensor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_height,
         in2_dims[0],
-        phi::errors::InvalidArgument("The two inputs height must be equal."
-                                     "But received first input height = "
-                                     "[%d], second input height = [%d]",
-                                     in1_height,
-                                     in2_dims[0]));
+        common::errors::InvalidArgument("The two inputs height must be equal."
+                                        "But received first input height = "
+                                        "[%d], second input height = [%d]",
+                                        in1_height,
+                                        in2_dims[0]));
 
     auto& in1_value = input1.value();
     auto& in1_rows = input1.rows();
@@ -315,7 +315,7 @@ struct SelectedRowsAddToTensor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_row_numel,
         input2->numel() / in1_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The two inputs width must be equal."
             "But received first input width = [%d], second input width = [%d]",
             in1_row_numel,
@@ -349,11 +349,11 @@ struct SelectedRowsAddToTensor<phi::XPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_height,
         in2_dims[0],
-        phi::errors::InvalidArgument("The two inputs height must be equal."
-                                     "But received first input height = "
-                                     "[%d], second input height = [%d]",
-                                     in1_height,
-                                     in2_dims[0]));
+        common::errors::InvalidArgument("The two inputs height must be equal."
+                                        "But received first input height = "
+                                        "[%d], second input height = [%d]",
+                                        in1_height,
+                                        in2_dims[0]));
 
     auto& in1_value = input1.value();
     auto& in1_rows = input1.rows();
@@ -365,7 +365,7 @@ struct SelectedRowsAddToTensor<phi::XPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_row_numel,
         input2->numel() / in1_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The two inputs width must be equal."
             "But received first input width = [%d], second input width = [%d]",
             in1_row_numel,
@@ -546,15 +546,15 @@ struct MergeAddImpl {
       if (input->rows().empty()) {
         continue;
       }
-      PADDLE_ENFORCE_EQ(
-          input_width,
-          input->value().dims()[1],
-          phi::errors::InvalidArgument("All inputs should have same "
-                                       "dimension except for the first one."));
-      PADDLE_ENFORCE_EQ(
-          input_height,
-          input->height(),
-          phi::errors::InvalidArgument("All inputs should have same height."));
+      PADDLE_ENFORCE_EQ(input_width,
+                        input->value().dims()[1],
+                        common::errors::InvalidArgument(
+                            "All inputs should have same "
+                            "dimension except for the first one."));
+      PADDLE_ENFORCE_EQ(input_height,
+                        input->height(),
+                        common::errors::InvalidArgument(
+                            "All inputs should have same height."));
       row_num += input->rows().size();
       merged_row_set.insert(input->rows().begin(), input->rows().end());
     }
@@ -744,15 +744,15 @@ struct MergeAdd<phi::XPUContext, T> {
       if (input->rows().size() == 0) {
         continue;
       }
-      PADDLE_ENFORCE_EQ(
-          input_width,
-          input->value().dims()[1],
-          phi::errors::InvalidArgument("All inputs should have same "
-                                       "dimension except for the first one."));
-      PADDLE_ENFORCE_EQ(
-          input_height,
-          input->height(),
-          phi::errors::InvalidArgument("All inputs should have same height."));
+      PADDLE_ENFORCE_EQ(input_width,
+                        input->value().dims()[1],
+                        common::errors::InvalidArgument(
+                            "All inputs should have same "
+                            "dimension except for the first one."));
+      PADDLE_ENFORCE_EQ(input_height,
+                        input->height(),
+                        common::errors::InvalidArgument(
+                            "All inputs should have same height."));
       row_num += input->rows().size();
       merged_row_set.insert(input->rows().begin(), input->rows().end());
     }
@@ -860,15 +860,15 @@ struct MergeAverage<phi::CPUContext, T> {
       if (input->rows().empty()) {
         continue;
       }
-      PADDLE_ENFORCE_EQ(
-          input_width,
-          input->value().dims()[1],
-          phi::errors::InvalidArgument("All inputs should have same "
-                                       "dimension except for the first one."));
-      PADDLE_ENFORCE_EQ(
-          input_height,
-          input->height(),
-          phi::errors::InvalidArgument("All input should have same height."));
+      PADDLE_ENFORCE_EQ(input_width,
+                        input->value().dims()[1],
+                        common::errors::InvalidArgument(
+                            "All inputs should have same "
+                            "dimension except for the first one."));
+      PADDLE_ENFORCE_EQ(input_height,
+                        input->height(),
+                        common::errors::InvalidArgument(
+                            "All input should have same height."));
       merged_row_set.insert(input->rows().begin(), input->rows().end());
     }
 
@@ -939,25 +939,25 @@ struct UpdateToTensor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_height,
         in2_dims[0],
-        phi::errors::InvalidArgument("The two inputs height must be equal."
-                                     "But received first input height = "
-                                     "[%d], second input height = [%d]",
-                                     in1_height,
-                                     in2_dims[0]));
+        common::errors::InvalidArgument("The two inputs height must be equal."
+                                        "But received first input height = "
+                                        "[%d], second input height = [%d]",
+                                        in1_height,
+                                        in2_dims[0]));
 
     auto& in1_value = input1.value();
     auto& in1_rows = input1.rows();
 
     int64_t in1_row_numel =
         static_cast<int64_t>(in1_value.numel() / in1_rows.size());
-    PADDLE_ENFORCE_EQ(
-        in1_row_numel,
-        input2->numel() / in1_height,
-        phi::errors::InvalidArgument("The two inputs width must be equal."
-                                     "But received first input width = [%d], "
-                                     "second input width = [%d]",
-                                     in1_row_numel,
-                                     input2->numel() / in1_height));
+    PADDLE_ENFORCE_EQ(in1_row_numel,
+                      input2->numel() / in1_height,
+                      common::errors::InvalidArgument(
+                          "The two inputs width must be equal."
+                          "But received first input width = [%d], "
+                          "second input width = [%d]",
+                          in1_row_numel,
+                          input2->numel() / in1_height));
 
     auto* in1_data = in1_value.data<T>();
     auto* input2_data = input2->data<T>();

--- a/paddle/phi/kernels/funcs/selected_rows_functor.cu
+++ b/paddle/phi/kernels/funcs/selected_rows_functor.cu
@@ -35,11 +35,11 @@ struct SelectedRowsAdd<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_height,
         input2.height(),
-        phi::errors::InvalidArgument("The two inputs height must be equal."
-                                     "But received first input height  = "
-                                     "[%d], second input height = [%d]",
-                                     in1_height,
-                                     input2.height()));
+        common::errors::InvalidArgument("The two inputs height must be equal."
+                                        "But received first input height  = "
+                                        "[%d], second input height = [%d]",
+                                        in1_height,
+                                        input2.height()));
     output->set_height(in1_height);
 
     phi::Vector<int64_t> in1_rows(input1.rows());
@@ -60,7 +60,7 @@ struct SelectedRowsAdd<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_row_numel,
         in2_value.numel() / in2_rows.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The two inputs width must be equal."
             "But received first input width = [%d], second input width = [%d]",
             in1_row_numel,
@@ -68,7 +68,7 @@ struct SelectedRowsAdd<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_row_numel,
         out_value->numel() / out_rows.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input and oupput width must be equal."
             "But received input width = [%d], output width = [%d]",
             in1_row_numel,
@@ -80,17 +80,17 @@ struct SelectedRowsAdd<phi::GPUContext, T> {
     auto in1_place = input1.place();
     PADDLE_ENFORCE_EQ(in1_place.GetType() == phi::AllocationType::GPU,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The running environment is not on the GPU place."));
     auto in2_place = input2.place();
     PADDLE_ENFORCE_EQ(in2_place.GetType() == phi::AllocationType::GPU,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The running environment is not on the GPU place."));
     auto out_place = context.GetPlace();
     PADDLE_ENFORCE_EQ(out_place.GetType() == phi::AllocationType::GPU,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The running environment is not on the GPU place."));
 
     memory_utils::Copy(out_place,
@@ -146,7 +146,7 @@ struct SelectedRowsAddTensor<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_height,
         in2_dims[0],
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The two inputs height must be equal."
             "But received first input height = [%d], first input height = [%d]",
             in1_height,
@@ -154,7 +154,7 @@ struct SelectedRowsAddTensor<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_height,
         out_dims[0],
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input and output height must be equal."
             "But received input height = [%d], output height = [%d]",
             in1_height,
@@ -167,7 +167,7 @@ struct SelectedRowsAddTensor<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_row_numel,
         input2.numel() / in1_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The two inputs width must be equal."
             "But received first input width = [%d], second input width = [%d]",
             in1_row_numel,
@@ -175,7 +175,7 @@ struct SelectedRowsAddTensor<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_row_numel,
         output->numel() / in1_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The input and output width must be equal."
             "But received input width = [%d], output width = [%d]",
             in1_row_numel,
@@ -220,11 +220,11 @@ struct SelectedRowsAddTo<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_height,
         input2->height(),
-        phi::errors::InvalidArgument("The two inputs height must be equal."
-                                     "But received first input height = "
-                                     "[%d], second input height = [%d]",
-                                     in1_height,
-                                     input2->height()));
+        common::errors::InvalidArgument("The two inputs height must be equal."
+                                        "But received first input height = "
+                                        "[%d], second input height = [%d]",
+                                        in1_height,
+                                        input2->height()));
 
     auto& in1_rows = input1.rows();
     auto& in2_rows = *(input2->mutable_rows());
@@ -241,12 +241,12 @@ struct SelectedRowsAddTo<phi::GPUContext, T> {
     auto in1_place = input1.place();
     PADDLE_ENFORCE_EQ(in1_place.GetType() == phi::AllocationType::GPU,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The running environment is not on the GPU place."));
     auto in2_place = input2->place();
     PADDLE_ENFORCE_EQ(in1_place.GetType() == phi::AllocationType::GPU,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The running environment is not on the GPU place."));
 
     auto* in1_data = in1_value.data<T>();
@@ -296,11 +296,11 @@ struct SelectedRowsAddToTensor<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_height,
         in2_dims[0],
-        phi::errors::InvalidArgument("The two inputs height must be equal."
-                                     "But received first input height = "
-                                     "[%d], second input height = [%d]",
-                                     in1_height,
-                                     in2_dims[0]));
+        common::errors::InvalidArgument("The two inputs height must be equal."
+                                        "But received first input height = "
+                                        "[%d], second input height = [%d]",
+                                        in1_height,
+                                        in2_dims[0]));
 
     auto& in1_value = input1.value();
     auto& in1_rows = input1.rows();
@@ -309,7 +309,7 @@ struct SelectedRowsAddToTensor<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_row_numel,
         input2->numel() / in1_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The two inputs width must be equal."
             "But received first input width = [%d], second input width = [%d]",
             in1_row_numel,
@@ -452,15 +452,15 @@ struct MergeAddImpl {
       if (input->rows().size() == 0) {
         continue;
       }
-      PADDLE_ENFORCE_EQ(
-          input_width,
-          input->value().dims()[1],
-          phi::errors::InvalidArgument("All input should have same "
-                                       "dimension except for the first one."));
-      PADDLE_ENFORCE_EQ(
-          input_height,
-          input->height(),
-          phi::errors::InvalidArgument("All input should have same height."));
+      PADDLE_ENFORCE_EQ(input_width,
+                        input->value().dims()[1],
+                        common::errors::InvalidArgument(
+                            "All input should have same "
+                            "dimension except for the first one."));
+      PADDLE_ENFORCE_EQ(input_height,
+                        input->height(),
+                        common::errors::InvalidArgument(
+                            "All input should have same height."));
       merged_row_set.insert(input->rows().begin(), input->rows().end());
     }
     std::vector<int64_t> merge_rows_cpu(merged_row_set.begin(),
@@ -610,11 +610,11 @@ struct UpdateToTensor<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_height,
         in2_dims[0],
-        phi::errors::InvalidArgument("The two inputs height must be equal."
-                                     "But received first input height = "
-                                     "[%d], second input height = [%d]",
-                                     in1_height,
-                                     in2_dims[0]));
+        common::errors::InvalidArgument("The two inputs height must be equal."
+                                        "But received first input height = "
+                                        "[%d], second input height = [%d]",
+                                        in1_height,
+                                        in2_dims[0]));
 
     auto& in1_value = merged_in1.value();
     auto& in1_rows = merged_in1.rows();
@@ -623,7 +623,7 @@ struct UpdateToTensor<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         in1_row_numel,
         input2->numel() / in1_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The two inputs width must be equal."
             "But received first input width = [%d], second input width = [%d]",
             in1_row_numel,

--- a/paddle/phi/kernels/funcs/sequence2batch.cc
+++ b/paddle/phi/kernels/funcs/sequence2batch.cc
@@ -29,14 +29,14 @@ class CopyMatrixRowsFunctor<phi::CPUContext, T> {
     const auto& dst_dims = common::vectorize<int>(dst->dims());
     PADDLE_ENFORCE_EQ(src_dims.size(),
                       2UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The source tensor must be a matrix with rank 2, but "
                           "got the source tensor rank is %lu. "
                           "Please check the rank of the source tensor",
                           src_dims.size()));
     PADDLE_ENFORCE_EQ(dst_dims.size(),
                       2UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The destination tensor must be a matrix with rank, "
                           "but got the destination tensor rank is %lu. "
                           "Please check the rank of the destination tensor",
@@ -44,7 +44,7 @@ class CopyMatrixRowsFunctor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         src_dims[1],
         dst_dims[1],
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The width of the source tensor and the destination tensor must be "
             "same. But got %lu != %lu.Please check the rank of the source "
             "tensor",

--- a/paddle/phi/kernels/funcs/sequence2batch.cu
+++ b/paddle/phi/kernels/funcs/sequence2batch.cu
@@ -50,14 +50,14 @@ class CopyMatrixRowsFunctor<phi::GPUContext, T> {
     auto dst_dims = dst->dims();
     PADDLE_ENFORCE_EQ(src_dims.size(),
                       2,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The source tensor must be a matrix with rank 2, but "
                           "got the source tensor rank is %lu. "
                           "Please check the rank of the source tensor",
                           src_dims.size()));
     PADDLE_ENFORCE_EQ(dst_dims.size(),
                       2,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The destination tensor must be a matrix with rank, "
                           "but got the destination tensor rank is %lu. "
                           "Please check the rank of the destination tensor",
@@ -65,7 +65,7 @@ class CopyMatrixRowsFunctor<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         src_dims[1],
         dst_dims[1],
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The width of the source tensor and the destination tensor must be "
             "same. But got %lu != %lu.Please check the rank of the source "
             "tensor",

--- a/paddle/phi/kernels/funcs/sequence2batch.h
+++ b/paddle/phi/kernels/funcs/sequence2batch.h
@@ -70,7 +70,7 @@ class LoDTensor2BatchFunctor {
       PADDLE_ENFORCE_GT(
           lods.size(),
           2UL,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The LoD of LoDTensor should include at least 2-level "
               "sequence information, but got the LoD level is %lu. Please "
               "check the input value.",
@@ -78,7 +78,7 @@ class LoDTensor2BatchFunctor {
       PADDLE_ENFORCE_EQ(
           lods[1].size(),
           static_cast<size_t>(lod_tensor.dims()[0]),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The LoD information should be consistent with the dims, but got "
               "%lu != %lu. Please check the input value.",
               lods[1].size(),
@@ -91,7 +91,7 @@ class LoDTensor2BatchFunctor {
     auto lods = lod_tensor.lod();
     PADDLE_ENFORCE_EQ(lods.size(),
                       1UL,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Only support one level sequence now, but got the "
                           "LoD level is %lu. Please check the input value.",
                           lods.size()));
@@ -183,7 +183,7 @@ class Batch2LoDTensorFunctor {
     PADDLE_ENFORCE_GT(
         in_lod.size(),
         2UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The LoD of LoDTensor should include at least 2-level "
             "sequence information, but got the LoD level is %lu. Please check "
             "the input value.",
@@ -191,7 +191,7 @@ class Batch2LoDTensorFunctor {
     PADDLE_ENFORCE_EQ(
         in_lod[1].size(),
         static_cast<size_t>(lod_tensor->dims()[0]),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The LoD information should be consistent with the dims, but got "
             "%lu != %lu. Please check the input value.",
             in_lod[1].size(),

--- a/paddle/phi/kernels/funcs/sequence_padding.cc
+++ b/paddle/phi/kernels/funcs/sequence_padding.cc
@@ -46,7 +46,7 @@ void CopyValidData(phi::DenseTensor* dst_tensor,
     PADDLE_ENFORCE_GE(
         pad_seq_len,
         valid_seq_len,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The padded sequence length can not "
             "be less than its original length. Expected %ld >= %ld, but got "
             "%ld < %ld. Please check input value.",
@@ -125,7 +125,7 @@ class PaddingLoDTensorFunctor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         pad_value.numel() == 1 || pad_value.numel() == step_width,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The numel of 'pad_value' can only be 1 or be equal to the "
             "'step_width', but got %ld != 1 and %ld. Please check the input "
             "value.",

--- a/paddle/phi/kernels/funcs/sequence_padding.cu
+++ b/paddle/phi/kernels/funcs/sequence_padding.cu
@@ -78,7 +78,7 @@ class PaddingLoDTensorFunctor<phi::GPUContext, T> {
     PADDLE_ENFORCE_GE(
         pad_seq_len,
         max_seq_len,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The pad_seq_len must be equal to or greater than the "
             "original max sequence length. Expected %ld >= %ld, but got %ld < "
             "%ld. Please check the input value.",
@@ -98,7 +98,7 @@ class PaddingLoDTensorFunctor<phi::GPUContext, T> {
     PADDLE_ENFORCE_EQ(
         pad_value.numel() == 1 || pad_value.numel() == step_width,
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The numel of 'pad_value' can only be 1 or be equal to "
             "the 'step_width', but got %ld != 1 and %ld. Please check the "
             "input value.",

--- a/paddle/phi/kernels/funcs/sequence_padding.h
+++ b/paddle/phi/kernels/funcs/sequence_padding.h
@@ -57,7 +57,7 @@ inline static void CheckDims(const phi::DDim& seq_tensor_dims,
   PADDLE_ENFORCE_EQ(
       static_cast<size_t>(seq_tensor_dims[0]),
       seq_offset.back(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Value of 1st dimension of the sequence tensor should be "
           "equal to sum of lengths of all sequences. Expected %ld == %ld, but "
           "got %ld != %ld. Please check the input value.",
@@ -70,7 +70,7 @@ inline static void CheckDims(const phi::DDim& seq_tensor_dims,
       seq_tensor_dims.size() + 1 == pad_tensor_dims.size() ||
           seq_tensor_dims.size() == pad_tensor_dims.size(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "pad_tensor's rank should be 1 greater than seq_tensor's "
           "rank, or be equal with it. The pad_tensor's rank is %ld, "
           "expected the seq_tensor's rank is %ld or %ld, but got %ld. "

--- a/paddle/phi/kernels/funcs/slice_utils.h
+++ b/paddle/phi/kernels/funcs/slice_utils.h
@@ -35,7 +35,7 @@ inline void CheckAndUpdateSliceAttrs(const DDim in_dims,
     PADDLE_ENFORCE_LT(
         axis,
         in_dims.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The axis value should be less than the rank of input, "
             "but received axes[%d] = %d, rank of input is %d.",
             i,
@@ -53,7 +53,7 @@ inline void CheckAndUpdateSliceAttrs(const DDim in_dims,
       PADDLE_ENFORCE_NE(
           step,
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Step should not be 0, but received step = %d.", step));
 
       T start = (*starts)[i] < 0 ? ((*starts)[i] + dim_value) : (*starts)[i];
@@ -69,7 +69,7 @@ inline void CheckAndUpdateSliceAttrs(const DDim in_dims,
         PADDLE_ENFORCE_GE(
             end,
             start,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "When step > 0, end should be greater than start, but "
                 "received end = %d, start = %d.",
                 end,
@@ -86,7 +86,7 @@ inline void CheckAndUpdateSliceAttrs(const DDim in_dims,
         PADDLE_ENFORCE_GE(
             start,
             end,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "When step < 0, start should be greater than end, but "
                 "received start = %d, end = %d.",
                 start,
@@ -191,7 +191,7 @@ inline DDim GetDecreasedDims(const DDim slice_dims,
       if (infer_flags && (*infer_flags)[i] != -1) {
         PADDLE_ENFORCE_EQ(decreased_dims[axis],
                           1,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "Decrease dim should be 1, but now received %d",
                               decreased_dims[axis]));
       }
@@ -223,14 +223,14 @@ inline void CheckAndUpdateSparseSliceAttrs(const DDim in_dims,
   PADDLE_ENFORCE_EQ(
       axes->size(),
       starts->size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The length of axes (%d) and length of starts (%d) should be same.",
           axes->size(),
           starts->size()));
   PADDLE_ENFORCE_EQ(
       axes->size(),
       ends->size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The length of axes (%d) and length of ends (%d) should be same.",
           axes->size(),
           ends->size()));

--- a/paddle/phi/kernels/funcs/sparse/convolution.h
+++ b/paddle/phi/kernels/funcs/sparse/convolution.h
@@ -105,13 +105,13 @@ inline void GetOutShape(const DDim& x_dims,
                         DDim* out_dims) {
   const bool is2D = out_dims->size() == 4 ? true : false;
   if (is2D) {
-    PADDLE_ENFORCE_EQ(
-        x_dims.size(),
-        4,
-        phi::errors::InvalidArgument("the shape of x should be (N, H, W, C)"));
+    PADDLE_ENFORCE_EQ(x_dims.size(),
+                      4,
+                      common::errors::InvalidArgument(
+                          "the shape of x should be (N, H, W, C)"));
     PADDLE_ENFORCE_EQ(kernel_sizes.size(),
                       4,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "the shape of kernel should be (H, W, C, OC)"));
 
     // infer out shape
@@ -126,11 +126,11 @@ inline void GetOutShape(const DDim& x_dims,
   } else {
     PADDLE_ENFORCE_EQ(x_dims.size(),
                       5,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "the shape of x should be (N, D, H, W, C)"));
     PADDLE_ENFORCE_EQ(kernel_sizes.size(),
                       5,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "the shape of kernel should be (D, H, W, C, OC)"));
 
     // infer out shape

--- a/paddle/phi/kernels/funcs/sparse/sparse_blas_impl.cu.h
+++ b/paddle/phi/kernels/funcs/sparse/sparse_blas_impl.cu.h
@@ -82,8 +82,8 @@ inline void CreateCsrDescriptor(const phi::SparseCsrTensor& x,
   PADDLE_ENFORCE_GE(
       x_ndims,
       2,
-      phi::errors::InvalidArgument("the dim size of SparseCsrTensor must be "
-                                   "greater than or equal to 2."));
+      common::errors::InvalidArgument("the dim size of SparseCsrTensor must be "
+                                      "greater than or equal to 2."));
   int64_t M = xdim_vec[x_ndims - 2];
   int64_t N = xdim_vec[x_ndims - 1];
   int batch_size = 1;
@@ -92,7 +92,7 @@ inline void CreateCsrDescriptor(const phi::SparseCsrTensor& x,
   }
   PADDLE_ENFORCE_EQ(x.non_zero_crows().numel(),
                     batch_size * (M + 1),
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "the length of SparseCsrTensor crows is not right."));
 
   const IntT* crows_data = x.non_zero_crows().data<IntT>();
@@ -121,7 +121,7 @@ inline void CreateCsrDescriptor(const phi::SparseCsrTensor& x,
           *descriptor, batch_size, M + 1, batch_nnz);
     });
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Batch Sparse matmul use 'cusparseCsrSetStridedBatch', which is "
         "supported from CUDA 11.8"));
 #endif
@@ -137,8 +137,8 @@ inline void CreateCooDescriptor(const phi::SparseCooTensor& x,
   PADDLE_ENFORCE_GE(
       x_ndims,
       2,
-      phi::errors::InvalidArgument("the dim size of SparseCsrTensor must be "
-                                   "greater than or equal to 2."));
+      common::errors::InvalidArgument("the dim size of SparseCsrTensor must be "
+                                      "greater than or equal to 2."));
 
   int64_t M = xdim_vec[x_ndims - 2];
   int64_t N = xdim_vec[x_ndims - 1];
@@ -176,7 +176,7 @@ inline void CreateCooDescriptor(const phi::SparseCooTensor& x,
           *descriptor, batch_size, batch_nnz);
     });
 #else
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Batch Sparse matmul use 'cusparseCooSetStridedBatch', which is "
         "supported from CUDA 11.8"));
 #endif
@@ -232,8 +232,8 @@ class CuSparseDnMatDescriptor {
     PADDLE_ENFORCE_GE(
         x_ndims,
         2,
-        phi::errors::InvalidArgument("the dim size of DenseTensor must be "
-                                     "greater than or equal to 2."));
+        common::errors::InvalidArgument("the dim size of DenseTensor must be "
+                                        "greater than or equal to 2."));
 
     int64_t M = xdim_vec[x_ndims - 2];
     int64_t N = xdim_vec[x_ndims - 1];
@@ -262,7 +262,7 @@ class CuSparseDnMatDescriptor {
             descriptor_, batch_size, M * N);
       });
 #else
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Batch Sparse matmul use 'cusparseDnMatSetStridedBatch', which is "
           "supported from CUDA 11.8"));
 #endif
@@ -295,7 +295,7 @@ class CuSparseDnVecDescriptor {
     auto x_ndims = xdim_vec.size();
     PADDLE_ENFORCE_GE(x_ndims,
                       1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "the dim size of Vec must be equal to 1."));
 
     const T* x_data = x.data<T>();

--- a/paddle/phi/kernels/funcs/sparse/sparse_blas_impl.hip.h
+++ b/paddle/phi/kernels/funcs/sparse/sparse_blas_impl.hip.h
@@ -69,8 +69,8 @@ inline void CreateCsrDescriptor(const phi::SparseCsrTensor& x,
   PADDLE_ENFORCE_GE(
       x_ndims,
       2,
-      phi::errors::InvalidArgument("the dim size of SparseCsrTensor must be "
-                                   "greater than or equal to 2."));
+      common::errors::InvalidArgument("the dim size of SparseCsrTensor must be "
+                                      "greater than or equal to 2."));
   int64_t M = xdim_vec[x_ndims - 2];
   int64_t N = xdim_vec[x_ndims - 1];
   int batch_size = 1;
@@ -79,7 +79,7 @@ inline void CreateCsrDescriptor(const phi::SparseCsrTensor& x,
   }
   PADDLE_ENFORCE_EQ(x.non_zero_crows().numel(),
                     batch_size * (M + 1),
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "the length of SparseCsrTensor crows is not right."));
 
   const IntT* crows_data = x.non_zero_crows().data<IntT>();
@@ -105,7 +105,7 @@ inline void CreateCsrDescriptor(const phi::SparseCsrTensor& x,
   });
   if (batch_size > 1) {
     // TODO(umiswing): Add batch sparse matmul support for ROCM after 5.2.0
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Batch Sparse matmul use 'rocsparse_coo_set_strided_batch', which is "
         "supported from ROCM 5.2.0"));
   }
@@ -120,8 +120,8 @@ inline void CreateCooDescriptor(const phi::SparseCooTensor& x,
   PADDLE_ENFORCE_GE(
       x_ndims,
       2,
-      phi::errors::InvalidArgument("the dim size of SparseCooTensor must be "
-                                   "greater than or equal to 2."));
+      common::errors::InvalidArgument("the dim size of SparseCooTensor must be "
+                                      "greater than or equal to 2."));
 
   int64_t M = xdim_vec[x_ndims - 2];
   int64_t N = xdim_vec[x_ndims - 1];
@@ -154,7 +154,7 @@ inline void CreateCooDescriptor(const phi::SparseCooTensor& x,
 
   if (batch_size > 1) {
     // TODO(umiswing): Add batch sparse matmul support for ROCM after 5.2.0
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Batch Sparse matmul use 'rocsparse_coo_set_strided_batch', which is "
         "supported from ROCM 5.2.0"));
   }
@@ -208,8 +208,8 @@ class RocSparseDnMatDescriptor {
     PADDLE_ENFORCE_GE(
         x_ndims,
         2,
-        phi::errors::InvalidArgument("the dim size of DenseTensor must be "
-                                     "greater than or equal to 2."));
+        common::errors::InvalidArgument("the dim size of DenseTensor must be "
+                                        "greater than or equal to 2."));
 
     int64_t M = xdim_vec[x_ndims - 2];
     int64_t N = xdim_vec[x_ndims - 1];
@@ -233,11 +233,11 @@ class RocSparseDnMatDescriptor {
     PADDLE_ENFORCE_EQ(
         x.numel(),
         batch_size * M * N,
-        phi::errors::InvalidArgument("The number of elements in DenseTensor "
-                                     "must equals to batch_size * M * N."));
+        common::errors::InvalidArgument("The number of elements in DenseTensor "
+                                        "must equals to batch_size * M * N."));
     if (batch_size > 1) {
       // TODO(umiswing): Add batch sparse matmul support for ROCM after 5.2.0
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Batch Sparse matmul use 'rocsparse_dnmat_set_strided_batch', which "
           "is supported from ROCM 5.2.0"));
     }

--- a/paddle/phi/kernels/funcs/strided_memcpy.h
+++ b/paddle/phi/kernels/funcs/strided_memcpy.h
@@ -61,7 +61,7 @@ inline void CopyWithContext(const Context& ctx,
   memory_utils::Copy(dst_place, dst, src_place, src, num, ctx.stream());
 #else
   PADDLE_THROW(
-      phi::errors::PreconditionNotMet("Paddle is not compiled with GPU."));
+      common::errors::PreconditionNotMet("Paddle is not compiled with GPU."));
 #endif
 }
 
@@ -97,7 +97,7 @@ inline void StridedNumelCopyWithAxis(const Context& ctx,
 
   PADDLE_ENFORCE_EQ(src_stride_numel.size(),
                     dst_stride_numel.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Source and destination tensor should have the same "
                         "dimension size, but source tensor dimension size is "
                         "%u, destination tensor size is %u.",
@@ -109,7 +109,7 @@ inline void StridedNumelCopyWithAxis(const Context& ctx,
       PADDLE_ENFORCE_EQ(
           src_stride_numel[i] / src_stride_numel[axis],
           dst_stride_numel[i] / dst_stride_numel[axis],
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Source and destination tensor should have the same number of "
               "elements except the specified axis, but the source elements "
               "number is %d, destination elements number is %d.",
@@ -121,7 +121,7 @@ inline void StridedNumelCopyWithAxis(const Context& ctx,
       PADDLE_ENFORCE_EQ(
           src_stride_numel[i],
           dst_stride_numel[i],
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Source and destination tensor should have the same number of "
               "elements except the specified axis, but the source elements "
               "number is %d, destination elements number is %d.",

--- a/paddle/phi/kernels/funcs/strided_utils.h
+++ b/paddle/phi/kernels/funcs/strided_utils.h
@@ -70,7 +70,7 @@ inline void StridedTensorCopy(const phi::DenseTensor& input,
                     out);
 #endif
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Place type is not supported when `strided_copy` kernel is called."));
   }
 }
@@ -108,7 +108,7 @@ inline void StridedTensorFill(const phi::DenseTensor& x,
         "fill", fill_key, fill_signature, false, *dev_ctx, x, value, out);
 #endif
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Place type is not supported when `fill` kernel is called."));
   }
 }
@@ -148,7 +148,7 @@ inline void StridedTensorContiguous(const phi::DenseTensor& input,
                     out);
 #endif
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Place type is not supported when `contiguous` kernel is called."));
   }
 }

--- a/paddle/phi/kernels/funcs/transpose_function.cu.h
+++ b/paddle/phi/kernels/funcs/transpose_function.cu.h
@@ -227,13 +227,13 @@ bool SelectProperTileSize(std::vector<std::pair<int, int>>* tiles) {
   PADDLE_ENFORCE_LE(
       TSIZE,
       16,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The tile size should smaller than 16, but received is:%d.", TSIZE));
 
   PADDLE_ENFORCE_EQ(
       (TSIZE & (TSIZE - 1)),
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Data types should be powers of 2, but reived size is:%d.", TSIZE));
 
   const int kMaxLongSideLen = 1024;
@@ -313,7 +313,7 @@ struct NarrowDims2TransposeDispatch {
     PADDLE_ENFORCE_EQ(
         (tile_long & (tile_long - 1)),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The length of the longer side of the tile should be power of 2."
             " But received value is:%d.",
             tile_long));
@@ -378,7 +378,7 @@ struct NarrowDims2TransposeDispatch<
     PADDLE_ENFORCE_EQ(
         (tile_long & (tile_long - 1)),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The length of the longer side of the tile should be power of 2."
             " But received value is:%d.",
             tile_long));
@@ -428,7 +428,7 @@ struct NarrowDims2TransposeDispatch<
     PADDLE_ENFORCE_EQ(
         (tile_long & (tile_long - 1)),
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The length of the longer side of the tile should be power of 2,"
             " but received is:%d.",
             tile_long));
@@ -456,7 +456,7 @@ void SwapDim1And2InNarrow(const phi::GPUContext& d,
   PADDLE_ENFORCE_EQ(
       ret,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "SelectProperTileSize should return true, but return value is:%d.",
           ret));
 
@@ -656,7 +656,7 @@ inline void CombineTransposeDim3(const DDim& shape,
                                  std::vector<int>* new_dims) {
   PADDLE_ENFORCE_EQ(shape.size(),
                     perm.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         " shape should have the save dim with perm, but"
                         " received shape size is:%d, perm size is:%d.",
                         shape.size(),

--- a/paddle/phi/kernels/funcs/uniform_random_functor.h
+++ b/paddle/phi/kernels/funcs/uniform_random_functor.h
@@ -99,7 +99,7 @@ inline std::vector<int64_t> GetNewDataFromShapeTensor(
     }
     return vec_new_data;
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Expected dtype of ShapeTensor must be int32, int64. But got "
         "unsupport dtype: %s.",
         new_data_tensor->dtype()));
@@ -117,7 +117,7 @@ inline std::vector<int64_t> GetNewDataFromShapeTensorList(
     PADDLE_ENFORCE_EQ(
         tensor->dims(),
         common::make_ddim({1}),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Shape of dim tensor in uniform_random_op should be [1]"
             "But received tensor's dim=%s.",
             tensor->dims()));
@@ -138,7 +138,7 @@ inline std::vector<int64_t> GetNewDataFromShapeTensorList(
         vec_new_shape.push_back(*tensor->data<int64_t>());
       }
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Expected dtype of ShapeTensorList of %d-th must be int32, int64. "
           "But got "
           "unsupport dtype: %s.",

--- a/paddle/phi/kernels/funcs/unique_functor.h
+++ b/paddle/phi/kernels/funcs/unique_functor.h
@@ -52,7 +52,7 @@ struct UniqueOpFunctor {
     PADDLE_ENFORCE_LT(
         in_->numel(),
         pow(2, 31),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The num of Input(X) elements should be less then INT_MAX, "
             "but received num is %d.",
             in_->numel()));
@@ -81,7 +81,7 @@ struct UniqueOpFunctor {
           index_type == DataType::INT32 || index_type == DataType::INT64;
       PADDLE_ENFORCE_EQ(index_type_match,
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Index holds the wrong type, it holds %s, "
                             "but desires to be %s or %s",
                             DataTypeToString(index_type),

--- a/paddle/phi/kernels/funcs/unsqueeze.h
+++ b/paddle/phi/kernels/funcs/unsqueeze.h
@@ -40,14 +40,14 @@ inline DDim GetOutputSqueezeShape(const std::vector<int> squeeze_dims,
         PADDLE_ENFORCE_GE(
             squeeze_dims[i],
             -1,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "For 0D Tensor, Each axis in Attr(axes) should be in the range "
                 "of [-1, 0]"
                 "But current axis is:%d, input tensor's shape = [%s]."));
         PADDLE_ENFORCE_LE(
             squeeze_dims[i],
             0,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "For 0D Tensor, Each axis in Attr(axes) should be in the range "
                 "of [-1, 0]"
                 "But current axis is:%d, input tensor's shape = [%s]."));
@@ -60,7 +60,7 @@ inline DDim GetOutputSqueezeShape(const std::vector<int> squeeze_dims,
       PADDLE_ENFORCE_GE(
           current,
           0,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Each axis in Attr(axes) should be in the range of [%d, %d]"
               "But current axis is:%d, input tensor's shape = [%s].",
               -in_dims.size(),
@@ -70,7 +70,7 @@ inline DDim GetOutputSqueezeShape(const std::vector<int> squeeze_dims,
       PADDLE_ENFORCE_LT(
           current,
           in_dims.size(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Each axis in Attr(axes) should be in the range of [%d, %d]"
               "But current axis is:%d, input tensor's shape = [%s].",
               -in_dims.size(),
@@ -113,9 +113,9 @@ inline DDim GetUnsqueezeShape(const std::vector<int64_t> unsqz_dims,
   PADDLE_ENFORCE_LE(
       output_rank,
       UNSQUEEZE_MAX_RANK_SUPPORTED,
-      phi::errors::InvalidArgument("The output "
-                                   "tensor's rank should be less than %d.",
-                                   UNSQUEEZE_MAX_RANK_SUPPORTED));
+      common::errors::InvalidArgument("The output "
+                                      "tensor's rank should be less than %d.",
+                                      UNSQUEEZE_MAX_RANK_SUPPORTED));
 
   for (int axis : unsqz_dims) {
     int cur = axis < 0 ? axis + cur_output_rank + 1 : axis;
@@ -123,11 +123,11 @@ inline DDim GetUnsqueezeShape(const std::vector<int64_t> unsqz_dims,
     PADDLE_ENFORCE_GE(
         cur,
         0,
-        phi::errors::InvalidArgument("The insert dimension value should "
-                                     "not be less than 0"));
+        common::errors::InvalidArgument("The insert dimension value should "
+                                        "not be less than 0"));
     PADDLE_ENFORCE_LE(cur,
                       cur_output_rank,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The insert dimension value shoule not be larger "
                           "than the dimension size of input tensor"));
     // Move old axis, and insert new axis

--- a/paddle/phi/kernels/funcs/values_vectors_functor.h
+++ b/paddle/phi/kernels/funcs/values_vectors_functor.h
@@ -40,7 +40,7 @@ static void CheckEighResult(const int batch, const int info) {
   PADDLE_ENFORCE_LE(
       info,
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "For batch [%d]: the [%d] off-diagonal elements of an intermediate"
           "tridiagonal form did not converge to zero",
           batch,
@@ -48,7 +48,7 @@ static void CheckEighResult(const int batch, const int info) {
   PADDLE_ENFORCE_GE(
       info,
       0,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "For batch [%d]: the [%d] argument had an illegal value",
           batch,
           info));
@@ -70,7 +70,7 @@ static bool use_cusolver_syevj_batched = false;
 template <class scalar_t, class value_t = scalar_t>
 void syevjBatched_bufferSize(
     CUDASOLVER_SYEVJ_BATCHED_BUFFERSIZE_ARGTYPES(scalar_t, value_t)) {
-  PADDLE_THROW(phi::errors::InvalidArgument(
+  PADDLE_THROW(common::errors::InvalidArgument(
       "syevjBatched_bufferSize: not implemented for %s",
       typeid(scalar_t).name()));
 }
@@ -130,7 +130,7 @@ inline void syevjBatched_bufferSize<phi::dtype::complex<double>, double>(
 
 template <class scalar_t, class value_t = scalar_t>
 void syevjBatched(CUDASOLVER_SYEVJ_BATCHED_ARGTYPES(scalar_t, value_t)) {
-  PADDLE_THROW(phi::errors::InvalidArgument(
+  PADDLE_THROW(common::errors::InvalidArgument(
       "syevjBatched: not implemented for %s", typeid(scalar_t).name()));
 }
 
@@ -313,7 +313,7 @@ struct MatrixEighFunctor<CPUContext, T> {
     }
     if (has_vectors) {
       PADDLE_ENFORCE_NOT_NULL(eigen_vectors,
-                              phi::errors::InvalidArgument(
+                              common::errors::InvalidArgument(
                                   "When has_vectors is true,"
                                   "the eigenvectors needs to be calculated, "
                                   "so the eigenvectors must be provided."));
@@ -463,7 +463,7 @@ struct MatrixEighFunctor<GPUContext, T> {
     }
     if (has_vectors) {
       PADDLE_ENFORCE_NOT_NULL(eigen_vectors,
-                              phi::errors::InvalidArgument(
+                              common::errors::InvalidArgument(
                                   "When has_vectors is true,"
                                   "the eigenvectors needs to be calculated,"
                                   "so the eigenvectors must be provided."));

--- a/paddle/phi/kernels/funcs/vol2col.cc
+++ b/paddle/phi/kernels/funcs/vol2col.cc
@@ -37,13 +37,13 @@ class Vol2ColFunctor<phi::CPUContext, T> {
                   const DataLayout data_layout) const {
     PADDLE_ENFORCE_EQ(vol.dims().size(),
                       4,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of vol should be 4, but received %d.",
                           vol.dims().size()));
 
     PADDLE_ENFORCE_EQ(col->dims().size(),
                       7,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of col should be 7, but received %d.",
                           col->dims().size()));
 
@@ -80,7 +80,7 @@ class Vol2ColFunctor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         input_depth_tmp,
         output_depth,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_depth(%d) and output_depth(%d) are mismatching.",
             input_depth_tmp,
             output_depth));
@@ -91,7 +91,7 @@ class Vol2ColFunctor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         input_height_tmp,
         output_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_height(%d) and output_height(%d) are mismatching.",
             input_height_tmp,
             output_height));
@@ -102,7 +102,7 @@ class Vol2ColFunctor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         input_width_tmp,
         output_width,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_width(%d) and output_width(%d) are mismatching.",
             input_width_tmp,
             output_width));
@@ -163,13 +163,13 @@ class Col2VolFunctor<phi::CPUContext, T> {
                   const DataLayout data_layout) const {
     PADDLE_ENFORCE_EQ(vol->dims().size(),
                       4,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of vol should be 4, but received %d.",
                           vol->dims().size()));
 
     PADDLE_ENFORCE_EQ(col.dims().size(),
                       7,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The dimension of col  should be 7, but received %d.",
                           col.dims().size()));
 
@@ -205,7 +205,7 @@ class Col2VolFunctor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         input_depth_tmp,
         output_depth,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_depth(%d) and output_depth(%d) are mismatching.",
             input_depth_tmp,
             output_depth));
@@ -216,7 +216,7 @@ class Col2VolFunctor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         input_height_tmp,
         output_height,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_height(%d) and output_height(%d) are mismatching.",
             input_height_tmp,
             output_height));
@@ -227,7 +227,7 @@ class Col2VolFunctor<phi::CPUContext, T> {
     PADDLE_ENFORCE_EQ(
         input_width_tmp,
         output_width,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "input_width(%d) and output_width(%d) are mismatching.",
             input_width_tmp,
             output_width));

--- a/paddle/phi/kernels/funcs/vol2col.cu
+++ b/paddle/phi/kernels/funcs/vol2col.cu
@@ -111,12 +111,12 @@ void Vol2ColFunctor<DeviceContext, T>::operator()(
     const DataLayout data_layout) const {
   PADDLE_ENFORCE_EQ(vol.dims().size(),
                     4,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dimension of vol should be 4, but received %d.",
                         vol.dims().size()));
   PADDLE_ENFORCE_EQ(col->dims().size(),
                     7,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dimension of col should be 7, but received %d.",
                         col->dims().size()));
 
@@ -148,7 +148,7 @@ void Vol2ColFunctor<DeviceContext, T>::operator()(
                          1;
   PADDLE_ENFORCE_EQ(input_depth_tmp,
                     output_depth,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "input_depth(%d) and output_depth(%d) are mismatching.",
                         input_depth_tmp,
                         output_depth));
@@ -159,7 +159,7 @@ void Vol2ColFunctor<DeviceContext, T>::operator()(
   PADDLE_ENFORCE_EQ(
       input_height_tmp,
       output_height,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "input_height(%d) and output_height(%d) are mismatching.",
           input_height_tmp,
           output_height));
@@ -169,7 +169,7 @@ void Vol2ColFunctor<DeviceContext, T>::operator()(
                          1;
   PADDLE_ENFORCE_EQ(input_width_tmp,
                     output_width,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "input_width(%d) and output_width(%d) are mismatching.",
                         input_width_tmp,
                         output_width));
@@ -317,12 +317,12 @@ void Col2VolFunctor<DeviceContext, T>::operator()(
     const DataLayout data_layout) const {
   PADDLE_ENFORCE_EQ(vol->dims().size(),
                     4,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dimension of vol should be 4, but received %d.",
                         vol->dims().size()));
   PADDLE_ENFORCE_EQ(col.dims().size(),
                     7,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dimension of col should be 7, but received %d.",
                         col.dims().size()));
 
@@ -355,7 +355,7 @@ void Col2VolFunctor<DeviceContext, T>::operator()(
                          1;
   PADDLE_ENFORCE_EQ(input_depth_tmp,
                     output_depth,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "input_depth(%d) and output_depth(%d) are mismatching.",
                         input_depth_tmp,
                         output_depth));
@@ -366,7 +366,7 @@ void Col2VolFunctor<DeviceContext, T>::operator()(
   PADDLE_ENFORCE_EQ(
       input_height_tmp,
       output_height,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "input_height(%d) and output_height(%d) are mismatching.",
           input_height_tmp,
           output_height));
@@ -376,7 +376,7 @@ void Col2VolFunctor<DeviceContext, T>::operator()(
                          1;
   PADDLE_ENFORCE_EQ(input_width_tmp,
                     output_width,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "input_width(%d) and output_width(%d) are mismatching.",
                         input_width_tmp,
                         output_width));

--- a/paddle/phi/kernels/funcs/weight_only_gemv.cu
+++ b/paddle/phi/kernels/funcs/weight_only_gemv.cu
@@ -1244,7 +1244,7 @@ void weight_only_batched_gemv_launcher(
       }
     }
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "WeightOnlyGemvKernel quant_type only support 'int4' or 'int8'."));
   }
 #endif
@@ -1270,7 +1270,7 @@ void WeightOnlyGemvWrapper(const Context& dev_ctx,
   if (weight_only_type == "per_channel") {
     PADDLE_ENFORCE_EQ(group_size,
                       -1,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "group size must be -1 in per-channel mode."));
 
     weight_only_batched_gemv_launcher<DataType, WeightOnlyPerChannel>(
@@ -1313,13 +1313,13 @@ void WeightOnlyGemvWrapper(const Context& dev_ctx,
           reinterpret_cast<DataType*>(output),
           dev_ctx.stream());
     } else {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "WeightOnlyGemvKernel group_size only support 64 or 128."));
     }
   } else {
-    PADDLE_THROW(
-        phi::errors::InvalidArgument("WeightOnlyGemvKernel type only support "
-                                     "'per_channel' or 'group_wise'."));
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "WeightOnlyGemvKernel type only support "
+        "'per_channel' or 'group_wise'."));
   }
 }
 
@@ -1337,7 +1337,7 @@ void WeightOnlyGemvWrapper(const phi::GPUContext& dev_ctx,
                            const std::string& weight_only_type,
                            const std::string& act_method,
                            float* output) {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "WeightOnlyGemvKernel type only support 'float16' and 'bfloa16."
       "Not support float32."));
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/66145#issuecomment-2249572051

Replace phi::errors to common::errors in paddle/phi