### PR TITLE
[Infra] Remove `WITH_CINN` check in coverage

### DIFF
--- a/tools/coverage/paddle_coverage.sh
+++ b/tools/coverage/paddle_coverage.sh
@@ -250,10 +250,6 @@ fi
 
 if [ "$COVERAGE_LINES_ASSERT" = "1" ] || [ "$PYTHON_COVERAGE_LINES_ASSERT" = "1" ]; then
     echo "exit 9" > /tmp/paddle_coverage.result
-    if [ "${WITH_CINN}" == "ON" ]; then
-        echo "You must one RD(liuhongyu or lanxiang or zhenghuihuang or tianchao zhangliujie)to approval this PR."
-        exit 9
-    fi
     python ${PADDLE_ROOT}/tools/get_pr_title.py skip_coverage_check && NOT_CHECK_COVERAGE_PR=1
     if [[ "${NOT_CHECK_COVERAGE_PR}" = "1" ]];then
         echo "Skip coverage check in the PR-CI-Coverage pipeline."


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#66815 将 CINN 流水线合并到了 Coverage，因此 Coverage `WITH_CINN` 永远是 ON，这里的检查会导致后面的跳过逻辑永远都走不到，如 #67302，因此本 PR 移除该逻辑

Pcard-67164
