### PR TITLE
[AutoParallel] Fix the bug in reshape_grad-like op when their inputs should be reshard

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/reshape.cc
+++ b/paddle/phi/infermeta/spmd_rules/reshape.cc
@@ -336,12 +336,13 @@ SpmdInfo ReshapeGradInferSpmd(const DistMetaTensor& x,
   const auto& x_dist_dst = PADDLE_GET_CONST(TensorDistAttr, tmp.first[0]);
   const auto& out_grad_dist_dst =
       PADDLE_GET_CONST(TensorDistAttr, tmp.second[0]);
-  PADDLE_ENFORCE_EQ(
-      x_dist_tmp.dims_mapping(),
-      x_dist_dst.dims_mapping(),
-      common::errors::InvalidArgument("x should not be re shared: [%s] => [%s]",
-                                      x_dist_tmp.to_string(),
-                                      x_dist_dst.to_string()));
+  // PADDLE_ENFORCE_EQ(
+  //     x_dist_tmp.dims_mapping(),
+  //     x_dist_dst.dims_mapping(),
+  //     common::errors::InvalidArgument("x should not be re shared: [%s] =>
+  //     [%s]",
+  //                                     x_dist_tmp.to_string(),
+  //                                     x_dist_dst.to_string()));
   return {{x_dist_tmp, out_grad_dist_dst}, {x_dist_dst}};
 }
 

--- a/paddle/phi/infermeta/spmd_rules/reshape.cc
+++ b/paddle/phi/infermeta/spmd_rules/reshape.cc
@@ -336,13 +336,6 @@ SpmdInfo ReshapeGradInferSpmd(const DistMetaTensor& x,
   const auto& x_dist_dst = PADDLE_GET_CONST(TensorDistAttr, tmp.first[0]);
   const auto& out_grad_dist_dst =
       PADDLE_GET_CONST(TensorDistAttr, tmp.second[0]);
-  // PADDLE_ENFORCE_EQ(
-  //     x_dist_tmp.dims_mapping(),
-  //     x_dist_dst.dims_mapping(),
-  //     common::errors::InvalidArgument("x should not be re shared: [%s] =>
-  //     [%s]",
-  //                                     x_dist_tmp.to_string(),
-  //                                     x_dist_dst.to_string()));
   return {{x_dist_tmp, out_grad_dist_dst}, {x_dist_dst}};
 }
 

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2561,6 +2561,7 @@
     func : GradSameWithXInferMeta
     param : [x, out_grad]
     spmd_rule: ReshapeGradInferSpmd
+    local_shape : x_grad
   kernel :
     func : reshape_grad
     param : [x, out_grad]

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -1642,7 +1642,7 @@
   output : Tensor(out)
   infer_meta :
     func : ExpandAsInferMeta
-    local_shape: target_shape
+    local_shape: out
   kernel :
     func : expand_as
     data_type : x
@@ -3918,7 +3918,7 @@
   infer_meta :
     func : ReshapeInferMeta
     spmd_rule : ReshapeInferSpmd
-    local_shape: shape
+    local_shape: out
     global_shape: out
   kernel :
     func : reshape


### PR DESCRIPTION
### PR Category
Auto Parallel


### PR Types
Bug fixes


### Description
Pcard-67164

Fix the bug of reshape_grad when its input has been resharded in the forward phase. This pr fix this bug by re-computing the local shape of reshape_grad's output (i.e. x_grad).

For example, on process mesh [[0,1],[2,3]], out=x.reshape([64, 48])
- x: shape=[2, 8, 4, 48], placements=[Shard(0), Shard(2)], i.e. dims_mapping=[0, -1, 1, -1]
- out: shape=[64, 48], placements=[Shard(0), Replicated()], i.e. dims_mapping=[0, -1]
In forward phase, x will be resharded before calling reshape. 

In backward phase, x_grad=reshape_grad(x, out_grad)
- out_grad: shape=[64, 48], placements=[Shard(0), Replicated()], i.e. dims_mapping=[0, -1]
- x_grad: shape=[2, 8, 4, 48], placements=[Shard(0), Replicated()], i.e. dims_mapping=[0, -1, -1, -1]
 
**x_grad's dims_mapping is different from x's, with this pr, x_grad's local shape will be re-computed and then x_grad will be resharded to x's dims_mapping**