### PR TITLE
[Dy2St] Cleanup legacy ir test cases (part4)

### DIFF
--- a/test/dygraph_to_static/test_mnist_amp.py
+++ b/test/dygraph_to_static/test_mnist_amp.py
@@ -16,9 +16,6 @@ import unittest
 from time import time
 
 import numpy as np
-from dygraph_to_static_utils import (
-    test_legacy_and_pt_and_pir,
-)
 from test_mnist import MNIST, SEED, TestMNIST
 
 import paddle
@@ -35,7 +32,6 @@ class TestAMP(TestMNIST):
     def train_dygraph(self):
         return self.train(to_static=False)
 
-    @test_legacy_and_pt_and_pir
     def test_mnist_to_static(self):
         dygraph_loss = self.train_dygraph()
         static_loss = self.train_static()

--- a/test/dygraph_to_static/test_rollback.py
+++ b/test/dygraph_to_static/test_rollback.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -72,7 +71,6 @@ def foo(x, flag=False):
 
 
 class TestRollBackPlainFunction(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_plain_func(self):
         paddle.set_device("cpu")
         st_foo = paddle.jit.to_static(foo)
@@ -90,7 +88,6 @@ class TestRollBackPlainFunction(Dy2StTestBase):
 
 class TestRollBackNet(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_net(self):
         paddle.set_device("cpu")
         net = paddle.jit.to_static(Net())
@@ -139,7 +136,6 @@ class FuncRollback(paddle.nn.Layer):
 
 class TestRollBackNotForward(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_rollback(self):
         x = paddle.zeros([2, 2])
         net = FuncRollback()

--- a/test/dygraph_to_static/test_save_inference_model.py
+++ b/test/dygraph_to_static/test_save_inference_model.py
@@ -21,7 +21,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
     test_legacy_and_pir,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -235,7 +234,6 @@ class TestDyToStaticSaveInferenceModel(Dy2StTestBase):
 
 class TestPartialProgramRaiseError(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_param_type(self):
         x_data = np.random.random((20, 20)).astype('float32')
 

--- a/test/dygraph_to_static/test_set_dynamic_shape.py
+++ b/test/dygraph_to_static/test_set_dynamic_shape.py
@@ -17,7 +17,6 @@ import unittest
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -25,7 +24,6 @@ import paddle
 
 class TestSetDynamicShape(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_start(self):
         def dygraph_func(loop_number):
             mask = paddle.randn([2, 2])
@@ -43,7 +41,6 @@ class TestSetDynamicShape(Dy2StTestBase):
         self.assertEqual(expected_shape, actual_shape)
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_pir_ast(self):
         def dygraph_func():
             mask = paddle.randn([2, 2])

--- a/test/dygraph_to_static/test_simnet.py
+++ b/test/dygraph_to_static/test_simnet.py
@@ -20,7 +20,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 from simnet_dygraph_model import BOW, HingeLoss
 
@@ -179,7 +178,6 @@ def train(conf_dict):
 
 
 class TestSimnet(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_dygraph_static_same_loss(self):
         if paddle.is_compiled_with_cuda():
             paddle.set_flags({"FLAGS_cudnn_deterministic": True})

--- a/test/dygraph_to_static/test_slice.py
+++ b/test/dygraph_to_static/test_slice.py
@@ -22,7 +22,6 @@ from dygraph_to_static_utils import (
     enable_to_static_guard,
     static_guard,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -142,7 +141,6 @@ class TestSliceWithoutControlFlow(TestSliceBase):
     def init_dygraph_func(self):
         self.dygraph_func = test_slice_without_control_flow
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         self.init_dygraph_func()
         static_res = self.run_static_mode()
@@ -154,7 +152,6 @@ class TestSliceInIf(TestSliceBase):
     def init_dygraph_func(self):
         self.dygraph_func = test_slice_in_if
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         self.init_dygraph_func()
         static_res = self.run_static_mode()
@@ -191,7 +188,6 @@ class TestSetValueWithLayerAndSave(Dy2StTestBase):
         self.temp_dir.cleanup()
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_set_value_with_save(self):
         with enable_to_static_guard(True):
             model = paddle.jit.to_static(
@@ -208,7 +204,6 @@ class TestSetValueWithLayerAndSave(Dy2StTestBase):
 
 class TestSliceSupplementSpecialCase(Dy2StTestBase):
     # unittest for slice index which abs(step)>0. eg: x[::2]
-    @test_legacy_and_pt_and_pir
     def test_static_slice_step(self):
         with static_guard():
             array = np.arange(4**3).reshape((4, 4, 4)).astype('int64')
@@ -227,7 +222,6 @@ class TestSliceSupplementSpecialCase(Dy2StTestBase):
         np.testing.assert_array_equal(out[0], array[::2])
         np.testing.assert_array_equal(out[1], array[::-2])
 
-    @test_legacy_and_pt_and_pir
     def test_static_slice_step_dygraph2static(self):
         array = np.arange(4**2 * 5).reshape((5, 4, 4)).astype('int64')
         inps = paddle.to_tensor(array)
@@ -250,7 +244,6 @@ class TestSliceSupplementSpecialCase(Dy2StTestBase):
 
 
 class TestPaddleStridedSlice(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_compare_paddle_strided_slice_with_numpy(self):
         array = np.arange(5)
         pt = paddle.to_tensor(array)
@@ -311,7 +304,6 @@ def slice_zero_shape_tensor(x):
 
 
 class TestSliceZeroShapeTensor(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_slice(self):
         x = paddle.ones([0, 0, 0, 0])
         y = slice_zero_shape_tensor(x)

--- a/test/dygraph_to_static/test_spec_names.py
+++ b/test/dygraph_to_static/test_spec_names.py
@@ -17,7 +17,6 @@ import unittest
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -49,7 +48,6 @@ class TestArgsSpecName(Dy2StTestBase):
         self.n = paddle.randn([4, 2, 8])
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_spec_name_hash(self):
         net = Net()
         net = paddle.jit.to_static(net)

--- a/test/dygraph_to_static/test_tensor_detach.py
+++ b/test/dygraph_to_static/test_tensor_detach.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -32,7 +31,6 @@ def detach_fn(x, y):
 
 
 class TestDetach(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_detach(self):
         static_fn = paddle.jit.to_static(detach_fn)
         x = paddle.ones([], 'float32')

--- a/test/dygraph_to_static/test_tensor_methods.py
+++ b/test/dygraph_to_static/test_tensor_methods.py
@@ -19,6 +19,7 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_ast_only,
+    test_pir_only,
 )
 
 import paddle
@@ -36,7 +37,6 @@ class TestTensorClone(Dy2StTestBase):
         return paddle.jit.to_static(tensor_clone)(x).numpy()
 
     def test_tensor_clone(self):
-        paddle.disable_static()
         with enable_to_static_guard(False):
             dygraph_res = self._run()
 
@@ -58,7 +58,6 @@ class TestTensorDygraphOnlyMethodError(Dy2StTestBase):
 
     @test_ast_only
     def test_to_static_numpy_report_error(self):
-        paddle.disable_static()
         with enable_to_static_guard(False):
             dygraph_res = self._run()
 
@@ -78,7 +77,6 @@ class TestTensorItem(Dy2StTestBase):
         return paddle.jit.to_static(tensor_item)(x)
 
     def test_tensor_clone(self):
-        paddle.disable_static()
         with enable_to_static_guard(False):
             dygraph_res = self._run()
 
@@ -103,11 +101,9 @@ class TestTensorSize(Dy2StTestBase):
             ret = ret.numpy()
         return ret
 
-    def test_tensor_clone(self):
-        paddle.disable_static()
-        with enable_to_static_guard(False):
-            dygraph_res = self._run(to_static=False)
-
+    @test_pir_only
+    def test_tensor_size(self):
+        dygraph_res = self._run(to_static=False)
         static_res = self._run(to_static=True)
         np.testing.assert_allclose(dygraph_res, static_res, rtol=1e-5)
 
@@ -124,7 +120,6 @@ class TestTrueDiv(Dy2StTestBase):
         return paddle.jit.to_static(true_div)(x, y).numpy()
 
     def test_true_div(self):
-        paddle.disable_static()
         with enable_to_static_guard(False):
             dygraph_res = self._run()
         static_res = self._run()

--- a/test/dygraph_to_static/test_tensor_methods.py
+++ b/test/dygraph_to_static/test_tensor_methods.py
@@ -19,7 +19,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -36,7 +35,6 @@ class TestTensorClone(Dy2StTestBase):
         x = paddle.ones([1, 2, 3])
         return paddle.jit.to_static(tensor_clone)(x).numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_tensor_clone(self):
         paddle.disable_static()
         with enable_to_static_guard(False):
@@ -59,7 +57,6 @@ class TestTensorDygraphOnlyMethodError(Dy2StTestBase):
         return y.numpy()
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_to_static_numpy_report_error(self):
         paddle.disable_static()
         with enable_to_static_guard(False):
@@ -80,7 +77,6 @@ class TestTensorItem(Dy2StTestBase):
         x = paddle.ones([1])
         return paddle.jit.to_static(tensor_item)(x)
 
-    @test_legacy_and_pt_and_pir
     def test_tensor_clone(self):
         paddle.disable_static()
         with enable_to_static_guard(False):
@@ -107,7 +103,6 @@ class TestTensorSize(Dy2StTestBase):
             ret = ret.numpy()
         return ret
 
-    @test_legacy_and_pt_and_pir
     def test_tensor_clone(self):
         paddle.disable_static()
         with enable_to_static_guard(False):
@@ -128,7 +123,6 @@ class TestTrueDiv(Dy2StTestBase):
         y = paddle.to_tensor([4], dtype='int64')
         return paddle.jit.to_static(true_div)(x, y).numpy()
 
-    @test_legacy_and_pt_and_pir
     def test_true_div(self):
         paddle.disable_static()
         with enable_to_static_guard(False):

--- a/test/dygraph_to_static/test_tensor_shape.py
+++ b/test/dygraph_to_static/test_tensor_shape.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
     test_pir_only,
     test_pt_only,
 )
@@ -290,7 +289,6 @@ class TestTensorShapeBasic(Dy2StTestBase):
     def get_static_output(self):
         return self._run(to_static=True)
 
-    @test_legacy_and_pt_and_pir
     def test_transformed_static_result(self):
         static_res = self.get_static_output()
         dygraph_res = self.get_dygraph_output()
@@ -795,7 +793,6 @@ def dyfunc_with_static_convert_var_shape(x):
 
 class TestFindStatiConvertVarShapeSuffixVar(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test(self):
         x_spec = paddle.static.InputSpec(shape=[None, 10])
         func = paddle.jit.to_static(

--- a/test/dygraph_to_static/test_to_tensor.py
+++ b/test/dygraph_to_static/test_to_tensor.py
@@ -18,7 +18,6 @@ import numpy
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -156,7 +155,6 @@ class TestToTensorReturnVal(Dy2StTestBase):
         self.assertTrue(a.stop_gradient == b.stop_gradient)
         self.assertTrue(a.place._equals(b.place))
 
-    @test_legacy_and_pt_and_pir
     def test_to_tensor_default_dtype(self):
         a = paddle.jit.to_static(case_to_tensor_default_dtype)()
         b = case_to_tensor_default_dtype()
@@ -164,7 +162,6 @@ class TestToTensorReturnVal(Dy2StTestBase):
         self.assertTrue(a.stop_gradient == b.stop_gradient)
         self.assertTrue(a.place._equals(b.place))
 
-    @test_legacy_and_pt_and_pir
     def test_to_tensor_err_log(self):
         paddle.disable_static()
         x = paddle.to_tensor([3])
@@ -178,7 +175,6 @@ class TestToTensorReturnVal(Dy2StTestBase):
 
 
 class TestStatic(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_static(self):
         paddle.enable_static()
         main_prog = paddle.static.Program()
@@ -209,7 +205,6 @@ class TestStatic(Dy2StTestBase):
 
 
 class TestInt16(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_static(self):
         paddle.enable_static()
         data = np.array([1, 2], dtype="int16")
@@ -221,7 +216,6 @@ class TestInt16(Dy2StTestBase):
 
 
 class TestNestedListWithTensor(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_nested_list_with_tensor(self):
         paddle.enable_static()
         x = paddle.to_tensor(1)

--- a/test/dygraph_to_static/test_typehint.py
+++ b/test/dygraph_to_static/test_typehint.py
@@ -18,7 +18,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -76,7 +75,6 @@ class TestTypeHints(Dy2StTestBase):
         else:
             return ret
 
-    @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
         static_numpy = self._run_static()
         dygraph_numpy = self._run_dygraph()
@@ -91,13 +89,11 @@ class TestAnnAssign(Dy2StTestBase):
         dygraph_res = dygraph_fn(x)
         np.testing.assert_allclose(dygraph_res, static_res, rtol=1e-05)
 
-    @test_legacy_and_pt_and_pir
     def test_ann_assign_with_value(self):
         self.assert_fn_dygraph_and_static_unified(
             fn_annotation_assign_with_value, paddle.to_tensor(1)
         )
 
-    @test_legacy_and_pt_and_pir
     def test_ann_assign_without_value(self):
         self.assert_fn_dygraph_and_static_unified(
             fn_annotation_assign_without_value, paddle.to_tensor(1)

--- a/test/dygraph_to_static/test_unuseful_inputs.py
+++ b/test/dygraph_to_static/test_unuseful_inputs.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -65,7 +64,6 @@ class Layer1(nn.Layer):
 
 
 class TestDuplicateOutput(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_case(self):
         # create network
         layer = Layer0(0)

--- a/test/dygraph_to_static/test_word2vec.py
+++ b/test/dygraph_to_static/test_word2vec.py
@@ -20,7 +20,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -320,7 +319,6 @@ def train():
 
 
 class TestWord2Vec(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
     def test_dygraph_static_same_loss(self):
         with enable_to_static_guard(False):
             dygraph_loss = train()

--- a/test/dygraph_to_static/test_write_python_container.py
+++ b/test/dygraph_to_static/test_write_python_container.py
@@ -17,7 +17,6 @@ import unittest
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
     test_sot_only,
 )
 
@@ -118,7 +117,6 @@ class TestWriteContainer(Dy2StTestBase):
         return out
 
     @test_sot_only
-    @test_legacy_and_pt_and_pir
     def test_write_container_sot(self):
         func_static = paddle.jit.to_static(self.func)
         input = paddle.to_tensor([1, 2, 3])
@@ -127,7 +125,6 @@ class TestWriteContainer(Dy2StTestBase):
         self.assertEqual(out_static, out_dygraph)
 
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_write_container(self):
         func_static = paddle.jit.to_static(self.func)
         input = paddle.to_tensor([1, 2, 3])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

既 #68229 之后，清理现存的 `test_legacy_and_pt_and_pir`，默认为 `test_pt_and_pir`，即移除 SOT+LEGACY_IR 和 AST+LEGACY_IR 这两种纯老 IR 的 case，减少 CI 时间，本 PR 为 part4

Pcard-67164