### PR TITLE
[paddle.incubate.jit.inference] Allow bool type as function input

### DIFF
--- a/python/paddle/incubate/jit/inference_decorator.py
+++ b/python/paddle/incubate/jit/inference_decorator.py
@@ -18,6 +18,7 @@ import inspect
 import os
 import sys
 import textwrap
+import warnings
 from pathlib import Path
 from typing import Callable, Protocol, TypeVar, overload
 
@@ -54,6 +55,16 @@ def register_triton_custom_ops(model_dir):
                 )
 
 
+# When return True, we will fix them when doing d2s.
+def is_fixed_type(input):
+    if input is None:
+        return True
+    elif isinstance(input, bool):
+        return True
+    else:
+        return False
+
+
 # get paddle.Tensor for paddle inference use.
 def get_tensor(run_time_args, arg_name):
     if isinstance(run_time_args, paddle.Tensor):
@@ -66,8 +77,8 @@ def get_tensor(run_time_args, arg_name):
             ), f"the elements in {arg_name} must be paddle.Tensor"
             this_input_tensor_lists.append(ele)
         return this_input_tensor_lists
-    elif run_time_args is None:
-        return [None]
+    elif is_fixed_type(run_time_args):
+        return [run_time_args]
     else:
         raise AssertionError(
             f'''we only support adding paddle.incubate.jit.inference() in functions whose arguments are paddle.Tensor or list[paddle.Tensor] or None,
@@ -89,9 +100,8 @@ def get_d2s_spec(run_time_args, name):
             )
             suffix += 1
         return this_input_spec
-    elif run_time_args is None:
-        # we need to add a None input_spec!
-        return None
+    elif is_fixed_type(run_time_args):
+        return run_time_args
 
 
 class InferenceEngine:
@@ -175,15 +185,15 @@ class InferenceEngine:
         # initiate the d2s_input_shapes.
         if len(d2s_input_shapes) == 0:
             for tensor in input_tensor_lists:
-                if tensor is None:
+                if is_fixed_type(tensor):
                     d2s_input_shapes.append([])
                 else:
+                    assert isinstance(tensor, paddle.Tensor)
                     d2s_input_shapes.append(tensor.shape)
-
         self.re_do_d2s = False
         # check whether the shape is changed
         for i in range(len(d2s_input_shapes)):
-            if input_tensor_lists[i] is None:
+            if is_fixed_type(input_tensor_lists[i]):
                 continue
             # The rank of this tensor has changed
             if len(d2s_input_shapes[i]) != len(input_tensor_lists[i].shape):
@@ -240,19 +250,15 @@ class InferenceEngine:
                 input_specs.append(get_d2s_spec(this_input, name=arg_names[i]))
             else:
                 this_input = arg_defaults[i]
-                if this_input is not None:
-                    raise ValueError(
-                        f"{arg_names[i]}'s default value must be None."
-                    )
-                input_specs.append(None)
+                assert is_fixed_type(this_input)
+                input_specs.append(this_input)
 
         for i in range(len(input_specs)):
-            if input_specs[i] is not None:
-                if isinstance(input_specs[i], list):
-                    for j in range(len(input_specs[i])):
-                        input_specs[i][j].stop_gradient = True
-                else:
-                    input_specs[i].stop_gradient = True
+            if isinstance(input_specs[i], list):
+                for j in range(len(input_specs[i])):
+                    input_specs[i][j].stop_gradient = True
+            elif isinstance(input_specs[i], paddle.static.InputSpec):
+                input_specs[i].stop_gradient = True
 
         # update the input_spec's shape for doing d2s
         d2s_shapes_id = 0
@@ -271,7 +277,7 @@ class InferenceEngine:
                 input_specs[i].shape = self.d2s_input_shapes[d2s_shapes_id]
                 self.d2s_input_names[d2s_shapes_id] = input_specs[i].name
                 d2s_shapes_id += 1
-            elif input_specs[i] is None:
+            else:
                 if self.used_as_at_decorator:
                     self.d2s_input_names[d2s_shapes_id] = arg_names[i + 1]
                 else:
@@ -332,10 +338,6 @@ class InferenceEngine:
                 collected_names.append(arg_names[i])
             else:
                 this_input = arg_defaults[i]
-                if this_input is not None:
-                    raise ValueError(
-                        f"{arg_names[i]}'s default value must be None."
-                    )
                 input_tensor_lists += [this_input]
                 collected_names.append(arg_names[i])
 
@@ -387,7 +389,7 @@ class InferenceEngine:
                 )
             else:
                 for i in range(len(input_tensor_lists)):
-                    if input_tensor_lists[i] is not None:
+                    if not is_fixed_type(input_tensor_lists[i]):
                         min_input_shape[self.d2s_input_names[i]] = (
                             input_tensor_lists[i].shape
                         )
@@ -415,6 +417,13 @@ class InferenceEngine:
 
         for pass_name in self.delete_pass_lists:
             config.delete_pass(pass_name)
+
+        for i in range(len(input_tensor_lists)):
+            if is_fixed_type(input_tensor_lists[i]):
+                warnings.warn(
+                    f"{self.d2s_input_names[i]} is fixed."
+                    + "You must ensure that this value will not change during your program."
+                )
 
         self.predictor = create_predictor(config)
 
@@ -608,7 +617,7 @@ def inference(
             infer_engine.check_and_update_d2s_input_shapes(input_tensor_lists)
 
             remove_non_input_tensor_lists = [
-                ele for ele in input_tensor_lists if ele is not None
+                ele for ele in input_tensor_lists if not is_fixed_type(ele)
             ]
 
             if (


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

Pcard-71500

paddle.incubate.jit.inference 支持 bool类型输入，但是他的值是不能变化的，也就是说第一次函数调用的时候是啥，之后就全部必须是啥

- 目前这个接口支持的value可变的输入类型是Paddle.Tensor和list[Paddle.Tensor]
- 支持的值不可辨的类型是NoneType和Bool
- 之后继续支持更多的类型！