### PR TITLE
[Dy2St] Skip ignored module by defining file

### DIFF
--- a/test/dygraph_to_static/test_ignore_module.py
+++ b/test/dygraph_to_static/test_ignore_module.py
@@ -12,21 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import traceback
 import unittest
 
-import astor
 import scipy
 
+import paddle
 from paddle.jit import ignore_module
 from paddle.jit.dy2static.convert_call_func import BUILTIN_LIKELY_MODULES
+
+logger = logging.getLogger(__file__)
+
+
+def logging_warning():
+    logging.warning('This is a warning message')
+    logger.warning('This is a warning message')
+
+
+class TestLoggingWarning(unittest.TestCase):
+    def test_skip_ast_convert_logging_warning(self):
+        static_logging_warning = paddle.jit.to_static(
+            logging_warning, full_graph=True
+        )
+        static_logging_warning()
 
 
 class TestIgnoreModule(unittest.TestCase):
     def test_ignore_module(self):
-        modules = [scipy, astor]
+        modules = [scipy, traceback]
         ignore_module(modules)
         self.assertEqual(
-            [scipy, astor],
+            [scipy, traceback],
             BUILTIN_LIKELY_MODULES[-2:],
             'Failed to add modules that ignore transcription',
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

skip module 的时候不能只看 module 下的成员，应该同时看该函数具体定义在哪里，是否是定义在该模块中，比如类下的方法就并不是 module 的成员，但是需要 skip 掉，比如单测里的 `logger.warning`，这里因为没有成功跳过转写导致 frame 与原来的不一致而挂掉了

之后需要看一下，通过成员来跳过的逻辑是否可以删除呢？这些成员是没有字节码的，自然也没有源码，因此前一种情况是否已经能够覆盖全部情况了呢？

Pcard-67164