### PR TITLE
[PIR]Fix pruning for saveload and backward

### DIFF
--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -390,6 +390,19 @@ def get_real_op_inputs(op):
         return op.operands_source()
 
 
+def get_real_op_outputs(op):
+    outputs = op.results()
+    if op.name() == "pd_op.array_write_":
+        for x in op.operands():
+            outputs.append(x.source())
+    if op.name() == "pd_op.while":
+        for internal_op in op.as_while_op().body().ops:
+            if internal_op.name() == "pd_op.array_write_":
+                for x in internal_op.operands():
+                    outputs.append(x.source())
+    return outputs
+
+
 def inverse_sort_op(old_ops):
     '''
     if topo graph is op1 -> op2 -> op3

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -32,6 +32,7 @@ from paddle.autograd.backward_utils import (
     dynamic_shape_prim_vjp_guard,
     get_grad_semantic_info,
     get_real_op_inputs,
+    get_real_op_outputs,
     get_split_op,
     inverse_sort_op,
     is_builtin_op,
@@ -260,13 +261,13 @@ def prune_ops(total_ops, inputs_set, outputs_set, no_grad_set):
     # from input to output
     if inputs_set:
         for i, op in enumerate(total_ops):
-            if some_in_set(op.results(), inputs_set):
+            if some_in_set(get_real_op_outputs(op), inputs_set):
                 union_op_flags[i] = True
                 continue
 
             if some_in_set(get_real_op_inputs(op), inputs_set):
                 union_op_flags[i] = True
-                for value in op.results():
+                for value in get_real_op_outputs(op):
                     if value not in no_grad_set:
                         inputs_set.add(value)
             else:
@@ -274,7 +275,7 @@ def prune_ops(total_ops, inputs_set, outputs_set, no_grad_set):
 
     # from output to input
     for i, op in reversed(list(enumerate(total_ops))):
-        if some_in_set(op.results(), outputs_set):
+        if some_in_set(get_real_op_outputs(op), outputs_set):
             union_op_flags[i] = True
             for operand in get_real_op_inputs(op):
                 if operand not in no_grad_set:

--- a/python/paddle/static/pir_io.py
+++ b/python/paddle/static/pir_io.py
@@ -27,6 +27,7 @@ from paddle import pir
 from paddle.autograd.backward_utils import (
     ValueSet,
     get_real_op_inputs,
+    get_real_op_outputs,
     some_in_set,
 )
 from paddle.base import (
@@ -175,7 +176,7 @@ def pir_prune_with_input(program, feed_vars, target_vars):
     # from output to input
     target_vars_ = ValueSet(target_vars)
     for i, op in reversed(list(enumerate(total_ops))):
-        if some_in_set(op.results(), target_vars_):
+        if some_in_set(get_real_op_outputs(op), target_vars_):
             for operand in get_real_op_inputs(op):
                 target_vars_.add(operand)
         else:
@@ -183,7 +184,7 @@ def pir_prune_with_input(program, feed_vars, target_vars):
 
     for i, op in reversed(list(enumerate(total_ops))):
         if not intersection_op_flags[i]:
-            if some_in_set(op.results(), ValueSet(feed_vars)):
+            if some_in_set(get_real_op_outputs(op), ValueSet(feed_vars)):
                 raise ValueError(
                     f"The feed_var create by: '{op.name()}' is not involved in the target_vars calculation"
                     f"Please remove it from feed_vars ."


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
saveload和backward之前的剪枝逻辑会跳过控制流while op，且array_write op由于是inplace算子，也会被跳过。
修改剪枝逻辑，对于array_write op以及while op中的array_write op保留其输入输出。