### PR TITLE
[AutoParallel] Refine global_and_sub_mesh reshard func

### DIFF
--- a/paddle/phi/core/distributed/auto_parallel/process_mesh.cc
+++ b/paddle/phi/core/distributed/auto_parallel/process_mesh.cc
@@ -16,6 +16,8 @@ limitations under the License. */
 
 #include <algorithm>
 #include <iterator>
+#include <numeric>
+#include <set>
 
 #include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 #include "paddle/phi/core/distributed/auto_parallel/utils.h"
@@ -121,13 +123,109 @@ void ProcessMesh::to_proto(ProcessMeshProto *proto) const {
 }
 
 bool operator==(const ProcessMesh &lhs, const ProcessMesh &rhs) {
-  if (lhs.shape() != rhs.shape()) {
-    return false;
+  if (lhs.shape() == rhs.shape() && lhs.process_ids() == rhs.process_ids()) {
+    return true;
   }
   if (lhs.process_ids() != rhs.process_ids()) {
     return false;
   }
-  return true;
+
+  // if the process ids are the same, and the shapes after
+  // removing all `1` are the same, then they are equal.
+  std::vector<int64_t> new_lhs_shape = lhs.shape();
+  std::vector<int64_t> new_rhs_shape = rhs.shape();
+  new_lhs_shape.erase(
+      std::remove(new_lhs_shape.begin(), new_lhs_shape.end(), 1),
+      new_lhs_shape.end());
+  new_rhs_shape.erase(
+      std::remove(new_rhs_shape.begin(), new_rhs_shape.end(), 1),
+      new_rhs_shape.end());
+
+  return new_lhs_shape == new_rhs_shape;
+}
+
+std::vector<ProcessMesh> SplitMesh(const ProcessMesh &mesh, int axis) {
+  std::vector<int64_t> mesh_shape = mesh.shape();
+  std::vector<int64_t> process_ids = mesh.process_ids();
+  std::vector<ProcessMesh> result;
+
+  int64_t total_elements = process_ids.size();
+
+  int64_t num_splits = mesh_shape[axis];
+  int64_t prod_before = std::accumulate(mesh_shape.begin(),
+                                        mesh_shape.begin() + axis,
+                                        1,
+                                        std::multiplies<int64_t>());
+  int64_t prod_after = std::accumulate(mesh_shape.begin() + axis + 1,
+                                       mesh_shape.end(),
+                                       1,
+                                       std::multiplies<int64_t>());
+
+  for (int i = 0; i < num_splits; ++i) {
+    std::vector<int64_t> new_shape = mesh_shape;
+    new_shape[axis] = 1;
+
+    std::vector<int64_t> new_process_ids;
+    for (int64_t j = 0; j < prod_before; ++j) {
+      for (int64_t k = 0; k < prod_after; ++k) {
+        int64_t index = j * mesh_shape[axis] * prod_after + i * prod_after + k;
+        if (index < total_elements) {
+          new_process_ids.push_back(process_ids[index]);
+        }
+      }
+    }
+
+    result.emplace_back(
+        ProcessMesh(new_shape, new_process_ids, mesh.dim_names()));
+  }
+
+  return result;
+}
+
+int SubMeshDim(const ProcessMesh &global_mesh, const ProcessMesh &sub_mesh) {
+  std::set<int64_t> global_ids(global_mesh.process_ids().begin(),
+                               global_mesh.process_ids().end());
+  std::set<int64_t> sub_ids(sub_mesh.process_ids().begin(),
+                            sub_mesh.process_ids().end());
+  if (!std::includes(
+          global_ids.begin(), global_ids.end(), sub_ids.begin(), sub_ids.end()))
+    return -1;
+
+  int sub_dim = -1;
+  std::vector<int64_t> global_shape = global_mesh.shape();
+  std::vector<int64_t> sub_shape = sub_mesh.shape();
+
+  if (global_mesh.ndim() == sub_mesh.ndim() + 1) {
+    // for the case that the `1` is not explicitly specified in the shape
+    // only supports the case that the sub_mesh is splitted from the 0-th
+    // from global_mesh now.
+    // e.g.
+    //  global_mesh: shape = [2,3], process_ids = [0,1,2,3,4,5]
+    //  sub_mesh: shape = [3], process_ids = [0,1,2]
+    if (std::equal(global_shape.begin() + 1,
+                   global_shape.end(),
+                   sub_shape.begin(),
+                   sub_shape.end())) {
+      sub_dim = 0;
+    }
+    return sub_dim;
+  } else if (global_mesh.ndim() != sub_mesh.ndim()) {
+    return -1;
+  }
+
+  auto it = std::find(sub_shape.begin(), sub_shape.end(), 1);
+  if (it == sub_shape.end()) {
+    return -1;
+  }
+
+  sub_dim = it - sub_shape.begin();
+  std::vector<ProcessMesh> sub_meshes = SplitMesh(global_mesh, sub_dim);
+  if (std::find(sub_meshes.begin(), sub_meshes.end(), sub_mesh) !=
+      sub_meshes.end()) {
+    return sub_dim;
+  }
+
+  return -1;
 }
 
 }  // namespace distributed

--- a/paddle/phi/core/distributed/auto_parallel/process_mesh.h
+++ b/paddle/phi/core/distributed/auto_parallel/process_mesh.h
@@ -99,5 +99,14 @@ std::vector<ProcessMesh> SplitMesh(const ProcessMesh& mesh, int axis);
 // if sub_mesh is not a subset of global_mesh, return -1
 int SubMeshDim(const ProcessMesh& global_mesh, const ProcessMesh& sub_mesh);
 
+// when the shapes of two meshes are different and their process_ids
+// are the same, check whether the only difference is that mesh 'a'
+// has an additional '1' on the splitted dim of its shape.
+// e.g. a.shape = [2], b.shape = [2, 1], and the process_ids are the
+// same, then they are equal.
+bool mesh_equal_ignore_shape1(const ProcessMesh& a,
+                              const ProcessMesh& b,
+                              int split_dim);
+
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/core/distributed/auto_parallel/process_mesh.h
+++ b/paddle/phi/core/distributed/auto_parallel/process_mesh.h
@@ -92,5 +92,12 @@ inline bool operator!=(const ProcessMesh& lhs, const ProcessMesh& rhs) {
   return !operator==(lhs, rhs);
 }
 
+// split the mesh into sub-meshes at the given axis
+std::vector<ProcessMesh> SplitMesh(const ProcessMesh& mesh, int axis);
+
+// return which dimension that the sub_mesh is splitted from the global_mesh,
+// if sub_mesh is not a subset of global_mesh, return -1
+int SubMeshDim(const ProcessMesh& global_mesh, const ProcessMesh& sub_mesh);
+
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/core/distributed/auto_parallel/reshard/global_and_sub_mesh_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/global_and_sub_mesh_reshard_function.cc
@@ -28,20 +28,20 @@ namespace distributed {
 bool GlobalToSubMeshReshardFunction::IsSuitable(
     const DistTensor& in, const TensorDistAttr& out_dist_attr) {
   const TensorDistAttr& in_dist_attr = in.dist_attr();
-  // 1. first dimension(pp) must be replicated
-  RESHARD_SHORTCUT_IF_FALSE(in_dist_attr.is_replicated(0));
-  // 2. out mesh is the value of a certain dimension of global mesh
-  // e.g. global_mesh = [[1, 2], [3, 4]], out_mesh = [1, 2] or [3, 4]
-  //      global_mesh = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
-  //      out_mesh = [[1, 2], [3, 4]] or [[5, 6], [7, 8]]
 
   const ProcessMesh& in_process_mesh = in_dist_attr.process_mesh();
   const ProcessMesh& out_process_mesh = out_dist_attr.process_mesh();
 
-  RESHARD_SHORTCUT_IF_FALSE(in_process_mesh.ndim() ==
-                            out_process_mesh.ndim() + 1);
+  int sub_mesh_dim = SubMeshDim(in_process_mesh, out_process_mesh);
+  RESHARD_SHORTCUT_IF_FALSE(sub_mesh_dim != -1);
+  // 1. the splitted dimension must be replicated
+  // 2. out mesh is the value of a certain dimension of global mesh
+  // e.g. global_mesh = [[1, 2], [3, 4]], out_mesh = [1, 2] or [3, 4]
+  //      global_mesh = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
+  //      out_mesh = [[1, 2], [3, 4]] or [[5, 6], [7, 8]]
+  RESHARD_SHORTCUT_IF_FALSE(in_dist_attr.is_replicated(sub_mesh_dim));
 
-  return IsSubMesh(in_process_mesh, out_process_mesh);
+  return true;
 }
 
 void GlobalToSubMeshReshardFunction::Eval(phi::DeviceContext* dev_ctx,
@@ -64,16 +64,15 @@ void GlobalToSubMeshReshardFunction::Eval(phi::DeviceContext* dev_ctx,
 
 bool SubMeshToGlobalReshardFunction::IsSuitable(
     const DistTensor& in, const TensorDistAttr& out_dist_attr) {
-  RESHARD_SHORTCUT_IF_FALSE(out_dist_attr.is_replicated(0));
-
   const TensorDistAttr& in_dist_attr = in.dist_attr();
   const ProcessMesh& in_process_mesh = in_dist_attr.process_mesh();
   const ProcessMesh& out_process_mesh = out_dist_attr.process_mesh();
 
-  RESHARD_SHORTCUT_IF_FALSE(in_process_mesh.ndim() ==
-                            out_process_mesh.ndim() - 1);
+  int sub_mesh_dim = SubMeshDim(out_process_mesh, in_process_mesh);
+  RESHARD_SHORTCUT_IF_FALSE(sub_mesh_dim != -1);
+  RESHARD_SHORTCUT_IF_FALSE(out_dist_attr.is_replicated(sub_mesh_dim));
 
-  return IsSubMesh(out_process_mesh, in_process_mesh);
+  return true;
 }
 
 void SubMeshToGlobalReshardFunction::Eval(phi::DeviceContext* dev_ctx,
@@ -85,7 +84,9 @@ void SubMeshToGlobalReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   const ProcessMesh& in_process_mesh = in_dist_attr.process_mesh();
   const ProcessMesh& out_process_mesh = out_dist_attr.process_mesh();
 
-  std::vector<ProcessMesh> sub_process_meshes = GetSubMeshes(out_process_mesh);
+  int sub_mesh_dim = SubMeshDim(out_process_mesh, in_process_mesh);
+  std::vector<ProcessMesh> sub_process_meshes =
+      SplitMesh(out_process_mesh, sub_mesh_dim);
   const std::vector<int64_t>& in_process_ids = in_process_mesh.process_ids();
   const std::vector<int64_t>& out_process_ids = out_process_mesh.process_ids();
   std::unordered_map<int64_t, std::vector<int64_t>> send2recv_map;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/global_and_sub_mesh_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/global_and_sub_mesh_reshard_function.cc
@@ -93,7 +93,7 @@ void SubMeshToGlobalReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   std::unordered_map<int64_t, int64_t> recv2send_map;
 
   for (const ProcessMesh& sub_mesh : sub_process_meshes) {
-    if (sub_mesh == in_process_mesh) {
+    if (mesh_equal_ignore_shape1(sub_mesh, in_process_mesh, sub_mesh_dim)) {
       continue;
     }
     const std::vector<int64_t>& sub_process_ids = sub_mesh.process_ids();


### PR DESCRIPTION
### PR Category
Auto Parallel

### PR Types
Improvements


### Description
Refine global_and_sub_mesh reshard func, making it able to reshard from the sub_mesh that is splitted from global_mesh other than 0th dim.

E.g. global_mesh=[[0,1],[2,3]], sub_mesh=[0,2], sub_mesh is splitted from the 1st dim of global_mesh.

Pcard-67164
