### PR TITLE
[CodeStyle][Ruff][BUAA][G-6,G-7,G-8,G-9,G-10] Fix ruff `RUF005` diagnostic for 5 files in `python/paddle/`

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -725,7 +725,7 @@ if __is_metainfo_generated and is_compiled_with_cuda():
                     if not path_patched:
                         prev_path = os.environ['PATH']
                         os.environ['PATH'] = ';'.join(
-                            dll_paths + [os.environ['PATH']]
+                            [*dll_paths, os.environ['PATH']]
                         )
                         path_patched = True
                     res = kernel32.LoadLibraryW(dll)

--- a/python/paddle/audio/functional/window.py
+++ b/python/paddle/audio/functional/window.py
@@ -383,6 +383,6 @@ def get_window(
     except KeyError as e:
         raise ValueError("Unknown window type.") from e
 
-    params = (win_length,) + args
+    params = (win_length, *args)
     kwargs = {'sym': sym}
     return winfunc(*params, dtype=dtype, **kwargs)

--- a/python/paddle/base/backward.py
+++ b/python/paddle/base/backward.py
@@ -1025,7 +1025,7 @@ def _append_backward_ops_with_checkpoints_(
             start_idx += 1
 
     if segments != [] and segments[0][0] != 0:
-        recompute_segments = [[0, segments[0][0]]] + segments
+        recompute_segments = [[0, segments[0][0]], *segments]
     else:
         recompute_segments = segments
 

--- a/python/paddle/base/lod_tensor.py
+++ b/python/paddle/base/lod_tensor.py
@@ -93,7 +93,7 @@ def create_lod_tensor(data, recursive_seq_lens, place):
         # FIXME(zjl): the original logic of create_lod_tensor would append
         # 1 to the shape. Maybe it is not a right way? Currently, we only
         # follow the previous logic
-        arr = arr.reshape(arr.shape + (1,))
+        arr = arr.reshape((*arr.shape, 1))
         tensor = core.LoDTensor()
         tensor.set(arr, place)
         tensor.set_recursive_sequence_lengths(recursive_seq_lens)
@@ -166,7 +166,7 @@ def create_random_int_lodtensor(
     """
     assert isinstance(base_shape, list), "base_shape should be a list"
     # append the total number of basic elements to the front of its shape
-    overall_shape = [sum(recursive_seq_lens[-1])] + base_shape
+    overall_shape = [sum(recursive_seq_lens[-1]), *base_shape]
     # the range of integer data elements is [low, high]
     data = np.random.random_integers(low, high, overall_shape).astype("int64")
     return create_lod_tensor(data, recursive_seq_lens, place)

--- a/python/paddle/dataset/imikolov.py
+++ b/python/paddle/dataset/imikolov.py
@@ -94,7 +94,7 @@ def reader_creator(filename, word_idx, n, data_type):
             for l in f:
                 if DataType.NGRAM == data_type:
                     assert n > -1, 'Invalid gram length'
-                    l = ['<s>'] + l.strip().split() + ['<e>']
+                    l = ['<s>', *l.strip().split(), '<e>']
                     if len(l) >= n:
                         l = [word_idx.get(w, UNK) for w in l]
                         for i in range(n, len(l) + 1):
@@ -102,8 +102,8 @@ def reader_creator(filename, word_idx, n, data_type):
                 elif DataType.SEQ == data_type:
                     l = l.strip().split()
                     l = [word_idx.get(w, UNK) for w in l]
-                    src_seq = [word_idx['<s>']] + l
-                    trg_seq = l + [word_idx['<e>']]
+                    src_seq = [word_idx['<s>'], *l]
+                    trg_seq = [*l, word_idx['<e>']]
                     if n > 0 and len(src_seq) > n:
                         continue
                     yield src_seq, trg_seq


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

修复如下文件 RUF005 的 Ruff 规则：

- ``python/paddle/__init__.py``
- ``python/paddle/audio/functional/window.py``
- ``python/paddle/base/backward.py``
- ``python/paddle/base/lod_tensor.py``
- ``python/paddle/dataset/imikolov.py``

### Related Links

- #67116 

@gouzil 


