### PR TITLE
[CINN]Fix InferSymbolicShape for scale and SetValueWithTensor

### DIFF
--- a/paddle/cinn/hlir/framework/pir/utils.cc
+++ b/paddle/cinn/hlir/framework/pir/utils.cc
@@ -421,7 +421,7 @@ bool IsSupportInCinn(const ::pir::Operation& op) {
 }  // namespace
 
 bool CompatibleInfo::IsDeniedForCinn(const ::pir::Operation& op) {
-  bool flag = IsDeniedInCinn(op);
+  bool flag = IsDeniedInCinn(op) || CauseNewSymbolicShape(op);
   VLOG(4) << "CompatibleInfo::IsDeniedForCinn of " << op.name()
           << " is: " << flag;
   return flag;

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.h"
+#include <optional>
 
 #define OP_SAME_OPERANDS_AND_RESULT(name)                                     \
   bool name##OpInferSymbolicShape(                                            \
@@ -205,30 +206,55 @@ bool ScaleOpInferSymbolicShape(pir::Operation *op,
       infer_context->GetShapeOrDataForValue(operand_source);
   std::vector<symbol::DimExpr> shape(operand_shape_or_data.shape());
 
-  if (operand_shape_or_data.data()) {
-    const std::vector<symbol::DimExpr> data = [&] {
-      const symbol::DimExpr scale = [&]() -> symbol::DimExpr {
-        if (op->num_operands() == 2) {
-          return infer_context->GetShapeOrDataForValue(op->operand_source(1))
-              .data()
-              ->at(0);
-        }
-        return static_cast<int64_t>(
-            op->attribute("scale").dyn_cast<pir::FloatAttribute>().data());
-      }();
-      int bias = op->attribute("bias").dyn_cast<pir::FloatAttribute>().data();
+  const auto &SetOutputWithOnlyShape = [&]() {
+    infer_context->SetShapeOrDataForValue(
+        op->result(0), symbol::TensorShapeOrDataDimExprs(shape));
+  };
 
+  const auto &SetOutputWithShapeAndData =
+      [&](const std::vector<symbol::DimExpr> &data) {
+        infer_context->SetShapeOrDataForValue(
+            op->result(0), symbol::TensorShapeOrDataDimExprs(shape, data));
+      };
+
+  const auto &GetOptionalAttributeData =
+      [&](const std::string &attr_name) -> std::optional<symbol::DimExpr> {
+    const auto &float_data =
+        op->attribute(attr_name).dyn_cast<pir::FloatAttribute>().data();
+    const int64_t &int_data = static_cast<int64_t>(float_data);
+    if (float_data - int_data > 1e-6 || float_data - int_data < -1e-6) {
+      return std::nullopt;
+    }
+    return symbol::DimExpr{int_data};
+  };
+
+  const auto &GetOptionalScaleData = [&]() -> std::optional<symbol::DimExpr> {
+    if (op->num_operands() == 2) {
+      const auto &scale_shape_or_data =
+          infer_context->GetShapeOrDataForValue(op->operand_source(1));
+      if (scale_shape_or_data.data())
+        return scale_shape_or_data.data()->at(0);
+      else
+        return std::nullopt;
+    }
+    return GetOptionalAttributeData("scale");
+  };
+
+  if (operand_shape_or_data.data()) {
+    const std::optional<symbol::DimExpr> &opt_scale = GetOptionalScaleData();
+    const std::optional<symbol::DimExpr> &opt_bias =
+        GetOptionalAttributeData("bias");
+    if (opt_scale && opt_bias) {
       std::vector<symbol::DimExpr> data;
       for (auto &val : *(operand_shape_or_data.data())) {
-        data.push_back(val * scale + bias);
+        data.push_back(val * (opt_scale.value()) + (opt_bias.value()));
       }
-      return data;
-    }();
-
-    infer_context->SetShapeOrDataForValue(
-        op->result(0), symbol::TensorShapeOrDataDimExprs(shape, data));
+      SetOutputWithShapeAndData(data);
+    } else {
+      SetOutputWithOnlyShape();
+    }
   } else {
-    infer_context->SetShapeOrDataForValue(op->result(0), operand_shape_or_data);
+    SetOutputWithOnlyShape();
   }
 
   return true;

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -2603,14 +2603,16 @@ bool SetValueOpInferSymbolicShape(
     pir::Operation *op, pir::InferSymbolicShapeContext *infer_context) {
   const auto &input_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
+  const auto &input_shape = input_shape_or_data.shape();
   PADDLE_ENFORCE_LT(
-      input_shape_or_data.shape().size(),
+      input_shape.size(),
       7,
       common::errors::InvalidArgument("The SetValueOp's rank of input should "
                                       "be less than 7, but received %d.",
-                                      input_shape_or_data.shape().size()));
+                                      input_shape.size()));
 
-  infer_context->SetShapeOrDataForValue(op->result(0), input_shape_or_data);
+  infer_context->SetShapeOrDataForValue(
+      op->result(0), symbol::TensorShapeOrDataDimExprs(input_shape));
   return true;
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR fixes InferSymbolicShape for scale and SetValueWithTensor.
