### PR TITLE
[CodeStyle] Enable Ruff `RUF017` and `Q004` rules and fix black regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,10 +92,14 @@ select = [
 
     # Ruff-specific rules
     "RUF010",
+    "RUF017",
     "RUF100",
 
     # Flake8-raise
     "RSE",
+
+    # Flake8-quotes
+    "Q004",
 ]
 unfixable = [
     "NPY001"

--- a/python/paddle/incubate/nn/layer/fused_ec_moe.py
+++ b/python/paddle/incubate/nn/layer/fused_ec_moe.py
@@ -72,6 +72,7 @@ class FusedEcMoe(Layer):
             >>> print(y.shape)
             [10, 128, 1024]
     """
+
     bmm_weight0: Tensor
     bmm_bias0: Tensor
     bmm_weight1: Tensor


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

PCard-66972

修复 black 升级后部分回归问题

启用 RUF017 和 Q004 rules

### Related links

- #67116

PCard-66972