### PR TITLE
[CodeStyle][Ruff][BUAA][G-[91-100]] Fix ruff `RUF005` diagnostic for 10 files in `python/paddle/`

### DIFF
--- a/test/auto_parallel/test_optimization_tuner_api.py
+++ b/test/auto_parallel/test_optimization_tuner_api.py
@@ -34,7 +34,7 @@ class TestOptimizationTunerAPI(unittest.TestCase):
         cmd = [
             sys.executable,
             "-u",
-            *coverage_args,  # Unpacking coverage_args
+            *coverage_args,
             "-m",
             "launch",
             "--gpus",

--- a/test/auto_parallel/test_optimization_tuner_api.py
+++ b/test/auto_parallel/test_optimization_tuner_api.py
@@ -31,19 +31,18 @@ class TestOptimizationTunerAPI(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "launch",
-                "--gpus",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,  # Unpacking coverage_args
+            "-m",
+            "launch",
+            "--gpus",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_pass_amp.py
+++ b/test/auto_parallel/test_pass_amp.py
@@ -30,19 +30,18 @@ class TestAMPPass(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_pass_generation_pipeline.py
+++ b/test/auto_parallel/test_pass_generation_pipeline.py
@@ -32,19 +32,18 @@ class TestGenerationPipeline(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_pass_grad_clip.py
+++ b/test/auto_parallel/test_pass_grad_clip.py
@@ -35,7 +35,7 @@ class TestGradientClip(unittest.TestCase):
         cmd = [
             sys.executable,
             "-u",
-            *coverage_args,  # Unpacking coverage_args into the list
+            *coverage_args,
             "-m",
             "paddle.distributed.launch",
             "--devices",

--- a/test/auto_parallel/test_pass_grad_clip.py
+++ b/test/auto_parallel/test_pass_grad_clip.py
@@ -32,19 +32,18 @@ class TestGradientClip(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,  # Unpacking coverage_args into the list
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_pass_gradient_merge.py
+++ b/test/auto_parallel/test_pass_gradient_merge.py
@@ -35,7 +35,7 @@ class TestGradientMergePass(unittest.TestCase):
         cmd = [
             sys.executable,
             "-u",
-            *coverage_args,  # Unpacking coverage_args directly into the list
+            *coverage_args,
             "-m",
             "paddle.distributed.launch",
             "--devices",

--- a/test/auto_parallel/test_pass_gradient_merge.py
+++ b/test/auto_parallel/test_pass_gradient_merge.py
@@ -32,19 +32,18 @@ class TestGradientMergePass(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,  # Unpacking coverage_args directly into the list
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_pass_quantization.py
+++ b/test/auto_parallel/test_pass_quantization.py
@@ -32,19 +32,18 @@ class TestQuantizationPass(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_pass_recompute.py
+++ b/test/auto_parallel/test_pass_recompute.py
@@ -30,19 +30,18 @@ class TestRecomputePass(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,  # Unpacking coverage_args into the list
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_pass_recompute.py
+++ b/test/auto_parallel/test_pass_recompute.py
@@ -33,7 +33,7 @@ class TestRecomputePass(unittest.TestCase):
         cmd = [
             sys.executable,
             "-u",
-            *coverage_args,  # Unpacking coverage_args into the list
+            *coverage_args,
             "-m",
             "paddle.distributed.launch",
             "--devices",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs


### Description
<!-- Describe what you’ve done -->

修复如下文件 RUF005 的 Ruff 规则：

- `test/auto_parallel/test_iterable_dataset.py`
- `test/auto_parallel/test_mp_allreduce_matmul_grad_overlapping.py`
- `test/auto_parallel/test_optimization_tuner_api.py`
- `test/auto_parallel/test_pass_1F1B.py`
- `test/auto_parallel/test_pass_amp.py`
- `test/auto_parallel/test_pass_generation_pipeline.py`
- `test/auto_parallel/test_pass_grad_clip.py`
- `test/auto_parallel/test_pass_gradient_merge.py`
- `test/auto_parallel/test_pass_quantization.py`
- `test/auto_parallel/test_pass_recompute.py`


### Related Links

- #67116 

@gouzil 
