### PR TITLE
[Docathon][Add API Legend No.18]add illustration for roll API

### DIFF
--- a/python/paddle/incubate/nn/functional/fused_layer_norm.py
+++ b/python/paddle/incubate/nn/functional/fused_layer_norm.py
@@ -12,26 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
 
 import paddle
 from paddle import _C_ops
 from paddle.framework import LayerHelper, in_dynamic_mode, in_pir_mode
 
+if TYPE_CHECKING:
+    from paddle import Tensor
 
 def fused_layer_norm(
-    x,
-    norm_weight,
-    norm_bias,
-    epsilon,
-    residual_alpha=1.0,
-    begin_norm_axis=1,
-    bias=None,
-    residual=None,
-    quant_scale=-1,
-    quant_round_type=0,
-    quant_max_bound=0,
-    quant_min_bound=0,
-):
+    x: Tensor,
+    norm_weight: Tensor,
+    norm_bias: Tensor,
+    epsilon: Tensor,
+    residual_alpha: float = 1.0,
+    begin_norm_axis: int = 1,
+    bias: Tensor | None = None,
+    residual: Tensor | None = None,
+    quant_scale: float = -1,
+    quant_round_type: float = 0,
+    quant_max_bound: float = 0,
+    quant_min_bound: float = 0,
+) -> Tensor:
     r"""
     Apply Fused LayerNorm kernel. Also support LayerNorm(bias + residual_alpha * residual + x) fused pattern.
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1946,6 +1946,14 @@ def roll(
         name(str|None, optional): The default value is None.  Normally there is no need for user to set this property.
                 For more information, please refer to :ref:`api_guide_Name` .
 
+    The image below shows a 2D tensor of shape `[[1,2,3],[4,5,6],[7,8,9]]` transformed into a tensor of different
+    shape through a roll operation. When a global roll (without the `axis` parameter) is applied, the tensor is flattened 
+    into a 1D array, cyclically rolled, and then reshaped to its original form. When rolled along rows (`axis=0`), the 
+    tensor is cyclically rolled along its rows; when rolled along columns (`axis=1`), the tensor is cyclically rolled along 
+    its columns. From the above operations, we can observe the positional changes of each element under different roll operations.
+    
+    .. image:: https://githubraw.cdn.bcebos.com/PaddlePaddle/docs/develop/docs/images/api_legend/roll.png
+    :alt: Legend
 
     Returns:
         Tensor, A Tensor with same data type as `x`.


### PR DESCRIPTION
PR Category
User Experience

PR Types
Docs

Description
为roll API 增加图例
对应的中文文档修复为：https://github.com/PaddlePaddle/docs/pull/6810