### PR TITLE
Replace phi::errors [fluid_ops] part19

### DIFF
--- a/paddle/fluid/pir/drr/src/attr_type_uilts.h
+++ b/paddle/fluid/pir/drr/src/attr_type_uilts.h
@@ -125,7 +125,7 @@ struct IrAttrTypeCast<std::vector<int64_t>> {
       result =
           attr.dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData();
     } else {
-      PADDLE_THROW(phi::errors::Unavailable(
+      PADDLE_THROW(common::errors::Unavailable(
           "Dynamic cast failed for IR attribute vector<int64_t>"));
     }
     return result;

--- a/paddle/fluid/pir/drr/src/ir_operation_factory.cc
+++ b/paddle/fluid/pir/drr/src/ir_operation_factory.cc
@@ -90,7 +90,7 @@ void OperationFactory::RegisterManualOpCreator() {
         if (inputs.size() == 3) {
           PADDLE_ENFORCE_NE(attrs.find("axes"),
                             attrs.end(),
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "'axes' Attribute is expected for SliceOp. "));
           std::vector<int64_t> axes;
           for (size_t i = 0;
@@ -106,7 +106,7 @@ void OperationFactory::RegisterManualOpCreator() {
           PADDLE_ENFORCE_NE(
               attrs.find("infer_flags"),
               attrs.end(),
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "'infer_flags' Attribute is expected for SliceOp. "));
           std::vector<int64_t> infer_flags;
           for (size_t i = 0;
@@ -123,7 +123,7 @@ void OperationFactory::RegisterManualOpCreator() {
           PADDLE_ENFORCE_NE(
               attrs.find("decrease_axis"),
               attrs.end(),
-              phi::errors::InvalidArgument(
+              common::errors::InvalidArgument(
                   "'decrease_axis' Attribute is expected for SliceOp. "));
           std::vector<int64_t> decrease_axis;
           for (size_t i = 0;
@@ -155,8 +155,8 @@ void OperationFactory::RegisterManualOpCreator() {
           PADDLE_ENFORCE_EQ(
               attrs.find("strides") != attrs.end(),
               true,
-              phi::errors::InvalidArgument("'strides' Attribute is expected "
-                                           "for Conv2dTransposeBiasOp. "));
+              common::errors::InvalidArgument("'strides' Attribute is expected "
+                                              "for Conv2dTransposeBiasOp. "));
           std::vector<int> strides;
           for (size_t i = 0;
                i < attrs.at("strides").dyn_cast<pir::ArrayAttribute>().size();
@@ -168,11 +168,11 @@ void OperationFactory::RegisterManualOpCreator() {
                                   .data());
           }
 
-          PADDLE_ENFORCE_EQ(
-              attrs.find("paddings") != attrs.end(),
-              true,
-              phi::errors::InvalidArgument("'paddings' Attribute is expected "
-                                           "for Conv2dTransposeBiasOp. "));
+          PADDLE_ENFORCE_EQ(attrs.find("paddings") != attrs.end(),
+                            true,
+                            common::errors::InvalidArgument(
+                                "'paddings' Attribute is expected "
+                                "for Conv2dTransposeBiasOp. "));
           std::vector<int> paddings;
           for (size_t i = 0;
                i < attrs.at("paddings").dyn_cast<pir::ArrayAttribute>().size();
@@ -186,7 +186,7 @@ void OperationFactory::RegisterManualOpCreator() {
 
           PADDLE_ENFORCE_EQ(attrs.find("output_padding") != attrs.end(),
                             true,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "'output_padding' Attribute is expected for "
                                 "Conv2dTransposeBiasOp. "));
           std::vector<int> output_padding;
@@ -203,26 +203,26 @@ void OperationFactory::RegisterManualOpCreator() {
 
           PADDLE_ENFORCE_EQ(attrs.find("padding_algorithm") != attrs.end(),
                             true,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "'padding_algorithm' Attribute is expected for "
                                 "Conv2dTransposeBiasOp. "));
           std::string padding_algorithm = attrs.at("padding_algorithm")
                                               .dyn_cast<pir::StrAttribute>()
                                               .AsString();
 
-          PADDLE_ENFORCE_EQ(
-              attrs.find("groups") != attrs.end(),
-              true,
-              phi::errors::InvalidArgument("'groups' Attribute is expected for "
-                                           "Conv2dTransposeBiasOp. "));
+          PADDLE_ENFORCE_EQ(attrs.find("groups") != attrs.end(),
+                            true,
+                            common::errors::InvalidArgument(
+                                "'groups' Attribute is expected for "
+                                "Conv2dTransposeBiasOp. "));
           int groups =
               attrs.at("groups").dyn_cast<pir::Int32Attribute>().data();
 
-          PADDLE_ENFORCE_EQ(
-              attrs.find("dilations") != attrs.end(),
-              true,
-              phi::errors::InvalidArgument("'dilations' Attribute is expected "
-                                           "for Conv2dTransposeBiasOp. "));
+          PADDLE_ENFORCE_EQ(attrs.find("dilations") != attrs.end(),
+                            true,
+                            common::errors::InvalidArgument(
+                                "'dilations' Attribute is expected "
+                                "for Conv2dTransposeBiasOp. "));
           std::vector<int> dilations;
           for (size_t i = 0;
                i < attrs.at("dilations").dyn_cast<pir::ArrayAttribute>().size();
@@ -236,7 +236,7 @@ void OperationFactory::RegisterManualOpCreator() {
 
           PADDLE_ENFORCE_EQ(attrs.find("data_format") != attrs.end(),
                             true,
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "'data_format' Attribute is expected for "
                                 "Conv2dTransposeBiasOp. "));
           std::string data_format =
@@ -245,8 +245,8 @@ void OperationFactory::RegisterManualOpCreator() {
           PADDLE_ENFORCE_EQ(
               attrs.find("is_test") != attrs.end(),
               true,
-              phi::errors::InvalidArgument("'is_test' Attribute is expected "
-                                           "for Conv2dTransposeBiasOp. "));
+              common::errors::InvalidArgument("'is_test' Attribute is expected "
+                                              "for Conv2dTransposeBiasOp. "));
           bool is_test =
               attrs.at("is_test").dyn_cast<pir::BoolAttribute>().data();
 
@@ -278,7 +278,7 @@ void OperationFactory::RegisterManualOpCreator() {
         if (inputs.size() == 2) {
           PADDLE_ENFORCE_NE(attrs.find("keepdim"),
                             attrs.end(),
-                            phi::errors::InvalidArgument(
+                            common::errors::InvalidArgument(
                                 "'keepdim' Attribute is expected for MaxOp. "));
           bool keepdim =
               attrs.at("keepdim").dyn_cast<pir::BoolAttribute>().data();
@@ -326,13 +326,13 @@ pir::Attribute CreateIrAttribute(const std::any& obj) {
       return IrAttributeCreator<phi::IntArray>()(
           std::any_cast<phi::IntArray>(obj));
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "Type error. CreateIrAttribute for type(%s) "
           "is unimplemented CreateInCurrently.",
           obj.type().name()));
     }
   } catch (const std::bad_any_cast& e) {
-    PADDLE_THROW(phi::errors::Fatal(
+    PADDLE_THROW(common::errors::Fatal(
         "%s: CreateIrAttribute for type(%s) not successfully.",
         e.what(),
         obj.type().name()));
@@ -391,7 +391,7 @@ void BindIrOutputsWithDrrOutputs(const std::vector<const Tensor*>& tensors,
   PADDLE_ENFORCE_LE(
       tensors.size(),
       op->num_results(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size of drr outputs should less equal the size of pir outputs"));
   for (size_t i = 0; i < tensors.size(); ++i) {
     match_ctx->BindIrValue(tensors[i]->name(), op->result(i));

--- a/paddle/fluid/pir/drr/src/ir_operation_factory.h
+++ b/paddle/fluid/pir/drr/src/ir_operation_factory.h
@@ -49,7 +49,7 @@ class OperationFactory {
     PADDLE_ENFORCE_NE(
         iter,
         op_creator_map.end(),
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "The op to be created is not found."
             "Suggest fix: Place check if the op named %s has been registered.",
             op_name));

--- a/paddle/fluid/pir/drr/src/match_context_impl.h
+++ b/paddle/fluid/pir/drr/src/match_context_impl.h
@@ -38,9 +38,9 @@ class MatchContextImpl final {
     PADDLE_ENFORCE_NE(
         tensor_map_.count(tensor_name),
         0,
-        phi::errors::NotFound("Not found tensor. The drr tensor [%s] must "
-                              "exist in pattern graph to be obtained.",
-                              tensor_name));
+        common::errors::NotFound("Not found tensor. The drr tensor [%s] must "
+                                 "exist in pattern graph to be obtained.",
+                                 tensor_name));
     return tensor_map_.at(tensor_name);
   }
 
@@ -48,7 +48,7 @@ class MatchContextImpl final {
     PADDLE_ENFORCE_NE(
         operation_map_.count(op_call),
         0,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Not found operation. The drr operation [%s] must exist in the "
             "pattern graph to be obtained.",
             op_call->name()));
@@ -65,7 +65,7 @@ class MatchContextImpl final {
     PADDLE_ENFORCE_NE(
         iter,
         tensor_map_.end(),
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Not found tensor. The drr tensor [%s] is not found in the map, "
             "unable to obtain the corresponding IrValue.",
             tensor_name));
@@ -77,7 +77,7 @@ class MatchContextImpl final {
     PADDLE_ENFORCE_NE(
         iter,
         attr_map_.end(),
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Not found attr. The drr attr [%s] is not found in the map, unable "
             "to obtain the corresponding Attribute.",
             attr_name));

--- a/paddle/fluid/pir/drr/src/pattern_graph.cc
+++ b/paddle/fluid/pir/drr/src/pattern_graph.cc
@@ -27,12 +27,13 @@ const drr::OpCall &PatternGraph::AddOpCall(
   owned_op_call_.push_back(op_call);
   for (const auto *input : op_call->inputs()) {
     const auto &tensor_name = input->name();
-    PADDLE_ENFORCE_NE(id2owned_tensor_.count(tensor_name),
-                      0,
-                      phi::errors::NotFound("Not found tensor."
-                                            "The intput tensor [%s] must exist "
-                                            "in pattern graph to be obtained.",
-                                            tensor_name));
+    PADDLE_ENFORCE_NE(
+        id2owned_tensor_.count(tensor_name),
+        0,
+        common::errors::NotFound("Not found tensor."
+                                 "The intput tensor [%s] must exist "
+                                 "in pattern graph to be obtained.",
+                                 tensor_name));
     id2owned_tensor_.at(tensor_name)->AddConsumer(op_call.get());
 
     if (input->producer() == nullptr) {
@@ -44,12 +45,13 @@ const drr::OpCall &PatternGraph::AddOpCall(
   }
   for (auto &output : op_call->outputs()) {
     const auto &out_tensor_name = output->name();
-    PADDLE_ENFORCE_NE(id2owned_tensor_.count(out_tensor_name),
-                      0,
-                      phi::errors::NotFound("Not found tensor."
-                                            "The output tensor [%s] must exist "
-                                            "in pattern graph to be obtained.",
-                                            out_tensor_name));
+    PADDLE_ENFORCE_NE(
+        id2owned_tensor_.count(out_tensor_name),
+        0,
+        common::errors::NotFound("Not found tensor."
+                                 "The output tensor [%s] must exist "
+                                 "in pattern graph to be obtained.",
+                                 out_tensor_name));
     id2owned_tensor_[output->name()]->set_producer(op_call.get());
   }
   return *owned_op_call_.back();
@@ -68,7 +70,7 @@ drr::Tensor &PatternGraph::AddTmpTensor(
     const std::shared_ptr<drr::Tensor> &tensor) {
   PADDLE_ENFORCE_EQ(id2owned_tensor_.count(tensor->name()),
                     0,
-                    phi::errors::AlreadyExists(
+                    common::errors::AlreadyExists(
                         "Tensor already exists."
                         "The tensor [%s] must not exist in pattern graph.",
                         tensor->name()));
@@ -122,12 +124,12 @@ void ResultPatternGraph::AssignTensor(const Tensor &from, const Tensor &to) {
     input_tensors_.insert(to.name());
   }
   output_tensors_.erase(to.name());
-  PADDLE_ENFORCE_EQ(
-      output_tensors_.count(from.name()),
-      1,
-      phi::errors::PreconditionNotMet("The Tensor (%s) which be assigned must "
-                                      "be the output of result pattern graph.",
-                                      from.name()));
+  PADDLE_ENFORCE_EQ(output_tensors_.count(from.name()),
+                    1,
+                    common::errors::PreconditionNotMet(
+                        "The Tensor (%s) which be assigned must "
+                        "be the output of result pattern graph.",
+                        from.name()));
   tensor_assign_map_[from.name()] = to.name();
 }
 
@@ -158,12 +160,13 @@ void GraphTopo::WalkGraphNodesTopoOrder(
 
   // init queue
   for (const auto &tensor_name : inputs_tensor) {
-    PADDLE_ENFORCE_NE(id2owned_tensor.count(tensor_name),
-                      0,
-                      phi::errors::NotFound("Not found tensor."
-                                            "The input tensor [%s] must exists "
-                                            "in pattern graph to be obtained.",
-                                            tensor_name));
+    PADDLE_ENFORCE_NE(
+        id2owned_tensor.count(tensor_name),
+        0,
+        common::errors::NotFound("Not found tensor."
+                                 "The input tensor [%s] must exists "
+                                 "in pattern graph to be obtained.",
+                                 tensor_name));
     for (const auto &tensor_consumer :
          id2owned_tensor.at(tensor_name).get()->consumers()) {
       opcall_dependent[tensor_consumer].erase(tensor_name);

--- a/paddle/fluid/pir/drr/src/rewrite_pattern.cc
+++ b/paddle/fluid/pir/drr/src/rewrite_pattern.cc
@@ -47,7 +47,7 @@ DrrRewritePattern::DrrRewritePattern(
       drr_pattern_owner_(std::move(drr_pattern_owner)) {
   PADDLE_ENFORCE_NE(source_pattern_graph_->owned_op_call().empty(),
                     true,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "Source pattern graph is empty. Suggested fix: please "
                         "check the drr source pattern definition code."));
   if (VLOG_IS_ON(4)) {
@@ -427,7 +427,7 @@ bool DrrRewritePattern::MatchFromOutputToInput(
     PADDLE_ENFORCE_EQ(
         step,
         source_pattern_graph.CountOfOpCalls(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "Pattern matching failed. The number of successful matches and the "
             "number of OpCalls in the source pattern graph are not equal."));
   } else {
@@ -477,7 +477,7 @@ MatchContextImpl DrrRewritePattern::CreateOperations(
     PADDLE_ENFORCE_NE(
         result_pattern_graph.id2owned_tensor().count(in_tensor),
         0,
-        phi::errors::NotFound(
+        common::errors::NotFound(
             "Not found the input tensor. Drr input tensor [%s] must exist in "
             "the result pattern graph to be obtained.",
             in_tensor));

--- a/paddle/fluid/pir/serialize_deserialize/include/deserialize_utils.h
+++ b/paddle/fluid/pir/serialize_deserialize/include/deserialize_utils.h
@@ -143,7 +143,7 @@ pir::Attribute deserializeAttrFromJson_scalarAttr(Json* attr_json,
     scalar = phi::Scalar(data);
   } else {
     PADDLE_ENFORCE(false,
-                   phi::errors::InvalidArgument(
+                   common::errors::InvalidArgument(
                        "Invalid tensor data type `", dtype_, "`."));
   }
 
@@ -190,7 +190,7 @@ pir::Type parseType(Json* type_json) {
   } else {
     PADDLE_ENFORCE(
         false,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Unknown Attr %s for parse builtin dialect attr", type_name));
   }
 
@@ -219,7 +219,7 @@ pir::Attribute parseAttr(Json* attr_json) {
   } else {
     PADDLE_ENFORCE(
         false,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Unknown Attr %s for parse builtin dialect attr", attr_name));
   }
 
@@ -285,7 +285,7 @@ pir::Attribute AttrTypeReader::ReadBuiltInAttr(const std::string attr_name,
   } else {
     PADDLE_ENFORCE(
         false,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Unknown Attr %s for parse builtin dialect attr", attr_name));
   }
   return pir::Attribute();
@@ -312,7 +312,7 @@ pir::Attribute AttrTypeReader::ReadPaddleOperatorAttr(
                                         int8_t>(attr_json, ctx);
   } else {
     PADDLE_ENFORCE(false,
-                   phi::errors::InvalidArgument(
+                   common::errors::InvalidArgument(
                        "Unknown Attr %s for parse paddleoperator dialect attr",
                        attr_name));
   }
@@ -392,7 +392,7 @@ pir::Type AttrTypeReader::ReadBuiltInType(const std::string type_name,
         type_json, ctx);
   } else {
     PADDLE_ENFORCE(false,
-                   phi::errors::InvalidArgument(
+                   common::errors::InvalidArgument(
                        "Unknown Type %s for parse builtintype", type_name));
   }
   return pir::Type();

--- a/paddle/fluid/pir/serialize_deserialize/include/serialize_utils.h
+++ b/paddle/fluid/pir/serialize_deserialize/include/serialize_utils.h
@@ -197,7 +197,8 @@ Json writeType(const pir::Type& type) {
     return AttrTypeWriter::WritePaddleOperatorType(type);
   } else {
     PADDLE_ENFORCE(
-        false, phi::errors::InvalidArgument("Unknown Type %s when write type"));
+        false,
+        common::errors::InvalidArgument("Unknown Type %s when write type"));
   }
   VLOG(8) << "Finish write Type ... ";
 
@@ -216,7 +217,8 @@ Json writeAttr(const pir::Attribute& attr) {
     return AttrTypeWriter::WritePaddleOperatorAttr(attr);
   } else {
     PADDLE_ENFORCE(
-        false, phi::errors::InvalidArgument("Unknown Attr %s when write attr"));
+        false,
+        common::errors::InvalidArgument("Unknown Attr %s when write attr"));
   }
 
   VLOG(8) << "Finish write attr ... ";
@@ -282,7 +284,7 @@ Json AttrTypeWriter::WriteBuiltInAttr(const pir::Attribute& attr) {
         attr.dyn_cast<pir::StrAttribute>());
   } else {
     PADDLE_ENFORCE(false,
-                   phi::errors::InvalidArgument(
+                   common::errors::InvalidArgument(
                        "Unknown Attr %s when write Buitin dialect attr"));
   }
   return attr_json;
@@ -382,7 +384,7 @@ Json AttrTypeWriter::WriteBuiltInType(const pir::Type& type) {
         type.dyn_cast<pir::DenseTensorType>());
   } else {
     PADDLE_ENFORCE(false,
-                   phi::errors::InvalidArgument(
+                   common::errors::InvalidArgument(
                        "Unknown Type when write builtin dialect type"));
   }
   return type_json;
@@ -412,7 +414,7 @@ Json AttrTypeWriter::WritePaddleOperatorAttr(const pir::Attribute& attr) {
   } else {
     PADDLE_ENFORCE(
         false,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Unknown Attr %s when write paddle.operatordialect attr"));
   }
   return Json::object();

--- a/paddle/fluid/pir/serialize_deserialize/src/patch_util.cc
+++ b/paddle/fluid/pir/serialize_deserialize/src/patch_util.cc
@@ -114,7 +114,7 @@ Json GetAttrJson(const YAML::Node &action) {
       json[ID] = dialect + paddle::dialect::PlaceAttribute::name();
     }
     PADDLE_ENFORCE(false,
-                   phi::errors::InvalidArgument(
+                   common::errors::InvalidArgument(
                        "Unknown Attr %s in the OpPatches.", at_name));
   }
   return json;
@@ -320,7 +320,7 @@ Json YamlParser(const std::string &yaml_file) {
   VLOG(8) << yaml_file;
   fin.open(yaml_file);
   if (!fin) {
-    // PADDLE_THROW(phi::errors::Unavailable("File %s is not available.",
+    // PADDLE_THROW(common::errors::Unavailable("File %s is not available.",
     //                                       yaml_file.c_str()));
     fin.open("../patch/patch.yaml");
   }

--- a/paddle/fluid/pir/serialize_deserialize/src/save_load_parameters.cc
+++ b/paddle/fluid/pir/serialize_deserialize/src/save_load_parameters.cc
@@ -72,7 +72,7 @@ void SaveFunction(const phi::DenseTensor& x,
   PADDLE_ENFORCE_EQ(
       FileExists(file_path) && !overwrite,
       false,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "%s exists!, cannot save to it when overwrite is set to false.",
           file_path,
           overwrite));
@@ -80,10 +80,10 @@ void SaveFunction(const phi::DenseTensor& x,
   MkDirRecursively(DirName(file_path).c_str());
   VLOG(6) << "save func save path: " << file_path;
   std::ofstream fout(file_path, std::ios::binary);
-  PADDLE_ENFORCE_EQ(
-      static_cast<bool>(fout),
-      true,
-      phi::errors::Unavailable("Cannot open %s to save variables.", file_path));
+  PADDLE_ENFORCE_EQ(static_cast<bool>(fout),
+                    true,
+                    common::errors::Unavailable(
+                        "Cannot open %s to save variables.", file_path));
 
   auto in_dtype = x.dtype();
   auto out_dtype = save_as_fp16 ? phi::DataType::FLOAT16 : in_dtype;
@@ -108,7 +108,7 @@ void SaveCombineFunction(const std::vector<const phi::DenseTensor*>& x,
   PADDLE_ENFORCE_EQ(
       FileExists(file_path) && !overwrite,
       false,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "%s exists!, cannot save to it when overwrite is set to false.",
           file_path,
           overwrite));
@@ -118,7 +118,7 @@ void SaveCombineFunction(const std::vector<const phi::DenseTensor*>& x,
   std::ostringstream ss;
   PADDLE_ENFORCE_GT(x.size(),
                     0UL,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The number of variables to be saved is %d, expect "
                         "it to be greater than 0.",
                         x.size()));
@@ -128,7 +128,7 @@ void SaveCombineFunction(const std::vector<const phi::DenseTensor*>& x,
     PADDLE_ENFORCE_EQ(
         tensor.IsInitialized(),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "The Tensor with Index (%d) to be saved is not initialized.", i));
     auto in_dtype = tensor.dtype();
     auto out_dtype = save_as_fp16 ? phi::DataType::FLOAT16 : in_dtype;
@@ -141,10 +141,10 @@ void SaveCombineFunction(const std::vector<const phi::DenseTensor*>& x,
   }
   MkDirRecursively(DirName(file_path).c_str());
   std::ofstream fout(file_path, std::ios::binary);
-  PADDLE_ENFORCE_EQ(
-      static_cast<bool>(fout),
-      true,
-      phi::errors::Unavailable("Cannot open %s to save variables.", file_path));
+  PADDLE_ENFORCE_EQ(static_cast<bool>(fout),
+                    true,
+                    common::errors::Unavailable(
+                        "Cannot open %s to save variables.", file_path));
   fout << ss.str();
   fout.close();
   VLOG(6) << "save combine done ";
@@ -159,19 +159,19 @@ void LoadFunction(const std::string& file_path,
   std::ifstream fin(file_path, std::ios::binary);
   PADDLE_ENFORCE_EQ(static_cast<bool>(fin),
                     true,
-                    phi::errors::Unavailable(
+                    common::errors::Unavailable(
                         "Load operator fail to open file %s, please check "
                         "whether the model file is complete or damaged.",
                         file_path));
   PADDLE_ENFORCE_NOT_NULL(out,
-                          phi::errors::InvalidArgument(
+                          common::errors::InvalidArgument(
                               "The variable to be loaded cannot be found."));
   const phi::DeviceContext* dev_ctx = GetDeviceContext(*out, place);
 
   if (seek != -1) {
     PADDLE_ENFORCE_GE(seek,
                       0,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "seek with tensor must great than or equal to 0"));
     paddle::framework::DeserializeFromStream(fin, out, *dev_ctx, seek, shape);
   } else {
@@ -194,14 +194,14 @@ void LoadCombineFunction(const std::string& file_path,
   std::ifstream fin(file_path, std::ios::binary);
   PADDLE_ENFORCE_EQ(static_cast<bool>(fin),
                     true,
-                    phi::errors::Unavailable(
+                    common::errors::Unavailable(
                         "Load operator fail to open file %s, please check "
                         "whether the model file is complete or damaged.",
                         file_path));
 
   PADDLE_ENFORCE_GT(out->size(),
                     0UL,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The number of variables to be saved is %d, expect "
                         "it to be greater than 0.",
                         out->size()));
@@ -218,11 +218,11 @@ void LoadCombineFunction(const std::string& file_path,
     }
   }
   fin.peek();
-  PADDLE_ENFORCE_EQ(
-      fin.eof(),
-      true,
-      phi::errors::Unavailable("Not allowed to load partial data via "
-                               "load_combine_op, please use load_op instead."));
+  PADDLE_ENFORCE_EQ(fin.eof(),
+                    true,
+                    common::errors::Unavailable(
+                        "Not allowed to load partial data via "
+                        "load_combine_op, please use load_op instead."));
 }
 
 }  // namespace pir

--- a/paddle/fluid/pir/serialize_deserialize/src/schema.cc
+++ b/paddle/fluid/pir/serialize_deserialize/src/schema.cc
@@ -72,7 +72,7 @@ std::string DialectIdMap::GetDecompressDialectId(const std::string& id) {
   } else {
     PADDLE_ENFORCE(
         false,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Unknown id %s for decompress dialect, pleace check your file",
             id));
   }

--- a/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
@@ -71,14 +71,14 @@ class AutoMixedPrecisionPass : public pir::Pass {
     PADDLE_ENFORCE_EQ(
         Has(pir::Pass::kPlaceAttr),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Pass initialize failed."
             "When using AutoMixedPrecisionPass, place attribute is required!"
             "Use Set method to set the place attribute."));
     PADDLE_ENFORCE_EQ(
         Has("__mixed_precision_mode__"),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Pass initialize failed."
             "When using AutoMixedPrecisionPass, precision_mode attribute is "
             "required!"
@@ -407,7 +407,7 @@ class AutoMixedPrecisionPass : public pir::Pass {
       auto new_vec_type = pir::VectorType::get(context, results_type);
       result.set_type(new_vec_type);
     } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
+      PADDLE_THROW(common::errors::Unimplemented(
           "result type is not DenseTensorType or VectorType"));
     }
   }
@@ -592,7 +592,7 @@ class AutoMixedPrecisionPass : public pir::Pass {
           GetPhiKernelInPrecision(op_type, backend, precision_mode_);
       PADDLE_ENFORCE(
           phi_kernel.IsValid(),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "op [%s] kernel doesn't support precision [%s] on backend [%s]",
               op->name(),
               phi::DataTypeToString(precision_mode_).c_str(),
@@ -637,7 +637,7 @@ class AutoMixedPrecisionPass : public pir::Pass {
       PADDLE_ENFORCE_EQ(
           op->num_results(),
           output_defs.size(),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "op [%s] kernel output args defs should equal op outputs",
               op->name()));
 

--- a/paddle/fluid/pir/transforms/general/constant_folding_pass.cc
+++ b/paddle/fluid/pir/transforms/general/constant_folding_pass.cc
@@ -178,8 +178,8 @@ class ConstantFoldingPattern : public pir::RewritePattern {
       auto* output_var = scope_->FindVar(output_var_name);
       PADDLE_ENFORCE_NOT_NULL(
           output_var,
-          phi::errors::InvalidArgument("Parameter var [%s] not in scope.",
-                                       output_var_name));
+          common::errors::InvalidArgument("Parameter var [%s] not in scope.",
+                                          output_var_name));
 
       if (use_parameter_op) {
         if (output_var->IsType<phi::DenseTensor>()) {
@@ -307,8 +307,8 @@ class ConstantFoldingPattern : public pir::RewritePattern {
     auto* var = scope_->FindVar(var_name);
     PADDLE_ENFORCE_NOT_NULL(
         var,
-        phi::errors::InvalidArgument("Persistable var [%s] not in scope.",
-                                     var_name));
+        common::errors::InvalidArgument("Persistable var [%s] not in scope.",
+                                        var_name));
     auto from_op =
         builder.Build<Op>(var_name, op->operand_source(index).type());
     if (op->operand_source(index).use_count() > 1) {
@@ -348,7 +348,7 @@ class ConstantFoldingPattern : public pir::RewritePattern {
                       j, prev_op, builder, rewriter);
               combine_op_inputs.push_back(constant_op->result(0));
             } else {
-              PADDLE_THROW(phi::errors::Fatal(
+              PADDLE_THROW(common::errors::Fatal(
                   "Not support %s before builtin.combine op!",
                   prev_prev_op->name()));
             }
@@ -366,8 +366,8 @@ class ConstantFoldingPattern : public pir::RewritePattern {
                   i, op, builder, rewriter);
           op_inputs.push_back(constant_op->result(0));
         } else {
-          PADDLE_THROW(phi::errors::Fatal("Not support %s before matched op!",
-                                          prev_op->name()));
+          PADDLE_THROW(common::errors::Fatal(
+              "Not support %s before matched op!", prev_op->name()));
         }
       } else {
         op_inputs.push_back(nullptr);
@@ -454,8 +454,8 @@ class ConstantFoldingPatternForTrain : public ConstantFoldingPattern {
       std::string output_var_name = output_var_names[i];
       PADDLE_ENFORCE_NOT_NULL(
           scope_->FindVar(output_var_name),
-          phi::errors::InvalidArgument("Parameter var [%s] not in scope.",
-                                       output_var_name));
+          common::errors::InvalidArgument("Parameter var [%s] not in scope.",
+                                          output_var_name));
 
       auto constant_op = rewriter.Build<pir::ConstantTensorOp>(
           output_var_name, op->result(i).type());
@@ -479,14 +479,14 @@ class ConstantFoldingPass : public pir::Pass {
     PADDLE_ENFORCE_EQ(
         Has(pir::Pass::kPlaceAttr),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Pass initialize failed."
             "When using ConstantFoldingPass, place attribute is required!"
             "Use Set method to set the place attribute."));
     PADDLE_ENFORCE_EQ(
         Has(pir::Pass::kParamScopeAttr),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Pass initialize failed."
             "When using ConstantFoldingPass, scope attribute is required!"
             "Use Set method to set the scope attribute."));
@@ -495,7 +495,7 @@ class ConstantFoldingPass : public pir::Pass {
     scope_ = &Get<paddle::framework::Scope>(pir::Pass::kParamScopeAttr);
 
     PADDLE_ENFORCE_NOT_NULL(
-        scope_, phi::errors::InvalidArgument("scope can not be nullptr"));
+        scope_, common::errors::InvalidArgument("scope can not be nullptr"));
 
     pir::RewritePatternSet ps(context);
 

--- a/paddle/fluid/pir/transforms/general/delete_quant_dequant_linear_op_pass.cc
+++ b/paddle/fluid/pir/transforms/general/delete_quant_dequant_linear_op_pass.cc
@@ -76,8 +76,8 @@ class DeleteQuantDequantLinearOpPattern : public paddle::drr::DrrPatternBase {
       auto* input_scale_var = this->scope_->FindVar(input_scale_name);
       PADDLE_ENFORCE_NOT_NULL(
           input_scale_var,
-          phi::errors::InvalidArgument("Persistable var [%s] not in scope.",
-                                       input_scale_name));
+          common::errors::InvalidArgument("Persistable var [%s] not in scope.",
+                                          input_scale_name));
       if (!input_scale_dtype.isa<pir::Float16Type>() &&
           !input_scale_dtype.isa<pir::Float32Type>()) {
         return false;
@@ -107,7 +107,7 @@ class DeleteQuantDequantLinearOpPattern : public paddle::drr::DrrPatternBase {
       PADDLE_ENFORCE_EQ(
           this->pass_state_.get().has_value(),
           true,
-          phi::errors::InvalidArgument("pass state has no value"));
+          common::errors::InvalidArgument("pass state has no value"));
 
       auto& quant_analysis =
           this->pass_state_.get()->am.GetAnalysis<pir::pass::QuantAnalysis>();
@@ -117,7 +117,7 @@ class DeleteQuantDequantLinearOpPattern : public paddle::drr::DrrPatternBase {
           this->pass_state_.get()
               ->preserved_analyses.IsPreserved<pir::pass::QuantAnalysis>(),
           true,
-          phi::errors::InvalidArgument("QuantAnalysis should be Preserved"));
+          common::errors::InvalidArgument("QuantAnalysis should be Preserved"));
 
       quant_analysis.scale_map[match_ctx.Tensor("x")] =
           std::vector<float>({input_scale});
@@ -141,14 +141,14 @@ class DeleteQuantDequantLinearOpPass : public pir::PatternRewritePass {
   pir::RewritePatternSet InitializePatterns(pir::IrContext* context) override {
     PADDLE_ENFORCE_EQ(Has(pir::Pass::kParamScopeAttr),
                       true,
-                      phi::errors::InvalidArgument(
+                      common::errors::InvalidArgument(
                           "Pass initialize failed."
                           "When using DeleteQuantDequantLinearOpPass, scope "
                           "attribute is required!"
                           "Use Set method to set the scope attribute."));
     scope_ = &Get<paddle::framework::Scope>(pir::Pass::kParamScopeAttr);
     PADDLE_ENFORCE_NOT_NULL(
-        scope_, phi::errors::InvalidArgument("scope can not be nullptr"));
+        scope_, common::errors::InvalidArgument("scope can not be nullptr"));
     pir::RewritePatternSet ps(context);
     ps.Add(paddle::drr::Create<DeleteQuantDequantLinearOpPattern>(
         context, scope_, std::ref(pass_state())));

--- a/paddle/fluid/pir/transforms/general/inplace_pass.cc
+++ b/paddle/fluid/pir/transforms/general/inplace_pass.cc
@@ -221,7 +221,7 @@ std::unordered_set<pir::Value> GetSkipDeletionValues(const pir::Block& block) {
     PADDLE_ENFORCE_GT(
         op.attributes().count("op_name"),
         0UL,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "kernel_dialect op should own an 'op_name' attribute."));
     auto upper_op_name =
         op.attributes().at("op_name").dyn_cast<pir::StrAttribute>().AsString();
@@ -253,7 +253,7 @@ void GetEagerDelValueOfOp(
       PADDLE_ENFORCE_GT(
           op.attributes().count("op_name"),
           0UL,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "kernel_dialect op should own an 'op_name' attribute."));
       upper_op_name = op.attributes()
                           .at("op_name")
@@ -418,7 +418,7 @@ std::unordered_map<pir::Operation*, std::string> GetInplaceOps(
             .GetInterfaceImpl<paddle::dialect::OpYamlInfoInterface>();
     PADDLE_ENFORCE_NOT_NULL(
         upper_inplace_op_interface,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "can not find OpYamlInfoInterface from [%s]", upper_op_name + "_"));
     paddle::dialect::OpYamlInfoParser upper_inplace_op_info_parser(
         upper_inplace_op_interface->get_op_info_(upper_op_name + "_"));
@@ -513,8 +513,8 @@ class InplacePass : public pir::Pass {
           PADDLE_ENFORCE_NE(
               insert_pos,
               block.end(),
-              phi::errors::InvalidArgument("Operator %s not found in block.",
-                                           kv.first->name()));
+              common::errors::InvalidArgument("Operator %s not found in block.",
+                                              kv.first->name()));
 
           kv.first->set_attribute(
               "op_name",

--- a/paddle/fluid/pir/transforms/general/params_sync_among_devices_pass.cc
+++ b/paddle/fluid/pir/transforms/general/params_sync_among_devices_pass.cc
@@ -38,14 +38,14 @@ class ParamsSyncAmongDevicesPass : public pir::Pass {
     PADDLE_ENFORCE_EQ(
         Has(pir::Pass::kPlaceAttr),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Pass initialize failed."
             "When using ConstantFoldingPass, place attribute is required!"
             "Use Set method to set the place attribute."));
     PADDLE_ENFORCE_EQ(
         Has(pir::Pass::kParamScopeAttr),
         true,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "Pass initialize failed."
             "When using ConstantFoldingPass, scope attribute is required!"
             "Use Set method to set the scope attribute."));
@@ -60,7 +60,7 @@ class ParamsSyncAmongDevicesPass : public pir::Pass {
     auto module_op = op->dyn_cast<pir::ModuleOp>();
     PADDLE_ENFORCE_NOT_NULL(
         module_op,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "params_sync_among_devices_pass should run on module op."));
     auto& block = module_op.block();
     int64_t num_rewrites_{0};
@@ -73,8 +73,8 @@ class ParamsSyncAmongDevicesPass : public pir::Pass {
         auto* param_var = scope_->FindVar(param_name);
         PADDLE_ENFORCE_NOT_NULL(
             param_var,
-            phi::errors::InvalidArgument("Parameter var [%s] not in scope.",
-                                         param_name));
+            common::errors::InvalidArgument("Parameter var [%s] not in scope.",
+                                            param_name));
         if (param_var->IsType<phi::DenseTensor>()) {
           auto* param_tensor = param_var->GetMutable<phi::DenseTensor>();
           phi::CPUPlace cpu_place;
@@ -86,7 +86,7 @@ class ParamsSyncAmongDevicesPass : public pir::Pass {
           paddle::framework::TensorCopySync(temp_tensor, place_, param_tensor);
           num_rewrites_++;
         } else {
-          PADDLE_THROW(phi::errors::Unimplemented(
+          PADDLE_THROW(common::errors::Unimplemented(
               "params_sync_among_devices_pass only support DenseTensor type of "
               "parameter var."));
         }
@@ -97,16 +97,16 @@ class ParamsSyncAmongDevicesPass : public pir::Pass {
 
   bool CanApplyOn(pir::Operation* op) const override {
     PADDLE_ENFORCE_NOT_NULL(
-        scope_, phi::errors::InvalidArgument("scope can not be nullptr"));
+        scope_, common::errors::InvalidArgument("scope can not be nullptr"));
 #ifdef PADDLE_WITH_XPU
     PADDLE_ENFORCE(phi::is_xpu_place(place_) || phi::is_cpu_place(place_),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "The Place attr in params_sync_among_devices_pass "
                        "should be cpu or xpu."));
 #endif
 #ifdef PADDLE_WITH_CUDA
     PADDLE_ENFORCE(phi::is_gpu_place(place_) || phi::is_cpu_place(place_),
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "The Place attr in params_sync_among_devices_pass "
                        "should be cpu or gpu."));
 #endif

--- a/paddle/fluid/pir/transforms/general/remove_shadow_feed_pass.cc
+++ b/paddle/fluid/pir/transforms/general/remove_shadow_feed_pass.cc
@@ -95,7 +95,7 @@ class RemoveShadowFeedPattern
         var_place =
             GetVarPlace<paddle::framework::VariableRefArray>(var, place_);
       } else {
-        PADDLE_THROW(phi::errors::InvalidArgument(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "RemoveShadowFeedPattern only support output "
             "variable of type DenseTensor, SelectedRows or VariableRefArray"));
       }
@@ -181,21 +181,21 @@ class RemoveShadowFeedPass : public pir::PatternRewritePass {
       PADDLE_ENFORCE_EQ(
           Has("top_block"),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Pass initialize failed."
               "When using RemoveShadowFeedPass, block attribute is required!"
               "Use Set method to set the place attribute."));
       PADDLE_ENFORCE_EQ(
           Has(pir::Pass::kPlaceAttr),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Pass initialize failed."
               "When using RemoveShadowFeedPass, place attribute is required!"
               "Use Set method to set the place attribute."));
       PADDLE_ENFORCE_EQ(
           Has(pir::Pass::kParamScopeAttr),
           true,
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Pass initialize failed."
               "When using RemoveShadowFeedPass, scope attribute is required!"
               "Use Set method to set the scope attribute."));
@@ -204,9 +204,9 @@ class RemoveShadowFeedPass : public pir::PatternRewritePass {
       auto scope =
           &Get<const paddle::framework::Scope>(pir::Pass::kParamScopeAttr);
       PADDLE_ENFORCE_NOT_NULL(
-          block, phi::errors::InvalidArgument("block can not be nullptr"));
+          block, common::errors::InvalidArgument("block can not be nullptr"));
       PADDLE_ENFORCE_NOT_NULL(
-          scope, phi::errors::InvalidArgument("scope can not be nullptr"));
+          scope, common::errors::InvalidArgument("scope can not be nullptr"));
 
       ps.Add<RemoveShadowFeedPattern>(context, block, place, scope);
     }

--- a/paddle/fluid/pir/transforms/onednn/elementwise_act_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/elementwise_act_onednn_fuse_pass.cc
@@ -32,7 +32,8 @@ std::string GetFusedElement(const std::string &elementwise_type) {
   if (it != fused_ops.end()) {
     return it->second;
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented("The op type is not supported."));
+    PADDLE_THROW(
+        common::errors::Unimplemented("The op type is not supported."));
   }
 }
 class ElementwiseActivationFusePattern : public paddle::drr::DrrPatternBase {

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -92,7 +92,7 @@ pir::Type ConvertOpTypeToKernelType(pir::IrContext* ctx,
     }
     return pir::VectorType::get(ctx, vec_target_type);
   }
-  PADDLE_THROW(phi::errors::Unimplemented(
+  PADDLE_THROW(common::errors::Unimplemented(
       "Not support op type %s in ConvertOpTypeToKernelType.", op_type));
 }
 
@@ -519,7 +519,7 @@ static pir::Value AddPlaceTransferOp(pir::Value in,
         {"kernel_key", KernelAttribute::get(ctx, copy_kernel_key)},
         {"dst_place_type", pir::Int32Attribute::get(ctx, 0)}};
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Only support cpu to gpu and gpu to cpu, src=%s, dst=%s.",
         src_place,
         dst_place));
@@ -682,7 +682,7 @@ static pir::Type BuildDtypeTransferOutputType(pir::Type type,
                                          AllocatedSparseCsrTensorType>(
         type, place, out_dtype, ctx);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "BuildOutputType only support DenseTensorType, SelectedRowsType, "
         "SparseCooTensorType and SparseCsrTensorType"));
   }
@@ -717,7 +717,7 @@ static pir::Type BuildOutputType(pir::Type type,
                                          AllocatedSparseCsrTensorType>(
         type, place, out_dtype, ctx);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "BuildOutputType only support DenseTensorType, SelectedRowsType, "
         "SparseCooTensorType and SparseCsrTensorType"));
   }
@@ -757,7 +757,7 @@ static pir::Type BuildOutputType(pir::Type type,
     return AllocatedDenseTensorArrayType::get(
         ctx, place, array_type.dtype(), array_type.dims(), layout);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "BuildOutputType only support DenseTensorType and SelectedRowsType"));
   }
 }
@@ -795,7 +795,7 @@ pir::Value AddDtypeTransferOp(pir::Value in,
     kernel_backend = std::get<0>(out);
     kernel_layout = std::get<1>(out);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Get kernelkey for CastOp only support "
         "DenseTensorType, SparseCooTensorType, SparseCsrTensorType, and "
         "SelectedRowsType"));
@@ -874,7 +874,7 @@ static phi::DataType GetKernelDtypeByYaml(
             kernel_data_type = TransToPhiDataType(
                 vec_data[0].dyn_cast<AllocatedSparseCsrTensorType>().dtype());
           } else {
-            PADDLE_THROW(phi::errors::Unimplemented(
+            PADDLE_THROW(common::errors::Unimplemented(
                 "Only support DenseTensorType and SelectedRowsType in vector"));
           }
         }
@@ -891,7 +891,7 @@ static phi::DataType GetKernelDtypeByYaml(
         kernel_data_type = TransToPhiDataType(
             type.dyn_cast<AllocatedDenseTensorArrayType>().dtype());
       } else {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Only support DenseTensorType, SelectedRows, SparseCooTensorType, "
             "SparseCsrTensorType and VectorType"));
       }
@@ -902,13 +902,13 @@ static phi::DataType GetKernelDtypeByYaml(
     } else {
       PADDLE_ENFORCE_EQ(attr_map.count(slot_name),
                         true,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "[%s] MUST in attribute map", slot_name));
 
       auto attr_type = op_info_parser->AttrTypeName(slot_name);
       PADDLE_ENFORCE_EQ(attr_type,
                         "paddle::dialect::DataTypeAttribute",
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "Type of [%s] should be DataType", slot_name));
       kernel_data_type =
           attr_map.at(slot_name).dyn_cast<DataTypeAttribute>().data();
@@ -953,7 +953,7 @@ static phi::Backend GetKernelBackendByYaml(
             kernel_backend = paddle::experimental::ParseBackend(
                 vec_data[0].dyn_cast<AllocatedDenseTensorType>().place());
           } else {
-            PADDLE_THROW(phi::errors::Unimplemented(
+            PADDLE_THROW(common::errors::Unimplemented(
                 "Only support DenseTensorType in vector"));
           }
         }
@@ -970,20 +970,20 @@ static phi::Backend GetKernelBackendByYaml(
         kernel_backend = paddle::experimental::ParseBackend(
             type.dyn_cast<AllocatedDenseTensorArrayType>().place());
       } else {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "Only support DenseTensorType, SelectedRows, SparseCooTensorType, "
             "SparseCsrTensorType and VectorType"));
       }
     } else {
       PADDLE_ENFORCE_EQ(attr_map.count(slot_name),
                         true,
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "[%s] MUST in attribute map", slot_name));
 
       auto attr_type = op_info_parser->AttrTypeName(slot_name);
       PADDLE_ENFORCE_EQ(attr_type,
                         "paddle::dialect::PlaceAttribute",
-                        phi::errors::PreconditionNotMet(
+                        common::errors::PreconditionNotMet(
                             "Type of [%s] should be DataType", slot_name));
       kernel_backend = paddle::experimental::ParseBackend(
           attr_map.at(slot_name).dyn_cast<PlaceAttribute>().data());
@@ -1409,7 +1409,7 @@ void HandleForIfOp(
   PADDLE_ENFORCE_EQ(
       map_value_pair->count(old_cond),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "[%d]'s input of [%s] op MUST in map pair", 0, op_item->name()));
   auto new_cond = map_value_pair->at(old_cond);
 
@@ -1525,7 +1525,7 @@ void HandleForWhileOp(
     PADDLE_ENFORCE_EQ(
         map_value_pair->count(cur_in),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "[%d]'s input of [%s] op MUST in map pair", 0, op_item->name()));
     auto new_in = map_value_pair->at(cur_in);
     if (i == 0) {
@@ -1570,7 +1570,7 @@ pir::Value GetNewInput(
   PADDLE_ENFORCE_EQ(
       map_value_pair.count(cur_in),
       true,
-      phi::errors::PreconditionNotMet(
+      common::errors::PreconditionNotMet(
           "[%d]'s input of [%s] op MUST be in map pair", index, op_name));
   auto new_in = map_value_pair.at(cur_in);
   return new_in;
@@ -1590,7 +1590,7 @@ phi::Place ParsePhiPlace(pir::Type type) {
   } else if (type.isa<pir::VectorType>()) {
     return ParsePhiPlace(type.dyn_cast<pir::VectorType>()[0]);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ParsePhiPlace only support AllocatedDenseTensorType or "
         "AllocatedSelectedRowsType or AllocatedSparseCooTensorType or "
         "AllocatedSparseCsrTensorType or AllocatedDenseTensorArrayType"));
@@ -1616,7 +1616,7 @@ phi::DataType ParsePhiDType(pir::Type type) {
   } else if (type.isa<pir::VectorType>()) {
     return ParsePhiDType(type.dyn_cast<pir::VectorType>()[0]);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "ParsePhiPlace only support AllocatedDenseTensorType or "
         "AllocatedSelectedRowsType or AllocatedDenseTensorArrayType or "
         "AllocatedSparseCooTensorType or AllocatedSparseCsrTensorType"));
@@ -1663,7 +1663,7 @@ void AddShadowFeedForValue(
       PADDLE_ENFORCE_EQ(
           vec_type[i].isa<DenseTensorType>(),
           true,
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "AddShadowFeedTensors only support DenseTensorType Now"));
     }
     // Add ShadowFeedTensors Op
@@ -1698,8 +1698,8 @@ void AddShadowFeedForValue(
     (*map_value_pair)[op_item->result(index)] = shadow_tensors_op->result(0);
   } else {
     PADDLE_THROW(
-        phi::errors::Unimplemented("AddShadowFeed for value only support "
-                                   "DenseTensorType and VectorType Now"));
+        common::errors::Unimplemented("AddShadowFeed for value only support "
+                                      "DenseTensorType and VectorType Now"));
   }
 }
 
@@ -1813,8 +1813,8 @@ void HandleForSpecialOp(
                            .data();
           op_output_types.push_back(vec_types[index]);
         } else {
-          PADDLE_THROW(
-              phi::errors::Unimplemented("only support vector type for now"));
+          PADDLE_THROW(common::errors::Unimplemented(
+              "only support vector type for now"));
         }
       }
     }
@@ -1838,8 +1838,8 @@ void HandleForSpecialOp(
             op_output_types.push_back(vec_types[idx]);
           }
         } else {
-          PADDLE_THROW(
-              phi::errors::Unimplemented("only support vector type for now"));
+          PADDLE_THROW(common::errors::Unimplemented(
+              "only support vector type for now"));
         }
       }
     }
@@ -1980,7 +1980,7 @@ void HandleForSpecialOp(
     }
     PADDLE_ENFORCE_EQ(op_item->result(0).type().isa<DenseTensorType>(),
                       true,
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "HasElementsOp's output should be bool type"));
     for (size_t i = 0; i < op_item->num_results(); ++i) {
       op_output_types.push_back(
@@ -2013,7 +2013,7 @@ void HandleForSpecialOp(
         auto cur_inlet_element = pop_back_op.inlet_element(i);
         PADDLE_ENFORCE_EQ(map_value_pair->count(cur_inlet_element),
                           true,
-                          phi::errors::PreconditionNotMet(
+                          common::errors::PreconditionNotMet(
                               "[%d]'s output of [%s] op MUST be in map pair",
                               i,
                               op_item->name()));
@@ -2194,7 +2194,7 @@ void PushBackOutputTypes(pir::IrContext* ctx,
           vec_inner_types.push_back(BuildOutputType(base_type, out_place, ctx));
 #endif
         } else {
-          PADDLE_THROW(phi::errors::Unimplemented(
+          PADDLE_THROW(common::errors::Unimplemented(
               "only support dense tensor and selected rows in vector type "
               "for now"));
         }
@@ -2221,7 +2221,7 @@ void PushBackOutputTypes(pir::IrContext* ctx,
     pir::Type t1 = pir::VectorType::get(ctx, vec_inner_types);
     op_output_types->push_back(t1);
   } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
+    PADDLE_THROW(common::errors::Unimplemented(
         "Result type only support DenseTensorType, SelectedRowType, "
         "SparseCooTensorType, SparseCsrTensorType and "
         "VectorType"));
@@ -2262,7 +2262,7 @@ void HandleForCustomOp(
     PADDLE_ENFORCE_EQ(
         map_value_pair->count(cur_in),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "[%d]'s input of [%s] op MUST in map pair", i, op_item->name()));
 
     auto new_in = map_value_pair->at(cur_in);
@@ -2358,7 +2358,7 @@ void HandleForTensorRTOp(
     PADDLE_ENFORCE_EQ(
         map_value_pair->count(cur_in),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "[%d]'s input of [%s] op MUST in map pair", i, op_item->name()));
 
     auto new_in = map_value_pair->at(cur_in);
@@ -2417,7 +2417,7 @@ std::vector<pir::Type> BuildOutputs(
     PADDLE_ENFORCE_EQ(
         op_item->num_results(),
         output_defs.size(),
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "op [%s] kernel output args (%d) defs should equal op outputs (%d)",
             op_item->name(),
             output_defs.size(),
@@ -2446,7 +2446,7 @@ std::vector<pir::Type> BuildOutputs(
       PADDLE_ENFORCE_EQ(
           output_types.size(),
           op_item->num_results(),
-          phi::errors::PreconditionNotMet(
+          common::errors::PreconditionNotMet(
               "output_types.size() is expected to be %d but got %d",
               op_item->num_results(),
               output_types.size()));
@@ -2477,7 +2477,7 @@ std::vector<pir::Type> BuildOutputs(
     auto base_types = InferMetaByValue(op_item, new_vec_inputs, &attribute_map);
     PADDLE_ENFORCE_EQ(base_types.size(),
                       op_item->num_results(),
-                      phi::errors::PreconditionNotMet(
+                      common::errors::PreconditionNotMet(
                           "base_types.size() is expected to be %d but got %d",
                           op_item->num_results(),
                           base_types.size()));
@@ -2519,7 +2519,7 @@ std::vector<pir::Value> BuildInputs(
     PADDLE_ENFORCE_EQ(
         map_value_pair->count(cur_in),
         true,
-        phi::errors::PreconditionNotMet(
+        common::errors::PreconditionNotMet(
             "[%d]'s input of [%s] op MUST in map pair", i, op_item->name()));
 
     auto new_in = map_value_pair->at(cur_in);
@@ -2660,7 +2660,7 @@ std::vector<pir::Value> BuildInputs(
               place =
                   in_i_type.dyn_cast<AllocatedDenseTensorArrayType>().place();
             } else {
-              PADDLE_THROW(phi::errors::Unimplemented(
+              PADDLE_THROW(common::errors::Unimplemented(
                   "builtin.combine Input type only support "
                   "VectorType<DenseTensorType> and "
                   "VectorType<SelectedRowsType> and"
@@ -2721,7 +2721,7 @@ std::vector<pir::Value> BuildInputs(
                         .type()
                         .dyn_cast<DenseTensorArrayType>());
               } else {
-                PADDLE_THROW(phi::errors::Unimplemented(
+                PADDLE_THROW(common::errors::Unimplemented(
                     "builtin.combine Input type only support "
                     "VectorType<DenseTensorType> and "
                     "VectorType<SelectedRowsType> and"
@@ -2897,7 +2897,7 @@ std::vector<pir::Value> BuildInputs(
               new_in, out_type, in_place, out_place, kernel_key, block);
         }
       } else {
-        PADDLE_THROW(phi::errors::Unimplemented(
+        PADDLE_THROW(common::errors::Unimplemented(
             "only support AllocatedDenseTensorType, VectorType, "
             "AllocatedSelectedRowsType, AllocatedDenseTensorArrayType, "
             "AllocatedSparseCooTensorType and AllocatedSparseCsrTensorType"));
@@ -2960,7 +2960,7 @@ void AddShadowFeedOpForDataOrFeed(
   bool add_shadow_feed = feed_op_add_shadow_feed || data_op_add_shadow_feed;
   if (add_shadow_feed) {
     PADDLE_ENFORCE(op_item->num_results() == 1,
-                   phi::errors::PreconditionNotMet(
+                   common::errors::PreconditionNotMet(
                        "op_item should have only one result, but got %d",
                        op_item->num_results()));
     AddShadowFeedForValue(

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -94,10 +94,10 @@ std::vector<pir::Operation*> InverselyTopologicalSort(pir::Block* block) {
   PADDLE_ENFORCE_EQ(
       block->size(),
       sort_ops.size(),
-      phi::errors::InvalidArgument("sort_ops.size() must be equal to "
-                                   "block.size(), but received %d != %d",
-                                   block->size(),
-                                   sort_ops.size()));
+      common::errors::InvalidArgument("sort_ops.size() must be equal to "
+                                      "block.size(), but received %d != %d",
+                                      block->size(),
+                                      sort_ops.size()));
 
   return sort_ops;
 }
@@ -118,7 +118,7 @@ std::vector<pir::Operation*> GetProducerOpsReverseSort(
       producers.insert(source_op);
       PADDLE_ENFORCE(
           op2id.count(source_op),
-          phi::errors::PreconditionNotMet("source op MUST in op2id map"));
+          common::errors::PreconditionNotMet("source op MUST in op2id map"));
       vec_res.emplace_back(source_op);
     }
   }

--- a/paddle/fluid/pir/transforms/sub_graph_extract_pass.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_extract_pass.cc
@@ -48,7 +48,7 @@ class SubGraphExtractPass : public pir::Pass {
     auto module_op = op->dyn_cast<pir::ModuleOp>();
     PADDLE_ENFORCE_NOT_NULL(
         module_op,
-        phi::errors::InvalidArgument(
+        common::errors::InvalidArgument(
             "sub_graph_extract_pass should run on module op."));
     auto& block = module_op.block();
 

--- a/paddle/fluid/pir/utils/general_functions.cc
+++ b/paddle/fluid/pir/utils/general_functions.cc
@@ -77,8 +77,8 @@ std::string GetParameterNameFromValue(const pir::Value& value) {
     name = op.tensor_name();
   } else {
     PADDLE_THROW(
-        phi::errors::Unimplemented("Value must be a weight from a Parameter "
-                                   "or a ConstantTensorOp op."));
+        common::errors::Unimplemented("Value must be a weight from a Parameter "
+                                      "or a ConstantTensorOp op."));
   }
   return name;
 }
@@ -91,17 +91,17 @@ std::vector<int64_t> GetShapeFromValue(const pir::Value& value) {
     return phi::vectorize(
         value.type().dyn_cast<paddle::dialect::SelectedRowsType>().dims());
   } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(common::errors::InvalidArgument(
         "Currently, we can only get shape for dense_tensor or selected_rows."));
   }
 }
 
 pir::Type GetDataTypeFromValue(const pir::Value& value) {
   // TODO(dev): Support other types like DenseTensor.
-  PADDLE_ENFORCE_EQ(
-      value.type().isa<paddle::dialect::DenseTensorType>(),
-      true,
-      phi::errors::InvalidArgument("Value's type must be a DenseTensorType."));
+  PADDLE_ENFORCE_EQ(value.type().isa<paddle::dialect::DenseTensorType>(),
+                    true,
+                    common::errors::InvalidArgument(
+                        "Value's type must be a DenseTensorType."));
   return value.type().dyn_cast<paddle::dialect::DenseTensorType>().dtype();
 }
 
@@ -109,16 +109,16 @@ Operation* GetDefiningOpForInput(const Operation* op, uint32_t index) {
   PADDLE_ENFORCE_EQ(
       index < op->num_operands() && op->operand_source(index),
       true,
-      phi::errors::InvalidArgument("Intput operand's index must be valid."));
+      common::errors::InvalidArgument("Intput operand's index must be valid."));
   return op->operand_source(index).defining_op();
 }
 
 std::vector<std::pair<Operation*, int32_t>> GetUseOpsForOutput(
     const Operation* op, uint32_t index) {
-  PADDLE_ENFORCE_EQ(
-      index < op->num_results(),
-      true,
-      phi::errors::InvalidArgument("Output op result's index must be valid."));
+  PADDLE_ENFORCE_EQ(index < op->num_results(),
+                    true,
+                    common::errors::InvalidArgument(
+                        "Output op result's index must be valid."));
   auto result = op->result(index);
   std::vector<std::pair<Operation*, int32_t>> use_ops;
   for (auto it = result.use_begin(); it != result.use_end(); ++it) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Replace phi::errors to common::errors in paddle/fluid