### PR TITLE
[Typing][PEP585 Upgrade][BUAA][31-40] Use standard collections for type hints for 10 files in `python/paddle/distributed` and `python/paddle/distribution`

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -10,6 +10,8 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
+from __future__ import annotations
+
 import os
 import queue
 import sys
@@ -17,7 +19,7 @@ import time
 import warnings
 from collections import defaultdict
 from enum import Enum
-from typing import Callable, Dict, List
+from typing import Callable
 
 import paddle
 from paddle import framework
@@ -160,7 +162,7 @@ class PipelineParallelMicroStepLocations(Enum):
 class PipelineParallelMicroStepCallback:
     def __init__(self):
         # Initializes a dictionary to store hooks for each micro-step location in the pipeline.
-        self.hooks: Dict[PipelineParallelMicroStepLocations, List[Callable]] = {
+        self.hooks: dict[PipelineParallelMicroStepLocations, list[Callable]] = {
             PipelineParallelMicroStepLocations.FORWARD_BEGIN: [],
             PipelineParallelMicroStepLocations.FORWARD_END: [],
             PipelineParallelMicroStepLocations.BACKWARD_BEGIN: [],

--- a/python/paddle/distributed/parallel.py
+++ b/python/paddle/distributed/parallel.py
@@ -24,7 +24,6 @@ from multiprocessing import Manager, Process
 from typing import (
     TYPE_CHECKING,
     Any,
-    Generator,
 )
 
 import numpy as np
@@ -67,6 +66,8 @@ from . import parallel_helper
 from .backup_env import getenv_or_backup
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from paddle import Tensor
     from paddle.nn.layer.layers import _StateDict
 __all__ = []

--- a/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
+++ b/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import paddle
 from paddle.distributed.auto_parallel.process_mesh import ProcessMesh
@@ -156,9 +157,9 @@ def _get_gm_cond_var(main_program, k_steps, dist_context):
 def _append_gradient_merge_backward_op(
     main_program,
     startup_program,
-    params_grads: List[Tuple[Any, Any]],
+    params_grads: list[tuple[Any, Any]],
     dist_context,
-) -> Tuple[List[Tuple[Any, Any]], Dict[str, Any]]:
+) -> tuple[list[tuple[Any, Any]], dict[str, Any]]:
     main_block = main_program.global_block()
     startup_block = startup_program.global_block()
 
@@ -444,8 +445,8 @@ def _pir_remove_cast_for_master_grad(main_program):
 def _create_cond_block_and_update_optimizer(
     main_program,
     cond_var,
-    new_params_to_grads: List[Tuple[Any, Any]],
-    grad_to_gradient_merge: Dict[str, str],
+    new_params_to_grads: list[tuple[Any, Any]],
+    grad_to_gradient_merge: dict[str, str],
     optimize_ops_block,
     k_steps,
     avg,

--- a/python/paddle/distributed/passes/auto_parallel_master_grad.py
+++ b/python/paddle/distributed/passes/auto_parallel_master_grad.py
@@ -11,14 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import copy
 import logging
 from collections import OrderedDict
-from typing import List, Tuple
+from typing import TYPE_CHECKING
 
 import paddle
-from paddle.base import Variable
 from paddle.distributed.auto_parallel.static.utils import (
     is_backward_op,
     is_gradient_clip_op,
@@ -35,6 +35,9 @@ from paddle.static import program_guard
 
 from ..utils.log_utils import get_logger
 from .pass_base import PassBase, register_pass
+
+if TYPE_CHECKING:
+    from paddle.base import Variable
 
 _supported_optimizer_type = [
     "adam",
@@ -80,7 +83,7 @@ def _is_master_grad_cast_op(block, op):
     )
 
 
-def get_output_in_varlist(op, var_names) -> List[str]:
+def get_output_in_varlist(op, var_names) -> list[str]:
     grad_names = []
     for output_name in op.output_arg_names:
         if output_name in var_names:
@@ -115,7 +118,7 @@ class MasterGradPass(PassBase):
         )
         logger.debug(f"After main program: {main_program}")
 
-    def _add_cast_op(self, cur_block, grad_names: List[str], dist_context):
+    def _add_cast_op(self, cur_block, grad_names: list[str], dist_context):
         grad_first_ids = OrderedDict()
         for idx, op in enumerate(cur_block.ops):
             if is_optimize_op(op):
@@ -209,7 +212,7 @@ class MasterGradPass(PassBase):
         self,
         main_program,
         startup_program,
-        params_grads: List[Tuple[Variable, Variable]],
+        params_grads: list[tuple[Variable, Variable]],
         dist_context,
     ):
         grad_names = [g.name for _, g in params_grads]

--- a/python/paddle/distribution/bernoulli.py
+++ b/python/paddle/distribution/bernoulli.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -29,6 +29,8 @@ from paddle.nn.functional import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor
     from paddle._typing.dtype_like import _DTypeLiteral
 

--- a/python/paddle/distribution/beta.py
+++ b/python/paddle/distribution/beta.py
@@ -14,12 +14,14 @@
 from __future__ import annotations
 
 import numbers
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import paddle
 from paddle.distribution import dirichlet, exponential_family
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor
 
 

--- a/python/paddle/distribution/categorical.py
+++ b/python/paddle/distribution/categorical.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence, Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 
@@ -26,6 +26,8 @@ from paddle.framework import in_dynamic_mode
 from paddle.tensor import multinomial
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     import numpy.typing as npt
     from typing_extensions import TypeAlias
 

--- a/python/paddle/distribution/cauchy.py
+++ b/python/paddle/distribution/cauchy.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import numbers
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -24,6 +24,8 @@ from paddle.base import framework
 from paddle.distribution import distribution
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from typing_extensions import Never
 
     from paddle import Tensor, dtype

--- a/python/paddle/distribution/dirichlet.py
+++ b/python/paddle/distribution/dirichlet.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import paddle
 from paddle.base.data_feeder import check_variable_and_dtype
@@ -24,6 +24,8 @@ from paddle.distribution import exponential_family
 from paddle.framework import in_dynamic_or_pir_mode
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor
 
 

--- a/python/paddle/distribution/distribution.py
+++ b/python/paddle/distribution/distribution.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -29,6 +29,8 @@ from paddle.framework import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from typing_extensions import TypeGuard
 
     from paddle import Tensor


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

为如下文件添加 PEP 563，并进行 PEP 585 升级：

- python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
- python/paddle/distributed/parallel.py
- python/paddle/distributed/passes/auto_parallel_gradient_merge.py
- python/paddle/distributed/passes/auto_parallel_master_grad.py
- python/paddle/distribution/bernoulli.py
- python/paddle/distribution/beta.py
- python/paddle/distribution/categorical.py
- python/paddle/distribution/cauchy.py
- python/paddle/distribution/dirichlet.py
- python/paddle/distribution/distribution.py

### Related links

- #66936

@gouzil