### PR TITLE
[CINN] Simplify the index expression of Reshape

### DIFF
--- a/paddle/cinn/ir/ir_analyzer/ir_analyzer.cc
+++ b/paddle/cinn/ir/ir_analyzer/ir_analyzer.cc
@@ -477,7 +477,8 @@ bool IsBroadcastSBlock(ir::Expr block) {
   };
   int num_load_index_zero = 0;
   for (size_t i = 0; i < load->indices.size(); ++i) {
-    if (IsIndexZero(load->indices[i]) && !IsIndexZero(store->indices[i])) {
+    if (IsIndexZero(load->indices[i]) && i < store->indices.size() &&
+        !IsIndexZero(store->indices[i])) {
       ++num_load_index_zero;
       continue;
     }

--- a/paddle/cinn/optim/ir_simplify.cc
+++ b/paddle/cinn/optim/ir_simplify.cc
@@ -339,7 +339,7 @@ struct SimplifyBlocksMutator : public ir::IRMutator<> {
 };
 
 struct SimplifyForLoopsMutator : public ir::IRMutator<> {
-  absl::flat_hash_map<std::string, cinn::common::CasInterval> var_intervals;
+  absl::flat_hash_map<std::string, Expr> var_mins;
   SimplifyForLoopsMutator() {}
 
   void operator()(Expr* x) { ir::IRMutator<ir::Expr*>::Visit(x, x); }
@@ -355,14 +355,12 @@ struct SimplifyForLoopsMutator : public ir::IRMutator<> {
     if (min_i && extent_i && extent_i->value - min_i->value == 1) {
       VLOG(6) << "Simplify current For Loop";
       std::string var_name = node->loop_var->name;
-      var_intervals.emplace(
-          var_name,
-          cinn::common::CasInterval{min_i->value, extent_i->value - 1});
+      var_mins.emplace(var_name, node->min);
 
       *expr = node->body;
 
       Visit(expr, expr);
-      var_intervals.erase(var_name);
+      var_mins.erase(var_name);
     } else {
       Visit(&node->body, &node->body);
     }
@@ -371,9 +369,8 @@ struct SimplifyForLoopsMutator : public ir::IRMutator<> {
   void Visit(const _Var_* op, Expr* expr) override {
     auto* node = expr->As<ir::_Var_>();
 
-    if (var_intervals.count(node->name)) {
-      auto loop_range = var_intervals.at(node->name);
-      *expr = Expr(loop_range.l);
+    if (var_mins.count(node->name)) {
+      *expr = var_mins.at(node->name);
     }
   }
 };


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Improvements


### Description
This PR introduces an optimization for the `pe::Reshape` index calculation. The previous implementation involved complex calculations to determine the input tensor indices from the output tensor indices, by computing the absolute offset in the output and then back-calculating each dimension of the input tensor. For example, transforming an input tensor `x` of shape `[S0, S1, S2, 128]` to an output tensor `y` of shape `[S0, S1*S2, 32, 4]` required calculating the `offset` as `offset=((i*S1*S2+j)*32+k)*4+m`, and then converting it to the input indices using `[offset/(S1*S2*128), offset/(S2*128)%S1, offset/128%S2, offset%128]`.

The optimization leverages the correspondence between input and output axes, for instance, `[32, 4]` corresponding to `[128]`, and `[S1*S2]` corresponding to `[S1, S2]`. The new approach generates each axis index directly based on this correspondence, resulting in simpler and more efficient calculations. For the given example, the optimized indices are computed as `[i, j/S2, j%S2, k*4+m]`.

pcard-85711