### PR TITLE
[CodeStyle] Enable Ruff `RUF013` and `RUF019` rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,9 @@ select = [
 
     # Ruff-specific rules
     "RUF010",
+    "RUF013",
     "RUF017",
+    "RUF019",
     "RUF100",
 
     # Flake8-raise


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

PCard-66972

启用 RUF013 和 RUF019 rules

### Related links

- #67116

PCard-66972