### PR TITLE
[PIR Unittest] fix 4 pir uts `test_elementwise_(add_op,div_op,nn_grad,sub_op)`

### DIFF
--- a/test/legacy_test/test_elementwise_add_op.py
+++ b/test/legacy_test/test_elementwise_add_op.py
@@ -620,12 +620,13 @@ class TestAddApi(unittest.TestCase):
         return paddle.add(x, y, name)
 
     def test_name(self):
-        with base.program_guard(base.Program()):
-            x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
-            y = paddle.static.data(name='y', shape=[2, 3], dtype='float32')
+        with paddle.pir_utils.OldIrGuard():
+            with base.program_guard(base.Program()):
+                x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
+                y = paddle.static.data(name='y', shape=[2, 3], dtype='float32')
 
-            y_1 = self._executed_api(x, y, name='add_res')
-            self.assertEqual(('add_res' in y_1.name), True)
+                y_1 = self._executed_api(x, y, name='add_res')
+                self.assertEqual(('add_res' in y_1.name), True)
 
     def test_declarative(self):
         with base.program_guard(base.Program()):
@@ -642,7 +643,7 @@ class TestAddApi(unittest.TestCase):
 
             place = base.CPUPlace()
             exe = base.Executor(place)
-            z_value = exe.run(feed=gen_data(), fetch_list=[z.name])
+            z_value = exe.run(feed=gen_data(), fetch_list=[z])
             z_expected = np.array([3.0, 8.0, 6.0])
             self.assertEqual((z_value == z_expected).all(), True)
 
@@ -857,27 +858,30 @@ class TestTensorAddNumpyScalar(unittest.TestCase):
 
 class TestTensorAddAPIWarnings(unittest.TestCase):
     def test_warnings(self):
-        with warnings.catch_warnings(record=True) as context:
-            warnings.simplefilter("always")
+        with paddle.pir_utils.OldIrGuard():
+            with warnings.catch_warnings(record=True) as context:
+                warnings.simplefilter("always")
 
-            paddle.enable_static()
-            helper = LayerHelper("elementwise_add")
-            data = paddle.static.data(
-                name='data', shape=[None, 3, 32, 32], dtype='float32'
-            )
-            out = helper.create_variable_for_type_inference(dtype=data.dtype)
-            os.environ['FLAGS_print_extra_attrs'] = "1"
-            helper.append_op(
-                type="elementwise_add",
-                inputs={'X': data, 'Y': data},
-                outputs={'Out': out},
-                attrs={'axis': 1, 'use_mkldnn': False},
-            )
-            self.assertTrue(
-                "op elementwise_add's attr axis = 1 is not the default value: -1"
-                in str(context[-1].message)
-            )
-            os.environ['FLAGS_print_extra_attrs'] = "0"
+                paddle.enable_static()
+                helper = LayerHelper("elementwise_add")
+                data = paddle.static.data(
+                    name='data', shape=[None, 3, 32, 32], dtype='float32'
+                )
+                out = helper.create_variable_for_type_inference(
+                    dtype=data.dtype
+                )
+                os.environ['FLAGS_print_extra_attrs'] = "1"
+                helper.append_op(
+                    type="elementwise_add",
+                    inputs={'X': data, 'Y': data},
+                    outputs={'Out': out},
+                    attrs={'axis': 1, 'use_mkldnn': False},
+                )
+                self.assertTrue(
+                    "op elementwise_add's attr axis = 1 is not the default value: -1"
+                    in str(context[-1].message)
+                )
+                os.environ['FLAGS_print_extra_attrs'] = "0"
 
 
 class TestTensorFloat32Bfloat16OrFloat16Add(unittest.TestCase):

--- a/test/legacy_test/test_elementwise_div_op.py
+++ b/test/legacy_test/test_elementwise_div_op.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import OpTest, convert_float_to_uint16, skip_check_grad_ci
 
 import paddle
+import paddle.static
 from paddle import base
 from paddle.base import core
 from paddle.pir_utils import test_with_pir_api
@@ -509,14 +510,15 @@ class TestElementwiseDivBroadcast(unittest.TestCase):
 class TestDivideOp(unittest.TestCase):
     def test_name(self):
         paddle.enable_static()
-        main_program = paddle.static.Program()
-        with paddle.static.program_guard(main_program):
-            x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
-            y = paddle.static.data(name='y', shape=[2, 3], dtype='float32')
+        with paddle.pir_utils.OldIrGuard():
+            main_program = paddle.static.Program()
+            with paddle.static.program_guard(main_program):
+                x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
+                y = paddle.static.data(name='y', shape=[2, 3], dtype='float32')
 
-            y_1 = paddle.divide(x, y, name='div_res')
+                y_1 = paddle.divide(x, y, name='div_res')
 
-            self.assertEqual(('div_res' in y_1.name), True)
+                self.assertEqual(('div_res' in y_1.name), True)
 
         paddle.disable_static()
 

--- a/test/legacy_test/test_elementwise_nn_grad.py
+++ b/test/legacy_test/test_elementwise_nn_grad.py
@@ -552,7 +552,8 @@ class TestElementwiseAddBroadcastTripleGradCheck(unittest.TestCase):
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
-            self.func(p)
+            with paddle.pir_utils.OldIrGuard():
+                self.func(p)
 
 
 class TestElementwiseMulTripleGradCheck(unittest.TestCase):
@@ -621,7 +622,8 @@ class TestElementwiseMulBroadcastTripleGradCheck(unittest.TestCase):
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
-            self.func(p)
+            with paddle.pir_utils.OldIrGuard():
+                self.func(p)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
同 (https://github.com/PaddlePaddle/Paddle/pull/67399) 存在 OpTest 的 check_ouput 中 check_inplace_output_with_place 对 PIR 的跳过逻辑
- test_elementwise_nn_grad.py 中梯度检查 `triple_grad_check` ，应该是对于 (x) -op - (y) 的单算子的检查，但是 pir 下 `paddle.tensor.math._add_with_axis` 是多个 op 的，使用加上 OldIrGuard() 
![图片](https://github.com/user-attachments/assets/c00632e6-77a6-49ff-878f-5d5528faf5fc)
不然中间 op 的 stop_gradinet 为 True，`base.gradients` 得到 None
- 给一些 旧 iR 下的用法，加上 OldIrGuard