### PR TITLE
[CINN]Add input shape constraint

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_dynamic_to_static_dim_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_dynamic_to_static_dim_pass.cc
@@ -108,7 +108,7 @@ class DynamicToStaticConverter {
     VisitEachValue(fusion_op_, [&](pir::Value value) {
       updated |= UpdateValueShape(value);
     });
-    shape_analysis_->Init();
+    shape_analysis_->InitInferContext();
     return updated;
   }
 

--- a/paddle/cinn/hlir/dialect/operator/transforms/local_infer_symbolic_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/local_infer_symbolic_util.cc
@@ -104,7 +104,7 @@ void InitLocalShapeAnalysis(const pir::Operation& op,
 std::shared_ptr<pir::ShapeConstraintIRAnalysis> MakeOpShapeAnalysis(
     const pir::Operation* op, const DimExprs4ValueT& GraphDimExprs4Value) {
   auto shape_analysis = std::make_shared<pir::ShapeConstraintIRAnalysis>();
-  shape_analysis->Init();
+  shape_analysis->InitInferContext();
   InitLocalShapeAnalysis(*op, shape_analysis.get(), GraphDimExprs4Value);
   return shape_analysis;
 }

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.cc
@@ -197,49 +197,63 @@ void BuildCstrEqForTensorListAlongAxis(
   }
 }
 
-void CheckAndReplaceInputConstraintDimExpr(
+std::vector<symbol::DimExpr> GetSymShapeForInputValue(
     const std::string &input_name,
-    const pir::InferSymbolicShapeContext &infer_context,
-    std::vector<symbol::DimExpr> *input_dim_exprs) {
-  if (infer_context.HasInputShapeInitSymbol(input_name)) {
-    const auto &dim_index_and_exprs =
-        infer_context.GetInputShapeInitSymbol(input_name);
-    const auto &constraints_manager = infer_context.constraints_manager();
-
-    const auto &CheckStaticDimMatchConstraints =
-        [&](const std::int64_t &static_value,
-            const symbol::DimExpr &dim_expr,
-            const int &dim_index) {
-          if (constraints_manager.IsBoundedInput(dim_expr)) {
-            const auto &range =
-                constraints_manager.GetRangeOfBoundedInput(dim_expr);
-            PADDLE_ENFORCE_EQ(
-                static_value >= range.min && static_value <= range.max,
-                true,
-                common::errors::InvalidArgument(
-                    "Input DimExpr range constraint is inconsistent "
-                    "with static shape dim. The input dim index is "
-                    "%d, static value is %d, range constraint is [%d, %d].",
-                    input_name,
-                    dim_index,
-                    static_value,
-                    range.min,
-                    range.max));
-          }
-        };
-
-    for (const auto &index_and_expr : dim_index_and_exprs) {
-      symbol::DimExpr origin_dim_expr =
-          input_dim_exprs->at(index_and_expr.index);
-      if (origin_dim_expr.isa<std::int64_t>()) {
-        const std::int64_t &static_value = origin_dim_expr.Get<std::int64_t>();
-        CheckStaticDimMatchConstraints(
-            static_value, index_and_expr.dim_expr, index_and_expr.index);
-      } else {
-        input_dim_exprs->at(index_and_expr.index) = index_and_expr.dim_expr;
+    const pir::Value &value,
+    pir::InferSymbolicShapeContext *infer_context) {
+  const common::DDim &result_dims =
+      value.type().dyn_cast<pir::DenseTensorType>().dims();
+  const auto &predefined_dim_index_to_expr = [&]() {
+    std::unordered_map<int, symbol::DimExpr> index_to_expr;
+    if (infer_context->HasPredefinedDimExprForInputName(input_name)) {
+      const auto &dim_index_and_exprs =
+          infer_context->GetPredefinedDimExprForInputName(input_name);
+      for (const auto &item : dim_index_and_exprs) {
+        index_to_expr[item.index] = item.dim_expr;
       }
     }
-  }
-}
+    return index_to_expr;
+  }();
 
+  const auto &CheckStaticDimMatchConstraints =
+      [&](const symbol::DimExpr &predefined_dim_expr,
+          const int64_t &static_dim,
+          const int &dim_index) {
+        if (static_dim == -1) {
+          // no need to check
+          return;
+        }
+        PADDLE_ENFORCE_EQ(
+            infer_context->HasPredefinedRange(predefined_dim_expr),
+            false,
+            common::errors::InvalidArgument(
+                "Dim with static shape can not set range. The input value name "
+                "is %s, dim index is %d, static value is %d.",
+                input_name,
+                dim_index,
+                static_dim));
+        infer_context->AddEqualCstr(predefined_dim_expr,
+                                    symbol::DimExpr{static_dim});
+      };
+
+  const auto &GetDimExpr = [&](const int64_t &static_dim,
+                               const int &dim_index) -> symbol::DimExpr {
+    if (predefined_dim_index_to_expr.find(dim_index) !=
+        predefined_dim_index_to_expr.end()) {
+      symbol::DimExpr dim_expr = predefined_dim_index_to_expr.at(dim_index);
+      CheckStaticDimMatchConstraints(dim_expr, static_dim, dim_index);
+      return dim_expr;
+    }
+    if (static_dim != -1) {
+      return symbol::DimExpr{static_dim};
+    }
+    return symbol::DimExpr{infer_context->GetNextSymName()};
+  };
+
+  std::vector<symbol::DimExpr> result_dim_exprs;
+  for (size_t i = 0; i < result_dims.size(); ++i) {
+    result_dim_exprs.emplace_back(GetDimExpr(result_dims[i], i));
+  }
+  return result_dim_exprs;
+}
 }  // namespace paddle::dialect::details

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.cc
@@ -251,7 +251,7 @@ std::vector<symbol::DimExpr> GetSymShapeForInputValue(
   };
 
   std::vector<symbol::DimExpr> result_dim_exprs;
-  for (size_t i = 0; i < result_dims.size(); ++i) {
+  for (int i = 0; i < result_dims.size(); ++i) {
     result_dim_exprs.emplace_back(GetDimExpr(result_dims[i], i));
   }
   return result_dim_exprs;

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
@@ -171,4 +171,9 @@ void BuildCstrEqForTensorListAlongAxis(
     const std::vector<pir::Value> &values,
     int axis);
 
+void CheckAndReplaceInputConstraintDimExpr(
+    const std::string &input_name,
+    const pir::InferSymbolicShapeContext &infer_context,
+    std::vector<symbol::DimExpr> *input_dim_exprs);
+
 }  // namespace paddle::dialect::details

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
@@ -171,9 +171,8 @@ void BuildCstrEqForTensorListAlongAxis(
     const std::vector<pir::Value> &values,
     int axis);
 
-void CheckAndReplaceInputConstraintDimExpr(
+std::vector<symbol::DimExpr> GetSymShapeForInputValue(
     const std::string &input_name,
-    const pir::InferSymbolicShapeContext &infer_context,
-    std::vector<symbol::DimExpr> *input_dim_exprs);
-
+    const pir::Value &value,
+    pir::InferSymbolicShapeContext *infer_context);
 }  // namespace paddle::dialect::details

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
@@ -105,26 +105,10 @@ bool AssignValue_OpInferSymbolicShape(
 
 bool DataOpInferSymbolicShape(pir::Operation *op,
                               pir::InferSymbolicShapeContext *infer_context) {
-  const auto &attributes = op->attributes();
-  pir::Attribute attr = attributes.at("shape");
-
-  const std::vector<symbol::DimExpr> sym_dims = [&] {
-    std::vector<symbol::DimExpr> sym_dims;
-    const std::vector<int64_t> &dims =
-        attr.dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData();
-    for (auto dim : dims) {
-      symbol::DimExpr dim_expr;
-      if (dim == pir::ShapedTypeInterface::kDynamic) {
-        symbol::DimExpr symbolic_dim_expr(infer_context->GetNextSymName());
-        dim_expr = symbolic_dim_expr;
-      } else {
-        symbol::DimExpr numeric_dim_expr(dim);
-        dim_expr = numeric_dim_expr;
-      }
-      sym_dims.push_back(dim_expr);
-    }
-    return sym_dims;
-  }();
+  std::string name =
+      op->attributes().at("name").dyn_cast<pir::StrAttribute>().AsString();
+  const std::vector<symbol::DimExpr> sym_dims =
+      details::GetSymShapeForInputValue(name, op->result(0), infer_context);
 
   auto IsNumelLEKMaxRank = [](pir::Value value) {
     const auto &dims = value.type().dyn_cast<pir::DenseTensorType>().dims();
@@ -204,28 +188,12 @@ bool EmptyOpInferSymbolicShape(pir::Operation *op,
 
 bool FeedOpInferSymbolicShape(pir::Operation *op,
                               pir::InferSymbolicShapeContext *infer_context) {
-  const common::DDim &result_dims =
-      op->result(0).type().dyn_cast<pir::DenseTensorType>().dims();
-  std::vector<symbol::DimExpr> out_dims;
-  for (int i = 0; i < result_dims.size(); i++) {
-    if (result_dims[i] == -1) {
-      out_dims.emplace_back(infer_context->GetNextSymName());
-    } else {
-      out_dims.emplace_back(result_dims[i]);
-    }
-  }
-
-  if (op->attributes().count("name")) {
-    std::string name =
-        op->attributes().at("name").dyn_cast<pir::StrAttribute>().AsString();
-    details::CheckAndReplaceInputConstraintDimExpr(
-        name, *infer_context, &out_dims);
-  }
-
+  std::string name =
+      op->attributes().at("name").dyn_cast<pir::StrAttribute>().AsString();
+  const auto &symbolic_shape =
+      details::GetSymShapeForInputValue(name, op->result(0), infer_context);
   infer_context->SetShapeOrDataForValue(
-      op->result(0),
-      symbol::ShapeOrDataDimExprs{symbol::TensorShapeOrDataDimExprs(out_dims)});
-
+      op->result(0), symbol::TensorShapeOrDataDimExprs(symbolic_shape));
   return true;
 }
 

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
@@ -215,6 +215,13 @@ bool FeedOpInferSymbolicShape(pir::Operation *op,
     }
   }
 
+  if (op->attributes().count("name")) {
+    std::string name =
+        op->attributes().at("name").dyn_cast<pir::StrAttribute>().AsString();
+    details::CheckAndReplaceInputConstraintDimExpr(
+        name, *infer_context, &out_dims);
+  }
+
   infer_context->SetShapeOrDataForValue(
       op->result(0),
       symbol::ShapeOrDataDimExprs{symbol::TensorShapeOrDataDimExprs(out_dims)});

--- a/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
+++ b/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
@@ -393,7 +393,7 @@ void InferSymExprForAllValues(ModuleOp module_op) {
         return symbol_shape_map;
       }();
 
-  shape_analysis.Init();
+  shape_analysis.InitInferContext();
   // init the kwarg symbol shape info
   for (const auto& kv : symbol_shape_map) {
     infer_context->SetShapeOrDataForValue(kv.first, kv.second);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-67164

# Support user-specified constraints for Input Shape

## 1. Background
The constraint information of dynamic shapes plays a crucial role in fusion optimization and various front-end graph optimizations. Currently, CINN’s dynamic shape constraint information is mainly obtained automatically from the limitations derived from the symbolic derivation of single operators, such as matmul.

To acquire more symbolic constraint information about shapes, it is necessary to expose the ability to add constraints to users or higher-level modules.

## 2. User Interfaces
- Allow users to name dims. Dims with the same name will have an equal constraint.
- Allow users to specify the range of dynamic Shapes through shape_range.

### 2.1. Inference Configuration
【High Priority】Inference process using CINN through the config mode. Currently, model inference mainly uses the method of exporting first, then loading, and performing corresponding optimizations based on the relevant configuration information before execution. Therefore, users can also configure shape information in JSON format and then specify the corresponding config to indicate the utilization of this information.
```
{
    "batch_size": {
        "bind_dim": [
            ["input_ids", 0],
            ["attention_mask", 0],
            ["position_ids", 0]
        ],
        "min": 2
    },
    "sequence_length": {
        "bind_dim": [
            ["input_ids", 1],
            ["attention_mask", 1],
            ["position_ids", 1]
        ],
        "max": 128
    }
}
````
### 2.2. InputSpec Specification
To support dynamic-to-static conversion and direct save/load of input shape constraints, users are allowed to specify shape equality constraint information through InputSpec and specify the shape range through DynamicShapeRange.
```
InputSpec(shape=["batch_size", "sequence_length"], dtype='int64', name='input_ids')
InputSpec(shape=["batch_size", "sequence_length"], dtype='int64', name='attention_mask')
InputSpec(shape=["batch_size", "sequence_length"], dtype='int64', name='position_ids')
DynamicShapeRange(shape_name = "batch_size", min = 2)
DynamicShapeRange(shape_name = "sequence_length", max = 128)
```
### 2.3. Abstraction
```
input_shape_constraints = [(dim_name, bind_info, range)]
bind_info = [(input_name, dim_index)]
range = (min, max)
min = int(default:1)
max = int(default:INT32_MAX)
```
## 3. Implementation
The implementation involves the following key steps:
- Step1: Modifying the Shape Symbolic Representation System and Symbolic Inference of Some Input Operators to Support the Storage and Utilization of Input Constraints;
- Step2: Support acquisition of Custom Input Constraint Information;
- Step3: Modify the backend to leverage the symbolic range information.

## Change in this PR(step1 of implementation)
- Extension of `ShapeConstraintIRAnalysis`
This PR add `input_shape_constraints_` in `ShapeConstraintIRAnalysis`, which is responsible for preserving the original input shape constraint information. The information stored in `input_shape_constraints_` can only be set or modified during initial phase. ShapeConstraintIRAnalysis will initialize its infer_context using this information. 
- Extension of `ConstraintsManager`
The `ConstraintsManager` will be enhanced to manage and utilize the input shape constraints.
A new data structure, `InputRangeConstraints`, will be added to represent input dimensions (`DimExpr`) that have range constraints.
- Extension of `InferSymbolicShapeContext`
`InferSymbolicShapeContext` adds a `predefined_dimexpr_map_for_inputs_` member, which, along with `ConstraintsManager`, is initialized by `input_shape_constraints_`.
```
input_shape_info = [(dim_name, bind_info, range)]
bind_info = [(input_name, dim_index)]
range = (min, max)
=====>
dim_name -> dim_expr
input_shape_constraints = [(dim_expr, bind_info, range)]
bind_info = [(input_name, dim_index)]
=====>
input_name -> [(dim_index, dim_expr)]
dim_epxr -> range

input_shape_init_symbol = input_name -> [(dim_index, dim_expr)]
InputRangeConstraints = dim_expr -> range
```
- Symbolic Inference:
Check if the input name has predefined dimexpr in predefined_dimexpr_map_for_inputs_. If it does, directly set the corresponding dimension of the output value to the initialized symbol. This PR support feed op and data op.



