### PR TITLE
[Dy2St] Cleanup legacy ir test cases (part3)

### DIFF
--- a/test/dygraph_to_static/test_len.py
+++ b/test/dygraph_to_static/test_len.py
@@ -20,7 +20,6 @@ from dygraph_to_static_utils import (
     static_guard,
     test_ast_only,
     test_legacy_and_pt,
-    test_legacy_and_pt_and_pir,
     test_pir_only,
 )
 
@@ -68,7 +67,6 @@ class TestLen(Dy2StTestBase):
         return out
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_len(self):
         dygraph_res = self._run(to_static=False)
         static_res = self._run(to_static=True)

--- a/test/dygraph_to_static/test_list.py
+++ b/test/dygraph_to_static/test_list.py
@@ -22,7 +22,6 @@ from dygraph_to_static_utils import (
     ToStaticMode,
     disable_test_case,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -266,7 +265,6 @@ class TestListWithoutControlFlowConfig(Dy2StTestBase):
 
 
 class TestListWithoutControlFlow(TestListWithoutControlFlowConfig):
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         self.compare_transformed_static_result()
 
@@ -299,7 +297,6 @@ class TestListInWhileLoop(TestListWithoutControlFlowConfig):
             return self.result_to_numpy(res)
 
     @disable_test_case((ToStaticMode.AST, IrMode.PT))
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         self.compare_transformed_static_result()
 
@@ -365,7 +362,6 @@ class ListWithCondNet(paddle.nn.Layer):
 
 
 class TestListWithCondGradInferVarType(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_to_static(self):
         net = ListWithCondNet()
         x = paddle.to_tensor([2, 3, 4], dtype='float32')
@@ -383,7 +379,6 @@ def tensor_array_dtype():
 
 class TestTensorArrayDtype(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_tensor_array_dtype(self):
         fn = tensor_array_dtype
         static_fn = paddle.jit.to_static(fn)

--- a/test/dygraph_to_static/test_load_transformer.py
+++ b/test/dygraph_to_static/test_load_transformer.py
@@ -18,7 +18,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -48,7 +47,6 @@ class TestFallback(Dy2StTestBase):
     def setUp(self):
         self.x = paddle.to_tensor(1.0).astype('int')
 
-    @test_legacy_and_pt_and_pir
     def test_name_load(self):
         net_dy = Net()
         net_st = Net()
@@ -58,7 +56,6 @@ class TestFallback(Dy2StTestBase):
 
 
 class TestLoad2(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_name_load_nograd(self):
         @paddle.no_grad()
         def func(x):
@@ -83,7 +80,6 @@ class LoadInCallKwargsNet(paddle.nn.Layer):
 
 
 class TestLoadInCallKwargs(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_name_load_nograd(self):
         net = LoadInCallKwargsNet()
         x = paddle.rand([10, 10])

--- a/test/dygraph_to_static/test_logical.py
+++ b/test/dygraph_to_static/test_logical.py
@@ -21,7 +21,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -254,12 +253,10 @@ class TestShapeNotEqual(TestLogicalNot):
 
 
 class TestCmpopNodeToStr(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_exception(self):
         with self.assertRaises(KeyError):
             cmpop_node_to_str(gast.Or())
 
-    @test_legacy_and_pt_and_pir
     def test_expected_result(self):
         self.assertEqual(cmpop_node_to_str(gast.Eq()), "==")
         self.assertEqual(cmpop_node_to_str(gast.NotEq()), "!=")

--- a/test/dygraph_to_static/test_logical.py
+++ b/test/dygraph_to_static/test_logical.py
@@ -190,7 +190,6 @@ class TestLogicalNot(TestLogicalBase):
     def _set_test_func(self):
         self.dygraph_func = test_logical_not
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_result(self):
         dygraph_res = self._run_dygraph()
         static_res = self._run_static()
@@ -206,7 +205,6 @@ class TestLogicalNot2(TestLogicalBase):
     def _set_test_func(self):
         self.dygraph_func = test_logical_not_2
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_result(self):
         dygraph_res = self._run_dygraph()
         static_res = self._run_static()

--- a/test/dygraph_to_static/test_loop.py
+++ b/test/dygraph_to_static/test_loop.py
@@ -19,7 +19,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -241,7 +240,6 @@ class TestNameVisitor(Dy2StTestBase):
 
         self.nested_for_loop_func = nested_for_loop_dyfunc
 
-    @test_legacy_and_pt_and_pir
     def test_loop_vars(self):
         for i in range(len(self.loop_funcs)):
             func = self.loop_funcs[i]
@@ -257,7 +255,6 @@ class TestNameVisitor(Dy2StTestBase):
                     self.assertEqual(loop_var_names, self.loop_var_names[i])
                     self.assertEqual(create_var_names, self.create_var_names[i])
 
-    @test_legacy_and_pt_and_pir
     def test_nested_loop_vars(self):
         func = self.nested_for_loop_func
         test_func = inspect.getsource(func)
@@ -322,7 +319,6 @@ class TestTransformWhileLoop(Dy2StTestBase):
         else:
             return ret
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         static_numpy = self._run_static()
         dygraph_numpy = self._run_dygraph()
@@ -396,7 +392,6 @@ class TestTransformForLoop(Dy2StTestBase):
             ret = self.dyfunc(self.len)
         return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         np.testing.assert_allclose(
             self._run_dygraph(), self._run_static(), rtol=1e-05
@@ -453,7 +448,6 @@ class Net(paddle.nn.Layer):
 
 
 class TestForLoopMeetDict(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_start(self):
         net = Net()
         model = paddle.jit.to_static(

--- a/test/dygraph_to_static/test_lstm.py
+++ b/test/dygraph_to_static/test_lstm.py
@@ -21,7 +21,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -70,7 +69,6 @@ class TestLstm(Dy2StTestBase):
             y = net(x)
             return y.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_lstm_to_static(self):
         dygraph_out = self.run_lstm(to_static=False)
         static_out = self.run_lstm(to_static=True)
@@ -120,12 +118,10 @@ class TestLstm(Dy2StTestBase):
         )
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_save_without_training(self):
         self.save_in_eval(with_training=False)
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_save_with_training(self):
         self.save_in_eval(with_training=True)
 
@@ -165,7 +161,6 @@ class TestSaveInEvalMode(Dy2StTestBase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    @test_legacy_and_pt_and_pir
     def test_save_in_eval(self):
         net = paddle.jit.to_static(LinearNet())
         x = paddle.randn((2, 10))
@@ -208,7 +203,6 @@ class TestEvalAfterSave(Dy2StTestBase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    @test_legacy_and_pt_and_pir
     def test_eval_after_save(self):
         x = paddle.randn((2, 10, 12)).astype('float32')
         net = Net(12, 2)

--- a/test/dygraph_to_static/test_mnist_pure_fp16.py
+++ b/test/dygraph_to_static/test_mnist_pure_fp16.py
@@ -16,7 +16,6 @@ import unittest
 from time import time
 
 import numpy as np
-from dygraph_to_static_utils import test_legacy_and_pt_and_pir
 from test_mnist import MNIST, SEED, TestMNIST
 
 import paddle
@@ -32,7 +31,6 @@ class TestPureFP16(TestMNIST):
     def train_dygraph(self):
         return self.train(to_static=False)
 
-    @test_legacy_and_pt_and_pir
     def test_mnist_to_static(self):
         if paddle.base.is_compiled_with_cuda():
             dygraph_loss = self.train_dygraph()

--- a/test/dygraph_to_static/test_multi_forward.py
+++ b/test/dygraph_to_static/test_multi_forward.py
@@ -16,7 +16,6 @@ import unittest
 
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -32,7 +31,6 @@ class MyLayer(paddle.nn.Layer):
 
 
 class TestBackward(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_order_0(self):
         """
         loss = 1 * w * 1 + 2 * w * 2
@@ -54,7 +52,6 @@ class TestBackward(Dy2StTestBase):
         loss.backward()
         self.assertEqual(model.linear.weight.grad, 5)
 
-    @test_legacy_and_pt_and_pir
     def test_order_1(self):
         """
         loss = 2 * w * 2  + 1 * w * 1

--- a/test/dygraph_to_static/test_name_load_jst_transformer.py
+++ b/test/dygraph_to_static/test_name_load_jst_transformer.py
@@ -18,7 +18,6 @@ import numpy
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -36,7 +35,6 @@ def f(x):
 
 class TestAssertVariable(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_load_name_in_args(self):
         x = paddle.to_tensor([1, 2, 3], dtype='float32')
         dy_out = f(x)

--- a/test/dygraph_to_static/test_no_gradient.py
+++ b/test/dygraph_to_static/test_no_gradient.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy
-from dygraph_to_static_utils import Dy2StTestBase, test_legacy_and_pt_and_pir
+from dygraph_to_static_utils import Dy2StTestBase
 
 import paddle
 
@@ -33,7 +33,6 @@ def main_func(x, index):
 
 
 class TestNoGradientCase(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_no_gradient(self):
         paddle.disable_static()
         x = paddle.randn([10, 3])

--- a/test/dygraph_to_static/test_param_guard.py
+++ b/test/dygraph_to_static/test_param_guard.py
@@ -19,7 +19,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -81,7 +80,6 @@ class TestParameterList(Dy2StTestBase):
 
             return loss
 
-    @test_legacy_and_pt_and_pir
     def test_parameter_list(self):
         static_loss = self.train(False, to_static=True)
         dygraph_loss = self.train(False, to_static=False)
@@ -133,7 +131,6 @@ class TestRawParameterList(Dy2StTestBase):
 
             return loss
 
-    @test_legacy_and_pt_and_pir
     def test_parameter_list(self):
         static_loss = self.train(to_static=True)
         dygraph_loss = self.train(to_static=False)

--- a/test/dygraph_to_static/test_params_no_grad.py
+++ b/test/dygraph_to_static/test_params_no_grad.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from dygraph_to_static_utils import Dy2StTestBase, test_legacy_and_pt_and_pir
+from dygraph_to_static_utils import Dy2StTestBase
 
 import paddle
 import paddle.distributed as dist
@@ -54,7 +54,6 @@ def train():
 
 
 class TestParamsNoGrad(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_two_card(self):
         if (
             paddle.is_compiled_with_cuda()

--- a/test/dygraph_to_static/test_partial_program.py
+++ b/test/dygraph_to_static/test_partial_program.py
@@ -19,7 +19,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
     test_legacy_and_pt,
-    test_legacy_and_pt_and_pir,
     test_pir_only,
 )
 from test_fetch_feed import Linear
@@ -88,7 +87,6 @@ class TestWithNestedInput(Dy2StTestBase):
 
         return out.numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_nest(self):
         dygraph_res = self._run(to_static=False)
         static_res = self._run(to_static=True)
@@ -114,7 +112,6 @@ class TestWithNestedOutput(Dy2StTestBase):
 
         return out
 
-    @test_legacy_and_pt_and_pir
     def test_nest(self):
         dygraph_res = self._run(to_static=False)
         dygraph_res = paddle.utils.flatten(dygraph_res)
@@ -248,7 +245,6 @@ class GPT2LMHeadModel(paddle.nn.Layer):
 
 
 class TestPruneUnusedParamInProgram(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_prune(self):
         input_ids = np.array([[15, 11, 6, 3, 18, 13]]).astype("float32")
 

--- a/test/dygraph_to_static/test_pir_selectedrows.py
+++ b/test/dygraph_to_static/test_pir_selectedrows.py
@@ -17,7 +17,6 @@ import unittest
 
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -74,7 +73,6 @@ def forward_static():
 
 
 class TestSimnet(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_dygraph_static_same_loss(self):
         dygraph_value = forward_dygraph()
         static_value = forward_static()

--- a/test/dygraph_to_static/test_print.py
+++ b/test/dygraph_to_static/test_print.py
@@ -18,7 +18,6 @@ import numpy
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -101,7 +100,6 @@ class TestPrintVariable(TestPrintBase):
     def set_test_func(self):
         self.dygraph_func = dyfunc_print_variable
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         self.get_dygraph_output()
         self.get_static_output()

--- a/test/dygraph_to_static/test_program_translator.py
+++ b/test/dygraph_to_static/test_program_translator.py
@@ -22,7 +22,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 from ifelse_simple_func import (
     dyfunc_with_if_else_early_return1,
@@ -221,13 +220,11 @@ class TestEnableDeclarative(Dy2StTestBase):
         self.weight = np.random.randn(32, 64).astype('float32')
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_raise_error(self):
         net = paddle.jit.to_static(full_graph=True)(NetWithError())
         with self.assertRaises(ValueError):
             net(paddle.to_tensor(self.x))
 
-    @test_legacy_and_pt_and_pir
     def test_enable_disable_to_static(self):
         static_output = paddle.jit.to_static(decorated_simple_func)(
             self.x, self.weight
@@ -275,7 +272,6 @@ switch_mode_function = paddle.jit.to_static(full_graph=True)(
 
 class TestFunctionTrainEvalMode(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_switch_mode(self):
         switch_mode_function.eval()
         switch_mode_function()
@@ -289,7 +285,6 @@ class TestFunctionTrainEvalMode(Dy2StTestBase):
         _, partial_layer = switch_mode_function.program_cache.last()[-1]
         self.assertEqual(partial_layer.training, True)
 
-    @test_legacy_and_pt_and_pir
     def test_raise_error(self):
         net = paddle.jit.to_static(SwitchModeNet())
 
@@ -304,7 +299,6 @@ class TestFunctionTrainEvalMode(Dy2StTestBase):
 
 
 class TestIfElseEarlyReturn(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_ifelse_early_return1(self):
         answer = np.zeros([2, 2]) + 1
         static_func = paddle.jit.to_static(dyfunc_with_if_else_early_return1)
@@ -316,7 +310,6 @@ class TestIfElseEarlyReturn(Dy2StTestBase):
         elif isinstance(out, tuple):
             np.testing.assert_allclose(answer, out[0].numpy(), rtol=1e-05)
 
-    @test_legacy_and_pt_and_pir
     def test_ifelse_early_return2(self):
         answer = np.zeros([2, 2]) + 3
         static_func = paddle.jit.to_static(dyfunc_with_if_else_early_return2)
@@ -337,7 +330,6 @@ class TestRemoveCommentInDy2St(Dy2StTestBase):
         # Comment3
         y = paddle.to_tensor([4, 5, 6])
 
-    @test_legacy_and_pt_and_pir
     def test_remove_comment(self):
         code_string = func_to_source_code(self.func_with_comment)
         self.assertEqual('#' not in code_string, True)
@@ -371,7 +363,6 @@ class Net2:
 
 
 class TestParameterRecorder(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_recorder(self):
         """function calls nn.Layer case."""
         net = Net()

--- a/test/dygraph_to_static/test_ptb_lm.py
+++ b/test/dygraph_to_static/test_ptb_lm.py
@@ -20,7 +20,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -323,7 +322,6 @@ def train_static():
 
 
 class TestPtb(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_check_result(self):
         loss_1, hidden_1, cell_1 = train_dygraph()
         loss_2, hidden_2, cell_2 = train_static()

--- a/test/dygraph_to_static/test_reinforcement_learning.py
+++ b/test/dygraph_to_static/test_reinforcement_learning.py
@@ -21,7 +21,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -203,7 +202,6 @@ class TestDeclarative(Dy2StTestBase):
     def setUp(self):
         self.args = Args()
 
-    @test_legacy_and_pt_and_pir
     def test_train(self):
         st_out = train(self.args, to_static=True)
         dy_out = train(self.args, to_static=False)

--- a/test/dygraph_to_static/test_return.py
+++ b/test/dygraph_to_static/test_return.py
@@ -19,7 +19,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
     test_legacy_only,
 )
 from ifelse_simple_func import dyfunc_with_if_else
@@ -279,7 +278,6 @@ class TestReturnBase(Dy2StTestBase):
             self.assertEqual(dygraph_res, static_res)
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         self.init_dygraph_func()
         if hasattr(self, "error"):
@@ -326,7 +324,6 @@ class TestReturnIf(Dy2StTestBase):
         else:
             self.assertEqual(dygraph_res, static_res)
 
-    @test_legacy_and_pt_and_pir
     @test_ast_only
     def test_transformed_static_result(self):
         self.init_dygraph_func()
@@ -428,7 +425,6 @@ class TestReturnIfElse(Dy2StTestBase):
         else:
             self.assertEqual(dygraph_res, static_res)
 
-    @test_legacy_and_pt_and_pir
     @test_ast_only
     def test_transformed_static_result(self):
         self.init_dygraph_func()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

既 #68229 之后，清理现存的 `test_legacy_and_pt_and_pir`，默认为 `test_pt_and_pir`，即移除 SOT+LEGACY_IR 和 AST+LEGACY_IR 这两种纯老 IR 的 case，减少 CI 时间，本 PR 为 part3

Pcard-67164