### PR TITLE
【Comm】clear redundant comm flags in unittests

### DIFF
--- a/test/collective/test_collective_allgather_api.py
+++ b/test/collective/test_collective_allgather_api.py
@@ -44,26 +44,6 @@ class TestCollectiveAllgatherAPI(TestDistBase):
                 dtype=dtype,
             )
 
-    def test_allgather_nccl_with_new_comm(self):
-        dtypes_to_test = [
-            "float16",
-            "float32",
-            "float64",
-            "int32",
-            "int64",
-            "int8",
-            "uint8",
-            "bool",
-        ]
-        for dtype in dtypes_to_test:
-            self.check_with_place(
-                "collective_allgather_api.py",
-                "allgather",
-                "nccl",
-                dtype=dtype,
-                need_envs={"FLAGS_dynamic_static_unified_comm": "true"},
-            )
-
     def test_allgather_gloo(self):
         dtypes_to_test = [
             "float16",

--- a/test/collective/test_collective_alltoall_api.py
+++ b/test/collective/test_collective_alltoall_api.py
@@ -54,7 +54,6 @@ class TestCollectiveAllToAllAPI(TestDistBase):
                 "alltoall",
                 "nccl",
                 dtype=dtype,
-                need_envs={"FLAGS_dynamic_static_unified_comm": "true"},
             )
 
     def test_alltoall_nccl_dygraph(self):

--- a/test/collective/test_collective_reduce_scatter_api.py
+++ b/test/collective/test_collective_reduce_scatter_api.py
@@ -37,7 +37,6 @@ class TestCollectiveReduceScatterAPI(test_base.TestDistBase):
                 "reduce_scatter",
                 "nccl",
                 dtype=dtype,
-                need_envs={"FLAGS_dynamic_static_unified_comm": "true"},
             )
 
     def test_reduce_scatter_nccl_dygraph(self):

--- a/test/legacy_test/distributed_fused_lamb_test_base.py
+++ b/test/legacy_test/distributed_fused_lamb_test_base.py
@@ -270,13 +270,7 @@ class TestDistributedFusedLamb(unittest.TestCase):
         paddle.enable_static()
         paddle.set_flags({'FLAGS_cudnn_deterministic': True})
         _clip_by_global_norm_using_mp_type(True)
-        if (
-            os.environ.get("FLAGS_dynamic_static_unified_comm", "true").lower()
-            == "true"
-        ):
-            paddle.distributed.collective._init_parallel_env("nccl")
-        else:
-            fleet.init(role_maker=get_role_maker())
+        paddle.distributed.collective._init_parallel_env("nccl")
 
     def config(self):
         clip_after_allreduce = bool(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

1. Delete the redundant comm FLAGS in ut.

Pcard-70448