### PR TITLE
register bf16 dtype for top_p_sampling kernel

### DIFF
--- a/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
+++ b/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
@@ -26,6 +26,11 @@ namespace cub = hipcub;
 #include <cub/cub.cuh>
 #endif
 
+#if defined(__CUDACC__) && CUDA_VERSION >= 11060
+#define CUDA_BFLOAT16_AVALIABLE
+#include <cuda_bf16.h>
+#endif
+
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -55,7 +60,7 @@ struct DataTypeTraits<phi::dtype::float16> {
   using DataType = half;
 };
 
-#ifdef PADDLE_CUDA_BF16
+#ifdef CUDA_BFLOAT16_AVALIABLE
 template <>
 struct DataTypeTraits<phi::dtype::bfloat16> {
   using DataType = __nv_bfloat16;
@@ -1241,6 +1246,18 @@ void TopPSamplingKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
+#ifdef CUDA_BFLOAT16_AVALIABLE
+PD_REGISTER_KERNEL(top_p_sampling,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::TopPSamplingKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}
+#else
 PD_REGISTER_KERNEL(top_p_sampling,
                    GPU,
                    ALL_LAYOUT,
@@ -1250,3 +1267,4 @@ PD_REGISTER_KERNEL(top_p_sampling,
                    int,
                    int64_t,
                    phi::dtype::float16) {}
+#endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
pcard-71500
register bf16 dtype for top_p_sampling kernel