### PR TITLE
【Fix PIR Unittest】 conv2d_bn_add_xpu_fuse_pass

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -628,6 +628,7 @@ const std::vector<std::string> kPirXpuPasses{
     "add_activation_xpu_fuse_pass",
     "add_layernorm_xpu_fuse_pass",
     "conv2d_bn_xpu_fuse_pass",
+    "conv2d_bn_add_xpu_fuse_pass",
     "conv2d_add_xpu_fuse_pass",
     "group_norm_silu_fuse_pass",
     "fc_xpu_fuse_pass"};

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -86,6 +86,7 @@ USE_PIR_PASS(matmul_reshape_add_fuse_pass);
 USE_PIR_PASS(add_activation_xpu_fuse_pass);
 USE_PIR_PASS(add_layernorm_xpu_fuse_pass);
 USE_PIR_PASS(conv2d_bn_xpu_fuse_pass);
+USE_PIR_PASS(conv2d_bn_add_xpu_fuse_pass);
 USE_PIR_PASS(conv2d_add_xpu_fuse_pass);
 USE_PIR_PASS(fc_xpu_fuse_pass);
 #endif

--- a/paddle/fluid/pir/transforms/xpu/conv2d_bn_add_xpu_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/xpu/conv2d_bn_add_xpu_fuse_pass.cc
@@ -1,0 +1,236 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/pir/transforms/xpu/conv2d_bn_add_xpu_fuse_pass.h"
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
+#include "paddle/fluid/pir/utils/general_functions.h"
+
+#include "paddle/phi/backends/xpu/xpu_info.h"
+
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pass/pass_registry.h"
+
+namespace {
+
+class Conv2dBnAddFusePattern : public paddle::drr::DrrPatternBase {
+ private:
+  bool bn_inplace_;
+
+ public:
+  explicit Conv2dBnAddFusePattern(bool bn_inplace) : bn_inplace_(bn_inplace) {}
+
+  std::string name() const override { return "Conv2dBnAddFusePattern"; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+    const auto &conv2d =
+        pat.Op(paddle::dialect::Conv2dOp::name(),
+               {{"strides", pat.Attr("strides")},
+                {"paddings", pat.Attr("paddings")},
+                {"padding_algorithm", pat.Attr("padding_algorithm")},
+                {"dilations", pat.Attr("dilations")},
+                {"groups", pat.Attr("groups")},
+                {"data_format", pat.Attr("data_format")}});
+
+    const auto &bn = pat.Op(bn_inplace_ ? paddle::dialect::BatchNorm_Op::name()
+                                        : paddle::dialect::BatchNormOp::name(),
+                            {
+                                {"epsilon", pat.Attr("epsilon")},
+                            });
+    const auto &add = pat.Op(paddle::dialect::AddOp::name());
+    conv2d({&pat.Tensor("input"), &pat.Tensor("filter")},
+           {&pat.Tensor("conv2d_out")});
+    bn({&pat.Tensor("conv2d_out"),
+        &pat.Tensor("bn_mean"),
+        &pat.Tensor("bn_var"),
+        &pat.Tensor("bn_scale"),
+        &pat.Tensor("bn_bias")},
+       {&pat.Tensor("bn_out"),
+        &pat.Tensor("mean_out"),
+        &pat.Tensor("var_out"),
+        &pat.Tensor("saved_mean"),
+        &pat.Tensor("saved_variance"),
+        &pat.Tensor("reserve_space")});
+
+    pat.Tensor("add_out") = add(pat.Tensor("bn_out"), pat.Tensor("y"));
+
+    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+      std::vector<int64_t> conv_input_shape =
+          pir::GetShapeFromValue(match_ctx.Tensor("input"));
+      auto paddings_size = match_ctx.Attr<std::vector<int>>("paddings");
+      std::vector<int64_t> bn_bias_shape =
+          pir::GetShapeFromValue(match_ctx.Tensor("bn_bias"));
+      std::vector<int64_t> filter_shape =
+          pir::GetShapeFromValue(match_ctx.Tensor("filter"));
+      if (conv_input_shape.size() != 4) {
+        return false;
+      }
+      if (!pir::ValueIsPersistable(match_ctx.Tensor("bn_mean")) ||
+          !pir::ValueIsPersistable(match_ctx.Tensor("bn_var")) ||
+          !pir::ValueIsPersistable(match_ctx.Tensor("bn_scale")) ||
+          !pir::ValueIsPersistable(match_ctx.Tensor("bn_bias"))) {
+        return false;
+      }
+      if (!(paddings_size.size() == 2 || paddings_size.size() == 4)) {
+        return false;
+      }
+      if (bn_bias_shape.at(0) != filter_shape.at(0)) {
+        return false;
+      }
+      return true;
+    });
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    // bn_var shape
+    const auto &bn_var_shape_attr = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int64_t> {
+          auto bn_var_shape =
+              pir::GetShapeFromValue(match_ctx.Tensor("bn_var"));
+          return bn_var_shape;
+        });
+
+    // reshape scale shape
+    const auto &scale_shape_attr = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int64_t> {
+          auto bn_scale_shape =
+              pir::GetShapeFromValue(match_ctx.Tensor("bn_scale"));
+          return {bn_scale_shape[0], 1, 1, 1};
+        });
+
+    // reshape scale shape
+    const auto &expand_1_shape =
+        res.ComputeAttr([&](const paddle::drr::MatchContext &match_ctx)
+                            -> std::vector<int64_t> {
+          return {static_cast<int64_t>(
+              phi::backends::xpu::get_xpu_max_ptr_size(-1))};
+        });
+
+    // paddings
+    const auto &paddings_attr = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int> {
+          auto paddings = match_ctx.Attr<std::vector<int>>("paddings");
+          if (paddings.size() == 2) {
+            return {paddings[0], paddings[0], paddings[1], paddings[1]};
+          } else {
+            return paddings;
+          }
+        });
+
+    const auto &out_dtype_attr = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> phi::DataType {
+          auto x_dtype = pir::GetDataTypeFromValue(match_ctx.Tensor("input"));
+          if (x_dtype.isa<pir::Float32Type>()) {
+            return phi::DataType::FLOAT32;
+          } else {
+            return phi::DataType::UNDEFINED;
+          }
+        });
+
+    // make new scale:  bn_scale/sqrt(bn_var+epsilon)
+    const auto &full1 = res.Op(paddle::dialect::FullOp::name(),
+                               {{"shape", bn_var_shape_attr},
+                                {"value", pat.Attr("epsilon")},
+                                {"dtype", res.DataTypeAttr("float32")},
+                                {"place", res.PlaceAttr("cpu")}});
+    const auto &var_add = res.Op(paddle::dialect::AddOp::name());
+    res.Tensor("var_add_out") = var_add(res.Tensor("bn_var"), full1());
+    const auto &sqrt = res.Op(paddle::dialect::SqrtOp::name());
+    res.Tensor("sqrt_out") = sqrt(res.Tensor("var_add_out"));
+    const auto &div = res.Op(paddle::dialect::DivideOp::name());
+    res.Tensor("new_scale") =
+        div(res.Tensor("bn_scale"), res.Tensor("sqrt_out"));
+    const auto &reshape_scale = res.Op(paddle::dialect::ReshapeOp::name(),
+                                       {{"shape", scale_shape_attr}});
+    res.Tensor("res_scale") = reshape_scale(res.Tensor("new_scale"));
+
+    //--- deal with filter ---
+    const auto &mul_filter_op = res.Op(paddle::dialect::MultiplyOp::name());
+    res.Tensor("res_filter") =
+        mul_filter_op(res.Tensor("filter"), res.Tensor("res_scale"));
+
+    // --- deal with bias ---
+    // new bias: bn_bias - (bn_mean * scale)
+    const auto &bn_mean_mul_op = res.Op(paddle::dialect::MultiplyOp::name());
+    res.Tensor("bn_mean_mul_out") =
+        bn_mean_mul_op(res.Tensor("bn_mean"), res.Tensor("new_scale"));
+    const auto &sub_bias_op = res.Op(paddle::dialect::SubtractOp::name());
+    res.Tensor("res_bias") =
+        sub_bias_op(res.Tensor("bn_bias"), res.Tensor("bn_mean_mul_out"));
+
+    // get max filter and max x
+    const auto &max_op1 =
+        res.Op(paddle::dialect::MaxOp::name(),
+               {{"axis", res.VectorInt64Attr(std::vector<int64_t>{})},
+                {"keepdim", res.BoolAttr(false)}});
+    res.Tensor("filter_max") = max_op1(res.Tensor("filter"));
+    const auto &expand =
+        res.Op(paddle::dialect::ExpandOp::name(), {{"shape", expand_1_shape}});
+    res.Tensor("res_filter_max") = expand(res.Tensor("filter_max"));
+
+    const auto &conv2d_xpu =
+        res.Op(paddle::dialect::Conv2dXpuOp::name(),
+               {{
+                   {"paddings", paddings_attr},
+                   {"dilations", pat.Attr("dilations")},
+                   {"strides", pat.Attr("strides")},
+                   {"padding_algorithm", pat.Attr("padding_algorithm")},
+                   {"groups", pat.Attr("groups")},
+                   {"act_type",
+                    res.Int32Attr(static_cast<int>(xpu::Activation_t::LINEAR))},
+                   // res.Int32Attr(static_cast<int>(0))},
+                   {"act_param", res.Float32Attr(0.0f)},
+                   {"out_dtype", out_dtype_attr},
+               }});
+    conv2d_xpu(
+        {
+            &res.Tensor("input"),
+            &res.InputNoneTensor(),
+            &res.Tensor("res_filter"),
+            &res.Tensor("res_filter_max"),
+            &res.Tensor("res_bias"),
+            &res.Tensor("y"),
+            &res.InputNoneTensor(),
+            &res.InputNoneTensor(),
+            &res.InputNoneTensor(),
+        },
+        {&res.Tensor("add_out"), &res.Tensor("out_max")});
+  }
+};
+
+class Conv2dBnAddFuseXpuPass : public pir::PatternRewritePass {
+ public:
+  Conv2dBnAddFuseXpuPass()
+      : pir::PatternRewritePass("conv2d_bn_add_xpu_fuse_pass", 2) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
+    pir::RewritePatternSet ps(context);
+    bool bn_inplace = true;
+    ps.Add(paddle::drr::Create<Conv2dBnAddFusePattern>(context, bn_inplace));
+    ps.Add(paddle::drr::Create<Conv2dBnAddFusePattern>(context, !bn_inplace));
+    return ps;
+  }
+};
+
+}  // namespace
+
+namespace pir {
+
+std::unique_ptr<Pass> CreateConv2dBnAddFuseXpuPass() {
+  return std::make_unique<Conv2dBnAddFuseXpuPass>();
+}
+
+}  // namespace pir
+
+REGISTER_IR_PASS(conv2d_bn_add_xpu_fuse_pass, Conv2dBnAddFuseXpuPass);

--- a/paddle/fluid/pir/transforms/xpu/conv2d_bn_add_xpu_fuse_pass.h
+++ b/paddle/fluid/pir/transforms/xpu/conv2d_bn_add_xpu_fuse_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/core/dll_decl.h"
+
+namespace pir {
+
+class Pass;
+
+IR_API std::unique_ptr<Pass> CreateConv2dBnAddFuseXpuPass();
+
+}  // namespace pir

--- a/test/ir/pir/fused_pass/xpu/test_conv2d_bn_add_fuse_xpu_pass.py
+++ b/test/ir/pir/fused_pass/xpu/test_conv2d_bn_add_fuse_xpu_pass.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from pass_test import PassTest
+
+import paddle
+from paddle.base import core
+
+paddle.enable_static()
+
+
+class TestConv2dBnPassXPUPattern(PassTest):
+    r"""
+    x_var   f_var
+      \       /
+         conv2d
+           |
+        BatchNorm
+           |
+          add
+    """
+
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(
+                    name='x', shape=[3, 1, 28, 28], dtype='float32'
+                )
+                y = paddle.static.data(
+                    name='y', shape=[3, 32, 28, 28], dtype='float32'
+                )
+                conv2d = paddle.nn.Conv2D(
+                    in_channels=1,
+                    out_channels=32,
+                    kernel_size=3,
+                    padding=1,
+                    data_format='NCHW',
+                    bias_attr=False,
+                )
+                bn = paddle.nn.BatchNorm2D(
+                    num_features=32,
+                    data_format='NCHW',
+                    use_global_stats=True,
+                )
+                out = bn(conv2d(x))
+                out = paddle.add(out, y)
+                out = paddle.assign(out)
+                self.feeds = {
+                    "x": np.random.random((3, 1, 28, 28)).astype("float32"),
+                    "y": np.random.random((3, 32, 28, 28)).astype("float32"),
+                }
+                self.fetch_list = [out]
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        pir_program = self.build_ir_program()
+        yield pir_program, False
+
+    def test_check_output(self):
+        self.check_pass_correct(atol=1e-3, rtol=1e-3)
+
+    def setUp(self):
+        if core.is_compiled_with_xpu():
+            self.places.append(paddle.device.XPUPlace(0))
+            self.pass_attr_list = [{'conv2d_bn_add_xpu_fuse_pass': {}}]
+            self.valid_op_map = {
+                "pd_op.conv2d_xpu": 1,
+                "pd_op.batch_norm": 0,
+                "pd_op.add": 1,
+            }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Inference

### PR Types
Bug fixes


### Description
- 本PR使用PIR的Pass机制重写了XPU的一个Pass : conv2d_bn_add_xpu_fuse_pass，并添加了相应的单测
- 该Pass是老IR中conv2d_xpu_fuse_pass.cc的一部分
card-71500
