### PR TITLE
[CINN] Fix reduce fusion without reduce axis reuse

### DIFF
--- a/test/ir/pir/cinn/test_reduce_fusion.py
+++ b/test/ir/pir/cinn/test_reduce_fusion.py
@@ -105,6 +105,31 @@ class TestReduceFusion(unittest.TestCase):
 
         self.compare_result(func, None, init)
 
+    def test_reduce_tree_grown(self):
+        #     R
+        #    / \
+        #   T   T
+        #    \ /
+        #     T
+        #     |
+        #     B
+        #     |
+        #     R
+        def func(x):
+            b = paddle.max(x, axis=-1)
+            c = b * 2
+            d = b / 2
+            e = c + d
+            f = paddle.expand(e, [128, 32, 32])
+            g = paddle.sum(f, axis=0)
+            return g
+
+        def init():
+            x = paddle.rand((32, 32, 128))
+            return (x,)
+
+        self.compare_result(func, None, init)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/ir/pir/cinn/test_reduce_fusion.py
+++ b/test/ir/pir/cinn/test_reduce_fusion.py
@@ -105,7 +105,7 @@ class TestReduceFusion(unittest.TestCase):
 
         self.compare_result(func, None, init)
 
-    def test_reduce_tree_grown(self):
+    def test_reduce_fusion_without_axis_reuse(self):
         #     R
         #    / \
         #   T   T
@@ -120,7 +120,7 @@ class TestReduceFusion(unittest.TestCase):
             c = b * 2
             d = b / 2
             e = c + d
-            f = paddle.expand(e, [128, 32, 32])
+            f = paddle.expand(e, [96, 32, 32])
             g = paddle.sum(f, axis=0)
             return g
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- Fix reduce fusion without reduce axis dim reuse