### PR TITLE
[Fix] 修复 numpy 2.0 版本转 list 后 print 行为不一致

### DIFF
--- a/python/paddle/hapi/dynamic_flops.py
+++ b/python/paddle/hapi/dynamic_flops.py
@@ -295,8 +295,8 @@ def dynamic_flops(model, inputs, custom_ops=None, print_detail=False):
             table.add_row(
                 [
                     m.full_name(),
-                    list(m.input_shape.numpy()),
-                    list(m.output_shape.numpy()),
+                    m.input_shape.numpy().tolist(),
+                    m.output_shape.numpy().tolist(),
                     int(m.total_params),
                     int(m.total_ops),
                 ]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
numpy 2.0 版本后，对于转为 list 后的 print 行为不一致，如，numpy 1.0 版本：

``` python
In [85]: import numpy as np

In [86]: a = np.random.randint(10, size=5)

In [87]: print(list(a))
[9, 1, 8, 9, 2]

In [88]: print(a.tolist())
[9, 1, 8, 9, 2]

In [89]: np.__version__
Out[89]: '1.24.4'

```

numpy 2.0 版本：

``` python
In [13]: import numpy as np

In [14]: a = np.random.randint(10, size=5)

In [15]: print(list(a))
[np.int64(6), np.int64(4), np.int64(4), np.int64(1), np.int64(2)]

In [16]: print(a.tolist())
[6, 4, 4, 1, 2]

In [18]: np.__version__
Out[18]: '2.0.1'

```

从而导致 `paddle.flops` 的输出不一致，如 numpy 2.0 版本中

``` python
++--------------+---------------------------------------------------------+---------------------------------------------------------+--------+--------+
+|  Layer Name  |                       Input Shape                       |                       Output Shape                      | Params | Flops  |
++--------------+---------------------------------------------------------+---------------------------------------------------------+--------+--------+
+|   conv2d_0   |  [np.int64(1), np.int64(1), np.int64(28), np.int64(28)] |  [np.int64(1), np.int64(6), np.int64(28), np.int64(28)] |   60   | 47040  |
+|   re_lu_0    |  [np.int64(1), np.int64(6), np.int64(28), np.int64(28)] |  [np.int64(1), np.int64(6), np.int64(28), np.int64(28)] |   0    |   0    |
+| max_pool2d_0 |  [np.int64(1), np.int64(6), np.int64(28), np.int64(28)] |  [np.int64(1), np.int64(6), np.int64(14), np.int64(14)] |   0    |   0    |
+|   conv2d_1   |  [np.int64(1), np.int64(6), np.int64(14), np.int64(14)] | [np.int64(1), np.int64(16), np.int64(10), np.int64(10)] |  2416  | 241600 |
+|   re_lu_1    | [np.int64(1), np.int64(16), np.int64(10), np.int64(10)] | [np.int64(1), np.int64(16), np.int64(10), np.int64(10)] |   0    |   0    |
+| max_pool2d_1 | [np.int64(1), np.int64(16), np.int64(10), np.int64(10)] |  [np.int64(1), np.int64(16), np.int64(5), np.int64(5)]  |   0    |   0    |
+|   linear_0   |               [np.int64(1), np.int64(400)]              |               [np.int64(1), np.int64(120)]              | 48120  | 48000  |
+|   linear_1   |               [np.int64(1), np.int64(120)]              |               [np.int64(1), np.int64(84)]               | 10164  | 10080  |
+|   linear_2   |               [np.int64(1), np.int64(84)]               |               [np.int64(1), np.int64(10)]               |  850   |  840   |
++--------------+---------------------------------------------------------+---------------------------------------------------------+--------+--------+
 Total Flops: 347560     Total Params: 61610
```

@SigureMo 
