### PR TITLE
【pir】delete catch error of  verifysig in op create func

### DIFF
--- a/paddle/pir/src/core/operation.cc
+++ b/paddle/pir/src/core/operation.cc
@@ -129,12 +129,7 @@ Operation *Operation::Create(const std::vector<Value> &inputs,
   }
   // 0. Verify
   if (op_info) {
-    try {
-      op_info.VerifySig(op);
-    } catch (const common::enforce::EnforceNotMet &e) {
-      op->Destroy();
-      throw e;
-    }
+    op_info.VerifySig(op);
   }
   return op;
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] --> Execute Infrastructure 


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] --> Bug fixes


### Description
<!-- Describe what you’ve done -->
pcard-67164

由于catch verify 检查错误之后会直接destroy op 会使得报错不能表达真实的原因，因此删掉该逻辑