### PR TITLE
[XPU] Modify the condition in the SelectKernelOrThrowError function for XPU fallback to CPU.

### DIFF
--- a/paddle/phi/core/kernel_factory.cc
+++ b/paddle/phi/core/kernel_factory.cc
@@ -353,9 +353,12 @@ KernelResult KernelFactory::SelectKernelOrThrowError(
       (kernel_iter == iter->second.end() || (xpu_unsupport && !has_kp_kernel))
 #elif defined(PADDLE_WITH_XPU) && !defined(PADDLE_WITH_XPU_KP)
   VLOG(6) << "fluid_op_name: " << TransToFluidOpName(kernel_name);
+  bool is_xpu_support1 = phi::backends::xpu::is_xpu_support_op(
+      TransToFluidOpName(kernel_name), kernel_key.dtype());
+  bool is_xpu_support2 =
+      phi::backends::xpu::is_xpu_support_op(kernel_name, kernel_key.dtype());
   if ((FLAGS_enable_api_kernel_fallback && kernel_iter == iter->second.end()) ||
-      !phi::backends::xpu::is_xpu_support_op(TransToFluidOpName(kernel_name),
-                                             kernel_key.dtype())
+      (!is_xpu_support1 && !is_xpu_support2)
 #elif defined(PADDLE_WITH_CUSTOM_DEVICE)
   if (kernel_iter == iter->second.end() &&
       kernel_key.backend() > phi::Backend::NUM_BACKENDS) {


### PR DESCRIPTION
### PR Category
Custom Device


### PR Types
Bug fixes


### Description
由于切新动态图的历史遗留问题，需要使用TransToFluidOpName函数将phi的名字转换为FluidOpName，is_xpu_support_op函数才能识别，所以这里有个限制：当存在转换关系时，必须使用FluidOpName的名字，否则无法成功注册。本修改解决该限制，注册时使用phi_kernel 或者 fluid_op_name都可。

