### PR TITLE
[Infra] Add `.env` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ CMakeSettings.json
 Makefile
 .test_env/
 .cache/
+.env
 third_party/
 *~
 bazel-*


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

将 `.env` 添加到 `.gitignore`，方便直接在 `.env` 添加 `PYTHONPATH=python`，以做到源码层面的类型提示（之前都是写一个 `.env~`，然后 VSCode 再配置下，太麻烦了）

Pcard-67164