### PR TITLE
[Auto Parallel] no need to slice scalar tensor

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/converter.py
+++ b/python/paddle/distributed/auto_parallel/static/converter.py
@@ -310,6 +310,9 @@ class Converter:
     def slice_with_dist_attr(tensor, dist_attr):
         """Slice tensor with distributed attribute"""
         dims_mapping = dist_attr["dims_mapping"]
+        if len(dims_mapping) == 0:
+            # NOTE: scalar tensor no need to split
+            return tensor
         process_shape = dist_attr["process_shape"]
         process_group = dist_attr["process_group"]
         # slice the tensor with dist_attr


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
对于scalar的parameter无需进行切分
Pcard-73145