### PR TITLE
[SOT] Add dispatch `eq`, `ne`, `iadd` for `list` and `tuple`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -335,6 +335,38 @@ Dispatcher.register(
     ("TupleVariable", "VariableBase"),
     lambda var, value: var.index(value),
 )
+Dispatcher.register(
+    operator.add,
+    ("TupleVariable", "TupleVariable"),
+    lambda var, other: var.concat(other),
+)
+Dispatcher.register(
+    operator.iadd,
+    ("TupleVariable", "TupleVariable"),
+    lambda var, other: var.concat(other),
+)
+
+
+@Dispatcher.register_decorator(operator.eq)
+def dispatch_tuple_eq(lhs: TupleVariable, rhs: TupleVariable):
+    if len(lhs) != len(rhs):
+        return ConstantVariable(False, lhs.graph, DummyTracker([lhs, rhs]))
+    size = len(lhs)
+
+    return ConstantVariable(
+        all(
+            Dispatcher.call(operator.eq, lhs[i], rhs[i]).get_py_value()
+            for i in range(size)
+        ),
+        lhs.graph,
+        DummyTracker([lhs, rhs]),
+    )
+
+
+@Dispatcher.register_decorator(operator.ne)
+def dispatch_tuple_ne(lhs: TupleVariable, rhs: TupleVariable):
+    return Dispatcher.call(operator.eq, lhs, rhs).bool_not()
+
 
 # list
 Dispatcher.register(
@@ -427,9 +459,9 @@ Dispatcher.register(
     lambda var, other: var.concat(other),
 )
 Dispatcher.register(
-    operator.add,
-    ("TupleVariable", "TupleVariable"),
-    lambda var, other: var.concat(other),
+    operator.iadd,
+    ("ListVariable", "ListVariable"),
+    lambda var, other: var.inplace_concat(other),
 )
 Dispatcher.register(
     operator.mul,

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -437,6 +437,28 @@ Dispatcher.register(
     lambda var, other: var.repeat(other),
 )
 
+
+@Dispatcher.register_decorator(operator.eq)
+def dispatch_list_eq(lhs: ListVariable, rhs: ListVariable):
+    if len(lhs) != len(rhs):
+        return ConstantVariable(False, lhs.graph, DummyTracker([lhs, rhs]))
+    size = len(lhs)
+
+    return ConstantVariable(
+        all(
+            Dispatcher.call(operator.eq, lhs[i], rhs[i]).get_py_value()
+            for i in range(size)
+        ),
+        lhs.graph,
+        DummyTracker([lhs, rhs]),
+    )
+
+
+@Dispatcher.register_decorator(operator.ne)
+def dispatch_list_ne(lhs: ListVariable, rhs: ListVariable):
+    return Dispatcher.call(operator.eq, lhs, rhs).bool_not()
+
+
 # getattr
 Dispatcher.register(
     getattr,

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
@@ -266,6 +266,11 @@ class ListVariable(ContainerVariable):
             DummyTracker([self, list_]),
         )
 
+    def inplace_concat(self, list_):
+        assert isinstance(list_, ListVariable)
+        self.extend(list_)
+        return self
+
     def repeat(self, length):
         assert isinstance(length, ConstantVariable)
         return ListVariable(

--- a/test/sot/test_03_tuple.py
+++ b/test/sot/test_03_tuple.py
@@ -65,6 +65,31 @@ def tuple_index_tensor(x: paddle.Tensor, y: tuple[paddle.Tensor]):
     return y.index(x)
 
 
+@check_no_breakgraph
+def tuple_compare():
+    # TODO(SigureMo): support gt, ge, lt, le
+    l1 = (1, 2, 3)
+    l2 = (1, 2, 3)
+    l3 = (1, 2, 4)
+    return l1 == l2, l1 == l3, l1 != l2, l1 != l3
+
+
+@check_no_breakgraph
+def tuple_add():
+    l0 = (1, 2, 3)
+    l1 = (4, 5, 6)
+    return l0 + l1
+
+
+@check_no_breakgraph
+def tuple_inplace_add():
+    l0 = (1, 2, 3)
+    l1 = l0
+    l2 = (4, 5, 6)
+    l0 += l2
+    return l0, l1
+
+
 class TestBuildTuple(TestCaseBase):
     def test_build_tuple(self):
         self.assert_results(build_tuple, 1, paddle.to_tensor(2))
@@ -87,6 +112,15 @@ class TestTupleMethods(TestCaseBase):
         b = paddle.to_tensor(2)
         self.assert_results(tuple_count_tensor, a, (a, b, a, b))
         self.assert_results(tuple_index_tensor, b, (b, b, b, a))
+
+    def test_tuple_compare(self):
+        self.assert_results(tuple_compare)
+
+    def test_tuple_add(self):
+        self.assert_results(tuple_add)
+
+    def test_tuple_inplace_add(self):
+        self.assert_results(tuple_inplace_add)
 
 
 if __name__ == "__main__":

--- a/test/sot/test_04_list.py
+++ b/test/sot/test_04_list.py
@@ -222,6 +222,15 @@ def list_no_arguments():
     return l1[0] + l2[0]
 
 
+@check_no_breakgraph
+def list_compare():
+    # TODO(SigureMo): support gt, ge, lt, le
+    l1 = [1, 2, 3]
+    l2 = [1, 2, 3]
+    l3 = [1, 2, 4]
+    return l1 == l2, l1 == l3, l1 != l2, l1 != l3
+
+
 class TestListBasic(TestCaseBase):
     def test_list_basic(self):
         self.assert_results(list_getitem_int, 1, paddle.to_tensor(2))
@@ -321,6 +330,9 @@ class TestListMethods(TestCaseBase):
 
     def test_list_noargs(self):
         self.assert_results(list_no_arguments)
+
+    def test_list_compare(self):
+        self.assert_results(list_compare)
 
 
 if __name__ == "__main__":

--- a/test/sot/test_04_list.py
+++ b/test/sot/test_04_list.py
@@ -231,6 +231,22 @@ def list_compare():
     return l1 == l2, l1 == l3, l1 != l2, l1 != l3
 
 
+@check_no_breakgraph
+def list_add():
+    l0 = [1, 2, 3]
+    l1 = [4, 5, 6]
+    return l0 + l1
+
+
+@check_no_breakgraph
+def list_inplace_add():
+    l0 = [1, 2, 3]
+    l1 = l0
+    l2 = [4, 5, 6]
+    l0 += l2
+    return l0, l1
+
+
 class TestListBasic(TestCaseBase):
     def test_list_basic(self):
         self.assert_results(list_getitem_int, 1, paddle.to_tensor(2))
@@ -333,6 +349,12 @@ class TestListMethods(TestCaseBase):
 
     def test_list_compare(self):
         self.assert_results(list_compare)
+
+    def test_list_add(self):
+        self.assert_results(list_add)
+
+    def test_list_inplace_add(self):
+        self.assert_results(list_inplace_add)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

SOT 添加如下 dispatch，避免引发的过多打断

- `eq(list, list)`
- `ne(list, list)`
- `iadd(list, list)`
- `eq(tuple, tuple)`
- `ne(tuple, tuple)`
- `iadd(tuple, tuple)`

Pcard-67164