### PR TITLE
[CodeStyle][Ruff][BUAA][G-[201-208]] Fix ruff `RUF005` diagnostic for 8 files in `python/test/legacy_test/`

### DIFF
--- a/test/legacy_test/test_crf_decoding_op.py
+++ b/test/legacy_test/test_crf_decoding_op.py
@@ -192,7 +192,7 @@ class TestCRFDecodingOp4(TestCRFDecodingOp2):
 
 def seq_pad(data, length):
     max_len = np.max(length)
-    shape = [len(length), max_len] + list(data.shape[1:])
+    shape = [len(length), max_len, *list(data.shape[1:])]
     padded = np.zeros(shape).astype(data.dtype)
     offset = 0
     for i, l in enumerate(length):

--- a/test/legacy_test/test_crf_decoding_op.py
+++ b/test/legacy_test/test_crf_decoding_op.py
@@ -192,7 +192,7 @@ class TestCRFDecodingOp4(TestCRFDecodingOp2):
 
 def seq_pad(data, length):
     max_len = np.max(length)
-    shape = [len(length), max_len, *list(data.shape[1:])]
+    shape = [len(length), max_len, *data.shape[1:]]
     padded = np.zeros(shape).astype(data.dtype)
     offset = 0
     for i, l in enumerate(length):

--- a/test/legacy_test/test_cross_entropy_op.py
+++ b/test/legacy_test/test_cross_entropy_op.py
@@ -179,13 +179,13 @@ class TestCrossEntropyOp4(TestCrossEntropyOp):
         self.X_2d = randomize_probability(self.ins_num, self.class_num).astype(
             self.dtype
         )
-        self.x = self.X_2d.reshape([*self.shape + self.class_num])
+        self.x = self.X_2d.reshape([*self.shape, self.class_num])
 
     def init_label(self):
         self.label_2d = np.random.randint(
             0, self.class_num, (self.ins_num, 1), dtype="int64"
         )
-        self.label = self.label_2d.reshape([*self.shape + 1])
+        self.label = self.label_2d.reshape([*self.shape, 1])
 
     def get_cross_entropy(self):
         cross_entropy_2d = np.array(
@@ -195,7 +195,7 @@ class TestCrossEntropyOp4(TestCrossEntropyOp):
             ]
         ).astype(self.dtype)
         self.cross_entropy = np.array(cross_entropy_2d).reshape(
-            [*self.shape + 1]
+            [*self.shape, 1]
         )
 
     def init_attr_type(self):
@@ -236,14 +236,14 @@ class TestCrossEntropyOp5(TestCrossEntropyOp):
         self.X_2d = randomize_probability(self.ins_num, self.class_num).astype(
             self.dtype
         )
-        self.x = self.X_2d.reshape([*self.shape + self.class_num])
+        self.x = self.X_2d.reshape([*self.shape, self.class_num])
 
     def init_label(self):
         self.label_2d = np.random.uniform(
             0.1, 1.0, [self.ins_num, self.class_num]
         ).astype(self.dtype)
         self.label_2d /= self.label_2d.sum(axis=1, keepdims=True)
-        self.label = self.label_2d.reshape([*self.shape + self.class_num])
+        self.label = self.label_2d.reshape([*self.shape, self.class_num])
 
     def get_cross_entropy(self):
         cross_entropy_2d = (
@@ -252,7 +252,7 @@ class TestCrossEntropyOp5(TestCrossEntropyOp):
             .astype(self.dtype)
         )
         self.cross_entropy = np.array(cross_entropy_2d).reshape(
-            [*self.shape + 1]
+            [*self.shape, 1]
         )
 
     def init_attr_type(self):
@@ -279,7 +279,7 @@ class TestCrossEntropyOp6(TestCrossEntropyOp):
         self.X_2d = randomize_probability(self.ins_num, self.class_num).astype(
             self.dtype
         )
-        self.x = self.X_2d.reshape([*self.shape + self.class_num])
+        self.x = self.X_2d.reshape([*self.shape, self.class_num])
 
     def init_label(self):
         self.label_index_2d = np.random.randint(
@@ -287,7 +287,7 @@ class TestCrossEntropyOp6(TestCrossEntropyOp):
         )
         label_2d = np.zeros(self.X_2d.shape)
         label_2d[np.arange(self.ins_num), self.label_index_2d] = 1
-        self.label = label_2d.reshape([*self.shape + self.class_num]).astype(
+        self.label = label_2d.reshape([*self.shape, self.class_num]).astype(
             self.dtype
         )
 
@@ -300,7 +300,7 @@ class TestCrossEntropyOp6(TestCrossEntropyOp):
         )
         self.cross_entropy = (
             np.array(cross_entropy_2d)
-            .reshape([*self.shape + 1])
+            .reshape([*self.shape, 1])
             .astype(self.dtype)
         )
 

--- a/test/legacy_test/test_cross_entropy_op.py
+++ b/test/legacy_test/test_cross_entropy_op.py
@@ -179,13 +179,13 @@ class TestCrossEntropyOp4(TestCrossEntropyOp):
         self.X_2d = randomize_probability(self.ins_num, self.class_num).astype(
             self.dtype
         )
-        self.x = self.X_2d.reshape(self.shape + [self.class_num])
+        self.x = self.X_2d.reshape([*self.shape + self.class_num])
 
     def init_label(self):
         self.label_2d = np.random.randint(
             0, self.class_num, (self.ins_num, 1), dtype="int64"
         )
-        self.label = self.label_2d.reshape(self.shape + [1])
+        self.label = self.label_2d.reshape([*self.shape + 1])
 
     def get_cross_entropy(self):
         cross_entropy_2d = np.array(
@@ -195,7 +195,7 @@ class TestCrossEntropyOp4(TestCrossEntropyOp):
             ]
         ).astype(self.dtype)
         self.cross_entropy = np.array(cross_entropy_2d).reshape(
-            self.shape + [1]
+            [*self.shape + 1]
         )
 
     def init_attr_type(self):
@@ -236,14 +236,14 @@ class TestCrossEntropyOp5(TestCrossEntropyOp):
         self.X_2d = randomize_probability(self.ins_num, self.class_num).astype(
             self.dtype
         )
-        self.x = self.X_2d.reshape(self.shape + [self.class_num])
+        self.x = self.X_2d.reshape([*self.shape + self.class_num])
 
     def init_label(self):
         self.label_2d = np.random.uniform(
             0.1, 1.0, [self.ins_num, self.class_num]
         ).astype(self.dtype)
         self.label_2d /= self.label_2d.sum(axis=1, keepdims=True)
-        self.label = self.label_2d.reshape(self.shape + [self.class_num])
+        self.label = self.label_2d.reshape([*self.shape + self.class_num])
 
     def get_cross_entropy(self):
         cross_entropy_2d = (
@@ -252,7 +252,7 @@ class TestCrossEntropyOp5(TestCrossEntropyOp):
             .astype(self.dtype)
         )
         self.cross_entropy = np.array(cross_entropy_2d).reshape(
-            self.shape + [1]
+            [*self.shape + 1]
         )
 
     def init_attr_type(self):
@@ -279,7 +279,7 @@ class TestCrossEntropyOp6(TestCrossEntropyOp):
         self.X_2d = randomize_probability(self.ins_num, self.class_num).astype(
             self.dtype
         )
-        self.x = self.X_2d.reshape(self.shape + [self.class_num])
+        self.x = self.X_2d.reshape([*self.shape + self.class_num])
 
     def init_label(self):
         self.label_index_2d = np.random.randint(
@@ -287,7 +287,7 @@ class TestCrossEntropyOp6(TestCrossEntropyOp):
         )
         label_2d = np.zeros(self.X_2d.shape)
         label_2d[np.arange(self.ins_num), self.label_index_2d] = 1
-        self.label = label_2d.reshape(self.shape + [self.class_num]).astype(
+        self.label = label_2d.reshape([*self.shape + self.class_num]).astype(
             self.dtype
         )
 
@@ -300,7 +300,7 @@ class TestCrossEntropyOp6(TestCrossEntropyOp):
         )
         self.cross_entropy = (
             np.array(cross_entropy_2d)
-            .reshape(self.shape + [1])
+            .reshape([*self.shape + 1])
             .astype(self.dtype)
         )
 

--- a/test/legacy_test/test_dataset_consistency_inspection.py
+++ b/test/legacy_test/test_dataset_consistency_inspection.py
@@ -163,14 +163,16 @@ class CTRDataset(fleet.MultiSlotDataGenerator):
                     pos_context_fea = pos_context_feas[p]
                     yield zip(
                         feature_name,
-                        [[1]]
-                        + sparse_query_feature
-                        + pos_url_fea
-                        + pos_click_fea
-                        + pos_context_fea
-                        + pos_url_fea
-                        + pos_click_fea
-                        + pos_context_fea,
+                        [
+                            [1],
+                            *sparse_query_feature,
+                            *pos_url_fea,
+                            *pos_click_fea,
+                            *pos_context_fea,
+                            *pos_url_fea,
+                            *pos_click_fea,
+                            *pos_context_fea,
+                        ],
                     )
                 for n in range(len(neg_url_feas)):
                     feature_name = ["click"]
@@ -181,14 +183,16 @@ class CTRDataset(fleet.MultiSlotDataGenerator):
                     neg_context_fea = neg_context_feas[n]
                     yield zip(
                         feature_name,
-                        [[0]]
-                        + sparse_query_feature
-                        + neg_url_fea
-                        + neg_click_fea
-                        + neg_context_fea
-                        + neg_url_fea
-                        + neg_click_fea
-                        + neg_context_fea,
+                        [
+                            [0],
+                            *sparse_query_feature,
+                            *neg_url_fea,
+                            *neg_click_fea,
+                            *neg_context_fea,
+                            *neg_url_fea,
+                            *neg_click_fea,
+                            *neg_context_fea,
+                        ],
                     )
             elif self.test == 0:
                 for p in range(len(pos_url_feas)):
@@ -215,14 +219,16 @@ class CTRDataset(fleet.MultiSlotDataGenerator):
                         yield list(
                             zip(
                                 feature_name,
-                                [[1]]
-                                + sparse_query_feature
-                                + pos_url_fea
-                                + pos_click_fea
-                                + pos_context_fea
-                                + neg_url_fea
-                                + neg_click_fea
-                                + neg_context_fea,
+                                [
+                                    [1],
+                                    *sparse_query_feature,
+                                    *pos_url_fea,
+                                    *pos_click_fea,
+                                    *pos_context_fea,
+                                    *neg_url_fea,
+                                    *neg_click_fea,
+                                    *neg_context_fea,
+                                ],
                             )
                         )
             elif self.test == 2:
@@ -250,14 +256,17 @@ class CTRDataset(fleet.MultiSlotDataGenerator):
                         yield list(
                             zip(
                                 feature_name,
-                                [[1], [2]]
-                                + sparse_query_feature
-                                + pos_url_fea
-                                + pos_click_fea
-                                + pos_context_fea
-                                + neg_url_fea
-                                + neg_click_fea
-                                + neg_context_fea,
+                                [
+                                    [1],
+                                    [2],
+                                    *sparse_query_feature,
+                                    *pos_url_fea,
+                                    *pos_click_fea,
+                                    *pos_context_fea,
+                                    *neg_url_fea,
+                                    *neg_click_fea,
+                                    *neg_context_fea,
+                                ],
                             )
                         )
             elif self.test == 3:
@@ -285,14 +294,17 @@ class CTRDataset(fleet.MultiSlotDataGenerator):
                         yield list(
                             zip(
                                 feature_name,
-                                [[1], [2.0]]
-                                + sparse_query_feature
-                                + pos_url_fea
-                                + pos_click_fea
-                                + pos_context_fea
-                                + neg_url_fea
-                                + neg_click_fea
-                                + neg_context_fea,
+                                [
+                                    [1],
+                                    [2.0],
+                                    *sparse_query_feature,
+                                    *pos_url_fea,
+                                    *pos_click_fea,
+                                    *pos_context_fea,
+                                    *neg_url_fea,
+                                    *neg_click_fea,
+                                    *neg_context_fea,
+                                ],
                             )
                         )
             elif self.test == 4:
@@ -320,14 +332,17 @@ class CTRDataset(fleet.MultiSlotDataGenerator):
                         yield list(
                             zip(
                                 feature_name,
-                                [[], [2.0]]
-                                + sparse_query_feature
-                                + pos_url_fea
-                                + pos_click_fea
-                                + pos_context_fea
-                                + neg_url_fea
-                                + neg_click_fea
-                                + neg_context_fea,
+                                [
+                                    [],
+                                    [2.0],
+                                    *sparse_query_feature,
+                                    *pos_url_fea,
+                                    *pos_click_fea,
+                                    *pos_context_fea,
+                                    *neg_url_fea,
+                                    *neg_click_fea,
+                                    *neg_context_fea,
+                                ],
                             )
                         )
             elif self.test == 5:

--- a/test/legacy_test/test_deform_conv2d.py
+++ b/test/legacy_test/test_deform_conv2d.py
@@ -50,7 +50,7 @@ class TestDeformConv2D(TestCase):
         self.weight = np.random.uniform(
             -1,
             1,
-            (self.out_channels, self.in_channels // self.groups) + filter_shape,
+            (self.out_channels, self.in_channels // self.groups, *filter_shape),
         ).astype(self.dtype)
         if not self.no_bias:
             self.bias = np.random.uniform(-1, 1, (self.out_channels,)).astype(
@@ -87,17 +87,20 @@ class TestDeformConv2D(TestCase):
         self.input_shape = (
             self.batch_size,
             self.in_channels,
-        ) + self.spatial_shape
+            *self.spatial_shape,
+        )
 
         self.offset_shape = (
             self.batch_size,
             self.deformable_groups * 2 * filter_shape[0] * filter_shape[1],
-        ) + out_shape
+            *out_shape,
+        )
 
         self.mask_shape = (
             self.batch_size,
             self.deformable_groups * filter_shape[0] * filter_shape[1],
-        ) + out_shape
+            *out_shape,
+        )
 
         self.input = np.random.uniform(-1, 1, self.input_shape).astype(
             self.dtype

--- a/test/legacy_test/test_detection.py
+++ b/test/legacy_test/test_detection.py
@@ -180,7 +180,7 @@ class TestDistributeFpnProposals(LayerTest):
                 refer_scale=224,
                 rois_num=rois_num,
             )
-            fetch_list = multi_rois + [restore_ind] + rois_num_per_level
+            fetch_list = [*multi_rois, restore_ind, *rois_num_per_level]
             output_stat = self.get_static_graph_result(
                 feed={'rois': rois_np, 'rois_num': rois_num_np},
                 fetch_list=fetch_list,
@@ -210,7 +210,7 @@ class TestDistributeFpnProposals(LayerTest):
                 rois_num=rois_num_dy,
             )
             print(type(multi_rois_dy))
-            output_dy = multi_rois_dy + [restore_ind_dy] + rois_num_per_level_dy
+            output_dy = [*multi_rois_dy, restore_ind_dy, *rois_num_per_level_dy]
             output_dy_np = []
             for output in output_dy:
                 output_np = output.numpy()

--- a/test/legacy_test/test_distribute_fpn_proposals_op.py
+++ b/test/legacy_test/test_distribute_fpn_proposals_op.py
@@ -220,7 +220,7 @@ class TestDistributeFpnProposalsAPI(unittest.TestCase):
             refer_scale=224,
             rois_num=rois_num,
         )
-        fetch_list = multi_rois + [restore_ind] + rois_num_per_level
+        fetch_list = [*multi_rois, restore_ind, *rois_num_per_level]
 
         exe = paddle.static.Executor()
         output_stat = exe.run(
@@ -250,7 +250,7 @@ class TestDistributeFpnProposalsAPI(unittest.TestCase):
             refer_scale=224,
             rois_num=rois_num_dy,
         )
-        output_dy = multi_rois_dy + [restore_ind_dy] + rois_num_per_level_dy
+        output_dy = [*multi_rois_dy, restore_ind_dy, *rois_num_per_level_dy]
         output_dy_np = []
         for output in output_dy:
             output_np = output.numpy()

--- a/test/legacy_test/test_dygraph_spectral_norm.py
+++ b/test/legacy_test/test_dygraph_spectral_norm.py
@@ -40,7 +40,7 @@ class TestDygraphSpectralNorm(unittest.TestCase):
             data_name = desc[0]
             data_shape = desc[1]
             data_value = np.random.random(
-                size=[self.batch_size] + data_shape
+                size=[self.batch_size, *data_shape]
             ).astype('float32')
             self.data[data_name] = data_value
 

--- a/test/legacy_test/test_dygraph_weight_norm.py
+++ b/test/legacy_test/test_dygraph_weight_norm.py
@@ -39,7 +39,7 @@ class TestDygraphWeightNorm(unittest.TestCase):
             data_name = desc[0]
             data_shape = desc[1]
             data_value = np.random.random(
-                size=[self.batch_size] + data_shape
+                size=[self.batch_size, *data_shape]
             ).astype('float32')
             self.data[data_name] = data_value
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
修复如下文件 RUF005 的 Ruff 规则：
1. test/legacy_test/test_crf_decoding_op.py
2. test/legacy_test/test_cross_entropy_op.py
3. test/legacy_test/test_dataset_consistency_inspection.py
4. test/legacy_test/test_deform_conv2d.py
5. test/legacy_test/test_detection.py
6. test/legacy_test/test_distribute_fpn_proposals_op.py
7. test/legacy_test/test_dygraph_spectral_norm.py
8. test/legacy_test/test_dygraph_weight_norm.py

### Related links

- #67116

@gouzil