### PR TITLE
[CINN]support generate shape for Reshape_Op

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/fuse_parallel_matmul_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/fuse_parallel_matmul_pass.cc
@@ -149,11 +149,17 @@ class MergeParallelMatmulPattern
         rewriter.Build<paddle::dialect::MatmulOp>(input_x, concat_out)
             .result(0);
 
+    const auto& matmul_out_rank =
+        matmul_out.type()
+            .dyn_cast<paddle::dialect::DenseTensorType>()
+            .dims()
+            .size();
+
     for (size_t i = 0; i < merge_ops.size(); ++i) {
       auto split_out = rewriter
                            .Build<paddle::dialect::SliceOp>(
                                matmul_out,
-                               std::vector<std::int64_t>{-1},
+                               std::vector<std::int64_t>{matmul_out_rank - 1},
                                std::vector<std::int64_t>{combine_shapes[i]},
                                std::vector<int64_t>{combine_shapes[i + 1]},
                                std::vector<std::int64_t>{},

--- a/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
@@ -488,6 +488,8 @@ class FuseShapeOpsIntoGenerateShapeOpPass : public pir::PatternRewritePass {
         context);
     ps.Add<FuseShapeOpsIntoGenerateShapeOpPattern<paddle::dialect::ReshapeOp>>(
         context);
+    ps.Add<FuseShapeOpsIntoGenerateShapeOpPattern<paddle::dialect::Reshape_Op>>(
+        context);
     ps.Add<FuseShapeOpsIntoGenerateShapeOpPattern<paddle::dialect::SliceOp>>(
         context);
     ps.Add<FuseSingleElementShapeOpsIntoGenerateShapeOpPattern>(context);

--- a/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
+++ b/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
@@ -150,7 +150,7 @@ void CheckInferSymWithInferMeta(
     pir::InferSymbolicShapeContext* infer_context = nullptr) {
   for (uint32_t i = 0; i < op->num_results(); ++i) {
     const auto& res = op->result(i);
-    if (!res || !res.type()) {
+    if (!res || !res.type() || res.use_empty()) {
       continue;
     }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR fixes some cx86 llvm compilation error by fusing generate shape ops in frontend.
The cx86 codegen may still have some errors.