### PR TITLE
[Dy2St] Cleanup `test_with_pir_api` check and cleanup `IrGuard` usage in uts

### DIFF
--- a/test/dygraph_to_static/check_approval.py
+++ b/test/dygraph_to_static/check_approval.py
@@ -132,6 +132,7 @@ ALLOW_LIST: dict[type[Diagnostic], list[str]] = {
         "test_move_cuda_pinned_tensor.py",
         "test_pylayer.py",
         "test_tensor_attr_consistency.py",
+        "test_partial_program_hook.py",
     ],
 }
 

--- a/test/dygraph_to_static/check_approval.py
+++ b/test/dygraph_to_static/check_approval.py
@@ -105,15 +105,6 @@ class TestClassInheritFromTestCaseDiagnostic(Diagnostic):
         )
 
 
-class TestCaseWithPirApiDecoratorDiagnostic(Diagnostic):
-    def __init__(self, start: Location, end: Location):
-        super().__init__(
-            start,
-            end,
-            'Test case should use @test_pt_and_pir instead of ',
-        )
-
-
 ALLOW_LIST: dict[type[Diagnostic], list[str]] = {
     UseToStaticAsDecoratorDiagnostic: [
         "test_rollback.py",
@@ -142,7 +133,6 @@ ALLOW_LIST: dict[type[Diagnostic], list[str]] = {
         "test_pylayer.py",
         "test_tensor_attr_consistency.py",
     ],
-    TestCaseWithPirApiDecoratorDiagnostic: [],
 }
 
 
@@ -163,8 +153,6 @@ class Checker(ast.NodeVisitor):
 
 
 class TestBaseChecker(Checker):
-    REGEX_TEST_WITH_PIR_API = re.compile(r".*test_with_pir_api")
-
     def visit_ClassDef(self, node: ast.ClassDef):
         if not is_test_class(node):
             return
@@ -184,31 +172,7 @@ class TestBaseChecker(Checker):
                 )
                 return
 
-            if (
-                isinstance(base, ast.Attribute)
-                and isinstance(base.value, ast.Name)
-                and base.value.id == 'dygraph_to_static'
-                and base.attr == 'Dy2StTestBase'
-            ) or (isinstance(base, ast.Name) and base.id == 'Dy2StTestBase'):
-                for sub_node in node.body:
-                    if isinstance(sub_node, ast.FunctionDef) and is_test_case(
-                        sub_node
-                    ):
-                        self.check_test_case(sub_node)
-                return
-
         self.generic_visit(node)
-
-    def check_test_case(self, node: ast.FunctionDef):
-        # Check if the test case use
-        for decorator in node.decorator_list:
-            decorator_str = ast_to_source_code(decorator).strip()
-            if TestBaseChecker.REGEX_TEST_WITH_PIR_API.match(decorator_str):
-                start = Location(node.lineno, node.col_offset)
-                end = Location(node.end_lineno, node.end_col_offset)  # type: ignore
-                self.diagnostics.append(
-                    TestCaseWithPirApiDecoratorDiagnostic(start, end)
-                )
 
 
 class FunctionTostaticChecker(Checker):
@@ -318,7 +282,6 @@ def main():
         (
             UseToStaticAsDecoratorDiagnostic,
             TestClassInheritFromTestCaseDiagnostic,
-            TestCaseWithPirApiDecoratorDiagnostic,
         ),
     )
     if diagnostics:

--- a/test/dygraph_to_static/test_partial_program_hook.py
+++ b/test/dygraph_to_static/test_partial_program_hook.py
@@ -14,8 +14,6 @@
 
 import unittest
 
-from dygraph_to_static_utils import Dy2StTestBase, test_ast_only, test_pir_only
-
 import paddle
 from paddle.base import core
 from paddle.jit.dy2static import (
@@ -24,29 +22,26 @@ from paddle.jit.dy2static import (
 )
 
 
-class TestPartiaProgramLayerHook(Dy2StTestBase):
+class TestPartiaProgramLayerHook(unittest.TestCase):
     def setUp(self):
         self._hook = pir_partial_program.PartialProgramLayerHook()
 
-    @test_ast_only
     def test_before_append_backward(self):
         self.assertEqual(
             self._hook.before_append_backward(None, None), (None, None)
         )
 
-    @test_ast_only
     def test_after_append_backward(self):
         self.assertEqual(
             self._hook.after_append_backward(None, None, None, None, 0, 0),
             (None, 0, None),
         )
 
-    @test_ast_only
     def test_after_infer(self):
         self.assertIsNone(self._hook.after_infer(None))
 
 
-class TestPrimHook(Dy2StTestBase):
+class TestPrimHook(unittest.TestCase):
     def setUp(self):
         core._set_prim_all_enabled(True)
 
@@ -64,8 +59,6 @@ class TestPrimHook(Dy2StTestBase):
     def tearDown(self):
         core._set_prim_all_enabled(False)
 
-    @test_ast_only
-    @test_pir_only
     def test_before_append_backward(self):
         program = self.partial_program_layer.program
 
@@ -80,7 +73,6 @@ class TestPrimHook(Dy2StTestBase):
             ),
         )
 
-    @test_ast_only
     def test_after_append_backward(self):
         program_ = self.partial_program_layer.train_program
         train_program = program_.program


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

#68384 已经将 `test_with_pir_api` 彻底移除，因此无需再检查动转静单测是否使用该装饰器，直接移除该检查

PIR 已经在 #68278 切为默认模式，`test/dygraph_to_static/test_partial_program_hook.py` 的 `IrGuard` 使用已经没有必要，因此删除

Pcard-67164