### PR TITLE
add logsumexp op spmd rule and its test and register elementwise spmd rule for logical_xxx ops

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/logsumexp.cc
+++ b/paddle/phi/infermeta/spmd_rules/logsumexp.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "paddle/phi/infermeta/spmd_rules/logsumexp.h"
-
 #include "glog/logging.h"
 
 namespace phi {

--- a/paddle/phi/infermeta/spmd_rules/logsumexp.cc
+++ b/paddle/phi/infermeta/spmd_rules/logsumexp.cc
@@ -38,5 +38,17 @@ SpmdInfo LogSumExpInferSpmdReverse(const DistMetaTensor& x,
   return ReductionInferSpmdReverse(x, out, new_axis, keepdims);
 }
 
+SpmdInfo LogSumExpGradInferSpmd(const DistMetaTensor& x,
+                                const DistMetaTensor& out,
+                                const DistMetaTensor& out_grad,
+                                const std::vector<int>& axis,
+                                bool keepdims,
+                                bool reduce_all) {
+  VLOG(4) << "LogSumExpGradInferSpmd Call ReductionGradInferSpmd";
+  std::vector<int64_t> new_axis(axis.begin(), axis.end());
+  return ReductionGradInferSpmd(
+      x, out, out_grad, new_axis, keepdims, reduce_all);
+}
+
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/logsumexp.cc
+++ b/paddle/phi/infermeta/spmd_rules/logsumexp.cc
@@ -1,0 +1,42 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/infermeta/spmd_rules/logsumexp.h"
+
+#include "glog/logging.h"
+
+namespace phi {
+namespace distributed {
+
+SpmdInfo LogSumExpInferSpmd(const DistMetaTensor& x,
+                            const std::vector<int>& axis,
+                            bool keepdims,
+                            bool reduce_all) {
+  VLOG(4) << "LogSumExpInferSpmd Call ReductionInferSpmd";
+  std::vector<int64_t> new_axis(axis.begin(), axis.end());
+  return ReductionInferSpmd(x, new_axis, keepdims);
+}
+
+SpmdInfo LogSumExpInferSpmdReverse(const DistMetaTensor& x,
+                                   const DistMetaTensor& out,
+                                   const std::vector<int>& axis,
+                                   bool keepdims,
+                                   bool reduce_all) {
+  VLOG(4) << "LogSumExpInferSpmdReverse Call ReductionInferSpmdReverse";
+  std::vector<int64_t> new_axis(axis.begin(), axis.end());
+  return ReductionInferSpmdReverse(x, out, new_axis, keepdims);
+}
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/logsumexp.h
+++ b/paddle/phi/infermeta/spmd_rules/logsumexp.h
@@ -34,11 +34,11 @@ SpmdInfo LogSumExpInferSpmdReverse(const DistMetaTensor& x,
                                    bool keepdims,
                                    bool reduce_all);
 
-SpmdInfo LogSumExpInferSpmd(const DistMetaTensor& x,
-                            const DistMetaTensor& out,
-                            const DistMetaTensor& out_grad,
-                            const std::vector<int>& axis,
-                            bool keepdims,
-                            bool reduce_all);
+SpmdInfo LogSumExpGradInferSpmd(const DistMetaTensor& x,
+                                const DistMetaTensor& out,
+                                const DistMetaTensor& out_grad,
+                                const std::vector<int>& axis,
+                                bool keepdims,
+                                bool reduce_all);
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/logsumexp.h
+++ b/paddle/phi/infermeta/spmd_rules/logsumexp.h
@@ -33,5 +33,12 @@ SpmdInfo LogSumExpInferSpmdReverse(const DistMetaTensor& x,
                                    const std::vector<int>& axis,
                                    bool keepdims,
                                    bool reduce_all);
+
+SpmdInfo LogSumExpInferSpmd(const DistMetaTensor& x,
+                            const DistMetaTensor& out,
+                            const DistMetaTensor& out_grad,
+                            const std::vector<int>& axis,
+                            bool keepdims,
+                            bool reduce_all);
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/logsumexp.h
+++ b/paddle/phi/infermeta/spmd_rules/logsumexp.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "paddle/phi/core/distributed/auto_parallel/dist_meta_tensor.h"
+#include "paddle/phi/core/distributed/type_defs.h"
+#include "paddle/phi/infermeta/spmd_rules/reduction.h"
+
+namespace phi {
+namespace distributed {
+
+SpmdInfo LogSumExpInferSpmd(const DistMetaTensor& x,
+                            const std::vector<int>& axis,
+                            bool keepdims,
+                            bool reduce_all);
+
+SpmdInfo LogSumExpInferSpmdReverse(const DistMetaTensor& x,
+                                   const DistMetaTensor& out,
+                                   const std::vector<int>& axis,
+                                   bool keepdims,
+                                   bool reduce_all);
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -681,5 +681,10 @@ PD_REGISTER_SPMD_RULE(unbind,
                       PD_INFER_SPMD(phi::distributed::UnbindInferSpmd),
                       PD_INFER_SPMD(phi::distributed::UnbindInferSpmdReverse));
 
+PD_REGISTER_SPMD_RULE(
+    logsumexp,
+    PD_INFER_SPMD(phi::distributed::LogSumExpInferSpmd),
+    PD_INFER_SPMD(phi::distributed::LogSumExpInferSpmdReverse));
+
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/rules.h
+++ b/paddle/phi/infermeta/spmd_rules/rules.h
@@ -34,6 +34,7 @@ limitations under the License. */
 #include "paddle/phi/infermeta/spmd_rules/gather.h"
 #include "paddle/phi/infermeta/spmd_rules/gather_nd.h"
 #include "paddle/phi/infermeta/spmd_rules/layer_norm.h"
+#include "paddle/phi/infermeta/spmd_rules/logsumexp.h"
 #include "paddle/phi/infermeta/spmd_rules/matmul.h"
 #include "paddle/phi/infermeta/spmd_rules/numel.h"
 #include "paddle/phi/infermeta/spmd_rules/one_hot.h"

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -1881,6 +1881,7 @@
   infer_meta :
     func : UnchangedInferMeta
     param: [x]
+    spmd_rule : LogSumExpGradInferSpmd
   kernel :
     func : logsumexp_grad
 

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -2987,6 +2987,7 @@
   output : Tensor(out)
   infer_meta :
     func : LogsumexpInferMeta
+    spmd_rule : LogSumExpInferSpmd
   kernel :
     func : logsumexp
   backward : logsumexp_grad

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -2900,6 +2900,7 @@
   output : Tensor(out)
   infer_meta :
     func : LogicalBinaryInferMeta
+    spmd_rule : ElementwiseBinaryInferSpmd
   kernel :
     func : logical_and
     data_type : x
@@ -2913,6 +2914,7 @@
   output : Tensor(out)
   infer_meta :
     func : LogicalNotInferMeta
+    spmd_rule : ElementwiseUnaryInferSpmd
   kernel :
     func : logical_not
     data_type : x
@@ -2926,6 +2928,7 @@
   output : Tensor(out)
   infer_meta :
     func : LogicalBinaryInferMeta
+    spmd_rule : ElementwiseBinaryInferSpmd
   kernel :
     func : logical_or
     data_type : x
@@ -2939,6 +2942,7 @@
   output : Tensor(out)
   infer_meta :
     func : LogicalBinaryInferMeta
+    spmd_rule : ElementwiseBinaryInferSpmd
   kernel :
     func : logical_xor
     data_type : x

--- a/test/auto_parallel/spmd_rules/CMakeLists.txt
+++ b/test/auto_parallel/spmd_rules/CMakeLists.txt
@@ -39,6 +39,7 @@ if(WITH_DISTRIBUTE)
   py_test_modules(test_gather_nd_rule MODULES test_gather_nd_rule)
   py_test_modules(test_fused_dropout_add_rule MODULES
                   test_fused_dropout_add_rule)
+  py_test_modules(test_logsumexp_rule MODULES test_logsumexp_rule)
   # End of unittests WITH single card WITHOUT timeout
 
 endif()

--- a/test/auto_parallel/spmd_rules/test_logsumexp_rule.py
+++ b/test/auto_parallel/spmd_rules/test_logsumexp_rule.py
@@ -1,0 +1,610 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from collections import OrderedDict
+
+from paddle.distributed.auto_parallel.static.dist_attribute import (
+    DistTensorSpec,
+    TensorDistAttr,
+)
+from paddle.distributed.fleet import auto
+from paddle.framework import core
+
+
+class TestLogSumExpSPMDRule(unittest.TestCase):
+    """
+    Unit tests for logsumexp spmd rule.
+    """
+
+    def config(self):
+        self.kernel = "logsumexp"
+
+    def setUp(self):
+        self.config()
+        self.rule = core.get_phi_spmd_rule(self.kernel)
+
+        x_shape = [64, 32]
+        process_mesh = auto.ProcessMesh(mesh=[0, 1, 2, 3])
+
+        x_tensor_dist_attr = TensorDistAttr()
+        x_tensor_dist_attr.dims_mapping = [1, 0]
+        x_tensor_dist_attr.process_mesh = process_mesh
+        self.x_dist_tensor_spec = DistTensorSpec(x_shape, x_tensor_dist_attr)
+
+        self.out_dist_tensor_spec = DistTensorSpec(self.x_dist_tensor_spec)
+
+        self.attrs = OrderedDict(
+            [('axis', [0]), ('keep_dim', False), ('reduce_all', False)]
+        )
+
+    def test_single_mesh_dim(self):
+        # reduce on dim 0, keep_dim = false, reduce_all = false
+        # [0, -1] --> [0, -1], [-1], partial_on_dim:[0]
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [0]
+        self.attrs['reduce_all'] = False
+        self.x_dist_tensor_spec.set_dims_mapping([0, -1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(infered_input_dist_attrs), 1)
+        self.assertEqual(len(infered_output_dist_attrs), 1)
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+
+        # reduce on dim 0, keep_dim = true, reduce_all = false
+        # [0, -1] --> [0, -1], [-1, -1], partial_on_dim:[0]
+        self.attrs['keep_dim'] = True
+        self.attrs['axis'] = [0]
+        self.attrs['reduce_all'] = False
+        self.x_dist_tensor_spec.set_dims_mapping([0, -1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+
+        # reduce on dim 1, keep_dim = false, reduce_all = false
+        # [0, -1] --> [0, -1], [0], partial_on_dim:[]
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [1]
+        self.attrs['reduce_all'] = False
+        self.x_dist_tensor_spec.set_dims_mapping([0, -1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+
+        # reduce on dim 1, keep_dim = true, reduce_all = false
+        # [0, -1] --> [0, -1], [0, -1], partial_on_dim:[]
+        self.attrs['keep_dim'] = True
+        self.attrs['axis'] = [1]
+        self.attrs['reduce_all'] = False
+        self.x_dist_tensor_spec.set_dims_mapping([0, -1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+
+        # reduce on dim 0 and 1, keep_dim = false, reduce_all = true
+        # [0, -1] --> [0, -1], [], partial_on_dim:[0]
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [0, 1]
+        self.attrs['reduce_all'] = True
+        self.x_dist_tensor_spec.set_dims_mapping([0, -1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [])
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+
+        # reduce on dim 0 and 1, keep_dim = true, reduce_all = true
+        # [0, -1] --> [0, -1], [-1, -1], partial_on_dim:[0]
+        self.attrs['keep_dim'] = True
+        self.attrs['axis'] = [0, 1]
+        self.attrs['reduce_all'] = True
+        self.x_dist_tensor_spec.set_dims_mapping([0, -1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+
+    def test_multi_mesh_dim(self):
+        process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
+        self.x_dist_tensor_spec.set_process_mesh(process_mesh)
+        self.x_dist_tensor_spec.shape = [96, 24, 48]
+
+        # reduce on dim 1, 2, keep_dim = false, reduce_all = false
+        # [0, -1, -1] --> [0, -1, -1], [0], partial_on_dim:[]
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [1, 2]
+        self.attrs['reduce_all'] = False
+        self.x_dist_tensor_spec.set_dims_mapping([0, -1, -1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(infered_input_dist_attrs), 1)
+        self.assertEqual(len(infered_output_dist_attrs), 1)
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+
+        # reduce on dim 1, 2, keep_dim = false, reduce_all = false
+        # [-1, 0, 1] --> [-1, 0, 1], [-1], partial_on_dim:[0, 1]
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [1, 2]
+        self.attrs['reduce_all'] = False
+        self.x_dist_tensor_spec.set_dims_mapping([-1, 0, 1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0, 1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0, 1})
+        infered_output_dist_attrs[0]._clean_partial_status()
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+
+        # reduction on dim 1, 2, keep_dim = false, reduce_all = false
+        # [1, -1, -1] --> [1, -1, -1], [1], partial_on_dim:[]
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [1, 2]
+        self.attrs['reduce_all'] = False
+        self.x_dist_tensor_spec.set_dims_mapping([1, -1, -1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1])
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+
+        # reduction on dim 1, 2, keep_dim = false, reduce_all = false
+        # [0, 1, -1] --> [0, 1, -1], [0], partial_on_dim:[1]
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [1, 2]
+        self.attrs['reduce_all'] = False
+        self.x_dist_tensor_spec.set_dims_mapping([0, 1, -1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {1})
+        infered_output_dist_attrs[0]._clean_partial_status()
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+
+        # reduction on dim 1, 2, keep_dim = true, reduce_all = false
+        # [0, 1, -1] --> [0, 1, -1], [0, -1, -1], partial_on_dim:[1]
+        self.attrs['keep_dim'] = True
+        self.attrs['axis'] = [1, 2]
+        self.attrs['reduce_all'] = False
+        self.x_dist_tensor_spec.set_dims_mapping([0, 1, -1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {1})
+
+        # reduction on dim 0, 1, 2, keep_dim = false, reduce_all = true
+        # [0, 1, -1] --> [0, 1, -1], [], partial_on_dim:[0, 1]
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [0, 1, 2]
+        self.attrs['reduce_all'] = True
+        self.x_dist_tensor_spec.set_dims_mapping([0, 1, -1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [])
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0, 1})
+
+        # reduction on dim 0, 1, 2, keep_dim = true, reduce_all = true
+        # [0, 1, -1] --> [0, 1, -1], [-1, -1, -1], partial_on_dim:[0, 1]
+        self.attrs['keep_dim'] = True
+        self.attrs['axis'] = [0, 1, 2]
+        self.attrs['reduce_all'] = True
+        self.x_dist_tensor_spec.set_dims_mapping([0, 1, -1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(
+            infered_output_dist_attrs[0].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0, 1})
+
+    def test_backward_single_mesh_dim(self):
+        # reduce on dim 0, keep_dim = false, reduce_all = false
+        # [-1] --> [-1, -1], [-1] (output --> input, output)
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [0]
+        self.attrs['reduce_all'] = False
+        self.out_dist_tensor_spec.shape = [32]
+        self.out_dist_tensor_spec.set_dims_mapping([-1])
+        result_dist_attrs = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.out_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(infered_input_dist_attrs), 1)
+        self.assertEqual(len(infered_output_dist_attrs), 1)
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+
+        # reduce on dim 0, keep_dim = true, reduce_all = false
+        # [-1, -1] --> [-1, -1], [-1, -1] (output --> input, output)
+        self.attrs['keep_dim'] = True
+        self.attrs['axis'] = [0]
+        self.attrs['reduce_all'] = False
+        self.out_dist_tensor_spec.shape = [1, 32]
+        self.out_dist_tensor_spec.set_dims_mapping([-1, -1])
+        result_dist_attrs = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.out_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+
+        # reduce on dim 1, keep_dim = false, reduce_all = false
+        # [0] --> [0, -1], [0] (output --> input, output)
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [1]
+        self.attrs['reduce_all'] = False
+        self.out_dist_tensor_spec.shape = [64]
+        self.out_dist_tensor_spec.set_dims_mapping([0])
+        result_dist_attrs = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.out_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+
+        # reduce on dim 1, keep_dim = true, reduce_all = false
+        # [0, -1] --> [0, -1], [0, -1] (output --> input, output)
+        self.attrs['keep_dim'] = True
+        self.attrs['axis'] = [1]
+        self.attrs['reduce_all'] = False
+        self.out_dist_tensor_spec.shape = [64, 1]
+        self.out_dist_tensor_spec.set_dims_mapping([0, -1])
+        result_dist_attrs = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.out_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+
+        # reduce on dim 0 and 1, keep_dim = false, reduce_all = true
+        # [] --> [-1, -1], [] (output --> input, output)
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [0, 1]
+        self.attrs['reduce_all'] = True
+        self.out_dist_tensor_spec.shape = []
+        self.out_dist_tensor_spec.set_dims_mapping([])
+        result_dist_attrs = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.out_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [])
+
+        # reduce on dim 0 and 1, keep_dim = true, reduce_all = true
+        # [-1, -1] --> [-1, -1], [-1, -1] (output --> input, output)
+        self.attrs['keep_dim'] = True
+        self.attrs['axis'] = [0, 1]
+        self.attrs['reduce_all'] = True
+        self.out_dist_tensor_spec.shape = [1, 1]
+        self.out_dist_tensor_spec.set_dims_mapping([-1, -1])
+        result_dist_attrs = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.out_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+
+    def test_backward_multi_mesh_dim(self):
+        process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
+        self.x_dist_tensor_spec.set_process_mesh(process_mesh)
+        self.x_dist_tensor_spec.shape = [96, 24, 48]
+        self.out_dist_tensor_spec.set_process_mesh(process_mesh)
+
+        # reduce on dim 1, 2, keep_dim = false, reduce_all = false
+        # [0] --> [0, -1, -1], [0] (output --> input, output)
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [1, 2]
+        self.attrs['reduce_all'] = False
+        self.out_dist_tensor_spec.shape = [96]
+        self.out_dist_tensor_spec.set_dims_mapping([0])
+        result_dist_attrs = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.out_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(infered_input_dist_attrs), 1)
+        self.assertEqual(len(infered_output_dist_attrs), 1)
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+
+        # reduce on dim 1, 2, keep_dim = false, reduce_all = false
+        # [-1] --> [-1, -1, -1], [-1] (output --> input, output)
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [1, 2]
+        self.attrs['reduce_all'] = False
+        self.out_dist_tensor_spec.shape = [96]
+        self.out_dist_tensor_spec.set_dims_mapping([-1])
+        result_dist_attrs = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.out_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+
+        # reduction on dim 1, 2, keep_dim = false, reduce_all = false
+        # [1] --> [1, -1, -1], [1] (output --> input, output)
+        self.attrs['keep_dim'] = False
+        self.attrs['axis'] = [1, 2]
+        self.attrs['reduce_all'] = False
+        self.out_dist_tensor_spec.shape = [96]
+        self.out_dist_tensor_spec.set_dims_mapping([1])
+        result_dist_attrs = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.out_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1])
+
+        # reduction on dim 1, 2, keep_dim = true, reduce_all = false
+        # [0, -1, -1] --> [0, -1, -1], [0, -1, -1] (output --> input, output)
+        self.attrs['keep_dim'] = True
+        self.attrs['axis'] = [1, 2]
+        self.attrs['reduce_all'] = False
+        self.out_dist_tensor_spec.shape = [96, 1, 1]
+        self.out_dist_tensor_spec.set_dims_mapping([0, -1, -1])
+        result_dist_attrs = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.out_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+
+    def test_backward_multi_mesh_dim_partial(self):
+        # reduction on dim 1, 2, keep_dim = true, reduce_all = false, partial_dim=[1]
+        # [0, -1, -1] --> [0, -1, -1], [0, -1, -1] (output --> input, output)
+        # output partial_dim: [1], input partial_dim: []
+        out_shape = [96, 1, 1]
+        process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
+
+        self.x_dist_tensor_spec.set_process_mesh(process_mesh)
+        self.x_dist_tensor_spec.shape = [96, 24, 48]
+        out_tensor_dist_attr = TensorDistAttr()
+        out_tensor_dist_attr.dims_mapping = [0, -1, -1]
+        out_tensor_dist_attr.process_mesh = process_mesh
+        out_tensor_dist_attr._set_partial_dims([1])
+        self.out_dist_tensor_spec = DistTensorSpec(
+            out_shape, out_tensor_dist_attr
+        )
+
+        self.attrs['keep_dim'] = True
+        self.attrs['axis'] = [1, 2]
+        self.attrs['reduce_all'] = False
+        result_dist_attrs = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.out_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_input_dist_attrs[0]._is_partial(), False)
+
+        # reduction on dim 0, 1, 2, keep_dim = true, reduce_all = true, partial_dim=[1]
+        # [-1, -1, -1] --> [-1, -1, -1], [-1, -1, -1] (output --> input, output)
+        # output partial_dim: [1], input partial_dim: []
+        out_tensor_dist_attr = TensorDistAttr()
+        out_tensor_dist_attr.dims_mapping = [-1, -1, -1]
+        out_tensor_dist_attr.process_mesh = process_mesh
+        out_tensor_dist_attr._set_partial_dims([1])
+        self.out_dist_tensor_spec = DistTensorSpec(
+            out_shape, out_tensor_dist_attr
+        )
+
+        self.attrs['keep_dim'] = True
+        self.attrs['axis'] = [0, 1, 2]
+        self.attrs['reduce_all'] = True
+        result_dist_attrs = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.out_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['keep_dim'],
+            self.attrs['reduce_all'],
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1])
+        self.assertEqual(
+            infered_output_dist_attrs[0].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(infered_input_dist_attrs[0]._is_partial(), False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
Others 


### Description
给logsumexp算子添加切分推导规则以及Python端单测
给logical_xxx算子添加elementwise类型的切分推导规则
