### PR TITLE
[PIR] paddle_test support pir deprecated

### DIFF
--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -463,6 +463,8 @@ function(cc_test_run TARGET_NAME)
     set(multiValueArgs COMMAND ARGS)
     cmake_parse_arguments(cc_test "${options}" "${oneValueArgs}"
                           "${multiValueArgs}" ${ARGN})
+    string(REGEX MATCH "_deprecated$" DEPRECATED_TARGET_NAME "${TARGET_NAME}")
+
     if(cc_test_DIR STREQUAL "")
       set(cc_test_DIR ${CMAKE_CURRENT_BINARY_DIR})
     endif()
@@ -470,14 +472,26 @@ function(cc_test_run TARGET_NAME)
       NAME ${TARGET_NAME}
       COMMAND ${cc_test_COMMAND} ${cc_test_ARGS}
       WORKING_DIRECTORY ${cc_test_DIR})
-    set_property(
-      TEST ${TARGET_NAME}
-      PROPERTY
-        ENVIRONMENT
-        FLAGS_init_allocated_mem=true
-        FLAGS_cudnn_deterministic=true
-        LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PADDLE_BINARY_DIR}/python/paddle/libs:${PADDLE_BINARY_DIR}/python/paddle/base
-    )
+    if(NOT "${DEPRECATED_TARGET_NAME}" STREQUAL "")
+      set_property(
+        TEST ${TARGET_NAME}
+        PROPERTY
+          ENVIRONMENT
+          FLAGS_init_allocated_mem=true
+          FLAGS_cudnn_deterministic=true
+          FLAGS_enable_pir_api=0
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PADDLE_BINARY_DIR}/python/paddle/libs:${PADDLE_BINARY_DIR}/python/paddle/base
+      )
+    else()
+      set_property(
+        TEST ${TARGET_NAME}
+        PROPERTY
+          ENVIRONMENT
+          FLAGS_init_allocated_mem=true
+          FLAGS_cudnn_deterministic=true
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PADDLE_BINARY_DIR}/python/paddle/libs:${PADDLE_BINARY_DIR}/python/paddle/base
+      )
+    endif()
     # No unit test should exceed 2 minutes.
     if(WIN32)
       set_tests_properties(${TARGET_NAME} PROPERTIES TIMEOUT 150)

--- a/test/deprecated/cpp/prim/CMakeLists.txt
+++ b/test/deprecated/cpp/prim/CMakeLists.txt
@@ -1,7 +1,7 @@
-paddle_test(test_comp_static SRCS test_static_prim_deprecated.cc)
+paddle_test(test_static_prim_deprecated SRCS test_static_prim_deprecated.cc)
 
 if(WITH_ONNXRUNTIME AND WIN32)
   # Copy onnxruntime for some c++ test in Windows, since the test will
   # be build only in CI, so suppose the generator in Windows is Ninja.
-  copy_onnx(test_comp_static)
+  copy_onnx(test_static_prim_deprecated)
 endif()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
paddle_test C++单测支持PIR deprecated
Pcard-67164