### PR TITLE
[Typing][PEP585 Upgrade][BUAA][41-50] Use standard collections for type hints for 10 files in `python/paddle/distribution`

### DIFF
--- a/python/paddle/distribution/exponential.py
+++ b/python/paddle/distribution/exponential.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -26,6 +26,8 @@ from paddle.distribution import exponential_family
 from paddle.framework import in_dynamic_mode
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor, dtype
 
 

--- a/python/paddle/distribution/gamma.py
+++ b/python/paddle/distribution/gamma.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import paddle
 from paddle import distribution
@@ -24,6 +24,8 @@ from paddle.distribution import exponential_family
 from paddle.framework import in_dynamic_mode
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor, dtype
 
 

--- a/python/paddle/distribution/geometric.py
+++ b/python/paddle/distribution/geometric.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import numbers
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -24,6 +24,8 @@ from paddle.base import framework
 from paddle.distribution import distribution
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor
 
 

--- a/python/paddle/distribution/gumbel.py
+++ b/python/paddle/distribution/gumbel.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import math
 import numbers
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -25,6 +25,8 @@ from paddle.base import framework
 from paddle.distribution.transformed_distribution import TransformedDistribution
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor
     from paddle.distribution import Transform, Uniform
 

--- a/python/paddle/distribution/independent.py
+++ b/python/paddle/distribution/independent.py
@@ -14,11 +14,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 from paddle.distribution import distribution
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor
 
 

--- a/python/paddle/distribution/laplace.py
+++ b/python/paddle/distribution/laplace.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 import numbers
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -23,6 +23,8 @@ from paddle.base import framework
 from paddle.distribution import distribution
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor
 
 

--- a/python/paddle/distribution/lognormal.py
+++ b/python/paddle/distribution/lognormal.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence, Union
+from typing import TYPE_CHECKING, Union
 
 import paddle
 from paddle.distribution.normal import Normal
@@ -21,6 +21,8 @@ from paddle.distribution.transform import ExpTransform
 from paddle.distribution.transformed_distribution import TransformedDistribution
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     import numpy as np
     import numpy.typing as npt
     from typing_extensions import TypeAlias

--- a/python/paddle/distribution/lognormal.py
+++ b/python/paddle/distribution/lognormal.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import paddle
 from paddle.distribution.normal import Normal
@@ -22,6 +22,7 @@ from paddle.distribution.transformed_distribution import TransformedDistribution
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import Union
 
     import numpy as np
     import numpy.typing as npt

--- a/python/paddle/distribution/normal.py
+++ b/python/paddle/distribution/normal.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
@@ -28,6 +28,8 @@ from paddle.framework import in_dynamic_mode
 from paddle.tensor import random
 
 if TYPE_CHECKING:
+    from typing import Union
+
     from typing_extensions import TypeAlias
 
     from paddle import Tensor, dtype

--- a/python/paddle/distribution/normal.py
+++ b/python/paddle/distribution/normal.py
@@ -14,8 +14,8 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Sequence, Union
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 import numpy.typing as npt

--- a/python/paddle/distribution/transform.py
+++ b/python/paddle/distribution/transform.py
@@ -19,7 +19,6 @@ import typing
 from typing import (
     TYPE_CHECKING,
     Any,
-    Sequence,
     overload,
 )
 
@@ -33,6 +32,8 @@ from paddle.distribution import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor
     from paddle.distribution import Distribution, TransformedDistribution
 

--- a/python/paddle/distribution/transformed_distribution.py
+++ b/python/paddle/distribution/transformed_distribution.py
@@ -14,11 +14,13 @@
 from __future__ import annotations
 
 import typing
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 from paddle.distribution import distribution, independent, transform
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor
     from paddle.distribution.distribution import Distribution
     from paddle.distribution.transform import Transform


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

为如下文件添加 PEP 563，并进行 PEP 585 升级：

- python/paddle/distribution/exponential.py
- python/paddle/distribution/gamma.py
- python/paddle/distribution/geometric.py
- python/paddle/distribution/gumbel.py
- python/paddle/distribution/independent.py
- python/paddle/distribution/laplace.py
- python/paddle/distribution/lognormal.py
- python/paddle/distribution/normal.py
- python/paddle/distribution/transform.py
- python/paddle/distribution/transformed_distribution.py

### Related links

- #66936

@gouzil