### PR TITLE
[CodeStyle][Ruff][BUAA][G-[111-120]] Fix ruff `RUF005` diagnostic for 10 files in `python/paddle/`

### DIFF
--- a/test/collective/fleet/pipeline_mnist_one_device.py
+++ b/test/collective/fleet/pipeline_mnist_one_device.py
@@ -56,7 +56,7 @@ def cnn_model(data):
 
     SIZE = 10
     input_shape = conv_pool_2.shape
-    param_shape = [reduce(lambda a, b: a * b, input_shape[1:], 1)] + [SIZE]
+    param_shape = [reduce(lambda a, b: a * b, input_shape[1:], 1), SIZE]
     scale = (2.0 / (param_shape[0] ** 2 * SIZE)) ** 0.5
 
     predict = paddle.static.nn.fc(

--- a/test/contrib/test_image_classification_fp16.py
+++ b/test/contrib/test_image_classification_fp16.py
@@ -234,7 +234,7 @@ def train(net_type, use_cuda, save_dirname, is_local):
     paddle.seed(123)
     with base.program_guard(train_program, startup_prog):
         images = paddle.static.data(
-            name='pixel', shape=[-1] + data_shape, dtype='float32'
+            name='pixel', shape=[-1, *data_shape], dtype='float32'
         )
         label = paddle.static.data(name='label', shape=[-1, 1], dtype='int64')
 

--- a/test/contrib/test_multi_precision_fp16_train.py
+++ b/test/contrib/test_multi_precision_fp16_train.py
@@ -113,7 +113,7 @@ def train(use_pure_fp16=True, use_nesterov=False, optimizer=""):
     paddle.seed(123)
     with base.program_guard(train_program, startup_prog):
         images = paddle.static.data(
-            name='pixel', shape=[-1] + data_shape, dtype='float32'
+            name='pixel', shape=[-1, *data_shape], dtype='float32'
         )
         label = paddle.static.data(name='label', shape=[-1, 1], dtype='int64')
         net = resnet_cifar10(images)

--- a/test/cpp_extension/mix_relu_and_extension_setup.py
+++ b/test/cpp_extension/mix_relu_and_extension_setup.py
@@ -22,8 +22,10 @@ setup(
     name='mix_relu_extension',
     ext_modules=CppExtension(
         sources=["mix_relu_and_extension.cc"],
-        include_dirs=paddle_includes
-        + [os.path.dirname(os.path.abspath(__file__))],
+        include_dirs=[
+            paddle_includes,
+            os.path.dirname(os.path.abspath(__file__)),
+        ],
         extra_compile_args={'cc': ['-w', '-g']},
         verbose=True,
     ),

--- a/test/cpp_extension/mix_relu_and_extension_setup.py
+++ b/test/cpp_extension/mix_relu_and_extension_setup.py
@@ -23,7 +23,7 @@ setup(
     ext_modules=CppExtension(
         sources=["mix_relu_and_extension.cc"],
         include_dirs=[
-            paddle_includes,
+            *paddle_includes,
             os.path.dirname(os.path.abspath(__file__)),
         ],
         extra_compile_args={'cc': ['-w', '-g']},

--- a/test/deprecated/book/test_image_classification_deprecated.py
+++ b/test/deprecated/book/test_image_classification_deprecated.py
@@ -109,7 +109,7 @@ def train(net_type, use_cuda, save_dirname, is_local):
     data_shape = [3, 32, 32]
 
     images = paddle.static.data(
-        name='pixel', shape=[-1] + data_shape, dtype='float32'
+        name='pixel', shape=[-1, *data_shape], dtype='float32'
     )
     label = paddle.static.data(name='label', shape=[-1, 1], dtype='int64')
 

--- a/test/deprecated/custom_op/custom_raw_op_kernel_op_setup.py
+++ b/test/deprecated/custom_op/custom_raw_op_kernel_op_setup.py
@@ -42,7 +42,7 @@ if core.is_compiled_with_nccl():
     macros.append(("PADDLE_WITH_NCCL", None))
 macros.append(("THRUST_IGNORE_CUB_VERSION_CHECK", None))
 
-include_dirs = list(paddle_includes) + [cwd]
+include_dirs = [*list(paddle_includes), cwd]
 setup(
     name=os.getenv("MODULE_NAME", "custom_raw_op_kernel_op_setup"),
     ext_modules=extension(

--- a/test/deprecated/custom_op/custom_raw_op_kernel_op_setup.py
+++ b/test/deprecated/custom_op/custom_raw_op_kernel_op_setup.py
@@ -42,7 +42,7 @@ if core.is_compiled_with_nccl():
     macros.append(("PADDLE_WITH_NCCL", None))
 macros.append(("THRUST_IGNORE_CUB_VERSION_CHECK", None))
 
-include_dirs = [*list(paddle_includes), cwd]
+include_dirs = [*paddle_includes, cwd]
 setup(
     name=os.getenv("MODULE_NAME", "custom_raw_op_kernel_op_setup"),
     ext_modules=extension(

--- a/test/deprecated/legacy_test/test_argsort_op_deprecated.py
+++ b/test/deprecated/legacy_test/test_argsort_op_deprecated.py
@@ -87,7 +87,7 @@ class TestArgsortOpCPU(unittest.TestCase):
 
         with base.program_guard(self.main_program, self.startup_program):
             x = paddle.static.data(
-                name="x", shape=[-1, *list(self.input_shape)], dtype=self.dtype
+                name="x", shape=[-1, *self.input_shape], dtype=self.dtype
             )
             x.stop_gradient = False
             x.desc.set_need_check_feed(False)

--- a/test/deprecated/legacy_test/test_argsort_op_deprecated.py
+++ b/test/deprecated/legacy_test/test_argsort_op_deprecated.py
@@ -87,13 +87,13 @@ class TestArgsortOpCPU(unittest.TestCase):
 
         with base.program_guard(self.main_program, self.startup_program):
             x = paddle.static.data(
-                name="x", shape=[-1] + list(self.input_shape), dtype=self.dtype
+                name="x", shape=[-1, *list(self.input_shape)], dtype=self.dtype
             )
             x.stop_gradient = False
             x.desc.set_need_check_feed(False)
             label = paddle.static.data(
                 name="label",
-                shape=[-1] + list(self.input_shape),
+                shape=[-1, *list(self.input_shape)],
                 dtype=self.dtype,
             )
             label.desc.set_need_check_feed(False)

--- a/test/deprecated/legacy_test/test_auto_parallel_reshard.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_reshard.py
@@ -268,7 +268,8 @@ def check_initialization_for_dp(dist_startup_prog):
         "layer_norm_0.w_0",
         "linear_0.w_0",
         "linear_0.b_0",
-        *['linear_1.w_0', 'linear_1.b_0'],
+        "linear_1.w_0",
+        "linear_1.b_0",
     ]
     params = []
     for var_name, var in dist_startup_prog.global_block().vars.items():

--- a/test/deprecated/legacy_test/test_auto_parallel_reshard.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_reshard.py
@@ -268,7 +268,8 @@ def check_initialization_for_dp(dist_startup_prog):
         "layer_norm_0.w_0",
         "linear_0.w_0",
         "linear_0.b_0",
-    ] + ['linear_1.w_0', 'linear_1.b_0']
+        *['linear_1.w_0', 'linear_1.b_0'],
+    ]
     params = []
     for var_name, var in dist_startup_prog.global_block().vars.items():
         if var.is_parameter:

--- a/test/deprecated/legacy_test/test_conv2d_layer_deprecated.py
+++ b/test/deprecated/legacy_test/test_conv2d_layer_deprecated.py
@@ -71,13 +71,16 @@ class Conv2DTestCase(unittest.TestCase):
         self.channel_last = self.data_format == "NHWC"
         if self.channel_last:
             input_shape = (
-                (self.batch_size,) + self.spartial_shape + (self.num_channels,)
+                self.batch_size,
+                *self.spartial_shape,
+                self.num_channels,
             )
         else:
             input_shape = (
                 self.batch_size,
                 self.num_channels,
-            ) + self.spartial_shape
+                *self.spartial_shape,
+            )
         self.input = np.random.randn(*input_shape).astype(self.dtype)
 
         if isinstance(self.filter_size, int):
@@ -87,7 +90,8 @@ class Conv2DTestCase(unittest.TestCase):
         self.weight_shape = weight_shape = (
             self.num_filters,
             self.num_channels // self.groups,
-        ) + tuple(filter_size)
+            *filter_size,
+        )
         self.weight = np.random.uniform(-1, 1, size=weight_shape).astype(
             self.dtype
         )

--- a/test/deprecated/legacy_test/test_conv2d_transpose_layer_deprecated.py
+++ b/test/deprecated/legacy_test/test_conv2d_transpose_layer_deprecated.py
@@ -62,13 +62,16 @@ class Conv2DTransposeTestCase(unittest.TestCase):
         self.channel_last = self.data_format == "NHWC"
         if self.channel_last:
             input_shape = (
-                (self.batch_size,) + self.spartial_shape + (self.num_channels,)
+                self.batch_size,
+                *self.spartial_shape,
+                self.num_channels,
             )
         else:
             input_shape = (
                 self.batch_size,
                 self.num_channels,
-            ) + self.spartial_shape
+                *self.spartial_shape,
+            )
         self.input = np.random.randn(*input_shape).astype(self.dtype)
 
         if isinstance(self.filter_size, int):
@@ -78,7 +81,8 @@ class Conv2DTransposeTestCase(unittest.TestCase):
         self.weight_shape = weight_shape = (
             self.num_channels,
             self.num_filters // self.groups,
-        ) + tuple(filter_size)
+            *filter_size,
+        )
         self.weight = np.random.uniform(-1, 1, size=weight_shape).astype(
             self.dtype
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

修复如下文件 RUF005 的 Ruff 规则：


- ``test/collective/fleet/pipeline_mnist_one_device.py``
- ``test/contrib/test_image_classification_fp16.py``
- ``test/contrib/test_multi_precision_fp16_train.py``
- ``test/cpp_extension/mix_relu_and_extension_setup.py``
- ``test/deprecated/book/test_image_classification_deprecated.py`` 
- ``test/deprecated/custom_op/custom_raw_op_kernel_op_setup.py``
- ``test/deprecated/legacy_test/test_argsort_op_deprecated.py``
- ``test/deprecated/legacy_test/test_auto_parallel_reshard.py``
- ``test/deprecated/legacy_test/test_conv2d_layer_deprecated.py``
- ``test/deprecated/legacy_test/test_conv2d_transpose_layer_deprecated.py``



### Related Links

- #67116 

@gouzil 