### PR TITLE
[XPU] fix integer overflow of full kernel when numel is large

### DIFF
--- a/paddle/phi/kernels/xpu/full_kernel.cc
+++ b/paddle/phi/kernels/xpu/full_kernel.cc
@@ -35,10 +35,9 @@ void FullKernel(const Context& dev_ctx,
                 DenseTensor* out) {
   using XPUInTDType = typename XPUTypeTrait<T>::Type;
   out->Resize(common::make_ddim(shape.GetData()));
-  int numel = out->numel();
   dev_ctx.template Alloc<T>(out);
   auto out_data = reinterpret_cast<XPUInTDType*>(out->data<T>());
-  if (numel > 0) {
+  if (out->numel() > 0) {
     int r = xpu::constant(dev_ctx.x_context(),
                           out_data,
                           out->numel(),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
1. fix integer overflow for full kernel when numel is large.