### PR TITLE
[PIR] Support `act` param in scale and fix `BatchNorm(act="hard_swish")`

### DIFF
--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from paddle import _C_ops, in_dynamic_mode
+from paddle import _C_ops, in_dynamic_mode, pir_utils
 from paddle.device import get_all_custom_device_type
 
 from ...base import dygraph_utils
@@ -1081,11 +1081,7 @@ class BatchNorm(Layer):
                 self._use_global_stats,
                 self._trainable_statistics,
             )
-            if self._act is None:
-                return batch_norm_out
-
-            act_op = getattr(_C_ops, self._act)
-            return act_op(batch_norm_out)
+            return pir_utils.append_activation_in_pir(batch_norm_out, self._act)
         else:
             # create output
             # mean and mean_out share the same memory

--- a/python/paddle/pir_utils.py
+++ b/python/paddle/pir_utils.py
@@ -254,3 +254,21 @@ def analysis_io(program: paddle.pir.Program):
             total_io += get_memory(value)
 
     return total_io / 1024 / 1024 / 1024
+
+
+def append_activation_in_pir(input, act=None, use_cudnn=None):
+    if act is None:
+        return input
+
+    act_name_mapping = {
+        "hard_swish": "hardswish",
+    }
+    act = act_name_mapping.get(act, act)
+
+    attrs = ()
+    if use_cudnn:
+        attrs = ('use_cudnn', use_cudnn)
+    act_op = getattr(paddle._C_ops, act)
+    if act == 'softmax':
+        return act_op(input, -1)
+    return act_op(input, *attrs)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -294,9 +294,8 @@ def scale(
         out = _C_ops.scale(x, scale, float(bias), bias_after_scale)
         return dygraph_utils._append_activation_in_dygraph(out, act)
     elif in_pir_mode():
-        if act is None:
-            return _C_ops.scale(x, scale, float(bias), bias_after_scale)
-        raise ValueError("act is not implement in pir of scale api.")
+        out = _C_ops.scale(x, scale, float(bias), bias_after_scale)
+        return paddle.pir_utils.append_activation_in_pir(out, act)
     else:
         check_variable_and_dtype(
             x,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

PaddleOCR 上发现开启 PIR 后 `BatchNorm` 传入 `act="hard_swish"` 后挂了，因为 PIR 下 `_C_ops` 下只有 `hardswish` 而没有以前的命名 `hard_swish` 而挂掉，因此对命名进行了转发

另外全局搜了下发现 scale 当初也没支持 `act` 参数，一并支持了下

Pcard-67164