### PR TITLE
[PHI]fix gather op check message

### DIFF
--- a/paddle/phi/kernels/funcs/gather.cu.h
+++ b/paddle/phi/kernels/funcs/gather.cu.h
@@ -57,14 +57,14 @@ __global__ void GatherNdCUDAKernel(const T* input,
     int64_t temp = slice_size;
     for (int64_t j = end_size - 1; j >= 0; --j) {
       auto index_value = indices[indices_i * end_size + j];
-      PADDLE_ENFORCE(
-          index_value >= 0 && index_value < input_dims[j],
-          "The index is out of bounds, "
-          "please check whether the dimensions of index and "
-          "input meet the requirements. It should "
-          "be less than [%d] and greater than or equal to 0, but received [%d]",
-          input_dims[j],
-          index_value);
+      PADDLE_ENFORCE(index_value >= 0 && index_value < input_dims[j],
+                     "The index is out of bounds, "
+                     "please check whether the dimensions of index and "
+                     "input meet the requirements. It should "
+                     "be less than [%ld] and greater than or equal to 0, but "
+                     "received [%ld]",
+                     input_dims[j],
+                     index_value);
       gather_i += (index_value * temp);
       temp *= input_dims[j];
     }
@@ -184,7 +184,7 @@ __global__ void GatherGPUKernel(const T* input,
         "The index is out of bounds, "
         "please check whether the dimensions of index and "
         "input meet the requirements. It should "
-        "be less than [%d] and greater than or equal to 0, but received [%d]",
+        "be less than [%ld] and greater than or equal to 0, but received [%ld]",
         input_index_dim_size,
         index_val);
 


### PR DESCRIPTION
### PR Category
CINN

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

优化gather_op, gather_nd_op的报错打印方式，当index是int64的时候，%d 的格式会打印0，无法正确打印错误信息
