### PR TITLE
[Feature] add non norm_topk in fused moe

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -5912,6 +5912,7 @@ void FusedMoeInferMeta(const MetaTensor& X,
                        const MetaTensor& ffn2_bias,
                        const std::string& quant_method,
                        const int moe_topk,
+                       const bool norm_topk_prob,
                        MetaTensor* out) {
   out->set_dims(X.dims());
   out->share_lod(X);

--- a/paddle/phi/infermeta/multiary.h
+++ b/paddle/phi/infermeta/multiary.h
@@ -1176,6 +1176,7 @@ void FusedMoeInferMeta(const MetaTensor& X,
                        const MetaTensor& ffn2_bias,
                        const std::string& quant_method,
                        const int moe_topk,
+                       const bool norm_topk_prob,
                        MetaTensor* out);
 
 void FusedMultiHeadAttentionInferMeta(const MetaTensor& query,

--- a/paddle/phi/kernels/fusion/cutlass/fused_moe_kernel.cu
+++ b/paddle/phi/kernels/fusion/cutlass/fused_moe_kernel.cu
@@ -56,6 +56,7 @@ void FusedMoeKernel(const Context& ctx,
                     const DenseTensor& ffn2_bias,
                     const std::string& quant_method,
                     const int moe_topk,
+                    const bool norm_topk_prob,
                     DenseTensor* out) {
   out->Resize(X.dims());
   auto* output_data = ctx.template Alloc<T>(out);
@@ -85,6 +86,7 @@ void FusedMoeKernel(const Context& ctx,
                          &ffn2_bias,
                          nullptr,
                          moe_topk,
+                         norm_topk_prob,
                          "ffn",
                          out);
 }

--- a/paddle/phi/kernels/fusion/cutlass/moe/fused_moe_helper.h
+++ b/paddle/phi/kernels/fusion/cutlass/moe/fused_moe_helper.h
@@ -132,6 +132,7 @@ class MoeHelper {
                   const DenseTensor *ffn2_bias,
                   const DenseTensor *moe_token_type_ids,
                   const int moe_topk,
+                  const bool norm_topk_prob,
                   const std::string moe_type,
                   DenseTensor *output) {
     auto *input_activations = X->data<T>();
@@ -413,6 +414,7 @@ class MoeHelper {
           hidden_size,
           k,
           static_cast<int>(1),
+          norm_topk_prob,
           ctx.stream());
     } else {
       finalize_moe_routing_kernelLauncher(
@@ -427,6 +429,7 @@ class MoeHelper {
           inter_size,
           k,
           static_cast<int>(0),
+          norm_topk_prob,
           ctx.stream());
     }
     VLOG(4) << " Finished EXPERT \n";

--- a/paddle/phi/ops/yaml/fused_ops.yaml
+++ b/paddle/phi/ops/yaml/fused_ops.yaml
@@ -842,7 +842,7 @@
 
 - op: fused_moe
   args: (Tensor x, Tensor gate_weight, Tensor ffn1_weight, Tensor ffn1_scale, Tensor ffn1_bias, Tensor ffn2_weight, Tensor ffn2_scale, Tensor ffn2_bias,
-    str quant_method = "None", int moe_topk = 2)
+    str quant_method = "None", int moe_topk = 2, bool norm_topk_prob = true)
   output: Tensor (out)
   infer_meta:
     func: FusedMoeInferMeta

--- a/python/paddle/incubate/nn/functional/fused_moe.py
+++ b/python/paddle/incubate/nn/functional/fused_moe.py
@@ -30,6 +30,7 @@ def fused_moe(
     ffn2_scale=None,
     quant_method="None",
     moe_topk=2,
+    norm_topk_prob=True,
 ):
     """
     Applies fused moe kernel.
@@ -45,7 +46,8 @@ def fused_moe(
         ffn1_scale (Tensor, optional): the input scale Tensor Provided to weight for dequantization. Its shape is [num_experts, d_feed_forward*2].
         ffn2_scale (Tensor, optional): the input scale Tensor Provided to weight for dequantization. Its shape is [num_experts, d_model].
         quant_method (string): Currently not supported.
-        moe_topk: Select the top k experts for each token.
+        moe_topk (int): Select the top k experts for each token.
+        norm_topk_prob (bool): Whether to normalize the topk probabilities.
 
     Returns:
         Tensor: the output Tensor.
@@ -66,7 +68,7 @@ def fused_moe(
             >>> ffn2_weight = paddle.randn([8, 2048, 1024])
             >>> ffn2_bias = paddle.randn([8, 1, 1024])
             >>> moe_topk = 2
-            >>> out = fused_moe(x, gate_weight, ffn1_weight, ffn1_bias, ffn2_weight, ffn2_bias, None, None,"None", moe_topk)
+            >>> out = fused_moe(x, gate_weight, ffn1_weight, ffn1_bias, ffn2_weight, ffn2_bias, None, None,"None", moe_topk, True)
             >>> print(out.shape)
             [10, 128, 1024]
 
@@ -83,6 +85,7 @@ def fused_moe(
             ffn2_bias,
             quant_method,
             moe_topk,
+            norm_topk_prob,
         )
         return final_out
     else:
@@ -104,6 +107,7 @@ def fused_moe(
             attrs={
                 'quant_method': quant_method,
                 'moe_topk': moe_topk,
+                'norm_topk_prob': norm_topk_prob,
             },
         )
         return final_out


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Inference


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

Pcard-71501

为fused moe算子添加topk是否做norm的可选参数，适配qwen_moe中不做topk_norm的场景