### PR TITLE
[Typing][PEP585 Upgrade][BUAA][226-235] Use standard collections for type hints for 10 uts in `test/ir/inference/`

### DIFF
--- a/test/ir/inference/test_trt_convert_softmax.py
+++ b/test/ir/inference/test_trt_convert_softmax.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -40,7 +42,7 @@ class TrtConvertSoftmaxTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]], batch):
+        def generate_input1(attrs: list[dict[str, Any]], batch):
             if self.dims == 4:
                 return np.ones([batch, 3, 24, 24]).astype(np.float32)
             elif self.dims == 3:
@@ -81,7 +83,7 @@ class TrtConvertSoftmaxTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_solve.py
+++ b/test/ir/inference/test_trt_convert_solve.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -60,7 +61,7 @@ class TrtConvertSolve(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "x_input_data": [1, 8, 8],

--- a/test/ir/inference/test_trt_convert_split.py
+++ b/test/ir/inference/test_trt_convert_split.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -81,7 +83,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]], batch):
+        def generate_input1(attrs: list[dict[str, Any]], batch):
             if self.dims == 4:
                 return np.random.random([batch, 3, 3, 24]).astype(np.float32)
             elif self.dims == 3:
@@ -91,13 +93,13 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
             elif self.dims == 1:
                 return np.random.random([24]).astype(np.int32)
 
-        def generate_AxisTensor(attrs: List[Dict[str, Any]]):
+        def generate_AxisTensor(attrs: list[dict[str, Any]]):
             return np.ones([1]).astype(np.int32)
 
-        def generate_SectionsTensorList1(attrs: List[Dict[str, Any]]):
+        def generate_SectionsTensorList1(attrs: list[dict[str, Any]]):
             return np.array([10]).astype(np.int32)
 
-        def generate_SectionsTensorList2(attrs: List[Dict[str, Any]]):
+        def generate_SectionsTensorList2(attrs: list[dict[str, Any]]):
             return np.array([14]).astype(np.int32)
 
         for num_input in [0, 1]:
@@ -191,7 +193,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -295,7 +297,7 @@ class TrtConvertSplitTest2(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             return np.random.random([3, 3, 3, 24]).astype(np.float32)
 
         for sections in [
@@ -380,7 +382,7 @@ class TrtConvertSplitTest2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"split_input": [1, 3, 3, 24]}
             self.dynamic_shape.max_input_shape = {"split_input": [9, 3, 3, 24]}

--- a/test/ir/inference/test_trt_convert_split.py
+++ b/test/ir/inference/test_trt_convert_split.py
@@ -193,7 +193,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -382,7 +382,7 @@ class TrtConvertSplitTest2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"split_input": [1, 3, 3, 24]}
             self.dynamic_shape.max_input_shape = {"split_input": [9, 3, 3, 24]}

--- a/test/ir/inference/test_trt_convert_square.py
+++ b/test/ir/inference/test_trt_convert_square.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -69,7 +70,7 @@ class TrtConvertSquareTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 0:
                 self.dynamic_shape.min_input_shape = {"input_data": []}

--- a/test/ir/inference/test_trt_convert_squeeze2.py
+++ b/test/ir/inference/test_trt_convert_squeeze2.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -67,7 +69,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
                         for i in range(dims):
                             self.input_shape[i] = np.random.randint(1, 20)
 
-                        def generate_input1(attrs: List[Dict[str, Any]], batch):
+                        def generate_input1(attrs: list[dict[str, Any]], batch):
                             self.input_shape[0] = batch
                             for i in new_axes:
                                 self.input_shape[i] = 1
@@ -93,7 +95,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             max_shape = list(self.input_shape)
             min_shape = list(self.input_shape)

--- a/test/ir/inference/test_trt_convert_stack.py
+++ b/test/ir/inference/test_trt_convert_stack.py
@@ -102,7 +102,7 @@ class TrtConvertStackTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_stack.py
+++ b/test/ir/inference/test_trt_convert_stack.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -41,19 +43,19 @@ class TrtConvertStackTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]], batch):
+        def generate_input1(attrs: list[dict[str, Any]], batch):
             if self.dims == 4:
                 return np.random.random([batch, 3, 24, 24]).astype(np.float32)
             else:
                 return np.random.random([]).astype(np.float32)
 
-        def generate_input2(attrs: List[Dict[str, Any]], batch):
+        def generate_input2(attrs: list[dict[str, Any]], batch):
             if self.dims == 4:
                 return np.random.random([batch, 3, 24, 24]).astype(np.float32)
             else:
                 return np.random.random([]).astype(np.float32)
 
-        def generate_input3(attrs: List[Dict[str, Any]], batch):
+        def generate_input3(attrs: list[dict[str, Any]], batch):
             if self.dims == 4:
                 return np.random.random([batch, 3, 24, 24]).astype(np.float32)
             else:
@@ -100,7 +102,7 @@ class TrtConvertStackTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_strided_slice.py
+++ b/test/ir/inference/test_trt_convert_strided_slice.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Generator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig

--- a/test/ir/inference/test_trt_convert_strided_slice.py
+++ b/test/ir/inference/test_trt_convert_strided_slice.py
@@ -19,14 +19,14 @@ from functools import partial
 from itertools import product
 from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
 from trt_layer_auto_scan_test import TrtLayerAutoScanTest
 
 import paddle.inference as paddle_infer
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class TrtConvertStridedSliceTest(TrtLayerAutoScanTest):

--- a/test/ir/inference/test_trt_convert_sum.py
+++ b/test/ir/inference/test_trt_convert_sum.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -97,7 +98,7 @@ class TrtConvertSumTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape():
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -261,7 +262,7 @@ class TrtConvertSumTest1(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape():
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {"input1": [1, 3, 24, 24]}

--- a/test/ir/inference/test_trt_convert_swish.py
+++ b/test/ir/inference/test_trt_convert_swish.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -28,7 +30,7 @@ class TrtConvertSwishTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(dims, attrs: List[Dict[str, Any]]):
+        def generate_input1(dims, attrs: list[dict[str, Any]]):
             if dims == 0:
                 return np.ones([]).astype(np.float32)
             elif dims == 1:
@@ -73,7 +75,7 @@ class TrtConvertSwishTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 0:
                 self.dynamic_shape.min_input_shape = {"input_data": []}

--- a/test/ir/inference/test_trt_convert_take_along_axis.py
+++ b/test/ir/inference/test_trt_convert_take_along_axis.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -84,7 +85,7 @@ class TrtConvertTakeAlongAxisTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if len(self.shape) == 1:
                 self.dynamic_shape.min_input_shape = {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs


### Description
<!-- Describe what you’ve done -->

为如下文件添加 PEP 563，并进行 PEP 585 升级：

- ``test_trt_convert_softmax.py``
- ``test_trt_convert_solve.py``
- ``test_trt_convert_split.py``
- ``test_trt_convert_square.py``
- ``test_trt_convert_squeeze2.py``
- ``test_trt_convert_stack.py``
- ``test_trt_convert_strided_slice.py``
- ``test_trt_convert_sum.py``
- ``test_trt_convert_swish.py``
- ``test_trt_convert_take_along_axis.py``

### Related links
- #66936

@gouzil

