### PR TITLE
[Auto Parallel] fix auto_parallel  api in static_mode

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -117,6 +117,19 @@ if TYPE_CHECKING:
 # Part1: Shard attributes related APIs
 
 
+def _to_lodtensor(tensor: paddle.Tensor):
+    lodtensor = core.LoDTensor()
+    if tensor.is_dist():
+        if tensor._is_initialized():
+            lodtensor._share_data_with(tensor._local_value().get_tensor())
+        else:
+            lodtensor = None
+    else:
+        lodtensor._share_data_with(tensor.get_tensor())
+
+    return lodtensor
+
+
 class DistAttr(core.TensorDistAttr):
     """
     DistAttr specifies how tensors are distributed or sliced on ProcessMesh.
@@ -2263,20 +2276,6 @@ class DistModel:
                 f"The model takes {feed_name_list} as input"
             )
 
-        def _to_lodtensor(tensor: paddle.Tensor):
-            lodtensor = core.LoDTensor()
-            if tensor.is_dist():
-                if tensor._is_initialized():
-                    lodtensor._share_data_with(
-                        tensor._local_value().get_tensor()
-                    )
-                else:
-                    lodtensor = None
-            else:
-                lodtensor._share_data_with(tensor.get_tensor())
-
-            return lodtensor
-
         feed_list = []
         no_data_ids = []
         # If the feed_var is None, its feed_name should be deleted.
@@ -2503,8 +2502,10 @@ class DistModel:
                 if k in self._structured_to_parameter_name
                 else k
             )
-            local_state_dict[param_name] = v._local_value()
-        dist_main_program.set_state_dict(local_state_dict)
+            local_state_dict[param_name] = _to_lodtensor(v._local_value())
+        dist_main_program.set_state_dict(
+            local_state_dict, paddle.static.global_scope()
+        )
 
 
 def to_static(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
当前DistModel.set_state_dict接口调不通。需要将dist tensor转换成libpaddle.tensor才能调用pir.Program的set_state_dict

Pcard-76459