### PR TITLE
[Xshape]Migrate flatten/squeeze/unsqueeze to drop XShape output and Remove generate_xshape

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
@@ -20,7 +20,6 @@
 #include "paddle/cinn/hlir/dialect/operator/ir/op_attribute.h"
 #include "paddle/common/ddim.h"
 #include "paddle/common/enforce.h"
-#include "paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h"
 #include "paddle/fluid/pir/dialect/operator/ir/ir_meta_tensor.h"
 #include "paddle/fluid/pir/dialect/operator/ir/ir_tensor.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
@@ -539,61 +538,6 @@ bool GenerateShapeOp::InferSymbolicShape(
   return true;
 }
 
-void GenerateXShapeOp::Build(pir::Builder& builder,             // NOLINT
-                             pir::OperationArgument& argument,  // NOLINT
-                             pir::Value input) {
-  VLOG(4) << "Start build GenerateXShapeOp";
-  VLOG(4) << "Builder construction inputs";
-  std::vector<pir::Value> inputs = {input};
-  argument.AddInputs(inputs);
-
-  std::vector<pir::Type> outputs = GenerateXShapeOp::InferMeta(inputs);
-  argument.AddOutputs(outputs);
-}
-
-bool GenerateXShapeOp::InferSymbolicShape(
-    pir::InferSymbolicShapeContext* infer_context) {
-  const symbol::ShapeOrDataDimExprs& x_dim_expr =
-      infer_context->GetShapeOrDataForValue(this->operand_source(0));
-  infer_context->SetShapeOrDataForValue(
-      this->result(0),
-      paddle::dialect::details::CreateShapeOrDataForXShape(x_dim_expr));
-  return true;
-}
-
-std::vector<pir::Type> GenerateXShapeOp::InferMeta(
-    const std::vector<pir::Value>& input_values) {
-  VLOG(4) << "Start infermeta GenerateXShapeOp";
-  PADDLE_ENFORCE_EQ(input_values.size(),
-                    1,
-                    ::common::errors::InvalidArgument(
-                        "Number of inputs is expected to be 1 but got %d.",
-                        input_values.size()));
-  pir::Value input = input_values[0];
-  VLOG(4) << "Builder construction outputs";
-  PADDLE_ENFORCE_EQ(input.type().isa<paddle::dialect::DenseTensorType>(),
-                    true,
-                    ::common::errors::InvalidArgument(
-                        "input type must be DenseTensorType, but received: %s.",
-                        input.type()));
-  auto input_type = input.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  const auto out_dims = [&]() -> decltype(auto) {
-    auto x_dims_data = phi::vectorize<int64_t>(input_type.dims());
-    x_dims_data.insert(x_dims_data.begin(), 0);
-    return phi::make_ddim(x_dims_data);
-  }();
-
-  std::vector<pir::Type> out_types;
-  out_types.push_back(
-      paddle::dialect::DenseTensorType::get(pir::IrContext::Instance(),
-                                            input_type.dtype(),
-                                            out_dims,
-                                            input_type.data_layout(),
-                                            input_type.lod(),
-                                            input_type.offset()));
-  return out_types;
-}
-
 }  // namespace dialect
 }  // namespace cinn
 
@@ -602,5 +546,4 @@ IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::FusionOp)
 IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::ConcatOp)
 IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::SplitOp)
 IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::GenerateShapeOp);
-IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::GenerateXShapeOp);
 IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::YieldStoreOp);

--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
@@ -183,24 +183,6 @@ class IR_API GenerateShapeOp
       const pir::Attribute &symbol_bindings);
 };
 
-class IR_API GenerateXShapeOp
-    : public pir::Op<GenerateXShapeOp,
-                     paddle::dialect::InferSymbolicShapeInterface> {
- public:
-  using Op::Op;
-  static const char *name() { return "cinn_op.generate_xshape"; }
-  static constexpr uint32_t attributes_num = 0;
-  static constexpr const char **attributes_name = nullptr;
-  static void Build(pir::Builder &builder,             // NOLINT
-                    pir::OperationArgument &argument,  // NOLINT
-                    pir::Value input);
-  void VerifySig() {}
-  pir::Value out() { return result(0); }
-  bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
-  static std::vector<pir::Type> InferMeta(
-      const std::vector<pir::Value> &input_values);
-};
-
 }  // namespace dialect
 }  // namespace cinn
 
@@ -209,5 +191,4 @@ IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::FusionOp)
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::ConcatOp)
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::SplitOp)
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::GenerateShapeOp);
-IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::GenerateXShapeOp);
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::YieldStoreOp);

--- a/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
@@ -58,7 +58,6 @@ void OperatorDialect::initialize() {
   RegisterOp<SplitOp>();
   RegisterOp<YieldStoreOp>();
   RegisterOp<GenerateShapeOp>();
-  RegisterOp<GenerateXShapeOp>();
   RegisterAttribute<GroupInfoAttribute>();
   RegisterAttribute<CINNKernelInfoAttribute>();
 }

--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -78,16 +78,13 @@ void ReplaceWithCinnReshapeOp(OpT op,
                               const std::vector<int> &out_shape) {
   PADDLE_ENFORCE_EQ(
       op->num_results(),
-      2U,
+      1U,
       ::common::errors::PreconditionNotMet(
           "The size of source op outputs must be 2, but received %d.",
           op->num_results()));
   auto cinn_reshape = rewriter.Build<cinn::dialect::ReshapeOp>(
       op->operand_source(0), out_shape);
-  auto generate_xshape =
-      rewriter.Build<cinn::dialect::GenerateXShapeOp>(op->operand_source(0));
   rewriter.ReplaceAllUsesWith(op.result(0), cinn_reshape.result(0));
-  rewriter.ReplaceAllUsesWith(op.result(1), generate_xshape.result(0));
 }
 
 }  // namespace
@@ -268,15 +265,7 @@ class ReshapeOpPattern
             out_shape_attr[i].dyn_cast<::pir::Int64Attribute>().data());
       }
     }
-    PADDLE_ENFORCE_EQ(
-        op->num_results(),
-        1U,
-        ::common::errors::PreconditionNotMet(
-            "The size of source op outputs must be 1, but received %d.",
-            op->num_results()));
-    auto cinn_reshape = rewriter.Build<cinn::dialect::ReshapeOp>(
-        op->operand_source(0), vec_out_shape);
-    rewriter.ReplaceAllUsesWith(op.result(0), cinn_reshape.result(0));
+    ReplaceWithCinnReshapeOp(op, rewriter, vec_out_shape);
     rewriter.EraseOp(op);
   }
 };

--- a/paddle/cinn/hlir/op/elementwise.cc
+++ b/paddle/cinn/hlir/op/elementwise.cc
@@ -1066,60 +1066,6 @@ std::shared_ptr<framework::OpStrategy> StrategyForGenerateShapeSymbolic(
   return strategy;
 }
 
-std::shared_ptr<framework::OpStrategy> StrategyForGenerateXShapeSymbolic(
-    const framework::NodeAttr &attrs,
-    const std::vector<ir::Tensor> &inputs,
-    const std::vector<Type> &out_type,
-    const std::vector<std::vector<ir::Dim>> &output_shapes,
-    const Target &target) {
-  PADDLE_ENFORCE_EQ(inputs.size(),
-                    1U,
-                    ::common::errors::InvalidArgument(
-                        "Require number of input tensors for generate_shape "
-                        "compute must be 1, but now get %d.",
-                        inputs.size()));
-  const auto out_shape = [&]() -> decltype(auto) {
-    std::vector<Expr> out_shape = inputs[0]->shape;
-    out_shape.insert(out_shape.begin(), Expr{0});
-    return out_shape;
-  }();
-
-  framework::CINNCompute generate_xshape_compute([=](lang::Args args,
-                                                     lang::RetValue *ret) {
-    PADDLE_ENFORCE(!args.empty(),
-                   ::common::errors::InvalidArgument(
-                       "Invalid argument. The input arguments of "
-                       "generate_xshape compute is empty! Please check."));
-    CINNValuePack pack_args = args[0];
-    PADDLE_ENFORCE_EQ(pack_args.size(),
-                      2U,
-                      ::common::errors::InvalidArgument(
-                          "Require number of input tensors for generate_shape "
-                          "compute must be 2, but now get %d.",
-                          pack_args.size()));
-    Expr input_x = pack_args[0];
-    PADDLE_ENFORCE_NOT_NULL(input_x.as_tensor(),
-                            ::common::errors::InvalidArgument(
-                                "Require input[0] must be a tensor."));
-    ir::Tensor input_tensor = input_x.as_tensor_ref();
-    auto shape_exprs = ToCinnExprs(out_shape);
-    const std::string tensor_name = pack_args[1].operator std::string();
-    ir::Tensor out = lang::Compute(
-        shape_exprs,
-        [=](const std::vector<Expr> &indices) {
-          return ir::Cast::Make(input_tensor->type(), 0.);
-        },
-        tensor_name);
-    std::vector<CINNValue> res;
-    *ret = CINNValuePack{res};
-  });
-
-  auto strategy = std::make_shared<framework::OpStrategy>();
-  strategy->AddImpl(
-      generate_xshape_compute, lang::PackedFunc(), "strategy.store.x86", 1);
-  return strategy;
-}
-
 std::shared_ptr<framework::OpStrategy> StrategyForArange(
     const framework::NodeAttr &attrs,
     const std::vector<ir::Tensor> &inputs,
@@ -1643,19 +1589,6 @@ CINN_REGISTER_HELPER(elementwise_ops) {
       .set_attr<cinn::hlir::framework::StrategyFunctionSymbolic>(
           "CINNStrategySymbolic",
           cinn::hlir::op::StrategyForGenerateShapeSymbolic)
-      .set_attr<cinn::hlir::framework::OpPatternKind>(
-          "OpPattern", cinn::hlir::framework::OpPatternKind::kNonFusible)
-      .set_support_level(4);
-
-  CINN_REGISTER_OP(generate_xshape)
-      .describe(
-          "This operator is used to generate xshape for some ops, such as "
-          "Reshape/Squeeze.")
-      .set_num_inputs(1)
-      .set_num_outputs(1)
-      .set_attr<cinn::hlir::framework::StrategyFunctionSymbolic>(
-          "CINNStrategySymbolic",
-          cinn::hlir::op::StrategyForGenerateXShapeSymbolic)
       .set_attr<cinn::hlir::framework::OpPatternKind>(
           "OpPattern", cinn::hlir::framework::OpPatternKind::kNonFusible)
       .set_support_level(4);

--- a/paddle/fluid/operators/generator/parse_utils.py
+++ b/paddle/fluid/operators/generator/parse_utils.py
@@ -694,7 +694,7 @@ def cross_validate(ops):
 
                 assert len(fw_call["outputs"]) == len(
                     fw_op["outputs"]
-                ), f"{name}: forward call has more outputs than the op "
+                ), f"{name}: requires outputs number of fw_call == fw_op, but received {fw_call['outputs']} != {fw_op['outputs']}"
                 for output, output_ in zip(
                     fw_call["outputs"], fw_op["outputs"]
                 ):

--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -1089,7 +1089,7 @@ void softmax_grad(const Tensor& out,
 }
 
 template <typename T>
-void squeeze_grad(const Tensor& xshape,
+void squeeze_grad(const Tensor& x,
                   const Tensor& out_grad,
                   const IntArray& axis,
                   Tensor* x_grad) {
@@ -1100,7 +1100,7 @@ void squeeze_grad(const Tensor& xshape,
 }
 
 template <typename T>
-void unsqueeze_grad(const Tensor& xshape,
+void unsqueeze_grad(const Tensor& x,
                     const Tensor& out_grad,
                     const IntArray& axis,
                     Tensor* x_grad) {
@@ -1116,7 +1116,7 @@ void unsqueeze_grad(const Tensor& xshape,
     // for axis = [0, 3, 3], it outputs [0, 3, 3+1], because unsqueeze support
     // duplicated axis.
     std::vector<int64_t> output_axis;
-    const int64_t x_rank = xshape.dims().size() - 1;
+    const int64_t x_rank = x.dims().size();
     const std::vector<int64_t> axis_data = axis.GetData();
     for (size_t i = 0; i < axis_data.size(); ++i) {
       int64_t value = axis_data[i];

--- a/paddle/phi/api/generator/dist_api_gen.py
+++ b/paddle/phi/api/generator/dist_api_gen.py
@@ -869,7 +869,7 @@ class DistForwardAPI(ForwardAPI):
         # TODO(GhostScreaming): specialized case for reshape_grad
         # xshape is not kernel params, but inferspmd needs it.
         if "reshape_grad" in self.kernel['func'][0]:
-            kernel_params = ["xshape"] + kernel_params
+            kernel_params = ["x"] + kernel_params
 
         input_decl_code = ""
         input_args_code = ""
@@ -1275,6 +1275,7 @@ class DistForwardAPI(ForwardAPI):
                     and self.infer_meta['global_shape'] is not None
                     and self.outputs['names'][i]
                     == self.infer_meta['global_shape']
+                    and i > 0
                 ):
                     output_decl_code += (
                         SINGLE_GLOBAL_META_OUT_DECL_TEMPLATE.format(
@@ -1597,7 +1598,9 @@ class DistForwardAPI(ForwardAPI):
                 ] and self.need_to_generate_code_for_inplace_impl(i):
                     infer_meta_code += SET_DIMS_TEMPLATE.format(
                         dst=self.dist_output_args[i],
-                        src=self.dist_output_args[i] + '_tmp',
+                        src=self.dist_output_args[i] + '_tmp'
+                        if i > 0
+                        else self.dist_output_args[i],
                     )
 
         # TODO(GhostScreaming): kernel like reshape need calculate local_shape

--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -962,6 +962,14 @@ void KernelWithXShapeInferMeta(const MetaTensor& xshape,
   dx->share_lod(xshape);
 }
 
+void SameWithXInferMeta(const MetaTensor& x,
+                        const MetaTensor& out,
+                        MetaTensor* dx) {
+  dx->set_dims(x.dims());
+  dx->set_dtype(out.dtype());
+  dx->share_lod(x);
+}
+
 void ReshapeGradInferMeta(const MetaTensor& xshape,
                           const MetaTensor& out,
                           MetaTensor* dx) {

--- a/paddle/phi/infermeta/backward.h
+++ b/paddle/phi/infermeta/backward.h
@@ -356,6 +356,10 @@ void KernelWithXShapeInferMeta(const MetaTensor& xshape,
                                const MetaTensor& out,
                                MetaTensor* dx);
 
+void SameWithXInferMeta(const MetaTensor& x,
+                        const MetaTensor& out,
+                        MetaTensor* dx);
+
 void ReshapeGradInferMeta(const MetaTensor& xshape,
                           const MetaTensor& out,
                           MetaTensor* dx);

--- a/paddle/phi/infermeta/spmd_rules/reshape.cc
+++ b/paddle/phi/infermeta/spmd_rules/reshape.cc
@@ -328,32 +328,32 @@ SpmdInfo ReshapeInferSpmdDynamic(const DistMetaTensor& x,
   return spmd_info;
 }
 
-SpmdInfo ReshapeGradInferSpmd(const DistMetaTensor& x_shape,
+SpmdInfo ReshapeGradInferSpmd(const DistMetaTensor& x,
                               const DistMetaTensor& out_grad) {
   std::vector<int64_t> out_grad_shape = common::vectorize(out_grad.dims());
-  auto x_shape_dist_tmp = x_shape.dist_attr();
-  auto x_dims_mapping = x_shape_dist_tmp.dims_mapping();
+  auto x_dist_tmp = x.dist_attr();
+  auto x_dims_mapping = x_dist_tmp.dims_mapping();
   x_dims_mapping.erase(x_dims_mapping.begin());
-  x_shape_dist_tmp.set_dims_mapping(x_dims_mapping);
-  auto tmp = ReshapeInferSpmd(DistMetaTensor(x_shape.dims(), x_shape_dist_tmp),
-                              out_grad_shape);
+  x_dist_tmp.set_dims_mapping(x_dims_mapping);
+  auto tmp =
+      ReshapeInferSpmd(DistMetaTensor(x.dims(), x_dist_tmp), out_grad_shape);
   // check no shard is needed
-  const auto& x_shape_dist_dst = PADDLE_GET_CONST(TensorDistAttr, tmp.first[0]);
+  const auto& x_dist_dst = PADDLE_GET_CONST(TensorDistAttr, tmp.first[0]);
   const auto& out_grad_dist_dst =
       PADDLE_GET_CONST(TensorDistAttr, tmp.second[0]);
-  PADDLE_ENFORCE_EQ(x_shape_dist_tmp.dims_mapping(),
-                    x_shape_dist_dst.dims_mapping(),
-                    phi::errors::InvalidArgument(
-                        "x_shape should not be re shared: [%s] => [%s]",
-                        x_shape_dist_tmp.to_string(),
-                        x_shape_dist_dst.to_string()));
-  return {{out_grad_dist_dst}, {x_shape_dist_dst}};
+  PADDLE_ENFORCE_EQ(
+      x_dist_tmp.dims_mapping(),
+      x_dist_dst.dims_mapping(),
+      phi::errors::InvalidArgument("x should not be re shared: [%s] => [%s]",
+                                   x_dist_tmp.to_string(),
+                                   x_dist_dst.to_string()));
+  return {{out_grad_dist_dst}, {x_dist_dst}};
 }
 
-SpmdInfo StaticReshapeGradInferSpmd(const DistMetaTensor& x_shape,
+SpmdInfo StaticReshapeGradInferSpmd(const DistMetaTensor& x,
                                     const DistMetaTensor& out_grad) {
-  auto spmd_info = ReshapeGradInferSpmd(x_shape, out_grad);
-  spmd_info.first.insert(spmd_info.first.begin(), x_shape.dist_attr());
+  auto spmd_info = ReshapeGradInferSpmd(x, out_grad);
+  spmd_info.first.insert(spmd_info.first.begin(), x.dist_attr());
   return spmd_info;
 }
 

--- a/paddle/phi/infermeta/spmd_rules/reshape.h
+++ b/paddle/phi/infermeta/spmd_rules/reshape.h
@@ -32,10 +32,10 @@ SpmdInfo ReshapeInferSpmdReverse(const DistMetaTensor& x,
 SpmdInfo ReshapeInferSpmdDynamic(const DistMetaTensor& x,
                                  const std::vector<int64_t>& shape);
 
-SpmdInfo ReshapeGradInferSpmd(const DistMetaTensor& x_shape,
+SpmdInfo ReshapeGradInferSpmd(const DistMetaTensor& x,
                               const DistMetaTensor& out_grad);
 
-SpmdInfo StaticReshapeGradInferSpmd(const DistMetaTensor& x_shape,
+SpmdInfo StaticReshapeGradInferSpmd(const DistMetaTensor& x,
                                     const DistMetaTensor& out_grad);
 
 }  // namespace distributed

--- a/paddle/phi/infermeta/spmd_rules/unsqueeze.cc
+++ b/paddle/phi/infermeta/spmd_rules/unsqueeze.cc
@@ -229,13 +229,12 @@ SpmdInfo UnsqueezeInferSpmdReverse(const DistMetaTensor& x,
           {out_dist_attr_dst, CreateUnsqueezeXshape(x_dist_attr)}};
 }
 
-SpmdInfo UnsqueezeGradInferSpmd(const DistMetaTensor& xshape,
+SpmdInfo UnsqueezeGradInferSpmd(const DistMetaTensor& x,
                                 const DistMetaTensor& out_grad,
                                 const IntArray& axis) {
-  auto shape = phi::vectorize(xshape.dims());
-  shape = std::vector<int64_t>(shape.begin() + 1, shape.end());
+  auto shape = phi::vectorize(x.dims());
   const auto& spmd = ReshapeInferSpmd(out_grad, shape);
-  return {{xshape.dist_attr(), spmd.first[0]}, {spmd.second[0]}};
+  return {{x.dist_attr(), spmd.first[0]}, {spmd.second[0]}};
 }
 
 }  // namespace phi::distributed

--- a/paddle/phi/kernels/flatten_grad_kernel.cc
+++ b/paddle/phi/kernels/flatten_grad_kernel.cc
@@ -22,12 +22,11 @@ namespace phi {
 
 template <typename T, typename Context>
 void FlattenGradKernel(const Context& dev_ctx,
-                       const DenseTensor& xshape,
+                       const DenseTensor& x,
                        const DenseTensor& out_grad,
                        DenseTensor* x_grad) {
-  auto xshape_dims = xshape.dims();
+  auto x_dims = x.dims();
   dev_ctx.Alloc(x_grad, out_grad.dtype());
-  auto x_dims = common::slice_ddim(xshape_dims, 1, xshape_dims.size());
   phi::Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
   x_grad->Resize(x_dims);
 }

--- a/paddle/phi/kernels/flatten_grad_kernel.h
+++ b/paddle/phi/kernels/flatten_grad_kernel.h
@@ -20,13 +20,13 @@ namespace phi {
 
 template <typename T, typename Context>
 void FlattenGradKernel(const Context& dev_ctx,
-                       const DenseTensor& xshape,
+                       const DenseTensor& x,
                        const DenseTensor& out_grad,
                        DenseTensor* x_grad);
 
 template <typename Context>
 void FlattenGradStridedKernel(const Context& dev_ctx,
-                              const DenseTensor& xshape,
+                              const DenseTensor& x,
                               const DenseTensor& out_grad,
                               DenseTensor* x_grad);
 

--- a/paddle/phi/kernels/flatten_kernel.cc
+++ b/paddle/phi/kernels/flatten_kernel.cc
@@ -42,8 +42,7 @@ void FlattenKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    int start_axis,
                    int stop_axis,
-                   DenseTensor* out,
-                   DenseTensor* xshape UNUSED) {
+                   DenseTensor* out) {
   FlattenInferKernel<T, Context>(dev_ctx, x, start_axis, stop_axis, out);
 }
 

--- a/paddle/phi/kernels/flatten_kernel.h
+++ b/paddle/phi/kernels/flatten_kernel.h
@@ -32,24 +32,21 @@ void FlattenKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    int start_axis,
                    int stop_axis,
-                   DenseTensor* out,
-                   DenseTensor* xshape);
+                   DenseTensor* out);
 
 template <typename Context>
 void FlattenInferStridedKernel(const Context& dev_ctx,
                                const DenseTensor& x,
                                int start_axis,
                                int stop_axis,
-                               DenseTensor* out,
-                               DenseTensor* xshape);
+                               DenseTensor* out);
 
 template <typename Context>
 void FlattenStridedKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           int start_axis,
                           int stop_axis,
-                          DenseTensor* out,
-                          DenseTensor* xshape);
+                          DenseTensor* out);
 
 template <typename T, typename Context>
 DenseTensor Flatten(const Context& dev_ctx,

--- a/paddle/phi/kernels/impl/solve_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/solve_grad_kernel_impl.h
@@ -83,7 +83,7 @@ void SolveGradKernel(const Context& dev_ctx,
   DenseTensor tmp_y;
   if (is_vector) {
     dev_ctx.Alloc(&tmp_y, y.dtype());
-    phi::Unsqueeze<T, Context>(dev_ctx, y, {-1}, &tmp_y, nullptr);
+    phi::Unsqueeze<T, Context>(dev_ctx, y, {-1}, &tmp_y);
   } else {
     tmp_y.Resize(y.dims());
     dev_ctx.Alloc(&tmp_y, y.dtype());
@@ -137,20 +137,14 @@ void SolveGradKernel(const Context& dev_ctx,
       DenseTensor tmp_dy_;
       dev_ctx.Alloc(&tmp_dy_, y.dtype());
 
-      phi::Unsqueeze<T, Context>(dev_ctx,
-                                 tmp_dy,
-                                 paddle::experimental::IntArray({-1}),
-                                 &tmp_dy_,
-                                 nullptr);
+      phi::Unsqueeze<T, Context>(
+          dev_ctx, tmp_dy, paddle::experimental::IntArray({-1}), &tmp_dy_);
 
       DenseTensor tmp_out_;
       dev_ctx.Alloc(&tmp_out_, out.dtype());
 
-      phi::Unsqueeze<T, Context>(dev_ctx,
-                                 out,
-                                 paddle::experimental::IntArray({-1}),
-                                 &tmp_out_,
-                                 nullptr);
+      phi::Unsqueeze<T, Context>(
+          dev_ctx, out, paddle::experimental::IntArray({-1}), &tmp_out_);
 
       auto mat_dim_a1 =
           phi::funcs::CreateMatrixDescriptor(tmp_dy_.dims(), 0, false);

--- a/paddle/phi/kernels/impl/solve_kernel_impl.h
+++ b/paddle/phi/kernels/impl/solve_kernel_impl.h
@@ -129,7 +129,7 @@ static void linalg_solve(const Context& dev_ctx,
   if (is_vector) {
     dev_ctx.Alloc(&tmp_y, y.dtype());
 
-    phi::Unsqueeze<T, Context>(dev_ctx, y, {-1}, &tmp_y, nullptr);
+    phi::Unsqueeze<T, Context>(dev_ctx, y, {-1}, &tmp_y);
   } else {
     tmp_y.Resize(y.dims());
     dev_ctx.Alloc(&tmp_y, y.dtype());

--- a/paddle/phi/kernels/onednn/flatten_kernel.cc
+++ b/paddle/phi/kernels/onednn/flatten_kernel.cc
@@ -68,8 +68,7 @@ void FlattenKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    int start_axis,
                    int stop_axis,
-                   DenseTensor* out,
-                   DenseTensor* xshape UNUSED) {
+                   DenseTensor* out) {
   FlattenInferKernel<T, Context>(dev_ctx, x, start_axis, stop_axis, out);
 }
 

--- a/paddle/phi/kernels/onednn/reshape_kernel.cc
+++ b/paddle/phi/kernels/onednn/reshape_kernel.cc
@@ -154,7 +154,7 @@ void ReshapeInferKernel(const Context& dev_ctx,
                         const DenseTensor& x,
                         const IntArray& shape,
                         DenseTensor* out) {
-  auto x_dims = x.dims();
+  const auto& x_dims = x.dims();
   ExecuteReshape<T, Context>(dev_ctx, x, shape, x_dims, out);
 }
 
@@ -162,9 +162,8 @@ template <typename T, typename Context>
 void ReshapeKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const IntArray& shape,
-                   DenseTensor* out,
-                   DenseTensor* xshape) {
-  auto x_dims = slice_ddim(xshape->dims(), 1, xshape->dims().size());
+                   DenseTensor* out) {
+  const auto& x_dims = x.dims();
   ExecuteReshape<T, Context>(dev_ctx, x, shape, x_dims, out);
 }
 

--- a/paddle/phi/kernels/onednn/squeeze_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/squeeze_grad_kernel.cc
@@ -21,7 +21,7 @@ namespace phi {
 
 template <typename T, typename Context>
 void SqueezeGradKernel(const Context& dev_ctx,
-                       const DenseTensor& xshape,
+                       const DenseTensor& x,
                        const DenseTensor& dout,
                        const IntArray& axes UNUSED,
                        DenseTensor* dx) {
@@ -29,6 +29,7 @@ void SqueezeGradKernel(const Context& dev_ctx,
                                                : std::vector<int64_t>{1};
 
   auto dout_type = funcs::ToOneDNNDataType(dout.dtype());
+  const auto& x_dim = x.dims();
 
   funcs::ReorderOneDNNHandler reorder_handler(
       dout_vec_dims, dout.dtype(), dout_type, dev_ctx.GetEngine());
@@ -46,9 +47,7 @@ void SqueezeGradKernel(const Context& dev_ctx,
   reorder_p->execute(astream, *reorder_src_memory_p, *reorder_dst_memory_p);
   astream.wait();
 
-  auto dx_dims = slice_ddim(xshape.dims(), 1, xshape.dims().size());
-  dx->Resize(dx_dims);
-  reorder_dst_memory_p->get_desc().reshape(common::vectorize(dx_dims));
+  reorder_dst_memory_p->get_desc().reshape(common::vectorize(x_dim));
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/onednn/squeeze_kernel.cc
+++ b/paddle/phi/kernels/onednn/squeeze_kernel.cc
@@ -90,15 +90,8 @@ template <typename T, typename Context>
 void SqueezeKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const IntArray& axes,
-                   DenseTensor* out,
-                   DenseTensor* xshape) {
-  if (xshape == nullptr) {
-    SqueezeInferKernel<T, Context>(dev_ctx, x, axes, out);
-  } else {
-    auto x_dims = slice_ddim(xshape->dims(), 1, xshape->dims().size());
-    auto out_dims = out->dims();
-    ExecuteSqueeze<T, Context>(dev_ctx, x, x_dims, out_dims, out);
-  }
+                   DenseTensor* out) {
+  SqueezeInferKernel<T, Context>(dev_ctx, x, axes, out);
 }
 }  // namespace phi
 

--- a/paddle/phi/kernels/reshape_kernel.cc
+++ b/paddle/phi/kernels/reshape_kernel.cc
@@ -78,8 +78,7 @@ template <typename Context>
 void ReshapeKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const IntArray& shape,
-                   DenseTensor* out,
-                   DenseTensor* xshape UNUSED) {
+                   DenseTensor* out) {
   ReshapeInferKernel(dev_ctx, x, shape, out);
 }
 

--- a/paddle/phi/kernels/reshape_kernel.h
+++ b/paddle/phi/kernels/reshape_kernel.h
@@ -31,15 +31,13 @@ template <typename Context>
 void ReshapeKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const IntArray& shape,
-                   DenseTensor* out,
-                   DenseTensor* xshape);
+                   DenseTensor* out);
 
 template <typename Context>
 void ReshapeStridedKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const IntArray& shape,
-                          DenseTensor* out,
-                          DenseTensor* xshape);
+                          DenseTensor* out);
 
 template <typename T, typename Context>
 void Reshape(const Context& dev_ctx,

--- a/paddle/phi/kernels/squeeze_grad_kernel.cc
+++ b/paddle/phi/kernels/squeeze_grad_kernel.cc
@@ -21,13 +21,11 @@
 namespace phi {
 template <typename T, typename Context>
 void SqueezeGradKernel(const Context& dev_ctx,
-                       const DenseTensor& xshape,
+                       const DenseTensor& x,
                        const DenseTensor& dout,
                        const IntArray& axes UNUSED,
                        DenseTensor* dx) {
-  auto xshape_dims = xshape.dims();
-  auto x_dims = common::slice_ddim(xshape_dims, 1, xshape_dims.size());
-
+  const auto& x_dims = x.dims();
   dev_ctx.template Alloc<T>(dx);
   phi::Copy(dev_ctx, dout, dev_ctx.GetPlace(), false, dx);
   dx->Resize(x_dims);

--- a/paddle/phi/kernels/squeeze_grad_kernel.h
+++ b/paddle/phi/kernels/squeeze_grad_kernel.h
@@ -22,14 +22,14 @@ namespace phi {
 
 template <typename T, typename Context>
 void SqueezeGradKernel(const Context& dev_ctx,
-                       const DenseTensor& xshape,
+                       const DenseTensor& x,
                        const DenseTensor& dout,
                        const IntArray& axes,
                        DenseTensor* dx);
 
 template <typename Context>
 void SqueezeGradStridedKernel(const Context& dev_ctx,
-                              const DenseTensor& xshape,
+                              const DenseTensor& x,
                               const DenseTensor& dout,
                               const IntArray& axes,
                               DenseTensor* dx);

--- a/paddle/phi/kernels/squeeze_kernel.cc
+++ b/paddle/phi/kernels/squeeze_kernel.cc
@@ -38,8 +38,7 @@ template <typename T, typename Context>
 void SqueezeKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const IntArray& axes,
-                   DenseTensor* out,
-                   DenseTensor* xshape UNUSED) {
+                   DenseTensor* out) {
   SqueezeInferKernel<T, Context>(dev_ctx, x, axes, out);
 }
 

--- a/paddle/phi/kernels/squeeze_kernel.h
+++ b/paddle/phi/kernels/squeeze_kernel.h
@@ -31,8 +31,7 @@ template <typename T, typename Context>
 void SqueezeKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const IntArray& axes,
-                   DenseTensor* out,
-                   DenseTensor* xshape);
+                   DenseTensor* out);
 
 template <typename Context>
 void SqueezeInferStridedKernel(const Context& dev_ctx,
@@ -44,8 +43,7 @@ template <typename Context>
 void SqueezeStridedKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const IntArray& axes,
-                          DenseTensor* out,
-                          DenseTensor* xshape);
+                          DenseTensor* out);
 
 template <typename T, typename Context>
 void Squeeze(const Context& dev_ctx,

--- a/paddle/phi/kernels/stride/flatten_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/flatten_grad_kernel.cc
@@ -32,11 +32,8 @@ void FlattenGradStridedKernel(const Context& dev_ctx,
                            "be called, something wrong has happened!"));
   }
   const auto& x_dims = x.dims();
-  ReshapeStridedKernel<Context>(dev_ctx,
-                                out_grad,
-                                IntArray(common::vectorize<int64_t>(x_dims)),
-                                x_grad,
-                                nullptr);
+  ReshapeStridedKernel<Context>(
+      dev_ctx, out_grad, IntArray(common::vectorize<int64_t>(x_dims)), x_grad);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/stride/flatten_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/flatten_grad_kernel.cc
@@ -23,7 +23,7 @@ namespace phi {
 
 template <typename Context>
 void FlattenGradStridedKernel(const Context& dev_ctx,
-                              const DenseTensor& xshape,
+                              const DenseTensor& x,
                               const DenseTensor& out_grad,
                               DenseTensor* x_grad) {
   if (!FLAGS_use_stride_kernel) {
@@ -31,8 +31,7 @@ void FlattenGradStridedKernel(const Context& dev_ctx,
         phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
                            "be called, something wrong has happened!"));
   }
-  auto xshape_dims = xshape.dims();
-  auto x_dims = common::slice_ddim(xshape_dims, 1, xshape_dims.size());
+  const auto& x_dims = x.dims();
   ReshapeStridedKernel<Context>(dev_ctx,
                                 out_grad,
                                 IntArray(common::vectorize<int64_t>(x_dims)),

--- a/paddle/phi/kernels/stride/flatten_kernel.cc
+++ b/paddle/phi/kernels/stride/flatten_kernel.cc
@@ -26,19 +26,14 @@ void FlattenInferStridedKernel(const Context& dev_ctx,
                                const DenseTensor& x,
                                int start_axis UNUSED,
                                int stop_axis UNUSED,
-                               DenseTensor* out,
-                               DenseTensor* xshape) {
+                               DenseTensor* out) {
   if (!FLAGS_use_stride_kernel) {
     PADDLE_THROW(
         phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
                            "be called, something wrong has happened!"));
   }
   ReshapeStridedKernel<Context>(
-      dev_ctx,
-      x,
-      IntArray(common::vectorize<int64_t>(out->dims())),
-      out,
-      xshape);
+      dev_ctx, x, IntArray(common::vectorize<int64_t>(out->dims())), out);
 }
 
 template <typename Context>
@@ -46,15 +41,13 @@ void FlattenStridedKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           int start_axis,
                           int stop_axis,
-                          DenseTensor* out,
-                          DenseTensor* xshape) {
+                          DenseTensor* out) {
   if (!FLAGS_use_stride_kernel) {
     PADDLE_THROW(
         phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
                            "be called, something wrong has happened!"));
   }
-  FlattenInferStridedKernel<Context>(
-      dev_ctx, x, start_axis, stop_axis, out, xshape);
+  FlattenInferStridedKernel<Context>(dev_ctx, x, start_axis, stop_axis, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/stride/reshape_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/reshape_grad_kernel.cc
@@ -35,8 +35,7 @@ void ReshapeGradStridedKernel(const Context& dev_ctx,
       dev_ctx,
       out_grad,
       IntArray(common::vectorize<int64_t>(x_grad->dims())),
-      x_grad,
-      nullptr);
+      x_grad);
 }
 
 template <typename Context>

--- a/paddle/phi/kernels/stride/reshape_kernel.cc
+++ b/paddle/phi/kernels/stride/reshape_kernel.cc
@@ -27,8 +27,7 @@ template <typename Context>
 void ReshapeStridedKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const IntArray& shape,
-                          DenseTensor* out,
-                          DenseTensor* xshape) {
+                          DenseTensor* out) {
   if (!FLAGS_use_stride_kernel) {
     PADDLE_THROW(
         phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
@@ -37,9 +36,6 @@ void ReshapeStridedKernel(const Context& dev_ctx,
   DDim x_dims = x.dims();
   DDim x_stride = x.strides();
   size_t x_offset = x.offset();
-  if (xshape) {
-    x_dims = DDim(xshape->dims().Get() + 1, xshape->dims().size() - 1);
-  }
   MetaTensor meta_out(out);
   InferMetaFromVecValue(x, shape.GetData(), &meta_out);
 

--- a/paddle/phi/kernels/stride/squeeze_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/squeeze_grad_kernel.cc
@@ -23,7 +23,7 @@ namespace phi {
 
 template <typename Context>
 void SqueezeGradStridedKernel(const Context& dev_ctx,
-                              const DenseTensor& xshape,
+                              const DenseTensor& x,
                               const DenseTensor& dout,
                               const IntArray& axes UNUSED,
                               DenseTensor* dx) {
@@ -32,8 +32,7 @@ void SqueezeGradStridedKernel(const Context& dev_ctx,
         phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
                            "be called, something wrong has happened!"));
   }
-  const auto& xshape_dims = xshape.dims();
-  auto x_dims = common::slice_ddim(xshape_dims, 1, xshape_dims.size());
+  const auto& x_dims = x.dims();
   ReshapeStridedKernel<Context>(
       dev_ctx, dout, IntArray(common::vectorize<int64_t>(x_dims)), dx, nullptr);
 }

--- a/paddle/phi/kernels/stride/squeeze_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/squeeze_grad_kernel.cc
@@ -34,7 +34,7 @@ void SqueezeGradStridedKernel(const Context& dev_ctx,
   }
   const auto& x_dims = x.dims();
   ReshapeStridedKernel<Context>(
-      dev_ctx, dout, IntArray(common::vectorize<int64_t>(x_dims)), dx, nullptr);
+      dev_ctx, dout, IntArray(common::vectorize<int64_t>(x_dims)), dx);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/stride/squeeze_kernel.cc
+++ b/paddle/phi/kernels/stride/squeeze_kernel.cc
@@ -126,8 +126,7 @@ template <typename Context>
 void SqueezeStridedKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const IntArray& axes,
-                          DenseTensor* out,
-                          DenseTensor* xshape UNUSED) {
+                          DenseTensor* out) {
   if (!FLAGS_use_stride_kernel) {
     PADDLE_THROW(
         phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "

--- a/paddle/phi/kernels/stride/unsqueeze_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/unsqueeze_grad_kernel.cc
@@ -23,7 +23,7 @@ namespace phi {
 
 template <typename Context>
 void UnsqueezeGradStridedKernel(const Context& dev_ctx,
-                                const DenseTensor& x_shape,
+                                const DenseTensor& x,
                                 const DenseTensor& dout,
                                 DenseTensor* dx) {
   if (!FLAGS_use_stride_kernel) {
@@ -31,8 +31,7 @@ void UnsqueezeGradStridedKernel(const Context& dev_ctx,
         phi::errors::Fatal("FLAGS_use_stride_kernel is closed. Strided kernel "
                            "be called, something wrong has happened!"));
   }
-  const auto& xshape_dims = x_shape.dims();
-  auto x_dims = common::slice_ddim(xshape_dims, 1, xshape_dims.size());
+  const auto& x_dims = x.dims();
   ReshapeStridedKernel<Context>(
       dev_ctx, dout, IntArray(common::vectorize<int64_t>(x_dims)), dx, nullptr);
 }

--- a/paddle/phi/kernels/stride/unsqueeze_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/unsqueeze_grad_kernel.cc
@@ -33,7 +33,7 @@ void UnsqueezeGradStridedKernel(const Context& dev_ctx,
   }
   const auto& x_dims = x.dims();
   ReshapeStridedKernel<Context>(
-      dev_ctx, dout, IntArray(common::vectorize<int64_t>(x_dims)), dx, nullptr);
+      dev_ctx, dout, IntArray(common::vectorize<int64_t>(x_dims)), dx);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/stride/unsqueeze_kernel.cc
+++ b/paddle/phi/kernels/stride/unsqueeze_kernel.cc
@@ -87,8 +87,7 @@ template <typename Context>
 void UnsqueezeStridedKernel(const Context& dev_ctx,
                             const DenseTensor& x,
                             const IntArray& axes,
-                            DenseTensor* out,
-                            DenseTensor* xshape) {
+                            DenseTensor* out) {
   UnsqueezeInferStridedKernel<Context>(dev_ctx, x, axes, out);
 }
 

--- a/paddle/phi/kernels/unsqueeze_grad_kernel.cc
+++ b/paddle/phi/kernels/unsqueeze_grad_kernel.cc
@@ -22,11 +22,10 @@
 namespace phi {
 template <typename T, typename Context>
 void UnsqueezeGradKernel(const Context& dev_ctx,
-                         const DenseTensor& x_shape,
+                         const DenseTensor& x,
                          const DenseTensor& dout,
                          DenseTensor* dx) {
-  auto xshape_dims = x_shape.dims();
-  auto x_dims = common::slice_ddim(xshape_dims, 1, xshape_dims.size());
+  const auto& x_dims = x.dims();
   dev_ctx.template Alloc<T>(dx);
   phi::Copy(dev_ctx, dout, dev_ctx.GetPlace(), true, dx);
   dx->Resize(x_dims);

--- a/paddle/phi/kernels/unsqueeze_grad_kernel.h
+++ b/paddle/phi/kernels/unsqueeze_grad_kernel.h
@@ -21,13 +21,13 @@ namespace phi {
 
 template <typename T, typename Context>
 void UnsqueezeGradKernel(const Context& dev_ctx,
-                         const DenseTensor& x_shape,
+                         const DenseTensor& x,
                          const DenseTensor& dout,
                          DenseTensor* dx);
 
 template <typename Context>
 void UnsqueezeGradStridedKernel(const Context& dev_ctx,
-                                const DenseTensor& x_shape,
+                                const DenseTensor& x,
                                 const DenseTensor& dout,
                                 DenseTensor* dx);
 }  // namespace phi

--- a/paddle/phi/kernels/unsqueeze_kernel.cc
+++ b/paddle/phi/kernels/unsqueeze_kernel.cc
@@ -43,8 +43,7 @@ template <typename T, typename Context>
 void UnsqueezeKernel(const Context& dev_ctx,
                      const DenseTensor& x,
                      const IntArray& axes,
-                     DenseTensor* out,
-                     DenseTensor* xshape UNUSED) {
+                     DenseTensor* out) {
   UnsqueezeInferKernel<T, Context>(dev_ctx, x, axes, out);
 }
 }  // namespace phi

--- a/paddle/phi/kernels/unsqueeze_kernel.h
+++ b/paddle/phi/kernels/unsqueeze_kernel.h
@@ -31,8 +31,7 @@ template <typename T, typename Context>
 void UnsqueezeKernel(const Context& dev_ctx,
                      const DenseTensor& x,
                      const IntArray& axes,
-                     DenseTensor* out,
-                     DenseTensor* xshape);
+                     DenseTensor* out);
 
 template <typename Context>
 void UnsqueezeInferStridedKernel(const Context& dev_ctx,
@@ -44,15 +43,13 @@ template <typename Context>
 void UnsqueezeStridedKernel(const Context& dev_ctx,
                             const DenseTensor& x,
                             const IntArray& axes,
-                            DenseTensor* out,
-                            DenseTensor* xshape);
+                            DenseTensor* out);
 
 template <typename T, typename Context>
 void Unsqueeze(const Context& dev_ctx,
                const DenseTensor& x,
                const IntArray& axes,
-               DenseTensor* out,
-               DenseTensor* xshape UNUSED) {
+               DenseTensor* out) {
   MetaTensor meta_out(out);
   UnsqueezeInferMeta(x, axes, &meta_out);
   UnsqueezeInferKernel<T, Context>(dev_ctx, x, axes, out);

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -1107,16 +1107,17 @@
     data_type: q
 
 - backward_op : flatten_grad
-  forward : flatten(Tensor x, int start_axis = 1, int stop_axis = 1) -> Tensor(out), Tensor(xshape)
-  args : (Tensor xshape, Tensor out_grad)
+  forward : flatten(Tensor x, int start_axis = 1, int stop_axis = 1) -> Tensor(out)
+  args : (Tensor x, Tensor out_grad)
   output : Tensor(x_grad)
   infer_meta :
-    func :  KernelWithXShapeInferMeta
-    param : [xshape, out_grad]
+    func :  SameWithXInferMeta
+    param : [x, out_grad]
     spmd_rule : FlattenGradInferSpmd
   kernel :
     func : flatten_grad
     data_type : out_grad
+  no_need_buffer : x
   inplace : (out_grad -> x_grad)
 
 - backward_op : flip_grad
@@ -3078,23 +3079,24 @@
     func : squared_l2_norm_grad
 
 - backward_op : squeeze_double_grad
-  forward : squeeze_grad(Tensor xshape, Tensor grad_out, IntArray axis) -> Tensor(grad_x)
+  forward : squeeze_grad(Tensor x, Tensor grad_out, IntArray axis) -> Tensor(grad_x)
   args : (Tensor grad_x_grad, IntArray axis)
-  output : Tensor(grad_out_grad), Tensor(xshape)
+  output : Tensor(grad_out_grad)
   invoke: squeeze(grad_x_grad, axis)
-  intermediate : xshape
 
 - backward_op : squeeze_grad
-  forward : squeeze(Tensor x, IntArray axis) -> Tensor(out), Tensor(xshape)
-  args : (Tensor xshape, Tensor out_grad, IntArray axis)
+  forward : squeeze(Tensor x, IntArray axis) -> Tensor(out)
+  args : (Tensor x, Tensor out_grad, IntArray axis)
   output : Tensor(x_grad)
   infer_meta :
-    func : KernelWithXShapeInferMeta
-    param: [xshape, out_grad]
+    func : SameWithXInferMeta
+    param: [x, out_grad]
     spmd_rule : SqueezeGradInferSpmd
   kernel :
     func : squeeze_grad
+    param: [x, out_grad]
     data_type : out_grad
+  no_need_buffer : x
   inplace : (out_grad -> x_grad)
   backward: squeeze_double_grad
 
@@ -3448,24 +3450,24 @@
   inplace : (out_grad -> x_grad)
 
 - backward_op : unsqueeze_double_grad
-  forward : unsqueeze_grad(Tensor xshape, Tensor grad_out, IntArray axis) -> Tensor(grad_x)
+  forward : unsqueeze_grad(Tensor x, Tensor grad_out, IntArray axis) -> Tensor(grad_x)
   args : (Tensor grad_x_grad, IntArray axis)
-  output : Tensor(grad_out_grad), Tensor(xshape)
+  output : Tensor(grad_out_grad)
   invoke : unsqueeze(grad_x_grad, axis)
-  intermediate : xshape
 
 - backward_op : unsqueeze_grad
-  forward : unsqueeze(Tensor x, IntArray axis) -> Tensor(out), Tensor(xshape)
-  args : (Tensor xshape, Tensor out_grad, IntArray axis)
+  forward : unsqueeze(Tensor x, IntArray axis) -> Tensor(out)
+  args : (Tensor x, Tensor out_grad, IntArray axis)
   output : Tensor(x_grad)
   infer_meta :
-    func : KernelWithXShapeInferMeta
-    param: [xshape, out_grad]
+    func : SameWithXInferMeta
+    param: [x, out_grad]
     spmd_rule : UnsqueezeGradInferSpmd
   kernel :
     func : unsqueeze_grad
-    param : [xshape, out_grad]
+    param : [x, out_grad]
     data_type : out_grad
+  no_need_buffer : x
   inplace : (out_grad -> x_grad)
   backward : unsqueeze_double_grad
 

--- a/paddle/phi/ops/yaml/inconsistent/dygraph_backward.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/dygraph_backward.yaml
@@ -267,7 +267,7 @@
   optional : fwd_grad_grad_x, fwd_grad_grad_y, grad_x_grad, grad_y_grad, grad_grad_out_grad
 
 - backward_op : reshape_double_grad
-  forward : reshape_grad (Tensor xshape, Tensor grad_out) -> Tensor(grad_x)
+  forward : reshape_grad (Tensor x, Tensor grad_out) -> Tensor(grad_x)
   args : (Tensor grad_out, Tensor grad_x_grad)
   output : Tensor(grad_out_grad)
   infer_meta :
@@ -279,12 +279,12 @@
   inplace : (grad_x_grad -> grad_out_grad)
 
 - backward_op : reshape_grad
-  forward : reshape (Tensor x, IntArray shape) -> Tensor(out), Tensor(xshape)
-  args : (Tensor xshape, Tensor out_grad)
+  forward : reshape (Tensor x, IntArray shape) -> Tensor(out)
+  args : (Tensor x, Tensor out_grad)
   output : Tensor(x_grad)
   infer_meta :
-    func : KernelWithXShapeInferMeta
-    param : [xshape, out_grad]
+    func : ReshapeGradInferMeta
+    param : [x, out_grad]
     spmd_rule: ReshapeGradInferSpmd
   kernel :
     func : reshape_grad
@@ -292,6 +292,7 @@
     data_type: out_grad
     backend: out_grad
     layout: out_grad
+  no_need_buffer : x
   backward : reshape_double_grad
   inplace : (out_grad -> x_grad)
 

--- a/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
@@ -294,9 +294,9 @@
 
 - op : reshape
   args : (Tensor x, IntArray shape)
-  output : Tensor(out), Tensor(xshape)
+  output : Tensor(out)
   infer_meta :
-    func : ReshapeWithXShapeInferMeta
+    func : ReshapeInferMeta
     spmd_rule : ReshapeInferSpmdDynamic
     local_shape: shape
     global_shape: out
@@ -304,7 +304,6 @@
     func : reshape
   inplace : (x -> out)
   view: (x -> out)
-  intermediate : xshape
   backward: reshape_grad
 
 - op : set_value

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -1854,16 +1854,15 @@
 
 - op : flatten
   args : (Tensor x, int start_axis = 1, int stop_axis = 1)
-  output : Tensor(out), Tensor(xshape)
+  output : Tensor(out)
   infer_meta :
-    func : FlattenWithXShapeInferMeta
+    func : FlattenInferMeta
     spmd_rule : FlattenInferSpmd
   kernel :
     func : flatten
     data_type : x
   inplace : (x -> out)
   view : (x -> out)
-  intermediate : xshape
   backward : flatten_grad
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
@@ -4313,16 +4312,15 @@
 
 - op : squeeze
   args : (Tensor x, IntArray axis={})
-  output : Tensor(out), Tensor(xshape)
+  output : Tensor(out)
   infer_meta :
-    func : SqueezeWithXShapeInferMeta
+    func : SqueezeInferMeta
     spmd_rule : SqueezeInferSpmd
   kernel :
     func : squeeze
     data_type : x
   inplace : (x -> out)
   view: (x -> out)
-  intermediate : xshape
   backward : squeeze_grad
   interfaces : paddle::dialect::InferSymbolicShapeInterface, paddle::dialect::LayoutTransformationInterface
 
@@ -4766,16 +4764,15 @@
 
 - op : unsqueeze
   args : (Tensor x, IntArray axis = {})
-  output : Tensor(out), Tensor(xshape)
+  output : Tensor(out)
   infer_meta :
-    func : UnsqueezeWithXShapeInferMeta
+    func : UnsqueezeInferMeta
     spmd_rule : UnsqueezeInferSpmd
   kernel :
     func : unsqueeze
     data_type : x
   inplace : (x -> out)
   view: (x -> out)
-  intermediate : xshape
   backward : unsqueeze_grad
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
BC Breaking

### Description
<!-- Describe what you’ve done -->

Pcard-67164
