### PR TITLE
[CodeStyle][Ruff] Enable and fix `FA` rule to force to use PEP 563

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,9 @@ select = [
 
     # Refurb
     "FURB",
+
+    # Flake8-future-annotations
+    "FA",
 ]
 unfixable = [
     "NPY001"

--- a/python/paddle/cinn/runtime/cinn_jit.py
+++ b/python/paddle/cinn/runtime/cinn_jit.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 import ast
 import functools
 import inspect
 import textwrap
-from typing import Callable, Generic, Optional, TypeVar, Union, cast
+from typing import Callable, Generic, TypeVar, cast
 
 from .utils import inspect_function_scope
 
@@ -103,9 +104,7 @@ def {self.fn.__name__}({jit_input_args}, target=cinn.common.DefaultHostTarget())
         return str(self.convert_to_llir())
 
 
-def to_cinn_llir(
-    fn: Optional[T] = None,
-) -> Union[CinnLowerLevelIrJit[T]]:
+def to_cinn_llir(fn: T | None = None) -> CinnLowerLevelIrJit[T]:
     def decorator(fn: T) -> CinnLowerLevelIrJit[T]:
         return CinnLowerLevelIrJit(fn)
 

--- a/python/paddle/inference/wrapper.py
+++ b/python/paddle/inference/wrapper.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
 import os
-from typing import Set
 
 import numpy as np
 
@@ -84,7 +85,7 @@ def convert_to_mixed_precision(
     mixed_precision: PrecisionType,
     backend: PlaceType,
     keep_io_types: bool = True,
-    black_list: Set[str] = set(),
+    black_list: set[str] = set(),
     **kwargs,
 ):
     '''

--- a/test/ir/inference/test_trt_convert_isnan_v2.py
+++ b/test/ir/inference/test_trt_convert_isnan_v2.py
@@ -12,16 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import unittest
 from functools import partial
-from typing import List
+from typing import TYPE_CHECKING
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
 from trt_layer_auto_scan_test import TrtLayerAutoScanTest
 
 import paddle.inference as paddle_infer
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class TrtConvertIsnanV2Test(TrtLayerAutoScanTest):
@@ -86,9 +91,13 @@ class TrtConvertIsnanV2Test(TrtLayerAutoScanTest):
 
             yield program_config
 
-    def sample_predictor_configs(
-        self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    def sample_predictor_configs(self, program_config) -> Generator[
+        tuple[
+            paddle_infer.Config, tuple[int, int], tuple[float, float] | float
+        ],
+        None,
+        None,
+    ]:
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}

--- a/test/legacy_test/test_logcumsumexp_op.py
+++ b/test/legacy_test/test_logcumsumexp_op.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import unittest
-from typing import Optional
 
 import numpy as np
 from op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
@@ -25,14 +26,14 @@ from paddle.base import core
 from paddle.pir_utils import test_with_pir_api
 
 
-def np_naive_logcumsumexp(x: np.ndarray, axis: Optional[int] = None):
+def np_naive_logcumsumexp(x: np.ndarray, axis: int | None = None):
     return np.log(np.cumsum(np.exp(x), axis=axis))
 
 
 def np_logcumsumexp(
     x: np.ndarray,
-    axis: Optional[int] = None,
-    flatten: Optional[bool] = None,
+    axis: int | None = None,
+    flatten: bool | None = None,
     reverse: bool = False,
     exclusive: bool = False,
 ):
@@ -71,8 +72,8 @@ def np_logcumsumexp(
 def np_logcumsumexp_grad(
     x: np.ndarray,
     dout: np.ndarray,
-    axis: Optional[int] = None,
-    flatten: Optional[bool] = None,
+    axis: int | None = None,
+    flatten: bool | None = None,
     reverse: bool = False,
     exclusive: bool = False,
 ):
@@ -252,7 +253,7 @@ class BaseTestCases:
                     np_logcumsumexp_grad(
                         self.inputs['X'],
                         1 / self.inputs['X'].size,
-                        **self.attrs
+                        **self.attrs,
                     )
                 ],
                 check_pir=True,

--- a/test/legacy_test/test_nan_to_num_op.py
+++ b/test/legacy_test/test_nan_to_num_op.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
-from typing import Optional
 
 import numpy as np
 
@@ -27,8 +28,8 @@ from paddle.pir_utils import test_with_pir_api
 def np_nan_to_num(
     x: np.ndarray,
     nan: float = 0.0,
-    posinf: Optional[float] = None,
-    neginf: Optional[float] = None,
+    posinf: float | None = None,
+    neginf: float | None = None,
 ) -> np.ndarray:
     return np.nan_to_num(x, True, nan=nan, posinf=posinf, neginf=neginf)
 

--- a/test/tokenizer/tokenizer_utils.py
+++ b/test/tokenizer/tokenizer_utils.py
@@ -14,12 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import copy
 import json
 import os
 import unicodedata
 from shutil import copyfile
-from typing import Optional
 
 from paddle.dataset.common import DATA_HOME
 from paddle.utils.download import get_path_from_url
@@ -190,7 +191,7 @@ class PretrainedTokenizer:
         self,
         text,
         text_pair=None,
-        max_seq_len: Optional[int] = None,
+        max_seq_len: int | None = None,
         stride=0,
         is_split_into_words=False,
         pad_to_max_seq_len=False,
@@ -409,7 +410,7 @@ class PretrainedTokenizer:
         """
         Converts a sequence of tokens into ids using the `vocab` attribute (an
         instance of `Vocab`). Override it if needed.
-        Args：
+        Args:
             tokens (list[int]): List of token ids.
         Returns:
             list: Converted id list.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

新增 rule `FA`[^1] 用于强制启用 PEP 563

PCard-66972

[^1]: https://docs.astral.sh/ruff/rules/#flake8-future-annotations-fa