### PR TITLE
Fix paddle.linalg.lu when `get_infos=True` 易用性提升

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2474,8 +2474,7 @@ void LUInferMeta(const MetaTensor& x,
       infos,
       common::errors::InvalidArgument("Output(Infos) should not be nullptr."));
   if (x_rank == 2) {
-    auto Infos_dim = std::vector<int>(1);
-    infos->set_dims(common::make_ddim(Infos_dim));
+    infos->set_dims(common::make_ddim({}));
   } else {
     auto Infos_dim =
         std::vector<int>(dims_vec.begin(), dims_vec.begin() + x_rank - 2);

--- a/paddle/phi/kernels/cpu/lu_kernel.cc
+++ b/paddle/phi/kernels/cpu/lu_kernel.cc
@@ -50,9 +50,6 @@ void LUKernel(const Context& dev_ctx,
   auto ipiv_data = pivots->data<int>();
 
   auto info_dims = common::slice_ddim(outdims, 0, outrank - 2);
-  if (info_dims.size() == 0) {
-    info_dims = common::make_ddim({1});
-  }
   infos->Resize(info_dims);
   dev_ctx.template Alloc<int>(infos);
   auto info_data = infos->data<int>();

--- a/paddle/phi/kernels/gpu/lu_kernel.cu
+++ b/paddle/phi/kernels/gpu/lu_kernel.cu
@@ -146,9 +146,6 @@ void LUKernel(const Context& dev_ctx,
   auto ipiv_data = pivots->data<int>();
 
   auto info_dims = common::slice_ddim(outdims, 0, outrank - 2);
-  if (info_dims.size() == 0) {
-    info_dims = common::make_ddim({1});
-  }
   infos->Resize(info_dims);
   dev_ctx.template Alloc<int>(infos);
   auto info_data = infos->data<int>();

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -3325,8 +3325,8 @@ def lu(
             Tensor(shape=[2], dtype=int32, place=Place(cpu), stop_gradient=True,
             [3, 3])
             >>> print(info)
-            Tensor(shape=[1], dtype=int32, place=Place(cpu), stop_gradient=True,
-            [0])
+            Tensor(shape=[], dtype=int32, place=Place(cpu), stop_gradient=True,
+            0)
 
             >>> P,L,U = paddle.linalg.lu_unpack(lu,p)
 

--- a/test/legacy_test/test_lu_op.py
+++ b/test/legacy_test/test_lu_op.py
@@ -139,7 +139,7 @@ class TestLUOp(OpTest):
         self.output = NLU
         self.Pivots = Pmat_to_perm(sP, min(ashape[-2], ashape[-1]))
         self.Infos = (
-            np.zeros(self.x_shape[:-2]) if len(X.shape) > 2 else np.array([0])
+            np.zeros(self.x_shape[:-2]) if len(X.shape) > 2 else np.array(0)
         )
 
     def setUp(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
当 paddle.linalg.lu 输入 `x` 形状为 [m, n] 时且 `get_infos=True`，将返回的 info Tensor 从 1-D Tensor 改为 0-D Tensor