### PR TITLE
fix einsum issue

### DIFF
--- a/python/paddle/tensor/einsum.py
+++ b/python/paddle/tensor/einsum.py
@@ -842,7 +842,7 @@ def parse_fake_shape(
             "length of shape and length of label must be the same, but received %d != %d"
             % (len(op.shape), len(label))
         )
-        fakes = [s for i, (l, s) in enumerate(zip(label, op.shape)) if l != '.']
+        fakes = [s for i, (l, s) in enumerate(zip(label, op.shape))]
         fakes = list(map(abs, fakes))  # make -1 -> 1
         if '.' in ori_label:
             fakes.insert(ori_label.index('.'), 1)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
Bug fixes

### Description

fix the following use case, which is simplified from https://github.com/arogozhnikov/einops/blob/master/tests/test_einsum.py

```python
import paddle
import numpy as np

p = "..., ..., ... -> ..."
in_shapes = ((3, 2), (3, 2), (3, 2))

in_arrays = [np.random.uniform(size=shape).astype("float32") for shape in in_shapes]
paddle_in_arrays = [paddle.to_tensor(array) for array in in_arrays]

paddle.einsum(p, *paddle_in_arrays)
```

this bug seems being introduced in #61348, this PR is only a workaround.

please ignore the following
PCard-66972