### PR TITLE
[Infra] Fix PR template missing a whitespace

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 <!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
 
 ### PR Category
-<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation] -->
+<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
 
 
 ### PR Types


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 #66905 修改的模板和检查脚本不一致导致默认情况下 `CheckPRTemplate` 总是失败的问题，模板里最右多删了一个空格，与检查脚本里删掉注释的模板不匹配，所以这段注释总是不能被删掉，就会出现如下错误（<https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/11253572/job/27101393>）：

```
ERROR MESSAGE: PR Category should be in ['User Experience', 'Execute Infrastructure', 'Operator Mechanism', 'CINN', 'Custom Device', 'Performance Optimization', 'Distributed Strategy', 'Parameter Server', 'Communication Library', 'Auto Parallel', 'Inference', 'Environment Adaptation']. but now is [<!-- one of [ user experience | execute infrastructure | operator mechanism | cinn | custom device | performance optimization | distributed strategy | parameter server | communication library | auto parallel | inference | environment adaptation] -->user experience.].
```

检测到的部分包含了没能删掉的注释 `[<!-- one of [ user experience | execute infrastructure | operator mechanism | cinn | custom device | performance optimization | distributed strategy | parameter server | communication library | auto parallel | inference | environment adaptation] -->user experience.]`

相关 PR 补充空格后通过

（其实这里的检查逻辑完全可以直接匹配所有注释并删掉的……）

PCard-66972