### PR TITLE
[CodeStyle][Ruff][BUAA][G-[233-240]] Fix ruff `RUF005` diagnostic for 8 files in `python/test/legacy_test/`

### DIFF
--- a/test/legacy_test/test_metrics.py
+++ b/test/legacy_test/test_metrics.py
@@ -23,7 +23,7 @@ from paddle.hapi.model import to_list
 
 def one_hot(x, n_class):
     res = np.eye(n_class)[np.array(x).reshape(-1)]
-    res = res.reshape(list(x.shape) + [n_class])
+    res = res.reshape([*x.shape, n_class])
     return res
 
 

--- a/test/legacy_test/test_ormqr.py
+++ b/test/legacy_test/test_ormqr.py
@@ -60,7 +60,7 @@ def geqrf(x):
     n_batch = x.shape[0]
     out = np.zeros([n_batch, m, n], dtype=x.dtype)
     taus = np.zeros([n_batch, min(m, n)], dtype=x.dtype)
-    org_taus_shape = list(org_x_shape[:-2]) + [min(m, n)]
+    org_taus_shape = [*org_x_shape[:-2], min(m, n)]
     for i in range(n_batch):
         out[i], t = _geqrf(x[i])
         taus[i, :] = t.reshape(-1)

--- a/test/legacy_test/test_overlap_add_op.py
+++ b/test/legacy_test/test_overlap_add_op.py
@@ -45,10 +45,10 @@ def overlap_add(x, hop_length, axis=-1):
     if len(x.shape) > 3:
         reshape_output = True
         if axis == 0:
-            target_shape = [seq_length] + list(x.shape[2:])
+            target_shape = [seq_length, *x.shape[2:]]
             x = x.reshape(n_frames, frame_length, np.prod(x.shape[2:]))
         else:
-            target_shape = list(x.shape[:-2]) + [seq_length]
+            target_shape = [*x.shape[:-2], seq_length]
             x = x.reshape(np.prod(x.shape[:-2]), frame_length, n_frames)
 
     if axis == 0:

--- a/test/legacy_test/test_pca_lowrank.py
+++ b/test/legacy_test/test_pca_lowrank.py
@@ -29,7 +29,7 @@ class TestPcaLowrankAPI(unittest.TestCase):
     def random_matrix(self, rows, columns, *batch_dims, **kwargs):
         dtype = kwargs.get('dtype', paddle.float64)
 
-        x = paddle.randn(batch_dims + (rows, columns), dtype=dtype)
+        x = paddle.randn((*batch_dims, rows, columns), dtype=dtype)
         if x.numel() == 0:
             return x
         u, _, vh = paddle.linalg.svd(x, full_matrices=False)
@@ -63,9 +63,9 @@ class TestPcaLowrankAPI(unittest.TestCase):
         self.assertEqual(v.shape[-2], columns)
 
         A1 = u.matmul(paddle.diag_embed(s)).matmul(self.transpose(v))
-        ones_m1 = paddle.ones(batches + (rows, 1), dtype=a.dtype)
+        ones_m1 = paddle.ones((*batches, rows, 1), dtype=a.dtype)
         c = a.sum(axis=-2) / rows
-        c = c.reshape(batches + (1, columns))
+        c = c.reshape((*batches, 1, columns))
         A2 = a - ones_m1.matmul(c)
         np.testing.assert_allclose(A1.numpy(), A2.numpy(), atol=1e-5)
 
@@ -143,7 +143,7 @@ class TestStaticPcaLowrankAPI(unittest.TestCase):
     def random_matrix(self, rows, columns, *batch_dims, **kwargs):
         dtype = kwargs.get('dtype', 'float64')
 
-        x = paddle.randn(batch_dims + (rows, columns), dtype=dtype)
+        x = paddle.randn((*batch_dims, rows, columns), dtype=dtype)
         u, _, vh = paddle.linalg.svd(x, full_matrices=False)
         k = min(rows, columns)
         s = paddle.linspace(1 / (k + 1), 1, k, dtype=dtype)
@@ -178,9 +178,9 @@ class TestStaticPcaLowrankAPI(unittest.TestCase):
             self.assertEqual(v.shape[-2], columns)
 
             A1 = u.matmul(paddle.diag_embed(s)).matmul(self.transpose(v))
-            ones_m1 = paddle.ones(batches + (rows, 1), dtype=a.dtype)
+            ones_m1 = paddle.ones((*batches, rows, 1), dtype=a.dtype)
             c = a.sum(axis=-2) / rows
-            c = c.reshape(batches + (1, columns))
+            c = c.reshape((*batches, 1, columns))
             A2 = a - ones_m1.matmul(c)
             detect_rank = (s.abs() > 1e-5).sum(axis=-1)
             left1 = actual_rank * paddle.ones(batches, dtype=paddle.int64)

--- a/test/legacy_test/test_repeat_interleave_op.py
+++ b/test/legacy_test/test_repeat_interleave_op.py
@@ -36,7 +36,7 @@ class TestRepeatInterleaveOp(OpTest):
         self.attrs = {'dim': self.dim}
 
         outer_loop = np.prod(self.x_shape[: self.dim])
-        x_reshape = [outer_loop] + list(self.x_shape[self.dim :])
+        x_reshape = [outer_loop, *self.x_shape[self.dim :]]
         x_np_reshape = np.reshape(x_np, tuple(x_reshape))
         out_list = []
         for i in range(outer_loop):
@@ -75,7 +75,7 @@ class TestRepeatInterleaveOp2(OpTest):
         self.attrs = {'dim': self.dim, 'Repeats': index_np}
 
         outer_loop = np.prod(self.x_shape[: self.dim])
-        x_reshape = [outer_loop] + list(self.x_shape[self.dim :])
+        x_reshape = [outer_loop, *self.x_shape[self.dim :]]
         x_np_reshape = np.reshape(x_np, tuple(x_reshape))
         out_list = []
         for i in range(outer_loop):

--- a/test/legacy_test/test_scatter_nd_op.py
+++ b/test/legacy_test/test_scatter_nd_op.py
@@ -37,9 +37,9 @@ def numpy_scatter_nd(ref, index, updates, fun):
     for i in range(end_size, len(ref_shape)):
         slice_size *= ref_shape[i]
 
-    flat_index = index.reshape([remain_numel] + list(index_shape[-1:]))
+    flat_index = index.reshape([remain_numel, *index_shape[-1:]])
     flat_updates = updates.reshape((remain_numel, slice_size))
-    flat_output = ref.reshape(list(ref_shape[:end_size]) + [slice_size])
+    flat_output = ref.reshape([*ref_shape[:end_size], slice_size])
 
     for i_up, i_out in enumerate(flat_index):
         i_out = tuple(i_out)

--- a/test/legacy_test/test_sgd_op_bf16.py
+++ b/test/legacy_test/test_sgd_op_bf16.py
@@ -340,11 +340,11 @@ class TestSGDOpBF16API(unittest.TestCase):
         with base.program_guard(main):
             ids_shape = list(self.ids_shape)
             x = paddle.static.data(
-                name='X', shape=[-1] + ids_shape, dtype='int64'
+                name='X', shape=[-1, *ids_shape], dtype='int64'
             )
             y_shape = list(self.y_shape)
             label = paddle.static.data(
-                name='Y', shape=[-1] + y_shape, dtype='uint16'
+                name='Y', shape=[-1, *y_shape], dtype='uint16'
             )
             pre_dtype = paddle.get_default_dtype()
             paddle.set_default_dtype("uint16")

--- a/test/legacy_test/test_sparse_pca_lowrank.py
+++ b/test/legacy_test/test_sparse_pca_lowrank.py
@@ -83,9 +83,9 @@ class TestSparsePcaLowrankAPI(unittest.TestCase):
         A1 = u.matmul(paddle.nn.functional.diag_embed(s)).matmul(
             self.transpose(v)
         )
-        ones_m1 = paddle.ones(batches + (rows, 1), dtype=a.dtype)
+        ones_m1 = paddle.ones((*batches, rows, 1), dtype=a.dtype)
         c = a.sum(axis=-2) / rows
-        c = c.reshape(batches + (1, columns))
+        c = c.reshape((*batches, 1, columns))
         A2 = a - ones_m1.matmul(c)
         np.testing.assert_allclose(A1.numpy(), A2.numpy(), atol=1e-5)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

修复如下文件中 Ruff 检测出的 `RUF005` 问题：

- test/legacy_test/test_metrics.py
- test/legacy_test/test_ormqr.py
- test/legacy_test/test_overlap_add_op.py
- test/legacy_test/test_pca_lowrank.py
- test/legacy_test/test_repeat_interleave_op.py
- test/legacy_test/test_scatter_nd_op.py
- test/legacy_test/test_sgd_op_bf16.py
- test/legacy_test/test_sparse_pca_lowrank.py

### Related links

- #67116

@gouzil