### PR TITLE
Recover the code in paddle/cinn/utils/error.h modified by pr#67306

### DIFF
--- a/paddle/cinn/utils/error.h
+++ b/paddle/cinn/utils/error.h
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// --------------------------------------------------------
 #pragma once
 
 #ifdef __GNUC__


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Recover the code in paddle/cinn/utils/error.h modified by pr#67306
delete the useless code added in  pr#67306 for testing PR-CI-CINN-GPU uts
pcard-67164