### PR TITLE
fix neg inf bug

### DIFF
--- a/paddle/cinn/ir/ir_printer.cc
+++ b/paddle/cinn/ir/ir_printer.cc
@@ -53,6 +53,11 @@ void IrPrinter::Visit(const IntImm *x) {
     str_ += std::to_string(x->value);
     str_ += "ll";
   } else if (x->type().is_int(32)) {
+    // The min int32_t constant(-2147483648) will be recognized as long
+    // and max(long, int32_t) is illegal, so we need to add cast here.
+    if (x->value == std::numeric_limits<std::int32_t>::min()) {
+      str_ += "(int32_t)";
+    }
     str_ += std::to_string(x->value);
   } else if (x->type().is_int(16)) {
     str_ += "(int16_t)";

--- a/paddle/cinn/optim/ir_simplify.cc
+++ b/paddle/cinn/optim/ir_simplify.cc
@@ -471,6 +471,7 @@ void Simplify(Expr* expr) {
   SimplifyLoadMutator()(expr);
   SimplifyStoreMutator()(expr);
   SimplifyIfThenElseMutator()(expr);
+
   cinn::common::cas_intervals_t var_intervals;
   SimplifyNoPureMathMutator mutator(var_intervals);
   mutator(expr);

--- a/paddle/cinn/optim/ir_simplify.cc
+++ b/paddle/cinn/optim/ir_simplify.cc
@@ -383,6 +383,9 @@ CastType NormCastValue(T value) {
   }
 
   if (std::isinf(value)) {
+    if (CastType(value) == -std::numeric_limits<CastType>::infinity()) {
+      return -std::numeric_limits<CastType>::infinity();
+    }
     return std::numeric_limits<CastType>::infinity();
   } else if (std::isnan(value)) {
     return std::numeric_limits<CastType>::signaling_NaN();
@@ -400,6 +403,7 @@ struct SimplifyCastMutator : public ir::IRMutator<> {
   void Visit(const ir::Cast* op, Expr* expr) {
     auto* node = expr->As<ir::Cast>();
 
+    std::cerr << "cast !!! " << *expr << std::endl;
     ir::IRMutator<ir::Expr*>::Visit(&node->v(), &node->v());
 
     if (op->type() == op->v().type()) {
@@ -468,10 +472,12 @@ void Simplify(Expr* expr) {
   SimplifyLoadMutator()(expr);
   SimplifyStoreMutator()(expr);
   SimplifyIfThenElseMutator()(expr);
-
+  VLOG(1) << "111111111";
   cinn::common::cas_intervals_t var_intervals;
   SimplifyNoPureMathMutator mutator(var_intervals);
+  VLOG(1) << "111111111";
   mutator(expr);
+  VLOG(1) << "111111111";
 
   ReplaceFracWithDivMutator()(expr);
 }

--- a/paddle/cinn/optim/ir_simplify.cc
+++ b/paddle/cinn/optim/ir_simplify.cc
@@ -403,7 +403,6 @@ struct SimplifyCastMutator : public ir::IRMutator<> {
   void Visit(const ir::Cast* op, Expr* expr) {
     auto* node = expr->As<ir::Cast>();
 
-    std::cerr << "cast !!! " << *expr << std::endl;
     ir::IRMutator<ir::Expr*>::Visit(&node->v(), &node->v());
 
     if (op->type() == op->v().type()) {
@@ -472,12 +471,9 @@ void Simplify(Expr* expr) {
   SimplifyLoadMutator()(expr);
   SimplifyStoreMutator()(expr);
   SimplifyIfThenElseMutator()(expr);
-  VLOG(1) << "111111111";
   cinn::common::cas_intervals_t var_intervals;
   SimplifyNoPureMathMutator mutator(var_intervals);
-  VLOG(1) << "111111111";
   mutator(expr);
-  VLOG(1) << "111111111";
 
   ReplaceFracWithDivMutator()(expr);
 }


### PR DESCRIPTION
### PR Category
CINN

### PR Types
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-76996

修复对于-inf处理的bug， 在c++中， 有-inf 和 inf之分，表示最小和最大值，在cinn得流程中，未区分，导致结果出现错误
