### PR TITLE
[Typing][PEP585 Upgrade][BUAA][161-170] Use standard collections for type hints for 10 uts in `test/ir/inference/`

### DIFF
--- a/test/ir/inference/test_trt_convert_cumsum.py
+++ b/test/ir/inference/test_trt_convert_cumsum.py
@@ -110,7 +110,7 @@ class TrtConvertCumsum(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape():
             if self.dims == 0:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_cumsum.py
+++ b/test/ir/inference/test_trt_convert_cumsum.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -109,7 +110,7 @@ class TrtConvertCumsum(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape():
             if self.dims == 0:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_deformable_conv.py
+++ b/test/ir/inference/test_trt_convert_deformable_conv.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -41,9 +43,9 @@ class TrtConvertDeformableConvTest(TrtLayerAutoScanTest):
 
     def sample_program_configs(self):
         def compute_output_size(
-            input_size: List[int],
-            kernel_sizes: List[int],
-            attrs: List[Dict[str, Any]],
+            input_size: list[int],
+            kernel_sizes: list[int],
+            attrs: list[dict[str, Any]],
         ):
             strides = attrs[0]['strides']
             paddings = attrs[0]['paddings']
@@ -58,17 +60,17 @@ class TrtConvertDeformableConvTest(TrtLayerAutoScanTest):
 
         def generate_input1(
             batch: int,
-            input_size: List[int],
-            kernel_sizes: List[int],
-            attrs: List[Dict[str, Any]],
+            input_size: list[int],
+            kernel_sizes: list[int],
+            attrs: list[dict[str, Any]],
         ):
             return np.random.random([batch, 3] + input_size).astype(np.float32)
 
         def generate_offset1(
             batch: int,
-            input_size: List[int],
-            kernel_sizes: List[int],
-            attrs: List[Dict[str, Any]],
+            input_size: list[int],
+            kernel_sizes: list[int],
+            attrs: list[dict[str, Any]],
         ):
             output_size = compute_output_size(input_size, kernel_sizes, attrs)
             return np.random.random(
@@ -77,9 +79,9 @@ class TrtConvertDeformableConvTest(TrtLayerAutoScanTest):
 
         def generate_mask1(
             batch: int,
-            input_size: List[int],
-            kernel_sizes: List[int],
-            attrs: List[Dict[str, Any]],
+            input_size: list[int],
+            kernel_sizes: list[int],
+            attrs: list[dict[str, Any]],
         ):
             output_size = compute_output_size(input_size, kernel_sizes, attrs)
             return np.random.random(
@@ -88,9 +90,9 @@ class TrtConvertDeformableConvTest(TrtLayerAutoScanTest):
 
         def generate_filter1(
             batch: int,
-            input_size: List[int],
-            kernel_sizes: List[int],
-            attrs: List[Dict[str, Any]],
+            input_size: list[int],
+            kernel_sizes: list[int],
+            attrs: list[dict[str, Any]],
         ):
             filter = np.random.random([6, 3] + kernel_sizes)
             filter[0][0][0][0] = 8.8978638e-08
@@ -184,7 +186,7 @@ class TrtConvertDeformableConvTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 3, 32, 32],

--- a/test/ir/inference/test_trt_convert_deformable_conv.py
+++ b/test/ir/inference/test_trt_convert_deformable_conv.py
@@ -186,7 +186,7 @@ class TrtConvertDeformableConvTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 3, 32, 32],

--- a/test/ir/inference/test_trt_convert_depthwise_conv2d.py
+++ b/test/ir/inference/test_trt_convert_depthwise_conv2d.py
@@ -122,7 +122,7 @@ class TrtConvertDepthwiseConv2dTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             groups = attrs[0]['groups']
             self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_depthwise_conv2d.py
+++ b/test/ir/inference/test_trt_convert_depthwise_conv2d.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -43,11 +45,11 @@ class TrtConvertDepthwiseConv2dTest(TrtLayerAutoScanTest):
     def sample_program_configs(self):
         self.trt_param.workspace_size = 1073741824
 
-        def generate_input1(batch, attrs: List[Dict[str, Any]]):
+        def generate_input1(batch, attrs: list[dict[str, Any]]):
             groups = attrs[0]['groups']
             return np.ones([batch, groups, 64, 64]).astype(np.float32)
 
-        def generate_weight1(attrs: List[Dict[str, Any]]):
+        def generate_weight1(attrs: list[dict[str, Any]]):
             return np.random.random([24, 1, 3, 3]).astype(np.float32)
 
         batch_options = [1]
@@ -120,7 +122,7 @@ class TrtConvertDepthwiseConv2dTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             groups = attrs[0]['groups']
             self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_depthwise_conv2d_transpose.py
+++ b/test/ir/inference/test_trt_convert_depthwise_conv2d_transpose.py
@@ -17,13 +17,16 @@ from __future__ import annotations
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Generator
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
 from trt_layer_auto_scan_test import SkipReasons, TrtLayerAutoScanTest
 
 import paddle.inference as paddle_infer
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class TrtConvertDepthwiseConv2dTransposeTest(TrtLayerAutoScanTest):

--- a/test/ir/inference/test_trt_convert_dropout.py
+++ b/test/ir/inference/test_trt_convert_dropout.py
@@ -78,7 +78,7 @@ class TrtConvertDropoutTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 3, 64, 64]}

--- a/test/ir/inference/test_trt_convert_dropout.py
+++ b/test/ir/inference/test_trt_convert_dropout.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -28,7 +30,7 @@ class TrtConvertDropoutTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input(attrs: List[Dict[str, Any]]):
+        def generate_input(attrs: list[dict[str, Any]]):
             return np.ones([1, 3, 64, 64]).astype(np.float32)
 
         for dropout_implementation in [
@@ -76,7 +78,7 @@ class TrtConvertDropoutTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 3, 64, 64]}

--- a/test/ir/inference/test_trt_convert_einsum.py
+++ b/test/ir/inference/test_trt_convert_einsum.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -91,7 +92,7 @@ class TrtConvertEinsumTest_SingleOperand(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {
@@ -251,7 +252,7 @@ class TrtConvertEinsumTest_DoubuleOperand_Vector_Matrix(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {
@@ -383,7 +384,7 @@ class TrtConvertEinsumTest_DoubuleOperand_Matrix_Matrix(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             min_xshape = self.x_shape[:]
             max_xshape = self.x_shape[:]

--- a/test/ir/inference/test_trt_convert_einsum.py
+++ b/test/ir/inference/test_trt_convert_einsum.py
@@ -92,7 +92,7 @@ class TrtConvertEinsumTest_SingleOperand(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {
@@ -252,7 +252,7 @@ class TrtConvertEinsumTest_DoubuleOperand_Vector_Matrix(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {
@@ -384,7 +384,7 @@ class TrtConvertEinsumTest_DoubuleOperand_Matrix_Matrix(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             min_xshape = self.x_shape[:]
             max_xshape = self.x_shape[:]

--- a/test/ir/inference/test_trt_convert_elementwise.py
+++ b/test/ir/inference/test_trt_convert_elementwise.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -110,7 +111,7 @@ class TrtConvertElementwiseTestOneInputSpecialCase0(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 4:
@@ -251,7 +252,7 @@ class TrtConvertElementwiseTestOneInputSpecialCase1(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [32]}
             self.dynamic_shape.max_input_shape = {"input_data": [64]}
@@ -396,7 +397,7 @@ class TrtConvertElementwiseTestOneInput(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 1:
@@ -539,7 +540,7 @@ class TrtConvertElementwiseTestTwoInputWithoutBroadcast(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {
@@ -749,7 +750,7 @@ class TrtConvertElementwiseTestTwoInputWithBroadcast(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             max_shape = [
                 [128],
@@ -901,7 +902,7 @@ class TrtConvertElementwiseTestOneInputCornerCase(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 1:
@@ -1023,7 +1024,7 @@ class TrtConvertElementwiseTestTwoInputSkipCase(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {
@@ -1169,7 +1170,7 @@ class TrtConvertPowOp(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 0:
                 self.dynamic_shape.min_input_shape = {"input_data": []}
@@ -1332,7 +1333,7 @@ class TrtConvertElementwise0D(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 0:

--- a/test/ir/inference/test_trt_convert_elementwise.py
+++ b/test/ir/inference/test_trt_convert_elementwise.py
@@ -111,7 +111,7 @@ class TrtConvertElementwiseTestOneInputSpecialCase0(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 4:
@@ -252,7 +252,7 @@ class TrtConvertElementwiseTestOneInputSpecialCase1(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [32]}
             self.dynamic_shape.max_input_shape = {"input_data": [64]}
@@ -397,7 +397,7 @@ class TrtConvertElementwiseTestOneInput(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 1:
@@ -540,7 +540,7 @@ class TrtConvertElementwiseTestTwoInputWithoutBroadcast(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {
@@ -750,7 +750,7 @@ class TrtConvertElementwiseTestTwoInputWithBroadcast(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             max_shape = [
                 [128],
@@ -902,7 +902,7 @@ class TrtConvertElementwiseTestOneInputCornerCase(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 1:
@@ -1024,7 +1024,7 @@ class TrtConvertElementwiseTestTwoInputSkipCase(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {
@@ -1170,7 +1170,7 @@ class TrtConvertPowOp(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 0:
                 self.dynamic_shape.min_input_shape = {"input_data": []}
@@ -1333,7 +1333,7 @@ class TrtConvertElementwise0D(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 0:

--- a/test/ir/inference/test_trt_convert_elementwiseadd_transpose.py
+++ b/test/ir/inference/test_trt_convert_elementwiseadd_transpose.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -130,7 +132,7 @@ class TrtConvertElementwiseAddTransposeTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs, inputs):
             channel = inputs['ele_input_1'].shape[2]
 

--- a/test/ir/inference/test_trt_convert_elementwiseadd_transpose.py
+++ b/test/ir/inference/test_trt_convert_elementwiseadd_transpose.py
@@ -132,7 +132,7 @@ class TrtConvertElementwiseAddTransposeTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs, inputs):
             channel = inputs['ele_input_1'].shape[2]
 

--- a/test/ir/inference/test_trt_convert_emb_eltwise_layernorm.py
+++ b/test/ir/inference/test_trt_convert_emb_eltwise_layernorm.py
@@ -264,7 +264,7 @@ class TrtConvertEmbEltwiseLayernormTest1(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data1": [1, 4, 1],

--- a/test/ir/inference/test_trt_convert_emb_eltwise_layernorm.py
+++ b/test/ir/inference/test_trt_convert_emb_eltwise_layernorm.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -263,7 +264,7 @@ class TrtConvertEmbEltwiseLayernormTest1(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data1": [1, 4, 1],

--- a/test/ir/inference/test_trt_convert_equal.py
+++ b/test/ir/inference/test_trt_convert_equal.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -82,7 +83,7 @@ class TrtConvertEqualOneInputCornerCase(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 0:

--- a/test/ir/inference/test_trt_convert_equal.py
+++ b/test/ir/inference/test_trt_convert_equal.py
@@ -83,7 +83,7 @@ class TrtConvertEqualOneInputCornerCase(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 0:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->Devs


### Description
<!-- Describe what you’ve done -->
为如下文件添加 PEP 563，并进行 PEP 585 升级：
test/ir/inference/test_trt_convert_cumsum.py
test/ir/inference/test_trt_convert_deformable_conv.py
test/ir/inference/test_trt_convert_depthwise_conv2d.py
test/ir/inference/test_trt_convert_depthwise_conv2d_transpose.py
test/ir/inference/test_trt_convert_dropout.py
test/ir/inference/test_trt_convert_einsum.py
test/ir/inference/test_trt_convert_elementwise.py
test/ir/inference/test_trt_convert_elementwiseadd_transpose.py
test/ir/inference/test_trt_convert_emb_eltwise_layernorm.py
test/ir/inference/test_trt_convert_equal.py

### Related links
https://github.com/PaddlePaddle/Paddle/issues/66936
@gouzil
