### PR TITLE
[CINN] Implement FusionIters for multi-downstream fusion

### DIFF
--- a/paddle/cinn/operator_fusion/graph_transformer/operation.h
+++ b/paddle/cinn/operator_fusion/graph_transformer/operation.h
@@ -44,6 +44,8 @@ struct MergeTrivialPatternOperation {
 
       if (can_fuse) {
         auto merged_node = graph->MergeNode(upstream, downstream, MergePattern);
+        merged_node->set_fusion_iters(
+            FuseItersForTrivialSink(upstream, downstream));
         graph->RemoveNode(downstream);
         VLOG(4) << "Spliting trivial pattern: \nupstream "
                 << upstream->DebugStr() << "\ndownstream "

--- a/paddle/cinn/operator_fusion/graph_transformer/operation.h
+++ b/paddle/cinn/operator_fusion/graph_transformer/operation.h
@@ -45,7 +45,7 @@ struct MergeTrivialPatternOperation {
       if (can_fuse) {
         auto merged_node = graph->MergeNode(upstream, downstream, MergePattern);
         merged_node->set_fusion_iters(
-            FuseItersForTrivialSink(upstream, downstream));
+            SingleDownstreamItersFusion(upstream, downstream, true));
         graph->RemoveNode(downstream);
         VLOG(4) << "Spliting trivial pattern: \nupstream "
                 << upstream->DebugStr() << "\ndownstream "
@@ -73,6 +73,8 @@ struct MergeReduceTreeOperation {
             node->downstream().size()));
     auto downstream = node->downstream().at(0);
     auto merged_node = graph->MergeNode(node, downstream, MergePattern);
+    merged_node->set_fusion_iters(
+        SingleDownstreamItersFusion(node, downstream, true));
     graph->RemoveNode(downstream);
     graph->RemoveNode(node);
     VLOG(4) << "MergeReduceTreeOperation: \nupstream " << node->DebugStr()
@@ -105,6 +107,8 @@ struct MergeReduceTreeAndTrivialOperation {
     };
     PatternNodePtr merged_node =
         graph->MergeNode(node, downstream, merge_pattern_fn);
+    merged_node->set_fusion_iters(
+        SingleDownstreamItersFusion(node, downstream, false));
     graph->RemoveNode(downstream);
     graph->RemoveNode(node);
     VLOG(4) << "MergeReduceTreeAndTrivialOperation: \nupstream "

--- a/paddle/cinn/operator_fusion/pattern_graph.h
+++ b/paddle/cinn/operator_fusion/pattern_graph.h
@@ -48,8 +48,8 @@ class PatternGraph {
   PatternNodePtr MergeNode(const PatternNodePtr& upstream,
                            const PatternNodePtr& downstream,
                            MergePatternFn merge_pattern_fn);
-  std::vector<PatternNodePtr> SortByTopoOrder();
-  std::vector<PatternNodePtr> SortByReverseTopoOrder();
+  std::vector<PatternNodePtr> SortByTopoOrder() const;
+  std::vector<PatternNodePtr> SortByReverseTopoOrder() const;
 
   const PatternNodePtrSet& all_pattern_nodes() const {
     return all_pattern_nodes_;

--- a/paddle/cinn/operator_fusion/pattern_node.h
+++ b/paddle/cinn/operator_fusion/pattern_node.h
@@ -16,6 +16,7 @@
 
 #include "paddle/cinn/operator_fusion/pattern.h"
 #include "paddle/cinn/operator_fusion/pattern_fuser.h"
+#include "paddle/cinn/operator_fusion/pir_graph_analyzing/shardable_axes_base.h"
 #include "paddle/cinn/operator_fusion/utils.h"
 
 namespace cinn::fusion {
@@ -25,8 +26,11 @@ struct PatternNode {
   using MergePatternFn =
       std::function<StmtPattern(const StmtPattern&, const StmtPattern&)>;
 
-  explicit PatternNode(const PatternContent& content)
-      : sink_op_(content.op), stmt_pattern_(ConvertToStmtPattern(content)) {}
+  explicit PatternNode(const PatternContent& content,
+                       const ShardableAxesSignature& axes)
+      : sink_op_(content.op),
+        stmt_pattern_(ConvertToStmtPattern(content)),
+        axes_(axes) {}
 
   explicit PatternNode(PatternNodePtr fused_up_node,
                        PatternNodePtr fused_down_node,
@@ -47,14 +51,16 @@ struct PatternNode {
   std::string DebugStr() const {
     std::stringstream ss;
     ss << "Node: " << this << ", Pattern: " << GetPatternName(stmt_pattern())
-       << ", ID: " << GetPatternId(stmt_pattern()) << "\n    -u>:  ";
+       << ", ID: " << GetPatternId(stmt_pattern());
+    ss << "\n    -u>:  ";
     for (const auto& u : upstream_) {
-      ss << u << ", ";
+      ss << GetPatternId(u->stmt_pattern()) << "(" << u << "), ";
     }
     ss << "\n    <d-:  ";
     for (const auto& d : downstream_) {
-      ss << d << ", ";
+      ss << GetPatternId(d->stmt_pattern()) << "(" << d << "), ";
     }
+    ss << "\n" << axes_.DebugStr();
     pir::IrPrinter printer(ss);
     if (GetPatternName(stmt_pattern_) == AnchorPattern::name()) {
       ss << "\n anchor: ";
@@ -62,9 +68,8 @@ struct PatternNode {
           std::get<AnchorPattern>(stmt_pattern_).anchor().defining_op();
       printer.PrintOperation(const_cast<pir::Operation*>(anchor_op));
     }
-    ss << "\nOps in pattern: \n################" << std::endl;
+    ss << "\nOps in pattern:" << std::endl;
     ss << OpsDebugStr(GetOpsInPattern(this->stmt_pattern()));
-    ss << "################" << std::endl;
     return ss.str();
   }
 
@@ -99,6 +104,8 @@ struct PatternNode {
 
   std::vector<PatternNodePtr> upstream_;
   std::vector<PatternNodePtr> downstream_;
+
+  ShardableAxesSignature axes_;
 };
 
 using PatternNodePtr = std::shared_ptr<PatternNode>;

--- a/paddle/cinn/operator_fusion/pattern_node.h
+++ b/paddle/cinn/operator_fusion/pattern_node.h
@@ -16,7 +16,7 @@
 
 #include "paddle/cinn/operator_fusion/pattern.h"
 #include "paddle/cinn/operator_fusion/pattern_fuser.h"
-#include "paddle/cinn/operator_fusion/pir_graph_analyzing/shardable_axes_base.h"
+#include "paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.h"
 #include "paddle/cinn/operator_fusion/utils.h"
 
 namespace cinn::fusion {
@@ -30,7 +30,7 @@ struct PatternNode {
                        const ShardableAxesSignature& axes)
       : sink_op_(content.op),
         stmt_pattern_(ConvertToStmtPattern(content)),
-        axes_(axes) {}
+        fusion_iters_(FusionItersSignature(content.op, axes)) {}
 
   explicit PatternNode(PatternNodePtr fused_up_node,
                        PatternNodePtr fused_down_node,
@@ -60,7 +60,7 @@ struct PatternNode {
     for (const auto& d : downstream_) {
       ss << GetPatternId(d->stmt_pattern()) << "(" << d << "), ";
     }
-    ss << "\n" << axes_.DebugStr();
+    ss << "\n" << fusion_iters_.DebugStr();
     pir::IrPrinter printer(ss);
     if (GetPatternName(stmt_pattern_) == AnchorPattern::name()) {
       ss << "\n anchor: ";
@@ -97,6 +97,11 @@ struct PatternNode {
     GetFusionTracker(stmt_pattern_)->append(instr);
   }
   void UpdateTracker() { PatternUpdateTracker(stmt_pattern_); }
+  FusionItersSignature fusion_iters() const { return fusion_iters_; }
+  void set_fusion_iters(const FusionItersSignature& fusion_iters) {
+    fusion_iters_ = fusion_iters;
+    VLOG(4) << "set_fusion_iters";
+  }
 
  private:
   StmtPattern stmt_pattern_;
@@ -105,7 +110,7 @@ struct PatternNode {
   std::vector<PatternNodePtr> upstream_;
   std::vector<PatternNodePtr> downstream_;
 
-  ShardableAxesSignature axes_;
+  FusionItersSignature fusion_iters_;
 };
 
 using PatternNodePtr = std::shared_ptr<PatternNode>;

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/CMakeLists.txt
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/CMakeLists.txt
@@ -1,2 +1,2 @@
 gather_srcs(fusion_graph_analyzing SRCS shardable_axes_base.cc dim_relation.cc
-            anchor_transform.cc)
+            anchor_transform.cc fusion_iters.cc)

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.cc
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.cc
@@ -66,9 +66,6 @@ FusionItersSignature SingleDownstreamItersFusion(PatternNodePtr upstream,
                                                  PatternNodePtr downstream,
                                                  bool is_sink) {
   VLOG(4) << "[ItersFusion] Start SingleDownstreamItersFusion.";
-  VLOG(4) << "[ItersFusion] Upstream " << upstream->fusion_iters().DebugStr();
-  VLOG(4) << "[ItersFusion] Downstream "
-          << downstream->fusion_iters().DebugStr();
   auto upstream_iters = upstream->fusion_iters();
   auto downstream_iters = downstream->fusion_iters();
   PADDLE_ENFORCE_EQ(upstream_iters.output_iters.size(),
@@ -94,7 +91,6 @@ FusionItersSignature SingleDownstreamItersFusion(PatternNodePtr upstream,
       fused_iters.input_values.push_back(downstream_iters.input_values[i]);
     }
   }
-  VLOG(4) << "[ItersFusion] Merged " << fused_iters.DebugStr();
   VLOG(4) << "[ItersFusion] End SingleDownstreamItersFusion.";
   return fused_iters;
 }

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.cc
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.cc
@@ -1,0 +1,101 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.h"
+#include "paddle/cinn/operator_fusion/pattern_node.h"
+
+namespace cinn::fusion {
+
+FusionItersSignature::FusionItersSignature(pir::Operation* op,
+                                           const ShardableAxesSignature& axes) {
+  PADDLE_ENFORCE_EQ(
+      axes.inputs.size(),
+      op->num_operands(),
+      ::common::errors::InvalidArgument("The number of input_iters should be "
+                                        "equal to the number of operands."));
+  PADDLE_ENFORCE_EQ(
+      axes.outputs.size(),
+      op->num_results(),
+      ::common::errors::InvalidArgument("The number of output_iters should be "
+                                        "equal to the number of results."));
+  loop_iters = axes.loop.axis_names;
+  for (const auto& iters : axes.inputs) {
+    input_iters.push_back(iters.axis_names);
+  }
+  for (const auto& iters : axes.outputs) {
+    output_iters.push_back(iters.axis_names);
+  }
+  input_values = op->operands_source();
+  output_values = op->results();
+}
+
+std::string PrintFusionIters(const FusionIters& iters) {
+  std::stringstream ss;
+  ss << "[ ";
+  for (const auto& iter : iters) {
+    ss << iter << ",";
+  }
+  return ss.str().substr(0, ss.str().size() - 1) + " ]";
+}
+
+std::string FusionItersSignature::DebugStr() const {
+  std::stringstream ss;
+  ss << "FusionIters Signature:";
+  ss << "\n    loop: " << PrintFusionIters(loop_iters);
+  for (size_t i = 0; i < input_iters.size(); ++i) {
+    ss << "\n    input " << i << ": " << PrintFusionIters(input_iters[i]);
+  }
+  for (size_t i = 0; i < output_iters.size(); ++i) {
+    ss << "\n    output " << i << ": " << PrintFusionIters(output_iters[i]);
+  }
+  return ss.str();
+}
+
+FusionItersSignature FuseItersForTrivialSink(PatternNodePtr upstream,
+                                             PatternNodePtr downstream) {
+  VLOG(4) << "[ItersFusion] Start FuseItersForTrivialSink.";
+  PADDLE_ENFORCE_EQ(GetPatternName(upstream->stmt_pattern()),
+                    TrivialPattern::name(),
+                    ::common::errors::InvalidArgument(
+                        "The upstream pattern should be TrivialPattern."));
+  auto upstream_iters = upstream->fusion_iters();
+  auto downstream_iters = downstream->fusion_iters();
+  PADDLE_ENFORCE_EQ(
+      upstream_iters.output_iters.size(),
+      1,
+      ::common::errors::InvalidArgument(
+          "The number of upstream outputs in TrivialSink should be 1."));
+
+  FusionItersSignature fused_iters;
+  fused_iters.loop_iters = downstream_iters.loop_iters;
+  fused_iters.output_values = downstream_iters.output_values;
+  fused_iters.output_iters = downstream_iters.output_iters;
+
+  const auto& upstream_output_value = upstream_iters.output_values[0];
+  for (size_t i = 0; i < downstream_iters.input_values.size(); ++i) {
+    if (downstream_iters.input_values[i] == upstream_output_value) {
+      for (size_t j = 0; j < upstream_iters.input_iters.size(); ++j) {
+        fused_iters.input_iters.push_back(upstream_iters.input_iters[j]);
+        fused_iters.input_values.push_back(upstream_iters.input_values[j]);
+      }
+    } else {
+      fused_iters.input_iters.push_back(downstream_iters.input_iters[i]);
+      fused_iters.input_values.push_back(downstream_iters.input_values[i]);
+    }
+  }
+  VLOG(4) << "[ItersFusion] End FuseItersForTrivialSink.";
+  return fused_iters;
+}
+
+}  // namespace cinn::fusion

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.h
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/cinn/operator_fusion/pir_graph_analyzing/shardable_axes_base.h"
+
+namespace cinn::fusion {
+
+using FusionIters = std::vector<std::string>;
+struct FusionItersSignature {
+  FusionItersSignature() = default;
+  FusionItersSignature(pir::Operation* op, const ShardableAxesSignature& axes);
+  std::string DebugStr() const;
+
+  FusionIters loop_iters = {};
+  std::vector<FusionIters> input_iters = {};
+  std::vector<FusionIters> output_iters = {};
+  std::vector<pir::Value> input_values = {};
+  std::vector<pir::Value> output_values = {};
+};
+
+class PatternNode;
+using PatternNodePtr = std::shared_ptr<PatternNode>;
+FusionItersSignature FuseItersForTrivialSink(PatternNodePtr upstream,
+                                             PatternNodePtr downstream);
+
+}  // namespace cinn::fusion

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.h
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.h
@@ -33,7 +33,8 @@ struct FusionItersSignature {
 
 class PatternNode;
 using PatternNodePtr = std::shared_ptr<PatternNode>;
-FusionItersSignature FuseItersForTrivialSink(PatternNodePtr upstream,
-                                             PatternNodePtr downstream);
+FusionItersSignature SingleDownstreamItersFusion(PatternNodePtr upstream,
+                                                 PatternNodePtr downstream,
+                                                 bool is_sink);
 
 }  // namespace cinn::fusion

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/shardable_axes_base.cc
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/shardable_axes_base.cc
@@ -453,7 +453,7 @@ ShardableAxesInfoManager::ShardableAxesInfoManager(
             });
 
   for (size_t i = 0; i < sorted_roots.size(); ++i) {
-    normalized_root_name_map_[sorted_roots[i]] = "i_" + std::to_string(i);
+    normalized_root_name_map_[sorted_roots[i]] = "I" + std::to_string(i);
   }
 
   VLOG(4) << NameUnionDebugStr();

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/shardable_axes_base.h
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/shardable_axes_base.h
@@ -27,6 +27,7 @@ struct ShardableAxes {
 };
 
 struct ShardableAxesSignature {
+  ShardableAxes loop;
   std::vector<ShardableAxes> inputs;
   std::vector<ShardableAxes> outputs;
   std::string DebugStr() const;

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/shardable_axes_base.h
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/shardable_axes_base.h
@@ -39,18 +39,23 @@ struct ShardableAxesInfoManager {
   ShardableAxesSignature GetSignature(pir::Operation* op);
   ShardableAxesSignature GetModifiedSignature(pir::Operation* op);
   ShardableAxes GetAxes(pir::Value value);
-  ShardableAxesSignature CreateShardableSignature(pir::Operation* op);
-  ShardableAxes ReplaceShardableAxesWithRootName(const ShardableAxes& axes);
   static std::string GetUniqueName();
   std::string NameUnionDebugStr() const;
 
  private:
+  ShardableAxesSignature CreateShardableSignature(pir::Operation* op);
+  ShardableAxes ReplaceShardableAxesWithRootName(const ShardableAxes& axes,
+                                                 bool normalize_name = false);
+
   const std::vector<pir::Operation*>& ops_;
   pir::ShapeConstraintIRAnalysis* shape_analysis_;
 
   std::unordered_map<pir::Operation*, ShardableAxesSignature> op_signature_map_;
   std::unordered_map<pir::Value, ShardableAxes> value_axes_map_;
   std::unordered_map<std::string, std::string> name_union_;
+
+  std::unordered_map<std::string, std::vector<std::string>> root_to_sons_;
+  std::unordered_map<std::string, std::string> normalized_root_name_map_;
 };
 
 }  // namespace cinn::fusion

--- a/paddle/cinn/operator_fusion/utils.cc
+++ b/paddle/cinn/operator_fusion/utils.cc
@@ -18,6 +18,116 @@
 
 namespace cinn::fusion {
 
+std::vector<int64_t> GetInt64ArrayAttributeData(
+    const ::pir::Attribute& attr_val) {
+  PADDLE_ENFORCE_EQ(attr_val.isa<::pir::ArrayAttribute>(),
+                    true,
+                    ::common::errors::InvalidArgument(
+                        "The input attribute should be an array."));
+  const auto& array_attr = attr_val.dyn_cast<::pir::ArrayAttribute>();
+  std::vector<int64_t> data;
+  for (int i = 0; i < array_attr.size(); ++i) {
+    const auto& int64_attr = array_attr.at(i).dyn_cast<::pir::Int64Attribute>();
+    PADDLE_ENFORCE_NOT_NULL(int64_attr,
+                            ::common::errors::InvalidArgument(
+                                "The array element should be int64 type."));
+    data.push_back(int64_attr.data());
+  }
+  return data;
+}
+
+std::vector<int32_t> GetInt32ArrayAttributeData(
+    const ::pir::Attribute& attr_val) {
+  PADDLE_ENFORCE_EQ(attr_val.isa<::pir::ArrayAttribute>(),
+                    true,
+                    ::common::errors::InvalidArgument(
+                        "The input attribute should be an array."));
+  const auto& array_attr = attr_val.dyn_cast<::pir::ArrayAttribute>();
+  std::vector<int32_t> data;
+  for (int i = 0; i < array_attr.size(); ++i) {
+    const auto& int32_attr = array_attr.at(i).dyn_cast<::pir::Int32Attribute>();
+    PADDLE_ENFORCE_NOT_NULL(int32_attr,
+                            ::common::errors::InvalidArgument(
+                                "The array element should be int32 type."));
+    data.push_back(int32_attr.data());
+  }
+  return data;
+}
+
+std::vector<int64_t> GetReduceAxisIdx(pir::Operation* reduce_op) {
+  const size_t input_rank = GetCompitableRank(reduce_op->operand_source(0));
+  const auto& attr_val = reduce_op->attributes().at("axis");
+  PADDLE_ENFORCE_EQ(attr_val.isa<::pir::ArrayAttribute>(),
+                    true,
+                    ::common::errors::InvalidArgument(
+                        "The axis attribute should be an array."));
+  const auto& axis_attr = attr_val.dyn_cast<::pir::ArrayAttribute>();
+  if (axis_attr.empty()) {
+    // dim: [] means reduce_all.
+    std::vector<int64_t> all_axis;
+    for (int i = 0; i < input_rank; ++i) {
+      all_axis.push_back(i);
+    }
+    return all_axis;
+  }
+  std::vector<int64_t> reduce_axis_idx;
+  for (int i = 0; i < axis_attr.size(); ++i) {
+    int64_t axis = axis_attr.at(i).dyn_cast<::pir::Int64Attribute>().data();
+    if (axis < 0) {
+      axis += input_rank;
+    }
+    PADDLE_ENFORCE_GE(
+        axis,
+        0,
+        ::common::errors::InvalidArgument(
+            "The 'axis' must be greater than or equal to 0, but received %d.",
+            axis));
+
+    PADDLE_ENFORCE_LT(axis,
+                      input_rank,
+                      ::common::errors::InvalidArgument(
+                          "The 'axis' must be less than 'input_rank', but "
+                          "received axis = %d and input_rank = %d.",
+                          axis,
+                          input_rank));
+
+    reduce_axis_idx.push_back(axis);
+  }
+  VLOG(4) << "GetReduceAxisIdx: " << utils::Join(reduce_axis_idx, ",");
+  return reduce_axis_idx;
+}
+
+bool GetReduceOpKeepDims(pir::Operation* reduce_op) {
+  const auto& attr_val = reduce_op->attributes().at("keepdim");
+  PADDLE_ENFORCE_EQ(attr_val.isa<::pir::BoolAttribute>(),
+                    true,
+                    ::common::errors::InvalidArgument(
+                        "The keepdim attribute should be a bool."));
+  return attr_val.dyn_cast<::pir::BoolAttribute>().data();
+}
+
+std::pair<std::vector<int64_t>, bool> GetSliceAxis(pir::Operation* slice_op) {
+  std::vector<int64_t> slice_axis =
+      GetInt64ArrayAttributeData(slice_op->attributes().at("axes"));
+  std::vector<int64_t> decrease_axis =
+      GetInt64ArrayAttributeData(slice_op->attributes().at("decrease_axis"));
+  PADDLE_ENFORCE_EQ(slice_axis.empty(),
+                    false,
+                    ::common::errors::InvalidArgument(
+                        "The axis attribute should not be empty."));
+
+  bool keepdim = true;
+  if (!decrease_axis.empty()) {
+    PADDLE_ENFORCE_EQ(
+        decrease_axis,
+        slice_axis,
+        ::common::errors::InvalidArgument(
+            "The size of decrease axis should be equal to the size of axis."));
+    keepdim = false;
+  }
+  return std::make_pair(slice_axis, keepdim);
+}
+
 std::optional<std::pair<pir::Value, pir::Value>> GetBroadcastOpInputOuputValue(
     pir::Operation* op) {
   auto* mut_op = const_cast<pir::Operation*>(op);
@@ -32,6 +142,35 @@ std::optional<std::pair<pir::Value, pir::Value>> GetBroadcastOpInputOuputValue(
                                                  op->name()));
   }
   return std::nullopt;
+}
+
+std::vector<std::pair<size_t, size_t>> GetNonBroadCastDims(pir::Operation* op) {
+  std::vector<std::pair<size_t, size_t>> res;
+  auto* shape_analysis =
+      &pir::ShapeAnalysisManager::Instance().Get(op->GetParentProgram());
+
+  const auto& broad_cast_value = GetBroadcastOpInputOuputValue(op);
+  CHECK(broad_cast_value.has_value());
+
+  const auto& [input_value, output_value] = broad_cast_value.value();
+  const int input_rank = GetRank(input_value);
+  const int output_rank = GetRank(output_value);
+  CHECK_GE(output_rank, input_rank);
+
+  // Compare axis one by one, from back to front.
+  // The rule of broadcasting:
+  // https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/beginner/tensor_cn.html#id7
+  for (int i = 1; i <= input_rank; ++i) {
+    int input_axis = input_rank - i;
+    int output_axis = output_rank - i;
+    if (input_axis < 0 || output_axis < 0) break;
+    if (shape_analysis->IsProductEqual(
+            input_value, {input_axis}, output_value, {output_axis})) {
+      res.emplace_back(input_axis, output_axis);
+    }
+  }
+
+  return res;
 }
 
 }  // namespace cinn::fusion

--- a/paddle/cinn/operator_fusion/utils.h
+++ b/paddle/cinn/operator_fusion/utils.h
@@ -67,90 +67,23 @@ static size_t GetCompitableRank(pir::Value value) {
   size_t rank = GetRank(value);
   return rank == 0 ? 1 : rank;
 }
-static std::vector<int64_t> GetReduceAxisIdx(pir::Operation* reduce_op) {
-  const size_t input_rank = GetCompitableRank(reduce_op->operand_source(0));
-  const auto& attr_val = reduce_op->attributes().at("axis");
-  PADDLE_ENFORCE_EQ(attr_val.isa<::pir::ArrayAttribute>(),
-                    true,
-                    ::common::errors::InvalidArgument(
-                        "The axis attribute should be an array."));
-  const auto& axis_attr = attr_val.dyn_cast<::pir::ArrayAttribute>();
-  if (axis_attr.empty()) {
-    // dim: [] means reduce_all.
-    std::vector<int64_t> all_axis;
-    for (int i = 0; i < input_rank; ++i) {
-      all_axis.push_back(i);
-    }
-    return all_axis;
-  }
-  std::vector<int64_t> reduce_axis_idx;
-  for (int i = 0; i < axis_attr.size(); ++i) {
-    int64_t axis = axis_attr.at(i).dyn_cast<::pir::Int64Attribute>().data();
-    if (axis < 0) {
-      axis += input_rank;
-    }
-    PADDLE_ENFORCE_GE(
-        axis,
-        0,
-        ::common::errors::InvalidArgument(
-            "The 'axis' must be greater than or equal to 0, but received %d.",
-            axis));
 
-    PADDLE_ENFORCE_LT(axis,
-                      input_rank,
-                      ::common::errors::InvalidArgument(
-                          "The 'axis' must be less than 'input_rank', but "
-                          "received axis = %d and input_rank = %d.",
-                          axis,
-                          input_rank));
+std::vector<int64_t> GetInt64ArrayAttributeData(
+    const ::pir::Attribute& attr_val);
 
-    reduce_axis_idx.push_back(axis);
-  }
-  VLOG(4) << "GetReduceAxisIdx: " << utils::Join(reduce_axis_idx, ",");
-  return reduce_axis_idx;
-}
+std::vector<int32_t> GetInt32ArrayAttributeData(
+    const ::pir::Attribute& attr_val);
 
-static bool GetReduceOpKeepDims(pir::Operation* reduce_op) {
-  const auto& attr_val = reduce_op->attributes().at("keepdim");
-  PADDLE_ENFORCE_EQ(attr_val.isa<::pir::BoolAttribute>(),
-                    true,
-                    ::common::errors::InvalidArgument(
-                        "The keepdim attribute should be a bool."));
-  return attr_val.dyn_cast<::pir::BoolAttribute>().data();
-}
+std::vector<int64_t> GetReduceAxisIdx(pir::Operation* reduce_op);
+
+std::pair<std::vector<int64_t>, bool> GetSliceAxis(pir::Operation* slice_op);
+
+bool GetReduceOpKeepDims(pir::Operation* reduce_op);
 
 std::optional<std::pair<pir::Value, pir::Value>> GetBroadcastOpInputOuputValue(
     pir::Operation* op);
 
-static std::vector<std::pair<size_t, size_t>> GetNonBroadCastDims(
-    pir::Operation* op) {
-  std::vector<std::pair<size_t, size_t>> res;
-  auto* shape_analysis =
-      &pir::ShapeAnalysisManager::Instance().Get(op->GetParentProgram());
-
-  const auto& broad_cast_value = GetBroadcastOpInputOuputValue(op);
-  CHECK(broad_cast_value.has_value());
-
-  const auto& [input_value, output_value] = broad_cast_value.value();
-  const int input_rank = GetRank(input_value);
-  const int output_rank = GetRank(output_value);
-  CHECK_GE(output_rank, input_rank);
-
-  // Compare axis one by one, from back to front.
-  // The rule of broadcasting:
-  // https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/beginner/tensor_cn.html#id7
-  for (int i = 1; i <= input_rank; ++i) {
-    int input_axis = input_rank - i;
-    int output_axis = output_rank - i;
-    if (input_axis < 0 || output_axis < 0) break;
-    if (shape_analysis->IsProductEqual(
-            input_value, {input_axis}, output_value, {output_axis})) {
-      res.emplace_back(input_axis, output_axis);
-    }
-  }
-
-  return res;
-}
+std::vector<std::pair<size_t, size_t>> GetNonBroadCastDims(pir::Operation* op);
 
 static std::string OpsDebugStr(std::vector<pir::Operation*> ops) {
   std::stringstream ss;

--- a/test/ir/pir/cinn/test_anchor_fusion.py
+++ b/test/ir/pir/cinn/test_anchor_fusion.py
@@ -26,7 +26,6 @@ os.environ['FLAGS_enable_pir_api'] = '1'
 os.environ['FLAGS_use_cinn'] = '1'
 os.environ['FLAGS_cinn_bucket_compile'] = '1'
 os.environ['FLAGS_cinn_new_cluster_op_method'] = '1'
-os.environ['FLAGS_deny_cinn_ops'] = 'slice;'
 
 import paddle
 
@@ -153,6 +152,34 @@ class TestAnchorFusion(unittest.TestCase):
         def init():
             x = paddle.rand((32, 32, 128))
             return (x,)
+
+        self.compare_result(func, None, init)
+
+    def test_shardable_axes(self):
+        #    T   T
+        #     \ /
+        #      T
+        #      |
+        #  Transpose
+        #     / \
+        #    S   R
+        #   /     \
+        #  B       B
+        def func(x, y):
+            a = x + 1
+            b = y * 2
+            c = a + b
+            d = paddle.transpose(c, [1, 0])
+            e = d[0, :]
+            f = paddle.expand(e, [16, 16])
+            g = paddle.max(d, axis=0)
+            h = paddle.expand(g, [16, 16])
+            return f, h
+
+        def init():
+            x = paddle.rand((16, 32))
+            y = paddle.rand((16, 32))
+            return (x, y)
 
         self.compare_result(func, None, init)
 

--- a/test/ir/pir/cinn/test_anchor_fusion.py
+++ b/test/ir/pir/cinn/test_anchor_fusion.py
@@ -155,7 +155,7 @@ class TestAnchorFusion(unittest.TestCase):
 
         self.compare_result(func, None, init)
 
-    def test_shardable_axes(self):
+    def test_fusion_iters(self):
         #     T   T
         #      \ /
         #       T

--- a/test/ir/pir/cinn/test_anchor_fusion.py
+++ b/test/ir/pir/cinn/test_anchor_fusion.py
@@ -156,15 +156,17 @@ class TestAnchorFusion(unittest.TestCase):
         self.compare_result(func, None, init)
 
     def test_shardable_axes(self):
-        #    T   T
-        #     \ /
-        #      T
-        #      |
-        #  Transpose
-        #     / \
-        #    S   R
-        #   /     \
-        #  B       B
+        #     T   T
+        #      \ /
+        #       T
+        #       |
+        #   Transpose
+        #      / \
+        #     S   R
+        #    /     \
+        #   B       B
+        #            \
+        #             R
         def func(x, y):
             a = x + 1
             b = y * 2
@@ -173,8 +175,9 @@ class TestAnchorFusion(unittest.TestCase):
             e = d[0, :]
             f = paddle.expand(e, [16, 16])
             g = paddle.max(d, axis=0)
-            h = paddle.expand(g, [16, 16])
-            return f, h
+            h = paddle.expand(g, [32, 16])
+            i = paddle.sum(h, axis=0)
+            return f, i
 
         def init():
             x = paddle.rand((16, 32))

--- a/test/ir/pir/cinn/test_reduce_fusion.py
+++ b/test/ir/pir/cinn/test_reduce_fusion.py
@@ -26,7 +26,7 @@ os.environ['FLAGS_enable_pir_api'] = '1'
 os.environ['FLAGS_use_cinn'] = '1'
 os.environ['FLAGS_cinn_bucket_compile'] = '1'
 os.environ['FLAGS_cinn_new_cluster_op_method'] = '1'
-os.environ['FLAGS_deny_cinn_ops'] = 'slice;'
+# os.environ['FLAGS_deny_cinn_ops'] = 'slice;'
 
 import paddle
 

--- a/test/ir/pir/cinn/test_reduce_fusion.py
+++ b/test/ir/pir/cinn/test_reduce_fusion.py
@@ -26,7 +26,6 @@ os.environ['FLAGS_enable_pir_api'] = '1'
 os.environ['FLAGS_use_cinn'] = '1'
 os.environ['FLAGS_cinn_bucket_compile'] = '1'
 os.environ['FLAGS_cinn_new_cluster_op_method'] = '1'
-# os.environ['FLAGS_deny_cinn_ops'] = 'slice;'
 
 import paddle
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-76996
#### Done in this PR
1. 扩展 ShardableAxesSignature：
    - 添加 loop 成员表示循环的轴
    - ReplaceShardableAxesWithRootName 可选择进行归一化，即从新的 I0 开始编号，方便日志查看
    - 添加 SliceOp 和 TransposeOp ShardableAxesSignature 的获取
2. 实现 FusionItersSignature 数据结构作为 PatternNode 的成员指导多下游融合
3. 实现 SingleDownstreamItersFusion 函数用于维护单下游融合后新的 FusionItersSignature 信息
4. 一些融合日志代码的优化