### PR TITLE
【Auto Parallel】【PIR】fix bug for pir pipline parallel

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -711,6 +711,7 @@ class Engine:
                             custom_black_list=self._strategy.amp.custom_black_list,
                             dtype=self._strategy.amp.dtype,
                         )
+                        self._optimizer._sorted = False
                         self._optimizer = paddle.static.amp.decorator.OptimizerWithMixedPrecision(
                             optimizer=self._optimizer,
                             amp_lists=amp_lists,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
fix bug for pir pipline parallel.

**before: run llama dp2mp2pp2 failed**
```
......
    lr_var = program.get_parameter_value_by_name(program.lr_name)
RuntimeError: 

--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   pir::utils::name_analysis::GetParameterValueByName(pir::Program const&, std::string const&)
1   common::enforce::EnforceNotMet::EnforceNotMet(common::ErrorSummary const&, char const*, int)
2   common::enforce::GetCurrentTraceBackString[abi:cxx11](bool)

----------------------
Error Message Summary:
----------------------
PreconditionNotMetError: More than one parameter named with learning_rate_0 found. (at /paddle/Paddle/paddle/fluid/pir/utils/name_analysis.cc:53)

```

PCard-85979
