### PR TITLE
[CINN] Remove the obsolete GroupInfo struct

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
@@ -47,16 +47,6 @@ class OpLowererImpl;
 
 typedef bool (OpLowererImpl::*ScheduleDetermineFunction)(::pir::Operation*);
 
-struct GroupInfo {
-  std::vector<int64_t> data_space;
-  std::vector<int64_t> reduce_axis;
-  std::vector<int64_t> loop_strides;
-  std::set<std::string> reduce_var_names;
-  std::set<std::string> shared_var_names;
-  std::set<std::string> direct_output_var_names;
-  std::vector<std::string> broadcast_output_names;
-};
-
 class OpLowererImpl : public OpLowererImplBase<OpLoweringGroupPtr> {
  public:
   explicit OpLowererImpl(const Target&);
@@ -160,11 +150,6 @@ class OpLowererImpl : public OpLowererImplBase<OpLoweringGroupPtr> {
                        const ::pir::Value& value);
   ir::Tensor GetTensorSymbolic(const OpLoweringGroupPtr& group,
                                const ::pir::Value& value);
-
-  std::shared_ptr<GroupInfo> GetGroupInfo(
-      const FusionGroupInfo& fusion_group_info,
-      const OpLoweringGroupPtr& group,
-      const std::unordered_map<::pir::Value, ir::Tensor>& tensor_map);
 
   void CollectOutputInfo(::pir::Operation* op,
                          std::vector<Type>* out_types,

--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
@@ -721,7 +721,7 @@ std::vector<int64_t> GetLoopStrides(const ir::Expr& body,
   return loop_strides;
 }
 
-FusionGroupInfo GetFusionGroupInfo(
+std::shared_ptr<FusionGroupInfo> GetFusionGroupInfo(
     const std::vector<ir::Expr>& op_compute_bodies) {
   using trivial_fusion_detail::AppendBound;
   using trivial_fusion_detail::GetAllForIters;
@@ -733,7 +733,8 @@ FusionGroupInfo GetFusionGroupInfo(
   using trivial_fusion_detail::ExprSetFinderUtils::
       ScheduleBlockRealizeIsSplitTransform;
 
-  FusionGroupInfo group_info = FusionGroupInfo();
+  std::shared_ptr<FusionGroupInfo> group_info =
+      std::make_shared<FusionGroupInfo>();
 
   const auto GetSplitTransformBlock = [](const ir::Expr& expr_body) {
     return (ChildScheduleBlockRealizes *
@@ -744,17 +745,17 @@ FusionGroupInfo GetFusionGroupInfo(
     std::vector<ir::Expr> split_transform_block = GetSplitTransformBlock(body);
     if (!split_transform_block.empty()) {
       CHECK_EQ(split_transform_block.size(), 1);
-      group_info.loop_strides = GetLoopStrides(body, split_transform_block[0]);
+      group_info->loop_strides = GetLoopStrides(body, split_transform_block[0]);
     }
 
     if (IsReduceBody(body)) {
       ReduceOp op = ReduceOp(body);
-      if (group_info.reduce_var_name.empty()) {
+      if (group_info->reduce_var_name.empty()) {
         std::vector<ir::Var> all_iters =
             AppendBound(GetAllForIters(body), body);
         std::transform(all_iters.begin(),
                        all_iters.end(),
-                       std::back_inserter(group_info.loop_ranges),
+                       std::back_inserter(group_info->loop_ranges),
                        [](const ir::Var var) {
                          VLOG(4) << "Var is : : " << var;
                          VLOG(4) << "Var->upper_bound: " << var->upper_bound;
@@ -769,20 +770,20 @@ FusionGroupInfo GetFusionGroupInfo(
         for (int64_t i = all_iters.size() - reduce_iters.size();
              i < all_iters.size();
              i++) {
-          group_info.reduce_axis.emplace_back(i);
+          group_info->reduce_axis.emplace_back(i);
         }
       }
-      group_info.reduce_var_name.emplace_back(GetOutputTensor(op)->name);
+      group_info->reduce_var_name.emplace_back(GetOutputTensor(op)->name);
     }
   }
 
-  if (group_info.reduce_var_name.empty()) {
+  if (group_info->reduce_var_name.empty()) {
     trivial_fusion_detail::TrivialOp op =
         trivial_fusion_detail::TrivialOp(*(op_compute_bodies.begin()));
     std::vector<ir::Var> iters = GetOutputIters(op);
     std::transform(iters.begin(),
                    iters.end(),
-                   std::back_inserter(group_info.loop_ranges),
+                   std::back_inserter(group_info->loop_ranges),
                    [](const ir::Var var) {
                      if (var->upper_bound.is_constant()) {
                        return var->upper_bound.as_int64();
@@ -791,7 +792,7 @@ FusionGroupInfo GetFusionGroupInfo(
                      }
                    });
   }
-  VLOG(4) << group_info.DebugPrint();
+  VLOG(4) << group_info->DebugPrint();
   return group_info;
 }
 

--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
@@ -177,7 +177,7 @@ struct FusionGroupInfo {
   }
 };
 
-FusionGroupInfo GetFusionGroupInfo(
+std::shared_ptr<FusionGroupInfo> GetFusionGroupInfo(
     const std::vector<ir::Expr>& op_compute_bodies);
 
 }  // namespace pir

--- a/paddle/cinn/ir/group_schedule/base_group_scheduler.cc
+++ b/paddle/cinn/ir/group_schedule/base_group_scheduler.cc
@@ -23,7 +23,7 @@ std::unique_ptr<GroupScheduler> GroupScheduler::Make(
     const std::unordered_set<std::string>& output_tensor_names,
     const cinn::common::Target& target,
     bool is_dy_shape,
-    const std::shared_ptr<hlir::framework::pir::GroupInfo>& group_info) {
+    const std::shared_ptr<FusionGroupInfo>& group_info) {
   return std::make_unique<DynamicShapeGroupScheduler>(
       ir_sch, output_tensor_names, target, group_info);
 }

--- a/paddle/cinn/ir/group_schedule/base_group_scheduler.h
+++ b/paddle/cinn/ir/group_schedule/base_group_scheduler.h
@@ -21,16 +21,13 @@
 #include "paddle/cinn/ir/schedule_block_graph.h"
 
 namespace cinn {
-namespace hlir {
-namespace framework {
-namespace pir {
-struct GroupInfo;
-}
-}  // namespace framework
-}  // namespace hlir
-}  // namespace cinn
 
-namespace cinn {
+namespace hlir::framework::pir {
+struct FusionGroupInfo;
+}  // namespace hlir::framework::pir
+
+using hlir::framework::pir::FusionGroupInfo;
+
 namespace ir {
 
 using SymbolicPredicate = Expr;
@@ -40,11 +37,10 @@ using SymbolicPredicate = Expr;
  */
 class GroupScheduler {
  public:
-  GroupScheduler(
-      ir::IRSchedule* ir_sch,
-      const std::unordered_set<std::string>& output_tensor_names,
-      const cinn::common::Target& target,
-      const std::shared_ptr<hlir::framework::pir::GroupInfo>& group_info)
+  GroupScheduler(ir::IRSchedule* ir_sch,
+                 const std::unordered_set<std::string>& output_tensor_names,
+                 const cinn::common::Target& target,
+                 const std::shared_ptr<FusionGroupInfo>& group_info)
       : ir_sch_(ir_sch),
         output_tensor_names_(output_tensor_names),
         target_(target),
@@ -57,8 +53,7 @@ class GroupScheduler {
       const std::unordered_set<std::string>& output_tensor_names,
       const cinn::common::Target& target,
       bool is_dy_shape = false,
-      const std::shared_ptr<hlir::framework::pir::GroupInfo>& group_info =
-          nullptr);
+      const std::shared_ptr<FusionGroupInfo>& group_info = nullptr);
 
   virtual ~GroupScheduler() = default;
 
@@ -80,7 +75,7 @@ class GroupScheduler {
   // ScheduleBlock in IR.
   std::unique_ptr<ir::ScheduleBlockGraph> schedule_block_graph_;
 
-  std::shared_ptr<hlir::framework::pir::GroupInfo> group_info_;
+  std::shared_ptr<FusionGroupInfo> group_info_;
 };
 
 }  // namespace ir

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.h
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.h
@@ -21,8 +21,10 @@
 namespace cinn {
 
 namespace hlir::framework::pir {
-struct GroupInfo;
+struct FusionGroupInfo;
 }  // namespace hlir::framework::pir
+
+using hlir::framework::pir::FusionGroupInfo;
 
 namespace ir {
 
@@ -39,11 +41,6 @@ struct ScheduleConfig {
     bool has_dynamic_reduce{false};
     bool is_reduce_all{false};
     IterSpaceType iter_space_type;
-
-    std::set<std::string> reduce_tensor_names;
-    std::set<std::string> temp_var_names;
-    std::set<std::string> shared_var_names;
-    std::set<std::string> direct_output_var_names;
   };
 
   struct TileConfig {
@@ -117,7 +114,7 @@ struct BucketInfoHash {
 };
 
 std::shared_ptr<ScheduleConfig::BaseInfo> InitBasicInfo(
-    const std::shared_ptr<hlir::framework::pir::GroupInfo>& group_info);
+    const std::shared_ptr<FusionGroupInfo>& group_info);
 
 std::unordered_map<BucketInfo, ScheduleConfig, BucketInfoHash>
 CombineBaseInfoAndConfig(
@@ -127,9 +124,8 @@ CombineBaseInfoAndConfig(
     const std::shared_ptr<ScheduleConfig::BaseInfo>& base_info);
 
 std::unordered_map<BucketInfo, ScheduleConfig, BucketInfoHash>
-BuildScheduleConfig(
-    const std::shared_ptr<hlir::framework::pir::GroupInfo>& group_info,
-    const common::Target& target);
+BuildScheduleConfig(const std::shared_ptr<FusionGroupInfo>& group_info,
+                    const common::Target& target);
 
 }  // namespace ir
 }  // namespace cinn

--- a/paddle/cinn/ir/group_schedule/config/schedule_config_manager.cc
+++ b/paddle/cinn/ir/group_schedule/config/schedule_config_manager.cc
@@ -33,7 +33,7 @@ void ScheduleConfigManager::AddConfigDatabase(
 
 ScheduleConfigMap ScheduleConfigManager::ExtractConfigs(
     const common::Target& target,
-    const std::shared_ptr<hlir::framework::pir::GroupInfo>& group_info) const {
+    const std::shared_ptr<FusionGroupInfo>& group_info) const {
   auto ReadConfigs = [&](std::string policy) -> ScheduleConfigMap {
     std::shared_ptr<ScheduleConfig::BaseInfo> base_info =
         InitBasicInfo(group_info);

--- a/paddle/cinn/ir/group_schedule/config/schedule_config_manager.h
+++ b/paddle/cinn/ir/group_schedule/config/schedule_config_manager.h
@@ -28,7 +28,7 @@ class ScheduleConfigManager {
 
   ScheduleConfigMap ExtractConfigs(
       const common::Target& target,
-      const std::shared_ptr<hlir::framework::pir::GroupInfo>& group_info) const;
+      const std::shared_ptr<FusionGroupInfo>& group_info) const;
 
   void SetPolicy(const std::string& policy);
 

--- a/paddle/cinn/ir/group_schedule/dy_shape_group_scheduler.h
+++ b/paddle/cinn/ir/group_schedule/dy_shape_group_scheduler.h
@@ -29,7 +29,7 @@ class DynamicShapeGroupScheduler : public GroupScheduler {
       ir::IRSchedule* ir_sch,
       const std::unordered_set<std::string>& output_tensor_names,
       const cinn::common::Target& target,
-      const std::shared_ptr<hlir::framework::pir::GroupInfo>& group_info)
+      const std::shared_ptr<FusionGroupInfo>& group_info)
       : GroupScheduler(ir_sch, output_tensor_names, target, group_info) {
     Init();
   }

--- a/paddle/cinn/ir/schedule/factorize_reduction.h
+++ b/paddle/cinn/ir/schedule/factorize_reduction.h
@@ -33,7 +33,7 @@ namespace ir {
 Tensor CreateRFTensor(const Tensor& original_tensor,
                       const Expr& rf_loop,
                       int rf_axis) {
-  std::string name = original_tensor->name + "_rf";
+  std::string name = common::UniqName(original_tensor->name + "_rf");
   std::vector<Expr> new_shape = original_tensor->shape;
   new_shape.insert(new_shape.begin() + rf_axis, rf_loop.As<For>()->extent);
   Tensor rf_tensor = _Tensor_::Make(name,
@@ -262,7 +262,7 @@ class RFBlockCreater : public ReduceBlockCreater {
  private:
   void CreateRFIter() override {
     std::string loop_var_name = rf_loop_.As<ir::For>()->loop_var->name;
-    std::string rf_var_name = "v" + loop_var_name;
+    std::string rf_var_name = common::UniqName("v" + loop_var_name);
     rf_var_ = Var(rf_loop_.As<ir::For>()->min,
                   rf_loop_.As<ir::For>()->extent,
                   rf_var_name,
@@ -335,7 +335,7 @@ class RFBlockCreater : public ReduceBlockCreater {
       if (loop_var2block_iters_.count(loop_var) == 0) {
         Var new_iter_var(loop.As<ir::For>()->min,
                          loop.As<ir::For>()->extent,
-                         "v" + loop_var->name,
+                         common::UniqName("v" + loop_var->name),
                          /* is_reduce = */ true);
         new_iter_vars_.push_back(new_iter_var);
         new_iter_values_.emplace_back(loop_var);
@@ -406,7 +406,7 @@ class RBBlockCreater : public ReduceBlockCreater {
  private:
   void CreateRFIter() override {
     std::string loop_var_name = rf_loop_.As<ir::For>()->loop_var->name;
-    std::string rf_var_name = "v" + loop_var_name;
+    std::string rf_var_name = common::UniqName("v" + loop_var_name);
     rf_var_ = Var(rf_loop_.As<ir::For>()->min,
                   rf_loop_.As<ir::For>()->extent,
                   rf_var_name,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Deprecations


### Description
Removed the `cinn::hlir::framework::GroupInfo` struct because its functionality has been completely replaced by `cinn::hlir::framework::FusionGroupInfo`.

Also, the information in `GroupInfo` came from the PIR FusionOp, which would not be compatible with the lowered CINN IR in the future. Developers should turn to use `FusionGroupInfo`.

Pcard-85711