### PR TITLE
[CodeStyle][Ruff][BUAA][C-[11-20]] Fix Ruff `RSE102` diagnostic for 10 files in `python/paddle/`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/mutable_data.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/mutable_data.py
@@ -153,13 +153,13 @@ class MutableData(Generic[InnerMutableDataT]):
         self.records[:] = self.records[:version]
 
     def get(self, key):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def set(self, key, value):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def apply(self, mutation: Mutation, write_cache: InnerMutableDataT):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def reproduce(self, version: int | None = None) -> InnerMutableDataT:
         if version is None:

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -406,7 +406,7 @@ class OpcodeExecutorBase:
             NotImplementedError: If the method is not implemented.
 
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def transform(self):
         """
@@ -416,7 +416,7 @@ class OpcodeExecutorBase:
             NotImplementedError: If the method is not implemented.
 
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def find_space_of_var_name(self, name):
         code = self._graph.pycode_gen._origin_code

--- a/python/paddle/jit/sot/opcode_translator/executor/side_effects.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/side_effects.py
@@ -101,10 +101,10 @@ class SideEffects:
 
 class SideEffectRestorer:
     def pre_gen(self, codegen: PyCodeGen):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def post_gen(self, codegen: PyCodeGen):
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class DictSideEffectRestorer(SideEffectRestorer):

--- a/python/paddle/jit/sot/opcode_translator/executor/tracker.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/tracker.py
@@ -57,7 +57,7 @@ class Tracker:
         Args:
             codegen (PyCodeGen): An instance of PyCodeGen to generate instructions.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     # TODO(xiongkun): trace_value_from_frame is not a good name, it should be more related to guard but not tracable.
     def trace_value_from_frame(self) -> StringifiedExpression:
@@ -67,7 +67,7 @@ class Tracker:
         Returns:
             The value of the tracked variables.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def is_traceable(self) -> bool:
         """

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
@@ -358,7 +358,7 @@ class VariableBase:
         """
         Abstract method to get the value of the variable
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def get_py_type(self):
         """

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
@@ -75,7 +75,7 @@ class SequenceIterVariable(IterVariable):
             self.idx += 1
             return val
         else:
-            raise StopIteration()
+            raise StopIteration
 
     def to_list(self) -> list:
         if self.has_side_effect():

--- a/python/paddle/jit/sot/utils/utils.py
+++ b/python/paddle/jit/sot/utils/utils.py
@@ -272,10 +272,10 @@ class Cache:
         self.hit_num = 0
 
     def key_fn(self, *args, **kwargs):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def value_fn(self, *args, **kwargs):
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 def execute_time(func):

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -259,10 +259,10 @@ def _squared_l2_norm(x):
 
 class BaseErrorClipAttr:
     def __str__(self):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _append_clip_op(self, block, grad_name):
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class ErrorClipByValue(BaseErrorClipAttr):
@@ -347,7 +347,7 @@ class ClipGradBase:
         super().__init__()
 
     def __str__(self):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     @imperative_base.no_grad()
     def _dygraph_clip(self, params_grads):
@@ -376,10 +376,10 @@ class ClipGradBase:
             return self._static_clip(params_grads)
 
     def _process_context(self, context, param, grad):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _create_operators(self, param, grad):
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class ClipGradByValue(ClipGradBase):

--- a/python/paddle/nn/initializer/initializer.py
+++ b/python/paddle/nn/initializer/initializer.py
@@ -73,7 +73,7 @@ class Initializer:
         self, param: paddle.Tensor, block: paddle.pir.Block | None = None
     ) -> paddle.Tensor | None:
         """Add corresponding initialization operations to the network."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _lazy_init(
         self, param: paddle.Tensor, block: paddle.pir.Block | None = None

--- a/python/paddle/regularizer.py
+++ b/python/paddle/regularizer.py
@@ -41,11 +41,11 @@ class WeightDecayRegularizer:
         self, param: paddle.Tensor, grad: paddle.Tensor, block: pir.Block
     ):
         """Add corresponding weight decay operations to the network"""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def __str__(self):
         """Debug string"""
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class L1Decay(WeightDecayRegularizer):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
修复如下文件 `RSE102` 的 Ruff 规则：
- python/paddle/jit/sot/opcode_translator/executor/mutable_data.py
- python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
- python/paddle/jit/sot/opcode_translator/executor/side_effects.py
- python/paddle/jit/sot/opcode_translator/executor/tracker.py
- python/paddle/jit/sot/opcode_translator/executor/variables/base.py
- python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
- python/paddle/jit/sot/utils/utils.py
- python/paddle/nn/clip.py
- python/paddle/nn/initializer/initializer.py
- python/paddle/regularizer.py

### Related links

- #67116

@gouzil