### PR TITLE
Replace phi::errors to ::common::errors in paddle/cinn

### DIFF
--- a/paddle/cinn/adt/equation_util.h
+++ b/paddle/cinn/adt/equation_util.h
@@ -75,18 +75,18 @@ EquationGraphTopoWalker<VT, FT> GetSubgraph(
       };
   const auto& VisitInputVariables =
       [graph, IsSelected](FT function, const std::function<void(VT)>& Visit) {
-        PADDLE_ENFORCE_EQ(
-            IsSelected(function),
-            true,
-            phi::errors::PreconditionNotMet("The function must be selected."));
+        PADDLE_ENFORCE_EQ(IsSelected(function),
+                          true,
+                          ::common::errors::PreconditionNotMet(
+                              "The function must be selected."));
         graph.VisitInputVariables(function, Visit);
       };
   const auto& VisitOutputVariables =
       [graph, IsSelected](FT function, const std::function<void(VT)>& Visit) {
-        PADDLE_ENFORCE_EQ(
-            IsSelected(function),
-            true,
-            phi::errors::PreconditionNotMet("The function must be selected."));
+        PADDLE_ENFORCE_EQ(IsSelected(function),
+                          true,
+                          ::common::errors::PreconditionNotMet(
+                              "The function must be selected."));
         graph.VisitOutputVariables(function, Visit);
       };
   return EquationGraphTopoWalker<VT, FT>(

--- a/paddle/cinn/adt/m_ir.cc
+++ b/paddle/cinn/adt/m_ir.cc
@@ -178,8 +178,8 @@ std::unordered_map<Index, LoopIterators> GenerateAnchorIndex2LoopIterators(
     PADDLE_ENFORCE_EQ(
         anchor_index2loop_iters.emplace(anchor_index, anchor_loop_iters).second,
         true,
-        phi::errors::AlreadyExists("The anchor index has already "
-                                   "been associated with loop iters."));
+        ::common::errors::AlreadyExists("The anchor index has already "
+                                        "been associated with loop iters."));
   }
   return anchor_index2loop_iters;
 }

--- a/paddle/cinn/adt/naive_op_equation_context.h
+++ b/paddle/cinn/adt/naive_op_equation_context.h
@@ -86,13 +86,13 @@ class NaiveOpEquationContext final : public OpEquationContext {
   }
 
   void Equal(const IteratorTuple& lhs, const IteratorTuple& rhs) override {
-    PADDLE_ENFORCE_EQ(
-        lhs->size(),
-        rhs->size(),
-        phi::errors::InvalidArgument("The sizes of lhs and rhs must be equal. "
-                                     "lhs size: %d, rhs size: %d",
-                                     lhs->size(),
-                                     rhs->size()));
+    PADDLE_ENFORCE_EQ(lhs->size(),
+                      rhs->size(),
+                      ::common::errors::InvalidArgument(
+                          "The sizes of lhs and rhs must be equal. "
+                          "lhs size: %d, rhs size: %d",
+                          lhs->size(),
+                          rhs->size()));
     for (std::size_t i = 0; i < lhs->size(); ++i) {
       this->Equal(lhs->at(i), rhs->at(i));
     }
@@ -259,7 +259,7 @@ class NaiveOpEquationContext final : public OpEquationContext {
         const auto& opt_expr = GetSymbolicInDim_(i, j);
         PADDLE_ENFORCE_EQ(opt_expr.has_value(),
                           true,
-                          phi::errors::InvalidArgument(
+                          ::common::errors::InvalidArgument(
                               "The optional expression must have a value."));
         vec->at(i)->emplace_back(opt_expr.value());
       }
@@ -274,7 +274,7 @@ class NaiveOpEquationContext final : public OpEquationContext {
         const auto& opt_expr = GetSymbolicOutDim_(i, j);
         PADDLE_ENFORCE_EQ(opt_expr.has_value(),
                           true,
-                          phi::errors::InvalidArgument(
+                          ::common::errors::InvalidArgument(
                               "The optional expression must have a value at "
                               "tensor index %d and dimension index %d.",
                               i,
@@ -288,7 +288,7 @@ class NaiveOpEquationContext final : public OpEquationContext {
                  const DimTuple& dim_tuple) {
     PADDLE_ENFORCE_EQ(iterator_tuple->size(),
                       dim_tuple->size(),
-                      phi::errors::InvalidArgument(
+                      ::common::errors::InvalidArgument(
                           "The sizes of iterator_tuple and dim_tuple must be "
                           "equal. iterator_tuple size: %d, dim_tuple size: %d",
                           iterator_tuple->size(),
@@ -343,8 +343,8 @@ class NaiveOpEquationContext final : public OpEquationContext {
     PADDLE_ENFORCE_EQ(
         iter != attr_map_type_.end(),
         true,
-        phi::errors::InvalidArgument("Can't find Attribute with this name: %s",
-                                     name.c_str()));
+        ::common::errors::InvalidArgument(
+            "Can't find Attribute with this name: %s", name.c_str()));
     return iter->second;
   }
 

--- a/paddle/cinn/adt/partition_op_stmts.cc
+++ b/paddle/cinn/adt/partition_op_stmts.cc
@@ -60,7 +60,7 @@ std::pair<std::optional<OpStmt>, List<OpStmt>> FindVisitedOpStmts(
     if (valid) {
       PADDLE_ENFORCE_EQ(opt_anchor_op_stmt.has_value(),
                         false,
-                        phi::errors::InvalidArgument(
+                        ::common::errors::InvalidArgument(
                             "The opt_anchor_op_stmt must not have a value."));
       opt_anchor_op_stmt = op_stmt;
     }
@@ -137,7 +137,7 @@ void MakeGetters4Indexes(
         PADDLE_ENFORCE_EQ(
             index2as_output->emplace(index, as_output).second,
             true,
-            phi::errors::InvalidArgument(
+            ::common::errors::InvalidArgument(
                 "Failed to emplace the new element into index2as_output."));
       };
 
@@ -153,7 +153,7 @@ void MakeGetters4Indexes(
         direction_equation_generator->OutMsgIndex4InMsgIndex(index);
     PADDLE_ENFORCE_EQ(out_msg_index.has_value(),
                       true,
-                      phi::errors::InvalidArgument(
+                      ::common::errors::InvalidArgument(
                           "The out_msg_index must not have a value."));
     return out_msg_index.value();
   };
@@ -200,7 +200,7 @@ void VisitProducerConsumerPair(const std::vector<Index>& tensor_indexes,
                                const DoEachT& DoEach) {
   PADDLE_ENFORCE_EQ(tensor_indexes.empty(),
                     false,
-                    phi::errors::InvalidArgument(
+                    ::common::errors::InvalidArgument(
                         "The tensor_indexes container must not be empty."));
   if (AsOutput4Index(tensor_indexes.at(0)).value()) {  // Write first
     auto producer = tensor_indexes.at(0);
@@ -215,7 +215,7 @@ void VisitProducerConsumerPair(const std::vector<Index>& tensor_indexes,
       PADDLE_ENFORCE_EQ(
           AsOutput4Index(tensor_index).value(),
           false,
-          phi::errors::InvalidArgument(
+          ::common::errors::InvalidArgument(
               "The value returned by AsOutput4Index(tensor_index).value() must "
               "be false."));
     }
@@ -317,8 +317,9 @@ void UpdateAnchorIndex2AnchorGroup(
       anchor_index2igroup_spec->emplace(igroup_spec.anchor_index, igroup_spec)
           .second,
       true,
-      phi::errors::InvalidArgument("Failed to emplace the element into the "
-                                   "map. The key might already exist."));
+      ::common::errors::InvalidArgument(
+          "Failed to emplace the element into the "
+          "map. The key might already exist."));
 }
 
 void EraseCandidateAnchorIndexes(
@@ -345,7 +346,7 @@ std::unordered_map<AnchorIndex, AnchorGroup> PartitionOpStmtsIntoAnchorGroups(
         direction_equation_generator) {
   PADDLE_ENFORCE_EQ(op_stmts->empty(),
                     false,
-                    phi::errors::InvalidArgument(
+                    ::common::errors::InvalidArgument(
                         "The op_stmts container must not be empty."));
   std::unordered_map<AnchorIndex, AnchorGroup> anchor_index2igroup_spec{};
 
@@ -380,7 +381,7 @@ std::unordered_map<AnchorIndex, AnchorGroup> PartitionOpStmtsIntoAnchorGroups(
     }
     PADDLE_ENFORCE_EQ(opt_anchor_op_stmt.has_value(),
                       true,
-                      phi::errors::InvalidArgument(
+                      ::common::errors::InvalidArgument(
                           "The opt_anchor_op_stmt must not have a value."));
     all_visited_op_stmts.insert(visited_op_stmts->begin(),
                                 visited_op_stmts->end());
@@ -447,7 +448,7 @@ void CheckEquationSolvable(const AnchorGroup& igroup_spec,
   AggregateAnchorGroupOpStmt(igroup_spec, [&](const auto& op_stmt) {
     PADDLE_ENFORCE_EQ(IsOpSolved(op_stmt),
                       true,
-                      phi::errors::InvalidArgument(
+                      ::common::errors::InvalidArgument(
                           "The operation statement must be solved."));
     return tBreak<bool>{false};
   });
@@ -461,7 +462,7 @@ std::function<std::size_t(const OpStmt&)> MakeGetterOrderValue4OpStmt(
     PADDLE_ENFORCE_EQ(
         op_stmt2order_value->emplace(op_stmts->at(idx), idx).second,
         true,
-        phi::errors::InvalidArgument(
+        ::common::errors::InvalidArgument(
             "Failed to emplace the element into op_stmt2order_value. The key "
             "might already exist."));
   }

--- a/paddle/cinn/adt/simplify_value.cc
+++ b/paddle/cinn/adt/simplify_value.cc
@@ -112,10 +112,10 @@ struct SimplifyDotUndot {
         pre_index_undot = index_undot_value;
       }
     }
-    PADDLE_ENFORCE_EQ(
-        pre_index_undot.has_value(),
-        true,
-        phi::errors::InvalidArgument("pre_index_undot should not be null"));
+    PADDLE_ENFORCE_EQ(pre_index_undot.has_value(),
+                      true,
+                      ::common::errors::InvalidArgument(
+                          "pre_index_undot should not be null"));
     const auto& [index_value, undot_dims] =
         pre_index_undot.value()
             .Get<IndexUnDotValue<Value, List<DimExpr>>>()
@@ -200,11 +200,11 @@ struct SimplifyGcdShape {
     const auto& dot_dim_values = dot_dims;
     PADDLE_ENFORCE_EQ(IsConstantListAllPositiveInt64(undot_dim_values),
                       true,
-                      phi::errors::InvalidArgument(
+                      ::common::errors::InvalidArgument(
                           "The undot_dim_values should be all positive int64"));
     PADDLE_ENFORCE_EQ(IsConstantListAllPositiveInt64(dot_dim_values),
                       true,
-                      phi::errors::InvalidArgument(
+                      ::common::errors::InvalidArgument(
                           "The dot_dim_values should be all positive int64"));
     const auto& sub_reshape_dim_ranges =
         GetSubReshapeDimRanges(undot_dim_values, dot_dim_values);
@@ -332,7 +332,7 @@ struct SimplifyDotDot {
       PADDLE_ENFORCE_EQ(
           dim.Has<std::int64_t>(),
           true,
-          phi::errors::InvalidArgument("dim should have std::int64_t"));
+          ::common::errors::InvalidArgument("dim should have std::int64_t"));
       ret *= dim.Get<std::int64_t>();
     }
     return ret;
@@ -411,10 +411,10 @@ struct SymbolicDim_SimplifyDotUndot {
         pre_index_undot = index_undot_value;
       }
     }
-    PADDLE_ENFORCE_EQ(
-        pre_index_undot.has_value(),
-        true,
-        phi::errors::InvalidArgument("pre_index_undot should not be null"));
+    PADDLE_ENFORCE_EQ(pre_index_undot.has_value(),
+                      true,
+                      ::common::errors::InvalidArgument(
+                          "pre_index_undot should not be null"));
     const auto& [index_value, undot_dims] =
         pre_index_undot.value()
             .Get<IndexUnDotValue<Value, List<DimExpr>>>()
@@ -461,10 +461,10 @@ struct SymbolicDim_SimplifyDotUndot_DimExpr {
         pre_index_undot = index_undot_value;
       }
     }
-    PADDLE_ENFORCE_EQ(
-        pre_index_undot.has_value(),
-        true,
-        phi::errors::InvalidArgument("pre_index_undot should not be null"));
+    PADDLE_ENFORCE_EQ(pre_index_undot.has_value(),
+                      true,
+                      ::common::errors::InvalidArgument(
+                          "pre_index_undot should not be null"));
     const auto& [index_value, undot_dims] =
         pre_index_undot.value()
             .Get<IndexUnDotValue<Value, List<DimExpr>>>()

--- a/paddle/cinn/auto_schedule/search_space/auto_gen_rule/auto_inline.cc
+++ b/paddle/cinn/auto_schedule/search_space/auto_gen_rule/auto_inline.cc
@@ -200,18 +200,18 @@ void AutoInline::Apply(int index) {
   PADDLE_ENFORCE_EQ(
       ir_schedule_ != nullptr,
       true,
-      phi::errors::InvalidArgument("Run AutoInline::Apply without Init"));
+      ::common::errors::InvalidArgument("Run AutoInline::Apply without Init"));
 
   PADDLE_ENFORCE_EQ(
       num_applicable_ > 0 && apply_indices_and_type_.size() == num_applicable_,
       true,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "AutoInline::Apply pre-condition doesn't meet"));
 
   PADDLE_ENFORCE_EQ(
       index >= 0 && num_applicable_ > index,
       true,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "Invalid index for AutoInline::Apply, the index needs 0 <= index && "
           "index < NumberApplicable(), "
           "Currently index = %d, NumberApplicable() = %d",
@@ -231,8 +231,8 @@ RuleApplyType AutoInline::AnalyseApplyType(
   auto* block_realize = block_expr.As<ir::ScheduleBlockRealize>();
   PADDLE_ENFORCE_NOT_NULL(
       block_realize,
-      phi::errors::InvalidArgument("stmt is not a ScheduleBlockRealize: %s",
-                                   block_expr));
+      ::common::errors::InvalidArgument(
+          "stmt is not a ScheduleBlockRealize: %s", block_expr));
 
   AnalyzeScheduleBlockReadWriteBuffer(
       block_realize->schedule_block.As<ir::ScheduleBlock>());
@@ -256,8 +256,8 @@ void AutoInline::Apply(ir::IRSchedule* ir_schedule, ir::Expr& block_expr) {
   auto* block_realize = block_expr.As<ir::ScheduleBlockRealize>();
   PADDLE_ENFORCE_NOT_NULL(
       block_realize,
-      phi::errors::InvalidArgument("stmt is not a ScheduleBlockRealize: %s",
-                                   block_expr));
+      ::common::errors::InvalidArgument(
+          "stmt is not a ScheduleBlockRealize: %s", block_expr));
 
   AnalyzeScheduleBlockReadWriteBuffer(
       block_realize->schedule_block.As<ir::ScheduleBlock>());

--- a/paddle/cinn/backends/codegen_cuda_host.cc
+++ b/paddle/cinn/backends/codegen_cuda_host.cc
@@ -39,7 +39,7 @@ llvm::Value* CodeGenCudaHost::LowerGPUKernelLauncher(
   PADDLE_ENFORCE_EQ(
       call_ir,
       nullptr,
-      phi::errors::InvalidArgument("The 'call_ir' must be true."));
+      ::common::errors::InvalidArgument("The 'call_ir' must be true."));
 
   // Create the function
   // @{
@@ -150,7 +150,7 @@ llvm::Value* CodeGenCudaHost::LowerGPUKernelLauncher(
         PADDLE_ENFORCE_EQ(
             global_args.count(r_arg.as_var()->name),
             1,
-            phi::errors::InvalidArgument(
+            ::common::errors::InvalidArgument(
                 "The argument '%s' must be present in global_args.",
                 r_arg.as_var()->name.c_str()));
         call_args.push_back(global_args[r_arg.as_var()->name]);
@@ -296,7 +296,7 @@ llvm::Value* CodeGenCudaHost::LowerGPUKernelCall(const ir::Call* call_ir) {
         PADDLE_ENFORCE_EQ(
             global_args.count(r_arg.as_var()->name),
             1,
-            phi::errors::InvalidArgument(
+            ::common::errors::InvalidArgument(
                 "The argument '%s' must be present in global_args.",
                 r_arg.as_var()->name.c_str()));
         call_args.push_back(global_args[r_arg.as_var()->name]);

--- a/paddle/cinn/backends/codegen_invoke_module.cc
+++ b/paddle/cinn/backends/codegen_invoke_module.cc
@@ -71,16 +71,16 @@ llvm::Value* CodeGenInvokeModule::LowerParseArgsValueCall(
       2,
       ::common::errors::InvalidArgument(
           "The number of arguments of ParseArgsValue should be 2"));
-  PADDLE_ENFORCE_EQ(
-      call_ir->read_args[0].is_var() &&
-          call_ir->read_args[0].as_var()->type().is_cpp_handle(),
-      true,
-      phi::errors::InvalidArgument("The first read argument must be a variable "
-                                   "with a C++ handle type."));
+  PADDLE_ENFORCE_EQ(call_ir->read_args[0].is_var() &&
+                        call_ir->read_args[0].as_var()->type().is_cpp_handle(),
+                    true,
+                    ::common::errors::InvalidArgument(
+                        "The first read argument must be a variable "
+                        "with a C++ handle type."));
 
   PADDLE_ENFORCE_EQ(call_ir->read_args[1].type().is_int(32),
                     true,
-                    phi::errors::InvalidArgument(
+                    ::common::errors::InvalidArgument(
                         "The second read argument must be of type int32."));
   args_type.push_back(CinnTypeToLLVMType(type_of<void*>(), m_));
   args_type.push_back(CinnTypeToLLVMType(type_of<int32_t>(), m_));
@@ -104,8 +104,8 @@ llvm::Value* CodeGenSwitchHost::LowerInnerCaseCall(const ir::Call* op) {
   llvm::Function* call_func = m_->getFunction(op->name);
   PADDLE_ENFORCE_NOT_NULL(
       call_func,
-      phi::errors::InvalidArgument("Unknown function referenced. [%s]",
-                                   op->name.c_str()));
+      ::common::errors::InvalidArgument("Unknown function referenced. [%s]",
+                                        op->name.c_str()));
   b_->CreateCall(call_func, ll_function_args);
   return nullptr;
 }

--- a/paddle/cinn/backends/compiler.cc
+++ b/paddle/cinn/backends/compiler.cc
@@ -330,10 +330,10 @@ void Compiler::RegisterCudaModuleSymbol() {
   nvrtc::Compiler compiler;
   std::string source_code = CodeGenCudaDev::GetSourceHeader() + device_fn_code_;
   auto ptx = compiler(source_code);
-  PADDLE_ENFORCE_EQ(
-      !ptx.empty(),
-      true,
-      phi::errors::InvalidArgument("Compile PTX failed from source code\n"));
+  PADDLE_ENFORCE_EQ(!ptx.empty(),
+                    true,
+                    ::common::errors::InvalidArgument(
+                        "Compile PTX failed from source code\n"));
   using runtime::cuda::CUDAModule;
   cuda_module_.reset(new CUDAModule(ptx,
                                     compiler.compile_to_cubin()
@@ -343,9 +343,9 @@ void Compiler::RegisterCudaModuleSymbol() {
   RuntimeSymbols symbols;
   for (const auto& kernel_fn_name : device_fn_name_) {
     auto fn_kernel = cuda_module_->GetFunction(kernel_fn_name);
-    PADDLE_ENFORCE_NOT_NULL(
-        fn_kernel,
-        phi::errors::InvalidArgument("Fail to get CUfunction kernel_fn_name"));
+    PADDLE_ENFORCE_NOT_NULL(fn_kernel,
+                            ::common::errors::InvalidArgument(
+                                "Fail to get CUfunction kernel_fn_name"));
     fn_ptr_.push_back(reinterpret_cast<void*>(fn_kernel));
     symbols.RegisterVar(kernel_fn_name + "_ptr_",
                         reinterpret_cast<void*>(fn_kernel));
@@ -365,8 +365,8 @@ void Compiler::RegisterHipModuleSymbol() {
   PADDLE_ENFORCE_EQ(
       !hsaco.empty(),
       true,
-      phi::errors::Fatal("Compile hsaco failed from source code:\n%s",
-                         source_code));
+      ::common::errors::Fatal("Compile hsaco failed from source code:\n%s",
+                              source_code));
   using runtime::hip::HIPModule;
   hip_module_.reset(new HIPModule(hsaco));
   // get device id
@@ -378,7 +378,7 @@ void Compiler::RegisterHipModuleSymbol() {
     auto fn_kernel = hip_module_->GetFunction(device_id, kernel_fn_name);
     PADDLE_ENFORCE_NOT_NULL(
         fn_kernel,
-        phi::errors::Fatal("HIP GetFunction Error: get valid kernel."));
+        ::common::errors::Fatal("HIP GetFunction Error: get valid kernel."));
     fn_ptr_.push_back(reinterpret_cast<void*>(fn_kernel));
     symbols.RegisterVar(kernel_fn_name + "_ptr_",
                         reinterpret_cast<void*>(fn_kernel));
@@ -413,7 +413,7 @@ void Compiler::CompileCudaModule(const Module& module,
 
   PADDLE_ENFORCE_EQ(!source_code.empty(),
                     true,
-                    phi::errors::InvalidArgument(
+                    ::common::errors::InvalidArgument(
                         "Compile CUDA C code failed from device module"));
   VLOG(3) << "[CUDA] C:\n" << source_code;
   SourceCodePrint::GetInstance()->write(source_code);
@@ -451,8 +451,8 @@ void Compiler::CompileHipModule(const Module& module, const std::string& code) {
   PADDLE_ENFORCE_EQ(
       !source_code.empty(),
       true,
-      phi::errors::Fatal("Compile HIP code failed from device module:\n%s",
-                         device_module));
+      ::common::errors::Fatal("Compile HIP code failed from device module:\n%s",
+                              device_module));
   VLOG(3) << "[HIP]:\n" << source_code;
   SourceCodePrint::GetInstance()->write(source_code);
   device_fn_code_ += source_code;
@@ -476,7 +476,7 @@ void Compiler::ExportObject(const std::string& path) {
 
 void* Compiler::Lookup(absl::string_view fn_name) {
   PADDLE_ENFORCE_NOT_NULL(
-      engine_, phi::errors::InvalidArgument("Sorry, engine_ is nullptr"));
+      engine_, ::common::errors::InvalidArgument("Sorry, engine_ is nullptr"));
   if (engine_->Lookup(fn_name) != nullptr) {
     return engine_->Lookup(fn_name);
   }

--- a/paddle/cinn/backends/extern_func_emitter.cc
+++ b/paddle/cinn/backends/extern_func_emitter.cc
@@ -48,7 +48,7 @@ void ExternFunctionEmitterRegistry::Register(const ExternFuncID& name,
   PADDLE_ENFORCE_EQ(
       !x.empty(),
       true,
-      phi::errors::InvalidArgument("Extern Function name is empty."));
+      ::common::errors::InvalidArgument("Extern Function name is empty."));
   data_[name] = x;
 }
 
@@ -73,8 +73,8 @@ const FunctionProto& ExternFunctionEmitter::func_proto() const {
   auto* proto = ExternFunctionProtoRegistry::Global().Lookup(func_name());
   PADDLE_ENFORCE_NOT_NULL(
       proto,
-      phi::errors::InvalidArgument("No prototype of function [" +
-                                   std::string(func_name()) + "]"));
+      ::common::errors::InvalidArgument("No prototype of function [" +
+                                        std::string(func_name()) + "]"));
   return *proto;
 }
 

--- a/paddle/cinn/backends/llvm/execution_engine.cc
+++ b/paddle/cinn/backends/llvm/execution_engine.cc
@@ -177,9 +177,10 @@ void ExecutionEngine::Link(const ir::Module &module) {
   VLOG(3) << "ir_emitter->Compile(module) Begin";
   ir_emitter->Compile(module);
   VLOG(3) << "ir_emitter->Compile(module) Succeed!";
-  PADDLE_ENFORCE_EQ(!llvm::verifyModule(*m, &llvm::errs()),
-                    true,
-                    phi::errors::InvalidArgument("Sorry,Invalid module found"));
+  PADDLE_ENFORCE_EQ(
+      !llvm::verifyModule(*m, &llvm::errs()),
+      true,
+      ::common::errors::InvalidArgument("Sorry,Invalid module found"));
   auto machine = std::move(llvm::cantFail(
       llvm::cantFail(llvm::orc::JITTargetMachineBuilder::detectHost())
           .createTargetMachine()));
@@ -188,7 +189,7 @@ void ExecutionEngine::Link(const ir::Module &module) {
   PADDLE_ENFORCE_EQ(
       !llvm::verifyModule(*m, &llvm::errs()),
       true,
-      phi::errors::InvalidArgument("Invalid optimized module detected"));
+      ::common::errors::InvalidArgument("Invalid optimized module detected"));
   for (auto &f : *m) {
     VLOG(5) << "function: " << DumpToString(f);
   }

--- a/paddle/cinn/common/dev_info_manager.h
+++ b/paddle/cinn/common/dev_info_manager.h
@@ -54,17 +54,17 @@ class DevInfoMgr final {
   using RetType = typename GetDevType<arch>::DevType;
 
   const RetType* operator->() const {
-    PADDLE_ENFORCE_EQ(
-        !std::is_void<RetType>(),
-        true,
-        phi::errors::InvalidArgument("Current device can't be recognized!"));
+    PADDLE_ENFORCE_EQ(!std::is_void<RetType>(),
+                      true,
+                      ::common::errors::InvalidArgument(
+                          "Current device can't be recognized!"));
     return dynamic_cast<const RetType*>(impl_.get());
   }
   RetType* operator->() {
-    PADDLE_ENFORCE_EQ(
-        !std::is_void<RetType>(),
-        true,
-        phi::errors::InvalidArgument("Current device can't be recognized!"));
+    PADDLE_ENFORCE_EQ(!std::is_void<RetType>(),
+                      true,
+                      ::common::errors::InvalidArgument(
+                          "Current device can't be recognized!"));
     return dynamic_cast<RetType*>(impl_.get());
   }
 };

--- a/paddle/cinn/common/integer_set.cc
+++ b/paddle/cinn/common/integer_set.cc
@@ -202,20 +202,20 @@ std::optional<bool> SymbolicExprAnalyzer::ProveDivisible(
     const ir::Expr& lhs, const ir::Expr& rhs) const {
   PADDLE_ENFORCE_EQ(rhs.is_var(),
                     true,
-                    phi::errors::InvalidArgument(
+                    ::common::errors::InvalidArgument(
                         "Rhs in ProveDivisible must be a var temporarily!\n"));
-  PADDLE_ENFORCE_EQ(
-      lhs.defined(),
-      true,
-      phi::errors::InvalidArgument("Lhs in ProveDivisible must be defined."));
-  PADDLE_ENFORCE_EQ(
-      rhs.defined(),
-      true,
-      phi::errors::InvalidArgument("Rhs in ProveDivisible must be defined."));
+  PADDLE_ENFORCE_EQ(lhs.defined(),
+                    true,
+                    ::common::errors::InvalidArgument(
+                        "Lhs in ProveDivisible must be defined."));
+  PADDLE_ENFORCE_EQ(rhs.defined(),
+                    true,
+                    ::common::errors::InvalidArgument(
+                        "Rhs in ProveDivisible must be defined."));
   PADDLE_ENFORCE_EQ(
       cinn::common::IsPureMath(lhs),
       true,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "Lhs in ProveDivisible must be a pure math expression."));
 
   ir::Expr lhs_copy = ir::ir_utils::IRCopy(lhs);
@@ -261,7 +261,7 @@ std::optional<bool> SymbolicExprAnalyzer::ProveDivisible(
       ops = lhs.As<ir::Sum>()->operands();
       PADDLE_ENFORCE_NE(ops.empty(),
                         true,
-                        phi::errors::InvalidArgument(
+                        ::common::errors::InvalidArgument(
                             "Operands in Sum node should not be empty."));
       std::for_each(ops.begin(), ops.end(), [&](const ir::Expr& expr) {
         res = OptionalAnd(res, this->ProveDivisible(expr, rhs));
@@ -273,7 +273,7 @@ std::optional<bool> SymbolicExprAnalyzer::ProveDivisible(
       ops = lhs.As<ir::Product>()->operands();
       PADDLE_ENFORCE_NE(ops.empty(),
                         true,
-                        phi::errors::InvalidArgument(
+                        ::common::errors::InvalidArgument(
                             "Operands in Sum node should not be empty."));
       std::for_each(ops.begin(), ops.end(), [&](const ir::Expr& expr) {
         res = OptionalOr(res, this->ProveDivisible(expr, rhs));

--- a/paddle/cinn/common/ir_util.cc
+++ b/paddle/cinn/common/ir_util.cc
@@ -91,10 +91,11 @@ Expr RampRelatedAdd(ir::Broadcast *broadcast, Expr other) {
 // ramp + ramp
 Expr RampRelatedAdd(ir::Ramp *ramp, ir::Ramp *other) {
   PADDLE_ENFORCE_NOT_NULL(
-      ramp, phi::errors::InvalidArgument("Ramp pointer should not be null."));
-  PADDLE_ENFORCE_NOT_NULL(
-      other,
-      phi::errors::InvalidArgument("Other ramp pointer should not be null."));
+      ramp,
+      ::common::errors::InvalidArgument("Ramp pointer should not be null."));
+  PADDLE_ENFORCE_NOT_NULL(other,
+                          ::common::errors::InvalidArgument(
+                              "Other ramp pointer should not be null."));
   if (ramp->lanes == other->lanes) {
     Expr base_add = cinn::common::AutoSimplify(ramp->base + other->base);
     Expr stride_add = cinn::common::AutoSimplify(ramp->stride + other->stride);
@@ -280,7 +281,7 @@ Expr select(Expr cond, Expr true_value, Expr false_value) {
 Expr and_all(const std::vector<Expr> &conds) {
   PADDLE_ENFORCE_NE(conds.empty(),
                     true,
-                    phi::errors::InvalidArgument(
+                    ::common::errors::InvalidArgument(
                         "The conditions vector should not be empty."));
   Expr res = conds.front();
   for (int i = 1; i < conds.size(); i++) {
@@ -292,7 +293,7 @@ Expr and_all(const std::vector<Expr> &conds) {
 Expr or_all(const std::vector<Expr> &conds) {
   PADDLE_ENFORCE_NE(conds.empty(),
                     true,
-                    phi::errors::InvalidArgument(
+                    ::common::errors::InvalidArgument(
                         "The conditions vector should not be empty."));
   Expr res = conds.front();
   for (int i = 1; i < conds.size(); i++) {
@@ -411,7 +412,7 @@ std::vector<std::string> GatherItersToTensorProducer(
       if (op->tensor.as_tensor()->name == target_tensor_name) {
         PADDLE_ENFORCE_EQ(iters.empty(),
                           true,
-                          phi::errors::InvalidArgument(
+                          ::common::errors::InvalidArgument(
                               "The iterators vector should be empty."));
         for (auto &e : for_stack) {
           auto *for_n = e->As<ir::For>();

--- a/paddle/cinn/common/type.cc
+++ b/paddle/cinn/common/type.cc
@@ -146,7 +146,7 @@ void Type::CheckTypeValid() const {
     PADDLE_ENFORCE_EQ((GetStorage().specific_type_ == specific_type_t::FP16 ||
                        GetStorage().specific_type_ == specific_type_t::BF16),
                       true,
-                      phi::errors::InvalidArgument(
+                      ::common::errors::InvalidArgument(
                           "When creating a 16-bit Float, the 'specific_type_t' "
                           "must be FP16 or BF16. "
                           "Received: specific_type_t = %d.",
@@ -157,10 +157,10 @@ void Type::CheckTypeValid() const {
 Type Type::PointerOf() const {
   CheckTypeValid();
   auto x = *this;
-  PADDLE_ENFORCE_EQ(
-      x.is_cpp_handle2(),
-      false,
-      phi::errors::InvalidArgument("Not support three levels of PointerOf."));
+  PADDLE_ENFORCE_EQ(x.is_cpp_handle2(),
+                    false,
+                    ::common::errors::InvalidArgument(
+                        "Not support three levels of PointerOf."));
   if (x.is_cpp_handle())
     x.set_cpp_handle2();
   else
@@ -194,7 +194,7 @@ Type Type::with_bits(int x) const {
   PADDLE_ENFORCE_EQ(
       is_primitive(),
       true,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "The type must be primitive to set the number of bits."));
   Type type = *this;
   type.GetStorage().bits_ = x;
@@ -210,7 +210,7 @@ Type Type::with_type(Type::type_t x) const {
 Type Type::with_lanes(int x) const {
   PADDLE_ENFORCE_EQ(valid(),
                     true,
-                    phi::errors::InvalidArgument(
+                    ::common::errors::InvalidArgument(
                         "The type must be valid to set the number of lanes."));
   Type type = *this;
   type.GetStorage().lanes_ = x;
@@ -262,10 +262,11 @@ Type::Type(Type::type_t t, int b, int w, specific_type_t st)
     PADDLE_ENFORCE_EQ(
         (st == specific_type_t::FP16 || st == specific_type_t::BF16),
         true,
-        phi::errors::InvalidArgument("When creating a 16-bit Float, the "
-                                     "'specific_type_t' must be FP16 or BF16. "
-                                     "Received: specific_type_t = %d.",
-                                     static_cast<int>(st)));
+        ::common::errors::InvalidArgument(
+            "When creating a 16-bit Float, the "
+            "'specific_type_t' must be FP16 or BF16. "
+            "Received: specific_type_t = %d.",
+            static_cast<int>(st)));
   }
 }
 bool Type::is_primitive() const {
@@ -286,7 +287,7 @@ bool Type::is_float(int bits, specific_type_t st) const {
     PADDLE_ENFORCE_NE(
         st,
         specific_type_t::None,
-        phi::errors::InvalidArgument(
+        ::common::errors::InvalidArgument(
             "When calling is_float(16), 'st' can't be specific_type_t::None to "
             "distinguish FP16/BF16. Use is_float16() or is_bfloat16() for "
             "short."));
@@ -357,14 +358,14 @@ Type &Type::operator=(const Type &other) {
 
 Type::Storage &Type::GetStorage() {
   PADDLE_ENFORCE_NOT_NULL(storage_,
-                          phi::errors::InvalidArgument(
+                          ::common::errors::InvalidArgument(
                               "The type is not initialized! Please check."));
   return *storage_;
 }
 
 const Type::Storage &Type::GetStorage() const {
   PADDLE_ENFORCE_NOT_NULL(storage_,
-                          phi::errors::InvalidArgument(
+                          ::common::errors::InvalidArgument(
                               "The type is not initialized! Please check."));
   return *storage_;
 }
@@ -591,8 +592,8 @@ Type Str2Type(const std::string &type) {
   PADDLE_ENFORCE_NE(
       str2type_map.find(type),
       str2type_map.end(),
-      phi::errors::InvalidArgument("Not supported type [%s]! Please check.",
-                                   type.c_str()));
+      ::common::errors::InvalidArgument(
+          "Not supported type [%s]! Please check.", type.c_str()));
   return str2type_map.at(type);
 }
 

--- a/paddle/cinn/ir/ir.h
+++ b/paddle/cinn/ir/ir.h
@@ -250,11 +250,11 @@ struct And : public BinaryOpNode<And> {
     PADDLE_ENFORCE_EQ(
         a->type().is_bool(),
         true,
-        phi::errors::PreconditionNotMet("The type of 'a' must be bool."));
+        ::common::errors::PreconditionNotMet("The type of 'a' must be bool."));
     PADDLE_ENFORCE_EQ(
         b->type().is_bool(),
         true,
-        phi::errors::PreconditionNotMet("The type of 'b' must be bool."));
+        ::common::errors::PreconditionNotMet("The type of 'b' must be bool."));
   }
 
   Type type() const { return Bool(a()->type().lanes()); }
@@ -283,11 +283,11 @@ struct Or : public BinaryOpNode<Or> {
     PADDLE_ENFORCE_EQ(
         a->type().is_bool(),
         true,
-        phi::errors::PreconditionNotMet("The type of 'a' must be bool."));
+        ::common::errors::PreconditionNotMet("The type of 'a' must be bool."));
     PADDLE_ENFORCE_EQ(
         b->type().is_bool(),
         true,
-        phi::errors::PreconditionNotMet("The type of 'b' must be bool."));
+        ::common::errors::PreconditionNotMet("The type of 'b' must be bool."));
   }
 
   static Expr Make(Expr a, Expr b);
@@ -524,7 +524,7 @@ struct Select : public ExprNode<Select> {
             "The type of true_value and false_value should be the same."));
     PADDLE_ENFORCE_EQ(condition.type().is_bool(),
                       true,
-                      phi::errors::PreconditionNotMet(
+                      ::common::errors::PreconditionNotMet(
                           "The condition must be of boolean type."));
     type_ = true_value.type();
   }
@@ -668,11 +668,11 @@ struct IfThenElse : public ExprNode<IfThenElse> {
     PADDLE_ENFORCE_EQ(
         condition.defined(),
         true,
-        phi::errors::PreconditionNotMet("The condition must be defined."));
+        ::common::errors::PreconditionNotMet("The condition must be defined."));
     PADDLE_ENFORCE_EQ(
         true_case.defined(),
         true,
-        phi::errors::PreconditionNotMet("The true_case must be defined."));
+        ::common::errors::PreconditionNotMet("The true_case must be defined."));
     PADDLE_ENFORCE_EQ(
         condition.type(),
         type_of<bool>(),
@@ -733,10 +733,10 @@ struct BindInfo {
   }
 
   friend std::ostream& operator<<(std::ostream& os, const BindInfo& bind_info) {
-    PADDLE_ENFORCE_EQ(
-        bind_info.valid(),
-        true,
-        phi::errors::PreconditionNotMet("Make invalid BindInfo to stream"));
+    PADDLE_ENFORCE_EQ(bind_info.valid(),
+                      true,
+                      ::common::errors::PreconditionNotMet(
+                          "Make invalid BindInfo to stream"));
     char axis_name = 'x' + bind_info.offset;
     std::string prefix =
         bind_info.for_type == ForType::GPUBlock ? "blockIdx." : "threadIdx.";
@@ -955,10 +955,10 @@ struct FracOp : public BinaryOpNode<FracOp> {
   bool is_constant() const { return a().is_constant() && b().is_constant(); }
 
   double get_constant() const {
-    PADDLE_ENFORCE_EQ(
-        is_constant(),
-        true,
-        phi::errors::PreconditionNotMet("The expression must be constant."));
+    PADDLE_ENFORCE_EQ(is_constant(),
+                      true,
+                      ::common::errors::PreconditionNotMet(
+                          "The expression must be constant."));
     PADDLE_ENFORCE_NE(b().get_constant(),
                       0.f,
                       ::common::errors::InvalidArgument(

--- a/paddle/cinn/ir/ir_analyzer/ir_analyzer.cc
+++ b/paddle/cinn/ir/ir_analyzer/ir_analyzer.cc
@@ -68,12 +68,12 @@ std::vector<Expr> GetLoops(const std::vector<Expr>& exprs, const Expr& block) {
   std::vector<Expr> result;
   PADDLE_ENFORCE_NOT_NULL(
       block.As<ir::ScheduleBlockRealize>(),
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "The block must be convertible to ir::ScheduleBlockRealize."));
   PADDLE_ENFORCE_NOT_NULL(
       block.As<ir::ScheduleBlockRealize>()
           ->schedule_block.As<ir::ScheduleBlock>(),
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "Cannot cast block to ir::ScheduleBlockRealize."));
   std::string block_name = block.As<ir::ScheduleBlockRealize>()
                                ->schedule_block.As<ir::ScheduleBlock>()
@@ -112,14 +112,14 @@ std::vector<Expr> GetAllBlocks(const std::vector<Expr>& exprs) {
   PADDLE_ENFORCE_EQ(
       result.empty(),
       false,
-      phi::errors::InvalidArgument("Didn't find blocks in expr."));
+      ::common::errors::InvalidArgument("Didn't find blocks in expr."));
   return result;
 }
 
 std::vector<Expr> GetChildBlocks(const Expr& expr) {
   if (!expr.As<ir::ScheduleBlockRealize>()) {
     PADDLE_ENFORCE_NOT_NULL(expr.As<ir::For>(),
-                            phi::errors::InvalidArgument(
+                            ::common::errors::InvalidArgument(
                                 "The expression must be convertible to either "
                                 "ir::ScheduleBlockRealize or ir::For."));
   }
@@ -160,7 +160,7 @@ Expr GetRootBlock(const std::vector<Expr>& exprs, const Expr& expr) {
     if (!find_expr.empty()) {
       PADDLE_ENFORCE_NOT_NULL(
           it_expr.As<ir::Block>(),
-          phi::errors::InvalidArgument(
+          ::common::errors::InvalidArgument(
               "The expression cannot be cast to ir::Block."));
       PADDLE_ENFORCE_EQ(it_expr.As<ir::Block>()->stmts.size(),
                         1U,
@@ -168,7 +168,7 @@ Expr GetRootBlock(const std::vector<Expr>& exprs, const Expr& expr) {
                             "The root block should only have one stmt!"));
       PADDLE_ENFORCE_NOT_NULL(
           it_expr.As<ir::Block>()->stmts[0].As<ir::ScheduleBlockRealize>(),
-          phi::errors::InvalidArgument(
+          ::common::errors::InvalidArgument(
               "The first statement in the block must be convertible to "
               "ir::ScheduleBlockRealize."));
       return it_expr.As<ir::Block>()->stmts[0];
@@ -185,7 +185,7 @@ DeviceAPI GetDeviceAPI(const std::vector<Expr>& exprs) {
   PADDLE_ENFORCE_EQ(
       find_for_nodes.empty(),
       false,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "The find_for_nodes container is empty. It must not be empty."));
   return (*find_for_nodes.begin()).As<ir::For>()->device_api;
 }
@@ -193,13 +193,13 @@ DeviceAPI GetDeviceAPI(const std::vector<Expr>& exprs) {
 Expr AddUnitLoop(const std::vector<Expr>& exprs, const Expr& block) {
   PADDLE_ENFORCE_NOT_NULL(
       block.As<ir::ScheduleBlockRealize>(),
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "The block is not convertible to ir::ScheduleBlockRealize. It must "
           "be convertible to ir::ScheduleBlockRealize."));
   PADDLE_ENFORCE_NOT_NULL(
       block.As<ir::ScheduleBlockRealize>()
           ->schedule_block.As<ir::ScheduleBlock>(),
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "The schedule_block must be convertible to ir::ScheduleBlock."));
   std::string block_name = block.As<ir::ScheduleBlockRealize>()
                                ->schedule_block.As<ir::ScheduleBlock>()
@@ -214,7 +214,7 @@ Expr AddUnitLoop(const std::vector<Expr>& exprs, const Expr& block) {
   }
 
   PADDLE_ENFORCE_NOT_NULL(visitor.target_,
-                          phi::errors::InvalidArgument(
+                          ::common::errors::InvalidArgument(
                               "The visitor target is nullptr. It must not be "
                               "nullptr."));
   if (visitor.target_->As<ir::Block>()) {
@@ -267,7 +267,7 @@ Expr AddUnitLoop(const std::vector<Expr>& exprs, const Expr& block) {
 
 Expr GetStoreOfSBlock(const Expr& block) {
   PADDLE_ENFORCE_NOT_NULL(block.As<ScheduleBlockRealize>(),
-                          phi::errors::InvalidArgument(
+                          ::common::errors::InvalidArgument(
                               "Failed to cast block to ScheduleBlockRealize."));
   std::set<Expr> find_store = ir_utils::CollectIRNodesWithoutTensor(
       block, [&](const Expr* x) { return x->As<Store>(); }, true);
@@ -280,23 +280,23 @@ Expr GetStoreOfSBlock(const Expr& block) {
 
 Tensor GetStoreTensorOfSBlock(const Expr& block) {
   PADDLE_ENFORCE_NOT_NULL(block.As<ScheduleBlockRealize>(),
-                          phi::errors::InvalidArgument(
+                          ::common::errors::InvalidArgument(
                               "Failed to cast block to ScheduleBlockRealize."));
   Expr find_store = GetStoreOfSBlock(block);
   PADDLE_ENFORCE_NOT_NULL(
       find_store.As<Store>()->tensor.as_tensor(),
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "The tensor must be convertible to Tensor type."));
   return find_store.As<Store>()->tensor.as_tensor_ref();
 }
 
 std::vector<Expr> GetConsumerSBlocks(const Expr& block, const Expr& root) {
   PADDLE_ENFORCE_NOT_NULL(block.As<ScheduleBlockRealize>(),
-                          phi::errors::InvalidArgument(
+                          ::common::errors::InvalidArgument(
                               "Failed to cast block to ScheduleBlockRealize."));
   PADDLE_ENFORCE_NOT_NULL(
       root.As<ScheduleBlockRealize>(),
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "Failed to cast 'root' to ScheduleBlockRealize."));
   std::vector<Expr> consumers;
   std::string store_tensor_name = GetStoreTensorOfSBlock(block)->name;
@@ -324,7 +324,7 @@ std::vector<Expr> GetConsumerSBlocks(const Expr& block, const Expr& root) {
     PADDLE_ENFORCE_NOT_NULL(
         find_block.As<ScheduleBlockRealize>()
             ->schedule_block.As<ScheduleBlock>(),
-        phi::errors::InvalidArgument(
+        ::common::errors::InvalidArgument(
             "The schedule_block within ScheduleBlockRealize must be "
             "convertible to ScheduleBlock type."));
     auto block_body = find_block.As<ScheduleBlockRealize>()
@@ -352,7 +352,7 @@ std::vector<Expr> GetConsumerSBlocks(const Expr& block, const Expr& root) {
 std::vector<std::pair<Expr, Expr>> GetConsumerLoadsAndSBlocks(
     const Expr& block, const Expr& root) {
   PADDLE_ENFORCE_NOT_NULL(block.As<ScheduleBlockRealize>(),
-                          phi::errors::InvalidArgument(
+                          ::common::errors::InvalidArgument(
                               "Failed to cast block to ScheduleBlockRealize."));
   PADDLE_ENFORCE_NOT_NULL(
       root.As<ScheduleBlockRealize>(),

--- a/paddle/cinn/ir/ir_base.cc
+++ b/paddle/cinn/ir/ir_base.cc
@@ -105,7 +105,7 @@ bool Expr::as_bool() const {
   PADDLE_ENFORCE_EQ(
       type().is_uint(1),
       true,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "Invalid type. The type must be a 1-bit unsigned integer type."));
   return As<UIntImm>()->value;
 }
@@ -114,7 +114,7 @@ int8_t Expr::as_int8() const {
   PADDLE_ENFORCE_EQ(
       type().is_int(8),
       true,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "Invalid type. The type must be an 8-bit integer type."));
   return As<IntImm>()->value;
 }
@@ -122,7 +122,7 @@ int16_t Expr::as_int16() const {
   PADDLE_ENFORCE_EQ(
       type().is_int(16),
       true,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "Invalid type. The type must be an 16-bit integer type."));
   return As<IntImm>()->value;
 }
@@ -130,18 +130,18 @@ int32_t Expr::as_int32() const {
   PADDLE_ENFORCE_EQ(
       type().is_int(32),
       true,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "Invalid type. The type must be an 32-bit integer type. %s",
           ::common::GetCurrentTraceBackString()));
   return As<IntImm>()->value;
 }
 int64_t Expr::as_int64() const {
   if (!type().is_int(64))
-    PADDLE_ENFORCE_EQ(
-        type().is_int(32),
-        true,
-        phi::errors::InvalidArgument("Invalid type. The type must be an 32-bit "
-                                     "integer or 64-bit integer type."));
+    PADDLE_ENFORCE_EQ(type().is_int(32),
+                      true,
+                      ::common::errors::InvalidArgument(
+                          "Invalid type. The type must be an 32-bit "
+                          "integer or 64-bit integer type."));
   return As<IntImm>()->value;
 }
 
@@ -149,7 +149,7 @@ uint8_t Expr::as_uint8() const {
   PADDLE_ENFORCE_EQ(
       type().is_uint(8),
       true,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "Invalid type. The type must be a 8-bit unsigned integer type."));
   return As<UIntImm>()->value;
 }
@@ -157,7 +157,7 @@ uint16_t Expr::as_uint16() const {
   PADDLE_ENFORCE_EQ(
       type().is_uint(16),
       true,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "Invalid type. The type must be a 16-bit unsigned integer type."));
   return As<UIntImm>()->value;
 }
@@ -165,7 +165,7 @@ uint32_t Expr::as_uint32() const {
   PADDLE_ENFORCE_EQ(
       type().is_uint(32),
       true,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "Invalid type. The type must be a 32-bit unsigned integer type."));
   return As<UIntImm>()->value;
 }
@@ -173,7 +173,7 @@ uint64_t Expr::as_uint64() const {
   PADDLE_ENFORCE_EQ(
       type().is_uint(64),
       true,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "Invalid type. The type must be a 64-bit unsigned integer type."));
   return As<UIntImm>()->value;
 }
@@ -181,28 +181,28 @@ uint64_t Expr::as_uint64() const {
 bfloat16 Expr::as_bfloat16() const {
   PADDLE_ENFORCE_EQ(type().is_bfloat16(),
                     true,
-                    phi::errors::InvalidArgument(
+                    ::common::errors::InvalidArgument(
                         "Invalid type. The type must be bfloat16() type."));
   return bfloat16(As<FloatImm>()->value);
 }
 float16 Expr::as_float16() const {
   PADDLE_ENFORCE_EQ(type().is_bfloat16(),
                     true,
-                    phi::errors::InvalidArgument(
+                    ::common::errors::InvalidArgument(
                         "Invalid type. The type must be bfloat16() type."));
   return float16(As<FloatImm>()->value);
 }
 float Expr::as_float() const {
   PADDLE_ENFORCE_EQ(type().is_float(32),
                     true,
-                    phi::errors::InvalidArgument(
+                    ::common::errors::InvalidArgument(
                         "The type must be a 32-bit floating point type."));
   return As<FloatImm>()->value;
 }
 double Expr::as_double() const {
   PADDLE_ENFORCE_EQ(type().is_float(64),
                     true,
-                    phi::errors::InvalidArgument(
+                    ::common::errors::InvalidArgument(
                         "The type must be a 64-bit floating point type."));
   return As<FloatImm>()->value;
 }
@@ -215,7 +215,8 @@ Expr &Expr::operator=(const Expr &other) {
 Expr::operator Var() {
   auto *x = As<ir::_Var_>();
   PADDLE_ENFORCE_NOT_NULL(
-      x, phi::errors::InvalidArgument("x is a nullptr. It must not be null"));
+      x,
+      ::common::errors::InvalidArgument("x is a nullptr. It must not be null"));
   return ir::Var(x);
 }
 
@@ -224,10 +225,10 @@ bool Expr::is_constant() const {
 }
 
 double Expr::get_constant() const {
-  PADDLE_ENFORCE_EQ(
-      is_constant(),
-      true,
-      phi::errors::InvalidArgument("%s is not constant! Please check.", *this));
+  PADDLE_ENFORCE_EQ(is_constant(),
+                    true,
+                    ::common::errors::InvalidArgument(
+                        "%s is not constant! Please check.", *this));
   auto *vi = As<IntImm>();
   auto *vf = As<FloatImm>();
   if (vi) return vi->value;
@@ -251,7 +252,7 @@ ir::Module Expr::as_module_ref() const {
   auto *module = as_module();
   PADDLE_ENFORCE_NOT_NULL(
       module,
-      phi::errors::InvalidArgument(
+      ::common::errors::InvalidArgument(
           "module is a nullptr. It must not be null"));  // Need check here?
   // TODO(Superjomn) remove the Reference here.
   return ir::Module(&Reference(module));
@@ -260,7 +261,7 @@ ir::Module Expr::as_module_ref() const {
 LoweredFunc Expr::as_lowered_func_ref() const {
   auto *function = as_lowered_func();
   PADDLE_ENFORCE_NOT_NULL(function,
-                          phi::errors::InvalidArgument(
+                          ::common::errors::InvalidArgument(
                               "function is a nullptr. It must not be null"));
   return LoweredFunc(&Reference(function));
 }
@@ -311,12 +312,12 @@ void IrNode::replace(Expr old_op, Expr new_op) {
 void IrNode::convert_int32_to_int64() {
   if (type_ != Int(64))
     if (type_ != Int(32))
-      PADDLE_ENFORCE_EQ(
-          type_.is_unk(),
-          true,
-          phi::errors::InvalidArgument("Current only support convert int32_t "
-                                       "to int64_t, but get type is: %s",
-                                       type_));
+      PADDLE_ENFORCE_EQ(type_.is_unk(),
+                        true,
+                        ::common::errors::InvalidArgument(
+                            "Current only support convert int32_t "
+                            "to int64_t, but get type is: %s",
+                            type_));
   type_ = Int(64);
   for (Expr &operand : operands) {
     operand->convert_int32_to_int64();
@@ -339,12 +340,12 @@ void TryElevateInt32ToInt64(const std::vector<Expr> &expr_vec) {
   for (const Expr &expr : expr_vec) {
     if (expr->type() != Int(64))
       if (expr->type() != Int(32))
-        PADDLE_ENFORCE_EQ(
-            expr->type().is_unk(),
-            true,
-            phi::errors::InvalidArgument("Current only support convert int32_t "
-                                         "to int64_t, but get type is: %s",
-                                         expr->type()));
+        PADDLE_ENFORCE_EQ(expr->type().is_unk(),
+                          true,
+                          ::common::errors::InvalidArgument(
+                              "Current only support convert int32_t "
+                              "to int64_t, but get type is: %s",
+                              expr->type()));
     if (expr->type() == Int(32)) {
       expr->convert_int32_to_int64();
     }

--- a/paddle/cinn/ir/ir_base.h
+++ b/paddle/cinn/ir/ir_base.h
@@ -200,7 +200,7 @@ class IrNodeRef : public cinn::common::Shared<IrNode> {
     static_assert(std::is_base_of<IrNode, T>());
     PADDLE_ENFORCE_NOT_NULL(
         get(),
-        phi::errors::InvalidArgument(
+        ::common::errors::InvalidArgument(
             "IrNodeRef holds null. "
             "The get() method should return a non-null value."));
     if (node_type() == T::_node_type_) return static_cast<const T*>(get());
@@ -262,11 +262,11 @@ struct IntImm : public ExprNode<IntImm> {
     PADDLE_ENFORCE_EQ(
         type().is_int(),
         true,
-        phi::errors::InvalidArgument("The type must be an integer type."));
+        ::common::errors::InvalidArgument("The type must be an integer type."));
     PADDLE_ENFORCE_EQ(
         type().is_scalar(),
         true,
-        phi::errors::InvalidArgument("The type must be scalar type."));
+        ::common::errors::InvalidArgument("The type must be scalar type."));
     if (type().bits() != 8)
       if (type().bits() != 16)
         if (type().bits() != 32)
@@ -289,12 +289,12 @@ struct UIntImm : public ExprNode<UIntImm> {
   void Verify() const override {
     PADDLE_ENFORCE_EQ(type().is_uint(),
                       true,
-                      phi::errors::InvalidArgument(
+                      ::common::errors::InvalidArgument(
                           "The type must be an unsigned integer type."));
     PADDLE_ENFORCE_EQ(
         type().is_scalar(),
         true,
-        phi::errors::InvalidArgument("The type must be scalar type."));
+        ::common::errors::InvalidArgument("The type must be scalar type."));
     if (type().bits() != 1)
       if (type().bits() != 8)
         if (type().bits() != 16)
@@ -319,11 +319,11 @@ struct FloatImm : public ExprNode<FloatImm> {
     PADDLE_ENFORCE_EQ(
         type().is_float(),
         true,
-        phi::errors::InvalidArgument("The type must be float type."));
+        ::common::errors::InvalidArgument("The type must be float type."));
     PADDLE_ENFORCE_EQ(
         type().is_scalar(),
         true,
-        phi::errors::InvalidArgument("The type must be scalar type."));
+        ::common::errors::InvalidArgument("The type must be scalar type."));
   }
 
   static const IrNodeTy _node_type_ = IrNodeTy::FloatImm;
@@ -438,7 +438,7 @@ struct UnaryOpNode : public ExprNode<T> {
     PADDLE_ENFORCE_EQ(
         v.defined(),
         true,
-        phi::errors::InvalidArgument("The variable must be defined."));
+        ::common::errors::InvalidArgument("The variable must be defined."));
     operands().resize(1);
     this->v() = v;
   }
@@ -447,7 +447,7 @@ struct UnaryOpNode : public ExprNode<T> {
     PADDLE_ENFORCE_EQ(
         v().defined(),
         true,
-        phi::errors::InvalidArgument("The variable must be defined."));
+        ::common::errors::InvalidArgument("The variable must be defined."));
     return v().type();
   }
 
@@ -469,17 +469,18 @@ template <typename T>
 struct BinaryOpNode : public ExprNode<T> {
   BinaryOpNode() { operands().resize(2); }
   BinaryOpNode(Type type, Expr a, Expr b) : ExprNode<T>(type) {
-    PADDLE_ENFORCE_EQ(type.valid(),
-                      true,
-                      phi::errors::InvalidArgument("The type must be valid."));
+    PADDLE_ENFORCE_EQ(
+        type.valid(),
+        true,
+        ::common::errors::InvalidArgument("The type must be valid."));
     PADDLE_ENFORCE_EQ(
         a.defined(),
         true,
-        phi::errors::InvalidArgument("The object 'a' must be defined."));
+        ::common::errors::InvalidArgument("The object 'a' must be defined."));
     PADDLE_ENFORCE_EQ(
         b.defined(),
         true,
-        phi::errors::InvalidArgument("The object 'b' must be defined."));
+        ::common::errors::InvalidArgument("The object 'b' must be defined."));
     operands().resize(2);
     this->a() = a;
     this->b() = b;

--- a/paddle/cinn/ir/layout.cc
+++ b/paddle/cinn/ir/layout.cc
@@ -22,11 +22,11 @@ void Layout::Verify() {
     PADDLE_ENFORCE_NE(
         name_.empty(),
         true,
-        phi::errors::InvalidArgument("The name should not be empty."));
+        ::common::errors::InvalidArgument("The name should not be empty."));
     PADDLE_ENFORCE_NE(
         axes_.empty(),
         true,
-        phi::errors::InvalidArgument("The axes should not be empty."));
+        ::common::errors::InvalidArgument("The axes should not be empty."));
     axis_names_ = "";
     for (auto& axis : axes_) {
       PADDLE_ENFORCE_EQ(
@@ -38,11 +38,11 @@ void Layout::Verify() {
           (axis_name >= 'A' && axis_name <= 'Z') ||
               (axis_name >= 'a' && axis_name <= 'z'),
           true,
-          phi::errors::InvalidArgument("Axis name must be a letter."));
-      PADDLE_ENFORCE_EQ(
-          axis_names_.find(axis_name) == axis_names_.npos,
-          true,
-          phi::errors::InvalidArgument("{} has already existed.", axis_name));
+          ::common::errors::InvalidArgument("Axis name must be a letter."));
+      PADDLE_ENFORCE_EQ(axis_names_.find(axis_name) == axis_names_.npos,
+                        true,
+                        ::common::errors::InvalidArgument(
+                            "{} has already existed.", axis_name));
       axis_names_ += axis_name;
     }
     int offset = 'A' - 'a';
@@ -56,8 +56,8 @@ void Layout::Verify() {
         PADDLE_ENFORCE_NE(
             axis_names_.find(axis_name + offset) == axis_names_.npos,
             true,
-            phi::errors::InvalidArgument("sub-axis {} finds no primal axis",
-                                         axis_name));
+            ::common::errors::InvalidArgument(
+                "sub-axis {} finds no primal axis", axis_name));
       }
     }
   }
@@ -66,7 +66,7 @@ Layout::Layout(const std::string& name) {
   PADDLE_ENFORCE_NE(
       name.empty(),
       true,
-      phi::errors::InvalidArgument("The name should not be empty."));
+      ::common::errors::InvalidArgument("The name should not be empty."));
   int factor = 0;
   std::vector<Var> axes;
   for (char c : name) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Replace phi::errors to ::common::errors in paddle/cinn
