### PR TITLE
[PIR] support lazy_init in pir, but not add test case

### DIFF
--- a/python/paddle/nn/initializer/initializer.py
+++ b/python/paddle/nn/initializer/initializer.py
@@ -25,6 +25,7 @@ from ...base.framework import (
     EagerParamBase,
     default_main_program,
     in_dygraph_mode,
+    use_pir_api,
 )
 from .lazy_init import lazy_init_helper
 
@@ -86,7 +87,10 @@ class Initializer:
         def init_op_creator(
             forward, param: paddle.Tensor, block: paddle.pir.Block | None
         ):
-            new_var = param._to_static_var(True, block=block)
+            if use_pir_api():
+                new_var = param
+            else:
+                new_var = param._to_static_var(True, block=block)
             # Record initializer operator
             with lazy_init_helper():
                 forward(new_var, block)

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -2484,11 +2484,15 @@ class Layer:
 
         NOTE(dev): This is a very low level API and only for inner developer.
         """
-        startup_program = Program()
-        for param in self.parameters():
-            param._create_init_op(startup_program.global_block())
-
-        return startup_program
+        startup_program = paddle.base.Program()
+        main_program = paddle.base.Program()
+        with paddle.base.program_guard(main_program, startup_program):
+            for param in self.parameters():
+                param._create_init_op(startup_program.global_block())
+        if paddle.framework.use_pir_api():
+            return main_program
+        else:
+            return startup_program
 
     # [aliases] Compatible with old method names
     set_dict = set_state_dict


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
PIR适配了lazy_init，但没有做详细测试。

PIR在信息上没有老静态图详细，不确定是否满足需求：
老静态图：
```
{ // block_idx:0  parent_idx:-1  forward_idx:-1  backward_idx:-1
    persist trainable param weight : LOD_TENSOR.shape(10, 10).dtype(float32).stop_gradient(True)
    persist trainable param bias : LOD_TENSOR.shape(10,).dtype(float32).stop_gradient(True)

    {Out=['weight']} = fill_constant(inputs={}, dtype = 5, force_cpu = False, op_device = , op_namescope = /, op_role = 0, op_role_var = [], place_type = -1, shape = [10, 10], str_value = 0.6, value = 0.6000000238418579, with_quant_attr = False)
    {Out=['bias']} = fill_constant(inputs={}, dtype = 5, force_cpu = False, op_device = , op_namescope = /, op_role = 0, op_role_var = [], place_type = -1, shape = [10], str_value = 0.3, value = 0.30000001192092896, with_quant_attr = False)
}
```

PIR:
```
{
    (%0) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[10,10],stop_gradient:[true],value:(Double)0.6} : () -> builtin.tensor<10x10xf32>
    (%1) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[10],stop_gradient:[true],value:(Double)0.3} : () -> builtin.tensor<10xf32>
}
```

Pcard-67164