### PR TITLE
Fix pipeline parallel error of using tensor method item

### DIFF
--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -857,6 +857,11 @@ def monkey_patch_tensor():
                 3.299999952316284
 
         """
+        # resolve the error issue in scenario of pipeline parallel
+        # where some devices do not have self data, return None does not affect
+        # the execution result in those devices, so currently we return None
+        if self.is_dist() and not self._is_initialized():
+            return None
         scalar = self._getitem_from_offset(*args)
         if scalar.dtype == np.uint16:
             return convert_uint16_to_float(scalar).item()

--- a/test/auto_parallel/semi_auto_parallel_for_item.py
+++ b/test/auto_parallel/semi_auto_parallel_for_item.py
@@ -42,18 +42,19 @@ class TestItemApiForSemiAutoParallel(SemiAutoParallelTestBase):
             np.testing.assert_equal(c.item(0, 0), a[0][0].item())
             np.testing.assert_equal(c.item(3, 5), a[3][5].item())
         else:  # in device 0
-            self.assertEqual(c.item(3, 5), None)
+            np.testing.assert_equal(c.item(3, 5), None)
 
     def run_test_case(self):
         if self._backend == "cpu":
             paddle.set_device("cpu")
         elif self._backend == "gpu":
             paddle.set_device("gpu:" + str(dist.get_rank()))
+            # only gpu can run pipeline
+            self.test_item_api_with_pp()
         else:
             raise ValueError("Only support cpu or gpu backend.")
 
         self.test_item_api()
-        self.test_item_api_with_pp()
 
 
 if __name__ == '__main__':

--- a/test/auto_parallel/semi_auto_parallel_for_item.py
+++ b/test/auto_parallel/semi_auto_parallel_for_item.py
@@ -38,11 +38,11 @@ class TestItemApiForSemiAutoParallel(SemiAutoParallelTestBase):
         a = paddle.rand(shape=[6, 8])
         b = dist.shard_tensor(a, mesh0, [dist.Replicate()])
         c = dist.reshard(b, mesh1, [dist.Replicate()])
-        if c.item(0, 0) is None:  # in device 0
-            self.assertEqual(c.item(3, 5), None)
-        else:  # in device 1
+        if c.item(0, 0):  # in device 1
             np.testing.assert_equal(c.item(0, 0), a[0][0].item())
             np.testing.assert_equal(c.item(3, 5), a[3][5].item())
+        else:  # in device 0
+            self.assertEqual(c.item(3, 5), None)
 
     def run_test_case(self):
         if self._backend == "cpu":


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Bug fixes

### Description
pcard-86208
In pipeline parallel, error will occur in some device when using Tensor method `item()`. e.g.

```python
import paddle
import paddle.distributed as dist

dense_tensor = paddle.to_tensor([[1,2],
                                 [3,4]], stop_gradient=False)
mesh0 = dist.ProcessMesh([0,1], dim_names=['dp'])
mesh1 = dist.ProcessMesh([2,3], dim_names=['dp'])
placements = [dist.Replicate()]

t1 = dist.shard_tensor(dense_tensor, mesh0, placements)
t2 = t1 * 2
lossmask = dist.reshard(t2, mesh1, placements)
print(lossmask.item(0))  # will error in device 0 and 1
```
![image](https://github.com/user-attachments/assets/27d3426a-0d96-4f40-909e-4bd9c620985e)

Tensor's method `item()` calls method `_getitem_from_offset`, which has code of `PADDLE_ENFORCE(dist_tensor->initialized(), ...)` and this assert may not be satisfied on some devices. because in the pipeline parallel, some devices do not have this data. this PR will fix this error.