### PR TITLE
[PIR][OneDNN] Add dispatch in multi build for several Op

### DIFF
--- a/paddle/fluid/pir/drr/src/ir_operation_factory.cc
+++ b/paddle/fluid/pir/drr/src/ir_operation_factory.cc
@@ -489,6 +489,12 @@ void OperationFactory::RegisterManualOpCreator() {
           bool keepdim =
               attrs.at("keepdim").dyn_cast<pir::BoolAttribute>().data();
 
+          PADDLE_ENFORCE_EQ(
+              attrs.find("dtype") != attrs.end(),
+              true,
+              phi::errors::InvalidArgument("'dtype' Attribute is expected "
+                                           "for SumOp. "));
+
           ::phi::DataType dtype =
               attrs.at("dtype")
                   .dyn_cast<paddle::dialect::DataTypeAttribute>()

--- a/paddle/fluid/pir/drr/src/ir_operation_factory.cc
+++ b/paddle/fluid/pir/drr/src/ir_operation_factory.cc
@@ -467,45 +467,44 @@ void OperationFactory::RegisterManualOpCreator() {
                                                                  attrs);
       });
 
-  // RegisterOperationCreator(
-  //     "onednn_op.sum",
-  //     [](const std::vector<pir::Value>& inputs,
-  //        const pir::AttributeMap& attrs,
-  //        pir::PatternRewriter& rewriter) {
-  //       if (inputs.size() == 2) {
-  //         PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
-  //                           true,
-  //                           phi::errors::InvalidArgument(
-  //                               "'mkldnn_data_type' Attribute is expected "
-  //                               "for SumOp. "));
-  //         std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
-  //                                            .dyn_cast<pir::StrAttribute>()
-  //                                            .AsString();
-  //         PADDLE_ENFORCE_EQ(
-  //             attrs.find("keepdim") != attrs.end(),
-  //             true,
-  //             phi::errors::InvalidArgument("'keepdim' Attribute is expected "
-  //                                          "for SumOp. "));
-  //         bool keepdim =
-  //             attrs.at("keepdim").dyn_cast<pir::BoolAttribute>().data();
+  RegisterOperationCreator(
+      "onednn_op.sum",
+      [](const std::vector<pir::Value>& inputs,
+         const pir::AttributeMap& attrs,
+         pir::PatternRewriter& rewriter) {
+        if (inputs.size() == 2) {
+          PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'mkldnn_data_type' Attribute is expected "
+                                "for SumOp. "));
+          std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
+                                             .dyn_cast<pir::StrAttribute>()
+                                             .AsString();
+          PADDLE_ENFORCE_EQ(
+              attrs.find("keepdim") != attrs.end(),
+              true,
+              phi::errors::InvalidArgument("'keepdim' Attribute is expected "
+                                           "for SumOp. "));
+          bool keepdim =
+              attrs.at("keepdim").dyn_cast<pir::BoolAttribute>().data();
 
-  //         PADDLE_ENFORCE_EQ(
-  //             attrs.find("dtype") != attrs.end(),
-  //             true,
-  //             phi::errors::InvalidArgument("'dtype' Attribute is expected "
-  //                                          "for SumOp. "));
+          PADDLE_ENFORCE_EQ(
+              attrs.find("dtype") != attrs.end(),
+              true,
+              phi::errors::InvalidArgument("'dtype' Attribute is expected "
+                                           "for SumOp. "));
 
-  //         ::phi::DataType dtype =
-  //             attrs.at("dtype")
-  //                 .dyn_cast<paddle::dialect::DataTypeAttribute>()
-  //                 .data();
+          ::phi::DataType dtype =
+              attrs.at("dtype")
+                  .dyn_cast<paddle::dialect::DataTypeAttribute>()
+                  .data();
 
-  //         return rewriter.Build<paddle::onednn::dialect::SumOp>(
-  //             inputs[0], inputs[1], dtype, keepdim, mkldnn_data_type);
-  //       }
-  //       return rewriter.Build<paddle::onednn::dialect::SumOp>(inputs[0],
-  //       attrs);
-  //     });
+          return rewriter.Build<paddle::onednn::dialect::SumOp>(
+              inputs[0], inputs[1], dtype, keepdim, mkldnn_data_type);
+        }
+        return rewriter.Build<paddle::onednn::dialect::SumOp>(inputs[0], attrs);
+      });
 
   RegisterOperationCreator(
       "onednn_op.slice",

--- a/paddle/fluid/pir/drr/src/ir_operation_factory.cc
+++ b/paddle/fluid/pir/drr/src/ir_operation_factory.cc
@@ -467,44 +467,45 @@ void OperationFactory::RegisterManualOpCreator() {
                                                                  attrs);
       });
 
-  RegisterOperationCreator(
-      "onednn_op.sum",
-      [](const std::vector<pir::Value>& inputs,
-         const pir::AttributeMap& attrs,
-         pir::PatternRewriter& rewriter) {
-        if (inputs.size() == 2) {
-          PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
-                            true,
-                            phi::errors::InvalidArgument(
-                                "'mkldnn_data_type' Attribute is expected "
-                                "for SumOp. "));
-          std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
-                                             .dyn_cast<pir::StrAttribute>()
-                                             .AsString();
-          PADDLE_ENFORCE_EQ(
-              attrs.find("keepdim") != attrs.end(),
-              true,
-              phi::errors::InvalidArgument("'keepdim' Attribute is expected "
-                                           "for SumOp. "));
-          bool keepdim =
-              attrs.at("keepdim").dyn_cast<pir::BoolAttribute>().data();
+  // RegisterOperationCreator(
+  //     "onednn_op.sum",
+  //     [](const std::vector<pir::Value>& inputs,
+  //        const pir::AttributeMap& attrs,
+  //        pir::PatternRewriter& rewriter) {
+  //       if (inputs.size() == 2) {
+  //         PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
+  //                           true,
+  //                           phi::errors::InvalidArgument(
+  //                               "'mkldnn_data_type' Attribute is expected "
+  //                               "for SumOp. "));
+  //         std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
+  //                                            .dyn_cast<pir::StrAttribute>()
+  //                                            .AsString();
+  //         PADDLE_ENFORCE_EQ(
+  //             attrs.find("keepdim") != attrs.end(),
+  //             true,
+  //             phi::errors::InvalidArgument("'keepdim' Attribute is expected "
+  //                                          "for SumOp. "));
+  //         bool keepdim =
+  //             attrs.at("keepdim").dyn_cast<pir::BoolAttribute>().data();
 
-          PADDLE_ENFORCE_EQ(
-              attrs.find("dtype") != attrs.end(),
-              true,
-              phi::errors::InvalidArgument("'dtype' Attribute is expected "
-                                           "for SumOp. "));
+  //         PADDLE_ENFORCE_EQ(
+  //             attrs.find("dtype") != attrs.end(),
+  //             true,
+  //             phi::errors::InvalidArgument("'dtype' Attribute is expected "
+  //                                          "for SumOp. "));
 
-          ::phi::DataType dtype =
-              attrs.at("dtype")
-                  .dyn_cast<paddle::dialect::DataTypeAttribute>()
-                  .data();
+  //         ::phi::DataType dtype =
+  //             attrs.at("dtype")
+  //                 .dyn_cast<paddle::dialect::DataTypeAttribute>()
+  //                 .data();
 
-          return rewriter.Build<paddle::onednn::dialect::SumOp>(
-              inputs[0], inputs[1], dtype, keepdim, mkldnn_data_type);
-        }
-        return rewriter.Build<paddle::onednn::dialect::SumOp>(inputs[0], attrs);
-      });
+  //         return rewriter.Build<paddle::onednn::dialect::SumOp>(
+  //             inputs[0], inputs[1], dtype, keepdim, mkldnn_data_type);
+  //       }
+  //       return rewriter.Build<paddle::onednn::dialect::SumOp>(inputs[0],
+  //       attrs);
+  //     });
 
   RegisterOperationCreator(
       "onednn_op.slice",

--- a/paddle/fluid/pir/drr/src/ir_operation_factory.cc
+++ b/paddle/fluid/pir/drr/src/ir_operation_factory.cc
@@ -473,14 +473,15 @@ void OperationFactory::RegisterManualOpCreator() {
          const pir::AttributeMap& attrs,
          pir::PatternRewriter& rewriter) {
         if (inputs.size() == 2) {
-          PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
-                            true,
-                            phi::errors::InvalidArgument(
-                                "'mkldnn_data_type' Attribute is expected "
-                                "for SumOp. "));
-          std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
-                                             .dyn_cast<pir::StrAttribute>()
-                                             .AsString();
+          // Add after mkldnn_data_type add in sum op
+          // PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
+          //                   true,
+          //                   phi::errors::InvalidArgument(
+          //                       "'mkldnn_data_type' Attribute is expected "
+          //                       "for SumOp. "));
+          // std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
+          //                                    .dyn_cast<pir::StrAttribute>()
+          //                                    .AsString();
           PADDLE_ENFORCE_EQ(
               attrs.find("keepdim") != attrs.end(),
               true,
@@ -501,7 +502,7 @@ void OperationFactory::RegisterManualOpCreator() {
                   .data();
 
           return rewriter.Build<paddle::onednn::dialect::SumOp>(
-              inputs[0], inputs[1], dtype, keepdim, mkldnn_data_type);
+              inputs[0], inputs[1], dtype, keepdim);
         }
         return rewriter.Build<paddle::onednn::dialect::SumOp>(inputs[0], attrs);
       });

--- a/paddle/fluid/pir/drr/src/ir_operation_factory.cc
+++ b/paddle/fluid/pir/drr/src/ir_operation_factory.cc
@@ -489,7 +489,7 @@ void OperationFactory::RegisterManualOpCreator() {
           bool keepdim =
               attrs.at("keepdim").dyn_cast<pir::BoolAttribute>().data();
 
-          const auto& dtype =
+          ::phi::DataType dtype =
               attrs.at("dtype")
                   .dyn_cast<paddle::dialect::DataTypeAttribute>()
                   .data();

--- a/paddle/fluid/pir/drr/src/ir_operation_factory.cc
+++ b/paddle/fluid/pir/drr/src/ir_operation_factory.cc
@@ -268,6 +268,404 @@ void OperationFactory::RegisterManualOpCreator() {
         return rewriter.Build<paddle::onednn::dialect::Conv2dTransposeBiasOp>(
             inputs[0], inputs[1], inputs[2], attrs);
       });
+
+  RegisterOperationCreator(
+      "onednn_op.reshape",
+      [](const std::vector<pir::Value>& inputs,
+         const pir::AttributeMap& attrs,
+         pir::PatternRewriter& rewriter) {
+        if (inputs.size() == 2) {
+          PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'mkldnn_data_type' Attribute is expected "
+                                "for ReshapeOp. "));
+          std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
+                                             .dyn_cast<pir::StrAttribute>()
+                                             .AsString();
+          PADDLE_ENFORCE_EQ(attrs.find("use_quantizer") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'use_quantizer' Attribute is expected "
+                                "for ReshapeOp. "));
+          bool use_quantizer =
+              attrs.at("use_quantizer").dyn_cast<pir::BoolAttribute>().data();
+
+          return rewriter.Build<paddle::onednn::dialect::ReshapeOp>(
+              inputs[0], inputs[1], mkldnn_data_type, use_quantizer);
+        }
+        return rewriter.Build<paddle::onednn::dialect::ReshapeOp>(inputs[0],
+                                                                  attrs);
+      });
+
+  RegisterOperationCreator(
+      "onednn_op.reshape_",
+      [](const std::vector<pir::Value>& inputs,
+         const pir::AttributeMap& attrs,
+         pir::PatternRewriter& rewriter) {
+        if (inputs.size() == 2) {
+          PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'mkldnn_data_type' Attribute is expected "
+                                "for Reshape_Op. "));
+          std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
+                                             .dyn_cast<pir::StrAttribute>()
+                                             .AsString();
+          PADDLE_ENFORCE_EQ(attrs.find("use_quantizer") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'use_quantizer' Attribute is expected "
+                                "for Reshape_Op. "));
+          bool use_quantizer =
+              attrs.at("use_quantizer").dyn_cast<pir::BoolAttribute>().data();
+
+          return rewriter.Build<paddle::onednn::dialect::Reshape_Op>(
+              inputs[0], inputs[1], mkldnn_data_type, use_quantizer);
+        }
+        return rewriter.Build<paddle::onednn::dialect::Reshape_Op>(inputs[0],
+                                                                   attrs);
+      });
+
+  RegisterOperationCreator(
+      "onednn_op.pool2d",
+      [](const std::vector<pir::Value>& inputs,
+         const pir::AttributeMap& attrs,
+         pir::PatternRewriter& rewriter) {
+        if (inputs.size() == 2) {
+          PADDLE_ENFORCE_EQ(attrs.find("strides") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'strides' Attribute is expected for "
+                                "Pool2dOp. "));
+          std::vector<int> strides;
+          for (size_t i = 0;
+               i < attrs.at("strides").dyn_cast<pir::ArrayAttribute>().size();
+               i++) {
+            strides.push_back(attrs.at("strides")
+                                  .dyn_cast<pir::ArrayAttribute>()
+                                  .at(i)
+                                  .dyn_cast<pir::Int32Attribute>()
+                                  .data());
+          }
+
+          PADDLE_ENFORCE_EQ(attrs.find("paddings") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'paddings' Attribute is expected for "
+                                "Pool2dOp. "));
+          std::vector<int> paddings;
+          for (size_t i = 0;
+               i < attrs.at("paddings").dyn_cast<pir::ArrayAttribute>().size();
+               i++) {
+            paddings.push_back(attrs.at("paddings")
+                                   .dyn_cast<pir::ArrayAttribute>()
+                                   .at(i)
+                                   .dyn_cast<pir::Int32Attribute>()
+                                   .data());
+          }
+
+          PADDLE_ENFORCE_EQ(
+              attrs.find("ceil_mode") != attrs.end(),
+              true,
+              phi::errors::InvalidArgument("'ceil_mode' Attribute is expected "
+                                           "for Pool2dOp. "));
+          bool ceil_mode =
+              attrs.at("ceil_mode").dyn_cast<pir::BoolAttribute>().data();
+
+          PADDLE_ENFORCE_EQ(
+              attrs.find("exclusive") != attrs.end(),
+              true,
+              phi::errors::InvalidArgument("'exclusive' Attribute is expected "
+                                           "for Pool2dOp. "));
+          bool exclusive =
+              attrs.at("exclusive").dyn_cast<pir::BoolAttribute>().data();
+
+          PADDLE_ENFORCE_EQ(attrs.find("data_format") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'data_format' Attribute is expected "
+                                "for Pool2dOp. "));
+          std::string data_format =
+              attrs.at("data_format").dyn_cast<pir::StrAttribute>().AsString();
+
+          PADDLE_ENFORCE_EQ(attrs.find("pooling_type") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'pooling_type' Attribute is expected "
+                                "for Pool2dOp. "));
+          std::string pooling_type =
+              attrs.at("pooling_type").dyn_cast<pir::StrAttribute>().AsString();
+
+          PADDLE_ENFORCE_EQ(attrs.find("global_pooling") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'global_pooling' Attribute is expected "
+                                "for Pool2dOp. "));
+          bool global_pooling =
+              attrs.at("global_pooling").dyn_cast<pir::BoolAttribute>().data();
+
+          PADDLE_ENFORCE_EQ(
+              attrs.find("adaptive") != attrs.end(),
+              true,
+              phi::errors::InvalidArgument("'adaptive' Attribute is expected "
+                                           "for Pool2dOp. "));
+          bool adaptive =
+              attrs.at("adaptive").dyn_cast<pir::BoolAttribute>().data();
+
+          PADDLE_ENFORCE_EQ(attrs.find("padding_algorithm") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'padding_algorithm' Attribute is expected "
+                                "for Pool2dOp. "));
+          std::string padding_algorithm = attrs.at("padding_algorithm")
+                                              .dyn_cast<pir::StrAttribute>()
+                                              .AsString();
+
+          PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'mkldnn_data_type' Attribute is expected "
+                                "for Pool2dOp. "));
+          std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
+                                             .dyn_cast<pir::StrAttribute>()
+                                             .AsString();
+
+          PADDLE_ENFORCE_EQ(attrs.find("use_quantizer") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'use_quantizer' Attribute is expected "
+                                "for Pool2dOp. "));
+          bool use_quantizer =
+              attrs.at("use_quantizer").dyn_cast<pir::BoolAttribute>().data();
+
+          PADDLE_ENFORCE_EQ(
+              attrs.find("is_test") != attrs.end(),
+              true,
+              phi::errors::InvalidArgument("'is_test' Attribute is expected "
+                                           "for Pool2dOp. "));
+          bool is_test =
+              attrs.at("is_test").dyn_cast<pir::BoolAttribute>().data();
+
+          return rewriter.Build<paddle::onednn::dialect::Pool2dOp>(
+              inputs[0],
+              inputs[1],
+              strides,
+              paddings,
+              ceil_mode,
+              exclusive,
+              data_format,
+              pooling_type,
+              global_pooling,
+              adaptive,
+              padding_algorithm,
+              use_quantizer,
+              mkldnn_data_type,
+              is_test);
+        }
+        return rewriter.Build<paddle::onednn::dialect::Pool2dOp>(inputs[0],
+                                                                 attrs);
+      });
+
+  RegisterOperationCreator(
+      "onednn_op.sum",
+      [](const std::vector<pir::Value>& inputs,
+         const pir::AttributeMap& attrs,
+         pir::PatternRewriter& rewriter) {
+        if (inputs.size() == 2) {
+          PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'mkldnn_data_type' Attribute is expected "
+                                "for SumOp. "));
+          std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
+                                             .dyn_cast<pir::StrAttribute>()
+                                             .AsString();
+          PADDLE_ENFORCE_EQ(
+              attrs.find("keepdim") != attrs.end(),
+              true,
+              phi::errors::InvalidArgument("'keepdim' Attribute is expected "
+                                           "for SumOp. "));
+          bool keepdim =
+              attrs.at("keepdim").dyn_cast<pir::BoolAttribute>().data();
+
+          const auto& dtype =
+              attrs.at("dtype")
+                  .dyn_cast<paddle::dialect::DataTypeAttribute>()
+                  .data();
+
+          return rewriter.Build<paddle::onednn::dialect::SumOp>(
+              inputs[0], inputs[1], dtype, keepdim, mkldnn_data_type);
+        }
+        return rewriter.Build<paddle::onednn::dialect::SumOp>(inputs[0], attrs);
+      });
+
+  RegisterOperationCreator(
+      "onednn_op.slice",
+      [](const std::vector<pir::Value>& inputs,
+         const pir::AttributeMap& attrs,
+         pir::PatternRewriter& rewriter) {
+        if (inputs.size() == 3) {
+          PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'mkldnn_data_type' Attribute is expected "
+                                "for SliceOp. "));
+          std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
+                                             .dyn_cast<pir::StrAttribute>()
+                                             .AsString();
+
+          PADDLE_ENFORCE_EQ(attrs.find("decrease_axis") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'paddings' Attribute is expected for "
+                                "SliceOp. "));
+          std::vector<int64_t> decrease_axis;
+          for (size_t i = 0;
+               i <
+               attrs.at("decrease_axis").dyn_cast<pir::ArrayAttribute>().size();
+               i++) {
+            decrease_axis.push_back(attrs.at("decrease_axis")
+                                        .dyn_cast<pir::ArrayAttribute>()
+                                        .at(i)
+                                        .dyn_cast<pir::Int64Attribute>()
+                                        .data());
+          }
+
+          PADDLE_ENFORCE_EQ(attrs.find("infer_flags") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'infer_flags' Attribute is expected for "
+                                "SliceOp. "));
+          std::vector<int64_t> infer_flags;
+          for (size_t i = 0;
+               i <
+               attrs.at("infer_flags").dyn_cast<pir::ArrayAttribute>().size();
+               i++) {
+            infer_flags.push_back(attrs.at("infer_flags")
+                                      .dyn_cast<pir::ArrayAttribute>()
+                                      .at(i)
+                                      .dyn_cast<pir::Int64Attribute>()
+                                      .data());
+          }
+
+          PADDLE_ENFORCE_EQ(
+              attrs.find("axes") != attrs.end(),
+              true,
+              phi::errors::InvalidArgument("'axes' Attribute is expected for "
+                                           "SliceOp. "));
+          std::vector<int64_t> axes;
+          for (size_t i = 0;
+               i < attrs.at("axes").dyn_cast<pir::ArrayAttribute>().size();
+               i++) {
+            axes.push_back(attrs.at("axes")
+                               .dyn_cast<pir::ArrayAttribute>()
+                               .at(i)
+                               .dyn_cast<pir::Int64Attribute>()
+                               .data());
+          }
+
+          return rewriter.Build<paddle::onednn::dialect::SliceOp>(
+              inputs[0],
+              inputs[1],
+              inputs[2],
+              axes,
+              infer_flags,
+              decrease_axis,
+              mkldnn_data_type);
+        }
+        return rewriter.Build<paddle::onednn::dialect::SliceOp>(inputs[0],
+                                                                attrs);
+      });
+
+  RegisterOperationCreator(
+      "onednn_op.squeeze",
+      [](const std::vector<pir::Value>& inputs,
+         const pir::AttributeMap& attrs,
+         pir::PatternRewriter& rewriter) {
+        if (inputs.size() == 2) {
+          PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'mkldnn_data_type' Attribute is expected "
+                                "for SqueezeOp. "));
+          std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
+                                             .dyn_cast<pir::StrAttribute>()
+                                             .AsString();
+
+          return rewriter.Build<paddle::onednn::dialect::SqueezeOp>(
+              inputs[0], inputs[1], mkldnn_data_type);
+        }
+        return rewriter.Build<paddle::onednn::dialect::SqueezeOp>(inputs[0],
+                                                                  attrs);
+      });
+
+  RegisterOperationCreator(
+      "onednn_op.squeeze_",
+      [](const std::vector<pir::Value>& inputs,
+         const pir::AttributeMap& attrs,
+         pir::PatternRewriter& rewriter) {
+        if (inputs.size() == 2) {
+          PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'mkldnn_data_type' Attribute is expected "
+                                "for Squeeze_Op. "));
+          std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
+                                             .dyn_cast<pir::StrAttribute>()
+                                             .AsString();
+
+          return rewriter.Build<paddle::onednn::dialect::Squeeze_Op>(
+              inputs[0], inputs[1], mkldnn_data_type);
+        }
+        return rewriter.Build<paddle::onednn::dialect::Squeeze_Op>(inputs[0],
+                                                                   attrs);
+      });
+
+  RegisterOperationCreator(
+      "onednn_op.clip",
+      [](const std::vector<pir::Value>& inputs,
+         const pir::AttributeMap& attrs,
+         pir::PatternRewriter& rewriter) {
+        if (inputs.size() == 3) {
+          PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'mkldnn_data_type' Attribute is expected "
+                                "for ClipOp. "));
+          std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
+                                             .dyn_cast<pir::StrAttribute>()
+                                             .AsString();
+
+          return rewriter.Build<paddle::onednn::dialect::ClipOp>(
+              inputs[0], inputs[1], inputs[2], mkldnn_data_type);
+        }
+        return rewriter.Build<paddle::onednn::dialect::ClipOp>(inputs[0],
+                                                               attrs);
+      });
+
+  RegisterOperationCreator(
+      "onednn_op.clip_",
+      [](const std::vector<pir::Value>& inputs,
+         const pir::AttributeMap& attrs,
+         pir::PatternRewriter& rewriter) {
+        if (inputs.size() == 3) {
+          PADDLE_ENFORCE_EQ(attrs.find("mkldnn_data_type") != attrs.end(),
+                            true,
+                            phi::errors::InvalidArgument(
+                                "'mkldnn_data_type' Attribute is expected "
+                                "for Clip_Op. "));
+          std::string mkldnn_data_type = attrs.at("mkldnn_data_type")
+                                             .dyn_cast<pir::StrAttribute>()
+                                             .AsString();
+
+          return rewriter.Build<paddle::onednn::dialect::Clip_Op>(
+              inputs[0], inputs[1], inputs[2], mkldnn_data_type);
+        }
+        return rewriter.Build<paddle::onednn::dialect::Clip_Op>(inputs[0],
+                                                                attrs);
+      });
+
 #endif
 
   RegisterOperationCreator(

--- a/paddle/phi/ops/yaml/inconsistent/onednn_ops_extra.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/onednn_ops_extra.yaml
@@ -302,7 +302,6 @@
 
 - op : sum
   dynamic_fallback : True
-  extra_args : str mkldnn_data_type="float32"
 
 - op : sum_grad
   dynamic_fallback : True

--- a/paddle/phi/ops/yaml/inconsistent/onednn_ops_extra.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/onednn_ops_extra.yaml
@@ -302,6 +302,7 @@
 
 - op : sum
   dynamic_fallback : True
+  extra_args : str mkldnn_data_type="float32"
 
 - op : sum_grad
   dynamic_fallback : True


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
For 10 op, such as reshape, pool2d, sum, slice, clip... There are multiple build methods for these op. Sometime consider parameter as input sometimes as attribute. We dispatch these op in register factory to support multiple build
