### PR TITLE
[CodeStyle][Ruff][BUAA][G-[161-170]] Fix ruff RUF005 diagnostic for 9 files

### DIFF
--- a/test/distribution/test_distribution_chi2.py
+++ b/test/distribution/test_distribution_chi2.py
@@ -147,13 +147,11 @@ class TestChi2Sample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': ()
-                + tuple(paddle.squeeze(self._paddle_chi2.df).shape),
+                'expect': (*paddle.squeeze(self._paddle_chi2.df).shape,),
             },
             {
                 'input': (2, 2),
-                'expect': (2, 2)
-                + tuple(paddle.squeeze(self._paddle_chi2.df).shape),
+                'expect': (2, 2, *paddle.squeeze(self._paddle_chi2.df).shape),
             },
         ]
         for case in cases:

--- a/test/distribution/test_distribution_chi2.py
+++ b/test/distribution/test_distribution_chi2.py
@@ -147,7 +147,7 @@ class TestChi2Sample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*paddle.squeeze(self._paddle_chi2.df).shape,),
+                'expect': tuple(paddle.squeeze(self._paddle_chi2.df).shape),
             },
             {
                 'input': (2, 2),

--- a/test/distribution/test_distribution_exponential.py
+++ b/test/distribution/test_distribution_exponential.py
@@ -179,13 +179,15 @@ class TestExponentialSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': ()
-                + tuple(paddle.squeeze(self._paddle_expon.rate).shape),
+                'expect': (*paddle.squeeze(self._paddle_expon.rate).shape,),
             },
             {
                 'input': (3, 2),
-                'expect': (3, 2)
-                + tuple(paddle.squeeze(self._paddle_expon.rate).shape),
+                'expect': (
+                    3,
+                    2,
+                    *paddle.squeeze(self._paddle_expon.rate).shape,
+                ),
             },
         ]
         for case in cases:
@@ -217,13 +219,15 @@ class TestExponentialSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': ()
-                + tuple(paddle.squeeze(self._paddle_expon.rate).shape),
+                'expect': (*paddle.squeeze(self._paddle_expon.rate).shape,),
             },
             {
                 'input': (2, 5),
-                'expect': (2, 5)
-                + tuple(paddle.squeeze(self._paddle_expon.rate).shape),
+                'expect': (
+                    2,
+                    5,
+                    *paddle.squeeze(self._paddle_expon.rate).shape,
+                ),
             },
         ]
         for case in cases:

--- a/test/distribution/test_distribution_exponential.py
+++ b/test/distribution/test_distribution_exponential.py
@@ -179,7 +179,7 @@ class TestExponentialSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*paddle.squeeze(self._paddle_expon.rate).shape,),
+                'expect': tuple(paddle.squeeze(self._paddle_expon.rate).shape),
             },
             {
                 'input': (3, 2),

--- a/test/distribution/test_distribution_exponential.py
+++ b/test/distribution/test_distribution_exponential.py
@@ -219,7 +219,7 @@ class TestExponentialSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*paddle.squeeze(self._paddle_expon.rate).shape,),
+                'expect': tuple(paddle.squeeze(self._paddle_expon.rate).shape),
             },
             {
                 'input': (2, 5),

--- a/test/distribution/test_distribution_exponential_static.py
+++ b/test/distribution/test_distribution_exponential_static.py
@@ -230,11 +230,11 @@ class TestExponentialSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': () + np.squeeze(self.rate).shape,
+                'expect': (*np.squeeze(self.rate).shape,),
             },
             {
                 'input': (4, 2),
-                'expect': (4, 2) + np.squeeze(self.rate).shape,
+                'expect': (4, 2, *np.squeeze(self.rate).shape),
             },
         ]
         for case in cases:
@@ -251,11 +251,11 @@ class TestExponentialSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': () + np.squeeze(self.rate).shape,
+                'expect': (*np.squeeze(self.rate).shape,),
             },
             {
                 'input': (3, 2),
-                'expect': (3, 2) + np.squeeze(self.rate).shape,
+                'expect': (3, 2, *np.squeeze(self.rate).shape),
             },
         ]
         for case in cases:

--- a/test/distribution/test_distribution_exponential_static.py
+++ b/test/distribution/test_distribution_exponential_static.py
@@ -230,7 +230,7 @@ class TestExponentialSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*np.squeeze(self.rate).shape,),
+                'expect': tuple(np.squeeze(self.rate).shape),
             },
             {
                 'input': (4, 2),
@@ -251,7 +251,7 @@ class TestExponentialSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*np.squeeze(self.rate).shape,),
+                'expect': tuple(np.squeeze(self.rate).shape),
             },
             {
                 'input': (3, 2),

--- a/test/distribution/test_distribution_gamma.py
+++ b/test/distribution/test_distribution_gamma.py
@@ -211,13 +211,15 @@ class TestGammaSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': ()
-                + tuple(paddle.squeeze(self._paddle_gamma.rate).shape),
+                'expect': (*paddle.squeeze(self._paddle_gamma.rate).shape,),
             },
             {
                 'input': (3, 2),
-                'expect': (3, 2)
-                + tuple(paddle.squeeze(self._paddle_gamma.rate).shape),
+                'expect': (
+                    3,
+                    2,
+                    *paddle.squeeze(self._paddle_gamma.rate).shape,
+                ),
             },
         ]
         for case in cases:
@@ -230,13 +232,15 @@ class TestGammaSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': ()
-                + tuple(paddle.squeeze(self._paddle_gamma.rate).shape),
+                'expect': (*paddle.squeeze(self._paddle_gamma.rate).shape,),
             },
             {
                 'input': (3, 2),
-                'expect': (3, 2)
-                + tuple(paddle.squeeze(self._paddle_gamma.rate).shape),
+                'expect': (
+                    3,
+                    2,
+                    *paddle.squeeze(self._paddle_gamma.rate).shape,
+                ),
             },
         ]
         for case in cases:

--- a/test/distribution/test_distribution_gamma.py
+++ b/test/distribution/test_distribution_gamma.py
@@ -211,7 +211,7 @@ class TestGammaSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*paddle.squeeze(self._paddle_gamma.rate).shape,),
+                'expect': tuple(paddle.squeeze(self._paddle_gamma.rate).shape),
             },
             {
                 'input': (3, 2),
@@ -232,7 +232,7 @@ class TestGammaSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*paddle.squeeze(self._paddle_gamma.rate).shape,),
+                'expect': tuple(paddle.squeeze(self._paddle_gamma.rate).shape),
             },
             {
                 'input': (3, 2),

--- a/test/distribution/test_distribution_gamma_static.py
+++ b/test/distribution/test_distribution_gamma_static.py
@@ -238,11 +238,11 @@ class TestGammaSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': () + np.squeeze(self.rate).shape,
+                'expect': (*np.squeeze(self.rate).shape,),
             },
             {
                 'input': (4, 2),
-                'expect': (4, 2) + np.squeeze(self.rate).shape,
+                'expect': (4, 2, *np.squeeze(self.rate).shape),
             },
         ]
         for case in cases:
@@ -259,11 +259,11 @@ class TestGammaSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': () + np.squeeze(self.rate).shape,
+                'expect': (*np.squeeze(self.rate).shape,),
             },
             {
                 'input': (3, 2),
-                'expect': (3, 2) + np.squeeze(self.rate).shape,
+                'expect': (3, 2, *np.squeeze(self.rate).shape),
             },
         ]
         for case in cases:

--- a/test/distribution/test_distribution_gamma_static.py
+++ b/test/distribution/test_distribution_gamma_static.py
@@ -238,7 +238,7 @@ class TestGammaSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*np.squeeze(self.rate).shape,),
+                'expect': tuple(np.squeeze(self.rate).shape),
             },
             {
                 'input': (4, 2),
@@ -259,7 +259,7 @@ class TestGammaSample(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*np.squeeze(self.rate).shape,),
+                'expect': tuple(np.squeeze(self.rate).shape),
             },
             {
                 'input': (3, 2),

--- a/test/distribution/test_distribution_geometric.py
+++ b/test/distribution/test_distribution_geometric.py
@@ -102,13 +102,15 @@ class TestGeometric(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': ()
-                + tuple(paddle.squeeze(self._paddle_geom.probs).shape),
+                'expect': (*paddle.squeeze(self._paddle_geom.probs).shape,),
             },
             {
                 'input': (4, 2),
-                'expect': (4, 2)
-                + tuple(paddle.squeeze(self._paddle_geom.probs).shape),
+                'expect': (
+                    4,
+                    2,
+                    *paddle.squeeze(self._paddle_geom.probs).shape,
+                ),
             },
         ]
         for case in cases:
@@ -140,13 +142,15 @@ class TestGeometric(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': ()
-                + tuple(paddle.squeeze(self._paddle_geom.probs).shape),
+                'expect': (*paddle.squeeze(self._paddle_geom.probs).shape,),
             },
             {
                 'input': (2, 5),
-                'expect': (2, 5)
-                + tuple(paddle.squeeze(self._paddle_geom.probs).shape),
+                'expect': (
+                    2,
+                    5,
+                    *paddle.squeeze(self._paddle_geom.probs).shape,
+                ),
             },
         ]
         for case in cases:

--- a/test/distribution/test_distribution_geometric.py
+++ b/test/distribution/test_distribution_geometric.py
@@ -102,7 +102,7 @@ class TestGeometric(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*paddle.squeeze(self._paddle_geom.probs).shape,),
+                'expect': tuple(paddle.squeeze(self._paddle_geom.probs).shape),
             },
             {
                 'input': (4, 2),
@@ -142,7 +142,7 @@ class TestGeometric(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*paddle.squeeze(self._paddle_geom.probs).shape,),
+                'expect': tuple(paddle.squeeze(self._paddle_geom.probs).shape),
             },
             {
                 'input': (2, 5),

--- a/test/distribution/test_distribution_lkj_cholesky.py
+++ b/test/distribution/test_distribution_lkj_cholesky.py
@@ -54,7 +54,7 @@ class TestLKJCholeskyShape(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': () + extra_shape,
+                'expect': (*extra_shape,),
             },
         ]
         return cases

--- a/test/distribution/test_distribution_lkj_cholesky.py
+++ b/test/distribution/test_distribution_lkj_cholesky.py
@@ -54,7 +54,7 @@ class TestLKJCholeskyShape(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*extra_shape,),
+                'expect': tuple(extra_shape),
             },
         ]
         return cases

--- a/test/distribution/test_distribution_lkj_cholesky_static.py
+++ b/test/distribution/test_distribution_lkj_cholesky_static.py
@@ -78,11 +78,11 @@ class TestLKJCholeskyShape(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': () + extra_shape,
+                'expect': (*extra_shape,),
             },
             {
                 'input': (2, 2),
-                'expect': (2, 2) + extra_shape,
+                'expect': (2, 2, *extra_shape),
             },
         ]
         return cases

--- a/test/distribution/test_distribution_lkj_cholesky_static.py
+++ b/test/distribution/test_distribution_lkj_cholesky_static.py
@@ -78,7 +78,7 @@ class TestLKJCholeskyShape(unittest.TestCase):
         cases = [
             {
                 'input': (),
-                'expect': (*extra_shape,),
+                'expect': tuple(extra_shape),
             },
             {
                 'input': (2, 2),

--- a/test/dygraph_to_static/bert_utils.py
+++ b/test/dygraph_to_static/bert_utils.py
@@ -215,9 +215,10 @@ def prepare_batch_data(
             self_input_mask,
             mask_label,
             mask_pos,
-        ] + labels_list
+            *labels_list,
+        ]
     else:
-        return_list = [src_id, pos_id, sent_id, self_input_mask] + labels_list
+        return_list = [src_id, pos_id, sent_id, self_input_mask, *labels_list]
 
     res = return_list if len(return_list) > 1 else return_list[0]
     return res

--- a/test/dygraph_to_static/seq2seq_dygraph_model.py
+++ b/test/dygraph_to_static/seq2seq_dygraph_model.py
@@ -173,7 +173,7 @@ class BaseModel(paddle.nn.Layer):
         )
 
     def _transpose_batch_time(self, x):
-        return paddle.transpose(x, [1, 0] + list(range(2, len(x.shape))))
+        return paddle.transpose(x, [1, 0, *range(2, len(x.shape))])
 
     def _merge_batch_beams(self, x):
         return paddle.reshape(x, shape=(-1, x.shape[2]))
@@ -642,7 +642,7 @@ class AttentionModel(paddle.nn.Layer):
         )
 
     def _transpose_batch_time(self, x):
-        return paddle.transpose(x, [1, 0] + list(range(2, len(x.shape))))
+        return paddle.transpose(x, [1, 0, *range(2, len(x.shape))])
 
     def _merge_batch_beams(self, x):
         return paddle.reshape(x, shape=(-1, x.shape[2]))
@@ -653,14 +653,14 @@ class AttentionModel(paddle.nn.Layer):
         expand_shape[1] = self.beam_size * x.shape[1]
         x = paddle.expand(x, expand_shape)  # [batch_size, beam_size, ...]
         x = paddle.transpose(
-            x, list(range(2, len(x.shape))) + [0, 1]
+            x, [*list(range(2, len(x.shape))), 0, 1]
         )  # [..., batch_size, beam_size]
         # use 0 to copy to avoid wrong shape
         x = paddle.reshape(
             x, shape=[0] * (len(x.shape) - 2) + [-1]
         )  # [..., batch_size * beam_size]
         x = paddle.transpose(
-            x, [len(x.shape) - 1] + list(range(0, len(x.shape) - 1))
+            x, [len(x.shape) - 1, *range(0, len(x.shape) - 1)]
         )  # [batch_size * beam_size, ...]
         return x
 

--- a/test/dygraph_to_static/seq2seq_dygraph_model.py
+++ b/test/dygraph_to_static/seq2seq_dygraph_model.py
@@ -173,7 +173,7 @@ class BaseModel(paddle.nn.Layer):
         )
 
     def _transpose_batch_time(self, x):
-        return paddle.transpose(x, [1, 0, *range(2, len(x.shape))])
+        return paddle.transpose(x, [1, 0] + list(range(2, len(x.shape))))
 
     def _merge_batch_beams(self, x):
         return paddle.reshape(x, shape=(-1, x.shape[2]))
@@ -642,7 +642,7 @@ class AttentionModel(paddle.nn.Layer):
         )
 
     def _transpose_batch_time(self, x):
-        return paddle.transpose(x, [1, 0, *range(2, len(x.shape))])
+        return paddle.transpose(x, [1, 0] + list(range(2, len(x.shape))))
 
     def _merge_batch_beams(self, x):
         return paddle.reshape(x, shape=(-1, x.shape[2]))
@@ -653,14 +653,14 @@ class AttentionModel(paddle.nn.Layer):
         expand_shape[1] = self.beam_size * x.shape[1]
         x = paddle.expand(x, expand_shape)  # [batch_size, beam_size, ...]
         x = paddle.transpose(
-            x, [*list(range(2, len(x.shape))), 0, 1]
+            x, list(range(2, len(x.shape))) + [0, 1]
         )  # [..., batch_size, beam_size]
         # use 0 to copy to avoid wrong shape
         x = paddle.reshape(
             x, shape=[0] * (len(x.shape) - 2) + [-1]
         )  # [..., batch_size * beam_size]
         x = paddle.transpose(
-            x, [len(x.shape) - 1, *range(0, len(x.shape) - 1)]
+            x, [len(x.shape) - 1] + list(range(0, len(x.shape) - 1))
         )  # [batch_size * beam_size, ...]
         return x
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Devs
### Description
修复G161-169 RUF005 的 `Ruff` 规则
* `test/distribution/test_distribution_chi2_static.py`
* `test/distribution/test_distribution_exponential.py`
* `test/distribution/test_distribution_exponential_static.py`
* `test/distribution/test_distribution_gamma.py`
* `test/distribution/test_distribution_gamma_static.py`
* `test/distribution/test_distribution_geometric.py`
* `test/distribution/test_distribution_lkj_cholesky.py`
* `test/distribution/test_distribution_lkj_cholesky_static.py`
* `test/dygraph_to_static/bert_utils.py`
### Related Links
 * [[CodeStyle][Ruff] Ruff 新 rule 引入计划（第二期） #67116](https://github.com/PaddlePaddle/Paddle/issues/67116)