### PR TITLE
Fix F.batch_norm output `variance_out` 易用性提升

### DIFF
--- a/paddle/phi/kernels/gpu/batch_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/batch_norm_kernel.cu
@@ -159,10 +159,15 @@ static __global__ LAUNCH_BOUNDS(BlockDim) void BNForwardTraining(
         save_mean[i] = mean_val;
         save_inv_variance[i] = inv_var_val;
       }
-      mean[i] = (1 - exponentialAverageFactor) * mean_val +
-                exponentialAverageFactor * mean[i];
-      variance[i] = (1 - exponentialAverageFactor) * variance_val +
-                    exponentialAverageFactor * variance[i];
+
+      double normalization_factor =
+          static_cast<double>(inner_size) /
+          static_cast<double>(inner_size - 1.0) mean[i] =
+              (1 - exponentialAverageFactor) * mean_val +
+              exponentialAverageFactor * mean[i];
+      variance[i] =
+          (1 - exponentialAverageFactor) * variance_val * normalization_factor +
+          exponentialAverageFactor * variance[i];
     }
     __syncthreads();
 
@@ -279,9 +284,14 @@ static __global__ void BNForwardTraining2DChannelLastCompStat(
             save_mean[i] = compute_mean_val;
             save_inv_variance[i] = compute_inv_var_val;
           }
-          global_mean[i] = (1 - exponentialAverageFactor) * compute_mean_val +
-                           exponentialAverageFactor * global_mean[i];
-          global_variance[i] = (1 - exponentialAverageFactor) * variance_val +
+
+          double normalization_factor =
+              static_cast<double>(inner_size) /
+              static_cast<double>(inner_size - 1.0) global_mean[i] =
+                  (1 - exponentialAverageFactor) * compute_mean_val +
+                  exponentialAverageFactor * global_mean[i];
+          global_variance[i] = (1 - exponentialAverageFactor) * variance_val *
+                                   normalization_factor +
                                exponentialAverageFactor * global_variance[i];
 
           compute_mean[i] = compute_mean_val;
@@ -300,9 +310,14 @@ static __global__ void BNForwardTraining2DChannelLastCompStat(
           save_mean[i] = compute_mean_val;
           save_inv_variance[i] = compute_inv_var_val;
         }
-        global_mean[i] = (1 - exponentialAverageFactor) * compute_mean_val +
-                         exponentialAverageFactor * global_mean[i];
-        global_variance[i] = (1 - exponentialAverageFactor) * variance_val +
+
+        double normalization_factor =
+            static_cast<double>(inner_size) /
+            static_cast<double>(inner_size - 1.0) global_mean[i] =
+                (1 - exponentialAverageFactor) * compute_mean_val +
+                exponentialAverageFactor * global_mean[i];
+        global_variance[i] = (1 - exponentialAverageFactor) * variance_val *
+                                 normalization_factor +
                              exponentialAverageFactor * global_variance[i];
 
         compute_mean[i] = compute_mean_val;
@@ -447,9 +462,14 @@ static __global__ void BNForwardTraining2DCompStat(
             save_mean[i] = compute_mean_val;
             save_inv_variance[i] = compute_inv_var_val;
           }
-          global_mean[i] = (1 - exponentialAverageFactor) * compute_mean_val +
-                           exponentialAverageFactor * global_mean[i];
-          global_variance[i] = (1 - exponentialAverageFactor) * variance_val +
+
+          double normalization_factor =
+              static_cast<double>(inner_size) /
+              static_cast<double>(inner_size - 1.0) global_mean[i] =
+                  (1 - exponentialAverageFactor) * compute_mean_val +
+                  exponentialAverageFactor * global_mean[i];
+          global_variance[i] = (1 - exponentialAverageFactor) * variance_val *
+                                   normalization_factor +
                                exponentialAverageFactor * global_variance[i];
 
           compute_mean[i] = compute_mean_val;
@@ -468,9 +488,14 @@ static __global__ void BNForwardTraining2DCompStat(
           save_mean[i] = compute_mean_val;
           save_inv_variance[i] = compute_inv_var_val;
         }
-        global_mean[i] = (1 - exponentialAverageFactor) * compute_mean_val +
-                         exponentialAverageFactor * global_mean[i];
-        global_variance[i] = (1 - exponentialAverageFactor) * variance_val +
+
+        double normalization_factor =
+            static_cast<double>(inner_size) /
+            static_cast<double>(inner_size - 1.0) global_mean[i] =
+                (1 - exponentialAverageFactor) * compute_mean_val +
+                exponentialAverageFactor * global_mean[i];
+        global_variance[i] = (1 - exponentialAverageFactor) * variance_val *
+                                 normalization_factor +
                              exponentialAverageFactor * global_variance[i];
 
         compute_mean[i] = compute_mean_val;

--- a/paddle/phi/kernels/onednn/batch_norm_kernel.cc
+++ b/paddle/phi/kernels/onednn/batch_norm_kernel.cc
@@ -114,13 +114,13 @@ void BatchNormKernel(const Context &dev_ctx,
         dev_ctx.template Alloc<T>(variance_out), C);
 
     const auto &x_dims = x.dims();
-    int N = -1, C = -1, H = -1, W = -1, D = -1;
-    funcs::ExtractNCWHD(x_dims, data_layout, &N, &C, &H, &W, &D);
+    int N = -1, c = -1, H = -1, W = -1, D = -1;
+    funcs::ExtractNCWHD(x_dims, data_layout, &N, &c, &H, &W, &D);
     N = (N == 0) ? 1 : N;
-    C = (C == 0) ? 1 : C;
     H = (H == 0) ? 1 : H;
     W = (W == 0) ? 1 : W;
     D = (D == 0) ? 1 : D;
+    W = W * D;
 
     float normalization_factor =
         static_cast<float>(N * H * W) / static_cast<float>(N * H * W - 1);

--- a/paddle/phi/kernels/xpu/batch_norm_kernel.cc
+++ b/paddle/phi/kernels/xpu/batch_norm_kernel.cc
@@ -132,6 +132,17 @@ void BatchNormKernel(const Context& dev_ctx,
                                      variance_out_data,
                                      is_nchw);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "batch_norm");
+
+    float normalization_factor =
+        static_cast<float>(N * H * W) / static_cast<float>(N * H * W - 1);
+    r = xpu::scale(dev_ctx.x_context(),
+                   reinterpret_cast<const XPUType*>(variance_out_data),
+                   reinterpret_cast<XPUType*>(variance_out_data),
+                   C,
+                   false,
+                   normalization_factor,
+                   0.0f);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale_variance_out");
   } else {
     const auto* mean_data = mean.data<float>();
     const auto* variance_data = variance.data<float>();

--- a/test/mkldnn/test_batch_norm_mkldnn_op.py
+++ b/test/mkldnn/test_batch_norm_mkldnn_op.py
@@ -54,11 +54,13 @@ class TestMKLDNNBatchNormOpTraining(TestBatchNormOpTraining):
             raise ValueError("Unknown data order.")
 
         # run forward
-        y, saved_mean, saved_variance = _reference_training(
+        y, saved_mean, saved_variance, saved_variance_out = _reference_training(
             x, scale, bias, epsilon, data_layout
         )
         mean_out = saved_mean * (1.0 - momentum) + momentum * mean
-        variance_out = saved_variance * (1.0 - momentum) + momentum * variance
+        variance_out = (
+            saved_variance_out * (1.0 - momentum) + momentum * variance
+        )
         # run backward
         x_grad, scale_grad, bias_grad = _reference_grad(
             x, y_grad, scale, saved_mean, saved_variance, epsilon, data_layout


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
PyConvert 中 tests/test_nn_functional_batch_norm.py: _test_case_3 paddle 与 pytorch 结果不一致

经排查发现导致结果不一致的原因是 `variance_out` 的计算不一致，在更新 running_variance 时，paddle 计算使用的 variance 是biased variance，pytorch 是 unbiased variance。
![image](https://github.com/user-attachments/assets/41decd77-158f-4fd3-a804-f8eeaba20122)
```python
x = paddle.arange(12, dtype="float32").reshape([2, 1, 2, 3])

running_mean = paddle.to_tensor([0], dtype="float32")
running_variance = paddle.to_tensor([1], dtype="float32")
weight = paddle.to_tensor([2], dtype="float32")
bias = paddle.to_tensor([1], dtype="float32")

batch_norm_out = paddle.nn.functional.batch_norm(x, running_mean,
                                            running_variance, weight, bias, training=True)
print(batch_norm_out)
Tensor(shape=[2, 1, 2, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
       [[[[-2.18650889, -1.60714364, -1.02777839],
          [-0.44841313,  0.13095212,  0.71031737]]],


        [[[ 1.28968263,  1.86904788,  2.44841313],
          [ 3.02777839,  3.60714364,  4.18650913]]]])

print(running_variance)
Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
       [2.09166694])

print(running_mean)
Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
       [0.55000013])

print(weight)
Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
       [2.])

print(bias)
Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
       [1.])
```
```python
x = torch.arange(12, dtype=torch.float32).reshape([2, 1, 2, 3])

running_mean = torch.tensor([0], dtype=torch.float32)
running_variance = torch.tensor([1], dtype=torch.float32)
weight = torch.tensor([2], dtype=torch.float32)
bias = torch.tensor([1], dtype=torch.float32)

batch_norm_out = torch.nn.functional.batch_norm(x, running_mean,
                                            running_variance, weight, bias, training=True)
print(batch_norm_out)
tensor([[[[-2.1865, -1.6071, -1.0278],
          [-0.4484,  0.1310,  0.7103]]],


        [[[ 1.2897,  1.8690,  2.4484],
          [ 3.0278,  3.6071,  4.1865]]]])

print(running_variance)
tensor([2.2000])

print(running_mean)
tensor([0.5500])

print(weight)
tensor([2.])

print(bias)
tensor([1.])
```