### PR TITLE
Fix reduce_scatter

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
@@ -145,7 +145,7 @@ phi::DeviceContext* ParseDeviceContext(pir::Operation* op,
               static_cast<phi::distributed::NCCLCommContext*>(comm_context)
                   ->GetDevContext());
           dev_ctx->SetCommContext(comm_context);
-          if (op_name.compare(paddle::dialect::CReducescatterOp::name()) == 0 ||
+          if (op_name.compare(paddle::dialect::ReduceScatterOp::name()) == 0 ||
               op_name.compare(paddle::dialect::AllGatherOp::name()) == 0) {
             return dev_ctx;
           }

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -49,6 +49,7 @@ const std::unordered_set<std::string> LegacyOpList = {
     CAllreduceSum_Op::name(),
     CAllreduceAvgOp::name(),
     CAllreduceAvg_Op::name(),
+    CReducescatterOp::name(),
     CReduceSumOp::name(),
     CReduceSum_Op::name(),
     CAllreduceMax_Op::name(),

--- a/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
@@ -171,8 +171,7 @@
     func : ReduceScatterInferMeta
     param: [x, nranks]
   kernel :
-    func : reduce_scatter
-    param: [x, nranks]
+    func : c_reducescatter
 
 - op : c_scatter
   args : (Tensor x, int ring_id = 0, int root = 0, int nranks = 0, bool use_calc_stream = false)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

1. replace c_reducescatter in auto_parallel_sequence_parallel_optimization.py
2. revert old OP kernel and update comm op dev_ctx

Pcard-70448