### PR TITLE
[CodeStyle][Ruff][BUAA][G-[81-90]] Fix ruff `RUF005` diagnostic for 10 files in `python/paddle/`

### DIFF
--- a/test/auto_parallel/test_amp_o2_pass.py
+++ b/test/auto_parallel/test_amp_o2_pass.py
@@ -30,19 +30,18 @@ class TestAMPO2(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,  # Unpacking coverage_args directly into the list
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_amp_o2_pass.py
+++ b/test/auto_parallel/test_amp_o2_pass.py
@@ -33,7 +33,7 @@ class TestAMPO2(unittest.TestCase):
         cmd = [
             sys.executable,
             "-u",
-            *coverage_args,  # Unpacking coverage_args directly into the list
+            *coverage_args,
             "-m",
             "paddle.distributed.launch",
             "--devices",

--- a/test/auto_parallel/test_auto_parallel_relaunch.py
+++ b/test/auto_parallel/test_auto_parallel_relaunch.py
@@ -125,23 +125,22 @@ class TestAutoParallelReLaunch(unittest.TestCase):
         else:
             coverage_args = []
 
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--log_dir",
-                self.temp_dir.name,
-                "--cluster_topo_path",
-                cluster_json_path,
-                "--rank_mapping_path",
-                mapping_json_path,
-                "--enable_auto_mapping",
-                "True",
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--log_dir",
+            self.temp_dir.name,
+            "--cluster_topo_path",
+            cluster_json_path,
+            "--rank_mapping_path",
+            mapping_json_path,
+            "--enable_auto_mapping",
+            "True",
+            launch_model_path,
+        ]
         process = subprocess.Popen(cmd)
         process.wait()
         self.assertEqual(process.returncode, 0)

--- a/test/auto_parallel/test_auto_tuner.py
+++ b/test/auto_parallel/test_auto_tuner.py
@@ -73,21 +73,20 @@ class TestEngineAPI(unittest.TestCase):
         with open(test_json_path, "w") as f:
             f.write(json_object)
 
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                "--auto_tuner_json",
-                test_json_path,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            "--auto_tuner_json",
+            test_json_path,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_auto_tuner_compare.py
+++ b/test/auto_parallel/test_auto_tuner_compare.py
@@ -72,21 +72,20 @@ class TestEngineAPI(unittest.TestCase):
         test_json_path = os.path.join(tmp_dir.name, "test.json")
         with open(test_json_path, "w") as f:
             f.write(json_object)
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                "--auto_tuner_json",
-                test_json_path,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            "--auto_tuner_json",
+            test_json_path,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_converter.py
+++ b/test/auto_parallel/test_converter.py
@@ -32,19 +32,18 @@ class TestConverter(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_engine_api.py
+++ b/test/auto_parallel/test_engine_api.py
@@ -30,19 +30,18 @@ class TestEngineAPI(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_engine_api_dp.py
+++ b/test/auto_parallel/test_engine_api_dp.py
@@ -30,19 +30,18 @@ class TestEngineAPI(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_gpt_with_pir.py
+++ b/test/auto_parallel/test_gpt_with_pir.py
@@ -30,19 +30,18 @@ class TestGPTPir(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_gpt_with_prim.py
+++ b/test/auto_parallel/test_gpt_with_prim.py
@@ -30,19 +30,18 @@ class TestGPTPrim(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs


### Description
<!-- Describe what you’ve done -->

修复如下文件 RUF005 的 Ruff 规则：

- `test/auto_parallel/test_amp_o2_pass.py`
- `test/auto_parallel/test_auto_parallel_relaunch.py`
- `test/auto_parallel/test_auto_tuner.py`
- `test/auto_parallel/test_auto_tuner_compare.py`
- `test/auto_parallel/test_converter.py`
- `test/auto_parallel/test_engine_api.py`
- `test/auto_parallel/test_engine_api_dp.py`
- `test/auto_parallel/test_gpt_with_pir.py`
- `test/auto_parallel/test_gpt_with_prim.py`
- `test/auto_parallel/test_high_order_grad.py`

### Related Links

- #67116 

@gouzil
