### PR TITLE
[Typing][PEP585 Upgrade][BUAA][11-20] Use standard collections for type hints for 8 files in `python/paddle/`

### DIFF
--- a/python/paddle/audio/datasets/dataset.py
+++ b/python/paddle/audio/datasets/dataset.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List
+from __future__ import annotations
 
 import paddle
 
@@ -33,8 +33,8 @@ class AudioClassificationDataset(paddle.io.Dataset):
 
     def __init__(
         self,
-        files: List[str],
-        labels: List[int],
+        files: list[str],
+        labels: list[int],
         feat_type: str = 'raw',
         sample_rate: int = None,
         **kwargs,

--- a/python/paddle/audio/datasets/esc50.py
+++ b/python/paddle/audio/datasets/esc50.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import collections
 import os
-from typing import List, Tuple
 
 from paddle.dataset.common import DATA_HOME
 from paddle.utils import download
@@ -166,14 +167,14 @@ class ESC50(AudioClassificationDataset):
             files=files, labels=labels, feat_type=feat_type, **kwargs
         )
 
-    def _get_meta_info(self) -> List[collections.namedtuple]:
+    def _get_meta_info(self) -> list[collections.namedtuple]:
         ret = []
         with open(os.path.join(DATA_HOME, self.meta), 'r') as rf:
             for line in rf.readlines()[1:]:
                 ret.append(self.meta_info(*line.strip().split(',')))
         return ret
 
-    def _get_data(self, mode: str, split: int) -> Tuple[List[str], List[int]]:
+    def _get_data(self, mode: str, split: int) -> tuple[list[str], list[int]]:
         if not os.path.isdir(
             os.path.join(DATA_HOME, self.audio_path)
         ) or not os.path.isfile(os.path.join(DATA_HOME, self.meta)):

--- a/python/paddle/audio/datasets/tess.py
+++ b/python/paddle/audio/datasets/tess.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import collections
 import os
-from typing import List, Tuple
 
 from paddle.dataset.common import DATA_HOME
 from paddle.utils import download
@@ -111,7 +112,7 @@ class TESS(AudioClassificationDataset):
             files=files, labels=labels, feat_type=feat_type, **kwargs
         )
 
-    def _get_meta_info(self, files) -> List[collections.namedtuple]:
+    def _get_meta_info(self, files) -> list[collections.namedtuple]:
         ret = []
         for file in files:
             basename_without_extend = os.path.basename(file)[:-4]
@@ -120,7 +121,7 @@ class TESS(AudioClassificationDataset):
 
     def _get_data(
         self, mode: str, n_folds: int, split: int
-    ) -> Tuple[List[str], List[int]]:
+    ) -> tuple[list[str], list[int]]:
         if not os.path.isdir(os.path.join(DATA_HOME, self.audio_path)):
             download.get_path_from_url(
                 self.archive['url'],

--- a/python/paddle/audio/functional/window.py
+++ b/python/paddle/audio/functional/window.py
@@ -10,8 +10,9 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
+from __future__ import annotations
+
 import math
-from typing import List, Tuple, Union
 
 import numpy as np
 
@@ -39,7 +40,7 @@ window_function_register = WindowFunctionRegister()
 
 
 @window_function_register.register()
-def _cat(x: List[Tensor], data_type: str) -> Tensor:
+def _cat(x: list[Tensor], data_type: str) -> Tensor:
     l = []
     for t in x:
         if np.isscalar(t) and not isinstance(t, str):
@@ -50,7 +51,7 @@ def _cat(x: List[Tensor], data_type: str) -> Tensor:
 
 
 @window_function_register.register()
-def _acosh(x: Union[Tensor, float]) -> Tensor:
+def _acosh(x: Tensor | float) -> Tensor:
     if isinstance(x, float):
         return math.log(x + math.sqrt(x**2 - 1))
     return paddle.log(x + paddle.sqrt(paddle.square(x) - 1))
@@ -333,7 +334,7 @@ def _cosine(M: int, sym: bool = True, dtype: str = 'float64') -> Tensor:
 
 
 def get_window(
-    window: Union[str, Tuple[str, float]],
+    window: str | tuple[str, float],
     win_length: int,
     fftbins: bool = True,
     dtype: str = 'float64',

--- a/python/paddle/autograd/autograd.py
+++ b/python/paddle/autograd/autograd.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
-from typing import Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
 
 import paddle
 from paddle.base import framework
@@ -448,10 +449,10 @@ def _multi_index(indexes, shape):
 
 
 def jacobian(
-    ys: Union[paddle.Tensor, Tuple[paddle.Tensor, ...]],
-    xs: Union[paddle.Tensor, Tuple[paddle.Tensor, ...]],
-    batch_axis: Optional[int] = None,
-) -> Union[Tuple[Tuple[Jacobian, ...], ...], Tuple[Jacobian, ...], Jacobian]:
+    ys: paddle.Tensor | tuple[paddle.Tensor, ...],
+    xs: paddle.Tensor | tuple[paddle.Tensor, ...],
+    batch_axis: int | None = None,
+) -> tuple[tuple[Jacobian, ...], ...] | tuple[Jacobian, ...] | Jacobian:
     r"""
     Computes the Jacobian of the dependent variable ``ys`` versus the independent
     variable ``xs``.
@@ -543,9 +544,9 @@ def jacobian(
 
 def hessian(
     ys: paddle.Tensor,
-    xs: Union[paddle.Tensor, Tuple[paddle.Tensor, ...]],
-    batch_axis: Optional[int] = None,
-) -> Union[Tuple[Tuple[Hessian, ...], ...], Hessian]:
+    xs: paddle.Tensor | tuple[paddle.Tensor, ...],
+    batch_axis: int | None = None,
+) -> tuple[tuple[Hessian, ...], ...] | Hessian:
     r"""
     Computes the Jacobian of the dependent variable ``ys`` versus the independent
     variable ``xs``.

--- a/python/paddle/autograd/backward_mode.py
+++ b/python/paddle/autograd/backward_mode.py
@@ -14,13 +14,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import paddle
 from paddle.base import core, framework
 from paddle.base.backward import gradients_with_optimizer  # noqa: F401
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor
 
 

--- a/python/paddle/autograd/py_layer.py
+++ b/python/paddle/autograd/py_layer.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from typing_extensions import Concatenate
 
@@ -22,6 +22,8 @@ import paddle
 from paddle.base import core
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor
 
 

--- a/python/paddle/base/dygraph/base.py
+++ b/python/paddle/base/dygraph/base.py
@@ -298,7 +298,7 @@ def _switch_tracer_mode_guard_(
 
 
 @overload
-def no_grad(func: None = ...) -> AbstractAsyncContextManager:
+def no_grad(func: None = ...) -> AbstractContextManager:
     ...
 
 

--- a/python/paddle/base/dygraph/base.py
+++ b/python/paddle/base/dygraph/base.py
@@ -40,7 +40,7 @@ from .tracer import Tracer
 if TYPE_CHECKING:
     from collections import OrderedDict
     from collections.abc import Generator, Sequence
-    from contextlib import AbstractAsyncContextManager
+    from contextlib import AbstractContextManager
     from types import TracebackType
 
     from typing_extensions import Self

--- a/python/paddle/base/dygraph/base.py
+++ b/python/paddle/base/dygraph/base.py
@@ -21,8 +21,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    ContextManager,
-    Sequence,
     TypeVar,
     overload,
 )
@@ -41,8 +39,9 @@ from .tracer import Tracer
 
 if TYPE_CHECKING:
     from collections import OrderedDict
+    from collections.abc import Generator, Sequence
+    from contextlib import AbstractAsyncContextManager
     from types import TracebackType
-    from typing import Generator
 
     from typing_extensions import Self
 
@@ -299,7 +298,7 @@ def _switch_tracer_mode_guard_(
 
 
 @overload
-def no_grad(func: None = ...) -> ContextManager:
+def no_grad(func: None = ...) -> AbstractAsyncContextManager:
     ...
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

为如下文件添加 PEP 563，并进行 PEP 585 升级：

- python/paddle/audio/backends/init_backend.py （无需修改）
- python/paddle/audio/backends/wave_backend.py （无需修改）
- python/paddle/audio/datasets/dataset.py
- python/paddle/audio/datasets/esc50.py
- python/paddle/audio/datasets/tess.py
- python/paddle/audio/functional/window.py
- python/paddle/autograd/autograd.py
- python/paddle/autograd/backward_mode.py
- python/paddle/autograd/py_layer.py
- python/paddle/base/dygraph/base.py

### Related links

- #66936

@gouzil