### PR TITLE
[CINN] Fix bug of convert pd.unsqueeze to cinn.rehape

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -930,26 +930,36 @@ class UnsqueezeOpPattern
                           .dyn_cast<pir::ShapedTypeInterface>()
                           .IsDynamicShape();
     if (IsDefinedBy<FullIntArrayOp>(op, 1) && !is_dyshape) {
-      const FullIntArrayOp axis_full_op = CastDefinedTo<FullIntArrayOp>(op, 1);
-      auto axis_vec = cinn::dialect::ir::GetVectorAttr(axis_full_op, "value");
-      std::set<int64_t> axis_set(axis_vec.begin(), axis_vec.end());
-
       auto in_shape =
           phi::vectorize(op.operand_source(0)
                              .type()
                              .dyn_cast<paddle::dialect::DenseTensorType>()
                              .dims());
 
-      std::vector<int> output_shape;
-      const size_t output_rank = in_shape.size() + axis_vec.size();
-
-      for (size_t i = 0, input_index = 0; i < output_rank; ++i) {
-        if (axis_set.count(i)) {
-          output_shape.push_back(1);
-          continue;
+      const std::set<int64_t> axis_set = [&] {
+        const FullIntArrayOp axis_full_op =
+            CastDefinedTo<FullIntArrayOp>(op, 1);
+        auto axis_vec = cinn::dialect::ir::GetVectorAttr(axis_full_op, "value");
+        std::set<int64_t> axis_set;
+        for (int64_t axis : axis_vec) {
+          int64_t axis_val = axis < 0 ? axis += in_shape.size() + 1 : axis;
+          axis_set.insert(axis_val);
         }
-        output_shape.push_back(in_shape[input_index++]);
-      }
+        return axis_set;
+      }();
+
+      const std::vector<int> output_shape = [&] {
+        const size_t output_rank = in_shape.size() + axis_set.size();
+        std::vector<int> output_shape;
+        for (size_t i = 0, input_index = 0; i < output_rank; ++i) {
+          if (axis_set.count(i)) {
+            output_shape.push_back(1);
+            continue;
+          }
+          output_shape.push_back(in_shape[input_index++]);
+        }
+        return output_shape;
+      }();
       ReplaceWithCinnReshapeOp(op, rewriter, output_shape);
       rewriter.EraseOp(op);
 

--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -941,12 +941,14 @@ class UnsqueezeOpPattern
                              .dims());
 
       std::vector<int> output_shape;
+      const size_t output_rank = in_shape.size() + axis_vec.size();
 
-      for (size_t i = 0; i < in_shape.size(); ++i) {
-        output_shape.push_back(in_shape[i]);
+      for (size_t i = 0, input_index = 0; i < output_rank; ++i) {
         if (axis_set.count(i)) {
           output_shape.push_back(1);
+          continue;
         }
+        output_shape.push_back(in_shape[input_index++]);
       }
       ReplaceWithCinnReshapeOp(op, rewriter, output_shape);
       rewriter.EraseOp(op);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复pd_to_cinn_pass中unsqueeze转换为reshape时维度处理错误的bug。