### PR TITLE
[CodeStyle][Ruff][BUAA][B-[1-6]] Fix ruff `Q004` diagnostic for 6 files in `Paddle`

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_optimizer_stage2.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_optimizer_stage2.py
@@ -224,7 +224,7 @@ class GroupShardedOptimizerStage2(Optimizer):
         if offload:
             assert (
                 self._pfp16
-            ), "Only support offload strategy while using \'Adam\', \'AdamW\' and \'Momentum\' optimizer with AMP/Pure FP16"
+            ), "Only support offload strategy while using 'Adam', 'AdamW' and 'Momentum' optimizer with AMP/Pure FP16"
 
         self.offload = offload  # Using for offload
         self.offload_device = "cpu"

--- a/python/paddle/distributed/launch/controllers/ipu_controller.py
+++ b/python/paddle/distributed/launch/controllers/ipu_controller.py
@@ -126,7 +126,7 @@ class IPUController(CollectiveController):
             cur_endpoint = endpoints[idx // poprun_args.nproc_per_host]
             rank_in_node = idx % poprun_args.nproc_per_host
             poprun_command.append(
-                f'--instance-mpi-local-args={idx}:\"-x PADDLE_TRAINER_ID={idx} -x PADDLE_CURRENT_ENDPOINT={cur_endpoint} -x PADDLE_RANK_IN_NODE={rank_in_node}\"'
+                f'--instance-mpi-local-args={idx}:"-x PADDLE_TRAINER_ID={idx} -x PADDLE_CURRENT_ENDPOINT={cur_endpoint} -x PADDLE_RANK_IN_NODE={rank_in_node}"'
             )
 
         # executor

--- a/test/legacy_test/prim_op_test.py
+++ b/test/legacy_test/prim_op_test.py
@@ -303,7 +303,7 @@ class PrimForwardChecker:
     def init_checker(self):
         assert hasattr(
             self.op_test, 'prim_op_type'
-        ), "if you want to test comp op, please set prim_op_type with \'prim\' or \'comp\' in setUp function."
+        ), "if you want to test comp op, please set prim_op_type with 'prim' or 'comp' in setUp function."
         assert self.op_test.prim_op_type in [
             "comp",
             "prim",

--- a/test/legacy_test/test_run.py
+++ b/test/legacy_test/test_run.py
@@ -122,7 +122,7 @@ class Collective_Test(unittest.TestCase):
         config_path = os.path.join(config_dir.name, 'auto_parallel_config.json')
         with open(config_path, 'w') as wobj:
             wobj.write(
-                '{\"tuner_save_path\":\"parallel_strategy.pkl\",\"tuner_load_path\":\"parallel_strategy.pkl\",\"tuner_run_mode\":\"tuner_and_run\"}'
+                '{"tuner_save_path":"parallel_strategy.pkl","tuner_load_path":"parallel_strategy.pkl","tuner_run_mode":"tuner_and_run"}'
             )
         port = random.randrange(6000, 8000)
         args = "--job_id test4 --devices 0,1 --log_dir {} --auto_parallel_config {}"

--- a/tools/externalError/spider.py
+++ b/tools/externalError/spider.py
@@ -52,7 +52,7 @@ def parsing(externalErrorDesc):
             m_message = m_message.replace(list_a[idx], list_shape[idx])
 
         m_message = m_message.replace(
-            '<h6 class=\"deprecated_header\">Deprecated</h6>', ''
+            '<h6 class="deprecated_header">Deprecated</h6>', ''
         )
 
         res_span = r'(<span class=.*?</span>)'

--- a/tools/jetson_infer_op.py
+++ b/tools/jetson_infer_op.py
@@ -166,7 +166,7 @@ def set_diff_value(file, atol="1e-5", inplace_atol="1e-7"):
         + atol
         + ",inplace_atol="
         + inplace_atol
-        + ",/g\' "
+        + ",/g' "
         + file
     )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

修复如下文件 Q004 的 Ruff 规则：

- `python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_optimizer_stage2.py`
- `python/paddle/distributed/launch/controllers/ipu_controller.py`
- `test/legacy_test/prim_op_test.py`
- `test/legacy_test/test_run.py`
- `tools/externalError/spider.py`
- `tools/jetson_infer_op.py`


### Related Links

- #67116 

@gouzil 
