### PR TITLE
Modify tile config tests

### DIFF
--- a/paddle/cinn/ir/group_schedule/search/config_searcher.cc
+++ b/paddle/cinn/ir/group_schedule/search/config_searcher.cc
@@ -96,7 +96,7 @@ WeightedSamplingTrailObjectiveFunc::WeightedSamplingTrailObjectiveFunc(
 ScoreType WeightedSamplingTrailObjectiveFunc::operator()(
     const CandidateType& candidate) {
   auto tile_config_database = std::make_shared<NaiveTileConfigDatabase>();
-  VLOG(3) << "Bucket_info_.space.size is " << bucket_info_.space.size();
+  // VLOG(3) << "Bucket_info_.space.size is " << bucket_info_.space.size();
   if (candidate.size() != 0) {
     ScheduleConfig::TileConfig config{
         candidate[0], candidate[1], candidate[2], NoneReduceMethod()};
@@ -198,10 +198,10 @@ bool CandidateGenerator::IsValid(const CandidateType& candidate) const {
 }
 
 ScheduleConfigSearcher::ScheduleConfigSearcher(
-    std::unique_ptr<BaseObjectiveFunc> objective_func,
+    std::vector<std::unique_ptr<BaseObjectiveFunc>> objective_funcs,
     const std::vector<std::pair<int, int>>& candidate_range,
     const std::vector<ConstraintFunc>& contraints)
-    : objective_func_(std::move(objective_func)),
+    : objective_funcs_(std::move(objective_funcs)),
       candidate_range_(candidate_range),
       contraints_(contraints) {}
 
@@ -212,7 +212,10 @@ std::pair<ScoreType, CandidateType> ScheduleConfigSearcher::Search(
   std::vector<CandidateType> candidates = candidate_generator.Candidates();
   VLOG(6) << "Candidate num = " << candidates.size();
   for (const auto& candidate : candidates) {
-    ScoreType score = (*objective_func_)(candidate);
+    ScoreType score = 0;
+    for (auto& objective_func_ : objective_funcs_) {
+      score += (*objective_func_)(candidate);
+    }
     VLOG(6) << "Candidate: [" << utils::Join<int64_t>(candidate, ", ") << "]";
     VLOG(6) << "Score = " << score;
     records_[score] = candidate;

--- a/paddle/cinn/ir/group_schedule/search/config_searcher.cc
+++ b/paddle/cinn/ir/group_schedule/search/config_searcher.cc
@@ -96,7 +96,7 @@ WeightedSamplingTrailObjectiveFunc::WeightedSamplingTrailObjectiveFunc(
 ScoreType WeightedSamplingTrailObjectiveFunc::operator()(
     const CandidateType& candidate) {
   auto tile_config_database = std::make_shared<NaiveTileConfigDatabase>();
-  // VLOG(3) << "Bucket_info_.space.size is " << bucket_info_.space.size();
+  VLOG(3) << "Bucket_info_.space.size is " << bucket_info_.space.size();
   if (candidate.size() != 0) {
     ScheduleConfig::TileConfig config{
         candidate[0], candidate[1], candidate[2], NoneReduceMethod()};

--- a/paddle/cinn/ir/group_schedule/search/config_searcher.h
+++ b/paddle/cinn/ir/group_schedule/search/config_searcher.h
@@ -83,14 +83,14 @@ class CandidateGenerator {
 class ScheduleConfigSearcher {
  public:
   ScheduleConfigSearcher(
-      std::unique_ptr<BaseObjectiveFunc> objective_func,
+      std::vector<std::unique_ptr<BaseObjectiveFunc>> objective_funcs,
       const std::vector<std::pair<int, int>>& candidate_range,
       const std::vector<ConstraintFunc>& contraints = {});
 
   std::pair<ScoreType, CandidateType> Search(bool is_search_minimun = true);
 
  private:
-  std::unique_ptr<BaseObjectiveFunc> objective_func_;
+  std::vector<std::unique_ptr<BaseObjectiveFunc>> objective_funcs_;
   std::vector<ConstraintFunc> contraints_;
   std::vector<std::pair<int, int>> candidate_range_;
 

--- a/test/cpp/pir/cinn/file_tile_config_test.cc
+++ b/test/cpp/pir/cinn/file_tile_config_test.cc
@@ -55,23 +55,26 @@ void RemoveDir(const cinn::common::Target target,
     filename += i.first + i.second;
     filename += "_";
   }
-  dirname = dirname.substr(0, dirname.size() - 1);
+  const std::string kDirSuffix = "_EREBE";
+  dirname = dirname.substr(0, dirname.size() - 1) + kDirSuffix;
   filename = filename.substr(0, filename.size() - 1);
 
-  auto removedir = [](const std::string& test_path) {
+  auto removedir = [](const std::string& test_path,
+                      const std::string& file_name) {
     if (PathExists(test_path)) {
-      std::remove(test_path.c_str());
+      std::string full_test_name = test_path + file_name;
+      std::remove(full_test_name.c_str());
       LOG(INFO) << "File exsit.";
     } else {
       LOG(INFO) << "File doesn't exsit.";
     }
   };
   std::string root_path = FLAGS_cinn_tile_config_filename_label;
-  dirname += "/" + filename + ".json";
-  removedir(root_path + target.arch_str() + "/" + dirname);
-  LOG(INFO) << "Dump_file "
-            << root_path + target.arch_str() + "/" + dirname +
-                   " has been removed";
+  std::string target_str = target.arch_str() + "_" + target.device_name_str();
+  std::string file_name = "/" + filename + ".json";
+  removedir(root_path + target_str + "/" + dirname, file_name);
+  LOG(INFO) << "Dump_path "
+            << root_path + target_str + "/" + dirname + " has been removed";
 }
 
 TEST(ConfigSearcher, TestReduceDemo) {
@@ -104,11 +107,16 @@ TEST(ConfigSearcher, TestReduceDemo) {
   tile_config.spatial_inner_num = 9;
   tile_config.warp_num = 14;
   tile_config.tree_reduce_num = 512;
+  // use test tile_config filename
+  const std::string prev_flag = FLAGS_cinn_tile_config_filename_label;
+  FLAGS_cinn_tile_config_filename_label = "./tile_file_test/";
   std::vector<std::pair<std::string, std::string>> iter_space_type = {
       std::make_pair(s_dimension_type,
                      s_dimension_is_dynamic == true ? "dynamic" : "static"),
       std::make_pair(r_dimension_type,
                      r_dimension_is_dynamic == true ? "dynamic" : "static")};
+  // If test file has been created, remove it.
+  RemoveDir(cinn::common::DefaultTarget(), iter_space_type);
   // Step 2: Add to json / Read from json
   cinn::ir::FileTileConfigDatabase file_database;
   file_database.AddConfig(
@@ -128,8 +136,6 @@ TEST(ConfigSearcher, TestReduceDemo) {
                 << " 's upper_bound is: " << it.first.space[i].upper_bound;
       auto dimension_lower = i == 0 ? s_dimension_lower : r_dimension_lower;
       auto dimension_upper = i == 0 ? s_dimension_upper : r_dimension_upper;
-      // TODO(xia zichao): remove check because the pieces of read data are more
-      // than the written data.
       PADDLE_ENFORCE_EQ(it.first.space[i].lower_bound,
                         dimension_lower,
                         ::common::errors::InvalidArgument(
@@ -154,4 +160,5 @@ TEST(ConfigSearcher, TestReduceDemo) {
                       ::common::errors::InvalidArgument(
                           "GetConfigs function gets wrong tree_reduce_num"));
   }
+  FLAGS_cinn_tile_config_filename_label = prev_flag;
 }

--- a/test/cpp/pir/cinn/tile_config_performance_test.cc
+++ b/test/cpp/pir/cinn/tile_config_performance_test.cc
@@ -703,10 +703,10 @@ void TestPerformanceForTileConfig(int spatial_left_bound,
  */
 
 TEST(ConfigSearcher, TestPerfDynamicDynamic) {
-  constexpr int spatial_left_bound = 2;      // for full test, set it to 2
-  constexpr int spatial_right_bound = 4096;  // for full test, set it to 4096
-  constexpr int reduce_left_bound = 2;       // for full test, set it to 2
-  constexpr int reduce_right_bound = 4096;   // for full test, set it to 4096
+  constexpr int spatial_left_bound = 2;   // for full test, set it to 2
+  constexpr int spatial_right_bound = 2;  // for full test, set it to 4096
+  constexpr int reduce_left_bound = 2;    // for full test, set it to 2
+  constexpr int reduce_right_bound = 2;   // for full test, set it to 4096
   constexpr bool is_spatial_dynamic = true;
   constexpr bool is_reduce_dynamic = true;
   TestPerformanceForTileConfig(spatial_left_bound,
@@ -718,10 +718,10 @@ TEST(ConfigSearcher, TestPerfDynamicDynamic) {
 }
 
 TEST(ConfigSearcher, TestPerfStaticDynamic) {
-  constexpr int spatial_left_bound = 2;      // for full test, set it to 2
-  constexpr int spatial_right_bound = 4096;  // for full test, set it to 4096
-  constexpr int reduce_left_bound = 2;       // for full test, set it to 2
-  constexpr int reduce_right_bound = 4096;   // for full test, set it to 4096
+  constexpr int spatial_left_bound = 2;   // for full test, set it to 2
+  constexpr int spatial_right_bound = 2;  // for full test, set it to 4096
+  constexpr int reduce_left_bound = 2;    // for full test, set it to 2
+  constexpr int reduce_right_bound = 2;   // for full test, set it to 4096
   constexpr bool is_spatial_dynamic = false;
   constexpr bool is_reduce_dynamic = true;
   TestPerformanceForTileConfig(spatial_left_bound,
@@ -733,10 +733,10 @@ TEST(ConfigSearcher, TestPerfStaticDynamic) {
 }
 
 TEST(ConfigSearcher, TestPerfDynamicStatic) {
-  constexpr int spatial_left_bound = 2;      // for full test, set it to 2
-  constexpr int spatial_right_bound = 4096;  // for full test, set it to 4096
-  constexpr int reduce_left_bound = 2;       // for full test, set it to 2
-  constexpr int reduce_right_bound = 4096;   // for full test, set it to 4096
+  constexpr int spatial_left_bound = 2;   // for full test, set it to 2
+  constexpr int spatial_right_bound = 2;  // for full test, set it to 4096
+  constexpr int reduce_left_bound = 2;    // for full test, set it to 2
+  constexpr int reduce_right_bound = 2;   // for full test, set it to 4096
   constexpr bool is_spatial_dynamic = true;
   constexpr bool is_reduce_dynamic = false;
   TestPerformanceForTileConfig(spatial_left_bound,

--- a/test/cpp/pir/cinn/tile_config_performance_test.cc
+++ b/test/cpp/pir/cinn/tile_config_performance_test.cc
@@ -42,9 +42,25 @@ PD_DECLARE_bool(cinn_measure_kernel_time);
 PHI_DECLARE_bool(enable_cinn_compile_cache);
 
 #define MKDIR(path) mkdir(path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
+struct PerfTestConfig {
+  int InnerTestNum;
+  int OuterTestNum;
+  int MaxTestNum;
+  float EarlyStopThreshold;
+  PerfTestConfig()
+      : InnerTestNum(1),
+        OuterTestNum(3),
+        MaxTestNum(3),
+        EarlyStopThreshold(1.2) {}
+  PerfTestConfig(int inner_num, int outer_num, int max_num, float earlystop)
+      : InnerTestNum(inner_num),
+        OuterTestNum(outer_num),
+        MaxTestNum(max_num),
+        EarlyStopThreshold(earlystop) {}
+};
 
 std::string GenCSVFilePath(const cinn::common::Target target,
-                           const cinn::ir::IterSpaceType& iter_space_type) {
+                           const cinn::ir::IterSpaceType &iter_space_type) {
   std::string dirname = "";
   std::string filename = "";
   for (auto i : iter_space_type) {
@@ -53,7 +69,8 @@ std::string GenCSVFilePath(const cinn::common::Target target,
     filename += i.first + i.second;
     filename += "_";
   }
-  dirname = dirname.substr(0, dirname.size() - 1);
+  const std::string kDirSuffix = "_EREBE";
+  dirname = dirname.substr(0, dirname.size() - 1) + kDirSuffix;
   filename = filename.substr(0, filename.size() - 1);
 
   auto checkexist = [](std::string test_path) {
@@ -82,15 +99,30 @@ std::string GenCSVFilePath(const cinn::common::Target target,
   return root_path + target_str + "/" + dirname + "/" + filename + ".csv";
 }
 
+void WriteBucketInfo(
+    std::ofstream &os,
+    const std::vector<std::pair<std::string, std::string>> &iter_space_type,
+    const cinn::ir::BucketInfo &bucket_info) {
+  std::stringstream ss;
+  ss << " { ";
+  for (int i = 0; i < iter_space_type.size(); ++i) {
+    ss << iter_space_type[i].first << "_" << iter_space_type[i].second << ": "
+       << bucket_info.space[i].lower_bound << "-"
+       << bucket_info.space[i].upper_bound << " ";
+  }
+  ss << "} ";
+  os << ss.str() << " \t ";
+}
+
+// reduce_sum
 std::shared_ptr<::pir::Program> BuildReduceSumProgram(int spatial_size,
                                                       int reduce_size) {
-  ::pir::IrContext* ctx = ::pir::IrContext::Instance();
+  ::pir::IrContext *ctx = ::pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
 
   auto program = std::make_shared<::pir::Program>(ctx);
   ::pir::Builder builder = ::pir::Builder(ctx, program->block());
 
-  const float value_one = 1.0;
   const std::vector<int64_t> shape = {spatial_size, reduce_size};
   auto x = builder
                .Build<paddle::dialect::DataOp>(
@@ -104,58 +136,422 @@ std::shared_ptr<::pir::Program> BuildReduceSumProgram(int spatial_size,
   return program;
 }
 
+// layerNorm
+std::shared_ptr<::pir::Program> BuildLayerNormProgram(int spatial_size,
+                                                      int reduce_size) {
+  ::pir::IrContext *ctx = ::pir::IrContext::Instance();
+  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
+
+  auto program = std::make_shared<::pir::Program>(ctx);
+  ::pir::Builder builder = ::pir::Builder(ctx, program->block());
+
+  const std::vector<int64_t> shape = {spatial_size, reduce_size};
+  auto x = builder
+               .Build<paddle::dialect::DataOp>(
+                   "x", shape, phi::DataType::FLOAT32, phi::GPUPlace())
+               .result(0);
+  auto sum_val =
+      builder
+          .Build<paddle::dialect::SumOp>(
+              x, std::vector<int64_t>{-1}, phi::DataType::FLOAT32, true)
+          .result(0);
+
+  auto divide_num =
+      builder
+          .Build<paddle::dialect::FullOp>(
+              std::vector<int64_t>({1}), 1024, phi::DataType::FLOAT32)
+          .out();
+  auto mean_val =
+      builder.Build<paddle::dialect::DivideOp>(sum_val, divide_num).result(0);
+  auto sub_num =
+      builder.Build<paddle::dialect::SubtractOp>(x, mean_val).result(0);
+  auto pow_val = builder.Build<paddle::dialect::PowOp>(x, 2.0).result(0);
+  auto pow_sum =
+      builder
+          .Build<paddle::dialect::SumOp>(
+              pow_val, std::vector<int64_t>{-1}, phi::DataType::FLOAT32, true)
+          .result(0);
+  auto variance_val =
+      builder.Build<paddle::dialect::DivideOp>(pow_sum, divide_num).result(0);
+  auto add_num =
+      builder
+          .Build<paddle::dialect::FullOp>(
+              std::vector<int64_t>({1}), 1e-6, phi::DataType::FLOAT32)
+          .out();
+  auto add_val =
+      builder.Build<paddle::dialect::AddOp>(variance_val, add_num).result(0);
+  auto rsqrt_val = builder.Build<paddle::dialect::RsqrtOp>(add_val).result(0);
+  auto out =
+      builder.Build<paddle::dialect::MultiplyOp>(rsqrt_val, sub_num).result(0);
+
+  builder.Build<paddle::dialect::FetchOp>(out, "out", 0);
+  return program;
+}
+
+// softmax
+std::shared_ptr<::pir::Program> BuildSoftmaxProgram(int spatial_size,
+                                                    int reduce_size) {
+  ::pir::IrContext *ctx = ::pir::IrContext::Instance();
+  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
+
+  auto program = std::make_shared<::pir::Program>(ctx);
+  ::pir::Builder builder = ::pir::Builder(ctx, program->block());
+
+  const std::vector<int64_t> shape = {spatial_size, reduce_size};
+  auto x = builder
+               .Build<paddle::dialect::DataOp>(
+                   "x", shape, phi::DataType::FLOAT32, phi::GPUPlace())
+               .result(0);
+  auto max_num =
+      builder.Build<paddle::dialect::MaxOp>(x, std::vector<int64_t>{-1}, true)
+          .result(0);
+  auto sub_num =
+      builder.Build<paddle::dialect::SubtractOp>(x, max_num).result(0);
+  auto exp_num = builder.Build<paddle::dialect::ExpOp>(sub_num).result(0);
+  auto exp_sum =
+      builder
+          .Build<paddle::dialect::SumOp>(
+              exp_num, std::vector<int64_t>{-1}, phi::DataType::FLOAT32, true)
+          .result(0);
+  auto out =
+      builder.Build<paddle::dialect::DivideOp>(exp_num, exp_sum).result(0);
+  builder.Build<paddle::dialect::FetchOp>(out, "out", 0);
+  return program;
+}
+
+// RMSNorm
+std::shared_ptr<::pir::Program> BuildRMSNormProgram(int spatial_size,
+                                                    int reduce_size) {
+  ::pir::IrContext *ctx = ::pir::IrContext::Instance();
+  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
+
+  auto program = std::make_shared<::pir::Program>(ctx);
+  ::pir::Builder builder = ::pir::Builder(ctx, program->block());
+
+  const std::vector<int64_t> shape = {spatial_size, reduce_size};
+  auto x = builder
+               .Build<paddle::dialect::DataOp>(
+                   "x", shape, phi::DataType::FLOAT32, phi::GPUPlace())
+               .result(0);
+  auto pow_val = builder.Build<paddle::dialect::PowOp>(x, 2.0).result(0);
+  auto sum_val =
+      builder
+          .Build<paddle::dialect::SumOp>(
+              pow_val, std::vector<int64_t>{-1}, phi::DataType::FLOAT32, true)
+          .result(0);
+  auto divide_num =
+      builder
+          .Build<paddle::dialect::FullOp>(
+              std::vector<int64_t>({1}), reduce_size, phi::DataType::FLOAT32)
+          .out();
+  auto div_val =
+      builder.Build<paddle::dialect::DivideOp>(sum_val, divide_num).result(0);
+  auto add_num =
+      builder
+          .Build<paddle::dialect::FullOp>(
+              std::vector<int64_t>({1}), 1e-6, phi::DataType::FLOAT32)
+          .out();
+  auto add_val =
+      builder.Build<paddle::dialect::AddOp>(div_val, add_num).result(0);
+  auto rsqrt_val = builder.Build<paddle::dialect::RsqrtOp>(add_val).result(0);
+  auto out = builder.Build<paddle::dialect::MultiplyOp>(rsqrt_val, x).result(0);
+
+  builder.Build<paddle::dialect::FetchOp>(out, "out", 0);
+  return program;
+}
+
+// Build test program for spatial reduce.
+std::shared_ptr<::pir::Program> BuildSpatialReduceProgram(int spatial_size,
+                                                          int reduce_size) {
+  std::shared_ptr<::pir::Program> program;
+  program = BuildSoftmaxProgram(spatial_size, reduce_size);
+  return program;
+}
+
 // Get the tile size configuration for the given dimension lower bound
 // dynamically.
-int get_tile_size_config(int dimension_lower) {
-  if (dimension_lower < 32) {
-    return 30;
-  } else if (dimension_lower < 128) {
-    return 32;
-  } else if (dimension_lower < 512) {
-    return 128;
-  } else if (dimension_lower < 1024) {
-    return 256;
-  } else if (dimension_lower < 2048) {
+int get_tile_size_config_in_small_area(int dimension_lower) {
+  if (dimension_lower <= 2) {
+    return 126;
+  } else if (dimension_lower <= 128) {
+    return 384;
+  } else if (dimension_lower <= 512) {
     return 512;
-  } else {
+  } else if (dimension_lower <= 1024) {
     return 1024;
+  } else if (dimension_lower <= 2048) {
+    return 2048;
   }
 }
 
-/**
- * @brief Test case for the ConfigSearcher.
- *
- * This test case performs a perormance test for the best configuration derived
- * from the ConfigSearcher. It iterates over different spatial and reduce tile
- * sizes and constructs a pir::Program. The objective function used for the
- * search is a WeightedSamplingTrailObjectiveFunc. The performance results are
- * logged, including the default score and the best candidate score.
- */
-TEST(ConfigSearcher, TestReducePipeline) {
+int get_tile_size_config_in_large_area(int dimension_lower) {
+  if (dimension_lower <= 2) {
+    return 510;
+  } else if (dimension_lower <= 512) {
+    return 512;
+  } else if (dimension_lower <= 4096) {
+    return 4096;
+  } else if (dimension_lower <= 8192) {
+    return 8192;
+  } else if (dimension_lower <= 16384) {
+    return 16384;
+  }
+}
+
+std::shared_ptr<::pir::Program> BuildProgram(bool is_spatial_dynamic,
+                                             bool is_reduce_dynamic,
+                                             int s_dimension_lower,
+                                             int r_dimension_lower) {
+  std::shared_ptr<::pir::Program> program;
+  if (!is_spatial_dynamic && !is_reduce_dynamic) {
+    program = BuildSpatialReduceProgram(s_dimension_lower, r_dimension_lower);
+  } else if (is_spatial_dynamic && !is_reduce_dynamic) {
+    program = BuildSpatialReduceProgram(-1, r_dimension_lower);
+  } else if (!is_spatial_dynamic && is_reduce_dynamic) {
+    program = BuildSpatialReduceProgram(s_dimension_lower, -1);
+  } else {
+    program = BuildSpatialReduceProgram(-1, -1);
+  }
+  return program;
+}
+
+cinn::ir::BucketInfo CreateBucket(int s_dimension_lower,
+                                  int spatial_tile_width,
+                                  int r_dimension_lower,
+                                  int reduce_tile_width,
+                                  bool is_spatial_dynamic,
+                                  bool is_reduce_dynamic) {
+  cinn::ir::BucketInfo bucket_info;
+  bucket_info.space.push_back(cinn::ir::BucketInfo::Dimension{
+      s_dimension_lower,
+      s_dimension_lower + spatial_tile_width - 1,
+      "S",
+      /* is_dynamic = */ is_spatial_dynamic});
+  bucket_info.space.push_back(
+      cinn::ir::BucketInfo::Dimension{r_dimension_lower,
+                                      r_dimension_lower + reduce_tile_width - 1,
+                                      "R",
+                                      /* is_dynamic = */ is_reduce_dynamic});
+  return bucket_info;
+}
+
+cinn::ir::search::CandidateType GetCandidate(
+    const cinn::ir::TileConfigMap &best_tile_config_map,
+    int s_dimension_lower,
+    int spatial_tile_width,
+    int r_dimension_lower,
+    int reduce_tile_width) {
+  cinn::ir::search::CandidateType best_candidate;
+  for (auto &it : best_tile_config_map) {
+    auto s_flag = false, r_flag = false;
+    auto dims = it.first.space.size();
+    // SR type support only
+    if (dims == 2) {
+      if (it.first.space[0].lower_bound <= s_dimension_lower &&
+          it.first.space[0].upper_bound >=
+              s_dimension_lower + spatial_tile_width - 1) {
+        s_flag = true;
+      } else if (it.first.space[0].lower_bound == 4096 &&
+                 s_dimension_lower == 4096) {
+        s_flag = true;
+      }
+      if (it.first.space[1].lower_bound <= r_dimension_lower &&
+          it.first.space[1].upper_bound >=
+              r_dimension_lower + reduce_tile_width - 1) {
+        r_flag = true;
+      } else if (it.first.space[1].lower_bound == 4096 &&
+                 r_dimension_lower == 4096) {
+        r_flag = true;
+      }
+    } else {
+      PADDLE_THROW(::common::errors::Unavailable("Now just support SR type."));
+    }
+    if (s_flag == true && r_flag == true) {
+      best_candidate = {it.second.warp_num,
+                        it.second.tree_reduce_num,
+                        it.second.spatial_inner_num};
+      break;
+    }
+  }
+  if (best_candidate.empty()) {
+    PADDLE_THROW(
+        ::common::errors::Unavailable("Not found the best candidate."));
+  }
+  return best_candidate;
+}
+
+void TestWindowPerformance(
+    std::ofstream &os,
+    const PerfTestConfig &perf_test_config,
+    const int graph_num,
+    const int s_dimension_lower,
+    const int spatial_tile_width,
+    const int r_dimension_lower,
+    const int reduce_tile_width,
+    const int is_spatial_dynamic,
+    const int is_reduce_dynamic,
+    const double s_weight,
+    const double r_weight,
+    const double sampling_prob,
+    const int kMaxSamplingTimes,
+    const int kRepeats,
+    const cinn::ir::TileConfigMap &best_tile_config_map,
+    const std::vector<std::pair<std::string, std::string>> &iter_space_type) {
+  std::vector<double> s_weights =
+      std::vector<double>(spatial_tile_width, s_weight);
+  std::vector<double> r_weights =
+      std::vector<double>(reduce_tile_width, r_weight);
+
+  LOG(INFO) << "spatial tile dimension lower bound = " << s_dimension_lower
+            << ", reduce tile dimension lower bound = " << r_dimension_lower
+            << std::endl;
+
+  // Construct pir::Program.
+  std::shared_ptr<::pir::Program> program;
+  program = BuildProgram(is_spatial_dynamic,
+                         is_reduce_dynamic,
+                         s_dimension_lower,
+                         r_dimension_lower);
+
+  // Construct iter space and objective function.
+  cinn::ir::BucketInfo bucket_info = CreateBucket(s_dimension_lower,
+                                                  spatial_tile_width,
+                                                  r_dimension_lower,
+                                                  reduce_tile_width,
+                                                  is_spatial_dynamic,
+                                                  is_reduce_dynamic);
+  std::unique_ptr<cinn::ir::search::BaseObjectiveFunc> obj_func =
+      std::make_unique<cinn::ir::search::WeightedSamplingTrailObjectiveFunc>(
+          program.get(),
+          bucket_info,
+          sampling_prob,
+          kMaxSamplingTimes,
+          kRepeats,
+          std::vector<std::vector<double>>{s_weights, r_weights});
+  cinn::ir::search::CandidateType best_candidate =
+      GetCandidate(best_tile_config_map,
+                   s_dimension_lower,
+                   spatial_tile_width,
+                   r_dimension_lower,
+                   reduce_tile_width);
+
+  // Write current bucket info to csv file.
+  WriteBucketInfo(os, iter_space_type, bucket_info);
+
+  int InnerTestNum = perf_test_config.InnerTestNum;
+  int OuterTestNum = perf_test_config.OuterTestNum;
+  int MaxTestNum = perf_test_config.MaxTestNum;
+  float EarlyStopThreshold = perf_test_config.EarlyStopThreshold;
+  cinn::ir::search::ScoreType record_baseline_score;
+  cinn::ir::search::ScoreType record_best_score;
+  double record_best_variance = 0;
+  // start test loop
+  for (int current_test_num = 0; current_test_num < MaxTestNum;
+       ++current_test_num) {
+    std::vector<cinn::ir::search::ScoreType> vec_best;
+    std::vector<cinn::ir::search::ScoreType> vec_baseline;
+    // start outer measure loop
+    for (int i = 0; i < OuterTestNum; ++i) {
+      cinn::ir::search::CandidateType default_candidate;
+      std::vector<cinn::ir::search::ScoreType> vec_best_score;
+      std::vector<cinn::ir::search::ScoreType> vec_baseline_score;
+      // start inner measure loop
+      for (int i = 0; i < InnerTestNum; i++) {
+        FLAGS_tile_config_policy = "default";
+        cinn::ir::search::ScoreType temp_baseline_score =
+            (*obj_func)(default_candidate);
+        FLAGS_tile_config_policy = "search";
+        cinn::ir::search::ScoreType temp_best_score =
+            (*obj_func)(best_candidate);
+        vec_best_score.push_back(temp_best_score);
+        vec_baseline_score.push_back(temp_baseline_score);
+      }
+      float best_total_time =
+          std::accumulate(vec_best_score.begin(), vec_best_score.end(), 0.0);
+      float baseline_total_time = std::accumulate(
+          vec_baseline_score.begin(), vec_baseline_score.end(), 0.0);
+      float best_avg_time = best_total_time / InnerTestNum;
+      float baseline_avg_time = baseline_total_time / InnerTestNum;
+      vec_best.push_back(best_avg_time);
+      vec_baseline.push_back(baseline_avg_time);
+    }
+    cinn::ir::search::ScoreType best_mean =
+        std::accumulate(vec_best.begin(), vec_best.end(), 0.0) / OuterTestNum;
+    cinn::ir::search::ScoreType baseline_mean =
+        std::accumulate(vec_baseline.begin(), vec_baseline.end(), 0.0) /
+        OuterTestNum;
+
+    // Compute variance of OuterTestNum times of outer measure in each test
+    double best_variance = 0.0;
+    double baseline_variance = 0.0;
+    for (int i = 0; i < OuterTestNum; i++) {
+      best_variance = best_variance + pow(vec_best[i] - best_mean, 2);
+      baseline_variance =
+          baseline_variance + pow(vec_baseline[i] - baseline_mean, 2);
+    }
+    best_variance = pow(best_variance / OuterTestNum, 0.5);
+    baseline_variance = pow(baseline_variance / OuterTestNum, 0.5);
+
+    // Early stop when current best_variance smaller than EarlyStopThreshold
+    if ((best_variance < EarlyStopThreshold) &&
+        (baseline_variance < EarlyStopThreshold)) {
+      record_baseline_score = baseline_mean;
+      record_best_score = best_mean;
+      record_best_variance = best_variance + baseline_variance;
+      break;
+    } else {
+      if (record_best_variance == 0) {
+        record_best_variance = best_variance + baseline_variance;
+        record_baseline_score = baseline_mean;
+        record_best_score = best_mean;
+      } else if ((best_variance + baseline_variance) < record_best_variance) {
+        record_best_variance = best_variance + baseline_variance;
+        record_baseline_score = baseline_mean;
+        record_best_score = best_mean;
+      }
+    }
+  }  // end of test_num loop
+  cinn::ir::search::ScoreType optim_percentage =
+      (1 / (record_best_score)-1 / record_baseline_score) *
+      record_baseline_score;
+  LOG(INFO) << "Best score: " << record_best_score / graph_num;
+  LOG(INFO) << "Baseline score: " << record_baseline_score / graph_num;
+  LOG(INFO) << "variance: " << (record_best_variance / 2);
+  LOG(INFO) << "optim percentage: " << optim_percentage;
+  LOG(INFO) << "Best candidate: " << best_candidate[0] << " "
+            << best_candidate[1] << " " << best_candidate[2];
+  // Write measure results to csv file
+  os << std::setprecision(3) << "  " << record_baseline_score / graph_num
+     << " \t " << record_best_score / graph_num << " \t " << optim_percentage
+     << "\n";
+}
+
+void TestPerformanceForTileConfig(int spatial_left_bound,
+                                  int spatial_right_bound,
+                                  int reduce_left_bound,
+                                  int reduce_right_bound,
+                                  bool is_spatial_dynamic,
+                                  bool is_reduce_dynamic) {
   FLAGS_enable_cinn_compile_cache = false;
   FLAGS_cinn_measure_kernel_time = true;
 
   constexpr int kThreadsPerWarp = 32;
   constexpr int kMaxThreadsPerBlock = 1024;
 
-  // Define the search space bounds and sampling probabilities.
-  constexpr int spatial_left_bound = 2;
-  constexpr int spatial_right_bound = 2;
-  constexpr int reduce_left_bound = 2;
-  constexpr int reduce_right_bound = 2;
-  constexpr bool is_spatial_dynamic = true;
-  constexpr bool is_reduce_dynamic = true;
   // now each has the same weight
   constexpr double s_w = 0.05;
   constexpr double r_w = 0.05;
   constexpr double sampling_prob = 1.0;
-  constexpr int kMaxSamplingTimes = 560;
-  constexpr int kGraphNum = 25;
+  constexpr int kMaxSamplingTimes = 360;
   constexpr int kRepeats = 5;
   constexpr int kInnerTestNum = 1;
   constexpr int kOuterTestNum = 3;
-  constexpr int kMaxTestNum = 3;
+  constexpr int kMaxTestNum = 1;
   constexpr float kEarlyStopThreshold = 1.2;
+  // number of nodes in cudaGraph for test, which is defined in
+  // performace_statistician.h as graph_nodes_num_. This parameter is set to
+  // make measure results corresponding to one launch for better readability
+  constexpr int kGraphNum = 25;
 
   // Define the initial grid size for the spatial and reduction dimensions
   int spatial_tile_config = 0, reduce_tile_config = 0;
@@ -166,6 +562,10 @@ TEST(ConfigSearcher, TestReducePipeline) {
 
   auto s_dimension_type = "S";
   auto r_dimension_type = "R";
+
+  // Define the performance test configuration.
+  PerfTestConfig perf_test_config = {
+      kInnerTestNum, kOuterTestNum, kMaxTestNum, kEarlyStopThreshold};
 
   // Get best configuration from json by file database.
   std::vector<std::pair<std::string, std::string>> iter_space_type = {
@@ -185,204 +585,164 @@ TEST(ConfigSearcher, TestReducePipeline) {
                     true,
                     ::common::errors::InvalidArgument(
                         "Cannot open the file to write:  %s", dump_path));
-
+  // run performance test for each data grid
   for (int s_dimension_lower = spatial_left_bound;
-       s_dimension_lower <= spatial_right_bound;
+       s_dimension_lower < spatial_right_bound ||
+       s_dimension_lower == spatial_right_bound &&
+           spatial_left_bound == spatial_right_bound;
        s_dimension_lower += spatial_tile_config) {
     // adjust the tile size for the spatial dimension dymaically
-    spatial_tile_config = get_tile_size_config(s_dimension_lower);
+    spatial_tile_config = get_tile_size_config_in_small_area(s_dimension_lower);
     spatial_tile_width = (is_spatial_dynamic ? spatial_tile_config : 1);
-    if (s_dimension_lower == 4096 && is_spatial_dynamic) {
-      spatial_tile_width = 5820 + 1 - s_dimension_lower;  // 1048576 = 2^20
-    }
     for (int r_dimension_lower = reduce_left_bound;
-         r_dimension_lower <= reduce_right_bound;
+         r_dimension_lower < reduce_right_bound ||
+         r_dimension_lower == reduce_right_bound &&
+             reduce_left_bound == reduce_right_bound;
          r_dimension_lower += reduce_tile_config) {
       // adjust the tile size for the reduce dimension dymaically
-      reduce_tile_config = get_tile_size_config(r_dimension_lower);
+      reduce_tile_config =
+          get_tile_size_config_in_small_area(r_dimension_lower);
       reduce_tile_width = (is_reduce_dynamic ? reduce_tile_config : 1);
-      if (r_dimension_lower == 4096 && is_reduce_dynamic) {
-        reduce_tile_width = 5820 + 1 - r_dimension_lower;  // 1048576 = 2^20
-      }
-
-      std::vector<double> s_weights =
-          std::vector<double>(spatial_tile_width, s_weight);
-      std::vector<double> r_weights =
-          std::vector<double>(reduce_tile_width, r_weight);
-
-      LOG(INFO) << "spatial tile dimension lower bound = " << s_dimension_lower
-                << ", reduce tile dimension lower bound = " << r_dimension_lower
-                << std::endl;
-      // Construct pir::Program.
-      ::pir::IrContext* ctx = ::pir::IrContext::Instance();
-      std::shared_ptr<::pir::Program> program;
-      if (!is_spatial_dynamic && !is_reduce_dynamic) {
-        program = BuildReduceSumProgram(s_dimension_lower, r_dimension_lower);
-      } else if (is_spatial_dynamic && !is_reduce_dynamic) {
-        program = BuildReduceSumProgram(-1, r_dimension_lower);
-      } else if (!is_spatial_dynamic && is_reduce_dynamic) {
-        program = BuildReduceSumProgram(s_dimension_lower, -1);
-      } else {
-        program = BuildReduceSumProgram(-1, -1);
-      }
-
-      // Construct iter space and objective function.
-      cinn::ir::BucketInfo bucket_info;
-      bucket_info.space.push_back(cinn::ir::BucketInfo::Dimension{
-          s_dimension_lower,
-          s_dimension_lower + spatial_tile_width - 1,
-          "S",
-          /* is_dynamic = */ is_spatial_dynamic});
-      bucket_info.space.push_back(cinn::ir::BucketInfo::Dimension{
-          r_dimension_lower,
-          r_dimension_lower + reduce_tile_width - 1,
-          "R",
-          /* is_dynamic = */ is_reduce_dynamic});
-      std::unique_ptr<cinn::ir::search::BaseObjectiveFunc> obj_func =
-          std::make_unique<
-              cinn::ir::search::WeightedSamplingTrailObjectiveFunc>(
-              program.get(),
-              bucket_info,
-              sampling_prob,
-              kMaxSamplingTimes,
-              kRepeats,
-              std::vector<std::vector<double>>{s_weights, r_weights});
-
-      cinn::ir::search::CandidateType best_candidate;
-      for (auto& it : best_tile_config_map) {
-        auto s_flag = false, r_flag = false;
-        auto dims = it.first.space.size();
-        // SR type support only
-        if (dims == 2) {
-          if (it.first.space[0].lower_bound <= s_dimension_lower &&
-              it.first.space[0].upper_bound >=
-                  s_dimension_lower + spatial_tile_width - 1) {
-            s_flag = true;
-          } else if (it.first.space[0].lower_bound == 4096 &&
-                     s_dimension_lower == 4096) {
-            s_flag = true;
-          }
-          if (it.first.space[1].lower_bound <= r_dimension_lower &&
-              it.first.space[1].upper_bound >=
-                  r_dimension_lower + reduce_tile_width - 1) {
-            r_flag = true;
-          } else if (it.first.space[1].lower_bound == 4096 &&
-                     r_dimension_lower == 4096) {
-            r_flag = true;
-          }
-        } else {
-          PADDLE_THROW(
-              ::common::errors::Unavailable("Now just support SR type."));
-        }
-        if (s_flag == true && r_flag == true) {
-          best_candidate = {it.second.warp_num,
-                            it.second.tree_reduce_num,
-                            it.second.spatial_inner_num};
-          break;
-        }
-      }
-      if (best_candidate.empty()) {
-        PADDLE_THROW(
-            ::common::errors::Unavailable("Not found the best candidate."));
-      }
-
-      cinn::ir::search::ScoreType record_baseline_score;
-      cinn::ir::search::ScoreType record_best_score;
-      double record_best_variance = 0;
-      // start test loop
-      for (int current_test_num = 0; current_test_num < kMaxTestNum;
-           ++current_test_num) {
-        std::vector<cinn::ir::search::ScoreType> vec_best;
-        std::vector<cinn::ir::search::ScoreType> vec_baseline;
-        // start outer loop
-        for (int i = 0; i < kOuterTestNum; ++i) {
-          cinn::ir::search::CandidateType default_candidate;
-          std::vector<cinn::ir::search::ScoreType> vec_best_score;
-          std::vector<cinn::ir::search::ScoreType> vec_baseline_score;
-          int compute_size = 1;
-          for (int i = 0; i < iter_space_type.size(); ++i) {
-            compute_size *= bucket_info.space[i].lower_bound;
-          }
-          // start inner loop
-          for (int i = 0; i < kInnerTestNum; i++) {
-            FLAGS_tile_config_policy = "default";
-            cinn::ir::search::ScoreType temp_baseline_score =
-                (*obj_func)(default_candidate);
-            FLAGS_tile_config_policy = "search";
-            cinn::ir::search::ScoreType temp_best_score =
-                (*obj_func)(best_candidate);
-            vec_best_score.push_back(temp_best_score);
-            vec_baseline_score.push_back(temp_baseline_score);
-          }
-          float best_total_time = std::accumulate(
-              vec_best_score.begin(), vec_best_score.end(), 0.0);
-          float baseline_total_time = std::accumulate(
-              vec_baseline_score.begin(), vec_baseline_score.end(), 0.0);
-          float best_avg_time = best_total_time / kInnerTestNum;
-          float baseline_avg_time = baseline_total_time / kInnerTestNum;
-          vec_best.push_back(best_avg_time);
-          vec_baseline.push_back(baseline_avg_time);
-        }
-        cinn::ir::search::ScoreType best_mean =
-            std::accumulate(vec_best.begin(), vec_best.end(), 0.0) /
-            kOuterTestNum;
-        cinn::ir::search::ScoreType baseline_mean =
-            std::accumulate(vec_baseline.begin(), vec_baseline.end(), 0.0) /
-            kOuterTestNum;
-        double best_variance = 0.0;
-        double baseline_variance = 0.0;
-
-        for (int i = 0; i < kOuterTestNum; i++) {
-          best_variance = best_variance + pow(vec_best[i] - best_mean, 2);
-          baseline_variance =
-              baseline_variance + pow(vec_baseline[i] - baseline_mean, 2);
-        }
-        best_variance = pow(best_variance / kOuterTestNum, 0.5);
-        baseline_variance = pow(baseline_variance / kOuterTestNum, 0.5);
-
-        if ((best_variance < kEarlyStopThreshold) &&
-            (baseline_variance < kEarlyStopThreshold)) {
-          record_baseline_score = baseline_mean;
-          record_best_score = best_mean;
-          record_best_variance = best_variance + baseline_variance;
-          break;
-        } else {
-          if (record_best_variance == 0) {
-            record_best_variance = best_variance + baseline_variance;
-            record_baseline_score = baseline_mean;
-            record_best_score = best_mean;
-          } else if ((best_variance + baseline_variance) <
-                     record_best_variance) {
-            record_best_variance = best_variance + baseline_variance;
-            record_baseline_score = baseline_mean;
-            record_best_score = best_mean;
-          }
-        }
-      }  // end of test_num loop
-
-      cinn::ir::search::ScoreType optim_percentage =
-          (1 / (record_best_score)-1 / record_baseline_score) *
-          record_baseline_score;
-      LOG(INFO) << "Best score: " << record_best_score / kGraphNum;
-      LOG(INFO) << "Baseline score: " << record_baseline_score / kGraphNum;
-      LOG(INFO) << "variance: " << (record_best_variance / 2);
-      LOG(INFO) << "optim percentage: " << optim_percentage;
-      LOG(INFO) << "Best candidate: " << best_candidate[0] << " "
-                << best_candidate[1] << " " << best_candidate[2];
-      // Write to csv file
-      std::stringstream ss;
-      ss << " { ";
-      for (int i = 0; i < iter_space_type.size(); ++i) {
-        ss << iter_space_type[i].first << "_" << iter_space_type[i].second
-           << ": " << bucket_info.space[i].lower_bound << "-"
-           << bucket_info.space[i].upper_bound << " ";
-      }
-      ss << "} ";
-      os << ss.str() << " \t ";
-      os << std::setprecision(3) << "  " << record_baseline_score / kGraphNum
-         << " \t " << record_best_score / kGraphNum << " \t "
-         << optim_percentage << "\n";
+      TestWindowPerformance(os,
+                            perf_test_config,
+                            kGraphNum,
+                            s_dimension_lower,
+                            spatial_tile_width,
+                            r_dimension_lower,
+                            reduce_tile_width,
+                            is_spatial_dynamic,
+                            is_reduce_dynamic,
+                            s_weight,
+                            r_weight,
+                            sampling_prob,
+                            kMaxSamplingTimes,
+                            kRepeats,
+                            best_tile_config_map,
+                            iter_space_type);
     }  // end of r_dimension_lower loop
   }    // end of s_dimention_lower loop
+
+  // (II) Test in the single large areas,
+  // i.e., S:[4096-32768]*R:[2-1024], S:[2-1024]*R:[4096-32768]
+  for (int s_dimension_lower = 2; s_dimension_lower < 1024;
+       s_dimension_lower += spatial_tile_config) {
+    // adjust the tile size for the spatial dimension dymaically
+    spatial_tile_config = get_tile_size_config_in_large_area(s_dimension_lower);
+    spatial_tile_width = (is_spatial_dynamic ? spatial_tile_config : 1);
+
+    for (int r_dimension_lower = 4096; r_dimension_lower < 32768;
+         r_dimension_lower += reduce_tile_config) {
+      // adjust the tile size for the reduce dimension dymaically
+      reduce_tile_config =
+          get_tile_size_config_in_large_area(r_dimension_lower);
+      reduce_tile_width = (is_reduce_dynamic ? reduce_tile_config : 1);
+
+      TestWindowPerformance(os,
+                            perf_test_config,
+                            kGraphNum,
+                            s_dimension_lower,
+                            spatial_tile_width,
+                            r_dimension_lower,
+                            reduce_tile_width,
+                            is_spatial_dynamic,
+                            is_reduce_dynamic,
+                            s_weight,
+                            r_weight,
+                            sampling_prob,
+                            kMaxSamplingTimes,
+                            kRepeats,
+                            best_tile_config_map,
+                            iter_space_type);
+    }
+  }
+
+  for (int s_dimension_lower = 4096; s_dimension_lower < 32768;
+       s_dimension_lower += spatial_tile_config) {
+    // adjust the tile size for the spatial dimension dymaically
+    spatial_tile_config = get_tile_size_config_in_large_area(s_dimension_lower);
+    spatial_tile_width = (is_spatial_dynamic ? spatial_tile_config : 1);
+
+    for (int r_dimension_lower = 2; r_dimension_lower < 1024;
+         r_dimension_lower += reduce_tile_config) {
+      // adjust the tile size for the reduce dimension dymaically
+      reduce_tile_config =
+          get_tile_size_config_in_large_area(r_dimension_lower);
+      reduce_tile_width = (is_reduce_dynamic ? reduce_tile_config : 1);
+      // Run performance test and write measure results to csv file.
+
+      TestWindowPerformance(os,
+                            perf_test_config,
+                            kGraphNum,
+                            s_dimension_lower,
+                            spatial_tile_width,
+                            r_dimension_lower,
+                            reduce_tile_width,
+                            is_spatial_dynamic,
+                            is_reduce_dynamic,
+                            s_weight,
+                            r_weight,
+                            sampling_prob,
+                            kMaxSamplingTimes,
+                            kRepeats,
+                            best_tile_config_map,
+                            iter_space_type);
+    }
+  }
   os.close();
+}
+
+/**
+ * @brief Test case for the ConfigSearcher.
+ *
+ * This test case performs a perormance test for the best configuration derived
+ * from the ConfigSearcher. It iterates over different spatial and reduce tile
+ * sizes and constructs a pir::Program. The objective function used for the
+ * search is a WeightedSamplingTrailObjectiveFunc. The performance results are
+ * written into a CSV file, including the default score and the best candidate
+ * score.
+ */
+
+TEST(ConfigSearcher, TestPerfDynamicDynamic) {
+  constexpr int spatial_left_bound = 2;      // for full test, set it to 2
+  constexpr int spatial_right_bound = 4096;  // for full test, set it to 4096
+  constexpr int reduce_left_bound = 2;       // for full test, set it to 2
+  constexpr int reduce_right_bound = 4096;   // for full test, set it to 4096
+  constexpr bool is_spatial_dynamic = true;
+  constexpr bool is_reduce_dynamic = true;
+  TestPerformanceForTileConfig(spatial_left_bound,
+                               spatial_right_bound,
+                               reduce_left_bound,
+                               reduce_right_bound,
+                               is_spatial_dynamic,
+                               is_reduce_dynamic);
+}
+
+TEST(ConfigSearcher, TestPerfStaticDynamic) {
+  constexpr int spatial_left_bound = 2;      // for full test, set it to 2
+  constexpr int spatial_right_bound = 4096;  // for full test, set it to 4096
+  constexpr int reduce_left_bound = 2;       // for full test, set it to 2
+  constexpr int reduce_right_bound = 4096;   // for full test, set it to 4096
+  constexpr bool is_spatial_dynamic = false;
+  constexpr bool is_reduce_dynamic = true;
+  TestPerformanceForTileConfig(spatial_left_bound,
+                               spatial_right_bound,
+                               reduce_left_bound,
+                               reduce_right_bound,
+                               is_spatial_dynamic,
+                               is_reduce_dynamic);
+}
+
+TEST(ConfigSearcher, TestPerfDynamicStatic) {
+  constexpr int spatial_left_bound = 2;      // for full test, set it to 2
+  constexpr int spatial_right_bound = 4096;  // for full test, set it to 4096
+  constexpr int reduce_left_bound = 2;       // for full test, set it to 2
+  constexpr int reduce_right_bound = 4096;   // for full test, set it to 4096
+  constexpr bool is_spatial_dynamic = true;
+  constexpr bool is_reduce_dynamic = false;
+  TestPerformanceForTileConfig(spatial_left_bound,
+                               spatial_right_bound,
+                               reduce_left_bound,
+                               reduce_right_bound,
+                               is_spatial_dynamic,
+                               is_reduce_dynamic);
 }

--- a/test/cpp/pir/cinn/tile_config_searcher_test.cc
+++ b/test/cpp/pir/cinn/tile_config_searcher_test.cc
@@ -487,10 +487,10 @@ void TestSearchForTileConfig(int spatial_l_bound,
 }
 
 TEST(ConfigSearcher, TestDynamicDeboule) {
-  int spatial_left_bound = 1024;
-  int spatial_right_bound = 2048;  // To reproduce, set it to 4096
-  int reduce_left_bound = 2048;
-  int reduce_right_bound = 4096;  // To reproduce, set it to 4096
+  int spatial_left_bound = 2;
+  int spatial_right_bound = 2;  // To reproduce, set it to 4096
+  int reduce_left_bound = 2;
+  int reduce_right_bound = 2;  // To reproduce, set it to 4096
   bool is_spatial_dynamic = true;
   bool is_reduce_dynamic = true;
   TestSearchForTileConfig(spatial_left_bound,
@@ -503,9 +503,9 @@ TEST(ConfigSearcher, TestDynamicDeboule) {
 
 TEST(ConfigSearcher, TestDynamicReduce) {
   int spatial_left_bound = 2;
-  int spatial_right_bound = 4096;  // To reproduce, set it to 4096
+  int spatial_right_bound = 2;  // To reproduce, set it to 4096
   int reduce_left_bound = 2;
-  int reduce_right_bound = 4096;  // To reproduce, set it to 4096
+  int reduce_right_bound = 2;  // To reproduce, set it to 4096
   bool is_spatial_dynamic = false;
   bool is_reduce_dynamic = true;
   TestSearchForTileConfig(spatial_left_bound,
@@ -518,9 +518,9 @@ TEST(ConfigSearcher, TestDynamicReduce) {
 
 TEST(ConfigSearcher, TestDynamicSpatial) {
   int spatial_left_bound = 2;
-  int spatial_right_bound = 4096;  // To reproduce, set it to 4096
+  int spatial_right_bound = 2;  // To reproduce, set it to 4096
   int reduce_left_bound = 2;
-  int reduce_right_bound = 4096;  // To reproduce, set it to 4096
+  int reduce_right_bound = 2;  // To reproduce, set it to 4096
   bool is_spatial_dynamic = true;
   bool is_reduce_dynamic = false;
   TestSearchForTileConfig(spatial_left_bound,

--- a/test/cpp/pir/cinn/tile_config_searcher_test.cc
+++ b/test/cpp/pir/cinn/tile_config_searcher_test.cc
@@ -43,11 +43,12 @@ constexpr int kMaxThreadsPerBlock = 1024;
 constexpr double s_w = 0.05;
 constexpr double r_w = 0.05;
 constexpr double sampling_prob = 1.0;
-constexpr int kMaxSamplingTimes = 100;
-constexpr int kRepeats = 2;
+constexpr int kMaxSamplingTimes = 300;
+constexpr int kRepeats = 3;
 
-std::shared_ptr<::pir::Program> BuildEREBEProgram(int spatial_size,
-                                                  int reduce_size) {
+// layernorm
+std::shared_ptr<::pir::Program> BuildLayerNormProgram(int spatial_size,
+                                                      int reduce_size) {
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
 
@@ -60,6 +61,60 @@ std::shared_ptr<::pir::Program> BuildEREBEProgram(int spatial_size,
                .Build<paddle::dialect::DataOp>(
                    "x", shape, phi::DataType::FLOAT32, phi::GPUPlace())
                .result(0);
+  auto sum_val =
+      builder
+          .Build<paddle::dialect::SumOp>(
+              x, std::vector<int64_t>{-1}, phi::DataType::FLOAT32, true)
+          .result(0);
+
+  auto divide_num =
+      builder
+          .Build<paddle::dialect::FullOp>(
+              std::vector<int64_t>({1}), 1024, phi::DataType::FLOAT32)
+          .out();
+  auto mean_val =
+      builder.Build<paddle::dialect::DivideOp>(sum_val, divide_num).result(0);
+  auto sub_num =
+      builder.Build<paddle::dialect::SubtractOp>(x, mean_val).result(0);
+  auto pow_val = builder.Build<paddle::dialect::PowOp>(x, 2.0).result(0);
+  auto pow_sum =
+      builder
+          .Build<paddle::dialect::SumOp>(
+              pow_val, std::vector<int64_t>{-1}, phi::DataType::FLOAT32, true)
+          .result(0);
+  auto variance_val =
+      builder.Build<paddle::dialect::DivideOp>(pow_sum, divide_num).result(0);
+  auto add_num =
+      builder
+          .Build<paddle::dialect::FullOp>(
+              std::vector<int64_t>({1}), 1e-6, phi::DataType::FLOAT32)
+          .out();
+  auto add_val =
+      builder.Build<paddle::dialect::AddOp>(variance_val, add_num).result(0);
+  auto rsqrt_val = builder.Build<paddle::dialect::RsqrtOp>(add_val).result(0);
+  auto out =
+      builder.Build<paddle::dialect::MultiplyOp>(rsqrt_val, sub_num).result(0);
+
+  builder.Build<paddle::dialect::FetchOp>(out, "out", 0);
+  return program;
+}
+
+// rmsnorm
+std::shared_ptr<::pir::Program> BuildRMSNormProgram(int spatial_size,
+                                                    int reduce_size) {
+  ::pir::IrContext* ctx = ::pir::IrContext::Instance();
+  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
+
+  auto program = std::make_shared<::pir::Program>(ctx);
+  ::pir::Builder builder = ::pir::Builder(ctx, program->block());
+
+  const float value_one = 1.0;
+  const std::vector<int64_t> shape = {spatial_size, reduce_size};
+  auto x = builder
+               .Build<paddle::dialect::DataOp>(
+                   "x", shape, phi::DataType::FLOAT32, phi::GPUPlace())
+               .result(0);
+  // auto out = builder.Build<paddle::dialect::RmsNormOp>(x);
   auto pow_val = builder.Build<paddle::dialect::PowOp>(x, 2.0).result(0);
   auto sum_val =
       builder
@@ -83,28 +138,6 @@ std::shared_ptr<::pir::Program> BuildEREBEProgram(int spatial_size,
   auto rsqrt_val = builder.Build<paddle::dialect::RsqrtOp>(add_val).result(0);
   auto out = builder.Build<paddle::dialect::MultiplyOp>(rsqrt_val, x).result(0);
 
-  builder.Build<paddle::dialect::FetchOp>(out, "out", 0);
-  return program;
-}
-
-std::shared_ptr<::pir::Program> BuildReduceSumProgram(int spatial_size,
-                                                      int reduce_size) {
-  ::pir::IrContext* ctx = ::pir::IrContext::Instance();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-
-  auto program = std::make_shared<::pir::Program>(ctx);
-  ::pir::Builder builder = ::pir::Builder(ctx, program->block());
-
-  const float value_one = 1.0;
-  const std::vector<int64_t> shape = {spatial_size, reduce_size};
-  auto x = builder
-               .Build<paddle::dialect::DataOp>(
-                   "x", shape, phi::DataType::FLOAT32, phi::GPUPlace())
-               .result(0);
-  auto out = builder
-                 .Build<paddle::dialect::SumOp>(
-                     x, std::vector<int64_t>{-1}, phi::DataType::FLOAT32, true)
-                 .result(0);
   builder.Build<paddle::dialect::FetchOp>(out, "out", 0);
   return program;
 }
@@ -139,6 +172,20 @@ int get_tile_size_config_in_large_area(int dimension_lower) {
   }
 }
 
+int get_spatial_range(int s_dimension_lower, int r_dimension_lower) {
+  int compute_size = s_dimension_lower * r_dimension_lower;
+  if (compute_size <= 1024 * 1024) {
+    return 1;
+  } else if (compute_size <= 1024 * 2048) {
+    return 2;
+  } else if (compute_size <= 2048 * 2048) {
+    return 4;
+  } else if ((s_dimension_lower > 4096) || (r_dimension_lower > 4096)) {
+    return 8;
+  }
+  return 1;
+}
+
 void search_then_save_one_window(bool is_spatial_dynamic,
                                  bool is_reduce_dynamic,
                                  int s_dimension_lower,
@@ -155,15 +202,28 @@ void search_then_save_one_window(bool is_spatial_dynamic,
       std::vector<double>(reduce_tile_width, r_weight);
   // Step 1: Construct pir::Program.
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
-  std::shared_ptr<::pir::Program> program;
+  std::shared_ptr<::pir::Program> program_layer_norm;
+  std::shared_ptr<::pir::Program> program_rms_norm;
   if (!is_spatial_dynamic && !is_reduce_dynamic) {
-    program = BuildEREBEProgram(s_dimension_lower, r_dimension_lower);
+    program_layer_norm =
+        BuildLayerNormProgram(s_dimension_lower, r_dimension_lower);
   } else if (is_spatial_dynamic && !is_reduce_dynamic) {
-    program = BuildEREBEProgram(-1, r_dimension_lower);
+    program_layer_norm = BuildLayerNormProgram(-1, r_dimension_lower);
   } else if (!is_spatial_dynamic && is_reduce_dynamic) {
-    program = BuildEREBEProgram(s_dimension_lower, -1);
+    program_layer_norm = BuildLayerNormProgram(s_dimension_lower, -1);
   } else {
-    program = BuildEREBEProgram(-1, -1);
+    program_layer_norm = BuildLayerNormProgram(-1, -1);
+  }
+
+  if (!is_spatial_dynamic && !is_reduce_dynamic) {
+    program_rms_norm =
+        BuildRMSNormProgram(s_dimension_lower, r_dimension_lower);
+  } else if (is_spatial_dynamic && !is_reduce_dynamic) {
+    program_rms_norm = BuildRMSNormProgram(-1, r_dimension_lower);
+  } else if (!is_spatial_dynamic && is_reduce_dynamic) {
+    program_rms_norm = BuildRMSNormProgram(s_dimension_lower, -1);
+  } else {
+    program_rms_norm = BuildRMSNormProgram(-1, -1);
   }
 
   // Step 2: Switch schedule config manager mode.
@@ -181,18 +241,32 @@ void search_then_save_one_window(bool is_spatial_dynamic,
                                       r_dimension_lower + reduce_tile_width - 1,
                                       "R",
                                       /* is_dynamic = */ is_reduce_dynamic});
-  std::unique_ptr<cinn::ir::search::BaseObjectiveFunc> obj_func =
+  std::unique_ptr<cinn::ir::search::BaseObjectiveFunc> obj_func_layernorm =
       std::make_unique<cinn::ir::search::WeightedSamplingTrailObjectiveFunc>(
-          program.get(),
+          program_layer_norm.get(),
           bucket_info,
           sampling_prob,
           kMaxSamplingTimes,
           kRepeats,
           std::vector<std::vector<double>>{s_weights, r_weights});
 
+  std::unique_ptr<cinn::ir::search::BaseObjectiveFunc> obj_func_rmsnorm =
+      std::make_unique<cinn::ir::search::WeightedSamplingTrailObjectiveFunc>(
+          program_rms_norm.get(),
+          bucket_info,
+          sampling_prob,
+          kMaxSamplingTimes,
+          kRepeats,
+          std::vector<std::vector<double>>{s_weights, r_weights});
+
+  std::vector<std::unique_ptr<cinn::ir::search::BaseObjectiveFunc>>
+      objective_funcs;
+  objective_funcs.emplace_back(std::move(obj_func_layernorm));
+  objective_funcs.emplace_back(std::move(obj_func_rmsnorm));
+
   // Step 4: Construct config candidate range and constraints.
   std::vector<std::pair<int, int>> candidate_range{
-      {1, 32}, {1, 512}, {1, 1}};  // {1, 8}, {1, 512}, {1, 8}
+      {1, 32}, {32, 1024}, {1, 8}};  // {1, 8}, {1, 512}, {1, 8}
   std::vector<cinn::ir::search::ConstraintFunc> constraints;
   constraints.emplace_back(
       [](const cinn::ir::search::CandidateType& candidate) -> bool {
@@ -219,12 +293,23 @@ void search_then_save_one_window(bool is_spatial_dynamic,
                s_dimension_lower;
       });
   constraints.emplace_back(
-      [](const cinn::ir::search::CandidateType& candidate) -> bool {
-        return candidate[2] == 1 || candidate[2] == 2;
+      [&](const cinn::ir::search::CandidateType& candidate) -> bool {
+        return candidate[2] <=
+               get_spatial_range(s_dimension_lower, r_dimension_lower);
+      });
+  constraints.emplace_back(
+      [&](const cinn::ir::search::CandidateType& candidate) -> bool {
+        return r_dimension_lower % candidate[1] == 0 || candidate[1] == 32 ||
+               candidate[1] == 64;
       });
   constraints.emplace_back(
       [](const cinn::ir::search::CandidateType& candidate) -> bool {
         return candidate[2] <= candidate[1];
+      });
+  constraints.emplace_back(
+      [](const cinn::ir::search::CandidateType& candidate) -> bool {
+        return candidate[2] == 1 || candidate[2] == 2 || candidate[2] == 4 ||
+               candidate[2] == 8;
       });
   constraints.emplace_back(
       [](const cinn::ir::search::CandidateType& candidate) -> bool {
@@ -235,7 +320,7 @@ void search_then_save_one_window(bool is_spatial_dynamic,
 
   // Step 5: Construct searcher and search.
   cinn::ir::search::ScheduleConfigSearcher searcher(
-      std::move(obj_func), candidate_range, constraints);
+      std::move(objective_funcs), candidate_range, constraints);
   auto search_res = searcher.Search();
 
   // Step 6: Save the best candidate's config of each grid search to json
@@ -346,11 +431,6 @@ void TestSearchForTileConfig(int spatial_l_bound,
                                   r_weight);
     }
   }
-  // early stop for test
-  if (reduce_left_bound == reduce_right_bound &&
-      spatial_left_bound == spatial_right_bound) {
-    exit(0);
-  }
   // (II) Search in the single large areas,
   // i.e., S:[4096-32768]*R:[2-1024], S:[2-1024]*R:[4096-32768]
   for (int s_dimension_lower = 2; s_dimension_lower < 1024;
@@ -406,11 +486,26 @@ void TestSearchForTileConfig(int spatial_l_bound,
   }
 }
 
+TEST(ConfigSearcher, TestDynamicDeboule) {
+  int spatial_left_bound = 1024;
+  int spatial_right_bound = 2048;  // To reproduce, set it to 4096
+  int reduce_left_bound = 2048;
+  int reduce_right_bound = 4096;  // To reproduce, set it to 4096
+  bool is_spatial_dynamic = true;
+  bool is_reduce_dynamic = true;
+  TestSearchForTileConfig(spatial_left_bound,
+                          spatial_right_bound,
+                          reduce_left_bound,
+                          reduce_right_bound,
+                          is_spatial_dynamic,
+                          is_reduce_dynamic);
+}
+
 TEST(ConfigSearcher, TestDynamicReduce) {
   int spatial_left_bound = 2;
-  int spatial_right_bound = 2;  // To reproduce, set it to 4096
+  int spatial_right_bound = 4096;  // To reproduce, set it to 4096
   int reduce_left_bound = 2;
-  int reduce_right_bound = 2;  // To reproduce, set it to 4096
+  int reduce_right_bound = 4096;  // To reproduce, set it to 4096
   bool is_spatial_dynamic = false;
   bool is_reduce_dynamic = true;
   TestSearchForTileConfig(spatial_left_bound,
@@ -423,26 +518,11 @@ TEST(ConfigSearcher, TestDynamicReduce) {
 
 TEST(ConfigSearcher, TestDynamicSpatial) {
   int spatial_left_bound = 2;
-  int spatial_right_bound = 2;  // To reproduce, set it to 4096
+  int spatial_right_bound = 4096;  // To reproduce, set it to 4096
   int reduce_left_bound = 2;
-  int reduce_right_bound = 2;  // To reproduce, set it to 4096
+  int reduce_right_bound = 4096;  // To reproduce, set it to 4096
   bool is_spatial_dynamic = true;
   bool is_reduce_dynamic = false;
-  TestSearchForTileConfig(spatial_left_bound,
-                          spatial_right_bound,
-                          reduce_left_bound,
-                          reduce_right_bound,
-                          is_spatial_dynamic,
-                          is_reduce_dynamic);
-}
-
-TEST(ConfigSearcher, TestDynamicSR) {
-  int spatial_left_bound = 2;
-  int spatial_right_bound = 2;  // To reproduce, set it to 4096
-  int reduce_left_bound = 2;
-  int reduce_right_bound = 2;  // To reproduce, set it to 4096
-  bool is_spatial_dynamic = true;
-  bool is_reduce_dynamic = true;
   TestSearchForTileConfig(spatial_left_bound,
                           spatial_right_bound,
                           reduce_left_bound,


### PR DESCRIPTION
### PR Category
CINN


### PR Types
Others


### Description
Pcard-74042
* reorganize test_config_searcher and test_config_performance to make them more readable;
* add Softmax , LayerNorm and RMSNorm function as benchmark function in test_config_performance;
* use LayerNorm and RMSNorm functions to search best tileconfig;
* fix file_tile_config_test 
