### PR TITLE
fix flash_attn_grad seed_offset backend bug

### DIFF
--- a/paddle/phi/kernels/gpu/flash_attn_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_grad_kernel.cu
@@ -1086,7 +1086,7 @@ PD_REGISTER_KERNEL(flash_attn_unpadded_grad,
                    phi::FlashAttnUnpaddedGradKernel,
                    phi::dtype::float16,
                    phi::dtype::bfloat16) {
-  kernel->InputAt(7).SetBackend(phi::Backend::ALL_BACKEND);  // seed_offset
+  kernel->InputAt(7).SetBackend(phi::Backend::CPU);  // seed_offset
 }
 
 PD_REGISTER_KERNEL(flash_attn_varlen_qkvpacked_grad,
@@ -1095,7 +1095,7 @@ PD_REGISTER_KERNEL(flash_attn_varlen_qkvpacked_grad,
                    phi::FlashAttnVarlenQKVPackedGradKernel,
                    phi::dtype::float16,
                    phi::dtype::bfloat16) {
-  kernel->InputAt(5).SetBackend(phi::Backend::ALL_BACKEND);  // seed_offset
+  kernel->InputAt(5).SetBackend(phi::Backend::CPU);  // seed_offset
 }
 
 PD_REGISTER_KERNEL(flash_attn_grad,
@@ -1104,7 +1104,7 @@ PD_REGISTER_KERNEL(flash_attn_grad,
                    phi::FlashAttnGradKernel,
                    phi::dtype::float16,
                    phi::dtype::bfloat16) {
-  kernel->InputAt(5).SetBackend(phi::Backend::ALL_BACKEND);  // seed_offset
+  kernel->InputAt(5).SetBackend(phi::Backend::CPU);  // seed_offset
 }
 
 PD_REGISTER_KERNEL(flash_attn_qkvpacked_grad,
@@ -1113,7 +1113,7 @@ PD_REGISTER_KERNEL(flash_attn_qkvpacked_grad,
                    phi::FlashAttnQKVPackedGradKernel,
                    phi::dtype::float16,
                    phi::dtype::bfloat16) {
-  kernel->InputAt(3).SetBackend(phi::Backend::ALL_BACKEND);  // seed_offset
+  kernel->InputAt(3).SetBackend(phi::Backend::CPU);  // seed_offset
 }
 
 PD_REGISTER_KERNEL(flashmask_attention_grad,
@@ -1122,5 +1122,5 @@ PD_REGISTER_KERNEL(flashmask_attention_grad,
                    phi::FlashMaskGradKernel,
                    phi::dtype::float16,
                    phi::dtype::bfloat16) {
-  kernel->InputAt(6).SetBackend(phi::Backend::ALL_BACKEND);  // seed_offset
+  kernel->InputAt(6).SetBackend(phi::Backend::CPU);  // seed_offset
 }


### PR DESCRIPTION
### PR Category
Auto Parallel


### PR Types
Others


### Description
Pcard-76459
grad merge的时候会切图，fw和bw切成了2个子图，flash_attn_grad会使用fw的输出，其中有个output是seed_offset，原来在fw是cpu数据但是到bw子图后会变成gpu数据，运行到flash_attn_grad的kernel里面的时候通过CPU的内存访问方式访问了在gpu上的seed_offset这个数据，从而报错
