### PR TITLE
[Operator] add origin_id for kernel op

### DIFF
--- a/paddle/fluid/framework/new_executor/pir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.cc
@@ -1673,7 +1673,7 @@ void PirInterpreter::TraceRunInstructionList(
     InstructionBase* instr_node = vec_instruction_base_.at(instr_id).get();
 
     VLOG(6) << "Run InstructionBase " << instr_node->Name() << "[" << instr_id
-            << "]";
+            << "], op id: " << instr_node->Operation()->id();
     RunInstructionBase(instr_node);
 
     if (UNLIKELY(exception_holder_.IsCaught())) {

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -2147,10 +2147,11 @@ void HandleForSpecialOp(
   pir::OpInfo op_info = ctx->GetRegisteredOpInfo(op_item->name());
   // Generate new op
 
-  auto& op_attribute = op_item->attributes().emplace("origin_id", pir::Int64Attribute::get(ctx, op_item->id()));
+  op_item->set_attribute("origin_id",
+                         pir::Int64Attribute::get(ctx, op_item->id()));
 
   pir::Operation* op = pir::Operation::Create(
-      vec_inputs, op_attribute, op_output_types, op_info);
+      vec_inputs, op_item->attributes(), op_output_types, op_info);
   block->push_back(op);
   (*map_op_pair)[op_item] = op;
   // only deal with single output
@@ -2320,7 +2321,8 @@ void HandleForCustomOp(
     op_attribute.emplace("is_inplace", pir::BoolAttribute::get(ctx, true));
   }
 
-    op_attribute.emplace("origin_id", pir::Int64Attribute::get(ctx, op_item->id()));
+  op_attribute.emplace("origin_id",
+                       pir::Int64Attribute::get(ctx, op_item->id()));
 
   VLOG(6) << "Lower custom op: " << op_item->name()
           << " to : " << CustomKernelOp::name();
@@ -3008,7 +3010,8 @@ pir::Operation* BuildKernelOp(
     op_attribute.emplace("is_inplace", pir::BoolAttribute::get(ctx, true));
   }
 
-    op_attribute.emplace("origin_id", pir::Int64Attribute::get(ctx, op_item->id()));
+  op_attribute.emplace("origin_id",
+                       pir::Int64Attribute::get(ctx, op_item->id()));
 
   pir::Operation* op = nullptr;
 #ifdef PADDLE_WITH_DNNL

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -2147,11 +2147,10 @@ void HandleForSpecialOp(
   pir::OpInfo op_info = ctx->GetRegisteredOpInfo(op_item->name());
   // Generate new op
 
-  op_item->set_attribute("origin_id",
-                         pir::Int64Attribute::get(ctx, op_item->id()));
-
   pir::Operation* op = pir::Operation::Create(
       vec_inputs, op_item->attributes(), op_output_types, op_info);
+  op->set_attribute("origin_id", pir::Int64Attribute::get(ctx, op_item->id()));
+
   block->push_back(op);
   (*map_op_pair)[op_item] = op;
   // only deal with single output

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -2146,8 +2146,11 @@ void HandleForSpecialOp(
 
   pir::OpInfo op_info = ctx->GetRegisteredOpInfo(op_item->name());
   // Generate new op
+
+  auto& op_attribute = op_item->attributes().emplace("origin_id", pir::Int64Attribute::get(ctx, op_item->id()));
+
   pir::Operation* op = pir::Operation::Create(
-      vec_inputs, op_item->attributes(), op_output_types, op_info);
+      vec_inputs, op_attribute, op_output_types, op_info);
   block->push_back(op);
   (*map_op_pair)[op_item] = op;
   // only deal with single output
@@ -2316,6 +2319,8 @@ void HandleForCustomOp(
   if (op_item->HasTrait<InplaceTrait>()) {
     op_attribute.emplace("is_inplace", pir::BoolAttribute::get(ctx, true));
   }
+
+    op_attribute.emplace("origin_id", pir::Int64Attribute::get(ctx, op_item->id()));
 
   VLOG(6) << "Lower custom op: " << op_item->name()
           << " to : " << CustomKernelOp::name();
@@ -3002,6 +3007,8 @@ pir::Operation* BuildKernelOp(
   if (op_item->HasTrait<InplaceTrait>()) {
     op_attribute.emplace("is_inplace", pir::BoolAttribute::get(ctx, true));
   }
+
+    op_attribute.emplace("origin_id", pir::Int64Attribute::get(ctx, op_item->id()));
 
   pir::Operation* op = nullptr;
 #ifdef PADDLE_WITH_DNNL

--- a/paddle/pir/include/core/operation.h
+++ b/paddle/pir/include/core/operation.h
@@ -288,7 +288,7 @@ class IR_API alignas(8) Operation final
   const uint32_t num_operands_ = 0;
   const uint32_t num_regions_ = 0;
   const uint32_t num_successors_ = 0;
-  const uint64_t id_;
+  const uint64_t id_ = -1;
 
   detail::BlockOperandImpl *block_operands_{nullptr};
   Region *regions_{nullptr};

--- a/paddle/pir/src/core/ir_printer.cc
+++ b/paddle/pir/src/core/ir_printer.cc
@@ -189,7 +189,9 @@ void IrPrinter::PrintOperationWithNoRegion(Operation* op) {
 
   os << " \"" << op->name() << "\"";
 
-  os << " [id:" << op->id() << "]";
+  if (VLOG_IS_ON(1) || FLAGS_pir_debug) {
+    os << " [id:" << op->id() << "]";
+  }
 
   // TODO(lyk): add API to get operands directly
   PrintOpOperands(op);

--- a/paddle/pir/src/core/ir_printer.cc
+++ b/paddle/pir/src/core/ir_printer.cc
@@ -17,6 +17,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "glog/logging.h"
 #include "paddle/common/flags.h"
 #include "paddle/pir/include/core/block.h"
 #include "paddle/pir/include/core/builtin_attribute.h"

--- a/paddle/pir/src/core/ir_printer.cc
+++ b/paddle/pir/src/core/ir_printer.cc
@@ -189,9 +189,7 @@ void IrPrinter::PrintOperationWithNoRegion(Operation* op) {
 
   os << " \"" << op->name() << "\"";
 
-  if (FLAGS_pir_debug) {
-    os << " [id:" << op->id() << "]";
-  }
+  os << " [id:" << op->id() << "]";
 
   // TODO(lyk): add API to get operands directly
   PrintOpOperands(op);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
pcard-67164
目前的实践中，调试中为了定位错误，往往需要获取到“哪两个op是前后对应的”这一信息。但目前的索引体系中，我们并没有这样的索引体系，能够为某一 op 标记添加另一个 op 的信息作为attr。具体需求如下：
1. pd_op lower 到 kernel 层前后需要体现 op 的对应关系
2. instruction 需要体现和 op 的对应关系

可以通过令 op 持有对应 op 的 id 来实现 op 之间对应关系的记录。为了不破坏 id_ 作为 key 的唯一性，也为了适应 op 有增删时无法完全对应的情况，可以增加 “origin_id” attr 来描述对应 op id。