### PR TITLE
Disable parallel tests when card number > 1

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1530,6 +1530,12 @@ function card_test() {
         parallel_job=$parallel_level_base
     fi
 
+    if (( $cardnumber == $CUDA_DEVICE_COUNT )); then
+        if (( $cardnumber > 1 )); then
+            parallel_job=1
+        fi
+    fi
+
     if [[ "$testcases" == "" ]]; then
         return 0
     fi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Distributed Strategy


### PR Types
Others

### Description
Fix some uts by disabling parallel tests when card number > 1.

Pcard-67164