### PR TITLE
【Comm】fix bug in pir pass

### DIFF
--- a/paddle/phi/core/distributed/check/static_check.cc
+++ b/paddle/phi/core/distributed/check/static_check.cc
@@ -81,7 +81,12 @@ void CommStaticCheck::CheckShape(const phi::DenseTensor& out_tensor,
       out_size * out_size_factor,
       in_size * in_size_factor,
       common::errors::InvalidArgument(
-          "Input and output tensors should have matching sizes."));
+          "Input and output tensors should have matching sizes. "
+          "out_size=%ld, out_size_factor=%d, in_size=%ld, in_size_factor=%d",
+          out_size,
+          out_size_factor,
+          in_size,
+          in_size_factor));
 }
 
 void CommStaticCheck::CheckShape(const phi::DenseTensor& out_tensor,

--- a/python/paddle/distributed/auto_parallel/static/pir_pass.py
+++ b/python/paddle/distributed/auto_parallel/static/pir_pass.py
@@ -367,7 +367,7 @@ comm_ops = [
     "pd_op.c_allreduce_sum",
     "pd_op.all_gather",
     "pd_op.c_allreduce_max",
-    "pd_op.c_reducescatter",
+    "pd_op.reduce_scatter",
 ]
 
 

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/p_to_s_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/p_to_s_reshard_func.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import paddle
-from paddle.distributed.passes.pass_utils import AutoParallelStreamType
+from paddle.distributed.utils.stream_utils import ExecutionStreamType
 
 from ..process_group import new_process_group
 from .base_reshard_func import (
@@ -81,7 +81,7 @@ class PToSReshardFunction(ReshardFunction):
             src_value, group.id, num_of_process
         )
         dst_value.get_defining_op().set_execution_stream(
-            AutoParallelStreamType.CALC_STREAM.value
+            ExecutionStreamType.DefaultStream.value
         )
 
         # set dist type and dist attr

--- a/python/paddle/distributed/passes/auto_parallel_sequence_parallel_optimization.py
+++ b/python/paddle/distributed/passes/auto_parallel_sequence_parallel_optimization.py
@@ -18,7 +18,7 @@ from paddle.distributed.auto_parallel.static.utils import (
     naive_set_dist_op_attr_for_program_by_mesh,
 )
 from paddle.distributed.fleet.meta_optimizers.common import OP_ROLE_KEY
-from paddle.distributed.passes.pass_utils import AutoParallelStreamType
+from paddle.distributed.utils.stream_utils import ExecutionStreamType
 from paddle.static import default_main_program
 
 from .auto_parallel_sharding import _is_reshard_op
@@ -135,7 +135,7 @@ class SequenceParallelOptimizationPass(PassBase):
                 },
             )
             new_op.dist_attr.execution_stream = (
-                AutoParallelStreamType.CALC_STREAM.value
+                ExecutionStreamType.DefaultStream.value
             )
             block._remove_op(i, False)
             block._remove_op(i - 1, False)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
llama dp2 开 sequence parallel 后跑不通，定位到是pir pass 里未将 nranks=1 的 reduce_scatter 算子过滤掉导致的。这是之前 reduce_scatter 算子切换 https://github.com/PaddlePaddle/Paddle/pull/66431/files 未切换完全引入的问题，但之前CI中未检测到，在llama sequence parallel 中发现
PCard-85979