### PR TITLE
[PIR][oneDNN] Fix data type in cpu_bfloat16_squash_pass

### DIFF
--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_squash_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_squash_pass.cc
@@ -27,12 +27,10 @@ namespace {
 
 template <class IrType1, class IrType2>
 static pir::Type create_type(pir::Type type,
-                             const phi::Place &place,
                              pir::Type out_dtype,
                              pir::IrContext *ctx) {
   auto input_type = type.dyn_cast<IrType1>();
   return IrType2::get(ctx,
-                      place,
                       out_dtype,
                       input_type.dims(),
                       input_type.data_layout(),
@@ -218,7 +216,7 @@ class QuantConvBf16SquashPattern
     op_attributes["scale_weights"] =
         rewriter.array_attr({rewriter.float_attr(1.0f)});
 
-    pir::IrContext *ctx = pir::IrContext::Instance();
+    pir::IrContext *ctx = rewriter.ir_context();
     auto op_info = ctx->GetRegisteredOpInfo(
         paddle::onednn::dialect::FusedConv2dOp::name());
     if (!op_info) return false;
@@ -227,9 +225,8 @@ class QuantConvBf16SquashPattern
     for (size_t i = 0; i < next_op->num_results(); ++i) {
       pir::Type type = next_op->result_type(i);
       pir::Type new_type =
-          create_type<pir::DenseTensorType,
-                      paddle::dialect::AllocatedDenseTensorType>(
-              type, phi::CPUPlace(), pir::BFloat16Type::get(ctx), ctx);
+          create_type<pir::DenseTensorType, paddle::dialect::DenseTensorType>(
+              type, pir::BFloat16Type::get(ctx), ctx);
       // set bf16 op tensor output type to bf16.
       op_item_inner_output_types.push_back(new_type);
     }
@@ -278,18 +275,17 @@ class QuantFusedConvBf16SquashPattern
     if (q_scale != 1.0f || q_shift != 0.0f) return false;
     if (next_op.input() != op.output()) return false;
 
-    auto op_info = pir::IrContext::Instance()->GetRegisteredOpInfo(
+    pir::IrContext *ctx = rewriter.ir_context();
+    auto op_info = ctx->GetRegisteredOpInfo(
         paddle::onednn::dialect::FusedConv2dOp::name());
     if (!op_info) return false;
 
-    pir::IrContext *ctx = pir::IrContext::Instance();
     std::vector<pir::Type> op_item_inner_output_types;
     for (size_t i = 0; i < next_op->num_results(); ++i) {
       pir::Type type = next_op->result_type(i);
       pir::Type new_type =
-          create_type<pir::DenseTensorType,
-                      paddle::dialect::AllocatedDenseTensorType>(
-              type, phi::CPUPlace(), pir::BFloat16Type::get(ctx), ctx);
+          create_type<pir::DenseTensorType, paddle::dialect::DenseTensorType>(
+              type, pir::BFloat16Type::get(ctx), ctx);
       // set bf16 op tensor output type to bf16.
       op_item_inner_output_types.push_back(new_type);
     }

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_squash_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_squash_pass.cc
@@ -224,6 +224,7 @@ class QuantConvBf16SquashPattern
     std::vector<pir::Type> op_item_inner_output_types;
     for (size_t i = 0; i < next_op->num_results(); ++i) {
       pir::Type type = next_op->result_type(i);
+      if (!type.isa<pir::DenseTensorType>()) return false;
       pir::Type new_type =
           create_type<pir::DenseTensorType, paddle::dialect::DenseTensorType>(
               type, pir::BFloat16Type::get(ctx), ctx);
@@ -283,6 +284,7 @@ class QuantFusedConvBf16SquashPattern
     std::vector<pir::Type> op_item_inner_output_types;
     for (size_t i = 0; i < next_op->num_results(); ++i) {
       pir::Type type = next_op->result_type(i);
+      if (!type.isa<pir::DenseTensorType>()) return false;
       pir::Type new_type =
           create_type<pir::DenseTensorType, paddle::dialect::DenseTensorType>(
               type, pir::BFloat16Type::get(ctx), ctx);

--- a/test/ir/pir/fused_pass/onednn/test_cpu_bfloat16_squash_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_cpu_bfloat16_squash_pass.py
@@ -34,13 +34,6 @@ class TestConv2dAddBf16Pass(PassTest):
                 x = paddle.static.data(
                     name='x', shape=[5, 5, 5, 5], dtype='float32'
                 )
-                bias_attr = paddle.ParamAttr(
-                    learning_rate=0.0,
-                    initializer=paddle.nn.initializer.Normal(mean=0.0, std=2.0),
-                )
-                bias = paddle.static.create_parameter(
-                    shape=[1], dtype='float32', attr=bias_attr, is_bias=False
-                )
                 w_attr = paddle.ParamAttr(
                     learning_rate=0.0,
                     initializer=paddle.nn.initializer.Normal(mean=0.0, std=2.0),
@@ -58,7 +51,6 @@ class TestConv2dAddBf16Pass(PassTest):
                     weight_attr=w_attr,
                 )
 
-                # out = paddle.add(conv2d(x), bias)
                 out = conv2d(x)
                 out = paddle.assign(out)
                 self.pass_attr_list = [
@@ -129,7 +121,6 @@ class TestFusedConv2dBf16Pass(PassTest):
                     weight_attr=w_attr,
                 )
 
-                # out = paddle.add(conv2d(x), bias)
                 out_conv = conv2d(x)
                 out = paddle.add(out_conv, bias)
                 out = paddle.assign(out)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Originally the context in pattern was newly initialized, which may cause tensor to be null and no way to find. Hence get context from rewriter to avoid such situation.