### PR TITLE
Fix bugs for pir current_expected_place in paddle/device

### DIFF
--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -500,7 +500,7 @@ class Event:
         interprocess: bool = False,
     ) -> None:
         if device is None:
-            self.device = paddle.framework._current_expected_place()
+            self.device = paddle.framework._current_expected_place_()
         elif isinstance(device, str):
             self.device = paddle.device._convert_to_place(device)
         else:
@@ -686,7 +686,7 @@ class Stream:
             return
 
         if device is None:
-            self.device = paddle.framework._current_expected_place()
+            self.device = paddle.framework._current_expected_place_()
         elif isinstance(device, str):
             self.device = paddle.device._convert_to_place(device)
         else:
@@ -885,7 +885,7 @@ def current_stream(device: PlaceLike | None = None) -> Stream:
 
     '''
     if device is None:
-        place = paddle.framework._current_expected_place()
+        place = paddle.framework._current_expected_place_()
     elif isinstance(device, str):
         place = paddle.device._convert_to_place(device)
     else:
@@ -996,7 +996,7 @@ class stream_guard:
 
         self.src_prev_stream = current_stream(cur_stream.device)
         if self.src_prev_stream.device != cur_stream.device:
-            self.tmp_place = paddle.base.framework._current_expected_place()
+            self.tmp_place = paddle.base.framework._current_expected_place_()
             paddle.base.framework._set_expected_place(cur_stream.device)
             self.dst_prev_stream = current_stream(cur_stream.device)
             set_stream(cur_stream)
@@ -1046,7 +1046,7 @@ def synchronize(device: PlaceLike | None = None) -> None:
     """
 
     if device is None:
-        place = paddle.framework._current_expected_place()
+        place = paddle.framework._current_expected_place_()
     elif isinstance(device, str):
         place = paddle.device._convert_to_place(device)
     else:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure


### PR Types
Bug fixes


### Description
<!-- Describe what you’ve done -->
pir模式下无法动态获取place信息，因而_current_expected_place会返回空：
```python
def _current_expected_place():
    if in_pir_mode():
        return core.Place() // return None
    return _current_expected_place_()
```
动态图下一些设备相关接口需要获取place信息，在动转静模式下将进入pir_mode，导致运行出错：
![image](https://github.com/user-attachments/assets/2bdfdc33-e876-4036-b9f9-54c7da0225b8)

本PR修复此问题。

Pcard-76459