### PR TITLE
[Executor] Fix `builtin_combine_instruction` always in device thread

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/builtin_combine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/builtin_combine_instruction.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/framework/new_executor/instruction/builtin_combine_instruction.h"
+#include "paddle/fluid/framework/new_executor/instruction/instruction_util.h"
 #include "paddle/fluid/framework/new_executor/new_executor_defs.h"
 
 namespace paddle {
@@ -25,6 +26,8 @@ BuiltinCombineInstruction::BuiltinCombineInstruction(
     ValueExecutionInfo* value_exe_info)
     : InstructionBase(id, place) {
   op_ = op;
+
+  SetKernelType(AnalyseOpFuncType(op, place));
 
   InitInputsOutputsIds(op, *value_exe_info);
 

--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
@@ -21,6 +21,7 @@
 
 #include "paddle/fluid/framework/new_executor/new_executor_defs.h"
 #include "paddle/fluid/pir/dialect/kernel/ir/kernel_dialect.h"
+#include "paddle/fluid/pir/dialect/kernel/ir/kernel_type.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/phi/api/profiler/event.h"
 #include "paddle/phi/core/platform/device_context.h"
@@ -232,6 +233,19 @@ OpFuncType AnalyseOpFuncType(pir::Operation* op, const phi::Place& place) {
 
     if (op_name.compare(paddle::dialect::ShapeOp::name()) == 0) {
       return OpFuncType::kGpuSync;
+    }
+  }
+
+  if (auto combine_op = op->dyn_cast<pir::CombineOp>()) {
+    for (size_t i = 0; i < combine_op.num_operands(); ++i) {
+      if (auto combine_operand_type =
+              combine_op.operand_source(i)
+                  .type()
+                  .dyn_cast<paddle::dialect::AllocatedDenseTensorType>()) {
+        if (phi::is_cpu_place(combine_operand_type.place())) {
+          return OpFuncType::kCpuSync;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复执行器 place 为 GPU 的情况下，`builtin_combine_instruction` 永远会分到 device thread 的问题

比如对于如下 program

```text
LoweredProgram( AfterPass ) is :
{
    (%0) = "data(phi_kernel)" () {dtype:(pd_op.DataType)int64,kernel_key:<backend:GPU|layout:Undefined(AnyLayout)|dtype:int64>,kernel_name:"data",name:"_jst.0.x.0",op_name:"pd_op.data",origin_id:(Int64)35,place:(pd_op.Place)Place(gpu:0),shape:(pd_op.IntArray)[3],stop_gradient:[true]} : () -> gpu_tensor<3xi64>
    (%1) = "data(phi_kernel)" () {dtype:(pd_op.DataType)int64,kernel_key:<backend:CPU|layout:Undefined(AnyLayout)|dtype:int64>,kernel_name:"data",name:"_jst.1.y.0",op_name:"pd_op.data",origin_id:(Int64)36,place:(pd_op.Place)Place(cpu),shape:(pd_op.IntArray)[],stop_gradient:[true]} : () -> cpu_tensor<i64>
    (%2) = "full(phi_kernel)" () {dtype:(pd_op.DataType)float32,kernel_key:<backend:CPU|layout:Undefined(AnyLayout)|dtype:float32>,kernel_name:"full",op_name:"pd_op.full",origin_id:(Int64)37,place:(pd_op.Place)Place(cpu),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Double)1} : () -> cpu_tensor<1xf32>
    (%3) = "scale(phi_kernel)" (%1, %2) {bias:(Float)1,bias_after_scale:true,kernel_key:<backend:CPU|layout:NCHW|dtype:int64>,kernel_name:"scale",op_name:"pd_op.scale",origin_id:(Int64)38,stop_gradient:[true]} : (cpu_tensor<i64>, cpu_tensor<1xf32>) -> cpu_tensor<i64>
    (%4) = "builtin.combine" (%1) {origin_id:(Int64)39,stop_gradient:[true]} : (cpu_tensor<i64>) -> vec[cpu_tensor<i64>]
    (%5) = "stack(phi_kernel)" (%4) {axis:(Int32)0,kernel_key:<backend:CPU|layout:NCHW|dtype:int64>,kernel_name:"stack",op_name:"pd_op.stack",origin_id:(Int64)40,stop_gradient:[true]} : (vec[cpu_tensor<i64>]) -> cpu_tensor<1xi64>
    (%6) = "builtin.combine" (%3) {origin_id:(Int64)41,stop_gradient:[true]} : (cpu_tensor<i64>) -> vec[cpu_tensor<i64>]
    (%7) = "stack(phi_kernel)" (%6) {axis:(Int32)0,kernel_key:<backend:CPU|layout:NCHW|dtype:int64>,kernel_name:"stack",op_name:"pd_op.stack",origin_id:(Int64)42,stop_gradient:[true]} : (vec[cpu_tensor<i64>]) -> cpu_tensor<1xi64>
    (%8) = "slice(phi_kernel)" (%0, %5, %7) {axes:[(Int64)0],decrease_axis:[(Int64)0],infer_flags:[(Int64)-1],kernel_key:<backend:GPU|layout:NCHW|dtype:int64>,kernel_name:"slice",op_name:"pd_op.slice",origin_id:(Int64)43,stop_gradient:[true]} : (gpu_tensor<3xi64>, cpu_tensor<1xi64>, cpu_tensor<1xi64>) -> gpu_tensor<i64>
    () = "builtin.shadow_output" (%8) {origin_id:(Int64)44,output_name:"output_0"} : (gpu_tensor<i64>) -> 
}
```

combine OP 输入输出都是 CPU Tensor，但是仍然被分到了 device thread，导致中间切换线程有额外的开销

![image](https://github.com/user-attachments/assets/71c3972d-d31e-44ad-ab7e-3a31825a0f34)

修复后 combine 正确分在了 host thread

![image](https://github.com/user-attachments/assets/d44e5659-16e8-4495-9943-95ab03ab65c3)

Pcard-67164