### PR TITLE
Determinant kernel support complex 易用性提升

### DIFF
--- a/paddle/phi/kernels/cpu/determinant_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/determinant_grad_kernel.cc
@@ -22,4 +22,6 @@ PD_REGISTER_KERNEL(determinant_grad,
                    ALL_LAYOUT,
                    phi::DeterminantGradKernel,
                    float,
-                   double) {}
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/cpu/determinant_kernel.cc
+++ b/paddle/phi/kernels/cpu/determinant_kernel.cc
@@ -17,5 +17,11 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/determinant_kernel_impl.h"
 
-PD_REGISTER_KERNEL(
-    determinant, CPU, ALL_LAYOUT, phi::DeterminantKernel, float, double) {}
+PD_REGISTER_KERNEL(determinant,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::DeterminantKernel,
+                   float,
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/gpu/determinant_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/determinant_grad_kernel.cu
@@ -23,4 +23,6 @@ PD_REGISTER_KERNEL(determinant_grad,
                    phi::DeterminantGradKernel,
                    phi::dtype::float16,
                    float,
-                   double) {}
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/gpu/determinant_kernel.cu
+++ b/paddle/phi/kernels/gpu/determinant_kernel.cu
@@ -14,8 +14,213 @@
 
 #include "paddle/phi/kernels/determinant_kernel.h"
 
+#include <Eigen/Dense>
+#include <Eigen/LU>
+#include <algorithm>
+#include <cmath>
+#include <vector>
+#include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/impl/determinant_kernel_impl.h"
+
+#include "glog/logging.h"
+#include "paddle/phi/common/amp_type_traits.h"
+
+#include "paddle/phi/common/memory_utils.h"
+#include "paddle/phi/core/enforce.h"
+#include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/kernels/funcs/blas/blas.h"
+
+namespace phi {
+namespace detail {
+template <typename T>
+class EigenMatrix {};
+
+template <>
+class EigenMatrix<phi::dtype::float16> {
+ public:
+  using MatrixType =
+      Eigen::Matrix<phi::dtype::float16, Eigen::Dynamic, Eigen::Dynamic>;
+};
+
+template <>
+class EigenMatrix<float> {
+ public:
+  using MatrixType = Eigen::MatrixXf;
+};
+
+template <>
+class EigenMatrix<double> {
+ public:
+  using MatrixType = Eigen::MatrixXd;
+};
+
+inline int64_t GetBatchCount(const DDim dims) {
+  int64_t batch_count = 1;
+  auto dim_size = dims.size();
+  PADDLE_ENFORCE_GE(
+      dim_size,
+      2,
+      common::errors::InvalidArgument(
+          "the input matrix dimension size should greater than 2."));
+
+  // Cumulative multiplying each dimension until the last 2 to get the batch
+  // count,
+  // for example a tensor with shape [3,3,3,3], the batch count of matrices is
+  // 9.
+  for (int64_t i = 0; i < dims.size() - 2; i++) {
+    batch_count *= dims[i];
+  }
+
+  return batch_count;
+}
+}  // namespace detail
+
+template <typename T, typename Context>
+struct DeterminantCudaFunctor {
+  void operator()(const Context& dev_ctx,
+                  const DenseTensor& input,
+                  int64_t rank,
+                  int64_t batch_count,
+                  DenseTensor* output) {
+    std::vector<T> input_vec;
+    std::vector<T> output_vec;
+    phi::TensorToVector(input, dev_ctx, &input_vec);
+    using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+    for (int64_t i = 0; i < batch_count; ++i) {  // maybe can be parallel
+      auto begin_iter = input_vec.begin() + i * rank * rank;
+      auto end_iter = input_vec.begin() + (i + 1) * rank * rank;
+      std::vector<T> sub_vec(begin_iter,
+                             end_iter);  // get every square matrix data
+      typename detail::EigenMatrix<T>::MatrixType matrix(rank, rank);
+      for (int64_t i = 0; i < rank; ++i) {
+        for (int64_t j = 0; j < rank; ++j) {
+          matrix(i, j) = sub_vec[rank * i + j];
+        }
+      }
+      output_vec.push_back(
+          static_cast<T>(matrix.template cast<MPType>().determinant()));
+    }
+    phi::TensorFromVector(output_vec, dev_ctx, output);
+  }
+};
+
+template <typename T>
+__global__ void GetDetFromLUComplex(const T* lu_data,
+                                    const int* ipiv,
+                                    int64_t n,
+                                    int64_t batch_size,
+                                    T* out_data) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (idx < batch_size) {
+    int offset_lu = idx * n * n;
+    int offset_ipiv = idx * n;
+    T out_idx = T(1.0, 0.0);
+    T negative = T(-1.0, 0.0);
+    for (int i = 0; i < n; ++i) {
+      out_idx *= lu_data[offset_lu + i * n + i];
+      if (ipiv[offset_ipiv + i] != i + 1) {
+        out_idx *= negative;
+      }
+    }
+    out_data[idx] = static_cast<T>(out_idx);
+  }
+}
+
+template <typename T, typename Context>
+struct DeterminantCudaFunctor<phi::dtype::complex<T>, Context> {
+  void operator()(const Context& dev_ctx,
+                  const DenseTensor& a,
+                  int64_t n,
+                  int64_t batch_size,
+                  DenseTensor* output) {
+    phi::Allocator::AllocationPtr tmp_gpu_mat_data;
+    const phi::dtype::complex<T>* gpu_mat = a.data<phi::dtype::complex<T>>();
+    // Copy all elements of input matrix A to a temporary memory space to
+    // avoid being overriden by getrf.
+    tmp_gpu_mat_data = phi::memory_utils::Alloc(
+        dev_ctx.GetPlace(),
+        a.numel() * sizeof(phi::dtype::complex<T>),
+        phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
+    memory_utils::Copy(dev_ctx.GetPlace(),
+                       tmp_gpu_mat_data->ptr(),
+                       dev_ctx.GetPlace(),
+                       a.data(),
+                       a.numel() * sizeof(phi::dtype::complex<T>),
+                       dev_ctx.stream());
+    gpu_mat = reinterpret_cast<const phi::dtype::complex<T>*>(
+        tmp_gpu_mat_data->ptr());
+
+    std::vector<const phi::dtype::complex<T>*> cpu_ptrs(batch_size);
+    for (int i = 0; i < batch_size; ++i) {
+      cpu_ptrs[i] = gpu_mat + i * n * n;
+    }
+
+    int num_ints = batch_size * (n + 1);
+    // num_ints is for pivot (n * batch_size) and info (batch_size)
+    size_t total_bytes =
+        batch_size * sizeof(phi::dtype::complex<T>*) + num_ints * sizeof(int);
+    phi::Allocator::AllocationPtr tmp_gpu_ptrs_data = phi::memory_utils::Alloc(
+        dev_ctx.GetPlace(),
+        total_bytes,
+        phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
+    memory_utils::Copy(dev_ctx.GetPlace(),
+                       tmp_gpu_ptrs_data->ptr(),
+                       phi::CPUPlace(),
+                       static_cast<void*>(cpu_ptrs.data()),
+                       cpu_ptrs.size() * sizeof(phi::dtype::complex<T>*),
+                       dev_ctx.stream());
+
+    phi::dtype::complex<T>** gpu_mat_ptr =
+        reinterpret_cast<phi::dtype::complex<T>**>(tmp_gpu_ptrs_data->ptr());
+    int* gpu_info_ptr = reinterpret_cast<int*>(gpu_mat_ptr + cpu_ptrs.size());
+    int* pivot_data = gpu_info_ptr + batch_size;
+
+    auto blas = phi::funcs::GetBlas<Context, phi::dtype::complex<T>>(dev_ctx);
+    // This function performs the LU factorization of each matrix A by the
+    // equation P * A = L * U. L and U are written back to original matrix A,
+    // and diagonal elements of L are discarded.
+    blas.BatchedGETRF(n, gpu_mat_ptr, pivot_data, gpu_info_ptr, batch_size);
+    phi::dtype::complex<T>* out_data =
+        dev_ctx.template Alloc<phi::dtype::complex<T>>(output);
+    int block_size = std::min(256, dev_ctx.GetMaxThreadsPerBlock());
+    dim3 dim_block(block_size);
+    dim3 num_blocks((batch_size + block_size - 1) / block_size);
+    GetDetFromLUComplex<phi::dtype::complex<T>><<<num_blocks, dim_block>>>(
+        gpu_mat, pivot_data, n, batch_size, out_data);
+  }
+};
+
+template <typename T, typename Context>
+void DeterminantKernel(const Context& dev_ctx,
+                       const DenseTensor& x,
+                       DenseTensor* out) {
+  auto input_dim = common::vectorize(x.dims());
+  auto input_dim_size = input_dim.size();
+
+  auto batch_count = detail::GetBatchCount(x.dims());
+  VLOG(10) << "input dim:" << x.dims();
+  PADDLE_ENFORCE_GE(
+      input_dim_size,
+      2,
+      common::errors::InvalidArgument("the input matrix dimension size should "
+                                      "greater than or equal to 2."));
+  PADDLE_ENFORCE_EQ(input_dim[input_dim_size - 1],
+                    input_dim[input_dim_size - 2],
+                    common::errors::InvalidArgument(
+                        "the input matrix should be square matrix."));
+  auto rank = input_dim[input_dim_size - 1];  // square matrix length
+  DeterminantCudaFunctor<T, Context>()(dev_ctx, x, rank, batch_count, out);
+  auto output_dims = common::slice_ddim(x.dims(), 0, input_dim_size - 2);
+  if (input_dim_size > 2) {
+    out->Resize(output_dims);
+  } else {
+    // when input is a two-dimension matrix, The det value is a number.
+    out->Resize(common::make_ddim({}));
+  }
+  VLOG(10) << "output dim:" << out->dims();
+}
+
+}  // namespace phi
 
 PD_REGISTER_KERNEL(determinant,
                    GPU,
@@ -23,4 +228,6 @@ PD_REGISTER_KERNEL(determinant,
                    phi::DeterminantKernel,
                    phi::dtype::float16,
                    float,
-                   double) {}
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2742,7 +2742,12 @@ def det(x: Tensor, name: str | None = None) -> Tensor:
     if in_dynamic_or_pir_mode():
         return _C_ops.det(x)
     else:
-        check_dtype(x.dtype, 'Input', ['float16', 'float32', 'float64'], 'det')
+        check_dtype(
+            x.dtype,
+            'Input',
+            ['float16', 'float32', 'float64', 'complex64', 'complex128'],
+            'det',
+        )
 
         input_shape = list(x.shape)
         assert len(input_shape) >= 2, (

--- a/test/legacy_test/test_determinant_op.py
+++ b/test/legacy_test/test_determinant_op.py
@@ -174,11 +174,7 @@ class TestDeterminantAPIComplex(TestDeterminantAPI):
         self.x = np.vectorize(complex)(
             np.random.random(self.shape), np.random.random(self.shape)
         ).astype(self.dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = paddle.CPUPlace()
 
 
 class TestDeterminantAPIComplex2(TestDeterminantAPI):
@@ -189,11 +185,7 @@ class TestDeterminantAPIComplex2(TestDeterminantAPI):
         self.x = np.vectorize(complex)(
             np.random.random(self.shape), np.random.random(self.shape)
         ).astype(self.dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = paddle.CPUPlace()
 
 
 class TestSlogDeterminantOp(OpTest):

--- a/test/legacy_test/test_determinant_op.py
+++ b/test/legacy_test/test_determinant_op.py
@@ -78,17 +78,76 @@ class TestDeterminantOpCase2FP16(TestDeterminantOp):
         )
 
 
+class TestDeterminantOpCase3(TestDeterminantOp):
+    def init_data(self):
+        np.random.seed(0)
+        self.case = np.vectorize(complex)(
+            np.random.rand(10, 10), np.random.rand(10, 10)
+        ).astype('complex64')
+        self.inputs = {'Input': self.case}
+        self.target = np.linalg.det(self.case)
+
+
+class TestDeterminantOpCase4(TestDeterminantOp):
+    def init_data(self):
+        np.random.seed(0)
+        self.case = np.vectorize(complex)(
+            np.random.rand(10, 10), np.random.rand(10, 10)
+        ).astype('complex128')
+        self.inputs = {'Input': self.case}
+        self.target = np.linalg.det(self.case)
+
+
+class TestDeterminantOpCase5(TestDeterminantOp):
+    def init_data(self):
+        np.random.seed(0)
+        # not invertible matrix
+        self.case = np.ones([4, 2, 4, 4]).astype('complex64')
+        self.inputs = {'Input': self.case}
+        self.target = np.linalg.det(self.case)
+
+
+class TestDeterminantOpCase6(TestDeterminantOp):
+    def init_data(self):
+        np.random.seed(0)
+        # not invertible matrix
+        self.case = np.ones([4, 2, 4, 4]).astype('complex128')
+        self.inputs = {'Input': self.case}
+        self.target = np.linalg.det(self.case)
+
+
+class TestDeterminantOpCase7(TestDeterminantOp):
+    def init_data(self):
+        np.random.seed(0)
+        self.case = np.vectorize(complex)(
+            np.random.rand(5, 3, 10, 10), np.random.rand(5, 3, 10, 10)
+        ).astype('complex64')
+        self.inputs = {'Input': self.case}
+        self.target = np.linalg.det(self.case)
+
+
+class TestDeterminantOpCase8(TestDeterminantOp):
+    def init_data(self):
+        np.random.seed(0)
+        self.case = np.vectorize(complex)(
+            np.random.rand(5, 3, 10, 10), np.random.rand(5, 3, 10, 10)
+        ).astype('complex128')
+        self.inputs = {'Input': self.case}
+        self.target = np.linalg.det(self.case)
+
+
 class TestDeterminantAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
+        self.dtype = np.float32
         self.shape = [3, 3, 5, 5]
-        self.x = np.random.random(self.shape).astype(np.float32)
+        self.x = np.random.random(self.shape).astype(self.dtype)
         self.place = paddle.CPUPlace()
 
     def test_api_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
-            x = paddle.static.data('X', self.shape)
+            x = paddle.static.data('X', self.shape, dtype=self.dtype)
             out_value = paddle.linalg.det(x)
             exe = paddle.static.Executor(self.place)
             (out_np,) = exe.run(feed={'X': self.x}, fetch_list=[out_value])
@@ -105,6 +164,36 @@ class TestDeterminantAPI(unittest.TestCase):
         out_ref = np.linalg.det(self.x)
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.001)
         paddle.enable_static()
+
+
+class TestDeterminantAPIComplex(TestDeterminantAPI):
+    def setUp(self):
+        np.random.seed(0)
+        self.dtype = np.complex64
+        self.shape = [2, 1, 4, 3, 6, 6]
+        self.x = np.vectorize(complex)(
+            np.random.random(self.shape), np.random.random(self.shape)
+        ).astype(self.dtype)
+        self.place = (
+            paddle.CUDAPlace(0)
+            if core.is_compiled_with_cuda()
+            else paddle.CPUPlace()
+        )
+
+
+class TestDeterminantAPIComplex2(TestDeterminantAPI):
+    def setUp(self):
+        np.random.seed(0)
+        self.dtype = np.complex128
+        self.shape = [3, 3, 5, 5]
+        self.x = np.vectorize(complex)(
+            np.random.random(self.shape), np.random.random(self.shape)
+        ).astype(self.dtype)
+        self.place = (
+            paddle.CUDAPlace(0)
+            if core.is_compiled_with_cuda()
+            else paddle.CPUPlace()
+        )
 
 
 class TestSlogDeterminantOp(OpTest):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Determinant kernel 支持complex64/complex128
- 前向：由于 Eigen 库当矩阵数据类型是 std::complex 时在 windows 平台上编译 cuda kernel 会出现 std::complex 类型的 operators 重复定义的错误，所以将 complex 类型的 cuda kernel 实现改为用 cublas 库，先进行 LU 分解，然后求对角线元素的乘积。
- 反向：原反向计算的公式依据是：https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf ，而该推导过程只适用于实数矩阵，对于复数矩阵需要修改的地方如下：
![image](https://github.com/user-attachments/assets/817a7fc9-d0df-47be-a916-fd7e2ca8f1f3)
因此在最后需要对 out*inverse(A) 求共轭：(section 2.2.4)

$$ dC = C \cdot Tr(A^{-1} dA)$$

$$ \bar{C}^{H}dC = \bar{C}^{H}C  \cdot Tr(A^{-1} dA) = Tr( \bar{C}^{H}C A^{-1} dA) $$

$$ dS_o = Tr(\bar{C}^H dC) = Tr( \bar{C}^{H}C A^{-1} dA)$$

$$ \bar{A} = \bar{C} \cdot (C A^{-1})^H $$