### PR TITLE
[CINN]Fix MatmulOpInferSymbolicShape

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1107,7 +1107,7 @@ PHI_DEFINE_EXPORTED_string(cinn_subgraph_graphviz_dir,
 /*
  * CINN related FLAG
  * Name: FLAGS_cinn_specify_input_dynamic_dim
- * Since Version: develop
+ * Since Version: 3.0 Beta
  * Value Range: bool, default=false
  * Example: FLAGS_cinn_specify_input_dynamic_dim=true will use file set by
  * FLAGS_cinn_input_dynamic_dim_spec_file to specify input dynamic dimention.
@@ -1119,7 +1119,7 @@ PHI_DEFINE_EXPORTED_bool(cinn_specify_input_dynamic_dim,
 /*
  * CINN related FLAG
  * Name: FLAGS_cinn_input_dynamic_dim_spec_file
- * Since Version: develop
+ * Since Version: 3.0 Beta
  * Value Range: string, default=""
  * Example: FLAGS_cinn_input_dynamic_dim_spec_file="./config.json",
  * FLAGS_cinn_specify_input_dynamic_dim=true would use input dynamic dimention

--- a/test/ir/pir/cinn/symbolic/test_infer_sym_shape_binary_op.py
+++ b/test/ir/pir/cinn/symbolic/test_infer_sym_shape_binary_op.py
@@ -145,8 +145,8 @@ class MatmulOpInferSymbolicShapeTest(TestBase):
             'shape[], data[NULL]',
             'shape[S0], data[NULL]',
             'shape[S0, S1], data[NULL]',
-            'shape[S0, S1, S5], data[NULL]',
-            'shape[S0, S1, S2, S7], data[NULL]',
+            'shape[Broadcast(S0, S3), S1, S5], data[NULL]',
+            'shape[Broadcast(S0, S4), Broadcast(S1, S5), S2, S7], data[NULL]',
             # with transpose
             'shape[S1, S3], data[NULL]',
             'shape[S0, S2], data[NULL]',


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR fixes MatmulOpInferSymbolicShape.
