### PR TITLE
add  pd_op.mean converter for PIR TRT

### DIFF
--- a/python/paddle/tensorrt/impls/core.py
+++ b/python/paddle/tensorrt/impls/core.py
@@ -150,6 +150,20 @@ def transpose_converter(network, paddle_op, inputs):
     transposed_tensor.second_transpose = perm
     return transposed_tensor
 
+@converter_registry.register("pd_op.mean", trt_version="8.x")
+def mean_converter(network, paddle_op, inputs):
+    input_tensor = inputs[0]
+    keep_dim = paddle_op.attrs().get("keepdim")
+    dim = paddle_op.attrs().get("axis")
+
+    mean_layer = network.add_reduce(
+            input_tensor,
+            trt.ReduceOperation.AVG,
+            axes=get_axes_for_reduce_op(dim, network.has_implicit_batch_dimension),
+            keep_dims=keep_dim,
+        )
+    return mean_layer
+
 
 @converter_registry.register("pd_op.full", trt_version="8.x")
 def full_converter(network, paddle_op, inputs):

--- a/test/tensorrt/test_converter_mean.py
+++ b/test/tensorrt/test_converter_mean.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from tensorrt_test_base import TensorRTBaseTest
+
+import paddle
+
+class TestMeanTRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.mean
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype(np.float32),
+            "axis": [1],
+            "keepdim": False,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1, 3]}
+        self.max_shape = {"x": [5, 3]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
+class TestMeanTRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.mean
+        self.api_args = {
+            "x": np.random.randn(2, 3, 2).astype(np.float32),
+            "axis": [1, 1],
+            "keepdim": True,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1, 3, 2]}
+        self.max_shape = {"x": [5, 3, 2]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Inference
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
card-71500
添加了pd_op.mean到PIR TRT转换支持