### PR TITLE
【Error Message No.405/406】【BUAA】Update error massage of 2 messages in `test/cpp/inference/infer_ut/`

### DIFF
--- a/test/cpp/inference/infer_ut/test_ernie_xnli_int8.cc
+++ b/test/cpp/inference/infer_ut/test_ernie_xnli_int8.cc
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include "paddle/fluid/platform/enforce.h"
 
 #include "test_helper.h"  // NOLINT
 #include "test_suite.h"   // NOLINT
@@ -91,7 +92,9 @@ std::vector<T> ParseTensor(const std::string &field) {
 void run(Predictor *predictor, std::vector<float> *out_data) {
   clock_t start, end;
   start = clock();
-  CHECK(predictor->Run());
+  PADDLE_ENFORCE_NOT_NULL(predictor->Run(),
+                          common::errors::InvalidArgument(
+                              "Predictor is not running! Please check."));
   end = clock();
 
   auto output_names = predictor->GetOutputNames();

--- a/test/cpp/inference/infer_ut/test_resnet50_quant.cc
+++ b/test/cpp/inference/infer_ut/test_resnet50_quant.cc
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include "paddle/fluid/platform/enforce.h"
 
 #include "test_suite.h"  // NOLINT
 
@@ -31,7 +32,10 @@ paddle::test::Record PrepareInput(int batch_size) {
   // load from binary data
   std::ifstream fs(FLAGS_datadir, std::ifstream::binary);
   EXPECT_TRUE(fs.is_open());
-  CHECK(fs.is_open());
+  PADDLE_ENFORCE_EQ(fs.is_open(),
+                    true,
+                    common::errors::InvalidArgument(
+                        "File system is not open! Please check."));  // NOLINT
 
   float* input = new float[input_num];
   memset(input, 0, input_num * sizeof(float));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Update error massage of 2 messages in `test/cpp/inference/infer_ut/`:
        modified:   test/cpp/inference/infer_ut/test_ernie_xnli_int8.cc
        modified:   test/cpp/inference/infer_ut/test_resnet50_quant.cc