### PR TITLE
[CINN] Add the ReplaceCrossBlockReduction backend pass

### DIFF
--- a/paddle/cinn/hlir/pe/reduction.cc
+++ b/paddle/cinn/hlir/pe/reduction.cc
@@ -1205,6 +1205,31 @@ std::string DiscreteReduceExternalFuncName(const ir::Expr& op,
   return "";
 }
 
+std::string GridReduceExternalFuncName(const ir::Expr& op,
+                                       const cinn::common::Type type) {
+  if (op.As<ir::Add>()) {
+    if (type.is_bool()) {
+      return "cinn_grid_reduce_any";
+    }
+    return "cinn_grid_reduce_sum" + Type2StrForReduce(type);
+  } else if (op.As<ir::Mul>()) {
+    if (type.is_bool()) {
+      return "cinn_grid_reduce_all";
+    }
+    return "cinn_grid_reduce_prod" + Type2StrForReduce(type);
+  } else if (op.As<ir::Max>()) {
+    return "cinn_grid_reduce_max" + Type2StrForReduce(type);
+  } else if (op.As<ir::Min>()) {
+    return "cinn_grid_reduce_min" + Type2StrForReduce(type);
+  } else if (op.As<ir::And>()) {
+    return "cinn_grid_reduce_all";
+  } else if (op.As<ir::Or>()) {
+    return "cinn_grid_reduce_any";
+  }
+  PADDLE_THROW(::common::errors::InvalidArgument(
+      "No matching grid reduce template for op: %s, type: %s", op, type));
+}
+
 }  // namespace pe
 }  // namespace hlir
 }  // namespace cinn

--- a/paddle/cinn/hlir/pe/reduction.h
+++ b/paddle/cinn/hlir/pe/reduction.h
@@ -474,6 +474,9 @@ std::string CrossThreadReduceExternalFuncName(const ir::Expr& op,
 std::string DiscreteReduceExternalFuncName(const ir::Expr& op,
                                            const ir::Expr& tensor);
 
+std::string GridReduceExternalFuncName(const ir::Expr& op,
+                                       const cinn::common::Type type);
+
 std::string Type2StrForReduce(cinn::common::Type type);
 }  // namespace pe
 }  // namespace hlir

--- a/paddle/cinn/ir/lowered_func.h
+++ b/paddle/cinn/ir/lowered_func.h
@@ -114,6 +114,28 @@ struct CudaAxisInfo {
 std::ostream& operator<<(std::ostream& os, const CudaAxisInfo& x);
 
 /**
+ * A struct representing a temporary global buffer (allocated on the heap) that
+ * is used as staging space during kernel execution.
+ */
+struct TempSpaceInfo {
+  TempSpaceInfo() = default;
+  TempSpaceInfo(const Expr& size, int arg_idx, bool need_zero_init = false)
+      : size_(size), arg_idx_(arg_idx), need_zero_init_(need_zero_init) {}
+
+  Expr size() const { return size_; }
+  int arg_idx() const { return arg_idx_; }
+  bool need_zero_init() const { return need_zero_init_; }
+
+ private:
+  // size of the space in bytes
+  Expr size_;
+  // index in the function's argument list
+  int arg_idx_;
+  // whether this space need to be zero-initialized
+  bool need_zero_init_;
+};
+
+/**
  * Definition of a lowered function. Note that, it should be functional.
  *
  * Arguments of the function:
@@ -130,6 +152,10 @@ struct _LoweredFunc_ : ExprNode<_LoweredFunc_> {
   //! Temporary buffers(as output), these buffers will not appear in the
   //! function's argument list, but will be used in the body.
   std::vector<Buffer> temp_bufs;
+
+  //! Temporary global buffers. These buffers will appear in the function's
+  //! argument list.
+  std::vector<TempSpaceInfo> temp_spaces;
 
   //! Body of this function.
   Expr body;

--- a/paddle/cinn/optim/CMakeLists.txt
+++ b/paddle/cinn/optim/CMakeLists.txt
@@ -24,6 +24,7 @@ gather_srcs(
   cast_bool_to_int8.cc
   var_mod_simplify.cc
   remove_schedule_block.cc
+  replace_cross_block_reduction.cc
   replace_cross_thread_reduction.cc
   replace_mod_to_max.cc
   resize_buffer.cc

--- a/paddle/cinn/optim/optimize.cc
+++ b/paddle/cinn/optim/optimize.cc
@@ -31,6 +31,7 @@
 #include "paddle/cinn/optim/rearrange_load_instruction.h"
 #include "paddle/cinn/optim/remove_schedule_block.h"
 #include "paddle/cinn/optim/replace_const_param_to_integer.h"
+#include "paddle/cinn/optim/replace_cross_block_reduction.h"
 #include "paddle/cinn/optim/replace_cross_thread_reduction.h"
 #include "paddle/cinn/optim/trans_buffer_with_dynamic_shape.h"
 #include "paddle/cinn/optim/transform_gpu_forloop.h"
@@ -59,6 +60,9 @@ Expr Optimize(Expr e,
   // Simplify already contains CastSimplify
   Simplify(&copied);
   ReplaceCrossThreadReduction(&copied);
+  VLOG(4) << "After Optimize ReplaceCrossThreadReduction:" << copied;
+  ReplaceCrossBlockReduction(&copied);
+  VLOG(4) << "After Optimize ReplaceCrossBlockReduction:" << copied;
   UnrollLoop(&copied);
   VLOG(4) << "After Optimize UnrollLoop:" << copied;
 

--- a/paddle/cinn/optim/replace_cross_block_reduction.cc
+++ b/paddle/cinn/optim/replace_cross_block_reduction.cc
@@ -1,0 +1,310 @@
+// Copyright (c) 2024 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/optim/replace_cross_block_reduction.h"
+#include <vector>
+
+#include "paddle/cinn/adt/adt.h"
+#include "paddle/cinn/common/common.h"
+#include "paddle/cinn/hlir/pe/reduction.h"
+#include "paddle/cinn/ir/ir.h"
+#include "paddle/cinn/ir/ir_mutator.h"
+#include "paddle/cinn/ir/schedule/ir_schedule_util.h"
+#include "paddle/cinn/lang/compute.h"
+
+namespace cinn {
+namespace optim {
+namespace {
+
+ir::Expr CalcBufferSizeInBytes(const ir::Buffer& buffer) {
+  const ir::Expr numel = buffer->SymbolicNumel();
+  return common::AutoSimplify(numel * buffer->dtype.bytes());
+}
+
+std::unordered_set<std::string> GetReduceVarNames(
+    const ir::ScheduleBlockRealize* block_realize) {
+  const ir::ScheduleBlock* schedule_block =
+      block_realize->schedule_block.As<ir::ScheduleBlock>();
+  const std::vector<ir::Expr>& iter_values = block_realize->iter_values;
+  const std::vector<ir::Var>& iter_vars = schedule_block->iter_vars;
+
+  std::unordered_set<std::string> reduce_var_names;
+  for (int i = 0; i < iter_values.size(); ++i) {
+    if (!iter_vars[i]->is_reduce_axis) {
+      continue;
+    }
+    ir::ir_utils::CollectIRNodesWithoutTensor(
+        iter_values[i], [&](const ir::Expr* x) {
+          if (x->as_var()) {
+            reduce_var_names.insert(x->as_var()->name);
+          }
+          return false;
+        });
+  }
+  return reduce_var_names;
+}
+
+ir::Expr GetRightOperand(const ir::Expr& expr) {
+#define GET_RIGHT_OPERAND(OpT)  \
+  if (expr.As<OpT>()) {         \
+    return expr.As<OpT>()->b(); \
+  }
+
+  GET_RIGHT_OPERAND(ir::Add);
+  GET_RIGHT_OPERAND(ir::Mul);
+  GET_RIGHT_OPERAND(ir::Max);
+  GET_RIGHT_OPERAND(ir::Min);
+  GET_RIGHT_OPERAND(ir::And);
+  GET_RIGHT_OPERAND(ir::Or);
+
+#undef GET_RIGHT_OPERAND
+  PADDLE_THROW(
+      ::common::errors::InvalidArgument("Not a supported reduce op: %s", expr));
+}
+
+struct CrossBlockReductionReplacer : public ir::IRMutator<> {
+  void operator()(ir::Expr* expr) { Visit(expr); }
+
+ private:
+  bool IsGridReduce(const ir::ScheduleBlockRealize* block_realize) {
+    if (cur_loops_.empty()) {
+      return false;
+    }
+    auto* innermost_loop = cur_loops_.back();
+    if (!innermost_loop->is_gpu_block_binded()) {
+      return false;
+    }
+    const std::unordered_set<std::string> reduce_var_names =
+        GetReduceVarNames(block_realize);
+    return reduce_var_names.count(innermost_loop->loop_var->name) > 0;
+  }
+
+  void ConvertHeapBuffersToFuncArgs(ir::_LoweredFunc_* func_node) {
+    std::vector<ir::Buffer> global_bufs;
+    std::vector<ir::Buffer> local_bufs;
+
+    for (auto& buf : func_node->temp_bufs) {
+      if (buf->memory_type == ir::MemoryType::Heap) {
+        global_bufs.push_back(buf);
+      } else {
+        local_bufs.push_back(buf);
+      }
+    }
+
+    PADDLE_ENFORCE_LE(global_bufs.size(),
+                      1UL,
+                      ::common::errors::PreconditionNotMet(
+                          "Currently supports at most one global buffer."));
+
+    for (auto& buf : global_bufs) {
+      func_node->temp_spaces.emplace_back(
+          CalcBufferSizeInBytes(buf), /* arg_idx= */ func_node->args.size());
+      func_node->args.emplace_back(buf, ir::Argument::IO::kOutput);
+    }
+    func_node->temp_bufs = local_bufs;
+  }
+
+  ir::Tensor CreateLastBlockDoneTensor() {
+    if (is_done_tensor_.defined()) {
+      return is_done_tensor_;
+    }
+    const std::string name = "is_last_block_done";
+    const std::vector<ir::Expr> shape = {};
+    is_done_tensor_ = ir::_Tensor_::Make(name, common::Bool(), shape, shape);
+    is_done_tensor_->WithBuffer("local", "_" + name + "_temp_buffer");
+    return is_done_tensor_;
+  }
+
+  ir::Expr GetBlockBindedSpatialLoopExtend(
+      const ir::ScheduleBlockRealize* block_realize) {
+    const std::unordered_set<std::string> reduce_var_names =
+        GetReduceVarNames(block_realize);
+    std::vector<ir::Expr> loop_extends;
+    for (auto* for_node : cur_loops_) {
+      if (reduce_var_names.count(for_node->loop_var->name) == 0 &&
+          for_node->is_gpu_block_binded()) {
+        loop_extends.push_back(for_node->extent);
+      }
+    }
+    PADDLE_ENFORCE_EQ(
+        loop_extends.size(),
+        1UL,
+        ::common::errors::PreconditionNotMet(
+            "There should be exactly one spatial loop binded on gpu block."));
+    return loop_extends[0];
+  }
+
+  ir::Expr GetThreadBindedSpatialLoopExtend(
+      const ir::ScheduleBlockRealize* block_realize) {
+    const std::unordered_set<std::string> reduce_var_names =
+        GetReduceVarNames(block_realize);
+    std::vector<ir::Expr> loop_extends;
+    for (auto* for_node : cur_loops_) {
+      if (reduce_var_names.count(for_node->loop_var->name) == 0 &&
+          for_node->is_gpu_thread_binded()) {
+        loop_extends.push_back(for_node->extent);
+      }
+    }
+    PADDLE_ENFORCE_LE(
+        loop_extends.size(),
+        1UL,
+        ::common::errors::PreconditionNotMet(
+            "There could be at most one spatial loop binded on gpu thread."));
+    if (loop_extends.empty()) {
+      return ir::Expr(1);
+    }
+    return loop_extends[0];
+  }
+
+  ir::Expr CreateSemaphoreUpdateStmt(
+      const std::vector<ir::Expr>& semaphore_shape) {
+    const std::string name = "semaphore";
+    ir::Tensor semaphore = ir::_Tensor_::Make(
+        name, common::Int(32), semaphore_shape, semaphore_shape);
+    semaphore->WithBuffer("global", "_" + name);
+    semaphore_buffer_ = semaphore->buffer;
+    ir::Expr update_semaphore =
+        lang::CallExtern("cinn_grid_reduce_update_semaphore", {semaphore});
+    ir::Tensor is_done = CreateLastBlockDoneTensor();
+    return ir::Store::Make(is_done, update_semaphore, /* indices= */ {});
+  }
+
+  ir::Expr WrapInLastBlockDone(ir::Expr* op) {
+    ir::Tensor is_done = CreateLastBlockDoneTensor();
+    ir::Expr load_is_done = ir::Load::Make(is_done, /* indices= */ {});
+    return ir::IfThenElse::Make(load_is_done, *op);
+  }
+
+  void ReplaceByGridReduceExternCall(const ir::ScheduleBlock* schedule_block,
+                                     const ir::Expr num_spatial_threads) {
+    ir::Expr update_stmt = schedule_block->body;
+    if (update_stmt.As<ir::Block>()) {
+      PADDLE_ENFORCE_EQ(
+          update_stmt.As<ir::Block>()->stmts.size(),
+          1UL,
+          ::common::errors::InvalidArgument(
+              "There should be exactly one statment inside schedule_block."));
+      update_stmt = update_stmt.As<ir::Block>()->stmts[0];
+    }
+    PADDLE_ENFORCE_NOT_NULL(
+        update_stmt.As<ir::Store>(),
+        ::common::errors::InvalidArgument(
+            "The top-level statement in schedule_block must be a store."));
+
+    auto* store_node = update_stmt.As<ir::Store>();
+    ir::Expr rvalue = GetRightOperand(store_node->value);
+    PADDLE_ENFORCE_NOT_NULL(rvalue.As<ir::Load>(),
+                            ::common::errors::InvalidArgument(
+                                "The rvalue of reduce is not a load."));
+
+    std::string func_name = hlir::pe::GridReduceExternalFuncName(
+        store_node->value, store_node->tensor->type());
+    ir::Tensor rf_tensor = rvalue.As<ir::Load>()->tensor.as_tensor_ref();
+    store_node->value =
+        lang::CallExtern(func_name, {rf_tensor, num_spatial_threads});
+  }
+
+  void Visit(const ir::_LoweredFunc_* expr, ir::Expr* op) override {
+    is_after_grid_reduce_ = false;
+    func_arg_buffer_names_.clear();
+    for (auto& arg : expr->args) {
+      if (arg.is_buffer()) {
+        func_arg_buffer_names_.insert(arg.buffer_arg()->name);
+      }
+    }
+
+    IRMutator::Visit(expr, op);
+    if (!is_after_grid_reduce_) {
+      return;
+    }
+
+    ir::_LoweredFunc_* func_node = op->As<ir::_LoweredFunc_>();
+    ConvertHeapBuffersToFuncArgs(func_node);
+
+    func_node->temp_bufs.push_back(is_done_tensor_->buffer);
+    func_node->temp_spaces.emplace_back(
+        CalcBufferSizeInBytes(semaphore_buffer_),
+        /* arg_idx= */ func_node->args.size(),
+        /* need_zero_init = */ true);
+    func_node->args.emplace_back(semaphore_buffer_, ir::Argument::IO::kOutput);
+  }
+
+  void Visit(const ir::ScheduleBlockRealize* expr, ir::Expr* op) override {
+    const ir::ScheduleBlock* schedule_block =
+        expr->schedule_block.As<ir::ScheduleBlock>();
+
+    if (schedule_block->name.substr(0, 4) == "root") {
+      IRMutator::Visit(expr, op);
+      return;
+    }
+
+    if (!IsGridReduce(expr)) {
+      if (is_after_grid_reduce_) {
+        *op = WrapInLastBlockDone(op);
+      }
+      return;
+    }
+
+    PADDLE_ENFORCE_EQ(
+        is_after_grid_reduce_,
+        false,
+        ::common::errors::PreconditionNotMet(
+            "Currently supports only one reduce in a fusion group."));
+    is_after_grid_reduce_ = true;
+
+    ir::Expr num_spatial_threads = GetThreadBindedSpatialLoopExtend(expr);
+    ReplaceByGridReduceExternCall(schedule_block, num_spatial_threads);
+
+    ir::Expr num_spatial_blocks = GetBlockBindedSpatialLoopExtend(expr);
+    ir::Expr semaphore_update = CreateSemaphoreUpdateStmt({num_spatial_blocks});
+    cur_parent_block_stmts_.push_back(semaphore_update);
+    *op = WrapInLastBlockDone(op);
+  }
+
+  void Visit(const ir::For* expr, ir::Expr* op) override {
+    cur_loops_.push_back(expr);
+    IRMutator::Visit(expr, op);
+    cur_loops_.pop_back();
+  }
+
+  void Visit(const ir::Block* block, ir::Expr* op) override {
+    // We override the Block visitor to facilitate statement insertion.
+    std::vector<ir::Expr> old_parent_block_stmts;
+    old_parent_block_stmts.swap(cur_parent_block_stmts_);
+    auto* node = op->As<ir::Block>();
+    for (auto& stmt : node->stmts) {
+      IRMutator::Visit(&stmt, &stmt);
+      cur_parent_block_stmts_.push_back(stmt);
+    }
+    node->stmts = std::move(cur_parent_block_stmts_);
+    cur_parent_block_stmts_ = std::move(old_parent_block_stmts);
+  }
+
+  void Visit(ir::Expr* expr) { IRMutator::Visit(expr, expr); }
+
+ private:
+  std::vector<const ir::For*> cur_loops_;
+  std::vector<ir::Expr> cur_parent_block_stmts_;
+  std::unordered_set<std::string> func_arg_buffer_names_;
+  ir::Tensor is_done_tensor_;
+  ir::Buffer semaphore_buffer_;
+  bool is_after_grid_reduce_{false};
+};
+
+}  // namespace
+
+void ReplaceCrossBlockReduction(Expr* e) { CrossBlockReductionReplacer()(e); }
+
+}  // namespace optim
+}  // namespace cinn

--- a/paddle/cinn/optim/replace_cross_block_reduction.h
+++ b/paddle/cinn/optim/replace_cross_block_reduction.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2024 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <vector>
+
+#include "paddle/cinn/common/common.h"
+#include "paddle/cinn/ir/ir.h"
+
+namespace cinn {
+namespace optim {
+
+/**
+ * This pass handles the cross-block reduction properly.
+ *
+ * Specific transformations:
+ * 1. Replaces the cross-block reduction with an external call to the
+ *    `grid_reduce` template function.
+ * 2. Adds a condition check `is_last_block_done` to the reduction operation
+ *    and all subsequent schedule blocks.
+ * 3. Pushes global buffers (`rf` and `semaphore`) to the function’s argument
+ *    list.
+ *
+ * Example:
+ *
+ * function reduce_sum (..., var_1)
+ * {
+ *   thread_bind[blockIdx.x] for (i, 0, 16):
+ *     thread_bind[blockIdx.y] for (j, 0, 8): // reduce axis
+ *       var_1[i] += var_1_rf[j, i]
+ * }
+ *
+ * After pass:
+ *
+ * function reduce_sum (..., var_1, var_1_rf, semaphore)
+ * {
+ *   thread_bind[blockIdx.x] for (i, 0, 16):
+ *     thread_bind[blockIdx.y] for (j, 0, 8): // reduce axis
+ *       is_last_block_done = update_semaphore(semaphore)
+ *       if (is_last_block_done):
+ *         var_1[i] = grid_reduce_sum(var_1_rf)
+ * }
+ */
+void ReplaceCrossBlockReduction(Expr* e);
+
+}  // namespace optim
+}  // namespace cinn

--- a/paddle/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
+++ b/paddle/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
@@ -719,6 +719,52 @@ EXPAND_REDUCE_FP16_MACRO(CINN_BLOCK_REDUCE_IMPL)
 
 #undef CINN_BLOCK_REDUCE_IMPL
 
+#define CINN_GRID_REDUCE_IMPL(REDUCE_TYPE, init_value, DTYPE)                    \
+  __shared__ DTYPE tmp_val;                                                      \
+  int tid = (threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x; \
+  if (tid < spatial_threads) {                                                   \
+    tmp_val = init_value;                                                        \
+    for (int y = 0; y < gridDim.y; y++) {                                        \
+      tmp_val = cinn_##REDUCE_TYPE(tmp_val, mem[(y * gridDim.x + blockIdx.x) * spatial_threads + tid]); \
+    }                                                                            \
+  }                                                                              \
+  __syncthreads();                                                               \
+  return tmp_val;
+
+#define CINN_GRID_REDUCE_MACRO(REDUCE_TYPE, INITIAL_VALUE, DTYPE)                \
+  __device__ inline DTYPE cinn_grid_reduce_##REDUCE_TYPE(const DTYPE* mem, int spatial_threads) { \
+    CINN_GRID_REDUCE_IMPL(REDUCE_TYPE, (DTYPE)(INITIAL_VALUE), DTYPE);           \
+  }
+
+EXPAND_REDUCE_INT32_MARCO(CINN_GRID_REDUCE_MACRO)
+EXPAND_REDUCE_INT64_MARCO(CINN_GRID_REDUCE_MACRO)
+EXPAND_REDUCE_FP32_MACRO(CINN_GRID_REDUCE_MACRO)
+EXPAND_REDUCE_FP64_MACRO(CINN_GRID_REDUCE_MACRO)
+EXPAND_REDUCE_BOOL_MACRO(CINN_GRID_REDUCE_MACRO)
+
+#ifdef CINN_CUDA_BF16
+EXPAND_REDUCE_BF16_MACRO(CINN_GRID_REDUCE_MACRO)
+#endif
+
+#ifdef CINN_CUDA_FP16
+EXPAND_REDUCE_FP16_MACRO(CINN_GRID_REDUCE_MACRO)
+#endif
+
+#undef CINN_GRID_REDUCE_IMPL
+#undef CINN_GRID_REDUCE_MACRO
+
+__device__ inline bool cinn_grid_reduce_update_semaphore(int *semaphores) {
+  __shared__ bool done;
+  __threadfence();
+  __syncthreads();
+  if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
+    int old = atomicAdd(&semaphores[blockIdx.x], 1);
+    done = (old == (gridDim.y - 1));
+  }
+  __syncthreads();
+  return done;
+}
+
 #undef EXPAND_REDUCE_INT32_MARCO
 #undef EXPAND_REDUCE_INT64_MARCO
 #undef EXPAND_REDUCE_FP32_MACRO

--- a/paddle/cinn/runtime/cuda/cuda_intrinsics_reduce.cc
+++ b/paddle/cinn/runtime/cuda/cuda_intrinsics_reduce.cc
@@ -165,6 +165,28 @@ CINN_REGISTER_HELPER(cuda_intrinsics_reduce) {
 
 #undef REGISTER_DISCRETE_REDUCE_INTERNAL_FUNC_IMPL
 
+#define REGISTER_GRID_REDUCE_FUNC_IMPL(REDUCE_TYPE, DTYPE)                   \
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_grid_reduce_##REDUCE_TYPE, target) \
+      .SetRetType<DTYPE>()                                                   \
+      .AddInputType<cinn_buffer_t *>()                                       \
+      .AddInputType<int>()                                                   \
+      .End();
+
+  EXPAND_REDUCE_INT32_REGISTER_MARCO(REGISTER_GRID_REDUCE_FUNC_IMPL)
+  EXPAND_REDUCE_INT64_REGISTER_MARCO(REGISTER_GRID_REDUCE_FUNC_IMPL)
+  EXPAND_REDUCE_BF16_REGISTER_MACRO(REGISTER_GRID_REDUCE_FUNC_IMPL)
+  EXPAND_REDUCE_FP16_REGISTER_MACRO(REGISTER_GRID_REDUCE_FUNC_IMPL)
+  EXPAND_REDUCE_FP32_REGISTER_MACRO(REGISTER_GRID_REDUCE_FUNC_IMPL)
+  EXPAND_REDUCE_FP64_REGISTER_MACRO(REGISTER_GRID_REDUCE_FUNC_IMPL)
+  EXPAND_REDUCE_BOOL_REGISTER_MACRO(REGISTER_GRID_REDUCE_FUNC_IMPL)
+
+#undef REGISTER_GRID_REDUCE_FUNC_IMPL
+
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_grid_reduce_update_semaphore, target)
+      .SetRetType<bool>()
+      .AddInputType<int *>()
+      .End();
+
 #define REGISTER_BLOCK_REDUCE_FUNC_IMPL(REDUCE_TYPE, DTYPE)                   \
   REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_block_reduce_##REDUCE_TYPE, target) \
       .SetRetType<DTYPE>()                                                    \

--- a/test/cpp/pir/cinn/CMakeLists.txt
+++ b/test/cpp/pir/cinn/CMakeLists.txt
@@ -39,6 +39,9 @@ if(WITH_TESTING AND WITH_CINN)
 
   paddle_test(test_file_tile_config SRCS file_tile_config_test.cc)
 
+  paddle_test(replace_cross_block_reduction_test SRCS
+              replace_cross_block_reduction_test.cc)
+
   # DO NOT forget add test name here, otherwise it will not be executed in
   # CINN CI.
   set(cinn_unit_tests
@@ -52,7 +55,8 @@ if(WITH_TESTING AND WITH_CINN)
       merge_parallel_matmul_pass_test
       test_tile_config_searcher
       test_tile_config_searcher_pure_spatial
-      test_file_tile_config)
+      test_file_tile_config
+      replace_cross_block_reduction_test)
 
   foreach(test_name ${cinn_unit_tests})
     get_property(

--- a/test/cpp/pir/cinn/replace_cross_block_reduction_test.cc
+++ b/test/cpp/pir/cinn/replace_cross_block_reduction_test.cc
@@ -1,0 +1,202 @@
+// Copyright (c) 2024 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/optim/replace_cross_block_reduction.h"
+
+#include <gtest/gtest.h>
+
+#include "paddle/cinn/cinn.h"
+#include "paddle/cinn/ir/ir.h"
+#include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/op/ir_operators.h"
+#include "paddle/cinn/ir/schedule/ir_schedule.h"
+#include "paddle/cinn/utils/string.h"
+
+namespace cinn {
+namespace optim {
+
+TEST(CrossBlockReductionReplacer, SRLayout) {
+  Context::Global().ResetNameId();
+
+  Placeholder<float> A("A", {Expr(8), Expr(16)});
+  Var reduce_k(8, "reduce_k");
+  ir::Tensor B = Compute(
+      {Expr(16)},
+      [&](Var i) { return lang::ReduceSum(A(reduce_k, i), {reduce_k}); },
+      "B");
+  ir::Tensor C = Compute(
+      {Expr(16)}, [&](Var i) { return lang::Sqrt(B(i)); }, "C");
+
+  ast_gen_ius::TensorGroup tensor_group({A, B, C});
+  auto func = lang::LowerToAst("reduce_sum_sqrt", {C}, &tensor_group);
+
+  ir::ModuleExpr mod_expr({func->body});
+  ir::IRSchedule ir_sch(mod_expr);
+
+  ir_sch.Bind(ir_sch.GetLoops("B")[0], "blockIdx.x");
+  ir_sch.Bind(ir_sch.GetLoops("B")[1], "blockIdx.y");
+  ir_sch.Bind(ir_sch.GetLoops("C")[0], "blockIdx.x");
+
+  func->body = ir_sch.GetModule().GetExprs()[0];
+  A->WithBuffer("global", "_A");
+  B->WithBuffer("local", "_B_temp_buffer");
+  func->temp_bufs = {A->buffer, B->buffer};
+
+  VLOG(6) << "Before ReplaceCrossBlockReduction: " << func;
+  auto expr_func = Expr(func);
+  ReplaceCrossBlockReduction(&expr_func);
+  VLOG(6) << "After ReplaceCrossBlockReduction: " << func;
+
+  EXPECT_EQ(utils::GetStreamCnt(func),
+            utils::Trim(R"ROC(function reduce_sum_sqrt (_C, _A, _semaphore)
+{
+  ScheduleBlock(root)
+  {
+    {
+      thread_bind[blockIdx.x] for (i, 0, 16)
+      {
+        ScheduleBlock(B__reduce_init)
+        {
+          i0 = axis.bind(i)
+          B__reduce_init[i0] = 0.00000000f
+        }
+        thread_bind[blockIdx.y] for (reduce_k, 0, 8)
+        {
+          is_last_block_done[0] = cinn_grid_reduce_update_semaphore(Tensor(semaphore, [16]))
+          if (is_last_block_done[0]) {
+            ScheduleBlock(B)
+            {
+              i0_0, i1 = axis.bind(i, reduce_k)
+              B[i0_0] = cinn_grid_reduce_sum_fp32(Tensor(A, [8,16]), 1)
+            }
+          }
+        }
+      }
+      thread_bind[blockIdx.x] for (i, 0, 16)
+      {
+        if (is_last_block_done[0]) {
+          ScheduleBlock(C)
+          {
+            i0_1 = axis.bind(i)
+            C[i0_1] = sqrt(B[i0_1])
+          }
+        }
+      }
+    }
+  }
+}
+)ROC"));
+  EXPECT_EQ(func->temp_spaces.size(), 2);
+  EXPECT_EQ(func->temp_spaces[0].size().as_int64(), 512);
+  EXPECT_EQ(func->temp_spaces[0].arg_idx(), 1);
+  EXPECT_EQ(func->temp_spaces[0].need_zero_init(), false);
+  EXPECT_EQ(func->temp_spaces[1].size().as_int64(), 64);
+  EXPECT_EQ(func->temp_spaces[1].arg_idx(), 2);
+  EXPECT_EQ(func->temp_spaces[1].need_zero_init(), true);
+}
+
+TEST(CrossBlockReductionReplacer, RSLayout) {
+  Context::Global().ResetNameId();
+
+  Placeholder<float> A("A", {Expr(8), Expr(4), Expr(32)});
+  Var reduce_k(8, "reduce_k");
+  ir::Tensor B = Compute(
+      {Expr(4), Expr(32)},
+      [&](Var i, Var j) {
+        return lang::ReduceMax(A(reduce_k, i, j), {reduce_k});
+      },
+      "B");
+  ir::Tensor C = Compute(
+      {Expr(4), Expr(32)},
+      [&](Var i, Var j) { return lang::Exp(B(i, j)); },
+      "C");
+
+  ast_gen_ius::TensorGroup tensor_group({A, B, C});
+  auto func = lang::LowerToAst("reduce_max_exp", {C}, &tensor_group);
+
+  ir::ModuleExpr mod_expr({func->body});
+  ir::IRSchedule ir_sch(mod_expr);
+
+  ir_sch.Bind(ir_sch.GetLoops("B")[0], "blockIdx.x");
+  ir_sch.Bind(ir_sch.GetLoops("B")[1], "threadIdx.x");
+  ir_sch.Bind(ir_sch.GetLoops("B")[2], "blockIdx.y");
+  ir_sch.Bind(ir_sch.GetLoops("C")[0], "blockIdx.x");
+  ir_sch.Bind(ir_sch.GetLoops("C")[1], "threadIdx.x");
+
+  func->body = ir_sch.GetModule().GetExprs()[0];
+  A->WithBuffer("global", "_A");
+  B->WithBuffer("local", "_B_temp_buffer");
+  func->temp_bufs = {A->buffer, B->buffer};
+
+  VLOG(6) << "Before ReplaceCrossBlockReduction: " << func;
+  auto expr_func = Expr(func);
+  ReplaceCrossBlockReduction(&expr_func);
+  VLOG(6) << "After ReplaceCrossBlockReduction: " << func;
+
+  EXPECT_EQ(utils::GetStreamCnt(func),
+            utils::Trim(R"ROC(function reduce_max_exp (_C, _A, _semaphore)
+{
+  ScheduleBlock(root)
+  {
+    {
+      thread_bind[blockIdx.x] for (i, 0, 4)
+      {
+        thread_bind[threadIdx.x] for (j, 0, 32)
+        {
+          ScheduleBlock(B__reduce_init)
+          {
+            i0, i1 = axis.bind(i, j)
+            B__reduce_init[i0, i1] = -3.40282346e+38f
+          }
+          thread_bind[blockIdx.y] for (reduce_k, 0, 8)
+          {
+            is_last_block_done[0] = cinn_grid_reduce_update_semaphore(Tensor(semaphore, [4]))
+            if (is_last_block_done[0]) {
+              ScheduleBlock(B)
+              {
+                i0_0, i1_0, i2 = axis.bind(i, j, reduce_k)
+                B[i0_0, i1_0] = cinn_grid_reduce_max_fp32(Tensor(A, [8,4,32]), 32)
+              }
+            }
+          }
+        }
+      }
+      thread_bind[blockIdx.x] for (i, 0, 4)
+      {
+        thread_bind[threadIdx.x] for (j, 0, 32)
+        {
+          if (is_last_block_done[0]) {
+            ScheduleBlock(C)
+            {
+              i0_1, i1_1 = axis.bind(i, j)
+              C[i0_1, i1_1] = exp(B[i0_1, i1_1])
+            }
+          }
+        }
+      }
+    }
+  }
+}
+)ROC"));
+  EXPECT_EQ(func->temp_spaces.size(), 2);
+  EXPECT_EQ(func->temp_spaces[0].size().as_int64(), 4096);
+  EXPECT_EQ(func->temp_spaces[0].arg_idx(), 1);
+  EXPECT_EQ(func->temp_spaces[0].need_zero_init(), false);
+  EXPECT_EQ(func->temp_spaces[1].size().as_int64(), 16);
+  EXPECT_EQ(func->temp_spaces[1].arg_idx(), 2);
+  EXPECT_EQ(func->temp_spaces[1].need_zero_init(), true);
+}
+
+}  // namespace optim
+}  // namespace cinn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
New features


### Description
This PR adds the `ReplaceCrossBlockReduction` pass in `optim::Optimize`, and provides the CUDA implementations for `grid_reduce` and `update_semaphore`.
<br>

The `ReplaceCrossBlockReduction` pass performs the following tasks:
* Replaces the cross-block reduction with an external call to `grid_reduce`.
* Adds a condition check `is_last_block_done` to the reduction operation and all subsequent schedule blocks.
* Adds global buffers (`rf` and `semaphore`) to the function’s argument list.
<br>

Example:
```C++
function reduce_sum (..., var_1)
{
  thread_bind[blockIdx.x] for (i, 0, 16):
    thread_bind[blockIdx.y] for (j, 0, 8): // reduce axis
      var_1[i] += var_1_rf[j, i]
}
```
After pass:
```C++
function reduce_sum (..., var_1, var_1_rf, semaphore)
{
  thread_bind[blockIdx.x] for (i, 0, 16):
    thread_bind[blockIdx.y] for (j, 0, 8): // reduce axis
      is_last_block_done = update_semaphore(semaphore)
      if (is_last_block_done):
        var_1[i] = grid_reduce_sum(var_1_rf)
}
```

<br>Pcard-85711