### PR TITLE
Replace phi::errors [fluid_ops] part18

### DIFF
--- a/paddle/fluid/imperative/all_reduce.cc
+++ b/paddle/fluid/imperative/all_reduce.cc
@@ -45,7 +45,7 @@ static const phi::Place &GetVarPlace(const framework::Variable &src) {
     return src.Get<phi::SelectedRows>().value().place();
 #endif
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Cannot get unsupported variable type %s for imperative allreduce, "
         "only "
         "LoDTensor and SelectedRows are supported.",
@@ -61,7 +61,7 @@ static void AllReduce(const phi::DenseTensor &src,
   PADDLE_ENFORCE_EQ(
       phi::is_gpu_place(place),
       true,
-      phi::errors::Unimplemented(
+      common::errors::Unimplemented(
           "Imperative mode does not support multi-CPU training yet."));
 
   const void *src_ptr = src.data();
@@ -90,7 +90,7 @@ static void AllReduce(const phi::SelectedRows &src,
   PADDLE_ENFORCE_EQ(
       phi::is_gpu_place(place),
       true,
-      phi::errors::Unimplemented(
+      common::errors::Unimplemented(
           "Imperative mode does not support multi-CPU training yet."));
 
   auto dtype = framework::TransToProtoVarType(src_tensor.dtype());
@@ -259,7 +259,7 @@ void AllReduce(const framework::Variable &src,
     }
 #endif
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Unsupported variable type %s for imperative allreduce, only "
         "LoDTensor and SelectedRows are supported.",
         platform::demangle(framework::ToTypeName(src.Type()))));

--- a/paddle/fluid/imperative/amp_auto_cast.cc
+++ b/paddle/fluid/imperative/amp_auto_cast.cc
@@ -58,7 +58,7 @@ OpSupportedInfos(const std::string& place,
   };
   PADDLE_ENFORCE_NE(is_target_place.count(query_place),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The argument `place` should be 'GPU', 'CPU', 'XPU' or "
                         "other Custom Device, but got '%s'.",
                         place));
@@ -180,7 +180,7 @@ AmpOperators::GetMutableUnsupportedOps(const phi::DataType& data_type) {
       data_type == phi::DataType::FLOAT16 ||
           data_type == phi::DataType::BFLOAT16,
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The data_type mismatch. It should be FLOAT16 or BFLOAT16."));
   if (data_type == phi::DataType::FLOAT16) {  // NOLINT
     return unsupported_fp16_ops_;

--- a/paddle/fluid/imperative/basic_engine.cc
+++ b/paddle/fluid/imperative/basic_engine.cc
@@ -48,7 +48,7 @@ void BasicEngine::Init(
   PADDLE_ENFORCE_EQ(
       tensors.size(),
       grad_tensors.size(),
-      phi::errors::Unavailable(
+      common::errors::Unavailable(
           "The size of tensors do not equal the size of grad_tensors,"
           "the size of tensors is %s, but the size of grad_tensors is %s.",
           tensors.size(),
@@ -56,12 +56,12 @@ void BasicEngine::Init(
 
   PADDLE_ENFORCE_EQ(accumulators_.empty(),
                     true,
-                    phi::errors::AlreadyExists(
+                    common::errors::AlreadyExists(
                         "Accumulators are not empty before preparing it for "
                         "backward network execution."));
   PADDLE_ENFORCE_EQ(accumulators_with_grad_node_.empty(),
                     true,
-                    phi::errors::AlreadyExists(
+                    common::errors::AlreadyExists(
                         "Accumulators with grad_node as the key are not empty "
                         "before preparing it for backward network execution."));
 
@@ -74,7 +74,7 @@ void BasicEngine::Init(
     PADDLE_ENFORCE_EQ(
         var->GradVarBase()->GraphIsFreed(),
         false,
-        phi::errors::Unavailable(
+        common::errors::Unavailable(
             "%s trying to backward through the same graph a second "
             "time, but this graph have already been freed. Please "
             "specify Tensor.backward(retain_graph=True) when "
@@ -99,7 +99,7 @@ void BasicEngine::Init(
     PADDLE_ENFORCE_EQ(
         var->HasGradVar(),
         true,
-        phi::errors::NotFound("Tensor %s has no gradient", var->Name()));
+        common::errors::NotFound("Tensor %s has no gradient", var->Name()));
 
     auto& fwd_var = var->Var().Get<phi::DenseTensor>();
     auto* grad_var =
@@ -192,7 +192,7 @@ void BasicEngine::PrepareGradAccumulators(
         for (auto& grad_pending_node : grad_pending_nodes) {
           PADDLE_ENFORCE_NOT_NULL(
               grad_pending_node,
-              phi::errors::NotFound("Grad pending node is nullptr."));
+              common::errors::NotFound("Grad pending node is nullptr."));
           for (auto& grad_pending_op : *grad_pending_node) {
             VLOG(6) << "Determine whether var (" << var->Name()
                     << ") is the input var of grad_pending_op ("
@@ -279,8 +279,8 @@ void BasicEngine::PrepareDeps() {
   PADDLE_ENFORCE_EQ(
       node_deps_.empty(),
       true,
-      phi::errors::AlreadyExists("Op deps are not empty before preparing "
-                                 "it for backward network execution."));
+      common::errors::AlreadyExists("Op deps are not empty before preparing "
+                                    "it for backward network execution."));
 
   std::queue<GradOpNode*> q;
   std::unordered_set<GradOpNode*> visited;
@@ -304,7 +304,7 @@ void BasicEngine::PrepareDeps() {
     for (auto& grad_pending_node : grad_pending_nodes) {
       PADDLE_ENFORCE_NOT_NULL(
           grad_pending_node,
-          phi::errors::NotFound("Grad pending node is nullptr."));
+          common::errors::NotFound("Grad pending node is nullptr."));
       ++node_deps_[grad_pending_node.get()];
       if (visited.count(grad_pending_node.get()) == 0) {
         visited.insert(grad_pending_node.get());
@@ -489,8 +489,8 @@ void BasicEngine::Execute() {
             PADDLE_ENFORCE_EQ(
                 iter != accumulators_.end(),
                 true,
-                phi::errors::NotFound("Cannot find gradient of variable %s",
-                                      var->Name()));
+                common::errors::NotFound("Cannot find gradient of variable %s",
+                                         var->Name()));
           }
 
           // leaf_accumulators_ : hooks and accumulate-grad for leaf tensor,
@@ -549,7 +549,7 @@ void BasicEngine::Execute() {
           PADDLE_ENFORCE_EQ(
               tensor_version,
               wrapper_version_snapshot,
-              phi::errors::PermissionDenied(
+              common::errors::PermissionDenied(
                   "Tensor '%s' used in gradient computation in grad op '%s' "
                   "has been "
                   "modified by an inplace operation. "
@@ -607,7 +607,7 @@ void BasicEngine::Execute() {
           throw exception;
         } catch (std::exception& ex) {
           Clear();
-          PADDLE_THROW(phi::errors::External("%s", ex.what()));
+          PADDLE_THROW(common::errors::External("%s", ex.what()));
         }
       }
 
@@ -656,7 +656,7 @@ void BasicEngine::Execute() {
     for (auto& grad_pending_node : shared_cur_node->GradPendingNodes()) {
       PADDLE_ENFORCE_NOT_NULL(
           grad_pending_node,
-          phi::errors::NotFound("Grad pending node is nullptr."));
+          common::errors::NotFound("Grad pending node is nullptr."));
       auto iter = node_deps_.find(grad_pending_node.get());
       if (iter == node_deps_.end()) {
         continue;

--- a/paddle/fluid/imperative/bkcl_context.cc
+++ b/paddle/fluid/imperative/bkcl_context.cc
@@ -41,7 +41,7 @@ static void AllReduce(const phi::DenseTensor &src,
   PADDLE_ENFORCE_EQ(
       phi::is_xpu_place(place),
       true,
-      phi::errors::Unimplemented(
+      common::errors::Unimplemented(
           "Dynamic graph mode does not support multi-CPU training yet."));
 
   const void *src_ptr = src.data();
@@ -50,15 +50,16 @@ static void AllReduce(const phi::DenseTensor &src,
   auto bkcl_dtype =
       platform::ToBKCLDataType(framework::TransToProtoVarType(src.dtype()));
 
-  PADDLE_ENFORCE_EQ(bkcl_all_reduce(comm->comm(),
-                                    src_ptr,
-                                    dst_ptr,
-                                    src.numel(),
-                                    bkcl_dtype,
-                                    BKCL_ADD,
-                                    stream),
-                    BKCL_SUCCESS,
-                    phi::errors::PreconditionNotMet("BKCL all reduce failed"));
+  PADDLE_ENFORCE_EQ(
+      bkcl_all_reduce(comm->comm(),
+                      src_ptr,
+                      dst_ptr,
+                      src.numel(),
+                      bkcl_dtype,
+                      BKCL_ADD,
+                      stream),
+      BKCL_SUCCESS,
+      common::errors::PreconditionNotMet("BKCL all reduce failed"));
 }
 /*
 Baidu Kunlun Communication Library(BKCL) is designed for multi Baidu Kunlun
@@ -92,7 +93,7 @@ void BKCLParallelContext::Init() {
       auto ret = bkcl_get_unique_id(&bkcl_ids[i]);
       PADDLE_ENFORCE_EQ(BKCL_SUCCESS,
                         ret,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "BKCL get unique id failed [%d]", ret));
     }
   }
@@ -123,10 +124,10 @@ void BKCLParallelContext::InitWithRingID(int ring_id) {
   if (strategy_.local_rank_ == 0) {
     // generate the unique bkclid on the root worker
     auto ret = bkcl_get_unique_id(&bkcl_ids[0]);
-    PADDLE_ENFORCE_EQ(
-        BKCL_SUCCESS,
-        ret,
-        phi::errors::PreconditionNotMet("BKCL get unique id failed [%d]", ret));
+    PADDLE_ENFORCE_EQ(BKCL_SUCCESS,
+                      ret,
+                      common::errors::PreconditionNotMet(
+                          "BKCL get unique id failed [%d]", ret));
   }
   BcastBKCLId(bkcl_ids, 0);
 
@@ -151,7 +152,7 @@ void BKCLParallelContext::AllReduceByStream(const framework::Variable &src,
   PADDLE_ENFORCE_EQ(
       phi::is_xpu_place(place_),
       true,
-      phi::errors::Unimplemented(
+      common::errors::Unimplemented(
           "Dynamic graph mode does not support multi-CPU training yet."));
   auto place = place_;
 
@@ -171,7 +172,7 @@ void BKCLParallelContext::AllReduceByStream(const framework::Variable &src,
               stream,
               comm);
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "XPU unsupported variable type %s for imperative allreduce, only "
         "LoDTensor are supported.",
         platform::demangle(framework::ToTypeName(src.Type()))));
@@ -198,7 +199,7 @@ void BKCLParallelContext::Broadcast(framework::Variable *src, int ring_id) {
                                    0,
                                    stream),
                     BKCL_SUCCESS,
-                    phi::errors::Unavailable("bkcl_broadcast failed"));
+                    common::errors::Unavailable("bkcl_broadcast failed"));
 }
 
 phi::DeviceContext *BKCLParallelContext::GetDeviceContext(int ring_id) {
@@ -211,13 +212,14 @@ void BKCLParallelContext::WaitCompute(int ring_id) {
   PADDLE_ENFORCE_GE(
       ring_id,
       0,
-      phi::errors::OutOfRange("Ring id expected >= 0, but got %d", ring_id));
-  PADDLE_ENFORCE_LT(ring_id,
-                    strategy_.nrings_,
-                    phi::errors::OutOfRange("Ring id expected < nrings,"
-                                            "but got ring id = %d, nrings = %d",
-                                            ring_id,
-                                            strategy_.nrings_));
+      common::errors::OutOfRange("Ring id expected >= 0, but got %d", ring_id));
+  PADDLE_ENFORCE_LT(
+      ring_id,
+      strategy_.nrings_,
+      common::errors::OutOfRange("Ring id expected < nrings,"
+                                 "but got ring id = %d, nrings = %d",
+                                 ring_id,
+                                 strategy_.nrings_));
   auto compute_stream = static_cast<phi::XPUContext *>(
                             phi::DeviceContextPool::Instance().Get(place_))
                             ->stream();
@@ -236,13 +238,14 @@ void BKCLParallelContext::WaitComm(int ring_id) {
   PADDLE_ENFORCE_GE(
       ring_id,
       0,
-      phi::errors::OutOfRange("Ring id expected >= 0, but got %d", ring_id));
-  PADDLE_ENFORCE_LT(ring_id,
-                    strategy_.nrings_,
-                    phi::errors::OutOfRange("Ring id expected < nrings,"
-                                            "but got ring id = %d, nrings = %d",
-                                            ring_id,
-                                            strategy_.nrings_));
+      common::errors::OutOfRange("Ring id expected >= 0, but got %d", ring_id));
+  PADDLE_ENFORCE_LT(
+      ring_id,
+      strategy_.nrings_,
+      common::errors::OutOfRange("Ring id expected < nrings,"
+                                 "but got ring id = %d, nrings = %d",
+                                 ring_id,
+                                 strategy_.nrings_));
   auto comm_stream = platform::BKCLCommContext::Instance()
                          .Get(ring_id, place_)
                          ->dev_context()

--- a/paddle/fluid/imperative/data_loader.cc
+++ b/paddle/fluid/imperative/data_loader.cc
@@ -113,7 +113,7 @@ static inline void setSignalHandler(int signal,
   sa.sa_flags = SA_RESTART | SA_SIGINFO | SA_NOCLDSTOP | SA_NODEFER;
   if (sigemptyset(&sa.sa_mask) != 0 ||
       sigaction(signal, &sa, old_sa_ptr) != 0) {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "An error occurred while setting handler for %s.", strsignal(signal)));
   }
 }
@@ -147,7 +147,7 @@ void ThrowErrorIfLoadProcessFailed() {
       if (infop.si_code == CLD_EXITED &&
           infop.si_status != EXIT_SUCCESS) {  // exit with error
         pids_set->clear();
-        PADDLE_THROW(phi::errors::Fatal(
+        PADDLE_THROW(common::errors::Fatal(
             "DataLoader process (pid %ld) exited unexpectedly with code %d. "
             "Error detailed are lost due to multiprocessing. Rerunning with:\n"
             "  1. If run DataLoader by DataLoader.from_generator(...), run "
@@ -163,7 +163,7 @@ void ThrowErrorIfLoadProcessFailed() {
                  infop.si_code == CLD_DUMPED) {  // killed by signal
         if (infop.si_status == SIGBUS) {
           pids_set->clear();
-          PADDLE_THROW(phi::errors::Fatal(
+          PADDLE_THROW(common::errors::Fatal(
               "DataLoader process (pid %ld) exited is killed by signal: %s.\n"
               "  It may be caused by insufficient shared storage space. This "
               "problem usually occurs when using docker as a development "
@@ -182,7 +182,7 @@ void ThrowErrorIfLoadProcessFailed() {
               process_pid,
               strsignal(infop.si_status)));
         } else {
-          PADDLE_THROW(phi::errors::Fatal(
+          PADDLE_THROW(common::errors::Fatal(
               "DataLoader process (pid %ld) exited is killed by signal: %s.",
               process_pid,
               strsignal(infop.si_status)));

--- a/paddle/fluid/imperative/dygraph_grad_maker.h
+++ b/paddle/fluid/imperative/dygraph_grad_maker.h
@@ -130,7 +130,7 @@ class GradOpBaseMakerBase {
     PADDLE_ENFORCE_EQ(
         it != attrs_.end(),
         true,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Cannot find attribute [%s] in operator [%s]", name, type_));
     return it->second;
   }

--- a/paddle/fluid/imperative/execution_context.h
+++ b/paddle/fluid/imperative/execution_context.h
@@ -50,7 +50,7 @@ class DygraphExecutionContext : public framework::ExecutionContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_in_.end(),
-        phi::errors::PreconditionNotMet("Can not find [%s] in Input", name));
+        common::errors::PreconditionNotMet("Can not find [%s] in Input", name));
     return it->second[0] ? GetNameFromVar(it->second[0])
                          : framework::kEmptyVarName;
   }
@@ -60,7 +60,7 @@ class DygraphExecutionContext : public framework::ExecutionContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_in_.end(),
-        phi::errors::NotFound("Can not find [%s] in Input", name));
+        common::errors::NotFound("Can not find [%s] in Input", name));
     std::vector<std::string> vec_res;
     vec_res.reserve(it->second.size());
     for (size_t i = 0; i < it->second.size(); ++i) {
@@ -78,7 +78,7 @@ class DygraphExecutionContext : public framework::ExecutionContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_out_.end(),
-        phi::errors::NotFound("Can not find [%s] in Output", name));
+        common::errors::NotFound("Can not find [%s] in Output", name));
     return it->second[0] ? GetNameFromVar(it->second[0])
                          : framework::kEmptyVarName;
   }
@@ -88,7 +88,7 @@ class DygraphExecutionContext : public framework::ExecutionContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_out_.end(),
-        phi::errors::NotFound("Can not find [%s] in Output", name));
+        common::errors::NotFound("Can not find [%s] in Output", name));
     std::vector<std::string> vec_res;
     vec_res.reserve(it->second.size());
     for (size_t i = 0; i < it->second.size(); ++i) {
@@ -114,10 +114,10 @@ class DygraphExecutionContext : public framework::ExecutionContext {
     if (it == attrs_.end()) {
       it = default_attrs_.find(name);
       if (it == default_attrs_.end()) {
-        PADDLE_THROW(
-            phi::errors::NotFound("Can not find [%s] in attributes of op %s.",
-                                  name,
-                                  this->GetOp().Type()));
+        PADDLE_THROW(common::errors::NotFound(
+            "Can not find [%s] in attributes of op %s.",
+            name,
+            this->GetOp().Type()));
       }
     }
 
@@ -155,7 +155,7 @@ class DygraphExecutionContext : public framework::ExecutionContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_in_.end(),
-        phi::errors::NotFound("Can not find [%s] in Input", name));
+        common::errors::NotFound("Can not find [%s] in Input", name));
     return it->second.size();
   }
 
@@ -164,7 +164,7 @@ class DygraphExecutionContext : public framework::ExecutionContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_out_.end(),
-        phi::errors::NotFound("Can not find [%s] in Output", name));
+        common::errors::NotFound("Can not find [%s] in Output", name));
     return it->second.size();
   }
 

--- a/paddle/fluid/imperative/gloo_context.cc
+++ b/paddle/fluid/imperative/gloo_context.cc
@@ -32,7 +32,7 @@ namespace paddle {
 namespace imperative {
 
 void GLOOParallelContext::Init() {
-  // PADDLE_THROW(phi::errors::OutOfRange(
+  // PADDLE_THROW(common::errors::OutOfRange(
   //  "Still not implement Init"));
   VLOG(4) << "Start GLOOParallelContext initialization";
   auto gloo_wrapper = framework::GlooWrapper::GetInstance();
@@ -61,7 +61,8 @@ void GLOOParallelContext::Init() {
 }
 
 void GLOOParallelContext::InitWithRingID(int ring_id) {
-  PADDLE_THROW(phi::errors::OutOfRange("Still not implement InitWithRingID"));
+  PADDLE_THROW(
+      common::errors::OutOfRange("Still not implement InitWithRingID"));
 }
 
 #define GLOO_CASE(type, T, gw)                                  \
@@ -98,7 +99,7 @@ void GLOOParallelContext::AllReduceByStream(const framework::Variable &src,
       *dst = std::move(tmp_dst);
     }
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Unsupported variable type %s for imperative allreduce, only "
         "LoDTensor and SelectedRows are supported.",
         platform::demangle(framework::ToTypeName(src.Type()))));
@@ -116,7 +117,7 @@ void GLOOParallelContext::AllReduce(const phi::DenseTensor &src_tensor,
     GLOO_CASE(framework::proto::VarType::INT64, int64_t, gloo_wrapper);
     default: {
       PADDLE_THROW(
-          phi::errors::InvalidArgument("Invalid datatype for allreduce"));
+          common::errors::InvalidArgument("Invalid datatype for allreduce"));
     }
   }
   gloo_wrapper->Barrier();
@@ -185,14 +186,14 @@ void GLOOParallelContext::AllReduce(const phi::SelectedRows &src,
         framework::proto::VarType::INT64, int64_t, gloo_wrapper);
     default: {
       PADDLE_THROW(
-          phi::errors::InvalidArgument("Invalid datatype for allreduce"));
+          common::errors::InvalidArgument("Invalid datatype for allreduce"));
     }
   }
 }
 
 void GLOOParallelContext::Broadcast(framework::Variable *src, int ring_id) {
-  PADDLE_THROW(
-      phi::errors::Unimplemented("Unimplemented inter-broadcast for CPU now."));
+  PADDLE_THROW(common::errors::Unimplemented(
+      "Unimplemented inter-broadcast for CPU now."));
 }
 
 phi::DeviceContext *GLOOParallelContext::GetDeviceContext(int ring_id) {

--- a/paddle/fluid/imperative/gradient_accumulator.h
+++ b/paddle/fluid/imperative/gradient_accumulator.h
@@ -36,7 +36,7 @@ class GradientAccumulator {
       } else if (var->Var().IsType<phi::SelectedRows>()) {
         var->SetType(framework::proto::VarType::SELECTED_ROWS);
       } else {
-        PADDLE_THROW(phi::errors::PermissionDenied(
+        PADDLE_THROW(common::errors::PermissionDenied(
             "Only support LoDTensor and SelectedRows for gradient var"));
       }
     }
@@ -187,7 +187,7 @@ void TensorAdd(const VarType& src, VarType* dst);
 inline void CheckVar(const std::shared_ptr<VariableWrapper>& pre,
                      const std::shared_ptr<VariableWrapper>& post) {
   if (pre->IsEmpty() && !post->IsEmpty()) {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "The tensor(%s) in before and after hook are not consistent",
         pre->Name()));
   }
@@ -196,7 +196,7 @@ inline void CheckVar(const std::shared_ptr<VariableWrapper>& pre,
     PADDLE_ENFORCE_EQ(
         pre->DataType(),
         post->DataType(),
-        phi::errors::PermissionDenied(
+        common::errors::PermissionDenied(
             "The dtype of tensor(%s) before(%s) and after(%s) hook are not "
             "consistent",
             pre->Name(),
@@ -204,7 +204,7 @@ inline void CheckVar(const std::shared_ptr<VariableWrapper>& pre,
             framework::DataTypeToString(post->DataType())));
     PADDLE_ENFORCE_EQ(pre->Place(),
                       post->Place(),
-                      phi::errors::PermissionDenied(
+                      common::errors::PermissionDenied(
                           "The place of tensor(%s) before(%s) and after(%s) "
                           "hook are not consistent",
                           pre->Name(),

--- a/paddle/fluid/imperative/heter_ccl_context.cc
+++ b/paddle/fluid/imperative/heter_ccl_context.cc
@@ -81,7 +81,7 @@ HeterParallelContext::HeterParallelContext(const ParallelStrategy &strategy,
 
   PADDLE_ENFORCE_NE(node_nranks,
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The number of local nranks should not be zero."));
   node_strategy_.nranks_ = node_nranks;
   node_strategy_.current_endpoint_ = strategy_.current_endpoint_;
@@ -116,7 +116,7 @@ void HeterParallelContext::Init() {
   PADDLE_ENFORCE_NE(
       node_parallel_ctx_,
       nullptr,
-      phi::errors::Unavailable(
+      common::errors::Unavailable(
           "The heter parallel context has not been initialized."));
 
   if (inter_parallel_ctx_ != nullptr) {
@@ -129,7 +129,7 @@ void HeterParallelContext::Init() {
 }
 
 void HeterParallelContext::InitWithRingID(int ring_id) {
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Unimplemented InitWithRingID from heter ctx."));
 }
 
@@ -172,7 +172,7 @@ void HeterParallelContext::AllReduceByStream(const framework::Variable &src,
 }
 
 void HeterParallelContext::Broadcast(framework::Variable *src, int ring_id) {
-  PADDLE_THROW(phi::errors::Unimplemented("Unimplemented function."));
+  PADDLE_THROW(common::errors::Unimplemented("Unimplemented function."));
 }
 
 phi::DeviceContext *HeterParallelContext::GetDeviceContext(int ring_id) {

--- a/paddle/fluid/imperative/infer_shape_context.h
+++ b/paddle/fluid/imperative/infer_shape_context.h
@@ -64,7 +64,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_EQ(
         in.size(),
         1UL,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Input %s should not have more than one inputs", name));
     return in[0] != nullptr;
   }
@@ -82,7 +82,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_EQ(
         out.size(),
         1UL,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Output %s should not have more than one outputs", name));
     return out[0] != nullptr;
   }
@@ -130,7 +130,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_in_->end(),
-        phi::errors::NotFound("can not find [%s] in input", name));
+        common::errors::NotFound("can not find [%s] in input", name));
 
     vec_res.reserve(it->second.size());
     for (auto& var : it->second) {
@@ -150,7 +150,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_out_->end(),
-        phi::errors::NotFound("can not find [%s] in output", name));
+        common::errors::NotFound("can not find [%s] in output", name));
 
     vec_res.reserve(it->second.size());
     for (auto& var : it->second) {
@@ -169,7 +169,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
         paddle::framework::OpInfoMap::Instance().Get(op_type_).proto_;
     PADDLE_ENFORCE_LT(idx,
                       op_proto->inputs().size(),
-                      phi::errors::OutOfRange(
+                      common::errors::OutOfRange(
                           "The index should be less than the size of inputs of "
                           "operator %s, but got index is %d and size is %d",
                           op_type_,
@@ -184,7 +184,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_LT(
         idx,
         op_proto->outputs().size(),
-        phi::errors::OutOfRange(
+        common::errors::OutOfRange(
             "The index should be less than the size of outputs of "
             "operator %s, but got index is %d and size is %d",
             op_type_,
@@ -199,19 +199,21 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
                 size_t j = 0) override {
     auto in_it = var_map_in_->find(in);
     auto out_it = var_map_out_->find(out);
-    PADDLE_ENFORCE_NE(in_it,
-                      var_map_in_->end(),
-                      phi::errors::NotFound("can not found [%s] in input", in));
+    PADDLE_ENFORCE_NE(
+        in_it,
+        var_map_in_->end(),
+        common::errors::NotFound("can not found [%s] in input", in));
     PADDLE_ENFORCE_GT(in_it->second.size(),
                       i,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Inputs %s should have %llu argument", in, i));
-    PADDLE_ENFORCE_NE(out_it,
-                      var_map_out_->end(),
-                      phi::errors::NotFound("can not found [%s] in input", in));
+    PADDLE_ENFORCE_NE(
+        out_it,
+        var_map_out_->end(),
+        common::errors::NotFound("can not found [%s] in input", in));
     PADDLE_ENFORCE_GT(out_it->second.size(),
                       j,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Outputs %s should have %llu argument", out, j));
 
     framework::Variable* in_var = in_it->second[i]->MutableVar();
@@ -219,7 +221,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
 
     PADDLE_ENFORCE_EQ(in_var->Type(),
                       out_var->Type(),
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "The type of %s and %s is not the same.", in, out));
 
     if (in_var->IsType<phi::DenseTensor>()) {
@@ -262,7 +264,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_in_->end(),
-        phi::errors::NotFound("Can not find [%s] in inputs.", name));
+        common::errors::NotFound("Can not find [%s] in inputs.", name));
     for (auto& var : it->second) {
       res.emplace_back(var->MutableVar());
     }
@@ -278,7 +280,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_out_->end(),
-        phi::errors::NotFound("Can not find [%s] in outputs.", name));
+        common::errors::NotFound("Can not find [%s] in outputs.", name));
     for (auto& var : it->second) {
       if (var) {
         res.emplace_back(var->MutableVar());
@@ -294,11 +296,11 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_in_->end(),
-        phi::errors::NotFound("can not find [%s] in input", name));
+        common::errors::NotFound("can not find [%s] in input", name));
     PADDLE_ENFORCE_EQ(
         it->second.size(),
         1UL,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Input(%s) should hold one element, but now it holds %d",
             name,
             it->second.size()));
@@ -312,7 +314,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_in_->end(),
-        phi::errors::NotFound("can not find [%s] in output", name));
+        common::errors::NotFound("can not find [%s] in output", name));
     vec_res.reserve(it->second.size());
     for (size_t i = 0; i < it->second.size(); ++i) {
       if (it->second[i]) {
@@ -331,7 +333,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_in_->end(),
-        phi::errors::NotFound("can not find [%s] in input", name));
+        common::errors::NotFound("can not find [%s] in input", name));
     return framework::ToVarType(it->second[0]->Var().Type());
   }
 
@@ -342,7 +344,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_in_->end(),
-        phi::errors::NotFound("can not find [%s] in input", name));
+        common::errors::NotFound("can not find [%s] in input", name));
     vec_res.reserve(it->second.size());
     for (size_t i = 0; i < it->second.size(); ++i) {
       if (it->second[i]) {
@@ -362,7 +364,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_out_->end(),
-        phi::errors::NotFound("can not find [%s] in output", name));
+        common::errors::NotFound("can not find [%s] in output", name));
     vec_res.reserve(it->second.size());
     for (size_t i = 0; i < it->second.size(); ++i) {
       if (it->second[i]) {
@@ -380,7 +382,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_out_->end(),
-        phi::errors::NotFound("can not find [%s] in output", name));
+        common::errors::NotFound("can not find [%s] in output", name));
 
     if (it->second[0]) {
       SetDim(it->second[0]->MutableVar(), dim);
@@ -393,11 +395,11 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_NE(
         it,
         var_map_out_->end(),
-        phi::errors::NotFound("can not find [%s] in output", name));
+        common::errors::NotFound("can not find [%s] in output", name));
 
     PADDLE_ENFORCE_EQ(dims.size(),
                       it->second.size(),
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "The number of dims is expected to be equal to the "
                           "number of Outputs(%s). But received: the number of "
                           "dims = %d, the number of Outputs(%s) = %d.",
@@ -415,14 +417,14 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
 
   int32_t GetLoDLevel(const std::string& in UNUSED,
                       size_t i UNUSED = 0) const override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "GetLoDLevel function not support in dygraph mode"));
   }
 
   void SetLoDLevel(const std::string& out UNUSED,
                    int32_t lod_level UNUSED,
                    size_t j UNUSED = 0) const override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "SetLoDLevel function not support in dygraph mode"));
   }
 
@@ -436,15 +438,15 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
 
  protected:
   DDim GetDim(framework::Variable* var) const {
-    PADDLE_ENFORCE_NOT_NULL(
-        var,
-        phi::errors::PreconditionNotMet("Input variable should not be null"));
+    PADDLE_ENFORCE_NOT_NULL(var,
+                            common::errors::PreconditionNotMet(
+                                "Input variable should not be null"));
     if (var->IsType<phi::DenseTensor>()) {
       return var->Get<phi::DenseTensor>().dims();
     } else if (var->IsType<phi::SelectedRows>()) {
       return var->Get<phi::SelectedRows>().GetCompleteDims();
     } else {
-      PADDLE_THROW(phi::errors::PermissionDenied(
+      PADDLE_THROW(common::errors::PermissionDenied(
           "Only LoDTensor/SelectedRows support 'GetDim', but Variables "
           "type_id is: %s.",
           framework::ToTypeName(var->Type())));
@@ -453,7 +455,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
 
   std::vector<DDim> GetRepeatedDims(
       const std::string& name UNUSED) const override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "GetRepeatedDims not support in dygraph runtime"));
   }
 
@@ -463,7 +465,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     } else if (var->IsType<phi::SelectedRows>()) {
       var->GetMutable<phi::SelectedRows>()->set_height(dim[0]);
     } else {
-      PADDLE_THROW(phi::errors::PermissionDenied(
+      PADDLE_THROW(common::errors::PermissionDenied(
           "Variable type_id %s, expect LoDTensor/SelectedRows."));
     }
   }
@@ -474,7 +476,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     PADDLE_ENFORCE_EQ(
         length,
         dims.size(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Vars number [%d] should be equal with dims number [%d]",
             length,
             dims.size()));
@@ -488,7 +490,7 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
 
   void SetRepeatedDims(const std::string& name UNUSED,
                        const std::vector<DDim>& dims UNUSED) override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "SetRepeatedDims not support in dygraph runtime"));
   }
 

--- a/paddle/fluid/imperative/infer_var_type_context.h
+++ b/paddle/fluid/imperative/infer_var_type_context.h
@@ -51,7 +51,7 @@ class RuntimeInferVarTypeContext : public framework::InferVarTypeContext {
       it = default_attrs_.find(name);
       if (it == default_attrs_.end()) {
         PADDLE_THROW(
-            phi::errors::NotFound("Can not find [%s] in attributes.", name));
+            common::errors::NotFound("Can not find [%s] in attributes.", name));
       }
     }
 
@@ -156,79 +156,79 @@ class RuntimeInferVarTypeContext : public framework::InferVarTypeContext {
 
  protected:
   bool HasVar(const std::string& name UNUSED) const override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "HasVar is not supported in runtime InferVarType"));
   }
 
   const std::vector<std::string>& InputVars(
       const std::string& name UNUSED) const override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "InputVars is not supported in runtime InferVarType"));
   }
 
   const std::vector<std::string>& OutputVars(
       const std::string& name UNUSED) const override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "OutputVars is not supported in runtime InferVarType"));
   }
 
   framework::proto::VarType::Type GetVarType(
       const std::string& name UNUSED) const override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Do not manipulate var in runtime InferVarType"));
   }
 
   void SetVarType(const std::string& name UNUSED,
                   framework::proto::VarType::Type type UNUSED) override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Do not manipulate var in runtime InferVarType"));
   }
 
   framework::proto::VarType::Type GetVarDataType(
       const std::string& name UNUSED) const override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Do not manipulate var in runtime InferVarType"));
   }
 
   void SetVarDataType(const std::string& name UNUSED,
                       framework::proto::VarType::Type type UNUSED) override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Do not manipulate var in runtime InferVarType"));
   }
 
   std::vector<framework::proto::VarType::Type> GetVarDataTypes(
       const std::string& name UNUSED) const override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "GetVarDataTypes is not supported in runtime InferVarType"));
   }
 
   void SetVarDataTypes(const std::string& name UNUSED,
                        const std::vector<framework::proto::VarType::Type>&
                            multiple_data_type UNUSED) override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "SetVarDataTypes is not supported in runtime InferVarType"));
   }
 
   std::vector<int64_t> GetVarShape(
       const std::string& name UNUSED) const override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Do not handle Shape in runtime InferVarType"));
   }
 
   void SetVarShape(const std::string& name UNUSED,
                    const std::vector<int64_t>& dims UNUSED) override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Do not handle Shape in runtime InferVarType"));
   }
 
   int32_t GetVarLoDLevel(const std::string& name UNUSED) const override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Do not handle LoDLevel in runtime InferVarType"));
   }
 
   void SetVarLoDLevel(const std::string& name UNUSED,
                       int32_t lod_level UNUSED) override {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Do not handle LoDLevel in runtime InferVarType"));
   }
 

--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -45,7 +45,7 @@ void ThreadSafeNameSet::Remove(const std::string& name) {
   PADDLE_ENFORCE_EQ(
       iter != set_.end(),
       true,
-      phi::errors::NotFound("Variable name %s does not exist", name));
+      common::errors::NotFound("Variable name %s does not exist", name));
   set_.erase(iter);
 }
 
@@ -285,7 +285,7 @@ std::shared_ptr<VarBase> VarBase::NewVarBase(const phi::Place& dst_place,
       Var().IsInitialized() && (Var().IsType<phi::DenseTensor>() ||
                                 Var().IsType<phi::SelectedRows>()),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Variable is not initialized or Variable's type is not "
           "LoDTensor or SelectedRows when getting numpy tensor"));
 
@@ -346,14 +346,14 @@ void VarBase::CopyFrom(const VarBase& src, const bool blocking) {
   if (Var().IsInitialized()) {
     PADDLE_ENFORCE_EQ(DataType(),
                       src.DataType(),
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Tensor %s has different data type with Tensor %s, "
                           "Tensor Copy cannot be performed!",
                           Name(),
                           src.Name()));
     PADDLE_ENFORCE_EQ(Type(),
                       src.Type(),
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Tensor %s has different type with Tensor %s, Tensor "
                           "Copy cannot be performed!",
                           Name(),
@@ -372,14 +372,14 @@ void VarBase::CopyFrom(const VarBase& src, const bool blocking) {
     if (dst_tensor && dst_tensor->IsInitialized()) {
       PADDLE_ENFORCE_EQ(dst_tensor->dims(),
                         src_tensor.dims(),
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "Tensor %s has different dims with Tensor %s, "
                             "Tensor Copy cannot be performed!",
                             Name(),
                             src.Name()));
       PADDLE_ENFORCE_EQ(dst_tensor->lod(),
                         src_tensor.lod(),
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "Tensor %s has different dims with Tensor %s, "
                             "Tensor Copy cannot be performed!",
                             Name(),
@@ -401,7 +401,7 @@ void VarBase::CopyFrom(const VarBase& src, const bool blocking) {
     if (dst_tensor && dst_tensor->IsInitialized()) {
       PADDLE_ENFORCE_EQ(dst_tensor->dims(),
                         src_tensor.dims(),
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "Tensor %s has different dims with Tensor %s, "
                             "Tensor Copy cannot be performed!",
                             Name(),
@@ -421,7 +421,7 @@ void VarBase::BumpInplaceVersion() {
   PADDLE_ENFORCE_EQ(
       Var().IsInitialized(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Tensor %s has not been initialized, please check if it has no data.",
           Name()));
   MutableVar()->BumpInplaceVersion();
@@ -434,13 +434,13 @@ void VarBase::_CopyGradientFrom(const VarBase& src) {
   if (Var().IsInitialized()) {
     PADDLE_ENFORCE_EQ(DataType(),
                       src.DataType(),
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Tensor %s has different data type with Tensor %s",
                           Name(),
                           src.Name()));
     PADDLE_ENFORCE_EQ(Type(),
                       src.Type(),
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Tensor %s has different type with Tensor %s, Tensor "
                           "ShareGradientDataWith cannot be performed!",
                           Name(),
@@ -451,7 +451,7 @@ void VarBase::_CopyGradientFrom(const VarBase& src) {
     auto& src_tensor = src.Var().Get<phi::DenseTensor>();
     PADDLE_ENFORCE_EQ(src_tensor.IsInitialized(),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Tensor %s has not been initialized", src.Name()));
     auto* grad_t = grad_var_->MutableVar()->GetMutable<phi::DenseTensor>();
     auto* var_ = MutableVar()->GetMutable<phi::DenseTensor>();
@@ -479,7 +479,7 @@ static void OpBaseRunImpl(const framework::OperatorBase& op,
   auto* op_kernel = static_cast<const framework::OperatorWithKernel*>(&op);
   PADDLE_ENFORCE_NOT_NULL(
       op_kernel,
-      phi::errors::PermissionDenied(
+      common::errors::PermissionDenied(
           "Only support operator with kernel in Dygraph mode."));
   auto& info = op.Info();
   if (info.infer_var_type_) {
@@ -576,7 +576,7 @@ void ClearNoNeedBufferInputs(OpBase* op) {
     PADDLE_ENFORCE_EQ(
         iter->second.IsGrad(),
         false,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Only forward variable buffers can be clear, this may be a bug"));
 
     for (auto& each_var : *(iter->second.MutableVarList())) {
@@ -585,7 +585,7 @@ void ClearNoNeedBufferInputs(OpBase* op) {
       auto& var = each_var->Var();
       PADDLE_ENFORCE_EQ(var.IsType<phi::DenseTensor>(),
                         true,
-                        phi::errors::PermissionDenied(
+                        common::errors::PermissionDenied(
                             "NoNeedBufferVars only support LoDTensor"));
       auto new_var = new VariableWrapper(each_var->Name());
       auto* new_tensor = new_var->MutableVar()->GetMutable<phi::DenseTensor>();

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -133,14 +133,14 @@ class VarBase {
   const framework::Variable& GradVar() const {
     PADDLE_ENFORCE_NOT_NULL(
         grad_var_,
-        phi::errors::NotFound("Gradient of %s does not exist", Name()));
+        common::errors::NotFound("Gradient of %s does not exist", Name()));
     return grad_var_->Var();
   }
 
   framework::Variable* MutableGradVar() {
     PADDLE_ENFORCE_NOT_NULL(
         grad_var_,
-        phi::errors::NotFound("Gradient of %s does not exist", Name()));
+        common::errors::NotFound("Gradient of %s does not exist", Name()));
     return grad_var_->MutableVar();
   }
 

--- a/paddle/fluid/imperative/layout_autotune.cc
+++ b/paddle/fluid/imperative/layout_autotune.cc
@@ -223,8 +223,8 @@ paddle::imperative::NameVarMap<VarType> AutoTuneLayout(
     }
     PADDLE_ENFORCE_NOT_NULL(
         transposer,
-        phi::errors::Unimplemented("%s 's LayoutTransformer is unimplemented.",
-                                   op_type));
+        common::errors::Unimplemented(
+            "%s 's LayoutTransformer is unimplemented.", op_type));
     return transposer->Apply(ins, outs, attrs, tracer);
   }
 }

--- a/paddle/fluid/imperative/nccl_context.cc
+++ b/paddle/fluid/imperative/nccl_context.cc
@@ -133,7 +133,7 @@ void NCCLParallelContext::AllReduceByStream(const framework::Variable &src,
   PADDLE_ENFORCE_EQ(
       phi::is_gpu_place(place_),
       true,
-      phi::errors::Unimplemented(
+      common::errors::Unimplemented(
           "Dynamic graph mode does not support multi-CPU training yet."));
   AllReduce(src, dst, strategy_, ring_id, use_calc_stream);
 }
@@ -163,14 +163,14 @@ void NCCLParallelContext::WaitCompute(int ring_id) {
   PADDLE_ENFORCE_GE(
       ring_id,
       0,
-      phi::errors::OutOfRange("ring id must >= 0, but got %d", ring_id));
-  PADDLE_ENFORCE_LT(
-      ring_id,
-      compute_events_.size(),
-      phi::errors::OutOfRange("ring id must < compute events size,"
-                              "but got ring id = %d, compute events size = %d",
-                              ring_id,
-                              compute_events_.size()));
+      common::errors::OutOfRange("ring id must >= 0, but got %d", ring_id));
+  PADDLE_ENFORCE_LT(ring_id,
+                    compute_events_.size(),
+                    common::errors::OutOfRange(
+                        "ring id must < compute events size,"
+                        "but got ring id = %d, compute events size = %d",
+                        ring_id,
+                        compute_events_.size()));
 
   auto compute_stream = static_cast<phi::GPUContext *>(
                             phi::DeviceContextPool::Instance().Get(place_))
@@ -193,14 +193,14 @@ void NCCLParallelContext::WaitComm(int ring_id) {
   PADDLE_ENFORCE_GE(
       ring_id,
       0,
-      phi::errors::OutOfRange("ring id must >= 0, but got %d", ring_id));
+      common::errors::OutOfRange("ring id must >= 0, but got %d", ring_id));
   PADDLE_ENFORCE_LT(
       ring_id,
       comm_events_.size(),
-      phi::errors::OutOfRange("ring id must < comm events size,"
-                              "but got ring id = %d, comm events size = %d",
-                              ring_id,
-                              comm_events_.size()));
+      common::errors::OutOfRange("ring id must < comm events size,"
+                                 "but got ring id = %d, comm events size = %d",
+                                 ring_id,
+                                 comm_events_.size()));
 
   auto compute_stream = static_cast<phi::GPUContext *>(
                             phi::DeviceContextPool::Instance().Get(place_))

--- a/paddle/fluid/imperative/op_base.h
+++ b/paddle/fluid/imperative/op_base.h
@@ -58,16 +58,16 @@ class OpBase {
   }
 
   const framework::OpInfo& Info() const {
-    PADDLE_ENFORCE_NOT_NULL(
-        op_,
-        phi::errors::PreconditionNotMet("OpBase::Info() should be called after "
-                                        "OpBase::SetType() is called"));
+    PADDLE_ENFORCE_NOT_NULL(op_,
+                            common::errors::PreconditionNotMet(
+                                "OpBase::Info() should be called after "
+                                "OpBase::SetType() is called"));
     return op_->Info();
   }
 
   const framework::OperatorBase& InnerOp() const {
     PADDLE_ENFORCE_NOT_NULL(op_,
-                            phi::errors::PreconditionNotMet(
+                            common::errors::PreconditionNotMet(
                                 "OpBase::InnerOp() should be called after "
                                 "OpBase::SetType() is called"));
     return *op_;
@@ -120,7 +120,7 @@ class OpBase {
 
   void SetBlockAttr(const std::string& name UNUSED,
                     framework::BlockDesc* block UNUSED) {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "SetBlockAttr is not support in dygraph OpBase"));
   }
 
@@ -148,7 +148,7 @@ class OpBase {
       PADDLE_ENFORCE_NE(
           it_default,
           default_attrs_->end(),
-          phi::errors::NotFound("can not find attribute [%s]", name));
+          common::errors::NotFound("can not find attribute [%s]", name));
       return it_default->second;
     }
   }
@@ -170,7 +170,7 @@ class OpBase {
     PADDLE_ENFORCE_NE(
         ins_.empty() && outs_.empty(),
         true,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Inputs and outputs of %s do not exist. This may be because:\n"
             "1. You use some output variables of the previous batch as the "
             "inputs of the current batch. Please try to call \"stop_gradient "

--- a/paddle/fluid/imperative/prepared_operator.cc
+++ b/paddle/fluid/imperative/prepared_operator.cc
@@ -368,7 +368,7 @@ PreparedOp PrepareImpl(
   PADDLE_ENFORCE_NE(
       kernels_iter,
       all_op_kernels.end(),
-      phi::errors::NotFound(
+      common::errors::NotFound(
           "There are no kernels which are registered in the %s operator.",
           op.Type()));
 
@@ -435,9 +435,9 @@ PreparedOp PrepareImpl(
   PADDLE_ENFORCE_NE(
       kernel_iter,
       kernels.end(),
-      phi::errors::NotFound("Operator %s does not have kernel for %s.",
-                            op.Type(),
-                            KernelTypeToString(fluid_kernel_type)));
+      common::errors::NotFound("Operator %s does not have kernel for %s.",
+                               op.Type(),
+                               KernelTypeToString(fluid_kernel_type)));
 
   if (!phi::places_are_same_class(fluid_kernel_type.place_,
                                   dev_ctx->GetPlace())) {

--- a/paddle/fluid/imperative/prepared_operator.h
+++ b/paddle/fluid/imperative/prepared_operator.h
@@ -267,7 +267,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
   PADDLE_ENFORCE_EQ(
       input_names.size(),
       input_defs.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s: the size of inputs_args names (%d) must be equal to "
           "the size of kernel input_defs (%d).",
           kernel_signature.name,
@@ -277,7 +277,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
   PADDLE_ENFORCE_EQ(
       output_names.size(),
       output_defs.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s: the size of outputs_args names (%d) must be equal to "
           "the size of kernel output_defs (%d).",
           kernel_signature.name,
@@ -287,7 +287,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
   PADDLE_ENFORCE_EQ(
       attr_names.size(),
       attr_defs.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Op %s: the size of attribute_args names (%d) must be equal "
           "to the size of kernel attribute_defs (%d).",
           kernel_signature.name,
@@ -314,7 +314,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
         kernel_ctx->AssignInputRange(std::make_pair(start_idx, end_idx), i);
         continue;
       } else {
-        PADDLE_THROW(phi::errors::NotFound(
+        PADDLE_THROW(common::errors::NotFound(
             "Can not find input variable '%s' for %s OP, please check whether "
             "the name setting in OpArgumentMapping is consistent with that in "
             "OpMaker.",
@@ -339,7 +339,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
         tensor_in = &(var.template Get<framework::LoDTensorArray>());
         kernel_ctx->EmplaceBackInputWithoutSetRange(tensor_in);
       } else {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Unsupported input `%s` type when call pt kernel.",
             framework::ToTypeName(var.Type())));
       }
@@ -381,7 +381,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
           tensor_out = var->template GetMutable<framework::LoDTensorArray>();
           kernel_ctx->EmplaceBackOutputWithoutSetRange(tensor_out);
         } else {
-          PADDLE_THROW(phi::errors::Unimplemented(
+          PADDLE_THROW(common::errors::Unimplemented(
               "Unsupported output `%s` type when call pt kernel.",
               framework::ToTypeName(var->Type())));
         }
@@ -432,7 +432,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
                   PADDLE_GET_CONST(paddle::experimental::Scalar, attr)));
               break;
             default:
-              PADDLE_THROW(phi::errors::Unimplemented(
+              PADDLE_THROW(common::errors::Unimplemented(
                   "Unsupported cast op attribute `%s` to Scalar when construct "
                   "KernelContext in dygraph.",
                   attr_names[i]));
@@ -464,7 +464,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
                   phi::IntArray(&PADDLE_GET_CONST(int64_t, attr), 1));
               break;
             default:
-              PADDLE_THROW(phi::errors::Unimplemented(
+              PADDLE_THROW(common::errors::Unimplemented(
                   "Unsupported cast op attribute `%s` to IntArray when "
                   "construct KernelContext.",
                   attr_names[i]));
@@ -488,9 +488,9 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
       case phi::AttributeType::SCALARS: {
         PADDLE_ENFORCE_NOT_NULL(
             attr_ptr,
-            phi::errors::NotFound("(%s) is not found in AttributeMap when "
-                                  "building dygraph KernelContext.",
-                                  attr_names[i]));
+            common::errors::NotFound("(%s) is not found in AttributeMap when "
+                                     "building dygraph KernelContext.",
+                                     attr_names[i]));
         auto& attr = *attr_ptr;
         switch (AttrTypeID(attr)) {
           case framework::proto::AttrType::INTS: {
@@ -549,7 +549,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
             kernel_ctx->EmplaceBackAttr(std::move(scalar_list));
           } break;
           default:
-            PADDLE_THROW(phi::errors::Unimplemented(
+            PADDLE_THROW(common::errors::Unimplemented(
                 "Unsupported cast op attribute `%s` to vector<Scalar> when "
                 "construct KernelContext.",
                 attr_names[i]));
@@ -558,9 +558,9 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
       default: {
         PADDLE_ENFORCE_NOT_NULL(
             attr_ptr,
-            phi::errors::NotFound("(%s) is not found in AttributeMap when "
-                                  "building dygraph KernelContext.",
-                                  attr_names[i]));
+            common::errors::NotFound("(%s) is not found in AttributeMap when "
+                                     "building dygraph KernelContext.",
+                                     attr_names[i]));
         auto& attr = *attr_ptr;
         switch (attr_defs[i].type_index) {
           case phi::AttributeType::FLOAT32:
@@ -606,7 +606,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
                 kernel_ctx->EmplaceBackAttr(vector_int64_attr);
               } break;
               default:
-                PADDLE_THROW(phi::errors::Unimplemented(
+                PADDLE_THROW(common::errors::Unimplemented(
                     "Unsupported cast op attribute `%s` to vector<int64_t> "
                     "when "
                     "construct KernelContext.",
@@ -622,7 +622,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
                 PADDLE_GET_CONST(std::vector<std::string>, attr));
             break;
           default:
-            PADDLE_THROW(phi::errors::Unimplemented(
+            PADDLE_THROW(common::errors::Unimplemented(
                 "Unsupported cast op attribute `%s` when construct "
                 "KernelContext in dygraph.",
                 attr_names[i]));
@@ -642,7 +642,7 @@ void PreparePhiData(const phi::Kernel& phi_kernel,
 
   PADDLE_ENFORCE_EQ(input_names.size(),
                     input_defs.size(),
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "the size of inputs_args names (%d) must be equal to "
                         "the size of kernel input_defs (%d).",
                         input_names.size(),

--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -49,7 +49,7 @@ void Group::DivNRanks(const phi::DeviceContext &context, int64_t nranks) {
 #ifdef PADDLE_WITH_HIP
     if (dtype_ == paddle::framework::proto::VarType_Type_BF16) {
       PADDLE_THROW(
-          phi::errors::Fatal("Unsupport BF16 in DataParallel for now"));
+          common::errors::Fatal("Unsupport BF16 in DataParallel for now"));
     }
     framework::VisitDataTypeForHIP(
         dtype_,
@@ -63,8 +63,8 @@ void Group::DivNRanks(const phi::DeviceContext &context, int64_t nranks) {
   } else if (phi::is_xpu_place(tensor->place())) {
 #ifdef PADDLE_WITH_XPU_BKCL
     PADDLE_THROW(
-        phi::errors::Unimplemented("DivNRanks is not supported on XPU / "
-                                   "XPU_BKCL, use EagerReducer instead."));
+        common::errors::Unimplemented("DivNRanks is not supported on XPU / "
+                                      "XPU_BKCL, use EagerReducer instead."));
 #endif
   }
 }
@@ -128,7 +128,7 @@ static void ConcatTensorsWithType(
           context, dense_tensors_, p_dense_contents);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported when it concats tensors for "
           "allreduce.",
           framework::DataTypeToString(type)));
@@ -155,7 +155,7 @@ static void SplitTensorsWithType(const DeviceContext &context,
           context, p_dense_contents, p_dense_tensors);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported when it splits tensors for "
           "allreduce.",
           framework::DataTypeToString(type)));
@@ -196,7 +196,7 @@ void ConcatTensorsWithType<phi::XPUContext>(
           context, dense_tensors_, p_dense_contents);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported when it concats tensors for "
           "allreduce.",
           framework::DataTypeToString(type)));
@@ -216,7 +216,7 @@ void SplitTensorsWithType<phi::XPUContext>(
           context, p_dense_contents, p_dense_tensors);
       break;
     default:
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Data type (%s) is not supported when it splits tensors for "
           "allreduce.",
           framework::DataTypeToString(type)));
@@ -233,7 +233,7 @@ void Group::ConcatTensors(const phi::DeviceContext &context) {
                           &dense_contents_,
                           dtype_);
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't concat grad tensors since it's not compiled with NCCL,"
         "Please recompile or reinstall Paddle with NCCL support."));
 #endif
@@ -244,7 +244,7 @@ void Group::ConcatTensors(const phi::DeviceContext &context) {
                           &dense_contents_,
                           dtype_);
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't concat xpu grads since it's not compiled with BKCL,"
         "Please recompile or reinstall Paddle with BKCL support."));
 #endif
@@ -254,7 +254,7 @@ void Group::ConcatTensors(const phi::DeviceContext &context) {
                           &dense_contents_,
                           dtype_);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Concat grad tensor not supported on place (%s)", place));
   }
 }
@@ -268,7 +268,7 @@ void Group::SplitTensors(const phi::DeviceContext &context) {
                          &dense_tensors_,
                          dtype_);
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't split grad tensor since it's not compiled with NCCL,"
         "Please recompile or reinstall Paddle with NCCL support."));
 #endif
@@ -279,7 +279,7 @@ void Group::SplitTensors(const phi::DeviceContext &context) {
                          &dense_tensors_,
                          dtype_);
 #else
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Paddle can't split xpu grad since it's not compiled with BKCL,"
         "Please recompile or reinstall Paddle with BKCL support."));
 #endif
@@ -289,7 +289,7 @@ void Group::SplitTensors(const phi::DeviceContext &context) {
                          &dense_tensors_,
                          dtype_);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Split grad tensor not supported on place (%s)", place));
   }
 }
@@ -362,7 +362,7 @@ void Reducer::InitializeDenseGroups(
     const auto &var_name = var->Name();
     PADDLE_ENFORCE_EQ(is_sparse_gradient_[variable_index],
                       false,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Tensor %s's GRAD must be LoDTensor, but received "
                           "GRAD is SelectedRows",
                           var_name));
@@ -370,13 +370,13 @@ void Reducer::InitializeDenseGroups(
     auto lod_tensor = var->MutableVar()->GetMutable<phi::DenseTensor>();
     PADDLE_ENFORCE_EQ(lod_tensor->IsInitialized(),
                       true,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "Tensor %s is not initialized.", var_name));
     const auto size = lod_tensor->numel();
     PADDLE_ENFORCE_GT(
         size,
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The number of tensor %s's elements is 0.", var_name));
     all_length += size;
 
@@ -392,7 +392,7 @@ void Reducer::InitializeDenseGroups(
       PADDLE_ENFORCE_EQ(
           dtype,
           p_group->dtype_,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "Tensor %s has different dtype. Expected dtype is %s, but actual "
               "dtype is %s",
               var_name,
@@ -400,7 +400,7 @@ void Reducer::InitializeDenseGroups(
               framework::DataTypeToString(dtype)));
       PADDLE_ENFORCE_EQ(place,
                         place_,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "Tensor %s has different place. Expected place is "
                             "%s, but actual place is %s",
                             var_name,
@@ -433,7 +433,7 @@ void Reducer::InitializeGroups(
     PADDLE_ENFORCE_GT(
         variable_indices_.size(),
         0,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The number of group[%d]'s elements is 0.", group_index));
     Group group;
 
@@ -468,7 +468,7 @@ void Reducer::PrepareDeps(const std::unordered_set<GradOpNode *> &init_nodes) {
   PADDLE_ENFORCE_EQ(
       node_deps_.empty(),
       true,
-      phi::errors::AlreadyExists("Op deps must be initialized here"));
+      common::errors::AlreadyExists("Op deps must be initialized here"));
 
   std::queue<GradOpNode *> q;
   std::unordered_set<GradOpNode *> visited;
@@ -486,7 +486,7 @@ void Reducer::PrepareDeps(const std::unordered_set<GradOpNode *> &init_nodes) {
     for (auto &grad_pending_node : grad_pending_nodes) {
       PADDLE_ENFORCE_NOT_NULL(
           grad_pending_node,
-          phi::errors::NotFound("Grad pending node should not be null"));
+          common::errors::NotFound("Grad pending node should not be null"));
       // py_layer is not supported in DataParallel
       auto begin = grad_pending_node->begin();
       auto end = grad_pending_node->end();
@@ -494,7 +494,7 @@ void Reducer::PrepareDeps(const std::unordered_set<GradOpNode *> &init_nodes) {
         PADDLE_ENFORCE_EQ(
             op_base->Type() != "py_layer",
             true,
-            phi::errors::PreconditionNotMet(
+            common::errors::PreconditionNotMet(
                 "Note: Currently PyLayer is not supported in DataParallel. For "
                 "using PyLayer in a DataParallel model, you can skip gradient "
                 "synchronization among multiple cards by 'no_sync', and "
@@ -559,7 +559,7 @@ void Reducer::TraverseBackwardGraph(
     for (const auto &grad_pending_node : cur_node->GradPendingNodes()) {
       PADDLE_ENFORCE_NOT_NULL(
           grad_pending_node,
-          phi::errors::NotFound("Grad pending node should not be nullptr"));
+          common::errors::NotFound("Grad pending node should not be nullptr"));
       auto iter = node_deps_.find(grad_pending_node.get());
       if (iter == node_deps_.end()) {
         continue;
@@ -598,7 +598,7 @@ void Reducer::PrepareForBackward(
   PADDLE_ENFORCE_EQ(
       groups_need_finalize_,
       false,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "A serious error has occurred here. Please "
           "set find_unused_parameters=True to traverse backward graph "
           "in each step to prepare reduce in advance. If you have "
@@ -655,10 +655,10 @@ void Reducer::AddDistHook(size_t var_index) {
   PADDLE_ENFORCE_LT(
       var_index,
       variable_locators_.size(),
-      phi::errors::OutOfRange("Out of bounds variable index. it must be less"
-                              "than %d, but it is %d",
-                              variable_locators_.size(),
-                              var_index));
+      common::errors::OutOfRange("Out of bounds variable index. it must be less"
+                                 "than %d, but it is %d",
+                                 variable_locators_.size(),
+                                 var_index));
 
   // gradient synchronization is not required when grad_need_hooks_ is false.
   if (!grad_need_hooks_) {
@@ -710,7 +710,7 @@ void Reducer::MarkVarReady(const size_t var_index, const bool is_used_var) {
 
     PADDLE_ENFORCE_EQ(has_marked_unused_vars_,
                       false,
-                      phi::errors::PreconditionNotMet(error_info));
+                      common::errors::PreconditionNotMet(error_info));
 
     error_info +=
         "3) Unused parameters retrieval is incorrect. "
@@ -726,7 +726,7 @@ void Reducer::MarkVarReady(const size_t var_index, const bool is_used_var) {
 
     PADDLE_ENFORCE_EQ(has_marked_unused_vars_,
                       true,
-                      phi::errors::PreconditionNotMet(error_info));
+                      common::errors::PreconditionNotMet(error_info));
   } else {
     vars_marked_ready_[var_index] = true;
   }
@@ -788,7 +788,7 @@ void Reducer::MarkVarReady(const size_t var_index, const bool is_used_var) {
     PADDLE_ENFORCE_EQ(
         HasGrad(var_index),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The sparse parameter[%d][%s] should have gradient. "
             "Currently, DataParallel does not support sparse "
             "parameters without generating gradients during training. "
@@ -802,7 +802,7 @@ void Reducer::MarkVarReady(const size_t var_index, const bool is_used_var) {
     PADDLE_ENFORCE_EQ(
         var_base->Var().IsType<phi::SelectedRows>(),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "The sparse parameter[%d][%s] must have a selectedrows gradient. "
             "Before forward pass, the parameter type is inferred to be "
             "SelectedRows, but after backward pass, its actual type becomes "
@@ -831,7 +831,7 @@ void Reducer::MarkGroupReady(size_t group_index) {
   PADDLE_ENFORCE_GE(
       group_index,
       next_group_,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "The index of the incoming group must be greater "
           "than or equal to the previously synchronized group index, "
           "expect it to greater than or equal to %d, but got %d.",
@@ -899,7 +899,7 @@ std::vector<std::vector<size_t>> Reducer::RebuildGroups() {
   PADDLE_ENFORCE_EQ(
       rebuild_vars_.size(),
       vars_.size(),
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "Rebuild vars's number should be equal to original vars'number, "
           "expect it to be %d, but got %d.",
           vars_.size(),
@@ -998,7 +998,7 @@ bool Reducer::HasGrad(size_t var_index) {
       return true;
     }
   } else {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Only support LoDTensor and SelectedRows for gradient var"));
   }
   return false;
@@ -1055,7 +1055,7 @@ std::vector<std::vector<size_t>> AssignGroupBySize(
     const std::vector<int64_t> &tensor_indices) {
   PADDLE_ENFORCE_EQ(vars.size(),
                     is_sparse_gradient.size(),
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "vars len must be equal to is_sparse_gradient len, but "
                         "[%lu] != [%lu]",
                         vars.size(),
@@ -1073,7 +1073,7 @@ std::vector<std::vector<size_t>> AssignGroupBySize(
   };
   PADDLE_ENFORCE_EQ(true,
                     check_perm(tensor_indices),
-                    phi::errors::PreconditionNotMet(
+                    common::errors::PreconditionNotMet(
                         "tensor_indices must be a permutation from 0 to %lu",
                         tensor_indices.size()));
   // the return vector
@@ -1144,7 +1144,7 @@ std::vector<std::vector<size_t>> AssignGroupBySize(
     PADDLE_ENFORCE_NE(
         group_index.empty(),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "AssignGroupBySize construct empty group, please check."));
   }
   if (tensor_indices.empty()) {

--- a/paddle/fluid/imperative/reducer.cu
+++ b/paddle/fluid/imperative/reducer.cu
@@ -23,7 +23,8 @@ void Group::DivNRanks(phi::DenseTensor *tensor,
                       const phi::DeviceContext &context) {
 #ifdef PADDLE_WITH_HIP
   if (dtype_ == paddle::framework::proto::VarType_Type_BF16) {
-    PADDLE_THROW(phi::errors::Fatal("Unsupport BF16 in DataParallel for now"));
+    PADDLE_THROW(
+        common::errors::Fatal("Unsupport BF16 in DataParallel for now"));
   }
   framework::VisitDataTypeForHIP(
       dtype_, DivNRanksForAllReduce<phi::GPUContext>(tensor, nranks, context));

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -140,7 +140,7 @@ paddle::framework::GarbageCollector* Tracer::MutableGarbageCollectorIfNotExists(
 
       VLOG(10) << "Created GarbageCollector at " << place;
 #else
-      PADDLE_THROW(phi::errors::PermissionDenied(
+      PADDLE_THROW(common::errors::PermissionDenied(
           "Paddle can't use CUDA device since it's not compiled with CUDA,"
           "Please recompile or reinstall Paddle with GPU support."));
 #endif
@@ -150,7 +150,7 @@ paddle::framework::GarbageCollector* Tracer::MutableGarbageCollectorIfNotExists(
 
       VLOG(10) << "Created GarbageCollector at " << place;
 #else
-      PADDLE_THROW(phi::errors::PermissionDenied(
+      PADDLE_THROW(common::errors::PermissionDenied(
           "Paddle can't use CUDAPinned device since it's not compiled with "
           "CUDA,"
           "Please recompile or reinstall Paddle with GPU support."));
@@ -160,7 +160,7 @@ paddle::framework::GarbageCollector* Tracer::MutableGarbageCollectorIfNotExists(
       gc = std::make_unique<framework::XPUGarbageCollector>(place, 0);
       VLOG(10) << "Created GarbageCollector at " << place;
 #else
-      PADDLE_THROW(phi::errors::PermissionDenied(
+      PADDLE_THROW(common::errors::PermissionDenied(
           "Paddle can't use XPU device since it's not compiled with XPU,"
           "Please recompile or reinstall Paddle with XPU support."));
 #endif
@@ -172,7 +172,7 @@ paddle::framework::GarbageCollector* Tracer::MutableGarbageCollectorIfNotExists(
       gc = std::make_unique<framework::IPUGarbageCollector>(place, 0);
       VLOG(10) << "Created GarbageCollector at " << place;
 #else
-      PADDLE_THROW(phi::errors::PermissionDenied(
+      PADDLE_THROW(common::errors::PermissionDenied(
           "Paddle can't use IPU device since it's not compiled with IPU,"
           "Please recompile or reinstall Paddle with IPU support."));
 #endif
@@ -189,14 +189,14 @@ paddle::framework::GarbageCollector* Tracer::MutableGarbageCollectorIfNotExists(
         VLOG(10) << "Created GarbageCollector at " << place;
       }
 #else
-      PADDLE_THROW(phi::errors::PermissionDenied(
+      PADDLE_THROW(common::errors::PermissionDenied(
           "Paddle can't use CustomDevice since it's not compiled with "
           "CustomDevice,"
           "Please recompile or reinstall Paddle with CustomDevice "
           "support."));
 #endif
     } else {
-      PADDLE_THROW(phi::errors::PreconditionNotMet(
+      PADDLE_THROW(common::errors::PreconditionNotMet(
           "Unsupported place for garbage collection"));
     }
     gcs_.emplace(place, std::move(gc));
@@ -312,30 +312,30 @@ void Tracer::TraceOpImpl(const std::string& type,
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
       platform::SetDeviceId(place.device);
 #else
-      PADDLE_THROW(phi::errors::PreconditionNotMet(
+      PADDLE_THROW(common::errors::PreconditionNotMet(
           "PaddlePaddle should compile with GPU if use CUDAPlace."));
 #endif
     } else if (phi::is_xpu_place(place)) {
 #ifdef PADDLE_WITH_XPU
       platform::SetXPUDeviceId(place.device);
 #else
-      PADDLE_THROW(phi::errors::PreconditionNotMet(
+      PADDLE_THROW(common::errors::PreconditionNotMet(
           "PaddlePaddle should compile with XPU if use XPUPlace."));
 #endif
     } else if (phi::is_custom_place(place)) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
       phi::DeviceManager::SetDevice(place);
 #else
-      PADDLE_THROW(phi::errors::PreconditionNotMet(
+      PADDLE_THROW(common::errors::PreconditionNotMet(
           "PaddlePaddle should compile with CustomDevice if use "
           "CustomPlace."));
 #endif
     }
 
     if (!use_default_attr_map) {
-      PADDLE_ENFORCE_NOT_NULL(
-          passed_default_attrs_,
-          phi::errors::PermissionDenied("Detected default_attrs = nullptr."));
+      PADDLE_ENFORCE_NOT_NULL(passed_default_attrs_,
+                              common::errors::PermissionDenied(
+                                  "Detected default_attrs = nullptr."));
       VLOG(6) << "Use passed in default attrs";
       OpBase::Run(*op, new_ins, outs, attrs, (*passed_default_attrs_), place);
     } else {
@@ -351,17 +351,17 @@ void Tracer::TraceOpImpl(const std::string& type,
     throw exception;
   } catch (std::exception& ex) {
     PADDLE_THROW(
-        phi::errors::Fatal("Operator %s raises an %s exception.\n"
-                           "The exception content is\n:%s.",
-                           type,
-                           platform::demangle(typeid(ex).name()),
-                           ex.what()));
+        common::errors::Fatal("Operator %s raises an %s exception.\n"
+                              "The exception content is\n:%s.",
+                              type,
+                              platform::demangle(typeid(ex).name()),
+                              ex.what()));
   } catch (...) {
     // NOTE: this branch represents a very serious bug with
     // low probability of occurrence, and we can't get its
     // exception content here.
-    PADDLE_THROW(
-        phi::errors::Fatal("Operator %s raises an unknown exception.", type));
+    PADDLE_THROW(common::errors::Fatal(
+        "Operator %s raises an unknown exception.", type));
   }
 
   {
@@ -372,7 +372,7 @@ void Tracer::TraceOpImpl(const std::string& type,
       PADDLE_ENFORCE_EQ(
           passed_default_attrs_,
           nullptr,
-          phi::errors::PermissionDenied(
+          common::errors::PermissionDenied(
               "We expect passed_default_attrs_ is nullptr while "
               "use_default_attr_map is true, however we got not null "
               "passed_default_attrs_. Please check your usage of trace_op. "));
@@ -637,7 +637,7 @@ phi::KernelSignature Tracer::GetExpectedKernelSignature(
       dynamic_cast<framework::OperatorWithKernel*>(op.get());
   PADDLE_ENFORCE_NE(opbase_with_kernel,
                     nullptr,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "This op type:`%s` is not a OperatorWithKernel, only "
                         "OperatorWithKernel can get KernelSignature",
                         type));

--- a/paddle/fluid/imperative/var_helper.cc
+++ b/paddle/fluid/imperative/var_helper.cc
@@ -70,7 +70,7 @@ void InitializeVariable(paddle::framework::Variable *var,
   } else if (var_type == paddle::framework::proto::VarType::RAW) {
     // GetMutable will be called in operator
   } else {
-    PADDLE_THROW(phi::errors::Unavailable(
+    PADDLE_THROW(common::errors::Unavailable(
         "paddle::framework::Variable type %d is not in "
         "[LOD_TENSOR, SELECTED_ROWS, FEED_MINIBATCH, FETCH_LIST, "
         "LOD_RANK_TABLE, PLACE_LIST, READER, RAW].",
@@ -87,7 +87,7 @@ const phi::Place &GetPlace(const std::shared_ptr<VarType> &var) {
   } else if (variable.IsType<phi::SelectedRows>()) {
     return variable.Get<phi::SelectedRows>().place();
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Variable type is %s, expect LoDTensor or SelectedRows.",
         paddle::framework::ToTypeName(var->Var().Type())));
   }
@@ -133,7 +133,7 @@ void SetType<egr::EagerVariable>(std::shared_ptr<egr::EagerVariable> var,
       break;
     }
     default: {
-      PADDLE_THROW(phi::errors::NotFound(
+      PADDLE_THROW(common::errors::NotFound(
           "Cannot found var type: %s while running runtime InferVarType",
           paddle::framework::ToTypeName(type)));
     }
@@ -178,7 +178,7 @@ framework::proto::VarType::Type GetDataType<egr::EagerVariable>(
     return framework::TransToProtoVarType(
         var->Var().Get<phi::DenseTensor>().type());
   } else {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "We only support phi::SelectedRows and phi::DenseTensor in "
         "eager mode, but we got %s here, please checkout your var type of "
         "tensor: %s",
@@ -202,7 +202,7 @@ phi::DataLayout GetDataLayout<egr::EagerVariable>(
   if (var->Var().IsType<phi::DenseTensor>()) {
     return var->Var().Get<phi::DenseTensor>().layout();
   } else {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Only support phi::DenseTensor, but got %s here, please checkout "
         "var type of "
         "tensor: %s",
@@ -225,7 +225,7 @@ void SetDataLayout<egr::EagerVariable>(std::shared_ptr<egr::EagerVariable> var,
   if (var->Var().IsType<phi::DenseTensor>()) {
     var->MutableVar()->GetMutable<phi::DenseTensor>()->set_layout(layout);
   } else {
-    PADDLE_THROW(phi::errors::PermissionDenied(
+    PADDLE_THROW(common::errors::PermissionDenied(
         "Only support phi::DenseTensor, but got %s here, please checkout "
         "var type of "
         "tensor: %s",
@@ -266,7 +266,7 @@ template <>
 std::shared_ptr<VariableWrapper> GetCachedValue(
     std::shared_ptr<egr::EagerVariable> var, const phi::KernelKey &key) {
   // TODO(jiabin): Support this later
-  //   PADDLE_THROW(phi::errors::Fatal("In eager mode program should not
+  //   PADDLE_THROW(common::errors::Fatal("In eager mode program should not
   //   reach this, support cache and remove this error check later, or this
   //   should not be supported."));
   //   VLOG(10) << "CheckCachedKey with tensor: " << tensor->name() << "and key
@@ -290,7 +290,7 @@ void SetCachedValue<egr::EagerVariable>(
     std::shared_ptr<egr::EagerVariable> tensor,
     const phi::KernelKey &key,
     std::shared_ptr<egr::EagerVariable> res) {
-  //   PADDLE_THROW(phi::errors::Fatal("In eager mode program should not
+  //   PADDLE_THROW(common::errors::Fatal("In eager mode program should not
   //   reach this, support cache and remove this error check later, or this
   //   should not be supported."));
   //   VLOG(10) << "CheckCachedKey with tensor: " << tensor->name() << "and key

--- a/paddle/fluid/imperative/variable_wrapper.h
+++ b/paddle/fluid/imperative/variable_wrapper.h
@@ -109,7 +109,7 @@ class VariableWrapper {
       } else if (var_.IsType<phi::SelectedRows>()) {
         tensor = &(var_.Get<phi::SelectedRows>().value());
       } else {
-        PADDLE_THROW(phi::errors::PermissionDenied(
+        PADDLE_THROW(common::errors::PermissionDenied(
             "Only support LoDTensor and SelectedRows for gradient var"));
       }
       if (tensor && tensor->IsInitialized()) {
@@ -286,7 +286,7 @@ class VariableWrapper {
       PADDLE_ENFORCE_EQ(
           shared_var,
           nullptr,
-          phi::errors::PermissionDenied(
+          common::errors::PermissionDenied(
               "Cannot set gradient variable wrapper twice for %s", name_));
       grad_var_ = var;
     }
@@ -305,7 +305,7 @@ class VariableWrapper {
         PADDLE_ENFORCE_EQ(
             shared_node,
             nullptr,
-            phi::errors::PermissionDenied(
+            common::errors::PermissionDenied(
                 "Cannot set gradient op twice unless using Inplace Strategy."));
       } else if (shared_node) {
         VLOG(3) << "The gradient op of Var (" << Name()

--- a/paddle/fluid/imperative/xccl_context.cc
+++ b/paddle/fluid/imperative/xccl_context.cc
@@ -42,7 +42,7 @@ static void XcclAllReduce(const phi::DenseTensor &src,
   PADDLE_ENFORCE_EQ(
       phi::is_custom_place(place),
       true,
-      phi::errors::Unimplemented(
+      common::errors::Unimplemented(
           "Dynamic graph mode does not support multi-CPU training yet."));
 
   void *src_ptr = const_cast<void *>(src.data());
@@ -162,7 +162,7 @@ void XCCLParallelContext::AllReduceByStream(const framework::Variable &src,
   PADDLE_ENFORCE_EQ(
       phi::is_custom_place(place_),
       true,
-      phi::errors::Unimplemented(
+      common::errors::Unimplemented(
           "Dynamic graph mode does not support multi-CPU training yet."));
   auto place = place_;
 
@@ -182,7 +182,7 @@ void XCCLParallelContext::AllReduceByStream(const framework::Variable &src,
                   *stream,
                   comm->comm());
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "custom device unsupported variable type %s for imperative allreduce, "
         "only "
         "LoDTensor are supported.",
@@ -221,14 +221,14 @@ void XCCLParallelContext::WaitCompute(int ring_id) {
   PADDLE_ENFORCE_GE(
       ring_id,
       0,
-      phi::errors::OutOfRange("ring id must >= 0, but got %d", ring_id));
-  PADDLE_ENFORCE_LT(
-      ring_id,
-      compute_events_.size(),
-      phi::errors::OutOfRange("ring id must < compute events size,"
-                              "but got ring id = %d, compute events size = %d",
-                              ring_id,
-                              compute_events_.size()));
+      common::errors::OutOfRange("ring id must >= 0, but got %d", ring_id));
+  PADDLE_ENFORCE_LT(ring_id,
+                    compute_events_.size(),
+                    common::errors::OutOfRange(
+                        "ring id must < compute events size,"
+                        "but got ring id = %d, compute events size = %d",
+                        ring_id,
+                        compute_events_.size()));
 
   auto compute_stream = static_cast<phi::CustomContext *>(
                             phi::DeviceContextPool::Instance().Get(place_))
@@ -247,14 +247,14 @@ void XCCLParallelContext::WaitComm(int ring_id) {
   PADDLE_ENFORCE_GE(
       ring_id,
       0,
-      phi::errors::OutOfRange("ring id must >= 0, but got %d", ring_id));
+      common::errors::OutOfRange("ring id must >= 0, but got %d", ring_id));
   PADDLE_ENFORCE_LT(
       ring_id,
       comm_events_.size(),
-      phi::errors::OutOfRange("ring id must < comm events size,"
-                              "but got ring id = %d, comm events size = %d",
-                              ring_id,
-                              comm_events_.size()));
+      common::errors::OutOfRange("ring id must < comm events size,"
+                                 "but got ring id = %d, comm events size = %d",
+                                 ring_id,
+                                 comm_events_.size()));
 
   auto compute_stream = static_cast<phi::CustomContext *>(
                             phi::DeviceContextPool::Instance().Get(place_))


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Replace phi::errors to common::errors in paddle/fluid