### PR TITLE
[CodeStyle][Ruff][BUAA][G-[225-232]] Fix ruff `RUF005` diagnostic for 8 files in `python/test/legacy_test/`

### DIFF
--- a/test/legacy_test/test_imperative_named_members.py
+++ b/test/legacy_test/test_imperative_named_members.py
@@ -84,7 +84,7 @@ class TestImperativeNamedSubLayers(unittest.TestCase):
 
             self.assertListEqual(
                 [l for _, l in list(model.named_sublayers(include_self=True))],
-                [model] + expected_sublayers,
+                [model, *expected_sublayers],
             )
 
 

--- a/test/legacy_test/test_imperative_ocr_attention_model.py
+++ b/test/legacy_test/test_imperative_ocr_attention_model.py
@@ -210,7 +210,7 @@ class DynamicGRU(paddle.nn.Layer):
             hidden, reset = self.gru_unit(input_, hidden)
             hidden_ = paddle.reshape(hidden, [-1, 1, hidden.shape[1]])
             if self.is_reverse:
-                res = [hidden_] + res
+                res = [hidden_, *res]
             else:
                 res.append(hidden_)
         res = paddle.concat(res, axis=1)
@@ -572,7 +572,7 @@ class TestDygraphOCRAttention(unittest.TestCase):
             optimizer = paddle.optimizer.SGD(learning_rate=0.001)
 
             images = paddle.static.data(
-                name='pixel', shape=[-1] + Config.DATA_SHAPE, dtype='float32'
+                name='pixel', shape=[-1, *Config.DATA_SHAPE], dtype='float32'
             )
             if not paddle.framework.use_pir_api():
                 images.desc.set_need_check_feed(False)

--- a/test/legacy_test/test_index_add_op.py
+++ b/test/legacy_test/test_index_add_op.py
@@ -30,12 +30,12 @@ def compute_index_add_ref(
         axis = axis + len(x_shape)
     if axis != 0:
         outer_loop = np.prod(x_shape[:axis]).astype(int)
-        x_reshape = [outer_loop, *list(x_shape[axis:])]
+        x_reshape = [outer_loop, *x_shape[axis:]]
         x_np_reshape = np.reshape(x_np, tuple(x_reshape))
 
         add_value_reshape = [
             np.prod(add_value_shape[:axis]).astype(int),
-            *list(add_value_shape[axis:]),
+            *add_value_shape[axis:],
         ]
 
         add_value_np_reshape = np.reshape(

--- a/test/legacy_test/test_index_add_op.py
+++ b/test/legacy_test/test_index_add_op.py
@@ -30,12 +30,13 @@ def compute_index_add_ref(
         axis = axis + len(x_shape)
     if axis != 0:
         outer_loop = np.prod(x_shape[:axis]).astype(int)
-        x_reshape = [outer_loop] + list(x_shape[axis:])
+        x_reshape = [outer_loop, *list(x_shape[axis:])]
         x_np_reshape = np.reshape(x_np, tuple(x_reshape))
 
         add_value_reshape = [
-            np.prod(add_value_shape[:axis]).astype(int)
-        ] + list(add_value_shape[axis:])
+            np.prod(add_value_shape[:axis]).astype(int),
+            *list(add_value_shape[axis:]),
+        ]
 
         add_value_np_reshape = np.reshape(
             add_value_np, tuple(add_value_reshape)

--- a/test/legacy_test/test_index_select_op.py
+++ b/test/legacy_test/test_index_select_op.py
@@ -45,7 +45,7 @@ class TestIndexSelectOp(OpTest):
         self.inputs = {'X': x_np, 'Index': index_np}
         self.attrs = {'dim': self.dim}
         outer_loop = np.prod(self.x_shape[: self.dim])
-        x_reshape = [outer_loop, *list(self.x_shape[self.dim :])]
+        x_reshape = [outer_loop, *self.x_shape[self.dim :]]
         x_np_reshape = np.reshape(x_np, tuple(x_reshape))
         out_list = []
         for i in range(outer_loop):
@@ -130,7 +130,7 @@ class TestIndexSelectBF16Op(OpTest):
         self.inputs = {'X': convert_float_to_uint16(x_np), 'Index': index_np}
         self.attrs = {'dim': self.dim}
         outer_loop = np.prod(self.x_shape[: self.dim])
-        x_reshape = [outer_loop, *list(self.x_shape[self.dim :])]
+        x_reshape = [outer_loop, *self.x_shape[self.dim :]]
         x_np_reshape = np.reshape(x_np, tuple(x_reshape))
         out_list = []
         for i in range(outer_loop):

--- a/test/legacy_test/test_index_select_op.py
+++ b/test/legacy_test/test_index_select_op.py
@@ -45,7 +45,7 @@ class TestIndexSelectOp(OpTest):
         self.inputs = {'X': x_np, 'Index': index_np}
         self.attrs = {'dim': self.dim}
         outer_loop = np.prod(self.x_shape[: self.dim])
-        x_reshape = [outer_loop] + list(self.x_shape[self.dim :])
+        x_reshape = [outer_loop, *list(self.x_shape[self.dim :])]
         x_np_reshape = np.reshape(x_np, tuple(x_reshape))
         out_list = []
         for i in range(outer_loop):
@@ -130,7 +130,7 @@ class TestIndexSelectBF16Op(OpTest):
         self.inputs = {'X': convert_float_to_uint16(x_np), 'Index': index_np}
         self.attrs = {'dim': self.dim}
         outer_loop = np.prod(self.x_shape[: self.dim])
-        x_reshape = [outer_loop] + list(self.x_shape[self.dim :])
+        x_reshape = [outer_loop, *list(self.x_shape[self.dim :])]
         x_np_reshape = np.reshape(x_np, tuple(x_reshape))
         out_list = []
         for i in range(outer_loop):

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -632,7 +632,7 @@ class TestBook(LayerTest):
     def _get_np_data(self, shape, dtype, append_batch_size=True):
         np.random.seed(self.seed)
         if append_batch_size:
-            shape = [self._batch_size] + shape
+            shape = [self._batch_size, *shape]
         if dtype == 'float32':
             return np.random.random(shape).astype(dtype)
         elif dtype == 'float64':
@@ -659,7 +659,7 @@ class TestBook(LayerTest):
                     shape, dtype, append_batch_size
                 )
             if append_batch_size:
-                shape = [-1] + shape
+                shape = [-1, *shape]
             data = paddle.static.data(
                 name=name,
                 shape=shape,

--- a/test/legacy_test/test_lu_op.py
+++ b/test/legacy_test/test_lu_op.py
@@ -75,8 +75,8 @@ def Pmat_to_perm(Pmat_org, cut):
         permmat.append(permlst)
     Pivot = (
         np.array(permmat).reshape(
-            list(shape[:-2])
-            + [
+            [
+                *list(shape[:-2]),
                 rows,
             ]
         )
@@ -101,7 +101,7 @@ def perm_to_Pmat(perm, dim):
         ones = paddle.eye(dim)
         nmat = paddle.scatter(ones, paddle.to_tensor(idlst), ones)
         oneslst.append(nmat)
-    return np.array(oneslst).reshape(list(pshape[:-1]) + [dim, dim])
+    return np.array(oneslst).reshape([*list(pshape[:-1]), dim, dim])
 
 
 # m < n

--- a/test/legacy_test/test_lu_op.py
+++ b/test/legacy_test/test_lu_op.py
@@ -76,7 +76,7 @@ def Pmat_to_perm(Pmat_org, cut):
     Pivot = (
         np.array(permmat).reshape(
             [
-                *list(shape[:-2]),
+                *shape[:-2],
                 rows,
             ]
         )
@@ -101,7 +101,7 @@ def perm_to_Pmat(perm, dim):
         ones = paddle.eye(dim)
         nmat = paddle.scatter(ones, paddle.to_tensor(idlst), ones)
         oneslst.append(nmat)
-    return np.array(oneslst).reshape([*list(pshape[:-1]), dim, dim])
+    return np.array(oneslst).reshape([*pshape[:-1], dim, dim])
 
 
 # m < n

--- a/test/legacy_test/test_lu_unpack_op.py
+++ b/test/legacy_test/test_lu_unpack_op.py
@@ -81,7 +81,7 @@ def Pmat_to_perm(Pmat_org, cut):
     Pivot = (
         np.array(permmat).reshape(
             [
-                *list(shape[:-2]),
+                *shape[:-2],
                 rows,
             ]
         )
@@ -107,7 +107,7 @@ def perm_to_Pmat(perm, dim):
         ones = paddle.eye(dim)
         nmat = paddle.scatter(ones, paddle.to_tensor(idlst), ones)
         oneslst.append(nmat)
-    return np.array(oneslst).reshape([*list(pshape[:-1]), dim, dim])
+    return np.array(oneslst).reshape([*pshape[:-1], dim, dim])
 
 
 # m > n

--- a/test/legacy_test/test_lu_unpack_op.py
+++ b/test/legacy_test/test_lu_unpack_op.py
@@ -80,8 +80,8 @@ def Pmat_to_perm(Pmat_org, cut):
         permmat.append(permlst)
     Pivot = (
         np.array(permmat).reshape(
-            list(shape[:-2])
-            + [
+            [
+                *list(shape[:-2]),
                 rows,
             ]
         )
@@ -107,7 +107,7 @@ def perm_to_Pmat(perm, dim):
         ones = paddle.eye(dim)
         nmat = paddle.scatter(ones, paddle.to_tensor(idlst), ones)
         oneslst.append(nmat)
-    return np.array(oneslst).reshape(list(pshape[:-1]) + [dim, dim])
+    return np.array(oneslst).reshape([*list(pshape[:-1]), dim, dim])
 
 
 # m > n

--- a/test/legacy_test/test_matmul_op_with_head.py
+++ b/test/legacy_test/test_matmul_op_with_head.py
@@ -41,14 +41,14 @@ def generate_compatible_shapes_mul_head(dim_X, dim_Y, transpose_X, transpose_Y):
         else:
             shape_X = [M, K]
     if dim_X == 3:
-        shape_X = [BATCH_SIZE] + shape_X
+        shape_X = [BATCH_SIZE, *shape_X]
     if dim_Y >= 2:
         if transpose_Y:
             shape_Y = [N, K]
         else:
             shape_Y = [K, N]
     if dim_Y == 3:
-        shape_Y = [BATCH_SIZE] + shape_Y
+        shape_Y = [BATCH_SIZE, *shape_Y]
     return shape_X, shape_Y
 
 
@@ -205,14 +205,14 @@ def generate_compatible_shapes_mul_head2(
         else:
             shape_X = [M1, K1]
     if dim_X == 3:
-        shape_X = [BATCH_SIZE] + shape_X
+        shape_X = [BATCH_SIZE, *shape_X]
     if dim_Y >= 2:
         if transpose_Y:
             shape_Y = [K2, M2]
         else:
             shape_Y = [M2, K2]
     if dim_Y == 3:
-        shape_Y = [BATCH_SIZE] + shape_Y
+        shape_Y = [BATCH_SIZE, *shape_Y]
     return shape_X, shape_Y
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

修复如下文件中 Ruff 检测出的 `RUF005` 问题：

- test/legacy_test/test_imperative_named_members.py
- test/legacy_test/test_imperative_ocr_attention_model.py
- test/legacy_test/test_index_add_op.py
- test/legacy_test/test_index_select_op.py
- test/legacy_test/test_layers.py
- test/legacy_test/test_lu_op.py
- test/legacy_test/test_lu_unpack_op.py
- test/legacy_test/test_matmul_op_with_head.py

### Related links

- #67116

@gouzil