### PR TITLE
fix test_quant_linear_op in pir

### DIFF
--- a/test/legacy_test/test_quant_linear_op.py
+++ b/test/legacy_test/test_quant_linear_op.py
@@ -544,13 +544,13 @@ class TestQuantLinearOpWithPadding2(TestQuantLinearOp):
 class TestQuantLinearOp_NumFlattenDims_NegOne(unittest.TestCase):
     def test_api(self):
         def run_program(num_flatten_dims):
-            paddle.seed(SEED)
-            np.random.seed(SEED)
-            startup_program = Program()
-            main_program = Program()
-
             with paddle.pir_utils.OldIrGuard():
-                with program_guard(main_program, startup_program):
+                paddle.seed(SEED)
+                np.random.seed(SEED)
+                startup_program = paddle.base.Program()
+                main_program = paddle.base.Program()
+
+                with paddle.base.program_guard(main_program, startup_program):
                     quant_round_type = 0
                     quant_max_bound = 127.0
                     quant_min_bound = -127.0


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复单测test_quant_linear_op 

Pcard-67164