### PR TITLE
Fix test_trt_convert_layer_norm failure on TensorRT 10.3.0

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -427,7 +427,18 @@ void TensorRTEngine::FreezeNetwork() {
 #else
   ihost_memory_.reset(infer_builder_->buildSerializedNetwork(
       *network(), *infer_builder_config_));
+  PADDLE_ENFORCE_NOT_NULL(
+      ihost_memory_,
+      common::errors::Fatal(
+          "Build TensorRT serialized network failed! Please recheck "
+          "you configurations related to paddle-TensorRT."));
+
   infer_runtime_.reset(createInferRuntime(&logger_));
+  PADDLE_ENFORCE_NOT_NULL(
+      infer_runtime_,
+      common::errors::Fatal("Build TensorRT runtime failed! Please recheck "
+                            "you configurations related to paddle-TensorRT."));
+
   infer_engine_.reset(infer_runtime_->deserializeCudaEngine(
       ihost_memory_->data(), ihost_memory_->size()));
 #endif

--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -643,7 +643,7 @@ class TrtLayerAutoScanTest(AutoScanTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.trt_param = self.TensorRTParam(
-            workspace_size=1024,
+            workspace_size=8192,
             max_batch_size=4,
             min_subgraph_size=0,
             precision=paddle_infer.PrecisionType.Float32,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Environment Adaptation
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
Bug fixes
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->


### Description
<!-- Describe what you’ve done -->
test_trt_convert_layer_norm failure on TensorRT 10.3.0.
Segmentation fault is reported due to nullptr access. The nullptr is caused by small workspace size, and segmentation fault is caused by lacking of nullptr checking.
I've added nullptr checking login to engine.cc, and expanded workspace size to 8192, to adapt to TensorRT 10.3.0.