### PR TITLE
[Cherry-pick]Remove the constraints that WITH_CINN and WITH_RPC cannot be set together

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,13 +594,6 @@ if(WITH_RPC)
         OFF
         CACHE BOOL "Disable WITH_RPC when compiling with XPU" FORCE)
   endif()
-  if(WITH_CINN AND WITH_RPC)
-    message(
-      WARNING "Disable WITH_RPC when compiling with CINN. Force WITH_RPC=OFF.")
-    set(WITH_RPC
-        OFF
-        CACHE BOOL "Disable WITH_RPC when compiling with CINN" FORCE)
-  endif()
 endif()
 
 if(WITH_MPI)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Environment Adaptation


### PR Types
Bug fixes

### Description
Cherry-pick https://github.com/PaddlePaddle/Paddle/pull/67219 .

Remove the constraints that WITH_CINN and WITH_RPC cannot be set together.

![image](https://github.com/user-attachments/assets/a24f64b8-9a3b-415d-8a6a-a8315489f762)

Pcard-67164