### PR TITLE
[XPU] Modify the XPU unit test of dropout_op.

### DIFF
--- a/test/xpu/test_dropout_op_xpu.py
+++ b/test/xpu/test_dropout_op_xpu.py
@@ -223,11 +223,17 @@ class XPUTestDropoutOp(XPUOpTestWrapper):
                     # where the values in the mask are either 1.0 or 0.0. In the bf16 format, when calculating 1.0 * 1.0,
                     # the result becomes slightly larger than 1.0, specifically 1.0078277587890625, due to the 0x8000 rounding
                     # when converting to fp32. After truncation, the optput is represented as 1.0078125  under the bf16 format.
-                    np.testing.assert_allclose(
-                        input.gradient(),
-                        self.cal_grad_downscale_in_infer(mask.numpy()),
-                        rtol=0.01,
-                    )
+                    if self.in_type == np.uint16:
+                        np.testing.assert_allclose(
+                            input.gradient(),
+                            self.cal_grad_downscale_in_infer(mask.numpy()),
+                            rtol=0.01,
+                        )
+                    else:
+                        np.testing.assert_allclose(
+                            input.gradient(),
+                            self.cal_grad_downscale_in_infer(mask.numpy()),
+                        )
 
         def test_backward_upscale_train(self):
             for place in self.places:


### PR DESCRIPTION
### PR Category
Custom Device


### PR Types
Bug fixes

### Description
 Modify the XPU unit test of dropout_op. Use a different diff for bfloat16 compared to other data formats.
