### PR TITLE
[AutoParallel] Add local view reshape and nd_mesh_alltoall reshard for moe

### DIFF
--- a/paddle/fluid/pybind/auto_parallel_py.cc
+++ b/paddle/fluid/pybind/auto_parallel_py.cc
@@ -435,6 +435,17 @@ void BindAutoParallel(py::module *m) {
           .def("is_partial", &phi::distributed::Placement::is_partial)
           .def("__hash__", &phi::distributed::Placement::hash)
           .def("__str__", &phi::distributed::Placement::to_string)
+          .def("__repr__", &phi::distributed::Placement::to_string)
+          .def("__copy__",
+               [](const phi::distributed::Placement &self) {
+                 return phi::distributed::Placement(self);
+               })
+          .def(
+              "__deepcopy__",
+              [](const phi::distributed::Placement &self, py::dict) {
+                return phi::distributed::Placement(self);
+              },
+              py::arg("memo"))
           .def(py::self == py::self)   // NOLINT
           .def(py::self != py::self);  // NOLINT
 
@@ -464,12 +475,24 @@ void BindAutoParallel(py::module *m) {
                    .def("get_dim", &phi::distributed::Shard::get_dim)
                    .def("__hash__", &phi::distributed::Shard::hash)
                    .def("__str__", &phi::distributed::Shard::to_string)
+                   .def("__repr__", &phi::distributed::Shard::to_string)
+                   .def("__copy__",
+                        [](const phi::distributed::Shard &self) {
+                          return phi::distributed::Shard(self);
+                        })
+                   .def(
+                       "__deepcopy__",
+                       [](const phi::distributed::Shard &self, py::dict) {
+                         return phi::distributed::Shard(self);
+                       },
+                       py::arg("memo"))
                    .def(py::self == py::self)   // NOLINT
                    .def(py::self != py::self);  // NOLINT
 
-  auto Replicate = py::class_<phi::distributed::Replicate,
-                              std::shared_ptr<phi::distributed::Replicate>>(
-                       *m, "Replicate", Placement, R"DOC(
+  auto Replicate =
+      py::class_<phi::distributed::Replicate,
+                 std::shared_ptr<phi::distributed::Replicate>>(
+          *m, "Replicate", Placement, R"DOC(
                    The `Replicate` describes the tensor placed repeatedly on ProcessMesh.
 
                    Examples:
@@ -484,11 +507,22 @@ void BindAutoParallel(py::module *m) {
                            >>> d_tensor = dist.shard_tensor(a, mesh, [dist.Replicate()])
 
                    )DOC")
-                       .def(py::init<>())
-                       .def("__hash__", &phi::distributed::Replicate::hash)
-                       .def("__str__", &phi::distributed::Replicate::to_string)
-                       .def(py::self == py::self)   // NOLINT
-                       .def(py::self != py::self);  // NOLINT
+          .def(py::init<>())
+          .def("__hash__", &phi::distributed::Replicate::hash)
+          .def("__str__", &phi::distributed::Replicate::to_string)
+          .def("__repr__", &phi::distributed::Replicate::to_string)
+          .def("__copy__",
+               [](const phi::distributed::Replicate &self) {
+                 return phi::distributed::Replicate(self);
+               })
+          .def(
+              "__deepcopy__",
+              [](const phi::distributed::Replicate &self, py::dict) {
+                return phi::distributed::Replicate(self);
+              },
+              py::arg("memo"))
+          .def(py::self == py::self)   // NOLINT
+          .def(py::self != py::self);  // NOLINT
 
   auto Partial =
       py::class_<phi::distributed::Partial,
@@ -516,6 +550,17 @@ void BindAutoParallel(py::module *m) {
           .def("reduce_type", &phi::distributed::Partial::get_reduce_type)
           .def("__hash__", &phi::distributed::Partial::hash)
           .def("__str__", &phi::distributed::Partial::to_string)
+          .def("__repr__", &phi::distributed::Partial::to_string)
+          .def("__copy__",
+               [](const phi::distributed::Partial &self) {
+                 return phi::distributed::Partial(self);
+               })
+          .def(
+              "__deepcopy__",
+              [](const phi::distributed::Partial &self, py::dict) {
+                return phi::distributed::Partial(self);
+              },
+              py::arg("memo"))
           .def(py::self == py::self)   // NOLINT
           .def(py::self != py::self);  // NOLINT
 

--- a/paddle/phi/core/distributed/auto_parallel/dist_tensor.cc
+++ b/paddle/phi/core/distributed/auto_parallel/dist_tensor.cc
@@ -49,6 +49,13 @@ TensorDistAttr ToTensorDistAttr(const ProcessMesh& process_mesh,
     auto& placement = placements[i];
     if (placement->is_shard()) {
       auto shard_dim = dynamic_cast<const Shard&>(*placement).get_dim();
+      if (dim_map[shard_dim] != -1) {
+        LOG(WARNING) << "WARNING: Tensor dim " << shard_dim
+                     << " is already sharded on "
+                     << "mesh dim" << dim_map[shard_dim]
+                     << ". Sharding a tensor dim with "
+                     << "multiple mesh dim is not supported yet.";
+      }
       // PADDLE_ENFORCE_EQ(
       //     dim_map[shard_dim],
       //     -1,

--- a/paddle/phi/core/distributed/auto_parallel/dist_tensor.cc
+++ b/paddle/phi/core/distributed/auto_parallel/dist_tensor.cc
@@ -49,16 +49,16 @@ TensorDistAttr ToTensorDistAttr(const ProcessMesh& process_mesh,
     auto& placement = placements[i];
     if (placement->is_shard()) {
       auto shard_dim = dynamic_cast<const Shard&>(*placement).get_dim();
-      PADDLE_ENFORCE_EQ(
-          dim_map[shard_dim],
-          -1,
-          common::errors::InvalidArgument(
-              "Tensor dim %lld is already sharded on mesh dim %lld,"
-              " DistTensor operator implementation does not support things "
-              "like hybrid"
-              " sharding strategies yet (i.e. [Shard(0), Shard(0)])",
-              shard_dim,
-              dim_map[shard_dim]));
+      // PADDLE_ENFORCE_EQ(
+      //     dim_map[shard_dim],
+      //     -1,
+      //     common::errors::InvalidArgument(
+      //         "Tensor dim %lld is already sharded on mesh dim %lld,"
+      //         " DistTensor operator implementation does not support things "
+      //         "like hybrid"
+      //         " sharding strategies yet (i.e. [Shard(0), Shard(0)])",
+      //         shard_dim,
+      //         dim_map[shard_dim]));
       dim_map[shard_dim] = i;
     }
   }

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -779,7 +779,6 @@ def reshard(
 
         alltoall_dim = _specific_alltoall_dim(dist_tensor, mesh, placements)
         if alltoall_dim is not None:
-            # return _nd_mesh_alltoall_reshard(dist_tensor, mesh, placements, alltoall_dim)
             return _NdMeshAlltoAll.apply(
                 dist_tensor, mesh, placements, alltoall_dim
             )

--- a/python/paddle/distributed/auto_parallel/moe_utils.py
+++ b/python/paddle/distributed/auto_parallel/moe_utils.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+import paddle
+import paddle.distributed as dist
+from paddle import Tensor
+from paddle.autograd import PyLayer
+
+from .placement_type import check_placements_equal
+from .static.reshard_funcs.nd_mesh_reshard_func import get_1D_sub_process_mesh
+
+if TYPE_CHECKING:
+    from paddle.distributed import Placement
+    from paddle.distributed.auto_parallel.process_mesh import ProcessMesh
+
+
+def _specific_alltoall_dim(
+    dist_tensor: Tensor, mesh: ProcessMesh, placements: list[Placement]
+):
+    """
+    Get the specific dimension for alltoall communication in nd_mesh reshard.
+    """
+    mesh_dim = None
+    src_mesh = dist_tensor.process_mesh
+    src_placements = dist_tensor.placements
+
+    if src_mesh != mesh or src_mesh.ndim == 1:
+        return None
+
+    if any(p.is_partial() for p in src_placements):
+        return None
+    if any(p.is_partial() for p in placements):
+        return None
+
+    for i in range(min(len(src_placements), len(placements))):
+        src_p = src_placements[i]
+        dst_p = placements[i]
+        if src_p.is_shard() and dst_p.is_shard() and src_p != dst_p:
+            # reshard from shard to shard, needs alltoall
+            # now only supports reshard on one dimension
+            src_dim = src_p.get_dim()
+            dst_dim = dst_p.get_dim()
+            if mesh_dim is not None or abs(src_dim - dst_dim) != 1:
+                return None
+            else:
+                mesh_dim = i
+
+    return mesh_dim
+
+
+class _NdMeshAlltoAll(PyLayer):
+    @staticmethod
+    def forward(
+        ctx,
+        dist_tensor: Tensor,
+        mesh: ProcessMesh,
+        placements: list[Placement],
+        dim: int,
+    ):
+        sub_mesh = get_1D_sub_process_mesh(mesh, dim)
+        ctx.alltoall_dim = dim
+        ctx.x_mesh = copy.deepcopy(dist_tensor.process_mesh)
+        ctx.x_placements = copy.deepcopy(dist_tensor.placements)
+        ctx.out_mesh = copy.deepcopy(mesh)
+        ctx.out_placements = copy.deepcopy(placements)
+
+        out = dist.auto_parallel.api.dtensor_from_local(
+            dist_tensor._local_value(), sub_mesh, [dist_tensor.placements[dim]]
+        )
+        out = dist.reshard(out, sub_mesh, [placements[dim]])
+        out = dist.auto_parallel.api.dtensor_from_local(
+            out._local_value(), mesh, placements
+        )
+        out.stop_gradient = dist_tensor.stop_gradient
+        return out
+
+    @staticmethod
+    def backward(ctx, out_grad):
+        if not check_placements_equal(ctx.out_placements, out_grad.placements):
+            out = dist.reshard(out_grad, ctx.out_mesh, ctx.out_placements)
+        out = _NdMeshAlltoAll.apply(
+            out_grad, ctx.x_mesh, ctx.x_placements, ctx.alltoall_dim
+        )
+        return out
+
+
+def _nd_mesh_alltoall_reshard(
+    dist_tensor: Tensor,
+    mesh: ProcessMesh,
+    placements: list[Placement],
+    dim: int,
+):
+    sub_mesh = get_1D_sub_process_mesh(mesh, dim)
+    out = dist.auto_parallel.api.dtensor_from_local(
+        dist_tensor._local_value(), sub_mesh, [dist_tensor.placements[dim]]
+    )
+    out.stop_gradient = dist_tensor.stop_gradient
+
+    out = dist.reshard(out, sub_mesh, [placements[dim]])
+    out = dist.auto_parallel.api.dtensor_from_local(
+        out._local_value(), mesh, placements
+    )
+    out.stop_gradient = dist_tensor.stop_gradient
+    return out
+
+
+def _cal_local_shape(global_shape, mesh, placements):
+    local_shape = list(global_shape)
+    for idx, placement in enumerate(placements):
+        if placement.is_shard():
+            shard_dim = placement.get_dim()
+            local_shape[shard_dim] = local_shape[shard_dim] // mesh.shape[idx]
+    return local_shape
+
+
+def infer_pos_shape(src_shape, tgt_shape):
+    if isinstance(tgt_shape, (list, tuple)):
+        ret_shape = np.array(tgt_shape)
+    else:
+        ret_shape = tgt_shape.copy()
+
+    neg_one_idx = np.where(ret_shape == -1)[0]
+    if neg_one_idx.size > 0:
+        assert (
+            neg_one_idx.size <= 1
+        ), "At most one -1 is allowed in target shape."
+
+        nelem = np.prod(src_shape)
+        ret_shape[neg_one_idx[0]] = 1
+        ret_shape[neg_one_idx[0]] = nelem // np.prod(ret_shape)
+
+    return list(ret_shape)
+
+
+class _local_reshape(PyLayer):
+    @staticmethod
+    def forward(
+        ctx,
+        dist_tensor: Tensor,
+        global_shape: list,
+        mesh: ProcessMesh,
+        placements: list[Placement],
+    ):
+        place = paddle.framework._current_expected_place()
+        place = paddle.framework._get_paddle_place(place)
+
+        local_tensor = dist_tensor._local_value().clone()
+        ctx.x_global_shape = copy.deepcopy(dist_tensor.shape)
+        ctx.x_local_shape = copy.deepcopy(local_tensor.shape)
+        ctx.x_mesh = copy.deepcopy(dist_tensor.process_mesh)
+        ctx.x_placements = copy.deepcopy(dist_tensor.placements)
+
+        local_shape = _cal_local_shape(global_shape, mesh, placements)
+        assert np.prod(local_shape) == np.prod(
+            local_tensor.shape
+        ), f"The local shapes {local_shape} and {local_tensor.shape} are mismatched."
+        local_tensor = local_tensor.reshape(local_shape)
+        out = paddle.Tensor(
+            local_tensor,
+            dims=global_shape,
+            process_mesh=mesh,
+            placements=placements,
+            place=place,
+        )
+        out.stop_gradient = dist_tensor.stop_gradient
+        return out
+
+    @staticmethod
+    def backward(ctx, out_grad):
+        place = paddle.framework._current_expected_place()
+        place = paddle.framework._get_paddle_place(place)
+
+        local_grad = out_grad._local_value().clone()
+        local_grad = local_grad.reshape(ctx.x_local_shape)
+        ret = paddle.Tensor(
+            local_grad,
+            dims=ctx.x_global_shape,
+            process_mesh=ctx.x_mesh,
+            placements=ctx.x_placements,
+            place=place,
+        )
+        return ret
+
+
+def _dist_reshape(
+    dist_tensor: Tensor,
+    global_shape: list,
+    mesh: ProcessMesh,
+    placements: list[Placement],
+):
+    """
+    Reshape the local tensors of the dist tensor on each rank,
+    and mannualy set the process_mesh and placements of the output.
+    """
+    tgt_global_shape = infer_pos_shape(dist_tensor.shape, global_shape)
+    if paddle.in_dynamic_mode():
+        return _local_reshape.apply(
+            dist_tensor, tgt_global_shape, mesh, placements
+        )
+    else:
+        raise NotImplementedError(
+            "dist_reshape is only supported in dynamic mode."
+        )
+
+
+def _reshard_mesh_shape(
+    dist_tensor: Tensor, mesh: ProcessMesh, placements: list[Placement]
+):
+    src_mesh = dist_tensor.process_mesh
+    if src_mesh == mesh or src_mesh.process_ids != mesh.process_ids:
+        return False
+
+    # only the mesh shapes are different,
+    # if the placements are all replicate,
+    # then we can reshard the mesh shapes
+    if not all(p.is_replicated() for p in dist_tensor.placements + placements):
+        return False
+
+    return True

--- a/python/paddle/distributed/auto_parallel/moe_utils.py
+++ b/python/paddle/distributed/auto_parallel/moe_utils.py
@@ -103,26 +103,6 @@ class _NdMeshAlltoAll(PyLayer):
         return out
 
 
-def _nd_mesh_alltoall_reshard(
-    dist_tensor: Tensor,
-    mesh: ProcessMesh,
-    placements: list[Placement],
-    dim: int,
-):
-    sub_mesh = get_1D_sub_process_mesh(mesh, dim)
-    out = dist.auto_parallel.api.dtensor_from_local(
-        dist_tensor._local_value(), sub_mesh, [dist_tensor.placements[dim]]
-    )
-    out.stop_gradient = dist_tensor.stop_gradient
-
-    out = dist.reshard(out, sub_mesh, [placements[dim]])
-    out = dist.auto_parallel.api.dtensor_from_local(
-        out._local_value(), mesh, placements
-    )
-    out.stop_gradient = dist_tensor.stop_gradient
-    return out
-
-
 def _cal_local_shape(global_shape, mesh, placements):
     local_shape = list(global_shape)
     for idx, placement in enumerate(placements):

--- a/test/auto_parallel/CMakeLists.txt
+++ b/test/auto_parallel/CMakeLists.txt
@@ -133,6 +133,9 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
     test_semi_auto_parallel_unshard_dtensor ENVS FLAGS_enable_pir_api=1)
   set_tests_properties(test_semi_auto_parallel_unshard_dtensor
                        PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 100)
+  py_test_modules(test_moe_utils MODULES test_moe_utils)
+  set_tests_properties(test_moe_utils PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE"
+                                                 TIMEOUT 30)
   # End of unittests WITH multi cards and timeout
 
   # NOTE(zyl): unittests WITH multi cards and WITHOUT timeout

--- a/test/auto_parallel/semi_auto_parallel_moe_utils.py
+++ b/test/auto_parallel/semi_auto_parallel_moe_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import unittest
 
 import numpy as np
 
@@ -63,6 +64,19 @@ class TestMoEUtils:
         np.testing.assert_array_equal(
             splitted_np_grad[dist.get_rank()],
             dist_x.grad._local_value().numpy(),
+        )
+
+        with unittest.TestCase().assertRaises(AssertionError):
+            dist_z = dist.auto_parallel.moe_utils._dist_reshape(
+                dist_x,
+                dist_x.shape,
+                self._mesh1,
+                [dist.Replicate(), dist.Replicate()],
+            )
+
+        # test the warning log message
+        dist_z = dist.auto_parallel.moe_utils._dist_reshape(
+            dist_x, dist_x.shape, self._mesh0, [dist.Shard(1), dist.Shard(1)]
         )
 
     def test_nd_mesh_alltoall(self):

--- a/test/auto_parallel/semi_auto_parallel_moe_utils.py
+++ b/test/auto_parallel/semi_auto_parallel_moe_utils.py
@@ -40,7 +40,7 @@ class TestMoEUtils:
             x, self._mesh0, [dist.Shard(1), dist.Replicate()]
         )
         dist_y = dist.auto_parallel.moe_utils._dist_reshape(
-            dist_x, tgt_shape, self._mesh0, [dist.Shard(1), dist.Replicate()]
+            dist_x, [-1, w * 2], self._mesh0, [dist.Shard(1), dist.Replicate()]
         )
 
         splitted_np_x = np.split(np_x, 2, axis=1)

--- a/test/auto_parallel/semi_auto_parallel_moe_utils.py
+++ b/test/auto_parallel/semi_auto_parallel_moe_utils.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import numpy as np
+
+import paddle
+import paddle.distributed as dist
+
+
+class TestMoEUtils:
+    def __init__(self):
+        self._dtype = os.getenv("dtype")
+        self._seed = eval(os.getenv("seed"))
+        self._backend = os.getenv("backend")
+        self._mesh0 = dist.ProcessMesh([[0], [1]], dim_names=["x", "y"])
+        self._mesh1 = dist.ProcessMesh([[0, 1]], dim_names=["x", "y"])
+
+    def test_local_reshape(self):
+        (h, w) = (4, 4)
+        src_shape = [h, w]
+        tgt_shape = [h // 2, w * 2]
+        x = paddle.arange(0, h * w).reshape(src_shape)
+        x.stop_gradient = False
+        np_x = x.numpy()
+
+        dist_x = dist.shard_tensor(
+            x, self._mesh0, [dist.Shard(1), dist.Replicate()]
+        )
+        dist_y = dist.auto_parallel.moe_utils._dist_reshape(
+            dist_x, tgt_shape, self._mesh0, [dist.Shard(1), dist.Replicate()]
+        )
+
+        splitted_np_x = np.split(np_x, 2, axis=1)
+        for i in range(len(splitted_np_x)):
+            splitted_np_x[i] = splitted_np_x[i].reshape([h // 2, w])
+        np.testing.assert_array_equal(
+            splitted_np_x[dist.get_rank()], dist_y._local_value().numpy()
+        )
+
+        label = paddle.ones(tgt_shape, dtype=paddle.int64)
+        label.stop_gradient = False
+        dist_label = dist.shard_tensor(
+            label, self._mesh0, [dist.Shard(1), dist.Replicate()]
+        )
+        loss = dist_y - dist_label
+        loss.backward()
+
+        np_grad = np.ones(src_shape, dtype="int64")
+        splitted_np_grad = np.split(np_grad, 2, axis=1)
+        np.testing.assert_array_equal(
+            splitted_np_grad[dist.get_rank()],
+            dist_x.grad._local_value().numpy(),
+        )
+
+    def test_nd_mesh_alltoall(self):
+        (h, w) = (4, 4)
+        src_shape = [h, w]
+        x = paddle.arange(0, h * w).reshape(src_shape)
+        x.stop_gradient = False
+
+        dist_x = dist.shard_tensor(
+            x, self._mesh0, [dist.Shard(1), dist.Replicate()]
+        )
+        dist_y = dist.reshard(
+            dist_x, self._mesh0, [dist.Shard(0), dist.Replicate()]
+        )
+        dist_y.backward()
+
+        assert dist_y.placements == [dist.Shard(0), dist.Replicate()]
+        assert dist_x.grad.placements == [dist.Shard(1), dist.Replicate()]
+        np_grad = np.ones(src_shape, dtype="int64")
+        splitted_np_grad = np.split(np_grad, 2, axis=1)
+        np.testing.assert_array_equal(
+            splitted_np_grad[dist.get_rank()],
+            dist_x.grad._local_value().numpy(),
+        )
+
+    def test_reshard_mesh_shape(self):
+        (h, w) = (4, 4)
+        src_shape = [h, w]
+        x = paddle.arange(0, h * w).reshape(src_shape)
+
+        dist_x = dist.shard_tensor(
+            x, self._mesh0, [dist.Replicate(), dist.Replicate()]
+        )
+        dist_y = dist.reshard(
+            dist_x, self._mesh1, [dist.Replicate(), dist.Replicate()]
+        )
+
+        assert dist_y.process_mesh == self._mesh1
+        np.testing.assert_array_equal(
+            dist_y._local_value().numpy(), dist_x._local_value().numpy()
+        )
+
+    def run_test_case(self):
+        self.test_local_reshape()
+        self.test_nd_mesh_alltoall()
+        self.test_reshard_mesh_shape()
+
+
+if __name__ == '__main__':
+    TestMoEUtils().run_test_case()

--- a/test/auto_parallel/test_moe_utils.py
+++ b/test/auto_parallel/test_moe_utils.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+
+sys.path.append("..")
+import collective.test_communication_api_base as test_base
+
+
+class TestSemiAutoParallelMoEUtils(test_base.CommunicationTestDistBase):
+    def setUp(self):
+        super().setUp(
+            num_of_devices=2,
+            timeout=30,
+        )
+        self._default_envs = {"dtype": "float32", "seed": "2024"}
+        self._changeable_envs = {"backend": ["gpu"]}
+
+    def test_moe_utils(self):
+        envs_list = test_base.gen_product_envs_list(
+            {"dtype": "float32", "seed": "2024"}, {"backend": ["gpu"]}
+        )
+        for envs in envs_list:
+            self.run_test_case(
+                "semi_auto_parallel_moe_utils.py",
+                user_defined_envs=envs,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Auto Parallel


### PR Types
New features


### Description
Pcard-67164

All operations in auto parallel are identical to the serial case, i.e. all operations are global view. In MoE, the global view reshape brings additional communication. 

This pr add local view reshape and nd_mesh_alltoall reshard to make the MoE training the same as original distributed training, to achieve higher performance.

Additional: add deepcopy function for placements.
