### PR TITLE
[CodeStyle][Ruff][BUAA][F-[1-10]] Fix ruff `FURB` diagnostic for 10 files in `python/paddle/{amp, distributed, happy, incubate}`

### DIFF
--- a/python/paddle/amp/accuracy_compare.py
+++ b/python/paddle/amp/accuracy_compare.py
@@ -696,5 +696,5 @@ def compare_accuracy(
 
     print(f"-- Write to {output_filename}")
 
-    print("")
+    print()
     excel_writer.close()

--- a/python/paddle/distributed/auto_parallel/static/cost/base_cost.py
+++ b/python/paddle/distributed/auto_parallel/static/cost/base_cost.py
@@ -590,9 +590,7 @@ class CommContext:
                     backward_order_beta = self.cluster.get_beta(
                         ranks[j], ranks[i]
                     )
-                    beta = (
-                        max(backward_order_beta, forward_order_beta)
-                    )
+                    beta = max(backward_order_beta, forward_order_beta)
                     if max_beta is None:
                         max_beta = beta
                     else:

--- a/python/paddle/distributed/auto_parallel/static/cost/base_cost.py
+++ b/python/paddle/distributed/auto_parallel/static/cost/base_cost.py
@@ -591,9 +591,7 @@ class CommContext:
                         ranks[j], ranks[i]
                     )
                     beta = (
-                        forward_order_beta
-                        if forward_order_beta > backward_order_beta
-                        else backward_order_beta
+                        max(backward_order_beta, forward_order_beta)
                     )
                     if max_beta is None:
                         max_beta = beta

--- a/python/paddle/distributed/auto_parallel/static/parallelizer.py
+++ b/python/paddle/distributed/auto_parallel/static/parallelizer.py
@@ -334,7 +334,7 @@ class AutoParallelizer:
             # serialize the dist context by planner
             if dist_context is not None:
                 logging.info("Start serialize searched dist attr")
-                cwd = pathlib.Path().resolve()
+                cwd = pathlib.Path().cwd()
                 searched_dist_context_path = os.path.join(
                     cwd, f"searched_dist_context_{time.time()}.pkl"
                 )

--- a/python/paddle/distributed/auto_parallel/static/tuner/rule_based_tuner.py
+++ b/python/paddle/distributed/auto_parallel/static/tuner/rule_based_tuner.py
@@ -819,7 +819,7 @@ class OperatorClusteringUtil:
         for i in range(1, len(seq)):
             x = seq[suffixes[i - 1] :]
             y = seq[suffixes[i] :]
-            max_len = len(x) if len(x) > len(y) else len(y)
+            max_len = max(len(y), len(x))
             same_count = 0
             for j in range(max_len):
                 if j >= len(x) or j >= len(y):
@@ -2380,9 +2380,7 @@ class RuleBasedTuner:
                         )
                         cost, _ = self._get_sub_program_cost(dist_context)
                         max_stage_cost = (
-                            min_max_stage_costs[s - 1][j]
-                            if local_stage_cost < min_max_stage_costs[s - 1][j]
-                            else local_stage_cost
+                            max(local_stage_cost, min_max_stage_costs[s - 1][j])
                         )
 
                         if cost <= min_cost:
@@ -2487,9 +2485,7 @@ class RuleBasedTuner:
                         memory_strategies[s][i][j] = memory
 
                         max_stage_cost = (
-                            min_max_stage_costs[s - 1][j]
-                            if local_stage_cost < min_max_stage_costs[s - 1][j]
-                            else local_stage_cost
+                            max(local_stage_cost, min_max_stage_costs[s - 1][j])
                         )
                         if memory > sum(max_mem):
                             cost = sys.maxsize

--- a/python/paddle/distributed/auto_parallel/static/tuner/rule_based_tuner.py
+++ b/python/paddle/distributed/auto_parallel/static/tuner/rule_based_tuner.py
@@ -2379,8 +2379,8 @@ class RuleBasedTuner:
                             ]
                         )
                         cost, _ = self._get_sub_program_cost(dist_context)
-                        max_stage_cost = (
-                            max(local_stage_cost, min_max_stage_costs[s - 1][j])
+                        max_stage_cost = max(
+                            local_stage_cost, min_max_stage_costs[s - 1][j]
                         )
 
                         if cost <= min_cost:
@@ -2484,8 +2484,8 @@ class RuleBasedTuner:
                         cost_strategies[s][i][j] = cost
                         memory_strategies[s][i][j] = memory
 
-                        max_stage_cost = (
-                            max(local_stage_cost, min_max_stage_costs[s - 1][j])
+                        max_stage_cost = max(
+                            local_stage_cost, min_max_stage_costs[s - 1][j]
                         )
                         if memory > sum(max_mem):
                             cost = sys.maxsize

--- a/python/paddle/distributed/fleet/elastic/manager.py
+++ b/python/paddle/distributed/fleet/elastic/manager.py
@@ -386,7 +386,7 @@ class ElasticManager:
             min_np = int(np_dict[0])
             max_np = int(np_dict[1])
             min_np = 1 if min_np <= 0 else min_np
-            max_np = min_np if min_np > max_np else max_np
+            max_np = max(max_np, min_np)
         else:
             raise ValueError(
                 f'the np={np} needs to be in "MIN" or "MIN:MAX" format'

--- a/python/paddle/distributed/fleet/launch.py
+++ b/python/paddle/distributed/fleet/launch.py
@@ -352,7 +352,7 @@ def get_cluster_info(args):
             os.environ["PADDLE_ENABLE_ELASTIC"] = str(
                 enable_elastic(args, device_mode)
             )
-            cwd = pathlib.Path().resolve()
+            cwd = pathlib.Path().cwd()
             rank_mapping_path = os.path.join(
                 cwd, "auto_parallel_rank_mapping.json"
             )

--- a/python/paddle/hapi/progressbar.py
+++ b/python/paddle/hapi/progressbar.py
@@ -38,7 +38,7 @@ class ProgressBar:
         if isinstance(num, int) and num <= 0:
             raise TypeError('num should be None or integer (> 0)')
         max_width = self._get_max_width()
-        self._width = width if width <= max_width else max_width
+        self._width = min(width, max_width)
         self._total_width = 0
         self._verbose = verbose
         self.file = file

--- a/python/paddle/incubate/autograd/generate_op_map.py
+++ b/python/paddle/incubate/autograd/generate_op_map.py
@@ -61,7 +61,7 @@ def generate_code(
     dct = {}
     map_dct = {}
     for op_path in [ops_yaml_path, ops_legacy_yaml_path]:
-        pattern = re.compile(r'[(](.*)[)]', re.S)
+        pattern = re.compile(r'[(](.*)[)]', re.DOTALL)
         with open(op_path, "rt") as f:
             ops = yaml.safe_load(f)
             for item in ops:

--- a/python/paddle/incubate/distributed/utils/io/save_for_auto.py
+++ b/python/paddle/incubate/distributed/utils/io/save_for_auto.py
@@ -167,7 +167,7 @@ def _save_param_attr(state_dict_, path, dims_mapping_dict=None):
 
     # Why condition 'pp_rank < 0' exists?
     # Because if pp_degree = 1, pp_rank is set -1
-    pp_rank = 0 if pp_rank <= 0 else pp_rank
+    pp_rank = max(0, pp_rank)
 
     if dist.get_world_size() > 1:
         process_group = _get_all_ranks_of_pp(

--- a/python/paddle/incubate/jit/inference_decorator.py
+++ b/python/paddle/incubate/jit/inference_decorator.py
@@ -154,7 +154,7 @@ class InferenceEngine:
         # get old d2s shapes!
         if os.path.exists(d2s_input_info_path) and self.cache_static_model:
             with open(d2s_input_info_path, "r") as f:
-                for line in f.readlines():
+                for line in f:
                     line = line.strip()
                     name_shape = line.split(":")
                     assert len(name_shape) == 2


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
修改了10个文件：
        modified:   python/paddle/amp/accuracy_compare.py
        modified:   python/paddle/distributed/auto_parallel/static/cost/base_cost.py
        modified:   python/paddle/distributed/auto_parallel/static/parallelizer.py
        modified:   python/paddle/distributed/auto_parallel/static/tuner/rule_based_tuner.py
        modified:   python/paddle/distributed/fleet/elastic/manager.py
        modified:   python/paddle/distributed/fleet/launch.py
        modified:   python/paddle/hapi/progressbar.py
        modified:   python/paddle/incubate/autograd/generate_op_map.py
        modified:   python/paddle/incubate/distributed/utils/io/save_for_auto.py
        modified:   python/paddle/incubate/jit/inference_decorator.py