### PR TITLE
[Paddle Inference][horizontal_fuse_pass] fix bug

### DIFF
--- a/paddle/fluid/pir/transforms/gpu/horizontal_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/horizontal_fuse_pass.cc
@@ -59,6 +59,11 @@ class HorizontalFusePattern : public pir::RewritePattern {
 
  private:
   bool IsValidOp(pir::Operation* curr_op, const pir::Value& x) const {
+    // x must be the first operand of fc/gemm_epilogue/matmul
+    if (!(curr_op->num_operands() > 0 && curr_op->operand_source(0) == x)) {
+      return false;
+    }
+
     if (curr_op->isa<paddle::dialect::GemmEpilogueOp>() ||
         curr_op->isa<paddle::dialect::FcOp>()) {
       return true;
@@ -76,11 +81,6 @@ class HorizontalFusePattern : public pir::RewritePattern {
         return false;
       }
       return true;
-    }
-
-    // x must be the first operand of fc/gemm_epilogue/matmul
-    if (curr_op->operand_source(0) != x) {
-      return false;
     }
 
     return false;

--- a/paddle/fluid/pir/transforms/gpu/horizontal_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/horizontal_fuse_pass.cc
@@ -58,7 +58,7 @@ class HorizontalFusePattern : public pir::RewritePattern {
   }
 
  private:
-  bool IsValidOp(pir::Operation* curr_op) const {
+  bool IsValidOp(pir::Operation* curr_op, const pir::Value& x) const {
     if (curr_op->isa<paddle::dialect::GemmEpilogueOp>() ||
         curr_op->isa<paddle::dialect::FcOp>()) {
       return true;
@@ -77,6 +77,12 @@ class HorizontalFusePattern : public pir::RewritePattern {
       }
       return true;
     }
+
+    // x must be the first operand of fc/gemm_epilogue/matmul
+    if (curr_op->operand_source(0) != x) {
+      return false;
+    }
+
     return false;
   }
 
@@ -108,8 +114,8 @@ class HorizontalFusePattern : public pir::RewritePattern {
     pir::AttributeMap op_example_attrs;
     for (auto it = x.use_begin(); it != x.use_end(); ++it) {
       pir::Operation* curr_op = it.owner();
-      if (!IsValidOp(curr_op)) {
-        continue;
+      if (!IsValidOp(curr_op, x)) {
+        return 0;
       }
       if (op_example == nullptr) {
         op_example = curr_op;
@@ -163,7 +169,7 @@ class HorizontalFusePattern : public pir::RewritePattern {
 
     for (auto it = x.use_begin(); it != x.use_end(); ++it) {
       pir::Operation* curr_op = it.owner();
-      if (!IsValidOp(curr_op)) {
+      if (!IsValidOp(curr_op, x)) {
         continue;
       }
       fused_matmul_ops.push_back(curr_op);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

P-card-71501


- 1. 这个pass本来应该要处理下面的这个case的，
  - 也就是一个var连接到了三个matmul和一个elementwise_mul，这个暂时没有很好的支持，我在pr里禁止了对这种情形的处理
- 2. 一个var连接到了多个matmul的Y上，我也禁止了这种case

上面两种情况实际上都要处理的，暂时通过增加约束，避免处理- 。


<img width="889" alt="image" src="https://github.com/user-attachments/assets/10546c96-81bc-49e7-a5e1-bb74c900e69d">



