### PR TITLE
[Operator] fix benchmark bug

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -3631,7 +3631,20 @@ struct Reshape2GradOpTranscriber : public OpTranscriber {
                       true,
                       common::errors::InvalidArgument(
                           "Reshape2_Grad op does not have input Out@GRAD"));
-    auto& input_outgrad_value = param_map->at(input_outgrad_name).value;
+    auto input_outgrad_value_info = param_map->at(input_outgrad_name);
+    if (input_outgrad_value_info.generated_by_vector) {
+      InsertSliceOperationForTarget(
+          ctx, param_map, block, input_outgrad_value_info, input_outgrad_name);
+      input_outgrad_value_info = param_map->at(input_outgrad_name);
+    }
+    pir::Value input_outgrad_value = input_outgrad_value_info.value;
+
+    PADDLE_ENFORCE_EQ(
+        input_outgrad_value.type().isa<paddle::dialect::DenseTensorType>(),
+        true,
+        ::common::errors::InvalidArgument(
+            "input type must be DenseTensorType, but received: %s.",
+            input_outgrad_value.type()));
 
     dialect::ReshapeGradOp reshape_grad_op =
         builder.Build<dialect::ReshapeGradOp>(xshape_value,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
修复PR 66089导致PaddleSeg_segformer_b0 动转静训练报错的问题
为reshape_grad op translator 添加对 VectorType 的处理