### PR TITLE
[SOT] Reduce eval frame callback launch overhead

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -18,6 +18,8 @@ import gc
 import traceback
 from typing import TYPE_CHECKING, List, Tuple
 
+from paddle.base.dygraph.base import sot_simulation_mode_guard
+
 from ...profiler import EventGuard, event_register
 from ...psdb import NO_FALLBACK_CODES
 from ...utils import (
@@ -217,7 +219,8 @@ def start_translate(
     simulator = OpcodeExecutor(frame, **kwargs)
     try:
         simulator.check_code_simulatable()
-        new_custom_code, guard_fn = simulator.transform()
+        with sot_simulation_mode_guard(True):
+            new_custom_code, guard_fn = simulator.transform()
         if not simulator._graph.need_cache:
             return (
                 CustomCode(None, True),

--- a/python/paddle/jit/sot/profiler/profiler.py
+++ b/python/paddle/jit/sot/profiler/profiler.py
@@ -37,9 +37,8 @@ class SotProfiler:
 
 @contextmanager
 def EventGuard(event_name, event_level=1):
+    need_pop = False
     try:
-        global _event_level
-        need_pop = False
         if ENV_SOT_EVENT_LEVEL.get_with_cache() >= event_level:
             core.nvprof_nvtx_push(event_name)
             need_pop = True
@@ -61,7 +60,7 @@ def event_register(event_name, event_level=1):
     def do_nothing(func):
         return func
 
-    if ENV_SOT_EVENT_LEVEL.get() >= event_level:
+    if ENV_SOT_EVENT_LEVEL.get_with_cache() >= event_level:
         return event_wrapper
     else:
         return do_nothing

--- a/python/paddle/jit/sot/utils/__init__.py
+++ b/python/paddle/jit/sot/utils/__init__.py
@@ -73,6 +73,7 @@ from .utils import (  # noqa: F401
     list_find_index_by_id,
     log,
     log_do,
+    log_enabled,
     log_format,
     map_if,
     map_if_extend,

--- a/python/paddle/jit/sot/utils/utils.py
+++ b/python/paddle/jit/sot/utils/utils.py
@@ -129,21 +129,25 @@ class ResumeFnNameFactory(metaclass=Singleton):
 
 
 def log(level, *args):
-    cur_level = ENV_SOT_LOG_LEVEL.get()
+    cur_level = ENV_SOT_LOG_LEVEL.get_with_cache()
     if level <= cur_level:
-        print(*args, end="")
+        print(*args, end="", flush=True)
 
 
 def log_do(level, fn):
-    cur_level = ENV_SOT_LOG_LEVEL.get()
+    cur_level = ENV_SOT_LOG_LEVEL.get_with_cache()
     if level <= cur_level:
         fn()
 
 
 def log_format(level, str, *args):
-    cur_level = ENV_SOT_LOG_LEVEL.get()
+    cur_level = ENV_SOT_LOG_LEVEL.get_with_cache()
     if level <= cur_level:
-        print(str.format(*args), end="")
+        print(str.format(*args), end="", flush=True)
+
+
+def log_enabled(level):
+    return level <= ENV_SOT_LOG_LEVEL.get_with_cache()
 
 
 def no_eval_frame(func):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

优化 eval frame callback lookup cache 前的启动开销

优化前：

<img width="381" alt="image" src="https://github.com/user-attachments/assets/507d3c3f-3c5f-471a-b01f-572ac45d6548">

优化后：

<img width="727" alt="image" src="https://github.com/user-attachments/assets/771a2f41-ccc6-4479-8ef4-fecf937b6653">

优化主要有三点：

- `sot_simulation_mode_guard` 不需要放在启动前，放在模拟执行时即可
- log level 只 check 一次，链路更短
- event level 和 log level 检查环境变量都使用 cache

Pcard-67164