### PR TITLE
fix VPP eval

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -1532,6 +1532,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                         recv_prev=recv_prev,
                         recv_next=recv_next,
                         batch_p2p_comm=self._use_batch_p2p_comm,
+                        skip_check_meta=not self.training,
                     )
                     # output_tensor_grad is not none if recv_next
                     # append output_tensor_grad no matter none or not
@@ -1543,6 +1544,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                         output_tensor,
                         recv_prev=recv_prev,
                         batch_p2p_comm=self._use_batch_p2p_comm,
+                        skip_check_meta=not self.training,
                     )
                 # append input_tensor no matter none or not
                 self.input_tensors[next_virtual_pp_rank].append(input_tensor)
@@ -1555,6 +1557,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     recv_prev=recv_prev,
                     batch_p2p_comm=self._use_batch_p2p_comm,
                     overlap_p2p_comm=True,
+                    skip_check_meta=not self.training,
                 )
                 if (
                     micro_step == (startup_steps - 1)
@@ -1665,6 +1668,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     recv_prev=recv_prev,
                     batch_p2p_comm=self._use_batch_p2p_comm,
                     overlap_p2p_comm=True,
+                    skip_check_meta=not self.training,
                 )
 
                 if bwd_wait_handles is not None:
@@ -1796,6 +1800,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     recv_prev=recv_prev,
                     recv_next=recv_next,
                     batch_p2p_comm=self._use_batch_p2p_comm,
+                    skip_check_meta=not self.training,
                 )
             # append input_tensor no matter none or not
             self.input_tensors[next_forward_virtual_pp_rank].append(
@@ -2101,6 +2106,7 @@ class PipelineParallelWithInterleaveFthenB(PipelineParallelWithInterleave):
                 output_tensor,
                 recv_prev=recv_prev,
                 batch_p2p_comm=self._use_batch_p2p_comm,
+                skip_check_meta=not self.training,
             )
             self.input_tensors[next_virtual_pp_rank].append(input_tensor)
 

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
@@ -801,6 +801,7 @@ class P2pHelper:
         recv_prev,
         recv_next,
         batch_p2p_comm=True,
+        skip_check_meta=False,
     ):
         # always have to send dtype info to downstream
         global _timers
@@ -808,7 +809,7 @@ class P2pHelper:
             _timers("send_forward_backward_recv_forward_backward").start()
 
         if output_tensor is not None:
-            self._send_meta(output_tensor)
+            self._send_meta(output_tensor, skip_check_meta=skip_check_meta)
         if recv_prev:
             self._recv_meta()
 
@@ -831,6 +832,7 @@ class P2pHelper:
         recv_prev,
         batch_p2p_comm=True,
         overlap_p2p_comm=False,
+        skip_check_meta=False,
     ):
         # always have to send dtype info to downstream
         global _timers
@@ -838,7 +840,7 @@ class P2pHelper:
             _timers("send_forward_recv_forward").start()
 
         if output_tensor is not None:
-            self._send_meta(output_tensor)
+            self._send_meta(output_tensor, skip_check_meta=skip_check_meta)
 
         if recv_prev:
             self._recv_meta()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
- 打开VPP的情况下(VPP>1)，先训练然后eval就会出现报错，定位到是因为这里的cache导致self.send_shape_message和self.send_dtype_message和训练保持一致的，eval的时候就没更新，最终eval的时候check shape和dtype就挂了。
<img width="617" alt="5f5eb0b251d5c982db722c5fe11342d9" src="https://github.com/user-attachments/assets/1e19bb79-9f9c-4898-8a96-7394366fa906">

训练和验证由于梯度原因对shape要求不一致，代码这里：https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py#L167

报错信息
<img width="1130" alt="eba99cb67a362306968e435803bac4b4" src="https://github.com/user-attachments/assets/4aa9e092-b2a0-4ef8-84ed-f3dfc25df306">


如果只eval就没问题，解决办法是：eval的时候不进行check，和[vpp=1](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py#L862)的时候对齐。