### PR TITLE
dist2dense_pass fix shape errors in shard randomly sampled data

### DIFF
--- a/paddle/fluid/pir/dialect/distributed/transforms/dist_to_dense_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/dist_to_dense_pass.cc
@@ -103,24 +103,29 @@ void ProcessDistBlock(pir::Block* block) {
         new_dims.push_back(pir::Int64Attribute::get(ctx, local_dims[index]));
       }
       prev_op->set_attribute("value", pir::ArrayAttribute::get(ctx, new_dims));
-    } else if (op_item->isa<RandintOp>() || op_item->isa<GaussianOp>()) {
+    } else if (op_item->isa<RandintOp>() || op_item->isa<GaussianOp>() ||
+               op_item->isa<UniformOp>()) {
       auto local_dims =
           op_item->result_type(0).dyn_cast<pir::DenseTensorType>().dims();
       auto shape_value = op_item->operand_source(0);
       auto prev_op = shape_value.defining_op();
-      if (prev_op == nullptr || !(prev_op->isa<FullIntArrayOp>())) {
-        auto op_name = prev_op ? prev_op->name() : "nullptr";
-        PADDLE_THROW(common::errors::PreconditionNotMet(
-            "The randint and gaussian op's shape input mush be the result of  "
-            "FullIntArrayOp. but it is %s",
-            op_name));
-      }
+      PADDLE_ENFORCE((prev_op != nullptr),
+                     common::errors::PreconditionNotMet(
+                         "The shape of randint, gaussian and uniform mush be "
+                         "the result of "
+                         "FullIntArrayOp, not null"));
+      PADDLE_ENFORCE_EQ(
+          prev_op->isa<FullIntArrayOp>(),
+          true,
+          common::errors::PreconditionNotMet(
+              "The shape of randint, gaussian and uniform mush be the result "
+              "of FullIntArrayOp."));
       auto array_attr = prev_op->attribute<pir::ArrayAttribute>("value");
       PADDLE_ENFORCE_EQ(
           array_attr.size(),
           local_dims.size(),
           common::errors::PreconditionNotMet(
-              "The randint and gaussian's shape inputs element's size must "
+              "The shape of randint, gaussian and uniform element's size must "
               "equal to result's dim size."));
       std::vector<pir::Attribute> new_dims;
       for (int index = 0; index < local_dims.size(); ++index) {


### PR DESCRIPTION
### PR Category
Auto Parallel


### PR Types
Bug fixes

### Description
pcard-86711
After PR #67589 supporting sharding of randomly sampled data, it is necessary to synchronously modify the shape in the attribute of previously operator of `pd_op.full_int_array` when use `paddle.distributed.to_static` and pir(`FLAGS_enable_pir_api=true`). Otherwise, the executor will still create data according to this wrong shape during actual execution, resulting in incorrect reporting of shape in subsequent calculations.
```python
import paddle
import paddle.distributed as dist
process_mesh = dist.ProcessMesh([0, 1], dim_names=['dp'])

noise = paddle.randn(x.shape)  
noise = dist.shard_tensor(noise, process_mesh, [dist.Shard(0)) # same shard as x
y = noise * x # will error when use paddle.distributed.to_static and pir
```
Printing pir program also shows that the shape in the attribute of operator of `pd_op.full_int_array` (line1 and line3) is inconsistent with correct shape (line2 and line4)
![image](https://github.com/user-attachments/assets/de0eb92e-375f-4808-9b96-9340d5453798)
this PR will fix this issue.