### PR TITLE
[third_party][glog] update glog v0.4.0 to v0.7.1

### DIFF
--- a/cmake/external/glog.cmake
+++ b/cmake/external/glog.cmake
@@ -21,12 +21,19 @@ set(GLOG_INCLUDE_DIR
     CACHE PATH "glog include directory." FORCE)
 set(GLOG_TAG v0.4.0)
 set(SOURCE_DIR ${PADDLE_SOURCE_DIR}/third_party/glog)
+add_definitions(-DGLOG_USE_GLOG_EXPORT)
 if(WIN32)
   set(GLOG_LIBRARIES
       "${GLOG_INSTALL_DIR}/lib/glog.lib"
       CACHE FILEPATH "glog library." FORCE)
   set(GLOG_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267 /wd4530")
   add_definitions("/DGOOGLE_GLOG_DLL_DECL=")
+elseif(APPLE)
+  set(GLOG_LIBRARIES
+      "${GLOG_INSTALL_DIR}/lib/libglog.dylib"
+      CACHE FILEPATH "glog library." FORCE)
+  set(GLOG_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  link_directories(${GLOG_INSTALL_DIR}/lib)
 else()
   set(GLOG_LIBRARIES
       "${GLOG_INSTALL_DIR}/lib/libglog.a"

--- a/cmake/external/glog.cmake
+++ b/cmake/external/glog.cmake
@@ -19,14 +19,13 @@ set(GLOG_INSTALL_DIR ${THIRD_PARTY_PATH}/install/glog)
 set(GLOG_INCLUDE_DIR
     "${GLOG_INSTALL_DIR}/include"
     CACHE PATH "glog include directory." FORCE)
-set(GLOG_TAG v0.4.0)
 set(SOURCE_DIR ${PADDLE_SOURCE_DIR}/third_party/glog)
 add_definitions(-DGLOG_USE_GLOG_EXPORT)
 if(WIN32)
   set(GLOG_LIBRARIES
       "${GLOG_INSTALL_DIR}/lib/glog.lib"
       CACHE FILEPATH "glog library." FORCE)
-  set(GLOG_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267 /wd4530")
+  set(GLOG_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   add_definitions("/DGOOGLE_GLOG_DLL_DECL=")
 elseif(APPLE)
   set(GLOG_LIBRARIES

--- a/paddle/fluid/framework/fleet/heter_ps/log_patch.h
+++ b/paddle/fluid/framework/fleet/heter_ps/log_patch.h
@@ -28,7 +28,9 @@ limitations under the License. */
 #undef LOG_IF
 #define LOG_IF(severity, condition) \
   static_cast<void>(0),             \
-      !(condition) ? (void)0 : google::LogMessageVoidify() & LOG(severity)
+      !(condition)                  \
+          ? (void)0                 \
+          : google::logging::internal::LogMessageVoidify() & LOG(severity)
 
 #undef VLOG
 #define VLOG(verboselevel) LOG_IF(INFO, VLOG_IS_ON(verboselevel))

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -289,7 +289,7 @@ const char *ParseSignalErrorString(const std::string &str) {
 }
 
 // Handle SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGBUS, and SIGTERM.
-void SignalHandle(const char *data, int size) {
+void SignalHandle(const char *data, size_t size) {
   try {
     // NOTE1: The glog FailureSignalHandler dumped messages
     //   are deal with line by line

--- a/paddle/fluid/platform/init.h
+++ b/paddle/fluid/platform/init.h
@@ -52,7 +52,7 @@ class SignalMessageDumper {
   std::shared_ptr<std::ostringstream> dumper_;
 };
 
-void SignalHandle(const char* data, int size);
+void SignalHandle(const char* data, size_t size);
 #endif
 
 void DisableSignalHandler();

--- a/paddle/fluid/platform/init_test.cc
+++ b/paddle/fluid/platform/init_test.cc
@@ -55,6 +55,6 @@ TEST(InitDevices, XPU) {
 #ifndef _WIN32
 TEST(SignalHandle, SignalHandle) {
   std::string msg = "Signal raises";
-  paddle::framework::SignalHandle(msg.c_str(), static_cast<int>(msg.size()));
+  paddle::framework::SignalHandle(msg.c_str(), msg.size());
 }
 #endif

--- a/paddle/phi/kernels/cpu/eigvals_kernel.cc
+++ b/paddle/phi/kernels/cpu/eigvals_kernel.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/eigvals_kernel.h"
+#include <cinttypes>
 
 #include "glog/logging.h"
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 #61837、#62874 遇到的问题

具体原因为 `google::int32 kLogSiteUninitialized` 不能正确初始化, 导致的最大日志输出。

![698061722582440_ pic](https://github.com/user-attachments/assets/78abe585-390b-4b64-8a27-209cea2b4027)

glog 已经在 google/glog#542 PR 中修复了这个问题。


> [!NOTE]
> 前置任务，glog 需要的最低 cmake 版本是 3.22

> [!IMPORTANT]
> 需要研发大哥帮忙推进