### PR TITLE
[CINN]Deprecate generate_xshape cinn op

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
@@ -20,7 +20,6 @@
 #include "paddle/cinn/hlir/dialect/operator/ir/op_attribute.h"
 #include "paddle/common/ddim.h"
 #include "paddle/common/enforce.h"
-#include "paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h"
 #include "paddle/fluid/pir/dialect/operator/ir/ir_meta_tensor.h"
 #include "paddle/fluid/pir/dialect/operator/ir/ir_tensor.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
@@ -544,61 +543,6 @@ bool GenerateShapeOp::InferSymbolicShape(
   return true;
 }
 
-void GenerateXShapeOp::Build(pir::Builder& builder,             // NOLINT
-                             pir::OperationArgument& argument,  // NOLINT
-                             pir::Value input) {
-  VLOG(4) << "Start build GenerateXShapeOp";
-  VLOG(4) << "Builder construction inputs";
-  std::vector<pir::Value> inputs = {input};
-  argument.AddInputs(inputs);
-
-  std::vector<pir::Type> outputs = GenerateXShapeOp::InferMeta(inputs);
-  argument.AddOutputs(outputs);
-}
-
-bool GenerateXShapeOp::InferSymbolicShape(
-    pir::InferSymbolicShapeContext* infer_context) {
-  const symbol::ShapeOrDataDimExprs& x_dim_expr =
-      infer_context->GetShapeOrDataForValue(this->operand_source(0));
-  infer_context->SetShapeOrDataForValue(
-      this->result(0),
-      paddle::dialect::details::CreateShapeOrDataForXShape(x_dim_expr));
-  return true;
-}
-
-std::vector<pir::Type> GenerateXShapeOp::InferMeta(
-    const std::vector<pir::Value>& input_values) {
-  VLOG(4) << "Start infermeta GenerateXShapeOp";
-  PADDLE_ENFORCE_EQ(input_values.size(),
-                    1,
-                    ::common::errors::InvalidArgument(
-                        "Number of inputs is expected to be 1 but got %d.",
-                        input_values.size()));
-  pir::Value input = input_values[0];
-  VLOG(4) << "Builder construction outputs";
-  PADDLE_ENFORCE_EQ(input.type().isa<paddle::dialect::DenseTensorType>(),
-                    true,
-                    ::common::errors::InvalidArgument(
-                        "input type must be DenseTensorType, but received: %s.",
-                        input.type()));
-  auto input_type = input.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  const auto out_dims = [&]() -> decltype(auto) {
-    auto x_dims_data = phi::vectorize<int64_t>(input_type.dims());
-    x_dims_data.insert(x_dims_data.begin(), 0);
-    return phi::make_ddim(x_dims_data);
-  }();
-
-  std::vector<pir::Type> out_types;
-  out_types.push_back(
-      paddle::dialect::DenseTensorType::get(pir::IrContext::Instance(),
-                                            input_type.dtype(),
-                                            out_dims,
-                                            input_type.data_layout(),
-                                            input_type.lod(),
-                                            input_type.offset()));
-  return out_types;
-}
-
 }  // namespace dialect
 }  // namespace cinn
 
@@ -607,5 +551,4 @@ IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::FusionOp)
 IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::ConcatOp)
 IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::SplitOp)
 IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::GenerateShapeOp);
-IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::GenerateXShapeOp);
 IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::YieldStoreOp);

--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
@@ -184,24 +184,6 @@ class IR_API GenerateShapeOp
       const pir::Attribute &symbol_bindings);
 };
 
-class IR_API GenerateXShapeOp
-    : public pir::Op<GenerateXShapeOp,
-                     paddle::dialect::InferSymbolicShapeInterface> {
- public:
-  using Op::Op;
-  static const char *name() { return "cinn_op.generate_xshape"; }
-  static constexpr uint32_t attributes_num = 0;
-  static constexpr const char **attributes_name = nullptr;
-  static void Build(pir::Builder &builder,             // NOLINT
-                    pir::OperationArgument &argument,  // NOLINT
-                    pir::Value input);
-  void VerifySig() {}
-  pir::Value out() { return result(0); }
-  bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
-  static std::vector<pir::Type> InferMeta(
-      const std::vector<pir::Value> &input_values);
-};
-
 }  // namespace dialect
 }  // namespace cinn
 
@@ -210,5 +192,4 @@ IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::FusionOp)
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::ConcatOp)
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::SplitOp)
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::GenerateShapeOp);
-IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::GenerateXShapeOp);
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::YieldStoreOp);

--- a/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
@@ -58,7 +58,6 @@ void OperatorDialect::initialize() {
   RegisterOp<SplitOp>();
   RegisterOp<YieldStoreOp>();
   RegisterOp<GenerateShapeOp>();
-  RegisterOp<GenerateXShapeOp>();
   RegisterAttribute<GroupInfoAttribute>();
   RegisterAttribute<CINNKernelInfoAttribute>();
   RegisterAttribute<FusionTrackerPtrAttribute>();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
Pcard-67164


删除 CINN Dialect 中的generate_xshape 算子，由于主框架中 reshape/flatten/squeeze/unsqueeze 算子的xshape输出均已退场，故不再需要此算子和机制。