### PR TITLE
[Dy2St] Switch default test mode to pt and pir

### DIFF
--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -442,8 +442,12 @@ def _run_paddle_cond(
     pred = cast_bool_if_necessary(pred)
     init_args = helper.get(return_name_ids)
     from paddle.jit.dy2static.program_translator import ProgramTranslator
+    from paddle.jit.pir_dy2static.parameter_recorder import _global_inplace_map
 
-    inplace_map = ProgramTranslator.get_instance()._inplace_map
+    if use_pir_api():
+        inplace_map = _global_inplace_map
+    else:
+        inplace_map = ProgramTranslator.get_instance()._inplace_map
     union_name = None
     # TODO(@xiongkun) lambda can have push_pop_names, which will cause error.
     if return_name_ids is None and push_pop_names is None:

--- a/python/paddle/jit/pir_dy2static/parameter_recorder.py
+++ b/python/paddle/jit/pir_dy2static/parameter_recorder.py
@@ -110,7 +110,11 @@ class InplaceMap:
         self.params_dict = checkpoint
 
     def save_checkpoint(self):
-        return dict(self.params_dict.items())
+        ckeckpoint = {}
+        for program_id, params in self.params_dict.items():
+            new_params = dict(params.items())
+            ckeckpoint[program_id] = new_params
+        return ckeckpoint
 
 
 _global_parameter_recorder = ParametersRecorder()

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -912,7 +912,7 @@ def monkey_patch_value():
         pass
 
     @fake_interface_only
-    def register_hook(self):
+    def register_hook(self, hook):
         """
         Value don't have 'register_hook' interface in static graph mode
         But this interface can greatly facilitate dy2static.

--- a/test/dygraph_to_static/check_approval.py
+++ b/test/dygraph_to_static/check_approval.py
@@ -105,21 +105,12 @@ class TestClassInheritFromTestCaseDiagnostic(Diagnostic):
         )
 
 
-class TestCaseWithoutDecoratorDiagnostic(Diagnostic):
-    def __init__(self, start: Location, end: Location):
-        super().__init__(
-            start,
-            end,
-            'Test case should use @test_legacy_and_pt_and_pir instead of no decorator',
-        )
-
-
 class TestCaseWithPirApiDecoratorDiagnostic(Diagnostic):
     def __init__(self, start: Location, end: Location):
         super().__init__(
             start,
             end,
-            'Test case should use @test_legacy_and_pt_and_pir instead of @test_with_pir_api',
+            'Test case should use @test_pt_and_pir instead of @test_with_pir_api',
         )
 
 
@@ -150,19 +141,6 @@ ALLOW_LIST: dict[type[Diagnostic], list[str]] = {
         "test_move_cuda_pinned_tensor.py",
         "test_pylayer.py",
         "test_tensor_attr_consistency.py",
-    ],
-    TestCaseWithoutDecoratorDiagnostic: [
-        "test_logical.py",
-        "test_inplace_assign.py",
-        # TODO: Remove these files from the allow list after it's support PIR mode
-        "test_tensor_hook.py",
-        "test_to_tensor.py",
-        "test_warning.py",
-        "test_typing.py",
-        "test_gradname_parse.py",
-        "test_for_enumerate.py",
-        "test_save_load.py",
-        "test_declarative.py",
     ],
     TestCaseWithPirApiDecoratorDiagnostic: [],
 }
@@ -222,13 +200,6 @@ class TestBaseChecker(Checker):
         self.generic_visit(node)
 
     def check_test_case(self, node: ast.FunctionDef):
-        # Check if the test case has not any decorator
-        if not node.decorator_list:
-            start = Location(node.lineno, node.col_offset)
-            end = Location(node.end_lineno, node.end_col_offset)  # type: ignore
-            self.diagnostics.append(
-                TestCaseWithoutDecoratorDiagnostic(start, end)
-            )
         # Check if the test case use @test_with_pir_api
         for decorator in node.decorator_list:
             decorator_str = ast_to_source_code(decorator).strip()
@@ -347,7 +318,6 @@ def main():
         (
             UseToStaticAsDecoratorDiagnostic,
             TestClassInheritFromTestCaseDiagnostic,
-            TestCaseWithoutDecoratorDiagnostic,
             TestCaseWithPirApiDecoratorDiagnostic,
         ),
     )

--- a/test/dygraph_to_static/dygraph_to_static_utils.py
+++ b/test/dygraph_to_static/dygraph_to_static_utils.py
@@ -89,7 +89,7 @@ class IrMode(Flag):
 DEFAULT_TO_STATIC_MODE = (
     ToStaticMode.AST | ToStaticMode.SOT | ToStaticMode.SOT_MGS10
 )
-DEFAULT_IR_MODE = IrMode.LEGACY_IR | IrMode.PT
+DEFAULT_IR_MODE = IrMode.PT | IrMode.PIR
 
 DISABLED_TO_STATIC_TEST_FILES = {
     ToStaticMode.AST: [],
@@ -303,9 +303,9 @@ class Dy2StTestMeta(type):
             for to_static_mode, ir_mode in to_static_with_ir_modes:
                 if (
                     to_static_mode == ToStaticMode.SOT_MGS10
-                    and ir_mode != IrMode.LEGACY_IR
+                    and ir_mode != IrMode.PIR
                 ):
-                    # SOT_MGS10 only test with LEGACY_IR
+                    # SOT_MGS10 only test with PIR
                     continue
                 new_attrs[
                     Dy2StTestMeta.test_case_name(

--- a/test/dygraph_to_static/dygraph_to_static_utils.py
+++ b/test/dygraph_to_static/dygraph_to_static_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import importlib
 import inspect
 import logging
@@ -347,7 +349,7 @@ def set_ir_mode(mode: IrMode):
     return decorator
 
 
-def disable_test_case(flags):
+def disable_test_case(flags: tuple[ToStaticMode, IrMode]):
     def decorator(fn):
         disabled_test_cases = getattr(fn, "disabled_test_cases", [])
         disabled_test_cases.append(flags)

--- a/test/dygraph_to_static/dygraph_to_static_utils.py
+++ b/test/dygraph_to_static/dygraph_to_static_utils.py
@@ -389,6 +389,11 @@ def test_legacy_and_pt(fn):
     return fn
 
 
+def test_pt_and_pir(fn):
+    fn = set_ir_mode(IrMode.PT | IrMode.PIR)(fn)
+    return fn
+
+
 def test_legacy_and_pir(fn):
     fn = set_ir_mode(IrMode.LEGACY_IR | IrMode.PIR)(fn)
     return fn

--- a/test/dygraph_to_static/test_cpu_cuda_to_tensor.py
+++ b/test/dygraph_to_static/test_cpu_cuda_to_tensor.py
@@ -15,16 +15,12 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils import (
-    Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
-)
+from dygraph_to_static_utils import Dy2StTestBase
 
 import paddle
 
 
 class TestCpuCuda(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_cpu_cuda(self):
         def func(x):
             x = paddle.to_tensor([1, 2, 3, 4])
@@ -40,7 +36,6 @@ class TestCpuCuda(Dy2StTestBase):
 
 
 class TestToTensor(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_to_tensor_with_variable_list(self):
         def func(x):
             ones = paddle.to_tensor(1)
@@ -58,7 +53,6 @@ class TestToTensor(Dy2StTestBase):
 
 
 class TestToTensor1(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_to_tensor_with_variable_list(self):
         def func(x):
             ones = paddle.to_tensor([1])
@@ -72,31 +66,12 @@ class TestToTensor1(Dy2StTestBase):
         x = paddle.to_tensor([3])
         np.testing.assert_allclose(
             paddle.jit.to_static(func)(x).numpy(),
-            np.array([[1], [2], [3], [4]]),
-            rtol=1e-05,
-        )
-
-    @test_legacy_and_pt_and_pir
-    def test_to_tensor_with_variable_list_sot(self):
-        def func(x):
-            ones = paddle.to_tensor([1])
-            twos = paddle.to_tensor([2])
-            """ we ignore the [3] and [4], they will be assign to a variable, and is regard as scalar.
-                TODO: deal with this case after 0-dim tensor is developed.
-            """
-            x = paddle.to_tensor([ones, twos, [3], [4]])
-            return x
-
-        x = paddle.to_tensor([3])
-        np.testing.assert_allclose(
-            paddle.jit.to_static(func)(x),
             np.array([[1], [2], [3], [4]]),
             rtol=1e-05,
         )
 
 
 class TestToTensor2(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_to_tensor_with_variable_list(self):
         def func(x):
             x = paddle.to_tensor([[1], [2], [3], [4]])
@@ -105,19 +80,6 @@ class TestToTensor2(Dy2StTestBase):
         x = paddle.to_tensor([3])
         np.testing.assert_allclose(
             paddle.jit.to_static(func)(x).numpy(),
-            np.array([[1], [2], [3], [4]]),
-            rtol=1e-05,
-        )
-
-    @test_legacy_and_pt_and_pir
-    def test_to_tensor_with_variable_list_sot(self):
-        def func(x):
-            x = paddle.to_tensor([[1], [2], [3], [4]])
-            return x
-
-        x = paddle.to_tensor([3])
-        np.testing.assert_allclose(
-            paddle.jit.to_static(func)(x),
             np.array([[1], [2], [3], [4]]),
             rtol=1e-05,
         )

--- a/test/dygraph_to_static/test_incubate_jit_inference.py
+++ b/test/dygraph_to_static/test_incubate_jit_inference.py
@@ -18,6 +18,7 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
+    test_legacy_and_pt,
     test_legacy_and_pt_and_pir,
 )
 
@@ -77,6 +78,7 @@ class TestToStaticInfenrenceModel(Dy2StTestBase):
 
 class TestToStaticInfenrenceTensorRTModel(Dy2StTestBase):
     @test_ast_only
+    @test_legacy_and_pt
     def test_dygraph_static_same_result(self):
         if paddle_infer.get_trt_compile_version()[0] == 0:
             return
@@ -116,6 +118,7 @@ class TestToStaticInfenrenceFunc(Dy2StTestBase):
 
 class TestToStaticInputListModel(Dy2StTestBase):
     @test_ast_only
+    @test_legacy_and_pt
     def test_dygraph_static_same_result(self):
         hidd = 1024
         batch = 4096

--- a/test/dygraph_to_static/test_op_attr.py
+++ b/test/dygraph_to_static/test_op_attr.py
@@ -14,7 +14,11 @@
 
 import unittest
 
-from dygraph_to_static_utils import Dy2StTestBase, test_ast_only
+from dygraph_to_static_utils import (
+    Dy2StTestBase,
+    test_ast_only,
+    test_pt_only,
+)
 
 import paddle
 from paddle.static import InputSpec
@@ -78,6 +82,7 @@ class CheckOpAttr(Dy2StTestBase):
         }
 
     @test_ast_only
+    @test_pt_only
     def test_set_op_attrs(self):
         net = NetWithOpAttr(self.in_num, self.out_num)
         # set attrs
@@ -120,6 +125,7 @@ class CheckOpAttr(Dy2StTestBase):
                             self.assertEqual(op_val, expect_val)
 
     @test_ast_only
+    @test_pt_only
     def test_set_op_attrs_with_sub_block(self):
         net = NetWithOpAttr(self.in_num, self.out_num)
         # set attrs
@@ -140,6 +146,7 @@ class CheckOpAttr(Dy2StTestBase):
         self.assertEqual(len(net.linear._forward_pre_hooks), 0)
         self.assertEqual(len(net.linear._forward_post_hooks), 0)
 
+    @test_pt_only
     def test_type_error(self):
         net = NetWithOpAttr(self.in_num, self.out_num)
         # attrs should be dict

--- a/test/dygraph_to_static/test_tensor_hook.py
+++ b/test/dygraph_to_static/test_tensor_hook.py
@@ -17,7 +17,8 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
+    test_pt_and_pir,
+    test_pt_only,
 )
 
 import paddle
@@ -26,6 +27,7 @@ from paddle.jit import to_static
 
 
 class TestTensorHook(Dy2StTestBase):
+    @test_pt_only
     def test_hook_for_different_parameter(self):
         def f(x):
             def h(g):
@@ -51,6 +53,7 @@ class TestTensorHook(Dy2StTestBase):
         loss.backward()
         np.testing.assert_allclose(x.grad.numpy(), x_jit.grad.numpy())
 
+    @test_pt_only
     def test_hook_in_sub_block(self):
         def f(x):
             def hook1(grad):
@@ -81,6 +84,7 @@ class TestTensorHook(Dy2StTestBase):
         loss.backward()
         np.testing.assert_allclose(x.grad.numpy(), x_jit.grad.numpy())
 
+    @test_pt_only
     def test_hook_sub_attr(self):
         IMAGE_SIZE = 784
         CLASS_NUM = 10
@@ -118,6 +122,7 @@ class TestTensorHook(Dy2StTestBase):
             jit_layer._linear.weight.grad.numpy(),
         )
 
+    @test_pt_only
     def test_hook_for_reassignment_parameter(self):
         def f(x):
             def h(g):
@@ -141,6 +146,7 @@ class TestTensorHook(Dy2StTestBase):
         loss.backward()
         np.testing.assert_allclose(x.grad.numpy(), x_jit.grad.numpy())
 
+    @test_pt_only
     def test_hook_for_repeat_register(self):
         def f(x):
             def h(g):
@@ -164,7 +170,7 @@ class TestTensorHook(Dy2StTestBase):
         loss.backward()
         np.testing.assert_allclose(x.grad.numpy(), x_jit.grad.numpy())
 
-    @test_legacy_and_pt_and_pir
+    @test_pt_and_pir
     def test_hook_in_init_for_layer(self):
         def hook(grad):
             return grad * 2
@@ -196,43 +202,6 @@ class TestTensorHook(Dy2StTestBase):
             layer.parameters()[0].grad.numpy(),
             jit_layer.parameters()[0].grad.numpy(),
         )
-
-    # def test_hook_in_forward_for_layer(self):
-    #
-    #     IMAGE_SIZE = 784
-    #     CLASS_NUM = 10
-    #
-    #     class LinearNet(nn.Layer):
-    #         def __init__(self):
-    #             super().__init__()
-    #             self._linear = nn.Linear(IMAGE_SIZE, CLASS_NUM)
-    #
-    #         def forward(self, x):
-    #             def hook(grad):
-    #                 return grad * 2
-    #
-    #             res = self._linear(x)
-    #
-    #             # register_hook in forward
-    #             self._linear.parameters()[0].register_hook(hook)
-    #             return res
-    #
-    #     # create network
-    #     layer = LinearNet()
-    #     jit_layer = to_static(LinearNet())
-    #     data = np.random.random([IMAGE_SIZE]).astype('float32')
-    #     image = paddle.to_tensor(data)
-    #     image_jit = paddle.to_tensor(data)
-    #     loss = layer(image)
-    #     loss_jit = jit_layer(image_jit)
-    #     loss_jit.backward()
-    #     loss.backward()
-    #     self.assertTrue(
-    #         np.allclose(
-    #             layer.parameters()[0].grad.numpy(),
-    #             jit_layer.parameters()[0].grad.numpy(),
-    #         )
-    #     )
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_tensor_hook.py
+++ b/test/dygraph_to_static/test_tensor_hook.py
@@ -17,8 +17,8 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_pt_and_pir,
-    test_pt_only,
+    test_legacy_and_pt,
+    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -27,7 +27,7 @@ from paddle.jit import to_static
 
 
 class TestTensorHook(Dy2StTestBase):
-    @test_pt_only
+    @test_legacy_and_pt
     def test_hook_for_different_parameter(self):
         def f(x):
             def h(g):
@@ -53,7 +53,7 @@ class TestTensorHook(Dy2StTestBase):
         loss.backward()
         np.testing.assert_allclose(x.grad.numpy(), x_jit.grad.numpy())
 
-    @test_pt_only
+    @test_legacy_and_pt
     def test_hook_in_sub_block(self):
         def f(x):
             def hook1(grad):
@@ -84,7 +84,7 @@ class TestTensorHook(Dy2StTestBase):
         loss.backward()
         np.testing.assert_allclose(x.grad.numpy(), x_jit.grad.numpy())
 
-    @test_pt_only
+    @test_legacy_and_pt
     def test_hook_sub_attr(self):
         IMAGE_SIZE = 784
         CLASS_NUM = 10
@@ -122,7 +122,7 @@ class TestTensorHook(Dy2StTestBase):
             jit_layer._linear.weight.grad.numpy(),
         )
 
-    @test_pt_only
+    @test_legacy_and_pt
     def test_hook_for_reassignment_parameter(self):
         def f(x):
             def h(g):
@@ -146,7 +146,7 @@ class TestTensorHook(Dy2StTestBase):
         loss.backward()
         np.testing.assert_allclose(x.grad.numpy(), x_jit.grad.numpy())
 
-    @test_pt_only
+    @test_legacy_and_pt
     def test_hook_for_repeat_register(self):
         def f(x):
             def h(g):
@@ -170,7 +170,7 @@ class TestTensorHook(Dy2StTestBase):
         loss.backward()
         np.testing.assert_allclose(x.grad.numpy(), x_jit.grad.numpy())
 
-    @test_pt_and_pir
+    @test_legacy_and_pt_and_pir
     def test_hook_in_init_for_layer(self):
         def hook(grad):
             return grad * 2

--- a/test/dygraph_to_static/test_tensor_memcpy_on_cpu.py
+++ b/test/dygraph_to_static/test_tensor_memcpy_on_cpu.py
@@ -17,6 +17,9 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
+    IrMode,
+    ToStaticMode,
+    disable_test_case,
     enable_to_static_guard,
 )
 
@@ -96,6 +99,7 @@ class TestTensorCopyToCUDAWithWarningOnCPU(Dy2StTestBase):
         )
         return x1.place, x2.place, x2.numpy()
 
+    @disable_test_case((ToStaticMode.SOT_MGS10, IrMode.PIR))
     def test_with_warning_on_cpu(self):
         if not paddle.is_compiled_with_cuda():
             return

--- a/test/dygraph_to_static/test_tensor_memcpy_on_cpu.py
+++ b/test/dygraph_to_static/test_tensor_memcpy_on_cpu.py
@@ -17,11 +17,7 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    IrMode,
-    ToStaticMode,
-    disable_test_case,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -51,7 +47,6 @@ class TestTensorCopyToCpuOnDefaultCPU(Dy2StTestBase):
         x2 = paddle.jit.to_static(tensor_copy_to_cpu)(x1)
         return x1.place, x2.place, x2.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_tensor_cpu_on_default_cpu(self):
         paddle.framework._set_expected_place(paddle.CPUPlace())
         with enable_to_static_guard(False):
@@ -71,7 +66,6 @@ class TestTensorCopyToCUDAOnDefaultCPU(Dy2StTestBase):
         x2 = paddle.jit.to_static(tensor_copy_to_cuda)(x1)
         return x1.place, x2.place, x2.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_tensor_cuda_on_default_cpu(self):
         if not paddle.is_compiled_with_cuda():
             return
@@ -102,9 +96,6 @@ class TestTensorCopyToCUDAWithWarningOnCPU(Dy2StTestBase):
         )
         return x1.place, x2.place, x2.numpy()
 
-    @test_legacy_and_pt_and_pir
-    @disable_test_case((ToStaticMode.SOT, IrMode.LEGACY_IR))
-    @disable_test_case((ToStaticMode.SOT_MGS10, IrMode.LEGACY_IR))
     def test_with_warning_on_cpu(self):
         if not paddle.is_compiled_with_cuda():
             return

--- a/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
+++ b/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
@@ -18,11 +18,7 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    IrMode,
-    ToStaticMode,
-    disable_test_case,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -52,7 +48,6 @@ class TestTensorCopyToCpuOnDefaultGPU(Dy2StTestBase):
         x2 = paddle.jit.to_static(tensor_copy_to_cpu)(x1)
         return x1.place, x2.place, x2.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_tensor_cpu_on_default_gpu(self):
         if not paddle.is_compiled_with_cuda():
             return
@@ -75,7 +70,6 @@ class TestTensorCopyToCUDAOnDefaultGPU(Dy2StTestBase):
         x2 = paddle.jit.to_static(tensor_copy_to_cuda)(x1)
         return x1.place, x2.place, x2.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_tensor_cuda_on_default_gpu(self):
         if not paddle.is_compiled_with_cuda():
             return
@@ -100,9 +94,6 @@ class TestTensorCopyToCUDAWithWarningOnGPU(Dy2StTestBase):
         )
         return x1.place, x2.place, x2.numpy()
 
-    @test_legacy_and_pt_and_pir
-    @disable_test_case((ToStaticMode.SOT, IrMode.LEGACY_IR))
-    @disable_test_case((ToStaticMode.SOT_MGS10, IrMode.LEGACY_IR))
     def test_with_warning_on_gpu(self):
         if not paddle.is_compiled_with_cuda():
             return

--- a/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
+++ b/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
@@ -18,6 +18,9 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
+    IrMode,
+    ToStaticMode,
+    disable_test_case,
     enable_to_static_guard,
 )
 
@@ -94,6 +97,7 @@ class TestTensorCopyToCUDAWithWarningOnGPU(Dy2StTestBase):
         )
         return x1.place, x2.place, x2.numpy()
 
+    @disable_test_case((ToStaticMode.SOT_MGS10, IrMode.PIR))
     def test_with_warning_on_gpu(self):
         if not paddle.is_compiled_with_cuda():
             return

--- a/test/dygraph_to_static/test_tensor_shape.py
+++ b/test/dygraph_to_static/test_tensor_shape.py
@@ -20,6 +20,7 @@ from dygraph_to_static_utils import (
     test_ast_only,
     test_legacy_and_pt_and_pir,
     test_pir_only,
+    test_pt_only,
 )
 
 import paddle
@@ -323,6 +324,7 @@ class TestTensorShapeBasic(Dy2StTestBase):
         return op_num, shape_op_num, slice_op_num
 
     @test_ast_only
+    @test_pt_only
     def test_op_num(self):
         static_layer = paddle.jit.to_static(self.dygraph_func, self.input_spec)
         program = static_layer.main_program
@@ -663,6 +665,7 @@ class TestOpNumBasicWithTensorShape(Dy2StTestBase):
         return op_num, shape_op_num, slice_op_num
 
     @test_ast_only
+    @test_pt_only
     def test_op_num(self):
         static_layer = paddle.jit.to_static(self.dygraph_func, self.input_spec)
         program = static_layer.main_program

--- a/test/dygraph_to_static/test_tensor_to.py
+++ b/test/dygraph_to_static/test_tensor_to.py
@@ -16,6 +16,9 @@ import unittest
 
 from dygraph_to_static_utils import (
     Dy2StTestBase,
+    IrMode,
+    ToStaticMode,
+    disable_test_case,
     test_ast_only,
     test_pir_only,
     test_sot_only,
@@ -160,7 +163,9 @@ class TensorToTest(Dy2StTestBase):
                 type_x_str = str(tensor_x.dtype)
                 self.assertEqual(type_x_str, "paddle." + dtype)
 
+    # TODO(gouzil): Fix MIN_GRAPH_SIZE=10 case
     @test_pir_only
+    @disable_test_case((ToStaticMode.SOT_MGS10, IrMode.PIR))
     def test_tensor_to_blocking(self):
         tensor_x = paddle.to_tensor([1, 2, 3])
         tensor_x = paddle.jit.to_static(to_device_dtype_blocking)(
@@ -181,6 +186,7 @@ class TensorToTest(Dy2StTestBase):
         self.assertEqual(tensor2.dtype, paddle.float16)
 
     @test_pir_only
+    @disable_test_case((ToStaticMode.SOT_MGS10, IrMode.PIR))
     def test_tensor_to_other(self):
         tensor1 = paddle.to_tensor([1, 2, 3], dtype="int8", place="cpu")
         tensor2 = paddle.to_tensor([1, 2, 3])
@@ -191,6 +197,7 @@ class TensorToTest(Dy2StTestBase):
         self.assertEqual(str(tensor2.place), get_place())
 
     @test_pir_only
+    @disable_test_case((ToStaticMode.SOT_MGS10, IrMode.PIR))
     def test_kwargs(self):
         tensor_x = paddle.to_tensor([1, 2, 3])
         tensor_x = paddle.jit.to_static(to_kwargs_device_dtype_blocking)(

--- a/test/dygraph_to_static/test_to_tensor.py
+++ b/test/dygraph_to_static/test_to_tensor.py
@@ -18,9 +18,6 @@ import numpy
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    IrMode,
-    ToStaticMode,
-    disable_test_case,
     test_legacy_and_pt_and_pir,
 )
 
@@ -167,9 +164,7 @@ class TestToTensorReturnVal(Dy2StTestBase):
         self.assertTrue(a.stop_gradient == b.stop_gradient)
         self.assertTrue(a.place._equals(b.place))
 
-    # MIN_GRAPH_SIZE=10 will cause fallback and raise error in dygraph
     @test_legacy_and_pt_and_pir
-    @disable_test_case((ToStaticMode.SOT_MGS10, IrMode.LEGACY_IR))
     def test_to_tensor_err_log(self):
         paddle.disable_static()
         x = paddle.to_tensor([3])

--- a/test/dygraph_to_static/test_warning.py
+++ b/test/dygraph_to_static/test_warning.py
@@ -18,11 +18,10 @@ import warnings
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pir,
+    test_pir_only,
 )
 
 import paddle
-from paddle.static.nn import cond
 
 
 def fun1():
@@ -44,32 +43,12 @@ def false_fn():
 
 class TestReturnNoneInIfelse(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pir
+    @test_pir_only
     def test_dy2static_warning(self):
         paddle.disable_static()
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             paddle.jit.to_static(fun1)()
-            flag = False
-            for warn in w:
-                if (
-                    issubclass(warn.category, UserWarning)
-                ) and "Set var to 'None' in ifelse block might lead to error." in str(
-                    warn.message
-                ):
-                    flag = True
-                    break
-            self.assertTrue(flag)
-
-    # TODO(cleanup-legacy-ir): This case cannot be supported by PIR, we should remove this
-    # in the future.
-    def test_cond_warning(self):
-        paddle.enable_static()
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            a = paddle.to_tensor(1)
-            b = paddle.to_tensor(2)
-            cond(a < b, true_fn, false_fn, return_names=['ret1', 'ret2'])
             flag = False
             for warn in w:
                 if (


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

将动转静单测默认模式迁移到 PT+PIR，纯老 IR 不再监控

### TODOs

- 清理老 IR 相关单测

Pcard-67164