### PR TITLE
[XPU] do not use null stream when CDNN_CLUSTER_PARALLEL is ON

### DIFF
--- a/paddle/phi/core/memory/allocation/allocator_facade.cc
+++ b/paddle/phi/core/memory/allocation/allocator_facade.cc
@@ -1893,6 +1893,12 @@ const std::shared_ptr<Allocator>& AllocatorFacade::GetAllocator(
   }
   return m->GetAllocator(place, /* A non-zero num to choose allocator_ */ 1);
 }
+void AllocatorFacade::SetDefaultStream(const phi::XPUPlace& place,
+                                       XPUStream stream) {
+  if (m_->IsStreamSafeCUDAAllocatorUsed()) {
+    m_->SetDefaultStream(place, stream);
+  }
+}
 #endif
 
 #ifdef PADDLE_WITH_CUSTOM_DEVICE

--- a/paddle/phi/core/memory/allocation/allocator_facade.h
+++ b/paddle/phi/core/memory/allocation/allocator_facade.h
@@ -97,6 +97,7 @@ class AllocatorFacade {
 #elif defined(PADDLE_WITH_XPU)
   TEST_API const std::shared_ptr<Allocator>& GetAllocator(
       const phi::Place& place, XPUStream stream);
+  void SetDefaultStream(const phi::XPUPlace& place, XPUStream stream);
 #endif
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
 Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
1. Do not use null stream when CDNN Cluster Parallel is ON.
框架中的`dev_ctx.Alloc`调用使用默认流(null)的allocator，然而，XPU开启CDNN cluster并行之后，实际使用的是新创建的stream，而非null stream。这会导致框架的`dev_ctx.Alloc`和重载的XHPC中的alloc使用不同的显存池，如下图所示。由于CDNN_CLUSTER并行开启后，null stream实际上并未使用，所以该问题不会影响精度。
<img width="1207" alt="a8694cd33e3056be1127c8e2c09dc766" src="https://github.com/user-attachments/assets/7be4af81-82f4-49f9-bb18-231c92d71c77">
本PR将XPU行为对齐GPU，在创建`XPUContext`及对应`XPUStream`时，设置`AllocatorFacade`的默认Stream，从而使所有`dev_ctx.Alloc`使用和XHPCBufferManager相同的stream，如下图所示：
<img width="1199" alt="35e3b0caf8693e8a3bdb308f2a81aa2f" src="https://github.com/user-attachments/assets/c9d0fb37-8835-4068-bcf4-88e2352da075">
