### PR TITLE
[CodeStyle][Ruff] Bump ruff to 0.6.1 and enable `RUF005`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.0
+    rev: v0.6.1
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix, --no-cache]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.0
+    rev: v0.6.0
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix, --no-cache]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 80
 skip-string-normalization = true
-target-version = ["py38", "py39", "py310", "py311", "py312"]
+target-version = ["py39", "py310", "py311", "py312"]
 extend-exclude = '''
 (
     third_party/.+      # Exclude third_party directory
@@ -92,7 +92,7 @@ select = [
     "TCH",
 
     # Ruff-specific rules
-    # "RUF005",
+    "RUF005",
     "RUF008",
     "RUF009",
     "RUF010",
@@ -172,6 +172,9 @@ known-first-party = ["paddle"]
 "test/dygraph_to_static/test_lambda.py" = ["PLC3002"]
 # Ignore docstring in tensor.pyi
 "python/paddle/tensor/tensor.prototype.pyi" = ["PYI021", "PYI048"]
+# Temproray ignore some dy2st test case because SOT bug
+# See https://github.com/PaddlePaddle/Paddle/pull/67344#discussion_r1714155671 for more details
+"test/dygraph_to_static/seq2seq_dygraph_model.py" = ["RUF005"]
 
 [tool.mypy]
 python_version = "3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 80
 skip-string-normalization = true
-target-version = ["py39", "py310", "py311", "py312"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 extend-exclude = '''
 (
     third_party/.+      # Exclude third_party directory

--- a/python/paddle/hapi/callbacks.py
+++ b/python/paddle/hapi/callbacks.py
@@ -70,16 +70,16 @@ def config_callbacks(
         _cbks if isinstance(_cbks, (list, tuple)) else [_cbks]
     )
     if not any(isinstance(k, ProgBarLogger) for k in cbks) and verbose:
-        cbks = [ProgBarLogger(log_freq, verbose=verbose)] + cbks
+        cbks = [ProgBarLogger(log_freq, verbose=verbose), *cbks]
 
     if not any(isinstance(k, ModelCheckpoint) for k in cbks):
-        cbks = cbks + [ModelCheckpoint(save_freq, save_dir)]
+        cbks = [*cbks, ModelCheckpoint(save_freq, save_dir)]
 
     for k in cbks:
         if isinstance(k, EarlyStopping):
             k.save_dir = save_dir
     if not any(isinstance(k, LRScheduler) for k in cbks):
-        cbks = cbks + [LRScheduler()]
+        cbks = [*cbks, LRScheduler()]
 
     cbk_list = CallbackList(cbks)
     cbk_list.set_model(model)

--- a/python/paddle/vision/models/resnet.py
+++ b/python/paddle/vision/models/resnet.py
@@ -35,7 +35,6 @@ if TYPE_CHECKING:
         'resnet152',
         'resnext50_32x4d',
         'resnext50_64x4d',
-        'resnext50_64x4d',
         'resnext101_32x4d',
         'resnext101_64x4d',
         'resnext152_32x4d',

--- a/test/auto_parallel/test_high_order_grad.py
+++ b/test/auto_parallel/test_high_order_grad.py
@@ -30,19 +30,18 @@ class TestHighOrderGrad(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_iterable_dataset.py
+++ b/test/auto_parallel/test_iterable_dataset.py
@@ -30,19 +30,18 @@ class TestEngineAPI(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_mp_allreduce_matmul_grad_overlapping.py
+++ b/test/auto_parallel/test_mp_allreduce_matmul_grad_overlapping.py
@@ -32,19 +32,18 @@ class TestMPAllreduceMatmulGradOverlapping(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_pass_1F1B.py
+++ b/test/auto_parallel/test_pass_1F1B.py
@@ -33,7 +33,7 @@ class Test1F1BPass(unittest.TestCase):
         cmd = [
             sys.executable,
             "-u",
-            coverage_args,
+            *coverage_args,
             "-m",
             "paddle.distributed.launch",
             "--devices",

--- a/test/auto_parallel/test_pass_1F1B.py
+++ b/test/auto_parallel/test_pass_1F1B.py
@@ -30,19 +30,18 @@ class Test1F1BPass(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/auto_parallel/test_pipeline_scheduler_zb_vpp.py
+++ b/test/auto_parallel/test_pipeline_scheduler_zb_vpp.py
@@ -32,19 +32,18 @@ class TestZBVPPPass(unittest.TestCase):
             coverage_args = []
 
         tmp_dir = tempfile.TemporaryDirectory()
-        cmd = (
-            [sys.executable, "-u"]
-            + coverage_args
-            + [
-                "-m",
-                "paddle.distributed.launch",
-                "--devices",
-                "0,1",
-                "--log_dir",
-                tmp_dir.name,
-                launch_model_path,
-            ]
-        )
+        cmd = [
+            sys.executable,
+            "-u",
+            *coverage_args,
+            "-m",
+            "paddle.distributed.launch",
+            "--devices",
+            "0,1",
+            "--log_dir",
+            tmp_dir.name,
+            launch_model_path,
+        ]
 
         process = subprocess.Popen(cmd)
         process.wait()

--- a/test/legacy_test/test_fake_quantize_op.py
+++ b/test/legacy_test/test_fake_quantize_op.py
@@ -224,7 +224,7 @@ class TestFakeChannelWiseQuantizeDequantizeAbsMaxOp(OpTest):
             )
             self.attrs['round_type'] = 1
         if quant_axis == 1:
-            scale_broadcast = np.transpose(scale_broadcast, (1,) + compute_axis)
+            scale_broadcast = np.transpose(scale_broadcast, (1, *compute_axis))
         scale = scale_broadcast.reshape(input_shape[quant_axis], -1)[:, 0]
         self.python_api = fake_channel_wise_quantize_dequantize_abs_max_wrapper
         self.inputs = {'X': input_data}

--- a/test/legacy_test/test_sync_batch_norm_op.py
+++ b/test/legacy_test/test_sync_batch_norm_op.py
@@ -249,14 +249,16 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
         (out, conv, bn, ops) = outs
         fetch_names = [out, conv, bn]
         if paddle.framework.use_pir_api():
-            fetch_names = fetch_names + [
+            fetch_names = [
+                *fetch_names,
                 ops[1].result(0),
                 ops[0].result(0),
                 ops[3].result(0),
                 ops[2].result(0),
             ]
         else:
-            fetch_names = fetch_names + [
+            fetch_names = [
+                *fetch_names,
                 'bn_moving_mean',
                 'bn_moving_variance',
                 'bn_scale',
@@ -330,7 +332,7 @@ class TestSyncBatchNormOpTraining(unittest.TestCase):
             layout, fetch_list=fetch_names, only_forward=only_forward
         )
 
-        fetch_names = [out, conv, bn] + fetch_names
+        fetch_names = [out, conv, bn, *fetch_names]
 
         for i in range(1, len(bn_fetches)):
             bn_val = bn_fetches[i]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

升级 Ruff 到 0.6.1，并启用 RUF005

Pcard-67164