### PR TITLE
[CINN] Fix bug of llama2-7b inference by skipping related code

### DIFF
--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -589,20 +589,21 @@ void SubgraphDetector::DoOpFusion() {
       MergeSubGraphs(producer, op, union_find, loop_detector);
     }
   }
-  for (auto* op : sort_ops_) {
-    auto producers = GetProducerOpsReverseSort(op, op2id_);
-    for (auto* producer : producers) {
-      if (op_classifier_(*op) && !op_classifier_(*producer)) {
-        for (auto* consumer : GetConsumerOpsSimple(producer)) {
-          if (op_classifier_(*consumer) &&
-              consumer->GetParent() == op->GetParent()) {
-            MergeSubGraphs(op, consumer, union_find, loop_detector);
-          }
-        }
-        continue;
-      }
-    }
-  }
+  // TODO(chenxi67): Redo this part after bug issue about llama2 is fixed
+  // for (auto* op : sort_ops_) {
+  //   auto producers = GetProducerOpsReverseSort(op, op2id_);
+  //   for (auto* producer : producers) {
+  //     if (op_classifier_(*op) && !op_classifier_(*producer)) {
+  //       for (auto* consumer : GetConsumerOpsSimple(producer)) {
+  //         if (op_classifier_(*consumer) &&
+  //             consumer->GetParent() == op->GetParent()) {
+  //           MergeSubGraphs(op, consumer, union_find, loop_detector);
+  //         }
+  //       }
+  //       continue;
+  //     }
+  //   }
+  // }
   for (const auto& op : sort_ops_) {
     subgraph_map_[op] = union_find.GetSetFromOp(op);
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
绕过 pr_67177 引入的 llama2-7b 在开启 cinn 推理出 core dumped 的问题
修复之后再打开