### PR TITLE
Fix custom-npu op error in optional parameter

### DIFF
--- a/paddle/phi/api/ext/op_meta_info.h
+++ b/paddle/phi/api/ext/op_meta_info.h
@@ -230,17 +230,11 @@ struct KernelFuncImpl<Return (*)(Args...), impl_fn> {
     template <int in_idx, int attr_idx, int out_idx, typename... PreviousArgs>
     static void Compute(CustomOpKernelContext* ctx, PreviousArgs&... pargs) {
       auto& range = ctx->InputRangeAt(in_idx);
-      auto& arg = ctx->InputAt(range.first);
-      if (!arg.initialized()) {
-        ComputeCallHelper<Tail...>::
-            template Compute<in_idx + 1, attr_idx, out_idx>(
-                ctx, pargs..., paddle::none);
-      } else {
-        ComputeCallHelper<
-            Tail...>::template Compute<in_idx + 1, attr_idx, out_idx>(ctx,
-                                                                      pargs...,
-                                                                      arg);
-      }
+      auto arg = ctx->OptionalInputAt(range.first);
+      ComputeCallHelper<
+          Tail...>::template Compute<in_idx + 1, attr_idx, out_idx>(ctx,
+                                                                    pargs...,
+                                                                    arg);
     }
   };
 
@@ -293,17 +287,11 @@ struct KernelFuncImpl<Return (*)(Args...), impl_fn> {
     template <int in_idx, int attr_idx, int out_idx, typename... PreviousArgs>
     static void Compute(CustomOpKernelContext* ctx, PreviousArgs&... pargs) {
       auto& range = ctx->InputRangeAt(in_idx);
-      auto arg = ctx->InputsBetween(range.first, range.second);
-      if (arg.empty() || !arg[0].initialized()) {
-        ComputeCallHelper<Tail...>::
-            template Compute<in_idx + 1, attr_idx, out_idx>(
-                ctx, pargs..., paddle::none);
-      } else {
-        ComputeCallHelper<
-            Tail...>::template Compute<in_idx + 1, attr_idx, out_idx>(ctx,
-                                                                      pargs...,
-                                                                      arg);
-      }
+      auto arg = ctx->OptionalInputsBetween(range.first, range.second);
+      ComputeCallHelper<
+          Tail...>::template Compute<in_idx + 1, attr_idx, out_idx>(ctx,
+                                                                    pargs...,
+                                                                    arg);
     }
   };
 
@@ -555,16 +543,16 @@ struct InferShapeFuncImpl<Return (*)(Args...), impl_fn> {
         const std::vector<std::vector<std::vector<int64_t>>>& vec_input_shapes,
         const std::vector<paddle::any>& attrs,
         const PreviousArgs&... pargs) {
-      const std::vector<int64_t>& arg = input_shapes[in_idx];
-      if (arg.empty()) {
-        return InferShapeCallHelper<Tail...>::
-            template InferShape<in_idx + 1, vec_in_idx, attr_idx>(
-                input_shapes, vec_input_shapes, attrs, pargs..., paddle::none);
-      } else {
-        return InferShapeCallHelper<Tail...>::
-            template InferShape<in_idx + 1, vec_in_idx, attr_idx>(
-                input_shapes, vec_input_shapes, attrs, pargs..., arg);
-      }
+      auto arg = [&] {
+        if (input_shapes[in_idx].size()) {
+          return paddle::optional<std::vector<int64_t>>(input_shapes[in_idx]);
+        } else {
+          return paddle::optional<std::vector<int64_t>>(paddle::none);
+        }
+      }();
+      return InferShapeCallHelper<Tail...>::
+          template InferShape<in_idx + 1, vec_in_idx, attr_idx>(
+              input_shapes, vec_input_shapes, attrs, pargs..., arg);
     }
   };
 
@@ -581,17 +569,18 @@ struct InferShapeFuncImpl<Return (*)(Args...), impl_fn> {
         const std::vector<std::vector<std::vector<int64_t>>>& vec_input_shapes,
         const std::vector<paddle::any>& attrs,
         const PreviousArgs&... pargs) {
-      const std::vector<std::vector<int64_t>>& arg =
-          vec_input_shapes[vec_in_idx];
-      if (arg.empty()) {
-        return InferShapeCallHelper<Tail...>::
-            template InferShape<in_idx, vec_in_idx + 1, attr_idx>(
-                input_shapes, vec_input_shapes, attrs, pargs..., paddle::none);
-      } else {
-        return InferShapeCallHelper<Tail...>::
-            template InferShape<in_idx, vec_in_idx + 1, attr_idx>(
-                input_shapes, vec_input_shapes, attrs, pargs..., arg);
-      }
+      auto arg = [&] {
+        if (vec_input_shapes[vec_in_idx].size()) {
+          return paddle::optional<std::vector<std::vector<int64_t>>>(
+              vec_input_shapes[vec_in_idx]);
+        } else {
+          return paddle::optional<std::vector<std::vector<int64_t>>>(
+              paddle::none);
+        }
+      }();
+      return InferShapeCallHelper<Tail...>::
+          template InferShape<in_idx, vec_in_idx + 1, attr_idx>(
+              input_shapes, vec_input_shapes, attrs, pargs..., arg);
     }
   };
 
@@ -748,16 +737,16 @@ struct InferDtypeFuncImpl<Return (*)(Args...), impl_fn> {
         const std::vector<std::vector<DataType>>& vec_input_dtypes,
         const std::vector<paddle::any>& attrs,
         const PreviousArgs&... pargs) {
-      const DataType& arg = input_dtypes[in_idx];
-      if (arg == DataType::UNDEFINED) {
-        return InferDtypeCallHelper<Tail...>::
-            template InferDtype<in_idx + 1, vec_in_idx, attr_idx>(
-                input_dtypes, vec_input_dtypes, attrs, pargs..., paddle::none);
-      } else {
-        return InferDtypeCallHelper<Tail...>::
-            template InferDtype<in_idx + 1, vec_in_idx, attr_idx>(
-                input_dtypes, vec_input_dtypes, attrs, pargs..., arg);
-      }
+      auto arg = [&] {
+        if (input_dtypes[in_idx] == DataType::UNDEFINED) {
+          return paddle::optional<DataType>(paddle::none);
+        } else {
+          return paddle::optional<DataType>(input_dtypes[in_idx]);
+        }
+      }();
+      return InferDtypeCallHelper<Tail...>::
+          template InferDtype<in_idx + 1, vec_in_idx, attr_idx>(
+              input_dtypes, vec_input_dtypes, attrs, pargs..., arg);
     }
   };
 
@@ -773,16 +762,17 @@ struct InferDtypeFuncImpl<Return (*)(Args...), impl_fn> {
         const std::vector<std::vector<DataType>>& vec_input_dtypes,
         const std::vector<paddle::any>& attrs,
         const PreviousArgs&... pargs) {
-      const std::vector<DataType>& arg = vec_input_dtypes[vec_in_idx];
-      if (arg.empty()) {
-        return InferDtypeCallHelper<Tail...>::
-            template InferDtype<in_idx, vec_in_idx + 1, attr_idx>(
-                input_dtypes, vec_input_dtypes, attrs, pargs..., paddle::none);
-      } else {
-        return InferDtypeCallHelper<Tail...>::
-            template InferDtype<in_idx, vec_in_idx + 1, attr_idx>(
-                input_dtypes, vec_input_dtypes, attrs, pargs..., arg);
-      }
+      auto arg = [&] {
+        if (vec_input_dtypes[vec_in_idx].empty()) {
+          return paddle::optional<std::vector<DataType>>(paddle::none);
+        } else {
+          return paddle::optional<std::vector<DataType>>(
+              vec_input_dtypes[vec_in_idx]);
+        }
+      }();
+      return InferDtypeCallHelper<Tail...>::
+          template InferDtype<in_idx, vec_in_idx + 1, attr_idx>(
+              input_dtypes, vec_input_dtypes, attrs, pargs..., arg);
     }
   };
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull//67865 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types 
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
card-85848, fix custom-npu op error in optional parameter.

1. The compilation of custom-npu become stuck when too many optional parameters are added to the custom-npu op. After commenting out some code in the op_meta_info.h, compilation resumes.
2. Fix the problem of unequal values passed to optional parameters in python and C++ when py_None is passed.