### PR TITLE
[Typing][PEP585 Upgrade][130,261] Use standard collections for type hints in `python/paddle/vision/ops.py` and `tools/sampcd_processor.py`

### DIFF
--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Literal, Sequence, overload
+from typing import TYPE_CHECKING, Callable, Literal, overload
 
 import numpy as np
 
@@ -38,6 +38,8 @@ from ..nn import BatchNorm2D, Conv2D, Layer, ReLU, Sequential
 from ..nn.initializer import Normal
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor, nn
     from paddle._typing import ParamAttrLike, Size2, Size4
     from paddle.nn.functional.common import _PaddingSizeMode
@@ -1097,6 +1099,7 @@ class DeformConv2D(Layer):
             >>> print(out.shape)
             [8, 16, 26, 26]
     """
+
     weight: Tensor
     bias: Tensor
 

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -22,6 +22,8 @@ for example, you can run cpu version testing like this:
 
 """
 
+from __future__ import annotations
+
 import collections
 import functools
 import multiprocessing
@@ -176,7 +178,7 @@ class Directive:
 
     pattern: typing.Pattern
 
-    def parse_directive(self, docstring: str) -> typing.Tuple[str, typing.Any]:
+    def parse_directive(self, docstring: str) -> tuple[str, typing.Any]:
         pass
 
 
@@ -345,14 +347,12 @@ class DeprecatedRequired(BadStatement):
 class Xdoctester(DocTester):
     """A Xdoctest doctester."""
 
-    directives: typing.Dict[str, typing.Tuple[typing.Type[Directive], ...]] = {
+    directives: dict[str, tuple[type[Directive], ...]] = {
         'timeout': (TimeoutDirective, TEST_TIMEOUT),
         'solo': (SingleProcessDirective,),
     }
 
-    bad_statements: typing.Dict[
-        str, typing.Tuple[typing.Type[BadStatement], ...]
-    ] = {
+    bad_statements: dict[str, tuple[type[BadStatement], ...]] = {
         'fluid': (Fluid,),
         'skip': (SkipNoReason,),
         'require': (DeprecatedRequired,),
@@ -415,7 +415,7 @@ class Xdoctester(DocTester):
 
     def _parse_directive(
         self, docstring: str
-    ) -> typing.Tuple[str, typing.Dict[str, Directive]]:
+    ) -> tuple[str, dict[str, Directive]]:
         directives = {}
         for name, directive_cls in self.directives.items():
             docstring, direct = directive_cls[0](
@@ -462,7 +462,7 @@ class Xdoctester(DocTester):
 
         self._test_capacity = test_capacity
 
-    def _check_bad_statements(self, docstring: str) -> typing.Set[BadStatement]:
+    def _check_bad_statements(self, docstring: str) -> set[BadStatement]:
         bad_results = set()
         for _, statement_cls in self.bad_statements.items():
             bad_statement = statement_cls[0](*statement_cls[1:])
@@ -471,7 +471,7 @@ class Xdoctester(DocTester):
 
         return bad_results
 
-    def run(self, api_name: str, docstring: str) -> typing.List[TestResult]:
+    def run(self, api_name: str, docstring: str) -> list[TestResult]:
         """Run the xdoctest with a docstring."""
         # check bad statements
         bad_results = self._check_bad_statements(docstring)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

为如下文件添加 PEP 563，并进行 PEP 585 升级：

- python/paddle/vision/ops.py
- tools/sampcd_processor.py

### Related links

- #66936

@gouzil

PCard-66972