### PR TITLE
limit numpy version on windows

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,7 @@
 httpx
-numpy>=1.13
-protobuf>=3.20.2 
+numpy>=1.13 ; platform_system != "Windows"
+numpy>=1.13,<2.1 ; platform_system == "Windows"
+protobuf>=3.20.2
 Pillow
 decorator
 astor


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
 Environment Adaptation 


### PR Types
Bug fixes 


### Description
Pcard-73263
windows平台上安装numpy2.1时，as_numpy接口存在bug
