### PR TITLE
[Typing][PEP585 Upgrade][BUAA][131-140] Use standard collections for type hints for 9 files in test/

### DIFF
--- a/test/auto_parallel/hybrid_strategy/semi_auto_parallel_llama_model.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_parallel_llama_model.py
@@ -14,7 +14,7 @@
 
 
 import math
-from typing import Optional, Tuple
+from typing import Optional
 
 import paddle
 import paddle.distributed as dist
@@ -172,14 +172,14 @@ class LlamaAttentionAuto(nn.Layer):
     def forward(
         self,
         hidden_states,
-        position_ids: Optional[Tuple[paddle.Tensor]] = None,
-        past_key_value: Optional[Tuple[paddle.Tensor]] = None,
+        position_ids: Optional[tuple[paddle.Tensor]] = None,
+        past_key_value: Optional[tuple[paddle.Tensor]] = None,
         attention_mask: Optional[paddle.Tensor] = None,
         output_attentions: bool = False,
         use_cache: bool = False,
         alibi: Optional[paddle.Tensor] = None,
-    ) -> Tuple[
-        paddle.Tensor, Optional[paddle.Tensor], Optional[Tuple[paddle.Tensor]]
+    ) -> tuple[
+        paddle.Tensor, Optional[paddle.Tensor], Optional[tuple[paddle.Tensor]]
     ]:
         """Input shape: Batch x Time x Channel"""
         # [bs, seq_len, num_head * head_dim] -> [seq_len / n, bs, num_head * head_dim] (n is model parallelism)
@@ -385,10 +385,10 @@ class LlamaDecoderLayerAuto(nn.Layer):
     def forward(
         self,
         hidden_states: paddle.Tensor,
-        position_ids: Optional[Tuple[paddle.Tensor]] = None,
+        position_ids: Optional[tuple[paddle.Tensor]] = None,
         attention_mask: Optional[paddle.Tensor] = None,
         output_attentions: Optional[bool] = False,
-        past_key_value: Optional[Tuple[paddle.Tensor]] = None,
+        past_key_value: Optional[tuple[paddle.Tensor]] = None,
         use_cache: Optional[bool] = False,
         alibi: Optional[paddle.Tensor] = None,
     ):

--- a/test/deprecated/legacy_test/auto_parallel_op_test.py
+++ b/test/deprecated/legacy_test/auto_parallel_op_test.py
@@ -20,7 +20,7 @@ import sys
 import tempfile
 import uuid
 from collections import defaultdict
-from typing import Dict, List, Tuple, cast
+from typing import cast
 
 import numpy as np
 
@@ -303,7 +303,7 @@ def run_subprocess(start_command, env, timeout):
         )
 
 
-def convert_input_placements_to_dims_map(placements: Dict, inputs: Dict):
+def convert_input_placements_to_dims_map(placements: dict, inputs: dict):
     all_dims_map = {}
     for name, item in inputs.items():
         if name not in placements:
@@ -328,7 +328,7 @@ def convert_input_placements_to_dims_map(placements: Dict, inputs: Dict):
 
 
 def convert_input_dims_map_to_placements(
-    dims_map: Dict, inputs: Dict, mesh_ndim: int
+    dims_map: dict, inputs: dict, mesh_ndim: int
 ):
     placements_map = {}
     for name, item in inputs.items():
@@ -354,7 +354,7 @@ def convert_input_dims_map_to_placements(
 # TODO: This method has been implementd in
 # paddle/phi/core/distributed/auto_parallel/placement_types.h, bind it
 # python and it's logic.
-def placements_to_dims_map(placements: List, tensor_ndim: int) -> Tuple[int]:
+def placements_to_dims_map(placements: list, tensor_ndim: int) -> tuple[int]:
     r = [-1] * tensor_ndim
     for i, placement in enumerate(placements):
         if placement.is_shard():
@@ -373,23 +373,23 @@ def placements_to_dims_map(placements: List, tensor_ndim: int) -> Tuple[int]:
 # paddle/phi/core/distributed/auto_parallel/placement_types.h, and bind it to
 # python
 def dims_map_to_placements(
-    dim_map: Tuple[int], mesh_ndim: int, sums: Tuple[int] = ()
-) -> Tuple[dist.Placement]:
+    dim_map: tuple[int], mesh_ndim: int, sums: tuple[int] = ()
+) -> tuple[dist.Placement]:
     """
     Construct a placements from dim_map list and pending sum.
 
     Args:
-        dim_map (Tuple[int]): a list of integer that represents sharding on each
+        dim_map (tuple[int]): a list of integer that represents sharding on each
             tensor dimension, see `dim_map` property doc for details
         mesh_ndim (int): the ndim of Process mesh.
-        sums (Tuple[int]): a list of integer that represents the dist tensor have
+        sums (tuple[int]): a list of integer that represents the dist tensor have
             pending sum on which device mesh dimension.
 
     Return:
         a placement sequence.
     """
     # by default replicate on device mesh dims
-    placements: List[dist.Placement] = [
+    placements: list[dist.Placement] = [
         dist.Replicate() for _ in range(mesh_ndim)
     ]
 

--- a/test/dygraph_to_static/test_dynamic_shape_infermeta.py
+++ b/test/dygraph_to_static/test_dynamic_shape_infermeta.py
@@ -15,7 +15,10 @@
 from __future__ import annotations
 
 import unittest
-from typing import Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 import numpy as np
 from dygraph_to_static_utils import (

--- a/test/dygraph_to_static/test_typehint.py
+++ b/test/dygraph_to_static/test_typehint.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-from typing import List
 
 import numpy as np
 from dygraph_to_static_utils import (
@@ -35,15 +34,15 @@ def function(x: A) -> A:
 
 def fn_annotation_assign_with_value(x: paddle.Tensor):
     if x:
-        y: List[paddle.Tensor] = [x + 1]
+        y: list[paddle.Tensor] = [x + 1]
     else:
-        y: List[paddle.Tensor] = [x - 1]
+        y: list[paddle.Tensor] = [x - 1]
     return y
 
 
 def fn_annotation_assign_without_value(x: paddle.Tensor):
     if x:
-        y: List[paddle.Tensor]
+        y: list[paddle.Tensor]
         y = [x + 1]
     else:
         y = [x - 1]

--- a/test/dygraph_to_static/test_typing.py
+++ b/test/dygraph_to_static/test_typing.py
@@ -14,7 +14,6 @@
 import os
 import tempfile
 import unittest
-from typing import Dict, List, Tuple
 
 import numpy as np
 from dygraph_to_static_utils import Dy2StTestBase, test_legacy_and_pir
@@ -37,7 +36,7 @@ class LinearNetWithTuple(BaseLayer):
     def __init__(self, in_size, out_size):
         super().__init__(in_size, out_size)
 
-    def forward(self, x) -> Tuple[paddle.Tensor, str]:
+    def forward(self, x) -> tuple[paddle.Tensor, str]:
         out1, out2 = self.build(x)
         return (out2, 'str')
 
@@ -46,7 +45,7 @@ class LinearNetWithTuple2(BaseLayer):
     def __init__(self, in_size, out_size):
         super().__init__(in_size, out_size)
 
-    def forward(self, x) -> Tuple[paddle.Tensor, np.array]:
+    def forward(self, x) -> tuple[paddle.Tensor, np.array]:
         out1, out2 = self.build(x)
         return (out2, np.ones([4, 16]))
 
@@ -55,7 +54,7 @@ class LinearNetWithList(BaseLayer):
     def __init__(self, in_size, out_size):
         super().__init__(in_size, out_size)
 
-    def forward(self, x) -> List[paddle.Tensor]:
+    def forward(self, x) -> list[paddle.Tensor]:
         out1, out2 = self.build(x)
         return [out2]
 
@@ -64,7 +63,7 @@ class LinearNetWithDict(BaseLayer):
     def __init__(self, in_size, out_size):
         super().__init__(in_size, out_size)
 
-    def forward(self, x) -> Dict[str, paddle.Tensor]:
+    def forward(self, x) -> dict[str, paddle.Tensor]:
         out1, out2 = self.build(x)
         return {'out': out2}
 

--- a/test/ipu/op_test_ipu.py
+++ b/test/ipu/op_test_ipu.py
@@ -16,7 +16,7 @@ import os
 import random
 import unittest
 from enum import IntEnum
-from typing import Dict, List, Optional
+from typing import Optional
 
 import numpy as np
 
@@ -118,9 +118,9 @@ class IPUOpTest(IPUTest):
         cls.main_prog: paddle.static.Program = None
         cls.startup_prog: paddle.static.Program = None
         cls.scope: paddle.static.Scope = None
-        cls.feed_list: List[str] = None
-        cls.fetch_list: List[str] = None
-        cls.output_dict: Optional[Dict] = {}
+        cls.feed_list: list[str] = None
+        cls.fetch_list: list[str] = None
+        cls.output_dict: Optional[dict] = {}
 
     def tearDown(self):
         # Manual reset when using ipumodel

--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -19,7 +19,7 @@ import os
 import shutil
 import time
 import unittest
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Optional
 
 import hypothesis
 import hypothesis.strategies as st
@@ -128,7 +128,7 @@ class AutoScanTest(unittest.TestCase):
 
     def run_test_config(
         self, model, params, prog_config, pred_config, feed_data
-    ) -> Dict[str, np.ndarray]:
+    ) -> dict[str, np.ndarray]:
         """
         Test a single case.
         """
@@ -157,8 +157,8 @@ class AutoScanTest(unittest.TestCase):
         self,
         atol: float,
         rtol: float,
-        tensor: Dict[str, np.array],
-        baseline: Dict[str, np.array],
+        tensor: dict[str, np.array],
+        baseline: dict[str, np.array],
     ):
         for key, arr in tensor.items():
             self.assertTrue(
@@ -179,8 +179,8 @@ class AutoScanTest(unittest.TestCase):
         raise NotImplementedError
 
     def generate_op_config(
-        self, ops_config: List[Dict[str, Any]]
-    ) -> List[OpConfig]:
+        self, ops_config: list[dict[str, Any]]
+    ) -> list[OpConfig]:
         ops = []
         for i in range(len(ops_config)):
             op_config = ops_config[i]
@@ -224,7 +224,7 @@ class AutoScanTest(unittest.TestCase):
     @abc.abstractmethod
     def create_inference_config(
         self,
-        passes: Optional[List[str]] = None,
+        passes: Optional[list[str]] = None,
         use_gpu: bool = False,
         use_mkldnn: bool = False,
         use_xpu: bool = False,
@@ -270,7 +270,7 @@ class MkldnnAutoScanTest(AutoScanTest):
                     "data": tensor_config.data,
                     "lod": tensor_config.lod,
                 }
-            results: List[Dict[str, np.ndarray]] = []
+            results: list[dict[str, np.ndarray]] = []
 
             # baseline: cpu no ir_optim run
             base_config = self.create_inference_config(ir_optim=False)
@@ -349,7 +349,7 @@ class PirMkldnnAutoScanTest(MkldnnAutoScanTest):
 
     def run_test_config(
         self, model, params, prog_config, pred_config, feed_data
-    ) -> Dict[str, np.ndarray]:
+    ) -> dict[str, np.ndarray]:
         """
         Test a single case.
         """
@@ -693,8 +693,8 @@ class TrtLayerAutoScanTest(AutoScanTest):
         self,
         atol: float,
         rtol: float,
-        tensor: Dict[str, np.array],
-        baseline: Dict[str, np.array],
+        tensor: dict[str, np.array],
+        baseline: dict[str, np.array],
     ):
         for key, arr in tensor.items():
             self.assertEqual(
@@ -900,7 +900,7 @@ class CutlassAutoScanTest(AutoScanTest):
                     'data': tensor_config.data,
                     'lod': tensor_config.lod,
                 }
-            results: List[Dict[str, np.ndarray]] = []
+            results: list[dict[str, np.ndarray]] = []
 
             # baseline: gpu no ir_optim run
             base_config = self.create_inference_config(

--- a/test/ir/inference/program_config.py
+++ b/test/ir/inference/program_config.py
@@ -15,7 +15,7 @@
 import copy
 import enum
 import os
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Optional
 
 import numpy as np
 
@@ -49,9 +49,9 @@ class TensorConfig:
 
     def __init__(
         self,
-        lod: Optional[List[List[int]]] = None,
+        lod: Optional[list[list[int]]] = None,
         data_gen: Optional[Callable[..., np.array]] = None,
-        shape: Optional[List[List[int]]] = None,
+        shape: Optional[list[list[int]]] = None,
     ):
         '''
         shape: The shape of the tensor.
@@ -93,11 +93,11 @@ class OpConfig:
     def __init__(
         self,
         type: str,
-        inputs: Dict[str, List[str]],
-        outputs: Dict[str, List[str]],
-        attrs: Dict[str, Any] = None,
-        outputs_var_type: Dict[str, VarType] = None,
-        outputs_dtype: Dict[str, np.dtype] = None,
+        inputs: dict[str, list[str]],
+        outputs: dict[str, list[str]],
+        attrs: dict[str, Any] = None,
+        outputs_var_type: dict[str, VarType] = None,
+        outputs_dtype: dict[str, np.dtype] = None,
         **kwargs,
     ):
         self.type = type
@@ -152,11 +152,11 @@ class BlockConfig:
 
     def __init__(
         self,
-        ops: List[OpConfig],
-        vars: List[str],
-        vars_dtype: Dict[str, np.dtype] = None,
-        vars_var_type: Dict[str, VarType] = None,
-        vars_lod_level: Dict[str, int] = None,
+        ops: list[OpConfig],
+        vars: list[str],
+        vars_dtype: dict[str, np.dtype] = None,
+        vars_var_type: dict[str, VarType] = None,
+        vars_lod_level: dict[str, int] = None,
     ):
         self.ops = ops
         self.vars = vars
@@ -248,17 +248,17 @@ class ProgramConfig:
     '''A config builder for generating a Program.
     input_type : (np.dtype, default=None), the inputs will be casted to input_type before
                 fed into TRT engine. If set to None, no casting will be performed.
-    no_cast_list : (List[str], default=None), specify the tensors that will skip the casting
+    no_cast_list : (list[str], default=None), specify the tensors that will skip the casting
     '''
 
     def __init__(
         self,
-        ops: List[OpConfig],
-        weights: Dict[str, TensorConfig],
-        inputs: Dict[str, TensorConfig],
-        outputs: List[str],
+        ops: list[OpConfig],
+        weights: dict[str, TensorConfig],
+        inputs: dict[str, TensorConfig],
+        outputs: list[str],
         input_type: Optional[np.dtype] = None,
-        no_cast_list: Optional[List[str]] = None,
+        no_cast_list: Optional[list[str]] = None,
     ):
         self.ops = ops
         # if no weight need to save, we create a place_holder to help serialize params.
@@ -306,7 +306,7 @@ class ProgramConfig:
 
         self.input_type = _type
 
-    def get_feed_data(self) -> Dict[str, Dict[str, Any]]:
+    def get_feed_data(self) -> dict[str, dict[str, Any]]:
         feed_data = {}
         for name, tensor_config in self.inputs.items():
             data = tensor_config.data

--- a/test/ir/inference/test_trt_convert_activation.py
+++ b/test/ir/inference/test_trt_convert_activation.py
@@ -14,7 +14,7 @@
 
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -32,7 +32,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input(attrs: List[Dict[str, Any]]):
+        def generate_input(attrs: list[dict[str, Any]]):
             if self.dims == 0:
                 return np.random.random([]).astype(np.float32)
             else:
@@ -114,7 +114,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> (paddle_infer.Config, list[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 0:
                 self.dynamic_shape.min_input_shape = {"input_data": []}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
修改了以下九个文件：
        modified:   test/auto_parallel/hybrid_strategy/semi_auto_parallel_llama_model.py
        modified:   test/deprecated/legacy_test/auto_parallel_op_test.py
        modified:   test/dygraph_to_static/test_dynamic_shape_infermeta.py
        modified:   test/dygraph_to_static/test_typehint.py
        modified:   test/dygraph_to_static/test_typing.py
        modified:   test/ipu/op_test_ipu.py
        modified:   test/ir/inference/auto_scan_test.py
        modified:   test/ir/inference/program_config.py
        modified:   test/ir/inference/test_trt_convert_activation.py
注：test/dygraph_to_static/check_approval.py报错为U036