### PR TITLE
[OneDNN][PIR] Remove concat in bf16 pass for googlenet error

### DIFF
--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_pass.cc
@@ -2047,7 +2047,6 @@ class CpuBfloat16Pass : public pir::PatternRewritePass {
 
     // op with two inputs and one output
     const std::vector<std::string> bfloat16_ops_two_one{
-        paddle::onednn::dialect::ConcatOp::name(),
         paddle::onednn::dialect::Conv2dOp::name(),
         paddle::onednn::dialect::MatmulOp::name(),
         paddle::onednn::dialect::Pool2dOp::name(),

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
@@ -47,7 +47,6 @@ class OneDNNBf16PlacementPattern : public pir::RewritePattern {
         !op->isa<paddle::onednn::dialect::Cast_Op>() &&
         !op->isa<paddle::onednn::dialect::ClipOp>() &&
         !op->isa<paddle::onednn::dialect::Clip_Op>() &&
-        !op->isa<paddle::onednn::dialect::ConcatOp>() &&
         !op->isa<paddle::onednn::dialect::Conv2dOp>() &&
         !op->isa<paddle::onednn::dialect::Conv2dTransposeOp>() &&
         !op->isa<paddle::onednn::dialect::Conv2dTransposeBiasOp>() &&
@@ -148,7 +147,6 @@ class RemoveOrphanedPattern : public pir::RewritePattern {
         !op->isa<paddle::onednn::dialect::Cast_Op>() &&
         !op->isa<paddle::onednn::dialect::ClipOp>() &&
         !op->isa<paddle::onednn::dialect::Clip_Op>() &&
-        !op->isa<paddle::onednn::dialect::ConcatOp>() &&
         !op->isa<paddle::onednn::dialect::Conv2dOp>() &&
         !op->isa<paddle::onednn::dialect::Conv2dTransposeOp>() &&
         !op->isa<paddle::onednn::dialect::Conv2dTransposeBiasOp>() &&
@@ -298,7 +296,6 @@ class RemoveUnsupportedOpPattern : public pir::RewritePattern {
         !op->isa<paddle::onednn::dialect::Cast_Op>() &&
         !op->isa<paddle::onednn::dialect::ClipOp>() &&
         !op->isa<paddle::onednn::dialect::Clip_Op>() &&
-        !op->isa<paddle::onednn::dialect::ConcatOp>() &&
         !op->isa<paddle::onednn::dialect::Conv2dOp>() &&
         !op->isa<paddle::onednn::dialect::Conv2dTransposeOp>() &&
         !op->isa<paddle::onednn::dialect::Conv2dTransposeBiasOp>() &&

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_type_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_type_placement_pass.cc
@@ -60,7 +60,6 @@ class CpuBfloat16TypePattern : public pir::RewritePattern {
         !op->isa<paddle::onednn::dialect::Cast_Op>() &&
         !op->isa<paddle::onednn::dialect::ClipOp>() &&
         !op->isa<paddle::onednn::dialect::Clip_Op>() &&
-        !op->isa<paddle::onednn::dialect::ConcatOp>() &&
         !op->isa<paddle::onednn::dialect::Conv2dOp>() &&
         !op->isa<paddle::onednn::dialect::Conv2dTransposeOp>() &&
         !op->isa<paddle::onednn::dialect::Conv2dTransposeBiasOp>() &&


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Inference

### PR Types
Bug fixes


### Description
Remove concat in bf16 pass for googlenet error. We found concat op has two input x and axis, but x is not a DenseTensorType like others, it's a vector of DenseTensorType, which will cause error since Quantize limit input must be a DenseTensorType. We have temporarily remove concat in bf16. In the future, we need to figure out how to implement bf16 on Concat, how to determine the number of DenseTensorType from an input node of x, and then split it into multiple Quantize.
