### PR TITLE
【Hackathon 7th PPSCI No.13】 Backward decomp for put_along_axis_grad op

### DIFF
--- a/paddle/fluid/primitive/codegen/gen.py
+++ b/paddle/fluid/primitive/codegen/gen.py
@@ -106,6 +106,7 @@ OTHER_PRIM_VJP_OPS = [
     'gather_nd_grad',
     'pad_grad',
     'prod_grad',
+    'put_along_axis_grad',
     'max_grad',
     'masked_select_grad',
     'scale_grad',

--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -2430,6 +2430,170 @@ void softsign_grad(const Tensor& x, const Tensor& out_grad, Tensor* x_grad) {
   }
 }
 
+template <typename T>
+void put_along_axis_grad(const Tensor& x,
+                         const Tensor& index,
+                         const Tensor& value,
+                         const Tensor& out,
+                         const Tensor& out_grad,
+                         int axis,
+                         const std::string& reduce,
+                         bool include_self,
+                         Tensor* x_grad,
+                         Tensor* value_grad) {
+  if (x_grad) {
+    Tensor x_grad_tmp = out_grad;
+    if (include_self == false || reduce == "assign") {
+      // 如果没有特殊说明，要替换的位置全部指在x这个tensor上的对应位置
+      // 对应位置的计算见文件paddle\phi\kernels\funcs\gather_scatter_functor.cc的L293-L319
+      // 将要替换的位置全部赋值为0
+      Tensor zero_tensor = full<T>(index.shape(), 0, out_grad.dtype());
+      x_grad_tmp = put_along_axis<T>(out_grad, index, zero_tensor, axis);
+    } else if (reduce == "multiply" || reduce == "mul") {
+      // 首先用一个vector称为num，维度等于x的dim，默认全0用于记录原tensor在对应位置上被索引的次数
+      /* 如果是multiply和mul
+       * 在要替换的位置做：out_grad * out / x
+       */
+      Tensor zero_tensor_x = full<T>(x.shape(), 0, x.dtype());
+      Tensor one_tensor_idx = full<T>(index.shape(), 1, x.dtype());
+      Tensor mask =
+          put_along_axis<T>(zero_tensor_x, index, one_tensor_idx, axis);
+      x_grad_tmp = where<T>(mask > zero_tensor_x, out_grad * out / x, out_grad);
+    } else if (reduce == "amin" || reduce == "amax") {
+      /*
+       * 假设当前在x上要替换的位置称为index_grad,
+       * 替换的值对应value中的位置为index_value
+       * 如果out[index_grad]和x[index_grad]的值不相等，那么就设置他的x_grad[index_grad]为0
+       * 否则，当out[index_grad]和value[index_value]相等时
+       * num[index_grad] += 1 (但其实num只有0和1两种情况)
+       * x_grad_tmp =  out_grad / (num+1)
+       */
+      Tensor zero_tensor = full<T>(x.shape(), 0, x.dtype());
+      Tensor one_tensor = full<T>(x.shape(), 1, x.dtype());
+
+      auto zero_result = cast<T>(equal<T>(out, x), x.dtype());
+
+      Tensor num = zero_tensor;
+      int64_t select_num = static_cast<int64_t>(index.shape()[axis]);
+      for (int64_t i = 0; i < select_num; i++) {
+        Tensor sub_index = slice<T>(index, {axis}, {i}, {i + 1}, {1}, {});
+        Tensor sub_value = slice<T>(value, {axis}, {i}, {i + 1}, {1}, {});
+        Tensor sub_out = take_along_axis<T>(out, sub_index, axis);
+        Tensor sub_count = cast<T>(equal<T>(sub_out, sub_value), x.dtype());
+        num = num + put_along_axis<T>(zero_tensor, sub_index, sub_count, axis);
+      }
+      x_grad_tmp = zero_result * out_grad / (num + 1);
+    } else if (reduce == "mean") {
+      // 继续使用vector num
+      /*
+       * 记录每个要替换的位置被索引的次数到num中
+       * 如果num的位置不为0，就设置x_grad_tmp = out_grad / (num+1)
+       */
+      Tensor zero_tensor_x = full<T>(x.shape(), 0, x.dtype());
+
+      Tensor num = zero_tensor_x;
+      int64_t select_num = static_cast<int64_t>(index.shape()[axis]);
+      for (int64_t i = 0; i < select_num; i++) {
+        Tensor sub_index = slice<T>(index, {axis}, {i}, {i + 1}, {1}, {});
+        Tensor sub_one_tensor = full<T>(sub_index.shape(), 1, x.dtype());
+        num = num +
+              put_along_axis<T>(zero_tensor_x, sub_index, sub_one_tensor, axis);
+      }
+      x_grad_tmp =
+          where<T>(num > zero_tensor_x, out_grad / (num + 1), out_grad);
+    }
+    set_output<T>(x_grad_tmp, x_grad);
+  }
+  if (value_grad) {
+    // 默认为全0
+    Tensor value_grad_tmp = full<T>(index.shape(), 0, x.dtype());
+    /*
+     * 假设当前在x上要替换的位置称为index_self,
+     * 替换的值对应value中的位置为index_grad
+     * 具体计算方式见文件：paddle\phi\kernels\funcs\gather_scatter_functor.cc的L457-L494
+     */
+    if (reduce == "assign") {
+      // 设置一个vector称为is_self_grad_used，全为false，维度和x的dim相同
+      // 用于记录value对应的索引位置是否被使用
+      // 如果index_self是第一次被使用，value_grad_tmp[index_grad] =
+      // out_grad[index_self] 并且is_self_grad_used[index_self] = true
+      int64_t select_num = static_cast<int64_t>(index.shape()[axis]);
+      Tensor mask = full<T>(out_grad.shape(), 1, out_grad.dtype());
+      Tensor zero = full<T>(out_grad.shape(), 0, out_grad.dtype());
+      std::vector<Tensor> res(select_num);
+      for (int64_t i = select_num - 1; i >= 0; i--) {
+        Tensor sub_index = slice<T>(index, {axis}, {i}, {i + 1}, {1}, {});
+        Tensor tmp_grad = out_grad * mask;
+        res[i] = take_along_axis<T>(tmp_grad, sub_index, axis);
+        mask = put_along_axis<T>(out_grad, sub_index, zero, axis);
+      }
+      value_grad_tmp = concat<T>(res, axis);
+    } else if (reduce == "add") {
+      // value_grad_tmp[index_grad] = self_data[index_self]
+      value_grad_tmp = take_along_axis<T>(out_grad, index, axis);
+    } else if (reduce == "mean") {
+      /* 设置一个vector称为num，如果include_self
+       * =true则全为1，否则全为0，维度和x的dim相同
+       * 记录index_self被索引的次数到num中
+       * 计算value_grad_tmp[index_grad] = out_grad[index_self] / num
+       */
+      Tensor one_tensor = full<T>(out_grad.shape(), 1, out_grad.dtype());
+      Tensor zero_tensor = full<T>(out_grad.shape(), 0, out_grad.dtype());
+      Tensor num = include_self ? one_tensor : zero_tensor;
+      int64_t select_num = static_cast<int64_t>(index.shape()[axis]);
+      for (int64_t i = 0; i < select_num; i++) {
+        Tensor sub_index = slice<T>(index, {axis}, {i}, {i + 1}, {1}, {});
+        num = num + put_along_axis<T>(zero_tensor, sub_index, one_tensor, axis);
+      }
+      Tensor grad_result = out_grad / num;
+      value_grad_tmp = take_along_axis<T>(grad_result, index, axis);
+    } else if (reduce == "mul" || reduce == "multiply") {
+      /*
+       * 计算value_grad_tmp[index_grad] = out_grad[index_self] *
+       * (out[index_self] / value[index_value])
+       */
+      Tensor out_grad_select = take_along_axis<T>(out_grad, index, axis);
+      Tensor out_select = take_along_axis<T>(out, index, axis);
+      value_grad_tmp = out_grad_select * (out_select / value);
+    } else if (reduce == "amin" || reduce == "amax") {
+      /* 设置一个vector称为num，全为0，维度和x的dim相同
+       * 如果out[index_self] == value[index_grad], 则num[index_self] += 1
+       * 计算好num后
+       * 条件1：out[index_self] == value[index_grad]
+       * 条件2：out[index_self] == x[index_self]
+       * 同时满足条件1,2时，value_grad_tmp[index_grad] = out_grad[index_self] /
+       * (num+1) 满足条件1不满足条件2时，value_grad_tmp[index_grad] =
+       * out_grad[index_self] / num
+       */
+      Tensor one_tensor_out = full<T>(out_grad.shape(), 1, out_grad.dtype());
+      Tensor zero_tensor_out = full<T>(out_grad.shape(), 0, out_grad.dtype());
+      Tensor num = zero_tensor_out;
+      int64_t select_num = static_cast<int64_t>(index.shape()[axis]);
+      for (int64_t i = 0; i < select_num; i++) {
+        Tensor sub_index = slice<T>(index, {axis}, {i}, {i + 1}, {1}, {});
+        Tensor sub_value = slice<T>(value, {axis}, {i}, {i + 1}, {1}, {});
+        Tensor one_tensor_idx = full<T>(sub_index.shape(), 1, out_grad.dtype());
+        Tensor sub_mask =
+            put_along_axis<T>(zero_tensor_out, sub_index, one_tensor_idx, axis);
+        Tensor sub_put_res =
+            put_along_axis<T>(zero_tensor_out, sub_index, sub_value, axis);
+        num = num +
+              cast<T>(equal<T>(out, sub_put_res), out_grad.dtype()) * sub_mask;
+      }
+      Tensor select_out = take_along_axis<T>(out, index, axis);
+      Tensor mask = cast<T>(equal<T>(select_out, value), out_grad.dtype());
+      Tensor select_out_grad = take_along_axis<T>(out_grad, index, axis);
+      Tensor select_cnt = take_along_axis<T>(num, index, axis);
+      Tensor select_x = take_along_axis<T>(x, index, axis);
+      Tensor res = where<T>(select_out == select_x,
+                            select_out_grad / (select_cnt + 1),
+                            select_out_grad / select_cnt);
+      value_grad_tmp = res * mask;
+    }
+    set_output<T>(value_grad_tmp, value_grad);
+  }
+}
+
 }  // namespace details
 }  // namespace primitive
 }  // namespace paddle

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -53,16 +53,12 @@ class TestPutAlongAxisOp(OpTest):
         self.outputs = {'Result': self.target}
 
     def test_check_output(self):
-        print(f" input : f{self.inputs['Input'].shape}")
-        print(f" Index : f{self.inputs['Index'].shape}")
-        print(f" Value : f{self.inputs['Value'].shape}")
-        print(f" reduce_op tpye : {self.reduce_op}")
-        print(f" axis : {self.axis}")
-        pass
-        # self.check_output(check_pir=True)
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(["Input", "Value"], "Result", check_pir=True, check_prim_pir=True)
+        self.check_grad(
+            ["Input", "Value"], "Result", check_pir=True, check_prim_pir=True
+        )
 
     def init_data(self):
         self.dtype = 'float64'
@@ -239,14 +235,6 @@ class TestPutAlongAxisOpAdd(TestPutAlongAxisOp):
                     self.target[i, self.index[i, j, k], k] += self.value[
                         i, j, k
                     ]
-        print(f"____________Input : {self.xnp.shape}")
-        print(f"____________Index : {self.index.shape}")
-        print(f"____________Value : {self.value.shape}")
-        print(f"___________ Target : {self.target.shape}")
-        print(f"____________Axis : {self.axis}")
-        print(f"____________Reduce : {self.reduce_op}")
-        print(f"____________Include_self : True")
-        print(f"____________Broadcast : False")
         self.inputs = {
             'Input': self.xnp,
             'Index': self.index,
@@ -539,12 +527,6 @@ class TestPutAlongAxisOpMax(TestPutAlongAxisOp):
                         self.target[i, self.index[i, j, k], k],
                         self.value[i, j, k],
                     )
-        print(f"____________Input : {self.xnp.shape}")
-        print(f"____________Index : {self.index.shape}")
-        print(f"____________Value : {self.value.shape}")
-        print(f"___________ Target : {self.target.shape}")
-        print(f"____________Axis : {self.axis}")
-        print(f"____________Reduce : {self.reduce_op}")
         self.inputs = {
             'Input': self.xnp,
             'Index': self.index,
@@ -662,7 +644,11 @@ class TestPutAlongAxisBF16Op(OpTest):
 
     def test_check_grad(self):
         self.check_grad_with_place(
-            self.place, ["Input", "Value"], "Result", check_pir=True, check_prim_pir=True
+            self.place,
+            ["Input", "Value"],
+            "Result",
+            check_pir=True,
+            check_prim_pir=True,
         )
 
     def init_data(self):

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -31,6 +31,8 @@ class TestPutAlongAxisOp(OpTest):
         self.init_data()
         self.reduce_op = "assign"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -51,10 +53,16 @@ class TestPutAlongAxisOp(OpTest):
         self.outputs = {'Result': self.target}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        print(f" input : f{self.inputs['Input'].shape}")
+        print(f" Index : f{self.inputs['Index'].shape}")
+        print(f" Value : f{self.inputs['Value'].shape}")
+        print(f" reduce_op tpye : {self.reduce_op}")
+        print(f" axis : {self.axis}")
+        pass
+        # self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(["Input", "Value"], "Result", check_pir=True)
+        self.check_grad(["Input", "Value"], "Result", check_pir=True, check_prim_pir=True)
 
     def init_data(self):
         self.dtype = 'float64'
@@ -86,6 +94,8 @@ class TestPutAlongAxisOpCase2(TestPutAlongAxisOp):
         self.init_data()
         self.reduce_op = "assign"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -126,6 +136,8 @@ class TestPutAlongAxisOpMul(TestPutAlongAxisOp):
         self.init_data()
         self.reduce_op = "mul"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -166,6 +178,8 @@ class TestPutAlongAxisOpMulNotIncludeSelf(TestPutAlongAxisOp):
         self.init_data()
         self.reduce_op = "mul"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -213,6 +227,8 @@ class TestPutAlongAxisOpAdd(TestPutAlongAxisOp):
         self.init_data()
         self.reduce_op = "add"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -223,6 +239,14 @@ class TestPutAlongAxisOpAdd(TestPutAlongAxisOp):
                     self.target[i, self.index[i, j, k], k] += self.value[
                         i, j, k
                     ]
+        print(f"____________Input : {self.xnp.shape}")
+        print(f"____________Index : {self.index.shape}")
+        print(f"____________Value : {self.value.shape}")
+        print(f"___________ Target : {self.target.shape}")
+        print(f"____________Axis : {self.axis}")
+        print(f"____________Reduce : {self.reduce_op}")
+        print(f"____________Include_self : True")
+        print(f"____________Broadcast : False")
         self.inputs = {
             'Input': self.xnp,
             'Index': self.index,
@@ -255,6 +279,8 @@ class TestPutAlongAxisOpAddNotIncludeSelf(TestPutAlongAxisOp):
         self.init_data()
         self.reduce_op = "add"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -302,6 +328,8 @@ class TestPutAlongAxisOpMean(TestPutAlongAxisOp):
         self.init_data()
         self.reduce_op = "mean"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -348,6 +376,8 @@ class TestPutAlongAxisOpMeanNotIncludeSelf(TestPutAlongAxisOp):
         self.init_data()
         self.reduce_op = "mean"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -402,6 +432,8 @@ class TestPutAlongAxisOpMin(TestPutAlongAxisOp):
         self.init_data()
         self.reduce_op = "amin"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -445,6 +477,8 @@ class TestPutAlongAxisOpMinNotIncludeSelf(TestPutAlongAxisOp):
         self.init_data()
         self.reduce_op = "amin"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -492,6 +526,8 @@ class TestPutAlongAxisOpMax(TestPutAlongAxisOp):
         self.init_data()
         self.reduce_op = "amax"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -503,6 +539,12 @@ class TestPutAlongAxisOpMax(TestPutAlongAxisOp):
                         self.target[i, self.index[i, j, k], k],
                         self.value[i, j, k],
                     )
+        print(f"____________Input : {self.xnp.shape}")
+        print(f"____________Index : {self.index.shape}")
+        print(f"____________Value : {self.value.shape}")
+        print(f"___________ Target : {self.target.shape}")
+        print(f"____________Axis : {self.axis}")
+        print(f"____________Reduce : {self.reduce_op}")
         self.inputs = {
             'Input': self.xnp,
             'Index': self.index,
@@ -535,6 +577,8 @@ class TestPutAlongAxisOpMaxNotIncludeSelf(TestPutAlongAxisOp):
         self.init_data()
         self.reduce_op = "amax"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -587,6 +631,8 @@ class TestPutAlongAxisBF16Op(OpTest):
         self.init_data()
         self.reduce_op = "assign"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -616,7 +662,7 @@ class TestPutAlongAxisBF16Op(OpTest):
 
     def test_check_grad(self):
         self.check_grad_with_place(
-            self.place, ["Input", "Value"], "Result", check_pir=True
+            self.place, ["Input", "Value"], "Result", check_pir=True, check_prim_pir=True
         )
 
     def init_data(self):
@@ -1058,6 +1104,8 @@ class TestPutAlongAxisAPIMulFloat32(unittest.TestCase):
         self.axis = 1
         self.axis_type = "int64"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -1108,6 +1156,8 @@ class TestPutAlongAxisAPIMulBF16(unittest.TestCase):
         self.axis = 1
         self.axis_type = "int64"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.random(self.x_shape).astype(self.x_type)
         self.target = copy.deepcopy(self.xnp)
@@ -1159,6 +1209,8 @@ class TestPutAlongAxisAPIMulInt32(unittest.TestCase):
         self.axis = 1
         self.axis_type = "int64"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.randint(1, 5, self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -1208,6 +1260,8 @@ class TestPutAlongAxisAPIMulInt64(unittest.TestCase):
         self.axis = 1
         self.axis_type = "int64"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.randint(1, 5, self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.
@@ -1257,6 +1311,8 @@ class TestPutAlongAxisAPIMulUint8(unittest.TestCase):
         self.axis = 1
         self.axis_type = "int64"
         self.op_type = "put_along_axis"
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
         self.xnp = np.random.randint(1, 5, self.x_shape).astype(self.x_type)
         # numpy put_along_axis is an inplace operation.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

 New features

### Description
<!-- Describe what you’ve done -->

反向拆解put_along_axis_grad op
