### PR TITLE
[Paddle TensorRT] add pd_op.slice converter

### DIFF
--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -642,16 +642,35 @@ class SliceOpPattern : public pir::OpRewritePattern<paddle::dialect::SliceOp> {
     for (const auto &attr : axes_attr.AsVector()) {
       axes.push_back(attr.dyn_cast<pir::Int64Attribute>().data());
     }
-    pir::Value input = op.operand_source(0);
 
-    auto inputs = input.type().dyn_cast<paddle::dialect::DenseTensorType>();
-    auto inputs_shape = inputs.dims();
-    if (axes.size() !=
-        static_cast<std::vector<int64_t>::size_type>(inputs_shape.size())) {
-      VLOG(3) << "The shape of attributes of the slice operator axes "
-                 "and starts are not equal.";
+    paddle::dialect::FullIntArrayOp full_int_array_op_start =
+        pir::GetDefiningOpForInput(op, 1)
+            ->dyn_cast<paddle::dialect::FullIntArrayOp>();
+    auto starts_attr =
+        full_int_array_op_start->attribute<pir::ArrayAttribute>("value");
+    std::vector<int64_t> starts;
+    for (const auto &attr : starts_attr.AsVector()) {
+      starts.push_back(attr.dyn_cast<pir::Int64Attribute>().data());
+    }
+    paddle::dialect::FullIntArrayOp full_int_array_op_end =
+        pir::GetDefiningOpForInput(op, 2)
+            ->dyn_cast<paddle::dialect::FullIntArrayOp>();
+
+    auto ends_attr =
+        full_int_array_op_end->attribute<pir::ArrayAttribute>("value");
+    std::vector<int64_t> ends;
+    for (const auto &attr : ends_attr.AsVector()) {
+      ends.push_back(attr.dyn_cast<pir::Int64Attribute>().data());
+    }
+
+    if (axes.size() != starts.size() || axes.size() != ends.size()) {
+      VLOG(3) << "The size of axes and starts are not equal. "
+                 "Axes size: "
+              << axes.size() << ", Starts size: " << starts.size()
+              << ", Ends size: " << ends.size();
       return false;
     }
+
     op->set_attribute(kCanRunTrtAttr, rewriter.bool_attr(true));
     return true;
   }

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -215,6 +215,15 @@ def slice_converter(network, paddle_op, inputs):
 
     axes = paddle_op.attrs()["axes"]
     decrease_axis = paddle_op.attrs().get("decrease_axis")
+    
+    starts_op =paddle_op.operands()[1].source().get_defining_op()
+    ends_op =paddle_op.operands()[2].source().get_defining_op()
+    if starts_op.name() =="pd_op.full_int_array":
+        starts=starts_op.attrs()["value"]
+    else:
+        starts=inputs[1]
+        ends=inputs[2]
+        
     starts = paddle_op.operands()[1].source().get_defining_op().attrs()["value"]
     ends = paddle_op.operands()[2].source().get_defining_op().attrs()["value"]
 

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import numpy as np
 import tensorrt as trt
 
 from paddle.tensorrt.converter_utils import (
@@ -205,3 +206,115 @@ def squeeze_converter(network, paddle_op, inputs):
     layer = network.add_shuffle(input_val)
     layer.reshape_dims = tuple(output_shape)
     return layer.get_output(0)
+
+
+@converter_registry.register("pd_op.slice", trt_version="8.x")
+def slice_converter(network, paddle_op, inputs):
+    input_tensor = inputs[0]
+    input_shape = paddle_op.operands()[0].source().shape
+
+    axes = paddle_op.attrs()["axes"]
+    decrease_axis = paddle_op.attrs().get("decrease_axis")
+    starts = paddle_op.operands()[1].source().get_defining_op().attrs()["value"]
+    ends = paddle_op.operands()[2].source().get_defining_op().attrs()["value"]
+
+    input_shape_tensor = network.add_shape(input_tensor).get_output(0)
+    input_rank = len(input_tensor.shape)
+
+    # Create start, size, stride tensors
+    start = []
+    size = []
+    stride = [1] * input_rank  # Default to 1
+
+    for i in range(input_rank):
+        if i in axes:
+            idx = axes.index(i)
+            start_idx = starts[idx]
+            end_idx = ends[idx]
+
+            # Get the size of the current dimension
+            dim_size = network.add_slice(
+                input_shape_tensor, [i], [1], [1]
+            ).get_output(0)
+
+            if start_idx < 0:
+                start_i = network.add_elementwise(
+                    dim_size,
+                    network.add_constant(
+                        [1], np.array([start_idx], dtype=np.int32)
+                    ).get_output(0),
+                    trt.ElementWiseOperation.SUM,
+                ).get_output(0)
+            else:
+                start_i = network.add_constant(
+                    [1], np.array([start_idx], dtype=np.int32)
+                ).get_output(0)
+
+            if end_idx < 0:
+                end_i = network.add_elementwise(
+                    dim_size,
+                    network.add_constant(
+                        [1], np.array([end_idx], dtype=np.int32)
+                    ).get_output(0),
+                    trt.ElementWiseOperation.SUM,
+                ).get_output(0)
+            else:
+                end_i = network.add_constant(
+                    [1], np.array([end_idx], dtype=np.int32)
+                ).get_output(0)
+
+            size_i = network.add_elementwise(
+                end_i, start_i, trt.ElementWiseOperation.SUB
+            ).get_output(0)
+            start.append(start_i)
+            size.append(size_i)
+        else:
+            # For unsliced dimensions, start is 0 and size is the dimension's size
+            start.append(
+                network.add_constant(
+                    [1], np.array([0], dtype=np.int32)
+                ).get_output(0)
+            )
+            size.append(
+                network.add_slice(input_shape_tensor, [i], [1], [1]).get_output(
+                    0
+                )
+            )
+
+    start_tensor = network.add_concatenation(start)
+    start_tensor.axis = 0
+    size_tensor = network.add_concatenation(size)
+    size_tensor.axis = 0
+
+    # Create Slice layer
+    slice_layer = network.add_slice(
+        input_tensor, [0] * input_rank, [0] * input_rank, [1] * input_rank
+    )
+    slice_layer.set_input(1, start_tensor.get_output(0))
+    slice_layer.set_input(2, size_tensor.get_output(0))
+
+    output_tensor = slice_layer.get_output(0)
+
+    # Handle decrease_axis
+    if decrease_axis:
+        output_shape = network.add_shape(output_tensor).get_output(0)
+        new_shape_dims = []
+        for i in range(output_shape.shape[0]):
+            if i not in decrease_axis:
+                dim = network.add_slice(output_shape, [i], [1], [1]).get_output(
+                    0
+                )
+                new_shape_dims.append(dim)
+        if len(new_shape_dims) == 0:
+            new_shape_tensor = network.add_constant(
+                [1], np.array([1], dtype=np.int32)
+            )
+        else:
+            new_shape_tensor = network.add_concatenation(new_shape_dims)
+            new_shape_tensor.axis = 0
+
+        reshape_layer = network.add_shuffle(output_tensor)
+        reshape_layer.set_input(1, new_shape_tensor.get_output(0))
+        output_tensor = reshape_layer.get_output(0)
+
+    return output_tensor

--- a/test/tensorrt/test_converter_manipulation.py
+++ b/test/tensorrt/test_converter_manipulation.py
@@ -55,5 +55,22 @@ class TestFlattenTRTPattern(TensorRTBaseTest):
         self.check_trt_result()
 
 
+class TestSliceTRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.slice
+        self.api_args = {
+            "x": np.random.random([6, 6, 64, 64]).astype("float32"),
+            "axes": [0, 1],
+            "starts": [0, 1],
+            "ends": [2, 2],
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [2, 6, 64, 64]}
+        self.max_shape = {"x": [8, 6, 64, 64]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/tensorrt/test_converter_manipulation.py
+++ b/test/tensorrt/test_converter_manipulation.py
@@ -18,6 +18,7 @@ import numpy as np
 from tensorrt_test_base import TensorRTBaseTest
 
 import paddle
+from paddle import _C_ops
 
 
 class TestConcatTRTPattern(TensorRTBaseTest):
@@ -55,14 +56,37 @@ class TestFlattenTRTPattern(TensorRTBaseTest):
         self.check_trt_result()
 
 
+def slice_python_api(x, axes, starts, ends, infer_flags, decrease_axis):
+    return _C_ops.slice(x, axes, starts, ends, infer_flags, decrease_axis)
+
+
 class TestSliceTRTPattern(TensorRTBaseTest):
     def setUp(self):
-        self.python_api = paddle.slice
+        self.python_api = slice_python_api
         self.api_args = {
             "x": np.random.random([6, 6, 64, 64]).astype("float32"),
             "axes": [0, 1],
             "starts": [0, 1],
             "ends": [2, 2],
+            "infer_flags": [1, 1],
+            "decrease_axis": [1],
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [2, 6, 64, 64]}
+        self.max_shape = {"x": [8, 6, 64, 64]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
+class TestSlice1TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.slice
+        self.api_args = {
+            "x": np.random.random([6, 6, 64, 64]).astype("float32"),
+            "axes": [0, 1],
+            "starts": [-2, -3],
+            "ends": [-1, -1],
         }
         self.program_config = {"feed_list": ["x"]}
         self.min_shape = {"x": [2, 6, 64, 64]}

--- a/test/tensorrt/test_trt_marker_slice.py
+++ b/test/tensorrt/test_trt_marker_slice.py
@@ -35,9 +35,9 @@ class TestSliceTRTPattern(PassTest):
                 )
 
                 # Convert starts and ends to tensors
-                axes = [0, 1, 2]
-                starts = [-3, 0, 2]
-                ends = [3, 2, 4]
+                axes = [0, 1]
+                starts = [0, 2]
+                ends = [2, 4]
 
                 sliced_1 = paddle.slice(x, axes=axes, starts=starts, ends=ends)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
card-71500
修改pd_op.slice的Marker以及marker单测，添加了pd_op.slice的converter，以及适配了了convert_to_trt的warmup_shape_infer多输入的场景