### PR TITLE
[CodeStyle] Enable Ruff `FURB` and some `RUF` rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,17 +91,30 @@ select = [
     "TCH",
 
     # Ruff-specific rules
+    # "RUF005",
+    "RUF008",
+    "RUF009",
     "RUF010",
     "RUF013",
+    # "RUF015",
+    "RUF016",
     "RUF017",
+    "RUF018",
     "RUF019",
+    "RUF020",
+    "RUF024",
+    "RUF026",
     "RUF100",
 
     # Flake8-raise
     "RSE",
 
     # Flake8-quotes
+    # "Q003",
     "Q004",
+
+    # Refurb
+    "FURB",
 ]
 unfixable = [
     "NPY001"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

PCard-66972

及时启用 `RUFB` rule 以免回归，不过需要等相关 PR 都合入

部分比较有用且能直接开启的 `RUF` rules 直接启用，部分待启用的使用注释的方式暂时注释掉

另外 `RUF022`[^1] 不错，可以考虑引入，只可惜目前还是 preview 的

### Related links

- #67116

PCard-66972

[^1]: https://docs.astral.sh/ruff/rules/unsorted-dunder-all/