### PR TITLE
fix sharding offload strategy bug

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_utils.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_utils.py
@@ -259,6 +259,11 @@ def GroupShardedScaler(scaler):
                         else:
                             param_grads_fp32.append(tgt_grad)
         else:
+            # inf found when step == 1
+            if optimizer.offload and len(optimizer._optim._parameter_list) > 1:
+                params_list = [optimizer.offload_params.buffer]
+                optimizer._optim._parameter_list = params_list
+                optimizer._optim._param_groups = params_list
             for param in optimizer._optim._parameter_list:
                 tgt_grad = None
                 if hasattr(param, "main_grad") and param.main_grad is not None:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
修复 sharding offload 机制下，第一个 step 出现 nan 值无法检测到的问题
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
bug 修复

### Description
<!-- Describe what you’ve done -->
开启 sharding offload 模式时，optimizer 里会有两份参数，一份存在 gpu 里，一份存在cpu 上，cpu 上的动量参数会在 optimizer 第一次调用 step 的时候替换掉 gpu 动量参数，参考：
https://github.com/PaddlePaddle/Paddle/blob/6f48ed6e85bba5c0045ddf82d73120b10b69213a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_optimizer_stage2.py#L564C1-L570C56
而 GradScaler 的 inf/nan 检测发生在optimizer 第一次 step 之前，参考：
https://github.com/PaddlePaddle/Paddle/blob/6f48ed6e85bba5c0045ddf82d73120b10b69213a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_utils.py#L293
这就导致 step == 1 时的 inf/nan 检测无法正确获取到 offload 的 cpu 参数，导致此处inf/nan检测值恒为 False。
https://github.com/PaddlePaddle/Paddle/blob/6f48ed6e85bba5c0045ddf82d73120b10b69213a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_utils.py#L329
这样在第一次更新出现 inf/nan 的情况下无法拦截更新操作，导致训练崩溃
![8e6e55cfff7df96731d37c7e1b0daa08](https://github.com/user-attachments/assets/445b2a7a-48ae-42cd-ba2d-1ae64d2bd752)
现在的解决方法是，在GradScaler里检测到 step==1，且开启了 offload 的情况下，手动将optimizer._optim._parameter_list更改为 cpu 版本的参数。
更改后训练可以正常检测 inf/nan 并拦截更新
![image](https://github.com/user-attachments/assets/43898ab9-45fd-4ccb-8d61-58c5b160bbb5)
