### PR TITLE
Vlog >= 3 triggers ElementWiseAAddCooGPUKernel input indices check

### DIFF
--- a/paddle/phi/kernels/sparse/gpu/elementwise_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/elementwise_kernel.cu
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
-
+#include <glog/logging.h>
 #include <thrust/equal.h>
 #include <thrust/execution_policy.h>
 
@@ -41,20 +41,22 @@ void ElementWiseAddCooGPUKernel(const GPUContext& dev_ctx,
           "The numel of x.indices() and y.indices() should be equal"));
   const IntT* x_indices_ptr = x_indices.data<IntT>();
   const IntT* y_indices_ptr = y_indices.data<IntT>();
+  if (VLOG_IS_ON(3)) {
 #ifdef PADDLE_WITH_HIP
-  bool is_same = thrust::equal(thrust::hip::par.on(dev_ctx.stream()),
+    bool is_same = thrust::equal(thrust::hip::par.on(dev_ctx.stream()),
 #else
-  bool is_same = thrust::equal(thrust::cuda::par.on(dev_ctx.stream()),
+    bool is_same = thrust::equal(thrust::cuda::par.on(dev_ctx.stream()),
 #endif
-                               x_indices_ptr,
-                               x_indices_ptr + x_indices.numel(),
-                               y_indices_ptr);
-  PADDLE_ENFORCE_EQ(
-      is_same,
-      true,
-      phi::errors::PreconditionNotMet(
-          "Currently, ElementWiseAddCooKernel only supports the case "
-          "where x and y have the same indices"));
+                                 x_indices_ptr,
+                                 x_indices_ptr + x_indices.numel(),
+                                 y_indices_ptr);
+    PADDLE_ENFORCE_EQ(
+        is_same,
+        true,
+        phi::errors::PreconditionNotMet(
+            "Currently, ElementWiseAddCooKernel only supports the case "
+            "where x and y have the same indices"));
+  }
   EmptyLikeCooKernel<T, GPUContext>(dev_ctx, x, out);
   phi::AddKernel<T, GPUContext>(
       dev_ctx, x.values(), y.values(), out->mutable_values());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Pcard-71500
ElementWiseAddCooGPUKernel利用thrust::equal方法保证输入的indices相同，thrust::equal内部的GPU利用率较低。
默认输入indices相同，在vlog大于等于3时才会进行校对。