### PR TITLE
[Typing][PEP585 Upgrade][BUAA][236-245] Use standard collections for type hints for 10 uts in `test/ir/inference/`

### DIFF
--- a/test/ir/inference/test_trt_convert_temporal_shift.py
+++ b/test/ir/inference/test_trt_convert_temporal_shift.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -72,7 +73,7 @@ class TrtConvertTemporalShiftTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             t = attrs[0]['seg_num']
             self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_tile.py
+++ b/test/ir/inference/test_trt_convert_tile.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import hypothesis.strategies as st
 import numpy as np
@@ -38,7 +40,7 @@ class TrtConvertTileTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self, *args, **kwargs):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             return np.ones([1, 2]).astype(np.float32)
 
         dics = [{"repeat_times": kwargs['repeat_times']}]
@@ -68,7 +70,7 @@ class TrtConvertTileTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 2]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 3]}
@@ -126,7 +128,7 @@ class TrtConvertTileTest2(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             return np.ones([1, 2]).astype(np.float32)
 
         dics = [{}]
@@ -167,7 +169,7 @@ class TrtConvertTileTest2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"tile_input": [1, 2]}
             self.dynamic_shape.max_input_shape = {"tile_input": [4, 3]}
@@ -214,7 +216,7 @@ class TrtConvertTileTest3(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             return np.ones([1, 2]).astype(np.float32)
 
         dics = [{}]
@@ -268,7 +270,7 @@ class TrtConvertTileTest3(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"tile_input": [1, 2]}
             self.dynamic_shape.max_input_shape = {"tile_input": [4, 3]}

--- a/test/ir/inference/test_trt_convert_tile.py
+++ b/test/ir/inference/test_trt_convert_tile.py
@@ -70,7 +70,7 @@ class TrtConvertTileTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 2]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 3]}
@@ -169,7 +169,7 @@ class TrtConvertTileTest2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"tile_input": [1, 2]}
             self.dynamic_shape.max_input_shape = {"tile_input": [4, 3]}
@@ -270,7 +270,7 @@ class TrtConvertTileTest3(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"tile_input": [1, 2]}
             self.dynamic_shape.max_input_shape = {"tile_input": [4, 3]}

--- a/test/ir/inference/test_trt_convert_top_k.py
+++ b/test/ir/inference/test_trt_convert_top_k.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -30,7 +32,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
     def sample_program_configs(self):
         self.trt_param.workspace_size = 1073741824
 
-        def generate_input1(dims, batch, attrs: List[Dict[str, Any]]):
+        def generate_input1(dims, batch, attrs: list[dict[str, Any]]):
             if dims == 1:
                 return np.random.random([32]).astype(np.float32)
             elif dims == 2:
@@ -76,7 +78,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}

--- a/test/ir/inference/test_trt_convert_top_k.py
+++ b/test/ir/inference/test_trt_convert_top_k.py
@@ -78,7 +78,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, list[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}

--- a/test/ir/inference/test_trt_convert_top_k_v2.py
+++ b/test/ir/inference/test_trt_convert_top_k_v2.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -30,7 +32,7 @@ class TrtConvertTopKV2Test(TrtLayerAutoScanTest):
     def sample_program_configs(self):
         self.trt_param.workspace_size = 1073741824
 
-        def generate_input1(dims, batch, attrs: List[Dict[str, Any]]):
+        def generate_input1(dims, batch, attrs: list[dict[str, Any]]):
             if dims == 1:
                 return np.random.random([32]).astype(np.float32)
             if dims == 4:
@@ -72,7 +74,7 @@ class TrtConvertTopKV2Test(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}

--- a/test/ir/inference/test_trt_convert_trans_layernorm.py
+++ b/test/ir/inference/test_trt_convert_trans_layernorm.py
@@ -19,14 +19,14 @@ from functools import partial
 from itertools import product
 from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
 from trt_layer_auto_scan_test import TrtLayerAutoScanTest
 
 import paddle.inference as paddle_infer
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class TrtConvertTransLayernormTest(TrtLayerAutoScanTest):

--- a/test/ir/inference/test_trt_convert_trans_layernorm.py
+++ b/test/ir/inference/test_trt_convert_trans_layernorm.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Generator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig

--- a/test/ir/inference/test_trt_convert_transpose.py
+++ b/test/ir/inference/test_trt_convert_transpose.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -40,7 +42,7 @@ class TrtConvertTransposeTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             return np.ones([1, 3, 24, 24]).astype(np.float32)
 
         for axis in [[0, 1, 3, 2], [1, 0]]:
@@ -69,7 +71,7 @@ class TrtConvertTransposeTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "transpose_input": [1, 3, 24, 24]

--- a/test/ir/inference/test_trt_convert_unary.py
+++ b/test/ir/inference/test_trt_convert_unary.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -34,7 +36,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
     def sample_program_configs(self):
         self.trt_param.workspace_size = 1073741824
 
-        def generate_input1(dims, batch, attrs: List[Dict[str, Any]]):
+        def generate_input1(dims, batch, attrs: list[dict[str, Any]]):
             if dims == 0:
                 out = np.random.random([]).astype(np.float32)
             elif dims == 2:
@@ -49,7 +51,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
             out[mask] = 0
             return out
 
-        def generate_int_input(dims, batch, attrs: List[Dict[str, Any]]):
+        def generate_int_input(dims, batch, attrs: list[dict[str, Any]]):
             if dims == 0:
                 return np.random.random([]).astype(np.int32)
             elif dims == 2:
@@ -150,7 +152,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 0:
                 self.dynamic_shape.min_input_shape = {"input_data": []}
@@ -299,7 +301,7 @@ class TrtConvertLogicalNotTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             if self.dims == 2:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_unbind.py
+++ b/test/ir/inference/test_trt_convert_unbind.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -71,7 +72,7 @@ class TrtConvertUnbind(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_trt_nodes_num(attrs, dynamic_shape):
             return 1, 4
 

--- a/test/ir/inference/test_trt_convert_unfold.py
+++ b/test/ir/inference/test_trt_convert_unfold.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import List
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -63,7 +64,7 @@ class TrtConvertUnfold(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 3, 4, 4],

--- a/test/ir/inference/test_trt_convert_unsqueeze2.py
+++ b/test/ir/inference/test_trt_convert_unsqueeze2.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -52,7 +54,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
                     for i in range(dims):
                         self.input_shape[i] = np.random.randint(1, 20)
 
-                    def generate_input1(attrs: List[Dict[str, Any]], batch):
+                    def generate_input1(attrs: list[dict[str, Any]], batch):
                         self.input_shape[0] = batch
                         return np.random.random(self.input_shape).astype(
                             np.float32
@@ -74,7 +76,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> tuple[paddle_infer.Config, list[int], float]:
         def generate_dynamic_shape(attrs):
             max_shape = list(self.input_shape)
             min_shape = list(self.input_shape)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

为如下文件添加 PEP 563，并进行 PEP 585 升级：
- ``test_trt_convert_temporal_shift.py``
- ``test_trt_convert_tile.py``
- ``test_trt_convert_top_k.py``
- ``test_trt_convert_top_k_v2.py``
- ``test_trt_convert_trans_layernorm.py``
- ``test_trt_convert_transpose.py``
- ``test_trt_convert_unary.py``
- ``test_trt_convert_unbind.py``
- ``test_trt_convert_unfold.py``
- ``test_trt_convert_unsqueeze2.py``


### Related links
- #66936

@gouzil
