### PR TITLE
[Bfloat16][PIR][oneDNN] Add cpu_bfloat16_squash_pass

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -681,6 +681,7 @@ const std::vector<std::string> kPirMkldnnBf16Passes{
     "cpu_bfloat16_placement_pass",
     "cpu_bfloat16_pass",
     "cpu_bfloat16_type_placement_pass",
+    "cpu_bf16_quantize_squash_pass",
 };
 
 const std::vector<std::string> kPirCpuPasses{

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_pass.cc
@@ -59,10 +59,12 @@ class CpuBfloat16Pattern : public paddle::drr::DrrPatternBase {
       op_attrs.emplace("data_format", pat.Attr("data_format"));
       op_attrs.emplace("is_test", pat.Attr("is_test"));
       op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
+      op_attrs.emplace("force_fp32_output", pat.Attr("force_fp32_output"));
     } else if (bfloat16_ops_ == "onednn_op.matmul") {
       op_attrs.emplace("transpose_x", pat.Attr("transpose_x"));
       op_attrs.emplace("transpose_y", pat.Attr("transpose_y"));
       op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
+      op_attrs.emplace("force_fp32_output", pat.Attr("force_fp32_output"));
 
     } else if (bfloat16_ops_ == "onednn_op.pool2d") {
       // op_attrs.emplace("kernel_size", pat.Attr("kernel_size"));
@@ -233,10 +235,12 @@ class CpuBfloat16DequantPattern : public paddle::drr::DrrPatternBase {
       op_attrs.emplace("data_format", pat.Attr("data_format"));
       op_attrs.emplace("is_test", pat.Attr("is_test"));
       op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
+      op_attrs.emplace("force_fp32_output", pat.Attr("force_fp32_output"));
     } else if (bfloat16_ops_ == "onednn_op.matmul") {
       op_attrs.emplace("transpose_x", pat.Attr("transpose_x"));
       op_attrs.emplace("transpose_y", pat.Attr("transpose_y"));
       op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
+      op_attrs.emplace("force_fp32_output", pat.Attr("force_fp32_output"));
 
     } else if (bfloat16_ops_ == "onednn_op.pool2d") {
       // op_attrs.emplace("kernel_size", pat.Attr("kernel_size"));
@@ -875,6 +879,7 @@ class CpuBfloat16PatternThree_one : public paddle::drr::DrrPatternBase {
       op_attrs.emplace("output_padding", pat.Attr("output_padding"));
       op_attrs.emplace("paddings", pat.Attr("paddings"));
       op_attrs.emplace("strides", pat.Attr("strides"));
+      op_attrs.emplace("force_fp32_output", pat.Attr("force_fp32_output"));
     }
 
     const auto &op = pat.Op(bfloat16_ops_, op_attrs);
@@ -1046,6 +1051,7 @@ class CpuBfloat16DequantPatternThree_one : public paddle::drr::DrrPatternBase {
       op_attrs.emplace("output_padding", pat.Attr("output_padding"));
       op_attrs.emplace("paddings", pat.Attr("paddings"));
       op_attrs.emplace("strides", pat.Attr("strides"));
+      op_attrs.emplace("force_fp32_output", pat.Attr("force_fp32_output"));
     }
 
     const auto &op = pat.Op(bfloat16_ops_, op_attrs);

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_squash_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_squash_pass.cc
@@ -84,8 +84,8 @@ class DequantQuantBf16SquashPattern
     if (q_scale == dq_scale && q_shift == dq_shift) {
       rewriter.ReplaceAllUsesWith(op.output(), pre_op->result(idx));
 
-      rewriter.EraseOp(dequant_op);
       rewriter.EraseOp(op);
+      rewriter.EraseOp(dequant_op);
     } else {
       return false;
     }
@@ -209,8 +209,6 @@ class QuantConvBf16SquashPattern
 
     op_attributes["force_fp32_output"] = rewriter.bool_attr(false);
     op_attributes["fuse_residual_connection"] = rewriter.bool_attr(false);
-    // op_attributes["mkldnn_data_type"] =
-    //     rewriter.str_attr("bfloat16");  // delete when lirong merge
     op_attributes["fuse_activation"] = rewriter.str_attr("");
     op_attributes["fuse_alpha"] = rewriter.float_attr(0.0f);
     op_attributes["fuse_beta"] = rewriter.float_attr(0.0f);
@@ -428,9 +426,9 @@ class CPUBf16QuantizeSquashPass : public pir::PatternRewritePass {
             });
     ps.Add(std::move(q_fusedconv_onednn_pattern));
 
-    auto dq_op_onednn_pattern = std::make_unique<OpDequantBf16SquashPattern>(
+    auto op_dq_onednn_pattern = std::make_unique<OpDequantBf16SquashPattern>(
         context, benfit--, std::vector<std::string>{});
-    ps.Add(std::move(dq_op_onednn_pattern));
+    ps.Add(std::move(op_dq_onednn_pattern));
 
     return ps;
   }

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_squash_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_squash_pass.cc
@@ -1,0 +1,449 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/pir/transforms/onednn/cpu_bfloat16_squash_pass.h"
+
+#include "paddle/fluid/pir/dialect/kernel/ir/kernel_type.h"
+#include "paddle/fluid/pir/dialect/operator/ir/onednn_op.h"
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
+#include "paddle/fluid/pir/utils/general_functions.h"
+
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pass/pass_registry.h"
+
+namespace {
+
+template <class IrType1, class IrType2>
+static pir::Type create_type(pir::Type type,
+                             const phi::Place &place,
+                             pir::Type out_dtype,
+                             pir::IrContext *ctx) {
+  auto input_type = type.dyn_cast<IrType1>();
+  return IrType2::get(ctx,
+                      place,
+                      out_dtype,
+                      input_type.dims(),
+                      input_type.data_layout(),
+                      input_type.lod(),
+                      input_type.offset());
+}
+
+// Currently quantize_squash_pass is only used by bf16_quantize_pass, which only
+// add quantize/dequantize with scale=1.0f & shift=0.0f, hence only deal with
+// such situation for simplicity
+class DequantQuantBf16SquashPattern
+    : public pir::OpRewritePattern<paddle::onednn::dialect::QuantizeOp> {
+ public:
+  using pir::OpRewritePattern<
+      paddle::onednn::dialect::QuantizeOp>::OpRewritePattern;
+  bool MatchAndRewrite(
+      paddle::onednn::dialect::QuantizeOp op,
+      pir::PatternRewriter &rewriter) const override {  // NOLINT
+    // The prev op should be dequant op.
+    paddle::onednn::dialect::DequantizeOp dequant_op =
+        pir::GetDefiningOpForInput(op, 0)
+            ->dyn_cast<paddle::onednn::dialect::DequantizeOp>();
+    if (!dequant_op) return false;
+    auto *pre_op = pir::GetDefiningOpForInput(dequant_op, 0);
+    if (!pre_op) return false;
+
+    auto quant_attributes = op->attributes();
+    auto dequant_attributes = dequant_op->attributes();
+    auto q_scale =
+        quant_attributes.at("scale").dyn_cast<pir::FloatAttribute>().data();
+    auto dq_scale =
+        dequant_attributes.at("scale").dyn_cast<pir::FloatAttribute>().data();
+    auto q_shift =
+        quant_attributes.at("shift").dyn_cast<pir::FloatAttribute>().data();
+    auto dq_shift =
+        dequant_attributes.at("shift").dyn_cast<pir::FloatAttribute>().data();
+
+    if (!dequant_op.output().HasOneUse()) return false;
+    uint32_t idx = pre_op->num_results();
+    for (uint32_t i = 0; i < pre_op->num_results(); i++) {
+      if (pre_op->result(i) == dequant_op.input()) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx == pre_op->num_results()) return false;
+    if (q_scale != 1.0f || q_shift != 0.0f) return false;
+
+    if (q_scale == dq_scale && q_shift == dq_shift) {
+      rewriter.ReplaceAllUsesWith(op.output(), pre_op->result(idx));
+
+      rewriter.EraseOp(dequant_op);
+      rewriter.EraseOp(op);
+    } else {
+      return false;
+    }
+    return true;
+  }
+};
+
+class DequantQuantBf16MultiUserPattern
+    : public pir::OpRewritePattern<paddle::onednn::dialect::DequantizeOp> {
+ public:
+  using pir::OpRewritePattern<
+      paddle::onednn::dialect::DequantizeOp>::OpRewritePattern;
+  bool MatchAndRewrite(
+      paddle::onednn::dialect::DequantizeOp op,
+      pir::PatternRewriter &rewriter) const override {  // NOLINT
+    // The user_ops should include quant op.
+    auto user_ops = pir::GetUseOpsForOutput(op, 0);
+    // indicate pre_op for future process
+    auto *pre_op = pir::GetDefiningOpForInput(op, 0);
+    if (!pre_op) return false;
+    // check if all user_ops are quantize
+    std::vector<bool> all_q(user_ops.size(), true);
+    uint32_t idx = 0;
+    for (auto [user_op, _] : user_ops) {
+      paddle::onednn::dialect::QuantizeOp new_op =
+          user_op->dyn_cast<paddle::onednn::dialect::QuantizeOp>();
+      if (!new_op) {
+        all_q[idx] = false;
+      }
+      idx++;
+    }
+    // indicate which output of pre_op is used by dq
+    idx = pre_op->num_results();
+    for (uint32_t i = 0; i < pre_op->num_results(); i++) {
+      if (pre_op->result(i) == op.input()) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx == pre_op->num_results()) return false;
+
+    auto dequant_attributes = op->attributes();
+    auto dq_scale =
+        dequant_attributes.at("scale").dyn_cast<pir::FloatAttribute>().data();
+    auto dq_shift =
+        dequant_attributes.at("shift").dyn_cast<pir::FloatAttribute>().data();
+
+    if (dq_scale != 1.0f || dq_shift != 0.0f) return false;
+
+    bool did_process = false;
+    if (std::find(all_q.begin(), all_q.end(), false) == all_q.end()) {
+      bool delete_flag = true;
+      for (auto [user_op, _] : user_ops) {
+        paddle::onednn::dialect::QuantizeOp new_op =
+            user_op->dyn_cast<paddle::onednn::dialect::QuantizeOp>();
+        auto quant_attributes = new_op->attributes();
+        auto q_scale =
+            quant_attributes.at("scale").dyn_cast<pir::FloatAttribute>().data();
+        auto q_shift =
+            quant_attributes.at("shift").dyn_cast<pir::FloatAttribute>().data();
+
+        if (q_scale == dq_scale && q_shift == dq_shift) {
+          rewriter.ReplaceAllUsesWith(new_op.output(), pre_op->result(idx));
+          rewriter.EraseOp(new_op);
+          did_process = true;
+        } else {
+          delete_flag = false;
+        }
+      }
+      if (delete_flag) rewriter.EraseOp(op);
+    } else {
+      for (uint32_t i = 0; i < all_q.size(); i++) {
+        if (all_q[i]) {
+          paddle::onednn::dialect::QuantizeOp new_op =
+              user_ops[i]
+                  .first->dyn_cast<paddle::onednn::dialect::QuantizeOp>();
+          auto quant_attributes = new_op->attributes();
+          auto q_scale = quant_attributes.at("scale")
+                             .dyn_cast<pir::FloatAttribute>()
+                             .data();
+          auto q_shift = quant_attributes.at("shift")
+                             .dyn_cast<pir::FloatAttribute>()
+                             .data();
+
+          if (q_scale == dq_scale && q_shift == dq_shift) {
+            rewriter.ReplaceAllUsesWith(new_op.output(), pre_op->result(idx));
+            rewriter.EraseOp(new_op);
+            did_process = true;
+          }
+        }
+      }
+    }
+    return did_process;
+  }
+};
+
+class QuantConvBf16SquashPattern
+    : public pir::OpRewritePattern<paddle::onednn::dialect::QuantizeOp> {
+ public:
+  using pir::OpRewritePattern<
+      paddle::onednn::dialect::QuantizeOp>::OpRewritePattern;
+  bool MatchAndRewrite(
+      paddle::onednn::dialect::QuantizeOp op,
+      pir::PatternRewriter &rewriter) const override {  // NOLINT
+    if (!op.output().HasOneUse()) return false;
+    paddle::onednn::dialect::Conv2dOp next_op =
+        pir::GetUseOpsForOutput(op, 0)[0]
+            .first->dyn_cast<paddle::onednn::dialect::Conv2dOp>();
+
+    if (!next_op) return false;
+
+    auto quant_attributes = op->attributes();
+    auto op_attributes = next_op->attributes();
+    auto q_scale =
+        quant_attributes.at("scale").dyn_cast<pir::FloatAttribute>().data();
+    auto q_shift =
+        quant_attributes.at("shift").dyn_cast<pir::FloatAttribute>().data();
+
+    if (q_scale != 1.0f || q_shift != 0.0f) return false;
+    if (next_op.input() != op.output()) return false;
+
+    op_attributes["force_fp32_output"] = rewriter.bool_attr(false);
+    op_attributes["fuse_residual_connection"] = rewriter.bool_attr(false);
+    // op_attributes["mkldnn_data_type"] =
+    //     rewriter.str_attr("bfloat16");  // delete when lirong merge
+    op_attributes["fuse_activation"] = rewriter.str_attr("");
+    op_attributes["fuse_alpha"] = rewriter.float_attr(0.0f);
+    op_attributes["fuse_beta"] = rewriter.float_attr(0.0f);
+    op_attributes["scale_in"] = rewriter.float_attr(1.0f);
+    op_attributes["scale_out"] = rewriter.float_attr(1.0f);
+    op_attributes["scale_in_eltwise"] = rewriter.float_attr(1.0f);
+    op_attributes["scale_weights"] =
+        rewriter.array_attr({rewriter.float_attr(1.0f)});
+
+    pir::IrContext *ctx = pir::IrContext::Instance();
+    auto op_info = ctx->GetRegisteredOpInfo(
+        paddle::onednn::dialect::FusedConv2dOp::name());
+    if (!op_info) return false;
+
+    std::vector<pir::Type> op_item_inner_output_types;
+    for (size_t i = 0; i < next_op->num_results(); ++i) {
+      pir::Type type = next_op->result_type(i);
+      pir::Type new_type =
+          create_type<pir::DenseTensorType,
+                      paddle::dialect::AllocatedDenseTensorType>(
+              type, phi::CPUPlace(), pir::BFloat16Type::get(ctx), ctx);
+      // set bf16 op tensor output type to bf16.
+      op_item_inner_output_types.push_back(new_type);
+    }
+
+    paddle::onednn::dialect::FusedConv2dOp new_conv2d_op =
+        rewriter
+            .Build(
+                std::vector<pir::Value>{
+                    op.input(), next_op.filter(), pir::Value{}, pir::Value{}},
+                op_attributes,
+                op_item_inner_output_types,
+                op_info)
+            ->dyn_cast<paddle::onednn::dialect::FusedConv2dOp>();
+
+    rewriter.ReplaceAllUsesWith(next_op.out(), new_conv2d_op.output());
+
+    rewriter.EraseOp(next_op);
+    rewriter.EraseOp(op);
+
+    return true;
+  }
+};
+
+class QuantFusedConvBf16SquashPattern
+    : public pir::OpRewritePattern<paddle::onednn::dialect::QuantizeOp> {
+ public:
+  using pir::OpRewritePattern<
+      paddle::onednn::dialect::QuantizeOp>::OpRewritePattern;
+  bool MatchAndRewrite(
+      paddle::onednn::dialect::QuantizeOp op,
+      pir::PatternRewriter &rewriter) const override {  // NOLINT
+    if (!op.output().HasOneUse()) return false;
+    paddle::onednn::dialect::FusedConv2dOp next_op =
+        pir::GetUseOpsForOutput(op, 0)[0]
+            .first->dyn_cast<paddle::onednn::dialect::FusedConv2dOp>();
+
+    if (!next_op) return false;
+
+    auto quant_attributes = op->attributes();
+    auto op_attributes = next_op->attributes();
+    auto q_scale =
+        quant_attributes.at("scale").dyn_cast<pir::FloatAttribute>().data();
+    auto q_shift =
+        quant_attributes.at("shift").dyn_cast<pir::FloatAttribute>().data();
+
+    if (q_scale != 1.0f || q_shift != 0.0f) return false;
+    if (next_op.input() != op.output()) return false;
+
+    auto op_info = pir::IrContext::Instance()->GetRegisteredOpInfo(
+        paddle::onednn::dialect::FusedConv2dOp::name());
+    if (!op_info) return false;
+
+    pir::IrContext *ctx = pir::IrContext::Instance();
+    std::vector<pir::Type> op_item_inner_output_types;
+    for (size_t i = 0; i < next_op->num_results(); ++i) {
+      pir::Type type = next_op->result_type(i);
+      pir::Type new_type =
+          create_type<pir::DenseTensorType,
+                      paddle::dialect::AllocatedDenseTensorType>(
+              type, phi::CPUPlace(), pir::BFloat16Type::get(ctx), ctx);
+      // set bf16 op tensor output type to bf16.
+      op_item_inner_output_types.push_back(new_type);
+    }
+
+    paddle::onednn::dialect::FusedConv2dOp new_conv2d_op =
+        rewriter
+            .Build(std::vector<pir::Value>{op.input(),
+                                           next_op.filter(),
+                                           next_op.bias(),
+                                           next_op.residual_param()},
+                   op_attributes,
+                   op_item_inner_output_types,
+                   op_info)
+            ->dyn_cast<paddle::onednn::dialect::FusedConv2dOp>();
+
+    rewriter.ReplaceAllUsesWith(next_op.output(), new_conv2d_op.output());
+    rewriter.ReplaceAllUsesWith(op.output(), op.input());
+
+    rewriter.EraseOp(op);
+    rewriter.EraseOp(next_op);
+
+    return true;
+  }
+};
+
+class OpDequantBf16SquashPattern
+    : public pir::OpRewritePattern<paddle::onednn::dialect::DequantizeOp> {
+ public:
+  using pir::OpRewritePattern<
+      paddle::onednn::dialect::DequantizeOp>::OpRewritePattern;
+  bool MatchAndRewrite(
+      paddle::onednn::dialect::DequantizeOp op,
+      pir::PatternRewriter &rewriter) const override {  // NOLINT
+    auto *pre_op = pir::GetDefiningOpForInput(op, 0);
+    if (!pre_op) return false;
+    auto pre_op_name = pre_op->name();
+    if (pre_op_name.find("onednn") == std::string::npos) return false;
+    auto op_info = pir::IrContext::Instance()->GetRegisteredOpInfo(pre_op_name);
+    if (!op_info) return false;
+
+    auto op_attributes = pre_op->attributes();
+    auto dequant_attributes = op->attributes();
+    auto dq_scale =
+        dequant_attributes.at("scale").dyn_cast<pir::FloatAttribute>().data();
+    auto dq_shift =
+        dequant_attributes.at("shift").dyn_cast<pir::FloatAttribute>().data();
+
+    if (op_attributes.find("mkldnn_data_type") == op_attributes.end()) {
+      return false;
+    }
+    auto onednn_dtype = op_attributes.at("mkldnn_data_type")
+                            .dyn_cast<pir::StrAttribute>()
+                            .AsString();
+
+    if (!op.input().HasOneUse()) return false;
+    if ((op_attributes.find("fuse_residual_connection") !=
+         op_attributes.end()) &&
+        (op_attributes.at("fuse_residual_connection")
+             .dyn_cast<pir::BoolAttribute>()
+             .data() == true)) {
+      return false;
+    }
+    if (onednn_dtype != "bfloat16") return false;
+    if (op_attributes.find("force_fp32_output") == op_attributes.end()) {
+      return false;
+    }
+    if (dq_scale != 1.0f || dq_shift != 0.0f) return false;
+
+    uint32_t idx = pre_op->num_results();
+    for (uint32_t i = 0; i < pre_op->num_results(); i++) {
+      if (pre_op->result(i) == op.input()) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx == pre_op->num_results()) return false;
+
+    op_attributes["force_fp32_output"] = rewriter.bool_attr(true);
+
+    std::vector<pir::Type> op_item_inner_output_types;
+    for (size_t i = 0; i < pre_op->num_results(); ++i) {
+      if (i == idx) {
+        op_item_inner_output_types.push_back(op->result_type(0));
+      } else {
+        op_item_inner_output_types.push_back(pre_op->result_type(i));
+      }
+    }
+
+    pir::Operation *new_op = rewriter.Build(pre_op->operands_source(),
+                                            op_attributes,
+                                            op_item_inner_output_types,
+                                            op_info);
+
+    rewriter.ReplaceOp(pre_op, new_op->results());
+    rewriter.ReplaceAllUsesWith(op.output(), new_op->result(idx));
+    rewriter.EraseOp(op);
+
+    return true;
+  }
+};
+
+class CPUBf16QuantizeSquashPass : public pir::PatternRewritePass {
+ public:
+  CPUBf16QuantizeSquashPass()
+      : pir::PatternRewritePass("cpu_bf16_quantize_squash_pass", 3) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
+    pir::RewritePatternSet ps(context);
+    uint32_t benfit = 100;
+
+    auto q_dq_onednn_pattern = std::make_unique<DequantQuantBf16SquashPattern>(
+        context, benfit--, std::vector<std::string>{});
+    ps.Add(std::move(q_dq_onednn_pattern));
+
+    auto q_dq_multi_onednn_pattern =
+        std::make_unique<DequantQuantBf16MultiUserPattern>(
+            context, benfit--, std::vector<std::string>{});
+    ps.Add(std::move(q_dq_multi_onednn_pattern));
+
+    auto q_conv_onednn_pattern = std::make_unique<QuantConvBf16SquashPattern>(
+        context,
+        benfit--,
+        std::vector<std::string>{
+            paddle::onednn::dialect::FusedConv2dOp::name(),
+        });
+    ps.Add(std::move(q_conv_onednn_pattern));
+
+    auto q_fusedconv_onednn_pattern =
+        std::make_unique<QuantFusedConvBf16SquashPattern>(
+            context,
+            benfit--,
+            std::vector<std::string>{
+                paddle::onednn::dialect::FusedConv2dOp::name(),
+            });
+    ps.Add(std::move(q_fusedconv_onednn_pattern));
+
+    auto dq_op_onednn_pattern = std::make_unique<OpDequantBf16SquashPattern>(
+        context, benfit--, std::vector<std::string>{});
+    ps.Add(std::move(dq_op_onednn_pattern));
+
+    return ps;
+  }
+};
+
+}  // namespace
+
+namespace pir {
+
+std::unique_ptr<Pass> CreateCPUBf16QuantizeSquashPass() {
+  return std::make_unique<CPUBf16QuantizeSquashPass>();
+}
+
+}  // namespace pir
+
+REGISTER_IR_PASS(cpu_bf16_quantize_squash_pass, CPUBf16QuantizeSquashPass);

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_squash_pass.h
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_squash_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/core/dll_decl.h"
+
+namespace pir {
+
+class Pass;
+
+IR_API std::unique_ptr<Pass> CreateCPUBf16QuantizeSquashPass();
+
+}  // namespace pir

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -83,6 +83,7 @@ USE_PIR_PASS(matmul_reshape_add_fuse_pass);
 USE_PIR_PASS(cpu_bfloat16_placement_pass);
 USE_PIR_PASS(cpu_bfloat16_type_placement_pass);
 USE_PIR_PASS(cpu_bfloat16_pass);
+USE_PIR_PASS(cpu_bf16_quantize_squash_pass);
 #endif
 
 #ifdef PADDLE_WITH_XPU

--- a/paddle/phi/ops/yaml/inconsistent/onednn_ops_extra.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/onednn_ops_extra.yaml
@@ -47,7 +47,7 @@
   extra_args : bool use_quantizer=false, str mkldnn_data_type="float32"
 
 - op : conv2d
-  extra_args : str mkldnn_data_type="float32", bool is_test=false
+  extra_args : str mkldnn_data_type="float32", bool is_test=false, bool force_fp32_output=false
   data_format_tensors : input
 
 - op : conv2d_grad
@@ -55,7 +55,7 @@
   data_format_tensors : input, out_grad
 
 - op : conv2d_transpose
-  extra_args : str mkldnn_data_type="float32", bool is_test=false
+  extra_args : str mkldnn_data_type="float32", bool is_test=false, bool force_fp32_output=false
   data_format_tensors : x
 
 - op : conv2d_transpose_bias
@@ -168,7 +168,7 @@
   data_format_tensors : x, out, mid_out, out_grad
 
 - op : matmul
-  extra_args : str mkldnn_data_type="float32"
+  extra_args : str mkldnn_data_type="float32", bool force_fp32_output=false
   data_format_tensors : x, y
 
 - op : matmul_grad

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -2380,7 +2380,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32", bool force_fp32_output = false]
   complex_promote : [X, Y]
 
 - op : matmul_with_flatten (mul)

--- a/test/ir/pir/fused_pass/onednn/test_cpu_bfloat16_squash_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_cpu_bfloat16_squash_pass.py
@@ -89,6 +89,7 @@ class TestConv2dAddBf16Pass(PassTest):
         self.places.append(paddle.CPUPlace())
 
     def test_check_output(self):
+        self.skip_accuracy_verification = True
         self.check_pass_correct(atol=1e-2, rtol=1e-2)
 
 
@@ -159,6 +160,7 @@ class TestFusedConv2dBf16Pass(PassTest):
         self.places.append(paddle.CPUPlace())
 
     def test_check_output(self):
+        self.skip_accuracy_verification = True
         self.check_pass_correct(atol=1e-2, rtol=1e-2)
 
 
@@ -248,6 +250,100 @@ class TestFcGeluReluBf16Pass(PassTest):
                     "pd_op.matmul": 0,
                     "onednn_op.gelu": 1,
                     "onednn_op.relu": 1,
+                    "onednn_op.dequantize": 2,
+                    "onednn_op.quantize": 1,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct(atol=5e-3, rtol=5e-3)
+
+
+class TestGeluReluBf16Pass(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(name='x', shape=[3, 2], dtype='float32')
+                out_1 = paddle.nn.functional.gelu(x)
+                out_2 = paddle.nn.functional.relu(out_1)
+                out_2 = paddle.assign(out_2)
+                self.pass_attr_list = [
+                    {'onednn_placement_pass': {}},
+                    {'cpu_bfloat16_placement_pass': {}},
+                    {'cpu_bfloat16_pass': {}},
+                    {'cpu_bfloat16_type_placement_pass': {}},
+                    {'cpu_bf16_quantize_squash_pass': {}},
+                ]
+                self.feeds = {
+                    "x": np.random.random((3, 2)).astype("float32"),
+                }
+                self.fetch_list = [out_2]
+                self.valid_op_map = {
+                    "onednn_op.gelu": 1,
+                    "onednn_op.relu": 1,
+                    "onednn_op.dequantize": 1,
+                    "onednn_op.quantize": 1,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct(atol=5e-3, rtol=5e-3)
+
+
+class TestFcGeluMishBf16Pass(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(name='x', shape=[3, 2], dtype='float32')
+                w = paddle.static.data(name='w', shape=[2, 3], dtype='float32')
+                y = paddle.static.data(name="y", shape=[3], dtype='float32')
+                out = paddle.add(paddle.matmul(x, w), y)
+                out_1 = paddle.nn.functional.gelu(out)
+                out_2 = paddle.nn.functional.mish(out)
+                out_1 = paddle.assign(out_1)
+                out_2 = paddle.assign(out_2)
+                self.pass_attr_list = [
+                    {'matmul_add_act_fuse_pass': {}},
+                    {'fc_onednn_enable_pass': {}},
+                    {'onednn_placement_pass': {}},
+                    {'cpu_bfloat16_placement_pass': {}},
+                    {'cpu_bfloat16_pass': {}},
+                    {'cpu_bfloat16_type_placement_pass': {}},
+                    {'cpu_bf16_quantize_squash_pass': {}},
+                ]
+                self.feeds = {
+                    "x": np.random.random((3, 2)).astype("float32"),
+                    "w": np.random.random((2, 3)).astype("float32"),
+                    "y": np.random.random(3).astype("float32"),
+                }
+                self.fetch_list = [out_1, out_2]
+                self.valid_op_map = {
+                    "onednn_op.fc": 1,
+                    "pd_op.matmul": 0,
+                    "onednn_op.gelu": 1,
+                    "onednn_op.mish": 1,
                     "onednn_op.dequantize": 2,
                     "onednn_op.quantize": 1,
                 }

--- a/test/ir/pir/fused_pass/onednn/test_cpu_bfloat16_squash_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_cpu_bfloat16_squash_pass.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from pass_test import PassTest
+
+import paddle
+
+paddle.enable_static()
+
+
+class TestConv2dAddBf16Pass(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(
+                    name='x', shape=[5, 5, 5, 5], dtype='float32'
+                )
+                bias_attr = paddle.ParamAttr(
+                    learning_rate=0.0,
+                    initializer=paddle.nn.initializer.Normal(mean=0.0, std=2.0),
+                )
+                bias = paddle.static.create_parameter(
+                    shape=[1], dtype='float32', attr=bias_attr, is_bias=False
+                )
+                w_attr = paddle.ParamAttr(
+                    learning_rate=0.0,
+                    initializer=paddle.nn.initializer.Normal(mean=0.0, std=2.0),
+                )
+                conv2d = paddle.nn.Conv2D(
+                    in_channels=5,
+                    out_channels=1,
+                    kernel_size=[1, 1],
+                    groups=1,
+                    stride=[1, 1],
+                    padding=[1, 1, 1, 1],
+                    dilation=[1, 1],
+                    data_format='NCHW',
+                    bias_attr=False,
+                    weight_attr=w_attr,
+                )
+
+                # out = paddle.add(conv2d(x), bias)
+                out = conv2d(x)
+                out = paddle.assign(out)
+                self.pass_attr_list = [
+                    {'onednn_placement_pass': {}},
+                    {'cpu_bfloat16_placement_pass': {}},
+                    {'cpu_bfloat16_pass': {}},
+                    {'cpu_bfloat16_type_placement_pass': {}},
+                    {'cpu_bf16_quantize_squash_pass': {}},
+                ]
+                self.feeds = {
+                    "x": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "bias": np.random.random(1).astype("float32"),
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.fused_conv2d": 1,
+                    "onednn_op.conv2d": 0,
+                    "pd_op.conv2d": 0,
+                    "onednn_op.dequantize": 0,
+                    "onednn_op.quantize": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct(atol=1e-2, rtol=1e-2)
+
+
+class TestFusedConv2dBf16Pass(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(
+                    name='x', shape=[5, 5, 5, 5], dtype='float32'
+                )
+                bias_attr = paddle.ParamAttr(
+                    learning_rate=0.0,
+                    initializer=paddle.nn.initializer.Normal(mean=0.0, std=2.0),
+                )
+                bias = paddle.static.create_parameter(
+                    shape=[1], dtype='float32', attr=bias_attr, is_bias=False
+                )
+                w_attr = paddle.ParamAttr(
+                    learning_rate=0.0,
+                    initializer=paddle.nn.initializer.Normal(mean=0.0, std=2.0),
+                )
+                conv2d = paddle.nn.Conv2D(
+                    in_channels=5,
+                    out_channels=1,
+                    kernel_size=[1, 1],
+                    groups=1,
+                    stride=[1, 1],
+                    padding=[1, 1, 1, 1],
+                    dilation=[1, 1],
+                    data_format='NCHW',
+                    bias_attr=False,
+                    weight_attr=w_attr,
+                )
+
+                # out = paddle.add(conv2d(x), bias)
+                out_conv = conv2d(x)
+                out = paddle.add(out_conv, bias)
+                out = paddle.assign(out)
+                self.pass_attr_list = [
+                    {'conv2d_bias_fuse_pass': {}},
+                    {'cpu_bfloat16_placement_pass': {}},
+                    {'cpu_bfloat16_pass': {}},
+                    {'cpu_bfloat16_type_placement_pass': {}},
+                    {'cpu_bf16_quantize_squash_pass': {}},
+                ]
+                self.feeds = {
+                    "x": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "bias": np.random.random(1).astype("float32"),
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.fused_conv2d": 1,
+                    "pd_op.conv2d": 0,
+                    "onednn_op.dequantize": 0,
+                    "onednn_op.quantize": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct(atol=1e-2, rtol=1e-2)
+
+
+class TestFcGeluBf16Pass(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(name='x', shape=[3, 2], dtype='float32')
+                w = paddle.static.data(name='w', shape=[2, 3], dtype='float32')
+                y = paddle.static.data(name="y", shape=[3], dtype='float32')
+                out = paddle.add(paddle.matmul(x, w), y)
+                out = paddle.nn.functional.gelu(out)
+                out = paddle.assign(out)
+                self.pass_attr_list = [
+                    {'matmul_add_act_fuse_pass': {}},
+                    {'fc_onednn_enable_pass': {}},
+                    {'onednn_placement_pass': {}},
+                    {'cpu_bfloat16_placement_pass': {}},
+                    {'cpu_bfloat16_pass': {}},
+                    {'cpu_bfloat16_type_placement_pass': {}},
+                    {'cpu_bf16_quantize_squash_pass': {}},
+                ]
+                self.feeds = {
+                    "x": np.random.random((3, 2)).astype("float32"),
+                    "w": np.random.random((2, 3)).astype("float32"),
+                    "y": np.random.random(3).astype("float32"),
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.fc": 1,
+                    "pd_op.matmul": 0,
+                    "onednn_op.gelu": 1,
+                    "onednn_op.dequantize": 1,
+                    "onednn_op.quantize": 1,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct(atol=5e-3, rtol=5e-3)
+
+
+class TestFcGeluReluBf16Pass(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(name='x', shape=[3, 2], dtype='float32')
+                w = paddle.static.data(name='w', shape=[2, 3], dtype='float32')
+                y = paddle.static.data(name="y", shape=[3], dtype='float32')
+                out = paddle.add(paddle.matmul(x, w), y)
+                out_1 = paddle.nn.functional.gelu(out)
+                out_2 = paddle.nn.functional.relu(out)
+                out_1 = paddle.assign(out_1)
+                out_2 = paddle.assign(out_2)
+                self.pass_attr_list = [
+                    {'matmul_add_act_fuse_pass': {}},
+                    {'fc_onednn_enable_pass': {}},
+                    {'onednn_placement_pass': {}},
+                    {'cpu_bfloat16_placement_pass': {}},
+                    {'cpu_bfloat16_pass': {}},
+                    {'cpu_bfloat16_type_placement_pass': {}},
+                    {'cpu_bf16_quantize_squash_pass': {}},
+                ]
+                self.feeds = {
+                    "x": np.random.random((3, 2)).astype("float32"),
+                    "w": np.random.random((2, 3)).astype("float32"),
+                    "y": np.random.random(3).astype("float32"),
+                }
+                self.fetch_list = [out_1, out_2]
+                self.valid_op_map = {
+                    "onednn_op.fc": 1,
+                    "pd_op.matmul": 0,
+                    "onednn_op.gelu": 1,
+                    "onednn_op.relu": 1,
+                    "onednn_op.dequantize": 2,
+                    "onednn_op.quantize": 1,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct(atol=5e-3, rtol=5e-3)
+
+
+class TestFcDqBf16Pass(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(name='x', shape=[3, 2], dtype='float32')
+                w = paddle.static.data(name='w', shape=[2, 3], dtype='float32')
+                y = paddle.static.data(name="y", shape=[3], dtype='float32')
+                out = paddle.add(paddle.matmul(x, w), y)
+                out = paddle.assign(out)
+                self.pass_attr_list = [
+                    {'matmul_add_act_fuse_pass': {}},
+                    {'fc_onednn_enable_pass': {}},
+                    {'cpu_bfloat16_placement_pass': {}},
+                    {'cpu_bfloat16_pass': {}},
+                    {'cpu_bfloat16_type_placement_pass': {}},
+                    {'cpu_bf16_quantize_squash_pass': {}},
+                ]
+                self.feeds = {
+                    "x": np.random.random((3, 2)).astype("float32"),
+                    "w": np.random.random((2, 3)).astype("float32"),
+                    "y": np.random.random(3).astype("float32"),
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.fc": 1,
+                    "pd_op.matmul": 0,
+                    "onednn_op.dequantize": 0,
+                    "onednn_op.quantize": 1,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct(atol=5e-3, rtol=5e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features


### Description
<!-- Describe what you’ve done -->
As the following pass of [PR](https://github.com/PaddlePaddle/Paddle/pull/66402), adding `cpu_bfloat16_squash_pass` to squash extra quantize/dequantize and change data type of relevant Tensors.