### PR TITLE
Replace phi::errors [fluid_ops] part16

### DIFF
--- a/paddle/fluid/distributed/auto_parallel/dist_attr.cc
+++ b/paddle/fluid/distributed/auto_parallel/dist_attr.cc
@@ -430,7 +430,7 @@ std::string OperatorDistAttr::serialize_to_string() {
   proto.SerializeToString(&data);
   PADDLE_ENFORCE_EQ(to_proto().SerializeToString(&data),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Failed to serialize op dist attr to string."));
   return data;
 }
@@ -439,7 +439,7 @@ void OperatorDistAttr::parse_from_string(const std::string& data) {
   OperatorDistAttrProto proto;
   PADDLE_ENFORCE_EQ(proto.ParseFromString(data),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Failed to parse op dist attr from string."));
   from_proto(proto);
 }

--- a/paddle/fluid/distributed/collective/async_load.cc
+++ b/paddle/fluid/distributed/collective/async_load.cc
@@ -56,7 +56,7 @@ std::shared_ptr<AsyncLoad::Task> AsyncLoad::Offload(
   PADDLE_ENFORCE_EQ(
       phi::is_gpu_place(place),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "AsyncLoad::Offload only support GPU -> GPUPinned now."));
 
   dst->Resize(src.dims());
@@ -96,12 +96,12 @@ std::shared_ptr<AsyncLoad::Task> AsyncLoad::Reload(
   PADDLE_ENFORCE_EQ(
       phi::is_cuda_pinned_place(place),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "AsyncLoad::Reload only support GPUPinned -> GPU now."));
 
   PADDLE_ENFORCE_EQ(is_initialized_,
                     true,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "You should call Offload before Reload."));
 
   auto* dev_ctx = static_cast<phi::GPUContext*>(

--- a/paddle/fluid/distributed/collective/bkcl_tools.cc
+++ b/paddle/fluid/distributed/collective/bkcl_tools.cc
@@ -26,7 +26,7 @@ BKCLOp ToBKCLRedType(ReduceOp reduction) {
   auto it = red_type.find(reduction);
   PADDLE_ENFORCE_EQ(it != red_type.end(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Invalid bkcl reduction. Must be BKCL_MIN | BKCL_MAX | "
                         "BKCL_ADD"));
   return it->second;
@@ -53,7 +53,7 @@ std::string BKCLDTypeToString(BKCLDataType dtype) {
   PD_BKCL_DTYPE_TO_STR(BKCL_INT64, "int64");
 
 #undef PD_BKCL_DTYPE_TO_STR
-  PADDLE_THROW(phi::errors::InvalidArgument(
+  PADDLE_THROW(common::errors::InvalidArgument(
       "This datatype %d in bkcl is not supported.", static_cast<int>(dtype)));
 }
 

--- a/paddle/fluid/distributed/collective/bkcl_tools.h
+++ b/paddle/fluid/distributed/collective/bkcl_tools.h
@@ -69,13 +69,13 @@ class XPUEventManager {
     if (!is_created_) {
       CreateEvent(device_index);
     }
-    PADDLE_ENFORCE_EQ(
-        device_index,
-        device_index_,
-        phi::errors::PreconditionNotMet("XPUContext's device %d does not match"
-                                        "Event's device %d",
-                                        device_index,
-                                        device_index_));
+    PADDLE_ENFORCE_EQ(device_index,
+                      device_index_,
+                      common::errors::PreconditionNotMet(
+                          "XPUContext's device %d does not match"
+                          "Event's device %d",
+                          device_index,
+                          device_index_));
 
     phi::backends::xpu::XPUDeviceGuard guard(device_index_);
     // TODO(zhangxiaoci) temporary solution: xpu::event seems buggy

--- a/paddle/fluid/distributed/collective/custom_ccl_tools.cc
+++ b/paddle/fluid/distributed/collective/custom_ccl_tools.cc
@@ -28,8 +28,8 @@ phi::ccl::CCLReduceOp ToXCCLRedType(ReduceOp reduction) {
   PADDLE_ENFORCE_EQ(
       it != red_type.end(),
       true,
-      phi::errors::InvalidArgument("Invalid CustomCCL reduction. "
-                                   "Must be Min | Max | Prod | Sum"));
+      common::errors::InvalidArgument("Invalid CustomCCL reduction. "
+                                      "Must be Min | Max | Prod | Sum"));
   return it->second;
 }
 

--- a/paddle/fluid/distributed/collective/mpi_tools.cc
+++ b/paddle/fluid/distributed/collective/mpi_tools.cc
@@ -30,7 +30,7 @@ MPI_Op ToMPIType(ReduceOp reduction) {
   auto it = red_type.find(reduction);
   PADDLE_ENFORCE_EQ(it != red_type.end(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Invalid mpi reduction. Must be MPI_MIN | MPI_MAX | "
                         "MPI_PROD | MPI_SUM."));
   return it->second;
@@ -43,11 +43,11 @@ void CheckValidInputs(const std::vector<phi::DenseTensor>& tensors) {
   PADDLE_ENFORCE_EQ(
       tensors.size() == 1,
       true,
-      phi::errors::InvalidArgument("the inputs size of MPI must be 1!"));
+      common::errors::InvalidArgument("the inputs size of MPI must be 1!"));
 
   PADDLE_ENFORCE_EQ(CheckTensorsInCudaPlace(tensors) && !CheckMpiCudaAware(),
                     false,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Found CUDA Tensor. But CUDA-aware MPI not support!"));
 }
 

--- a/paddle/fluid/distributed/collective/mpi_tools.h
+++ b/paddle/fluid/distributed/collective/mpi_tools.h
@@ -39,7 +39,7 @@ namespace mpi {
       std::stringstream ss;                                        \
       ss << "Failed, MPI error in" << __FILE__ << ":" << __LINE__  \
          << "with error code: " << std::to_string(r) << std::endl; \
-      PADDLE_THROW(phi::errors::Fatal(ss.str()));                  \
+      PADDLE_THROW(common::errors::Fatal(ss.str()));               \
       exit(EXIT_FAILURE);                                          \
     }                                                              \
   } while (0)

--- a/paddle/fluid/distributed/collective/process_group.h
+++ b/paddle/fluid/distributed/collective/process_group.h
@@ -50,7 +50,8 @@ using phi::distributed::ProcessGroupMapFromGid;
 
 static void CheckTensorContiguous(const phi::DenseTensor& tensor) {
   if (!tensor.meta().is_contiguous()) {
-    PADDLE_THROW(phi::errors::InvalidArgument("The tensor must be contiguous"));
+    PADDLE_THROW(
+        common::errors::InvalidArgument("The tensor must be contiguous"));
   }
 }
 
@@ -58,7 +59,7 @@ static void CheckTensorContiguous(const std::vector<phi::DenseTensor>& inputs) {
   for (const auto& tensor : inputs) {
     if (!tensor.meta().is_contiguous()) {
       PADDLE_THROW(
-          phi::errors::InvalidArgument("The tensor must be contiguous"));
+          common::errors::InvalidArgument("The tensor must be contiguous"));
     }
   }
 }

--- a/paddle/fluid/distributed/collective/process_group_bkcl.cc
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.cc
@@ -267,7 +267,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Collective(
 
   if (!use_calc_stream) {
     PADDLE_ENFORCE_NOT_NULL(comm_ctx.get(),
-                            phi::errors::Fatal("comm context is nullptr."));
+                            common::errors::Fatal("comm context is nullptr."));
     if (!is_coalescing_) {
       task->comm_event_->Record(*comm_ctx.get());
     } else {
@@ -321,7 +321,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Point2Point(
 
   if (!use_calc_stream) {
     PADDLE_ENFORCE_NOT_NULL(comm_ctx.get(),
-                            phi::errors::Fatal("comm context is nullptr."));
+                            common::errors::Fatal("comm context is nullptr."));
     if (!is_coalescing_) {
       task->comm_event_->Record(*comm_ctx.get());
     } else {
@@ -506,7 +506,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Barrier(
     const BarrierOptions& opts) {
   PADDLE_ENFORCE_GE(opts.device_id,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The barrier device id must greater or equal than 0."));
   phi::XPUPlace place(opts.device_id);
   auto allocator = std::unique_ptr<phi::Allocator>(
@@ -545,7 +545,7 @@ phi::DeviceContext* ProcessGroupBKCL::GetDeviceContext(
     const auto& iter = place_to_comm_ctx_.find(key);
     PADDLE_ENFORCE_NE(iter,
                       place_to_comm_ctx_.end(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Cannot find device context in process group."));
     return iter->second.get();
   }
@@ -569,14 +569,14 @@ phi::distributed::BKCLCommContext* ProcessGroupBKCL::GetCommContext() {
       comm_context_manager.Get(std::to_string(this->gid_)));
   PADDLE_ENFORCE_NE(comm_context,
                     nullptr,
-                    phi::errors::Unavailable("BKCLCommContext is nullptr"));
+                    common::errors::Unavailable("BKCLCommContext is nullptr"));
   return comm_context;
 }
 
 void ProcessGroupBKCL::StartCoalescing() {
   PADDLE_ENFORCE_EQ(is_coalescing_,
                     false,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Coalescing is on, please call EndCoalesce."));
   is_coalescing_ = true;
   GroupStart();
@@ -598,7 +598,7 @@ void ProcessGroupBKCL::EndCoalescing(
   PADDLE_ENFORCE_EQ(
       tasks.size(),
       colaescing_place_keys_.size(),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Number of tasks[%d] do not match number of collectives[%d].",
           tasks.size(),
           colaescing_place_keys_.size()));

--- a/paddle/fluid/distributed/collective/process_group_custom.cc
+++ b/paddle/fluid/distributed/collective/process_group_custom.cc
@@ -143,7 +143,7 @@ phi::DeviceContext* ProcessGroupCustom::GetDeviceContext(
     PADDLE_ENFORCE_NE(
         iter,
         place_to_comm_ctx_.end(),
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Cannot find the device context in this process group."));
     return iter->second.get();
   }
@@ -155,7 +155,7 @@ phi::ccl::CCLComm ProcessGroupCustom::XCCLComm(const Place& place) const {
   PADDLE_ENFORCE_NE(
       iter,
       place_to_comm_ctx_.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Cannot find the XCCL communicator in this process group."));
   return iter->second->xccl_comm();
 }
@@ -163,13 +163,13 @@ phi::ccl::CCLComm ProcessGroupCustom::XCCLComm(const Place& place) const {
 std::string ProcessGroupCustom::GetCommName(int rank) {
   PADDLE_ENFORCE_GE(rank,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The rank must greater or equal than 0!"));
   auto num_devices = phi::DeviceManager::GetDeviceCount(device_type_);
   PADDLE_ENFORCE_GT(
       num_devices,
       0,
-      phi::errors::InvalidArgument("The num_devices must greater than 0!"));
+      common::errors::InvalidArgument("The num_devices must greater than 0!"));
 
   auto place_id = rank % num_devices;
   phi::CustomPlace place(device_type_, place_id);
@@ -303,7 +303,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Barrier(
     const BarrierOptions& opts) {
   PADDLE_ENFORCE_GE(opts.device_id,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The barrier device id must greater or equal than 0."));
   phi::CustomPlace place(device_type_, opts.device_id);
   auto allocator = std::unique_ptr<phi::Allocator>(
@@ -471,7 +471,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Gather(
   auto& gather_tensors = *gather_tensors_ptr;
   PADDLE_ENFORCE_GT(size_,
                     opts.root_rank,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "root world size [%d]  is less than root rank [%d]",
                         size_,
                         opts.root_rank));
@@ -685,7 +685,7 @@ void ProcessGroupCustom::CreateXCCLManagerCache(
     const std::string& places_key, const std::vector<Place>& places) {
   PADDLE_ENFORCE_EQ(places_key.empty(),
                     false,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Not able to create/get the XCCL Communicator since "
                         "the CustomPlace are not known"));
 
@@ -862,7 +862,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllReduce(
   PADDLE_ENFORCE_EQ(
       CheckTensorsInCustomPlace(in_tensors, device_type_),
       true,
-      phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
+      common::errors::InvalidArgument("All inputs should be in CustomPlace."));
   return Collective(
       in_tensors,
       out_tensors,
@@ -890,7 +890,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Broadcast(
   PADDLE_ENFORCE_EQ(
       CheckTensorsInCustomPlace(in_tensors, device_type_),
       true,
-      phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
+      common::errors::InvalidArgument("All inputs should be in CustomPlace."));
 
   return Collective(
       in_tensors,
@@ -912,25 +912,25 @@ inline void CheckTensorsInDifferentDevices(
   PADDLE_ENFORCE_EQ(
       tensors.empty(),
       false,
-      phi::errors::InvalidArgument("Tensor list must be nonempty."));
+      common::errors::InvalidArgument("Tensor list must be nonempty."));
   PADDLE_ENFORCE_LE(
       tensors.size(),
       num_devices,
-      phi::errors::InvalidArgument("Tensor list mustn't be larger than the "
-                                   "number of available CustomDevices."));
+      common::errors::InvalidArgument("Tensor list mustn't be larger than the "
+                                      "number of available CustomDevices."));
 
   std::set<Place> used_devices;
 
   for (const auto& t : tensors) {
     PADDLE_ENFORCE_EQ(phi::is_custom_place(t.place()),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Tensors must be CustomDevice and dense tensor."));
 
     const auto inserted = used_devices.insert(t.place()).second;
     PADDLE_ENFORCE_EQ(inserted,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Tensors must be on distinct CustomDevice devices."));
   }
 }
@@ -984,11 +984,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllGather(
   PADDLE_ENFORCE_EQ(
       CheckTensorsInCustomPlace(in_tensors, device_type_),
       true,
-      phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
+      common::errors::InvalidArgument("All inputs should be in CustomPlace."));
   PADDLE_ENFORCE_EQ(
       CheckTensorsInCustomPlace(out_tensors, device_type_),
       true,
-      phi::errors::InvalidArgument("All outputs should be in CustomPlace."));
+      common::errors::InvalidArgument("All outputs should be in CustomPlace."));
   return Collective(
       in_tensors,
       out_tensors,
@@ -1011,11 +1011,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllToAll(
   PADDLE_ENFORCE_EQ(
       CheckTensorsInCustomPlace(in_tensors, device_type_),
       true,
-      phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
+      common::errors::InvalidArgument("All inputs should be in CustomPlace."));
   PADDLE_ENFORCE_EQ(
       CheckTensorsInCustomPlace(out_tensors, device_type_),
       true,
-      phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
+      common::errors::InvalidArgument("All inputs should be in CustomPlace."));
   return Collective(
       in_tensors,
       out_tensors,
@@ -1064,7 +1064,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Reduce(
   PADDLE_ENFORCE_EQ(
       CheckTensorsInCustomPlace(in_tensors, device_type_),
       true,
-      phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
+      common::errors::InvalidArgument("All inputs should be in CustomPlace."));
   return Collective(
       in_tensors,
       out_tensors,
@@ -1092,11 +1092,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Scatter(
   PADDLE_ENFORCE_EQ(
       CheckTensorsInCustomPlace(in_tensors, device_type_),
       true,
-      phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
+      common::errors::InvalidArgument("All inputs should be in CustomPlace."));
   PADDLE_ENFORCE_EQ(
       CheckTensorsInCustomPlace(out_tensors, device_type_),
       true,
-      phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
+      common::errors::InvalidArgument("All inputs should be in CustomPlace."));
   return Collective(
       in_tensors,
       out_tensors,
@@ -1144,7 +1144,7 @@ phi::distributed::XCCLCommContext* ProcessGroupCustom::GetCommContext() {
       comm_context_manager.Get(std::to_string(this->gid_)));
   PADDLE_ENFORCE_NE(comm_context,
                     nullptr,
-                    phi::errors::Unavailable("XCCLCommContext is nullptr"));
+                    common::errors::Unavailable("XCCLCommContext is nullptr"));
   return comm_context;
 }
 

--- a/paddle/fluid/distributed/collective/process_group_gloo.cc
+++ b/paddle/fluid/distributed/collective/process_group_gloo.cc
@@ -636,7 +636,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupGloo::Gather(
   PADDLE_ENFORCE_NE(
       use_calc_stream,
       true,
-      phi::errors::InvalidArgument("Gloo cannot use use_calc_stream."));
+      common::errors::InvalidArgument("Gloo cannot use use_calc_stream."));
   std::shared_ptr<GatherGlooTask> task;
   auto tag = next_tag();
   auto comm_context = this->GetCommContext();
@@ -667,7 +667,7 @@ ProcessGroupGloo::createDefaultDevice() {
   PADDLE_ENFORCE_EQ(
       ret,
       0,
-      phi::errors::Fatal("Get hostname error for createDefaultDevice."));
+      common::errors::Fatal("Get hostname error for createDefaultDevice."));
   ::addrinfo* result;
   result = phi::distributed::tcputils::get_addr_info(
       hostname.data(), "", 0, AF_UNSPEC);
@@ -725,7 +725,7 @@ phi::distributed::GlooCommContext* ProcessGroupGloo::GetCommContext() {
       comm_context_manager.Get(std::to_string(this->gid_)));
   PADDLE_ENFORCE_NE(comm_context,
                     nullptr,
-                    phi::errors::Unavailable("GlooCommContext is nullptr"));
+                    common::errors::Unavailable("GlooCommContext is nullptr"));
   return comm_context;
 }
 

--- a/paddle/fluid/distributed/collective/process_group_gloo.h
+++ b/paddle/fluid/distributed/collective/process_group_gloo.h
@@ -222,7 +222,7 @@ class ProcessGroupGloo : public ProcessGroupWithoutStream {
     PADDLE_ENFORCE_NE(
         use_calc_stream,
         true,
-        phi::errors::InvalidArgument("Gloo cannot use use_calc_stream."));
+        common::errors::InvalidArgument("Gloo cannot use use_calc_stream."));
     return GetDeviceContext(place);
   }
 

--- a/paddle/fluid/distributed/collective/process_group_mpi.cc
+++ b/paddle/fluid/distributed/collective/process_group_mpi.cc
@@ -113,8 +113,8 @@ void ProcessGroupMPI::InitOneTimeMPI() {
     PADDLE_ENFORCE_EQ(
         mpi_thread_support < MPI_THREAD_SERIALIZED,
         false,
-        phi::errors::InvalidArgument("MPI supports the number of threads "
-                                     "less than MPI_THREAD_SERIALIZED. "));
+        common::errors::InvalidArgument("MPI supports the number of threads "
+                                        "less than MPI_THREAD_SERIALIZED. "));
 
     std::atexit(ProcessGroupMPI::ExitMPI);
   });
@@ -159,7 +159,7 @@ std::shared_ptr<ProcessGroupMPI> ProcessGroupMPI::CreateProcessGroupMPI(
       PADDLE_ENFORCE_EQ(
           rank < 0 || size < 0,
           false,
-          phi::errors::InvalidArgument("get world_size or rank failed!"));
+          common::errors::InvalidArgument("get world_size or rank failed!"));
     }
   }
 
@@ -180,7 +180,7 @@ ProcessGroupMPI::ProcessGroupMPI(int rank, int size, MPI_Comm pg_comm, int gid)
   PADDLE_ENFORCE_EQ(
       pg_comm == MPI_COMM_NULL,
       false,
-      phi::errors::InvalidArgument("Error! mpi comm is MPI_COMM_NULL!"));
+      common::errors::InvalidArgument("Error! mpi comm is MPI_COMM_NULL!"));
 
   worker_thread = std::thread(&ProcessGroupMPI::workLoop, this);
 }
@@ -356,7 +356,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::AllGather(
   PADDLE_ENFORCE_EQ(
       out_tensors.size() == 1,
       true,
-      phi::errors::InvalidArgument("MPI only support a single tensor op."));
+      common::errors::InvalidArgument("MPI only support a single tensor op."));
 
   std::function<void(std::unique_ptr<TaskEntry>&)> runFunc =
       [this](std::unique_ptr<TaskEntry>& entry) {
@@ -391,7 +391,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::AllToAll(
   PADDLE_ENFORCE_EQ(in_tensors[0].numel() == out_tensors[0].numel() &&
                         in_tensors[0].dtype() == out_tensors[0].dtype(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "MPI AlltoAll: input and output are not equal in "
                         "size or data type."));
 

--- a/paddle/fluid/distributed/collective/process_group_mpi.h
+++ b/paddle/fluid/distributed/collective/process_group_mpi.h
@@ -80,7 +80,7 @@ class ProcessGroupMPI : public ProcessGroupWithoutStream {
         PADDLE_ENFORCE_EQ(
             is_completed_,
             true,
-            phi::errors::InvalidArgument("MPI operation timeout! "));
+            common::errors::InvalidArgument("MPI operation timeout! "));
       }
       if (exception_) {
         std::rethrow_exception(exception_);

--- a/paddle/fluid/distributed/collective/process_group_nccl.cc
+++ b/paddle/fluid/distributed/collective/process_group_nccl.cc
@@ -181,7 +181,7 @@ phi::DeviceContext* ProcessGroupNCCL::GetDeviceContext(
     PADDLE_ENFORCE_NE(
         iter,
         place_to_comm_ctx_.end(),
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Cannot find the device context in this process group."));
     return iter->second.get();
   }
@@ -193,7 +193,7 @@ ncclComm_t ProcessGroupNCCL::NCCLComm(const Place& place) const {
   PADDLE_ENFORCE_NE(
       iter,
       place_to_comm_ctx_.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Cannot find the NCCL communicator in this process group."));
   return iter->second->nccl_comm();
 }
@@ -348,7 +348,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Barrier(
     const BarrierOptions& opts) {
   PADDLE_ENFORCE_GE(opts.device_id,
                     0,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "The barrier device id must greater or equal than 0."));
   phi::GPUPlace place(opts.device_id);
   auto allocator = std::unique_ptr<phi::Allocator>(
@@ -564,7 +564,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Gather(
   auto& gather_tensors = *gather_tensors_ptr;
   PADDLE_ENFORCE_GT(size_,
                     opts.root_rank,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "root world size [%d]  is less than root rank [%d]",
                         size_,
                         opts.root_rank));
@@ -1060,14 +1060,14 @@ phi::distributed::NCCLCommContext* ProcessGroupNCCL::GetCommContext(
       comm_context_manager.Get(store_key));
   PADDLE_ENFORCE_NE(comm_context,
                     nullptr,
-                    phi::errors::Unavailable("NCCLCommContext is nullptr"));
+                    common::errors::Unavailable("NCCLCommContext is nullptr"));
   return comm_context;
 }
 
 void ProcessGroupNCCL::StartCoalescing() {
   PADDLE_ENFORCE_EQ(is_coalescing_,
                     false,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Coalescing is on, please call EndCoalesce."));
   is_coalescing_ = true;
   GroupStart();
@@ -1089,7 +1089,7 @@ void ProcessGroupNCCL::EndCoalescing(
   PADDLE_ENFORCE_EQ(
       tasks.size(),
       colaescing_tensors_.size(),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Number of tasks[%d] do not match number of collectives[%d].",
           tasks.size(),
           colaescing_tensors_.size()));

--- a/paddle/fluid/distributed/collective/process_group_with_stream.h
+++ b/paddle/fluid/distributed/collective/process_group_with_stream.h
@@ -107,7 +107,7 @@ class ProcessGroupWithStream : public ProcessGroup {
       int64_t numel UNUSED,
       bool sync_op UNUSED,
       bool use_calc_stream UNUSED) override {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ProcessGroupWithStream (%s) does not support all_gather.",
         GetBackendName()));
   }
@@ -130,7 +130,7 @@ class ProcessGroupWithStream : public ProcessGroup {
       const AllreduceOptions& opts UNUSED,
       bool sync_op UNUSED,
       bool use_calc_stream UNUSED) override {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ProcessGroupWithStream (%s) does not support all_reduce.",
         GetBackendName()));
   }
@@ -156,7 +156,7 @@ class ProcessGroupWithStream : public ProcessGroup {
       const std::vector<int64_t>& in_size_each_rank UNUSED,
       bool sync_op UNUSED,
       bool use_calc_stream UNUSED) override {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ProcessGroupWithStream (%s) does not support all_to_all.",
         GetBackendName()));
   }
@@ -179,7 +179,7 @@ class ProcessGroupWithStream : public ProcessGroup {
       const BroadcastOptions& opts UNUSED,
       bool sync_op UNUSED,
       bool use_calc_stream UNUSED) override {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ProcessGroupWithStream (%s) does not support broadcast.",
         GetBackendName()));
   }
@@ -201,7 +201,7 @@ class ProcessGroupWithStream : public ProcessGroup {
       const ReduceOptions& opts UNUSED,
       bool sync_op UNUSED,
       bool use_calc_stream UNUSED) override {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ProcessGroupWithStream (%s) does not support reduce.",
         GetBackendName()));
   }
@@ -224,7 +224,7 @@ class ProcessGroupWithStream : public ProcessGroup {
       const ReduceScatterOptions& opts UNUSED,
       bool sync_op UNUSED,
       bool use_calc_stream UNUSED) override {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ProcessGroupWithStream (%s) does not support reduce_scatter.",
         GetBackendName()));
   }
@@ -246,7 +246,7 @@ class ProcessGroupWithStream : public ProcessGroup {
       const ScatterOptions& opts UNUSED,
       bool sync_op UNUSED,
       bool use_calc_stream UNUSED) override {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ProcessGroupWithStream (%s) does not support scatter.",
         GetBackendName()));
   }
@@ -293,7 +293,7 @@ class ProcessGroupWithStream : public ProcessGroup {
                                            bool sync_op UNUSED,
                                            bool use_calc_stream
                                                UNUSED) override {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ProcessGroupWithStream (%s) does not support recv.",
         GetBackendName()));
   }
@@ -340,7 +340,7 @@ class ProcessGroupWithStream : public ProcessGroup {
       int64_t numel UNUSED,
       bool sync_op UNUSED,
       bool use_calc_stream UNUSED) override {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ProcessGroupWithStream (%s) does not support send.",
         GetBackendName()));
   }

--- a/paddle/fluid/distributed/collective/process_group_without_stream.h
+++ b/paddle/fluid/distributed/collective/process_group_without_stream.h
@@ -45,7 +45,7 @@ class ProcessGroupWithoutStream : public ProcessGroup {
       int64_t offset,
       int64_t numel,
       bool sync_op) override {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ProcessGroupWithoutStream (%s) does not support all_gather.",
         GetBackendName()));
   }
@@ -65,7 +65,7 @@ class ProcessGroupWithoutStream : public ProcessGroup {
                                            int64_t offset,
                                            int64_t numel,
                                            bool sync_op) override {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ProcessGroupWithoutStream (%s) does not support recv.",
         GetBackendName()));
   }
@@ -85,7 +85,7 @@ class ProcessGroupWithoutStream : public ProcessGroup {
                                            int64_t offset,
                                            int64_t numel,
                                            bool sync_op) override {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ProcessGroupWithoutStream (%s) does not support send.",
         GetBackendName()));
   }

--- a/paddle/fluid/distributed/collective/reducer.cc
+++ b/paddle/fluid/distributed/collective/reducer.cc
@@ -39,7 +39,7 @@ static Backend TransToBackend(phi::Place place) {
   auto it = type_backend.find(type);
   PADDLE_ENFORCE_EQ(it != type_backend.end(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Place type (%s) is not supported. ", place));
   return it->second;
 }
@@ -52,7 +52,7 @@ std::vector<std::vector<size_t>> Eager_AssignGroupBySize(
   PADDLE_ENFORCE_EQ(
       tensors.size(),
       is_sparse_gradient.size(),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "tensors len must be equal to is_sparse_gradient len, but "
           "[%lu] != [%lu]",
           tensors.size(),
@@ -71,7 +71,7 @@ std::vector<std::vector<size_t>> Eager_AssignGroupBySize(
 
   PADDLE_ENFORCE_EQ(true,
                     check_perm(tensor_indices),
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "tensor_indices must be a permutation from 0 to %lu",
                         tensor_indices.size()));
   // the return vector
@@ -144,7 +144,7 @@ std::vector<std::vector<size_t>> Eager_AssignGroupBySize(
     PADDLE_ENFORCE_NE(
         group_index.empty(),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "AssignGroupBySize construct empty group, please check."));
   }
   if (tensor_indices.empty()) {
@@ -278,7 +278,7 @@ static void ConcatTensorsWithType(
           context, dense_tensors_, p_dense_contents);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported when it concats tensors for "
           "allreduce.",
           type));
@@ -309,7 +309,7 @@ static void SplitTensorsWithType(const DeviceContext &context,
           context, p_dense_contents, p_dense_tensors);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported when it splits tensors for "
           "allreduce.",
           type));
@@ -338,7 +338,7 @@ void ConcatTensorsWithType<phi::XPUContext>(
           context, dense_tensors_, p_dense_contents);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported when it concats tensors for "
           "allreduce.",
           type));
@@ -366,7 +366,7 @@ void SplitTensorsWithType<phi::XPUContext>(
           context, p_dense_contents, p_dense_tensors);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported when it splits tensors for "
           "allreduce.",
           type));
@@ -385,7 +385,7 @@ void EagerGroup::ConcatTensors(const phi::Place &place) {
     ConcatTensorsWithType(
         *default_ctx, dense_tensors_, &dense_contents_, dtype_);
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't concat grad tensors since it's not compiled with NCCL,"
         "Please recompile or reinstall Paddle with NCCL support."));
 #endif
@@ -396,7 +396,7 @@ void EagerGroup::ConcatTensors(const phi::Place &place) {
     ConcatTensorsWithType(
         *default_ctx, dense_tensors_, &dense_contents_, dtype_);
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't concat grad tensors since it's not compiled with "
         "CUSTOM_DEVICE,"
         "Please recompile or reinstall Paddle with CUSTOM_DEVICE support."));
@@ -408,7 +408,7 @@ void EagerGroup::ConcatTensors(const phi::Place &place) {
     ConcatTensorsWithType(
         *default_ctx, dense_tensors_, &dense_contents_, dtype_);
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't concat grad tensors since it's not compiled with BKCL,"
         "Please recompile or reinstall Paddle with BKCL support."));
 #endif
@@ -418,7 +418,7 @@ void EagerGroup::ConcatTensors(const phi::Place &place) {
     ConcatTensorsWithType(
         *default_ctx, dense_tensors_, &dense_contents_, dtype_);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Concat grad tensor not supported on place (%s)", place));
   }
 }
@@ -438,7 +438,7 @@ void EagerGroup::SplitTensors(const phi::DeviceContext &context) {
       dense_contents_.reset();
     }
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't split grad tensor since it's not compiled with NCCL,"
         "Please recompile or reinstall Paddle with NCCL support."));
 #endif
@@ -449,7 +449,7 @@ void EagerGroup::SplitTensors(const phi::DeviceContext &context) {
                          &dense_tensors_,
                          dtype_);
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't split grad tensor since it's not compiled with "
         "CUSTOM_DEVICE,"
         "Please recompile or reinstall Paddle with CUSTOM_DEVICE support."));
@@ -461,7 +461,7 @@ void EagerGroup::SplitTensors(const phi::DeviceContext &context) {
     SplitTensorsWithType(
         *default_ctx, &dense_contents_, &dense_tensors_, dtype_);
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't split grad tensor since it's not compiled with BKCL,"
         "Please recompile or reinstall Paddle with BKCL support."));
 #endif
@@ -471,7 +471,7 @@ void EagerGroup::SplitTensors(const phi::DeviceContext &context) {
                          &dense_tensors_,
                          dtype_);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Split grad tensor not supported on place (%s)", place));
   }
 }
@@ -509,10 +509,11 @@ EagerReducer::EagerReducer(
 
     const auto &grad_node = GetGradNodeFromTensor(&tensor);
 
-    PADDLE_ENFORCE(grad_node.get() != nullptr,
-                   phi::errors::Fatal("Detected NULL grad_node,"
-                                      "Leaf tensor should have had grad_node "
-                                      "with type: GradNodeAccumulation"));
+    PADDLE_ENFORCE(
+        grad_node.get() != nullptr,
+        common::errors::Fatal("Detected NULL grad_node,"
+                              "Leaf tensor should have had grad_node "
+                              "with type: GradNodeAccumulation"));
     const auto &accumulation_grad_node =
         std::dynamic_pointer_cast<egr::GradNodeAccumulation>(grad_node);
     accumulation_grad_node->RegisterReduceHook(
@@ -557,7 +558,7 @@ void EagerReducer::InitializeGroups(
     PADDLE_ENFORCE_GT(
         tensor_indices_.size(),
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The number of group[%d]'s elements is 0.", group_index));
 
     EagerGroup group;
@@ -600,20 +601,20 @@ void EagerReducer::InitializeDenseGroups(
 
     PADDLE_ENFORCE_EQ(is_sparse_gradient_[tensor_index],
                       false,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Tensor %s's GRAD must be Tensor, but received "
                           "GRAD is SelectedRows",
                           tensor_name));
 
     PADDLE_ENFORCE_EQ(tensor.initialized(),
                       true,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Tensor %s is not initialized.", tensor_name));
     const auto size = tensor.numel();
     PADDLE_ENFORCE_GT(
         size,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The number of tensor %s's elements is 0.", tensor_name));
     all_length += size;
 
@@ -628,7 +629,7 @@ void EagerReducer::InitializeDenseGroups(
     if (index > 0) {
       PADDLE_ENFORCE_EQ(dtype,
                         p_group->dtype_,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "Tensor %s has unexpected dtype.", tensor_name));
     } else {
       p_group->dtype_ = dtype;
@@ -704,7 +705,7 @@ void EagerReducer::PrepareForBackward(const std::vector<Tensor> &outputs) {
   PADDLE_ENFORCE_EQ(
       groups_need_finalize_,
       false,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "A serious error has occurred here. Please "
           "set find_unused_parameters=True to traverse backward graph "
           "in each step to prepare reduce in advance. If you have "
@@ -752,10 +753,10 @@ void EagerReducer::AddDistHook(size_t var_index) {
   PADDLE_ENFORCE_LT(
       var_index,
       variable_locators_.size(),
-      phi::errors::OutOfRange("Out of bounds variable index. it must be less"
-                              "than %d, but it is %d",
-                              variable_locators_.size(),
-                              var_index));
+      common::errors::OutOfRange("Out of bounds variable index. it must be less"
+                                 "than %d, but it is %d",
+                                 variable_locators_.size(),
+                                 var_index));
 
   // gradient synchronization is not required when grad_need_hooks_ is false.
   if (!grad_need_hooks_) {
@@ -810,7 +811,7 @@ void EagerReducer::MarkVarReady(const size_t var_index,
 
     PADDLE_ENFORCE_EQ(has_marked_unused_vars_,
                       false,
-                      phi::errors::PreconditionNotMet(error_info));
+                      common::errors::PreconditionNotMet(error_info));
 
     error_info +=
         "3) Unused parameters retrieval is incorrect. "
@@ -826,7 +827,7 @@ void EagerReducer::MarkVarReady(const size_t var_index,
 
     PADDLE_ENFORCE_EQ(has_marked_unused_vars_,
                       true,
-                      phi::errors::PreconditionNotMet(error_info));
+                      common::errors::PreconditionNotMet(error_info));
   } else {
     vars_marked_ready_[var_index] = true;
   }
@@ -909,7 +910,7 @@ void EagerReducer::MarkVarReady(const size_t var_index,
     PADDLE_ENFORCE_EQ(
         HasGrad(var_index),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The sparse parameter[%d][%s] should have gradient. "
             "Currently, DataParallel does not support sparse "
             "parameters without generating gradients during training. "
@@ -923,7 +924,7 @@ void EagerReducer::MarkVarReady(const size_t var_index,
     PADDLE_ENFORCE_EQ(
         grad_tensor.is_selected_rows(),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The sparse parameter[%d][%s] must have a selected rows gradient. "
             "Before forward pass, the parameter type is inferred to be "
             "SelectedRows, but after backward pass, its actual type becomes "
@@ -954,7 +955,7 @@ void EagerReducer::MarkGroupReady(size_t group_index) {
   PADDLE_ENFORCE_GE(
       group_index,
       next_group_,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The index of the incoming group must be greater "
           "than or equal to the previously synchronized group index, "
           "expect it to greater than or equal to %d, but got %d.",
@@ -1134,7 +1135,7 @@ void EagerReducer::AllReduceSparse(EagerGroup *group,
     dev_ctx = static_cast<phi::GPUContext *>(
         phi::DeviceContextPool::Instance().Get(inner_place_));
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't concat grad tensors since it's not compiled with NCCL,"
         "Please recompile or reinstall Paddle with NCCL support."));
 #endif
@@ -1143,7 +1144,7 @@ void EagerReducer::AllReduceSparse(EagerGroup *group,
     dev_ctx = static_cast<phi::XPUContext *>(
         phi::DeviceContextPool::Instance().Get(inner_place_));
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't concat grad tensors since it's not compiled with XCCL,"
         "Please recompile or reinstall Paddle with XCCL support."));
 #endif
@@ -1152,7 +1153,7 @@ void EagerReducer::AllReduceSparse(EagerGroup *group,
     dev_ctx = static_cast<phi::CustomContext *>(
         phi::DeviceContextPool::Instance().Get(inner_place_));
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't concat grad tensors since it's not compiled with "
         "CUSTOM_DEVICE,"
         "Please recompile or reinstall Paddle with CUSTOM_DEVICE support."));
@@ -1161,7 +1162,7 @@ void EagerReducer::AllReduceSparse(EagerGroup *group,
     dev_ctx = static_cast<phi::CPUContext *>(
         phi::DeviceContextPool::Instance().Get(inner_place_));
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Split grad tensor not supported on place (%s)", inner_place_));
   }
 

--- a/paddle/fluid/distributed/common/chunk_allocator.h
+++ b/paddle/fluid/distributed/common/chunk_allocator.h
@@ -92,7 +92,7 @@ class ChunkAllocator {
                                alloc_size);
     PADDLE_ENFORCE_EQ(error,
                       0,
-                      phi::errors::ResourceExhausted(
+                      common::errors::ResourceExhausted(
                           "Fail to alloc memory of %ld size, error code is %d.",
                           alloc_size,
                           error));

--- a/paddle/fluid/distributed/fleet_executor/cond_interceptor.cc
+++ b/paddle/fluid/distributed/fleet_executor/cond_interceptor.cc
@@ -62,7 +62,7 @@ void CondInterceptor::PrepareDeps() {
 bool CondInterceptor::GetCondResult() {
   PADDLE_ENFORCE_LT(cur_scope_id_,
                     microbatch_scopes_.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Step out of range. There are %ld "
                         "microbatch_scopes, but receive scope index %ld",
                         microbatch_scopes_.size(),
@@ -71,9 +71,9 @@ bool CondInterceptor::GetCondResult() {
       microbatch_scopes_[cur_scope_id_]->FindVar(node_->cond_var());
   PADDLE_ENFORCE(
       cond_var,
-      phi::errors::NotFound("Condition variable %s not exists in scope %ld",
-                            node_->cond_var(),
-                            cur_scope_id_));
+      common::errors::NotFound("Condition variable %s not exists in scope %ld",
+                               node_->cond_var(),
+                               cur_scope_id_));
   const auto& cond_tensor = cond_var->Get<phi::DenseTensor>();
   bool res = false;
   if (phi::is_gpu_place(cond_tensor.place())) {
@@ -93,8 +93,8 @@ bool CondInterceptor::GetCondResult() {
   } else if (phi::is_cpu_place(cond_tensor.place())) {
     res = cond_tensor.data<bool>()[0];
   } else {
-    PADDLE_THROW(
-        phi::errors::Unimplemented("Unsupport device for cond interceptor."));
+    PADDLE_THROW(common::errors::Unimplemented(
+        "Unsupport device for cond interceptor."));
   }
   return res;
 }
@@ -138,7 +138,7 @@ void CondInterceptor::Compute(int64_t gen_step) {
   } else {
     PADDLE_ENFORCE_NE(scope_id_to_gen_step_.find(cur_scope_id_),
                       scope_id_to_gen_step_.end(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Can not find scope id %ld in scope_id_to_gen_step",
                           cur_scope_id_));
     VLOG(3) << "Finish loop in scope " << cur_scope_id_ << " with "
@@ -174,7 +174,7 @@ void CondInterceptor::Run(const InterceptorMessage& msg) {
     PADDLE_ENFORCE_NE(
         scope_id_to_gen_step_.find(scope_id),
         scope_id_to_gen_step_.end(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Can not find scope id %ld in scope_id_to_gen_step", scope_id));
     // Keep the message in order with scope_id
     // message with scope 3 never send before scope 1.
@@ -203,9 +203,9 @@ void CondInterceptor::Run(const InterceptorMessage& msg) {
           ready_scope_ids.emplace_back(iter->first);
         } else if (iter->second > gen_step) {
           PADDLE_THROW(
-              phi::errors::Fatal("Some error may occur. Scope %ld's "
-                                 "gen_step is much larger than previous.",
-                                 iter->first));
+              common::errors::Fatal("Some error may occur. Scope %ld's "
+                                    "gen_step is much larger than previous.",
+                                    iter->first));
         } else {
           break;
         }

--- a/paddle/fluid/distributed/fleet_executor/dist_model.cc
+++ b/paddle/fluid/distributed/fleet_executor/dist_model.cc
@@ -63,11 +63,11 @@ bool LoadDataFromDistModelTensor(const DistModelTensor &input_data,
 
   PADDLE_ENFORCE_NOT_NULL(
       input_tensor_ptr,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "LoDTensor creation failed. DistModel loaded data failed."));
   PADDLE_ENFORCE_NOT_NULL(
       input_data.data.data(),
-      phi::errors::InvalidArgument("DistModelTensor contains no data."));
+      common::errors::InvalidArgument("DistModelTensor contains no data."));
 
   if (phi::is_cpu_place(place)) {
     VLOG(3) << "Loading data for CPU.";
@@ -87,7 +87,7 @@ bool LoadDataFromDistModelTensor(const DistModelTensor &input_data,
                  input_data.data.length(),
                  dev_ctx->stream());
 #else
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "Paddle wasn't compiled with CUDA, but place is GPU."));
 #endif
   } else if (phi::is_xpu_place(place)) {
@@ -100,7 +100,7 @@ bool LoadDataFromDistModelTensor(const DistModelTensor &input_data,
                  input_data.data.data(),
                  input_data.data.length());
 #else
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "Paddle wasn't compiled with XPU, but place is XPU."));
 #endif
   } else if (phi::is_custom_place(place)) {
@@ -116,12 +116,12 @@ bool LoadDataFromDistModelTensor(const DistModelTensor &input_data,
                  input_data.data.length(),
                  dev_ctx->stream());
 #else
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "Paddle wasn't compiled with custom_device, but place is "
         "CustomPlace."));
 #endif
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "DistModel only supports CPU and GPU and XPU and CustomDevice."));
   }
 
@@ -174,13 +174,13 @@ bool DistModel::Init() {
   bool init_method = (!config_.model_dir.empty() || config_.program_desc);
   PADDLE_ENFORCE_EQ(init_method,
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "One of model dir or program desc must be provided to "
                         "dist model inference."));
   if (config_.program_desc) {
     PADDLE_ENFORCE_NOT_NULL(
         config_.scope,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Scope must be provided to dist model inference if "
             "program desc has been provided."));
   }
@@ -224,7 +224,7 @@ bool DistModel::PreparePlace() {
   } else if (config_.place == "CUSTOM_DEVICE") {
     place_ = phi::CustomPlace(config_.device_type, config_.device_id);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Place must be choosen from GPU or CPU or XPU, but got %s.",
         config_.place));
   }
@@ -400,7 +400,7 @@ bool DistModel::LoadProgram() {
   PADDLE_ENFORCE_NE(
       config_.model_dir,
       "",
-      phi::errors::InvalidArgument("Model dir must be provided."));
+      common::errors::InvalidArgument("Model dir must be provided."));
   std::string model_path = config_.model_dir + ".pdmodel";
   framework::proto::ProgramDesc program_proto;
   std::string pb_content;
@@ -409,7 +409,7 @@ bool DistModel::LoadProgram() {
   PADDLE_ENFORCE_EQ(
       static_cast<bool>(fin.is_open()),
       true,
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "Cannot open file %s, please confirm whether the file is normal.",
           model_path));
   fin.seekg(0, std::ios::end);
@@ -425,9 +425,9 @@ bool DistModel::LoadProgram() {
 
 bool DistModel::LoadParameters() {
   VLOG(3) << "Loading parameters from " << config_.model_dir;
-  PADDLE_ENFORCE_NOT_NULL(
-      program_.get(),
-      phi::errors::PreconditionNotMet("The program should be loaded first."));
+  PADDLE_ENFORCE_NOT_NULL(program_.get(),
+                          common::errors::PreconditionNotMet(
+                              "The program should be loaded first."));
   const auto &global_block = program_->MutableBlock(0);
 
   // create a temporary program to load parameters.
@@ -605,7 +605,7 @@ bool DistModel::FetchResults(std::vector<DistModelTensor> *output_data,
     PADDLE_ENFORCE_EQ(
         static_cast<size_t>(idx),
         i,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Fetch op's col attr(%d) should be equal to the index(%d)",
             idx,
             i));

--- a/paddle/fluid/distributed/fleet_executor/dist_model_tensor_wrapper.cc
+++ b/paddle/fluid/distributed/fleet_executor/dist_model_tensor_wrapper.cc
@@ -29,7 +29,7 @@ void DistModelDataBuf::Free() {
   if (memory_owned_ && data_) {
     PADDLE_ENFORCE_GT(length_,
                       0UL,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Error occurred when deconstruct DistModelDataBuf: "
                           "it contains no data!"));
     // NOTE: if own the memory, it must be char* type
@@ -49,7 +49,7 @@ void DistModelDataBuf::Resize(size_t length) {
     length_ = length;
     memory_owned_ = true;
   } else {
-    PADDLE_THROW(phi::errors::PreconditionNotMet(
+    PADDLE_THROW(common::errors::PreconditionNotMet(
         "The memory is allocated externally, can not Resized"));
   }
 }
@@ -67,7 +67,7 @@ DistModelDataBuf& DistModelDataBuf::operator=(const DistModelDataBuf& other) {
     if (other.length() && other.data()) {
       std::memcpy(data_, other.data(), other.length());
     } else if (other.length()) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "Invalid argument, null pointer data with length %u is passed",
           other.length()));
     }

--- a/paddle/fluid/distributed/fleet_executor/fleet_executor.cc
+++ b/paddle/fluid/distributed/fleet_executor/fleet_executor.cc
@@ -34,7 +34,7 @@ namespace distributed {
 FleetExecutor::FleetExecutor(const std::string& exe_desc_str) : carrier_ids_() {
   bool parse_flag = exe_desc_.ParseFromString(exe_desc_str);
   PADDLE_ENFORCE(parse_flag,
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "Error occurs while parsing string to proto"));
   // Message bus will be created and inited only once
   GlobalVal<MessageBus>::Create();
@@ -154,7 +154,7 @@ void FleetExecutor::Init(
     const std::vector<framework::Scope*>& micro_scope_list) {
   PADDLE_ENFORCE_GT(task_nodes.size(),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Fleet executor is inited with empty task node"));
   // Set the unused var after running while op
   std::set<TaskNode*> sub_block_tasks;
@@ -265,12 +265,12 @@ void FleetExecutor::InitMessageBus() {
     PADDLE_ENFORCE_EQ(
         rank_to_addr.size(),
         1,
-        phi::errors::NotFound("Empty address is not valid for "
-                              "paddle.distributed.launch method."));
+        common::errors::NotFound("Empty address is not valid for "
+                                 "paddle.distributed.launch method."));
     PADDLE_ENFORCE_EQ(
         cur_rank,
         0,
-        phi::errors::NotFound("Address is empty but cur rank is not 0."));
+        common::errors::NotFound("Address is empty but cur rank is not 0."));
   }
   VLOG(3) << "Current rank is " << cur_rank << " and the ip_port is "
           << (addr.empty() ? "empty" : addr) << ".";

--- a/paddle/fluid/distributed/fleet_executor/global.h
+++ b/paddle/fluid/distributed/fleet_executor/global.h
@@ -25,7 +25,7 @@ class GlobalVal final {
   static T* Get() {
     T* ptr = GetPPtr()->get();
     PADDLE_ENFORCE_NOT_NULL(
-        ptr, phi::errors::NotFound("This value is not global value."));
+        ptr, common::errors::NotFound("This value is not global value."));
     return ptr;
   }
   template <typename... Args>
@@ -34,7 +34,7 @@ class GlobalVal final {
     PADDLE_ENFORCE_EQ(
         ptr->get(),
         nullptr,
-        phi::errors::AlreadyExists("This value is already a global value."));
+        common::errors::AlreadyExists("This value is already a global value."));
     T* item = new T(std::forward<Args>(args)...);
     ptr->reset(item);
     return item;
@@ -59,7 +59,7 @@ class GlobalMap final {
   static ValueT* Get(KeyT id) {
     ValueT* item = GetPPtr(id)->get();
     PADDLE_ENFORCE_NOT_NULL(
-        item, phi::errors::NotFound("This value is not in global map."));
+        item, common::errors::NotFound("This value is not in global map."));
     return item;
   }
 
@@ -69,7 +69,7 @@ class GlobalMap final {
     PADDLE_ENFORCE_EQ(
         ptr->get(),
         nullptr,
-        phi::errors::AlreadyExists("This value has already in global map."));
+        common::errors::AlreadyExists("This value has already in global map."));
     ValueT* item = new ValueT(std::forward<Args>(args)...);
     ptr->reset(item);
     return item;
@@ -89,7 +89,8 @@ class ThreadSafeGlobalMap final {
     ValueT* item = GetPPtr(id)->get();
     PADDLE_ENFORCE_NOT_NULL(
         item,
-        phi::errors::NotFound("This value is not in thread safe global map."));
+        common::errors::NotFound(
+            "This value is not in thread safe global map."));
     return item;
   }
   template <typename... Args>
@@ -97,7 +98,7 @@ class ThreadSafeGlobalMap final {
     auto* ptr = GetPPtr(id);
     PADDLE_ENFORCE_EQ(ptr->get(),
                       nullptr,
-                      phi::errors::AlreadyExists(
+                      common::errors::AlreadyExists(
                           "This value has already in thread safe global map."));
     ValueT* item = new ValueT(std::forward<Args>(args)...);
     ptr->reset(item);

--- a/paddle/fluid/distributed/fleet_executor/interceptor.cc
+++ b/paddle/fluid/distributed/fleet_executor/interceptor.cc
@@ -31,7 +31,7 @@ Interceptor::~Interceptor() {  // NOLINT
   // FIXME(wangxi): throw in stop function
   // std::lock_guard<std::mutex> lock(mutex_);
   // PADDLE_ENFORCE_EQ(messages_.empty(), true,
-  //                  phi::errors::PreconditionNotMet(
+  //                  common::errors::PreconditionNotMet(
   //                      "Interceptor must destruct with messages empty"));
 }
 
@@ -40,7 +40,7 @@ void Interceptor::RegisterMsgHandle(MsgHandle handle) { handle_ = handle; }
 void Interceptor::Handle(const InterceptorMessage& msg) {
   PADDLE_ENFORCE_NOT_NULL(
       handle_,
-      phi::errors::PreconditionNotMet("Message handle is not registered."));
+      common::errors::PreconditionNotMet("Message handle is not registered."));
   handle_(msg);
 }
 
@@ -52,7 +52,7 @@ void Interceptor::LoopOnce() {
   }
   PADDLE_ENFORCE_EQ(tmp_messages.empty(),
                     false,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "tmp_messages must not empty in task loop"));
 
   for (auto& msg : tmp_messages) {
@@ -67,7 +67,8 @@ void Interceptor::LoopOnce() {
 
 void Interceptor::StopCarrier() {
   PADDLE_ENFORCE_NOT_NULL(
-      carrier_, phi::errors::PreconditionNotMet("Carrier is not registered."));
+      carrier_,
+      common::errors::PreconditionNotMet("Carrier is not registered."));
   carrier_->WakeUp();
 }
 
@@ -90,7 +91,8 @@ void Interceptor::EnqueueRemoteInterceptorMessage(
 
 bool Interceptor::Send(int64_t dst_id, InterceptorMessage& msg) {
   PADDLE_ENFORCE_NOT_NULL(
-      carrier_, phi::errors::PreconditionNotMet("Carrier is not registered."));
+      carrier_,
+      common::errors::PreconditionNotMet("Carrier is not registered."));
   msg.set_src_id(interceptor_id_);
   msg.set_dst_id(dst_id);
   return carrier_->Send(msg);
@@ -109,7 +111,7 @@ std::unique_ptr<Interceptor> InterceptorFactory::Create(const std::string& type,
   PADDLE_ENFORCE_NE(
       iter,
       interceptor_map.end(),
-      phi::errors::NotFound("interceptor %s is not register", type));
+      common::errors::NotFound("interceptor %s is not register", type));
   return iter->second(id, node);
 }
 

--- a/paddle/fluid/distributed/fleet_executor/message_bus.cc
+++ b/paddle/fluid/distributed/fleet_executor/message_bus.cc
@@ -29,9 +29,10 @@ void MessageBus::Init(
     int64_t rank,
     const std::unordered_map<int64_t, std::string>& rank_to_addr,
     const std::string& addr) {
-  PADDLE_ENFORCE_EQ(is_init_,
-                    false,
-                    phi::errors::AlreadyExists("MessageBus is already init."));
+  PADDLE_ENFORCE_EQ(
+      is_init_,
+      false,
+      common::errors::AlreadyExists("MessageBus is already init."));
   rank_ = rank;
   is_init_ = true;
   rank_to_addr_ = rank_to_addr;
@@ -42,11 +43,11 @@ void MessageBus::Init(
     PADDLE_ENFORCE_EQ(
         addr,
         addr_,
-        phi::errors::Fatal("The current rank's addr is %s, while the "
-                           "message bus's addr is %s, which are different. "
-                           "Init error.",
-                           addr,
-                           addr_));
+        common::errors::Fatal("The current rank's addr is %s, while the "
+                              "message bus's addr is %s, which are different. "
+                              "Init error.",
+                              addr,
+                              addr_));
   }
 
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL) || \
@@ -81,7 +82,7 @@ const std::string& MessageBus::GetAddr(int64_t rank) const {
   PADDLE_ENFORCE_NE(
       rank_to_addr_.find(rank),
       rank_to_addr_.end(),
-      phi::errors::NotFound("Cannot find addr rank id %lld.", rank));
+      common::errors::NotFound("Cannot find addr rank id %lld.", rank));
   return rank_to_addr_.at(rank);
 }
 
@@ -90,7 +91,7 @@ bool MessageBus::Send(int64_t dst_rank,
   PADDLE_ENFORCE_EQ(
       IsInit(),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Using message bus since it has not been initialized."));
 #if defined(PADDLE_WITH_DISTRIBUTE) && !defined(PADDLE_WITH_PSLIB)
   int retry_time = 0;  // message bus will retry sending for 10 times
@@ -107,7 +108,7 @@ bool MessageBus::Send(int64_t dst_rank,
   VLOG(3) << "Message bus sends inter rank fail after 10 times retries.";
   return false;
 #else
-  PADDLE_THROW(phi::errors::Unavailable(
+  PADDLE_THROW(common::errors::Unavailable(
       "Fleet executor does not support sending message between different "
       "ranks when Paddle isn't compiled with distributed for now."));
 #endif
@@ -181,7 +182,7 @@ void MessageBus::ListenPort() {
   PADDLE_ENFORCE_EQ(
       server_.AddService(&message_service_, brpc::SERVER_DOESNT_OWN_SERVICE),
       0,
-      phi::errors::Unavailable("Message bus: init brpc service error."));
+      common::errors::Unavailable("Message bus: init brpc service error."));
 
   // start the server
   const char* ip_for_brpc = addr_.c_str();
@@ -220,7 +221,7 @@ bool MessageBus::SendInterRank(int64_t dst_rank,
   PADDLE_ENFORCE_EQ(
       channel.Init(dst_addr_for_brpc, &options),
       0,
-      phi::errors::Unavailable("Message bus: init brpc channel error."));
+      common::errors::Unavailable("Message bus: init brpc channel error."));
   MessageService_Stub stub(&channel);
   InterceptorResponse response;
   brpc::Controller ctrl;

--- a/paddle/fluid/distributed/fleet_executor/start_interceptor.cc
+++ b/paddle/fluid/distributed/fleet_executor/start_interceptor.cc
@@ -26,7 +26,7 @@ StartInterceptor::StartInterceptor(int64_t interceptor_id, TaskNode* node)
   PADDLE_ENFORCE_EQ(
       downstream.size(),
       1,
-      phi::errors::OutOfRange(
+      common::errors::OutOfRange(
           "The downstream for StartInterceptor only support 1 for now."));
   for (auto down : downstream) {
     batch_size_ = down.second;
@@ -34,7 +34,7 @@ StartInterceptor::StartInterceptor(int64_t interceptor_id, TaskNode* node)
   bool evenly_divisible = ((node_->max_run_times() % batch_size_) == 0);
   PADDLE_ENFORCE(
       evenly_divisible,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "Wrong config: Num of step should be divided by batch_size,"
           "num_step=%lld, batch_size=%lld",
           node_->max_run_times(),
@@ -56,12 +56,12 @@ void StartInterceptor::SendDataReadyToDownStream() {
       PADDLE_ENFORCE_LE(
           used_size,
           max_buff_size,
-          phi::errors::OutOfRange("downstream=%lld used buff size must <= "
-                                  "max_buff_size, but now used_size=%lld, "
-                                  "max_buff_size=%lld",
-                                  down_id,
-                                  used_size,
-                                  max_buff_size));
+          common::errors::OutOfRange("downstream=%lld used buff size must <= "
+                                     "max_buff_size, but now used_size=%lld, "
+                                     "max_buff_size=%lld",
+                                     down_id,
+                                     used_size,
+                                     max_buff_size));
     }
     outs.second.second = used_size;
   }

--- a/paddle/fluid/distributed/fleet_executor/task_loop.cc
+++ b/paddle/fluid/distributed/fleet_executor/task_loop.cc
@@ -28,7 +28,7 @@ TaskLoop::TaskLoop()
   PADDLE_ENFORCE_EQ(
       thread_local_loop_,
       nullptr,
-      phi::errors::AlreadyExists("Another TaskLoop is already init."));
+      common::errors::AlreadyExists("Another TaskLoop is already init."));
   thread_local_loop_ = this;
 }
 
@@ -37,7 +37,7 @@ TaskLoop::~TaskLoop() { thread_local_loop_ = nullptr; }
 void TaskLoop::Loop() {
   PADDLE_ENFORCE_EQ(looping_,
                     false,
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "Loop can only execute in one loop thread"));
   AssertInLoopThread();
 
@@ -74,7 +74,7 @@ void TaskLoop::WakeUp() {
 }
 
 void TaskLoop::AbortNotInLoopThread() {
-  PADDLE_THROW(phi::errors::PreconditionNotMet(
+  PADDLE_THROW(common::errors::PreconditionNotMet(
       "This TaskLoop was created in thread %d, but current thread is %d",
       thread_id_,
       std::this_thread::get_id()));

--- a/paddle/fluid/distributed/fleet_executor/task_loop_thread.cc
+++ b/paddle/fluid/distributed/fleet_executor/task_loop_thread.cc
@@ -33,7 +33,7 @@ TaskLoop* TaskLoopThread::StartLoop() {
   PADDLE_ENFORCE_EQ(
       start_,
       false,
-      phi::errors::PreconditionNotMet("thread is already running."));
+      common::errors::PreconditionNotMet("thread is already running."));
   start_ = true;
   thread_ = std::thread([this]() { Loop(); });
 

--- a/paddle/fluid/distributed/fleet_executor/task_loop_thread_pool.cc
+++ b/paddle/fluid/distributed/fleet_executor/task_loop_thread_pool.cc
@@ -32,11 +32,11 @@ void TaskLoopThreadPool::Start() {
   PADDLE_ENFORCE_EQ(
       start_,
       false,
-      phi::errors::PreconditionNotMet("thread pool is already start."));
+      common::errors::PreconditionNotMet("thread pool is already start."));
   PADDLE_ENFORCE_GT(
       thread_num_,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "thread num must greater than 0, but now is %d", thread_num_));
 
   start_ = true;
@@ -50,12 +50,12 @@ TaskLoop* TaskLoopThreadPool::GetLoop(int tid) {
   PADDLE_ENFORCE_EQ(
       start_,
       true,
-      phi::errors::PreconditionNotMet("thread pool must start first."));
+      common::errors::PreconditionNotMet("thread pool must start first."));
   PADDLE_ENFORCE_GE(
-      tid, 0, phi::errors::OutOfRange("tid must >= 0, but now is %d", tid));
+      tid, 0, common::errors::OutOfRange("tid must >= 0, but now is %d", tid));
   PADDLE_ENFORCE_LT(tid,
                     thread_num_,
-                    phi::errors::OutOfRange(
+                    common::errors::OutOfRange(
                         "tid must < thread_num, but now tid=%d thread_num=%d",
                         tid,
                         thread_num_));
@@ -66,7 +66,7 @@ std::vector<TaskLoop*> TaskLoopThreadPool::GetAllLoops() {
   PADDLE_ENFORCE_EQ(
       start_,
       true,
-      phi::errors::PreconditionNotMet("thread pool must start first."));
+      common::errors::PreconditionNotMet("thread pool must start first."));
   return loops_;
 }
 

--- a/paddle/fluid/distributed/fleet_executor/task_node.cc
+++ b/paddle/fluid/distributed/fleet_executor/task_node.cc
@@ -155,7 +155,7 @@ std::string TaskNode::DebugString() const {
 void TaskNode::SetRunPerSteps(int64_t value) {
   PADDLE_ENFORCE_GE(value,
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "run_per_steps must >= 1, but received %ld", value));
   run_per_steps_ = value;
 }
@@ -163,7 +163,7 @@ void TaskNode::SetRunPerSteps(int64_t value) {
 void TaskNode::SetRunAtOffset(int64_t value) {
   PADDLE_ENFORCE_GE(value,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "run_at_offset must >= 0, but received %ld", value));
   run_at_offset_ = value;
 }
@@ -172,7 +172,7 @@ void TaskNode::SetReplyUpPerSteps(int64_t value) {
   PADDLE_ENFORCE_GE(
       value,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "reply_up_per_steps must >= 1, but received %ld", value));
   reply_up_per_steps_ = value;
 }
@@ -181,7 +181,7 @@ void TaskNode::SetSendDownPerSteps(int64_t value) {
   PADDLE_ENFORCE_GE(
       value,
       1,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "send_down_per_steps must >= 1, but received %ld", value));
   send_down_per_steps_ = value;
 }

--- a/paddle/fluid/distributed/index_dataset/index_sampler.h
+++ b/paddle/fluid/distributed/index_dataset/index_sampler.h
@@ -68,12 +68,12 @@ class LayerWiseSampler : public IndexSampler {
     PADDLE_ENFORCE_GT(
         start_sample_layer_,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "start sampler layer = [%d], it should greater than 0.",
             start_sample_layer_));
     PADDLE_ENFORCE_LT(start_sample_layer_,
                       tree_->Height(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "start sampler layer = [%d], it should less than "
                           "max_layer, which is [%d].",
                           start_sample_layer_,

--- a/paddle/fluid/distributed/index_dataset/index_wrapper.cc
+++ b/paddle/fluid/distributed/index_dataset/index_wrapper.cc
@@ -31,7 +31,7 @@ int TreeIndex::Load(const std::string filename) {
   PADDLE_ENFORCE_NE(
       fp,
       nullptr,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Open file %s failed. Please check whether the file exists.",
           filename));
 
@@ -49,7 +49,7 @@ int TreeIndex::Load(const std::string filename) {
     PADDLE_ENFORCE_EQ(
         read_num,
         static_cast<size_t>(num),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Read from file: %s failed. Valid Format is "
             "an integer representing the length of the following string, "
             "and the string itself.We got an integer[% d], "
@@ -62,9 +62,9 @@ int TreeIndex::Load(const std::string filename) {
     PADDLE_ENFORCE_EQ(
         item.ParseFromString(content),
         true,
-        phi::errors::InvalidArgument("Parse from file: %s failed. It's "
-                                     "content can't be parsed by KVItem.",
-                                     filename));
+        common::errors::InvalidArgument("Parse from file: %s failed. It's "
+                                        "content can't be parsed by KVItem.",
+                                        filename));
 
     if (item.key() == ".tree_meta") {
       meta_.ParseFromString(item.value());
@@ -74,7 +74,7 @@ int TreeIndex::Load(const std::string filename) {
       node.ParseFromString(item.value());
 
       // PADDLE_ENFORCE_NE(node.id(), 0,
-      //                  phi::errors::InvalidArgument(
+      //                  common::errors::InvalidArgument(
       //                      "Node'id should not be equal to zero."));
       if (node.is_leaf()) {
         id_codes_map_[node.id()] = code;
@@ -176,7 +176,7 @@ std::vector<uint64_t> TreeIndex::GetTravelCodes(uint64_t id, int start_level) {
   PADDLE_ENFORCE_NE(
       id_codes_map_.find(id),
       id_codes_map_.end(),
-      phi::errors::InvalidArgument("id = %d doesn't exist in Tree.", id));
+      common::errors::InvalidArgument("id = %d doesn't exist in Tree.", id));
   auto code = id_codes_map_.at(id);
   int level = meta_.height() - 1;
 

--- a/paddle/fluid/distributed/index_dataset/index_wrapper.h
+++ b/paddle/fluid/distributed/index_dataset/index_wrapper.h
@@ -78,7 +78,7 @@ class IndexWrapper {
   TreePtr get_tree_index(const std::string name) {
     PADDLE_ENFORCE_NE(tree_map.find(name),
                       tree_map.end(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "tree [%s] doesn't exist. Please insert it firstly "
                           "by API[\' insert_tree_index \'].",
                           name));
@@ -94,7 +94,7 @@ class IndexWrapper {
     int ret = tree->Load(tree_path);
     PADDLE_ENFORCE_EQ(ret,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Load tree[%s] from path[%s] failed. Please "
                           "check whether the file exists.",
                           name,

--- a/paddle/fluid/distributed/ps/service/brpc_ps_client.cc
+++ b/paddle/fluid/distributed/ps/service/brpc_ps_client.cc
@@ -1461,8 +1461,8 @@ int32_t BrpcPsClient::RecvAndSaveTable(const uint64_t table_id,
   PADDLE_ENFORCE_NE(
       var_name,
       "",
-      phi::errors::InvalidArgument("Cannot find table id %d to save variables.",
-                                   table_id));
+      common::errors::InvalidArgument(
+          "Cannot find table id %d to save variables.", table_id));
 
   std::string var_store = string::Sprintf("%s", path);
   MkDirRecursively(var_store.c_str());
@@ -1515,10 +1515,10 @@ int32_t BrpcPsClient::RecvAndSaveTable(const uint64_t table_id,
 
   std::string file_name = string::Sprintf("%s/%s", var_store, var_name);
   std::ofstream fout(file_name, std::ios::binary);
-  PADDLE_ENFORCE_EQ(
-      static_cast<bool>(fout),
-      true,
-      phi::errors::Unavailable("Cannot open %s to save variables.", file_name));
+  PADDLE_ENFORCE_EQ(static_cast<bool>(fout),
+                    true,
+                    common::errors::Unavailable(
+                        "Cannot open %s to save variables.", file_name));
 
   framework::SerializeToStream(fout, *var_tensor, dev_ctx);
   fout.close();

--- a/paddle/fluid/distributed/ps/service/brpc_ps_server.cc
+++ b/paddle/fluid/distributed/ps/service/brpc_ps_server.cc
@@ -140,7 +140,7 @@ std::future<int32_t> BrpcPsServer::SendPServer2PServerMsg(
     std::stringstream ss;
     ss << "to_pserver_id is out of range pservers, which size is "
        << _pserver_channels.size();
-    PADDLE_THROW(phi::errors::Fatal(ss.str()));
+    PADDLE_THROW(common::errors::Fatal(ss.str()));
     promise->set_value(-1);
     return fut;
   }

--- a/paddle/fluid/distributed/ps/service/brpc_utils.cc
+++ b/paddle/fluid/distributed/ps/service/brpc_utils.cc
@@ -44,7 +44,7 @@ framework::proto::VarType::Type VarMessageToVarType(
     case VariableMessage::BOOL:
       return framework::proto::VarType::BOOL;  // NOLINT
     default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "VarMessageToVarType:Unsupported type %d", type));
   }
 }
@@ -209,7 +209,7 @@ void DeserializeFromMultiVarMsgAndIOBuf(const MultiVarMsg& multi_msg,
     auto* var = scope->FindVar(msg.varname());
     PADDLE_ENFORCE_NE(var,
                       nullptr,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Not find variable %s in scope.", msg.varname()));
     if (msg.type() == ::paddle::distributed::LOD_TENSOR) {
       DeserializeLodTensor(var, msg, io_buffer_itr, ctx);

--- a/paddle/fluid/distributed/ps/service/communicator/communicator.cc
+++ b/paddle/fluid/distributed/ps/service/communicator/communicator.cc
@@ -554,7 +554,7 @@ void AsyncCommunicator::SendByCommunicator() {
         PADDLE_ENFORCE_EQ(
             varnames.size(),
             1,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "sparse variables can only be merged by one variables"));
         RpcSendSparse(varnames[0], table_id, *send_scope_);
       } else {
@@ -819,7 +819,7 @@ void AsyncCommunicator::PushSparseFromTensorAsync(
   PADDLE_ENFORCE_EQ(
       this->Check(table_id),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "can not find table: %s, please check your config", table_id));
   auto status = _worker_ptr->PushSparse(table_id,
                                         push_keys.data(),
@@ -917,7 +917,7 @@ bool AsyncCommunicator::Check(const std::vector<std::string> &var_tables) {
   PADDLE_ENFORCE_EQ(
       var_tables.size(),
       1,
-      phi::errors::InvalidArgument("var_tables.size() == 1 is permitted"));
+      common::errors::InvalidArgument("var_tables.size() == 1 is permitted"));
 
   auto table_name = var_tables[0];
   if (send_varname_to_ctx_.find(table_name) == send_varname_to_ctx_.end()) {
@@ -1035,7 +1035,7 @@ void HalfAsyncCommunicator::SendByCommunicator() {
         PADDLE_ENFORCE_EQ(
             varnames.size(),
             1,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "sparse variables can only be merged by one variables"));
         RpcSendSparse(varnames[0], table_id, *send_scope_);
       } else {
@@ -1092,7 +1092,7 @@ void GeoCommunicator::Send(
 
   PADDLE_ENFORCE_EQ(var->IsType<phi::SelectedRows>(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Only need to send Sparse Grad in Geo mode."));
   auto &rows = var->Get<phi::SelectedRows>().rows();
 
@@ -1242,11 +1242,11 @@ void GeoCommunicator::SendDense(const CommContext &send_ctx) {
 
     PADDLE_ENFORCE_EQ(var_latest->IsInitialized(),
                       true,
-                      phi::errors::Unavailable(
+                      common::errors::Unavailable(
                           "%s is not initialized, please check", param_name));
     PADDLE_ENFORCE_EQ(var_timestamp->IsInitialized(),
                       true,
-                      phi::errors::Unavailable(
+                      common::errors::Unavailable(
                           "%s is not initialized, please check", param_name));
 
     auto &t_latest = var_latest->Get<phi::DenseTensor>();
@@ -1393,11 +1393,11 @@ void GeoCommunicator::SendSparse(const std::string &varname,
 
   PADDLE_ENFORCE_EQ(var_latest->IsInitialized(),
                     true,
-                    phi::errors::Unavailable(
+                    common::errors::Unavailable(
                         "%s is not initialized, please check", param_name));
   PADDLE_ENFORCE_EQ(var_old->IsInitialized(),
                     true,
-                    phi::errors::Unavailable(
+                    common::errors::Unavailable(
                         "%s is not initialized, please check", param_name));
 
   auto &t_latest = var_latest->Get<phi::DenseTensor>();
@@ -1530,7 +1530,7 @@ void GeoCommunicator::MainThread() {
         PADDLE_ENFORCE_EQ(
             varnames.size(),
             1,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "sparse variables can only be merged by one variables"));
         int pserver_num = static_cast<int>(ctx.epmap.size());
         for (int ep_idx = 0; ep_idx < pserver_num; ep_idx++) {

--- a/paddle/fluid/distributed/ps/service/communicator/communicator.h
+++ b/paddle/fluid/distributed/ps/service/communicator/communicator.h
@@ -64,10 +64,10 @@ template <typename T>
 class BlockingQueue {
  public:
   explicit BlockingQueue(size_t capacity) : capacity_(capacity) {
-    PADDLE_ENFORCE_GT(
-        capacity_,
-        0,
-        phi::errors::InvalidArgument("The capacity must be greater than 0."));
+    PADDLE_ENFORCE_GT(capacity_,
+                      0,
+                      common::errors::InvalidArgument(
+                          "The capacity must be greater than 0."));
   }
 
   bool Push(const T &elem) {
@@ -163,7 +163,7 @@ inline void MergeVars(const std::string &var_name,
                       bool merge_add = true) {
   PADDLE_ENFORCE_NE(vars.empty(),
                     true,
-                    phi::errors::InvalidArgument("vector vars are empty."));
+                    common::errors::InvalidArgument("vector vars are empty."));
   auto cpu_place = phi::CPUPlace();
   auto &var0 = vars[0];
   auto *out_var = scope->Var(var_name);
@@ -181,7 +181,7 @@ inline void MergeVars(const std::string &var_name,
       PADDLE_ENFORCE_EQ(
           var_t.dims(),
           dims,
-          phi::errors::InvalidArgument("vars should have the same dims."));
+          common::errors::InvalidArgument("vars should have the same dims."));
     }
 
     // set output tensor to 0.
@@ -221,8 +221,8 @@ inline void MergeVars(const std::string &var_name,
     VLOG(3) << "merge " << var_name << " SelectedRows height: " << slr0.height()
             << " dims: " << slr0.value().dims() << "; merge add: " << merge_add;
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument("unsupported var type: %s!",
-                                              var0->Type()));
+    PADDLE_THROW(common::errors::InvalidArgument("unsupported var type: %s!",
+                                                 var0->Type()));
   }
 }
 
@@ -322,7 +322,7 @@ class Communicator {
     int status = rets.get();
     PADDLE_ENFORCE_EQ(status,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The ret status must be 0 when barrier with table"));
   }
 

--- a/paddle/fluid/distributed/ps/service/heter_client.cc
+++ b/paddle/fluid/distributed/ps/service/heter_client.cc
@@ -30,7 +30,7 @@ int GetMicroId(const phi::DeviceContext& ctx, const framework::Scope* scope) {
   framework::Variable* var = scope->FindVar("microbatch_id");
   PADDLE_ENFORCE_EQ(var->IsType<phi::DenseTensor>(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "the type of micro id should be LoDTensor."));
   auto micro_id = -1;
   auto* tensor = var->GetMutable<phi::DenseTensor>();
@@ -133,7 +133,7 @@ void HeterClient::SendAndRecvAsync(
     PADDLE_ENFORCE_NE(
         closure->cntl.Failed(),
         true,
-        phi::errors::Unimplemented(
+        common::errors::Unimplemented(
             "HeterClient::SendAndRecv meets brpc error, error message is %s",
             closure->cntl.ErrorText()));
     VLOG(4) << "call heter_worker success";
@@ -225,7 +225,7 @@ int HeterClient::Send(const phi::DeviceContext& ctx,
       PADDLE_ENFORCE_NE(
           closure->cntl.Failed(),
           true,
-          phi::errors::Unimplemented(
+          common::errors::Unimplemented(
               "HeterClient::SendToSwitch meets brpc error, error message is %s",
               closure->cntl.ErrorText()));
     }

--- a/paddle/fluid/distributed/ps/service/heter_server.h
+++ b/paddle/fluid/distributed/ps/service/heter_server.h
@@ -232,7 +232,7 @@ class SendAndRecvVariableHandler final : public ServiceHandlerBase {
     auto* var = local_scope.FindVar("microbatch_id");
     PADDLE_ENFORCE_NE(var,
                       nullptr,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Not find variable microbatch_id in scope."));
     auto* tensor = var->GetMutable<phi::DenseTensor>();
     auto data = reinterpret_cast<const float*>(tensor->data());
@@ -249,7 +249,7 @@ class SendAndRecvVariableHandler final : public ServiceHandlerBase {
       PADDLE_ENFORCE_EQ(
           (*micro_scopes_).find(minibatch_index) != (*micro_scopes_).end(),
           1,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "minibatch index should in current trainer"));
 
     } else {
@@ -390,7 +390,7 @@ class HeterService : public PsService {
     PADDLE_ENFORCE_NE(
         itr,
         handler_map_.end(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "HeterService::SendAndRecvVariable Get illegal message_name: %s "
             "which is not in HeterService::handler_map_",
             message_name));
@@ -439,7 +439,7 @@ class HeterService : public PsService {
         PADDLE_ENFORCE_NE(
             closure->cntl.Failed(),
             true,
-            phi::errors::Unimplemented(
+            common::errors::Unimplemented(
                 "HeterClient::SendS2S meets brpc error, error message is %s",
                 closure->cntl.ErrorText()));
       }

--- a/paddle/fluid/distributed/ps/service/ps_local_client.cc
+++ b/paddle/fluid/distributed/ps/service/ps_local_client.cc
@@ -107,9 +107,10 @@ int32_t PsLocalClient::Initialize() {
   size_t region_data_idx = 0;
   size_t shard_data_size = num_per_shard;
   size_t shard_buffer_remain = shard_data_size * sizeof(float);
-  PADDLE_ENFORCE_EQ(shard_buffer_remain,
-                    region_buffer.size() * sizeof(float),
-                    phi::errors::PreconditionNotMet("pull dense size error."));
+  PADDLE_ENFORCE_EQ(
+      shard_buffer_remain,
+      region_buffer.size() * sizeof(float),
+      common::errors::PreconditionNotMet("pull dense size error."));
   size_t index = 0;
   while (shard_buffer_remain > 0 && region_idx < region_num) {
     auto& region = regions[region_idx];
@@ -204,7 +205,7 @@ int32_t PsLocalClient::Initialize() {
     PADDLE_ENFORCE_LE(
         offset + data_num,
         data_size,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "invalid dense size, cur pos[%d] data_num[%d] size[%d]",
             offset,
             data_num,

--- a/paddle/fluid/distributed/ps/service/server.h
+++ b/paddle/fluid/distributed/ps/service/server.h
@@ -100,7 +100,7 @@ class PSServer {
       int msg_type UNUSED,
       int to_pserver_id UNUSED,
       const std::string &msg UNUSED) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "NotImplementError: PSServer::send_pserver2pserver_msg"));
     std::promise<int32_t> promise;
     std::future<int> fut = promise.get_future();
@@ -131,7 +131,7 @@ class PSServer {
   virtual int32_t ReceiveFromPServer(int msg_type UNUSED,
                                      int pserver_id UNUSED,
                                      const std::string &msg UNUSED) {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "NotImplementError::PSServer::ReceiveFromPServer"));
     return -1;
   }

--- a/paddle/fluid/distributed/ps/service/simple_rpc/rpc_server.cc
+++ b/paddle/fluid/distributed/ps/service/simple_rpc/rpc_server.cc
@@ -62,19 +62,20 @@ inline std::string get_local_ip_internal() {
   ifconf.ifc_len = 512;
   ifconf.ifc_buf = buf;
   sockfd = socket(AF_INET, SOCK_DGRAM, 0);
-  PADDLE_ENFORCE_EQ((sockfd >= 0),
-                    true,
-                    phi::errors::PreconditionNotMet("Socket should be >= 0."));
+  PADDLE_ENFORCE_EQ(
+      (sockfd >= 0),
+      true,
+      common::errors::PreconditionNotMet("Socket should be >= 0."));
   int ret = ioctl(sockfd, SIOCGIFCONF, &ifconf);
   PADDLE_ENFORCE_EQ(
       (ret >= 0),
       true,
-      phi::errors::PreconditionNotMet("Ioctl ret should be >= 0."));
+      common::errors::PreconditionNotMet("Ioctl ret should be >= 0."));
   ret = close(sockfd);
   PADDLE_ENFORCE_EQ(
       (0 == ret),
       true,
-      phi::errors::PreconditionNotMet("Close call should return 0."));
+      common::errors::PreconditionNotMet("Close call should return 0."));
 
   ifreq = (struct ifreq*)buf;
   for (int i = 0; i < static_cast<int>(ifconf.ifc_len / sizeof(struct ifreq));
@@ -129,7 +130,7 @@ void RpcServer::set_connection_num(int n) {
   PADDLE_ENFORCE_EQ(
       (n >= 1),
       true,
-      phi::errors::InvalidArgument("Connect num need more than 1."));
+      common::errors::InvalidArgument("Connect num need more than 1."));
   _conn_num = n;
 }
 void RpcServer::set_thread_num(int n) {
@@ -139,7 +140,7 @@ void RpcServer::set_thread_num(int n) {
   PADDLE_ENFORCE_EQ(
       (n >= 1),
       true,
-      phi::errors::InvalidArgument("Thread num need more than 1."));
+      common::errors::InvalidArgument("Thread num need more than 1."));
   _thread_num = n;
 }
 void* RpcServer::add_service(RpcCallback callback, bool simplex) {

--- a/paddle/fluid/distributed/ps/table/common_graph_table.cc
+++ b/paddle/fluid/distributed/ps/table/common_graph_table.cc
@@ -2653,7 +2653,7 @@ Node *GraphTable::find_node(GraphTableType table_type, uint64_t id) {
                             : node_shards;
   for (auto &search_shard : search_shards) {
     PADDLE_ENFORCE_NOT_NULL(search_shard[index],
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "search_shard[%d] should not be null.", index));
     node = search_shard[index]->find_node(id);
     if (node != nullptr) {
@@ -2674,7 +2674,7 @@ Node *GraphTable::find_node(GraphTableType table_type, int idx, uint64_t id) {
       : table_type == GraphTableType::FEATURE_TABLE ? feature_shards[idx]
                                                     : node_shards[idx];
   PADDLE_ENFORCE_NOT_NULL(search_shards[index],
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "search_shard[%d] should not be null.", index));
   Node *node = search_shards[index]->find_node(id);
   return node;

--- a/paddle/fluid/distributed/ps/table/graph/graph_node.h
+++ b/paddle/fluid/distributed/ps/table/graph/graph_node.h
@@ -134,9 +134,9 @@ class FeatureNode : public Node {
   }
 
   virtual int get_feature_ids(std::vector<uint64_t> *res) const {
-    PADDLE_ENFORCE_NOT_NULL(
-        res,
-        phi::errors::InvalidArgument("get_feature_ids res should not be null"));
+    PADDLE_ENFORCE_NOT_NULL(res,
+                            common::errors::InvalidArgument(
+                                "get_feature_ids res should not be null"));
     errno = 0;
     for (auto &feature_item : feature) {
       const uint64_t *feas = (const uint64_t *)(feature_item.c_str());
@@ -152,15 +152,15 @@ class FeatureNode : public Node {
     PADDLE_ENFORCE_EQ(
         errno,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "get_feature_ids get errno should be 0, but got %d.", errno));
     return 0;
   }
 
   virtual int get_feature_ids(int slot_idx, std::vector<uint64_t> *res) const {
-    PADDLE_ENFORCE_NOT_NULL(
-        res,
-        phi::errors::InvalidArgument("get_feature_ids res should not be null"));
+    PADDLE_ENFORCE_NOT_NULL(res,
+                            common::errors::InvalidArgument(
+                                "get_feature_ids res should not be null"));
     res->clear();
     errno = 0;
     if (slot_idx < static_cast<int>(this->feature.size())) {
@@ -178,7 +178,7 @@ class FeatureNode : public Node {
     PADDLE_ENFORCE_EQ(
         errno,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "get_feature_ids get errno should be 0, but got %d.", errno));
     return 0;
   }
@@ -202,7 +202,7 @@ class FeatureNode : public Node {
     PADDLE_ENFORCE_EQ(
         errno,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "get_feature_ids get errno should be 0, but got %d.", errno));
     return num;
   }
@@ -330,9 +330,9 @@ class FloatFeatureNode : public FeatureNode {
   }
 
   virtual int get_feature_ids(std::vector<uint64_t> *res) const {
-    PADDLE_ENFORCE_NOT_NULL(
-        res,
-        phi::errors::InvalidArgument("get_feature_ids res should not be null"));
+    PADDLE_ENFORCE_NOT_NULL(res,
+                            common::errors::InvalidArgument(
+                                "get_feature_ids res should not be null"));
     errno = 0;
     for (int slot_idx = 0; slot_idx < float_feature_start_idx; slot_idx++) {
       auto &feature_item = this->feature[slot_idx];
@@ -350,15 +350,15 @@ class FloatFeatureNode : public FeatureNode {
     PADDLE_ENFORCE_EQ(
         errno,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "get_feature_ids get errno should be 0, but got %d.", errno));
     return 0;
   }
 
   virtual int get_feature_ids(int slot_idx, std::vector<uint64_t> *res) const {
-    PADDLE_ENFORCE_NOT_NULL(
-        res,
-        phi::errors::InvalidArgument("get_feature_ids res should not be null"));
+    PADDLE_ENFORCE_NOT_NULL(res,
+                            common::errors::InvalidArgument(
+                                "get_feature_ids res should not be null"));
     res->clear();
     errno = 0;
     if (slot_idx < static_cast<int>(float_feature_start_idx)) {
@@ -376,7 +376,7 @@ class FloatFeatureNode : public FeatureNode {
     PADDLE_ENFORCE_EQ(
         errno,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "get_feature_ids get errno should be 0, but got %d.", errno));
     return 0;
   }
@@ -400,7 +400,7 @@ class FloatFeatureNode : public FeatureNode {
     PADDLE_ENFORCE_EQ(
         errno,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "get_feature_ids get errno should be 0, but got %d.", errno));
     return num;
   }
@@ -426,7 +426,7 @@ class FloatFeatureNode : public FeatureNode {
     PADDLE_ENFORCE_EQ(
         errno,
         0,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "get_feature_ids get errno should be 0, but got %d.", errno));
     return num;
   }

--- a/paddle/fluid/distributed/ps/table/memory_dense_table.cc
+++ b/paddle/fluid/distributed/ps/table/memory_dense_table.cc
@@ -33,7 +33,8 @@ void MemoryDenseTable::CreateInitializer(const std::string &attr,
   } else if (slices[0] == "truncated_gaussian_random") {
     initializers_[name] = new TruncatedGaussianInitializer(slices);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument("%s can not be supported", name));
+    PADDLE_THROW(
+        common::errors::InvalidArgument("%s can not be supported", name));
   }
 }
 
@@ -156,7 +157,7 @@ int32_t MemoryDenseTable::PushDenseParam(const float *values, size_t num) {
   PADDLE_ENFORCE_GE(
       num,
       param_dim_,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "update dense param numel expected %d, but got %d", param_dim_, num));
   std::copy_n(values, param_dim_, values_[param_idx_].begin());
   return 0;
@@ -187,7 +188,7 @@ int32_t MemoryDenseTable::_PushDense(const float *values, size_t num) {
   PADDLE_ENFORCE_GE(
       num,
       param_dim_,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "update dense numel expected %d, but got %d", param_dim_, num));
 
   std::vector<int> buckets = bucket(param_dim_, task_pool_size_);

--- a/paddle/fluid/distributed/ps/table/ssd_sparse_table.cc
+++ b/paddle/fluid/distributed/ps/table/ssd_sparse_table.cc
@@ -720,7 +720,7 @@ int32_t SSDSparseTable::SaveWithString(const std::string& path,
         std::stringstream ss;
         ss << "SSDSparseTable save failed, retry it! path:"
            << channel_config.path;
-        PADDLE_THROW(phi::errors::Fatal(ss.str()));
+        PADDLE_THROW(common::errors::Fatal(ss.str()));
       }
     }
     write_channel->close();
@@ -1663,7 +1663,7 @@ int32_t SSDSparseTable::SaveWithBinary(const std::string& path,
           std::stringstream ss;
           ss << "DownpourSparseSSDTable save failed, retry it! path:"
              << channel_config.path;
-          PADDLE_THROW(phi::errors::Fatal(ss.str()));
+          PADDLE_THROW(common::errors::Fatal(ss.str()));
           CHECK(false);
         }
         region->reset();
@@ -1706,7 +1706,7 @@ int32_t SSDSparseTable::SaveWithBinary(const std::string& path,
             std::stringstream ss;
             ss << "SSDSparseTable save failed, retry it! path:"
                << channel_config.path;
-            PADDLE_THROW(phi::errors::Fatal(ss.str()));
+            PADDLE_THROW(common::errors::Fatal(ss.str()));
           }
           remain -= len;
           cursor += len;
@@ -1991,7 +1991,7 @@ int32_t SSDSparseTable::SaveWithBinary_v2(const std::string& path,
           std::stringstream ss;
           ss << "DownpourSparseSSDTable save failed, retry it! path:"
              << channel_config.path;
-          PADDLE_THROW(phi::errors::Fatal(ss.str()));
+          PADDLE_THROW(common::errors::Fatal(ss.str()));
           CHECK(false);
         }
         region->reset();
@@ -2023,7 +2023,7 @@ int32_t SSDSparseTable::SaveWithBinary_v2(const std::string& path,
           std::stringstream ss;
           ss << "DownpourSparseSSDTable save feature failed, retry it! path:"
              << channel_config_for_slot_feature.path;
-          PADDLE_THROW(phi::errors::Fatal(ss.str()));
+          PADDLE_THROW(common::errors::Fatal(ss.str()));
           CHECK(false);
         }
         region_for_slot_feature->reset();
@@ -2067,7 +2067,7 @@ int32_t SSDSparseTable::SaveWithBinary_v2(const std::string& path,
             std::stringstream ss;
             ss << "SSDSparseTable save failed, retry it! path:"
                << channel_config.path;
-            PADDLE_THROW(phi::errors::Fatal(ss.str()));
+            PADDLE_THROW(common::errors::Fatal(ss.str()));
           }
           remain -= len;
           cursor += len;
@@ -2119,7 +2119,7 @@ int32_t SSDSparseTable::SaveWithBinary_v2(const std::string& path,
             std::stringstream ss;
             ss << "SSDSparseTable save feature failed, retry it! path:"
                << channel_config_for_slot_feature.path;
-            PADDLE_THROW(phi::errors::Fatal(ss.str()));
+            PADDLE_THROW(common::errors::Fatal(ss.str()));
           }
           remain -= len;
           cursor += len;

--- a/paddle/fluid/distributed/ps/wrapper/fleet.cc
+++ b/paddle/fluid/distributed/ps/wrapper/fleet.cc
@@ -504,7 +504,7 @@ void FleetWrapper::PushSparseVarsAsync(
   PADDLE_ENFORCE_EQ(
       communicator->Check(table_id),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "can not find table: %s, please check your config", table_id));
   communicator->Send(varnames, scope);
 }
@@ -813,7 +813,7 @@ void FleetWrapper::ShrinkDenseTable(int table_id,
   push_status.wait();
   auto status = push_status.get();
   if (status != 0) {
-    // PADDLE_THROW(phi::errors::Fatal(
+    // PADDLE_THROW(common::errors::Fatal(
     //    "push shrink dense param failed, status is [%d].", status));
     sleep(sleep_seconds_before_fail_exit_);
     exit(-1);

--- a/paddle/fluid/distributed/rpc/future_wrapper.h
+++ b/paddle/fluid/distributed/rpc/future_wrapper.h
@@ -37,7 +37,7 @@ class FutureWrapper {
     PADDLE_ENFORCE_EQ(
         PyGILState_Check(),
         false,
-        phi::errors::Fatal(
+        common::errors::Fatal(
             "GIL must be released before fut.wait(), otherwise fut_.get() "
             "blocking will cause the service to fail to "
             "process RPC requests, leading to deadlock"));

--- a/paddle/fluid/distributed/rpc/rpc_agent.cc
+++ b/paddle/fluid/distributed/rpc/rpc_agent.cc
@@ -42,7 +42,7 @@ RpcAgent::RpcAgent(std::string name, std::vector<WorkerInfo> infos) {
   PADDLE_ENFORCE_EQ(
       server_.AddService(rpc_service_.get(), brpc::SERVER_DOESNT_OWN_SERVICE),
       0,
-      phi::errors::Fatal("Fail to add service: %s", name_));
+      common::errors::Fatal("Fail to add service: %s", name_));
 }
 
 int RpcAgent::StartWorker() {
@@ -52,7 +52,7 @@ int RpcAgent::StartWorker() {
   brpc::ServerOptions options;
   PADDLE_ENFORCE_EQ(server_.Start(port, &options),
                     0,
-                    phi::errors::Fatal("Fail to start worker: %s", name_));
+                    common::errors::Fatal("Fail to start worker: %s", name_));
   VLOG(0) << "Start worker : " << name_;
   return 0;
 }
@@ -73,10 +73,11 @@ int RpcAgent::StartClient() {
     PADDLE_ENFORCE_EQ(
         channels_[i]->Init(info.ip_.c_str(), info.port_, &channel_options),
         0,
-        phi::errors::Fatal("Fail to initialize channel: %d, ip: %s, port: %d",
-                           i,
-                           info.ip_,
-                           info.port_));
+        common::errors::Fatal(
+            "Fail to initialize channel: %d, ip: %s, port: %d",
+            i,
+            info.ip_,
+            info.port_));
   }
   VLOG(0) << "Init Channels: " << name_;
   return 0;
@@ -94,7 +95,7 @@ void OnRpcDone::Run() {
   // delete this after Run
   std::unique_ptr<OnRpcDone> self_guard(this);
   PADDLE_ENFORCE_EQ(
-      cntl_.Failed(), false, phi::errors::Fatal(cntl_.ErrorText()));
+      cntl_.Failed(), false, common::errors::Fatal(cntl_.ErrorText()));
   promise_->set_value(response_.message());
   VLOG(2) << "Received response from " << cntl_.remote_side() << " to "
           << cntl_.local_side() << " (attached=" << cntl_.response_attachment()
@@ -108,7 +109,7 @@ std::future<std::string> RpcAgent::InvokeRpc(const std::string &py_func,
   auto it = name_to_infos_.find(to);
   PADDLE_ENFORCE_NE(it,
                     name_to_infos_.end(),
-                    phi::errors::OutOfRange("Worker %s doesn't exist!", to));
+                    common::errors::OutOfRange("Worker %s doesn't exist!", to));
   uint32_t id = it->second.id_;
   auto channel = channels_[id];
   // `done` must be allocated on the heap because its life cycle is after
@@ -125,7 +126,7 @@ std::future<std::string> RpcAgent::InvokeRpc(const std::string &py_func,
 std::shared_ptr<RpcAgent> RpcAgent::RpcAgentInstance() {
   PADDLE_ENFORCE_NE(rpc_agent_instance_,
                     nullptr,
-                    phi::errors::Fatal(
+                    common::errors::Fatal(
                         "RpcAgent is not set, please calling "
                         "paddle.distributed.rpc.int_rpc() to init rpc agent."));
   return rpc_agent_instance_;
@@ -134,7 +135,7 @@ void RpcAgent::SetAgentInstance(std::shared_ptr<RpcAgent> agent) {
   PADDLE_ENFORCE_EQ(
       rpc_agent_instance_,
       nullptr,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "RpcAgent has been set, please don't set rpc agent repeatedly."));
   rpc_agent_instance_ = agent;
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/66145#issuecomment-2249572051

Replace phi::errors to common::errors in paddle/fluid