### PR TITLE
[CINN]【Infer Symbolic Shape 】Add coalesce_tensor_ op 

### DIFF
--- a/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
@@ -183,6 +183,7 @@
     func : coalesce_tensor
     data_type : dtype
   inplace: (input -> output)
+  interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : comm_init_all
   args : (int[] devices={}, int ring_id=0)


### PR DESCRIPTION
### PR Category
CINN


### PR Types
improvements


### Description
添加pyramid_hash 算子符号推导接口

添加ops.yaml的时候已经增加了CoalesceTensor和CoalesceTensor_ ，因此在static_ops里面直接用。
pr见https://github.com/PaddlePaddle/Paddle/pull/67566
Pcard-67164