### PR TITLE
[PIR][oneDNN] Optimize onednn_placement_pass

### DIFF
--- a/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
@@ -37,10 +37,19 @@ class OneDNNPlacementPattern : public pir::OpRewritePattern<OpType> {
       OpType op,
       pir::PatternRewriter &rewriter) const override {  // NOLINT
     std::string target_op_name = op->name();
-    if (target_op_name == "pd_op.cast" || target_op_name == "pd_op.cast_") {
+    if (target_op_name == "pd_op.scale" || target_op_name == "pd_op.scale_" ||
+        target_op_name == "pd_op.cast" || target_op_name == "pd_op.cast_") {
       auto input_type = pir::GetDataTypeFromValue(op->operand_source(0));
       if (!(pir::isa<pir::Float32Type>(input_type) ||
             pir::isa<pir::BFloat16Type>(input_type)))
+        return false;
+    }
+    if (target_op_name == "pd_op.slice") {
+      auto input_type = pir::GetDataTypeFromValue(op->operand_source(0));
+      if (!(pir::isa<pir::Float32Type>(input_type) ||
+            pir::isa<pir::BFloat16Type>(input_type) ||
+            pir::isa<pir::UInt8Type>(input_type) ||
+            pir::isa<pir::Int8Type>(input_type)))
         return false;
     }
     target_op_name.replace(0, 5, "onednn_op");


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
For ops like `Scale` & `Slice`, there is no support for data type i32/i64, causing fallback at `pd_op_to_kernel_pass`. Thus this PR aims to prevent such ops turning into onednn op at early stage, in order to avoid extra fallback.