### PR TITLE
Replace framework::ThreadPool to phi::ThreadPool [fluid_ops] 

### DIFF
--- a/paddle/fluid/distributed/ps/service/ps_graph_client.cc
+++ b/paddle/fluid/distributed/ps/service/ps_graph_client.cc
@@ -54,7 +54,7 @@ int32_t PsGraphClient::Initialize() {
     }
   }
   for (uint32_t k = 0; k < max_shard_num; ++k) {
-    _thread_pools.push_back(std::make_shared<paddle::framework::ThreadPool>(1));
+    _thread_pools.push_back(std::make_shared<phi::ThreadPool>(1));
   }
   _local_shard_keys.resize(max_shard_num);
   _shard_ars.resize(max_shard_num);

--- a/paddle/fluid/distributed/ps/service/ps_graph_client.h
+++ b/paddle/fluid/distributed/ps/service/ps_graph_client.h
@@ -82,7 +82,7 @@ class PsGraphClient : public PsLocalClient {
   void *_partition_key_service = nullptr;
   int _rank_id = 0;
   int _rank_num = 0;
-  std::vector<std::shared_ptr<framework::ThreadPool>> _thread_pools;
+  std::vector<std::shared_ptr<phi::ThreadPool>> _thread_pools;
   std::vector<std::vector<uint64_t>> _local_shard_keys;
   std::vector<std::vector<paddle::framework::BinaryArchive>> _shard_ars;
 };

--- a/paddle/fluid/framework/data_set.cc
+++ b/paddle/fluid/framework/data_set.cc
@@ -472,16 +472,15 @@ void MultiSlotDataset::PrepareTrain() {
   return;
 }
 
-inline std::vector<std::shared_ptr<paddle::framework::ThreadPool>>&
-GetReadThreadPool(int thread_num) {
-  static std::vector<std::shared_ptr<paddle::framework::ThreadPool>>
-      thread_pools;
+inline std::vector<std::shared_ptr<phi::ThreadPool>>& GetReadThreadPool(
+    int thread_num) {
+  static std::vector<std::shared_ptr<phi::ThreadPool>> thread_pools;
   if (!thread_pools.empty()) {
     return thread_pools;
   }
   thread_pools.resize(thread_num);
   for (int i = 0; i < thread_num; ++i) {
-    thread_pools[i].reset(new paddle::framework::ThreadPool(1));
+    thread_pools[i].reset(new phi::ThreadPool(1));
   }
   return thread_pools;
 }

--- a/paddle/fluid/framework/dist_multi_trainer.cc
+++ b/paddle/fluid/framework/dist_multi_trainer.cc
@@ -94,16 +94,15 @@ void DistMultiTrainer::InitDumpEnv() {
   }
 }
 
-inline std::vector<std::shared_ptr<paddle::framework::ThreadPool>>
-    &GetThreadPool(int thread_num) {
-  static std::vector<std::shared_ptr<paddle::framework::ThreadPool>>
-      thread_pools;
+inline std::vector<std::shared_ptr<phi::ThreadPool>> &GetThreadPool(
+    int thread_num) {
+  static std::vector<std::shared_ptr<phi::ThreadPool>> thread_pools;
   if (!thread_pools.empty()) {
     return thread_pools;
   }
   thread_pools.resize(thread_num);
   for (int i = 0; i < thread_num; ++i) {
-    thread_pools[i].reset(new paddle::framework::ThreadPool(1));
+    thread_pools[i].reset(new phi::ThreadPool(1));
   }
   return thread_pools;
 }

--- a/paddle/fluid/framework/multi_trainer.cc
+++ b/paddle/fluid/framework/multi_trainer.cc
@@ -120,16 +120,15 @@ void MultiTrainer::InitDumpEnv() {
     dump_thread_.emplace_back([this, i] { DumpWork(i); });
   }
 }
-inline std::vector<std::shared_ptr<paddle::framework::ThreadPool>>&
-GetThreadPool(int thread_num) {
-  static std::vector<std::shared_ptr<paddle::framework::ThreadPool>>
-      thread_pools;
+inline std::vector<std::shared_ptr<phi::ThreadPool>>& GetThreadPool(
+    int thread_num) {
+  static std::vector<std::shared_ptr<phi::ThreadPool>> thread_pools;
   if (!thread_pools.empty()) {
     return thread_pools;
   }
   thread_pools.resize(thread_num);
   for (int i = 0; i < thread_num; ++i) {
-    thread_pools[i].reset(new paddle::framework::ThreadPool(1));
+    thread_pools[i].reset(new phi::ThreadPool(1));
   }
   return thread_pools;
 }

--- a/test/cpp/fluid/framework/threadpool_test.cc
+++ b/test/cpp/fluid/framework/threadpool_test.cc
@@ -31,11 +31,11 @@ void do_sum(std::vector<std::future<void>>* fs,
 }
 
 TEST(ThreadPool, ConcurrentInit) {
-  framework::ThreadPool* pool;
+  phi::ThreadPool* pool;
   int n = 50;
   std::vector<std::thread> threads;
   for (int i = 0; i < n; ++i) {
-    std::thread t([&pool]() { pool = framework::ThreadPool::GetInstance(); });
+    std::thread t([&pool]() { pool = phi::ThreadPool::GetInstance(); });
     threads.push_back(std::move(t));
   }
   for (auto& t : threads) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Replace framework::ThreadPool to phi::ThreadPool