### PR TITLE
[Dy2St] Cleanup legacy ir test cases (part1)

### DIFF
--- a/test/dygraph_to_static/test_amp_case.py
+++ b/test/dygraph_to_static/test_amp_case.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
     test_pir_only,
 )
 
@@ -41,7 +40,6 @@ class TestAmp64Case(Dy2StTestBase):
             st_out = static_func(x)
         np.testing.assert_allclose(dy_out.numpy(), st_out.numpy())
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self._run_static()
 

--- a/test/dygraph_to_static/test_assert.py
+++ b/test/dygraph_to_static/test_assert.py
@@ -18,7 +18,6 @@ import numpy
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -49,7 +48,6 @@ class TestAssertVariable(Dy2StTestBase):
         self._run(func, x, with_exception, True)
         self._run(func, x, with_exception, False)
 
-    @test_legacy_and_pt_and_pir
     def test_non_variable(self):
         self._run_dy_static(
             paddle.jit.to_static(dyfunc_assert_non_variable),
@@ -62,7 +60,6 @@ class TestAssertVariable(Dy2StTestBase):
             with_exception=False,
         )
 
-    @test_legacy_and_pt_and_pir
     def test_bool_variable(self):
         self._run_dy_static(
             paddle.jit.to_static(dyfunc_assert_variable),
@@ -75,7 +72,6 @@ class TestAssertVariable(Dy2StTestBase):
             with_exception=False,
         )
 
-    @test_legacy_and_pt_and_pir
     def test_int_variable(self):
         self._run_dy_static(
             paddle.jit.to_static(dyfunc_assert_variable),

--- a/test/dygraph_to_static/test_backward_without_params.py
+++ b/test/dygraph_to_static/test_backward_without_params.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -33,7 +32,6 @@ class Net(paddle.nn.Layer):
 
 
 class TestBackwardWithoutParams(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_run(self):
         net = paddle.jit.to_static(Net())
 
@@ -57,7 +55,6 @@ class ZeroSizeNet(paddle.nn.Layer):
 
 
 class TestZeroSizeNet(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_run(self):
         net = paddle.jit.to_static(ZeroSizeNet())
         x = paddle.ones([2, 2])

--- a/test/dygraph_to_static/test_bert.py
+++ b/test/dygraph_to_static/test_bert.py
@@ -23,7 +23,6 @@ from bert_utils import get_bert_config, get_feed_data_reader
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
     test_sot_only,
 )
 from predictor_utils import PredictorTools
@@ -282,7 +281,6 @@ class TestBert(Dy2StTestBase):
         out = output()
         return out
 
-    @test_legacy_and_pt_and_pir
     def test_train(self):
         static_loss, static_ppl = self.train_static(
             self.bert_config, self.data_reader
@@ -296,7 +294,6 @@ class TestBert(Dy2StTestBase):
         self.verify_predict()
 
     @test_sot_only
-    @test_legacy_and_pt_and_pir
     def test_train_composite(self):
         core._set_prim_backward_enabled(True)
         # core._add_skip_comp_ops("layer_norm")

--- a/test/dygraph_to_static/test_bmn.py
+++ b/test/dygraph_to_static/test_bmn.py
@@ -22,7 +22,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     static_guard,
-    test_legacy_and_pt_and_pir,
 )
 from predictor_utils import PredictorTools
 
@@ -730,7 +729,6 @@ class TestTrain(Dy2StTestBase):
                         break
             return np.array(loss_data)
 
-    @test_legacy_and_pt_and_pir
     def test_train(self):
         with enable_to_static_guard(True):
             static_res = self.train_bmn(self.args, to_static=True)

--- a/test/dygraph_to_static/test_break_continue.py
+++ b/test/dygraph_to_static/test_break_continue.py
@@ -20,7 +20,6 @@ from dygraph_to_static_utils import (
     enable_to_static_guard,
     exe_sequential_run_guard,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -38,7 +37,6 @@ class TestDy2staticException(Dy2StTestBase):
         self.error = "Your if/else have different number of return value."
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_error(self):
         if self.dyfunc:
             with self.assertRaisesRegex(Dygraph2StaticException, self.error):
@@ -230,7 +228,6 @@ class TestContinueInFor(TestContinueBase):
     def init_dygraph_func(self):
         self.dygraph_func = test_continue_in_for
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         self.init_dygraph_func()
         dygraph_res = self.run_dygraph_mode()
@@ -244,7 +241,6 @@ class TestContinueInFor(TestContinueBase):
 
 
 class TestContinueNotPirBase(TestContinueInFor):
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         self.init_dygraph_func()
         dygraph_res = self.run_dygraph_mode()
@@ -276,7 +272,6 @@ class TestBreakContinueInFor(TestContinueBase):
     def init_dygraph_func(self):
         self.dygraph_func = test_break_continue_in_for
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         self.init_dygraph_func()
         dygraph_res = self.run_dygraph_mode()
@@ -298,7 +293,6 @@ class TestContinueInWhile(TestContinueNotPirBase):
     def init_dygraph_func(self):
         self.dygraph_func = test_continue_in_while
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         self.init_dygraph_func()
         dygraph_res = self.run_dygraph_mode()
@@ -315,7 +309,6 @@ class TestBreakInWhile(TestContinueInWhile):
     def init_dygraph_func(self):
         self.dygraph_func = test_break_in_while
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         self.init_dygraph_func()
         dygraph_res = self.run_dygraph_mode()
@@ -332,7 +325,6 @@ class TestWhileLoopClassVar(TestContinueInWhile):
     def init_dygraph_func(self):
         self.dygraph_func = while_loop_class_var
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         self.init_dygraph_func()
         dygraph_res = self.run_dygraph_mode()
@@ -356,7 +348,6 @@ class TestOptimBreakInWhile(TestContinueInWhile):
     def init_dygraph_func(self):
         self.dygraph_func = test_optim_break_in_while
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         self.init_dygraph_func()
         dygraph_res = self.run_dygraph_mode()

--- a/test/dygraph_to_static/test_build_strategy.py
+++ b/test/dygraph_to_static/test_build_strategy.py
@@ -19,7 +19,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_default_and_pir,
-    test_legacy_and_pt_and_pir,
     test_pir_only,
 )
 from test_resnet import ResNetHelper
@@ -90,7 +89,6 @@ class TestResnetWithPass(Dy2StTestBase):
 
 
 class TestError(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_type_error(self):
         def foo(x):
             out = x + 1

--- a/test/dygraph_to_static/test_cache_program.py
+++ b/test/dygraph_to_static/test_cache_program.py
@@ -20,7 +20,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 from test_fetch_feed import Linear, Pool2D
 
@@ -34,7 +33,6 @@ class TestCacheProgram(Dy2StTestBase):
         self.dygraph_class = Pool2D
         self.data = np.random.random((1, 2, 4, 4)).astype('float32')
 
-    @test_legacy_and_pt_and_pir
     @test_ast_only
     def test_cache(self):
         prev_ops, cur_ops = Counter(), Counter()
@@ -121,7 +119,6 @@ class TestCacheProgramWithOptimizer(Dy2StTestBase):
 
         return loss_data
 
-    @test_legacy_and_pt_and_pir
     def test_with_optimizer(self):
         dygraph_loss = self.train_dygraph()
         static_loss = self.train_static()
@@ -140,7 +137,6 @@ def simple_func(x):
 
 
 class TestConvertWithCache(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_cache(self):
         static_func = convert_to_static(simple_func)
         # Get transformed function from cache.
@@ -170,7 +166,6 @@ def sum_under_while(limit):
 
 
 class TestToOutputWithCache(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_output(self):
         ret = paddle.jit.to_static(sum_even_until_limit)(80, 10)
         self.assertEqual(ret.numpy(), 30)

--- a/test/dygraph_to_static/test_capture_free_vars.py
+++ b/test/dygraph_to_static/test_capture_free_vars.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -102,7 +101,6 @@ class CheckDy2StWithDygraphMixin:
 
 
 class TestClosure(Dy2StTestBase, CheckDy2StWithDygraphMixin):
-    @test_legacy_and_pt_and_pir
     def test_simple_closure(self):
         simple_closure = create_simple_closure()
         x = paddle.to_tensor(1.0)
@@ -110,25 +108,21 @@ class TestClosure(Dy2StTestBase, CheckDy2StWithDygraphMixin):
 
 
 class TestSuperCall(Dy2StTestBase, CheckDy2StWithDygraphMixin):
-    @test_legacy_and_pt_and_pir
     def test_super_call_without_argument_in_forward(self):
         model = SuperCallWithoutArgumentInForward()
         x = paddle.to_tensor(1.0)
         self.check_fn(model, x)
 
-    @test_legacy_and_pt_and_pir
     def test_super_call_without_argument_in_control_flow(self):
         model = SuperCallWithoutArgumentInControlFlow()
         x = paddle.to_tensor(1.0)
         self.check_fn(model, x)
 
-    @test_legacy_and_pt_and_pir
     def test_user_defined_super_call_without_argument(self):
         model = UserDefinedSuperCallWithoutArgument()
         x = paddle.to_tensor(1.0)
         self.check_fn(model, x)
 
-    @test_legacy_and_pt_and_pir
     def test_super_call_with_argument(self):
         model = SuperCallWithArgument()
         x = paddle.to_tensor(1.0)
@@ -136,7 +130,6 @@ class TestSuperCall(Dy2StTestBase, CheckDy2StWithDygraphMixin):
 
 
 class TestRecursiveCall(Dy2StTestBase, CheckDy2StWithDygraphMixin):
-    @test_legacy_and_pt_and_pir
     def test_recursive_call(self):
         x = 5
         self.check_fn(recursive_call, x)

--- a/test/dygraph_to_static/test_cast.py
+++ b/test/dygraph_to_static/test_cast.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -86,7 +85,6 @@ class TestCastBase(Dy2StTestBase):
         return res
 
     @test_ast_only  # TODO: add new sot only test.
-    @test_legacy_and_pt_and_pir
     def test_cast_result(self):
         self.set_func()
         res = self.do_test().numpy()
@@ -151,7 +149,6 @@ class TestMixCast(TestCastBase):
         self.func = paddle.jit.to_static(full_graph=True)(test_mix_cast)
 
     @test_ast_only  # TODO: add new symbolic only test.
-    @test_legacy_and_pt_and_pir
     def test_cast_result(self):
         self.set_func()
         res = self.do_test().numpy()
@@ -182,7 +179,6 @@ class TestNotVarCast(TestCastBase):
         self.func = paddle.jit.to_static(full_graph=True)(test_not_var_cast)
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_cast_result(self):
         self.set_func()
         res = self.do_test()

--- a/test/dygraph_to_static/test_closure_analysis.py
+++ b/test/dygraph_to_static/test_closure_analysis.py
@@ -15,9 +15,9 @@
 import inspect
 import unittest
 
+import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 from numpy import append
 
@@ -193,7 +193,6 @@ class TestClosureAnalysis(Dy2StTestBase):
             {'func': set('i'), 'test_normal_argument': set('x')},
         ]
 
-    @test_legacy_and_pt_and_pir
     def test_main(self):
         if self.judge_type == 'push_pop_vars':
             for push_pop_vars, func in zip(
@@ -260,7 +259,6 @@ class TestClosureAnalysis_PushPop(TestClosureAnalysis):
 
 
 class TestPushPopTrans(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test(self):
         def vlist_of_dict(x):
             ma = {'a': []}
@@ -271,10 +269,7 @@ class TestPushPopTrans(Dy2StTestBase):
         x = paddle.to_tensor([3])
         print(paddle.jit.to_static(vlist_of_dict)(x))
 
-    @test_legacy_and_pt_and_pir
     def test2(self):
-        import numpy as np
-
         def vlist_of_dict(x):
             a = np.array([1, 2, 3])
             for i in range(3):
@@ -284,10 +279,7 @@ class TestPushPopTrans(Dy2StTestBase):
         x = paddle.to_tensor([3])
         print(paddle.jit.to_static(vlist_of_dict)(x))
 
-    @test_legacy_and_pt_and_pir
     def test3(self):
-        import numpy as np
-
         def vlist_of_dict(x):
             a = np.array([1, 2, 3])
             if True:
@@ -297,10 +289,7 @@ class TestPushPopTrans(Dy2StTestBase):
         x = paddle.to_tensor([3])
         print(paddle.jit.to_static(vlist_of_dict)(x))
 
-    @test_legacy_and_pt_and_pir
     def test4(self):
-        import numpy as np
-
         def vlist_of_dict(x):
             a = np.array([1, 2, 3])
             for i in range(3):
@@ -310,10 +299,7 @@ class TestPushPopTrans(Dy2StTestBase):
         x = paddle.to_tensor([3])
         print(paddle.jit.to_static(vlist_of_dict)(x))
 
-    @test_legacy_and_pt_and_pir
     def test5(self):
-        import numpy as np
-
         def vlist_of_dict(x):
             a = np.array([1, 2, 3])
             for i in range(3):

--- a/test/dygraph_to_static/test_container.py
+++ b/test/dygraph_to_static/test_container.py
@@ -19,7 +19,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -108,7 +107,6 @@ class TestSequential(Dy2StTestBase):
 
         return out
 
-    @test_legacy_and_pt_and_pir
     def test_train(self):
         dy_out = self._run(to_static=False)
         st_out = self._run(to_static=True)

--- a/test/dygraph_to_static/test_contiguous.py
+++ b/test/dygraph_to_static/test_contiguous.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -33,7 +32,6 @@ def func_test_to_static():
 
 
 class TestContiguous(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_to_static(self):
         static_func = to_static(func_test_to_static)
         static_result = static_func()

--- a/test/dygraph_to_static/test_convert_call_generator.py
+++ b/test/dygraph_to_static/test_convert_call_generator.py
@@ -17,7 +17,6 @@ import unittest
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -38,7 +37,6 @@ def main_func():
 class TestConvertGenerator(Dy2StTestBase):
     # fallback will ok.
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_raise_error(self):
         translator_logger.verbosity_level = 1
         with self.assertLogs(

--- a/test/dygraph_to_static/test_convert_operators.py
+++ b/test/dygraph_to_static/test_convert_operators.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -47,7 +46,6 @@ net.forward = "A string so that convert forward will fail"
 class TestConvertCall(Dy2StTestBase):
     # fallback mode will raise a InnerError, it's ok.
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_class_exception(self):
         def call_not_exist():
             net = CallNotExist()
@@ -62,7 +60,6 @@ class TestConvertCall(Dy2StTestBase):
         with self.assertRaises(AttributeError):
             paddle.jit.to_static(forward_not_exist)()
 
-    @test_legacy_and_pt_and_pir
     def test_callable_list(self):
         def callable_list(x, y):
             callable_list = CallableList()
@@ -85,7 +82,6 @@ class ShapeLayer(paddle.nn.Layer):
 
 
 class TestChooseShapeAttrOrApiWithLayer(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_tensor_shape(self):
         x = paddle.zeros(shape=[4, 1], dtype='float32')
         net = paddle.jit.to_static(
@@ -98,7 +94,6 @@ class TestChooseShapeAttrOrApiWithLayer(Dy2StTestBase):
 
 
 class TestIfElseNoValue(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_else_ret_none(self):
         input_x = paddle.to_tensor([[1, 2, 3], [4, 5, 6]])
 
@@ -126,7 +121,6 @@ class TestIfElseNoValue(Dy2StTestBase):
         out = paddle.jit.to_static(without_common_value)(input_x, False)
         self.assertIsNone(out)
 
-    @test_legacy_and_pt_and_pir
     def test_else_ret_c(self):
         input_x = paddle.to_tensor([[1, 2, 3], [4, 5, 6]])
 
@@ -157,7 +151,6 @@ class TestIfElseNoValue(Dy2StTestBase):
         self.assertListEqual(paddle.tolist(y), paddle.tolist(input_x + 1))
         self.assertListEqual(paddle.tolist(z), paddle.tolist(input_x + 2))
 
-    @test_legacy_and_pt_and_pir
     def test_else_ret_cz(self):
         input_x = paddle.to_tensor([[1, 2, 3], [4, 5, 6]])
 

--- a/test/dygraph_to_static/test_cycle_gan.py
+++ b/test/dygraph_to_static/test_cycle_gan.py
@@ -29,7 +29,6 @@ os.environ["CUDA_VISIBLE_DEVICES"] = "1"
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -689,7 +688,6 @@ class TestCycleGANModel(Dy2StTestBase):
             out = train(self.args)
         return out
 
-    @test_legacy_and_pt_and_pir
     def test_train(self):
         st_out = self.train(to_static=True)
         dy_out = self.train(to_static=False)

--- a/test/dygraph_to_static/test_declarative.py
+++ b/test/dygraph_to_static/test_declarative.py
@@ -20,7 +20,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -107,7 +106,6 @@ def create_simple_net():
 
 
 class TestStaticFunctionInstance(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_instance_same_class(self):
         SimpleNet = create_simple_net()
         net_1 = SimpleNet()
@@ -133,7 +131,6 @@ class TestInputSpec(Dy2StTestBase):
         self.temp_dir.cleanup()
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_with_input_spec(self):
         x = paddle.to_tensor(np.ones([4, 10]).astype('float32'))
         y = paddle.to_tensor(np.ones([4, 10]).astype('float32') * 2)
@@ -170,7 +167,6 @@ class TestInputSpec(Dy2StTestBase):
         int_np = np.ones([1]).astype('float32')
         out = net.func_with_list_dict([int_np, {'x': x, 'y': y}])
 
-    @test_legacy_and_pt_and_pir
     def test_with_error(self):
         x = paddle.to_tensor(np.ones([4, 10]).astype('float32'))
         y = paddle.to_tensor(np.ones([4, 10]).astype('float32') * 2)
@@ -195,7 +191,6 @@ class TestInputSpec(Dy2StTestBase):
             net.add_func(x, y)
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_concrete_program(self):
         SimpleNet = create_simple_net()
 
@@ -239,7 +234,6 @@ class TestDifferentInputSpecCacheProgram(Dy2StTestBase):
         pass
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_with_different_input(self):
         x_data = np.ones([16, 10]).astype('float32')
         y_data = np.ones([10]).astype('float32') * 2
@@ -277,7 +271,6 @@ class TestDifferentInputSpecCacheProgram(Dy2StTestBase):
         self.assertTrue(first_program == recent_program)
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_get_concrete_program(self):
         foo = paddle.jit.to_static(foo_func)
 
@@ -319,7 +312,6 @@ class TestDifferentInputSpecCacheProgram(Dy2StTestBase):
             )
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_concrete_program(self):
         # usage 1
         foo_1 = paddle.jit.to_static(
@@ -369,7 +361,6 @@ class TestInputDefaultName(Dy2StTestBase):
 
 class TestDeclarativeAPI(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_error(self):
         func = paddle.jit.to_static(call_to_tensor)
 
@@ -389,7 +380,6 @@ class TestDecorateModelDirectly(Dy2StTestBase):
         self.x = paddle.to_tensor(np.ones([4, 10]).astype('float32'))
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_fake_input(self):
         SimpleNet = create_simple_net()
         net = SimpleNet()
@@ -398,7 +388,6 @@ class TestDecorateModelDirectly(Dy2StTestBase):
         self.assertTrue(len(net.forward.program_cache) == 1)
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_input_spec(self):
         SimpleNet = create_simple_net()
         net = SimpleNet()
@@ -415,7 +404,6 @@ class TestDecorateModelDirectly(Dy2StTestBase):
 
 
 class TestErrorWithInitFromStaticMode(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_raise_error(self):
         # disable imperative
         paddle.enable_static()
@@ -460,7 +448,6 @@ class CallNonForwardFuncSubNet(paddle.nn.Layer):
 
 
 class TestCallNonForwardFunc(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_call_non_forward(self):
         paddle.disable_static()
         net = paddle.jit.to_static(CallNonForwardFuncNet())
@@ -497,7 +484,6 @@ class TestSetBuffers(Dy2StTestBase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    @test_legacy_and_pt_and_pir
     def test_set_buffers1(self):
         net = paddle.jit.to_static(SetBuffersNet1())
         out = net()
@@ -517,7 +503,6 @@ class ClassNoInheritLayer:
 
 
 class TestClassNoInheritLayer(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_to_static(self):
         paddle.disable_static()
         net = ClassNoInheritLayer()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

既 #68229 之后，清理现存的 `test_legacy_and_pt_and_pir`，默认为 `test_pt_and_pir`，即移除 SOT+LEGACY_IR 和 AST+LEGACY_IR 这两种纯老 IR 的 case，减少 CI 时间，本 PR 为 part1

Pcard-67164