### PR TITLE
[inference] forbid conv+add fuse when data format is NHWC(cuDNN Backend)

### DIFF
--- a/paddle/fluid/pir/transforms/gpu/conv2d_add_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/conv2d_add_fuse_pass.cc
@@ -84,8 +84,7 @@ class Conv2dAddFusePattern : public paddle::drr::DrrPatternBase {
           return false;
         }
         auto data_format = match_ctx.Attr<std::string>("data_format");
-        if (data_format != "NCHW" && data_format != "AnyLayout" &&
-            data_format != "NHWC") {
+        if (data_format != "NCHW" && data_format != "AnyLayout") {
           return false;
         }
       } else {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
inference


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
forbid conv+add fuse when data format is NHWC

Pcard-71500