### PR TITLE
[AutoParallel] Add spmd rules for fused_dropout_add op

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/fused_dropout_add.cc
+++ b/paddle/phi/infermeta/spmd_rules/fused_dropout_add.cc
@@ -30,6 +30,7 @@ SpmdInfo FusedDropoutAddSpmdBase(const DistMetaTensor& x,
   SpmdInfo out_info = ElementwiseBinaryInferSpmd(x, y);
 
   TensorDistAttr seed_offset_dist_attr({2});
+  seed_offset_dist_attr.set_process_mesh(x.dist_attr().process_mesh());
   seed_offset_dist_attr.set_dims_mapping({-1});
 
   VLOG(4) << "x dist_attr: [" << x.dist_attr().to_string() << "]";

--- a/paddle/phi/infermeta/spmd_rules/fused_dropout_add.cc
+++ b/paddle/phi/infermeta/spmd_rules/fused_dropout_add.cc
@@ -1,0 +1,66 @@
+/* Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/phi/infermeta/spmd_rules/fused_dropout_add.h"
+#include <numeric>
+
+#include "glog/logging.h"
+
+#include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
+#include "paddle/phi/core/distributed/auto_parallel/inferspmd_utils.h"
+#include "paddle/phi/core/distributed/auto_parallel/utils.h"
+#include "paddle/phi/infermeta/spmd_rules/dim_trans.h"
+#include "paddle/phi/infermeta/spmd_rules/utils.h"
+
+namespace phi::distributed {
+
+SpmdInfo FusedDropoutAddSpmd(const DistMetaTensor& x, const DistMetaTensor& y) {
+  SpmdInfo out_info = ElementwiseBinaryInferSpmd(x, y);
+
+  TensorDistAttr seed_offset_dist_attr({2});
+  seed_offset_dist_attr.set_dims_mapping({-1});
+
+  LOG_SPMD_INPUT(x);
+  LOG_SPMD_INPUT(y);
+  VLOG(4) << "out dist_attr: [" << out_info.second[0].to_string() << "]";
+  VLOG(4) << "seed_offset dist_attr: [" << seed_offset_dist_attr.to_string()
+          << "]";
+  return {{x_dist_attr_dst.dist_attr(), y_dist_attr_dst.dist_attr()},
+          {out_info.second[0], seed_offset_dist_attr}};
+}
+
+SpmdInfo FusedDropoutAddSpmdReverse(const DistMetaTensor& x,
+                                    const DistMetaTensor& y,
+                                    const DistMetaTensor& out,
+                                    const DistMetaTensor& seed_offset) {
+  SpmdInfo reverse_info = ElementwiseBinaryInferSpmdReverse(x, y, out);
+  LOG_SPMD_INPUT(out);
+  LOG_SPMD_INPUT(seed_offset);
+  VLOG(4) << "x dist_attr: [" << reverse_info.first[0].to_string() << "]";
+  VLOG(4) << "y dist_attr: [" << reverse_info.first[1].to_string() << "]";
+  return {reverse_info.first,
+          {reverse_info.second[0], seed_offset.dist_attr()}};
+}
+
+SpmdInfo FusedDropoutAddGradInferSpmd(const DistMetaTensor& seed_offset,
+                                      const DistMetaTensor& out_grad) {
+  LOG_SPMD_INPUT(seed_offset);
+  LOG_SPMD_INPUT(out_grad);
+  VLOG(4) << "x_grad dist_attr: [" << out_grad.dist_attr().to_string() << "]";
+  VLOG(4) << "y_grad dist_attr: [" << out_grad.dist_attr().to_string() << "]";
+  return {{seed_offset.dist_attr(), out_grad.dist_attr()},
+          {out_grad.dist_attr(), out_grad.dist_attr()}};
+}
+
+}  // namespace phi::distributed

--- a/paddle/phi/infermeta/spmd_rules/fused_dropout_add.h
+++ b/paddle/phi/infermeta/spmd_rules/fused_dropout_add.h
@@ -25,7 +25,8 @@ SpmdInfo FusedDropoutAddSpmdBase(const DistMetaTensor& x,
 
 SpmdInfo FusedDropoutAddSpmdReverseBase(const DistMetaTensor& x,
                                         const DistMetaTensor& y,
-                                        const DistMetaTensor& out);
+                                        const DistMetaTensor& out,
+                                        const DistMetaTensor& seed_offset);
 
 SpmdInfo FusedDropoutAddGradInferSpmdBase(const DistMetaTensor& seed_offset,
                                           const DistMetaTensor& out_grad);

--- a/paddle/phi/infermeta/spmd_rules/fused_dropout_add.h
+++ b/paddle/phi/infermeta/spmd_rules/fused_dropout_add.h
@@ -1,0 +1,35 @@
+/* Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <vector>
+
+#include "paddle/phi/core/distributed/auto_parallel/dist_meta_tensor.h"
+#include "paddle/phi/core/distributed/type_defs.h"
+
+namespace phi {
+namespace distributed {
+SpmdInfo FusedDropoutAddSpmd(const DistMetaTensor& x, const DistMetaTensor& y);
+
+SpmdInfo FusedDropoutAddSpmdReverse(const DistMetaTensor& x,
+                                    const DistMetaTensor& y,
+                                    const DistMetaTensor& out,
+                                    const DistMetaTensor& seed_offset);
+
+SpmdInfo FusedDropoutAddGradInferSpmd(const DistMetaTensor& seed_offset,
+                                      const DistMetaTensor& out_grad);
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/fused_dropout_add.h
+++ b/paddle/phi/infermeta/spmd_rules/fused_dropout_add.h
@@ -14,22 +14,47 @@ limitations under the License. */
 
 #pragma once
 
-#include <vector>
-
+#include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/distributed/auto_parallel/dist_meta_tensor.h"
 #include "paddle/phi/core/distributed/type_defs.h"
 
 namespace phi {
 namespace distributed {
-SpmdInfo FusedDropoutAddSpmd(const DistMetaTensor& x, const DistMetaTensor& y);
+SpmdInfo FusedDropoutAddSpmdBase(const DistMetaTensor& x,
+                                 const DistMetaTensor& y);
+
+SpmdInfo FusedDropoutAddSpmdReverseBase(const DistMetaTensor& x,
+                                        const DistMetaTensor& y,
+                                        const DistMetaTensor& out);
+
+SpmdInfo FusedDropoutAddGradInferSpmdBase(const DistMetaTensor& seed_offset,
+                                          const DistMetaTensor& out_grad);
+
+SpmdInfo FusedDropoutAddSpmd(const DistMetaTensor& x,
+                             const DistMetaTensor& y,
+                             const DistMetaTensor& seed_tensor,
+                             const Scalar& p,
+                             bool is_test,
+                             const std::string& mode,
+                             int seed,
+                             bool fix_seed);
 
 SpmdInfo FusedDropoutAddSpmdReverse(const DistMetaTensor& x,
                                     const DistMetaTensor& y,
+                                    const DistMetaTensor& seed_tensor,
                                     const DistMetaTensor& out,
-                                    const DistMetaTensor& seed_offset);
+                                    const DistMetaTensor& seed_offset,
+                                    const Scalar& p,
+                                    bool is_test,
+                                    const std::string& mode,
+                                    int seed,
+                                    bool fix_seed);
 
 SpmdInfo FusedDropoutAddGradInferSpmd(const DistMetaTensor& seed_offset,
-                                      const DistMetaTensor& out_grad);
-
+                                      const DistMetaTensor& out_grad,
+                                      const Scalar& p,
+                                      bool is_test,
+                                      std::string mode,
+                                      bool fix_seed);
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -350,6 +350,11 @@ PD_REGISTER_SPMD_RULE(
     PD_INFER_SPMD(phi::distributed::ElementwiseUnaryInferSpmd),
     PD_INFER_SPMD(phi::distributed::ElementwiseUnaryInferSpmdReverse));
 
+PD_REGISTER_SPMD_RULE(
+    fused_dropout_add,
+    PD_INFER_SPMD(phi::distributed::FusedDropoutAddSpmd),
+    PD_INFER_SPMD(phi::distributed::FusedDropoutAddSpmdReverse));
+
 // elementwise binary rule
 PD_REGISTER_SPMD_RULE(
     add,

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -352,8 +352,8 @@ PD_REGISTER_SPMD_RULE(
 
 PD_REGISTER_SPMD_RULE(
     fused_dropout_add,
-    PD_INFER_SPMD(phi::distributed::FusedDropoutAddSpmd),
-    PD_INFER_SPMD(phi::distributed::FusedDropoutAddSpmdReverse));
+    PD_INFER_SPMD(phi::distributed::FusedDropoutAddSpmdBase),
+    PD_INFER_SPMD(phi::distributed::FusedDropoutAddSpmdReverseBase));
 
 // elementwise binary rule
 PD_REGISTER_SPMD_RULE(

--- a/paddle/phi/infermeta/spmd_rules/rules.h
+++ b/paddle/phi/infermeta/spmd_rules/rules.h
@@ -28,6 +28,7 @@ limitations under the License. */
 #include "paddle/phi/infermeta/spmd_rules/flash_attention.h"
 #include "paddle/phi/infermeta/spmd_rules/flatten.h"
 #include "paddle/phi/infermeta/spmd_rules/full_like.h"
+#include "paddle/phi/infermeta/spmd_rules/fused_dropout_add.h"
 #include "paddle/phi/infermeta/spmd_rules/fused_linear_param_grad_add.h"
 #include "paddle/phi/infermeta/spmd_rules/fused_rope.h"
 #include "paddle/phi/infermeta/spmd_rules/gather.h"

--- a/paddle/phi/ops/yaml/fused_backward.yaml
+++ b/paddle/phi/ops/yaml/fused_backward.yaml
@@ -35,6 +35,7 @@
   output : Tensor(x_grad), Tensor(y_grad)
   infer_meta :
     func : FusedDropoutAddGradInferMeta
+    spmd_rule : FusedDropoutAddGradInferSpmd
     param : [seed_offset, out_grad]
   kernel :
     func : fused_dropout_add_grad

--- a/paddle/phi/ops/yaml/fused_ops.yaml
+++ b/paddle/phi/ops/yaml/fused_ops.yaml
@@ -274,6 +274,7 @@
   output : Tensor(out), Tensor(seed_offset)
   infer_meta :
     func : FusedDropoutAddInferMeta
+    spmd_rule : FusedDropoutAddSpmd
     param : [x, y]
   kernel :
     func : fused_dropout_add

--- a/test/auto_parallel/spmd_rules/CMakeLists.txt
+++ b/test/auto_parallel/spmd_rules/CMakeLists.txt
@@ -37,6 +37,8 @@ if(WITH_DISTRIBUTE)
   py_test_modules(test_unbind_rule MODULES test_unbind_rule)
   py_test_modules(test_stack_rule MODULES test_stack_rule)
   py_test_modules(test_gather_nd_rule MODULES test_gather_nd_rule)
+  py_test_modules(test_fused_dropout_add_rule MODULES
+                  test_fused_dropout_add_rule)
   # End of unittests WITH single card WITHOUT timeout
 
 endif()

--- a/test/auto_parallel/spmd_rules/test_fused_dropout_add_rule.py
+++ b/test/auto_parallel/spmd_rules/test_fused_dropout_add_rule.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from paddle.distributed.auto_parallel.static.dist_attribute import (
+    DistTensorSpec,
+    TensorDistAttr,
+)
+from paddle.distributed.fleet import auto
+from paddle.framework import core
+
+
+class TestFusedDropoutAddSPMDRule(unittest.TestCase):
+    """
+    Unit tests for fused_dropout_add spmd rule.
+    """
+
+    def setUp(self):
+        self.process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2, 3], [4, 5, 6, 7]])
+        self.shapes = [[2, 4], [2, 4]]
+        self.dim_mappings = [[0, -1], [0, -1]]
+
+    def build_inputs(self):
+        inputs = {}
+        x_dist_attr = TensorDistAttr()
+        x_dist_attr.dims_mapping = [0, -1]
+        x_dist_attr.process_mesh = self.process_mesh
+        inputs['x'] = DistTensorSpec([2, 4], x_dist_attr)
+        y_dist_attr = TensorDistAttr()
+        y_dist_attr.dims_mapping = [0, -1]
+        y_dist_attr.process_mesh = self.process_mesh
+        inputs['y'] = DistTensorSpec([2, 4], y_dist_attr)
+        return inputs
+
+    def build_outputs(self):
+        outputs = {}
+        out_dist_attr = TensorDistAttr()
+        out_dist_attr.dims_mapping = [0, -1]
+        out_dist_attr.process_mesh = self.process_mesh
+        outputs['out'] = DistTensorSpec([2, 4], out_dist_attr)
+        seed_offset_dist_attr = TensorDistAttr()
+        seed_offset_dist_attr.dims_mapping = [-1]
+        seed_offset_dist_attr.process_mesh = self.process_mesh
+        outputs['seed_offset'] = DistTensorSpec([2], seed_offset_dist_attr)
+        return outputs
+
+    def test_infer_forward(self):
+        inputs = self.build_inputs()
+        rule = core.get_phi_spmd_rule("fused_dropout_add")
+        infered_dist_attrs = rule.infer_forward(inputs['x'], inputs['y'])
+
+        self.assertEqual(len(infered_dist_attrs), 2)
+
+        infered_input_dist_attrs = infered_dist_attrs[0]
+        self.assertEqual(len(infered_input_dist_attrs), 2)
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
+
+        infered_output_dist_attrs = infered_dist_attrs[1]
+        self.assertEqual(len(infered_output_dist_attrs), 2)
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [-1])
+
+    def test_infer_backward(self):
+        inputs = self.build_inputs()
+        outputs = self.build_outputs()
+        rule = core.get_phi_spmd_rule("fused_dropout_add")
+        infered_dist_attrs = rule.infer_backward(
+            inputs['x'], inputs['y'], outputs['out'], outputs['seed_offset']
+        )
+
+        self.assertEqual(len(infered_dist_attrs), 2)
+
+        infered_input_dist_attrs = infered_dist_attrs[0]
+        self.assertEqual(len(infered_input_dist_attrs), 2)
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
+
+        infered_output_dist_attrs = infered_dist_attrs[1]
+        self.assertEqual(len(infered_output_dist_attrs), 2)
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [-1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Add spmd rules for fused_dropout_add op
Pcard-67164
