### PR TITLE
[CINN] Run the program with shape_optimation_pass during symbolic inference check

### DIFF
--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -1413,7 +1413,7 @@ class OpTest(unittest.TestCase):
                         raise ValueError(
                             "output of python api should be Value or list of Value or tuple of Value"
                         )
-
+                    
                 # executor run
                 executor = Executor(place)
                 outs = executor.run(
@@ -1704,7 +1704,11 @@ class OpTest(unittest.TestCase):
                         raise ValueError(
                             "output of python api should be Value or list of Value or tuple of Value"
                         )
-
+                    
+                # run the program with shape_optimation_pass
+                pm = paddle.base.pir.PassManager()
+                paddle.base.libpaddle.pir.infer_symbolic_shape_pass(pm, program)
+                
                 # executor run
                 executor = Executor(place)
                 outs = executor.run(program, feed=feed, fetch_list=[fetch_list])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164
在执行器执行和符号推导检查前手动执行 shape_optimation_pass pass