### PR TITLE
[CINN] Fix eliminate common global memory read insert

### DIFF
--- a/paddle/cinn/optim/eliminate_common_global_memory_read.cc
+++ b/paddle/cinn/optim/eliminate_common_global_memory_read.cc
@@ -301,6 +301,13 @@ struct CommonGlobalMemoryEliminator : public ir::IRMutator<Expr*> {
         ::common::errors::InvalidArgument("The input expr should be a Block"));
     current_block_ = node;
     IRMutator<>::Visit(op, expr);
+    if (block_to_insert_stmts_.find(node) != block_to_insert_stmts_.end()) {
+      const std::vector<ir::Expr>& insert_schedule_blocks =
+          block_to_insert_stmts_[node];
+      for (const ir::Expr& block : insert_schedule_blocks) {
+        node->stmts.insert(node->stmts.begin(), block);
+      }
+    }
   }
 
   void Visit(const ir::ScheduleBlockRealize* op, Expr* expr) override {
@@ -362,7 +369,7 @@ struct CommonGlobalMemoryEliminator : public ir::IRMutator<Expr*> {
             "buffer_name %s should not be in global_buffer_to_local_buffer_",
             buffer_name));
     global_buffer_to_local_buffer_[buffer_name] = new_tensor;
-    current_block_->stmts.insert(current_block_->stmts.begin(), new_sbr);
+    block_to_insert_stmts_[current_block_].push_back(new_sbr);
   }
 
   void SubstituteGlobalTensor(ir::Load* load_node,
@@ -378,6 +385,7 @@ struct CommonGlobalMemoryEliminator : public ir::IRMutator<Expr*> {
 
   std::unordered_set<std::string> eliminate_buffer_names_;
   std::unordered_map<std::string, ir::Expr> global_buffer_to_local_buffer_;
+  std::unordered_map<ir::Block*, std::vector<ir::Expr>> block_to_insert_stmts_;
 
   ir::Block* current_block_;
   ir::ScheduleBlockRealize* current_sbr_;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

 Performance Optimization 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

[CINN] Fix eliminate common global memory read insert