### PR TITLE
Fix matrix_rank_atol_rtol kernel when `rtol = None` 易用性提升

### DIFF
--- a/paddle/phi/kernels/cpu/matrix_rank_tol_kernel.cc
+++ b/paddle/phi/kernels/cpu/matrix_rank_tol_kernel.cc
@@ -227,9 +227,6 @@ void MatrixRankAtolRtolKernel(const Context& dev_ctx,
     // when `rtol` is specified to be None in py api
     // use rtol=eps*max(m, n) only if `atol` is passed with value 0.0, else use
     // rtol=0.0
-    DenseTensor zero_tensor;
-    zero_tensor = phi::FullLike<T, Context>(dev_ctx, atol, static_cast<T>(0.0));
-
     T rtol_T = std::numeric_limits<T>::epsilon() * std::max(rows, cols);
     DenseTensor default_rtol_tensor;
     default_rtol_tensor =
@@ -237,13 +234,17 @@ void MatrixRankAtolRtolKernel(const Context& dev_ctx,
     default_rtol_tensor =
         phi::Multiply<T>(dev_ctx, default_rtol_tensor, max_eigenvalue_tensor);
 
+    DenseTensor zero_tensor;
+    zero_tensor = phi::FullLike<T, Context>(
+        dev_ctx, default_rtol_tensor, static_cast<T>(0.0));
+
     DenseTensor atol_compare_result;
-    atol_compare_result.Resize(atol.dims());
+    atol_compare_result.Resize(default_rtol_tensor.dims());
     phi::EqualKernel<T, Context>(
         dev_ctx, atol, zero_tensor, &atol_compare_result);
 
     DenseTensor selected_rtol_tensor;
-    selected_rtol_tensor.Resize(atol.dims());
+    selected_rtol_tensor.Resize(default_rtol_tensor.dims());
     phi::WhereKernel<T, Context>(dev_ctx,
                                  atol_compare_result,
                                  default_rtol_tensor,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
![mr-bug](https://github.com/user-attachments/assets/7f2c6452-317b-46a8-b426-7e805193dbdb)
以上案例中 `rtol=None` 时计算结果不稳定，是因为 kernel 中该分支的 rtol_tensor 形状是 [1, ] 而不是 [batch_shape, ]。需调整形状。