### PR TITLE
[PIR Unittest] fix 2 pir uts (`test_copysign_op.py,test_elementwise_mul_op.py`)

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -7806,7 +7806,7 @@ def copysign(x: Tensor, y: Tensor | float, name: str | None = None) -> Tensor:
     if isinstance(y, (float, int)):
         y = paddle.to_tensor(y, dtype=x.dtype)
     out_shape = broadcast_shape(x.shape, y.shape)
-    if out_shape != x.shape:
+    if out_shape != list(x.shape):
         warnings.warn(
             f"The shape of broadcast output {out_shape} is different from the input tensor x with shape: {x.shape}, please make sure you are using copysign api correctly."
         )

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -2064,8 +2064,13 @@ class OpTest(unittest.TestCase):
         if getattr(self, "no_need_check_inplace", False):
             return
 
-        if os.getenv("FLAGS_enable_pir_in_executor") or os.getenv(
-            "FLAGS_enable_pir_api"
+        if (
+            os.getenv("FLAGS_enable_pir_in_executor")
+            or os.getenv("FLAGS_enable_pir_api")
+            or get_flags("FLAGS_enable_pir_in_executor")[
+                "FLAGS_enable_pir_in_executor"
+            ]
+            or get_flags("FLAGS_enable_pir_api")["FLAGS_enable_pir_api"]
         ):
             return
 

--- a/test/legacy_test/test_copysign_op.py
+++ b/test/legacy_test/test_copysign_op.py
@@ -45,16 +45,16 @@ class TestCopySignOp(OpTest):
         self.outputs = {'out': self.target}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['x', 'y'], ['out'])
+        self.check_grad(['x', 'y'], ['out'], check_pir=True)
 
     def test_check_grad_ignore_x(self):
-        self.check_grad(['y'], ['out'])
+        self.check_grad(['y'], ['out'], check_pir=True)
 
     def test_check_grad_ignore_y(self):
-        self.check_grad(['x'], ['out'])
+        self.check_grad(['x'], ['out'], check_pir=True)
 
     def init_config(self):
         self.x = np.random.randn(20, 6).astype('float64')
@@ -87,19 +87,21 @@ class TestCopySignBF16(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad_with_place(self.place, ['x', 'y'], ['out'])
+        self.check_grad_with_place(
+            self.place, ['x', 'y'], ['out'], check_pir=True
+        )
 
     def test_check_grad_ignore_x(self):
         self.check_grad_with_place(
-            self.place, ['y'], ['out'], no_grad_set=set('x')
+            self.place, ['y'], ['out'], no_grad_set=set('x'), check_pir=True
         )
 
     def test_check_grad_ignore_y(self):
         self.check_grad_with_place(
-            self.place, ['x'], ['out'], no_grad_set=set('y')
+            self.place, ['x'], ['out'], no_grad_set=set('y'), check_pir=True
         )
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
- test_copysign_op.py
    - 在 Optest 相关 check 加上 check_pir = True （可能和 test_elementwise_mul_op 一样）
    - 旧静态图下，Tensor 的 shape 为 tuple，给 x.shape 加上 list，减少警告信息（静态图下存在 -1 也会有提醒）
- test_elementwise_mul_op
    - 在默认设置 Flags use_pir_api 为 True 时，Optest 中的 check_output ，有一步骤 `check_inplace_output_with_place` 会通过 PIR 环境变量来跳过一些检查，但是开启 PIR 后，不匹配环境变量的判断方式，加上 FLAGS 判断。
