### PR TITLE
[CodeStyle][Black] Explicit declare black target versions to make formatting more modernize

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.black]
 line-length = 80
 skip-string-normalization = true
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 extend-exclude = '''
 (
     third_party/.+      # Exclude third_party directory

--- a/python/paddle/base/wrapped_decorator.py
+++ b/python/paddle/base/wrapped_decorator.py
@@ -34,7 +34,7 @@ def wrap_decorator(
     def __impl__(
         func: Callable[_InputT, _RetT1],
         *args: _InputT.args,
-        **kwargs: _InputT.kwargs
+        **kwargs: _InputT.kwargs,
     ) -> _RetT2:
         wrapped_func = decorator_func(func)
         return wrapped_func(*args, **kwargs)

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_optimizer_stage2.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_optimizer_stage2.py
@@ -77,7 +77,7 @@ class GroupShardedOptimizerStage2(Optimizer):
         device="gpu",
         pretrain_sync_models=True,
         dp_group=None,
-        **kw
+        **kw,
     ):
         super().__init__(learning_rate=optim._learning_rate, parameters=params)
         assert (

--- a/python/paddle/utils/gast/ast3.py
+++ b/python/paddle/utils/gast/ast3.py
@@ -218,7 +218,7 @@ class Ast3ToGAst(AstToGAst):
             self._visit(node.arg),
             gast.Param(),
             self._visit(node.annotation),
-            *extra_args  # type_comment
+            *extra_args,  # type_comment
         )
         ast.copy_location(new_node, node)
         return new_node
@@ -453,7 +453,7 @@ class GAstToAst3(GAstToAst):
             new_node = ast.arguments(
                 [self._make_arg(arg) for arg in node.posonlyargs],
                 [self._make_arg(n) for n in node.args],
-                *extra_args
+                *extra_args,
             )
         else:
             new_node = ast.arguments(

--- a/test/collective/fleet/hybrid_parallel_pp_multiple_losses_alignment.py
+++ b/test/collective/fleet/hybrid_parallel_pp_multiple_losses_alignment.py
@@ -151,7 +151,7 @@ class SimpleNetPipe(PipelineLayer):
         super().__init__(
             layers=self.descs,
             loss_fn=[MSEPipe(), LossNet(), L1Pipe()],
-            **kwargs
+            **kwargs,
         )
 
 

--- a/test/collective/fleet/test_rnn_dp.py
+++ b/test/collective/fleet/test_rnn_dp.py
@@ -30,7 +30,7 @@ class RNNEncoder(nn.Layer):
         direction="forward",
         dropout=0.0,
         pooling_type=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._input_size = input_size
@@ -44,7 +44,7 @@ class RNNEncoder(nn.Layer):
             num_layers=num_layers,
             direction=direction,
             dropout=dropout,
-            **kwargs
+            **kwargs,
         )
 
     def get_input_dim(self):

--- a/test/deprecated/legacy_test/test_run_program_op_deprecated.py
+++ b/test/deprecated/legacy_test/test_run_program_op_deprecated.py
@@ -269,7 +269,7 @@ class RunProgramOpTest(unittest.TestCase):
                 outputs['Out'],
                 outputs['OutScope'],
                 None,
-                *self.attrs
+                *self.attrs,
             )
 
             return outputs['Out']
@@ -321,7 +321,7 @@ class RunProgramOpTest(unittest.TestCase):
                 outputs['Out'],
                 outputs['OutScope'],
                 None,
-                *self.attrs
+                *self.attrs,
             )
 
             for param in input_param_list:

--- a/test/ipu/test_cross_entropy2_op_ipu.py
+++ b/test/ipu/test_cross_entropy2_op_ipu.py
@@ -68,7 +68,7 @@ class TestBase(IPUOpTest):
             label=label,
             reduction='none',
             use_softmax=False,
-            **self.attrs
+            **self.attrs,
         )
         self.fetch_list = [out.name]
 

--- a/test/ipu/test_groupnorm_op_ipu.py
+++ b/test/ipu/test_groupnorm_op_ipu.py
@@ -74,7 +74,7 @@ class TestBase(IPUOpTest):
                 num_channels=conv1.shape[index],
                 weight_attr=scale,
                 bias_attr=bias,
-                **self.attrs
+                **self.attrs,
             )(conv1)
             loss = paddle.mean(out)
             adam = paddle.optimizer.Adam(learning_rate=1e-2)

--- a/test/ipu/test_instancenorm_op_ipu.py
+++ b/test/ipu/test_instancenorm_op_ipu.py
@@ -72,7 +72,7 @@ class TestBase(IPUOpTest):
                 num_features=self.feed_shape[0][1],
                 weight_attr=True,
                 bias_attr=True,
-                **self.attrs
+                **self.attrs,
             )(x)
             self.fetch_list = [out.name]
 

--- a/test/ipu/test_warpctc_op_ipu.py
+++ b/test/ipu/test_warpctc_op_ipu.py
@@ -104,7 +104,7 @@ class TestBase(IPUOpTest):
             input_length=input_length,
             label_length=label_length,
             reduction='mean',
-            **self.attrs
+            **self.attrs,
         )
         loss = paddle.mean(out)
         adam = paddle.optimizer.Adam(learning_rate=1e-2)

--- a/test/legacy_test/dygraph_recompute_hybrid.py
+++ b/test/legacy_test/dygraph_recompute_hybrid.py
@@ -90,7 +90,7 @@ class Naive_fc_net(paddle.nn.Layer):
                     },
                     self.layers[i],
                     inputs,
-                    **self.recompute_kwargs
+                    **self.recompute_kwargs,
                 )
             else:
                 inputs = self.layers[i](inputs)

--- a/test/legacy_test/test_atleast_xd.py
+++ b/test/legacy_test/test_atleast_xd.py
@@ -227,7 +227,7 @@ class BaseTest(unittest.TestCase):
                             else input
                         )
                         for input in inputs
-                    ]
+                    ],
                 )
 
                 if len(inputs) == 1:
@@ -259,7 +259,7 @@ class BaseTest(unittest.TestCase):
                             else input
                         )
                         for input in inputs
-                    ]
+                    ],
                 )
 
                 for n, p in zip(out_ref, out):

--- a/test/legacy_test/test_elementwise_div_op.py
+++ b/test/legacy_test/test_elementwise_div_op.py
@@ -464,7 +464,7 @@ def create_test_fp16_class(parent, max_relative_error=2e-3):
                         **check_kwargs,
                         check_pir=True,
                         check_prim=True,
-                        check_prim_pir=True
+                        check_prim_pir=True,
                     )
 
     cls_name = "{}_{}".format(parent.__name__, "Fp16")

--- a/test/legacy_test/test_sparse_unary_op.py
+++ b/test/legacy_test/test_sparse_unary_op.py
@@ -36,7 +36,7 @@ class TestSparseUnary(unittest.TestCase):
         format,
         device='cpu',
         dtype='float32',
-        *args
+        *args,
     ):
         if dtype == 'complex64':
             origin_x_real = paddle.rand([8, 16, 32], 'float32')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

显式声明 black target version 以确保 black 解析不再需要自动检测，使解析更高效

另一方面，这使得格式化后的代码不再需要考虑兼容性，比如 Python 3.5 支持了 `*args` 后跟随 trailing comma，之前是不会在格式化时自动加的，是为了确保兼容性，而如今声明只需支持 3.8+，因此格式化时会自动添加该 trailing comma

这对未来弃用 3.8 时，推动新代码在 with 格式化时避免使用反斜线也是有推动作用的

PCard-66972