### PR TITLE
Eliminating redundancy memcpy for shadow feed

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
@@ -103,15 +103,15 @@ void GroupOp::VerifySig() {}
 void GroupOp::Print(pir::IrPrinter& printer) {
   auto& os = printer.os;
   auto op = operation();
-  printer.PrintOpResult(op);
+  printer.PrintOpResult(*op);
   os << " = \"" << name() << "\" [id:" << op->id() << "]";
-  printer.PrintOpOperands(op);
+  printer.PrintOpOperands(*op);
   os << " -> ";
-  printer.PrintOpReturnType(op);
+  printer.PrintOpReturnType(*op);
   os << " {\n";
   printer.AddIndentation();
   for (auto& sub_op : GetOperators()) {
-    printer.PrintOperation(sub_op);
+    printer.PrintOperation(*sub_op);
     os << "\n";
   }
   printer.DecreaseIndentation();
@@ -187,15 +187,15 @@ void FusionOp::VerifySig() {}
 void FusionOp::Print(pir::IrPrinter& printer) {
   auto& os = printer.os;
   auto op = operation();
-  printer.PrintOpResult(op);
+  printer.PrintOpResult(*op);
   os << " = \"" << name() << "\" [id:" << op->id() << "]";
-  printer.PrintOpOperands(op);
+  printer.PrintOpOperands(*op);
   os << " -> ";
-  printer.PrintOpReturnType(op);
+  printer.PrintOpReturnType(*op);
   os << " {\n";
   printer.AddIndentation();
   for (auto& sub_op : GetOperators()) {
-    printer.PrintOperation(sub_op);
+    printer.PrintOperation(*sub_op);
     os << "\n";
   }
   printer.DecreaseIndentation();

--- a/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
@@ -91,7 +91,7 @@ void OperatorDialect::PrintAttribute(pir::Attribute attr,
   }
 }
 
-pir::OpPrintFn OperatorDialect::PrintOperation(pir::Operation *op) const {
+pir::OpPrintFn OperatorDialect::PrintOperation(const pir::Operation &op) const {
   if (auto group_op = op->dyn_cast<GroupOp>()) {
     return [](pir::Operation *op, pir::IrPrinter &printer) {
       auto group_op = op->dyn_cast<GroupOp>();

--- a/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
@@ -92,14 +92,14 @@ void OperatorDialect::PrintAttribute(pir::Attribute attr,
 }
 
 pir::OpPrintFn OperatorDialect::PrintOperation(const pir::Operation &op) const {
-  if (auto group_op = op->dyn_cast<GroupOp>()) {
-    return [](pir::Operation *op, pir::IrPrinter &printer) {
-      auto group_op = op->dyn_cast<GroupOp>();
+  if (auto group_op = op.dyn_cast<GroupOp>()) {
+    return [](const pir::Operation &op, pir::IrPrinter &printer) {
+      auto group_op = op.dyn_cast<GroupOp>();
       group_op.Print(printer);
     };
-  } else if (auto fusion_op = op->dyn_cast<FusionOp>()) {
-    return [](pir::Operation *op, pir::IrPrinter &printer) {
-      auto fusion_op = op->dyn_cast<FusionOp>();
+  } else if (auto fusion_op = op.dyn_cast<FusionOp>()) {
+    return [](const pir::Operation &op, pir::IrPrinter &printer) {
+      auto fusion_op = op.dyn_cast<FusionOp>();
       fusion_op.Print(printer);
     };
   }

--- a/paddle/cinn/hlir/dialect/operator/ir/op_dialect.h
+++ b/paddle/cinn/hlir/dialect/operator/ir/op_dialect.h
@@ -27,7 +27,8 @@ class OperatorDialect : public ::pir::Dialect {
 
   void PrintType(pir::Type type, std::ostream& os) const override;
   void PrintAttribute(pir::Attribute type, std::ostream& os) const override;
-  pir::OpPrintFn PrintOperation(pir::Operation* op) const override;  // NOLINT
+  pir::OpPrintFn PrintOperation(
+      const pir::Operation& op) const override;  // NOLINT
 
  private:
   void initialize();

--- a/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
@@ -170,7 +170,7 @@ std::ostream& operator<<(std::ostream& os, const OpLoweringGroup& group) {
   os << "Group id: " << group.group_id() << ", func_name: " << group.FuncName()
      << "\n";
   for (auto* op : group.ops()) {
-    printer.PrintOperation(op);
+    printer.PrintOperation(*op);
     PrintSymbolDims(*op);
     os << "\n";
   }

--- a/paddle/cinn/operator_fusion/pattern_node.h
+++ b/paddle/cinn/operator_fusion/pattern_node.h
@@ -66,7 +66,7 @@ struct PatternNode {
       ss << "\n anchor: ";
       auto anchor_op =
           std::get<AnchorPattern>(stmt_pattern_).anchor().defining_op();
-      printer.PrintOperation(const_cast<pir::Operation*>(anchor_op));
+      printer.PrintOperation(*anchor_op);
     }
     ss << "\nOps in pattern:" << std::endl;
     ss << OpsDebugStr(GetOpsInPattern(this->stmt_pattern()));

--- a/paddle/cinn/operator_fusion/utils.h
+++ b/paddle/cinn/operator_fusion/utils.h
@@ -89,7 +89,7 @@ static std::string OpsDebugStr(std::vector<pir::Operation*> ops) {
   std::stringstream ss;
   pir::IrPrinter printer(ss);
   for (const auto* op : ops) {
-    printer.PrintOperation(const_cast<pir::Operation*>(op));
+    printer.PrintOperation(*op);
     ss << "(" << op << ")"
        << "\n";
   }

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
@@ -119,7 +119,7 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
   }
 }
 
-pir::OpPrintFn DistDialect::PrintOperation(pir::Operation *op) const {
+pir::OpPrintFn DistDialect::PrintOperation(const pir::Operation &op) const {
   return nullptr;
 }
 

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.h
@@ -29,7 +29,8 @@ class DistDialect : public pir::Dialect {
 
   void PrintAttribute(pir::Attribute attr, std::ostream& os) const override;
 
-  pir::OpPrintFn PrintOperation(pir::Operation* op) const override;  // NOLINT
+  pir::OpPrintFn PrintOperation(
+      const pir::Operation& op) const override;  // NOLINT
 
  private:
   void initialize();

--- a/paddle/fluid/pir/dialect/kernel/ir/kernel_dialect.cc
+++ b/paddle/fluid/pir/dialect/kernel/ir/kernel_dialect.cc
@@ -112,16 +112,16 @@ void KernelDialect::PrintAttribute(pir::Attribute attr,
   PrintKernelAttribute(attr, os);
 }
 
-pir::OpPrintFn KernelDialect::PrintOperation(pir::Operation *op) const {
-  if (op->dyn_cast<PhiKernelOp>() || op->dyn_cast<LegacyKernelOp>()) {
-    return [](pir::Operation *op, pir::IrPrinter &printer) {
+pir::OpPrintFn KernelDialect::PrintOperation(const pir::Operation &op) const {
+  if (op.dyn_cast<PhiKernelOp>() || op.dyn_cast<LegacyKernelOp>()) {
+    return [](const pir::Operation &op, pir::IrPrinter &printer) {
       auto &os = printer.os;
       printer.PrintOpResult(op);
       os << " =";
-      if (auto phi_kernel_op = op->dyn_cast<PhiKernelOp>()) {
+      if (auto phi_kernel_op = op.dyn_cast<PhiKernelOp>()) {
         std::string kernel_name = phi_kernel_op.kernel_name();
-        if (op->attributes().count("is_inplace") != 0 &&
-            op->attributes()
+        if (op.attributes().count("is_inplace") != 0 &&
+            op.attributes()
                 .at("is_inplace")
                 .dyn_cast<pir::BoolAttribute>()
                 .data()) {
@@ -129,10 +129,10 @@ pir::OpPrintFn KernelDialect::PrintOperation(pir::Operation *op) const {
         }
         os << " \"" << kernel_name << "(phi_kernel)\"";
       } else {
-        auto legacy_kernel_op = op->dyn_cast<LegacyKernelOp>();
+        auto legacy_kernel_op = op.dyn_cast<LegacyKernelOp>();
         std::string kernel_name = legacy_kernel_op.kernel_name();
-        if (op->attributes().count("is_inplace") != 0 &&
-            op->attributes()
+        if (op.attributes().count("is_inplace") != 0 &&
+            op.attributes()
                 .at("is_inplace")
                 .dyn_cast<pir::BoolAttribute>()
                 .data()) {
@@ -169,15 +169,16 @@ void CustomKernelDialect::PrintAttribute(pir::Attribute attr,
   PrintKernelAttribute(attr, os);
 }
 
-pir::OpPrintFn CustomKernelDialect::PrintOperation(pir::Operation *op) const {
-  return [](pir::Operation *op, pir::IrPrinter &printer) {
+pir::OpPrintFn CustomKernelDialect::PrintOperation(
+    const pir::Operation &op) const {
+  return [](const pir::Operation &op, pir::IrPrinter &printer) {
     auto &os = printer.os;
     printer.PrintOpResult(op);
     os << " =";
-    auto custom_kernel_op = op->dyn_cast<CustomKernelOp>();
+    auto custom_kernel_op = op.dyn_cast<CustomKernelOp>();
     std::string kernel_name = custom_kernel_op.kernel_name();
-    if (op->attributes().count("is_inplace") != 0 &&
-        op->attributes()
+    if (op.attributes().count("is_inplace") != 0 &&
+        op.attributes()
             .at("is_inplace")
             .dyn_cast<pir::BoolAttribute>()
             .data()) {
@@ -213,16 +214,19 @@ void OneDNNKernelDialect::PrintAttribute(pir::Attribute attr,
   PrintKernelAttribute(attr, os);
 }
 
-pir::OpPrintFn OneDNNKernelDialect::PrintOperation(pir::Operation *op) const {
-  if (op->dyn_cast<PhiKernelOp>() || op->dyn_cast<LegacyKernelOp>()) {
-    return [](pir::Operation *op, pir::IrPrinter &printer) {
+pir::OpPrintFn OneDNNKernelDialect::PrintOperation(
+    const pir::Operation &op) const {
+  if (const_cast<pir::Operation *>(op)->dyn_cast<PhiKernelOp>() ||
+      const_cast<pir::Operation *>(op)->dyn_cast<LegacyKernelOp>()) {
+    return [](const pir::Operation &op, pir::IrPrinter &printer) {
       auto &os = printer.os;
       printer.PrintOpResult(op);
       os << " =";
-      if (auto phi_kernel_op = op->dyn_cast<PhiKernelOp>()) {
+      if (auto phi_kernel_op =
+              const_cast<pir::Operation *>(op)->dyn_cast<PhiKernelOp>()) {
         std::string kernel_name = phi_kernel_op.kernel_name();
-        if (op->attributes().count("is_inplace") != 0 &&
-            op->attributes()
+        if (op.attributes().count("is_inplace") != 0 &&
+            op.attributes()
                 .at("is_inplace")
                 .dyn_cast<pir::BoolAttribute>()
                 .data()) {
@@ -232,8 +236,8 @@ pir::OpPrintFn OneDNNKernelDialect::PrintOperation(pir::Operation *op) const {
       } else {
         auto legacy_kernel_op = op->dyn_cast<LegacyKernelOp>();
         std::string kernel_name = legacy_kernel_op.kernel_name();
-        if (op->attributes().count("is_inplace") != 0 &&
-            op->attributes()
+        if (op.attributes().count("is_inplace") != 0 &&
+            op.attributes()
                 .at("is_inplace")
                 .dyn_cast<pir::BoolAttribute>()
                 .data()) {

--- a/paddle/fluid/pir/dialect/kernel/ir/kernel_dialect.cc
+++ b/paddle/fluid/pir/dialect/kernel/ir/kernel_dialect.cc
@@ -232,7 +232,7 @@ pir::OpPrintFn OneDNNKernelDialect::PrintOperation(
         }
         os << " \"" << kernel_name << "(phi_kernel)\"";
       } else {
-        auto legacy_kernel_op = op->dyn_cast<LegacyKernelOp>();
+        auto legacy_kernel_op = op.dyn_cast<LegacyKernelOp>();
         std::string kernel_name = legacy_kernel_op.kernel_name();
         if (op.attributes().count("is_inplace") != 0 &&
             op.attributes()

--- a/paddle/fluid/pir/dialect/kernel/ir/kernel_dialect.cc
+++ b/paddle/fluid/pir/dialect/kernel/ir/kernel_dialect.cc
@@ -216,14 +216,12 @@ void OneDNNKernelDialect::PrintAttribute(pir::Attribute attr,
 
 pir::OpPrintFn OneDNNKernelDialect::PrintOperation(
     const pir::Operation &op) const {
-  if (const_cast<pir::Operation *>(op)->dyn_cast<PhiKernelOp>() ||
-      const_cast<pir::Operation *>(op)->dyn_cast<LegacyKernelOp>()) {
+  if (op.dyn_cast<PhiKernelOp>() || op.dyn_cast<LegacyKernelOp>()) {
     return [](const pir::Operation &op, pir::IrPrinter &printer) {
       auto &os = printer.os;
       printer.PrintOpResult(op);
       os << " =";
-      if (auto phi_kernel_op =
-              const_cast<pir::Operation *>(op)->dyn_cast<PhiKernelOp>()) {
+      if (auto phi_kernel_op = op.dyn_cast<PhiKernelOp>()) {
         std::string kernel_name = phi_kernel_op.kernel_name();
         if (op.attributes().count("is_inplace") != 0 &&
             op.attributes()

--- a/paddle/fluid/pir/dialect/kernel/ir/kernel_dialect.h
+++ b/paddle/fluid/pir/dialect/kernel/ir/kernel_dialect.h
@@ -29,7 +29,8 @@ class KernelDialect : public pir::Dialect {
 
   void PrintAttribute(pir::Attribute attr, std::ostream& os) const override;
 
-  pir::OpPrintFn PrintOperation(pir::Operation* op) const override;  // NOLINT
+  pir::OpPrintFn PrintOperation(
+      const pir::Operation& op) const override;  // NOLINT
 
  private:
   void initialize();
@@ -45,7 +46,8 @@ class CustomKernelDialect : public pir::Dialect {
 
   void PrintAttribute(pir::Attribute attr, std::ostream& os) const override;
 
-  pir::OpPrintFn PrintOperation(pir::Operation* op) const override;  // NOLINT
+  pir::OpPrintFn PrintOperation(
+      const pir::Operation& op) const override;  // NOLINT
 
  private:
   void initialize();
@@ -62,7 +64,8 @@ class OneDNNKernelDialect : public pir::Dialect {
 
   void PrintAttribute(pir::Attribute attr, std::ostream& os) const override;
 
-  pir::OpPrintFn PrintOperation(pir::Operation* op) const override;  // NOLINT
+  pir::OpPrintFn PrintOperation(
+      const pir::Operation& op) const override;  // NOLINT
 
  private:
   void initialize();

--- a/paddle/fluid/pir/dialect/operator/interface/decomp.h
+++ b/paddle/fluid/pir/dialect/operator/interface/decomp.h
@@ -35,7 +35,7 @@ class DecompInterface : public pir::OpInterfaceBase<DecompInterface> {
   };
 
   /// Constructor
-  DecompInterface(pir::Operation* op, Concept* impl)
+  DecompInterface(const pir::Operation* op, Concept* impl)
       : pir::OpInterfaceBase<DecompInterface>(op), impl_(impl) {}
 
   std::vector<std::vector<pir::Value>> Decomp(pir::Operation* op) {

--- a/paddle/fluid/pir/dialect/operator/interface/decomp_vjp.h
+++ b/paddle/fluid/pir/dialect/operator/interface/decomp_vjp.h
@@ -35,7 +35,7 @@ class DecompVjpInterface : public pir::OpInterfaceBase<DecompVjpInterface> {
   };
 
   /// Constructor
-  DecompVjpInterface(pir::Operation* op, Concept* impl)
+  DecompVjpInterface(const pir::Operation* op, Concept* impl)
       : pir::OpInterfaceBase<DecompVjpInterface>(op), impl_(impl) {}
 
   std::vector<std::vector<pir::Value>> DecompVjp(pir::Operation* op) {

--- a/paddle/fluid/pir/dialect/operator/interface/get_kernel_type_for_var.h
+++ b/paddle/fluid/pir/dialect/operator/interface/get_kernel_type_for_var.h
@@ -48,7 +48,7 @@ class GetKernelTypeForVarInterface
   };
 
   /// Constructor
-  GetKernelTypeForVarInterface(pir::Operation* op, Concept* impl)
+  GetKernelTypeForVarInterface(const pir::Operation* op, Concept* impl)
       : pir::OpInterfaceBase<GetKernelTypeForVarInterface>(op), impl_(impl) {}
 
   phi::DataType GetKernelTypeForVar(

--- a/paddle/fluid/pir/dialect/operator/interface/infermeta.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infermeta.h
@@ -47,7 +47,7 @@ class InferMetaInterface : public pir::OpInterfaceBase<InferMetaInterface> {
   };
 
   /// Constructor
-  InferMetaInterface(pir::Operation *op, Concept *impl)
+  InferMetaInterface(const pir::Operation *op, Concept *impl)
       : pir::OpInterfaceBase<InferMetaInterface>(op), impl_(impl) {}
 
   void InferMeta(phi::InferMetaContext *infer_meta) {

--- a/paddle/fluid/pir/dialect/operator/interface/layout_transformation.h
+++ b/paddle/fluid/pir/dialect/operator/interface/layout_transformation.h
@@ -86,7 +86,7 @@ class LayoutTransformationInterface
                   CanBeModifiedModel) {}
   };
 
-  LayoutTransformationInterface(pir::Operation* op, Concept* impl)
+  LayoutTransformationInterface(const pir::Operation* op, Concept* impl)
       : pir::OpInterfaceBase<LayoutTransformationInterface>(op), impl_(impl) {}
 
   common::DataLayout PreferLayout(pir::Operation* op) {

--- a/paddle/fluid/pir/dialect/operator/interface/op_yaml_info.h
+++ b/paddle/fluid/pir/dialect/operator/interface/op_yaml_info.h
@@ -43,7 +43,7 @@ class OpYamlInfoInterface : public pir::OpInterfaceBase<OpYamlInfoInterface> {
   };
 
   /// Constructor
-  OpYamlInfoInterface(pir::Operation* op, Concept* impl)
+  OpYamlInfoInterface(const pir::Operation* op, Concept* impl)
       : pir::OpInterfaceBase<OpYamlInfoInterface>(op), impl_(impl) {}
 
   OpInfoTuple GetOpInfo() { return impl_->get_op_info_(operation_->name()); }

--- a/paddle/fluid/pir/dialect/operator/interface/parse_kernel_key.h
+++ b/paddle/fluid/pir/dialect/operator/interface/parse_kernel_key.h
@@ -43,7 +43,7 @@ class ParseKernelKeyInterface
   };
 
   /// Constructor
-  ParseKernelKeyInterface(pir::Operation *op, Concept *impl)
+  ParseKernelKeyInterface(const pir::Operation *op, Concept *impl)
       : pir::OpInterfaceBase<ParseKernelKeyInterface>(op), impl_(impl) {}
 
   KernelKeyTuple ParseKernelKey(pir::Operation *op) {

--- a/paddle/fluid/pir/dialect/operator/interface/vjp.h
+++ b/paddle/fluid/pir/dialect/operator/interface/vjp.h
@@ -50,7 +50,7 @@ class VjpInterface : public pir::OpInterfaceBase<VjpInterface> {
   };
 
   /// Constructor
-  VjpInterface(pir::Operation* op, Concept* impl)
+  VjpInterface(const pir::Operation* op, Concept* impl)
       : pir::OpInterfaceBase<VjpInterface>(op), impl_(impl) {}
 
   std::vector<std::vector<pir::Value>> Vjp(

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -168,28 +168,28 @@ pir::Block &IfOp::false_block() {
 void IfOp::Print(pir::IrPrinter &printer) {
   auto &os = printer.os;
   auto op = operation();
-  printer.PrintOpResult(op);
+  printer.PrintOpResult(*op);
   os << " = \"" << name() << "\"";
 
   if (VLOG_IS_ON(1) || FLAGS_pir_debug) {
     os << " [id:" << op->id() << "]";
   }
 
-  printer.PrintOpOperands(op);
-  printer.PrintAttributeMap(op);
+  printer.PrintOpOperands(*op);
+  printer.PrintAttributeMap(*op);
   os << " -> ";
-  printer.PrintOpReturnType(op);
+  printer.PrintOpReturnType(*op);
   os << " {\n";
   printer.AddIndentation();
   for (auto &item : true_block()) {
-    printer.PrintOperation(&item);
+    printer.PrintOperation(item);
     os << "\n";
   }
   printer.DecreaseIndentation();
   os << printer.indentation() << "} else {\n";
   printer.AddIndentation();
   for (auto &item : false_block()) {
-    printer.PrintOperation(&item);
+    printer.PrintOperation(item);
     os << "\n";
   }
   printer.DecreaseIndentation();
@@ -426,7 +426,7 @@ pir::Value WhileOp::cond() { return (*this)->operand_source(0); }
 void WhileOp::Print(pir::IrPrinter &printer) {
   auto &os = printer.os;
   auto op = operation();
-  printer.PrintOpResult(op);
+  printer.PrintOpResult(*op);
   os << " = \"" << name() << "\"";
   if (VLOG_IS_ON(1) || FLAGS_pir_debug) {
     os << " [id:" << op->id() << "]";
@@ -450,7 +450,7 @@ void WhileOp::Print(pir::IrPrinter &printer) {
   os << "\n";
   printer.AddIndentation();
   for (auto &item : body()) {
-    printer.PrintOperation(&item);
+    printer.PrintOperation(item);
     os << "\n";
   }
   printer.DecreaseIndentation();

--- a/paddle/fluid/pir/dialect/operator/ir/manual_pylayer_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_pylayer_op.cc
@@ -118,21 +118,21 @@ pir::Block &PyLayerOp::forward_block() {
 void PyLayerOp::Print(pir::IrPrinter &printer) {
   auto &os = printer.os;
   auto op = operation();
-  printer.PrintOpResult(op);
+  printer.PrintOpResult(*op);
   os << " = pd_op.pylayer";
 
   if (VLOG_IS_ON(1) || FLAGS_pir_debug) {
     os << " [id:" << op->id() << "]";
   }
 
-  printer.PrintOpOperands(op);
-  printer.PrintAttributeMap(op);
+  printer.PrintOpOperands(*op);
+  printer.PrintAttributeMap(*op);
   os << " -> ";
-  printer.PrintOpReturnType(op);
+  printer.PrintOpReturnType(*op);
   os << "{";
   for (auto &item : forward_block()) {
     os << "\n  ";
-    printer.PrintOperation(&item);
+    printer.PrintOperation(item);
   }
   os << "\n }";
 }

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -326,13 +326,13 @@ void PrintAttributeImpl(pir::Attribute attr, std::ostream& os) {
   }
 }
 
-void PrintOperationImpl(pir::Operation* op,
+void PrintOperationImpl(const pir::Operation& op,
                         pir::IrPrinter& printer) {  // NOLINT
-  if (auto if_op = op->dyn_cast<IfOp>()) {
+  if (auto if_op = op.dyn_cast<IfOp>()) {
     if_op.Print(printer);
-  } else if (auto while_op = op->dyn_cast<WhileOp>()) {
+  } else if (auto while_op = op.dyn_cast<WhileOp>()) {
     while_op.Print(printer);
-  } else if (auto pylayer_op = op->dyn_cast<PyLayerOp>()) {
+  } else if (auto pylayer_op = op.dyn_cast<PyLayerOp>()) {
     pylayer_op.Print(printer);
   } else {
     printer.PrintGeneralOperation(op);
@@ -431,8 +431,8 @@ pir::Attribute OperatorDialect::ParseAttribute(
   }
 }
 
-pir::OpPrintFn OperatorDialect::PrintOperation(pir::Operation* op) const {
-  if (op->isa<IfOp>() || op->isa<WhileOp>() || op->isa<PyLayerOp>()) {
+pir::OpPrintFn OperatorDialect::PrintOperation(const pir::Operation& op) const {
+  if (op.isa<IfOp>() || op.isa<WhileOp>() || op.isa<PyLayerOp>()) {
     return PrintOperationImpl;
   }
   return nullptr;
@@ -1074,7 +1074,7 @@ void CustomOpDialect::PrintAttribute(pir::Attribute attr,
   PrintAttributeImpl(attr, os);
 }
 
-pir::OpPrintFn CustomOpDialect::PrintOperation(pir::Operation* op) const {
+pir::OpPrintFn CustomOpDialect::PrintOperation(const pir::Operation& op) const {
   return nullptr;
 }
 

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.h
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.h
@@ -34,7 +34,8 @@ class TEST_API OperatorDialect : public pir::Dialect {
   void PrintType(pir::Type type, std::ostream& os) const override;
   void PrintAttribute(pir::Attribute attr, std::ostream& os) const override;
 
-  pir::OpPrintFn PrintOperation(pir::Operation* op) const override;  // NOLINT
+  pir::OpPrintFn PrintOperation(
+      const pir::Operation& op) const override;  // NOLINT
 
  private:
   void initialize();
@@ -59,7 +60,8 @@ class CustomOpDialect : public pir::Dialect {
   void PrintType(pir::Type type, std::ostream& os) const override;
   void PrintAttribute(pir::Attribute type, std::ostream& os) const override;
 
-  pir::OpPrintFn PrintOperation(pir::Operation* op) const override;  // NOLINT
+  pir::OpPrintFn PrintOperation(
+      const pir::Operation& op) const override;  // NOLINT
 
   void RegisterCustomOp(const paddle::OpMetaInfo& op_meta);
 

--- a/paddle/fluid/pir/dialect/operator/ir/op_onednn_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_onednn_dialect.cc
@@ -129,7 +129,8 @@ pir::Attribute OneDNNOperatorDialect::ParseAttribute(
   }
 }
 
-pir::OpPrintFn OneDNNOperatorDialect::PrintOperation(pir::Operation *op) const {
+pir::OpPrintFn OneDNNOperatorDialect::PrintOperation(
+    const pir::Operation &op) const {
   if (auto if_op = op->dyn_cast<IfOp>()) {
     return [](pir::Operation *op, pir::IrPrinter &printer) {
       auto if_op = op->dyn_cast<IfOp>();

--- a/paddle/fluid/pir/dialect/operator/ir/op_onednn_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_onednn_dialect.cc
@@ -131,19 +131,19 @@ pir::Attribute OneDNNOperatorDialect::ParseAttribute(
 
 pir::OpPrintFn OneDNNOperatorDialect::PrintOperation(
     const pir::Operation &op) const {
-  if (auto if_op = op->dyn_cast<IfOp>()) {
+  if (auto if_op = op.dyn_cast<IfOp>()) {
     return [](pir::Operation *op, pir::IrPrinter &printer) {
-      auto if_op = op->dyn_cast<IfOp>();
+      auto if_op = op.dyn_cast<IfOp>();
       if_op.Print(printer);
     };
-  } else if (auto pylayer_op = op->dyn_cast<PyLayerOp>()) {
+  } else if (auto pylayer_op = op.dyn_cast<PyLayerOp>()) {
     return [](pir::Operation *op, pir::IrPrinter &printer) {
-      auto pylayer_op = op->dyn_cast<PyLayerOp>();
+      auto pylayer_op = op.dyn_cast<PyLayerOp>();
       pylayer_op.Print(printer);
     };
-  } else if (auto while_op = op->dyn_cast<WhileOp>()) {
+  } else if (auto while_op = op.dyn_cast<WhileOp>()) {
     return [](pir::Operation *op, pir::IrPrinter &printer) {
-      auto while_op = op->dyn_cast<WhileOp>();
+      auto while_op = op.dyn_cast<WhileOp>();
       while_op.Print(printer);
     };
   }

--- a/paddle/fluid/pir/dialect/operator/ir/op_onednn_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_onednn_dialect.cc
@@ -132,17 +132,17 @@ pir::Attribute OneDNNOperatorDialect::ParseAttribute(
 pir::OpPrintFn OneDNNOperatorDialect::PrintOperation(
     const pir::Operation &op) const {
   if (auto if_op = op.dyn_cast<IfOp>()) {
-    return [](pir::Operation *op, pir::IrPrinter &printer) {
+    return [](const pir::Operation &op, pir::IrPrinter &printer) {
       auto if_op = op.dyn_cast<IfOp>();
       if_op.Print(printer);
     };
   } else if (auto pylayer_op = op.dyn_cast<PyLayerOp>()) {
-    return [](pir::Operation *op, pir::IrPrinter &printer) {
+    return [](const pir::Operation &op, pir::IrPrinter &printer) {
       auto pylayer_op = op.dyn_cast<PyLayerOp>();
       pylayer_op.Print(printer);
     };
   } else if (auto while_op = op.dyn_cast<WhileOp>()) {
-    return [](pir::Operation *op, pir::IrPrinter &printer) {
+    return [](const pir::Operation &op, pir::IrPrinter &printer) {
       auto while_op = op.dyn_cast<WhileOp>();
       while_op.Print(printer);
     };

--- a/paddle/fluid/pir/dialect/operator/ir/op_onednn_dialect.h
+++ b/paddle/fluid/pir/dialect/operator/ir/op_onednn_dialect.h
@@ -30,7 +30,7 @@ class OneDNNOperatorDialect : public pir::Dialect {
   void PrintType(pir::Type type, std::ostream& os) const override;
   void PrintAttribute(pir::Attribute type, std::ostream& os) const override;
 
-  pir::OpPrintFn PrintOperation(pir::Operation* op) const override;
+  pir::OpPrintFn PrintOperation(const pir::Operation& op) const override;
 
  private:
   void initialize();

--- a/paddle/fluid/pir/dialect/operator/trait/custom_vjp.h
+++ b/paddle/fluid/pir/dialect/operator/trait/custom_vjp.h
@@ -28,7 +28,7 @@ namespace paddle {
 namespace dialect {
 class CustomVjpTrait : public pir::OpTraitBase<CustomVjpTrait> {
  public:
-  explicit CustomVjpTrait(pir::Operation *op)
+  explicit CustomVjpTrait(const pir::Operation *op)
       : pir::OpTraitBase<CustomVjpTrait>(op) {}
 };
 

--- a/paddle/fluid/pir/dialect/operator/trait/forward_only.h
+++ b/paddle/fluid/pir/dialect/operator/trait/forward_only.h
@@ -20,7 +20,7 @@ namespace paddle {
 namespace dialect {
 class ForwardOnlyTrait : public pir::OpTraitBase<ForwardOnlyTrait> {
  public:
-  explicit ForwardOnlyTrait(pir::Operation *op)
+  explicit ForwardOnlyTrait(const pir::Operation *op)
       : pir::OpTraitBase<ForwardOnlyTrait>(op) {}
 };
 

--- a/paddle/fluid/pir/dialect/operator/trait/inplace.h
+++ b/paddle/fluid/pir/dialect/operator/trait/inplace.h
@@ -20,7 +20,7 @@ namespace paddle {
 namespace dialect {
 class InplaceTrait : public pir::OpTraitBase<InplaceTrait> {
  public:
-  explicit InplaceTrait(pir::Operation *op)
+  explicit InplaceTrait(const pir::Operation *op)
       : pir::OpTraitBase<InplaceTrait>(op) {}
 };
 

--- a/paddle/fluid/pir/dialect/operator/trait/onednn.h
+++ b/paddle/fluid/pir/dialect/operator/trait/onednn.h
@@ -22,20 +22,20 @@ namespace paddle {
 namespace dialect {
 class OneDNNTrait : public pir::OpTraitBase<OneDNNTrait> {
  public:
-  explicit OneDNNTrait(pir::Operation *op)
+  explicit OneDNNTrait(const pir::Operation *op)
       : pir::OpTraitBase<OneDNNTrait>(op) {}
 };
 
 class OneDNNOnlyTrait : public pir::OpTraitBase<OneDNNOnlyTrait> {
  public:
-  explicit OneDNNOnlyTrait(pir::Operation *op)
+  explicit OneDNNOnlyTrait(const pir::Operation *op)
       : pir::OpTraitBase<OneDNNOnlyTrait>(op) {}
 };
 
 class OneDNNDynamicFallbackTrait
     : public pir::OpTraitBase<OneDNNDynamicFallbackTrait> {
  public:
-  explicit OneDNNDynamicFallbackTrait(pir::Operation *op)
+  explicit OneDNNDynamicFallbackTrait(const pir::Operation *op)
       : pir::OpTraitBase<OneDNNDynamicFallbackTrait>(op) {}
 };
 

--- a/paddle/fluid/pir/transforms/build_cinn_pass.cc
+++ b/paddle/fluid/pir/transforms/build_cinn_pass.cc
@@ -72,7 +72,7 @@ static std::string OpsDebugStr(std::vector<pir::Operation*> ops) {
   std::stringstream ss;
   pir::IrPrinter printer(ss);
   for (const auto* op : ops) {
-    printer.PrintOperation(const_cast<pir::Operation*>(op));
+    printer.PrintOperation(*op);
     ss << "{" << op->id() << "}\n";
   }
   return ss.str();

--- a/paddle/fluid/pir/transforms/general/remove_shadow_feed_pass.cc
+++ b/paddle/fluid/pir/transforms/general/remove_shadow_feed_pass.cc
@@ -86,7 +86,7 @@ class RemoveShadowFeedPattern
       if (!var) {
         return false;
       }
-      phi::Place var_place;
+      phi::Place var_place, dst_place;
       if (var->IsType<phi::DenseTensor>()) {
         var_place = GetVarPlace<phi::DenseTensor>(var, place_);
       } else if (var->IsType<phi::SelectedRows>()) {
@@ -99,7 +99,16 @@ class RemoveShadowFeedPattern
             "RemoveShadowFeedPattern only support output "
             "variable of type DenseTensor, SelectedRows or VariableRefArray"));
       }
-      return var_place == place_;
+
+      int dst_place_type =
+          op.attribute("dst_place_type").dyn_cast<pir::Int32Attribute>().data();
+      if (dst_place_type == 0) {
+        dst_place = phi::CPUPlace();
+      } else {
+        dst_place = place_;
+      }
+
+      return var_place == dst_place;
     }
     return false;
   }

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -1664,7 +1664,8 @@ void AddShadowFeedForValue(
     std::unordered_map<std::string, pir::Attribute> attr_map{
         {"op_name", pir::StrAttribute::get(ctx, "pd_op.shadow_feed")},
         {"kernel_name", pir::StrAttribute::get(ctx, "shadow_feed")},
-        {"kernel_key", KernelAttribute::get(ctx, shadow_key)}};
+        {"kernel_key", KernelAttribute::get(ctx, shadow_key)},
+        {"dst_place_type", pir::Int32Attribute::get(ctx, 1)}};
 
     auto out_type = AllocatedDenseTensorType::get(
         ctx,
@@ -1699,7 +1700,8 @@ void AddShadowFeedForValue(
     std::unordered_map<std::string, pir::Attribute> attr_map{
         {"op_name", pir::StrAttribute::get(ctx, "pd_op.shadow_feed_tensors")},
         {"kernel_name", pir::StrAttribute::get(ctx, "shadow_feed_tensors")},
-        {"kernel_key", KernelAttribute::get(ctx, shadow_key)}};
+        {"kernel_key", KernelAttribute::get(ctx, shadow_key)},
+        {"dst_place_type", pir::Int32Attribute::get(ctx, 1)}};
 
     pir::OpInfo phi_kernel_op_info =
         ctx->GetRegisteredOpInfo(PhiKernelOp::name());
@@ -3001,6 +3003,32 @@ void AddShadowFeedOpForDataOrFeed(
   }
 }
 
+// shadow_feed(x) + memcpy_d2h(x, y) + any_op(y) -> shadow_feed(x,
+// dst_place=cpu_place) + any_op(x) shadow_feed(x) + memcpy_h2d(x, y) +
+// any_op(y) -> shadow_feed(x, dst_place=gpu_place) + any_op(x)
+void RemoveRedundantMemcpyAfterShadowFeed(pir::Block* block,
+                                          pir::IrContext* ctx) {
+  for (auto it = block->rbegin(); it != block->rend(); ++it) {
+    if (it->isa<ShadowFeedOp>() || it->isa<ShadowFeedTensorsOp>()) {
+      pir::Value shadow_value = it->result(0);
+      if (shadow_value.use_count() == 1) {
+        pir::Operation* next_op = shadow_value.first_use().owner();
+
+        if (next_op->isa<MemcpyD2hOp>() || next_op->isa<MemcpyH2dOp>()) {
+          // remove memcpy op
+          next_op->operand(0).source().ReplaceAllUsesWith(shadow_value);
+          block->erase(next_op->operator pir::Block::ConstIterator());
+
+          // set dst_place_type for shadow_feed
+          int dst_place_type = next_op->isa<MemcpyD2hOp>() ? 0 : 1;
+          it->set_attribute("dst_place_type",
+                            pir::Int32Attribute::get(ctx, dst_place_type));
+        }
+      }
+    }
+  }
+}
+
 pir::Operation* BuildKernelOp(
     const std::string& kernel_fn_str,
     const phi::KernelKey& kernel_key,
@@ -3215,7 +3243,8 @@ void ProcessBlock(
         std::unordered_map<std::string, pir::Attribute> attr_map{
             {"op_name", pir::StrAttribute::get(ctx, "pd_op.shadow_feed")},
             {"kernel_name", pir::StrAttribute::get(ctx, "shadow_feed")},
-            {"kernel_key", KernelAttribute::get(ctx, shadow_key)}};
+            {"kernel_key", KernelAttribute::get(ctx, shadow_key)},
+            {"dst_place_type", pir::Int32Attribute::get(ctx, 1)}};
 
         auto out_type =
             AllocatedDenseTensorType::get(ctx, place, dense_tensor_type);
@@ -3356,6 +3385,8 @@ void ProcessBlock(
     AddShadowFeedOpForDataOrFeed(
         place, op_item, op, new_block, ctx, map_op_pair, map_value_pair);
   }
+
+  RemoveRedundantMemcpyAfterShadowFeed(new_block, ctx);
 }
 
 std::unique_ptr<pir::Program> PdOpLowerToKernelPass(pir::Program* prog,

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -3010,11 +3010,16 @@ void RemoveRedundantMemcpyAfterShadowFeed(pir::Block* block,
                                           pir::IrContext* ctx) {
   for (auto it = block->rbegin(); it != block->rend(); ++it) {
     if (it->isa<ShadowFeedOp>() || it->isa<ShadowFeedTensorsOp>()) {
+      VLOG(6) << *it;
       pir::Value shadow_value = it->result(0);
       if (shadow_value.use_count() == 1) {
         pir::Operation* next_op = shadow_value.first_use().owner();
 
         if (next_op->isa<MemcpyD2hOp>() || next_op->isa<MemcpyH2dOp>()) {
+          VLOG(6) << "Remove redundant memcpy op after shadow_feed";
+          VLOG(6) << *it;
+          VLOG(6) << next_op;
+
           // remove memcpy op
           next_op->operand(0).source().ReplaceAllUsesWith(shadow_value);
           block->erase(next_op->operator pir::Block::ConstIterator());

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -3012,7 +3012,7 @@ void AddShadowFeedOpForDataOrFeed(
 */
 void RemoveRedundantMemcpyAfterShadowFeed(pir::Block* block,
                                           pir::IrContext* ctx) {
-  for (auto it = block->rbegin(); it != block->rend(); ++it) {
+  for (auto it = block->begin(); it != block->end(); ++it) {
     if (it->isa<PhiKernelOp>() &&
         (it->dyn_cast<PhiKernelOp>().op_name() == "pd_op.shadow_feed" ||
          it->dyn_cast<PhiKernelOp>().op_name() ==

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -217,7 +217,7 @@ static std::string OpsDebugStr(std::vector<pir::Operation*> ops) {
   std::stringstream ss;
   pir::IrPrinter printer(ss);
   for (const auto* op : ops) {
-    printer.PrintOperation(const_cast<pir::Operation*>(op));
+    printer.PrintOperation(*op);
     ss << "{" << op->id() << "}\n";
   }
   return ss.str();

--- a/paddle/phi/kernels/data_kernel.h
+++ b/paddle/phi/kernels/data_kernel.h
@@ -34,11 +34,13 @@ void ShadowOutputKernel(const Context& ctx,
 template <typename T, typename Context>
 void ShadowFeedKernel(const Context& ctx,
                       const DenseTensor& x,
+                      int dst_place_type,
                       DenseTensor* out);
 
 template <typename T, typename Context>
 void ShadowFeedTensorsKernel(const Context& ctx,
                              const std::vector<const DenseTensor*>& xs,
+                             int dst_place_type,
                              std::vector<DenseTensor*> outs);
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/impl/data_impl.h
+++ b/paddle/phi/kernels/impl/data_impl.h
@@ -34,7 +34,7 @@ void ShadowFeedKernel(const Context& ctx,
       target_place = CPUPlace();
       break;
     case 1:  // CUDAPlace
-      target_place = GPUPlace();
+      target_place = GPUPlace(backends::gpu::GetCurrentDeviceId());
       break;
     default:
       PADDLE_THROW(errors::Unimplemented("dst_place_type: %d is not supported.",

--- a/paddle/phi/kernels/impl/data_impl.h
+++ b/paddle/phi/kernels/impl/data_impl.h
@@ -33,9 +33,11 @@ void ShadowFeedKernel(const Context& ctx,
     case 0:  // CPUPlace
       target_place = CPUPlace();
       break;
+#if defined(PADDLE_WITH_CUDA)
     case 1:  // CUDAPlace
       target_place = GPUPlace(backends::gpu::GetCurrentDeviceId());
       break;
+#endif
     default:
       PADDLE_THROW(errors::Unimplemented("dst_place_type: %d is not supported.",
                                          dst_place_type));

--- a/paddle/phi/kernels/impl/data_impl.h
+++ b/paddle/phi/kernels/impl/data_impl.h
@@ -26,25 +26,46 @@ const char kBackward[] = "BACKWARD";
 template <typename T, typename Context>
 void ShadowFeedKernel(const Context& ctx,
                       const DenseTensor& x,
+                      int dst_place_type,
                       DenseTensor* out) {
+  Place target_place;
+  switch (dst_place_type) {
+    case 0:  // CPUPlace
+      target_place = CPUPlace();
+      break;
+    case 1:  // CUDAPlace
+      target_place = GPUPlace();
+      break;
+    default:
+      PADDLE_THROW(errors::Unimplemented("dst_place_type: %d is not supported.",
+                                         dst_place_type));
+      break;
+  }
+
   if (!x.initialized()) {
-    ctx.template Alloc<T>(out);
+    if (target_place == CPUPlace()) {
+      ctx.template HostAlloc<T>(out);
+    } else {
+      ctx.template Alloc<T>(out);
+    }
     return;
   }
-  if (x.place() == ctx.GetPlace()) {
+
+  if (x.place() == target_place) {
     out->ShareDataWith(x);
     out->set_lod(x.lod());
   } else {
-    phi::Copy<Context>(ctx, x, ctx.GetPlace(), true, out);
+    phi::Copy<Context>(ctx, x, target_place, true, out);
   }
 }
 
 template <typename T, typename Context>
 void ShadowFeedTensorsKernel(const Context& ctx,
                              const std::vector<const DenseTensor*>& xs,
+                             int dst_place_type,
                              std::vector<DenseTensor*> outs) {
   for (size_t i = 0; i < xs.size(); ++i) {
-    ShadowFeedKernel<T, Context>(ctx, *(xs[i]), outs[i]);
+    ShadowFeedKernel<T, Context>(ctx, *(xs[i]), dst_place_type, outs[i]);
   }
 }
 

--- a/paddle/phi/kernels/impl/data_impl.h
+++ b/paddle/phi/kernels/impl/data_impl.h
@@ -33,9 +33,13 @@ void ShadowFeedKernel(const Context& ctx,
     case 0:  // CPUPlace
       target_place = CPUPlace();
       break;
-#if defined(PADDLE_WITH_CUDA)
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     case 1:  // CUDAPlace
       target_place = GPUPlace(backends::gpu::GetCurrentDeviceId());
+      break;
+#elif defined(PADDLE_WITH_XPU)
+    case 1:  // XPUPlace
+      target_place = XPUPlace(backends::xpu::GetXPUCurrentDeviceId());
       break;
 #endif
     default:

--- a/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
@@ -844,25 +844,25 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : shadow_feed
-  args : (Tensor x)
+  args : (Tensor x,  int dst_place_type)
   output : Tensor(out)
   infer_meta:
     func: UnchangedInferMeta
     param: [x]
   kernel:
     func: shadow_feed
-    param: [x]
+    param: [x, dst_place_type]
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : shadow_feed_tensors
-  args : (Tensor[] x)
+  args : (Tensor[] x, int dst_place_type)
   output : Tensor[](out){x.size()}
   infer_meta:
     func: UnchangedVectorInferMeta
     param: [x]
   kernel:
     func: shadow_feed_tensors
-    param: [x]
+    param: [x, dst_place_type]
 
 - op : share_data_
   args : (Tensor x)

--- a/paddle/pir/include/core/block.h
+++ b/paddle/pir/include/core/block.h
@@ -198,6 +198,8 @@ class IR_API Block {
   Region *parent_;     // not owned
 };
 
+std::ostream &operator<<(std::ostream &os, const Block &block);
+
 template <class TypeIter>
 void Block::AddArgs(TypeIter first, TypeIter last) {
   while (first != last) {

--- a/paddle/pir/include/core/builtin_op.h
+++ b/paddle/pir/include/core/builtin_op.h
@@ -244,7 +244,7 @@ class IR_API ConstantTensorOp : public ConstantOp {
  public:
   using ConstantOp::ConstantOp;
 
-  static ConstantTensorOp dyn_cast(Operation *op);
+  static ConstantTensorOp dyn_cast(const Operation *op);
   static bool classof(const Operation *op);
 
   static void Build(Builder &builder,             // NOLINT

--- a/paddle/pir/include/core/builtin_op.h
+++ b/paddle/pir/include/core/builtin_op.h
@@ -211,7 +211,7 @@ class IR_API SplitOp : public pir::Op<SplitOp> {
 
 class IR_API ConstantLikeTrait : public OpTraitBase<ConstantLikeTrait> {
  public:
-  explicit ConstantLikeTrait(Operation *op)
+  explicit ConstantLikeTrait(const Operation *op)
       : OpTraitBase<ConstantLikeTrait>(op) {}
 };
 

--- a/paddle/pir/include/core/dialect.h
+++ b/paddle/pir/include/core/dialect.h
@@ -33,7 +33,7 @@ class IrParser;
 class DialectInterface;
 
 using OpPrintFn =
-    std::function<void(Operation *op, IrPrinter &printer)>;  // NOLINT
+    std::function<void(const Operation &op, IrPrinter &printer)>;  // NOLINT
 
 ///
 /// \brief Dialect can basically be understood as a namespace. In Dialect, we
@@ -158,7 +158,7 @@ class IR_API Dialect {
     IR_THROW("dialect has no registered attribute parsing hook");
   }
 
-  virtual OpPrintFn PrintOperation(Operation *op) const;
+  virtual OpPrintFn PrintOperation(const Operation &op) const;
 
   virtual Operation ParseOperation(IrParser &parser) {  // NOLINT
     IR_THROW("dialect has no registered operation parsing hook");

--- a/paddle/pir/include/core/ir_printer.h
+++ b/paddle/pir/include/core/ir_printer.h
@@ -49,26 +49,26 @@ class IR_API IrPrinter : public BasicIrPrinter {
   void PrintProgram(const Program* program);
 
   /// @brief dispatch to custom printer function or PrintGeneralOperation
-  virtual void PrintOperation(Operation* op);
+  virtual void PrintOperation(const Operation& op);
   /// @brief print operation itself without its regions
-  void PrintOperationWithNoRegion(Operation* op);
+  void PrintOperationWithNoRegion(const Operation& op);
   /// @brief print operation and its regions
-  void PrintGeneralOperation(Operation* op);
+  void PrintGeneralOperation(const Operation& op);
 
   void PrintRegion(const Region& Region);
   void PrintBlock(const Block& block);
 
   virtual void PrintValue(Value v);
 
-  void PrintOpResult(Operation* op);
+  void PrintOpResult(const Operation& op);
 
-  void PrintAttributeMap(Operation* op);
+  void PrintAttributeMap(const Operation& op);
 
-  void PrintOpOperands(Operation* op);
+  void PrintOpOperands(const Operation& op);
 
-  void PrintOperandsType(Operation* op);
+  void PrintOperandsType(const Operation& op);
 
-  void PrintOpReturnType(Operation* op);
+  void PrintOpReturnType(const Operation& op);
 
   void AddValueAlias(Value value, const std::string& alias);
 
@@ -90,7 +90,7 @@ using TypePrintHook =
 using AttributePrintHook =
     std::function<void(Attribute attr, IrPrinter& printer)>;  // NOLINT
 using OpPrintHook =
-    std::function<void(Operation* op, IrPrinter& printer)>;  // NOLINT
+    std::function<void(const Operation& op, IrPrinter& printer)>;  // NOLINT
 
 struct IR_API PrintHooks {
   ValuePrintHook value_print_hook{nullptr};

--- a/paddle/pir/include/core/op_base.h
+++ b/paddle/pir/include/core/op_base.h
@@ -29,7 +29,8 @@ class Block;
 
 class IR_API OpBase {
  public:
-  explicit OpBase(Operation *operation = nullptr) : operation_(operation) {}
+  explicit OpBase(const Operation *operation = nullptr)
+      : operation_(const_cast<pir::Operation *>(operation)) {}
 
   Operation *operation() const {
     PADDLE_ENFORCE_NOT_NULL(
@@ -91,11 +92,11 @@ template <class ConcreteTrait>
 class OpTraitBase : public OpBase {
  public:
   using Base = OpTraitBase<ConcreteTrait>;
-  explicit OpTraitBase(Operation *op) : OpBase(op) {}
+  explicit OpTraitBase(const Operation *op) : OpBase(op) {}
 
   static TypeId GetTraitId() { return TypeId::get<ConcreteTrait>(); }
 
-  static ConcreteTrait dyn_cast(Operation *op) {
+  static ConcreteTrait dyn_cast(const Operation *op) {
     if (op && op->HasTrait<ConcreteTrait>()) {
       return ConcreteTrait(op);
     }
@@ -109,7 +110,7 @@ class OpTraitBase : public OpBase {
 template <typename ConcreteInterface>
 class OpInterfaceBase : public OpBase {
  public:
-  explicit OpInterfaceBase(Operation *op) : OpBase(op) {}
+  explicit OpInterfaceBase(const Operation *op) : OpBase(op) {}
 
   ///
   /// \brief Accessor for the ID of this interface.
@@ -123,7 +124,7 @@ class OpInterfaceBase : public OpBase {
     return op->HasInterface<ConcreteInterface>();
   }
 
-  static ConcreteInterface dyn_cast(Operation *op) {
+  static ConcreteInterface dyn_cast(const Operation *op) {
     if (op && op->HasInterface<ConcreteInterface>()) {
       return ConcreteInterface(
           op, op->info().GetInterfaceImpl<ConcreteInterface>());
@@ -158,7 +159,7 @@ class Op : public OpBase {
                               std::tuple<TraitOrInterface...>>::Type;
 
   // TODO(zhangbopd): Use classof
-  static ConcreteOp dyn_cast(Operation *op) {
+  static ConcreteOp dyn_cast(const Operation *op) {
     if (op && op->info().id() == TypeId::get<ConcreteOp>()) {
       return ConcreteOp(op);
     }

--- a/paddle/pir/include/core/op_trait.h
+++ b/paddle/pir/include/core/op_trait.h
@@ -26,7 +26,7 @@ namespace pir {
 class IR_API SameOperandsShapeTrait
     : public pir::OpTraitBase<SameOperandsShapeTrait> {
  public:
-  explicit SameOperandsShapeTrait(pir::Operation *op)
+  explicit SameOperandsShapeTrait(const pir::Operation *op)
       : pir::OpTraitBase<SameOperandsShapeTrait>(op) {}
   static void Verify(Operation *op);
 };
@@ -38,7 +38,7 @@ class IR_API SameOperandsShapeTrait
 class IR_API SameOperandsAndResultShapeTrait
     : public pir::OpTraitBase<SameOperandsAndResultShapeTrait> {
  public:
-  explicit SameOperandsAndResultShapeTrait(pir::Operation *op)
+  explicit SameOperandsAndResultShapeTrait(const pir::Operation *op)
       : pir::OpTraitBase<SameOperandsAndResultShapeTrait>(op) {}
   static void Verify(Operation *op);
 };
@@ -50,7 +50,7 @@ class IR_API SameOperandsAndResultShapeTrait
 class IR_API SameOperandsElementTypeTrait
     : public pir::OpTraitBase<SameOperandsElementTypeTrait> {
  public:
-  explicit SameOperandsElementTypeTrait(pir::Operation *op)
+  explicit SameOperandsElementTypeTrait(const pir::Operation *op)
       : pir::OpTraitBase<SameOperandsElementTypeTrait>(op) {}
   static void Verify(Operation *op);
 };
@@ -62,7 +62,7 @@ class IR_API SameOperandsElementTypeTrait
 class IR_API SameOperandsAndResultElementTypeTrait
     : public pir::OpTraitBase<SameOperandsAndResultElementTypeTrait> {
  public:
-  explicit SameOperandsAndResultElementTypeTrait(pir::Operation *op)
+  explicit SameOperandsAndResultElementTypeTrait(const pir::Operation *op)
       : pir::OpTraitBase<SameOperandsAndResultElementTypeTrait>(op) {}
   static void Verify(Operation *op);
 };
@@ -75,7 +75,7 @@ class IR_API SameOperandsAndResultElementTypeTrait
 class IR_API SameOperandsAndResultTypeTrait
     : public pir::OpTraitBase<SameOperandsAndResultTypeTrait> {
  public:
-  explicit SameOperandsAndResultTypeTrait(pir::Operation *op)
+  explicit SameOperandsAndResultTypeTrait(const pir::Operation *op)
       : pir::OpTraitBase<SameOperandsAndResultTypeTrait>(op) {}
 
   static void Verify(Operation *op);
@@ -88,7 +88,7 @@ class IR_API SameOperandsAndResultTypeTrait
 class IR_API SameTypeOperandsTrait
     : public pir::OpTraitBase<SameTypeOperandsTrait> {
  public:
-  explicit SameTypeOperandsTrait(pir::Operation *op)
+  explicit SameTypeOperandsTrait(const pir::Operation *op)
       : pir::OpTraitBase<SameTypeOperandsTrait>(op) {}
   static void Verify(Operation *op);
 };

--- a/paddle/pir/include/core/operation.h
+++ b/paddle/pir/include/core/operation.h
@@ -184,7 +184,7 @@ class IR_API alignas(8) Operation final
   operator Block::ConstIterator() const { return position_; }
   void MoveTo(Block *block, Block::Iterator position);
 
-  void Print(std::ostream &os);
+  void Print(std::ostream &os) const;
   pir::OpInfo info() const { return info_; }
   std::string name() const;
 
@@ -207,7 +207,7 @@ class IR_API alignas(8) Operation final
   bool use_empty();
 
   template <typename T>
-  T dyn_cast() {
+  T dyn_cast() const {
     return CastUtil<T>::call(this);
   }
 
@@ -256,7 +256,7 @@ class IR_API alignas(8) Operation final
 
   template <typename To, typename Enabler = void>
   struct CastUtil {
-    static To call(Operation *op) {
+    static To call(const Operation *op) {
       throw("Can't dyn_cast to To, To should be a Op or Trait or Interface");
     }
   };
@@ -269,7 +269,7 @@ class IR_API alignas(8) Operation final
   struct CastUtil<
       To,
       typename std::enable_if<std::is_base_of<OpBase, To>::value>::type> {
-    static To call(Operation *op) { return To::dyn_cast(op); }
+    static To call(const Operation *op) { return To::dyn_cast(op); }
   };
 
   AttributeMap attributes_;
@@ -295,5 +295,7 @@ class IR_API alignas(8) Operation final
   Block *parent_{nullptr};
   Block::Iterator position_;
 };
+
+IR_API std::ostream &operator<<(std::ostream &os, const Operation &op);
 
 }  // namespace pir

--- a/paddle/pir/include/dialect/control_flow/ir/cf_dialect.h
+++ b/paddle/pir/include/dialect/control_flow/ir/cf_dialect.h
@@ -25,7 +25,7 @@ class ControlFlowDialect : public Dialect {
   }
   static const char *name() { return "cf"; }
   TEST_API void PrintType(Type type, std::ostream &os) const override;
-  TEST_API OpPrintFn PrintOperation(Operation *op) const override;
+  TEST_API OpPrintFn PrintOperation(const Operation &op) const override;
 
  private:
   TEST_API void initialize();

--- a/paddle/pir/include/dialect/control_flow/ir/cf_interface.h
+++ b/paddle/pir/include/dialect/control_flow/ir/cf_interface.h
@@ -77,7 +77,7 @@ class ContainerOpInterface : public OpInterfaceBase<ContainerOpInterface> {
   TuplePushOp tuple_push_op();
   TuplePopOp tuple_pop_op();
   /// Constructor
-  ContainerOpInterface(pir::Operation* op, Concept* impl)
+  ContainerOpInterface(const pir::Operation* op, Concept* impl)
       : OpInterfaceBase<ContainerOpInterface>(op), impl_(impl) {}
 
  private:

--- a/paddle/pir/include/dialect/shape/interface/infer_symbolic_shape/cache_grad_op_symbolic_shape.h
+++ b/paddle/pir/include/dialect/shape/interface/infer_symbolic_shape/cache_grad_op_symbolic_shape.h
@@ -46,7 +46,7 @@ class CacheGradOpSymbolicShapeInterface
   };
 
   /// Constructor
-  CacheGradOpSymbolicShapeInterface(pir::Operation *op, Concept *impl)
+  CacheGradOpSymbolicShapeInterface(const pir::Operation *op, Concept *impl)
       : pir::OpInterfaceBase<CacheGradOpSymbolicShapeInterface>(op),
         impl_(impl) {}
 

--- a/paddle/pir/include/dialect/shape/interface/infer_symbolic_shape/infer_symbolic_shape.h
+++ b/paddle/pir/include/dialect/shape/interface/infer_symbolic_shape/infer_symbolic_shape.h
@@ -48,7 +48,7 @@ class InferSymbolicShapeInterface
   };
 
   /// Constructor
-  InferSymbolicShapeInterface(pir::Operation *op, Concept *impl)
+  InferSymbolicShapeInterface(const pir::Operation *op, Concept *impl)
       : pir::OpInterfaceBase<InferSymbolicShapeInterface>(op), impl_(impl) {}
 
   bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);

--- a/paddle/pir/src/core/builtin_op.cc
+++ b/paddle/pir/src/core/builtin_op.cc
@@ -171,15 +171,15 @@ void GroupOp::VerifySig() {}
 void GroupOp::Print(IrPrinter &printer) {
   auto &os = printer.os;
   auto op = operation();
-  printer.PrintOpResult(op);
+  printer.PrintOpResult(*op);
   os << " = \"" << name() << "\" [id:" << op->id() << "]";
-  printer.PrintOpOperands(op);
+  printer.PrintOpOperands(*op);
   os << " -> ";
-  printer.PrintOpReturnType(op);
+  printer.PrintOpReturnType(*op);
   os << " {\n";
   printer.AddIndentation();
   for (auto &sub_op : GetOperators()) {
-    printer.PrintOperation(sub_op);
+    printer.PrintOperation(*sub_op);
     os << "\n";
   }
   printer.DecreaseIndentation();
@@ -644,7 +644,7 @@ void ConstantTensorOp::VerifySig() const {
       common::errors::InvalidArgument("Type of value must be str attribute"));
 }
 
-ConstantTensorOp ConstantTensorOp::dyn_cast(Operation *op) {
+ConstantTensorOp ConstantTensorOp::dyn_cast(const Operation *op) {
   if (ConstantTensorOp::classof(op)) return ConstantTensorOp(op);
   return ConstantTensorOp(nullptr);
 }

--- a/paddle/pir/src/core/dialect.cc
+++ b/paddle/pir/src/core/dialect.cc
@@ -28,7 +28,7 @@ void Dialect::RegisterInterface(std::unique_ptr<DialectInterface> interface) {
                                  std::move(interface));
 }
 
-OpPrintFn Dialect::PrintOperation(Operation *op) const { return nullptr; }
+OpPrintFn Dialect::PrintOperation(const Operation &op) const { return nullptr; }
 
 DialectInterface::~DialectInterface() = default;
 

--- a/paddle/pir/src/core/ir_printer.cc
+++ b/paddle/pir/src/core/ir_printer.cc
@@ -172,10 +172,10 @@ void IrPrinter::PrintProgram(const Program* program) {
   }
 }
 
-void IrPrinter::PrintOperation(Operation* op) {
+void IrPrinter::PrintOperation(const Operation& op) {
   os << indentation();
 
-  if (auto* dialect = op->dialect()) {
+  if (auto* dialect = op.dialect()) {
     if (auto print_fn = dialect->PrintOperation(op)) {
       print_fn(op, *this);
       return;
@@ -185,15 +185,15 @@ void IrPrinter::PrintOperation(Operation* op) {
   PrintGeneralOperation(op);
 }
 
-void IrPrinter::PrintOperationWithNoRegion(Operation* op) {
+void IrPrinter::PrintOperationWithNoRegion(const Operation& op) {
   // TODO(lyk): add API to get opresults directly
   PrintOpResult(op);
   os << " =";
 
-  os << " \"" << op->name() << "\"";
+  os << " \"" << op.name() << "\"";
 
   if (VLOG_IS_ON(1) || FLAGS_pir_debug) {
-    os << " [id:" << op->id() << "]";
+    os << " [id:" << op.id() << "]";
   }
 
   // TODO(lyk): add API to get operands directly
@@ -210,13 +210,13 @@ void IrPrinter::PrintOperationWithNoRegion(Operation* op) {
   PrintOpReturnType(op);
 }
 
-void IrPrinter::PrintGeneralOperation(Operation* op) {
+void IrPrinter::PrintGeneralOperation(const Operation& op) {
   PrintOperationWithNoRegion(op);
-  if (op->num_regions() > 0) {
+  if (op.num_regions() > 0) {
     os << newline;
   }
-  for (size_t i = 0; i < op->num_regions(); ++i) {
-    auto& region = op->region(i);
+  for (size_t i = 0; i < op.num_regions(); ++i) {
+    auto& region = op.region(i);
     PrintRegion(region);
   }
 }
@@ -241,7 +241,7 @@ void IrPrinter::PrintBlock(const Block& block) {
     os << "\n";
   }
   for (auto& item : block) {
-    PrintOperation(&item);
+    PrintOperation(item);
     os << "\n";
   }
   DecreaseIndentation();
@@ -273,13 +273,13 @@ void IrPrinter::PrintValue(Value v) {
   }
 }
 
-void IrPrinter::PrintOpResult(Operation* op) {
+void IrPrinter::PrintOpResult(const Operation& op) {
   os << "(";
-  auto num_op_result = op->num_results();
+  auto num_op_result = op.num_results();
   std::vector<Value> op_results;
   op_results.reserve(num_op_result);
   for (size_t idx = 0; idx < num_op_result; idx++) {
-    op_results.push_back(op->result(idx));
+    op_results.push_back(op.result(idx));
   }
   pir::detail::PrintInterleave(
       op_results.begin(),
@@ -289,8 +289,8 @@ void IrPrinter::PrintOpResult(Operation* op) {
   os << ")";
 }
 
-void IrPrinter::PrintAttributeMap(Operation* op) {
-  AttributeMap attributes = op->attributes();
+void IrPrinter::PrintAttributeMap(const Operation& op) {
+  AttributeMap attributes = op.attributes();
   std::map<std::string, Attribute, std::less<>> order_attributes(
       attributes.begin(), attributes.end());
 
@@ -312,13 +312,13 @@ void IrPrinter::PrintAttributeMap(Operation* op) {
   os << "}";
 }
 
-void IrPrinter::PrintOpOperands(Operation* op) {
+void IrPrinter::PrintOpOperands(const Operation& op) {
   os << " (";
-  auto num_op_operands = op->num_operands();
+  auto num_op_operands = op.num_operands();
   std::vector<Value> op_operands;
   op_operands.reserve(num_op_operands);
   for (size_t idx = 0; idx < num_op_operands; idx++) {
-    op_operands.push_back(op->operand_source(idx));
+    op_operands.push_back(op.operand_source(idx));
   }
   pir::detail::PrintInterleave(
       op_operands.begin(),
@@ -328,12 +328,12 @@ void IrPrinter::PrintOpOperands(Operation* op) {
   os << ")";
 }
 
-void IrPrinter::PrintOperandsType(Operation* op) {
-  auto num_op_operands = op->num_operands();
+void IrPrinter::PrintOperandsType(const Operation& op) {
+  auto num_op_operands = op.num_operands();
   std::vector<Type> op_operand_types;
   op_operand_types.reserve(num_op_operands);
   for (size_t idx = 0; idx < num_op_operands; idx++) {
-    auto op_operand = op->operand(idx);
+    auto op_operand = op.operand(idx);
     if (op_operand) {
       op_operand_types.push_back(op_operand.type());
     } else {
@@ -349,12 +349,12 @@ void IrPrinter::PrintOperandsType(Operation* op) {
   os << ")";
 }
 
-void IrPrinter::PrintOpReturnType(Operation* op) {
-  auto num_op_result = op->num_results();
+void IrPrinter::PrintOpReturnType(const Operation& op) {
+  auto num_op_result = op.num_results();
   std::vector<Type> op_result_types;
   op_result_types.reserve(num_op_result);
   for (size_t idx = 0; idx < num_op_result; idx++) {
-    auto op_result = op->result(idx);
+    auto op_result = op.result(idx);
     if (op_result) {
       op_result_types.push_back(op_result.type());
     } else {
@@ -397,7 +397,7 @@ class CustomPrinter : public IrPrinter {
     }
   }
 
-  void PrintOperation(Operation* op) override {
+  void PrintOperation(const Operation& op) override {
     if (hooks_.op_print_hook) {
       hooks_.op_print_hook(op, *this);
     } else {
@@ -428,9 +428,9 @@ void Program::Print(std::ostream& os) const {
   printer.PrintProgram(this);
 }
 
-void Operation::Print(std::ostream& os) {
+void Operation::Print(std::ostream& os) const {
   IrPrinter printer(os);
-  printer.PrintOperation(this);
+  printer.PrintOperation(*this);
 }
 
 void Value::Print(std::ostream& os) const {

--- a/paddle/pir/src/core/ir_printer.cc
+++ b/paddle/pir/src/core/ir_printer.cc
@@ -458,6 +458,12 @@ std::ostream& operator<<(std::ostream& os, Attribute attr) {
   return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const Block& block) {
+  IrPrinter printer(os);
+  printer.PrintBlock(block);
+  return os;
+}
+
 std::ostream& operator<<(std::ostream& os, const Program& prog) {
   prog.Print(os);
   return os;

--- a/paddle/pir/src/core/op_trait.cc
+++ b/paddle/pir/src/core/op_trait.cc
@@ -20,7 +20,7 @@
 
 namespace {
 
-void VerifySameOperandsShapeTrait(pir::Operation *op) {
+void VerifySameOperandsShapeTrait(const pir::Operation *op) {
   VLOG(10) << "Verify SameOperandsShapeTrait for : " << op->name();
 
   PADDLE_ENFORCE_GT(
@@ -47,7 +47,7 @@ void VerifySameOperandsShapeTrait(pir::Operation *op) {
           op->name()));
 }
 
-void VerifySameOperandsAndResultShapeTrait(pir::Operation *op) {
+void VerifySameOperandsAndResultShapeTrait(const pir::Operation *op) {
   VLOG(10) << "Verify SameOperandsAndResultShapeTrait for : " << op->name();
 
   PADDLE_ENFORCE_GT(
@@ -90,7 +90,7 @@ void VerifySameOperandsAndResultShapeTrait(pir::Operation *op) {
           op->name()));
 }
 
-void VerifySameOperandsElementTypeTrait(pir::Operation *op) {
+void VerifySameOperandsElementTypeTrait(const pir::Operation *op) {
   VLOG(10) << "Verify SameOperandsElementTypeTrait for : " << op->name();
 
   PADDLE_ENFORCE_GT(
@@ -114,7 +114,7 @@ void VerifySameOperandsElementTypeTrait(pir::Operation *op) {
   }
 }
 
-void VerifySameOperandsAndResultElementTypeTrait(pir::Operation *op) {
+void VerifySameOperandsAndResultElementTypeTrait(const pir::Operation *op) {
   VLOG(10) << "Verify SameOperandsAndResultElementTypeTrait for : "
            << op->name();
 
@@ -161,7 +161,7 @@ void VerifySameOperandsAndResultElementTypeTrait(pir::Operation *op) {
   }
 }
 
-void VerifySameOperandsAndResultTypeTrait(pir::Operation *op) {
+void VerifySameOperandsAndResultTypeTrait(const pir::Operation *op) {
   VLOG(10) << "Verify SameOperandsAndResultTypeTrait for : " << op->name();
 
   PADDLE_ENFORCE_GT(
@@ -222,7 +222,7 @@ void VerifySameOperandsAndResultTypeTrait(pir::Operation *op) {
   }
 }
 
-void VerifySameTypeOperandsTrait(pir::Operation *op) {
+void VerifySameTypeOperandsTrait(const pir::Operation *op) {
   VLOG(10) << "Verify SameTypeOperandsTrait for : " << op->name();
 
   // For zero or only one operand.
@@ -242,7 +242,7 @@ void VerifySameTypeOperandsTrait(pir::Operation *op) {
   }
 }
 
-void VerifyOneResultTrait(pir::Operation *op) {
+void VerifyOneResultTrait(const pir::Operation *op) {
   PADDLE_ENFORCE_EQ(
       op->num_results(),
       1,

--- a/paddle/pir/src/core/operation.cc
+++ b/paddle/pir/src/core/operation.cc
@@ -460,4 +460,10 @@ void *Operation::value_property(const std::string &key, size_t index) const {
 
 COMPONENT_IMPL(op_result, OpResult)
 COMPONENT_IMPL(op_operand, OpOperand)
+
+IR_API std::ostream &operator<<(std::ostream &os, const Operation &op) {
+  op.Print(os);
+  return os;
+}
+
 }  // namespace pir

--- a/paddle/pir/src/dialect/control_flow/ir/cf_dialect.cc
+++ b/paddle/pir/src/dialect/control_flow/ir/cf_dialect.cc
@@ -36,10 +36,11 @@ void ControlFlowDialect::PrintType(pir::Type type, std::ostream& os) const {
   }
 }
 
-pir::OpPrintFn ControlFlowDialect::PrintOperation(pir::Operation* op) const {
-  if (auto create_op = op->dyn_cast<StackCreateOp>()) {
-    return [](pir::Operation* op, pir::IrPrinter& printer) {
-      auto create_op = op->dyn_cast<StackCreateOp>();
+pir::OpPrintFn ControlFlowDialect::PrintOperation(
+    const pir::Operation& op) const {
+  if (auto create_op = op.dyn_cast<StackCreateOp>()) {
+    return [](const pir::Operation& op, pir::IrPrinter& printer) {
+      auto create_op = op.dyn_cast<StackCreateOp>();
       create_op.Print(printer);
     };
   }

--- a/paddle/pir/src/dialect/control_flow/ir/cf_op.cc
+++ b/paddle/pir/src/dialect/control_flow/ir/cf_op.cc
@@ -250,7 +250,7 @@ void StackCreateOp::Print(IrPrinter &printer) {  // NOLINT
     printer.AddValueAlias(inlet(), "%inlet_" + std::to_string(index));
     printer.AddValueAlias(outlet(), "%outlet_" + std::to_string(index));
   }
-  printer.PrintGeneralOperation(*this);
+  printer.PrintGeneralOperation(**this);
 }
 
 }  // namespace pir

--- a/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
+++ b/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
@@ -98,14 +98,14 @@ std::string PrintOperationWithNoRegion(Operation* op) {
   }
   os << ")";
 
-  printer.PrintAttributeMap(op);
+  printer.PrintAttributeMap(*op);
   os << " :";
 
   // PrintOpSignature
-  printer.PrintOperandsType(op);
+  printer.PrintOperandsType(*op);
   os << " -> ";
 
-  printer.PrintOpReturnType(op);
+  printer.PrintOpReturnType(*op);
 
   return os.str();
 }

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -736,21 +736,21 @@ symbol::DimExpr ShapeConstraintIRAnalysis::GetProductDimExpr(
 
 pir::PrintHooks ShapeConstraintIRAnalysis::PrintHook() {
   pir::PrintHooks print_hook;
-  print_hook.op_print_hook = [&](Operation* op, IrPrinter& printer) {
+  print_hook.op_print_hook = [&](const Operation& op, IrPrinter& printer) {
     printer.IrPrinter::PrintOperation(op);
     printer.os << " { ";
-    for (uint32_t i = 0; i < op->num_results(); ++i) {
-      if (context_.HasShapeOrDataForValue(op->result(i))) {
-        printer.os << "(" << this->GetShapeOrDataForValue(op->result(i)) << ")";
+    for (uint32_t i = 0; i < op.num_results(); ++i) {
+      if (context_.HasShapeOrDataForValue(op.result(i))) {
+        printer.os << "(" << this->GetShapeOrDataForValue(op.result(i)) << ")";
       } else {
         printer.os << "()";
       }
-      if (i < op->num_results() - 1) {
+      if (i < op.num_results() - 1) {
         printer.os << ", ";
       }
     }
     printer.os << " }";
-    printer.os << "\t(op_" << op->id() << ")";
+    printer.os << "\t(op_" << op.id() << ")";
   };
   return print_hook;
 }

--- a/test/cpp/pir/core/ir_op_test.cc
+++ b/test/cpp/pir/core/ir_op_test.cc
@@ -530,11 +530,11 @@ TEST(printer_test, custom_hooks) {
     printer.os << " [extra info]";
   };
   // this one overrides old printing
-  hooks.op_print_hook = [](pir::Operation *op, pir::IrPrinter &printer) {
+  hooks.op_print_hook = [](const pir::Operation &op, pir::IrPrinter &printer) {
     printer.PrintOpResult(op);
     printer.os << " :=";
 
-    printer.os << " \"" << op->name() << "\"";
+    printer.os << " \"" << op.name() << "\"";
     printer.PrintOpOperands(op);
     printer.PrintAttributeMap(op);
     printer.os << " :";

--- a/test/cpp/pir/tools/test1_dialect.cc
+++ b/test/cpp/pir/tools/test1_dialect.cc
@@ -25,12 +25,12 @@ void Test1Dialect::initialize() {
   RegisterOps<Operation1, Operation2, Operation3, Operation4>();
 }
 
-pir::OpPrintFn Test1Dialect::PrintOperation(pir::Operation *op) const {
-  return [](pir::Operation *op, pir::IrPrinter &printer) {
+pir::OpPrintFn Test1Dialect::PrintOperation(const pir::Operation &op) const {
+  return [](const pir::Operation &op, pir::IrPrinter &printer) {
     printer.PrintOpResult(op);
     printer.os << " =";
 
-    printer.os << " \"" << op->name() << "\"";
+    printer.os << " \"" << op.name() << "\"";
     printer.PrintOpOperands(op);
   };
 }

--- a/test/cpp/pir/tools/test1_dialect.h
+++ b/test/cpp/pir/tools/test1_dialect.h
@@ -22,7 +22,7 @@ class Test1Dialect : public pir::Dialect {
  public:
   explicit Test1Dialect(pir::IrContext *context);
   static const char *name() { return "test1"; }
-  pir::OpPrintFn PrintOperation(pir::Operation *op) const override;
+  pir::OpPrintFn PrintOperation(const pir::Operation &op) const override;
 
  private:
   void initialize();

--- a/test/cpp/pir/tools/test_dialect.cc
+++ b/test/cpp/pir/tools/test_dialect.cc
@@ -41,12 +41,12 @@ void TestDialect::initialize() {
               SameOperandsAndResultTypeTraitOp3>();
 }
 
-pir::OpPrintFn TestDialect::PrintOperation(pir::Operation *op) const {
-  return [](pir::Operation *op, pir::IrPrinter &printer) {
+pir::OpPrintFn TestDialect::PrintOperation(const pir::Operation &op) const {
+  return [](const pir::Operation &op, pir::IrPrinter &printer) {
     printer.PrintOpResult(op);
     printer.os << " =";
 
-    printer.os << " \"" << op->name() << "\"";
+    printer.os << " \"" << op.name() << "\"";
     printer.PrintOpOperands(op);
   };
 }

--- a/test/cpp/pir/tools/test_dialect.h
+++ b/test/cpp/pir/tools/test_dialect.h
@@ -22,7 +22,7 @@ class TestDialect : public pir::Dialect {
  public:
   explicit TestDialect(pir::IrContext *context);
   static const char *name() { return "test"; }
-  pir::OpPrintFn PrintOperation(pir::Operation *op) const override;
+  pir::OpPrintFn PrintOperation(const pir::Operation &op) const override;
 
  private:
   void initialize();

--- a/test/cpp/pir/tools/test_trait.h
+++ b/test/cpp/pir/tools/test_trait.h
@@ -22,13 +22,13 @@ namespace test {
 
 class ReadOnlyTrait : public pir::OpTraitBase<ReadOnlyTrait> {
  public:
-  explicit ReadOnlyTrait(pir::Operation *op)
+  explicit ReadOnlyTrait(const pir::Operation *op)
       : pir::OpTraitBase<ReadOnlyTrait>(op) {}
 };
 
 class OneRegionTrait : public pir::OpTraitBase<OneRegionTrait> {
  public:
-  explicit OneRegionTrait(pir::Operation *op)
+  explicit OneRegionTrait(const pir::Operation *op)
       : pir::OpTraitBase<OneRegionTrait>(op) {}
   static void Verify(pir::Operation *op);
 };


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure


### PR Types
Bug fixes


### Description
<!-- Describe what you’ve done -->
1. pir静态建图时shadow_feed操作引入了冗余的同步memcpy拷贝，从而引起1F1B通信死锁（两张卡同时send之后由于sync操作无法拉起recv）。本PR对shadow_feed的冗余拷贝做消除。相关修改文件：

- paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
- paddle/fluid/pir/transforms/general/remove_shadow_feed_pass.cc

2. 对PIR operation输出流进行支持，方便调试打印，同时对print operation相关代码传参格式进行规范，将传递非const指针统一修改为传递const引用。

Pcard-76459