### PR TITLE
[CodeStyle][Ruff][BUAA][C-[31-37]] Fix Ruff `RSE102` diagnostic for 7 files in `test/legacy_test/`

### DIFF
--- a/test/legacy_test/check_nan_inf_base_dygraph.py
+++ b/test/legacy_test/check_nan_inf_base_dygraph.py
@@ -97,7 +97,7 @@ def run_check(args):
         if use_cuda:
             try:
                 check_main(use_cuda=True, use_amp=args.use_amp)
-                raise AssertionError()
+                raise AssertionError
             except Exception as e:
                 print(e)
                 print(type(e))
@@ -107,7 +107,7 @@ def run_check(args):
         else:
             try:
                 check_main(use_cuda=False, use_amp=False)
-                raise AssertionError()
+                raise AssertionError
             except Exception as e:
                 print(e)
                 print(type(e))

--- a/test/legacy_test/distributed_fused_lamb_test_base.py
+++ b/test/legacy_test/distributed_fused_lamb_test_base.py
@@ -78,7 +78,7 @@ class GradClipDecorator(ClipGradBase):
         self.clip_after_allreduce = clip_after_allreduce
 
     def _dygraph_clip(self, params_grads):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _insert_allreduce_ops(self, params_grads):
         world_size = paddle.distributed.get_world_size()

--- a/test/legacy_test/fleet_meta_optimizer_base.py
+++ b/test/legacy_test/fleet_meta_optimizer_base.py
@@ -259,4 +259,4 @@ class TestFleetMetaOptimizer(unittest.TestCase):
         elif name == 'asp':
             strategy.asp = True
         else:
-            raise NotImplementedError()
+            raise NotImplementedError

--- a/test/legacy_test/test_imperative_optimizer.py
+++ b/test/legacy_test/test_imperative_optimizer.py
@@ -44,10 +44,10 @@ class TestImperativeOptimizerBase(unittest.TestCase):
         self.batch_num = 20
 
     def get_optimizer_dygraph(self, parameter_list):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def get_optimizer(self):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def reader_decorator(self, reader):
         def _reader_simple():

--- a/test/legacy_test/test_imperative_optimizer_v2.py
+++ b/test/legacy_test/test_imperative_optimizer_v2.py
@@ -71,10 +71,10 @@ class TestImperativeOptimizerBase(unittest.TestCase):
         self.batch_num = 20
 
     def get_optimizer_dygraph(self, parameter_list):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def get_optimizer(self):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def reader_decorator(self, reader):
         def _reader_simple():

--- a/test/legacy_test/test_logcumsumexp_op.py
+++ b/test/legacy_test/test_logcumsumexp_op.py
@@ -259,7 +259,7 @@ class BaseTestCases:
             )
 
         def input_and_attrs(self):
-            raise NotImplementedError()
+            raise NotImplementedError
 
 
 class TestLogcumsumexpOp1(BaseTestCases.BaseOpTest):

--- a/test/legacy_test/test_nan_inf.py
+++ b/test/legacy_test/test_nan_inf.py
@@ -206,7 +206,7 @@ class TestNanInfCheckResult(TestNanInfBase):
             out = paddle.log(x)
             sys.stdout.flush()
             if add_assert:
-                raise AssertionError()
+                raise AssertionError
         except Exception as e:
             # Cannot catch the log in CUDA kernel.
             err_str_list = (


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
修复如下文件 `RSE102` 的 Ruff 规则：
- test/legacy_test/check_nan_inf_base_dygraph.py
- test/legacy_test/distributed_fused_lamb_test_base.py
- test/legacy_test/fleet_meta_optimizer_base.py
- test/legacy_test/test_imperative_optimizer.py
- test/legacy_test/test_imperative_optimizer_v2.py
- test/legacy_test/test_logcumsumexp_op.py
- test/legacy_test/test_nan_inf.py

### Related links

- #67116

@gouzil