### PR TITLE
fix to_tensor bug

### DIFF
--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -398,7 +398,7 @@ void SetTensorFromPyArrayT(
       self->ResetHolderWithType(holder, framework::TransToPhiDataType(type));
     } else {
       auto dst = self->mutable_data<T>(place);
-      std::memcpy(dst, array.data(), array.nbytes());
+      std::memcpy(dst, array.data(), array.size()*sizeof(T));
     }
   } else if (paddle::platform::is_xpu_place(place)) {
 #ifdef PADDLE_WITH_XPU
@@ -427,10 +427,10 @@ void SetTensorFromPyArrayT(
       // IPU does not store Tensor data, Tensor will be created on CPU
       if (!self->initialized()) {
         auto dst = self->mutable_data<T>(place);
-        std::memcpy(dst, array.data(), array.nbytes());
+        std::memcpy(dst, array.data(), array.size()*sizeof(T));
       } else {
         auto dst = self->mutable_data<T>(self->place());
-        std::memcpy(dst, array.data(), array.nbytes());
+        std::memcpy(dst, array.data(), array.size()*sizeof(T));
       }
     }
 #else
@@ -473,7 +473,7 @@ void SetTensorFromPyArrayT(
 
     } else if (paddle::platform::is_cuda_pinned_place(place)) {
       auto dst = self->mutable_data<T>(place);
-      std::memcpy(dst, array.data(), array.nbytes());
+      std::memcpy(dst, array.data(), array.size()*sizeof(T));
     } else {
       PADDLE_THROW(platform::errors::InvalidArgument(
           "Incompatible place type: Tensor.set() supports "


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复paddle2.6+numpy2.0，paddle.to_tensor输出全是0的错误