### PR TITLE
align amp accuary in auto parallel with pir.

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -800,7 +800,7 @@ void BindOperation(py::module *m) {
       .def("num_operands", &Operation::num_operands)
       .def("num_results", &Operation::num_results)
       .def("num_regions", &Operation::num_regions)
-
+      .def("id", &Operation::id)
       .def("operand", &Operation::operand)
       .def("result",
            [](Operation &self, uint32_t index) {

--- a/paddle/phi/infermeta/spmd_rules/elementwise.cc
+++ b/paddle/phi/infermeta/spmd_rules/elementwise.cc
@@ -123,6 +123,10 @@ SpmdInfo ElementwiseUnaryInferSpmd(const DistMetaTensor& x) {
   return {{x_dst_dist_attr}, {out_dist_attr}};
 }
 
+SpmdInfo AssignInferSpmd(const DistMetaTensor& x) {
+  return {{x.dist_attr()}, {x.dist_attr()}};
+}
+
 // NOTE(lizhiyu): This function is only for `cast` right now to support partial
 // propagation
 SpmdInfo ElementwiseUnaryWithPartialInferSpmd(const DistMetaTensor& x) {

--- a/paddle/phi/infermeta/spmd_rules/elementwise.h
+++ b/paddle/phi/infermeta/spmd_rules/elementwise.h
@@ -55,6 +55,7 @@ SpmdInfo ElementwiseBinaryGradInferSpmd(const DistMetaTensor& x,
                                         int64_t axis = -1);
 
 SpmdInfo SwiGLUInferSpmd(const DistMetaTensor& x, const DistMetaTensor& y);
+SpmdInfo AssignInferSpmd(const DistMetaTensor& x);
 
 SpmdInfo SwiGLUInferSpmdReverse(const DistMetaTensor& x,
                                 const DistMetaTensor& y,

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -1129,6 +1129,7 @@ void EmbeddingGradSparseInferMeta(const MetaTensor& x,
       out->set_dtype(x.dtype());
     } else {
       out->share_dims(weight);
+      out->set_dtype(weight.dtype());
     }
   }
 }

--- a/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
@@ -37,6 +37,7 @@
   output : Tensor
   infer_meta :
     func : UnchangedInferMeta
+    spmd_rule : AssignInferSpmd
   kernel :
     func : assign
   backward : assign_grad

--- a/paddle/phi/ops/yaml/inconsistent/static_backward.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_backward.yaml
@@ -171,6 +171,7 @@
   infer_meta :
     func : EmbeddingGradSparseInferMeta
     param : [x,weight]
+    spmd_rule : EmbeddingGradInferSpmd
   kernel :
     func : embedding_grad {dense, dense, dense -> dense}
            embedding_sparse_grad {dense, dense, dense -> selected_rows}

--- a/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
@@ -55,6 +55,7 @@
   output : Tensor
   infer_meta :
     func : UnchangedInferMeta
+    spmd_rule : AssignInferSpmd
   kernel :
     func : assign_raw
   backward : assign_grad

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -93,6 +93,9 @@ def append_full_like(float_value, copy_value, value, state, backward_ops):
 def append_add_n(
     op, value, state, backward_ops, bwd_value_to_block_argument_map
 ):
+    _MAX_ADD_NUM_ = paddle.framework._global_flags()[
+        'FLAGS_max_inplace_grad_add'
+    ]
     with paddle.amp.auto_cast(enable=False):
         # value is input of more than one fwd_op,
         # so more than one bwd_op create input_grad,
@@ -108,6 +111,21 @@ def append_add_n(
             for tmp in state.value_to_valuegrad[value]:
                 state.value_to_sumvaluegrad[value].append(tmp)
             state.value_to_valuegrad[value] = []
+        elif len(add_n_list) <= _MAX_ADD_NUM_:
+            grad_value = add_n_list[0]
+            index = 1
+            grad_op_list = []
+            while index < len(add_n_list):
+                grad_value += add_n_list[index]
+                grad_op_list.append(grad_value.get_defining_op())
+                index += 1
+            update_bwdop_structure(
+                backward_ops, state.op_to_opgrad[op], grad_op_list
+            )
+            for tmp in state.value_to_valuegrad[value]:
+                state.value_to_sumvaluegrad[value].append(tmp)
+            state.value_to_valuegrad[value] = [[grad_value]]
+
         else:
             if value.is_dense_tensor_array_type():
                 add_n_value = paddle._C_ops.add_n_array(add_n_list)

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -703,6 +703,9 @@ class Engine:
             if loss.initialized():
                 with static.program_guard(dist_program, startup_program):
                     if self._strategy.amp.enable:
+                        self._strategy.amp.level = (
+                            self._strategy.amp.level.upper()
+                        )
                         amp_lists = paddle.static.amp.decorator.AutoMixedPrecisionLists(
                             custom_white_list=self._strategy.amp.custom_white_list,
                             custom_black_list=self._strategy.amp.custom_black_list,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
align amp accuary in auto parallel with pir.
- support 'FLAGS_max_inplace_grad_add' flags in pir backward mode.
- add inferspmd rule for embeding_grad.
- add inferspmd rule for assign_op.
- add id interface for operation in python end.
### Other
Pcard-67164