### PR TITLE
[Typing] 类型提示的 CI 失败时引导到文档

### DIFF
--- a/tools/type_checking.py
+++ b/tools/type_checking.py
@@ -192,6 +192,9 @@ class MypyChecker(TypeChecker):
                 "> python tools/type_checking.py "
                 + " ".join(sorted(failed_apis))
             )
+            logger.error(
+                ">>> For more information: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/dev_guides/style_guide_and_references/type_annotations_specification_cn.html"
+            )
             logger.error("----------------End of the Check--------------------")
 
             log_exit(1)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
类型提示的 CI 失败时引导到文档

依赖 https://github.com/PaddlePaddle/docs/pull/6836
关联 https://github.com/PaddlePaddle/Paddle/issues/63597

@SigureMo 