### PR TITLE
[CINN] Remove stop_gradient attribute in InferSymbolicShapeCacheKey

### DIFF
--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -753,6 +753,7 @@ bool IsStaticShape(const Value& value) {
 static const char* kOpCallStack = "op_callstack";
 static const char* kSymShapeStr = "sym_shape_str";
 static const char* kResultName = "name";
+static const char* kStopGradient = "stop_gradient";
 
 InferSymbolicShapeCacheKey::InferSymbolicShapeCacheKey(
     const Operation& op,
@@ -771,7 +772,7 @@ InferSymbolicShapeCacheKey::InferSymbolicShapeCacheKey(
   attributes_.reserve(attributes.size());
   for (const auto& [attr_name, attr_value] : order_attributes) {
     if (!attr_value || attr_name == kOpCallStack || attr_name == kSymShapeStr ||
-        attr_name == kResultName)
+        attr_name == kStopGradient || attr_name == kResultName)
       continue;
     attributes_.emplace_back(attr_name, attr_value);
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

由于 `stop_gradient` 属性与符号推导并无关系，因此移除InferSymbolicShapeCacheKey中的`stop_gradient` 属性，避免cache失效。