### PR TITLE
[CINN] Add method to check applicability of GridReduce

### DIFF
--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
@@ -25,6 +25,7 @@
 #include "paddle/cinn/hlir/pe/map_expr_to_ir.h"
 #include "paddle/cinn/ir/dim.h"
 #include "paddle/cinn/ir/group_schedule/base_group_scheduler.h"
+#include "paddle/cinn/ir/group_schedule/config/group_tile_util.h"
 #include "paddle/cinn/ir/schedule/ir_schedule.h"
 #include "paddle/cinn/ir/schedule/ir_schedule_util.h"
 #include "paddle/cinn/lang/placeholder.h"
@@ -792,6 +793,10 @@ std::shared_ptr<FusionGroupInfo> GetFusionGroupInfo(
                      }
                    });
   }
+
+  group_info->can_apply_grid_reduce =
+      GetCanApplyGridReduce(op_compute_bodies, group_info->reduce_axis);
+
   VLOG(4) << group_info->DebugPrint();
   return group_info;
 }

--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
@@ -168,12 +168,16 @@ struct FusionGroupInfo {
   std::vector<int64_t> loop_strides;
   std::vector<int64_t> reduce_axis;
   std::vector<std::string> reduce_var_name;
+  bool can_apply_grid_reduce;
 
   std::string DebugPrint() {
-    return "GroupInfo\nloop_ranges: " + cinn::utils::Join(loop_ranges, " ") +
-           "\nloop_strides: " + cinn::utils::Join(loop_strides, ", ") +
-           "\nreduce_axis: " + cinn::utils::Join(reduce_axis, " ") +
-           "\nreduce_var_name: " + cinn::utils::Join(reduce_var_name, " ");
+    std::stringstream ss;
+    ss << "GroupInfo\nloop_ranges: " << cinn::utils::Join(loop_ranges, " ")
+       << "\nloop_strides: " << cinn::utils::Join(loop_strides, ", ")
+       << "\nreduce_axis: " << cinn::utils::Join(reduce_axis, " ")
+       << "\nreduce_var_name: " << cinn::utils::Join(reduce_var_name, " ")
+       << "\ncan_apply_grid_reduce: " << can_apply_grid_reduce;
+    return ss.str();
   }
 };
 

--- a/paddle/cinn/ir/group_schedule/config/CMakeLists.txt
+++ b/paddle/cinn/ir/group_schedule/config/CMakeLists.txt
@@ -3,6 +3,7 @@ cinn_proto_library(tile_config_proto SRCS tile_config_desc.proto)
 core_gather_headers()
 
 gather_srcs(cinnapi_src SRCS group_tile_config.cc)
+gather_srcs(cinnapi_src SRCS group_tile_util.cc)
 gather_srcs(cinnapi_src SRCS database.cc)
 gather_srcs(cinnapi_src SRCS file_database.cc)
 gather_srcs(cinnapi_src SRCS schedule_config_manager.cc)

--- a/paddle/cinn/ir/group_schedule/config/group_tile_util.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_util.cc
@@ -1,0 +1,112 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/ir/group_schedule/config/group_tile_util.h"
+#include "paddle/cinn/hlir/framework/pir/trivial_op_impl.h"
+#include "paddle/cinn/ir/ir_analyzer/ir_analyzer.h"
+
+namespace cinn {
+
+using hlir::framework::pir::trivial_fusion_detail::GetAllForIters;
+using hlir::framework::pir::trivial_fusion_detail::ExprSetFinderUtils::
+    ChildScheduleBlockRealizes;
+using hlir::framework::pir::trivial_fusion_detail::ExprSetFinderUtils::
+    ChildTensorLoads;
+using hlir::framework::pir::trivial_fusion_detail::ExprSetFinderUtils::
+    ScheduleBlockRealizeIsNotInit;
+
+namespace ir {
+
+bool GetCanApplyGridReduce(const std::vector<ir::Expr>& op_compute_bodies,
+                           const std::vector<int64_t>& reduce_axis) {
+  // Names of tensors that are downstream of reduce.
+  // A tensor is downstream of reduce either if it is produced by a reduce, or
+  // if it has data dependency on another tensor that is downstream of reduce.
+  std::unordered_set<std::string> reduce_downstream_tensor_names;
+  int reduce_count = 0;
+
+  const auto IsReduceDownstream = [&](const ir::Expr& expr_block) {
+    for (auto& expr_load : ChildTensorLoads(expr_block)) {
+      std::string load_tensor_name = expr_load.As<ir::Load>()->name();
+      if (reduce_downstream_tensor_names.count(load_tensor_name) > 0) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const auto AddReduceDownstream = [&](const ir::Expr& expr_block) {
+    auto expr_store = analyzer::GetStoreOfSBlock(expr_block);
+    std::string store_tensor_name = expr_store.As<ir::Store>()->name();
+    reduce_downstream_tensor_names.insert(store_tensor_name);
+  };
+
+  const auto CheckOutputHasReduceAxis = [&](const ir::Expr& body,
+                                            const ir::Expr& expr_block) {
+    std::vector<ir::Var> all_loop_vars = GetAllForIters(body);
+    std::unordered_set<std::string> reduce_loop_vars;
+    for (int64_t axis : reduce_axis) {
+      reduce_loop_vars.insert(all_loop_vars[axis]->name);
+    }
+
+    std::unordered_set<std::string> reduce_iter_vars;
+    auto* block = expr_block.As<ir::ScheduleBlockRealize>();
+    auto& iter_vars = block->schedule_block.As<ir::ScheduleBlock>()->iter_vars;
+    for (int i = 0; i < iter_vars.size(); i++) {
+      ir::Var loop_var = block->iter_values[i].as_var_ref();
+      if (reduce_loop_vars.count(loop_var->name) > 0) {
+        reduce_iter_vars.insert(iter_vars[i]->name);
+      }
+    }
+
+    // The result is true if the indices of the output tensor contain any
+    // reduce iter vars.
+    auto expr_store = analyzer::GetStoreOfSBlock(expr_block);
+    for (auto& index_expr : expr_store.As<ir::Store>()->indices) {
+      if (reduce_iter_vars.count(index_expr.as_var_ref()->name) > 0) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  for (const auto& body : op_compute_bodies) {
+    ir::Expr expr_block =
+        (ChildScheduleBlockRealizes * ScheduleBlockRealizeIsNotInit)
+            .GetSingle(body);
+    bool is_reduce = analyzer::IsReductionSBlock(expr_block);
+    bool is_reduce_downstream = IsReduceDownstream(expr_block);
+    bool output_has_reduce_axis = CheckOutputHasReduceAxis(body, expr_block);
+
+    if (is_reduce) {
+      ++reduce_count;
+    }
+    if (is_reduce_downstream || is_reduce) {
+      AddReduceDownstream(expr_block);
+    }
+
+    // When a block is downstream of reduce, its output shouldn't contain
+    // reduce axis. Otherwise, it broadcasts the result of reduce. If this
+    // is the case, we cannot apply grid reduce.
+    if (is_reduce_downstream && output_has_reduce_axis) {
+      VLOG(4) << "grid reduce is prohibited by block: " << expr_block;
+      return false;
+    }
+  }
+
+  return reduce_count == 1;
+}
+
+}  // namespace ir
+}  // namespace cinn

--- a/paddle/cinn/ir/group_schedule/config/group_tile_util.h
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_util.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "paddle/cinn/ir/ir.h"
+
+namespace cinn {
+namespace ir {
+
+// Check whether we can apply grid reduce in this group.
+// We can apply grid reduce if there is exactly one reduce, and whose result is
+// not broadcasted before output.
+bool GetCanApplyGridReduce(const std::vector<ir::Expr>& op_compute_bodies,
+                           const std::vector<int64_t>& reduce_axis);
+
+}  // namespace ir
+}  // namespace cinn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
New features


### Description
Add the `GetCanApplyGridReduce` method to check whether we can apply grid reduce in the given fusion group. The result is saved in the `can_apply_grid_reduce` field in the `FusionGroupInfo` struct.

We can apply grid reduce if there is exactly one reduce in the fusion group, and whose result is not broadcasted before output.

Pcard-85711