### PR TITLE
Add ConcatTensor Op

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
@@ -245,7 +245,7 @@ NO_NEED_GEN_STATIC_ONLY_APIS = [
     'push_box_sparse_',
     'send_and_recv',
     'send_and_recv_',
-    'concat_tensor',
+    'concat_tensor_',
 ]
 
 

--- a/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
@@ -245,6 +245,7 @@ NO_NEED_GEN_STATIC_ONLY_APIS = [
     'push_box_sparse_',
     'send_and_recv',
     'send_and_recv_',
+    'concat_tensor',
 ]
 
 

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -1344,7 +1344,16 @@ void ChunkEvalInferMeta(const MetaTensor& inference,
   num_label_chunks->set_dtype(phi::DataType::INT64);
   num_correct_chunks->set_dtype(phi::DataType::INT64);
 }
-
+void ConcatTensorInferMeta(const std::vector<const MetaTensor*>& input,
+                           std::vector<MetaTensor*> output,
+                           MetaTensor* concated_out) {
+  ConcatInferMeta(input, -1, concated_out);
+  for (size_t i = 0; i < output.size(); ++i) {
+    output[i]->set_dims(input[i]->dims());
+    output[i]->set_dtype(input[i]->dtype());
+    output[i]->share_lod(*input[i]);
+  }
+}
 void CrfDecodingInferMeta(const MetaTensor& emission,
                           const MetaTensor& transition,
                           const MetaTensor& label,

--- a/paddle/phi/infermeta/multiary.h
+++ b/paddle/phi/infermeta/multiary.h
@@ -298,6 +298,10 @@ void ChunkEvalInferMeta(const MetaTensor& inference,
                         MetaTensor* num_label_chunks,
                         MetaTensor* num_correct_chunks);
 
+void ConcatTensorInferMeta(const std::vector<const MetaTensor*>& input,
+                           std::vector<MetaTensor*> output,
+                           MetaTensor* concated_out);
+
 void CrfDecodingInferMeta(const MetaTensor& emission,
                           const MetaTensor& transition,
                           const MetaTensor& label,

--- a/paddle/phi/kernels/concat_tensor_kernel.h
+++ b/paddle/phi/kernels/concat_tensor_kernel.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void ConcatTensorKernel(const Context& dev_ctx,
+                        const std::vector<const DenseTensor*>& input,
+                        std::vector<DenseTensor*> output,
+                        DenseTensor* concated_out);
+
+}  // namespace phi

--- a/paddle/phi/kernels/cpu/concat_tensor_kernel.cc
+++ b/paddle/phi/kernels/cpu/concat_tensor_kernel.cc
@@ -1,0 +1,121 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/concat_tensor_kernel.h"
+#include "paddle/phi/kernels/concat_kernel.h"
+
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/complex.h"
+#include "paddle/phi/common/scalar.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/concat_funcs.h"
+
+namespace phi {
+template <typename T>
+bool IsConcated(const std::vector<const DenseTensor*>& tensors) {
+  if (tensors.size() < 2) {
+    return true;
+  }
+  std::vector<int64_t> numels(tensors.size());
+  std::vector<const T*> tensors_data(tensors.size());
+
+  for (size_t i = 0; i < tensors.size(); i++) {
+    numels[i] = tensors[i]->numel();
+    tensors_data[i] = tensors[i]->data<T>();
+  }
+
+  for (size_t i = 0; i < tensors.size() - 1; i++) {
+    if (tensors_data[i] + numels[i] != tensors_data[i + 1]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+template <typename T, typename Context>
+void ConcatTensorKernel(const Context& dev_ctx,
+                        const std::vector<const DenseTensor*>& input,
+                        std::vector<DenseTensor*> output,
+                        DenseTensor* concated_out) {
+  PADDLE_ENFORCE_GT(
+      input.size(),
+      static_cast<size_t>(0),
+      errors::InvalidArgument("The ConcatTensor operator has no input."));
+  PADDLE_ENFORCE_EQ(
+      input.size(),
+      output.size(),
+      errors::InvalidArgument("The number of ConcatTensor operator's input and "
+                              "output is not match, "
+                              "input number is %u, output number is %u.",
+                              input.size(),
+                              output.size()));
+
+  bool is_concated = IsConcated<T>(input);
+  if (is_concated) {
+    auto axis_val = phi::funcs::ComputeAxis(-1, input[0]->dims().size());
+    std::vector<phi::DDim> input_dims;
+    for (size_t i = 0; i < input.size(); ++i) {
+      input_dims.push_back(input[i]->dims());
+    }
+    phi::DDim concated_out_dims =
+        phi::funcs::ComputeAndCheckShape(true, input_dims, axis_val);
+    concated_out->ShareDataWith(*input[0]);
+    concated_out->Resize(concated_out_dims);
+  } else {
+    ConcatKernel<T, Context>(dev_ctx, input, -1, concated_out);
+    for (size_t i = 0; i < input.size(); ++i) {
+      auto input_ptr = const_cast<DenseTensor*>(input[i]);
+      input_ptr->clear();
+    }
+  }
+
+  auto concated_out_numel = concated_out->numel();
+  auto concated_out_dims = concated_out->dims();
+  concated_out->Resize({concated_out_numel});
+
+  size_t offset = 0;
+  for (size_t i = 0; i < output.size(); ++i) {
+    size_t len = static_cast<size_t>(output[i]->numel());
+    auto dim = output[i]->dims();
+    output[i]
+        ->ShareDataWith(concated_out->Slice(
+            static_cast<int64_t>(offset),
+            static_cast<int64_t>(offset) + static_cast<int64_t>(len)))
+        .Resize(dim);
+    offset += len;
+  }
+  concated_out->Resize(concated_out_dims);
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(concat_tensor,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::ConcatTensorKernel,
+                   float,
+                   double,
+                   bool,
+                   int64_t,
+                   int,
+                   uint8_t,
+                   int8_t,
+                   int16_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/gpu/concat_tensor_kernel.cu
+++ b/paddle/phi/kernels/gpu/concat_tensor_kernel.cu
@@ -1,0 +1,121 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/concat_tensor_kernel.h"
+#include "paddle/phi/kernels/concat_kernel.h"
+
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/complex.h"
+#include "paddle/phi/common/scalar.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/concat_funcs.h"
+
+namespace phi {
+template <typename T>
+bool IsConcated(const std::vector<const DenseTensor*>& tensors) {
+  if (tensors.size() < 2) {
+    return true;
+  }
+  std::vector<int64_t> numels(tensors.size());
+  std::vector<const T*> tensors_data(tensors.size());
+
+  for (size_t i = 0; i < tensors.size(); i++) {
+    numels[i] = tensors[i]->numel();
+    tensors_data[i] = tensors[i]->data<T>();
+  }
+
+  for (size_t i = 0; i < tensors.size() - 1; i++) {
+    if (tensors_data[i] + numels[i] != tensors_data[i + 1]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+template <typename T, typename Context>
+void ConcatTensorKernel(const Context& dev_ctx,
+                        const std::vector<const DenseTensor*>& input,
+                        std::vector<DenseTensor*> output,
+                        DenseTensor* concated_out) {
+  PADDLE_ENFORCE_GT(
+      input.size(),
+      static_cast<size_t>(0),
+      errors::InvalidArgument("The ConcatTensor operator has no input."));
+  PADDLE_ENFORCE_EQ(
+      input.size(),
+      output.size(),
+      errors::InvalidArgument("The number of ConcatTensor operator's input and "
+                              "output is not match, "
+                              "input number is %u, output number is %u.",
+                              input.size(),
+                              output.size()));
+
+  bool is_concated = IsConcated<T>(input);
+  if (is_concated) {
+    auto axis_val = phi::funcs::ComputeAxis(-1, input[0]->dims().size());
+    std::vector<phi::DDim> input_dims;
+    for (size_t i = 0; i < input.size(); ++i) {
+      input_dims.push_back(input[i]->dims());
+    }
+    phi::DDim concated_out_dims =
+        phi::funcs::ComputeAndCheckShape(true, input_dims, axis_val);
+    concated_out->ShareDataWith(*input[0]);
+    concated_out->Resize(concated_out_dims);
+  } else {
+    ConcatKernel<T, Context>(dev_ctx, input, -1, concated_out);
+    for (size_t i = 0; i < input.size(); ++i) {
+      auto input_ptr = const_cast<DenseTensor*>(input[i]);
+      input_ptr->clear();
+    }
+  }
+
+  auto concated_out_numel = concated_out->numel();
+  auto concated_out_dims = concated_out->dims();
+  concated_out->Resize({concated_out_numel});
+
+  size_t offset = 0;
+  for (size_t i = 0; i < output.size(); ++i) {
+    size_t len = static_cast<size_t>(output[i]->numel());
+    auto dim = output[i]->dims();
+    output[i]
+        ->ShareDataWith(concated_out->Slice(
+            static_cast<int64_t>(offset),
+            static_cast<int64_t>(offset) + static_cast<int64_t>(len)))
+        .Resize(dim);
+    offset += len;
+  }
+  concated_out->Resize(concated_out_dims);
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(concat_tensor,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::ConcatTensorKernel,
+                   float,
+                   double,
+                   bool,
+                   int64_t,
+                   int,
+                   uint8_t,
+                   int8_t,
+                   int16_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
@@ -956,6 +956,16 @@
     data_type : logits
   backward: c_softmax_with_cross_entropy_grad
 
+- op: concat_tensor_
+  args: (Tensor[] input)
+  output: Tensor[](output){input.size()}, Tensor(concated_output)
+  infer_meta:
+    func: ConcatTensorInferMeta
+  kernel:
+    func: concat_tensor
+    data_type: input
+  inplace: (input -> output)
+
 - op: fused_attention
   args: (Tensor x, Tensor ln_scale, Tensor ln_bias, Tensor qkv_weight, Tensor qkv_bias, Tensor cache_kv, Tensor src_mask, Tensor out_linear_weight, Tensor out_linear_bias, Tensor ln_scale_2, Tensor ln_bias_2, int num_heads, bool transpose_qkv_wb, bool pre_layer_norm, float epsilon, float attn_dropout_rate, bool is_test, bool attn_dropout_fix_seed, int attn_dropout_seed, str attn_dropout_implementation, float dropout_rate, bool dropout_fix_seed, int dropout_seed, str dropout_implementation, float ln_epsilon, bool add_residual, int ring_id)
   output: Tensor(ln_mean), Tensor(ln_var), Tensor(ln_out), Tensor(qkv_out), Tensor(qkv_bias_out), Tensor(transpose_out_2), Tensor(qk_out), Tensor(qktv_out), Tensor(softmax_out), Tensor(attn_dropout_mask_out), Tensor(attn_dropout_out), Tensor(src_mask_out), Tensor(fmha_out), Tensor(out_linear_out), Tensor(dropout_mask_out), Tensor(ln_mean_2), Tensor(ln_var_2), Tensor(bias_dropout_residual_out), Tensor(cache_kv_out), Tensor(out)

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -993,6 +993,15 @@
   backward : unsqueeze_grad
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
+- op: concat_tensor
+  args: (Tensor[] input)
+  output: Tensor[](output){input.size()}, Tensor(concated_output)
+  infer_meta:
+    func: ConcatTensorInferMeta
+  kernel:
+    func: concat_tensor
+    data_type: input
+
 - op: multiclass_nms
   args: (Tensor bboxes, Tensor scores, float score_threshold,
     int nms_top_k, int keep_top_k, float nms_threshold = 0.3, float nms_eta = 1.0,

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -993,7 +993,7 @@
   backward : unsqueeze_grad
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
-- op: concat_tensor
+- op: concat_tensor_
   args: (Tensor[] input)
   output: Tensor[](output){input.size()}, Tensor(concated_output)
   infer_meta:
@@ -1001,6 +1001,7 @@
   kernel:
     func: concat_tensor
     data_type: input
+  inplace: (input -> output)
 
 - op: multiclass_nms
   args: (Tensor bboxes, Tensor scores, float score_threshold,

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -993,16 +993,6 @@
   backward : unsqueeze_grad
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
-- op: concat_tensor_
-  args: (Tensor[] input)
-  output: Tensor[](output){input.size()}, Tensor(concated_output)
-  infer_meta:
-    func: ConcatTensorInferMeta
-  kernel:
-    func: concat_tensor
-    data_type: input
-  inplace: (input -> output)
-
 - op: multiclass_nms
   args: (Tensor bboxes, Tensor scores, float score_threshold,
     int nms_top_k, int keep_top_k, float nms_threshold = 0.3, float nms_eta = 1.0,

--- a/test/cpp/fluid/math/concat_test.cc
+++ b/test/cpp/fluid/math/concat_test.cc
@@ -522,20 +522,20 @@ void ConcatCase5(DeviceContext* context) {
 
   PADDLE_ENFORCE_EQ(output[1]->data<int>(),
                     output[0]->data<int>() + 4,
-                    paddle::platform::errors::PreconditionNotMet(
+                    phi::errors:: ::PreconditionNotMet(
                         "splited_out[0] and splited_out[1] should logically be "
                         "stored side by side."));
 
   PADDLE_ENFORCE_EQ(
       output[0]->dims(),
       common::make_ddim({2, 2}),
-      paddle::platform::errors::PreconditionNotMet(
+      phi::errors:: ::PreconditionNotMet(
           "output[0] and output[1]'s dims should be the same as input"));
 
   PADDLE_ENFORCE_EQ(
       output[1]->dims(),
       common::make_ddim({2, 2}),
-      paddle::platform::errors::PreconditionNotMet(
+      phi::errors:: ::PreconditionNotMet(
           "output[0] and output[1]'s dims should be the same as input"));
 
   std::vector<const phi::DenseTensor*> second_input;
@@ -559,14 +559,14 @@ void ConcatCase5(DeviceContext* context) {
 
   PADDLE_ENFORCE_EQ(concated_out2.data<int>(),
                     output[0]->data<int>(),
-                    paddle::platform::errors::PreconditionNotMet(
+                    phi::errors:: ::PreconditionNotMet(
                         "If the input tensors are already stored side by side "
                         "in memory, then the ConcatTensorKernel will not "
                         "reallocate memory for the concatenation."));
 
   PADDLE_ENFORCE_EQ(concated_out2.dims(),
                     common::make_ddim({2, 4}),
-                    paddle::platform::errors::PreconditionNotMet(
+                    phi::errors:: ::PreconditionNotMet(
                         "For the same inputs, multiple executions of the "
                         "ConcatTensorKernel should produce the same results."));
 }

--- a/test/cpp/fluid/math/concat_test.cc
+++ b/test/cpp/fluid/math/concat_test.cc
@@ -522,20 +522,20 @@ void ConcatCase5(DeviceContext* context) {
 
   PADDLE_ENFORCE_EQ(output[1]->data<int>(),
                     output[0]->data<int>() + 4,
-                    phi::errors:: ::PreconditionNotMet(
+                    phi::errors::PreconditionNotMet(
                         "splited_out[0] and splited_out[1] should logically be "
                         "stored side by side."));
 
   PADDLE_ENFORCE_EQ(
       output[0]->dims(),
       common::make_ddim({2, 2}),
-      phi::errors:: ::PreconditionNotMet(
+      phi::errors::PreconditionNotMet(
           "output[0] and output[1]'s dims should be the same as input"));
 
   PADDLE_ENFORCE_EQ(
       output[1]->dims(),
       common::make_ddim({2, 2}),
-      phi::errors:: ::PreconditionNotMet(
+      phi::errors::PreconditionNotMet(
           "output[0] and output[1]'s dims should be the same as input"));
 
   std::vector<const phi::DenseTensor*> second_input;
@@ -559,14 +559,14 @@ void ConcatCase5(DeviceContext* context) {
 
   PADDLE_ENFORCE_EQ(concated_out2.data<int>(),
                     output[0]->data<int>(),
-                    phi::errors:: ::PreconditionNotMet(
+                    phi::errors::PreconditionNotMet(
                         "If the input tensors are already stored side by side "
                         "in memory, then the ConcatTensorKernel will not "
                         "reallocate memory for the concatenation."));
 
   PADDLE_ENFORCE_EQ(concated_out2.dims(),
                     common::make_ddim({2, 4}),
-                    phi::errors:: ::PreconditionNotMet(
+                    phi::errors::PreconditionNotMet(
                         "For the same inputs, multiple executions of the "
                         "ConcatTensorKernel should produce the same results."));
 }

--- a/test/cpp/fluid/math/concat_test.cc
+++ b/test/cpp/fluid/math/concat_test.cc
@@ -15,9 +15,8 @@ limitations under the License. */
 #include <gtest/gtest.h>
 
 #include "paddle/fluid/framework/tensor_util.h"
-#include "paddle/fluid/platform/device_context.h"
 #include "paddle/phi/common/place.h"
-#include "paddle/phi/kernels/concat_tensor_kernel.h"
+#include "paddle/phi/core/platform/device_context.h"
 #include "paddle/phi/kernels/funcs/concat_and_split_functor.h"
 
 /**
@@ -84,14 +83,14 @@ void ConcatCase1(DeviceContext* context) {
   // check the dim of input_a, input_b
   PADDLE_ENFORCE_EQ(input_a.dims(),
                     dim_a,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_a.dims(),
                         dim_a));
   PADDLE_ENFORCE_EQ(input_b.dims(),
                     dim_b,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_b.dims(),
@@ -111,13 +110,13 @@ void ConcatCase1(DeviceContext* context) {
     if (j >= cols) {
       PADDLE_ENFORCE_EQ(out_ptr[j],
                         b_ptr[idx_b],
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Concat test failed, the result should be equal."));
       ++idx_b;
     } else {
       PADDLE_ENFORCE_EQ(out_ptr[j],
                         a_ptr[idx_a],
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Concat test failed, the result should be equal."));
       ++idx_a;
     }
@@ -188,14 +187,14 @@ void ConcatCase2(DeviceContext* context) {
   // check the dim of input_a, input_b
   PADDLE_ENFORCE_EQ(input_a.dims(),
                     dim_a,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_a.dims(),
                         dim_a));
   PADDLE_ENFORCE_EQ(input_b.dims(),
                     dim_b,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_b.dims(),
@@ -217,14 +216,14 @@ void ConcatCase2(DeviceContext* context) {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 28 + j],
             b_ptr[idx_b],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_b;
       } else {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 28 + j],
             a_ptr[idx_a],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_a;
       }
@@ -296,14 +295,14 @@ void ConcatCase3(DeviceContext* context) {
   // check the dim of input_a, input_b
   PADDLE_ENFORCE_EQ(input_a.dims(),
                     dim_a,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_a.dims(),
                         dim_a));
   PADDLE_ENFORCE_EQ(input_b.dims(),
                     dim_b,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_b.dims(),
@@ -326,14 +325,14 @@ void ConcatCase3(DeviceContext* context) {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 9 + j],
             b_ptr[idx_b],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_b;
       } else {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 9 + j],
             a_ptr[idx_a],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_a;
       }
@@ -407,14 +406,14 @@ void ConcatCase4(DeviceContext* context) {
   // check the dim of input_a, input_b
   PADDLE_ENFORCE_EQ(input_a.dims(),
                     dim_a,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_a.dims(),
                         dim_a));
   PADDLE_ENFORCE_EQ(input_b.dims(),
                     dim_b,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_b.dims(),
@@ -437,14 +436,14 @@ void ConcatCase4(DeviceContext* context) {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 24 + j],
             b_ptr[idx_b],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_b;
       } else {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 24 + j],
             a_ptr[idx_a],
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_a;
       }
@@ -586,6 +585,7 @@ void TestConcatMain() {
                        .GetAllocator(cpu_place)
                        .get());
   ConcatCase5<phi::CPUContext, phi::CPUPlace>(&ctx);
+
   delete context;
 }
 
@@ -603,6 +603,7 @@ void TestConcatMain<phi::GPUContext, phi::GPUPlace>() {
   ConcatCase3<phi::GPUContext, phi::GPUPlace>(context);
   ConcatCase4<phi::GPUContext, phi::GPUPlace>(context);
   ConcatCase5<phi::GPUContext, phi::GPUPlace>(context);
+
   delete context;
 }
 #endif

--- a/test/cpp/fluid/math/concat_test.cc
+++ b/test/cpp/fluid/math/concat_test.cc
@@ -451,6 +451,125 @@ void ConcatCase4(DeviceContext* context) {
   }
 }
 
+/**
+ * case 5:
+ *   ConcatTensorTest
+ */
+template <typename DeviceContext, typename Place>
+void ConcatCase5(DeviceContext* context) {
+  phi::DenseTensor input1;
+  phi::DenseTensor input2;
+  phi::DenseTensor input1_cpu;
+  phi::DenseTensor input2_cpu;
+  phi::DenseTensor output1;
+  phi::DenseTensor output2;
+  phi::DenseTensor concated_out;
+
+  auto dim1 = common::make_ddim({2, 2});
+  auto dim2 = common::make_ddim({2, 2});
+  auto dim_out = common::make_ddim({2, 4});
+
+  input1.mutable_data<int>(dim1, Place());
+  input2.mutable_data<int>(dim2, Place());
+  output1.mutable_data<int>(dim1, Place());
+  output2.mutable_data<int>(dim2, Place());
+  concated_out.mutable_data<int>(dim_out, Place());
+
+  if (phi::is_gpu_place(Place())) {
+    input1_cpu.mutable_data<int>(dim1, phi::CPUPlace());
+    input2_cpu.mutable_data<int>(dim2, phi::CPUPlace());
+    int* input1_cpu_ptr = input1_cpu.data<int>();
+    int* input2_cpu_ptr = input2_cpu.data<int>();
+    for (int i = 0; i < 4; ++i) {
+      input1_cpu_ptr[i] = i + 1;
+      input2_cpu_ptr[i] = i + 1 + 4;
+    }
+    paddle::framework::TensorCopySync(input1_cpu, Place(), &input1);
+    paddle::framework::TensorCopySync(input1_cpu, Place(), &input1);
+  } else {
+    int* input1_ptr = input1.data<int>();
+    int* input2_ptr = input2.data<int>();
+
+    for (int i = 0; i < 4; ++i) {
+      input1_ptr[i] = i + 1;
+      input2_ptr[i] = i + 1 + 4;
+    }
+  }
+
+  std::vector<const phi::DenseTensor*> input;
+  input.push_back(&input1);
+  input.push_back(&input2);
+
+  std::vector<phi::DenseTensor*> output;
+  output.push_back(&output1);
+  output.push_back(&output2);
+
+  phi::ConcatTensorKernel<int, DeviceContext>(
+      *context, input, output, &concated_out);
+
+  /**
+   * concated_out =
+   *  [[1,2,5,6],
+   *   [3,4,7,8]]
+   * output[0] =
+   *  [[1,2],
+   *    [5,6]]
+   * output[1] =
+   *  [[3,4],
+   *   [7,8]]
+   **/
+
+  PADDLE_ENFORCE_EQ(output[1]->data<int>(),
+                    output[0]->data<int>() + 4,
+                    paddle::platform::errors::PreconditionNotMet(
+                        "splited_out[0] and splited_out[1] should logically be "
+                        "stored side by side."));
+
+  PADDLE_ENFORCE_EQ(
+      output[0]->dims(),
+      common::make_ddim({2, 2}),
+      paddle::platform::errors::PreconditionNotMet(
+          "output[0] and output[1]'s dims should be the same as input"));
+
+  PADDLE_ENFORCE_EQ(
+      output[1]->dims(),
+      common::make_ddim({2, 2}),
+      paddle::platform::errors::PreconditionNotMet(
+          "output[0] and output[1]'s dims should be the same as input"));
+
+  std::vector<const phi::DenseTensor*> second_input;
+  second_input.push_back(output[0]);
+  second_input.push_back(output[1]);
+
+  phi::DenseTensor tmp1;
+  phi::DenseTensor tmp2;
+  tmp1.mutable_data<int>(dim1, Place());
+  tmp2.mutable_data<int>(dim2, Place());
+
+  std::vector<phi::DenseTensor*> tmp;
+  tmp.push_back(&tmp1);
+  tmp.push_back(&tmp2);
+
+  phi::DenseTensor concated_out2;
+  concated_out2.mutable_data<int>(dim_out, Place());
+
+  phi::ConcatTensorKernel<int, DeviceContext>(
+      *context, second_input, tmp, &concated_out2);
+
+  PADDLE_ENFORCE_EQ(concated_out2.data<int>(),
+                    output[0]->data<int>(),
+                    paddle::platform::errors::PreconditionNotMet(
+                        "If the input tensors are already stored side by side "
+                        "in memory, then the ConcatTensorKernel will not "
+                        "reallocate memory for the concatenation."));
+
+  PADDLE_ENFORCE_EQ(concated_out2.dims(),
+                    common::make_ddim({2, 4}),
+                    paddle::platform::errors::PreconditionNotMet(
+                        "For the same inputs, multiple executions of the "
+                        "ConcatTensorKernel should produce the same results."));
+}
+
 template <typename DeviceContext, typename Place>
 void TestConcatMain() {
   DeviceContext* context = new DeviceContext(Place());
@@ -459,6 +578,13 @@ void TestConcatMain() {
   ConcatCase2<DeviceContext, Place>(context);
   ConcatCase3<DeviceContext, Place>(context);
   ConcatCase4<DeviceContext, Place>(context);
+
+  phi::CPUPlace cpu_place;
+  phi::CPUContext ctx(cpu_place);
+  ctx.SetAllocator(paddle::memory::allocation::AllocatorFacade::Instance()
+                       .GetAllocator(cpu_place)
+                       .get());
+  ConcatCase5<phi::CPUContext, phi::CPUPlace>(&ctx);
 
   delete context;
 }
@@ -476,6 +602,13 @@ void TestConcatMain<phi::GPUContext, phi::GPUPlace>() {
   ConcatCase2<phi::GPUContext, phi::GPUPlace>(context);
   ConcatCase3<phi::GPUContext, phi::GPUPlace>(context);
   ConcatCase4<phi::GPUContext, phi::GPUPlace>(context);
+
+  phi::GPUPlace gpu_place;
+  phi::GPUContext ctx(gpu_place);
+  ctx.SetAllocator(paddle::memory::allocation::AllocatorFacade::Instance()
+                       .GetAllocator(gpu_place)
+                       .get());
+  ConcatCase5<phi::GPUContext, phi::GPUPlace>(ctx);
 
   delete context;
 }

--- a/test/cpp/fluid/math/concat_test.cc
+++ b/test/cpp/fluid/math/concat_test.cc
@@ -17,6 +17,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/platform/device_context.h"
+#include "paddle/phi/kernels/concat_tensor_kernel.h"
 #include "paddle/phi/kernels/funcs/concat_and_split_functor.h"
 
 /**

--- a/test/cpp/fluid/math/concat_test.cc
+++ b/test/cpp/fluid/math/concat_test.cc
@@ -15,8 +15,9 @@ limitations under the License. */
 #include <gtest/gtest.h>
 
 #include "paddle/fluid/framework/tensor_util.h"
+#include "paddle/fluid/platform/device_context.h"
 #include "paddle/phi/common/place.h"
-#include "paddle/phi/core/platform/device_context.h"
+#include "paddle/phi/kernels/concat_tensor_kernel.h"
 #include "paddle/phi/kernels/funcs/concat_and_split_functor.h"
 
 /**
@@ -83,14 +84,14 @@ void ConcatCase1(DeviceContext* context) {
   // check the dim of input_a, input_b
   PADDLE_ENFORCE_EQ(input_a.dims(),
                     dim_a,
-                    common::errors::InvalidArgument(
+                    phi::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_a.dims(),
                         dim_a));
   PADDLE_ENFORCE_EQ(input_b.dims(),
                     dim_b,
-                    common::errors::InvalidArgument(
+                    phi::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_b.dims(),
@@ -110,13 +111,13 @@ void ConcatCase1(DeviceContext* context) {
     if (j >= cols) {
       PADDLE_ENFORCE_EQ(out_ptr[j],
                         b_ptr[idx_b],
-                        common::errors::InvalidArgument(
+                        phi::errors::InvalidArgument(
                             "Concat test failed, the result should be equal."));
       ++idx_b;
     } else {
       PADDLE_ENFORCE_EQ(out_ptr[j],
                         a_ptr[idx_a],
-                        common::errors::InvalidArgument(
+                        phi::errors::InvalidArgument(
                             "Concat test failed, the result should be equal."));
       ++idx_a;
     }
@@ -187,14 +188,14 @@ void ConcatCase2(DeviceContext* context) {
   // check the dim of input_a, input_b
   PADDLE_ENFORCE_EQ(input_a.dims(),
                     dim_a,
-                    common::errors::InvalidArgument(
+                    phi::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_a.dims(),
                         dim_a));
   PADDLE_ENFORCE_EQ(input_b.dims(),
                     dim_b,
-                    common::errors::InvalidArgument(
+                    phi::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_b.dims(),
@@ -216,14 +217,14 @@ void ConcatCase2(DeviceContext* context) {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 28 + j],
             b_ptr[idx_b],
-            common::errors::InvalidArgument(
+            phi::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_b;
       } else {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 28 + j],
             a_ptr[idx_a],
-            common::errors::InvalidArgument(
+            phi::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_a;
       }
@@ -295,14 +296,14 @@ void ConcatCase3(DeviceContext* context) {
   // check the dim of input_a, input_b
   PADDLE_ENFORCE_EQ(input_a.dims(),
                     dim_a,
-                    common::errors::InvalidArgument(
+                    phi::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_a.dims(),
                         dim_a));
   PADDLE_ENFORCE_EQ(input_b.dims(),
                     dim_b,
-                    common::errors::InvalidArgument(
+                    phi::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_b.dims(),
@@ -325,14 +326,14 @@ void ConcatCase3(DeviceContext* context) {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 9 + j],
             b_ptr[idx_b],
-            common::errors::InvalidArgument(
+            phi::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_b;
       } else {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 9 + j],
             a_ptr[idx_a],
-            common::errors::InvalidArgument(
+            phi::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_a;
       }
@@ -406,14 +407,14 @@ void ConcatCase4(DeviceContext* context) {
   // check the dim of input_a, input_b
   PADDLE_ENFORCE_EQ(input_a.dims(),
                     dim_a,
-                    common::errors::InvalidArgument(
+                    phi::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_a.dims(),
                         dim_a));
   PADDLE_ENFORCE_EQ(input_b.dims(),
                     dim_b,
-                    common::errors::InvalidArgument(
+                    phi::errors::InvalidArgument(
                         "The dims of Input tensor should be the same as the "
                         "declared dims. Tensor dims: [%s], declared dims: [%s]",
                         input_b.dims(),
@@ -436,14 +437,14 @@ void ConcatCase4(DeviceContext* context) {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 24 + j],
             b_ptr[idx_b],
-            common::errors::InvalidArgument(
+            phi::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_b;
       } else {
         PADDLE_ENFORCE_EQ(
             out_ptr[i * 24 + j],
             a_ptr[idx_a],
-            common::errors::InvalidArgument(
+            phi::errors::InvalidArgument(
                 "Concat test failed, the result should be equal."));
         ++idx_a;
       }
@@ -585,7 +586,6 @@ void TestConcatMain() {
                        .GetAllocator(cpu_place)
                        .get());
   ConcatCase5<phi::CPUContext, phi::CPUPlace>(&ctx);
-
   delete context;
 }
 
@@ -602,14 +602,7 @@ void TestConcatMain<phi::GPUContext, phi::GPUPlace>() {
   ConcatCase2<phi::GPUContext, phi::GPUPlace>(context);
   ConcatCase3<phi::GPUContext, phi::GPUPlace>(context);
   ConcatCase4<phi::GPUContext, phi::GPUPlace>(context);
-
-  phi::GPUPlace gpu_place;
-  phi::GPUContext ctx(gpu_place);
-  ctx.SetAllocator(paddle::memory::allocation::AllocatorFacade::Instance()
-                       .GetAllocator(gpu_place)
-                       .get());
-  ConcatCase5<phi::GPUContext, phi::GPUPlace>(ctx);
-
+  ConcatCase5<phi::GPUContext, phi::GPUPlace>(context);
   delete context;
 }
 #endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
增加ConcatTensor Op，功能类似CoalesceTensor Op,但是输出tensor的内存排布为concat之后的tensor.
输入输出举例：
input:  [[1,2],[3,4]],[[5,6],[7,8]]
concated_out =[[1,2,5,6], [3,4,7,8]]
output[0] = [[1,2], [5,6]]
output[1] = [[3,4],[7,8]]