### PR TITLE
[CINN] Fix fusion error when reduce all plus reshape 0D to 1D

### DIFF
--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/dim_relation.cc
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/dim_relation.cc
@@ -21,7 +21,7 @@ namespace cinn::fusion {
 
 ValueUsage GetValueUsage(const pir::Value& v, const size_t usage_idx) {
   ValueUsage valud_dim;
-  size_t rank = GetCompitableRank(v);
+  size_t rank = GetRank(v);
   for (size_t i = 0; i < rank; ++i) {
     valud_dim.emplace_back(v, i, usage_idx);
   }

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/dim_relation.cc
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/dim_relation.cc
@@ -21,7 +21,7 @@ namespace cinn::fusion {
 
 ValueUsage GetValueUsage(const pir::Value& v, const size_t usage_idx) {
   ValueUsage valud_dim;
-  size_t rank = GetRank(v);
+  size_t rank = GetCompitableRank(v);
   for (size_t i = 0; i < rank; ++i) {
     valud_dim.emplace_back(v, i, usage_idx);
   }

--- a/paddle/cinn/operator_fusion/policy/relative_judge_policy.cc
+++ b/paddle/cinn/operator_fusion/policy/relative_judge_policy.cc
@@ -257,12 +257,12 @@ bool RelativeJudgePolicy::ReducePlusTrivialCanMerge(
   const auto& downstream_free_dims = GatherVectorExcept(
       GetValueUsage(downstream->sink_op()->result(0), 0), fakes);
 
-  bool res = true;
-  if (non_related_dims.size() > 0) {
-    res = ElementwiseEqual(non_related_dims, upstream_reduce_dims);
-  } else {
-    res =
-        IsProductSmallerOrEqual(downstream_free_dims, upstream_non_reduce_dims);
+  bool res =
+      ElementwiseEqual(non_related_dims, upstream_reduce_dims) ||
+      IsProductSmallerOrEqual(downstream_free_dims, upstream_non_reduce_dims);
+
+  if (res && downstream_free_dims.empty() && !fakes.empty()) {
+    res = false;
   }
 
   VLOG(4) << "ReducePlusTrivialCanMerge: " << res;

--- a/paddle/cinn/operator_fusion/policy/relative_judge_policy.cc
+++ b/paddle/cinn/operator_fusion/policy/relative_judge_policy.cc
@@ -257,9 +257,13 @@ bool RelativeJudgePolicy::ReducePlusTrivialCanMerge(
   const auto& downstream_free_dims = GatherVectorExcept(
       GetValueUsage(downstream->sink_op()->result(0), 0), fakes);
 
-  auto res =
-      ElementwiseEqual(non_related_dims, upstream_reduce_dims) ||
-      IsProductSmallerOrEqual(downstream_free_dims, upstream_non_reduce_dims);
+  bool res = true;
+  if (non_related_dims.size() > 0) {
+    res = ElementwiseEqual(non_related_dims, upstream_reduce_dims);
+  } else {
+    res =
+        IsProductSmallerOrEqual(downstream_free_dims, upstream_non_reduce_dims);
+  }
 
   VLOG(4) << "ReducePlusTrivialCanMerge: " << res;
   return res;

--- a/test/ir/pir/cinn/test_reduce_fusion.py
+++ b/test/ir/pir/cinn/test_reduce_fusion.py
@@ -130,6 +130,19 @@ class TestReduceFusion(unittest.TestCase):
 
         self.compare_result(func, None, init)
 
+    def test_reduce_all_reshape(self):
+        # R(reduce all) -> reshape
+        def func(x):
+            a = paddle.max(x, axis=[0, 1, 2, 3], keepdim=False)
+            b = paddle.reshape(a, [1])
+            return b
+
+        def init():
+            x = paddle.rand((1, 1, 128, 128))
+            return (x,)
+
+        self.compare_result(func, None, init)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- Fix fusion error when reduce all plus reshape 0D to 1D