### PR TITLE
s_to_r reshard support unbalanced split

### DIFF
--- a/paddle/fluid/pir/dialect/distributed/ir/dist_tools.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_tools.h
@@ -46,7 +46,10 @@ pir::Attribute CvtToPirAttr(const phi::distributed::ArgDistAttr& dist_attr);
 pir::Attribute CreateReplicatedDistAttr(pir::Type prim_type,
                                         ProcessMeshAttribute mesh);
 
-pir::Type CvtToPirDistType(pir::Type global_type, pir::Attribute dist_attr);
+pir::Type CvtToPirDistType(
+    pir::Type global_type,
+    pir::Attribute dist_attr,
+    const std::vector<int64_t>& local_ddim = std::vector<int64_t>());
 
 ///
 /// When the following conditions are met:

--- a/paddle/fluid/pybind/dist_api.cc
+++ b/paddle/fluid/pybind/dist_api.cc
@@ -131,7 +131,11 @@ void BindDistUtils(pybind11::module *m) {
   m->def("create_tensor_dist_attribute", CreateTensorDistAttribute);
   m->def("create_op_dist_attribute", CreateOperationDistAttribute);
   m->def("get_sub_meshes", phi::distributed::GetSubMeshes);
-  m->def("cvt_to_dist_type", &dialect::CvtToPirDistType);
+  m->def("cvt_to_dist_type",
+         &dialect::CvtToPirDistType,
+         py::arg("global_type"),
+         py::arg("dist_attr"),
+         py::arg("local_ddim") = std::vector<int64_t>());
 }
 
 void BindDistPassAPI(pybind11::module *module) {

--- a/paddle/fluid/pybind/dist_api.cc
+++ b/paddle/fluid/pybind/dist_api.cc
@@ -42,6 +42,7 @@ using paddle::dialect::DistTypeInterface;
 using paddle::dialect::OperationDistAttribute;
 using paddle::dialect::ProcessMeshAttribute;
 using paddle::dialect::TensorDistAttribute;
+using pir::ArrayAttribute;
 
 namespace paddle::pybind {
 
@@ -127,9 +128,15 @@ OperationDistAttribute CreateOperationDistAttribute(
       pir::IrContext::Instance(), mesh, operands, results);
 }
 
+ArrayAttribute CreateArrayAttribute(
+    const std::vector<pir::Attribute> &elements) {
+  return ArrayAttribute::get(pir::IrContext::Instance(), elements);
+}
+
 void BindDistUtils(pybind11::module *m) {
   m->def("create_tensor_dist_attribute", CreateTensorDistAttribute);
   m->def("create_op_dist_attribute", CreateOperationDistAttribute);
+  m->def("create_array_attribute", CreateArrayAttribute);
   m->def("get_sub_meshes", phi::distributed::GetSubMeshes);
   m->def("cvt_to_dist_type",
          &dialect::CvtToPirDistType,

--- a/test/auto_parallel/pir/pir_reshard_s_to_r.py
+++ b/test/auto_parallel/pir/pir_reshard_s_to_r.py
@@ -149,7 +149,8 @@ class TestReshardSToR:
                 assert operand_1_dist_attr.dims_mapping == [-1, -1]
                 assert operand_2_dist_attr.dims_mapping == [-1]
 
-                assert operand_dist_attr.partial_status == {}
+                assert operand_1_dist_attr.partial_status == {}
+                assert operand_2_dist_attr.partial_status == {}
 
                 result_dist_attrs = op.dist_attr.result(0).as_array_attr()
                 assert len(result_dist_attrs) == 2

--- a/test/auto_parallel/pir/pir_reshard_s_to_r.py
+++ b/test/auto_parallel/pir/pir_reshard_s_to_r.py
@@ -210,6 +210,263 @@ class TestReshardSToR:
                 assert op_value.dist_attr().dims_mapping == [-1, -1]
                 assert op_value.dist_attr().partial_status == {}
 
+    def run_pir_unbalanced_split_test_case(self):
+        paddle.enable_static()
+        if self._backend == "cpu":
+            paddle.set_device("cpu")
+            place = paddle.CPUPlace()
+        elif self._backend == "gpu":
+            place = paddle.CUDAPlace(dist.get_rank())
+
+        BATCH_SIZE = 2
+        SEQ_LEN = 4
+        HIDDEN_SIZE = 9
+        MP_SIZE = 2
+
+        with paddle.pir_utils.IrGuard():
+            main_program = paddle.base.Program()
+            with paddle.base.program_guard(main_program):
+                mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
+                input = paddle.static.data(
+                    name='input', shape=[BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE]
+                )
+                w1 = paddle.pir.core.create_parameter(
+                    dtype="float32",
+                    shape=[HIDDEN_SIZE, HIDDEN_SIZE],
+                    name="w1",
+                    initializer=paddle.nn.initializer.Uniform(),
+                )
+
+                input_tensor = dist.shard_tensor(
+                    w1, self._mesh, [dist.Shard(self._shard)]
+                )
+
+                reshard_tensor = paddle._C_ops.reshard(
+                    input_tensor, self._mesh, [dist.Replicate()]
+                )
+            apply_reshard_pass(main_program)
+        # last one will pad
+        need_padding = dist.get_rank() == self._mesh.process_ids[-1]
+        ops = [op.name() for op in main_program.global_block().ops]
+        if need_padding:
+            np.testing.assert_equal(main_program.num_ops(), 18)
+            std_ops = [
+                'builtin.parameter',
+                'pd_op.data',
+                'dist_op.shard_tensor',
+                'pd_op.full',
+                'pd_op.full',
+                'builtin.combine',
+                'pd_op.concat',
+                'pd_op.all_gather',
+                'pd_op.full',
+                'pd_op.split_with_num',
+                'builtin.split',
+                'pd_op.full_int_array',
+                'pd_op.full',
+                'pd_op.split',
+                'builtin.split',
+                'pd_op.full',
+                'builtin.combine',
+                'pd_op.concat',
+            ]
+            np.testing.assert_equal(
+                ops,
+                std_ops,
+            )
+        else:
+            np.testing.assert_equal(main_program.num_ops(), 14)
+            std_ops = [
+                'builtin.parameter',
+                'pd_op.data',
+                'dist_op.shard_tensor',
+                'pd_op.all_gather',
+                'pd_op.full',
+                'pd_op.split_with_num',
+                'builtin.split',
+                'pd_op.full_int_array',
+                'pd_op.full',
+                'pd_op.split',
+                'builtin.split',
+                'pd_op.full',
+                'builtin.combine',
+                'pd_op.concat',
+            ]
+
+            np.testing.assert_equal(
+                ops,
+                std_ops,
+            )
+
+        first_concat = True
+        for op in main_program.global_block().ops:
+            if op.name() == 'pd_op.all_gather':
+                # check op dist_attr
+                assert op.dist_attr.num_operands() == 1
+                assert op.dist_attr.num_results() == 1
+
+                operand_dist_attr = op.dist_attr.operand(
+                    0
+                ).as_tensor_dist_attr()
+                result_dist_attr = op.dist_attr.result(0).as_tensor_dist_attr()
+
+                assert op.dist_attr.process_mesh == self._mesh
+                assert operand_dist_attr.process_mesh == self._mesh
+                if self._shard == 0:
+                    assert operand_dist_attr.dims_mapping == [0, -1]
+                elif self._shard == 1:
+                    assert operand_dist_attr.dims_mapping == [-1, 0]
+                assert operand_dist_attr.partial_status == {}
+
+                assert result_dist_attr.process_mesh == self._mesh
+                assert result_dist_attr.dims_mapping == [-1, -1]
+                assert result_dist_attr.partial_status == {}
+
+                # check op_value dist_attr
+                assert op.num_results() == 1
+                op_value = op.result(0)
+                assert op_value.is_dense_tensor_type()
+                assert op_value.is_dist_dense_tensor_type()
+                assert op_value.is_dist_dense_tensor_type()
+                assert op_value.dist_attr().process_mesh == self._mesh
+                assert op_value.dist_attr().dims_mapping == [-1, -1]
+                assert op_value.dist_attr().partial_status == {}
+            elif op.name() == 'pd_op.split_with_num':
+                # check op dist_attr
+                assert op.dist_attr.num_operands() == 2
+                assert op.dist_attr.num_results() == 1
+
+                operand_1_dist_attr = op.dist_attr.operand(
+                    0
+                ).as_tensor_dist_attr()
+                operand_2_dist_attr = op.dist_attr.operand(
+                    1
+                ).as_tensor_dist_attr()
+
+                assert op.dist_attr.process_mesh == self._mesh
+                assert operand_1_dist_attr.process_mesh == self._mesh
+                assert operand_2_dist_attr.process_mesh == self._mesh
+
+                assert operand_1_dist_attr.dims_mapping == [-1, -1]
+                assert operand_2_dist_attr.dims_mapping == [-1]
+
+                assert operand_1_dist_attr.partial_status == {}
+                assert operand_2_dist_attr.partial_status == {}
+
+                result_dist_attrs = op.dist_attr.result(0).as_array_attr()
+                assert len(result_dist_attrs) == 2
+                result_dist_attr_1 = result_dist_attrs[0].as_tensor_dist_attr()
+                result_dist_attr_2 = result_dist_attrs[1].as_tensor_dist_attr()
+                assert result_dist_attr_1.process_mesh == self._mesh
+                assert result_dist_attr_1.dims_mapping == [-1, -1]
+                assert result_dist_attr_1.partial_status == {}
+
+                assert result_dist_attr_2.process_mesh == self._mesh
+                assert result_dist_attr_2.dims_mapping == [-1, -1]
+                assert result_dist_attr_2.partial_status == {}
+
+                # check op_value dist_attr
+                assert op.num_results() == 1
+                op_value = op.result(0)
+                assert op_value.is_combine()
+                values = op_value.first_use().owner().results()
+                for value in values:
+                    assert value.dist_attr().process_mesh == self._mesh
+                    assert value.dist_attr().dims_mapping == [-1, -1]
+                    assert value.dist_attr().partial_status == {}
+            elif op.name() == 'pd_op.concat':
+                if need_padding and first_concat:
+                    first_concat = False
+                    # check op dist_attr
+                    assert op.dist_attr.num_operands() == 2
+                    assert op.dist_attr.num_results() == 1
+
+                    operand_1_dist_attrs = op.dist_attr.operand(
+                        0
+                    ).as_array_attr()
+                    assert len(operand_1_dist_attrs) == 2
+
+                    operand_1_dist_attr_1 = operand_1_dist_attrs[
+                        0
+                    ].as_tensor_dist_attr()
+                    operand_1_dist_attr_2 = operand_1_dist_attrs[
+                        1
+                    ].as_tensor_dist_attr()
+                    assert operand_1_dist_attr_1.process_mesh == self._mesh
+                    if self._shard == 0:
+                        assert operand_1_dist_attr_1.dims_mapping == [0, -1]
+                    elif self._shard == 1:
+                        assert operand_1_dist_attr_1.dims_mapping == [-1, 0]
+                    assert operand_1_dist_attr_1.partial_status == {}
+
+                    assert operand_1_dist_attr_2.process_mesh == self._mesh
+                    assert operand_1_dist_attr_2.dims_mapping == [-1, -1]
+                    assert operand_1_dist_attr_2.partial_status == {}
+
+                    result_dist_attr = op.dist_attr.result(
+                        0
+                    ).as_tensor_dist_attr()
+                    assert result_dist_attr.process_mesh == self._mesh
+                    if self._shard == 0:
+                        assert result_dist_attr.dims_mapping == [0, -1]
+                    elif self._shard == 1:
+                        assert result_dist_attr.dims_mapping == [-1, 0]
+                    assert result_dist_attr.partial_status == {}
+
+                    # check op_value dist_attr
+                    assert op.num_results() == 1
+                    op_value = op.result(0)
+                    assert op_value.is_dense_tensor_type()
+                    assert op_value.is_dist_dense_tensor_type()
+                    assert op_value.is_dist_dense_tensor_type()
+                    assert op_value.dist_attr().process_mesh == self._mesh
+                    if self._shard == 0:
+                        assert op_value.dist_attr().dims_mapping == [0, -1]
+                    elif self._shard == 1:
+                        assert op_value.dist_attr().dims_mapping == [-1, 0]
+                    assert op_value.dist_attr().partial_status == {}
+                else:
+                    # check op dist_attr
+                    assert op.dist_attr.num_operands() == 2
+                    assert op.dist_attr.num_results() == 1
+
+                    operand_1_dist_attrs = op.dist_attr.operand(
+                        0
+                    ).as_array_attr()
+                    assert len(operand_1_dist_attrs) == 2
+
+                    operand_1_dist_attr_1 = operand_1_dist_attrs[
+                        0
+                    ].as_tensor_dist_attr()
+                    operand_1_dist_attr_2 = operand_1_dist_attrs[
+                        1
+                    ].as_tensor_dist_attr()
+                    assert operand_1_dist_attr_1.process_mesh == self._mesh
+                    assert operand_1_dist_attr_1.dims_mapping == [-1, -1]
+                    assert operand_1_dist_attr_1.partial_status == {}
+
+                    assert operand_1_dist_attr_2.process_mesh == self._mesh
+                    assert operand_1_dist_attr_2.dims_mapping == [-1, -1]
+                    assert operand_1_dist_attr_2.partial_status == {}
+
+                    result_dist_attr = op.dist_attr.result(
+                        0
+                    ).as_tensor_dist_attr()
+                    assert result_dist_attr.process_mesh == self._mesh
+                    assert result_dist_attr.dims_mapping == [-1, -1]
+                    assert result_dist_attr.partial_status == {}
+
+                    # check op_value dist_attr
+                    assert op.num_results() == 1
+                    op_value = op.result(0)
+                    assert op_value.is_dense_tensor_type()
+                    assert op_value.is_dist_dense_tensor_type()
+                    assert op_value.is_dist_dense_tensor_type()
+                    assert op_value.dist_attr().process_mesh == self._mesh
+                    assert op_value.dist_attr().dims_mapping == [-1, -1]
+                    assert op_value.dist_attr().partial_status == {}
+
 
 if __name__ == '__main__':
     TestReshardSToR().run_pir_test_case()
+    TestReshardSToR().run_pir_unbalanced_split_test_case()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
New features

### Description
pcard-86471
s_to_r reshard should support unbalanced split or will error in some model (Dit etc)
```python
import paddle
import paddle.distributed as dist
process_mesh = dist.ProcessMesh([0, 1], dim_names=['dp'])

class ParallelLabelEmbedder(nn.Layer):
    def __init__(self, num_classes, hidden_size, dropout_prob):
        ......
        self.embedding_table = nn.Embedding(embedding_dim, hidden_size) # parameter shape=(1001, 1024)
        self.embedding_table.weight = dist.shard_tensor(self.embedding_table.weight, process_mesh, [dist.Replicate()])
        # Although we DO NOT shard the parameters in the forward and backward processes, 
        # But when using sharding parallel(eg. sharding stage 1), the optimizer will shard the parameters
        # at the 0th dimension, (1001/2) resulting unbalanced splitting. 
        # and using all_gather to update parameters, an error will occur
```
![image](https://github.com/user-attachments/assets/4a858441-7ca2-401b-85d8-a1154484a317)

