### PR TITLE
[SOT] Use `full` instead of `to_tensor` for symbolic input conversion

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -761,13 +761,18 @@ class FunctionGraph:
         self, inputs: OrderedSet[TensorVariable | SymbolicVariable]
     ):
         for input_var in inputs:
+            # For SymbolicVariable, we use paddle.full([], value, "int64")
+            # to convert it to a Tensor
             if isinstance(input_var, SymbolicVariable):
                 self.pycode_gen.gen_load_object(
-                    paddle.to_tensor, "___paddle_to_tensor"
+                    paddle.full,
+                    "___paddle_full",
                 )
+                self.pycode_gen.gen_build_list(0)
             input_var.tracker.gen_instructions(self.pycode_gen)
             if isinstance(input_var, SymbolicVariable):
-                self.pycode_gen.gen_call_function(1)
+                self.pycode_gen.gen_load_const("int64")
+                self.pycode_gen.gen_call_function(3)
 
     def _find_tensor_outputs(
         self, outputs: list[VariableBase]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

之前 SOT 生成代码中的 Symbol 使用 `to_tensor` 转为 Tensor，但这有一个问题是会产生额外的 memcpy，因此本 PR 使用 `full` 替换掉 `to_tensor` 以消除 memcpy 的开销

优化前：

![image](https://github.com/user-attachments/assets/85851acc-c945-44d3-9242-b1dd860cdc4c)

优化后：

![image](https://github.com/user-attachments/assets/3987d96c-08e8-4492-9c4b-ef2599c87883)

Pcard-67164