### PR TITLE
[PHI] Cleanup deprecated `is_initialized` usage

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_func.h
+++ b/paddle/fluid/eager/to_static/run_program_op_func.h
@@ -138,7 +138,7 @@ static std::vector<paddle::Tensor> Trans2ContiguousTensors(
     const std::vector<paddle::Tensor>& tensors) {
   std::vector<paddle::Tensor> res;
   for (const auto& t : tensors) {
-    if (t.is_initialized() && t.is_dense_tensor() &&
+    if (t.initialized() && t.is_dense_tensor() &&
         !std::dynamic_pointer_cast<phi::DenseTensor>(t.impl())
              ->meta()
              .is_contiguous()) {

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -50,7 +50,7 @@ static void Trans2ContiguousTensorsInplace(
     const std::vector<paddle::Tensor> &tensors) {
   std::vector<Tensor> res;
   for (auto &t : tensors) {
-    if (t.is_initialized() && t.is_dense_tensor() &&
+    if (t.initialized() && t.is_dense_tensor() &&
         !std::dynamic_pointer_cast<phi::DenseTensor>(t.impl())
              ->meta()
              .is_contiguous()) {

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -832,7 +832,7 @@ std::string EagerUtils::TensorStr(const paddle::Tensor& t) {
                                              GradNodeStr(t),
                                              ad_meta->StopGradient());
       auto* data_ptr = dynamic_cast<phi::DenseTensor*>(t.impl().get());
-      if (t.is_initialized() && data_ptr) {
+      if (t.initialized() && data_ptr) {
         return paddle::string::Sprintf(TENSOR_PRINT_TEMPLATE,
                                        tensor_name_str,
                                        t.initialized(),
@@ -851,7 +851,7 @@ std::string EagerUtils::TensorStr(const paddle::Tensor& t) {
       }
     } else {
       auto* data_ptr = dynamic_cast<phi::DenseTensor*>(t.impl().get());
-      if (t.is_initialized() && data_ptr) {
+      if (t.initialized() && data_ptr) {
         return paddle::string::Sprintf(TENSOR_PRINT_TEMPLATE,
                                        tensor_name_str,
                                        t.initialized(),

--- a/paddle/phi/api/ext/op_meta_info.h
+++ b/paddle/phi/api/ext/op_meta_info.h
@@ -231,7 +231,7 @@ struct KernelFuncImpl<Return (*)(Args...), impl_fn> {
     static void Compute(CustomOpKernelContext* ctx, PreviousArgs&... pargs) {
       auto& range = ctx->InputRangeAt(in_idx);
       auto& arg = ctx->InputAt(range.first);
-      if (!arg.is_initialized()) {
+      if (!arg.initialized()) {
         ComputeCallHelper<Tail...>::
             template Compute<in_idx + 1, attr_idx, out_idx>(
                 ctx, pargs..., paddle::none);
@@ -294,7 +294,7 @@ struct KernelFuncImpl<Return (*)(Args...), impl_fn> {
     static void Compute(CustomOpKernelContext* ctx, PreviousArgs&... pargs) {
       auto& range = ctx->InputRangeAt(in_idx);
       auto arg = ctx->InputsBetween(range.first, range.second);
-      if (arg.empty() || !arg[0].is_initialized()) {
+      if (arg.empty() || !arg[0].initialized()) {
         ComputeCallHelper<Tail...>::
             template Compute<in_idx + 1, attr_idx, out_idx>(
                 ctx, pargs..., paddle::none);

--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -170,7 +170,7 @@ std::vector<Tensor>* CustomOpKernelContext::AllMutableInput() {
 
 paddle::optional<Tensor> CustomOpKernelContext::OptionalInputAt(
     size_t idx) const {
-  if (!inputs_.at(idx).is_initialized()) {
+  if (!inputs_.at(idx).initialized()) {
     return paddle::none;
   }
   return paddle::make_optional<paddle::Tensor>(inputs_.at(idx));
@@ -180,7 +180,7 @@ paddle::optional<std::vector<Tensor>>
 CustomOpKernelContext::OptionalInputsBetween(size_t start, size_t end) const {
   std::vector<Tensor> rlt;
   for (size_t i = start; i < end; ++i) {
-    if (!inputs_.at(i).is_initialized()) {
+    if (!inputs_.at(i).initialized()) {
       return paddle::none;
     }
     rlt.emplace_back(inputs_.at(i));

--- a/test/cpp/phi/api/test_phi_tensor.cc
+++ b/test/cpp/phi/api/test_phi_tensor.cc
@@ -340,11 +340,11 @@ void GroupTestDtype() {
 
 void TestInitialized() {
   auto test_tensor = paddle::experimental::empty({1, 1});
-  PADDLE_ENFORCE_EQ(test_tensor.is_initialized(),
+  PADDLE_ENFORCE_EQ(test_tensor.initialized(),
                     true,
                     common::errors::InvalidArgument(
                         "test_tensor should be initialized, but got %s",
-                        test_tensor.is_initialized()));
+                        test_tensor.initialized()));
   float* tensor_data = test_tensor.data<float>();
   for (int i = 0; i < test_tensor.size(); i++) {
     tensor_data[i] = 0.5;
@@ -363,11 +363,11 @@ void TestInitialized() {
 void TestDataInterface() {
   // Test DenseTensor
   auto test_tensor = paddle::experimental::empty({1, 1});
-  PADDLE_ENFORCE_EQ(test_tensor.is_initialized(),
+  PADDLE_ENFORCE_EQ(test_tensor.initialized(),
                     true,
                     common::errors::InvalidArgument(
                         "test_tensor should be initialized, but got %s",
-                        test_tensor.is_initialized()));
+                        test_tensor.initialized()));
   void* tensor_ptr = test_tensor.data();
   PADDLE_ENFORCE_NE(
       tensor_ptr,
@@ -389,11 +389,11 @@ void TestDataInterface() {
   selected_rows->mutable_value()->mutable_data<float>(phi::CPUPlace())[0] =
       static_cast<float>(10.0f);
   paddle::Tensor sr_tensor = paddle::Tensor(selected_rows);
-  PADDLE_ENFORCE_EQ(sr_tensor.is_initialized(),
+  PADDLE_ENFORCE_EQ(sr_tensor.initialized(),
                     true,
                     common::errors::InvalidArgument(
                         "sr_tensor should be initialized, but got %s",
-                        sr_tensor.is_initialized()));
+                        sr_tensor.initialized()));
   tensor_ptr = sr_tensor.data();
   PADDLE_ENFORCE_NE(tensor_ptr,
                     nullptr,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

清理已经弃用的 `is_initialized` 方法的调用，不然每次跑都会有如下提示（至少动转静一定会有）：

```
W0811 10:46:56.899423 18456 tensor.cc:417] The `is_initialized` method is deprecated since version 2.3, and will be removed in version 2.4! Please use `initialized` method instead.
```

Pcard-67164