### PR TITLE
[Bug Fixes] fix bug kernel on defalult stream

### DIFF
--- a/paddle/phi/kernels/gpu/accuracy_kernel.cu
+++ b/paddle/phi/kernels/gpu/accuracy_kernel.cu
@@ -35,7 +35,8 @@ __global__ void AccuracyCudaKernel(const int N,
                                    const int64_t* labeldata,
                                    int* correct_data,
                                    T* accuracy,
-                                   int* total_data) {
+                                   int* total_data,
+                                   gpuStream_t stream) {
   using MT = typename phi::dtype::MPTypeTrait<T>::Type;
   int count = 0;
   __shared__ int total[BlockSize];
@@ -54,7 +55,8 @@ __global__ void AccuracyCudaKernel(const int N,
 
 // reduce the count with init value 0, and output accuracy.
 #ifdef PADDLE_WITH_CUDA
-  int result = thrust::reduce(thrust::device, total, total + BlockSize, 0);
+  int result =
+      thrust::reduce(thrust::cuda::par.on(stream), total, total + BlockSize, 0);
 #else
   // HIP thrust::reduce not support __device__
   for (int s = BlockSize / 2; s > 0; s >>= 1) {

--- a/paddle/phi/kernels/gpu/unique_consecutive_functor.h
+++ b/paddle/phi/kernels/gpu/unique_consecutive_functor.h
@@ -56,22 +56,26 @@ static void UniqueConsecutiveFlattenedCUDATensor(const Context& context,
   DenseTensor sorted_indices;
   sorted_indices.Resize(common::make_ddim({num_input}));
   auto sorted_indices_data = context.template Alloc<IndexT>(&sorted_indices);
-  thrust::sequence(
-      thrust::device, sorted_indices_data, sorted_indices_data + num_input);
+  thrust::sequence(thrust::cuda::par.on(dev_ctx.stream()),
+                   sorted_indices_data,
+                   sorted_indices_data + num_input);
   // 1. Calculate op result: 'out'
   DenseTensor range;
   range.Resize(common::make_ddim({num_input + 1}));
   auto range_data_ptr = context.template Alloc<IndexT>(&range);
-  thrust::sequence(
-      thrust::device, range_data_ptr, range_data_ptr + num_input + 1);
+  thrust::sequence(thrust::cuda::par.on(dev_ctx.stream()),
+                   range_data_ptr,
+                   range_data_ptr + num_input + 1);
   phi::Copy(context, in_hat, context.GetPlace(), false, out);
   int num_out;
   auto out_data = context.template Alloc<InT>(out);
-  num_out =
-      thrust::unique_by_key(
-          thrust::device, out_data, out_data + num_input, range_data_ptr, equal)
-          .first -
-      out_data;
+  num_out = thrust::unique_by_key(thrust::cuda::par.on(dev_ctx.stream()),
+                                  out_data,
+                                  out_data + num_input,
+                                  range_data_ptr,
+                                  equal)
+                .first -
+            out_data;
   out->Resize(common::make_ddim({num_out}));
 
   // 2. Calculate inverse index: 'inverse'
@@ -81,18 +85,18 @@ static void UniqueConsecutiveFlattenedCUDATensor(const Context& context,
     DenseTensor inv_loc;
     inv_loc.Resize(common::make_ddim({num_input}));
     auto inv_loc_data_ptr = context.template Alloc<IndexT>(&inv_loc);
-    thrust::adjacent_difference(thrust::device,
+    thrust::adjacent_difference(thrust::cuda::par.on(dev_ctx.stream()),
                                 in_data_hat,
                                 in_data_hat + num_input,
                                 inv_loc_data_ptr,
                                 not_equal);
     thrust::device_ptr<IndexT> inv_loc_data_dev(inv_loc_data_ptr);
     inv_loc_data_dev[0] = 0;  // without device_ptr, segmentation fault
-    thrust::inclusive_scan(thrust::device,
+    thrust::inclusive_scan(thrust::cuda::par.on(dev_ctx.stream()),
                            inv_loc_data_ptr,
                            inv_loc_data_ptr + num_input,
                            inv_loc_data_ptr);
-    thrust::scatter(thrust::device,
+    thrust::scatter(thrust::cuda::par.on(dev_ctx.stream()),
                     inv_loc_data_ptr,
                     inv_loc_data_ptr + num_input,
                     sorted_indices_data,
@@ -103,10 +107,13 @@ static void UniqueConsecutiveFlattenedCUDATensor(const Context& context,
     counts->Resize(common::make_ddim({num_out}));
     auto count_data = context.template Alloc<IndexT>(counts);
     // init 'count_data' as 0
-    thrust::fill(thrust::device, count_data, count_data + num_out, 0);
+    thrust::fill(thrust::cuda::par.on(dev_ctx.stream()),
+                 count_data,
+                 count_data + num_out,
+                 0);
     thrust::device_ptr<IndexT> range_data_ptr_dev(range_data_ptr);
     range_data_ptr_dev[num_out] = num_input;
-    thrust::adjacent_difference(thrust::device,
+    thrust::adjacent_difference(thrust::cuda::par.on(dev_ctx.stream()),
                                 range_data_ptr + 1,
                                 range_data_ptr + num_out + 1,
                                 count_data);
@@ -184,18 +191,18 @@ static void ComputeUniqueConsecutiveDims(const Context& context,
   DenseTensor inv_loc;
   inv_loc.Resize(common::make_ddim({row}));
   auto inv_loc_data_ptr = context.template Alloc<IndexT>(&inv_loc);
-  thrust::adjacent_difference(thrust::device,
+  thrust::adjacent_difference(thrust::cuda::par.on(dev_ctx.stream()),
                               sorted_indices_data,
                               sorted_indices_data + row,
                               inv_loc_data_ptr,
                               not_equal);
   thrust::device_ptr<IndexT> inv_loc_data_dev(inv_loc_data_ptr);
   inv_loc_data_dev[0] = 0;
-  thrust::inclusive_scan(thrust::device,
+  thrust::inclusive_scan(thrust::cuda::par.on(dev_ctx.stream()),
                          inv_loc_data_ptr,
                          inv_loc_data_ptr + row,
                          inv_loc_data_ptr);
-  thrust::scatter(thrust::device,
+  thrust::scatter(thrust::cuda::par.on(dev_ctx.stream()),
                   inv_loc_data_ptr,
                   inv_loc_data_ptr + row,
                   sorted_indices_data,
@@ -205,9 +212,11 @@ static void ComputeUniqueConsecutiveDims(const Context& context,
   DenseTensor range;
   range.Resize(common::make_ddim({row + 1}));
   auto range_data_ptr = context.template Alloc<IndexT>(&range);
-  thrust::sequence(thrust::device, range_data_ptr, range_data_ptr + row + 1);
+  thrust::sequence(thrust::cuda::par.on(dev_ctx.stream()),
+                   range_data_ptr,
+                   range_data_ptr + row + 1);
   int num_out;
-  num_out = thrust::unique_by_key(thrust::device,
+  num_out = thrust::unique_by_key(thrust::cuda::par.on(dev_ctx.stream()),
                                   sorted_indices_data,
                                   sorted_indices_data + row,
                                   range_data_ptr,
@@ -222,8 +231,11 @@ static void ComputeUniqueConsecutiveDims(const Context& context,
   if (return_counts) {
     counts->Resize(common::make_ddim({num_out}));
     auto count_data = context.template Alloc<IndexT>(counts);
-    thrust::fill(thrust::device, count_data, count_data + row, 0);
-    thrust::adjacent_difference(thrust::device,
+    thrust::fill(thrust::cuda::par.on(dev_ctx.stream()),
+                 count_data,
+                 count_data + row,
+                 0);
+    thrust::adjacent_difference(thrust::cuda::par.on(dev_ctx.stream()),
                                 range_data_ptr + 1,
                                 range_data_ptr + row + 1,
                                 count_data);
@@ -386,8 +398,9 @@ static void UniqueConsecutiveDimsCUDATensor(const Context& context,
 
   // 2. Calculate 'inverse', 'counts'
   // Init index
-  thrust::sequence(
-      thrust::device, sorted_indices_data, sorted_indices_data + row);
+  thrust::sequence(thrust::cuda::par.on(dev_ctx.stream()),
+                   sorted_indices_data,
+                   sorted_indices_data + row);
   ComputeUniqueConsecutiveDims<Context, InT, IndexT>(
       context,
       &sorted_indices,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
 Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-71500

修复使用thrust::device时跑在默认steam上的bug，在指定stream推理时候，使用default stream在不同stream上会出现偶发性core