### PR TITLE
[Prim][PIR] expand_as_grad backward decomposite

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -652,6 +652,16 @@ void expand_grad(const Tensor& x,
 }
 
 template <typename T>
+void expand_as_grad(const Tensor& x,
+                    const Tensor& out_grad,
+                    const std::vector<int>& shape,
+                    Tensor* x_grad) {
+  if (x_grad) {
+    expand_grad<T>(x, out_grad, {}, x_grad);
+  }
+}
+
+template <typename T>
 void log_grad(const Tensor& x, const Tensor& out_grad, Tensor* x_grad) {
   if (x_grad) {
     // dx = dout / x

--- a/paddle/fluid/primitive/base/primitive_ops.h
+++ b/paddle/fluid/primitive/base/primitive_ops.h
@@ -107,6 +107,7 @@ const std::set<std::string>& GetPrimitiveOpNames() {
       "builtin.shadow_output",
       "pd_op.sigmoid",
       "pd_op.reduce_as",
+      "pd_op.expand_as",
       /* skip some special ops */
       "pd_op.conv2d",
       "pd_op.pad3d",

--- a/paddle/fluid/primitive/codegen/gen.py
+++ b/paddle/fluid/primitive/codegen/gen.py
@@ -88,6 +88,7 @@ BINARY_PRIM_VJP_OPS = [
     'elementwise_pow_grad',
     'maximum_grad',
     'reduce_as_grad',
+    'expand_as_grad',
 ]
 
 OTHER_PRIM_VJP_OPS = [

--- a/paddle/fluid/primitive/primitive.yaml
+++ b/paddle/fluid/primitive/primitive.yaml
@@ -124,3 +124,4 @@
 - unique_consecutive
 - sigmoid
 - reduce_as
+- expand_as

--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -973,16 +973,31 @@ void expand_grad(const Tensor& x,
                  const IntArray& shape,
                  Tensor* x_grad) {
   if (x_grad) {
-    if (out_grad.dims() != x.dims()) {
-      auto axes = get_reduce_dims_from_out(out_grad.dims(), x.dims());
-      auto reduced = out_grad.sum(common::vectorize(axes), x.dtype(), false);
-      if (reduced.dims().size() != x.dims().size()) {
-        reduced = reshape<T>(reduced, x.shape());
-      }
+    if (has_dynamic_shape(x.shape()) || has_dynamic_shape(out_grad.shape())) {
+      auto reduced = reduce_as<T>(out_grad, x);
       set_output<T>(reduced, x_grad);
     } else {
-      by_pass<T>(out_grad, x_grad);
+      if (out_grad.dims() != x.dims()) {
+        auto axes = get_reduce_dims_from_out(out_grad.dims(), x.dims());
+        auto reduced = out_grad.sum(common::vectorize(axes), x.dtype(), false);
+        if (reduced.dims().size() != x.dims().size()) {
+          reduced = reshape<T>(reduced, x.shape());
+        }
+        set_output<T>(reduced, x_grad);
+      } else {
+        by_pass<T>(out_grad, x_grad);
+      }
     }
+  }
+}
+
+template <typename T>
+void expand_as_grad(const Tensor& x,
+                    const Tensor& out_grad,
+                    const std::vector<int>& target_shape,
+                    Tensor* x_grad) {
+  if (x_grad) {
+    expand_grad<T>(x, out_grad, {}, x_grad);
   }
 }
 

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -55,6 +55,7 @@ ALLOW_DYNAMIC_SHAPE_VJP_OPS = [
     "pd_op.elementwise_pow",
     "pd_op.softmax",
     "pd_op.matmul",
+    "pd_op.expand_as",
 ]
 
 

--- a/test/legacy_test/test_expand_as_v2_op.py
+++ b/test/legacy_test/test_expand_as_v2_op.py
@@ -26,7 +26,7 @@ from paddle.pir_utils import test_with_pir_api
 class TestExpandAsBasic(OpTest):
     def setUp(self):
         self.op_type = "expand_as_v2"
-        self.prim_op_type = "comp"
+        self.prim_op_type = "prim"
         self.python_api = paddle.expand_as
         self.public_python_api = paddle.expand_as
         self.init_dtype()
@@ -49,10 +49,10 @@ class TestExpandAsBasic(OpTest):
         pass
 
     def test_check_output(self):
-        self.check_output(check_prim=True, check_pir=True)
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', check_prim=True, check_pir=True)
+        self.check_grad(['X'], 'Out', check_prim_pir=True, check_pir=True)
 
 
 class TestExpandAs_ZeroDim1(TestExpandAsBasic):
@@ -109,7 +109,11 @@ class TestExpandAsBasicBFP16OP(TestExpandAsBasic):
 
     def test_check_grad(self):
         self.check_grad_with_place(
-            paddle.CUDAPlace(0), ['X'], 'Out', check_prim=True, check_pir=True
+            paddle.CUDAPlace(0),
+            ['X'],
+            'Out',
+            check_prim_pir=True,
+            check_pir=True,
         )
 
 

--- a/test/prim/pir_prim/test_prim_sub_graph_backward_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_backward_dynamic_shape.py
@@ -123,6 +123,14 @@ def matmul_net(x, y):
     return paddle.matmul(x, y)
 
 
+def expand_net(x):
+    return paddle.expand(x, [30, 200, 40])
+
+
+def expand_as_net(x, y):
+    return paddle.expand_as(x, y)
+
+
 def apply_to_static(net, use_cinn, input_spec=None):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
@@ -1445,6 +1453,154 @@ class TestPrimMatmulWithGrad5(TestPrimTwoWithGrad):
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.y = np.random.random(self.y_shape).astype(self.dtype)
         self.net = matmul_net
+        self.enable_cinn = False
+        self.tol = 1e-5
+
+
+class TestPrimExpandWithGrad1(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [200, 40]
+        self.init_x_shape = [None, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = expand_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimExpandWithGrad2(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [30, 1, 40]
+        self.init_x_shape = [None, None, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = expand_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimExpandWithGrad3(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 1]
+        self.init_x_shape = [None, None, 1]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = expand_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimExpandWithGrad4(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [30, 1, 1]
+        self.init_x_shape = [None, None, 1]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = expand_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimBaseOneGradTwoInputs(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [200, 40]
+        self.init_x_shape = [None, 200]
+        self.y_shape = [30, 200, 40]
+        self.init_y_shape = [None, None, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = expand_as_net
+        self.enable_cinn = False
+        self.tol = 1e-5
+        self.y_without_grad = True
+
+    def base_net(self, flag=None):
+        if flag == "prim":
+            core._set_prim_all_enabled(True)
+        x = paddle.to_tensor(self.x, stop_gradient=False)
+        y = paddle.to_tensor(self.y, stop_gradient=False)
+        if flag == "prim":
+            fn = apply_to_static(
+                self.net,
+                use_cinn=self.enable_cinn,
+                input_spec=[
+                    InputSpec(shape=self.init_x_shape, dtype='float32'),
+                    InputSpec(shape=self.init_y_shape, dtype='float32'),
+                ],
+            )
+            fn.train()
+        else:
+            fn = self.net
+        res = fn(x, y)
+        res.backward()
+        if self.y_without_grad:
+            grad = x.gradient()
+        else:
+            grad = y.gradient()
+        if flag == "prim":
+            core._set_prim_all_enabled(False)
+        return res, [grad]
+
+    def test_prim_all_dynamic(self):
+        res_ref, grad_ref = self.base_net()
+        res, grad = self.base_net("prim")
+
+        for ref, actual in zip(res_ref, res):
+            np.testing.assert_allclose(
+                ref, actual, rtol=self.tol, atol=self.tol
+            )
+
+        for dr, d in zip(grad_ref, grad):
+            np.testing.assert_allclose(dr, d, rtol=self.tol, atol=self.tol)
+
+
+class TestPrimExpandAsWithGrad2(TestPrimBaseOneGradTwoInputs):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [30, 1, 40]
+        self.init_x_shape = [None, None, 40]
+        self.y_shape = [30, 200, 40]
+        self.init_y_shape = [None, None, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = expand_as_net
+        self.enable_cinn = False
+        self.tol = 1e-5
+
+
+class TestPrimExpandAsWithGrad3(TestPrimBaseOneGradTwoInputs):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 1]
+        self.init_x_shape = [None, None, 1]
+        self.y_shape = [30, 200, 40]
+        self.init_y_shape = [None, None, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = expand_as_net
+        self.enable_cinn = False
+        self.tol = 1e-5
+
+
+class TestPrimExpandAsWithGrad4(TestPrimBaseOneGradTwoInputs):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [30, 1, 1]
+        self.init_x_shape = [None, None, 1]
+        self.y_shape = [30, 200, 40]
+        self.init_y_shape = [None, None, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = expand_as_net
         self.enable_cinn = False
         self.tol = 1e-5
 

--- a/test/prim/pir_prim/test_prim_sub_graph_backward_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_backward_dynamic_shape.py
@@ -1573,6 +1573,7 @@ class TestPrimExpandAsWithGrad2(TestPrimBaseOneGradTwoInputs):
         self.net = expand_as_net
         self.enable_cinn = False
         self.tol = 1e-5
+        self.y_without_grad = True
 
 
 class TestPrimExpandAsWithGrad3(TestPrimBaseOneGradTwoInputs):
@@ -1588,6 +1589,7 @@ class TestPrimExpandAsWithGrad3(TestPrimBaseOneGradTwoInputs):
         self.net = expand_as_net
         self.enable_cinn = False
         self.tol = 1e-5
+        self.y_without_grad = True
 
 
 class TestPrimExpandAsWithGrad4(TestPrimBaseOneGradTwoInputs):
@@ -1603,6 +1605,7 @@ class TestPrimExpandAsWithGrad4(TestPrimBaseOneGradTwoInputs):
         self.net = expand_as_net
         self.enable_cinn = False
         self.tol = 1e-5
+        self.y_without_grad = True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

为expand_grad的反向拆解支持动态shape，设置`expand_as`为Prim op，并实现其反向拆解和动态shape支持。

`reduce_as` op是Prim op，在大部分涉及到广播操作的反向计算时都会使用。在为`reduce_as_grad`支持动态shape时，发现获取reduce_dim的部分不能在编译期的时候直接获得，若要让`reduce_as_grad`支持动态shape，则需要`expand_as`算子将获取reduce_dim的过程封装在Phi算子内部，从而避免在编译期获取reduce_dim。同样的`expand_as`的反向拆解也可以使用`reduce_as `快速实现

