### PR TITLE
[CodeStyle][Ruff][BUAA][G-[257-262]] Fix Ruff `RUF005` diagnostic for 6 files in `test/xpu/` and `tools/`

### DIFF
--- a/test/xpu/test_repeat_interleave_op_xpu.py
+++ b/test/xpu/test_repeat_interleave_op_xpu.py
@@ -35,7 +35,7 @@ def ref_repeat_interleave(x_np, index_np, axis):
         index_np = np.full([index_size], index_np, dtype=np.int32)
 
     outer_loop = np.prod(x_shape[:axis])
-    x_reshape = [outer_loop] + list(x_shape[axis:])
+    x_reshape = [outer_loop, *x_shape[axis:]]
     x_np_reshape = np.reshape(x_np, tuple(x_reshape))
     out_list = []
     for i in range(outer_loop):

--- a/test/xpu/test_scatter_nd_add_op_xpu.py
+++ b/test/xpu/test_scatter_nd_add_op_xpu.py
@@ -37,9 +37,9 @@ def numpy_scatter_nd(ref, index, updates, fun):
     remain_numel = np.prod(index_shape[:-1]).astype("int32")
     slice_size = np.prod(ref_shape[end_size : len(ref_shape)]).astype("int32")
 
-    flat_index = index.reshape([remain_numel] + list(index_shape[-1:]))
+    flat_index = index.reshape([remain_numel, *index_shape[-1:]])
     flat_updates = updates.reshape((remain_numel, slice_size))
-    flat_output = ref.reshape(list(ref_shape[:end_size]) + [slice_size])
+    flat_output = ref.reshape([*ref_shape[:end_size], slice_size])
 
     for i_up, i_out in enumerate(flat_index):
         i_out = tuple(i_out)

--- a/test/xpu/test_sequence_conv_op_xpu.py
+++ b/test/xpu/test_sequence_conv_op_xpu.py
@@ -262,9 +262,11 @@ class XPUTestSequenceConv(XPUOpTestWrapper):
             idx = list(range(self.input_size[0]))
             del idx[0]
             offset_lod = [
-                [0]
-                + np.sort(random.sample(idx, 8)).tolist()
-                + [self.input_size[0]]
+                [
+                    0,
+                    *np.sort(random.sample(idx, 8)).tolist(),
+                    self.input_size[0],
+                ]
             ]
             self.lod = [[]]
             # convert from offset-based lod to length-based lod

--- a/test/xpu/test_sigmoid_cross_entropy_with_logits_op_xpu.py
+++ b/test/xpu/test_sigmoid_cross_entropy_with_logits_op_xpu.py
@@ -192,12 +192,12 @@ class XPUTestSigmoidCrossEntropyWithLogitsOp(XPUOpTestWrapper):
             num_classes = 20
             self.inputs = {
                 'X': logit(
-                    np.random.uniform(
-                        0, 1, tuple(batch_size + [num_classes])
-                    ).astype(self.dtype)
+                    np.random.uniform(0, 1, (*batch_size, num_classes)).astype(
+                        self.dtype
+                    )
                 ),
                 'Label': np.random.uniform(
-                    0, 1, tuple(batch_size + [num_classes])
+                    0, 1, (*batch_size, num_classes)
                 ).astype(self.dtype),
             }
             self.attrs = {'num_classes': num_classes, 'batch_size': batch_size}
@@ -221,12 +221,12 @@ class XPUTestSigmoidCrossEntropyWithLogitsOp(XPUOpTestWrapper):
             num_classes = 20
             self.inputs = {
                 'X': logit(
-                    np.random.uniform(
-                        0, 1, tuple(batch_size + [num_classes])
-                    ).astype(self.dtype)
+                    np.random.uniform(0, 1, (*batch_size, num_classes)).astype(
+                        self.dtype
+                    )
                 ),
                 'Label': np.random.randint(
-                    0, 2, tuple(batch_size + [num_classes])
+                    0, 2, (*batch_size, num_classes)
                 ).astype(self.dtype),
             }
             self.attrs = {'num_classes': num_classes, 'batch_size': batch_size}
@@ -250,15 +250,15 @@ class XPUTestSigmoidCrossEntropyWithLogitsOp(XPUOpTestWrapper):
             num_classes = 20
             self.inputs = {
                 'X': logit(
-                    np.random.uniform(
-                        0, 1, tuple(batch_size + [num_classes])
-                    ).astype(self.dtype)
+                    np.random.uniform(0, 1, (*batch_size, num_classes)).astype(
+                        self.dtype
+                    )
                 ),
                 'Label': np.random.randint(
-                    0, 2, tuple(batch_size + [num_classes])
+                    0, 2, (*batch_size, num_classes)
                 ).astype(self.dtype),
                 'pos_weight': np.random.uniform(
-                    0, 1, tuple(batch_size + [num_classes])
+                    0, 1, (*batch_size, num_classes)
                 ).astype(self.dtype),
             }
             self.attrs = {'num_classes': num_classes, 'batch_size': batch_size}
@@ -287,12 +287,12 @@ class XPUTestSigmoidCrossEntropyWithLogitsOp(XPUOpTestWrapper):
             self.ignore_index = ignore_index
             self.inputs = {
                 'X': logit(
-                    np.random.uniform(
-                        0, 1, tuple(batch_size + [num_classes])
-                    ).astype(self.dtype)
+                    np.random.uniform(0, 1, (*batch_size, num_classes)).astype(
+                        self.dtype
+                    )
                 ),
                 'Label': np.random.randint(
-                    -1, 2, tuple(batch_size + [num_classes])
+                    -1, 2, (*batch_size, num_classes)
                 ).astype(self.dtype),
             }
             self.attrs = {'ignore_index': ignore_index, 'normalize': True}

--- a/test/xpu/test_swiglu_op_xpu.py
+++ b/test/xpu/test_swiglu_op_xpu.py
@@ -133,7 +133,7 @@ class TestSwiGLUDygraph(unittest.TestCase):
         y = paddle.static.data(name='y', shape=shape, dtype=dtype)
         concated_x = paddle.static.data(
             name='concated_x',
-            shape=list(shape[:-1]) + [shape[-1] * 2],
+            shape=[*shape[:-1], shape[-1] * 2],
             dtype=dtype,
         )
         out1 = fused_swiglu_impl(x, y)

--- a/tools/count_api_without_core_ops.py
+++ b/tools/count_api_without_core_ops.py
@@ -116,7 +116,7 @@ def visit_member(parent_name, member, func):
 
 def is_primitive(instance):
     int_types = (int,)
-    pritimitive_types = int_types + (float, str)
+    pritimitive_types = (*int_types, float, str)
     if isinstance(instance, pritimitive_types):
         return True
     elif isinstance(instance, (list, tuple, set)):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
修复如下文件 `RUF005` 的 Ruff 规则：
- test/xpu/test_repeat_interleave_op_xpu.py
- test/xpu/test_scatter_nd_add_op_xpu.py
- test/xpu/test_sequence_conv_op_xpu.py
- test/xpu/test_sigmoid_cross_entropy_with_logits_op_xpu.py
- test/xpu/test_swiglu_op_xpu.py
- tools/count_api_without_core_ops.py

### Related links

- #67116

@gouzil