### PR TITLE
[CodeStyle][Ruff][BUAA][G-[101-110]] Fix ruff `RUF005` diagnostic for 10 files in `python/paddle/`

### DIFF
--- a/test/auto_parallel/test_pass_sharding.py
+++ b/test/auto_parallel/test_pass_sharding.py
@@ -31,17 +31,16 @@ class TestShardingPass(unittest.TestCase):
 
         tmp_dir = tempfile.TemporaryDirectory()
         cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
         )
 
         process = subprocess.Popen(cmd)

--- a/test/auto_parallel/test_pass_sharding.py
+++ b/test/auto_parallel/test_pass_sharding.py
@@ -30,7 +30,7 @@ class TestShardingPass(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
+        cmd = [
             sys.executable,
             "-u",
             *coverage_args,
@@ -41,7 +41,7 @@ class TestShardingPass(unittest.TestCase):
             "--log_dir",
             tmp_dir.name,
             launch_model_path,
-        )
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_pipeline_scheduler.py
+++ b/test/auto_parallel/test_pipeline_scheduler.py
@@ -32,19 +32,18 @@ class TestFThenBPass(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_pipeline_scheduler_vpp.py
+++ b/test/auto_parallel/test_pipeline_scheduler_vpp.py
@@ -32,19 +32,18 @@ class TestVPPPass(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,  # Unpack coverage_args
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_pipeline_scheduler_vpp.py
+++ b/test/auto_parallel/test_pipeline_scheduler_vpp.py
@@ -35,7 +35,7 @@ class TestVPPPass(unittest.TestCase):
         cmd = [
             sys.executable,
             "-u",
-            *coverage_args,  # Unpack coverage_args
+            *coverage_args,
             "-m",
             "paddle.distributed.launch",
             "--devices",

--- a/test/auto_parallel/test_pipeline_scheduler_zb.py
+++ b/test/auto_parallel/test_pipeline_scheduler_zb.py
@@ -32,19 +32,18 @@ class TestZBH1Pass(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_random_ctrl.py
+++ b/test/auto_parallel/test_random_ctrl.py
@@ -30,19 +30,18 @@ class TestRandomCtrlPass(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_relaunch_with_gpt_planner.py
+++ b/test/auto_parallel/test_relaunch_with_gpt_planner.py
@@ -55,23 +55,22 @@ class TestPlannerReLaunch(unittest.TestCase):
         else:
             coverage_args = []
 
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--log_dir",
-                self.temp_dir.name,
-                "--cluster_topo_path",
-                cluster_json_path,
-                "--rank_mapping_path",
-                mapping_json_path,
-                "--enable_auto_mapping",
-                "True",
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--log_dir",
+            self.temp_dir.name,
+            "--cluster_topo_path",
+            cluster_json_path,
+            "--rank_mapping_path",
+            mapping_json_path,
+            "--enable_auto_mapping",
+            "True",
+            launch_model_path,
+        ]
         process = subprocess.Popen(cmd)
         process.wait()
         self.assertEqual(process.returncode, 0)

--- a/test/auto_parallel/test_relaunch_with_planner.py
+++ b/test/auto_parallel/test_relaunch_with_planner.py
@@ -55,23 +55,22 @@ class TestPlannerReLaunch(unittest.TestCase):
         else:
             coverage_args = []
 
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--log_dir",
-                self.temp_dir.name,
-                "--cluster_topo_path",
-                cluster_json_path,
-                "--rank_mapping_path",
-                mapping_json_path,
-                "--enable_auto_mapping",
-                "True",
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--log_dir",
+            self.temp_dir.name,
+            "--cluster_topo_path",
+            cluster_json_path,
+            "--rank_mapping_path",
+            mapping_json_path,
+            "--enable_auto_mapping",
+            "True",
+            launch_model_path,
+        ]
         process = subprocess.Popen(cmd)
         process.wait()
         self.assertEqual(process.returncode, 0)

--- a/test/auto_parallel/test_sharding_with_newexe.py
+++ b/test/auto_parallel/test_sharding_with_newexe.py
@@ -32,19 +32,18 @@ class TestShardingWithNewEXE(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/collective/fleet/pipeline_mnist.py
+++ b/test/collective/fleet/pipeline_mnist.py
@@ -56,7 +56,7 @@ def cnn_model(data):
 
     SIZE = 10
     input_shape = conv_pool_2.shape
-    param_shape = [reduce(lambda a, b: a * b, input_shape[1:], 1)] + [SIZE]
+    param_shape = [reduce(lambda a, b: a * b, input_shape[1:], 1), SIZE]
     scale = (2.0 / (param_shape[0] ** 2 * SIZE)) ** 0.5
 
     with base.device_guard("gpu:1"):

--- a/test/collective/fleet/pipeline_mnist_multi_device.py
+++ b/test/collective/fleet/pipeline_mnist_multi_device.py
@@ -56,7 +56,7 @@ def cnn_model(data):
 
     SIZE = 10
     input_shape = conv_pool_2.shape
-    param_shape = [reduce(lambda a, b: a * b, input_shape[1:], 1)] + [SIZE]
+    param_shape = [reduce(lambda a, b: a * b, input_shape[1:], 1), SIZE]
     scale = (2.0 / (param_shape[0] ** 2 * SIZE)) ** 0.5
 
     with base.device_guard("gpu:1"):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs


### Description
<!-- Describe what you’ve done -->

修复如下文件 RUF005 的 Ruff 规则：

- `test/auto_parallel/test_pass_sharding.py`
- `test/auto_parallel/test_pipeline_scheduler.py`
- `test/auto_parallel/test_pipeline_scheduler_vpp.py`
- `test/auto_parallel/test_pipeline_scheduler_zb.py`
- `test/auto_parallel/test_random_ctrl.py`
- `test/auto_parallel/test_relaunch_with_gpt_planner.py`
- `test/auto_parallel/test_relaunch_with_planner.py`
- `test/auto_parallel/test_sharding_with_newexe.py`
- `test/collective/fleet/pipeline_mnist.py`
- `test/collective/fleet/pipeline_mnist_multi_device.py`

### Related Links

- #67116 

@gouzil 
