### PR TITLE
[Typing] Remove common type `IntSequence`

### DIFF
--- a/python/paddle/_typing/__init__.py
+++ b/python/paddle/_typing/__init__.py
@@ -17,7 +17,6 @@ from .backport import EllipsisType as EllipsisType
 
 # Basic
 from .basic import (
-    IntSequence as IntSequence,
     NestedList as NestedList,
     NestedNumbericSequence as NestedNumbericSequence,
     NestedSequence as NestedSequence,

--- a/python/paddle/_typing/basic.py
+++ b/python/paddle/_typing/basic.py
@@ -55,7 +55,6 @@ NestedList = Union[_T, List["NestedList[_T]"]]
 NestedStructure = Union[
     _T, Dict[str, "NestedStructure[_T]"], Sequence["NestedStructure[_T]"]
 ]
-IntSequence = Sequence[int]
 NumbericSequence = Sequence[Numberic]
 NestedNumbericSequence: TypeAlias = NestedSequence[Numberic]
 TensorOrTensors: TypeAlias = Union["Tensor", Sequence["Tensor"]]

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -43,6 +43,8 @@ from ...tensor.creation import zeros
 from ...tensor.manipulation import squeeze, unsqueeze
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from typing_extensions import TypeAlias
 
     from paddle import Tensor
@@ -51,7 +53,6 @@ if TYPE_CHECKING:
         DataLayout2D,
         DataLayout3D,
         DataLayoutND,
-        IntSequence,
         ShapeLike,
         Size2,
         Size4,
@@ -1040,7 +1041,7 @@ def bilinear(
 def dropout(
     x: Tensor,
     p: float = 0.5,
-    axis: int | IntSequence | None = None,
+    axis: int | Sequence[int] | None = None,
     training: bool = True,
     mode: _DropoutMode = "upscale_in_train",
     name: str | None = None,

--- a/python/paddle/nn/layer/common.py
+++ b/python/paddle/nn/layer/common.py
@@ -23,13 +23,14 @@ from .. import functional as F
 from .layers import Layer
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from paddle import Tensor
     from paddle._typing import (
         DataLayout1D,
         DataLayout1DVariant,
         DataLayout2D,
         DataLayout3D,
-        IntSequence,
         ParamAttrLike,
         ShapeLike,
         Size2,
@@ -42,7 +43,7 @@ if TYPE_CHECKING:
         _PaddingTensorMode,
     )
 
-    _T_Padding = TypeVar("_T_Padding", Tensor, IntSequence)
+    _T_Padding = TypeVar("_T_Padding", Tensor, Sequence[int])
 
 __all__ = []
 
@@ -843,14 +844,14 @@ class Dropout(Layer):
     """
 
     p: float
-    axis: int | IntSequence | None
+    axis: int | Sequence[int] | None
     mode: _DropoutMode
     name: str | None
 
     def __init__(
         self,
         p: float = 0.5,
-        axis: int | IntSequence | None = None,
+        axis: int | Sequence[int] | None = None,
         mode: _DropoutMode = "upscale_in_train",
         name: str | None = None,
     ) -> None:
@@ -1216,7 +1217,7 @@ class Pad1D(Layer):
 
     def __init__(
         self,
-        padding: Tensor | IntSequence | int,
+        padding: Tensor | Sequence[int] | int,
         mode: _PaddingTensorMode = 'constant',
         value: float = 0.0,
         data_format: DataLayout1D = "NCL",
@@ -1284,7 +1285,7 @@ class ZeroPad1D(Layer):
 
     def __init__(
         self,
-        padding: Tensor | IntSequence | int,
+        padding: Tensor | Sequence[int] | int,
         data_format: DataLayout1D = "NCL",
         name: str | None = None,
     ) -> None:
@@ -1358,7 +1359,7 @@ class Pad2D(Layer):
 
     def __init__(
         self,
-        padding: Tensor | IntSequence | int,
+        padding: Tensor | Sequence[int] | int,
         mode: _PaddingTensorMode = 'constant',
         value: float = 0.0,
         data_format: DataLayout2D = "NCHW",
@@ -1429,7 +1430,7 @@ class ZeroPad2D(Layer):
 
     def __init__(
         self,
-        padding: Tensor | IntSequence | int,
+        padding: Tensor | Sequence[int] | int,
         data_format: DataLayout2D = "NCHW",
         name: str | None = None,
     ) -> None:
@@ -1503,7 +1504,7 @@ class Pad3D(Layer):
 
     def __init__(
         self,
-        padding: Tensor | IntSequence | int,
+        padding: Tensor | Sequence[int] | int,
         mode: _PaddingTensorMode = 'constant',
         value: float = 0.0,
         data_format: DataLayout3D = "NCDHW",
@@ -1574,7 +1575,7 @@ class ZeroPad3D(Layer):
 
     def __init__(
         self,
-        padding: Tensor | IntSequence | int,
+        padding: Tensor | Sequence[int] | int,
         data_format: DataLayout3D = "NCDHW",
         name: str | None = None,
     ) -> None:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

移除类型 `IntSequence`，直接使用 `Sequence[int]`

Pcard-67164