### PR TITLE
fix unbalanced pp flag mistake

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -1067,9 +1067,10 @@ class PipelineParallelWithInterleave(PipelineParallel):
         self._best_unbalanced_scheduler = strategy.pipeline_configs[
             "best_unbalanced_scheduler"
         ]
-        assert (
-            self._comm_overlap and self._best_unbalanced_scheduler
-        ), "pp best unbalaced scheduler can not run together with dp/sharding overlap"
+        if self._best_unbalanced_scheduler:
+            assert (
+                not self._comm_overlap
+            ), "pp best unbalaced scheduler can not run together with dp/sharding overlap"
 
     def _check_sanity(self):
         assert (


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复不均衡pp的开关设置，不能和sharding_overlap同时使用