### PR TITLE
[PIR][CSE] Deny no operand ops in CINN (e.g. `FullOp`)

### DIFF
--- a/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
@@ -32,7 +32,9 @@
 #include "paddle/pir/include/pass/pass_registry.h"
 
 COMMON_DECLARE_int32(cse_max_count);
+#ifdef PADDLE_WITH_CINN
 COMMON_DECLARE_bool(use_cinn);
+#endif
 
 namespace {
 
@@ -139,13 +141,16 @@ std::map<int, int> GetOpInplaceInfo(const pir::Operation* op) {
 }
 
 bool IsTerminateOp(pir::Operation* op) {
+  bool res = op->isa<paddle::dialect::DataOp>() ||
+             op->isa<pir::ParameterOp>() || op->isa<pir::ConstantTensorOp>();
+#ifdef PADDLE_WITH_CINN
   // In CINN mode, if an OP has no inputs, it can usually be fused with
   // neighboring OPs, such as the FullOp.
   // Eliminating it would make fusion impossible, so we make it a terminate
   // node to avoid eliminating it.
-  return op->isa<paddle::dialect::DataOp>() || op->isa<pir::ParameterOp>() ||
-         op->isa<pir::ConstantTensorOp>() ||
-         (FLAGS_use_cinn && op->num_operands() == 0);
+  res = res || (FLAGS_use_cinn && op->num_operands() == 0);
+#endif
+  return res;
 }
 bool IsTerminateValue(const pir::Value& value) {
   return !value.defining_op() || IsTerminateOp(value.defining_op());

--- a/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
@@ -32,6 +32,7 @@
 #include "paddle/pir/include/pass/pass_registry.h"
 
 COMMON_DECLARE_int32(cse_max_count);
+COMMON_DECLARE_bool(use_cinn);
 
 namespace {
 
@@ -138,8 +139,13 @@ std::map<int, int> GetOpInplaceInfo(const pir::Operation* op) {
 }
 
 bool IsTerminateOp(pir::Operation* op) {
+  // In CINN mode, if an OP has no inputs, it can usually be fused with
+  // neighboring OPs, such as the FullOp.
+  // Eliminating it would make fusion impossible, so we make it a terminate
+  // node to avoid eliminating it.
   return op->isa<paddle::dialect::DataOp>() || op->isa<pir::ParameterOp>() ||
-         op->isa<pir::ConstantTensorOp>();
+         op->isa<pir::ConstantTensorOp>() ||
+         (FLAGS_use_cinn && op->num_operands() == 0);
 }
 bool IsTerminateValue(const pir::Value& value) {
   return !value.defining_op() || IsTerminateOp(value.defining_op());

--- a/test/ir/pir/test_cse_pass.py
+++ b/test/ir/pir/test_cse_pass.py
@@ -406,6 +406,10 @@ class TestCSECanNotReplace(unittest.TestCase, AssertOpCountEqualMixin):
             self.assert_op_count_equal(main_program, {"pd_op.while": 2})
 
 
+@unittest.skipUnless(
+    paddle.is_compiled_with_cinn(),
+    "This case only works when compiled with CINN",
+)
 class TestCSEDenyFullInCinn(unittest.TestCase, AssertOpCountEqualMixin):
     CINN_FLAGS_NAME = "FLAGS_use_cinn"
 

--- a/test/ir/pir/test_cse_pass.py
+++ b/test/ir/pir/test_cse_pass.py
@@ -31,6 +31,16 @@ def program_scope_guard():
             yield main_program
 
 
+@contextmanager
+def flag_guard(flag_name, flag_value):
+    old_value = paddle.get_flags(flag_name)[flag_name]
+    paddle.set_flags({flag_name: flag_value})
+    try:
+        yield
+    finally:
+        paddle.set_flags({flag_name: old_value})
+
+
 def walk_block(block, fn):
     for op in block.ops:
         fn(op)
@@ -394,6 +404,34 @@ class TestCSECanNotReplace(unittest.TestCase, AssertOpCountEqualMixin):
             self.assert_op_count_equal(main_program, {"pd_op.while": 2})
             paddle.base.libpaddle.pir.apply_cse_pass(main_program)
             self.assert_op_count_equal(main_program, {"pd_op.while": 2})
+
+
+class TestCSEDenyFullInCinn(unittest.TestCase, AssertOpCountEqualMixin):
+    CINN_FLAGS_NAME = "FLAGS_use_cinn"
+
+    def test_replace_full_without_cinn(self):
+        with flag_guard(
+            self.CINN_FLAGS_NAME, False
+        ), program_scope_guard() as main_program:
+            # Inputs
+            x1 = paddle.full([2], 1.0, dtype="float32")
+            x2 = paddle.full([2], 1.0, dtype="float32")
+
+            self.assert_op_count_equal(main_program, {"pd_op.full": 2})
+            paddle.base.libpaddle.pir.apply_cse_pass(main_program)
+            self.assert_op_count_equal(main_program, {"pd_op.full": 1})
+
+    def test_replace_full_with_cinn(self):
+        with flag_guard(
+            self.CINN_FLAGS_NAME, True
+        ), program_scope_guard() as main_program:
+            # Inputs
+            x1 = paddle.full([2], 1.0, dtype="float32")
+            x2 = paddle.full([2], 1.0, dtype="float32")
+
+            self.assert_op_count_equal(main_program, {"pd_op.full": 2})
+            paddle.base.libpaddle.pir.apply_cse_pass(main_program)
+            self.assert_op_count_equal(main_program, {"pd_op.full": 2})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

CINN 场景下，CSE 中不再消除相同的 FullOp 等无输入的 OP，因为 FullOp 大多数情况都跟随在一些其它可以融合的 OP，消除后会导致 OP 无法融合

该改动仅针对 CINN 场景，其它场景消除掉 FullOp 还是会有收益的，因此仍然消除

Pcard-67164