### PR TITLE
[PIR][oneDNN] Fix bf16 quantization for cast

### DIFF
--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_pass.cc
@@ -28,19 +28,6 @@
 #include "paddle/pir/include/pass/pass_registry.h"
 
 namespace {
-template <class IrType1, class IrType2>
-static pir::Type create_type(pir::Type type,
-                             pir::Type out_dtype,
-                             pir::IrContext *ctx) {
-  auto input_type = type.dyn_cast<IrType1>();
-  return IrType2::get(ctx,
-                      out_dtype,
-                      input_type.dims(),
-                      input_type.data_layout(),
-                      input_type.lod(),
-                      input_type.offset());
-}
-
 class CpuBfloat16Pattern : public paddle::drr::DrrPatternBase {
  private:
   std::string bfloat16_ops_;
@@ -2055,9 +2042,9 @@ class CastBf16Pattern : public pir::OpRewritePattern<OpType> {
       return false;
 
     auto attributes = op->attributes();
-    auto dtyp_attr = attributes["dtype"];
+    auto dtype_attr = attributes["dtype"];
     phi::DataType dtype =
-        dtyp_attr.template dyn_cast<paddle::dialect::DataTypeAttribute>()
+        dtype_attr.template dyn_cast<paddle::dialect::DataTypeAttribute>()
             .data();
     if (dtype == phi::DataType::FLOAT32) {
       pir::Attribute new_dtype = paddle::dialect::DataTypeAttribute::get(

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_pass.cc
@@ -28,6 +28,19 @@
 #include "paddle/pir/include/pass/pass_registry.h"
 
 namespace {
+template <class IrType1, class IrType2>
+static pir::Type create_type(pir::Type type,
+                             pir::Type out_dtype,
+                             pir::IrContext *ctx) {
+  auto input_type = type.dyn_cast<IrType1>();
+  return IrType2::get(ctx,
+                      out_dtype,
+                      input_type.dims(),
+                      input_type.data_layout(),
+                      input_type.lod(),
+                      input_type.offset());
+}
+
 class CpuBfloat16Pattern : public paddle::drr::DrrPatternBase {
  private:
   std::string bfloat16_ops_;
@@ -398,11 +411,6 @@ class CpuBfloat16PatternOne_one : public paddle::drr::DrrPatternBase {
       op_attrs.emplace("perm", pat.Attr("perm"));
       op_attrs.emplace("data_format", pat.Attr("data_format"));
       op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
-    } else if (bfloat16_ops_ == "onednn_op.cast" ||
-               bfloat16_ops_ == "onednn_op.cast_") {
-      op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
-      op_attrs.emplace("dtype", pat.Attr("dtype"));
-
     } else if (bfloat16_ops_ == "onednn_op.relu" ||
                bfloat16_ops_ == "onednn_op.relu_") {
       op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
@@ -518,11 +526,6 @@ class CpuBfloat16DequantPatternOne_one : public paddle::drr::DrrPatternBase {
       op_attrs.emplace("perm", pat.Attr("perm"));
       op_attrs.emplace("data_format", pat.Attr("data_format"));
       op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
-    } else if (bfloat16_ops_ == "onednn_op.cast" ||
-               bfloat16_ops_ == "onednn_op.cast_") {
-      op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
-      op_attrs.emplace("dtype", pat.Attr("dtype"));
-
     } else if (bfloat16_ops_ == "onednn_op.relu" ||
                bfloat16_ops_ == "onednn_op.relu_") {
       op_attrs.emplace("mkldnn_data_type", pat.Attr("mkldnn_data_type"));
@@ -2038,6 +2041,47 @@ class CpuBfloat16DequantPatternFour_one : public paddle::drr::DrrPatternBase {
   }
 };
 
+template <typename OpType>
+class CastBf16Pattern : public pir::OpRewritePattern<OpType> {
+ public:
+  using pir::OpRewritePattern<OpType>::OpRewritePattern;
+
+  bool MatchAndRewrite(
+      OpType op,
+      pir::PatternRewriter &rewriter) const override {  // NOLINT
+    std::string target_op_name = op->name();
+    if (!(target_op_name == "onednn_op.cast" ||
+          target_op_name == "onednn_op.cast_"))
+      return false;
+
+    auto attributes = op->attributes();
+    auto dtyp_attr = attributes["dtype"];
+    phi::DataType dtype =
+        dtyp_attr.template dyn_cast<paddle::dialect::DataTypeAttribute>()
+            .data();
+    if (dtype == phi::DataType::FLOAT32) {
+      pir::Attribute new_dtype = paddle::dialect::DataTypeAttribute::get(
+          rewriter.ir_context(), phi::DataType::BFLOAT16);
+      attributes["dtype"] = new_dtype;
+    } else {
+      return false;
+    }
+
+    OpType new_cast = rewriter.Build<OpType>(op->operand_source(0), attributes);
+
+    std::unordered_map<std::string, pir::Attribute> dq_attributes;
+    dq_attributes["scale"] = rewriter.float_attr(1.0f);
+    dq_attributes["shift"] = rewriter.float_attr(0.0f);
+    paddle::onednn::dialect::DequantizeOp dq_op =
+        rewriter.Build<paddle::onednn::dialect::DequantizeOp>(new_cast.out(),
+                                                              dq_attributes);
+
+    rewriter.ReplaceAllUsesWith(op->result(0), dq_op.output());
+    rewriter.EraseOp(op);
+    return true;
+  }
+};
+
 class CpuBfloat16Pass : public pir::PatternRewritePass {
  public:
   CpuBfloat16Pass() : pir::PatternRewritePass("cpu_bfloat16_pass", 3) {}
@@ -2071,8 +2115,6 @@ class CpuBfloat16Pass : public pir::PatternRewritePass {
         paddle::onednn::dialect::Softmax_Op::name(),
         paddle::onednn::dialect::TransposeOp::name(),
         paddle::onednn::dialect::Transpose_Op::name(),
-        paddle::onednn::dialect::CastOp::name(),
-        paddle::onednn::dialect::Cast_Op::name(),
         paddle::onednn::dialect::ReluOp::name(),
         paddle::onednn::dialect::Relu_Op::name(),
         paddle::onednn::dialect::SigmoidOp::name(),
@@ -2192,6 +2234,24 @@ class CpuBfloat16Pass : public pir::PatternRewritePass {
 
     ps.Add(paddle::drr::Create<CpuBfloat16DequantPatternFour_one>(
         context, paddle::onednn::dialect::FusedConv2dOp::name(), 3));
+
+    auto cast_bf16_pattern =
+        std::make_unique<CastBf16Pattern<paddle::onednn::dialect::CastOp>>(
+            context,
+            benefit_idx++,
+            std::vector<std::string>{
+                paddle::onednn::dialect::DequantizeOp::name(),
+            });
+    ps.Add(std::move(cast_bf16_pattern));
+
+    auto cast_bf16_pattern_2 =
+        std::make_unique<CastBf16Pattern<paddle::onednn::dialect::Cast_Op>>(
+            context,
+            benefit_idx++,
+            std::vector<std::string>{
+                paddle::onednn::dialect::DequantizeOp::name(),
+            });
+    ps.Add(std::move(cast_bf16_pattern_2));
 
     return ps;
   }

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
@@ -43,8 +43,6 @@ class OneDNNBf16PlacementPattern : public pir::RewritePattern {
 
   bool Match(pir::Operation* op) const override {  // NOLINT
     if (!op->isa<paddle::onednn::dialect::BilinearInterpOp>() &&
-        !op->isa<paddle::onednn::dialect::CastOp>() &&
-        !op->isa<paddle::onednn::dialect::Cast_Op>() &&
         !op->isa<paddle::onednn::dialect::ClipOp>() &&
         !op->isa<paddle::onednn::dialect::Clip_Op>() &&
         !op->isa<paddle::onednn::dialect::Conv2dOp>() &&
@@ -142,8 +140,6 @@ class RemoveOrphanedPattern : public pir::RewritePattern {
   // revert mkldnn_data_type attr to float32
   bool Match(pir::Operation* op) const override {  // NOLINT
     if (!op->isa<paddle::onednn::dialect::BilinearInterpOp>() &&
-        !op->isa<paddle::onednn::dialect::CastOp>() &&
-        !op->isa<paddle::onednn::dialect::Cast_Op>() &&
         !op->isa<paddle::onednn::dialect::ClipOp>() &&
         !op->isa<paddle::onednn::dialect::Clip_Op>() &&
         !op->isa<paddle::onednn::dialect::Conv2dOp>() &&
@@ -290,8 +286,6 @@ class RemoveUnsupportedOpPattern : public pir::RewritePattern {
 
   bool Match(pir::Operation* op) const override {  // NOLINT
     if (!op->isa<paddle::onednn::dialect::BilinearInterpOp>() &&
-        !op->isa<paddle::onednn::dialect::CastOp>() &&
-        !op->isa<paddle::onednn::dialect::Cast_Op>() &&
         !op->isa<paddle::onednn::dialect::ClipOp>() &&
         !op->isa<paddle::onednn::dialect::Clip_Op>() &&
         !op->isa<paddle::onednn::dialect::Conv2dOp>() &&

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_type_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_type_placement_pass.cc
@@ -42,8 +42,6 @@ class CpuBfloat16TypePattern : public pir::RewritePattern {
   bool Match(pir::Operation* op) const override {  // NOLINT
     if (!op->isa<paddle::onednn::dialect::QuantizeOp>() &&
         !op->isa<paddle::onednn::dialect::BilinearInterpOp>() &&
-        !op->isa<paddle::onednn::dialect::CastOp>() &&
-        !op->isa<paddle::onednn::dialect::Cast_Op>() &&
         !op->isa<paddle::onednn::dialect::ClipOp>() &&
         !op->isa<paddle::onednn::dialect::Clip_Op>() &&
         !op->isa<paddle::onednn::dialect::Conv2dOp>() &&

--- a/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
@@ -37,7 +37,7 @@ class OneDNNPlacementPattern : public pir::OpRewritePattern<OpType> {
       OpType op,
       pir::PatternRewriter &rewriter) const override {  // NOLINT
     std::string target_op_name = op->name();
-    if (target_op_name == "pd_op.cast") {
+    if (target_op_name == "pd_op.cast" || target_op_name == "pd_op.cast_") {
       auto input_type = pir::GetDataTypeFromValue(op->operand_source(0));
       if (!(pir::isa<pir::Float32Type>(input_type) ||
             pir::isa<pir::BFloat16Type>(input_type)))

--- a/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
@@ -20,6 +20,7 @@
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/fluid/pir/dialect/operator/utils/op_yaml_info_parser.h"
 #include "paddle/fluid/pir/dialect/operator/utils/op_yaml_info_util.h"
+#include "paddle/fluid/pir/utils/general_functions.h"
 
 #include "paddle/pir/include/pass/pass.h"
 #include "paddle/pir/include/pass/pass_registry.h"
@@ -36,6 +37,12 @@ class OneDNNPlacementPattern : public pir::OpRewritePattern<OpType> {
       OpType op,
       pir::PatternRewriter &rewriter) const override {  // NOLINT
     std::string target_op_name = op->name();
+    if (target_op_name == "pd_op.cast") {
+      auto input_type = pir::GetDataTypeFromValue(op->operand_source(0));
+      if (!(pir::isa<pir::Float32Type>(input_type) ||
+            pir::isa<pir::BFloat16Type>(input_type)))
+        return false;
+    }
     target_op_name.replace(0, 5, "onednn_op");
 
     auto op_info =

--- a/paddle/fluid/pir/transforms/onednn/shuffle_channel_detect_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/shuffle_channel_detect_pass.cc
@@ -236,9 +236,8 @@ class ShuffleChannelDetectPass : public pir::PatternRewritePass {
 namespace pir {
 
 std::unique_ptr<Pass> CreateShuffleChannelDetectPass() {
-  // pd_op.matmul + pd_op.transpose + pd_op.reshape -> onednn_op.fused_matmul
-  // pd_op.fused_matmul + pd_op.transpose + pd_op.reshape ->
-  // onednn_op.fused_matmul
+  // pd_op.reshape + pd_op.transpose + pd_op.reshape ->
+  // onednn_op.shuffle_channel
   return std::make_unique<ShuffleChannelDetectPass>();
 }
 }  // namespace pir

--- a/paddle/phi/ops/yaml/inconsistent/onednn_ops_extra.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/onednn_ops_extra.yaml
@@ -32,7 +32,6 @@
 
 - op : cast
   dynamic_fallback : True
-  extra_args : str mkldnn_data_type="float32"
 
 - op : clip
   extra_args : str mkldnn_data_type="float32"

--- a/test/ir/pir/fused_pass/onednn/test_cpu_bfloat16_pir_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_cpu_bfloat16_pir_pass.py
@@ -1006,6 +1006,7 @@ class TestConvTransposeOpBf16Pass(PassTest):
     def test_check_output(self):
         self.check_pass_correct()
 
+
 class TestCastBf16Pass(PassTest):
     def is_program_valid(self, program=None):
         return True
@@ -1019,7 +1020,7 @@ class TestCastBf16Pass(PassTest):
                     name='x1', shape=[1, 30], dtype='float32'
                 )
 
-                out= paddle.cast(x1, 'float32')
+                out = paddle.cast(x1, 'float32')
                 out = paddle.assign(out)
                 self.pass_attr_list = [
                     {'onednn_placement_pass': {}},

--- a/test/ir/pir/fused_pass/onednn/test_cpu_bfloat16_pir_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_cpu_bfloat16_pir_pass.py
@@ -1006,6 +1006,46 @@ class TestConvTransposeOpBf16Pass(PassTest):
     def test_check_output(self):
         self.check_pass_correct()
 
+class TestCastBf16Pass(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x1 = paddle.static.data(
+                    name='x1', shape=[1, 30], dtype='float32'
+                )
+
+                out= paddle.cast(x1, 'float32')
+                out = paddle.assign(out)
+                self.pass_attr_list = [
+                    {'onednn_placement_pass': {}},
+                    {'cpu_bfloat16_placement_pass': {}},
+                    {'cpu_bfloat16_pass': {}},
+                ]
+                self.feeds = {
+                    "x1": np.random.random((1, 30)).astype("float32"),
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.cast": 1,
+                    "onednn_op.dequantize": 1,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+        self.skip_accuracy_verification = True
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
There are situations when `Cast` is receiving input other than `float32/bf16`, in which case `Cast` shall not be transformed to oneDNN op. Besides, `Cast` itself has the ability to transform tensor dtype, no need to add extra Quantize.

This PR is targeting to issue and improvement both as described above.