### PR TITLE
[Typing][PEP585 Upgrade][BUAA][216-225] Use standard collections for type hints for 10 uts in `test/ir/inference/`

### DIFF
--- a/test/ir/inference/test_trt_convert_roi_align.py
+++ b/test/ir/inference/test_trt_convert_roi_align.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Generator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig

--- a/test/ir/inference/test_trt_convert_roi_align.py
+++ b/test/ir/inference/test_trt_convert_roi_align.py
@@ -19,14 +19,14 @@ from functools import partial
 from itertools import product
 from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
 from trt_layer_auto_scan_test import SkipReasons, TrtLayerAutoScanTest
 
 import paddle.inference as paddle_infer
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class TrtConvertRoiAlignTest(TrtLayerAutoScanTest):

--- a/test/ir/inference/test_trt_convert_roll.py
+++ b/test/ir/inference/test_trt_convert_roll.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import random
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -36,7 +38,7 @@ class TrtConvertRollTest(TrtLayerAutoScanTest):
     def sample_program_configs(self):
         self.trt_param.workspace_size = random.randint(1024, 1 << 30)
 
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             return np.random.random([1, 56, 56, 192]).astype(np.float32)
 
         for axis in [[1, 2]]:
@@ -73,7 +75,7 @@ class TrtConvertRollTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 56, 56, 192]

--- a/test/ir/inference/test_trt_convert_scale.py
+++ b/test/ir/inference/test_trt_convert_scale.py
@@ -19,14 +19,14 @@ from functools import partial
 from itertools import product
 from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
 from trt_layer_auto_scan_test import SkipReasons, TrtLayerAutoScanTest
 
 import paddle.inference as paddle_infer
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class TrtConvertScaleTest(TrtLayerAutoScanTest):

--- a/test/ir/inference/test_trt_convert_scale.py
+++ b/test/ir/inference/test_trt_convert_scale.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Generator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig

--- a/test/ir/inference/test_trt_convert_scatter.py
+++ b/test/ir/inference/test_trt_convert_scatter.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -72,7 +73,7 @@ class TrtConvertScatter(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1],

--- a/test/ir/inference/test_trt_convert_scatter_nd_add.py
+++ b/test/ir/inference/test_trt_convert_scatter_nd_add.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -73,7 +74,7 @@ class TrtConvertScatterNd(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1],

--- a/test/ir/inference/test_trt_convert_shape.py
+++ b/test/ir/inference/test_trt_convert_shape.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -65,7 +66,7 @@ class TrtConvertSumTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape():
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {"input1": [1, 3, 24, 24]}

--- a/test/ir/inference/test_trt_convert_share_data.py
+++ b/test/ir/inference/test_trt_convert_share_data.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -92,7 +93,7 @@ class TrtConvertShareDataTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}

--- a/test/ir/inference/test_trt_convert_shuffle_channel.py
+++ b/test/ir/inference/test_trt_convert_shuffle_channel.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -28,7 +30,7 @@ class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]], batch):
+        def generate_input1(attrs: list[dict[str, Any]], batch):
             return np.ones([batch, 6, 24, 24]).astype(np.float32)
 
         for batch in [1, 2, 4]:
@@ -58,7 +60,7 @@ class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "shuffle_channel_input": [1, 6, 24, 24]

--- a/test/ir/inference/test_trt_convert_size.py
+++ b/test/ir/inference/test_trt_convert_size.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -63,7 +64,7 @@ class TrtConvertNumelTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_slice.py
+++ b/test/ir/inference/test_trt_convert_slice.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -61,7 +63,7 @@ class TrtConvertSliceTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             return np.random.random([6, 6, 64, 64]).astype(np.float32)
 
         for axes in [[0, 1], [1, 3], [2, 3]]:
@@ -106,7 +108,7 @@ class TrtConvertSliceTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [8, 8, 64, 64]}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs


### Description
<!-- Describe what you’ve done -->

为如下文件添加 PEP 563，并进行 PEP 585 升级：
- ``test_trt_convert_roi_align.py``
- ``test_trt_convert_roll.py``
- ``test_trt_convert_scale.py``
- ``test_trt_convert_scatter.py``
- ``test_trt_convert_scatter_nd_add.py``
- ``test_trt_convert_shape.py``
- ``test_trt_convert_share_data.py``
- ``test_trt_convert_shuffle_channel.py``
- ``test_trt_convert_size.py``
- ``test_trt_convert_slice.py``

### Related links
- #66936

@gouzil
