### PR TITLE
[CodeStyle][Ruff][BUAA][G-[241-248]] Fix ruff `RUF005` diagnostic for 8 files in `python/test/legacy_test/` and `python/test/prim/model/`

### DIFF
--- a/test/legacy_test/test_sparse_softmax_op.py
+++ b/test/legacy_test/test_sparse_softmax_op.py
@@ -158,7 +158,7 @@ class TestCooSoftmax(unittest.TestCase):
                     i2p[c] = len(i2p)
                 pool[i] = i2p[c]
 
-            mx = paddle.empty((pool.max() + 1,) + dense_size).numpy()
+            mx = paddle.empty((pool.max() + 1, *dense_size)).numpy()
             mx[:] = -inf
             np_values = values.numpy()
             for n in range(nnz):

--- a/test/legacy_test/test_stft_op.py
+++ b/test/legacy_test/test_stft_op.py
@@ -32,11 +32,11 @@ def frame_from_librosa(x, frame_length, hop_length, axis=-1):
 
     if axis == -1:
         shape = list(x.shape)[:-1] + [frame_length, n_frames]
-        strides = list(strides) + [hop_length * x.itemsize]
+        strides = [*strides, hop_length * x.itemsize]
 
     elif axis == 0:
         shape = [n_frames, frame_length] + list(x.shape)[1:]
-        strides = [hop_length * x.itemsize] + list(strides)
+        strides = [hop_length * x.itemsize, *strides]
 
     else:
         raise ValueError(f"Frame axis={axis} must be either 0 or -1")

--- a/test/legacy_test/test_svd_lowrank.py
+++ b/test/legacy_test/test_svd_lowrank.py
@@ -29,7 +29,7 @@ class TestSvdLowrankAPI(unittest.TestCase):
     def random_matrix(self, rows, columns, *batch_dims, **kwargs):
         dtype = kwargs.get('dtype', paddle.float64)
 
-        x = paddle.randn(batch_dims + (rows, columns), dtype=dtype)
+        x = paddle.randn((*batch_dims, rows, columns), dtype=dtype)
         if x.numel() == 0:
             return x
         u, _, vh = paddle.linalg.svd(x, full_matrices=False)
@@ -64,9 +64,9 @@ class TestSvdLowrankAPI(unittest.TestCase):
         self.assertEqual(v.shape[-2], columns)
 
         A1 = u.matmul(paddle.diag_embed(s)).matmul(self.transpose(v))
-        ones_m1 = paddle.ones(batches + (rows, 1), dtype=a.dtype)
+        ones_m1 = paddle.ones((*batches, rows, 1), dtype=a.dtype)
         c = a.sum(axis=-2) / rows
-        c = c.reshape(batches + (1, columns))
+        c = c.reshape((*batches, 1, columns))
         A2 = a - ones_m1.matmul(c)
         np.testing.assert_allclose(A1.numpy(), A2.numpy(), atol=1e-5)
 
@@ -143,7 +143,7 @@ class TestStaticSvdLowrankAPI(unittest.TestCase):
     def random_matrix(self, rows, columns, *batch_dims, **kwargs):
         dtype = kwargs.get('dtype', 'float64')
 
-        x = paddle.randn(batch_dims + (rows, columns), dtype=dtype)
+        x = paddle.randn((*batch_dims, rows, columns), dtype=dtype)
         u, _, vh = paddle.linalg.svd(x, full_matrices=False)
         k = min(rows, columns)
         s = paddle.linspace(1 / (k + 1), 1, k, dtype=dtype)
@@ -179,9 +179,9 @@ class TestStaticSvdLowrankAPI(unittest.TestCase):
             self.assertEqual(v.shape[-2], columns)
 
             A1 = u.matmul(paddle.diag_embed(s)).matmul(self.transpose(v))
-            ones_m1 = paddle.ones(batches + (rows, 1), dtype=a.dtype)
+            ones_m1 = paddle.ones((*batches, rows, 1), dtype=a.dtype)
             c = a.sum(axis=-2) / rows
-            c = c.reshape(batches + (1, columns))
+            c = c.reshape((*batches, 1, columns))
             A2 = a - ones_m1.matmul(c)
             detect_rank = (s.abs() > 1e-5).sum(axis=-1)
             left1 = actual_rank * paddle.ones(batches, dtype=paddle.int64)

--- a/test/legacy_test/test_swiglu.py
+++ b/test/legacy_test/test_swiglu.py
@@ -141,7 +141,7 @@ class TestSwiGLUDygraph(unittest.TestCase):
         y = paddle.static.data(name='y', shape=shape, dtype=dtype)
         concated_x = paddle.static.data(
             name='concated_x',
-            shape=list(shape[:-1]) + [shape[-1] * 2],
+            shape=[*shape[:-1], shape[-1] * 2],
             dtype=dtype,
         )
         out1 = fused_swiglu_impl(x, y)

--- a/test/legacy_test/test_viterbi_decode_op.py
+++ b/test/legacy_test/test_viterbi_decode_op.py
@@ -49,7 +49,7 @@ class Decoder:
             alpha_exp = np.expand_dims(alpha, 2)
             alpha_trn_sum = alpha_exp + trans_exp
             max_res = np.amax(alpha_trn_sum, 1), np.argmax(alpha_trn_sum, 1)
-            histories = histories + [max_res[1]] if i >= 1 else []
+            histories = [*histories, max_res[1]] if i >= 1 else []
             alpha_nxt = max_res[0] + logit
             mask = left_length > 0
             alpha = mask * alpha_nxt + (1 - mask) * alpha

--- a/test/legacy_test/test_zero_dim_sundry_static_api_part1.py
+++ b/test/legacy_test/test_zero_dim_sundry_static_api_part1.py
@@ -158,7 +158,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         )
         x_out_grad = [_grad for _param, _grad in grad_list]
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out] + x_out_grad)
+        res = self.exe.run(prog, fetch_list=[out, *x_out_grad])
 
         self.assertEqual(res[0].shape, ())
         np.testing.assert_allclose(res[0], np.array(119))
@@ -213,7 +213,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x, out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x, out, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], 1.0)
         self.assertEqual(res[1].shape, (1,))
@@ -231,7 +231,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         )
         grad_list = [_grad for _param, _grad in grad_list]
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x1, out1] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x1, out1, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], 1.0)
         self.assertEqual(res[1].shape, ())
@@ -249,7 +249,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         )
         grad_list = [_grad for _param, _grad in grad_list]
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x2, out2] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x2, out2, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], 1.0)
         self.assertEqual(res[1].shape, (3, 3))
@@ -273,7 +273,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x, out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x, out, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], 1.0)
         self.assertEqual(res[1].shape, ())
@@ -294,7 +294,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x1, out1] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x1, out1, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], 1.0)
         self.assertEqual(res[1].shape, (1,))
@@ -314,7 +314,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         )
         grad_list = [_grad for _param, _grad in grad_list]
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x2, out2] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x2, out2, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], 1.0)
         self.assertEqual(res[1].shape, (3, 3))
@@ -335,7 +335,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         )
         grad_list = [_grad for _param, _grad in grad_list]
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x, out, indices] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x, out, indices, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], 1.0)
         self.assertEqual(res[1].shape, ())
@@ -355,7 +355,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         )
         grad_list = [_grad for _param, _grad in grad_list]
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x1, out1, indices1] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x1, out1, indices1, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], 1.0)
         self.assertEqual(res[1].shape, ())
@@ -381,7 +381,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         )
         grad_list = [_grad for _param, _grad in grad_list]
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x, out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x, out, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], 1.0)
         self.assertEqual(res[1].shape, (1,))
@@ -400,7 +400,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x1, out1] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x1, out1, *grad_list])
 
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], 1.0)
@@ -484,7 +484,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x, out, index] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x, out, index, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
         self.assertTrue(res[1] == res[0])
@@ -502,7 +502,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out1, index1] + grad_list)
+        res = self.exe.run(prog, fetch_list=[out1, index1, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[2].shape, (5,))
@@ -518,7 +518,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out, index] + grad_list)
+        res = self.exe.run(prog, fetch_list=[out, index, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[2].shape, ())
@@ -532,7 +532,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out1, index1] + grad_list)
+        res = self.exe.run(prog, fetch_list=[out1, index1, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[2].shape, (5,))
@@ -589,7 +589,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         prog = paddle.static.default_main_program()
         res = self.exe.run(
             prog,
-            fetch_list=[x, out] + grad_list,
+            fetch_list=[x, out, *grad_list],
         )
 
         self.assertEqual(res[0].shape, (2,))
@@ -803,8 +803,8 @@ class TestSundryAPIStatic(unittest.TestCase):
                 x,
                 out1,
                 out2,
-            ]
-            + grad_list,
+                *grad_list,
+            ],
         )
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
@@ -831,8 +831,8 @@ class TestSundryAPIStatic(unittest.TestCase):
                 x,
                 out1,
                 out2,
-            ]
-            + grad_list,
+                *grad_list,
+            ],
         )
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())

--- a/test/legacy_test/test_zero_dim_sundry_static_api_part2.py
+++ b/test/legacy_test/test_zero_dim_sundry_static_api_part2.py
@@ -69,9 +69,9 @@ class TestSundryAPIStatic(unittest.TestCase):
             fetch_list=[
                 out1,
                 out2,
-            ]
-            + grad_list1
-            + grad_list2,
+                *grad_list1,
+                *grad_list2,
+            ],
         )
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
@@ -128,7 +128,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x, out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x, out, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[2].shape, ())
@@ -155,7 +155,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x, out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x, out, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[2].shape, ())
@@ -171,7 +171,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x, out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[x, out, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[2].shape, ())
@@ -187,7 +187,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[out, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[2].shape, ())
@@ -247,7 +247,7 @@ class TestSundryAPIStatic(unittest.TestCase):
             grad_list = [
                 _grad for _param, _grad in grad_list if _grad is not None
             ]
-            res = self.exe.run(prog, fetch_list=[x, out] + grad_list)
+            res = self.exe.run(prog, fetch_list=[x, out, *grad_list])
             self.assertEqual(res[0].shape, ())
             self.assertEqual(res[1].shape, ())
             if len(grad_list) > 0:
@@ -310,7 +310,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[out, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[1], 1.0)
@@ -330,7 +330,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[out, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[1], 1.0)
@@ -353,7 +353,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[out, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], 1)
         self.assertEqual(res[1].shape, (10,))
@@ -372,7 +372,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[out, *grad_list])
         self.assertEqual(res[0].shape, (3,))
         np.testing.assert_array_equal(res[0], [1.0, 1.0, 1.0])
         self.assertEqual(res[1].shape, (2, 3))
@@ -391,7 +391,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[out, *grad_list])
         self.assertEqual(res[0].shape, (2,))
         np.testing.assert_array_equal(res[0], [1.0, 1.0])
         self.assertEqual(res[1].shape, (2, 3))
@@ -455,7 +455,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[out, *grad_list])
         self.assertEqual(res[0].shape, (10,))
         self.assertEqual(res[0][2], 4.0)
         self.assertEqual(res[1].shape, (10,))
@@ -475,7 +475,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[out, *grad_list])
         self.assertEqual(res[0].shape, (2, 3))
         np.testing.assert_array_equal(res[0][1], [4.0, 4.0, 4.0])
         self.assertEqual(res[1].shape, (2, 3))
@@ -537,7 +537,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[out, *grad_list])
         self.assertEqual(res[0].shape, (5,))
         self.assertEqual(res[0][3], 2)
         self.assertEqual(res[1].shape, (5,))
@@ -559,7 +559,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, feed={}, fetch_list=[out] + grad_list)
+        res = self.exe.run(prog, feed={}, fetch_list=[out, *grad_list])
 
         self.assertEqual(res[0].shape, (1,))
         self.assertEqual(res[1].shape, ())
@@ -586,7 +586,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = [_grad for _param, _grad in grad_list]
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out] + grad_list)
+        res = self.exe.run(prog, fetch_list=[out, *grad_list])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[2].shape, ())

--- a/test/prim/model/bert.py
+++ b/test/prim/model/bert.py
@@ -426,9 +426,7 @@ class Bert(nn.Layer):
                 total_loss = masked_lm_loss + next_sentence_loss
 
             output = (prediction_scores, seq_relationship_score) + outputs[2:]
-            return (
-                ((total_loss,) + output) if total_loss is not None else output
-            )
+            return ((total_loss, *output)) if total_loss is not None else output
 
 
 class BertPretrainingCriterion(paddle.nn.Layer):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

修复如下文件中 Ruff 检测出的 `RUF005` 问题：

- test/legacy_test/test_sparse_softmax_op.py
- test/legacy_test/test_stft_op.py
- test/legacy_test/test_svd_lowrank.py
- test/legacy_test/test_swiglu.py
- test/legacy_test/test_viterbi_decode_op.py
- test/legacy_test/test_zero_dim_sundry_static_api_part1.py
- test/legacy_test/test_zero_dim_sundry_static_api_part2.py
- test/prim/model/bert.py

### Related links

- #67116

@gouzil