### PR TITLE
[SOT] Enable dynamic shape as default in PIR mode

### DIFF
--- a/python/paddle/jit/sot/utils/envs.py
+++ b/python/paddle/jit/sot/utils/envs.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 
+import paddle
 from paddle.utils.environments import (
     BooleanEnvironmentVariable,
     EnvironmentVariableGuard,
@@ -33,7 +34,9 @@ ENV_SOT_WITH_CONTROL_FLOW = BooleanEnvironmentVariable(
 )
 ENV_SOT_EXPORT = StringEnvironmentVariable("SOT_EXPORT", "")
 ENV_SOT_ALLOW_DYNAMIC_SHAPE = BooleanEnvironmentVariable(
-    "SOT_ALLOW_DYNAMIC_SHAPE", False
+    "SOT_ALLOW_DYNAMIC_SHAPE",
+    # Enable SOT dynamic shape as default in PIR mode only
+    paddle.framework.use_pir_api(),
 )
 ENV_SOT_EVENT_LEVEL = IntegerEnvironmentVariable("SOT_EVENT_LEVEL", 0)
 ENV_ENABLE_SOT_STEP_PROFILER = BooleanEnvironmentVariable(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

在 PIR 下默认开启 SOT 动态 shape，之前在 #64919 开启过，因为有一个机制未完善 revert 掉了

PCard-66972