### PR TITLE
[CodeStyle][Ruff][BUAA][G-[209-216]] Fix ruff `RUF005` diagnostic for 8 files in `python/test/legacy_test/`

### DIFF
--- a/test/legacy_test/test_eigh_op.py
+++ b/test/legacy_test/test_eigh_op.py
@@ -152,7 +152,7 @@ class TestEighAPI(unittest.TestCase):
             self.dtype
         ) + 1j * np.random.random(self.x_shape).astype(self.dtype)
         self.trans_dims = [
-            *list(range(len(self.x_shape) - 2)),
+            *range(len(self.x_shape) - 2),
             len(self.x_shape) - 1,
             len(self.x_shape) - 2,
         ]

--- a/test/legacy_test/test_eigh_op.py
+++ b/test/legacy_test/test_eigh_op.py
@@ -151,7 +151,8 @@ class TestEighAPI(unittest.TestCase):
         complex_data = np.random.random(self.x_shape).astype(
             self.dtype
         ) + 1j * np.random.random(self.x_shape).astype(self.dtype)
-        self.trans_dims = list(range(len(self.x_shape) - 2)) + [
+        self.trans_dims = [
+            *list(range(len(self.x_shape) - 2)),
             len(self.x_shape) - 1,
             len(self.x_shape) - 2,
         ]

--- a/test/legacy_test/test_eigvalsh_op.py
+++ b/test/legacy_test/test_eigvalsh_op.py
@@ -128,7 +128,7 @@ class TestEigvalshAPI(unittest.TestCase):
             self.dtype
         ) + 1j * np.random.random(self.x_shape).astype(self.dtype)
         self.trans_dims = [
-            *list(range(len(self.x_shape) - 2)),
+            *range(len(self.x_shape) - 2),
             len(self.x_shape) - 1,
             len(self.x_shape) - 2,
         ]

--- a/test/legacy_test/test_eigvalsh_op.py
+++ b/test/legacy_test/test_eigvalsh_op.py
@@ -127,7 +127,8 @@ class TestEigvalshAPI(unittest.TestCase):
         complex_data = np.random.random(self.x_shape).astype(
             self.dtype
         ) + 1j * np.random.random(self.x_shape).astype(self.dtype)
-        self.trans_dims = list(range(len(self.x_shape) - 2)) + [
+        self.trans_dims = [
+            *list(range(len(self.x_shape) - 2)),
             len(self.x_shape) - 1,
             len(self.x_shape) - 2,
         ]

--- a/test/legacy_test/test_embedding_deterministic.py
+++ b/test/legacy_test/test_embedding_deterministic.py
@@ -99,7 +99,7 @@ def generate_input_data(
     weight = paddle.randn([vocab_size, hidden_size]).astype(weight_dtype)
     weight.stop_gradient = False
 
-    out_grad_shape = list(ids_shape) + [hidden_size]
+    out_grad_shape = [*list(ids_shape), hidden_size]
     if allow_duplicate_id and not allow_pure_random:
         out_grad = paddle.randint(low=-10, high=10, shape=out_grad_shape)
     else:

--- a/test/legacy_test/test_embedding_deterministic.py
+++ b/test/legacy_test/test_embedding_deterministic.py
@@ -99,7 +99,7 @@ def generate_input_data(
     weight = paddle.randn([vocab_size, hidden_size]).astype(weight_dtype)
     weight.stop_gradient = False
 
-    out_grad_shape = [*list(ids_shape), hidden_size]
+    out_grad_shape = [*ids_shape, hidden_size]
     if allow_duplicate_id and not allow_pure_random:
         out_grad = paddle.randint(low=-10, high=10, shape=out_grad_shape)
     else:

--- a/test/legacy_test/test_fake_quantize_op.py
+++ b/test/legacy_test/test_fake_quantize_op.py
@@ -455,7 +455,7 @@ class TestChannelWiseFakeQuantizeDequantizeAbsMaxOp(OpTest):
             )
             self.attrs['round_type'] = 1
         if quant_axis == 1:
-            scale_broadcast = np.transpose(scale_broadcast, (1, compute_axis))
+            scale_broadcast = np.transpose(scale_broadcast, (1, *compute_axis))
         scale = scale_broadcast.reshape(input_shape[quant_axis], -1)[:, 0]
         self.python_api = fake_channel_wise_quantize_dequantize_abs_max_wrapper
         self.inputs = {'X': input_data}

--- a/test/legacy_test/test_fake_quantize_op.py
+++ b/test/legacy_test/test_fake_quantize_op.py
@@ -156,7 +156,7 @@ class TestFakeChannelWiseQuantizeAbsMaxOp(OpTest):
             )
             self.attrs['round_type'] = 1
         if quant_axis == 1:
-            scale_broadcast = np.transpose(scale_broadcast, (1,) + compute_axis)
+            scale_broadcast = np.transpose(scale_broadcast, (1, *compute_axis))
         scale = scale_broadcast.reshape(input_shape[quant_axis], -1)[:, 0]
         self.inputs = {'X': input_data}
         self.outputs = {'Out': output_data, 'OutScale': scale}
@@ -455,7 +455,7 @@ class TestChannelWiseFakeQuantizeDequantizeAbsMaxOp(OpTest):
             )
             self.attrs['round_type'] = 1
         if quant_axis == 1:
-            scale_broadcast = np.transpose(scale_broadcast, (1,) + compute_axis)
+            scale_broadcast = np.transpose(scale_broadcast, (1, compute_axis))
         scale = scale_broadcast.reshape(input_shape[quant_axis], -1)[:, 0]
         self.python_api = fake_channel_wise_quantize_dequantize_abs_max_wrapper
         self.inputs = {'X': input_data}

--- a/test/legacy_test/test_flash_attention.py
+++ b/test/legacy_test/test_flash_attention.py
@@ -567,10 +567,10 @@ class TestFlashAttentionGQA(unittest.TestCase):
             low=1, high=self.seq_len, size=[self.batch_size]
         )
         cu_seqlen_q = paddle.to_tensor(
-            [0, *np.cumsum(seq_len_q).tolist()], dtype=paddle.int32
+            [0, *np.cumsum(seq_len_q)], dtype=paddle.int32
         )
         cu_seqlen_k = paddle.to_tensor(
-            [0, *np.cumsum(seq_len_k).tolist()], dtype=paddle.int32
+            [0, *np.cumsum(seq_len_k)], dtype=paddle.int32
         )
 
         qs, ks, vs = [], [], []
@@ -772,7 +772,7 @@ class TestFlashAttentionGQA(unittest.TestCase):
 
             tmp_shape = tmp_xs[i].shape
             tmp_pad = paddle.zeros(
-                [max_seqlen - tmp_shape[0], *list(tmp_shape[1:])], dtype=x.dtype
+                [max_seqlen - tmp_shape[0], *tmp_shape[1:]], dtype=x.dtype
             )
             tmp_x = paddle.concat([tmp_xs[i], tmp_pad]).unsqueeze(0)
             tmp_x_pads.append(tmp_x)
@@ -966,7 +966,7 @@ class TestFlashAttentionVarlenQKVPackedGQA(TestFlashAttentionGQA):
         )
         seq_len_k = seq_len_q
         cu_seqlen_q = paddle.to_tensor(
-            [0, *np.cumsum(seq_len_q).tolist()], dtype=paddle.int32
+            [0, *np.cumsum(seq_len_q)], dtype=paddle.int32
         )
         cu_seqlen_k = cu_seqlen_q
 

--- a/test/legacy_test/test_flash_attention.py
+++ b/test/legacy_test/test_flash_attention.py
@@ -567,10 +567,10 @@ class TestFlashAttentionGQA(unittest.TestCase):
             low=1, high=self.seq_len, size=[self.batch_size]
         )
         cu_seqlen_q = paddle.to_tensor(
-            [0] + np.cumsum(seq_len_q).tolist(), dtype=paddle.int32
+            [0, *np.cumsum(seq_len_q).tolist()], dtype=paddle.int32
         )
         cu_seqlen_k = paddle.to_tensor(
-            [0] + np.cumsum(seq_len_k).tolist(), dtype=paddle.int32
+            [0, *np.cumsum(seq_len_k).tolist()], dtype=paddle.int32
         )
 
         qs, ks, vs = [], [], []
@@ -772,7 +772,7 @@ class TestFlashAttentionGQA(unittest.TestCase):
 
             tmp_shape = tmp_xs[i].shape
             tmp_pad = paddle.zeros(
-                [max_seqlen - tmp_shape[0]] + list(tmp_shape[1:]), dtype=x.dtype
+                [max_seqlen - tmp_shape[0], *list(tmp_shape[1:])], dtype=x.dtype
             )
             tmp_x = paddle.concat([tmp_xs[i], tmp_pad]).unsqueeze(0)
             tmp_x_pads.append(tmp_x)
@@ -966,7 +966,7 @@ class TestFlashAttentionVarlenQKVPackedGQA(TestFlashAttentionGQA):
         )
         seq_len_k = seq_len_q
         cu_seqlen_q = paddle.to_tensor(
-            [0] + np.cumsum(seq_len_q).tolist(), dtype=paddle.int32
+            [0, *np.cumsum(seq_len_q).tolist()], dtype=paddle.int32
         )
         cu_seqlen_k = cu_seqlen_q
 

--- a/test/legacy_test/test_fleet_executor.py
+++ b/test/legacy_test/test_fleet_executor.py
@@ -46,11 +46,11 @@ class TestFleetExecutor(unittest.TestCase):
         empty_program = paddle.static.Program()
         with base.program_guard(empty_program, empty_program):
             x = paddle.static.data(
-                name='x', shape=[-1, *list(x_data.shape)], dtype=x_data.dtype
+                name='x', shape=[-1, *x_data.shape], dtype=x_data.dtype
             )
             x.desc.set_need_check_feed(False)
             y = paddle.static.data(
-                name='y', shape=[-1, *list(y_data.shape)], dtype=y_data.dtype
+                name='y', shape=[-1, *y_data.shape], dtype=y_data.dtype
             )
             y.desc.set_need_check_feed(False)
             z = x + y

--- a/test/legacy_test/test_fleet_executor.py
+++ b/test/legacy_test/test_fleet_executor.py
@@ -46,11 +46,11 @@ class TestFleetExecutor(unittest.TestCase):
         empty_program = paddle.static.Program()
         with base.program_guard(empty_program, empty_program):
             x = paddle.static.data(
-                name='x', shape=[-1] + list(x_data.shape), dtype=x_data.dtype
+                name='x', shape=[-1, *list(x_data.shape)], dtype=x_data.dtype
             )
             x.desc.set_need_check_feed(False)
             y = paddle.static.data(
-                name='y', shape=[-1] + list(y_data.shape), dtype=y_data.dtype
+                name='y', shape=[-1, *list(y_data.shape)], dtype=y_data.dtype
             )
             y.desc.set_need_check_feed(False)
             z = x + y

--- a/test/legacy_test/test_fleet_executor_origin_scheduler.py
+++ b/test/legacy_test/test_fleet_executor_origin_scheduler.py
@@ -46,11 +46,11 @@ class TestFleetExecutor(unittest.TestCase):
         empty_program = paddle.static.Program()
         with base.program_guard(empty_program, empty_program):
             x = paddle.static.data(
-                name='x', shape=[-1, *list(x_data.shape)], dtype=x_data.dtype
+                name='x', shape=[-1, *x_data.shape], dtype=x_data.dtype
             )
             x.desc.set_need_check_feed(False)
             y = paddle.static.data(
-                name='y', shape=[-1, *list(y_data.shape)], dtype=y_data.dtype
+                name='y', shape=[-1, *y_data.shape], dtype=y_data.dtype
             )
             y.desc.set_need_check_feed(False)
             z = x + y

--- a/test/legacy_test/test_fleet_executor_origin_scheduler.py
+++ b/test/legacy_test/test_fleet_executor_origin_scheduler.py
@@ -46,11 +46,11 @@ class TestFleetExecutor(unittest.TestCase):
         empty_program = paddle.static.Program()
         with base.program_guard(empty_program, empty_program):
             x = paddle.static.data(
-                name='x', shape=[-1] + list(x_data.shape), dtype=x_data.dtype
+                name='x', shape=[-1, *list(x_data.shape)], dtype=x_data.dtype
             )
             x.desc.set_need_check_feed(False)
             y = paddle.static.data(
-                name='y', shape=[-1] + list(y_data.shape), dtype=y_data.dtype
+                name='y', shape=[-1, *list(y_data.shape)], dtype=y_data.dtype
             )
             y.desc.set_need_check_feed(False)
             z = x + y

--- a/test/legacy_test/test_fleet_executor_with_task_nodes.py
+++ b/test/legacy_test/test_fleet_executor_with_task_nodes.py
@@ -29,11 +29,11 @@ class TestFleetExecutor(unittest.TestCase):
         empty_program = paddle.static.Program()
         with base.program_guard(empty_program, empty_program):
             x = paddle.static.data(
-                name='x', shape=[-1, *list(x_data.shape)], dtype=x_data.dtype
+                name='x', shape=[-1, *x_data.shape], dtype=x_data.dtype
             )
             x.desc.set_need_check_feed(False)
             y = paddle.static.data(
-                name='y', shape=[-1, *list(y_data.shape)], dtype=y_data.dtype
+                name='y', shape=[-1, *y_data.shape], dtype=y_data.dtype
             )
             y.desc.set_need_check_feed(False)
             z = x + y

--- a/test/legacy_test/test_fleet_executor_with_task_nodes.py
+++ b/test/legacy_test/test_fleet_executor_with_task_nodes.py
@@ -29,11 +29,11 @@ class TestFleetExecutor(unittest.TestCase):
         empty_program = paddle.static.Program()
         with base.program_guard(empty_program, empty_program):
             x = paddle.static.data(
-                name='x', shape=[-1] + list(x_data.shape), dtype=x_data.dtype
+                name='x', shape=[-1, *list(x_data.shape)], dtype=x_data.dtype
             )
             x.desc.set_need_check_feed(False)
             y = paddle.static.data(
-                name='y', shape=[-1] + list(y_data.shape), dtype=y_data.dtype
+                name='y', shape=[-1, *list(y_data.shape)], dtype=y_data.dtype
             )
             y.desc.set_need_check_feed(False)
             z = x + y


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
修复如下文件 RUF005 的 Ruff 规则：
1. test/legacy_test/test_eigh_op.py
2. test/legacy_test/test_eigvalsh_op.py
3. test/legacy_test/test_embedding_deterministic.py
4. test/legacy_test/test_fake_quantize_op.py
5. test/legacy_test/test_flash_attention.py
6. test/legacy_test/test_fleet_executor.py
7. test/legacy_test/test_fleet_executor_origin_scheduler.py
8. test/legacy_test/test_fleet_executor_with_task_nodes.py

### Related links

- #67116

@gouzil