### PR TITLE
[SOT][dynamic shape] add symbolic fallback when SymbolicVariable's handler not exists.

### DIFF
--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -310,10 +310,9 @@ class VariableCreator(metaclass=Singleton):
                 if isinstance(func, str):
                     # TODO(Aurelius84): Is length of args always greater than 0?
                     # Do we need add condition check here?
-                    out = getattr(args[0], func)(*args[1:], **kwargs)
-                else:
-                    out = func(*args, **kwargs)
-
+                    func = getattr(args[0], func)
+                    args = args[1:]
+                out = func(*args, **kwargs)
         return convert_variable_to_meta_info(out)
 
 

--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -65,7 +65,9 @@ class OpcodeExecutorCache(metaclass=Singleton):
         self.translate_count = 0
         self.code_symbolic_inputs = {}
 
-    def get_symbolic_inputs(self, code: types.CodeType):
+    def get_symbolic_inputs(
+        self, code: types.CodeType
+    ) -> dict[str, dict[int, int] | None]:
         self.code_symbolic_inputs.setdefault(code, {})
         return self.code_symbolic_inputs[code]
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -645,7 +645,9 @@ Dispatcher.register(
 )
 
 Dispatcher.register(
-    operator.truth, ("VariableBase",), lambda var: Dispatcher.call(bool, var)
+    operator.truth,
+    ("ConstantVariable",),
+    lambda var: Dispatcher.call(bool, var),
 )
 
 # str

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -954,18 +954,6 @@ for unary_fn in UNARY_OPS:
             ("TensorVariable",),
             raise_break_graph_fn,
         )
-        Dispatcher.register(
-            unary_fn,
-            ("SymbolicVariable",),
-            partial(
-                lambda fn, var: VariableFactory.from_value(
-                    fn(var.get_py_value()),
-                    var.graph,
-                    tracker=DummyTracker([var]),
-                ),
-                unary_fn,
-            ),
-        )
         continue
 
     if unary_fn is len:

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -645,9 +645,7 @@ Dispatcher.register(
 )
 
 Dispatcher.register(
-    operator.truth,
-    ("ConstantVariable",),
-    lambda var: var.bool(),
+    operator.truth, ("VariableBase",), lambda var: Dispatcher.call(bool, var)
 )
 
 # str

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -637,13 +637,6 @@ Dispatcher.register(
     ),
 )
 
-# bool
-Dispatcher.register(
-    bool,
-    ("VariableBase",),
-    lambda var: var.bool(),
-)
-
 # str
 Dispatcher.register(
     str,
@@ -1268,4 +1261,17 @@ Dispatcher.register(
         x.graph,
         tracker=DummyTracker([x]),
     ),
+)
+
+# bool
+Dispatcher.register(
+    bool,
+    ("VariableBase",),
+    lambda var: var.bool(),
+)
+
+Dispatcher.register(
+    operator.truth,
+    ("VariableBase",),
+    lambda var: var.bool(),
 )

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -637,6 +637,19 @@ Dispatcher.register(
     ),
 )
 
+# bool
+Dispatcher.register(
+    bool,
+    ("ContainerVariable",),
+    lambda var: var.bool(),
+)
+
+Dispatcher.register(
+    operator.truth,
+    ("ConstantVariable",),
+    lambda var: var.bool(),
+)
+
 # str
 Dispatcher.register(
     str,
@@ -1261,17 +1274,4 @@ Dispatcher.register(
         x.graph,
         tracker=DummyTracker([x]),
     ),
-)
-
-# bool
-Dispatcher.register(
-    bool,
-    ("VariableBase",),
-    lambda var: var.bool(),
-)
-
-Dispatcher.register(
-    operator.truth,
-    ("VariableBase",),
-    lambda var: var.bool(),
 )

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -686,6 +686,7 @@ class SymbolicVariable(VariableBase):
                 [], paddle.int64, True, self.var_name, False, None, None
             )
         self.need_guard_value = False
+        self.graph.side_effects.record_mutable_variable(self)
 
     def to_constant(self):
         return ConstantVariable(

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -666,6 +666,7 @@ class SymbolicVariable(VariableBase):
 
     var_name_generator = NameGenerator("symint_")
     value: int | SymbolicValue
+    mutable_attrs = ["need_guard_value"]
 
     def __init__(
         self,
@@ -685,6 +686,11 @@ class SymbolicVariable(VariableBase):
                 [], paddle.int64, True, self.var_name, False, None, None
             )
         self.need_guard_value = False
+
+    def to_constant(self):
+        return ConstantVariable(
+            self.get_py_value(), self.graph, DummyTracker([self])
+        )
 
     def get_py_value(self, allow_tensor: bool = False) -> bool | int | float:
         self.need_guard_value = True

--- a/python/paddle/jit/sot/utils/__init__.py
+++ b/python/paddle/jit/sot/utils/__init__.py
@@ -32,6 +32,7 @@ from .envs import (  # noqa: F401
 )
 from .exceptions import (  # noqa: F401
     BreakGraphError,
+    DynamicShapeFallbackError,
     ExportError,
     FallbackError,
     InnerError,

--- a/python/paddle/jit/sot/utils/exceptions.py
+++ b/python/paddle/jit/sot/utils/exceptions.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import traceback
 
@@ -41,6 +42,10 @@ class FallbackError(SotErrorBase):
         self.disable_eval_frame = disable_eval_frame
 
 
+class DynamicShapeFallbackError(SotErrorBase):
+    pass
+
+
 # raise in inline function call strategy.
 class BreakGraphError(SotErrorBase):
     pass
@@ -52,6 +57,8 @@ def inner_error_default_handler(func, message_fn):
     def impl(*args, **kwargs):
         try:
             return func(*args, **kwargs)
+        except SotErrorBase as e:
+            raise e
         except Exception as e:
             message = message_fn(*args, **kwargs)
             origin_exception_message = "\n".join(

--- a/test/sot/test_trace_list_arg.py
+++ b/test/sot/test_trace_list_arg.py
@@ -62,16 +62,15 @@ class TestTraceListArg(TestCaseBase):
 
     @with_allow_dynamic_shape_guard(True)
     def test_bar_dynamic_shape(self):
-        # TODO: Fix this after implement symbolic fallback mechanism
         a = [paddle.to_tensor(1), paddle.to_tensor(2), paddle.to_tensor(3)]
         b = [paddle.to_tensor([2, 3]), paddle.to_tensor(4), paddle.to_tensor(5)]
         with test_instruction_translator_cache_context() as cache:
             self.assert_results(bar, a, 1, 1)
             self.assertEqual(cache.translate_count, 1)
             self.assert_results(bar, a, 2, 0)  # Cache hit, but break graph
-            self.assertEqual(cache.translate_count, 3)
+            self.assertEqual(cache.translate_count, 2)
             self.assert_results(bar, b, 1, 1)  # Cache hit
-            self.assertEqual(cache.translate_count, 3)
+            self.assertEqual(cache.translate_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->
完善函数调用在参数包含 SymbolicVariable 时的 dispatch 机制，找不到 SymbolicVariable 对应的handler时，fallback到ConstantVariable 的。