### PR TITLE
[CINN] Fix bug of move_generate_shape_ops_to_prologue

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/generate_shape_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/generate_shape_util.cc
@@ -53,6 +53,7 @@ std::vector<pir::Value> GetBlockArgs(pir::Block* block) {
   for (auto op = block->begin(); op != block->end(); ++op) {
     for (int i = 0; i < op->num_operands(); ++i) {
       pir::Value input = op->operand_source(i);
+      if (!input.type().isa<pir::DenseTensorType>()) continue;
       if (values_produced_by_block_op.count(input) == 0) {
         if (std::find(ret.begin(), ret.end(), input) == ret.end()) {
           ret.push_back(input);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复move_generate_shape_ops_to_prologue pass中将非dense_tensor类型作为generate_shape候选输入导致的类型检查报错的问题。