### PR TITLE
[CodeStyle] Fix codestyle regression introduced by #67110

### DIFF
--- a/python/paddle/sparse/nn/functional/pooling.py
+++ b/python/paddle/sparse/nn/functional/pooling.py
@@ -16,10 +16,12 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
-from paddle.nn.functional.pooling import _update_padding_nd
-from paddle.utils import convert_to_list
+
 from paddle import _C_ops
 from paddle.framework import in_dynamic_or_pir_mode
+from paddle.nn.functional.pooling import _update_padding_nd
+from paddle.utils import convert_to_list
+
 if TYPE_CHECKING:
     from paddle import Tensor
     from paddle._typing import (


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->

修复 #67110 的 CodeStyle 相关问题
```console
python/paddle/sparse/nn/functional/pooling.py:16:1: I001 [*] Import block is un-sorted or un-formatted
   |
16 | / from __future__ import annotations
17 | |
18 | | from typing import TYPE_CHECKING, Literal
19 | | from paddle.nn.functional.pooling import _update_padding_nd
20 | | from paddle.utils import convert_to_list
21 | | from paddle import _C_ops
22 | | from paddle.framework import in_dynamic_or_pir_mode
23 | | if TYPE_CHECKING:
   | |_^ I001
24 |       from paddle import Tensor
25 |       from paddle._typing import (
   |
   = help: Organize imports
```

