### PR TITLE
[SOT] Add a quick guard implementation for Tensor in PIR mode

### DIFF
--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -112,19 +112,15 @@ class MetaInfo:
 
     @staticmethod
     def _handle_legacy_ir_amp_dtype(dtype):
-        expected_dtype_class = (
-            paddle.core.DataType
-            if paddle.framework.use_pir_api()
-            else paddle.core.VarDesc.VarType
-        )
-        assert isinstance(dtype, expected_dtype_class)
-
-        # TODO(@xiongkun) remove after pir become default state.
+        # TODO(cleanup-legacy-ir) remove after pir become default state.
         # We always use float32 in simulation if AMP is enabled.
+        if use_pir_api():
+            return dtype
+        assert isinstance(dtype, paddle.core.VarDesc.VarType)
+
         current_amp_state = amp_state()
         if (
-            not use_pir_api()
-            and dtype == paddle.float16
+            dtype == paddle.float16
             and current_amp_state is not None
             and current_amp_state["dtype"] == "float16"
         ):

--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -104,10 +104,9 @@ def make_guard(stringified_guards: list[StringifiedExpression]) -> Guard:
             guard.original_guard = guard
             return guard
 
-        free_vars = {}
-        for expr in stringified_guards:
-            free_vars = union_free_vars(free_vars, expr.free_vars)
-
+        free_vars = union_free_vars(
+            *(expr.free_vars for expr in stringified_guards)
+        )
         inlined_guard_expr = "lambda frame: " + " and ".join(
             [expr.inlined_expr for expr in stringified_guards]
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

SOT 为 PIR 添加一个 Tensor 的 guard 快速实现，全部 inline 为表达式，尽可能消除函数调用

优化前：

<img width="326" alt="image" src="https://github.com/user-attachments/assets/79dfb424-c753-4cde-9436-fcd3d30a0572">

优化后：

<img width="352" alt="image" src="https://github.com/user-attachments/assets/ea38c174-8412-4448-963a-19a83ef6d602">

可以看到 guard 开销从 83us 降低到了 46us，降低了 45% guard 开销，端到端时间也得到了明显优化

非 PIR 下由于 AMP 会导致 dtype 可能会不一致，因此不做处理，未来也会清理掉

未来可能进一步将其下沉到 C++ 以进一步降低开销

Pcard-67164