### PR TITLE
【Comm】del redundant comm flags

### DIFF
--- a/test/collective/fleet/test_parallel_class_center_sample.py
+++ b/test/collective/fleet/test_parallel_class_center_sample.py
@@ -23,7 +23,6 @@ class TestParallelClassCenterSample(TestMultipleAccelerators):
     def test_parallel_class_center_sample(self):
         self.run_mnist_2accelerators(
             'parallel_class_center_sample.py',
-            need_envs={"FLAGS_dynamic_static_unified_comm": "true"},
         )
 
 

--- a/test/collective/fleet/test_parallel_margin_cross_entropy.py
+++ b/test/collective/fleet/test_parallel_margin_cross_entropy.py
@@ -23,7 +23,6 @@ class TestParallelMarginSoftmaxWithCrossEntropy(TestMultipleAccelerators):
     def test_parallel_margin_cross_entropy(self):
         self.run_mnist_2accelerators(
             'parallel_margin_cross_entropy.py',
-            need_envs={"FLAGS_dynamic_static_unified_comm": "true"},
         )
 
 

--- a/test/collective/test_collective_allreduce_api.py
+++ b/test/collective/test_collective_allreduce_api.py
@@ -80,7 +80,6 @@ class TestCollectiveAllreduceAPI(TestDistBase):
                     "nccl",
                     dtype=dtype,
                     reduce_type=red_type,
-                    need_envs={"FLAGS_dynamic_static_unified_comm": "1"},
                 )
 
     def test_allreduce_bkcl(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

1. Delete the redundant code and ut.

Pcard-70448