### PR TITLE
[CINN] Improve recompute strategy to avoid being interrupted by unfusible op while fusing

### DIFF
--- a/python/paddle/decomposition/recompute.py
+++ b/python/paddle/decomposition/recompute.py
@@ -161,6 +161,133 @@ def DebugPrint(*args):
         print(*args)
 
 
+class JudgeFusionLoop:
+    def __init__(self, program, unrecomputable_ops):
+        self.ops = program.global_block().ops
+        self.operand_value_set = set()
+        self.result_value_set = set()
+        self.unrecomputable_ops = unrecomputable_ops
+        self.has_unfusible_on_path_map = self._set_has_unfusible_on_path_map()
+
+    def _set_has_unfusible_on_path_map(self):
+        def _get_used_external_value(op):
+            defined_values = set()
+            used_values = []
+            _get_used_external_value_impl(defined_values, used_values, op)
+            return used_values
+
+        def _get_used_external_value_impl(defined_values, used_values, op):
+            for operand in op.operands_source():
+                if operand not in defined_values:
+                    used_values.append(operand)
+                    defined_values.add(operand)
+            for block in op.blocks():
+                for value in block.args():
+                    defined_values.add(value)
+                for _, value in block.kwargs():
+                    defined_values.add(value)
+            for block in op.blocks():
+                for inner_op in block.ops():
+                    _get_used_external_value_impl(
+                        defined_values, used_values, inner_op
+                    )
+            for result_value in op.results():
+                defined_values.add(result_value)
+
+        def _get_producer_ops(op):
+            producers = set()
+            for operand in _get_used_external_value(op):
+                if operand.get_defining_op() is None:
+                    continue
+                source_op = operand.get_defining_op()
+                if source_op.get_parent_block() == op.get_parent_block():
+                    producers.add(source_op)
+                    self.operand_value_set.add(operand)
+            return producers
+
+        def _get_consumer_ops(op):
+            consumers = set()
+            for result in op.results():
+                for parent_op in result.all_used_ops():
+                    while parent_op is not None:
+                        if (
+                            parent_op.get_parent_block()
+                            == op.get_parent_block()
+                        ):
+                            consumers.add(parent_op)
+                            self.result_value_set.add(result)
+                            break
+                        parent_op = (
+                            parent_op.get_parent_block().parent_op
+                            if parent_op.get_parent_block() is not None
+                            else None
+                        )
+            return consumers
+
+        def _get_producer_ops_recursivly(root):
+            visited = set()
+            queue = deque()
+            result = set()
+            queue.append(root)
+            visited.add(root)
+            while queue:
+                cur = queue.popleft()
+                result.add(cur)
+                for new_op in _get_producer_ops(cur):
+                    if new_op in visited:
+                        continue
+                    visited.add(new_op)
+                    queue.append(new_op)
+            return result
+
+        def _get_consumer_ops_recursivly(root):
+            visited = set()
+            queue = deque()
+            result = set()
+            queue.append(root)
+            visited.add(root)
+            while queue:
+                cur = queue.popleft()
+                result.add(cur)
+                for new_op in _get_consumer_ops(cur):
+                    if new_op in visited:
+                        continue
+                    visited.add(new_op)
+                    queue.append(new_op)
+            return result
+
+        has_unfusible_on_path_map = {
+            op1: {op2: False for op2 in self.ops} for op1 in self.ops
+        }
+        for op in self.ops:
+            if op.name() in self.unrecomputable_ops:
+                upstream_set = _get_producer_ops_recursivly(op)
+                downstream_set = _get_consumer_ops_recursivly(op)
+
+                for upstream_op in upstream_set:
+                    for downstream_op in downstream_set:
+                        has_unfusible_on_path_map[upstream_op][
+                            downstream_op
+                        ] = True
+                        has_unfusible_on_path_map[downstream_op][
+                            upstream_op
+                        ] = True
+        return has_unfusible_on_path_map
+
+    def _has_unfusible_op_on_any_path(self, op1, op2):
+        return (
+            self.has_unfusible_on_path_map[op1][op2]
+            if op1 is not None and op2 is not None
+            else False
+        )
+
+    def _get_operand_value_set(self):
+        return backward_utils.ValueSet(self.operand_value_set)
+
+    def _get_result_value_set(self):
+        return backward_utils.ValueSet(self.result_value_set)
+
+
 def auto_recompute(
     program: paddle.static.Program,
     inputs: Sequence[pir.Value],
@@ -325,168 +452,6 @@ def auto_recompute(
         users = find_value_node_users(value_node)
         return not all(_is_fusible(value_node, user) for user in users)
 
-    def _set_has_unfusible_on_path_map():
-        ops = program.global_block().ops
-
-        # breakpoint()
-        def _get_used_external_value(op):
-            defined_values = set()
-            used_values = []
-            _get_used_external_value_impl(defined_values, used_values, op)
-            return used_values
-
-        def _get_used_external_value_impl(defined_values, used_values, op):
-            for operand in op.operands_source():
-                if operand not in defined_values:
-                    used_values.append(operand)
-                    defined_values.add(operand)
-            for block in op.blocks():
-                for value in block.args():
-                    defined_values.add(value)
-                for _, value in block.kwargs():
-                    defined_values.add(value)
-            for block in op.blocks():
-                for inner_op in block.ops():
-                    _get_used_external_value_impl(
-                        defined_values, used_values, inner_op
-                    )
-            for result_value in op.results():
-                defined_values.add(result_value)
-
-        def _get_producer_ops(op):
-            producers = set()
-            for operand in _get_used_external_value(op):
-                if operand.get_defining_op() is None:
-                    continue
-                source_op = operand.get_defining_op()
-                if source_op.get_parent_block() == op.get_parent_block():
-                    producers.add(source_op)
-
-            return producers
-
-        def _get_consumer_ops(op):
-            consumers = set()
-            for result in op.results():
-                for it in result.all_used_ops():
-                    parent_block = it.get_parent_block()
-                    parent_op = (
-                        parent_block.parent_op
-                        if parent_block is not None
-                        else None
-                    )
-                    while parent_op is not None:
-                        if (
-                            parent_op.get_parent_block()
-                            == op.get_parent_block()
-                        ):
-                            consumers.add(parent_op)
-                            break
-                        parent_op = (
-                            parent_op.get_parent_block().parent_op
-                            if parent_op.get_parent_block() is not None
-                            else None
-                        )
-            return consumers
-
-        def _get_producer_ops_recursivly(root):
-            visited = set()
-            queue = deque()
-            result = []
-            queue.append(root)
-            visited.add(root)
-            while queue:
-                cur = queue.popleft()
-                result.append(cur)
-                for new_op in _get_producer_ops(cur):
-                    if new_op in visited:
-                        continue
-                    visited.add(new_op)
-                    queue.append(new_op)
-            return result
-
-        def _get_consumer_ops_recursivly(root):
-            visited = set()
-            queue = deque()
-            result = []
-            queue.append(root)
-            visited.add(root)
-            while queue:
-                cur = queue.popleft()
-                result.append(cur)
-                for new_op in _get_consumer_ops(cur):
-                    if new_op in visited:
-                        continue
-                    visited.add(new_op)
-                    queue.append(new_op)
-            return result
-
-        def _get_upstream_op_set(op):
-            results = set()
-            producers = _get_producer_ops_recursivly(op)
-            for producer in producers:
-                results.add(producer)
-            return results
-
-        def _get_downstream_op_set(op):
-            results = set()
-            consumers = _get_consumer_ops_recursivly(op)
-            for consumer in consumers:
-                results.add(consumer)
-            return results
-
-        has_unfusible_on_path_map = {
-            op1: {op2: False for op2 in ops} for op1 in ops
-        }
-        for op in ops:
-            if op.name() in unrecomputable_ops:
-                upstream_set = _get_upstream_op_set(op)
-                downstream_set = _get_downstream_op_set(op)
-
-                for upstream_op in upstream_set:
-                    for downstream_op in downstream_set:
-                        has_unfusible_on_path_map[upstream_op][
-                            downstream_op
-                        ] = True
-                        has_unfusible_on_path_map[downstream_op][
-                            upstream_op
-                        ] = True
-        return has_unfusible_on_path_map
-
-    def _has_unfusible_op_on_any_path(value_node, has_unfusible_on_path_map):
-        for user in value_node.all_used_ops():
-            if value_node.get_defining_op() is None or user is None:
-                continue
-            if has_unfusible_on_path_map[value_node.get_defining_op()][user]:
-                return True
-        return False
-
-    def _add_force_checkpoint_for_unfusible_ops(
-        nx_graph, has_unfusible_on_path_map
-    ):
-        for op1, value in has_unfusible_on_path_map.items():
-            for op2, _has_unfusible in value:
-                if _has_unfusible:
-                    DebugPrint(
-                        "add edge link from: ",
-                        " source ",
-                        " -> ",
-                        value_node.id,
-                        "(inf)",
-                    )
-                    DebugPrint(
-                        "add edge link from: ",
-                        value_node.id,
-                        " -> ",
-                        " sink ",
-                        "(inf)",
-                    )
-                    nx_graph.add_edge(
-                        "source", value_node.id + "_in", capacity=math.inf
-                    )
-                    nx_graph.add_edge(
-                        value_node.id + "_out", "sink", capacity=math.inf
-                    )
-
     def _get_node_weight(value_node, placeholder_value_nodes):
         mem_sz = cal_value_node_size(value_node)
 
@@ -529,6 +494,9 @@ def auto_recompute(
     inputs = backward_utils.ValueSet(inputs)
     value_id_dict = {}
     nx_graph = nx.DiGraph()
+
+    judge_fusion_loop = JudgeFusionLoop(program, unrecomputable_ops)
+    forward_ops = set(program.global_block().ops[: fwd_op_end_idx + 1])
 
     for value_node in (
         required_fw_value_nodes
@@ -612,8 +580,33 @@ def auto_recompute(
             nx_graph.add_edge(
                 value_node.id + "_out", user.id + "_in", capacity=math.inf
             )
-    has_unfusible_on_path_map = _set_has_unfusible_on_path_map()
-    _add_force_checkpoint_for_unfusible_ops(nx_graph, has_unfusible_on_path_map)
+        for user in value_node.all_used_ops():
+            if user in forward_ops:
+                if judge_fusion_loop._has_unfusible_op_on_any_path(
+                    value_node.get_defining_op(), user
+                ):
+                    DebugPrint(
+                        "add edge link from: ",
+                        " source ",
+                        " -> ",
+                        value_node.id,
+                        "(inf)",
+                    )
+                    nx_graph.add_edge(
+                        "source", value_node.id + "_in", capacity=math.inf
+                    )
+
+                    DebugPrint(
+                        "add edge link from: ",
+                        value_node.id,
+                        " -> ",
+                        " sink ",
+                        "(inf)",
+                    )
+
+                    nx_graph.add_edge(
+                        value_node.id + "_out", "sink", capacity=math.inf
+                    )
 
     # 1.5  find saved values by minimum cut.
     cut_value, partition = nx.minimum_cut(nx_graph, "source", "sink")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-67164

The raw Re-compute strategy in use has't taken fusion information into account. Therefore the recomputed program might be interrupted while fusing because of unfusible op (If there is unfusible op on any path between 2 ops, they cannot be fused otherwise will cause loop in program). This might cause more IOs, leading worse performance.
This PR  Improve recompute strategy by analyzing loop condition while do recomputing.