### PR TITLE
[Auto Parallel] change lookup_table_v2 auto cast for align mode

### DIFF
--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -703,6 +703,16 @@ def amp_guard(
 
             # set amp op list
             original_white_list, original_black_list = tracer._get_amp_op_list()
+
+            # TODO(zhangyuqin1998): In auto parallel align mode, ensure lookup_table_v2 runs in FP32.
+            # By default, lookup_table_v2 is in the white_list, and runs in BF16/BF16.
+            # Users can add lookup_table_v2 to the amp_custom_black_list but cannot remove it from the default white_list.
+            # If lookup_table_v2 appears in both the white_list and black_list, AMP will select it in BF16/BF16.
+            # Therefore, in auto parallel align mode, add lookup_table_v2 to the black_list and ensure it is not in the white_list.
+            if paddle.in_auto_parallel_align_mode():
+                _black_list.add("lookup_table_v2")
+                if "lookup_table_v2" in _white_list:
+                    _white_list.remove("lookup_table_v2")
             tracer._set_amp_op_list(_white_list, _black_list)
 
             # TODO(zhiqiu) set amp related flags automatically in this guard

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -710,6 +710,7 @@ def amp_guard(
             # If lookup_table_v2 appears in both the white_list and black_list, AMP will select it in BF16/BF16.
             # Therefore, in auto parallel align mode, add lookup_table_v2 to the black_list and ensure it is not in the white_list.
             from paddle.distributed import in_auto_parallel_align_mode
+
             if in_auto_parallel_align_mode():
                 _black_list.add("lookup_table_v2")
                 if "lookup_table_v2" in _white_list:

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -40,7 +40,6 @@ from paddle.base.framework import (
     in_pir_mode,
 )
 from paddle.base.wrapped_decorator import signature_safe_contextmanager
-from paddle.distributed import in_auto_parallel_align_mode
 from paddle.static.amp.decorator import OptimizerWithMixedPrecision
 
 from .amp_lists import black_list, white_list
@@ -710,6 +709,7 @@ def amp_guard(
             # Users can add lookup_table_v2 to the amp_custom_black_list but cannot remove it from the default white_list.
             # If lookup_table_v2 appears in both the white_list and black_list, AMP will select it in BF16/BF16.
             # Therefore, in auto parallel align mode, add lookup_table_v2 to the black_list and ensure it is not in the white_list.
+            from paddle.distributed import in_auto_parallel_align_mode
             if in_auto_parallel_align_mode():
                 _black_list.add("lookup_table_v2")
                 if "lookup_table_v2" in _white_list:

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -40,6 +40,7 @@ from paddle.base.framework import (
     in_pir_mode,
 )
 from paddle.base.wrapped_decorator import signature_safe_contextmanager
+from paddle.distributed import in_auto_parallel_align_mode
 from paddle.static.amp.decorator import OptimizerWithMixedPrecision
 
 from .amp_lists import black_list, white_list
@@ -709,7 +710,7 @@ def amp_guard(
             # Users can add lookup_table_v2 to the amp_custom_black_list but cannot remove it from the default white_list.
             # If lookup_table_v2 appears in both the white_list and black_list, AMP will select it in BF16/BF16.
             # Therefore, in auto parallel align mode, add lookup_table_v2 to the black_list and ensure it is not in the white_list.
-            if paddle.in_auto_parallel_align_mode():
+            if in_auto_parallel_align_mode():
                 _black_list.add("lookup_table_v2")
                 if "lookup_table_v2" in _white_list:
                     _white_list.remove("lookup_table_v2")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
In auto parallel align mode, ensure lookup_table_v2 runs in FP32. By default, lookup_table_v2 is in the white_list, and runs in BF16/BF16. Users can add lookup_table_v2 to the amp_custom_black_list but cannot remove it from the default white_list.
If lookup_table_v2 appears in both the white_list and black_list, AMP will select it in BF16/BF16. Therefore, in auto parallel align mode, add lookup_table_v2 to the black_list and ensure it is not in the white_list.

Pcard-76459