### PR TITLE
[Inference] Remove scale op when save inference model

### DIFF
--- a/test/legacy_test/test_jit_save_load.py
+++ b/test/legacy_test/test_jit_save_load.py
@@ -257,7 +257,7 @@ class LinearNetWithMultiStaticFunc(paddle.nn.Layer):
         return self._linear_0(x)
 
     def forward_no_param(self, x):
-        return x
+        return x * 1.0
 
     def forward_general(self, x):
         return self._linear_0(x) + self._linear_1(x) * self._scale
@@ -1437,10 +1437,13 @@ class TestJitSaveLoadEmptyLayer(unittest.TestCase):
         layer = EmptyLayer()
         x = paddle.to_tensor(np.random.random(10).astype('float32'))
         out = layer(x)
-        paddle.jit.save(layer, self.model_path)
-        load_layer = paddle.jit.load(self.model_path)
-        load_out = load_layer(x)
-        np.testing.assert_array_equal(out, load_out)
+        try:
+            paddle.jit.save(layer, self.model_path)
+        except ValueError as e:
+            self.assertTrue(
+                'program must not be empty. at least one operator is required!'
+                in str(e)
+            )
 
 
 class TestJitSaveLoadNoParamLayer(unittest.TestCase):
@@ -2085,7 +2088,7 @@ class InputSepcLayer(paddle.nn.Layer):
     # A layer with InputSpec to test InputSpec compatibility
 
     def forward(self, x, y):
-        return x, y
+        return x * 1.0, y * 1.0
 
 
 class TestInputSpecCompatibility(unittest.TestCase):

--- a/test/legacy_test/test_static_save_load.py
+++ b/test/legacy_test/test_static_save_load.py
@@ -1204,9 +1204,7 @@ class TestSaveLoadInferenceModel(unittest.TestCase):
             else:
                 self.assertEqual(fetch_targets[0].shape, (10, 10))
                 ops = [op.type for op in inference_program.block(0).ops]
-                self.assertEqual(
-                    ops, ['feed', 'elementwise_add', 'scale', 'fetch']
-                )
+                self.assertEqual(ops, ['feed', 'elementwise_add', 'fetch'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-71500

Remove scale op when save inference model.