### PR TITLE
[OneDNN] Fix Prelu kernel failed in bf16 since data type error

### DIFF
--- a/paddle/phi/backends/onednn/onednn_reuse.h
+++ b/paddle/phi/backends/onednn/onednn_reuse.h
@@ -1293,18 +1293,18 @@ class PReluOneDNNHandler
 
   std::shared_ptr<memory> AcquireWeightsMemoryPossiblyWithReorder(
       const DenseTensor* weights, const bool is_test) {
-    const T* weights_data = weights->data<T>();
+    const float* weights_data = weights->data<float>();
 
     // if weights are 1D, every format tag is correct, so we accept
     // format_tag::any's output and no reorder is needed
     if (weights->dims().size() == 1) {
-      return this->AcquireMemoryFromPrimitive(this->fwd_pd_->weights_desc(),
-                                              to_void_cast<T>(weights_data));
+      return this->AcquireMemoryFromPrimitive(
+          this->fwd_pd_->weights_desc(), to_void_cast<float>(weights_data));
     }
 
     return this->AcquireMemoryWithReorder(weights->mem_desc(),
                                           this->fwd_pd_->weights_desc(),
-                                          to_void_cast<T>(weights_data),
+                                          to_void_cast<float>(weights_data),
                                           is_test);
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
 Bug fixes


### Description
We found in bf16, prelu kernel will failed. Since in bf16, many inputs such as filter, bias, scale, alpha do not require quantization.
But Prelu kernel input 'alpha', it use x data type as it's data type, which will failed if x is bf16.
Refer to clip, fc, layernorm kernel, such kinds of input can use fp32 as it's type directly.
