### PR TITLE
[CINN] Fix type mismatch when inline generated dynamic shape into concat 

### DIFF
--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
@@ -162,9 +162,14 @@ void SubstitudeTargetExprWithDestExpr(const ir::Expr& source,
                                       ir::Expr* body) {
   VLOG(4) << "SubstitideExpr Start";
   VLOG(5) << "Substitide Body : " << *body;
+  ir::Expr new_dest = dest;
+  if (source.type() != dest.type()) {
+    VLOG(4) << "Cast the dest" << dest << " to type" << source.type();
+    new_dest = ir::Cast::Make(source.type(), dest);
+  }
   VLOG(4) << "Substitide From : " << source;
-  VLOG(4) << "Substitide To   : " << dest;
-  MappingTargetExprToDestExprMutator mapper(source, dest);
+  VLOG(4) << "Substitide To   : " << new_dest;
+  MappingTargetExprToDestExprMutator mapper(source, new_dest);
   mapper(body);
   VLOG(5) << "SubstitideExpr Result: " << *body;
 }

--- a/test/ir/pir/cinn/test_trivial_fusion.py
+++ b/test/ir/pir/cinn/test_trivial_fusion.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+import numpy
+
+os.environ['FLAGS_cinn_new_group_scheduler'] = '1'
+os.environ['FLAGS_group_schedule_tiling_first'] = '1'
+os.environ['FLAGS_prim_all'] = 'true'
+os.environ['FLAGS_prim_enable_dynamic'] = 'true'
+os.environ['FLAGS_print_ir'] = '1'
+os.environ['FLAGS_enable_pir_api'] = '1'
+os.environ['FLAGS_use_cinn'] = '1'
+os.environ['FLAGS_cinn_bucket_compile'] = '1'
+os.environ['FLAGS_cinn_new_cluster_op_method'] = '1'
+
+import paddle
+
+build_strategy = paddle.static.BuildStrategy()
+build_strategy.build_cinn_pass = True
+
+
+def generate_input_spec(rank_dtype_list):
+    input_spec = []
+    for rank, dtype in rank_dtype_list:
+        input_spec.append(
+            paddle.static.InputSpec(shape=[None] * rank, dtype=dtype)
+        )
+    return input_spec
+
+
+class TestTrivialFusion(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def compare_result(self, dy_compute, input_spec, data_init):
+        inputs = data_init()
+        dy_out = dy_compute(*inputs)
+        static_compute = paddle.jit.to_static(
+            full_graph=True,
+            build_strategy=build_strategy,
+            input_spec=input_spec,
+        )(dy_compute)
+        st_out = static_compute(*inputs)
+        for a, b in zip(
+            paddle.utils.flatten(dy_out), paddle.utils.flatten(st_out)
+        ):
+            numpy.testing.assert_allclose(a, b, atol=1e-5, rtol=1e-6)
+
+    def test_generate_shape_concat(self):
+        def func(x, y, z):
+            x = paddle.cast(x, 'int32')
+            y = paddle.cast(y, 'int32')
+            a = paddle.shape(z)[0:1]
+            b = paddle.concat([a, x, y], axis=0)
+            return b
+
+        def init():
+            x = paddle.rand([1])
+            y = paddle.rand([1])
+            z = paddle.rand([32, 32, 32])
+            return x, y, z
+
+        def input_spec():
+            return [
+                paddle.static.InputSpec(shape=[], dtype='float32', name='x'),
+                paddle.static.InputSpec(shape=[], dtype='float32', name='y'),
+                paddle.static.InputSpec(
+                    shape=[-1, -1, -1], dtype='float32', name='z'
+                ),
+            ]
+
+        self.compare_result(func, input_spec(), init)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- Fix type mismatch when inline generate dynamic shape into concat 