### PR TITLE
[Typing][PEP585 Upgrade][BUAA][202-206] Use standard collections for type hints for 5 uts in `test/ir/inference/`

### DIFF
--- a/test/ir/inference/test_trt_convert_one_hot.py
+++ b/test/ir/inference/test_trt_convert_one_hot.py
@@ -84,7 +84,7 @@ class TrtConvertOneHotTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_one_hot.py
+++ b/test/ir/inference/test_trt_convert_one_hot.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -83,7 +84,7 @@ class TrtConvertOneHotTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_p_norm.py
+++ b/test/ir/inference/test_trt_convert_p_norm.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import typing
 import unittest
 from functools import partial
 
@@ -26,7 +27,7 @@ import paddle.inference as paddle_infer
 
 class TrtConvertPNormTest(TrtLayerAutoScanTest):
     def sample_program_configs(self):
-        def generate_input1(dims, attrs: list[dict[str, any]]):
+        def generate_input1(dims, attrs: list[dict[str, typing.Any]]):
             if dims == 1:
                 return np.ones([3]).astype(np.float32)
             elif dims == 2:
@@ -82,7 +83,7 @@ class TrtConvertPNormTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}

--- a/test/ir/inference/test_trt_convert_p_norm.py
+++ b/test/ir/inference/test_trt_convert_p_norm.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import unittest
 from functools import partial
 
-# from typing import Any, Dict, List
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
 from trt_layer_auto_scan_test import TrtLayerAutoScanTest

--- a/test/ir/inference/test_trt_convert_p_norm.py
+++ b/test/ir/inference/test_trt_convert_p_norm.py
@@ -14,9 +14,9 @@
 
 from __future__ import annotations
 
-import typing
 import unittest
 from functools import partial
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -27,7 +27,7 @@ import paddle.inference as paddle_infer
 
 class TrtConvertPNormTest(TrtLayerAutoScanTest):
     def sample_program_configs(self):
-        def generate_input1(dims, attrs: list[dict[str, typing.Any]]):
+        def generate_input1(dims, attrs: list[dict[str, Any]]):
             if dims == 1:
                 return np.ones([3]).astype(np.float32)
             elif dims == 2:

--- a/test/ir/inference/test_trt_convert_p_norm.py
+++ b/test/ir/inference/test_trt_convert_p_norm.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
 
+# from typing import Any, Dict, List
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
 from trt_layer_auto_scan_test import TrtLayerAutoScanTest
@@ -25,7 +27,7 @@ import paddle.inference as paddle_infer
 
 class TrtConvertPNormTest(TrtLayerAutoScanTest):
     def sample_program_configs(self):
-        def generate_input1(dims, attrs: List[Dict[str, Any]]):
+        def generate_input1(dims, attrs: list[dict[str, any]]):
             if dims == 1:
                 return np.ones([3]).astype(np.float32)
             elif dims == 2:
@@ -81,7 +83,7 @@ class TrtConvertPNormTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}

--- a/test/ir/inference/test_trt_convert_pad.py
+++ b/test/ir/inference/test_trt_convert_pad.py
@@ -14,9 +14,9 @@
 
 from __future__ import annotations
 
-import typing
 import unittest
 from functools import partial
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -42,10 +42,10 @@ class TrtConvertPadTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: list[dict[str, typing.Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             return np.ones([1, 3, 64, 64]).astype(np.float32)
 
-        def generate_weight1(attrs: list[dict[str, typing.Any]]):
+        def generate_weight1(attrs: list[dict[str, Any]]):
             return np.random.random([24, 3, 3, 3]).astype(np.float32)
 
         for pad_value in [0.0, 1.0, 2.0, -100, 100.0]:

--- a/test/ir/inference/test_trt_convert_pad.py
+++ b/test/ir/inference/test_trt_convert_pad.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import typing
 import unittest
 from functools import partial
 
@@ -41,10 +42,10 @@ class TrtConvertPadTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: list[dict[str, any]]):
+        def generate_input1(attrs: list[dict[str, typing.Any]]):
             return np.ones([1, 3, 64, 64]).astype(np.float32)
 
-        def generate_weight1(attrs: list[dict[str, any]]):
+        def generate_weight1(attrs: list[dict[str, typing.Any]]):
             return np.random.random([24, 3, 3, 3]).astype(np.float32)
 
         for pad_value in [0.0, 1.0, 2.0, -100, 100.0]:
@@ -81,7 +82,7 @@ class TrtConvertPadTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 3, 64, 64]}

--- a/test/ir/inference/test_trt_convert_pad.py
+++ b/test/ir/inference/test_trt_convert_pad.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -40,10 +41,10 @@ class TrtConvertPadTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, any]]):
             return np.ones([1, 3, 64, 64]).astype(np.float32)
 
-        def generate_weight1(attrs: List[Dict[str, Any]]):
+        def generate_weight1(attrs: list[dict[str, any]]):
             return np.random.random([24, 3, 3, 3]).astype(np.float32)
 
         for pad_value in [0.0, 1.0, 2.0, -100, 100.0]:
@@ -80,7 +81,7 @@ class TrtConvertPadTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 3, 64, 64]}

--- a/test/ir/inference/test_trt_convert_pad3d.py
+++ b/test/ir/inference/test_trt_convert_pad3d.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -93,7 +94,7 @@ class TrtConvertPad3dTensorPadding(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [6, 6, 6, 64, 64],
@@ -207,7 +208,7 @@ class TrtConvertPad3dListPadding(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [6, 6, 6, 64, 64],

--- a/test/ir/inference/test_trt_convert_pad3d.py
+++ b/test/ir/inference/test_trt_convert_pad3d.py
@@ -94,7 +94,7 @@ class TrtConvertPad3dTensorPadding(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [6, 6, 6, 64, 64],
@@ -208,7 +208,7 @@ class TrtConvertPad3dListPadding(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [6, 6, 6, 64, 64],

--- a/test/ir/inference/test_trt_convert_pool2d.py
+++ b/test/ir/inference/test_trt_convert_pool2d.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import copy
 import itertools
 import unittest
 from functools import partial
-from typing import Any, Dict, List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -49,10 +50,10 @@ class TrtConvertPool2dTest(TrtLayerAutoScanTest):
     def sample_program_configs(self):
         self.trt_param.workspace_size = 1073741824
 
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, any]]):
             return np.ones([1, 3, 64, 64]).astype(np.float32)
 
-        def generate_weight1(attrs: List[Dict[str, Any]]):
+        def generate_weight1(attrs: list[dict[str, any]]):
             return np.random.random([24, 3, 3, 3]).astype(np.float32)
 
         strides_options = [[1, 2]]
@@ -132,7 +133,7 @@ class TrtConvertPool2dTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [1, 3, 64, 64]}
@@ -194,8 +195,8 @@ class TrtConvertPool2dTest(TrtLayerAutoScanTest):
         self,
         atol: float,
         rtol: float,
-        tensor: Dict[str, np.array],
-        baseline: Dict[str, np.array],
+        tensor: dict[str, np.array],
+        baseline: dict[str, np.array],
     ):
         for key, arr in tensor.items():
             self.assertEqual(

--- a/test/ir/inference/test_trt_convert_pool2d.py
+++ b/test/ir/inference/test_trt_convert_pool2d.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import copy
 import itertools
+import typing
 import unittest
 from functools import partial
 
@@ -50,10 +51,10 @@ class TrtConvertPool2dTest(TrtLayerAutoScanTest):
     def sample_program_configs(self):
         self.trt_param.workspace_size = 1073741824
 
-        def generate_input1(attrs: list[dict[str, any]]):
+        def generate_input1(attrs: list[dict[str, typing.Any]]):
             return np.ones([1, 3, 64, 64]).astype(np.float32)
 
-        def generate_weight1(attrs: list[dict[str, any]]):
+        def generate_weight1(attrs: list[dict[str, typing.Any]]):
             return np.random.random([24, 3, 3, 3]).astype(np.float32)
 
         strides_options = [[1, 2]]
@@ -133,7 +134,7 @@ class TrtConvertPool2dTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [1, 3, 64, 64]}

--- a/test/ir/inference/test_trt_convert_pool2d.py
+++ b/test/ir/inference/test_trt_convert_pool2d.py
@@ -16,9 +16,9 @@ from __future__ import annotations
 
 import copy
 import itertools
-import typing
 import unittest
 from functools import partial
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -51,10 +51,10 @@ class TrtConvertPool2dTest(TrtLayerAutoScanTest):
     def sample_program_configs(self):
         self.trt_param.workspace_size = 1073741824
 
-        def generate_input1(attrs: list[dict[str, typing.Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             return np.ones([1, 3, 64, 64]).astype(np.float32)
 
-        def generate_weight1(attrs: list[dict[str, typing.Any]]):
+        def generate_weight1(attrs: list[dict[str, Any]]):
             return np.random.random([24, 3, 3, 3]).astype(np.float32)
 
         strides_options = [[1, 2]]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs


### Description
<!-- Describe what you’ve done --> 

为如下文件添加 PEP 563，并进行 PEP 585 升级。

- ``test_trt_convert_one_hot.py``
- ``test_trt_convert_p_norm.py``
- ``test_trt_convert_pad.py``
- ``test_trt_convert_pad3d.py``
- ``test_trt_convert_pool2d.py``

### Related links
- #66936

@gouzil 
