### PR TITLE
[XPU] Fix L3 autotune

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -2278,6 +2278,12 @@ bool AnalysisPredictor::ZeroCopyRun() {
                              config_.xpu_config_.l3_autotune_size,
                              place_);
   }
+
+  if (config_.use_xpu_ && infer_xpu_ctx != nullptr &&
+      config_.xpu_config_.l3_autotune_size > 0) {
+    infer_xpu_ctx->L3CacheAutotune();
+  }
+
 #endif
 
   if (config_.new_executor_enabled()) {
@@ -2286,12 +2292,6 @@ bool AnalysisPredictor::ZeroCopyRun() {
     executor_->Run();
   }
   inference::DisplayMemoryInfo(place_, "after run");
-
-#ifdef PADDLE_WITH_XPU
-  if (config_.use_xpu_ && !config_.use_lite_ && infer_xpu_ctx != nullptr) {
-    infer_xpu_ctx->L3CacheAutotune();
-  }
-#endif
 
   // Fix TensorArray reuse not cleaned bug.
   tensor_array_batch_cleaner_.CollectTensorArrays(sub_scope_);

--- a/paddle/fluid/inference/api/infer_context.cc
+++ b/paddle/fluid/inference/api/infer_context.cc
@@ -225,7 +225,7 @@ void InferXPUContext::SetFcAutotuneInfo(std::string fc_autotune_file,
 }
 
 void InferXPUContext::L3CacheAutotune() {
-  if (l3_autotune_size_ == 0) return;
+  if (l3_autotune_size_ == 0 || l3_blocks_.size() == 0) return;
   if (holder_map_.empty()) {
     l3_plan_.RunAutotune(l3_blocks_, l3_size_);
     auto* plan = l3_plan_.plan();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Others

### PR Types
Bug fixes


### Description
- card-85565
- 相关PR：https://github.com/PaddlePaddle/Paddle/pull/65548
- 修复在超大Batch下，因为使用L3Cache导致Output Tensor指针不一致的问题
- 相关修复PR：https://github.com/PaddlePaddle/Paddle/pull/66125 ，本PR在此基础上允许XPU L3存放output tensor，进一步提升推理速度

- 原始问题：
![image](https://github.com/user-attachments/assets/f5c01950-81f5-4373-a9ae-005f8e83f221)
- 修复后：
![image](https://github.com/user-attachments/assets/87f293bf-527d-455a-a64b-ab4b5bb1bf6e)