### PR TITLE
[CodeStyle][Ruff][BUAA][G-[249-256]] Fix ruff `RUF005` diagnostic for 8 files in `python/test/`

### DIFF
--- a/test/ps/dataset_generator_B.py
+++ b/test/ps/dataset_generator_B.py
@@ -45,7 +45,7 @@ class CriteoDataset(fleet.MultiSlotDataGenerator):
             label = [int(features[0])]
             feature_name = ["dense_feature"]
             feature_name.append("label")
-            yield list(zip(feature_name, [label] + [dense_feature]))
+            yield list(zip(feature_name, [label, dense_feature]))
 
         return reader
 

--- a/test/ps/ps_dnn_model.py
+++ b/test/ps/ps_dnn_model.py
@@ -46,11 +46,11 @@ class DNNLayer(nn.Layer):
             ),
         )
 
-        sizes = (
-            [sparse_feature_dim * num_field + dense_feature_dim]
-            + self.layer_sizes
-            + [2]
-        )
+        sizes = [
+            sparse_feature_dim * num_field + dense_feature_dim,
+            *self.layer_sizes,
+            2,
+        ]
         acts = ["relu" for _ in range(len(self.layer_sizes))] + [None]
         self._mlp_layers = []
         for i in range(len(layer_sizes) + 1):
@@ -85,7 +85,7 @@ class DNNLayer(nn.Layer):
             # emb.stop_gradient = True
             sparse_embs.append(emb)
 
-        y_dnn = paddle.concat(x=sparse_embs + [dense_inputs], axis=1)
+        y_dnn = paddle.concat(x=[*sparse_embs, dense_inputs], axis=1)
 
         if self.sync_mode == 'heter':
             with paddle.base.device_guard('gpu'):
@@ -318,7 +318,7 @@ class StaticModel:
 
         label = paddle.static.data(name="label", shape=[None, 1], dtype="int64")
 
-        feeds_list = [label] + sparse_input_ids + [dense_input]
+        feeds_list = [label, *sparse_input_ids, dense_input]
         return feeds_list
 
     def net(self, input, is_infer=False):

--- a/test/ps/ps_dnn_trainer.py
+++ b/test/ps/ps_dnn_trainer.py
@@ -91,7 +91,7 @@ class YamlHelper:
                     nests.append(k)
                     fatten_env_namespace(nests, v)
                 else:
-                    global_k = ".".join(namespace_nests + [k])
+                    global_k = ".".join([*namespace_nests, k])
                     all_flattens[global_k] = v
 
         fatten_env_namespace([], _envs)

--- a/test/sequence/test_sequence_conv.py
+++ b/test/sequence/test_sequence_conv.py
@@ -278,9 +278,7 @@ class TestSeqProjectCase3(TestSeqProject):
         self.input_size = [self.input_row, 25]
         idx = list(range(self.input_size[0]))
         del idx[0]
-        offset_lod = [
-            [0] + np.sort(random.sample(idx, 8)).tolist() + [self.input_size[0]]
-        ]
+        offset_lod = [[0, *np.sort(random.sample(idx, 8)), self.input_size[0]]]
         self.lod = [[]]
         # convert from offset-based lod to length-based lod
         for i in range(len(offset_lod[0]) - 1):

--- a/test/sequence/test_sequence_mask.py
+++ b/test/sequence/test_sequence_mask.py
@@ -65,10 +65,7 @@ class SequenceMaskTestBase(OpTest):
 
     def calc_ground_truth_mask(self):
         maxlen = np.max(self.x) if self.maxlen < 0 else self.maxlen
-        shape = (
-            *self.x.shape,
-            maxlen,
-        )
+        shape = (*self.x.shape, maxlen)
         index_broadcast = np.broadcast_to(
             np.reshape(range(maxlen), newshape=[1] * self.x.ndim + [-1]),
             shape=shape,
@@ -76,10 +73,7 @@ class SequenceMaskTestBase(OpTest):
         x_broadcast = np.broadcast_to(
             np.reshape(
                 self.x,
-                newshape=(
-                    *self.x.shape,
-                    -1,
-                ),
+                newshape=(*self.x.shape, -1),
             ),
             shape=shape,
         )
@@ -145,10 +139,7 @@ class SequenceMaskTestBase_tensor_attr(OpTest):
 
     def calc_ground_truth_mask(self):
         maxlen = np.max(self.x) if self.maxlen < 0 else self.maxlen
-        shape = (
-            *self.x.shape,
-            maxlen,
-        )
+        shape = (*self.x.shape, maxlen)
         index_broadcast = np.broadcast_to(
             np.reshape(range(maxlen), newshape=[1] * self.x.ndim + [-1]),
             shape=shape,
@@ -156,10 +147,7 @@ class SequenceMaskTestBase_tensor_attr(OpTest):
         x_broadcast = np.broadcast_to(
             np.reshape(
                 self.x,
-                newshape=(
-                    *self.x.shape,
-                    -1,
-                ),
+                newshape=(*self.x.shape, -1),
             ),
             shape=shape,
         )

--- a/test/sequence/test_sequence_mask.py
+++ b/test/sequence/test_sequence_mask.py
@@ -65,13 +65,23 @@ class SequenceMaskTestBase(OpTest):
 
     def calc_ground_truth_mask(self):
         maxlen = np.max(self.x) if self.maxlen < 0 else self.maxlen
-        shape = self.x.shape + (maxlen,)
+        shape = (
+            *self.x.shape,
+            maxlen,
+        )
         index_broadcast = np.broadcast_to(
             np.reshape(range(maxlen), newshape=[1] * self.x.ndim + [-1]),
             shape=shape,
         )
         x_broadcast = np.broadcast_to(
-            np.reshape(self.x, newshape=self.x.shape + (-1,)), shape=shape
+            np.reshape(
+                self.x,
+                newshape=(
+                    *self.x.shape,
+                    -1,
+                ),
+            ),
+            shape=shape,
         )
         return (index_broadcast < x_broadcast).astype(self.mask_dtype)
 
@@ -135,13 +145,23 @@ class SequenceMaskTestBase_tensor_attr(OpTest):
 
     def calc_ground_truth_mask(self):
         maxlen = np.max(self.x) if self.maxlen < 0 else self.maxlen
-        shape = self.x.shape + (maxlen,)
+        shape = (
+            *self.x.shape,
+            maxlen,
+        )
         index_broadcast = np.broadcast_to(
             np.reshape(range(maxlen), newshape=[1] * self.x.ndim + [-1]),
             shape=shape,
         )
         x_broadcast = np.broadcast_to(
-            np.reshape(self.x, newshape=self.x.shape + (-1,)), shape=shape
+            np.reshape(
+                self.x,
+                newshape=(
+                    *self.x.shape,
+                    -1,
+                ),
+            ),
+            shape=shape,
         )
         return (index_broadcast < x_broadcast).astype(self.mask_dtype)
 

--- a/test/tokenizer/bert_tokenizer.py
+++ b/test/tokenizer/bert_tokenizer.py
@@ -426,7 +426,7 @@ class BertTokenizer(PretrainedTokenizer):
             List[int]: List of input_id with the appropriate special tokens.
         """
         if token_ids_1 is None:
-            return [self.cls_token_id] + token_ids_0 + [self.sep_token_id]
+            return [self.cls_token_id, *token_ids_0, self.sep_token_id]
         _cls = [self.cls_token_id]
         _sep = [self.sep_token_id]
         return _cls + token_ids_0 + _sep + token_ids_1 + _sep

--- a/test/tokenizer/tokenizer_utils.py
+++ b/test/tokenizer/tokenizer_utils.py
@@ -668,7 +668,7 @@ class PretrainedTokenizer:
             overflowing_tokens = []
             for _ in range(num_tokens_to_remove):
                 if pair_ids is None or len(ids) > len(pair_ids):
-                    overflowing_tokens = [ids[-1]] + overflowing_tokens
+                    overflowing_tokens = [ids[-1], *overflowing_tokens]
                     ids = ids[:-1]
                 else:
                     pair_ids = pair_ids[:-1]

--- a/test/xpu/test_index_select_op_xpu.py
+++ b/test/xpu/test_index_select_op_xpu.py
@@ -47,7 +47,7 @@ class XPUTestIndexSelect(XPUOpTestWrapper):
             self.inputs = {'X': x_np, 'Index': index_np}
             self.attrs = {'dim': self.dim}
             outer_loop = np.prod(self.x_shape[: self.dim])
-            x_reshape = [outer_loop] + list(self.x_shape[self.dim :])
+            x_reshape = [outer_loop, *self.x_shape[self.dim :]]
             x_np_reshape = np.reshape(x_np, tuple(x_reshape))
             out_list = []
             for i in range(outer_loop):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

修复如下文件中 Ruff 检测出的 `Q003` 问题：

- test/ps/dataset_generator_B.py
- test/ps/ps_dnn_model.py
- test/ps/ps_dnn_trainer.py
- test/sequence/test_sequence_conv.py
- test/sequence/test_sequence_mask.py
- test/tokenizer/bert_tokenizer.py
- test/tokenizer/tokenizer_utils.py
- test/xpu/test_index_select_op_xpu.py

### Related links

- #67116

@gouzil