### PR TITLE
[SOT] Modify `DELETE_FAST` instruction arg

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -323,7 +323,6 @@ def modify_extended_args(instructions: list[Instruction]) -> bool:
 
 
 def modify_vars(instructions: list[Instruction], code_options):
-    co_names = code_options['co_names']
     co_varnames = code_options['co_varnames']
     co_freevars = code_options['co_freevars']
     for instrs in instructions:

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -327,7 +327,12 @@ def modify_vars(instructions: list[Instruction], code_options):
     co_varnames = code_options['co_varnames']
     co_freevars = code_options['co_freevars']
     for instrs in instructions:
-        if instrs.opname in ['LOAD_FAST', 'LOAD_FAST_CHECK', 'STORE_FAST']:
+        if instrs.opname in [
+            'LOAD_FAST',
+            'LOAD_FAST_CHECK',
+            'STORE_FAST',
+            'DELETE_FAST',
+        ]:
             assert (
                 instrs.argval in co_varnames
             ), f"`{instrs.argval}` not in {co_varnames}"

--- a/test/sot/test_delete_fast.py
+++ b/test/sot/test_delete_fast.py
@@ -19,6 +19,7 @@ import unittest
 from test_case_base import TestCaseBase
 
 import paddle
+from paddle.jit.sot.psdb import breakgraph
 
 
 def test_delete_fast(a):
@@ -28,10 +29,32 @@ def test_delete_fast(a):
     return a
 
 
+def inner_call_with_breakgraph(a):
+    breakgraph()
+    return a + 1
+
+
+def test_delete_fast_with_breakgraph(a):
+    a = a + 2
+    t1 = a * 3
+    out1 = inner_call_with_breakgraph(a + t1)
+    t2 = a - 4
+    t3 = a / 5
+    out2 = inner_call_with_breakgraph(t1 + t2)
+    del t1, t2, t3
+    return a + out1 + out2
+
+
 class TestDeleteFast(TestCaseBase):
     def test_simple(self):
         a = paddle.to_tensor(1)
         self.assert_results(test_delete_fast, a)
+
+
+class TestDeleteFastWithBreakGraph(TestCaseBase):
+    def test_delete_fast_with_break_graph(self):
+        a = paddle.to_tensor(1)
+        self.assert_results(test_delete_fast_with_breakgraph, a)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

在生成代码中，我们针对 `LOAD_FAST` 和 `STORE_FAST` 根据 `co_varnames` 修改了 instruction 的 `arg`，但是没有修改 `DELETE_FAST`，这就可能导致生成代码里 `DELETE_FAST` 错位，因此将 `DELETE_FAST` 也添加到 modify 的列表

Pcard-67164