### PR TITLE
[PIR][oneDNN] Optimize Fc InferMeta

### DIFF
--- a/paddle/phi/infermeta/fusion.cc
+++ b/paddle/phi/infermeta/fusion.cc
@@ -3911,6 +3911,88 @@ void FCInferMeta(const MetaTensor& input,
   out->set_dtype(input.dtype());
 }
 
+void FCOneDNNInferMeta(const MetaTensor& input,
+                       const MetaTensor& w,
+                       const MetaTensor& bias,
+                       const int in_num_col_dims,
+                       const std::string& activation_type,
+                       const bool padding_weights,
+                       const std::vector<int>& fused_reshape2_shape,
+                       MetaTensor* out) {
+  PADDLE_ENFORCE_GE(
+      in_num_col_dims,
+      1,
+      common::errors::InvalidArgument(
+          "The in_num_col_dims is expected to equal or greater than 1. "
+          "But received the in_num_col_dims is %d. ",
+          in_num_col_dims));
+
+  auto w_dims = w.dims();
+  PADDLE_ENFORCE_EQ(
+      w_dims.size(),
+      2,
+      common::errors::InvalidArgument(
+          "The input Weight of fc is expected to be a 2-D tensor. "
+          "But received the number of Weight's dimensions is %d, "
+          "Weight's shape is %s.",
+          w_dims.size(),
+          w_dims));
+
+  if (bias) {
+    auto bias_dims = bias.dims();
+    auto w_dims1 = padding_weights ? w_dims[1] - 4 : w_dims[1];
+
+    PADDLE_ENFORCE_EQ(
+        bias_dims[bias_dims.size() - 1],
+        w_dims1,
+        common::errors::InvalidArgument(
+            "The last dimension of input Bias is expected be equal "
+            "to the actual width of input Weight. But received the last "
+            "dimension of Bias is %d, Bias's shape is %s; "
+            "the actual width of Weight is %d, Weight's shape is %s.",
+            bias_dims[bias_dims.size() - 1],
+            bias_dims,
+            w_dims1,
+            w_dims));
+  }
+
+  auto in_dims = input.dims();
+  // VLOG(-2) << "fc in dims: " << in_dims.size();
+  PADDLE_ENFORCE_LT(
+      in_num_col_dims,
+      in_dims.size(),
+      common::errors::InvalidArgument(
+          "The attribute in_num_col_dims used to flatten Input to "
+          "a 2-D tensor, is expected to be less than the number of "
+          "Input's dimensions. But received in_num_col_dims is %d, "
+          "the number of Input's dimensions is %d, Input's shape is %s.",
+          in_num_col_dims,
+          in_dims.size(),
+          in_dims));
+
+  std::unordered_set<std::string> support_acts = {"", "relu", "gelu"};
+  PADDLE_ENFORCE_EQ(
+      support_acts.count(activation_type),
+      1,
+      common::errors::InvalidArgument(
+          "The attribute activation_type of fc is expected "
+          "to be one of [\"\", \"relu\", \"gelu\"], but received %s.",
+          activation_type.c_str()));
+
+  std::vector<int64_t> output_dims;
+  phi::funcs::FCOutputSize(
+      in_dims, w_dims, output_dims, in_num_col_dims, padding_weights);
+
+  auto out_dims = common::make_ddim(output_dims);
+  auto reshape_size = fused_reshape2_shape;
+  if (!reshape_size.empty()) {
+    out_dims = out_dims.reshape(reshape_size);
+  }
+  out->set_dims(out_dims);
+  out->share_lod(input);
+  out->set_dtype(input.dtype());
+}
+
 void SelfDPAttenInferMeta(const MetaTensor& x,
                           const float alpha,
                           const int head_number,

--- a/paddle/phi/infermeta/fusion.h
+++ b/paddle/phi/infermeta/fusion.h
@@ -974,6 +974,15 @@ void FCInferMeta(const MetaTensor& input,
                  const bool padding_weights,
                  MetaTensor* out);
 
+void FCOneDNNInferMeta(const MetaTensor& input,
+                       const MetaTensor& w,
+                       const MetaTensor& bias,
+                       const int in_num_col_dims,
+                       const std::string& activation_type,
+                       const bool padding_weights,
+                       const std::vector<int>& fused_reshape2_shape,
+                       MetaTensor* out);
+
 void VariableLengthMemoryEfficientAttentionInferMeta(
     const MetaTensor& query,
     const MetaTensor& key,

--- a/paddle/phi/ops/yaml/inconsistent/onednn_ops_extra.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/onednn_ops_extra.yaml
@@ -95,9 +95,6 @@
 - op : expand_grad
   extra_args : str mkldnn_data_type="float32"
 
-- op : fc
-  extra_args : bool use_quantizer=false, str mkldnn_data_type="float32", float scale_in=1.0, float[] scale_weights={1.0f}, float scale_out=1.0, bool force_fp32_output=false, str fuse_activation = "", float fuse_alpha = 0.0, float fuse_beta = 0.0, float fused_output_scale = 1.0f, int[] fused_reshape2_shape = {}
-
 - op : flatten
   extra_args : str mkldnn_data_type="float32"
 

--- a/paddle/phi/ops/yaml/inconsistent/onednn_static.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/onednn_static.yaml
@@ -8,6 +8,17 @@
     func : dequantize
     data_type : input
 
+- op : fc
+  args : (Tensor input, Tensor w, Tensor bias, int in_num_col_dims = 1, str activation_type = "", bool padding_weights = false, bool use_quantizer=false, str mkldnn_data_type="float32", float scale_in=1.0, float[] scale_weights={1.0f}, float scale_out=1.0, bool force_fp32_output=false, str fuse_activation = "", float fuse_alpha = 0.0, float fuse_beta = 0.0, float fused_output_scale = 1.0f, int[] fused_reshape2_shape = {})
+  output : Tensor(out)
+  infer_meta :
+    func : FCOneDNNInferMeta
+    param : [input, w, bias, in_num_col_dims, activation_type, padding_weights, fused_reshape2_shape]
+  kernel :
+    func : fc
+    data_type : input
+  optional : bias
+
 - op : fused_conv2d
   args : (Tensor input, Tensor filter, Tensor bias, Tensor residual_param, int[] strides={1, 1}, int[] paddings={0, 0}, str padding_algorithm="EXPLICIT", int[] dilations={1, 1}, int groups=1, str data_format="NCHW", str mkldnn_data_type="float32", str fuse_activation="", bool fuse_residual_connection=false, bool force_fp32_output=false)
   output : Tensor(output)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
During test on vit-ocr model, we found inconsistent Input Tensor and Perm in `Transpose` Op. After investigation, it turned out that the problem was relevant to InferMeta of its previous Op `onednn_op.fc`. It neglected attribute `fused_reshape2_shape`, which may change the dims of output of Fc.

Here I add specific InferMeta for `onednn_op.fc`, considering the impact of extra attribute `fused_reshape2_shape`.
