### PR TITLE
[Eager] Avoid redundant memcpy in `to_tensor`

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -726,7 +726,7 @@ def _to_tensor_non_static(
             data = _handle_tensor_dtype(data, dtype)
             data.stop_gradient = stop_gradient
             return data
-        elif isinstance(data, (core.LoDTensor, core.Tensor)):
+        elif isinstance(data, core.Tensor):
             # should't expose it to users, just for internal use.
             # convert core.Tensor/core.LoDTensor to Tensor first
             # Currently, there is no copy when places are same

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -731,8 +731,6 @@ def _to_tensor_non_static(
             # convert core.Tensor/core.LoDTensor to Tensor first
             # Currently, there is no copy when places are same
             data = paddle.Tensor(data, place=place)
-            if not data.place._equals(place):
-                data = data._copy_to(place, False)
             data = _handle_tensor_dtype(data, dtype)
             data.stop_gradient = stop_gradient
             return data

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -730,10 +730,7 @@ def _to_tensor_non_static(
             # should't expose it to users, just for internal use.
             # convert core.Tensor/core.LoDTensor to Tensor first
             # Currently, there is no copy when places are same
-            if in_dynamic_mode():
-                data = core.eager.Tensor(data)
-            else:
-                data = paddle.Tensor(data)
+            data = paddle.Tensor(data, place=place)
             if not data.place._equals(place):
                 data = data._copy_to(place, False)
             data = _handle_tensor_dtype(data, dtype)

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -1534,5 +1534,15 @@ class TestEagerTensorGradNameValue(unittest.TestCase):
         self.assertIsNotNone(a._grad_value())
 
 
+class TestDenseTensorToTensor(unittest.TestCase):
+    def test_same_place_data_ptr_consistency(self):
+        for place in [paddle.CPUPlace(), paddle.CUDAPlace(0)]:
+            x = paddle.rand([3, 5]).to(device=place)
+            x_dense = x.get_tensor()
+            y = paddle.to_tensor(x_dense, place=place)
+
+            self.assertEqual(x.data_ptr(), y.data_ptr())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -1536,7 +1536,10 @@ class TestEagerTensorGradNameValue(unittest.TestCase):
 
 class TestDenseTensorToTensor(unittest.TestCase):
     def test_same_place_data_ptr_consistency(self):
-        for place in [paddle.CPUPlace(), paddle.CUDAPlace(0)]:
+        places = [paddle.CPUPlace()]
+        if paddle.is_compiled_with_cuda():
+            places.append(paddle.CUDAPlace(0))
+        for place in places:
             x = paddle.rand([3, 5]).to(device=place)
             x_dense = x.get_tensor()
             y = paddle.to_tensor(x_dense, place=place)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

目前 `to_tensor` 传入 DenseTensor 时，因为 `paddle.Tensor` 没有传入 place，会导致先 copy 到 expected place，然后后面因为 place 和需要的不一致再次发生 copy

就比如，默认 device 为 GPU 时，对于 CPU Tensor `x`，首先会 H2D，然后 copy 时候 D2H，两次 memcpy

```python
>>> x = paddle.to_tensor([1], place="cpu")
>>> x.data_ptr()
93857196027904
>>> x.place
Place(cpu)
>>> y = paddle.to_tensor(x.get_tensor(), place="cpu")
>>> y.data_ptr()
93857196032000
>>> y.place
Place(cpu)
```

修复后不再发生 memcpy

```python
>>> x = paddle.to_tensor([1], place="cpu")
>>> x.data_ptr()
94572035518464
>>> x.place
Place(cpu)
>>> y = paddle.to_tensor(x.get_tensor(), place="cpu")
>>> y.data_ptr()
94572035518464
>>> y.place
Place(cpu)
```

顺带清理等价类 `paddle.Tensor`、`paddle.base.core.eager.Tensor` 和 `paddle.base.core.Tensor`、`paddle.base.core.LoDTensor` 相关分支

```python
>>> paddle.Tensor is paddle.base.core.eager.Tensor         # 以前新老动态图中间态不一样，现在一样了
True
>>> paddle.base.core.Tensor is paddle.base.core.LoDTensor  # 以前有 LoDTensor，现在只是 DenseTensor 的 alias 了
True
```

> [!NOTE]
>
> 仅针对 `to_tensor` 传入 DenseTensor 的情况，传入 EagerTensor 仍然需要 copy

cc @HydrogenSulfate 

Pcard-67164