### PR TITLE
[XPU] sharding V2 uses single comm buffer

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -709,7 +709,7 @@ class DygraphShardingOptimizerV2:
         var_groups = assign_group_by_size(self._parameter_list, group_size)
 
         # NOTE(lijin23): for XPU, we fuse all params to a single comm buffer to
-        #  improve the communication bandwidth of BKCL.
+        # improve the communication bandwidth of BKCL.
         if paddle.is_compiled_with_xpu():
             group_size = 2**62
 

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -707,6 +707,11 @@ class DygraphShardingOptimizerV2:
 
         comm_group = self._hcg.get_sharding_parallel_group()
         var_groups = assign_group_by_size(self._parameter_list, group_size)
+
+        # NOTE(lijin23): for XPU, we fuse all params to a single comm buffer to improve the communication bandwidth of BKCL.
+        if paddle.is_compiled_with_xpu():
+            group_size = 2**62
+
         for group_idx, parameters in var_groups.items():
             buffer = FusedCommBuffer(
                 group_idx,

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -704,15 +704,12 @@ class DygraphShardingOptimizerV2:
     def _build_comm_buffers(self, acc_steps, group_size=256 * 1024 * 1024):
         if self.pp_overlap:
             return
-
-        comm_group = self._hcg.get_sharding_parallel_group()
-        var_groups = assign_group_by_size(self._parameter_list, group_size)
-
         # NOTE(lijin23): for XPU, we fuse all params to a single comm buffer to
         # improve the communication bandwidth of BKCL.
         if paddle.is_compiled_with_xpu():
             group_size = 2**62
-
+        comm_group = self._hcg.get_sharding_parallel_group()
+        var_groups = assign_group_by_size(self._parameter_list, group_size)
         for group_idx, parameters in var_groups.items():
             buffer = FusedCommBuffer(
                 group_idx,

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -706,7 +706,10 @@ class DygraphShardingOptimizerV2:
             return
         # NOTE(lijin23): for XPU, we fuse all params to a single comm buffer to
         # improve the communication bandwidth of BKCL.
-        if paddle.is_compiled_with_xpu():
+        if (
+            paddle.is_compiled_with_xpu()
+            and os.getenv("XPU_PADDLE_FUSE_SHARDING_BUFFER") is not None
+        ):
             group_size = 2**62
         comm_group = self._hcg.get_sharding_parallel_group()
         var_groups = assign_group_by_size(self._parameter_list, group_size)

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -708,7 +708,8 @@ class DygraphShardingOptimizerV2:
         comm_group = self._hcg.get_sharding_parallel_group()
         var_groups = assign_group_by_size(self._parameter_list, group_size)
 
-        # NOTE(lijin23): for XPU, we fuse all params to a single comm buffer to improve the communication bandwidth of BKCL.
+        # NOTE(lijin23): for XPU, we fuse all params to a single comm buffer to
+        #  improve the communication bandwidth of BKCL.
         if paddle.is_compiled_with_xpu():
             group_size = 2**62
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
1. XPU do not have calc-comm overlap for sharding V2 now, so we use a single large comm buffer to facilitate the bandwidth of BKCL.