### PR TITLE
[CodeStyle][Ruff][BUAA][G-[151-160]] Fix ruff RUF005 diagnostic for 10 files

### DIFF
--- a/test/distributed_passes/test_dist_fuse_adam_pass.py
+++ b/test/distributed_passes/test_dist_fuse_adam_pass.py
@@ -49,7 +49,7 @@ class TestFuseAdamPass(DistPassTestBase):
 
     def get_model(self, place, batch_size=32, image_shape=[224, 224, 3]):
         image = paddle.static.data(
-            shape=[batch_size] + image_shape, dtype='float32', name='image'
+            shape=[batch_size, *image_shape], dtype='float32', name='image'
         )
 
         model = DemoNet()

--- a/test/distributed_passes/test_dist_fuse_bn_act_pass.py
+++ b/test/distributed_passes/test_dist_fuse_bn_act_pass.py
@@ -49,7 +49,7 @@ class TestFuseBatchNormActPass(DistPassTestBase):
 
     def get_model(self, place, batch_size=32, image_shape=[224, 224, 3]):
         image = paddle.static.data(
-            shape=[batch_size] + image_shape, dtype='float32', name='image'
+            shape=[batch_size, *image_shape], dtype='float32', name='image'
         )
 
         model = BatchNormActNet()

--- a/test/distributed_passes/test_dist_fuse_bn_add_act_pass.py
+++ b/test/distributed_passes/test_dist_fuse_bn_add_act_pass.py
@@ -53,7 +53,7 @@ class TestFuseBatchNormAddActPass(DistPassTestBase):
 
     def get_model(self, place, batch_size=32, image_shape=[224, 224, 3]):
         image = paddle.static.data(
-            shape=[batch_size] + image_shape, dtype='float32', name='image'
+            shape=[batch_size, *image_shape], dtype='float32', name='image'
         )
 
         model = BatchNormAddActNet()

--- a/test/distributed_passes/test_dist_fuse_momentum_pass.py
+++ b/test/distributed_passes/test_dist_fuse_momentum_pass.py
@@ -49,7 +49,7 @@ class TestFuseAdamPass(DistPassTestBase):
 
     def get_model(self, place, batch_size=32, image_shape=[224, 224, 3]):
         image = paddle.static.data(
-            shape=[batch_size] + image_shape, dtype='float32', name='image'
+            shape=[batch_size, *image_shape], dtype='float32', name='image'
         )
 
         model = DemoNet()

--- a/test/distributed_passes/test_dist_fuse_relu_depthwise_conv_pass.py
+++ b/test/distributed_passes/test_dist_fuse_relu_depthwise_conv_pass.py
@@ -49,7 +49,7 @@ class TestFuseReluDepthwiseConvPass(DistPassTestBase):
 
     def get_model(self, place, batch_size=32, image_shape=[3, 224, 224]):
         image = paddle.static.data(
-            shape=[batch_size] + image_shape, dtype='float32', name='image'
+            shape=[batch_size, *image_shape], dtype='float32', name='image'
         )
 
         model = ReluDepthwiseConvNet()

--- a/test/distributed_passes/test_dist_fuse_resunit_pass.py
+++ b/test/distributed_passes/test_dist_fuse_resunit_pass.py
@@ -221,7 +221,7 @@ class TestFuseResUnitPass(DistPassTestBase):
 
     def get_model(self, place, batch_size=32, image_shape=[224, 224, 3]):
         image = paddle.static.data(
-            shape=[batch_size] + image_shape, dtype='float32', name='image'
+            shape=[batch_size, *image_shape], dtype='float32', name='image'
         )
 
         model = ResUnitNet(self.shortcut)

--- a/test/distributed_passes/test_dist_fuse_sgd_pass.py
+++ b/test/distributed_passes/test_dist_fuse_sgd_pass.py
@@ -49,7 +49,7 @@ class TestFuseAdamPass(DistPassTestBase):
 
     def get_model(self, place, batch_size=32, image_shape=[224, 224, 3]):
         image = paddle.static.data(
-            shape=[batch_size] + image_shape, dtype='float32', name='image'
+            shape=[batch_size, *image_shape], dtype='float32', name='image'
         )
 
         model = DemoNet()

--- a/test/distributed_passes/test_dist_inplace_addto_pass.py
+++ b/test/distributed_passes/test_dist_inplace_addto_pass.py
@@ -51,7 +51,7 @@ class TestInplaceAddtoPass(DistPassTestBase):
 
     def get_model(self, place, batch_size=32, image_shape=[224, 224, 3]):
         image = paddle.static.data(
-            shape=[batch_size] + image_shape, dtype='float32', name='image'
+            shape=[batch_size, *image_shape], dtype='float32', name='image'
         )
 
         model = DemoNet()

--- a/test/distribution/test_distribution_beta.py
+++ b/test/distribution/test_distribution_beta.py
@@ -99,12 +99,15 @@ class TestBeta(unittest.TestCase):
         cases = [
             {
                 'input': [],
-                'expect': [] + paddle.squeeze(self._paddle_beta.alpha).shape,
+                'expect': [*paddle.squeeze(self._paddle_beta.alpha).shape],
             },
             {
                 'input': [2, 3],
-                'expect': [2, 3]
-                + paddle.squeeze(self._paddle_beta.alpha).shape,
+                'expect': [
+                    2,
+                    3,
+                    *paddle.squeeze(self._paddle_beta.alpha).shape,
+                ],
             },
         ]
         for case in cases:

--- a/test/distribution/test_distribution_beta.py
+++ b/test/distribution/test_distribution_beta.py
@@ -99,7 +99,7 @@ class TestBeta(unittest.TestCase):
         cases = [
             {
                 'input': [],
-                'expect': [*paddle.squeeze(self._paddle_beta.alpha).shape],
+                'expect': list(paddle.squeeze(self._paddle_beta.alpha).shape),
             },
             {
                 'input': [2, 3],

--- a/test/distribution/test_distribution_chi2_static.py
+++ b/test/distribution/test_distribution_chi2_static.py
@@ -191,11 +191,11 @@ class TestChi2Sample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': () + np.squeeze(self.df).shape,
+                'expect': (*np.squeeze(self.df).shape,),
             },
             {
                 'input': (2, 2),
-                'expect': (2, 2) + np.squeeze(self.df).shape,
+                'expect': (2, 2, *np.squeeze(self.df).shape),
             },
         ]
         for case in cases:

--- a/test/distribution/test_distribution_chi2_static.py
+++ b/test/distribution/test_distribution_chi2_static.py
@@ -191,7 +191,7 @@ class TestChi2Sample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*np.squeeze(self.df).shape,),
+                'expect': tuple(np.squeeze(self.df).shape),
             },
             {
                 'input': (2, 2),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Devs
### Description
修复G151-160 RUF005 的 `Ruff` 规则
* `test/distributed_passes/test_dist_fuse_adam_pass.py`
* `test/distributed_passes/test_dist_fuse_bn_act_pass.py`
* `test/distributed_passes/test_dist_fuse_bn_add_act_pass.py`
* `test/distributed_passes/test_dist_fuse_momentum_pass.py`
* `test/distributed_passes/test_dist_fuse_relu_depthwise_conv_pass.py`
* `test/distributed_passes/test_dist_fuse_resunit_pass.py`
* `test/distributed_passes/test_dist_fuse_sgd_pass.py`
* `test/distributed_passes/test_dist_inplace_addto_pass.py`
* `test/distribution/test_distribution_beta.py`
* `test/distribution/test_distribution_chi2.py`
### Related Links
 * [[CodeStyle][Ruff] Ruff 新 rule 引入计划（第二期） #67116](https://github.com/PaddlePaddle/Paddle/issues/67116)