### PR TITLE
[CodeStyle][Ruff][BUAA][C-[21-30]] Fix Ruff `RSE102` diagnostic for 10 files in `python/paddle/` and `test/`

### DIFF
--- a/python/paddle/utils/environments.py
+++ b/python/paddle/utils/environments.py
@@ -41,10 +41,10 @@ class EnvironmentVariable(Generic[T]):
         self.default = default
 
     def get(self) -> T:
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def set(self, value: T) -> None:
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def delete(self) -> None:
         del os.environ[self.name]

--- a/test/book/notest_understand_sentiment.py
+++ b/test/book/notest_understand_sentiment.py
@@ -82,7 +82,7 @@ def train(
             data, label, input_dim=dict_dim, class_dim=class_dim
         )
     else:
-        raise NotImplementedError()
+        raise NotImplementedError
 
     adagrad = paddle.optimizer.Adagrad(learning_rate=0.002)
     adagrad.minimize(cost)

--- a/test/deprecated/book/test_recognize_digits_deprecated.py
+++ b/test/deprecated/book/test_recognize_digits_deprecated.py
@@ -90,7 +90,7 @@ def train(
         net_conf = conv_net
 
     if parallel:
-        raise NotImplementedError()
+        raise NotImplementedError
     else:
         prediction, avg_loss, acc = net_conf(img, label)
 

--- a/test/deprecated/book/test_word2vec_book_deprecated.py
+++ b/test/deprecated/book/test_word2vec_book_deprecated.py
@@ -119,7 +119,7 @@ def train(
             [first_word, second_word, third_word, forth_word, next_word]
         )
     else:
-        raise NotImplementedError()
+        raise NotImplementedError
 
     sgd_optimizer = paddle.optimizer.SGD(learning_rate=0.001)
     if use_bf16:

--- a/test/deprecated/legacy_test/test_multiprocess_reader_exception.py
+++ b/test/deprecated/legacy_test/test_multiprocess_reader_exception.py
@@ -48,7 +48,7 @@ class TestMultiprocessReaderExceptionWithQueueSuccess(unittest.TestCase):
                             np.random.uniform(low=-1, high=1, size=[10])
                         ),
                     else:
-                        raise ValueError()
+                        raise ValueError
 
             return __impl__
 
@@ -94,7 +94,7 @@ class TestMultiprocessReaderExceptionWithQueueSuccess(unittest.TestCase):
                         self.assertEqual(num, batch_num)
                     except SystemError as ex:
                         self.assertEqual(num, 0)
-                        raise ReaderException()
+                        raise ReaderException
             else:
                 for _ in range(3):
                     num = 0
@@ -110,7 +110,7 @@ class TestMultiprocessReaderExceptionWithQueueSuccess(unittest.TestCase):
                     except SystemError as ex:
                         self.assertTrue(self.raise_exception)
                         self.assertEqual(num, 0)
-                        raise ReaderException()
+                        raise ReaderException
 
     def test_main(self):
         for p in self.places():

--- a/test/distributed_passes/auto_parallel_pass_test_base.py
+++ b/test/distributed_passes/auto_parallel_pass_test_base.py
@@ -53,10 +53,10 @@ class AutoParallelPassTestBase(DistPassTestBase):
         pass
 
     def get_model(self, place, **kwargs):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def apply_passes(self):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def apply_no_passes(self):
         dist_strategy = fleet.DistributedStrategy()

--- a/test/distributed_passes/dist_pass_test_base.py
+++ b/test/distributed_passes/dist_pass_test_base.py
@@ -81,10 +81,10 @@ class DistPassTestBase(unittest.TestCase):
         pass
 
     def get_model(self, place, **kwargs):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def apply_passes(self, main_prog, startup_prog):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def check_main(self, model=None, gpus=None, **kwargs):
         pass_rets = self._distributed_launch(
@@ -269,7 +269,7 @@ class PassConflictChecker(DistPassTestBase):
         super().setUp()
 
     def pass_config(self):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def apply_passes(self, main_prog, startup_prog):
         passes = self.pass_config()

--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -473,13 +473,13 @@ class PassAutoScanTest(AutoScanTest):
             self.fail_log(
                 f"At least {min_success_num} programs need to ran successfully, but now only about {successful_ran_programs} programs satisfied."
             )
-            raise AssertionError()
+            raise AssertionError
         used_time = time.time() - start_time
         if max_duration > 0 and used_time > max_duration:
             self.fail_log(
                 f"The duration exceeds {max_duration} seconds, if this is necessary, try to set a larger number for parameter `max_duration`."
             )
-            raise AssertionError()
+            raise AssertionError
 
     def run_test(self, quant=False, prog_configs=None):
         status = True

--- a/test/ir/inference/test_trt_convert_prelu.py
+++ b/test/ir/inference/test_trt_convert_prelu.py
@@ -43,7 +43,7 @@ class TrtConvertPreluTest(TrtLayerAutoScanTest):
                 elif attrs[0]["data_format"] == "NHWC":
                     return np.random.random([batch, 16, 3]).astype(np.float32)
                 else:
-                    raise AssertionError()
+                    raise AssertionError
             else:
                 if attrs[0]["data_format"] == "NCHW":
                     return np.random.random([batch, 3, 16, 32]).astype(
@@ -72,7 +72,7 @@ class TrtConvertPreluTest(TrtLayerAutoScanTest):
                     elif attrs[0]["data_format"] == "NHWC":
                         return np.random.random([1, 16, 3]).astype(np.float32)
                     else:
-                        raise AssertionError()
+                        raise AssertionError
                 else:
                     if attrs[0]["data_format"] == "NCHW":
                         return np.random.random([1, 3, 16, 32]).astype(
@@ -83,7 +83,7 @@ class TrtConvertPreluTest(TrtLayerAutoScanTest):
                             np.float32
                         )
                     else:
-                        raise AssertionError()
+                        raise AssertionError
 
         for batch in [1, 4]:
             for dims in [0, 1, 2, 3, 4]:
@@ -165,7 +165,7 @@ class TrtConvertPreluTest(TrtLayerAutoScanTest):
                         "input_data": [1, 16, 3]
                     }
                 else:
-                    raise AssertionError()
+                    raise AssertionError
             else:
                 if attrs[0]["data_format"] == "NCHW":
                     self.dynamic_shape.min_input_shape = {
@@ -188,7 +188,7 @@ class TrtConvertPreluTest(TrtLayerAutoScanTest):
                         "input_data": [1, 16, 32, 3]
                     }
                 else:
-                    raise AssertionError()
+                    raise AssertionError
 
         def clear_dynamic_shape():
             self.dynamic_shape.max_input_shape = {}

--- a/test/legacy_test/check_nan_inf_base.py
+++ b/test/legacy_test/check_nan_inf_base.py
@@ -99,7 +99,7 @@ def check(use_cuda):
 if __name__ == '__main__':
     try:
         check(use_cuda=False)
-        raise AssertionError()
+        raise AssertionError
     except Exception as e:
         print(e)
         print(type(e))
@@ -108,7 +108,7 @@ if __name__ == '__main__':
     if core.is_compiled_with_cuda():
         try:
             check(use_cuda=True)
-            raise AssertionError()
+            raise AssertionError
         except Exception as e:
             print(e)
             print(type(e))


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
修复如下文件 `RSE102` 的 Ruff 规则：
- python/paddle/utils/environments.py
- test/book/notest_understand_sentiment.py
- test/deprecated/book/test_recognize_digits_deprecated.py
- test/deprecated/book/test_word2vec_book_deprecated.py
- test/deprecated/legacy_test/test_multiprocess_reader_exception.py
- test/distributed_passes/auto_parallel_pass_test_base.py
- test/distributed_passes/dist_pass_test_base.py
- test/ir/inference/auto_scan_test.py
- test/ir/inference/test_trt_convert_prelu.py
- test/legacy_test/check_nan_inf_base.py

### Related links

- #67116

@gouzil