### PR TITLE
[XPU] support ascend send/recv for multi-node

### DIFF
--- a/paddle/fluid/distributed/collective/process_group_bkcl.cc
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.cc
@@ -89,6 +89,7 @@ bool ProcessGroupBKCL::BKCLTask::Wait(std::chrono::milliseconds timeout) {
 void ProcessGroupBKCL::BKCLTask::Synchronize() { Wait(kWaitTimeout); }
 
 void ProcessGroupBKCL::BKCLTask::StartDelayedCommFunc() {
+  VLOG(0) << "Start a delayed func";
   for (auto& fn : delayed_funcs_) {
     fn();
   }
@@ -101,7 +102,7 @@ void ProcessGroupBKCL::BKCLTask::RegisterDelayedCommFunc(const CommFunc& func) {
 }
 
 static bool IsCrossNodeComm(int src_rank, int tgt_rank) {
-  VLOG(1) << "src_rank: " << src_rank << "tgt_rank: " << tgt_rank;
+  VLOG(0) << "src_rank: " << src_rank << "tgt_rank: " << tgt_rank;
   return true;
 }
 
@@ -135,7 +136,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Recv(
   }
 
   return Point2Point(
-      [&](phi::distributed::BKCLCommContext* comm_context,
+      [=](phi::distributed::BKCLCommContext* comm_context,
           XPUStream stream,
           int rank_in_group) {
         VLOG(3) << "bkcl_recv "
@@ -366,6 +367,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Point2Point(
   if (std::getenv("BKCL_ASYNC_SEND_RECV") != nullptr &&
       IsCrossNodeComm(rank_, p2p_target_rank) && comm_type == CommType::RECV) {
     // delay dispatch of comm kernels
+    VLOG(0) << "In async send /recv mode, delay recv from " << peer << ".";
     task->RegisterDelayedCommFunc(
         [=] { fn(bkcl_comm_ctx, bkcl_stream, p2p_target_rank); });
   } else {

--- a/paddle/fluid/distributed/collective/process_group_bkcl.cc
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.cc
@@ -89,7 +89,7 @@ bool ProcessGroupBKCL::BKCLTask::Wait(std::chrono::milliseconds timeout) {
 void ProcessGroupBKCL::BKCLTask::Synchronize() { Wait(kWaitTimeout); }
 
 void ProcessGroupBKCL::BKCLTask::StartDelayedCommFunc() {
-  VLOG(0) << "Start a delayed func";
+  VLOG(3) << "Start a delayed func";
   for (auto& fn : delayed_funcs_) {
     fn();
   }
@@ -102,7 +102,7 @@ void ProcessGroupBKCL::BKCLTask::RegisterDelayedCommFunc(const CommFunc& func) {
 }
 
 static bool IsCrossNodeComm(int src_rank, int tgt_rank) {
-  VLOG(0) << "src_rank: " << src_rank << "tgt_rank: " << tgt_rank;
+  VLOG(3) << "src_rank: " << src_rank << "tgt_rank: " << tgt_rank;
   return true;
 }
 
@@ -367,7 +367,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Point2Point(
   if (std::getenv("BKCL_ASYNC_SEND_RECV") != nullptr &&
       IsCrossNodeComm(rank_, p2p_target_rank) && comm_type == CommType::RECV) {
     // delay dispatch of comm kernels
-    VLOG(0) << "In async send /recv mode, delay recv from " << peer << ".";
+    VLOG(3) << "In async send /recv mode, delay recv from " << peer << ".";
     task->RegisterDelayedCommFunc(
         [=] { fn(bkcl_comm_ctx, bkcl_stream, p2p_target_rank); });
   } else {

--- a/paddle/fluid/distributed/collective/process_group_bkcl.cc
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.cc
@@ -101,11 +101,6 @@ void ProcessGroupBKCL::BKCLTask::RegisterDelayedCommFunc(const CommFunc& func) {
   delayed_funcs_.push_back(func);
 }
 
-static bool IsCrossNodeComm(int src_rank, int tgt_rank) {
-  VLOG(3) << "src_rank: " << src_rank << "tgt_rank: " << tgt_rank;
-  return true;
-}
-
 ProcessGroupBKCL::ProcessGroupBKCL(
     const std::shared_ptr<phi::distributed::Store>& store,
     int rank,
@@ -365,7 +360,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Point2Point(
 
   auto bkcl_comm_ctx = this->GetCommContext();
   if (std::getenv("BKCL_ASYNC_SEND_RECV") != nullptr &&
-      IsCrossNodeComm(rank_, p2p_target_rank) && comm_type == CommType::RECV) {
+      comm_type == CommType::RECV) {
     // delay dispatch of comm kernels
     VLOG(3) << "In async send /recv mode, delay recv from " << peer << ".";
     task->RegisterDelayedCommFunc(

--- a/paddle/fluid/distributed/collective/process_group_bkcl.cc
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.cc
@@ -57,6 +57,9 @@ bool ProcessGroupBKCL::BKCLTask::IsCompleted() {
 
 // TODO(sheniang03): Add timeout for wait, now timeout unused
 bool ProcessGroupBKCL::BKCLTask::Wait(std::chrono::milliseconds timeout) {
+  if (HasDelayedCommFunc()) {
+    StartDelayedCommFunc();
+  }
   const auto* calc_ctx =
       static_cast<XPUContext*>(phi::DeviceContextPool::Instance().Get(place_));
   if (barrier_) {
@@ -84,6 +87,23 @@ bool ProcessGroupBKCL::BKCLTask::Wait(std::chrono::milliseconds timeout) {
 
 // Same as Wait
 void ProcessGroupBKCL::BKCLTask::Synchronize() { Wait(kWaitTimeout); }
+
+void ProcessGroupBKCL::BKCLTask::StartDelayedCommFunc() {
+  for (auto& fn : delayed_funcs_) {
+    fn();
+  }
+
+  delayed_funcs_.clear();
+}
+
+void ProcessGroupBKCL::BKCLTask::RegisterDelayedCommFunc(const CommFunc& func) {
+  delayed_funcs_.push_back(func);
+}
+
+static bool IsCrossNodeComm(int src_rank, int tgt_rank) {
+  VLOG(1) << "src_rank: " << src_rank << "tgt_rank: " << tgt_rank;
+  return true;
+}
 
 ProcessGroupBKCL::ProcessGroupBKCL(
     const std::shared_ptr<phi::distributed::Store>& store,
@@ -343,7 +363,14 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Point2Point(
   auto bkcl_stream = use_calc_stream ? calc_ctx->stream() : comm_ctx->stream();
 
   auto bkcl_comm_ctx = this->GetCommContext();
-  fn(bkcl_comm_ctx, bkcl_stream, p2p_target_rank);
+  if (std::getenv("BKCL_ASYNC_SEND_RECV") != nullptr &&
+      IsCrossNodeComm(rank_, p2p_target_rank) && comm_type == CommType::RECV) {
+    // delay dispatch of comm kernels
+    task->RegisterDelayedCommFunc(
+        [=] { fn(bkcl_comm_ctx, bkcl_stream, p2p_target_rank); });
+  } else {
+    fn(bkcl_comm_ctx, bkcl_stream, p2p_target_rank);
+  }
 
   if (!use_calc_stream) {
     PADDLE_ENFORCE_NOT_NULL(comm_ctx.get(),

--- a/python/paddle/distributed/utils/bkcl_utils.py
+++ b/python/paddle/distributed/utils/bkcl_utils.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import paddle
+
+
+def check_bkcl_async_p2p_conn(ranks):
+    ranks_per_node = int(os.getenv("XPU_PADDLE_NODES_PER_RANK", "8"))
+    assert ranks_per_node > 0, (
+        "The XPU_PADDLE_NODES_PER_RANK must be greater than 0, bot got %d"
+        % ranks_per_node
+    )
+    for i in range(len(ranks) - 1):
+        rank_interval = ranks[i + 1] - ranks[i]
+        assert (
+            rank_interval % ranks_per_node == 0
+        ), "When BKCL_ASYNC_SEND_RECV is set, we assume all of the send/recv \
+            are cross-node communication, but now we found you have \
+            single node send/recv, which would cause hange problem."
+
+
+def build_bkcl_async_p2p_conn(stage_id, prev_rank, next_rank, pp_comm_group):
+    tmp_send_tensor = paddle.zeros([1], dtype="int32")
+    if stage_id % 2 == 0:
+        paddle.distributed.send(tmp_send_tensor, next_rank, pp_comm_group)
+        paddle.distributed.recv(tmp_send_tensor, prev_rank, pp_comm_group)
+        paddle.distributed.send(tmp_send_tensor, prev_rank, pp_comm_group)
+        paddle.distributed.recv(tmp_send_tensor, next_rank, pp_comm_group)
+    else:
+        paddle.distributed.recv(tmp_send_tensor, prev_rank, pp_comm_group)
+        paddle.distributed.send(tmp_send_tensor, next_rank, pp_comm_group)
+        paddle.distributed.recv(tmp_send_tensor, next_rank, pp_comm_group)
+        paddle.distributed.send(tmp_send_tensor, prev_rank, pp_comm_group)

--- a/python/paddle/distributed/utils/bkcl_utils.py
+++ b/python/paddle/distributed/utils/bkcl_utils.py
@@ -19,10 +19,9 @@ import paddle
 
 def check_bkcl_async_p2p_conn(ranks):
     ranks_per_node = int(os.getenv("XPU_PADDLE_NODES_PER_RANK", "8"))
-    assert ranks_per_node > 0, (
-        "The XPU_PADDLE_NODES_PER_RANK must be greater than 0, bot got %d"
-        % ranks_per_node
-    )
+    assert (
+        ranks_per_node > 0
+    ), f"The XPU_PADDLE_NODES_PER_RANK must be greater than 0, bot got {ranks_per_node}"
     for i in range(len(ranks) - 1):
         rank_interval = ranks[i + 1] - ranks[i]
         assert (

--- a/python/paddle/distributed/utils/bkcl_utils.py
+++ b/python/paddle/distributed/utils/bkcl_utils.py
@@ -18,10 +18,10 @@ import paddle
 
 
 def check_bkcl_async_p2p_conn(ranks):
-    ranks_per_node = int(os.getenv("XPU_PADDLE_NODES_PER_RANK", "8"))
+    ranks_per_node = int(os.getenv("PADDLE_LOCAL_SIZE", "8"))
     assert (
         ranks_per_node > 0
-    ), f"The XPU_PADDLE_NODES_PER_RANK must be greater than 0, bot got {ranks_per_node}"
+    ), f"The PADDLE_LOCAL_SIZE must be greater than 0, bot got {ranks_per_node}"
     for i in range(len(ranks) - 1):
         rank_interval = ranks[i + 1] - ranks[i]
         assert (

--- a/python/paddle/distributed/utils/bkcl_utils.py
+++ b/python/paddle/distributed/utils/bkcl_utils.py
@@ -18,17 +18,17 @@ import paddle
 
 
 def check_bkcl_async_p2p_conn(ranks):
-    ranks_per_node = int(os.getenv("PADDLE_LOCAL_SIZE", "8"))
+    ranks_per_node = int(os.getenv("PADDLE_LOCAL_SIZE"))
     assert (
         ranks_per_node > 0
     ), f"The PADDLE_LOCAL_SIZE must be greater than 0, bot got {ranks_per_node}"
     for i in range(len(ranks) - 1):
         rank_interval = ranks[i + 1] - ranks[i]
-        assert (
-            rank_interval % ranks_per_node == 0
-        ), "When BKCL_ASYNC_SEND_RECV is set, we assume all of the send/recv \
-            are cross-node communication, but now we found you have \
-            single node send/recv, which would cause hange problem."
+        assert rank_interval >= ranks_per_node, (
+            "When BKCL_ASYNC_SEND_RECV is set, we assume all of the send/recv "
+            "are cross-node communication, but now we found you have "
+            f"single node send/recv between rank {ranks[i]} and rank {ranks[i + 1]}, which would cause hang problem."
+        )
 
 
 def build_bkcl_async_p2p_conn(stage_id, prev_rank, next_rank, pp_comm_group):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->
1. support async send and delayed dispatch of recv to enable calc-comm overlap in multi-node communication.