### PR TITLE
[Dy2St] Cleanup legacy ir test cases (part2)

### DIFF
--- a/test/dygraph_to_static/test_decorator_transform.py
+++ b/test/dygraph_to_static/test_decorator_transform.py
@@ -22,7 +22,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
     test_pt_only,
 )
 
@@ -186,7 +185,6 @@ def deco_with_paddle_api():
 
 
 class TestDecoratorTransform(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_deco_transform(self):
         outs = paddle.jit.to_static(forward)()
         np.testing.assert_allclose(outs[0], np.array(3), rtol=1e-05)
@@ -216,7 +214,6 @@ class TestDecoratorTransform(Dy2StTestBase):
                     break
             self.assertTrue(flag)
 
-    @test_legacy_and_pt_and_pir
     def test_deco_with_paddle_api(self):
         self.assertTrue(paddle.jit.to_static(deco_with_paddle_api)())
 

--- a/test/dygraph_to_static/test_deepcopy.py
+++ b/test/dygraph_to_static/test_deepcopy.py
@@ -16,7 +16,7 @@ import unittest
 from copy import deepcopy
 
 import numpy as np
-from dygraph_to_static_utils import Dy2StTestBase, test_legacy_and_pt_and_pir
+from dygraph_to_static_utils import Dy2StTestBase
 from test_rollback import Net, foo
 
 import paddle
@@ -24,7 +24,6 @@ from paddle.jit.dy2static.program_translator import StaticFunction
 
 
 class TestDeepCopy(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_net(self):
         net = Net()
         net = paddle.jit.to_static(net)
@@ -40,7 +39,6 @@ class TestDeepCopy(Dy2StTestBase):
         self.assertTrue(id(copy_net), id(copy_net.forward.__self__))
         np.testing.assert_array_equal(src_out.numpy(), copy_out.numpy())
 
-    @test_legacy_and_pt_and_pir
     def test_func(self):
         st_foo = paddle.jit.to_static(foo)
         x = paddle.randn([3, 4])

--- a/test/dygraph_to_static/test_dict.py
+++ b/test/dygraph_to_static/test_dict.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -139,7 +138,6 @@ class TestNetWithDict(Dy2StTestBase):
             ret = net(self.x)
             return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -191,7 +189,6 @@ class TestDictPop(Dy2StTestBase):
             result = self.dygraph_func(self.input)
             return result.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_result(self):
         dygraph_res = self._run_dygraph()
         static_res = self._run_static()
@@ -233,7 +230,6 @@ class TestDictPop3(TestNetWithDict):
             ret = net(z=0, x=self.x, y=True)
             return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         dygraph_result = self._run_dygraph()
         static_result = self._run_static()
@@ -245,7 +241,6 @@ class TestDictPop3(TestNetWithDict):
 
 
 class TestDictCmpInFor(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_with_for(self):
         def func():
             pos = [1, 3]
@@ -262,7 +257,6 @@ class TestDictCmpInFor(Dy2StTestBase):
 
         self.assertEqual(paddle.jit.to_static(func)()['minus'], 8)
 
-    @test_legacy_and_pt_and_pir
     def test_with_for_enumerate(self):
         def func():
             pos = [1, 3]

--- a/test/dygraph_to_static/test_drop_path.py
+++ b/test/dygraph_to_static/test_drop_path.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -39,7 +38,6 @@ class DropPath(paddle.nn.Layer):
 
 
 class TestTrainEval(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_train_and_eval(self):
         model = paddle.jit.to_static(DropPath())
         x = paddle.to_tensor([1, 2, 3]).astype("int64")

--- a/test/dygraph_to_static/test_duplicate_output.py
+++ b/test/dygraph_to_static/test_duplicate_output.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -59,7 +58,6 @@ class TestDuplicateOutput(Dy2StTestBase):
 
         self.assertEqual(param[0].grad.numpy(), 1.0)
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self._run_static()
 
@@ -71,7 +69,6 @@ class TestDuplicateOutputInPaddleLayer(Dy2StTestBase):
         st_out = static_net(x)
         np.testing.assert_allclose(dy_out, st_out)
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         net = DuplicateOutputInPaddleLayer()
         x = paddle.randn([10, 10])

--- a/test/dygraph_to_static/test_fetch_feed.py
+++ b/test/dygraph_to_static/test_fetch_feed.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -84,7 +83,6 @@ class TestPool2D(Dy2StTestBase):
         with enable_to_static_guard(False):
             return self.train()
 
-    @test_legacy_and_pt_and_pir
     def test_to_static(self):
         dygraph_res = self.train_dygraph()
         static_res = self.train_static()

--- a/test/dygraph_to_static/test_for_enumerate.py
+++ b/test/dygraph_to_static/test_for_enumerate.py
@@ -21,7 +21,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_legacy_and_pir,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -397,7 +396,6 @@ class TestForInRangeConfig(TestTransform):
 
 
 class TestForInRange(TestForInRangeConfig):
-    @test_legacy_and_pt_and_pir
     def test_transformed_result_compare(self):
         self.set_test_func()
         self.transformed_result_compare()
@@ -407,7 +405,6 @@ class TestForIterList(TestTransform):
     def set_test_func(self):
         self.dygraph_func = for_iter_list
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_result_compare(self):
         self.set_test_func()
         self.transformed_result_compare()
@@ -430,7 +427,6 @@ class TestForIterVarNumpy(TestTransform):
     def set_test_func(self):
         self.dygraph_func = for_iter_var_numpy
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_result_compare(self):
         self.set_test_func()
         self.transformed_result_compare()
@@ -490,7 +486,6 @@ class TestForIterVarList(TestForInRangeConfig):
     def set_test_func(self):
         self.dygraph_func = for_iter_var_list
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_result_compare(self):
         self.set_test_func()
         self.transformed_result_compare()
@@ -500,7 +495,6 @@ class TestForEnumerateVarList(TestForInRangeConfig):
     def set_test_func(self):
         self.dygraph_func = for_enumerate_var_list
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_result_compare(self):
         self.set_test_func()
         self.transformed_result_compare()
@@ -530,7 +524,6 @@ class TestForOriginalList(TestTransformForOriginalList):
     def set_test_func(self):
         self.dygraph_func = for_original_list
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_result_compare(self):
         self.set_test_func()
         self.transformed_result_compare()
@@ -553,7 +546,6 @@ class TestForZip(Dy2StTestBase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    @test_legacy_and_pt_and_pir
     def test_for_zip_error(self):
         with self.assertRaises(RuntimeError):
             model_path = os.path.join(self.temp_dir.name, 'for_zip_error')

--- a/test/dygraph_to_static/test_full_name_usage.py
+++ b/test/dygraph_to_static/test_full_name_usage.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -62,7 +61,6 @@ class DoubleDecorated:
 
 class TestFullNameDecorator(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_run_success(self):
         x = np.ones([1, 2]).astype("float32")
         answer = np.zeros([1, 2]).astype("float32")

--- a/test/dygraph_to_static/test_grad.py
+++ b/test/dygraph_to_static/test_grad.py
@@ -19,7 +19,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
     test_pir_only,
 )
 
@@ -75,7 +74,6 @@ class TestGrad(Dy2StTestBase):
         self.x = paddle.ones(shape=[10, 2, 5], dtype='float32')
         self.x.stop_gradient = False
 
-    @test_legacy_and_pt_and_pir
     def test_forward(self):
         dygraph_res = self.func(self.x).numpy()
         static_res = paddle.jit.to_static(self.func)(self.x).numpy()
@@ -99,7 +97,6 @@ class TestGradLinear(TestGrad):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    @test_legacy_and_pt_and_pir
     def test_save_infer_program(self):
         static_fn = paddle.jit.to_static(self.func)
         input_spec = [
@@ -112,7 +109,6 @@ class TestGradLinear(TestGrad):
         load_res = load_func(self.x).numpy()
         np.testing.assert_allclose(origin_res, load_res, rtol=1e-05)
 
-    @test_legacy_and_pt_and_pir
     def test_save_train_program(self):
         static_fn = paddle.jit.to_static(self.func)
         grad_clip = paddle.nn.ClipGradByGlobalNorm(2.0)

--- a/test/dygraph_to_static/test_gradient_aggregation.py
+++ b/test/dygraph_to_static/test_gradient_aggregation.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -41,7 +40,6 @@ class SimpleNet(paddle.nn.Layer):
 
 
 class TestGradientAggregationInDy2Static(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_to_static(self):
         def simplenet_grad(inp, to_static=False):
             net = SimpleNet()

--- a/test/dygraph_to_static/test_gradname_parse.py
+++ b/test/dygraph_to_static/test_gradname_parse.py
@@ -18,7 +18,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -85,7 +84,6 @@ class TestTanhHighOrderGrad(Dy2StTestBase):
         self.dy2st_input = (x2,)
         self.dy2st_grad_input = (x2,)
 
-    @test_legacy_and_pt_and_pir
     def test_run(self):
         try:
             dy_out = self.func(*self.dy_input)

--- a/test/dygraph_to_static/test_grid_generator.py
+++ b/test/dygraph_to_static/test_grid_generator.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -147,7 +146,6 @@ class TestGridGenerator(Dy2StTestBase):
             ret = net(self.x, [32, 100])
         return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_to_static(self):
         st_out = self._run(to_static=True)
         dy_out = self._run(to_static=False)

--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -23,7 +23,6 @@ from dygraph_to_static_utils import (
     enable_to_static_guard,
     test_ast_only,
     test_legacy_and_pir,
-    test_legacy_and_pt_and_pir,
     test_pir_only,
 )
 from ifelse_simple_func import (
@@ -65,7 +64,6 @@ class TestDy2staticException(Dy2StTestBase):
         self.error = "Your if/else have different number of return value."
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_error(self):
         if self.dyfunc:
             with self.assertRaisesRegex(Dygraph2StaticException, self.error):
@@ -96,7 +94,6 @@ class TestDygraphIfElse(Dy2StTestBase):
             ret = self.dyfunc(x_v)
         return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -108,7 +105,6 @@ class TestDygraphIfElse2(TestDygraphIfElse):
 
     # TODO(dev): fix AST mode
     @disable_test_case((ToStaticMode.AST, IrMode.PT))
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -129,7 +125,6 @@ class TestDygraphIfElse3(Dy2StTestBase):
             ret = self.dyfunc(x_v)
         return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -145,7 +140,6 @@ class TestDygraphIfElseWithListGenerator(TestDygraphIfElse):
         self.x = np.random.random([10, 16]).astype('float32')
         self.dyfunc = dyfunc_with_if_else_with_list_generator
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -166,7 +160,6 @@ class TestDygraphNestedIfElse(Dy2StTestBase):
             ret = self.dyfunc(x_v)
         return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -176,7 +169,6 @@ class TestDygraphNestedIfElse2(TestDygraphIfElse):
         self.x = np.random.random([10, 16]).astype('float32')
         self.dyfunc = nested_if_else_2
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -197,7 +189,6 @@ class TestDygraphNestedIfElse3(Dy2StTestBase):
             ret = self.dyfunc(x_v)
         return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -310,7 +301,6 @@ class TestDygraphIfTensor(Dy2StTestBase):
             ret = self.dyfunc(x_v)
         return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -338,7 +328,6 @@ class TestDygraphIfElseNet(Dy2StTestBase):
             ret = net(x_v)
             return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -391,7 +380,6 @@ class TestNetWithExternalFunc(TestDygraphIfElseNet):
         self.x = np.random.random([10, 16]).astype('float32')
         self.Net = NetWithExternalFunc
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -449,7 +437,6 @@ class TestDiffModeNet(Dy2StTestBase):
             ret = net(self.x, self.y)
             return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_train_mode(self):
         self.assertTrue(
             (
@@ -458,7 +445,6 @@ class TestDiffModeNet(Dy2StTestBase):
             ).all()
         )
 
-    @test_legacy_and_pt_and_pir
     def test_infer_mode(self):
         self.assertTrue(
             (
@@ -474,7 +460,6 @@ class TestDiffModeNet2(TestDiffModeNet):
 
 
 class TestNewVarCreateInOneBranch(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_var_used_in_another_for(self):
         def case_func(training):
             # targets and targets_list is dynamically defined by training
@@ -510,7 +495,6 @@ class TestDy2StIfElseRetInt1(Dy2StTestBase):
         return out
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self.setUp()
         self.assertIsInstance(self.out[0], paddle.Tensor)
@@ -524,7 +508,6 @@ class TestDy2StIfElseRetInt3(TestDy2StIfElseRetInt1):
         self.out = self.get_dy2stat_out()
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         self.setUp()
         self.assertIsInstance(self.out, paddle.Tensor)
@@ -536,7 +519,6 @@ class TestDy2StIfElseRetInt4(TestDy2StIfElseRetInt1):
         self.dyfunc = paddle.jit.to_static(dyfunc_ifelse_ret_int4)
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         with enable_to_static_guard(True):
             with self.assertRaises(Dygraph2StaticException):
@@ -602,7 +584,6 @@ def ifelse_use_undefined_var(x):
 
 
 class TestIfElseMaybeUnbound(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_maybe_unbound(self):
         truethy = paddle.to_tensor(1)
         falsy = paddle.to_tensor(0)

--- a/test/dygraph_to_static/test_incubate_jit_inference.py
+++ b/test/dygraph_to_static/test_incubate_jit_inference.py
@@ -19,7 +19,7 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
     test_legacy_and_pt,
-    test_legacy_and_pt_and_pir,
+    test_pt_and_pir,
 )
 
 import paddle
@@ -63,7 +63,7 @@ class TestLayer2(paddle.nn.Layer):
 
 class TestToStaticInfenrenceModel(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
+    @test_pt_and_pir
     def test_dygraph_static_same_result(self):
         hidd = 1024
         batch = 4096
@@ -95,7 +95,7 @@ class TestToStaticInfenrenceTensorRTModel(Dy2StTestBase):
 
 class TestToStaticInfenrenceFunc(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
+    @test_pt_and_pir
     def test_dygraph_static_same_result(self):
         hidd = 1024
         batch = 4096

--- a/test/dygraph_to_static/test_incubate_jit_inference.py
+++ b/test/dygraph_to_static/test_incubate_jit_inference.py
@@ -19,7 +19,7 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
     test_legacy_and_pt,
-    test_pt_and_pir,
+    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -63,7 +63,7 @@ class TestLayer2(paddle.nn.Layer):
 
 class TestToStaticInfenrenceModel(Dy2StTestBase):
     @test_ast_only
-    @test_pt_and_pir
+    @test_legacy_and_pt_and_pir
     def test_dygraph_static_same_result(self):
         hidd = 1024
         batch = 4096
@@ -95,7 +95,7 @@ class TestToStaticInfenrenceTensorRTModel(Dy2StTestBase):
 
 class TestToStaticInfenrenceFunc(Dy2StTestBase):
     @test_ast_only
-    @test_pt_and_pir
+    @test_legacy_and_pt_and_pir
     def test_dygraph_static_same_result(self):
         hidd = 1024
         batch = 4096

--- a/test/dygraph_to_static/test_isinstance.py
+++ b/test/dygraph_to_static/test_isinstance.py
@@ -29,7 +29,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -86,21 +85,18 @@ def train(model, to_static):
 
 
 class TestIsinstance(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_isinstance_simple_return_layer(self):
         model_creator = lambda: paddle.jit.to_static(
             IsInstanceLayer(SimpleReturnLayer())
         )
         self._test_model(model_creator)
 
-    @test_legacy_and_pt_and_pir
     def test_isinstance_add_attr_layer(self):
         model_creator = lambda: paddle.jit.to_static(
             IsInstanceLayer(AddAttrLayer())
         )
         self._test_model(model_creator)
 
-    @test_legacy_and_pt_and_pir
     def test_sequential_layer(self):
         def model_creator():
             layers = []

--- a/test/dygraph_to_static/test_jit_property_save.py
+++ b/test/dygraph_to_static/test_jit_property_save.py
@@ -16,7 +16,6 @@ import unittest
 
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -36,22 +35,18 @@ class TestPropertySave(Dy2StTestBase):
         self.a = a
         self.b = b
 
-    @test_legacy_and_pt_and_pir
     def test_property_save(self):
         self.assertEqual(self.a.get_float('a'), self.b.get_float('a'))
         self.assertEqual(self.a.get_float(0), 1.0)
 
-    @test_legacy_and_pt_and_pir
     def test_size(self):
         self.assertEqual(self.b.size(), 2)
         self.assertEqual(self.a.size(), 2)
 
-    @test_legacy_and_pt_and_pir
     def test_load_float(self):
         with self.assertRaises(ValueError):
             self.a.get_float(1)
 
-    @test_legacy_and_pt_and_pir
     def test_set(self):
         """test property set."""
         try:

--- a/test/dygraph_to_static/test_jit_setitem.py
+++ b/test/dygraph_to_static/test_jit_setitem.py
@@ -18,7 +18,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -43,7 +42,6 @@ class TestSetItemBase(Dy2StTestBase):
 
         return foo
 
-    @test_legacy_and_pt_and_pir
     def test_case(self):
         func = self.init_func()
         dy_res = self.run_dygraph(func)
@@ -202,7 +200,6 @@ class TestCase12(TestSetItemBase):
         y = func()
         return (y,)
 
-    @test_legacy_and_pt_and_pir
     def test_case(self):
         func = self.init_func()
         dy_res = self.run_dygraph(func)

--- a/test/dygraph_to_static/test_lambda.py
+++ b/test/dygraph_to_static/test_lambda.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -98,27 +97,22 @@ class TestLambda(Dy2StTestBase):
             ret = func(x_v)
         return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_call_lambda_as_func(self):
         fn = call_lambda_as_func
         self.assertTrue((self.run_dygraph(fn) == self.run_static(fn)).all())
 
-    @test_legacy_and_pt_and_pir
     def test_call_lambda_directly(self):
         fn = call_lambda_directly
         self.assertTrue((self.run_dygraph(fn) == self.run_static(fn)).all())
 
-    @test_legacy_and_pt_and_pir
     def test_call_lambda_in_func(self):
         fn = call_lambda_in_func
         self.assertTrue((self.run_dygraph(fn) == self.run_static(fn)).all())
 
-    @test_legacy_and_pt_and_pir
     def test_call_lambda_with_if_expr(self):
         fn = call_lambda_with_if_expr
         self.assertTrue((self.run_dygraph(fn) == self.run_static(fn)).all())
 
-    @test_legacy_and_pt_and_pir
     def test_call_lambda_with_if_expr2(self):
         fn = call_lambda_with_if_expr2
         self.assertTrue((self.run_dygraph(fn) == self.run_static(fn)).all())

--- a/test/dygraph_to_static/test_layer_hook.py
+++ b/test/dygraph_to_static/test_layer_hook.py
@@ -19,7 +19,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -85,7 +84,6 @@ class TestNestLayerHook(Dy2StTestBase):
         out = net(self.x)
         return float(out)
 
-    @test_legacy_and_pt_and_pir
     def test_hook(self):
         dy_out = self.train_net(to_static=False)
         st_out = self.train_net(to_static=True)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

既 #68229 之后，清理现存的 `test_legacy_and_pt_and_pir`，默认为 `test_pt_and_pir`，即移除 SOT+LEGACY_IR 和 AST+LEGACY_IR 这两种纯老 IR 的 case，减少 CI 时间，本 PR 为 part2

Pcard-67164