### PR TITLE
[CINN]Fix bug caused by Fake Value in symbolic shape interface

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.cc
@@ -258,6 +258,6 @@ std::vector<symbol::DimExpr> GetSymShapeForInputValue(
 }
 
 bool IsFakeValue(const pir::Value &value) {
-  return value.impl() == nullptr || !value.type();
+  return value.impl() == nullptr || value.type() == pir::Type();
 }
 }  // namespace paddle::dialect::details

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.cc
@@ -256,4 +256,8 @@ std::vector<symbol::DimExpr> GetSymShapeForInputValue(
   }
   return result_dim_exprs;
 }
+
+bool IsFakeValue(const pir::Value &value) {
+  return value.impl() == nullptr || !value.type();
+}
 }  // namespace paddle::dialect::details

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
@@ -175,4 +175,6 @@ std::vector<symbol::DimExpr> GetSymShapeForInputValue(
     const std::string &input_name,
     const pir::Value &value,
     pir::InferSymbolicShapeContext *infer_context);
+
+bool IsFakeValue(const pir::Value &value);
 }  // namespace paddle::dialect::details

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -1496,17 +1496,18 @@ bool GenerateProposalsOpInferSymbolicShape(
       symbol::ShapeOrDataDimExprs{
           symbol::TensorShapeOrDataDimExprs(rpn_roi_probs_shape)});
 
-  const symbol::ShapeOrDataDimExprs &score_shape_or_data =
-      infer_context->GetShapeOrDataForValue(op->operand_source(0));
+  if (paddle::dialect::details::IsFakeValue(op->result(2))) {
+    const std::vector<symbol::DimExpr> &score_shape =
+        infer_context->GetShapeOrDataForValue(op->operand_source(0)).shape();
+    std::vector<symbol::DimExpr> rpn_rois_num_shape = {score_shape[0]};
 
-  std::vector<symbol::DimExpr> score_shape = score_shape_or_data.shape();
-  auto rpn_rois_num_shape = std::vector<symbol::DimExpr>{score_shape[0]};
-
-  infer_context->SetShapeOrDataForValue(
-      op->result(2),
-      symbol::ShapeOrDataDimExprs{
-          symbol::TensorShapeOrDataDimExprs(rpn_rois_num_shape)});
-
+    infer_context->SetShapeOrDataForValue(
+        op->result(2),
+        symbol::ShapeOrDataDimExprs{
+            symbol::TensorShapeOrDataDimExprs(rpn_rois_num_shape)});
+  } else {
+    infer_context->SetSymbolForValueByStaticShape(op->result(2));
+  }
   return true;
 }
 

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -1496,7 +1496,21 @@ bool GenerateProposalsOpInferSymbolicShape(
       symbol::ShapeOrDataDimExprs{
           symbol::TensorShapeOrDataDimExprs(rpn_roi_probs_shape)});
 
-  if (paddle::dialect::details::IsFakeValue(op->result(2))) {
+  // NOTE(gongshaotian): In the training task, the isFakeValue() interface can
+  // be used to determine whether rpn_rois_num needs to be output. However, in
+  // the inference task of executing the old model that has already been
+  // trained, since the InferMeta() function will no longer be executed, it is
+  // impossible to determine whether rpn_rois_num is a Fake value through
+  // isFakeValue(), so it is necessary to judge based on the dimension of
+  // DenseTensor.
+  if (paddle::dialect::details::IsFakeValue(op->result(2)) ||
+      op->result(2)
+              .type()
+              .dyn_cast<paddle::dialect::DenseTensorType>()
+              .dims()
+              .size() == 0) {
+    infer_context->SetSymbolForValueByStaticShape(op->result(2));
+  } else {
     const std::vector<symbol::DimExpr> &score_shape =
         infer_context->GetShapeOrDataForValue(op->operand_source(0)).shape();
     std::vector<symbol::DimExpr> rpn_rois_num_shape = {score_shape[0]};
@@ -1505,9 +1519,8 @@ bool GenerateProposalsOpInferSymbolicShape(
         op->result(2),
         symbol::ShapeOrDataDimExprs{
             symbol::TensorShapeOrDataDimExprs(rpn_rois_num_shape)});
-  } else {
-    infer_context->SetSymbolForValueByStaticShape(op->result(2));
   }
+
   return true;
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
1. 符号推导namespace下添加fake value检查接口
2. 修复facke value导致的 generate_proposals op 符号推导bug
其他涉及 optional 类型输出的 op 的修复PR后续提交

关联PR：
https://github.com/PaddlePaddle/Paddle/pull/67465 修改了Optional类型输出的设置方式
https://github.com/PaddlePaddle/Paddle/pull/67413 添加的GenerateProposals op的符号推导接口