### PR TITLE
[Typing] 修复 `spawn` 中示例代码的类型标注

### DIFF
--- a/python/paddle/distributed/spawn.py
+++ b/python/paddle/distributed/spawn.py
@@ -530,7 +530,7 @@ def spawn(
             ...     process_group = group.process_group if group else None
             ...     # 2. create data parallel layer & optimizer
             ...     layer = LinearNet()
-            ...     dp_layer = paddle.DataParallel(layer, group = process_group)
+            ...     dp_layer = paddle.DataParallel(layer, group = process_group) # type: ignore[arg-type]
             ...     loss_fn = nn.MSELoss()
             ...     adam = opt.Adam(
             ...         learning_rate=0.001, parameters=dp_layer.parameters())


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 `spawn` 中示例代码的类型标注。

示例中

``` python
            >>> def train(print_result=False):
            ...     # 1. initialize parallel environment
            ...     group = dist.init_parallel_env()
            ...     process_group = group.process_group if group else None
            ...     # 2. create data parallel layer & optimizer
            ...     layer = LinearNet()
            ...     dp_layer = paddle.DataParallel(layer, group = process_group) # type: ignore[arg-type]
```

传给 `DataParallel` 的是个 `ProcessGroup`，但是 `DataParallel` 中明确要求

``` python
                self.group = (
                    paddle.distributed.collective._get_default_group()
                    if self.group is None
                    else self.group
                )

                assert isinstance(
                    self.group, paddle.distributed.collective.Group
                ), "ProcessGroup must be an instance of Group in DataParallel."
```

也就是说，`ProcessGroup` 应该是 `Group` 的子类，但是，`ProcessGroup` 是在  `from paddle.base.core import ProcessGroup` 中的，而 `Group` 是在 `paddle/distributed/communication/group.py` 中的，这俩也没有继承关系 ～ 

搞不清楚这俩的实际关系，也没有环境验证，所以这里 `ignore` 了 ～

另外，这个问题是在 https://github.com/PaddlePaddle/Paddle/pull/66357 中发现的，不太清楚为啥在之前那个 typing all 监控的 PR 里没有发现，可以留意一下 ～

@SigureMo