### PR TITLE
[CodeStyle][Ruff][BUAA][E-1,K-11] Fix Ruff `RUF017` and `RUF019` diagnostic for 2 files in `python/paddle/distributed/auto_parallel/static/` and `test/xpu/`

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/reshard.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard.py
@@ -14,6 +14,7 @@
 
 
 import copy
+import operator
 from collections import OrderedDict
 from functools import reduce
 
@@ -976,7 +977,9 @@ class Remover:
         )
         # 'feed_var_names' cannot be removed from auto_parallel_main_prog
         feed_var_names = []
-        for var in sum(list(dist_context.serial_feed_vars.values()), []):
+        for var in reduce(
+            operator.iadd, list(dist_context.serial_feed_vars.values()), []
+        ):
             feed_var_names.append(var.name)
         Remover.remove_no_need_vars(
             auto_parallel_main_prog, dist_params_grads, feed_var_names

--- a/test/xpu/op_test_xpu.py
+++ b/test/xpu/op_test_xpu.py
@@ -292,7 +292,7 @@ class XPUOpTest(OpTest):
 
             # oneDNN numeric gradient should use CPU kernel
             use_onednn = False
-            if "use_mkldnn" in op_attrs and op_attrs["use_mkldnn"]:
+            if op_attrs.get("use_mkldnn"):
                 op_attrs["use_mkldnn"] = False
                 use_onednn = True
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
修复如下文件 `RUF017` 的 Ruff 规则：
- python/paddle/distributed/auto_parallel/static/reshard.py
修复如下文件 `RUF019` 的 Ruff 规则：
- test/xpu/op_test_xpu.py


### Related links

- #67116

@gouzil