### PR TITLE
[CodeStyle][Ruff][BUAA][G-[217-224]] Fix ruff `RUF005` diagnostic for 8 files in `python/test/legacy_test/`

### DIFF
--- a/test/legacy_test/test_frame_op.py
+++ b/test/legacy_test/test_frame_op.py
@@ -33,11 +33,11 @@ def frame_from_librosa(x, frame_length, hop_length, axis=-1):
 
     if axis == -1:
         shape = list(x.shape)[:-1] + [frame_length, n_frames]
-        strides = [*list(strides), hop_length * x.itemsize]
+        strides = [*strides, hop_length * x.itemsize]
 
     elif axis == 0:
         shape = [n_frames, frame_length] + list(x.shape)[1:]
-        strides = [hop_length * x.itemsize, *list(strides)]
+        strides = [hop_length * x.itemsize, *strides]
 
     else:
         raise ValueError(f"Frame axis={axis} must be either 0 or -1")

--- a/test/legacy_test/test_frame_op.py
+++ b/test/legacy_test/test_frame_op.py
@@ -33,11 +33,11 @@ def frame_from_librosa(x, frame_length, hop_length, axis=-1):
 
     if axis == -1:
         shape = list(x.shape)[:-1] + [frame_length, n_frames]
-        strides = list(strides) + [hop_length * x.itemsize]
+        strides = [*list(strides), hop_length * x.itemsize]
 
     elif axis == 0:
         shape = [n_frames, frame_length] + list(x.shape)[1:]
-        strides = [hop_length * x.itemsize] + list(strides)
+        strides = [hop_length * x.itemsize, *list(strides)]
 
     else:
         raise ValueError(f"Frame axis={axis} must be either 0 or -1")

--- a/test/legacy_test/test_functional_conv2d.py
+++ b/test/legacy_test/test_functional_conv2d.py
@@ -53,7 +53,8 @@ class TestFunctionalConv2DError(TestCase):
         self.weight_shape = (
             self.out_channels,
             self.in_channels // self.groups,
-        ) + filter_shape
+            *filter_shape,
+        )
         self.bias_shape = (self.out_channels,)
 
     def static_graph_case(self):

--- a/test/legacy_test/test_functional_conv3d.py
+++ b/test/legacy_test/test_functional_conv3d.py
@@ -53,7 +53,8 @@ class TestFunctionalConv3DError(TestCase):
         self.weight_shape = (
             self.out_channels,
             self.in_channels // self.groups,
-        ) + filter_shape
+            *filter_shape,
+        )
         self.bias_shape = (self.out_channels,)
 
     def static_graph_case(self):

--- a/test/legacy_test/test_functional_conv3d_transpose.py
+++ b/test/legacy_test/test_functional_conv3d_transpose.py
@@ -54,7 +54,8 @@ class TestFunctionalConv3DTransposeError(TestCase):
         self.weight_shape = (
             self.in_channels,
             self.out_channels // self.groups,
-        ) + filter_shape
+            *filter_shape,
+        )
         self.bias_shape = (self.out_channels,)
 
     def static_graph_case(self):

--- a/test/legacy_test/test_fused_attention_no_dropout.py
+++ b/test/legacy_test/test_fused_attention_no_dropout.py
@@ -165,7 +165,7 @@ class TestFusedAttention(unittest.TestCase):
         out = layer(x, mask, use_ref)
         loss = out.mean()
         loss.backward()
-        vars_need_gradients = [('out', x)] + list(layer.named_parameters())
+        vars_need_gradients = [('out', x), *list(layer.named_parameters())]
         numpy_values = [out.numpy()]
         for i, (name, var) in enumerate(vars_need_gradients):
             tmp = var.grad.numpy()

--- a/test/legacy_test/test_fused_attention_no_dropout.py
+++ b/test/legacy_test/test_fused_attention_no_dropout.py
@@ -165,7 +165,7 @@ class TestFusedAttention(unittest.TestCase):
         out = layer(x, mask, use_ref)
         loss = out.mean()
         loss.backward()
-        vars_need_gradients = [('out', x), *list(layer.named_parameters())]
+        vars_need_gradients = [('out', x), *layer.named_parameters()]
         numpy_values = [out.numpy()]
         for i, (name, var) in enumerate(vars_need_gradients):
             tmp = var.grad.numpy()

--- a/test/legacy_test/test_graph_send_ue_recv_op.py
+++ b/test/legacy_test/test_graph_send_ue_recv_op.py
@@ -115,7 +115,8 @@ def compute_graph_send_ue_recv_for_sum(inputs, attributes):
     gather_x = x[src_index]
     out_shp = [
         x.shape[0],
-    ] + get_broadcast_shape(x.shape[1:], y.shape[1:])
+        *get_broadcast_shape(x.shape[1:], y.shape[1:]),
+    ]
     results = np.zeros(out_shp, dtype=x.dtype)
 
     # Calculate forward output.
@@ -138,7 +139,8 @@ def compute_graph_send_ue_recv_for_mean(inputs, attributes):
     gather_x = x[src_index]
     out_shp = [
         x.shape[0],
-    ] + get_broadcast_shape(x.shape[1:], y.shape[1:])
+        *get_broadcast_shape(x.shape[1:], y.shape[1:]),
+    ]
     results = np.zeros(out_shp, dtype=x.dtype)
 
     # Calculate forward output.
@@ -168,7 +170,8 @@ def compute_graph_send_ue_recv_for_max_min(inputs, attributes):
     gather_x = x[src_index]
     out_shp = [
         x.shape[0],
-    ] + get_broadcast_shape(x.shape[1:], y.shape[1:])
+        *get_broadcast_shape(x.shape[1:], y.shape[1:]),
+    ]
     results = np.zeros(out_shp, dtype=x.dtype)
 
     # Calculate forward output.

--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -1542,7 +1542,7 @@ class TestCompositeGroupNorm(unittest.TestCase):
                 scale_.name: self.scale,
                 bias_.name: self.bias,
             },
-            fetch_list=vars_list + [grads],
+            fetch_list=[*vars_list, grads],
         )
         paddle.disable_static()
         core._set_prim_all_enabled(True)
@@ -1635,7 +1635,7 @@ class TestCompositeGroupNorm(unittest.TestCase):
                         scale_.name: self.scale,
                         bias_.name: self.bias,
                     },
-                    fetch_list=vars_list + [grads],
+                    fetch_list=[*vars_list, grads],
                 )
                 if self.dtype == "bfloat16":
                     out_list[0] = convert_uint16_to_float(out_list[0])

--- a/test/legacy_test/test_householder_product.py
+++ b/test/legacy_test/test_householder_product.py
@@ -60,7 +60,7 @@ def geqrf(x):
     n_batch = x.shape[0]
     out = np.zeros([n_batch, m, n], dtype=x.dtype)
     taus = np.zeros([n_batch, min(m, n)], dtype=x.dtype)
-    org_taus_shape = [*list(org_x_shape[:-2]), min(m, n)]
+    org_taus_shape = [*org_x_shape[:-2], min(m, n)]
     for i in range(n_batch):
         out[i], t = _geqrf(x[i])
         taus[i, :] = t.reshape(-1)

--- a/test/legacy_test/test_householder_product.py
+++ b/test/legacy_test/test_householder_product.py
@@ -60,7 +60,7 @@ def geqrf(x):
     n_batch = x.shape[0]
     out = np.zeros([n_batch, m, n], dtype=x.dtype)
     taus = np.zeros([n_batch, min(m, n)], dtype=x.dtype)
-    org_taus_shape = list(org_x_shape[:-2]) + [min(m, n)]
+    org_taus_shape = [*list(org_x_shape[:-2]), min(m, n)]
     for i in range(n_batch):
         out[i], t = _geqrf(x[i])
         taus[i, :] = t.reshape(-1)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

修复如下文件中 Ruff 检测出的 `RUF005` 问题：

- test/legacy_test/test_frame_op.py
- test/legacy_test/test_functional_conv2d.py
- test/legacy_test/test_functional_conv3d.py
- test/legacy_test/test_functional_conv3d_transpose.py
- test/legacy_test/test_fused_attention_no_dropout.py
- test/legacy_test/test_graph_send_ue_recv_op.py
- test/legacy_test/test_group_norm_op.py
- test/legacy_test/test_householder_product.py

### Related links

- #67116

@gouzil