### PR TITLE
[Typing][PEP585 Upgrade][BUAA][207-215] Use standard collections for type hints for 9 uts in `test/ir/inference/`

### DIFF
--- a/test/ir/inference/test_trt_convert_preln_residual_bias.py
+++ b/test/ir/inference/test_trt_convert_preln_residual_bias.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -40,16 +42,16 @@ class TrtConvertSkipLayernormTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]], batch):
+        def generate_input1(attrs: list[dict[str, Any]], batch):
             return np.ones([batch, 128, 768]).astype(np.float32)
 
-        def generate_input2(attrs: List[Dict[str, Any]], batch):
+        def generate_input2(attrs: list[dict[str, Any]], batch):
             return np.ones([batch, 128, 768]).astype(np.float32)
 
-        def generate_weight1(attrs: List[Dict[str, Any]]):
+        def generate_weight1(attrs: list[dict[str, Any]]):
             return np.random.random([768]).astype(np.float32)
 
-        def generate_weight2(attrs: List[Dict[str, Any]]):
+        def generate_weight2(attrs: list[dict[str, Any]]):
             return np.random.random([768]).astype(np.float32)
 
         for batch in [4]:
@@ -131,7 +133,7 @@ class TrtConvertSkipLayernormTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "inputX_data": [4, 128, 768],

--- a/test/ir/inference/test_trt_convert_preln_residual_no_bias.py
+++ b/test/ir/inference/test_trt_convert_preln_residual_no_bias.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -40,16 +42,16 @@ class TrtConvertSkipLayernormTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]], batch):
+        def generate_input1(attrs: list[dict[str, Any]], batch):
             return np.ones([batch, 128, 768]).astype(np.float32)
 
-        def generate_input2(attrs: List[Dict[str, Any]], batch):
+        def generate_input2(attrs: list[dict[str, Any]], batch):
             return np.ones([batch, 128, 768]).astype(np.float32)
 
-        def generate_weight1(attrs: List[Dict[str, Any]]):
+        def generate_weight1(attrs: list[dict[str, Any]]):
             return np.random.random([768]).astype(np.float32)
 
-        def generate_weight2(attrs: List[Dict[str, Any]]):
+        def generate_weight2(attrs: list[dict[str, Any]]):
             return np.random.random([768]).astype(np.float32)
 
         for batch in [4]:
@@ -119,7 +121,7 @@ class TrtConvertSkipLayernormTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "inputX_data": [4, 128, 768],

--- a/test/ir/inference/test_trt_convert_prelu.py
+++ b/test/ir/inference/test_trt_convert_prelu.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -28,7 +30,7 @@ class TrtConvertPreluTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input(attrs: List[Dict[str, Any]], batch):
+        def generate_input(attrs: list[dict[str, Any]], batch):
             if self.dims == 0:
                 return np.random.random([]).astype(np.float32)
             elif self.dims == 1:
@@ -52,7 +54,7 @@ class TrtConvertPreluTest(TrtLayerAutoScanTest):
                         np.float32
                     )
 
-        def generate_alpha(attrs: List[Dict[str, Any]]):
+        def generate_alpha(attrs: list[dict[str, Any]]):
             if self.dims == 0:
                 return np.random.random([]).astype(np.float32)
             if attrs[0]["mode"] == "all":
@@ -127,7 +129,7 @@ class TrtConvertPreluTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 0:
                 self.dynamic_shape.min_input_shape = {"input_data": []}

--- a/test/ir/inference/test_trt_convert_qk_multihead_matmul.py
+++ b/test/ir/inference/test_trt_convert_qk_multihead_matmul.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -301,7 +302,7 @@ class TrtConvertQkAttentionTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             # The last dim of input1 and input2 should be static.
             self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_quantize_dequantize_linear.py
+++ b/test/ir/inference/test_trt_convert_quantize_dequantize_linear.py
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -114,7 +115,7 @@ class TrtConvertQuantizeDequantizeTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data_1": [1, 8, 32, 32],

--- a/test/ir/inference/test_trt_convert_range.py
+++ b/test/ir/inference/test_trt_convert_range.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -97,7 +98,7 @@ class TrtConvertRangeDynamicTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "start_data": [1],
@@ -198,7 +199,7 @@ class TrtConvertRangeStaticTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def clear_dynamic_shape():
             self.dynamic_shape.min_input_shape = {}
             self.dynamic_shape.max_input_shape = {}

--- a/test/ir/inference/test_trt_convert_reduce.py
+++ b/test/ir/inference/test_trt_convert_reduce.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -46,7 +48,7 @@ class TrtConvertReduceTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(dtype, attrs: List[Dict[str, Any]]):
+        def generate_input1(dtype, attrs: list[dict[str, Any]]):
             if dtype == -1 or dtype == 5:
                 return np.random.random([1, 3, 64, 64]).astype(np.float32)
             elif dtype == 2:
@@ -134,7 +136,7 @@ class TrtConvertReduceTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 3, 64, 64]}

--- a/test/ir/inference/test_trt_convert_reshape.py
+++ b/test/ir/inference/test_trt_convert_reshape.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -46,7 +48,7 @@ class TrtConvertReshapeTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             if self.dims == 4:
                 self.input_shape = [1, 2, 4, 6]
                 return np.ones([1, 2, 4, 6]).astype(np.float32)
@@ -60,13 +62,13 @@ class TrtConvertReshapeTest(TrtLayerAutoScanTest):
                 self.input_shape = [48]
                 return np.ones([48]).astype(np.float32)
 
-        def generate_weight1(attrs: List[Dict[str, Any]]):
+        def generate_weight1(attrs: list[dict[str, Any]]):
             return np.array([1, 48]).astype(np.int32)
 
-        def generate_shapeT1_data(attrs: List[Dict[str, Any]]):
+        def generate_shapeT1_data(attrs: list[dict[str, Any]]):
             return np.array([2]).astype(np.int32)
 
-        def generate_shapeT2_data(attrs: List[Dict[str, Any]]):
+        def generate_shapeT2_data(attrs: list[dict[str, Any]]):
             return np.array([24]).astype(np.int32)
 
         for dims in [4, 3, 2, 1]:
@@ -114,7 +116,7 @@ class TrtConvertReshapeTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -209,7 +211,7 @@ class TrtConvertReshapeTest2(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             if self.dims == 4:
                 return np.random.random([1, 2, 4, 6]).astype(np.float32)
             elif self.dims == 3:
@@ -278,7 +280,7 @@ class TrtConvertReshapeTest2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape():
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -332,7 +334,7 @@ class TrtConvertReshapeTest3(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             if self.dims == 4:
                 return np.random.random([1, 2, 12, 6]).astype(np.float32)
             elif self.dims == 3:
@@ -391,7 +393,7 @@ class TrtConvertReshapeTest3(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape():
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -444,7 +446,7 @@ class TrtConvertReshapeZeroDimsTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             if self.dims > 0:
                 self.input_shape = [1] * self.dims
                 return np.random.random(self.input_shape).astype(np.float32)
@@ -489,7 +491,7 @@ class TrtConvertReshapeZeroDimsTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "reshape_input": self.input_shape

--- a/test/ir/inference/test_trt_convert_rnn.py
+++ b/test/ir/inference/test_trt_convert_rnn.py
@@ -20,14 +20,14 @@ from functools import partial
 from itertools import product
 from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
 from trt_layer_auto_scan_test import TrtLayerAutoScanTest
 
 import paddle.inference as paddle_infer
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class TrtConvertSliceTest(TrtLayerAutoScanTest):

--- a/test/ir/inference/test_trt_convert_rnn.py
+++ b/test/ir/inference/test_trt_convert_rnn.py
@@ -18,7 +18,10 @@ import os
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Generator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs


### Description
<!-- Describe what you’ve done -->

为如下文件添加 PEP 563，并进行 PEP 585 升级：
- ``test_trt_convert_preln_residual_bias.py``
- ``test_trt_convert_preln_residual_no_bias.py``
- ``test_trt_convert_prelu.py``
- ``test_trt_convert_qk_multihead_matmul.py``
- ``test_trt_convert_quantize_dequantize_linear.py``
- ``test_trt_convert_range.py``
- ``test_trt_convert_reduce.py``
- ``test_trt_convert_reshape.py``
- ``test_trt_convert_rnn.py``

### Related links
- #66936

@gouzil