### PR TITLE
[Typing][PEP585 Upgrade][BUAA][256-260] Use standard collections for type hints for 5 uts in `test/`

### DIFF
--- a/test/legacy_test/utils.py
+++ b/test/legacy_test/utils.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
+from collections.abc import Callable
 from functools import wraps
-from typing import Callable, List, Union
+from typing import Union
 
 import numpy as np
 
@@ -234,8 +237,8 @@ def convert_place(place: PlaceType) -> str:
 
 def get_places(
     func: FuncType = lambda: True, isStr: bool = False
-) -> List[PlaceType]:
-    places: List[PlaceType] = []
+) -> list[PlaceType]:
+    places: list[PlaceType] = []
     if paddle.is_compiled_with_cuda() and func():
         places.append(paddle.CUDAPlace(0))
     if (

--- a/test/legacy_test/utils.py
+++ b/test/legacy_test/utils.py
@@ -15,9 +15,8 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
 from functools import wraps
-from typing import Union
+from typing import Callable, Union
 
 import numpy as np
 

--- a/test/prim/model/bert.py
+++ b/test/prim/model/bert.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import functools
 import warnings
-from typing import Optional, Tuple
 
 import numpy as np
 
@@ -160,9 +161,9 @@ class BertEmbeddings(nn.Layer):
     def forward(
         self,
         input_ids: Tensor,
-        token_type_ids: Optional[Tensor] = None,
-        position_ids: Optional[Tensor] = None,
-        past_key_values_length: Optional[int] = None,
+        token_type_ids: Tensor | None = None,
+        position_ids: Tensor | None = None,
+        past_key_values_length: int | None = None,
     ):
         if position_ids is None:
             ones = paddle.ones_like(input_ids, dtype="int64")
@@ -265,14 +266,14 @@ class BertModel(nn.Layer):
     def forward(
         self,
         input_ids: Tensor,
-        token_type_ids: Optional[Tensor] = None,
-        position_ids: Optional[Tensor] = None,
-        attention_mask: Optional[Tensor] = None,
-        past_key_values: Optional[Tuple[Tuple[Tensor]]] = None,
-        use_cache: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        output_attentions: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
+        token_type_ids: Tensor | None = None,
+        position_ids: Tensor | None = None,
+        attention_mask: Tensor | None = None,
+        past_key_values: tuple[tuple[Tensor]] | None = None,
+        use_cache: bool | None = None,
+        output_hidden_states: bool | None = None,
+        output_attentions: bool | None = None,
+        return_dict: bool | None = None,
     ):
         return_dict = (
             return_dict
@@ -383,15 +384,15 @@ class Bert(nn.Layer):
     def forward(
         self,
         input_ids: Tensor,
-        token_type_ids: Optional[Tensor] = None,
-        position_ids: Optional[Tensor] = None,
-        attention_mask: Optional[Tensor] = None,
-        masked_positions: Optional[Tensor] = None,
-        labels: Optional[Tensor] = None,
-        next_sentence_label: Optional[Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
-        output_attentions: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
+        token_type_ids: Tensor | None = None,
+        position_ids: Tensor | None = None,
+        attention_mask: Tensor | None = None,
+        masked_positions: Tensor | None = None,
+        labels: Tensor | None = None,
+        next_sentence_label: Tensor | None = None,
+        output_hidden_states: bool | None = None,
+        output_attentions: bool | None = None,
+        return_dict: bool | None = None,
     ):
         with paddle.static.amp.fp16_guard():
             outputs = self.bert(

--- a/test/quantization/test_customized_quanter.py
+++ b/test/quantization/test_customized_quanter.py
@@ -12,15 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
-from typing import Iterable, Union
+from typing import TYPE_CHECKING
 
-import numpy as np
-
-import paddle
 from paddle.nn import Linear
 from paddle.quantization.base_quanter import BaseQuanter
 from paddle.quantization.factory import quanter
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    import numpy as np
+
+    import paddle
 
 linear_quant_axis = 1
 
@@ -33,16 +39,16 @@ class CustomizedQuanterLayer(BaseQuanter):
         self._bit_length = bit_length
         self._kwargs1 = kwargs1
 
-    def scales(self) -> Union[paddle.Tensor, np.ndarray]:
+    def scales(self) -> paddle.Tensor | np.ndarray:
         return None
 
     def bit_length(self):
         return self._bit_length
 
-    def quant_axis(self) -> Union[int, Iterable]:
+    def quant_axis(self) -> int | Iterable:
         return linear_quant_axis if isinstance(self._layer, Linear) else None
 
-    def zero_points(self) -> Union[paddle.Tensor, np.ndarray]:
+    def zero_points(self) -> paddle.Tensor | np.ndarray:
         return None
 
     def forward(self, input):

--- a/test/sot/test_builtin_map.py
+++ b/test/sot/test_builtin_map.py
@@ -15,13 +15,16 @@
 from __future__ import annotations
 
 import unittest
-from typing import Iterable
+from typing import TYPE_CHECKING
 
 from test_case_base import TestCaseBase
 
 from paddle.jit import sot
 from paddle.jit.sot.psdb import check_no_breakgraph
 from paddle.jit.sot.utils import strict_mode_guard
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def double_num(num: float):

--- a/tools/cinn/gen_c++_tutorial.py
+++ b/tools/cinn/gen_c++_tutorial.py
@@ -23,9 +23,10 @@ This script helps to extract the tutorial content from a C++ source file.
 #  - @ROC, the code block inside a C++ multi-line string guard `ROC()ROC`,
 #          display as a markdown code block.
 
+from __future__ import annotations
+
 import logging
 import sys
-from typing import List
 
 
 class Markdown:
@@ -34,7 +35,7 @@ class Markdown:
     '''
 
     def __init__(self):
-        self.content: List[str] = []
+        self.content: list[str] = []
 
     def h1(self, title: str):
         self.add_line('# ' + title)
@@ -45,7 +46,7 @@ class Markdown:
     def h3(self, title: str):
         self.add_line('### ' + title)
 
-    def code_block(self, lang: str, block: List[str]):
+    def code_block(self, lang: str, block: list[str]):
         # drop the precending and tailing empty lines to make code block more compact
         pre_valid_offset = 0
         tail_valid_offset = 0


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs


### Description
<!-- Describe what you’ve done -->

为如下文件添加 PEP 563，并进行 PEP 585 升级：

- ``test/legacy_test/utils.py``
- ``test/prim/model/bert.py``
- ``test/quantization/test_customized_quanter.py``
- ``test/sot/test_builtin_map.py``
- ``tools/cinn/gen_c++_tutorial.py``

### Related links
- #66936

@gouzil
