### PR TITLE
[Typing][PEP585 Upgrade][BUAA][171-180] Use standard collections for type hints for 10 uts in `test/ir/inference/`

### DIFF
--- a/test/ir/inference/test_trt_convert_expand_as_v2.py
+++ b/test/ir/inference/test_trt_convert_expand_as_v2.py
@@ -94,7 +94,7 @@ class TrtConvertExpandASV2Test(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -232,7 +232,7 @@ class TrtConvertExpandV2Test2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape():
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"expand_v2_input": [1]}

--- a/test/ir/inference/test_trt_convert_expand_as_v2.py
+++ b/test/ir/inference/test_trt_convert_expand_as_v2.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -36,7 +38,7 @@ class TrtConvertExpandASV2Test(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             if self.dims == 4:
                 self.input_shape = [1, 8, 1, 32]
                 return np.random.random([1, 8, 1, 32]).astype(np.float32)
@@ -92,7 +94,7 @@ class TrtConvertExpandASV2Test(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -180,7 +182,7 @@ class TrtConvertExpandV2Test2(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             if self.dims == 1:
                 self.input_shape = [1]
                 return np.random.random([1]).astype(np.float32)
@@ -230,7 +232,7 @@ class TrtConvertExpandV2Test2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape():
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"expand_v2_input": [1]}

--- a/test/ir/inference/test_trt_convert_expand_v2.py
+++ b/test/ir/inference/test_trt_convert_expand_v2.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -36,7 +38,7 @@ class TrtConvertExpandV2Test(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             if self.dims == 4:
                 self.input_shape = [1, 1, 4, 6]
                 return np.random.random([1, 1, 4, 6]).astype(np.float32)
@@ -50,13 +52,13 @@ class TrtConvertExpandV2Test(TrtLayerAutoScanTest):
                 self.input_shape = [48]
                 return np.random.random([48]).astype(np.float32)
 
-        def generate_weight1(attrs: List[Dict[str, Any]]):
+        def generate_weight1(attrs: list[dict[str, Any]]):
             return np.array([1, 48]).astype(np.int32)
 
-        def generate_shapeT1_data(attrs: List[Dict[str, Any]]):
+        def generate_shapeT1_data(attrs: list[dict[str, Any]]):
             return np.array([2]).astype(np.int32)
 
-        def generate_shapeT2_data(attrs: List[Dict[str, Any]]):
+        def generate_shapeT2_data(attrs: list[dict[str, Any]]):
             return np.array([24]).astype(np.int32)
 
         for dims in [4, 3, 2, 1]:
@@ -93,7 +95,7 @@ class TrtConvertExpandV2Test(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -186,7 +188,7 @@ class TrtConvertExpandV2Test2(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             if self.dims == 1:
                 self.input_shape = [1]
                 return np.random.random([1]).astype(np.float32)
@@ -236,7 +238,7 @@ class TrtConvertExpandV2Test2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape():
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"expand_v2_input": [1]}
@@ -275,7 +277,7 @@ class TrtConvertExpandV2Test3(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             if self.dims == 4:
                 self.input_shape = [1, 1, 4, 6]
                 return np.random.random([1, 1, 4, 6]).astype(np.float32)
@@ -366,7 +368,7 @@ class TrtConvertExpandV2Test3(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape():
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_expand_v2.py
+++ b/test/ir/inference/test_trt_convert_expand_v2.py
@@ -95,7 +95,7 @@ class TrtConvertExpandV2Test(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -238,7 +238,7 @@ class TrtConvertExpandV2Test2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape():
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"expand_v2_input": [1]}
@@ -368,7 +368,7 @@ class TrtConvertExpandV2Test3(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape():
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_fill_any_like.py
+++ b/test/ir/inference/test_trt_convert_fill_any_like.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -32,7 +34,7 @@ class TrtConvertExpandV2Test(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             if self.dims == 4:
                 self.input_shape = [1, 1, 4, 6]
                 if self.dtype == 0:
@@ -61,13 +63,13 @@ class TrtConvertExpandV2Test(TrtLayerAutoScanTest):
                 self.input_shape = [48]
                 return np.random.random([48]).astype(np.int32)
 
-        def generate_weight1(attrs: List[Dict[str, Any]]):
+        def generate_weight1(attrs: list[dict[str, Any]]):
             return np.array([1, 48]).astype(np.int32)
 
-        def generate_shapeT1_data(attrs: List[Dict[str, Any]]):
+        def generate_shapeT1_data(attrs: list[dict[str, Any]]):
             return np.array([2]).astype(np.int32)
 
-        def generate_shapeT2_data(attrs: List[Dict[str, Any]]):
+        def generate_shapeT2_data(attrs: list[dict[str, Any]]):
             return np.array([24]).astype(np.int32)
 
         for dims in [1, 2, 3, 4]:
@@ -107,7 +109,7 @@ class TrtConvertExpandV2Test(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], int):
+    ) -> (paddle_infer.Config, list[int], int):
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_fill_any_like.py
+++ b/test/ir/inference/test_trt_convert_fill_any_like.py
@@ -109,7 +109,7 @@ class TrtConvertExpandV2Test(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], int):
+    ) -> tuple[paddle_infer.Config, list[int], int]:
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_fill_constant.py
+++ b/test/ir/inference/test_trt_convert_fill_constant.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -153,7 +154,7 @@ class TrtConvertFillConstantTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.mode == "ValueTensor":
                 self.input_shape = [1, 1]

--- a/test/ir/inference/test_trt_convert_fill_constant.py
+++ b/test/ir/inference/test_trt_convert_fill_constant.py
@@ -154,7 +154,7 @@ class TrtConvertFillConstantTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.mode == "ValueTensor":
                 self.input_shape = [1, 1]

--- a/test/ir/inference/test_trt_convert_flash_multihead_matmul.py
+++ b/test/ir/inference/test_trt_convert_flash_multihead_matmul.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -246,7 +247,7 @@ class TrtConvertFlashMultiHeadMatmulTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             # The last dim of input1 and input2 should be static.
             self.dynamic_shape.min_input_shape = {
@@ -545,7 +546,7 @@ class TrtConvertFlashMultiHeadMatmulWeightInputTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data1": [1, 4096, 320],

--- a/test/ir/inference/test_trt_convert_flash_multihead_matmul.py
+++ b/test/ir/inference/test_trt_convert_flash_multihead_matmul.py
@@ -247,7 +247,7 @@ class TrtConvertFlashMultiHeadMatmulTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             # The last dim of input1 and input2 should be static.
             self.dynamic_shape.min_input_shape = {
@@ -546,7 +546,7 @@ class TrtConvertFlashMultiHeadMatmulWeightInputTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data1": [1, 4096, 320],

--- a/test/ir/inference/test_trt_convert_flatten_contiguous_range.py
+++ b/test/ir/inference/test_trt_convert_flatten_contiguous_range.py
@@ -81,7 +81,7 @@ class TrtConvertFlattenContiguousRangeTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 0:
                 self.dynamic_shape.min_input_shape = {"input_data": []}

--- a/test/ir/inference/test_trt_convert_flatten_contiguous_range.py
+++ b/test/ir/inference/test_trt_convert_flatten_contiguous_range.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -80,7 +81,7 @@ class TrtConvertFlattenContiguousRangeTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 0:
                 self.dynamic_shape.min_input_shape = {"input_data": []}

--- a/test/ir/inference/test_trt_convert_flip.py
+++ b/test/ir/inference/test_trt_convert_flip.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -75,7 +76,7 @@ class TrtConvertFlipTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_flip.py
+++ b/test/ir/inference/test_trt_convert_flip.py
@@ -76,7 +76,7 @@ class TrtConvertFlipTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_fused_conv2d_add_act.py
+++ b/test/ir/inference/test_trt_convert_fused_conv2d_add_act.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -53,15 +55,15 @@ class TrtConvertFusedConv2dAddActTest(TrtLayerAutoScanTest):
     def sample_program_configs(self):
         self.trt_param.workspace_size = 1073741824
 
-        def generate_input1(batch, attrs: List[Dict[str, Any]]):
+        def generate_input1(batch, attrs: list[dict[str, Any]]):
             return np.ones([batch, attrs[0]['groups'] * 3, 64, 64]).astype(
                 np.float32
             )
 
-        def generate_weight1(attrs: List[Dict[str, Any]]):
+        def generate_weight1(attrs: list[dict[str, Any]]):
             return np.random.random([24, 3, 3, 3]).astype(np.float32)
 
-        def generate_weight2(attrs: List[Dict[str, Any]]):
+        def generate_weight2(attrs: list[dict[str, Any]]):
             return np.random.random([24, 1, 1]).astype(np.float32)
 
         batch_options = [1, 2]
@@ -148,7 +150,7 @@ class TrtConvertFusedConv2dAddActTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             input_groups = attrs[0]['groups'] * 3
             self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_fused_conv2d_add_act.py
+++ b/test/ir/inference/test_trt_convert_fused_conv2d_add_act.py
@@ -150,7 +150,7 @@ class TrtConvertFusedConv2dAddActTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             input_groups = attrs[0]['groups'] * 3
             self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_fused_token_prune.py
+++ b/test/ir/inference/test_trt_convert_fused_token_prune.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -30,13 +32,13 @@ class TrtConvertFusedTokenPruneTest(TrtLayerAutoScanTest):
     def sample_program_configs(self):
         self.trt_param.workspace_size = 1073741824
 
-        def generate_attn_or_mask(attrs: List[Dict[str, Any]]):
+        def generate_attn_or_mask(attrs: list[dict[str, Any]]):
             return np.ones([4, 12, 64, 64]).astype(np.float32)
 
-        def generate_x(attrs: List[Dict[str, Any]]):
+        def generate_x(attrs: list[dict[str, Any]]):
             return np.random.random([4, 64, 76]).astype(np.float32)
 
-        def generate_new_mask(attrs: List[Dict[str, Any]]):
+        def generate_new_mask(attrs: list[dict[str, Any]]):
             return np.random.random([4, 12, 32, 32]).astype(np.float32)
 
         for keep_first_token in [True, False]:
@@ -86,7 +88,7 @@ class TrtConvertFusedTokenPruneTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "attn": [4, 12, 64, 64],

--- a/test/ir/inference/test_trt_convert_fused_token_prune.py
+++ b/test/ir/inference/test_trt_convert_fused_token_prune.py
@@ -88,7 +88,7 @@ class TrtConvertFusedTokenPruneTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "attn": [4, 12, 64, 64],

--- a/test/ir/inference/test_trt_convert_gather_nd.py
+++ b/test/ir/inference/test_trt_convert_gather_nd.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -67,7 +68,7 @@ class TrtConvertGatherNdTest_dim_4_1(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [2, 32, 64, 64],
@@ -162,7 +163,7 @@ class TrtConvertGatherNdTest_dim_4_1_2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [2, 32, 64, 64],
@@ -257,7 +258,7 @@ class TrtConvertGatherNdTest_dim_4_2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [2, 32, 64, 64],
@@ -352,7 +353,7 @@ class TrtConvertGatherNdTest_dim_4_3(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [2, 32, 64, 64],
@@ -447,7 +448,7 @@ class TrtConvertGatherNdTest_dim_2_2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [2, 32],
@@ -544,7 +545,7 @@ class TrtConvertGatherNdTest_dim_3_3(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [16, 32, 256],

--- a/test/ir/inference/test_trt_convert_gather_nd.py
+++ b/test/ir/inference/test_trt_convert_gather_nd.py
@@ -68,7 +68,7 @@ class TrtConvertGatherNdTest_dim_4_1(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [2, 32, 64, 64],
@@ -163,7 +163,7 @@ class TrtConvertGatherNdTest_dim_4_1_2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [2, 32, 64, 64],
@@ -258,7 +258,7 @@ class TrtConvertGatherNdTest_dim_4_2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [2, 32, 64, 64],
@@ -353,7 +353,7 @@ class TrtConvertGatherNdTest_dim_4_3(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [2, 32, 64, 64],
@@ -448,7 +448,7 @@ class TrtConvertGatherNdTest_dim_2_2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [2, 32],
@@ -545,7 +545,7 @@ class TrtConvertGatherNdTest_dim_3_3(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [16, 32, 256],


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->Devs


### Description
<!-- Describe what you’ve done -->
为如下文件添加 PEP 563，并进行 PEP 585 升级：
test/ir/inference/test_trt_convert_expand_as_v2.py
test/ir/inference/test_trt_convert_expand_v2.py
test/ir/inference/test_trt_convert_fill_any_like.py
test/ir/inference/test_trt_convert_fill_constant.py
test/ir/inference/test_trt_convert_flash_multihead_matmul.py
test/ir/inference/test_trt_convert_flatten_contiguous_range.py
test/ir/inference/test_trt_convert_flip.py
test/ir/inference/test_trt_convert_fused_conv2d_add_act.py
test/ir/inference/test_trt_convert_fused_token_prune.py
test/ir/inference/test_trt_convert_gather_nd.py

### Related links
https://github.com/PaddlePaddle/Paddle/issues/66936
@gouzil