### PR TITLE
[AutoParallel] Add spmd rules for nonzero op

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/nonzero.cc
+++ b/paddle/phi/infermeta/spmd_rules/nonzero.cc
@@ -1,0 +1,92 @@
+/* Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHoutput WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/phi/infermeta/spmd_rules/nonzero.h"
+
+#include "glog/logging.h"
+
+#include "paddle/phi/core/enforce.h"
+#include "paddle/phi/infermeta/spmd_rules/spmd_rule_macro_define.h"
+#include "paddle/phi/infermeta/spmd_rules/utils.h"
+
+namespace phi::distributed {
+using phi::distributed::auto_parallel::str_join;
+
+SpmdInfo NonZeroInferSpmd(const DistMetaTensor& x) {
+  // Step0: Verify input args based on nonzero logic
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(x);
+
+  // Step1: Build einsum notation
+  std::string x_axes(x_ndim, '1');
+  std::string output_axes(2, '1');
+
+  // Step2: Sharding Propogation
+  // Step2.1: Merge input shardings
+  std::unordered_map<std::string, int64_t> axis_to_dim_map =
+      ShardingMergeForTensors({{x_axes, x_dims_mapping_src}});
+
+  // Step2.2: Infer input and output dims mapping
+  auto x_dims_mapping_dst = GetDimsMappingForAxes(x_axes, axis_to_dim_map);
+  auto x_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  x_dist_attr_dst.set_dims_mapping(x_dims_mapping_dst);
+  auto output_dims_mapping_dst =
+      GetDimsMappingForAxes(output_axes, axis_to_dim_map);
+  auto output_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  output_dist_attr_dst.set_dims_mapping(output_dims_mapping_dst);
+
+  // Step 3: Log messages
+  VLOG(4) << "NonZeroInferSpmd:";
+  VLOG(4) << "Einsum Notation: " << x_axes << "-->" << output_axes;
+
+  LOG_SPMD_INPUT(x);
+  LOG_SPMD_OUTPUT(output_dist_attr_dst);
+
+  return SpmdInfo({x_dist_attr_dst}, {output_dist_attr_dst});
+}
+
+SpmdInfo NonZeroInferSpmdReverse(const DistMetaTensor& x,
+                                 const DistMetaTensor& output) {
+  // Step0: Verify input args based on nonzero logic
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(x);
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(output);
+
+  // Step1: Build einsum notation
+  std::string x_axes(x_ndim, '1');
+  std::string output_axes(2, '1');
+
+  // Step2: Sharding Propogation
+  // Step2.1: Merge input shardings
+  std::unordered_map<std::string, int64_t> axis_to_dim_map =
+      ShardingMergeForTensors({{output_axes, output_dims_mapping_src}});
+
+  // Step2.2: Infer input and output dims mapping
+  auto x_dims_mapping_dst = GetDimsMappingForAxes(x_axes, axis_to_dim_map);
+  auto x_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  x_dist_attr_dst.set_dims_mapping(x_dims_mapping_dst);
+  auto output_dims_mapping_dst =
+      GetDimsMappingForAxes(output_axes, axis_to_dim_map);
+  auto output_dist_attr_dst = CopyTensorDistAttrForOutput(output_dist_attr_src);
+  output_dist_attr_dst.set_dims_mapping(output_dims_mapping_dst);
+
+  // Step 3: Log messages
+  VLOG(4) << "NonZeroInferSpmdReverse:";
+  VLOG(4) << "Einsum Notation: " << x_axes << "-->" << output_axes;
+
+  LOG_SPMD_INPUT(x);
+  LOG_SPMD_INPUT(output);
+  LOG_SPMD_OUTPUT(output_dist_attr_dst);
+
+  return SpmdInfo({x_dist_attr_dst}, {output_dist_attr_dst});
+}  // namespace distributed
+}  // namespace phi::distributed

--- a/paddle/phi/infermeta/spmd_rules/nonzero.h
+++ b/paddle/phi/infermeta/spmd_rules/nonzero.h
@@ -1,0 +1,35 @@
+/* Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <iterator>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "paddle/phi/common/int_array.h"
+#include "paddle/phi/core/distributed/auto_parallel/dist_meta_tensor.h"
+#include "paddle/phi/core/distributed/type_defs.h"
+
+namespace phi {
+namespace distributed {
+
+SpmdInfo NonZeroInferSpmd(const DistMetaTensor& x);
+
+SpmdInfo NonZeroInferSpmdReverse(const DistMetaTensor& x,
+                                 const DistMetaTensor& out);
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -701,5 +701,9 @@ PD_REGISTER_SPMD_RULE(pad,
                       PD_INFER_SPMD(phi::distributed::PadInferSpmd),
                       PD_INFER_SPMD(phi::distributed::PadGradInferSpmd));
 
+// nonzero
+PD_REGISTER_SPMD_RULE(nonzero,
+                      PD_INFER_SPMD(phi::distributed::NonZeroInferSpmd),
+                      PD_INFER_SPMD(phi::distributed::NonZeroInferSpmdReverse));
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/rules.h
+++ b/paddle/phi/infermeta/spmd_rules/rules.h
@@ -39,6 +39,7 @@ limitations under the License. */
 #include "paddle/phi/infermeta/spmd_rules/matmul.h"
 #include "paddle/phi/infermeta/spmd_rules/moe_combine.h"
 #include "paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.h"
+#include "paddle/phi/infermeta/spmd_rules/nonzero.h"
 #include "paddle/phi/infermeta/spmd_rules/numel.h"
 #include "paddle/phi/infermeta/spmd_rules/one_hot.h"
 #include "paddle/phi/infermeta/spmd_rules/optimizer.h"

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -3471,6 +3471,7 @@
   output : Tensor(out)
   infer_meta :
     func : NonZeroInferMeta
+    spmd_rule: NonZeroInferSpmd
   kernel :
     func : nonzero
     data_type: condition

--- a/test/auto_parallel/spmd_rules/CMakeLists.txt
+++ b/test/auto_parallel/spmd_rules/CMakeLists.txt
@@ -42,6 +42,7 @@ if(WITH_DISTRIBUTE)
   py_test_modules(test_fused_dropout_add_rule MODULES
                   test_fused_dropout_add_rule)
   py_test_modules(test_logsumexp_rule MODULES test_logsumexp_rule)
+  py_test_modules(test_nonzero_rule MODULES test_nonzero_rule)
   # End of unittests WITH single card WITHOUT timeout
 
 endif()

--- a/test/auto_parallel/spmd_rules/test_nonzero_rule.py
+++ b/test/auto_parallel/spmd_rules/test_nonzero_rule.py
@@ -75,9 +75,10 @@ class TestNonZeroSPMDRule(unittest.TestCase):
         self.assertEqual(infered_input_dist_attr[0].dims_mapping, [-1, -1, -1])
         self.assertEqual(infered_output_dist_attr[0].dims_mapping, [-1, -1])
 
-    def _test_infer_reverse(self):
-        # [1, 1] (output) -->
+    def test_infer_reverse(self):
+        # [1, 1, 1], [-1, -1] (x, output) -->
         # [-1, -1, -1], [-1, -1] (x, output)
+        self.x_dist_tensor_spec.set_dims_mapping([1, 1, 1])
         self.output_dist_tensor_spec.set_dims_mapping([1, 1])
 
         infered_dist_attr = self.rule1.infer_backward(
@@ -94,8 +95,9 @@ class TestNonZeroSPMDRule(unittest.TestCase):
         self.assertEqual(infered_input_dist_attr[0].dims_mapping, [-1, -1, -1])
         self.assertEqual(infered_output_dist_attr[0].dims_mapping, [-1, -1])
 
-        # [-1, -1] (output) -->
+        # [-1, -1, -1], [-1, -1] (x, output) -->
         # [-1, -1, -1], [-1, -1] (x, output)
+        self.x_dist_tensor_spec.set_dims_mapping([1, 1, 1])
         self.output_dist_tensor_spec.set_dims_mapping([-1, -1])
 
         infered_dist_attr = self.rule1.infer_backward(

--- a/test/auto_parallel/spmd_rules/test_nonzero_rule.py
+++ b/test/auto_parallel/spmd_rules/test_nonzero_rule.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from paddle.distributed.auto_parallel.static.dist_attribute import (
+    DistTensorSpec,
+    TensorDistAttr,
+)
+from paddle.distributed.fleet import auto
+from paddle.framework import core
+
+
+class TestNonZeroSPMDRule(unittest.TestCase):
+    """
+    Unit tests for nonzero spmd rule.
+    """
+
+    def setUp(self):
+        self.rule1 = core.get_phi_spmd_rule("nonzero")
+        process_mesh = auto.ProcessMesh(mesh=[[0, 1], [2, 3]])
+        x_shape = [16, 16, 16]
+        x_tensor_dist_attr = TensorDistAttr()
+        x_tensor_dist_attr.process_mesh = process_mesh
+        self.x_dist_tensor_spec = DistTensorSpec(x_shape, x_tensor_dist_attr)
+
+        output_shape = [8, 8]
+        output_tensor_dist_attr = TensorDistAttr()
+        output_tensor_dist_attr.process_mesh = process_mesh
+        self.output_dist_tensor_spec = DistTensorSpec(
+            output_shape, output_tensor_dist_attr
+        )
+
+    def test_infer_forward(self):
+        # [1, 1, 1] (x) -->
+        # [-1, -1, -1], [-1, -1] (x, output)
+        self.x_dist_tensor_spec.set_dims_mapping([1, 1, 1])
+
+        infered_dist_attr = self.rule1.infer_forward(self.x_dist_tensor_spec)
+
+        self.assertEqual(len(infered_dist_attr), 2)
+        infered_input_dist_attr = infered_dist_attr[0]
+        infered_output_dist_attr = infered_dist_attr[1]
+
+        self.assertEqual(len(infered_input_dist_attr), 1)
+        self.assertEqual(len(infered_output_dist_attr), 1)
+
+        self.assertEqual(infered_input_dist_attr[0].dims_mapping, [-1, -1, -1])
+        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [-1, -1])
+
+        # [-1, -1, -1] (x) -->
+        # [-1, -1, -1], [-1, -1] (x, output)
+        self.x_dist_tensor_spec.set_dims_mapping([-1, -1, -1])
+
+        infered_dist_attr = self.rule1.infer_forward(self.x_dist_tensor_spec)
+
+        self.assertEqual(len(infered_dist_attr), 2)
+        infered_input_dist_attr = infered_dist_attr[0]
+        infered_output_dist_attr = infered_dist_attr[1]
+
+        self.assertEqual(len(infered_input_dist_attr), 1)
+        self.assertEqual(len(infered_output_dist_attr), 1)
+
+        self.assertEqual(infered_input_dist_attr[0].dims_mapping, [-1, -1, -1])
+        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [-1, -1])
+
+    def _test_infer_reverse(self):
+        # [1, 1] (output) -->
+        # [-1, -1, -1], [-1, -1] (x, output)
+        self.output_dist_tensor_spec.set_dims_mapping([1, 1])
+
+        infered_dist_attr = self.rule1.infer_backward(
+            self.x_dist_tensor_spec, self.output_dist_tensor_spec
+        )
+
+        self.assertEqual(len(infered_dist_attr), 2)
+        infered_input_dist_attr = infered_dist_attr[0]
+        infered_output_dist_attr = infered_dist_attr[1]
+
+        self.assertEqual(len(infered_input_dist_attr), 1)
+        self.assertEqual(len(infered_output_dist_attr), 1)
+
+        self.assertEqual(infered_input_dist_attr[0].dims_mapping, [-1, -1, -1])
+        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [-1, -1])
+
+        # [-1, -1] (output) -->
+        # [-1, -1, -1], [-1, -1] (x, output)
+        self.output_dist_tensor_spec.set_dims_mapping([-1, -1])
+
+        infered_dist_attr = self.rule1.infer_backward(
+            self.x_dist_tensor_spec, self.output_dist_tensor_spec
+        )
+
+        self.assertEqual(len(infered_dist_attr), 2)
+        infered_input_dist_attr = infered_dist_attr[0]
+        infered_output_dist_attr = infered_dist_attr[1]
+
+        self.assertEqual(len(infered_input_dist_attr), 1)
+        self.assertEqual(len(infered_output_dist_attr), 1)
+
+        self.assertEqual(infered_input_dist_attr[0].dims_mapping, [-1, -1, -1])
+        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [-1, -1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features


### Description
<!-- Describe what you’ve done -->
Add spmd rules for nonzero op
Pcard-67164