### PR TITLE
【GPUPS】edit afs-api module work when with_pscore=on

### DIFF
--- a/cmake/external/afs_api.cmake
+++ b/cmake/external/afs_api.cmake
@@ -52,7 +52,7 @@ ExternalProject_Add(
   ${EXTERNAL_PROJECT_LOG_ARGS}
   PREFIX ${AFSAPI_PREFIX_DIR}
   DOWNLOAD_DIR ${AFSAPI_DOWNLOAD_DIR}
-  DOWNLOAD_COMMAND wget --no-check-certificate ${AFSAPI_URL} -c -O
+  DOWNLOAD_COMMAND wget --no-check-certificate ${AFSAPI_URL} -c -q -O
                    ${AFSAPI_NAME}.tar.gz && tar zxvf ${AFSAPI_NAME}.tar.gz
   DOWNLOAD_NO_PROGRESS 1
   UPDATE_COMMAND ""

--- a/cmake/external/afs_api.cmake
+++ b/cmake/external/afs_api.cmake
@@ -24,7 +24,7 @@ if((NOT DEFINED AFSAPI_VER) OR (NOT DEFINED AFSAPI_URL))
       "afs_api"
       CACHE STRING "" FORCE)
   set(AFSAPI_URL
-      "https://pslib.bj.bcebos.com/afs_api_so.tar.gz"
+      "https://fleet.bj.bcebos.com/heterps/afs_api.tar.gz"
       CACHE STRING "" FORCE)
 endif()
 message(STATUS "AFSAPI_NAME: ${AFSAPI_NAME}, AFSAPI_URL: ${AFSAPI_URL}")
@@ -52,7 +52,7 @@ ExternalProject_Add(
   ${EXTERNAL_PROJECT_LOG_ARGS}
   PREFIX ${AFSAPI_PREFIX_DIR}
   DOWNLOAD_DIR ${AFSAPI_DOWNLOAD_DIR}
-  DOWNLOAD_COMMAND wget --no-check-certificate ${AFSAPI_URL} -c -q -O
+  DOWNLOAD_COMMAND wget --no-check-certificate ${AFSAPI_URL} -c -O
                    ${AFSAPI_NAME}.tar.gz && tar zxvf ${AFSAPI_NAME}.tar.gz
   DOWNLOAD_NO_PROGRESS 1
   UPDATE_COMMAND ""

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -521,11 +521,9 @@ if(WITH_PSCORE)
 
   include(external/jemalloc) # download, build, install jemalloc
   list(APPEND third_party_deps extern_jemalloc)
-  if(WITH_HETERPS)
-    include(external/afs_api)
-    list(APPEND third_party_deps extern_afs_api)
-    set(WITH_AFSAPI ON)
-  endif()
+
+  include(external/afs_api)
+  list(APPEND third_party_deps extern_afs_api)
 endif()
 
 if(WITH_RPC

--- a/paddle/fluid/framework/fleet/ps_gpu_wrapper.cc
+++ b/paddle/fluid/framework/fleet/ps_gpu_wrapper.cc
@@ -120,7 +120,7 @@ void PSGPUWrapper::InitAfsApi(const std::string& fs_name,
 }
 #endif
 
-#if defined(PADDLE_WITH_PSCORE) && defined(PADDLE_WITH_HETERPS)
+#if defined(PADDLE_WITH_PSCORE)
 void PSGPUWrapper::InitAfsApi(const std::string& fs_name,
                               const std::string& fs_user,
                               const std::string& pass_wd,

--- a/paddle/fluid/framework/fleet/ps_gpu_wrapper.h
+++ b/paddle/fluid/framework/fleet/ps_gpu_wrapper.h
@@ -176,14 +176,14 @@ class AfsWrapper {
   }
 
   std::vector<std::string> List(const std::string& path) {
-    int list_size = 0;
+    size_t list_size = 0;
     char** lists = phi::dynload::afs_list(handle_, path.c_str(), &list_size);
     std::vector<std::string> ret_lists(list_size);
-    for (int i = 0; i < list_size; i++) {
+    for (size_t i = 0; i < list_size; i++) {
       ret_lists[i] = std::string(lists[i]);
     }
 
-    for (int i = 0; i < list_size; i++) {
+    for (size_t i = 0; i < list_size; i++) {
       phi::dynload::afs_free(reinterpret_cast<void*>(lists[i]));
     }
     phi::dynload::afs_free(reinterpret_cast<void*>(lists));
@@ -191,8 +191,11 @@ class AfsWrapper {
   }
 
   std::string Cat(const std::string& path) {
-    auto ret = phi::dynload::afs_cat(handle_, path.c_str());
-    return std::string(ret);
+    size_t file_len = 0;
+    const char* ret = phi::dynload::afs_cat(handle_, path.c_str(), &file_len);
+    auto ret_str = std::string(ret, file_len);
+    phi::dynload::afs_free(const_cast<char*>(ret));
+    return ret_str;
   }
 
   int Exist(const std::string& path) {
@@ -1048,7 +1051,6 @@ class PSGPUWrapper {
                const char* data,
                size_t len,
                bool direct) {
-    VLOG(1) << "CALL AfsWrite: " << len << ", direct:" << direct;
     return phi::dynload::afs_writer_write(handle, data, len, direct);
   }
 

--- a/paddle/fluid/framework/fleet/ps_gpu_wrapper.h
+++ b/paddle/fluid/framework/fleet/ps_gpu_wrapper.h
@@ -192,9 +192,9 @@ class AfsWrapper {
 
   std::string Cat(const std::string& path) {
     size_t file_len = 0;
-    const char* ret = phi::dynload::afs_cat(handle_, path.c_str(), &file_len);
+    char* ret = phi::dynload::afs_cat(handle_, path.c_str(), &file_len);
     auto ret_str = std::string(ret, file_len);
-    phi::dynload::afs_free(const_cast<char*>(ret));
+    phi::dynload::afs_free(reinterpret_cast<void*>(ret));
     return ret_str;
   }
 

--- a/paddle/phi/backends/dynload/CMakeLists.txt
+++ b/paddle/phi/backends/dynload/CMakeLists.txt
@@ -85,7 +85,7 @@ if(WITH_FLASHATTN)
   list(APPEND DYNLOAD_COMMON_SRCS flashattn.cc)
 endif()
 
-if(WITH_HETERPS AND WITH_PSCORE)
+if(WITH_PSCORE)
   list(APPEND DYNLOAD_COMMON_SRCS afs_api.cc)
 endif()
 

--- a/python/paddle/distributed/fleet/utils/fs.py
+++ b/python/paddle/distributed/fleet/utils/fs.py
@@ -1282,12 +1282,14 @@ class HDFSClient(FS):
 class AFSClient(FS):
     """
     A tool of AFS. Use AfsWrapper.
+    When WITH_PSLIB=ON, you can use this class directly.
+    When WITH_PSCORE=ON, you should export LD_LIBRARY_PATH='YOUR_AFSAPISO_PATH' before using this class.
 
     Examples:
 
         .. code-block:: python
 
-            >>> # doctest: +SKIP('depend on WITH_PSLIB')
+            >>> # doctest: +SKIP('depend on external file')
             >>> from paddle.distributed.fleet.utils.fs import AFSClient
 
             >>> client = AFSClient()
@@ -1317,7 +1319,7 @@ class AFSClient(FS):
 
             .. code-block:: python
 
-                >>> # doctest: +SKIP('depend on WITH_PSLIB')
+                >>> # doctest: +SKIP('depend on external file')
                 >>> from paddle.distributed.fleet.utils.fs import AFSClient
 
                 >>> client = AFSClient()
@@ -1346,7 +1348,7 @@ class AFSClient(FS):
 
             .. code-block:: python
 
-                >>> # doctest: +SKIP('depend on WITH_PSLIB')
+                >>> # doctest: +SKIP('depend on external file')
                 >>> from paddle.distributed.fleet.utils.fs import AFSClient
 
                 >>> client = AFSClient()
@@ -1378,7 +1380,7 @@ class AFSClient(FS):
 
             .. code-block:: python
 
-                >>> # doctest: +SKIP('depend on WITH_PSLIB')
+                >>> # doctest: +SKIP('depend on external file')
                 >>> from paddle.distributed.fleet.utils.fs import AFSClient
 
                 >>> client = AFSClient()
@@ -1412,7 +1414,7 @@ class AFSClient(FS):
 
             .. code-block:: python
 
-                >>> # doctest: +SKIP('depend on WITH_PSLIB')
+                >>> # doctest: +SKIP('depend on external file')
                 >>> from paddle.distributed.fleet.utils.fs import AFSClient
 
                 >>> client = AFSClient()
@@ -1440,7 +1442,7 @@ class AFSClient(FS):
 
             .. code-block:: python
 
-                >>> # doctest: +SKIP('depend on WITH_PSLIB')
+                >>> # doctest: +SKIP('depend on external file')
                 >>> from paddle.distributed.fleet.utils.fs import AFSClient
 
                 >>> client = AFSClient()
@@ -1484,7 +1486,7 @@ class AFSClient(FS):
 
             .. code-block:: python
 
-                >>> # doctest: +SKIP('depend on WITH_PSLIB')
+                >>> # doctest: +SKIP('depend on external file')
                 >>> from paddle.distributed.fleet.utils.fs import AFSClient
 
                 >>> client = AFSClient()
@@ -1513,7 +1515,7 @@ class AFSClient(FS):
 
             .. code-block:: python
 
-                >>> # doctest: +SKIP('depend on WITH_PSLIB')
+                >>> # doctest: +SKIP('depend on external file')
                 >>> from paddle.distributed.fleet.utils.fs import AFSClient
 
                 >>> client = AFSClient()
@@ -1564,7 +1566,7 @@ class AFSClient(FS):
 
             .. code-block:: python
 
-                >>> # doctest: +SKIP('depend on WITH_PSLIB')
+                >>> # doctest: +SKIP('depend on external file')
                 >>> from paddle.distributed.fleet.utils.fs import AFSClient
 
                 >>> client = AFSClient()
@@ -1590,7 +1592,7 @@ class AFSClient(FS):
 
             .. code-block:: python
 
-                >>> # doctest: +SKIP('depend on WITH_PSLIB')
+                >>> # doctest: +SKIP('depend on external file')
                 >>> from paddle.distributed.fleet.utils.fs import AFSClient
 
                 >>> client = AFSClient()
@@ -1622,7 +1624,7 @@ class AFSClient(FS):
             .. code-block:: python
 
 
-                >>> # doctest: +SKIP('depend on WITH_PSLIB')
+                >>> # doctest: +SKIP('depend on external file')
                 >>> from paddle.distributed.fleet.utils.fs import AFSClient
 
                 >>> client = AFSClient()
@@ -1647,7 +1649,7 @@ class AFSClient(FS):
 
             .. code-block:: python
 
-                >>> # doctest: +SKIP('depend on WITH_PSLIB')
+                >>> # doctest: +SKIP('depend on external file')
                 >>> from paddle.distributed.fleet.utils.fs import AFSClient
 
                 >>> client = AFSClient()
@@ -1679,7 +1681,7 @@ class AFSClient(FS):
 
             .. code-block:: python
 
-                >>> # doctest: +SKIP('depend on WITH_PSLIB')
+                >>> # doctest: +SKIP('depend on external file')
                 >>> from paddle.distributed.fleet.utils.fs import AFSClient
 
                 >>> client = AFSClient()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Parameter Server

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
edit afs-api module work when with_pscore=on
AFSClient work when with_pscore=on or with_pslib=on
Pcard-86396