### PR TITLE
[cherry-pick] Fix numpy2.1 bug in py3.10

### DIFF
--- a/paddle/fluid/pybind/tensor.cc
+++ b/paddle/fluid/pybind/tensor.cc
@@ -210,8 +210,16 @@ void BindTensor(pybind11::module &m) {  // NOLINT
   g_framework_tensor_pytype =
       reinterpret_cast<PyTypeObject *>(framework_tensor.ptr());
   framework_tensor
-      .def("__array__",
-           [](phi::DenseTensor &self) { return TensorToPyArray(self); })
+      .def(
+          // TODO(risemeup): Modify the logic of
+          // TensorToPyArray() according to the dtype and copy
+          // parameters.
+          "__array__",
+          [](phi::DenseTensor &self, py::object dtype, py::object copy) {
+            return TensorToPyArray(self);
+          },
+          py::arg("dtype") = py::none(),
+          py::arg("copy") = py::none())
       .def("_ptr",
            [](const phi::DenseTensor &self) {
              return reinterpret_cast<uintptr_t>(self.data());

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -848,7 +848,11 @@ def monkey_patch_tensor():
     def __bool__(self):
         return self.__nonzero__()
 
-    def __array__(self, dtype=None):
+    def __array__(
+        self,
+        dtype=None,
+        copy=None,
+    ):
         """
         Returns a numpy array shows the value of current Tensor.
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 httpx
-numpy>=1.21
+numpy>=1.13
 protobuf>=3.20.2 ; platform_system != "Windows"
 protobuf>=3.1.0, <=3.20.2 ; platform_system == "Windows"
 Pillow

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 httpx
-numpy>=1.13
+numpy>=1.21
 protobuf>=3.20.2 ; platform_system != "Windows"
 protobuf>=3.1.0, <=3.20.2 ; platform_system == "Windows"
 Pillow


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Fix the bug in PaddlePaddle under Python 3.10 and NumPy 2.1.


<img width="814" alt="image" src="https://github.com/user-attachments/assets/739f5e6d-cdfa-4f44-b83b-40ca014499c7">

- For any `__array__` method on a non-NumPy array-like object, dtype=None and copy=None keywords must be added to the signature - this will work with older NumPy versions as well (although older numpy versions will never pass in copy keyword). If the keywords are added to the `__array__` signature, then for:

    copy=True and any dtype value always return a new copy,
    
    copy=None create a copy if required (for example by dtype),

    copy=False a copy must never be made. If a copy is needed to return a numpy array or satisfy dtype, then raise an exception (ValueError).

- ~~Restricting numpy to version 1.21 or above is to fix the bug of not finding the ‘NDArray’ attribute when using the `numpy.typing` module.~~ It's no need to cherry-pick to 2.6

To do：
Modify the logic in TensorToPyArray(self) according to the dtype and copy parameters.
pcard-67164