### PR TITLE
[CodeStyle][Ruff][BUAA][C-[1-10]] Fix Ruff `RSE102` diagnostic for 10 files in `python/paddle/`

### DIFF
--- a/python/paddle/audio/backends/init_backend.py
+++ b/python/paddle/audio/backends/init_backend.py
@@ -174,7 +174,7 @@ def set_backend(backend_name: str) -> None:
 
     """
     if backend_name not in list_available_backends():
-        raise NotImplementedError()
+        raise NotImplementedError
 
     if backend_name == "wave_backend":
         module = wave_backend

--- a/python/paddle/base/reader.py
+++ b/python/paddle/base/reader.py
@@ -136,10 +136,10 @@ class DataLoaderBase:
         return self
 
     def __iter__(self):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def __next__(self):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     @classmethod
     def _check_input_array(cls, item):

--- a/python/paddle/distributed/auto_parallel/static/auto_align_tool.py
+++ b/python/paddle/distributed/auto_parallel/static/auto_align_tool.py
@@ -100,7 +100,7 @@ class AutoAlignTool:
         elif level == 5:
             return self.get_backward_tmp_var()
         else:
-            raise ValueError()
+            raise ValueError
 
     def set_program(self, program: Program):
         assert isinstance(program, Program)

--- a/python/paddle/distributed/auto_tuner/tuner.py
+++ b/python/paddle/distributed/auto_tuner/tuner.py
@@ -53,7 +53,7 @@ class AutoTuner:
 
             self.algo = CustomizeSearch(tuner_cfg)
         else:
-            raise NotImplementedError()
+            raise NotImplementedError
 
         self.history_cfgs = []
         self.resume_cfgs = []

--- a/python/paddle/distributed/passes/pass_base.py
+++ b/python/paddle/distributed/passes/pass_base.py
@@ -143,7 +143,7 @@ class CPPPassWrapper(PassBase):
 
     @property
     def cpp_name(self):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     @property
     def cpp_attr_types(self):

--- a/python/paddle/incubate/distributed/fleet/parameter_server/distribute_transpiler/__init__.py
+++ b/python/paddle/incubate/distributed/fleet/parameter_server/distribute_transpiler/__init__.py
@@ -851,10 +851,10 @@ class ParameterServerOptimizer(DistributedOptimizer):
         no_grad_set=None,
         callbacks=None,
     ):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def apply_gradients(self, params_grads):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _build_trainer_programs(self, compiled_config):
         _main = fleet._origin_main_program.clone()

--- a/python/paddle/incubate/distributed/fleet/parameter_server/pslib/__init__.py
+++ b/python/paddle/incubate/distributed/fleet/parameter_server/pslib/__init__.py
@@ -1219,7 +1219,7 @@ class DownpourOptimizer(DistributedOptimizer):
         """
         Currently, backward function can not be called through DistributedOptimizer
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _remove_collective_ops(self, program, name):
         """
@@ -1235,7 +1235,7 @@ class DownpourOptimizer(DistributedOptimizer):
         """
         Currently, apply_gradients function can not be called through DistributedOptimizer
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def get_dist_env(self):
         trainer_id = int(os.getenv('PADDLE_TRAINER_ID', '0'))

--- a/python/paddle/incubate/nn/attn_bias.py
+++ b/python/paddle/incubate/nn/attn_bias.py
@@ -30,7 +30,7 @@ import paddle
 class AttentionBias(ABC):
     @abstractmethod
     def materialize(self, shape, dtype=paddle.float32):
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class LowerTriangularMask(AttentionBias):
@@ -119,7 +119,7 @@ class PaddedSeqLenInfo(SeqLenInfo):
         )
 
     def split(self, x, batch_sizes=None):
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 @dataclass

--- a/python/paddle/incubate/nn/layer/fused_transformer.py
+++ b/python/paddle/incubate/nn/layer/fused_transformer.py
@@ -985,10 +985,10 @@ class FusedTransformer(Layer):
         custom_decoder=None,
     ):
         super().__init__()
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def forward(self, src, tgt, src_mask=None, tgt_mask=None, memory_mask=None):
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class FusedMultiTransformer(Layer):

--- a/python/paddle/jit/dy2static/py_layer.py
+++ b/python/paddle/jit/dy2static/py_layer.py
@@ -66,15 +66,15 @@ class StaticPyLayerContext:
 
     # TODO(MarioLulab): support not_inplace
     def mark_not_inplace(self, *args):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     # TODO(MarioLulab): support non_differentiable
     def mark_non_differentiable(self, *args):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     # TODO(MarioLulab): support materialize_grads
     def set_materialize_grads(self, value: bool):
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class StaticPyLayer:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
修复如下文件 `RSE102` 的 Ruff 规则：
- python/paddle/audio/backends/init_backend.py
- python/paddle/base/reader.py
- python/paddle/distributed/auto_parallel/static/auto_align_tool.py
- python/paddle/distributed/auto_tuner/tuner.py
- python/paddle/distributed/passes/pass_base.py
- python/paddle/incubate/distributed/fleet/parameter_server/distribute_transpiler/__init__.py
- python/paddle/incubate/distributed/fleet/parameter_server/pslib/__init__.py
- python/paddle/incubate/nn/attn_bias.py
- python/paddle/incubate/nn/layer/fused_transformer.py
- python/paddle/jit/dy2static/py_layer.py

### Related links

- #67116

@gouzil