### PR TITLE
fix issue of sync_batch_norm grad error

### DIFF
--- a/paddle/phi/kernels/funcs/sync_batch_norm_utils.h
+++ b/paddle/phi/kernels/funcs/sync_batch_norm_utils.h
@@ -447,7 +447,6 @@ void SyncBatchNormGradFunctor(
                         C,
                         scale.dims()[0]));
 
-  ctx.template Alloc<T>(d_x);
   if (d_scale && d_bias) {
     ctx.template Alloc<BatchNormParamType<T>>(d_scale);
     ctx.template Alloc<BatchNormParamType<T>>(d_bias);
@@ -592,6 +591,7 @@ void SyncBatchNormGradFunctor(
                                          d_bias->data<BatchNormParamType<T>>());
     }
     if (d_x) {
+      ctx.template Alloc<T>(d_x);
       KeBNBackwardData<T, DataLayout::kNCHW><<<grid2, block, 0, stream>>>(
           dy_d,
           x_d,
@@ -663,6 +663,7 @@ void SyncBatchNormGradFunctor(
       }
     }
     if (d_x) {
+      ctx.template Alloc<T>(d_x);
       KeBNBackwardData<T, DataLayout::kNHWC><<<grid2, block, 0, stream>>>(
           dy_d,
           x_d,


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Bug fixes

### Description
pcard-86297
fix issue of [67182](https://github.com/PaddlePaddle/Paddle/issues/67182)
when running program below, error will report at `avg_loss.backward()`
The reason of this issue is that `paddle.nn.SyncBatchNorm` is in the first layer of the network, and the input received is `img`. which does not need to calculate gradients(img.stop_gradient == True), so the pointer of `x_grad` is null, and kernel(`SyncBatchNormGradFunctor`) is executed `ctx.template Alloc<T>(d_x);` directly with `d_x == x_grad == null`, resulting in an error
```python
import numpy as np
import paddle
from paddle.distributed import fleet, all_gather
from paddle.io import Dataset, BatchSampler, DataLoader

base_lr = 0.1   # 学习率
momentum_rate = 0.9 # 冲量
l2_decay = 1e-4 # 权重衰减

epoch = 5  #训练迭代次数
batch_num = 10 #每次迭代的 batch 数
batch_size = 32 #训练批次大小
class_dim = 10

class RandomDataset(Dataset):
    def __init__(self, num_samples):
        self.num_samples = num_samples

    def __getitem__(self, idx):
        image = np.random.random([64]).astype('float32')
        label = np.random.randint(0, class_dim - 1, (1, )).astype('int64')
        return image, label

    def __len__(self):
        return self.num_samples

class SimpleNet(paddle.nn.Layer):
    def __init__(self):
        super(SimpleNet, self).__init__()
        self.batch_norm = paddle.nn.BatchNorm1D(64)
        self.fc1 = paddle.nn.Linear(64, 8)
        self.fc2 = paddle.nn.Linear(8, 1)

    def forward(self, x):
        x = self.batch_norm(x)
        x = self.fc1(x)
        output = self.fc2(x)
        return output

dist_strategy = fleet.DistributedStrategy()

def train_model():
    fleet.init(is_collective=True, strategy=dist_strategy)

    model = SimpleNet()
    model = paddle.nn.SyncBatchNorm.convert_sync_batchnorm(model)
    loss_func = paddle.nn.CrossEntropyLoss()
    optimizer = paddle.optimizer.SGD(learning_rate=0.01, 
                    parameters=model.parameters())
    
    model = fleet.distributed_model(model)
    optimizer = fleet.distributed_optimizer(optimizer)

    dataset = RandomDataset(batch_num * batch_size)
    sampler = BatchSampler(dataset,
                        batch_size=batch_size,shuffle=False, drop_last=True)
    train_loader = DataLoader(dataset,
                            batch_sampler=sampler,
                            num_workers=1)

    for eop in range(epoch):
        model.train()

        for batch_id, data in enumerate(train_loader()):
            img, label = data
            label.stop_gradient = True

            out = model(img)
            avg_loss = loss_func(input=out, label=label)

            avg_loss.backward()  # will report error
            optimizer.step()
            optimizer.clear_grad()

            if batch_id % 5 == 0:
                print("[Epoch %d, batch %d] loss: %.5f" % (eop, batch_id, np.array(avg_loss)))
# 启动训练
if __name__ == '__main__':
    train_model()
```