### PR TITLE
[Fix] Fix det infermeta and support 0-D tensor for `paddle.eye`

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -4717,6 +4717,17 @@ void SumInferMeta(const MetaTensor& x,
   SumRawInferMeta(x, axis, keep_dim, reduce_all, dtype, out, config);
 }
 
+void DetInferMeta(const MetaTensor& x, MetaTensor* out, MetaConfig config) {
+  // remove the last two demension
+  auto out_dim = common::vectorize<int>(x.dims());
+  out_dim.pop_back();
+  out_dim.pop_back();
+
+  out->set_dims(common::make_ddim(out_dim));
+  out->set_dtype(x.dtype());
+  out->set_layout(x.layout());
+}
+
 void PartialSumInferMeta(const std::vector<const MetaTensor*>& xs,
                          int start_index,
                          int length,

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -775,6 +775,10 @@ void SumInferMeta(const MetaTensor& x,
                   MetaTensor* out,
                   MetaConfig config = MetaConfig());
 
+void DetInferMeta(const MetaTensor& x,
+                  MetaTensor* out,
+                  MetaConfig config = MetaConfig());
+
 void SumRawInferMeta(const MetaTensor& x,
                      const IntArray& axis,
                      bool keep_dim,

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -1325,7 +1325,7 @@
   args : (Tensor x)
   output : Tensor
   infer_meta :
-    func : UnchangedInferMeta
+    func : DetInferMeta
   kernel :
     func : determinant
   backward : det_grad

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1360,7 +1360,9 @@ def eye(
 
     def _check_attr(attr, message):
         if isinstance(attr, ((Variable, core.eager.Tensor, paddle.pir.Value))):
-            assert len(attr.shape) == 1 and attr.shape[0] in [1, -1]
+            assert len(attr.shape) == 0 or (
+                len(attr.shape) == 1 and attr.shape[0] in [1, -1]
+            )
         elif not isinstance(attr, int) or attr < 0:
             raise TypeError(f"{message} should be a non-negative int.")
 

--- a/test/legacy_test/test_determinant_op.py
+++ b/test/legacy_test/test_determinant_op.py
@@ -91,13 +91,14 @@ class TestDeterminantAPI(unittest.TestCase):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', self.shape)
-            out = paddle.linalg.det(x)
+            out_value = paddle.linalg.det(x)
             exe = paddle.static.Executor(self.place)
-            res = exe.run(feed={'X': self.x}, fetch_list=[out])
+            (out_np,) = exe.run(feed={'X': self.x}, fetch_list=[out_value])
         out_ref = np.linalg.det(self.x)
 
-        for out in res:
-            np.testing.assert_allclose(out, out_ref, rtol=0.001)
+        np.testing.assert_allclose(out_np, out_ref, rtol=0.001)
+        self.assertEqual(out_np.shape, out_ref.shape)
+        self.assertEqual(tuple(out_value.shape), out_ref.shape)
 
     def test_api_dygraph(self):
         paddle.disable_static(self.place)

--- a/test/legacy_test/test_zero_dim_no_backward_api.py
+++ b/test/legacy_test/test_zero_dim_no_backward_api.py
@@ -269,6 +269,16 @@ class TestNoBackwardAPI(unittest.TestCase):
         out_d = paddle.linalg.matrix_rank(d, tol=tol_2)
         self.assertEqual(out_d.shape, [2])
 
+    def test_eye_zero_dim_input(self):
+        # use zero-dim tensor as inputs
+        num_cols = paddle.to_tensor(4, stop_gradient=False)
+        num_rows = paddle.to_tensor(5, stop_gradient=False)
+        out = paddle.linalg.eye(num_rows, num_cols)
+
+        self.assertEqual(num_cols.shape, [])
+        self.assertEqual(num_rows.shape, [])
+        self.assertEqual(out.shape, [4, 5])
+
 
 class TestNoBackwardAPIStatic(unittest.TestCase):
     def setUp(self):

--- a/test/legacy_test/test_zero_dim_no_backward_api.py
+++ b/test/legacy_test/test_zero_dim_no_backward_api.py
@@ -271,13 +271,13 @@ class TestNoBackwardAPI(unittest.TestCase):
 
     def test_eye_zero_dim_input(self):
         # use zero-dim tensor as inputs
-        num_cols = paddle.to_tensor(4, stop_gradient=False)
         num_rows = paddle.to_tensor(5, stop_gradient=False)
-        out = paddle.linalg.eye(num_rows, num_cols)
+        num_cols = paddle.to_tensor(4, stop_gradient=False)
+        out = paddle.eye(num_rows, num_cols)
 
         self.assertEqual(num_cols.shape, [])
         self.assertEqual(num_rows.shape, [])
-        self.assertEqual(out.shape, [4, 5])
+        self.assertEqual(out.shape, [5, 4])
 
 
 class TestNoBackwardAPIStatic(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Pcard-75624

1. 修复`paddle.linalg.det`的infershape不正确，导致新IR下导出模型报错
2. 修复`paddle.eye`不能接受0-Dtensor作为输入的问题