### PR TITLE
[Typing][B-79,B-80,B-81] Add type annotations for `python/paddle/profiler/{profiler,profiler_statistic,utils}.py`

### DIFF
--- a/python/paddle/profiler/profiler.py
+++ b/python/paddle/profiler/profiler.py
@@ -19,7 +19,7 @@ import json
 import os
 import socket
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Callable, Literal, Self
 from warnings import warn
 
 import paddle
@@ -45,6 +45,9 @@ from .utils import RecordEvent, wrap_optimizers
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from types import TracebackType
+
+    from paddle.base.core import _ProfilerResult
 
 
 class SummaryView(Enum):
@@ -128,7 +131,7 @@ def make_scheduler(
     record: int,
     repeat: int = 0,
     skip_first: int = 0,
-) -> Callable:
+) -> Callable[[int], ProfilerState]:
     r"""
     Return a scheduler function, which scheduler the :ref:`ProfilerState <api_paddle_profiler_ProfilerState>` according to the setting.
     The state transform confirms to:
@@ -221,7 +224,7 @@ def _default_state_scheduler(step: int):
 
 def export_chrome_tracing(
     dir_name: str, worker_name: str | None = None
-) -> Callable:
+) -> Callable[[Profiler], None]:
     r"""
     Return a callable, used for outputing tracing data to chrome tracing format file.
     The output file will be saved in directory ``dir_name``, and file name will be set as `worker_name`.
@@ -272,7 +275,9 @@ def export_chrome_tracing(
     return handle_fn
 
 
-def export_protobuf(dir_name: str, worker_name: str | None = None) -> Callable:
+def export_protobuf(
+    dir_name: str, worker_name: str | None = None
+) -> Callable[[Profiler], None]:
     r"""
     Return a callable, used for outputing tracing data to protobuf file.
     The output file will be saved in directory ``dir_name``, and file name will be set as ``worker_name``.
@@ -478,19 +483,36 @@ class Profiler:
                 >>> # |       ips       |    1086.42904   |    1227.30604   |    959.92796    |
     """
 
+    targets: Iterable[ProfilerTarget]
+    profiler: _Profiler
+    scheduler: Callable[[int], ProfilerState]
+    on_trace_ready: Callable[[Profiler], None]
+    step_num: int
+    previous_state: ProfilerState
+    current_state: ProfilerState
+    record_event: RecordEvent
+    profiler_result: _ProfilerResult
+    timer_only: bool
+    record_shapes: bool
+    profile_memory: bool
+    with_flops: bool
+    emit_nvtx: bool
+
     def __init__(
         self,
         *,
         targets: Iterable[ProfilerTarget] | None = None,
-        scheduler: Callable[[int], ProfilerState] | tuple | None = None,
-        on_trace_ready: Callable[..., Any] | None = None,
-        record_shapes: bool | None = False,
-        profile_memory: bool | None = False,
-        timer_only: bool | None = False,
-        emit_nvtx: bool | None = False,
-        custom_device_types: list | None = [],
-        with_flops: bool | None = False,
-    ):
+        scheduler: (
+            Callable[[int], ProfilerState] | tuple[int, int] | None
+        ) = None,
+        on_trace_ready: Callable[[Profiler], None] | None = None,
+        record_shapes: bool = False,
+        profile_memory: bool = False,
+        timer_only: bool = False,
+        emit_nvtx: bool = False,
+        custom_device_types: list[str] = [],
+        with_flops: bool = False,
+    ) -> None:
         supported_targets = _get_supported_targets()
         if targets:
             self.targets = set(targets)
@@ -553,14 +575,19 @@ class Profiler:
         self.with_flops = with_flops
         self.emit_nvtx = emit_nvtx
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         self.start()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         self.stop()
 
-    def start(self):
+    def start(self) -> None:
         r'''
         Start profiler and enter the first profiler step(0).
         State transformed from CLOSED to self.current_state and trigger corresponding action.
@@ -609,7 +636,7 @@ class Profiler:
         )
         self.record_event.begin()
 
-    def stop(self):
+    def stop(self) -> None:
         r'''
         Stop profiler and State transformed from self.current_state to CLOSED.
         Trigger corresponding action and post-process profiler result using self.on_trace_ready if result exists.
@@ -659,7 +686,7 @@ class Profiler:
                 self.on_trace_ready(self)
         utils._is_profiler_used = False
 
-    def step(self, num_samples: int | None = None):
+    def step(self, num_samples: int | None = None) -> None:
         r"""
         Signals the profiler that the next profiling step has started.
         Get the new ProfilerState and trigger corresponding action.
@@ -703,7 +730,7 @@ class Profiler:
         )
         self.record_event.begin()
 
-    def step_info(self, unit=None):
+    def step_info(self, unit: str | None = None) -> str:
         r"""
         Get statistics for current step. If the function is called at certain iteration
         intervals, the result is the average of all steps between the previous call and
@@ -821,7 +848,7 @@ class Profiler:
             if self.on_trace_ready:
                 self.on_trace_ready(self)
 
-    def export(self, path="", format="json"):
+    def export(self, path: str = "", format: str = "json") -> None:
         r"""
         Exports the tracing data to file.
 
@@ -853,12 +880,12 @@ class Profiler:
 
     def summary(
         self,
-        sorted_by=SortedKeys.CPUTotal,
-        op_detail=True,
-        thread_sep=False,
-        time_unit='ms',
-        views=None,
-    ):
+        sorted_by: SortedKeys = SortedKeys.CPUTotal,
+        op_detail: bool = True,
+        thread_sep: bool = False,
+        time_unit: Literal['s', 'ms', 'us', 'ns'] = 'ms',
+        views: SummaryView | list[SummaryView] | None = None,
+    ) -> None:
         r"""
         Print the Summary table. Currently support overview, model, distributed, operator, memory manipulation and user-defined summary.
 
@@ -866,7 +893,7 @@ class Profiler:
             sorted_by( :ref:`SortedKeys <api_paddle_profiler_SortedKeys>` , optional): how to rank the op table items, default value is SortedKeys.CPUTotal.
             op_detail(bool, optional): expand each operator detail information, default value is True.
             thread_sep(bool, optional): print op table each thread, default value is False.
-            time_unit(str, optional): time unit for display, can be chosen form ['s', 'ms', 'us', 'ns'], default value is 'ms'.
+            time_unit(str, optional): time unit for display, can be chosen from ['s', 'ms', 'us', 'ns'], default value is 'ms'.
             views(SummaryView|list[SummaryView], optional): summary tables to print, default to None means all views to be printed.
 
         Examples:

--- a/python/paddle/profiler/profiler.py
+++ b/python/paddle/profiler/profiler.py
@@ -19,7 +19,7 @@ import json
 import os
 import socket
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, Literal, Self
+from typing import TYPE_CHECKING, Callable, Literal
 from warnings import warn
 
 import paddle
@@ -46,6 +46,8 @@ from .utils import RecordEvent, wrap_optimizers
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from types import TracebackType
+
+    from typing_extensions import Self
 
     from paddle.base.core import _ProfilerResult
 

--- a/python/paddle/profiler/utils.py
+++ b/python/paddle/profiler/utils.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import functools
 import sys
 from contextlib import ContextDecorator, contextmanager
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING
 from warnings import warn
 
 from paddle.base import core
@@ -25,6 +25,8 @@ from paddle.base.core import TracerEventType, _RecordEvent
 
 if TYPE_CHECKING:
     import types
+
+    from typing_extensions import Self
 
     from paddle.base.core import _ProfilerResult
 

--- a/python/paddle/profiler/utils.py
+++ b/python/paddle/profiler/utils.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import functools
 import sys
 from contextlib import ContextDecorator, contextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 from warnings import warn
 
 from paddle.base import core
@@ -25,6 +25,8 @@ from paddle.base.core import TracerEventType, _RecordEvent
 
 if TYPE_CHECKING:
     import types
+
+    from paddle.base.core import _ProfilerResult
 
 _is_profiler_used = False
 _has_optimizer_wrapped = False
@@ -74,16 +76,20 @@ class RecordEvent(ContextDecorator):
         RecordEvent will take effect only when :ref:`Profiler <api_paddle_profiler_Profiler>` is on and at the state of `RECORD`.
     """
 
+    name: str
+    event_type: TracerEventType
+    event: _RecordEvent | None
+
     def __init__(
         self,
         name: str,
         event_type: TracerEventType = TracerEventType.PythonUserDefined,
-    ):
+    ) -> None:
         self.name = name
         self.event_type = event_type
         self.event = None
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         self.begin()
         return self
 
@@ -92,10 +98,10 @@ class RecordEvent(ContextDecorator):
         exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
         traceback: types.TracebackType | None,
-    ):
+    ) -> None:
         self.end()
 
-    def begin(self):
+    def begin(self) -> None:
         r"""
         Record the time of beginning.
 
@@ -127,7 +133,7 @@ class RecordEvent(ContextDecorator):
         else:
             self.event = _RecordEvent(self.name, self.event_type)
 
-    def end(self):
+    def end(self) -> None:
         r"""
         Record the time of ending.
 
@@ -150,7 +156,7 @@ class RecordEvent(ContextDecorator):
             self.event.end()
 
 
-def load_profiler_result(filename: str):
+def load_profiler_result(filename: str) -> _ProfilerResult:
     r"""
     Load dumped profiler data back to memory.
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

类型标注：

- `python/paddle/profiler/profiler.py`
- `python/paddle/profiler/profiler_statistic.py` 实际只有一个 Enum ，不需要再标注了
- `python/paddle/profiler/utils.py`

### Related links
 
- https://github.com/PaddlePaddle/Paddle/issues/65008

@SigureMo @megemini 
