### PR TITLE
【PIR】Add inference flag for AutoLayout & AutoLayoutSimplify pass

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -42,6 +42,7 @@ COMMON_DECLARE_bool(use_cinn);
 #endif
 
 COMMON_DECLARE_bool(enable_pir_api);
+COMMON_DECLARE_bool(enable_auto_layout_pass);
 namespace paddle {
 
 extern const std::vector<std::string> kTRTSubgraphPasses;
@@ -1496,6 +1497,11 @@ bool AnalysisConfig::cinn_enabled() const {
 #ifdef PADDLE_WITH_CINN
   is_enabled = is_enabled || FLAGS_use_cinn;
 #endif
+  return is_enabled;
+}
+
+bool AnalysisConfig::autolayout_enabled() const {
+  bool is_enabled = FLAGS_enable_auto_layout_pass;
   return is_enabled;
 }
 

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -864,8 +864,17 @@ void AnalysisPredictor::OptimizeInferencePirProgram() {
           if (std::find(config_.deleted_passes_.begin(),
                         config_.deleted_passes_.end(),
                         gpu_pass) == config_.deleted_passes_.end()) {
+            if (gpu_pass == "transfer_layout_pass" &&
+                config_.autolayout_enabled())
+              continue;
             pass_pm.AddPass(pir::PassRegistry::Instance().Get(gpu_pass));
           }
+        }
+        if (config_.autolayout_enabled()) {
+          pass_pm.AddPass(
+              pir::PassRegistry::Instance().Get("auto_layout_pass"));
+          pass_pm.AddPass(
+              pir::PassRegistry::Instance().Get("auto_layout_simplify_pass"));
         }
       }
 
@@ -2204,7 +2213,13 @@ void AnalysisPredictor::PrepareArgument() {
         pass_builder->ClearPasses();
         for (const auto &pass : kGpuLowerPrecisionPasses) {
           if (deleted_passes.count(pass)) continue;
+          if (pass == "transfer_layout_pass" && config_.autolayout_enabled())
+            continue;
           pass_builder->AppendPass(pass);
+        }
+        if (config_.autolayout_enabled()) {
+          pass_builder->AppendPass("auto_layout_pass");
+          pass_builder->AppendPass("auto_layout_simplify_pass");
         }
       } else if (config_.use_xpu()) {  // NOLINT
         // All passes support fp16. Not reset pass_builder.

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -1146,6 +1146,13 @@ struct PD_INFER_DECL AnalysisConfig {
   bool cinn_enabled() const;
 
   ///
+  /// \brief A boolean state telling whether the AutoLayoutPass is turned on.
+  ///
+  /// \return bool Whether the AutoLayoutPass is turned on.
+  ///
+  bool autolayout_enabled() const;
+
+  ///
   /// \brief Set the custom passes list .
   ///
   /// \param passes The custom passes list.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
暂时方案：推理流程中暂时通过 flag 来执行 AutoLayout pss，测试如果能平滑取代 transfer_layout_pass，将去除 flag，并加入默认。
Pcard-67164
