### PR TITLE
[pir] fix windows inference bug

### DIFF
--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -412,7 +412,7 @@ class PassAutoScanTest(AutoScanTest):
         max_examples=100,
         reproduce=None,
         min_success_num=25,
-        max_duration=180,
+        max_duration=1000,
         passes=None,
     ):
         if os.getenv("HYPOTHESIS_TEST_PROFILE", "ci") == "dev":

--- a/test/legacy_test/test_imperative_se_resnext.py
+++ b/test/legacy_test/test_imperative_se_resnext.py
@@ -447,7 +447,7 @@ class TestImperativeResneXt(unittest.TestCase):
                 name='label', shape=[-1, 1], dtype='int64'
             )
             out = se_resnext(img)
-            softmax_out = paddle.nn.function.softmax(out)
+            softmax_out = paddle.nn.functional.softmax(out)
             loss = paddle.nn.functional.cross_entropy(
                 input=softmax_out,
                 label=label,

--- a/test/mkldnn/test_flags_use_mkldnn.py
+++ b/test/mkldnn/test_flags_use_mkldnn.py
@@ -29,7 +29,7 @@ class TestFlagsUseMkldnn(unittest.TestCase):
         self.env["DNNL_VERBOSE"] = "1"
         self.env["FLAGS_use_mkldnn"] = "1"
 
-        self.relu_regex = b"^onednn_verbose,exec,cpu,eltwise,.+alg:eltwise_relu alpha:0 beta:0,10x20x30"
+        self.relu_regex = b"^onednn_verbose,primitive,exec,cpu,eltwise,.+alg:eltwise_relu alpha:0 beta:0,10x20x30"
 
     def _print_when_false(self, cond, out, err):
         if not cond:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
inference


### PR Types
Bug fixes

### Description
修复 windows inference bug
test_callback_visualdl , test_reinforcement_learning 安装依赖 python/unittest_py/requirements.txt 已存在
test_flags_use_mkldnn 已修改测试pattern
test_fc_fuse_pass  test_simplify_with_basic_ops_pass_autoscan 修改test/ir/inference/auto_scan_test.py超时时间 
test_imperative_se_resnext 修改调用参数
Pcard-67164
