### PR TITLE
FIX: expression too big in ctest -R

### DIFF
--- a/tools/group_case_for_parallel.py
+++ b/tools/group_case_for_parallel.py
@@ -121,15 +121,27 @@ def group_case_for_parallel(rootPath):
         new_f.close()
 
     # no parallel cases
+    max_case_num_per_line = 100
+    no_parallel_case_line_list = []
     cases = '^job'
     if len(all_need_run_cases) != 0:
+        cnt = 0
         for case in all_need_run_cases:
             if case not in nightly_tests:
                 cases = cases + f'$|^{case}'
+                cnt += 1
+                if cnt == max_case_num_per_line:
+                    cases = f'{cases}$'
+                    no_parallel_case_line_list.append(cases)
+                    cnt = 0
+                    cases = '^job'
+
         cases = f'{cases}$'
+        no_parallel_case_line_list.append(cases)
 
     new_f = open(f'{rootPath}/tools/no_parallel_case_file', 'w')
-    new_f.write(cases + '\n')
+    for case_line in no_parallel_case_line_list:
+        new_f.write(case_line + '\n')
     new_f.close()
     f.close()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
 Bug fixes

### Description
<!-- Describe what you’ve done -->
RegularExpression::compile(): Expression too big.
After merging the CINN pipeline, the number of unit tests increased, and the number of unit tests in the no_parallel_case  exceeded the maximum expression length supported by ctest -R. Therefore, the tests should be split, and the number of unit tests per split should not exceed 100.
pcard-67164