### PR TITLE
rename CodeGenCudaHost to CodeGenGpuHost

### DIFF
--- a/paddle/cinn/backends/codegen_cuda_host.cc
+++ b/paddle/cinn/backends/codegen_cuda_host.cc
@@ -32,7 +32,7 @@ using cinn::common::float16;
 
 const int kArgsArrayMaxLen = 20;
 
-llvm::Value* CodeGenCudaHost::LowerGPUKernelLauncher(
+llvm::Value* CodeGenGpuHost::LowerGPUKernelLauncher(
     const ir::_LoweredFunc_* func) {
   auto body = func->body;
   auto* call_ir = body.As<ir::Call>();
@@ -202,7 +202,7 @@ llvm::Value* CodeGenCudaHost::LowerGPUKernelLauncher(
   return function;
 }
 
-llvm::Value* CodeGenCudaHost::LowerGPUKernelCall(const ir::Call* call_ir) {
+llvm::Value* CodeGenGpuHost::LowerGPUKernelCall(const ir::Call* call_ir) {
   std::vector<llvm::Value*> ll_function_args;
   std::transform(f_->arg_begin(),
                  f_->arg_end(),

--- a/paddle/cinn/backends/codegen_cuda_host.h
+++ b/paddle/cinn/backends/codegen_cuda_host.h
@@ -24,14 +24,14 @@ namespace cinn {
 namespace backends {
 
 /**
- * CodeGenCudaHost takes a CINN Module with CUDA host functions and output a
+ * CodeGenGpuHost takes a CINN Module with CUDA/HIP host functions and output a
  * LLVM module.
  */
-class CodeGenCudaHost : public CodeGenHost {
+class CodeGenGpuHost : public CodeGenHost {
  public:
-  explicit CodeGenCudaHost(llvm::Module *m,
-                           llvm::IRBuilder<> *b,
-                           const std::shared_ptr<SymbolTable> &vars = nullptr)
+  explicit CodeGenGpuHost(llvm::Module *m,
+                          llvm::IRBuilder<> *b,
+                          const std::shared_ptr<SymbolTable> &vars = nullptr)
       : CodeGenHost(m, b, vars) {}
 
   // TODO(Hongqing-work): remove this after we clear some old codes.
@@ -65,9 +65,9 @@ class CodeGenCudaHost : public CodeGenHost {
 
  private:
   /**
-   * Lower a CUDA kernel launcher.
+   * Lower a CUDA/HIP kernel launcher.
    *
-   * We launch a CUDA kernel in the following way:
+   * We launch a CUDA/HIP kernel in the following way:
    *
    * 1. a GPU function (called fn) will compiled to PTX and lower by CUDA driver
    * to a function pointer, which we store as a `void*` type global variable

--- a/paddle/cinn/backends/compiler.cc
+++ b/paddle/cinn/backends/compiler.cc
@@ -423,7 +423,7 @@ void Compiler::CompileCudaModule(const Module& module,
     std::string kernel_fn_name = fn->name;
     device_fn_name_.emplace_back(kernel_fn_name);
   }
-  engine_->Link<CodeGenCudaHost>(host_module);
+  engine_->Link<CodeGenGpuHost>(host_module);
 
 #else
   CINN_NOT_IMPLEMENTED
@@ -460,7 +460,7 @@ void Compiler::CompileHipModule(const Module& module, const std::string& code) {
     std::string kernel_fn_name = fn->name;
     device_fn_name_.emplace_back(kernel_fn_name);
   }
-  engine_->Link<CodeGenCUDA_Host>(host_module);
+  engine_->Link<CodeGenGpuHost>(host_module);
 #else
   CINN_NOT_IMPLEMENTED
 #endif

--- a/paddle/cinn/backends/llvm/execution_engine.cc
+++ b/paddle/cinn/backends/llvm/execution_engine.cc
@@ -278,7 +278,7 @@ void ExecutionEngine::RegisterGlobalRuntimeSymbols() {
 
 template void ExecutionEngine::Link<CodeGenLLVM>(const ir::Module &module);
 template void ExecutionEngine::Link<CodeGenX86>(const ir::Module &module);
-template void ExecutionEngine::Link<CodeGenCudaHost>(const ir::Module &module);
+template void ExecutionEngine::Link<CodeGenGpuHost>(const ir::Module &module);
 template void ExecutionEngine::Link<CodeGenSwitchHost>(
     const ir::Module &module);
 

--- a/paddle/cinn/backends/llvm/simple_jit.cc
+++ b/paddle/cinn/backends/llvm/simple_jit.cc
@@ -141,8 +141,7 @@ void SimpleJIT::Link(ir::Module module, bool optimize) {
 }
 
 template void SimpleJIT::Link<CodeGenLLVM>(ir::Module module, bool optimize);
-template void SimpleJIT::Link<CodeGenCudaHost>(ir::Module module,
-                                               bool optimize);
+template void SimpleJIT::Link<CodeGenGpuHost>(ir::Module module, bool optimize);
 
 }  // namespace backends
 

--- a/paddle/cinn/common/cuda_test_helper.cc
+++ b/paddle/cinn/common/cuda_test_helper.cc
@@ -73,7 +73,7 @@ void CudaModuleTester::Compile(const ir::Module& m,
   jit_ = backends::SimpleJIT::Create();
 
   // compile host module
-  jit_->Link<backends::CodeGenCudaHost>(host_module, false);
+  jit_->Link<backends::CodeGenGpuHost>(host_module, false);
 }
 
 void* CudaModuleTester::CreateDeviceBuffer(const cinn_buffer_t* host_buffer) {


### PR DESCRIPTION
### PR Category
CINN


### PR Types
Improvements

### Description
重命名CodeGenCudaHost为CodeGenGpuHost，该类支持cuda/hip后端。

Pcard-67164

