### PR TITLE
[Bug fix] fix dygraph linear ad_func

### DIFF
--- a/paddle/fluid/pybind/eager_custom_python_api.h
+++ b/paddle/fluid/pybind/eager_custom_python_api.h
@@ -31,7 +31,7 @@ static PyObject *eager_api_linear(PyObject *self,
 
     tstate = PyEval_SaveThread();
 
-    if (bias.initialized()) {
+    if (bias.is_dist_tensor() || bias.initialized()) {
       const phi::distributed::ProcessMesh *mesh = nullptr;
       if (InputsContainDistTensor(&mesh, x, weight, bias)) {
         ConvertAllInputsToDistTensor(mesh, x, weight, bias);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-85940

in pipeline parallel, error will occur when using nn.Linear in if statement. e.g.
```python
import paddle
import paddle.distributed as dist
import paddle.nn.functional as F
from paddle import Tensor, nn

mesh0 = dist.ProcessMesh([0], dim_names=['dp'])
mesh1 = dist.ProcessMesh([1], dim_names=['dp'])
placements = [dist.Replicate()]


class Linear(nn.Layer):
    def __init__(self):
        super(Linear, self).__init__()

        self.weight = self.create_parameter(
            shape=([1, 1])
        )
        self.bias = self.create_parameter(
            shape=[1]
        )

        self.weight = dist.shard_tensor(
            self.weight,
            mesh1,
            placements,
        )

        self.bias = dist.shard_tensor(
            self.bias,
            mesh1,
            placements,
        )

    def forward(self, hidden_states):
        hidden_states = dist.reshard(hidden_states, mesh1, placements)

        logits = F.linear(hidden_states, self.weight, self.bias)
        return logits

if __name__ == "__main__":
    # 模拟input
    dense_tensor = paddle.ones([1, 1])
    dense_tensor = dist.shard_tensor(
        dense_tensor,
        mesh0,
        placements,
    )

    # 模拟组网
    net = Linear()

    # 模拟执行
    out = net(dense_tensor)
    out.backward()

    print(net.weight._grad_ivar())  # mesh0 和 mesh1 都有值
    print(net.bias._grad_ivar())    # mesh0 为 None, mesh1有值
```
The root cause is that when using pipeline parallel, the bias will not be initialized if it is not on some meshes. Furthermore, the add_ad_func will not be called if the bias is not initialized.