### PR TITLE
[SOT] Temperarily disable SOT step profiler ut

### DIFF
--- a/test/sot/test_step_profiler.py
+++ b/test/sot/test_step_profiler.py
@@ -18,7 +18,7 @@ import unittest
 
 import paddle
 from paddle.jit import sot
-from paddle.jit.sot.utils import sot_step_profiler_guard, strict_mode_guard
+from paddle.jit.sot.utils import strict_mode_guard
 from paddle.pir_utils import DygraphPirGuard
 
 
@@ -43,7 +43,8 @@ class SimpleModel(paddle.nn.Layer):
 
 
 class TestStepProfilerSmokeTest(unittest.TestCase):
-    @sot_step_profiler_guard(True)
+    # Temperarily disable this test
+    # @sot_step_profiler_guard(True)
     @strict_mode_guard(False)
     def test_step_profiler_smoke(self):
         with DygraphPirGuard():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

开启 SOT profiler 后会随机发生段错误，需要后续分析修复，暂时禁用掉，以免影响 CI

Pcard-67164