### PR TITLE
Fix `paddle.diff` when `n!=1` and has `prepend` or `append` 易用性提升

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6306,6 +6306,16 @@ def diff(
             Tensor(shape=[5], dtype=int64, place=Place(cpu), stop_gradient=True,
             [ 3,  1, -3,  5,  2])
 
+            >>> out = paddle.diff(x, n=2, append=y)
+            >>> out
+            Tensor(shape=[5], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [ -2, -4,  8, -3])
+
+            >>> out = paddle.diff(x, n=3, append=y)
+            >>> out
+            Tensor(shape=[5], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [ -2,  12, -11])
+
             >>> z = paddle.to_tensor([[1, 2, 3], [4, 5, 6]])
             >>> out = paddle.diff(z, axis=0)
             >>> out
@@ -6450,7 +6460,7 @@ def diff(
     if n > 1:
         for _ in range(n - 1):
             out = _diff_handler(
-                out, n=1, axis=axis, prepend=prepend, append=append, name=name
+                out, n=1, axis=axis, prepend=None, append=None, name=name
             )
     return out
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6308,13 +6308,13 @@ def diff(
 
             >>> out = paddle.diff(x, n=2, append=y)
             >>> out
-            Tensor(shape=[5], dtype=int64, place=Place(cpu), stop_gradient=True,
-            [ -2, -4,  8, -3])
+            Tensor(shape=[4], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [-2, -4,  8, -3])
 
             >>> out = paddle.diff(x, n=3, append=y)
             >>> out
-            Tensor(shape=[5], dtype=int64, place=Place(cpu), stop_gradient=True,
-            [ -2,  12, -11])
+            Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [-2 ,  12, -11])
 
             >>> z = paddle.to_tensor([[1, 2, 3], [4, 5, 6]])
             >>> out = paddle.diff(z, axis=0)

--- a/test/legacy_test/test_diff_op.py
+++ b/test/legacy_test/test_diff_op.py
@@ -180,15 +180,6 @@ class TestDiffOpNAxis(TestDiffOp):
         self.append = None
 
 
-class TestDiffOpNAxis1(TestDiffOp):
-    def set_args(self):
-        self.input = np.array([[1, 4, 5, 2], [1, 5, 4, 2]]).astype('float32')
-        self.n = 2
-        self.axis = 0
-        self.prepend = None
-        self.append = None
-
-
 class TestDiffOpNPrepend(TestDiffOp):
     def set_args(self):
         self.input = np.array([[1, 4, 5, 2], [1, 5, 4, 2]]).astype('float32')

--- a/test/legacy_test/test_diff_op.py
+++ b/test/legacy_test/test_diff_op.py
@@ -171,6 +171,86 @@ class TestDiffOpN(TestDiffOp):
         self.append = None
 
 
+class TestDiffOpNAxis(TestDiffOp):
+    def set_args(self):
+        self.input = np.array([[1, 4, 5, 2], [1, 5, 4, 2]]).astype('float32')
+        self.n = 2
+        self.axis = 1
+        self.prepend = None
+        self.append = None
+
+
+class TestDiffOpNAxis1(TestDiffOp):
+    def set_args(self):
+        self.input = np.array([[1, 4, 5, 2], [1, 5, 4, 2]]).astype('float32')
+        self.n = 2
+        self.axis = 0
+        self.prepend = None
+        self.append = None
+
+
+class TestDiffOpNPrepend(TestDiffOp):
+    def set_args(self):
+        self.input = np.array([[1, 4, 5, 2], [1, 5, 4, 2]]).astype('float32')
+        self.n = 2
+        self.axis = -1
+        self.prepend = np.array([[2, 3, 4, 11], [1, 3, 5, 10]]).astype(
+            'float32'
+        )
+        self.append = None
+
+
+class TestDiffOpNAppend(TestDiffOp):
+    def set_args(self):
+        self.input = np.array([[1, 4, 5, 2], [1, 5, 4, 2]]).astype('float32')
+        self.n = 2
+        self.axis = -1
+        self.prepend = None
+        self.append = np.array([[2, 3, 4, 11], [1, 3, 5, 10]]).astype('float32')
+
+
+class TestDiffOpNPreAppend(TestDiffOp):
+    def set_args(self):
+        self.input = np.array([[1, 4, 5, 2], [1, 5, 4, 2]]).astype('float32')
+        self.n = 2
+        self.axis = -1
+        self.prepend = np.array([[2, 3, 4, 11], [1, 3, 5, 10]]).astype(
+            'float32'
+        )
+        self.append = np.array([[2, 3, 4, 11], [1, 3, 5, 10]]).astype('float32')
+
+
+class TestDiffOpNPrependAxis(TestDiffOp):
+    def set_args(self):
+        self.input = np.array([[1, 4, 5, 2], [1, 5, 4, 2]]).astype('float32')
+        self.n = 2
+        self.axis = 0
+        self.prepend = np.array([[2, 3, 4, 11], [1, 3, 5, 10]]).astype(
+            'float32'
+        )
+        self.append = None
+
+
+class TestDiffOpNAppendAxis(TestDiffOp):
+    def set_args(self):
+        self.input = np.array([[1, 4, 5, 2], [1, 5, 4, 2]]).astype('float32')
+        self.n = 2
+        self.axis = 0
+        self.prepend = None
+        self.append = np.array([[2, 3, 4, 11], [1, 3, 5, 10]]).astype('float32')
+
+
+class TestDiffOpNPreAppendAxis(TestDiffOp):
+    def set_args(self):
+        self.input = np.array([[1, 4, 5, 2], [1, 5, 4, 2]]).astype('float32')
+        self.n = 2
+        self.axis = 0
+        self.prepend = np.array([[2, 3, 4, 11], [1, 3, 5, 10]]).astype(
+            'float32'
+        )
+        self.append = np.array([[2, 3, 4, 11], [1, 3, 5, 10]]).astype('float32')
+
+
 class TestDiffOpAxis(TestDiffOp):
     def set_args(self):
         self.input = np.array([[1, 4, 5, 2], [1, 5, 4, 2]]).astype('float32')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复当 `paddle.diff` 设置 `n!=1` 且传入 `prepend` 或 `append` 参数时，结果与 pytorch 及 numpy 不一致。