### PR TITLE
fix the unit test: test_semi_auto_llama_acc_align

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1566,7 +1566,7 @@ void BindInsertionPoint(pybind11::module *m) {
                   "The insertion point is already at the begin and can't call "
                   "prev()."));
             }
-            return *(self.value.second--);
+            return *(--self.value.second);
           },
           return_value_policy::reference)
       .def(

--- a/paddle/phi/infermeta/spmd_rules/reshape.cc
+++ b/paddle/phi/infermeta/spmd_rules/reshape.cc
@@ -350,11 +350,11 @@ SpmdInfo ReshapeGradInferSpmd(const DistMetaTensor& x_shape,
   return {{out_grad_dist_dst}, {x_shape_dist_dst}};
 }
 
-SpmdInfo StaticReshapeGradInferSpmd(const DistMetaTensor& x_shape,
+SpmdInfo StaticReshapeGradInferSpmd(const DistMetaTensor& x,
                                     const DistMetaTensor& out_grad) {
-  auto spmd_info = ReshapeGradInferSpmd(x_shape, out_grad);
-  spmd_info.first.insert(spmd_info.first.begin(), x_shape.dist_attr());
-  return spmd_info;
+  std::vector<int64_t> out_grad_shape = common::vectorize(out_grad.dims());
+  auto tmp = ReshapeInferSpmd(x, out_grad_shape);
+  return {{tmp.first[0], tmp.second[0]}, {tmp.first[0]}};
 }
 
 }  // namespace phi::distributed

--- a/paddle/phi/infermeta/spmd_rules/reshape.h
+++ b/paddle/phi/infermeta/spmd_rules/reshape.h
@@ -35,7 +35,7 @@ SpmdInfo ReshapeInferSpmdDynamic(const DistMetaTensor& x,
 SpmdInfo ReshapeGradInferSpmd(const DistMetaTensor& x_shape,
                               const DistMetaTensor& out_grad);
 
-SpmdInfo StaticReshapeGradInferSpmd(const DistMetaTensor& x_shape,
+SpmdInfo StaticReshapeGradInferSpmd(const DistMetaTensor& x,
                                     const DistMetaTensor& out_grad);
 
 }  // namespace distributed

--- a/paddle/phi/ops/yaml/inconsistent/static_backward.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_backward.yaml
@@ -383,7 +383,7 @@
   infer_meta :
     func : ReshapeGradInferMeta
     param : [x, out_grad]
-    spmd_rule: ReshapeGradInferSpmd
+    spmd_rule: StaticReshapeGradInferSpmd
   kernel :
     func : reshape_grad
     param : [out_grad]

--- a/python/paddle/distributed/auto_parallel/static/pir_pass.py
+++ b/python/paddle/distributed/auto_parallel/static/pir_pass.py
@@ -233,6 +233,8 @@ def _remove_other_rank_params_grads(dist_params_grads):
     cur_rank = paddle.distributed.get_rank()
     need_remove_idx = []
     for idx, (_, grad) in enumerate(dist_params_grads):
+        if grad is None:
+            continue
         if cur_rank not in grad.dist_attr().process_mesh.process_ids:
             need_remove_idx.append(idx)
     for idx in need_remove_idx[::-1]:

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/s_to_r_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/s_to_r_reshard_func.py
@@ -14,7 +14,6 @@
 
 
 import paddle
-from paddle.distributed.passes.pass_utils import AutoParallelStreamType
 
 from ..process_group import new_process_group
 from .base_reshard_func import ReshardFunction, is_replicated, is_shard
@@ -146,9 +145,6 @@ class SToRReshardFunction(ReshardFunction):
             paddle.base.libpaddle.pir.create_op_dist_attribute(
                 src_mesh, [src_dist_attr], [new_dist_attr]
             )
-        )
-        allgather_value.get_defining_op().set_execution_stream(
-            AutoParallelStreamType.CALC_STREAM.value
         )
 
         if split_axis != 0 or padding_num != 0:

--- a/test/auto_parallel/hybrid_strategy/test_semi_auto_llama_acc_align.py
+++ b/test/auto_parallel/hybrid_strategy/test_semi_auto_llama_acc_align.py
@@ -27,6 +27,7 @@ class TestSemiAutoParallelLlamaACCTest(test_base.CommunicationTestDistBase):
             "acc_step": "1",
             "FLAGS_embedding_deterministic": "1",
             "FLAGS_cudnn_deterministic": "1",
+            "FLAGS_enable_pir_api": "1",
         }
         self._changeable_envs = {
             "backend": ["gpu"],


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes
### Description
<!-- Describe what you’ve done -->

- set “FLAGS_enable_pir_api=1” in test_semi_auto_llama_acc_align.py， and it will. take effect in PR-CI-Auto-Parallel.
- fix inferspmd function error for reshape_grad.
- remove the "execution_stream" attribute  of all_gather op, which will lead to the communication group's mistake in executor.
- fix the insert_point's prev funciton. which will cause segment fault while set op_role for the last op in the block.

### Other

Pcard-67164