### PR TITLE
[PIR] Skip verify when operation clone

### DIFF
--- a/paddle/pir/include/core/operation.h
+++ b/paddle/pir/include/core/operation.h
@@ -77,7 +77,8 @@ class IR_API alignas(8) Operation final
                            const std::vector<pir::Type> &output_types,
                            pir::OpInfo op_info,
                            size_t num_regions = 0,
-                           const std::vector<Block *> &successors = {});
+                           const std::vector<Block *> &successors = {},
+                           bool verify = true);
   static Operation *Create(OperationArgument &&op_argument);
 
   ///

--- a/paddle/pir/src/core/operation.cc
+++ b/paddle/pir/src/core/operation.cc
@@ -56,7 +56,8 @@ Operation *Operation::Create(const std::vector<Value> &inputs,
                              const std::vector<Type> &output_types,
                              pir::OpInfo op_info,
                              size_t num_regions,
-                             const std::vector<Block *> &successors) {
+                             const std::vector<Block *> &successors,
+                             bool verify) {
   // 1. Calculate the required memory size for OpResults + Operation +
   // OpOperands.
   uint32_t num_results = output_types.size();
@@ -128,7 +129,7 @@ Operation *Operation::Create(const std::vector<Value> &inputs,
     }
   }
   // 0. Verify
-  if (op_info) {
+  if (verify && op_info) {
     try {
       op_info.VerifySig(op);
     } catch (const common::enforce::EnforceNotMet &e) {
@@ -159,8 +160,13 @@ Operation *Operation::Clone(IrMapping &ir_mapping, CloneOptions options) const {
       successors.push_back(ir_mapping.Lookup(successor(i)));
     }
   }
-  auto *new_op = Create(
-      inputs, attributes_, output_types, info_, num_regions_, successors);
+  auto *new_op = Create(inputs,
+                        attributes_,
+                        output_types,
+                        info_,
+                        num_regions_,
+                        successors,
+                        false);
   ir_mapping.Add(this, new_op);
 
   // record outputs mapping info


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

跳过 Operation clone 时的 verify 行为，clone 时候不需要 verify

虽然我们创建 OP 时候已经跑过一次 verify，但创建之后是可能发生修改的，就比如 while OP 如果输入输出其中有一个是动态 shape，就会修改另一个不是动态 shape 的，就会影响这个被修改的 Value 的相关 OP，比如 CombineOp

Pcard-67164