### PR TITLE
fix numpy2.1 bug when python >=3.10

### DIFF
--- a/paddle/fluid/pybind/tensor.cc
+++ b/paddle/fluid/pybind/tensor.cc
@@ -203,12 +203,13 @@ void BindTensor(pybind11::module &m) {  // NOLINT
   g_framework_tensor_pytype =
       reinterpret_cast<PyTypeObject *>(framework_tensor.ptr());
   framework_tensor
-      .def("__array__",// NOLINT
-           //To do：Modify the logic in TensorToPyArray(self) according to the dtype and copy parameters.
-           [](phi::DenseTensor &self, py::object dtype, py::object copy) {
-             return TensorToPyArray(self); },
-           py::arg("dtype") = py::none(),
-           py::arg("copy")  = py::none())
+    .def("__array__",  // NOLINT
+        // To do (risemeup): Modify the logic of TensorToPyArray() according to the dtype and copy parameters. // NOLINT
+        [](phi::DenseTensor &self, py::object dtype, py::object copy) {
+          return TensorToPyArray(self);
+        },
+        py::arg("dtype") = py::none(),
+        py::arg("copy") = py::none())
       .def("_ptr",
            [](const phi::DenseTensor &self) {
              return reinterpret_cast<uintptr_t>(self.data());

--- a/paddle/fluid/pybind/tensor.cc
+++ b/paddle/fluid/pybind/tensor.cc
@@ -732,7 +732,7 @@ void BindTensor(pybind11::module &m) {  // NOLINT
              auto dtype =
                  static_cast<phi::DataType>(t[1].cast<int>());
              auto dims = common::make_ddim(t[2].cast<std::vector<int>>());
-             auto lod_info = t[3].cast<framework::LoD>();
+             auto lod_info = t[3].cast<phi::LoD>();
              auto device_id = t[4].cast<int>();
 
              auto shared_reader_holder =
@@ -843,7 +843,7 @@ void BindTensor(pybind11::module &m) {  // NOLINT
                  shared_reader_holder,
                  static_cast<phi::DataType>(t[3].cast<int>()));
              tensor.Resize(common::make_ddim(t[4].cast<std::vector<int>>()));
-             tensor.set_lod(t[5].cast<framework::LoD>());
+             tensor.set_lod(t[5].cast<phi::LoD>());
 
              return tensor;
            },
@@ -978,7 +978,7 @@ void BindTensor(pybind11::module &m) {  // NOLINT
                  shared_holder,
                  static_cast<phi::DataType>(t[3].cast<int>()));
              tensor.Resize(common::make_ddim(t[4].cast<std::vector<int>>()));
-             tensor.set_lod(t[5].cast<framework::LoD>());
+             tensor.set_lod(t[5].cast<phi::LoD>());
 
              return tensor;
            },
@@ -1066,7 +1066,7 @@ void BindTensor(pybind11::module &m) {  // NOLINT
                 shared_reader_holder,
                 static_cast<phi::DataType>(t[2].cast<int>()));
             tensor.Resize(common::make_ddim(t[3].cast<std::vector<int>>()));
-            tensor.set_lod(t[4].cast<framework::LoD>());
+            tensor.set_lod(t[4].cast<phi::LoD>());
 
             return tensor;
           }));

--- a/paddle/fluid/pybind/tensor.cc
+++ b/paddle/fluid/pybind/tensor.cc
@@ -203,13 +203,16 @@ void BindTensor(pybind11::module &m) {  // NOLINT
   g_framework_tensor_pytype =
       reinterpret_cast<PyTypeObject *>(framework_tensor.ptr());
   framework_tensor
-    .def("__array__",  // NOLINT
-        // To do (risemeup): Modify the logic of TensorToPyArray() according to the dtype and copy parameters. // NOLINT
-        [](phi::DenseTensor &self, py::object dtype, py::object copy) {
-          return TensorToPyArray(self);
-        },
-        py::arg("dtype") = py::none(),
-        py::arg("copy") = py::none())
+      .def(
+          // TODO(risemeup): Modify the logic of
+          // TensorToPyArray() according to the dtype and copy
+          // parameters.
+          "__array__",
+          [](phi::DenseTensor &self, py::object dtype, py::object copy) {
+            return TensorToPyArray(self);
+          },
+          py::arg("dtype") = py::none(),
+          py::arg("copy") = py::none())
       .def("_ptr",
            [](const phi::DenseTensor &self) {
              return reinterpret_cast<uintptr_t>(self.data());

--- a/paddle/fluid/pybind/tensor.cc
+++ b/paddle/fluid/pybind/tensor.cc
@@ -203,8 +203,11 @@ void BindTensor(pybind11::module &m) {  // NOLINT
   g_framework_tensor_pytype =
       reinterpret_cast<PyTypeObject *>(framework_tensor.ptr());
   framework_tensor
-      .def("__array__",
-           [](phi::DenseTensor &self) { return TensorToPyArray(self); })
+      .def("__array__",// NOLINT
+           [](phi::DenseTensor &self, py::object dtype, py::object copy) {
+             return TensorToPyArray(self); },
+           py::arg("dtype") = py::none(),
+           py::arg("copy")  = py::none())
       .def("_ptr",
            [](const phi::DenseTensor &self) {
              return reinterpret_cast<uintptr_t>(self.data());
@@ -729,7 +732,7 @@ void BindTensor(pybind11::module &m) {  // NOLINT
              auto dtype =
                  static_cast<phi::DataType>(t[1].cast<int>());
              auto dims = common::make_ddim(t[2].cast<std::vector<int>>());
-             auto lod_info = t[3].cast<phi::LoD>();
+             auto lod_info = t[3].cast<framework::LoD>();
              auto device_id = t[4].cast<int>();
 
              auto shared_reader_holder =
@@ -840,7 +843,7 @@ void BindTensor(pybind11::module &m) {  // NOLINT
                  shared_reader_holder,
                  static_cast<phi::DataType>(t[3].cast<int>()));
              tensor.Resize(common::make_ddim(t[4].cast<std::vector<int>>()));
-             tensor.set_lod(t[5].cast<phi::LoD>());
+             tensor.set_lod(t[5].cast<framework::LoD>());
 
              return tensor;
            },
@@ -975,7 +978,7 @@ void BindTensor(pybind11::module &m) {  // NOLINT
                  shared_holder,
                  static_cast<phi::DataType>(t[3].cast<int>()));
              tensor.Resize(common::make_ddim(t[4].cast<std::vector<int>>()));
-             tensor.set_lod(t[5].cast<phi::LoD>());
+             tensor.set_lod(t[5].cast<framework::LoD>());
 
              return tensor;
            },
@@ -1063,7 +1066,7 @@ void BindTensor(pybind11::module &m) {  // NOLINT
                 shared_reader_holder,
                 static_cast<phi::DataType>(t[2].cast<int>()));
             tensor.Resize(common::make_ddim(t[3].cast<std::vector<int>>()));
-            tensor.set_lod(t[4].cast<phi::LoD>());
+            tensor.set_lod(t[4].cast<framework::LoD>());
 
             return tensor;
           }));

--- a/paddle/fluid/pybind/tensor.cc
+++ b/paddle/fluid/pybind/tensor.cc
@@ -204,6 +204,7 @@ void BindTensor(pybind11::module &m) {  // NOLINT
       reinterpret_cast<PyTypeObject *>(framework_tensor.ptr());
   framework_tensor
       .def("__array__",// NOLINT
+           //To do：Modify the logic in TensorToPyArray(self) according to the dtype and copy parameters.
            [](phi::DenseTensor &self, py::object dtype, py::object copy) {
              return TensorToPyArray(self); },
            py::arg("dtype") = py::none(),

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -959,7 +959,9 @@ def monkey_patch_tensor():
         return self.__nonzero__()
 
     def __array__(
-        self: Tensor, dtype: npt.DTypeLike | None = None
+        self: Tensor,
+        dtype: npt.DTypeLike | None = None,
+        copy: bool | None = None,
     ) -> npt.NDArray[Any]:
         """
         Returns a numpy array shows the value of current Tensor.

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,5 @@
 httpx
-numpy>=1.13 ; platform_system != "Windows"
-numpy>=1.13,<2.1 ; platform_system == "Windows"
+numpy>=1.21
 protobuf>=3.20.2
 Pillow
 decorator


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Fix the bug in PaddlePaddle under Python 3.10 and NumPy 2.1.


<img width="814" alt="image" src="https://github.com/user-attachments/assets/739f5e6d-cdfa-4f44-b83b-40ca014499c7">

- For any `__array__` method on a non-NumPy array-like object, dtype=None and copy=None keywords must be added to the signature - this will work with older NumPy versions as well (although older numpy versions will never pass in copy keyword). If the keywords are added to the `__array__` signature, then for:

    copy=True and any dtype value always return a new copy,
    
    copy=None create a copy if required (for example by dtype),

    copy=False a copy must never be made. If a copy is needed to return a numpy array or satisfy dtype, then raise an exception (ValueError).

- Restricting numpy to version 1.21 or above is to fix the bug of not finding the ‘NDArray’ attribute when using the `numpy.typing` module.

To do：
Modify the logic in TensorToPyArray(self) according to the dtype and copy parameters.
pcard-67164