### PR TITLE
[Typing][PEP585 Upgrade][1] Use standard collections for type hints in `paddle/fluid/ir_adaptor/translator/op_compat_gen.py`

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
+++ b/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import argparse
 from pathlib import Path
-from typing import Dict, List, Set
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
@@ -48,10 +49,10 @@ def OpNameNormalizerInitialization(
 
     with open(op_compat_yaml_file, "r") as f:
         op_compat_infos = yaml.safe_load(f)
-    op_name_mappings: Dict[str, str] = {}
-    op_arg_name_mappings: Dict[str, Dict[str, str]] = {}
-    op_mutable_attributes: Dict[str, Set[str]] = {}
-    op_mutable_attribute_infos: Dict[str, Dict[str, List[str]]] = {}
+    op_name_mappings: dict[str, str] = {}
+    op_arg_name_mappings: dict[str, dict[str, str]] = {}
+    op_mutable_attributes: dict[str, set[str]] = {}
+    op_mutable_attribute_infos: dict[str, dict[str, list[str]]] = {}
 
     for op_compat_item in op_compat_infos:
 
@@ -62,7 +63,7 @@ def OpNameNormalizerInitialization(
             op_name_mappings[legacy_name] = normalized_name
             return normalized_name, legacy_name
 
-        def insert_new_arg_mappings(op_name: str, arg_mapping: Dict[str, str]):
+        def insert_new_arg_mappings(op_name: str, arg_mapping: dict[str, str]):
             if op_name is None:
                 return
             if op_name not in op_arg_name_mappings:
@@ -70,7 +71,7 @@ def OpNameNormalizerInitialization(
             op_arg_name_mappings[op_name].update(arg_mapping)
 
         def insert_new_mutable_attributes(
-            op_name: str, mutable_attribute_infos: Dict[str, Dict[str, str]]
+            op_name: str, mutable_attribute_infos: dict[str, dict[str, str]]
         ):
             if op_name not in op_mutable_attributes:
                 op_mutable_attributes[op_name] = set()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
- https://github.com/PaddlePaddle/Paddle/issues/66936
No.1 paddle/fluid/ir_adaptor/translator/op_compat_gen.py
