### PR TITLE
[CodeStyle][PLE0101] Clean an explicit return in `__init__`

### DIFF
--- a/python/paddle/autograd/py_layer.py
+++ b/python/paddle/autograd/py_layer.py
@@ -274,7 +274,7 @@ class PyLayerMeta(type):
             name + '_backward', (PyLayerBackward,), {"_forward_cls": cls}
         )
 
-        return super().__init__(name, bases, attrs)
+        super().__init__(name, bases, attrs)
 
 
 class PyLayer(core.eager.PyLayer, PyLayerContext, metaclass=PyLayerMeta):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

修复 Ruff 0.5.6 升级发现的一个问题，`__init__` 无需显式 return

PCard-66972