### PR TITLE
Replace phi::errors [fluid_ops] part17

### DIFF
--- a/paddle/fluid/eager/accumulation/accumulation_node.cc
+++ b/paddle/fluid/eager/accumulation/accumulation_node.cc
@@ -114,12 +114,13 @@ static void CopyOrAddTensor(paddle::Tensor* tensor,
           }
         }
       } else if (LIKELY(t.is_dist_tensor())) {
-        PADDLE_ENFORCE(tensor->is_dist_tensor(),
-                       phi::errors::Fatal("A DistTensor can only do gradient "
-                                          "merge with another DistTensor."));
+        PADDLE_ENFORCE(
+            tensor->is_dist_tensor(),
+            common::errors::Fatal("A DistTensor can only do gradient "
+                                  "merge with another DistTensor."));
         PADDLE_ENFORCE(
             !t.is_custom_device(),
-            phi::errors::Fatal("DistTensor doesn't support custom device."));
+            common::errors::Fatal("DistTensor doesn't support custom device."));
         auto t_dist =
             std::dynamic_pointer_cast<phi::distributed::DistTensor>(t.impl());
         paddle::Tensor t_values(
@@ -155,12 +156,12 @@ GradNodeAccumulation::operator()(
     bool is_new_grad) {
   VLOG(3) << "Running AD API Grad: GradNodeAccumulation";
   PADDLE_ENFORCE(grads.size() == 1,
-                 phi::errors::Fatal(
+                 common::errors::Fatal(
                      "GradNodeAccumulation should take exactly 1 grad tensor"
                      "However received: %d slot.",
                      grads.size()));
   PADDLE_ENFORCE(grads[0].size() == 1,
-                 phi::errors::Fatal(
+                 common::errors::Fatal(
                      "GradNodeAccumulation should take exactly 1 grad tensor"
                      "However received: %d in slot %d .",
                      grads[0].size(),

--- a/paddle/fluid/eager/api/generated/eager_generated/backwards/scale_node.cc
+++ b/paddle/fluid/eager/api/generated/eager_generated/backwards/scale_node.cc
@@ -85,7 +85,7 @@ static void ScaleDeviceDispatch(const phi::DenseTensor& dense_tensor,
       break;
     }
     default: {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "Detected unsupported data type."
           "Only Float64, Float32, Int64, Int32 are supported for now."));
       break;
@@ -119,10 +119,10 @@ void ScaleAPI(const paddle::Tensor& x,
     auto* dev_ctx =
         dynamic_cast<phi::CPUContext*>(pool.Get(expected_kernel_place));
     if (!dev_ctx) {
-      PADDLE_THROW(
-          phi::errors::Fatal("Cannot convert device_context to phi::CPUContext."
-                             "This indicates backend mismatch."
-                             "Pleas double check your expected place"));
+      PADDLE_THROW(common::errors::Fatal(
+          "Cannot convert device_context to phi::CPUContext."
+          "This indicates backend mismatch."
+          "Pleas double check your expected place"));
     }
     ScaleDeviceDispatch<phi::CPUContext>(*dense_tensor.get(),
                                          *dev_ctx,
@@ -136,7 +136,7 @@ void ScaleAPI(const paddle::Tensor& x,
     auto* dev_ctx =
         dynamic_cast<phi::GPUContext*>(pool.Get(expected_kernel_place));
     if (!dev_ctx) {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "Cannot convert device_context to CUDADeviceContext."
           "This indicates backend mismatch."
           "Pleas double check your expected place"));
@@ -149,7 +149,7 @@ void ScaleAPI(const paddle::Tensor& x,
                                          dense_out.get());
 #endif
   } else {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "Detected unsupported backend."
         "Only CPU and CUDA Backend are supported for now."
         "Please double check if your backend falls into the above two "
@@ -176,7 +176,7 @@ GradNodeScale::operator()(
   VLOG(6) << "grad size is: " << grads.size();
   PADDLE_ENFORCE(
       ((grads.size() == 1) && (grads[0].size() == 1)),
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "ScaleGradNode takes exactly 1 grad tensor."
           "However received: %d",
           "This indicates an issue with Eager Dygraph Backward logic",

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/reshard_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/reshard_fwd_func.cc
@@ -80,7 +80,7 @@ paddle::Tensor reshard_ad_function(
 
   return out;
 #else
-  PADDLE_THROW(phi::errors::Unavailable(
+  PADDLE_THROW(common::errors::Unavailable(
       "Reshard is not supported in this version of Paddle. Try to recompile it "
       "with WITH_DISTRIBUTE=ON and reinstall this package."));
   return paddle::Tensor();

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/multiply_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/multiply_node.cc
@@ -461,7 +461,7 @@ MultiplyDoubleGradNode::operator()(
 
   if (need_skip) {
     if (trace_backward) {
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "The Op multiply_double_grad doesn't have any grad"
           "op. If you don't intend calculating higher order"
           "derivatives, please set `create_graph`to False."));
@@ -637,7 +637,7 @@ MultiplyGradNode::operator()(
 
   // Create Grad Node
   if (trace_backward) {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "The Op multiply_grad doesn't have any grad"
         "op. If you don't intend calculating higher order"
         "derivatives, please set `create_graph`to False."));

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/reshard_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/reshard_node.cc
@@ -110,7 +110,7 @@ ReshardGradNode::operator()(
 
   return returns;
 #else
-  PADDLE_THROW(phi::errors::Unavailable(
+  PADDLE_THROW(common::errors::Unavailable(
       "ReshardGrad is not supported in this version of Paddle. Try to "
       "recompile it with WITH_DISTRIBUTE=ON and reinstall this package."));
   return paddle::small_vector<std::vector<paddle::Tensor>,

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/sync_batch_norm_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/sync_batch_norm_node.cc
@@ -196,7 +196,7 @@ SyncBatchNormGradNode::operator()(
 
   // Create Grad Node
   if (trace_backward) {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "The Op sync_batch_norm_grad doesn't have any grad"
         "op. If you don't intend calculating higher order"
         "derivatives, please set `create_graph`to False."));
@@ -428,7 +428,7 @@ SyncBatchNormGradNode::operator()(
 
   // Create Grad Node
   if (trace_backward) {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "The Op sync_batch_norm_grad doesn't have any grad"
         "op. If you don't intend calculating higher order"
         "derivatives, please set `create_graph`to False."));

--- a/paddle/fluid/eager/api/manual/fluid_manual/nodes/nodes.h
+++ b/paddle/fluid/eager/api/manual/fluid_manual/nodes/nodes.h
@@ -31,7 +31,7 @@ const T& GetAttrWithDefault(
     return PADDLE_GET_CONST(T, iter2->second);
   }
   PADDLE_THROW(
-      phi::errors::InvalidArgument("Attribute(%s) cannot be found.", name));
+      common::errors::InvalidArgument("Attribute(%s) cannot be found.", name));
 }
 
 class fused_gate_attentionGradNodeCompat : public egr::GradNodeBase {

--- a/paddle/fluid/eager/api/utils/hook_utils.cc
+++ b/paddle/fluid/eager/api/utils/hook_utils.cc
@@ -38,17 +38,18 @@ void RegisterReduceHookForTensor(const paddle::Tensor& tensor,
   if (EagerUtils::IsLeafTensor(tensor)) {
     VLOG(6) << "Register ReduceHook for leaf tensor";
     std::shared_ptr<GradNodeBase> grad_node = EagerUtils::grad_node(tensor);
-    PADDLE_ENFORCE(grad_node.get() != nullptr,
-                   phi::errors::Fatal("Detected NULL grad_node,"
-                                      "Leaf tensor should have had grad_node "
-                                      "with type: GradNodeAccumulation"));
+    PADDLE_ENFORCE(
+        grad_node.get() != nullptr,
+        common::errors::Fatal("Detected NULL grad_node,"
+                              "Leaf tensor should have had grad_node "
+                              "with type: GradNodeAccumulation"));
     auto accumulation_grad_node =
         std::dynamic_pointer_cast<GradNodeAccumulation>(grad_node);
     accumulation_grad_node->RegisterReduceHook(
         std::make_shared<CppVoidHook>(hook));
   } else {
-    PADDLE_THROW(
-        phi::errors::Fatal("Only can register reduce hook for leaf Tensor."));
+    PADDLE_THROW(common::errors::Fatal(
+        "Only can register reduce hook for leaf Tensor."));
   }
 }
 

--- a/paddle/fluid/eager/auto_code_generator/eager_generator.cc
+++ b/paddle/fluid/eager/auto_code_generator/eager_generator.cc
@@ -344,7 +344,7 @@ static std::string AttrTypeToString(const proto::AttrType& type) {
       break;
     }
     default: {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "AttrType of type paddle::variant only supports specific data types."
           "However, detected unrecognized AttrType: %d",
           type));
@@ -455,7 +455,7 @@ static std::pair<std::string, std::string> GetAttrType(
       break;
     }
     default: {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "AttrType of type paddle::variant only supports specific data types."
           "However, detected unrecognized AttrType: %d",
           variant_pos));
@@ -501,7 +501,7 @@ static void SlotNameMatching(
           if (grad_var == fwd_var) {
             if (grad_fwd_slotname_map.count(grad_slot_name) &&
                 grad_fwd_slotname_map[grad_slot_name] != fwd_slot_name) {
-              PADDLE_THROW(phi::errors::Fatal(
+              PADDLE_THROW(common::errors::Fatal(
                   "Detected mismatched slot names."
                   "grad_slot_name %s matches both %s and %s fwd_slot_name",
                   grad_slot_name,
@@ -515,7 +515,7 @@ static void SlotNameMatching(
           if (fwd_var->GetGradVar() && grad_var == fwd_var->GetGradVar()) {
             if (grad_grad_slotname_map.count(grad_slot_name) &&
                 grad_grad_slotname_map[grad_slot_name] != fwd_slot_name) {
-              PADDLE_THROW(phi::errors::Fatal(
+              PADDLE_THROW(common::errors::Fatal(
                   "Detected mismatched slot names."
                   "grad_slot_name %s matches both %s and %s fwd_slot_name",
                   grad_slot_name,
@@ -536,7 +536,7 @@ static void SlotNameMatching(
           if (grad_var == fwd_var) {
             if (grad_fwd_slotname_map.count(grad_slot_name) &&
                 grad_fwd_slotname_map[grad_slot_name] != fwd_slot_name) {
-              PADDLE_THROW(phi::errors::Fatal(
+              PADDLE_THROW(common::errors::Fatal(
                   "Detected mismatched slot names"
                   "grad_slot_name %s matches both %s and %s fwd_slot_name",
                   grad_slot_name,
@@ -550,7 +550,7 @@ static void SlotNameMatching(
           if (fwd_var->GetGradVar() && grad_var == fwd_var->GetGradVar()) {
             if (grad_grad_slotname_map.count(grad_slot_name) &&
                 grad_grad_slotname_map[grad_slot_name] != fwd_slot_name) {
-              PADDLE_THROW(phi::errors::Fatal(
+              PADDLE_THROW(common::errors::Fatal(
                   "Detected mismatched slot names."
                   "grad_slot_name %s matches both %s and %s fwd_slot_name",
                   grad_slot_name,
@@ -565,7 +565,7 @@ static void SlotNameMatching(
     }
 
     if (!found_matching) {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "Detected mismatched slot names."
           "Found no matching fwd_slot_name for grad_slot_name: %s",
           grad_slot_name));
@@ -729,7 +729,7 @@ static void PurifyGradNodeGenerationInfo(const proto::OpProto& op_proto,
 
               PADDLE_ENFORCE(
                   grad_outs->count(grad_output_name) > 0,
-                  phi::errors::Fatal(
+                  common::errors::Fatal(
                       "Unable to find gradient output name in grad_outs."));
               // grad_outs
               grad_outs->erase(grad_output_name);
@@ -767,7 +767,7 @@ static void PurifyGradNodeGenerationInfo(const proto::OpProto& op_proto,
 
               PADDLE_ENFORCE(
                   grad_ins->count(grad_input_name) > 0,
-                  phi::errors::Fatal(
+                  common::errors::Fatal(
                       "Unable to find gradient input name in grad_ins."));
               // grad_ins
               grad_ins->erase(grad_input_name);
@@ -1685,7 +1685,7 @@ static std::pair<std::string, std::string> GenerateForwardFunctionContents(
       PADDLE_ENFORCE_NE(
           forward_inplace_map[output_name],
           "",
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Inplace op %s has no input corresponding to output %s.",
               op_type,
               output_name));
@@ -2290,10 +2290,10 @@ static std::string GenerateSingleOpBase(
                                     can_be_inplaced_name);
       }
     } else {
-      PADDLE_THROW(
-          phi::errors::Fatal("Detected mismatched slot names."
-                             "Unable to find forward slot name that matches %s",
-                             grad_input_name));
+      PADDLE_THROW(common::errors::Fatal(
+          "Detected mismatched slot names."
+          "Unable to find forward slot name that matches %s",
+          grad_input_name));
     }
   }
   if (!ins_contents_str.empty())
@@ -2388,7 +2388,7 @@ static std::string GenerateSingleOpBase(
       */
       if (!fwd_inputs_name_pos_map.count(fwd_name)) {
         PADDLE_ENFORCE(fwd_outputs_name_pos_map.count(fwd_name),
-                       phi::errors::Fatal(
+                       common::errors::Fatal(
                            "fwd_name not found in fwd_inputs_name_pos_map nor "
                            "fwd_outputs_name_pos_map"));
 
@@ -2438,10 +2438,10 @@ static std::string GenerateSingleOpBase(
         }
       }
     } else {
-      PADDLE_THROW(
-          phi::errors::Fatal("Detected mismatched slot names."
-                             "Unable to find forward slot name that matches %s",
-                             grad_output_name));
+      PADDLE_THROW(common::errors::Fatal(
+          "Detected mismatched slot names."
+          "Unable to find forward slot name that matches %s",
+          grad_output_name));
     }
   }
 
@@ -2495,10 +2495,10 @@ static std::string GenerateSingleOpBase(
         }
       }
     } else {
-      PADDLE_THROW(
-          phi::errors::Fatal("Detected mismatched slot names."
-                             "Unable to find forward slot name that matches %s",
-                             grad_output_name));
+      PADDLE_THROW(common::errors::Fatal(
+          "Detected mismatched slot names."
+          "Unable to find forward slot name that matches %s",
+          grad_output_name));
     }
   }
 
@@ -2600,7 +2600,7 @@ static std::string GenerateSingleOpBase(
       num_appended_outputs++;
     } else {
       PADDLE_ENFORCE(fwd_outputs_name_pos_map.count(fwd_name),
-                     phi::errors::Fatal(
+                     common::errors::Fatal(
                          "fwd_name not found in fwd_inputs_name_pos_map nor "
                          "fwd_outputs_name_pos_map"));
     }

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -391,7 +391,7 @@ BEFORE_LOG_PRINT_TEMPLATE = """
 
 STRIDED_FLAGS_CHECK_TEMPLATE = """
   if (!FLAGS_use_stride_kernel) {
-    PADDLE_THROW(phi::errors::Fatal(\"FLAGS_use_stride_kernel is closed. Inplace strided API should not be called!\"));
+    PADDLE_THROW(common::errors::Fatal(\"FLAGS_use_stride_kernel is closed. Inplace strided API should not be called!\"));
   }
 """
 
@@ -2249,7 +2249,7 @@ class DygraphNodeGenerator(DygraphFunctionGeneratorBase):
                     next_grad_node_creation_str = f"""
   if (!paddle::prim::PrimCommonUtils::IsEagerPrimEnabled() || need_skip) {{
     if (trace_backward) {{
-       PADDLE_THROW(phi::errors::Unavailable(
+       PADDLE_THROW(common::errors::Unavailable(
        \"The Op {self.backward_api_name} doesn't have any grad\"
        \"op. If you don't intend calculating higher order\"
        \"derivatives, please set `create_graph`to False.\"));
@@ -2269,7 +2269,7 @@ class DygraphNodeGenerator(DygraphFunctionGeneratorBase):
         # TODO(Ruting):Integrate invoke and composite as composite so the rest branch canbe covered
         elif not is_invoke_forward_api and not is_composite_grad_api:
             next_grad_node_creation_str = f"""  if (trace_backward) {{
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
     \"The Op {self.backward_api_name} doesn't have any grad\"
     \"op. If you don't intend calculating higher order\"
     \"derivatives, please set `create_graph`to False.\"));
@@ -2765,7 +2765,7 @@ if (paddle::prim::PrimCommonUtils::IsEagerPrimEnabled() && !need_skip) {{
                             code
                             + f"""
 }} else {{
-  PADDLE_THROW(phi::errors::Unavailable(
+  PADDLE_THROW(common::errors::Unavailable(
   \"The grad op of {self.backward_api_name} doesn't implemented yet.\"));
 }}
 """

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -150,7 +150,7 @@ FUNCTION_SET_DEVICE_TEMPLATE = """{}
       phi::backends::gpu::SetDeviceId(place.device);
       VLOG(4) <<"CurrentDeviceId: " << phi::backends::gpu::GetCurrentDeviceId() << " from " << (int)place.device;
 #else
-      PADDLE_THROW(phi::errors::PreconditionNotMet(
+      PADDLE_THROW(common::errors::PreconditionNotMet(
         "PaddlePaddle should compile with GPU if use CUDAPlace."));
 #endif
     }}
@@ -159,7 +159,7 @@ FUNCTION_SET_DEVICE_TEMPLATE = """{}
       phi::DeviceManager::SetDevice(place);
       VLOG(4) <<"CurrentDeviceId: " << phi::DeviceManager::GetDevice(place.GetDeviceType()) << " from " << (int)place.device;
 #else
-      PADDLE_THROW(phi::errors::PreconditionNotMet(
+      PADDLE_THROW(common::errors::PreconditionNotMet(
         "PaddlePaddle should compile with CUSTOM_DEVICE if use CustomPlace."));
 #endif
     }}
@@ -168,7 +168,7 @@ FUNCTION_SET_DEVICE_TEMPLATE = """{}
       phi::backends::xpu::SetXPUDeviceId(place.device);
       VLOG(4) <<"CurrentDeviceId: " << phi::backends::xpu::GetXPUCurrentDeviceId() << " from " << (int)place.device;
 #else
-      PADDLE_THROW(phi::errors::PreconditionNotMet(
+      PADDLE_THROW(common::errors::PreconditionNotMet(
         "PaddlePaddle should compile with XPU if use XPUPlace."));
 #endif
     }}
@@ -205,11 +205,11 @@ static PyMethodDef EagerFinalStateMethods[] = {{
 
 void BindFinalStateEagerOpFunctions(pybind11::module *module) {{
   if (PyModule_AddFunctions(module->ptr(), EagerFinalStateMethods) < 0) {{
-    PADDLE_THROW(phi::errors::Fatal ("Add functions to core.eager.ops failed!"));
+    PADDLE_THROW(common::errors::Fatal ("Add functions to core.eager.ops failed!"));
   }}
 
   if (PyModule_AddFunctions(module->ptr(), CustomEagerFinalStateMethods) < 0) {{
-    PADDLE_THROW(phi::errors::Fatal ("Add functions to core.eager.ops failed!"));
+    PADDLE_THROW(common::errors::Fatal ("Add functions to core.eager.ops failed!"));
   }}
 }}
 

--- a/paddle/fluid/eager/autograd_meta.h
+++ b/paddle/fluid/eager/autograd_meta.h
@@ -71,7 +71,7 @@ class AutogradMeta : public AbstractAutogradMeta {
   const paddle::Tensor& Grad() const {
     PADDLE_ENFORCE_NOT_NULL(
         grad_.get(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Should Not get NULL from Grad pointer, since "
             "we should have default Tensor once we init AutoGradMeta. "
             "if you got this error may indicates framework error in "
@@ -86,7 +86,7 @@ class AutogradMeta : public AbstractAutogradMeta {
   void SetGradNode(const std::shared_ptr<GradNodeBase>& grad_node) {
     PADDLE_ENFORCE_NOT_NULL(
         grad_node.get(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Should Not set NULL as GradNode pointer, since "
             "our default Edge and autogradMeta has nullptr for "
             "grad node. Set Nullptr will lead error."));

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -43,7 +43,7 @@ std::unordered_map<GradNodeBase*, int> getInDegreeMap(
 
     PADDLE_ENFORCE_NOT_NULL(
         node,
-        phi::errors::Fatal(
+        common::errors::Fatal(
             "We got null node when we traverse the backward graph, and this "
             "should not happened please check your code and contact us."));
     // Find and append next nodes
@@ -75,7 +75,7 @@ void EnforceGradNodeHasInput(GradNodeBase* node) {
   PADDLE_ENFORCE_NE(
       node->IsTensorWrappersCleared(),
       true,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "The TensorWrappers of %s do not exist. This may be because:\n"
           "You calculate backward twice for the same subgraph without "
           "setting retain_graph=True. Please set retain_graph=True in the "
@@ -91,7 +91,7 @@ void DuplicateCheck(const std::vector<paddle::Tensor>& inputs, bool is_input) {
     PADDLE_ENFORCE_EQ(
         visited_ins.count(auto_grad_meta),
         0,
-        phi::errors::AlreadyExists(
+        common::errors::AlreadyExists(
             "%s contain duplicate tensor %s, please check %s carefully.",
             msg,
             in.name(),
@@ -183,7 +183,7 @@ std::vector<paddle::Tensor> RunBackward(
     if (!grad_tensors.empty() && grad_tensors[i].initialized()) {
       PADDLE_ENFORCE(
           grad_tensors.size() == tensors.size(),
-          phi::errors::Fatal(
+          common::errors::Fatal(
               "Detected size mismatch between tensors and grad_tensors"
               "grad_tensors should either have "
               "size = 0 or same size as tensors."));
@@ -265,7 +265,7 @@ std::vector<paddle::Tensor> RunBackward(
     PADDLE_ENFORCE_NE(
         node_input_buffer_iter,
         node_input_buffers_dict.end(),
-        phi::errors::Fatal(
+        common::errors::Fatal(
             "Unable to find next node in the GradTensorHolder \n"
             "Trying to run Node without configuring its GradTensorHolder."));
 
@@ -315,7 +315,7 @@ std::vector<paddle::Tensor> RunBackward(
     const paddle::small_vector<std::vector<GradSlotMeta>, kSlotSmallVectorSize>&
         metas = node->OutputMeta();
     PADDLE_ENFORCE(metas.size() == grad_output_tensors.size() || metas.empty(),
-                   phi::errors::Fatal(
+                   common::errors::Fatal(
                        "Number of edges should be either empty ( for leaf node "
                        ") or the same as number of output grad tensors, but we "
                        "got edges size is: %d, grad_output size is: %d",
@@ -346,7 +346,7 @@ std::vector<paddle::Tensor> RunBackward(
         PADDLE_ENFORCE_LT(
             j,
             grad_output_tensors[i].size(),
-            phi::errors::Fatal(
+            common::errors::Fatal(
                 "Rank of grad_output_tensors should be less than "
                 "grad_output_tensors[i].size(), which is: %d. This error may "
                 "indicate autoprune or autograd api error. ",
@@ -388,7 +388,7 @@ std::vector<paddle::Tensor> RunBackward(
 
         PADDLE_ENFORCE(
             node_in_degree_map[next_node] >= 0,
-            phi::errors::Fatal(
+            common::errors::Fatal(
                 "Detected in-degree value smaller than zero. For Node: %s"
                 "Node's in-degree cannot be negative.",
                 next_node->name()));

--- a/paddle/fluid/eager/custom_operator/custom_operator_node.cc
+++ b/paddle/fluid/eager/custom_operator/custom_operator_node.cc
@@ -49,7 +49,7 @@ static void ConstructFwdAndBwdMap(
   PADDLE_ENFORCE_LE(
       grad_outputs_names.size(),
       inputs_names.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Grad outputs num should be less equal than forward inputs num."));
   for (size_t i = 0; i < grad_outputs_names.size(); i++) {
     auto end = grad_outputs_names[i].find("@GRAD@GRAD");
@@ -89,7 +89,7 @@ static void ConstructFwdAndBwdMap(
             }
           }
         } else {
-          PADDLE_THROW(phi::errors::NotFound(
+          PADDLE_THROW(common::errors::NotFound(
               "All Grad outputs should be end of @GRAD@GRAD or @GRAD@NEW or "
               "@GRAD and we got %s is not one of them, "
               "please check your op and change to fit the rule.",
@@ -144,7 +144,7 @@ static void ConstructFwdAndBwdMap(
         std::find(attrs_names.begin(), attrs_names.end(), grad_attrs_names[i]);
     PADDLE_ENFORCE_NE(end,
                       attrs_names.end(),
-                      phi::errors::NotFound(
+                      common::errors::NotFound(
                           "All Grad attrs should be one of forward attrs and "
                           "we got %s is not one of them, please check your "
                           "op and change to fit the rule.",
@@ -267,7 +267,7 @@ RunCustomOpNode::operator()(paddle::small_vector<std::vector<paddle::Tensor>,
             paddle::framework::detail::IsOptionalVar(
                 grad_outputs_names.at(i)) ||
                 out_tensor->is_dist_tensor(),
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Custom grad operator's %d-th output is not initialized. "
                 "Please check your implementation again. If you are "
                 "using inplace optional outputs, then you must use "

--- a/paddle/fluid/eager/custom_operator/custom_operator_utils.cc
+++ b/paddle/fluid/eager/custom_operator/custom_operator_utils.cc
@@ -43,7 +43,7 @@ static std::vector<std::vector<phi::DDim>> RunDefaultInferShapeFunc(
     PADDLE_ENFORCE_EQ(
         inputs.size(),
         1UL,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator contains multiple inputs. "
             "We only allow a custom operator that contains only one input "
             "and only one output without setting the InferShapeFn. "
@@ -54,7 +54,7 @@ static std::vector<std::vector<phi::DDim>> RunDefaultInferShapeFunc(
     PADDLE_ENFORCE_EQ(
         outputs.size(),
         1UL,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator contains multiple outputs. "
             "We only allow a custom operator that contains only one input "
             "and only one output without setting the InferShapeFn. "
@@ -69,7 +69,7 @@ static std::vector<std::vector<phi::DDim>> RunDefaultInferShapeFunc(
     PADDLE_ENFORCE_EQ(
         inplace_map.size(),
         outputs.size(),
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator uses `SetInplaceMap` without setting the "
             "InferShapeFn. However, `Outputs` size = %d does not match the "
             "`InplaceMap` size = %d. Please check `SetInplaceMap` again or set "
@@ -117,12 +117,12 @@ static std::vector<std::vector<phi::DDim>> RunDefaultGradInferShapeFunc(
       // Duplicable forward var must as backward input
       auto iter =
           std::find(grad_op_inputs.begin(), grad_op_inputs.end(), fwd_name);
-      PADDLE_ENFORCE_NE(
-          iter,
-          grad_op_inputs.end(),
-          phi::errors::NotFound("Custom grad operator should have the forward "
-                                "input(%s) as backward input",
-                                fwd_name));
+      PADDLE_ENFORCE_NE(iter,
+                        grad_op_inputs.end(),
+                        common::errors::NotFound(
+                            "Custom grad operator should have the forward "
+                            "input(%s) as backward input",
+                            fwd_name));
       auto pair = ctx.InputRangeAt(iter - grad_op_inputs.begin());
       std::vector<phi::DDim> tmp;
       for (size_t i = pair.first; i < pair.second; ++i) {
@@ -138,9 +138,9 @@ static std::vector<std::vector<phi::DDim>> RunDefaultGradInferShapeFunc(
         PADDLE_ENFORCE_NE(
             iter,
             grad_op_inputs.end(),
-            phi::errors::NotFound("Custom grad operator should have the "
-                                  "forward input(%s) as backward input",
-                                  fwd_name));
+            common::errors::NotFound("Custom grad operator should have the "
+                                     "forward input(%s) as backward input",
+                                     fwd_name));
         auto pair = ctx.InputRangeAt(iter - grad_op_inputs.begin());
         result.push_back({ctx.InputAt(pair.first).dims()});
       }
@@ -178,7 +178,7 @@ static std::vector<std::vector<phi::DDim>> RunInferShapeFunc(
   if (inplace_map.empty()) {
     PADDLE_ENFORCE_EQ(outputs.size(),
                       output_shapes.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Your custom operator has set the InferShapeFn. "
                           "However, `Outputs` size = %d does not match the "
                           "returned vector size of InferShapeFn = %d. Please "
@@ -189,7 +189,7 @@ static std::vector<std::vector<phi::DDim>> RunInferShapeFunc(
     PADDLE_ENFORCE_EQ(
         outputs.size(),
         output_shapes.size() + inplace_map.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Your custom operator uses `SetInplaceMap` and sets the "
             "InferShapeFn. However, `Outputs` size = %d does not match the "
             "`InplaceMap size + InferShapeFn output size` = %d. Please check "
@@ -208,7 +208,7 @@ static std::vector<std::vector<phi::DDim>> RunInferShapeFunc(
     if (paddle::framework::detail::IsDuplicableVar(outputs[i])) {
       PADDLE_ENFORCE(
           inplace_reverse_map.find(i) != inplace_reverse_map.end(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Custom operator only supports `paddle::Vec(...)` inputs and "
               "cannot support `paddle::Vec(...)` output without setting "
               "InplaceMap. If you have to use `paddle::Vec(...)` output, "
@@ -244,7 +244,7 @@ static std::vector<std::vector<phi::DataType>> RunDefaultInferDtypeFunc(
     PADDLE_ENFORCE_EQ(
         inputs.size(),
         1UL,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator contains multiple inputs. "
             "We only allow a custom operator that contains only one input "
             "and only one output without setting the InferDtypeFn. "
@@ -255,7 +255,7 @@ static std::vector<std::vector<phi::DataType>> RunDefaultInferDtypeFunc(
     PADDLE_ENFORCE_EQ(
         outputs.size(),
         1UL,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator contains multiple outputs. "
             "We only allow a custom operator that contains only one input "
             "and only one output without setting the InferDtypeFn. "
@@ -270,7 +270,7 @@ static std::vector<std::vector<phi::DataType>> RunDefaultInferDtypeFunc(
     PADDLE_ENFORCE_EQ(
         inplace_map.size(),
         outputs.size(),
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "Your custom operator uses `SetInplaceMap` without setting the "
             "InferDtypeFn. However, `Outputs` size = %d does not match the "
             "`InplaceMap` size = %d. Please check `SetInplaceMap` again or set "
@@ -309,12 +309,12 @@ static std::vector<std::vector<phi::DataType>> RunDefaultGradInferDtypeFunc(
       // Duplicable forward var must as backward input
       auto iter =
           std::find(grad_op_inputs.begin(), grad_op_inputs.end(), fwd_name);
-      PADDLE_ENFORCE_NE(
-          iter,
-          grad_op_inputs.end(),
-          phi::errors::NotFound("Custom grad operator should have the forward "
-                                "input(%s) as backward input",
-                                fwd_name));
+      PADDLE_ENFORCE_NE(iter,
+                        grad_op_inputs.end(),
+                        common::errors::NotFound(
+                            "Custom grad operator should have the forward "
+                            "input(%s) as backward input",
+                            fwd_name));
       auto pair = ctx.InputRangeAt(iter - grad_op_inputs.begin());
       std::vector<phi::DataType> tmp;
       for (size_t i = pair.first; i < pair.second; ++i) {
@@ -330,9 +330,9 @@ static std::vector<std::vector<phi::DataType>> RunDefaultGradInferDtypeFunc(
         PADDLE_ENFORCE_NE(
             iter,
             grad_op_inputs.end(),
-            phi::errors::NotFound("Custom grad operator should have the "
-                                  "forward input(%s) as backward input",
-                                  fwd_name));
+            common::errors::NotFound("Custom grad operator should have the "
+                                     "forward input(%s) as backward input",
+                                     fwd_name));
         auto pair = ctx.InputRangeAt(iter - grad_op_inputs.begin());
         result.push_back({ctx.InputAt(pair.first).dtype()});
       }
@@ -371,7 +371,7 @@ static std::vector<std::vector<phi::DataType>> RunInferDtypeFunc(
   if (inplace_map.empty()) {
     PADDLE_ENFORCE_EQ(outputs.size(),
                       output_dtypes.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Your custom operator has set the InferDtypeFn. "
                           "However, `Outputs` size = %d does not match the "
                           "returned vector size of InferDtypeFn = %d. Please "
@@ -382,7 +382,7 @@ static std::vector<std::vector<phi::DataType>> RunInferDtypeFunc(
     PADDLE_ENFORCE_EQ(
         outputs.size(),
         output_dtypes.size() + inplace_map.size(),
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Your custom operator uses `SetInplaceMap` and sets the "
             "InferDtypeFn. However, `Outputs` size = %d does not match the "
             "`InplaceMap size + InferDtypeFn output size` = %d. Please check "
@@ -401,7 +401,7 @@ static std::vector<std::vector<phi::DataType>> RunInferDtypeFunc(
     if (paddle::framework::detail::IsDuplicableVar(outputs[i])) {
       PADDLE_ENFORCE(
           inplace_reverse_map.find(i) != inplace_reverse_map.end(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Custom operator only supports `paddle::Vec(...)` inputs and "
               "cannot support `paddle::Vec(...)` output without setting "
               "InplaceMap. If you have to use `paddle::Vec(...)` output, "
@@ -566,7 +566,7 @@ std::vector<std::vector<phi::DDim>> RunInferShapeFn(
   PADDLE_ENFORCE_EQ(
       out_dims.size(),
       ctx.OutputRange().size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Custom op infer_shape return size should be %d, but got %d.",
           ctx.OutputRange().size(),
           out_dims.size()));
@@ -599,7 +599,7 @@ std::vector<std::vector<phi::DataType>> RunInferDtypeFn(
   PADDLE_ENFORCE_EQ(
       out_dtypes.size(),
       ctx.OutputRange().size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Custom op infer_dtype return size should be %d, but got %d.",
           ctx.OutputRange().size(),
           out_dtypes.size()));
@@ -674,19 +674,19 @@ std::
       PADDLE_ENFORCE_EQ(
           out_dim.size(),
           pair.second - pair.first,
-          phi::errors::InvalidArgument("custom op infer_shape result[%d]'s "
-                                       "size should be %d, but got %d.",
-                                       i,
-                                       pair.second - pair.first,
-                                       out_dim.size()));
+          common::errors::InvalidArgument("custom op infer_shape result[%d]'s "
+                                          "size should be %d, but got %d.",
+                                          i,
+                                          pair.second - pair.first,
+                                          out_dim.size()));
       PADDLE_ENFORCE_EQ(
           out_dtype.size(),
           pair.second - pair.first,
-          phi::errors::InvalidArgument("custom op infer_shape result[%d]'s "
-                                       "size should be %d, but got %d.",
-                                       i,
-                                       pair.second - pair.first,
-                                       out_dtype.size()));
+          common::errors::InvalidArgument("custom op infer_shape result[%d]'s "
+                                          "size should be %d, but got %d.",
+                                          i,
+                                          pair.second - pair.first,
+                                          out_dtype.size()));
 
       if (out_dim.size() == 1) {
         output_dims.emplace_back(out_dim[0]);

--- a/paddle/fluid/eager/eager_tensor.h
+++ b/paddle/fluid/eager/eager_tensor.h
@@ -52,11 +52,11 @@ class VariableCompatTensor
         paddle::framework::IsRegisteredVarType<T>(),
         "Not registered type. Please register T inside var_type_traits.h");
     PADDLE_ENFORCE_NOT_NULL(
-        holder_, phi::errors::NotFound("Variable is not initialized."));
+        holder_, common::errors::NotFound("Variable is not initialized."));
     PADDLE_ENFORCE_EQ(
         holder_->Type(),
         paddle::framework::VarTypeTrait<T>::kId,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The Variable type must be %s, but the type it holds is %s.",
             paddle::framework::ToTypeName(
                 paddle::framework::VarTypeTrait<T>::kId),
@@ -74,7 +74,7 @@ class VariableCompatTensor
       PADDLE_ENFORCE_EQ(
           holder_->Type(),
           paddle::framework::VarTypeTrait<T>::kId,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The Variable type must be %s, but the type it holds is %s.",
               paddle::framework::ToTypeName(
                   paddle::framework::VarTypeTrait<T>::kId),
@@ -93,7 +93,7 @@ class VariableCompatTensor
 
   int Type() const {
     PADDLE_ENFORCE_NOT_NULL(
-        holder_, phi::errors::NotFound("Variable is not initialized."));
+        holder_, common::errors::NotFound("Variable is not initialized."));
     return holder_->Type();
   }
 
@@ -104,27 +104,27 @@ class VariableCompatTensor
   ~VariableCompatTensor() override = default;
 
   int64_t numel() const override {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "VariableCompatTensor does not support `numel` method."));
   }
 
   const phi::DDim& dims() const override {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "VariableCompatTensor does not support `dims` method."));
   }
 
   phi::DataType dtype() const override {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "VariableCompatTensor does not support `dtype` method."));
   }
 
   phi::DataLayout layout() const override {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "VariableCompatTensor does not support `layout` method."));
   }
 
   const phi::Place& place() const override {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "VariableCompatTensor does not support `place` method."));
   }
 
@@ -136,7 +136,7 @@ class VariableCompatTensor
                      phi::DataType dtype UNUSED,
                      size_t requested_size UNUSED = 0,
                      bool fake_alloc UNUSED = false) override {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "VariableCompatTensor does not support `AllocateFrom` method."));
   }
 
@@ -219,7 +219,7 @@ class EagerVariable final {
                      ->IsType<paddle::framework::Strings>()) {
         ConstructVariableFromCompatTensor<paddle::framework::Strings>(tensor);
       } else {
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "Unrecognized egr::EagerVariable type, only "
             "DenseTensor and SelectedRows are supported for now."));
       }
@@ -251,12 +251,12 @@ class EagerVariable final {
         return SetImplWithLegacyTensor<phi::SelectedRows>();
       } else {
         PADDLE_THROW(
-            phi::errors::Fatal("Unable to fetch underlying tensor "
-                               "from EagerVariable, only LoDTensor and "
-                               "Tensor are supported for now"));
+            common::errors::Fatal("Unable to fetch underlying tensor "
+                                  "from EagerVariable, only LoDTensor and "
+                                  "Tensor are supported for now"));
       }
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "Can not Sync EagerVariable %s whose paddle::framework::Variable is "
           "not initialized!",
           name()));
@@ -289,7 +289,7 @@ class EagerVariable final {
     PADDLE_ENFORCE_EQ(
         (tensor_dense.get() && tensor_dense),
         true,
-        phi::errors::Fatal(
+        common::errors::Fatal(
             "Tensor %s does not hold phi::SelectedRows or phi::DenseTensor. "
             "Or it holds empty impl, this should not happened since we should "
             "treat all kinds of tensor as what they are.",
@@ -311,10 +311,10 @@ class EagerVariable final {
         static_cast<VariableCompatTensor*>(tensor.impl().get());
     PADDLE_ENFORCE_NOT_NULL(
         compat_tensor,
-        phi::errors::Fatal("Tensor %s holds empty impl, this should not "
-                           "happened since we should "
-                           "treat all kinds of tensor as what they are.",
-                           tensor.name()));
+        common::errors::Fatal("Tensor %s holds empty impl, this should not "
+                              "happened since we should "
+                              "treat all kinds of tensor as what they are.",
+                              tensor.name()));
     *framework_holder = compat_tensor->Get<VarType>();
   }
 

--- a/paddle/fluid/eager/general_grad.h
+++ b/paddle/fluid/eager/general_grad.h
@@ -52,7 +52,7 @@ class GeneralGrad {
             EagerUtils::unsafe_autograd_meta(inputs[i]);
         PADDLE_ENFORCE_NOT_NULL(
             auto_grad_meta,
-            phi::errors::Fatal(
+            common::errors::Fatal(
                 "We got %s:[%d] 's autograd meta is NULL.", msg, i));
         auto* target_node = auto_grad_meta->GetMutableGradNode().get();
 
@@ -66,10 +66,10 @@ class GeneralGrad {
 
         PADDLE_ENFORCE_NOT_NULL(
             target_node,
-            phi::errors::Fatal("There is no grad op for %s:[%d] or it's"
-                               "stop_gradient=True.",
-                               msg,
-                               i));
+            common::errors::Fatal("There is no grad op for %s:[%d] or it's"
+                                  "stop_gradient=True.",
+                                  msg,
+                                  i));
 
         if (is_no_grad_vars) {
           (no_grad_var_nodes_inputmeta_map_)[target_node] = auto_grad_meta;
@@ -304,9 +304,9 @@ class GeneralGrad {
 
         PADDLE_ENFORCE_NOT_NULL(
             target_node,
-            phi::errors::Fatal("There is no grad op for inputs:[%d] or it's"
-                               "stop_gradient=True.",
-                               i));
+            common::errors::Fatal("There is no grad op for inputs:[%d] or it's"
+                                  "stop_gradient=True.",
+                                  i));
 
         if (!IsEndingNodes(target_node)) {
           // Fetch grad for tensor in target_node on path.
@@ -465,7 +465,7 @@ class GeneralGrad {
       } else {
         PADDLE_ENFORCE_EQ(allow_unused,
                           true,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The %d-th input does not appear in the backward "
                               "graph. Please check the input tensor or set "
                               "allow_unused=True to get None result.",
@@ -532,7 +532,7 @@ class GeneralGrad {
 
       PADDLE_ENFORCE(
           orig_to_copied_node_map_.count(orig_node),
-          phi::errors::Fatal(
+          common::errors::Fatal(
               "Cannot copy backward graph,"
               "unable to find copied target for certain grad node."));
       GradNodeBase* copied_node = orig_to_copied_node_map_[orig_node].get();

--- a/paddle/fluid/eager/grad_node_info.cc
+++ b/paddle/fluid/eager/grad_node_info.cc
@@ -38,7 +38,7 @@ namespace egr {
 
 static void CheckTensor(const paddle::Tensor& pre, const paddle::Tensor& post) {
   if (!pre.initialized() && post.initialized()) {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "The tensor in before and after hook are not consistent"));
   }
   if (pre.initialized() && post.initialized()) {
@@ -47,14 +47,14 @@ static void CheckTensor(const paddle::Tensor& pre, const paddle::Tensor& post) {
     PADDLE_ENFORCE_EQ(
         pre.dtype(),
         post.dtype(),
-        phi::errors::PermissionDenied(
+        common::errors::PermissionDenied(
             "The dtype of tensor before(%s) and after(%s) hook are not "
             "consistent",
             phi::DataTypeToString(pre.dtype()),
             phi::DataTypeToString(post.dtype())));
     PADDLE_ENFORCE_EQ(pre.place(),
                       post.place(),
-                      phi::errors::PermissionDenied(
+                      common::errors::PermissionDenied(
                           "The place of tensor before(%s) and after(%s) "
                           "hook are not consistent",
                           pre.place().DebugString(),
@@ -91,7 +91,7 @@ void GradNodeBase::SetGradInMeta(const paddle::Tensor& fwd_out,
   PADDLE_ENFORCE_LE(
       slot_rank,
       (bwd_in_meta_.size() - 1),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Slot Rank should less equal than bwd_in_meta_ size, since "
           "bwd_in_meta_ is designed to hold as same num as backward "
           "inputs."));
@@ -149,7 +149,7 @@ void GradNodeBase::SetGradInMeta(const paddle::Tensor& fwd_out,
   PADDLE_ENFORCE_NE(
       dense_tensor->meta().dtype,
       phi::DataType::UNDEFINED,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "Attempting to copy DenseTensorMeta with phi::DataType::UNDEFINED,"
           "which is illegal."));
 
@@ -169,7 +169,7 @@ void GradNodeBase::SetGradInMeta(const std::vector<paddle::Tensor>& fwd_out,
   PADDLE_ENFORCE_LE(
       slot_rank,
       (bwd_in_meta_.size() - 1),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Slot Rank should less equal than bwd_in_meta_ size, since "
           "bwd_in_meta_ is designed to hold as same num as backward "
           "inputs."));
@@ -185,7 +185,7 @@ void GradNodeBase::SetGradInMeta(const std::vector<paddle::Tensor>& fwd_out,
     auto* fwd_out_meta =
         egr::EagerUtils::nullable_autograd_meta(fwd_out_tensor);
     PADDLE_ENFORCE_NOT_NULL(fwd_out_meta,
-                            phi::errors::PreconditionNotMet(
+                            common::errors::PreconditionNotMet(
                                 "Bwd_in_meta should only be called while "
                                 "autograd_meta is not null. If you got this "
                                 "error, it indicates bugs in framework."));
@@ -214,11 +214,12 @@ void GradNodeBase::SetGradInMeta(const std::vector<paddle::Tensor>& fwd_out,
       phi::DenseTensor* dense_tensor =
           static_cast<phi::DenseTensor*>(fwd_out_tensor.impl().get());
 
-      PADDLE_ENFORCE_NE(dense_tensor->meta().dtype,
-                        phi::DataType::UNDEFINED,
-                        phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                                           "with phi::DataType::UNDEFINED,"
-                                           "which is illegal."));
+      PADDLE_ENFORCE_NE(
+          dense_tensor->meta().dtype,
+          phi::DataType::UNDEFINED,
+          common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                "with phi::DataType::UNDEFINED,"
+                                "which is illegal."));
       meta.SetTensorMeta(dense_tensor->meta());
       meta.SetPlace(fwd_out_tensor.place());
 
@@ -241,11 +242,12 @@ void GradNodeBase::SetGradInMeta(const std::vector<paddle::Tensor>& fwd_out,
                               fwd_out_tensor.impl().get())
                               ->value();
 
-      PADDLE_ENFORCE_NE(dense_tensor.meta().dtype,
-                        phi::DataType::UNDEFINED,
-                        phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                                           "with phi::DataType::UNDEFINED,"
-                                           "which is illegal."));
+      PADDLE_ENFORCE_NE(
+          dense_tensor.meta().dtype,
+          phi::DataType::UNDEFINED,
+          common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                "with phi::DataType::UNDEFINED,"
+                                "which is illegal."));
       meta.SetTensorMeta(dense_tensor.meta());
       meta.SetPlace(fwd_out_tensor.place());
 
@@ -267,7 +269,7 @@ void GradNodeBase::SetGradInMeta(const std::vector<paddle::Tensor*>& fwd_out,
   PADDLE_ENFORCE_LE(
       slot_rank,
       (bwd_in_meta_.size() - 1),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Slot Rank should less equal than bwd_in_meta_ size, since "
           "bwd_in_meta_ is designed to hold as same num as backward "
           "inputs."));
@@ -283,7 +285,7 @@ void GradNodeBase::SetGradInMeta(const std::vector<paddle::Tensor*>& fwd_out,
     auto* fwd_out_meta =
         egr::EagerUtils::nullable_autograd_meta(fwd_out_tensor);
     PADDLE_ENFORCE_NOT_NULL(fwd_out_meta,
-                            phi::errors::PreconditionNotMet(
+                            common::errors::PreconditionNotMet(
                                 "Bwd_in_meta should only be called while "
                                 "autograd_meta is not null. If you got this "
                                 "error, it indicates bugs in framework."));
@@ -312,11 +314,12 @@ void GradNodeBase::SetGradInMeta(const std::vector<paddle::Tensor*>& fwd_out,
       phi::DenseTensor* dense_tensor =
           static_cast<phi::DenseTensor*>(fwd_out_tensor.impl().get());
 
-      PADDLE_ENFORCE_NE(dense_tensor->meta().dtype,
-                        phi::DataType::UNDEFINED,
-                        phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                                           "with phi::DataType::UNDEFINED,"
-                                           "which is illegal."));
+      PADDLE_ENFORCE_NE(
+          dense_tensor->meta().dtype,
+          phi::DataType::UNDEFINED,
+          common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                "with phi::DataType::UNDEFINED,"
+                                "which is illegal."));
       meta.SetTensorMeta(dense_tensor->meta());
       meta.SetPlace(fwd_out_tensor.place());
 
@@ -339,11 +342,12 @@ void GradNodeBase::SetGradInMeta(const std::vector<paddle::Tensor*>& fwd_out,
                               fwd_out_tensor.impl().get())
                               ->value();
 
-      PADDLE_ENFORCE_NE(dense_tensor.meta().dtype,
-                        phi::DataType::UNDEFINED,
-                        phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                                           "with phi::DataType::UNDEFINED,"
-                                           "which is illegal."));
+      PADDLE_ENFORCE_NE(
+          dense_tensor.meta().dtype,
+          phi::DataType::UNDEFINED,
+          common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                "with phi::DataType::UNDEFINED,"
+                                "which is illegal."));
       meta.SetTensorMeta(dense_tensor.meta());
       meta.SetPlace(fwd_out_tensor.place());
 
@@ -364,7 +368,7 @@ void GradNodeBase::SetGradOutMeta(const paddle::Tensor& fwd_in,
   PADDLE_ENFORCE_LE(
       (slot_rank + 1),
       bwd_out_meta_.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Slot Rank should less equal than bwd_out_meta_ size, "
           "since bwd_out_meta_ is designed to hold as same num as "
           "backward outputs."));
@@ -400,22 +404,24 @@ void GradNodeBase::SetGradOutMeta(const paddle::Tensor& fwd_in,
       // Only Copy Meta
       phi::DenseTensor* dense_tensor =
           static_cast<phi::DenseTensor*>(fwd_in.impl().get());
-      PADDLE_ENFORCE_NE(dense_tensor->meta().dtype,
-                        phi::DataType::UNDEFINED,
-                        phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                                           "with phi::DataType::UNDEFINED,"
-                                           "which is illegal."));
+      PADDLE_ENFORCE_NE(
+          dense_tensor->meta().dtype,
+          phi::DataType::UNDEFINED,
+          common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                "with phi::DataType::UNDEFINED,"
+                                "which is illegal."));
       meta.SetTensorMeta(dense_tensor->meta());
       meta.SetPlace(fwd_in.place());
     } else if (phi::distributed::DistTensor::classof(fwd_in.impl().get())) {
       const phi::distributed::DistTensor* dist_tensor =
           static_cast<phi::distributed::DistTensor*>(fwd_in.impl().get());
       const phi::DenseTensor& dense_tensor = dist_tensor->value();
-      PADDLE_ENFORCE_NE(dense_tensor.meta().dtype,
-                        phi::DataType::UNDEFINED,
-                        phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                                           "with phi::DataType::UNDEFINED,"
-                                           "which is illegal."));
+      PADDLE_ENFORCE_NE(
+          dense_tensor.meta().dtype,
+          phi::DataType::UNDEFINED,
+          common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                "with phi::DataType::UNDEFINED,"
+                                "which is illegal."));
       meta.SetTensorMeta(dense_tensor.meta());
       meta.SetPlace(fwd_in.place());
       // Set DistAttr
@@ -423,7 +429,7 @@ void GradNodeBase::SetGradOutMeta(const paddle::Tensor& fwd_in,
       PADDLE_ENFORCE_NE(
           dist_tensor->dist_attr().empty(),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "The forward input DistTensor's dist attr is empty."));
       auto dist_attr = dist_tensor->dist_attr();
       dist_attr.clean_partial_status();
@@ -435,11 +441,12 @@ void GradNodeBase::SetGradOutMeta(const paddle::Tensor& fwd_in,
           static_cast<phi::SparseCsrTensor*>(fwd_in.impl().get());
       const phi::DenseTensor dense_tensor =
           static_cast<const phi::DenseTensor>(sparse_tensor->values());
-      PADDLE_ENFORCE_NE(dense_tensor.dtype(),
-                        phi::DataType::UNDEFINED,
-                        phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                                           "with phi::DataType::UNDEFINED,"
-                                           "which is illegal."));
+      PADDLE_ENFORCE_NE(
+          dense_tensor.dtype(),
+          phi::DataType::UNDEFINED,
+          common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                "with phi::DataType::UNDEFINED,"
+                                "which is illegal."));
       meta.SetTensorMeta(dense_tensor.meta());
       meta.SetPlace(fwd_in.place());
     } else if (phi::SparseCooTensor::classof(fwd_in.impl().get())) {
@@ -447,11 +454,12 @@ void GradNodeBase::SetGradOutMeta(const paddle::Tensor& fwd_in,
           static_cast<phi::SparseCooTensor*>(fwd_in.impl().get());
       const phi::DenseTensor dense_tensor =
           static_cast<const phi::DenseTensor>(sparse_tensor->values());
-      PADDLE_ENFORCE_NE(dense_tensor.dtype(),
-                        phi::DataType::UNDEFINED,
-                        phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                                           "with phi::DataType::UNDEFINED,"
-                                           "which is illegal."));
+      PADDLE_ENFORCE_NE(
+          dense_tensor.dtype(),
+          phi::DataType::UNDEFINED,
+          common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                "with phi::DataType::UNDEFINED,"
+                                "which is illegal."));
       meta.SetTensorMeta(dense_tensor.meta());
       meta.SetPlace(fwd_in.place());
     } else {
@@ -477,7 +485,7 @@ void GradNodeBase::SetGradOutMeta(const paddle::Tensor& fwd_in,
   PADDLE_ENFORCE_LE(
       (slot_rank + 1),
       bwd_out_meta_.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Slot Rank should less equal than bwd_out_meta_ size, "
           "since bwd_out_meta_ is designed to hold as same num as "
           "backward outputs."));
@@ -513,11 +521,12 @@ void GradNodeBase::SetGradOutMeta(const paddle::Tensor& fwd_in,
       // Only Copy Meta
       phi::DenseTensor* dense_tensor =
           static_cast<phi::DenseTensor*>(fwd_in.impl().get());
-      PADDLE_ENFORCE_NE(dense_tensor->meta().dtype,
-                        phi::DataType::UNDEFINED,
-                        phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                                           "with phi::DataType::UNDEFINED,"
-                                           "which is illegal."));
+      PADDLE_ENFORCE_NE(
+          dense_tensor->meta().dtype,
+          phi::DataType::UNDEFINED,
+          common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                "with phi::DataType::UNDEFINED,"
+                                "which is illegal."));
       meta.SetTensorMeta(dense_tensor->meta());
       meta.SetPlace(fwd_in.place());
     } else if (phi::distributed::DistTensor::classof(fwd_in.impl().get())) {
@@ -532,11 +541,12 @@ void GradNodeBase::SetGradOutMeta(const paddle::Tensor& fwd_in,
       auto dense_tensor =
           static_cast<phi::distributed::DistTensor*>(fwd_in.impl().get())
               ->value();
-      PADDLE_ENFORCE_NE(dense_tensor.meta().dtype,
-                        phi::DataType::UNDEFINED,
-                        phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                                           "with phi::DataType::UNDEFINED,"
-                                           "which is illegal."));
+      PADDLE_ENFORCE_NE(
+          dense_tensor.meta().dtype,
+          phi::DataType::UNDEFINED,
+          common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                "with phi::DataType::UNDEFINED,"
+                                "which is illegal."));
       meta.SetTensorMeta(dense_tensor.meta());
       meta.SetPlace(fwd_in.place());
     }
@@ -552,7 +562,7 @@ void GradNodeBase::SetGradOutMeta(const std::vector<paddle::Tensor>& fwd_in,
   PADDLE_ENFORCE_LE(
       slot_rank,
       (bwd_out_meta_.size() - 1),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Slot Rank should less equal than bwd_out_meta_ size, "
           "since bwd_out_meta_ is designed to hold as same num as "
           "backward outputs."));
@@ -592,9 +602,9 @@ void GradNodeBase::SetGradOutMeta(const std::vector<paddle::Tensor>& fwd_in,
         PADDLE_ENFORCE_NE(
             dense_tensor->dtype(),
             phi::DataType::UNDEFINED,
-            phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                               "with phi::DataType::UNDEFINED,"
-                               "which is illegal."));
+            common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                  "with phi::DataType::UNDEFINED,"
+                                  "which is illegal."));
         meta.SetTensorMeta(dense_tensor->meta());
         meta.SetPlace(fwd_in_tensor.place());
       } else if (phi::distributed::DistTensor::classof(
@@ -612,9 +622,9 @@ void GradNodeBase::SetGradOutMeta(const std::vector<paddle::Tensor>& fwd_in,
         PADDLE_ENFORCE_NE(
             dense_tensor.dtype(),
             phi::DataType::UNDEFINED,
-            phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                               "with phi::DataType::UNDEFINED,"
-                               "which is illegal."));
+            common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                  "with phi::DataType::UNDEFINED,"
+                                  "which is illegal."));
         meta.SetTensorMeta(dense_tensor.meta());
         meta.SetPlace(fwd_in_tensor.place());
       }
@@ -632,7 +642,7 @@ void GradNodeBase::SetGradOutMeta(
   PADDLE_ENFORCE_LE(
       slot_rank,
       (bwd_out_meta_.size() - 1),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Slot Rank should less equal than bwd_out_meta_ size, "
           "since bwd_out_meta_ is designed to hold as same num as "
           "backward outputs."));
@@ -673,9 +683,9 @@ void GradNodeBase::SetGradOutMeta(
         PADDLE_ENFORCE_NE(
             dense_tensor->dtype(),
             phi::DataType::UNDEFINED,
-            phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                               "with phi::DataType::UNDEFINED,"
-                               "which is illegal."));
+            common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                  "with phi::DataType::UNDEFINED,"
+                                  "which is illegal."));
         meta.SetTensorMeta(dense_tensor->meta());
         meta.SetPlace(fwd_in_tensor.place());
       } else if (phi::distributed::DistTensor::classof(
@@ -694,9 +704,9 @@ void GradNodeBase::SetGradOutMeta(
         PADDLE_ENFORCE_NE(
             dense_tensor.dtype(),
             phi::DataType::UNDEFINED,
-            phi::errors::Fatal("Attempting to copy DenseTensorMeta "
-                               "with phi::DataType::UNDEFINED,"
-                               "which is illegal."));
+            common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                  "with phi::DataType::UNDEFINED,"
+                                  "which is illegal."));
         meta.SetTensorMeta(dense_tensor.meta());
         meta.SetPlace(fwd_in_tensor.place());
       }
@@ -710,7 +720,7 @@ void GradNodeBase::SetGradOutMeta(
 
 void GradNodeBase::SetDefaultGradInOutMeta() {
   PADDLE_ENFORCE((bwd_out_meta_.size() == 1) && (bwd_in_meta_.size() == 1),
-                 phi::errors::PreconditionNotMet(
+                 common::errors::PreconditionNotMet(
                      "We can only support 1 input and 1 output in default grad "
                      "meta setter, other size of inputs and outputs should "
                      "create with Setter and Getters"));
@@ -739,12 +749,12 @@ GradNodeBase::ApplyGradientHooks(
     auto hook = std::get<2>(hook_pair.second);
 
     PADDLE_ENFORCE(slot_id < tensors.size(),
-                   phi::errors::Fatal(
+                   common::errors::Fatal(
                        "Slot_id from registered hook should be smaller than "
                        "slot size of grad_tensors"));
 
     PADDLE_ENFORCE(rank < tensors[slot_id].size(),
-                   phi::errors::Fatal(
+                   common::errors::Fatal(
                        "rank of slot %d from registered hook should be smaller "
                        "than rank size of grad_tensors",
                        slot_id));
@@ -787,7 +797,7 @@ void GradNodeBase::HandleComplexGradToRealGrad(
       const GradSlotMeta& slot_meta = bwd_out_meta_[slot_id][rank_id];
       PADDLE_ENFORCE(
           slot_meta.HasTensorMeta() > 0,
-          phi::errors::Fatal(
+          common::errors::Fatal(
               "We require TensorMeta in GradInputMeta() to obtain forward data "
               "types."
               "However, no TensorMeta is detected in bwd_out_meta_."));

--- a/paddle/fluid/eager/grad_node_info.h
+++ b/paddle/fluid/eager/grad_node_info.h
@@ -140,7 +140,7 @@ class GradSlotMeta {
   bool HasTensorMeta() const { return meta_ && meta_.get(); }
   const phi::DenseTensorMeta& GetTensorMeta() const {
     if (!HasTensorMeta()) {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "meta_ of GradSlotMeta has not been initialized yet."
           "You're expected to check Edge availability with HasTensorMeta()"
           "before calling GetTensorMeta() interface."));

--- a/paddle/fluid/eager/grad_tensor_holder.cc
+++ b/paddle/fluid/eager/grad_tensor_holder.cc
@@ -39,8 +39,8 @@ void GradTensorHolder::CopyValueFromTensor(size_t slot_id,
   // empty;
   PADDLE_ENFORCE(
       slot_id < buffer_.size(),
-      phi::errors::Fatal("Invalid slot_id for GradTensorHolder::add() "
-                         "which exceeds size of buffer"));
+      common::errors::Fatal("Invalid slot_id for GradTensorHolder::add() "
+                            "which exceeds size of buffer"));
   VLOG(6) << "Add Tensor for buffer_ slot: " << slot_id
           << ", size: " << buffer_[slot_id].size();
   if (buffer_[slot_id].empty()) {
@@ -50,7 +50,7 @@ void GradTensorHolder::CopyValueFromTensor(size_t slot_id,
   }
   PADDLE_ENFORCE(
       rank < buffer_[slot_id].size(),
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "Invalid rank for GradTensorHolder::add() which exceeds size "
           "of buffer slot %d, got slot size is: %d rank is: %d",
           slot_id,
@@ -71,7 +71,7 @@ void GradTensorHolder::CopyValueFromTensor(size_t slot_id,
         meta->WeakGrad() = origin_meta->WeakGrad();
       }
     } else {
-      PADDLE_THROW(phi::errors::Fatal(
+      PADDLE_THROW(common::errors::Fatal(
           "Cannot copy grad_tensors' value to grad tensor holders,"
           "input buffer has already been initialized."));
     }
@@ -98,7 +98,7 @@ void GradTensorHolder::CopyValueFromTensor(size_t slot_id,
             global_dense_t, dist_attr));
         buffer_[slot_id][rank] = init_grad;
       } else {
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "Only Support DENSE_TENSOR, SPARSE_COO_TENSOR, SPARSE_CSR_TENSOR "
             "now."));
       }
@@ -130,8 +130,8 @@ void GradTensorHolder::add(size_t slot_id,
 
   PADDLE_ENFORCE(
       slot_id < buffer_.size(),
-      phi::errors::Fatal("Invalid slot_id for GradTensorHolder::add() "
-                         "which exceeds size of buffer"));
+      common::errors::Fatal("Invalid slot_id for GradTensorHolder::add() "
+                            "which exceeds size of buffer"));
   if (buffer_[slot_id].empty()) {
     VLOG(6) << "Pass add Tensor for buffer_ slot: " << slot_id
             << " since its buffer_ is empty ";
@@ -139,7 +139,7 @@ void GradTensorHolder::add(size_t slot_id,
   }
   PADDLE_ENFORCE(
       rank < buffer_[slot_id].size(),
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "Invalid rank for GradTensorHolder::add() which exceeds size "
           "of buffer slot %d, got slot size is: %d rank is: %d",
           slot_id,
@@ -161,13 +161,13 @@ void GradTensorHolder::add(size_t slot_id,
     VLOG(6) << "Add Tensor for buffer_ slot: " << slot_id
             << ", size: " << buffer_[slot_id].size();
     // Accumulation
-    PADDLE_ENFORCE_EQ(
-        t.initialized(),
-        true,
-        phi::errors::Fatal("We can only accumulate initialized tensor, but we "
-                           "got tensor: %s is empty please check you network "
-                           "and make sure it creates grads.",
-                           t.name()));
+    PADDLE_ENFORCE_EQ(t.initialized(),
+                      true,
+                      common::errors::Fatal(
+                          "We can only accumulate initialized tensor, but we "
+                          "got tensor: %s is empty please check you network "
+                          "and make sure it creates grads.",
+                          t.name()));
 
     if (t.is_dense_tensor()) {
       if (buffer_tensor.is_dense_tensor()) {

--- a/paddle/fluid/eager/hooks.h
+++ b/paddle/fluid/eager/hooks.h
@@ -94,7 +94,7 @@ class SavedTensorsHooks {
                 std::shared_ptr<UnPackHookBase> unpack_hook) {
     PADDLE_ENFORCE_EQ(pack_hook_ == nullptr && unpack_hook_ == nullptr,
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "paddle.autograd.saved_tensors_hooks only one pair "
                           "of hooks is allowed at a time."));
     pack_hook_ = pack_hook;

--- a/paddle/fluid/eager/nan_inf_utils.cc
+++ b/paddle/fluid/eager/nan_inf_utils.cc
@@ -107,7 +107,7 @@ void CheckTensorHasNanOrInf(const std::string& api_name, const Tensor& tensor) {
       paddle::framework::details::tensor_check<phi::GPUContext>(
           api_name, tensor_name, *dense_tensor, place);
 #else
-      PADDLE_THROW(phi::errors::PreconditionNotMet(
+      PADDLE_THROW(common::errors::PreconditionNotMet(
           "Tensor[%s] use gpu place. PaddlePaddle must compile with GPU.",
           tensor_name));
 #endif

--- a/paddle/fluid/eager/pylayer/py_layer_node.cc
+++ b/paddle/fluid/eager/pylayer/py_layer_node.cc
@@ -49,7 +49,7 @@ GradNodePyLayer::operator()(
 
   PADDLE_ENFORCE_EQ(ctx->forward_output_tensor_is_duplicable.size(),
                     grads.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "%s's grad input size(%s) must be equal with it's "
                         "forward's output size(%s).",
                         name(),
@@ -149,7 +149,8 @@ GradNodePyLayer::operator()(
   auto backward_fn =
       PyObject_GetAttrString(reinterpret_cast<PyObject*>(ctx), "backward");
   if (!backward_fn) {
-    PADDLE_THROW(phi::errors::InvalidArgument("Get backward function failed."));
+    PADDLE_THROW(
+        common::errors::InvalidArgument("Get backward function failed."));
   }
   bool need_grad_tmp = egr::Controller::Instance().HasGrad();
   egr::Controller::Instance().SetHasGrad(create_graph && need_grad_tmp);
@@ -157,7 +158,7 @@ GradNodePyLayer::operator()(
   egr::Controller::Instance().SetHasGrad(need_grad_tmp);
   if (!outputs) {
     PADDLE_THROW(
-        phi::errors::External(pybind11::detail::error_string().c_str()));
+        common::errors::External(pybind11::detail::error_string().c_str()));
   }
 
   VLOG(6) << "PyLayer backward function finish...";
@@ -174,7 +175,7 @@ GradNodePyLayer::operator()(
   size_t outputs_size = PyTuple_GET_SIZE(outputs_tuple);
 
   if (outputs_size > ctx->forward_input_tensor_is_duplicable.size()) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "The number of outputs of `PyLayer.backward` should be %d, but "
         "received %d.",
         ctx->forward_input_tensor_is_duplicable.size(),
@@ -191,7 +192,7 @@ GradNodePyLayer::operator()(
         PADDLE_ENFORCE_EQ(
             obj,
             Py_None,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "%s's backward function should return None at %d position, "
                 "because it's forward Tensor's stopgradient is true.",
                 name(),
@@ -209,7 +210,7 @@ GradNodePyLayer::operator()(
             VLOG(4) << "Got None for Tensor with pos: " << i;
             grad_out.push_back({paddle::Tensor()});
           } else {
-            PADDLE_THROW(phi::errors::InvalidArgument(
+            PADDLE_THROW(common::errors::InvalidArgument(
                 "We can only support Tensor or None for backward output, "
                 ", but got %s, please check your PyLayer code and make it fits",
                 reinterpret_cast<PyTypeObject*>(obj->ob_type)->tp_name));
@@ -220,7 +221,7 @@ GradNodePyLayer::operator()(
       PADDLE_ENFORCE_EQ(
           this->OutputMeta()[i][0].IsStopGradient(),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "%s's backward function should not return empty at %d position.",
               name(),
               i));

--- a/paddle/fluid/eager/tensor_wrapper.h
+++ b/paddle/fluid/eager/tensor_wrapper.h
@@ -86,7 +86,7 @@ class TensorWrapper {
             dist_tensor->value().meta());
         intermidiate_tensor_.set_impl(no_buffer_dist_tensor);
       } else {
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "Unrecognized tensor type for no_need_buffer feature"));
       }
     } else {
@@ -164,8 +164,8 @@ class TensorWrapper {
                                ->unsafe_mutable_value();
       } else {
         PADDLE_THROW(
-            phi::errors::Fatal("Unrecognized tensor_unpacked type "
-                               "for egr::TensorWrapper::recover"));
+            common::errors::Fatal("Unrecognized tensor_unpacked type "
+                                  "for egr::TensorWrapper::recover"));
       }
 
       if (intermidiate_tensor_.is_dense_tensor()) {
@@ -180,8 +180,8 @@ class TensorWrapper {
             ->ResetHolder(src_dense_tensor->MoveMemoryHolder());
       } else {
         PADDLE_THROW(
-            phi::errors::Fatal("Unrecognized intermidiate_tensor_ type for "
-                               "egr::TensorWrapper::recover"));
+            common::errors::Fatal("Unrecognized intermidiate_tensor_ type for "
+                                  "egr::TensorWrapper::recover"));
       }
     } else {
 #endif
@@ -246,7 +246,7 @@ class TensorWrapper {
       PADDLE_ENFORCE_EQ(
           tensor_version,
           wrapper_version_snapshot,
-          phi::errors::PermissionDenied(
+          common::errors::PermissionDenied(
               "Tensor '%s' used in gradient computation has been "
               "modified by an inplace operation. "
               "Its version is %d but the expected version is %d. "

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -78,7 +78,7 @@ AutogradMeta* EagerUtils::autograd_meta(paddle::Tensor* target) {
 AutogradMeta* EagerUtils::unsafe_autograd_meta(const paddle::Tensor& target) {
   auto* p_autograd_meta = target.get_autograd_meta();
   PADDLE_ENFORCE(p_autograd_meta,
-                 phi::errors::Fatal(
+                 common::errors::Fatal(
                      "Null autograd_meta gotten from unsafe_autograd_meta()"));
   return static_cast<AutogradMeta*>(p_autograd_meta);
 }
@@ -237,12 +237,12 @@ void EagerUtils::CheckInplace(const paddle::Tensor& target,
                               const AutogradMeta* autograd_meta,
                               bool require_any_grad) {
   if (require_any_grad && autograd_meta) {
-    PADDLE_ENFORCE_EQ(
-        !autograd_meta->StopGradient() && IsLeafTensor(target),
-        false,
-        phi::errors::InvalidArgument("Leaf Var (%s) that doesn't stop gradient "
-                                     "can't use inplace strategy.",
-                                     target.name()));
+    PADDLE_ENFORCE_EQ(!autograd_meta->StopGradient() && IsLeafTensor(target),
+                      false,
+                      common::errors::InvalidArgument(
+                          "Leaf Var (%s) that doesn't stop gradient "
+                          "can't use inplace strategy.",
+                          target.name()));
   }
 }
 
@@ -260,7 +260,7 @@ std::vector<std::shared_ptr<egr::EagerVariable>> EagerUtils::TrySyncToVars(
     paddle::Tensor* tensor) {
   PADDLE_ENFORCE_NOT_NULL(
       tensor,
-      phi::errors::Fatal(
+      common::errors::Fatal(
           "Should Not Pass Empty tensor pointer in, since only output can "
           "reach this, please check output value and make sure it's not null"));
   return {TrySyncToVar(*tensor)};
@@ -275,10 +275,11 @@ std::vector<std::shared_ptr<egr::EagerVariable>> EagerUtils::TrySyncToVars(
     auto* tensor = tensors[i];
     PADDLE_ENFORCE_NOT_NULL(
         tensor,
-        phi::errors::Fatal("Tensor is null and cannot be copied. "
-                           "We are tring to TrySyncToVars tensor from its "
-                           "shared_ptr, this error may indicate some outputs "
-                           "are nullptr"));
+        common::errors::Fatal(
+            "Tensor is null and cannot be copied. "
+            "We are tring to TrySyncToVars tensor from its "
+            "shared_ptr, this error may indicate some outputs "
+            "are nullptr"));
     res.emplace_back(TrySyncToVar(*tensor));
   }
   return res;
@@ -312,8 +313,8 @@ void EagerUtils::HandleViewBetweenInputAndOutput(
   PADDLE_ENFORCE_EQ(
       input_var->Var().IsInitialized(),
       true,
-      phi::errors::InvalidArgument("Tensor %s has not been initialized!",
-                                   input_var->name()));
+      common::errors::InvalidArgument("Tensor %s has not been initialized!",
+                                      input_var->name()));
 
   if (phi::DenseTensor::classof(input_var->GetTensorBase().get())) {
     auto input_dense_tensor =
@@ -321,8 +322,8 @@ void EagerUtils::HandleViewBetweenInputAndOutput(
     PADDLE_ENFORCE_EQ(
         input_dense_tensor->IsInitialized(),
         true,
-        phi::errors::InvalidArgument("DenseTensor %s has not been initialized!",
-                                     input_var->name()));
+        common::errors::InvalidArgument(
+            "DenseTensor %s has not been initialized!", input_var->name()));
 
     auto* view_output_tensor =
         view_output_var->MutableVar()->GetMutable<phi::DenseTensor>();
@@ -340,8 +341,8 @@ void EagerUtils::HandleViewBetweenInputAndOutput(
   PADDLE_ENFORCE_EQ(
       input_tensor.initialized(),
       true,
-      phi::errors::InvalidArgument("Tensor %s has not been initialized!",
-                                   input_tensor.name()));
+      common::errors::InvalidArgument("Tensor %s has not been initialized!",
+                                      input_tensor.name()));
 
   if (input_tensor.is_dense_tensor()) {
     auto input_dense_tensor =
@@ -350,7 +351,7 @@ void EagerUtils::HandleViewBetweenInputAndOutput(
       view_output_tensor->set_impl(std::make_shared<phi::DenseTensor>());
     } else {
       PADDLE_ENFORCE(view_output_tensor->is_dense_tensor(),
-                     phi::errors::Unavailable(
+                     common::errors::Unavailable(
                          "DenseTensor can not be inplaced with other Tensor."));
     }
     auto view_output_dense_tensor =
@@ -377,7 +378,7 @@ void EagerUtils::HandleViewBetweenInputAndOutput(
                   ->dist_attr()));
     } else {
       PADDLE_ENFORCE(view_output_tensor->is_dist_tensor(),
-                     phi::errors::Unavailable(
+                     common::errors::Unavailable(
                          "DistTensor can not be inplaced with other Tensor."));
     }
     auto view_output_dense_tensor =
@@ -402,11 +403,12 @@ std::vector<paddle::Tensor> EagerUtils::GetOutputs(
   for (const auto& out : outs) {
     PADDLE_ENFORCE_NOT_NULL(
         out.get(),
-        phi::errors::Fatal("Eager Tensor %s is null and cannot be copied. "
-                           "We are tring to Get Output tensor from its "
-                           "shared_ptr, this error may indicate some outputs "
-                           "are nullptr",
-                           out->name()));
+        common::errors::Fatal(
+            "Eager Tensor %s is null and cannot be copied. "
+            "We are tring to Get Output tensor from its "
+            "shared_ptr, this error may indicate some outputs "
+            "are nullptr",
+            out->name()));
     res.emplace_back(out->GetTensorBase(), out->name());
   }
   return res;
@@ -416,10 +418,11 @@ paddle::Tensor EagerUtils::GetOutput(
     const std::shared_ptr<EagerVariable>& out) {
   PADDLE_ENFORCE_NOT_NULL(
       out.get(),
-      phi::errors::Fatal("Eager Tensor %s is null and cannot be copied. We "
-                         "are tring to Get Output tensor from its shared_ptr, "
-                         "this error may indicate output is nullptr",
-                         out->name()));
+      common::errors::Fatal(
+          "Eager Tensor %s is null and cannot be copied. We "
+          "are tring to Get Output tensor from its shared_ptr, "
+          "this error may indicate output is nullptr",
+          out->name()));
   return paddle::Tensor(out->GetTensorBase(), out->name());
 }
 
@@ -427,10 +430,10 @@ void EagerUtils::GetOutput(const std::shared_ptr<EagerVariable>& out,
                            paddle::Tensor* out_var) {
   PADDLE_ENFORCE_NOT_NULL(
       out_var,
-      phi::errors::Fatal("Tensor is null and cannot be copied. "
-                         "We are tring to OverwriteOutput from its "
-                         "shared_ptr, this error may indicate some outputs "
-                         "are nullptr"));
+      common::errors::Fatal("Tensor is null and cannot be copied. "
+                            "We are tring to OverwriteOutput from its "
+                            "shared_ptr, this error may indicate some outputs "
+                            "are nullptr"));
   out_var->set_impl(out->GetTensorBase());
   out_var->set_name(out->name());
 }
@@ -449,10 +452,11 @@ void EagerUtils::GetOutputs(
   for (size_t i = 0; i < outs.size(); i++) {
     PADDLE_ENFORCE_NOT_NULL(
         out_var[i],
-        phi::errors::Fatal("Tensor is null and cannot be copied. "
-                           "We are tring to OverwriteOutput from its "
-                           "shared_ptr, this error may indicate some outputs "
-                           "are nullptr"));
+        common::errors::Fatal(
+            "Tensor is null and cannot be copied. "
+            "We are tring to OverwriteOutput from its "
+            "shared_ptr, this error may indicate some outputs "
+            "are nullptr"));
     out_var[i]->set_impl(outs[i]->GetTensorBase());
   }
 }
@@ -466,10 +470,10 @@ void EagerUtils::GetOutputs(const std::shared_ptr<EagerVariable>& out,
                             const std::vector<paddle::Tensor*>& out_var) {
   PADDLE_ENFORCE_NOT_NULL(
       out_var[0],
-      phi::errors::Fatal("Tensor is null and cannot be copied. "
-                         "We are tring to OverwriteOutput from its "
-                         "shared_ptr, this error may indicate some outputs "
-                         "are nullptr"));
+      common::errors::Fatal("Tensor is null and cannot be copied. "
+                            "We are tring to OverwriteOutput from its "
+                            "shared_ptr, this error may indicate some outputs "
+                            "are nullptr"));
   out_var[0]->set_impl(out->GetTensorBase());
 }
 
@@ -509,7 +513,7 @@ std::shared_ptr<egr::GradNodeBase> EagerUtils::GetGradAccumulationNode(
         return accumulation_ptr;
       } else {
         // Current GradNode is not a egr::GradNodeAccumulation
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "GetGradAccumulationNode should only be called on leaf tensor, but "
             "target tensor: %s has GradNode which is not a "
             "GradNodeAccumulation, and this should not happened unless target "
@@ -608,7 +612,7 @@ void EagerUtils::FillZeroForEmptyGradInput(paddle::Tensor* in_grad,
   if (!in_grad->initialized()) {
     PADDLE_ENFORCE(
         grad_in_meta.HasTensorMeta(),
-        phi::errors::Fatal(
+        common::errors::Fatal(
             "Unable to fill empty grad inputs due to empty GradSlotMeta"));
     const auto& tensor_meta = grad_in_meta.GetTensorMeta();
     if (grad_in_meta.IsDistMeta()) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Replace phi::errors to common::errors in paddle/fluid