### PR TITLE
[OneDNN][PIR] Fix bf16 pass data type replacement error

### DIFF
--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_pass.cc
@@ -2083,7 +2083,6 @@ class CpuBfloat16Pass : public pir::PatternRewritePass {
     const std::vector<std::string> bfloat16_ops_three_one{
         paddle::onednn::dialect::FcOp::name(),
         paddle::onednn::dialect::SliceOp::name(),
-        paddle::onednn::dialect::SplitOp::name(),
         paddle::onednn::dialect::FusedMatmulOp::name(),
         paddle::onednn::dialect::ClipOp::name(),
         paddle::onednn::dialect::Clip_Op::name(),

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
@@ -72,7 +72,6 @@ class OneDNNBf16PlacementPattern : public pir::RewritePattern {
         !op->isa<paddle::onednn::dialect::SliceOp>() &&
         !op->isa<paddle::onednn::dialect::SoftmaxOp>() &&
         !op->isa<paddle::onednn::dialect::Softmax_Op>() &&
-        !op->isa<paddle::onednn::dialect::SplitOp>() &&
         !op->isa<paddle::onednn::dialect::SqueezeOp>() &&
         !op->isa<paddle::onednn::dialect::Squeeze_Op>() &&
         !op->isa<paddle::onednn::dialect::SumOp>() &&
@@ -172,7 +171,6 @@ class RemoveOrphanedPattern : public pir::RewritePattern {
         !op->isa<paddle::onednn::dialect::SliceOp>() &&
         !op->isa<paddle::onednn::dialect::SoftmaxOp>() &&
         !op->isa<paddle::onednn::dialect::Softmax_Op>() &&
-        !op->isa<paddle::onednn::dialect::SplitOp>() &&
         !op->isa<paddle::onednn::dialect::SqueezeOp>() &&
         !op->isa<paddle::onednn::dialect::Squeeze_Op>() &&
         !op->isa<paddle::onednn::dialect::SumOp>() &&
@@ -321,7 +319,6 @@ class RemoveUnsupportedOpPattern : public pir::RewritePattern {
         !op->isa<paddle::onednn::dialect::SliceOp>() &&
         !op->isa<paddle::onednn::dialect::SoftmaxOp>() &&
         !op->isa<paddle::onednn::dialect::Softmax_Op>() &&
-        !op->isa<paddle::onednn::dialect::SplitOp>() &&
         !op->isa<paddle::onednn::dialect::SqueezeOp>() &&
         !op->isa<paddle::onednn::dialect::Squeeze_Op>() &&
         !op->isa<paddle::onednn::dialect::SumOp>() &&

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_type_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_type_placement_pass.cc
@@ -31,21 +31,6 @@
 #include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
 
 namespace {
-template <class IrType1, class IrType2>
-static pir::Type create_type(pir::Type type,
-                             const phi::Place& place,
-                             pir::Type out_dtype,
-                             pir::IrContext* ctx) {
-  auto input_type = type.dyn_cast<IrType1>();
-  return IrType2::get(ctx,
-                      place,
-                      out_dtype,
-                      input_type.dims(),
-                      input_type.data_layout(),
-                      input_type.lod(),
-                      input_type.offset());
-}
-
 class CpuBfloat16TypePattern : public pir::RewritePattern {
  public:
   explicit CpuBfloat16TypePattern(pir::IrContext* context)
@@ -114,30 +99,51 @@ class CpuBfloat16TypePattern : public pir::RewritePattern {
   void Rewrite(pir::Operation* op,
                pir::PatternRewriter& rewriter) const override {  // NOLINT
     auto op_info = pir::IrContext::Instance()->GetRegisteredOpInfo(op->name());
-    pir::IrContext* ctx = pir::IrContext::Instance();
     if (op_info) {
-      std::vector<pir::Type> op_item_inner_output_types;
       for (size_t i = 0; i < op->num_results(); ++i) {
         pir::Type type = op->result_type(i);
-        auto dense_type = type.dyn_cast<paddle::dialect::DenseTensorType>();
-        auto new_type = paddle::dialect::DenseTensorType::get(
-            rewriter.ir_context(),
-            paddle::dialect::TransToIrDataType(phi::DataType::BFLOAT16,
-                                               rewriter.ir_context()),
-            dense_type.dims(),
-            dense_type.data_layout(),
-            dense_type.lod(),
-            dense_type.offset());
-        // set bf16 op tensor output type to bf16.
-        op_item_inner_output_types.push_back(new_type);
-      }
-      auto attributes = op->attributes();
+        if (type.isa<paddle::dialect::DenseTensorType>()) {
+          auto dense_type = type.dyn_cast<paddle::dialect::DenseTensorType>();
+          auto new_type = paddle::dialect::DenseTensorType::get(
+              rewriter.ir_context(),
+              paddle::dialect::TransToIrDataType(phi::DataType::BFLOAT16,
+                                                 rewriter.ir_context()),
+              dense_type.dims(),
+              dense_type.data_layout(),
+              dense_type.lod(),
+              dense_type.offset());
 
-      pir::Operation* op_item_inner = rewriter.Build(op->operands_source(),
-                                                     attributes,
-                                                     op_item_inner_output_types,
-                                                     op_info);
-      rewriter.ReplaceOp(op, op_item_inner->results());
+          op->result(i).set_type(new_type);
+          std::cout << "set bf16 op tensor output type to bf16" << std::endl;
+          // set bf16 op tensor output type to bf16.
+          op_item_inner_output_types.push_back(new_type);
+        } else if (type.isa<pir::VectorType>()) {
+          auto vec_type = type.dyn_cast<pir::VectorType>();
+          auto output_num = vec_type.size();
+          std::vector<pir::Type> results_type(output_num);
+          for (size_t idx = 0; idx < output_num; ++idx) {
+            auto dense_type =
+                vec_type[idx].dyn_cast<paddle::dialect::DenseTensorType>();
+            auto new_type = paddle::dialect::DenseTensorType::get(
+                rewriter.ir_context(),
+                paddle::dialect::TransToIrDataType(phi::DataType::BFLOAT16,
+                                                   rewriter.ir_context()),
+                dense_type.dims(),
+                dense_type.data_layout(),
+                dense_type.lod(),
+                dense_type.offset());
+            results_type[idx] = new_type;
+          }
+          auto new_vec_type =
+              pir::VectorType::get(rewriter.ir_context(), results_type);
+          op->result(i).set_type(new_vec_type);
+
+        } else {
+          PADDLE_THROW(common::errors::Unimplemented(
+              "result type is not DenseTensorType or VectorType, please close "
+              "MKLDNNBf16"));
+        }
+      }
     }
   }
 };

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_type_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_type_placement_pass.cc
@@ -71,7 +71,6 @@ class CpuBfloat16TypePattern : public pir::RewritePattern {
         !op->isa<paddle::onednn::dialect::SliceOp>() &&
         !op->isa<paddle::onednn::dialect::SoftmaxOp>() &&
         !op->isa<paddle::onednn::dialect::Softmax_Op>() &&
-        !op->isa<paddle::onednn::dialect::SplitOp>() &&
         !op->isa<paddle::onednn::dialect::SqueezeOp>() &&
         !op->isa<paddle::onednn::dialect::Squeeze_Op>() &&
         !op->isa<paddle::onednn::dialect::SumOp>() &&

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_type_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_type_placement_pass.cc
@@ -112,11 +112,8 @@ class CpuBfloat16TypePattern : public pir::RewritePattern {
               dense_type.data_layout(),
               dense_type.lod(),
               dense_type.offset());
-
-          op->result(i).set_type(new_type);
-          std::cout << "set bf16 op tensor output type to bf16" << std::endl;
           // set bf16 op tensor output type to bf16.
-          op_item_inner_output_types.push_back(new_type);
+          op->result(i).set_type(new_type);
         } else if (type.isa<pir::VectorType>()) {
           auto vec_type = type.dyn_cast<pir::VectorType>();
           auto output_num = vec_type.size();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Inference


### PR Types
Bug fixes


### Description
Fix bf16 pass data type replacement error
Also delete SplitOp for vector output and cause error in DequantizeOp. We will implement it soon.
