### PR TITLE
[AutoParallel][PIR] Adjust dist2dense pass for kwargs-type inputs

### DIFF
--- a/paddle/fluid/pir/dialect/distributed/transforms/dist_to_dense_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/dist_to_dense_pass.cc
@@ -73,6 +73,14 @@ void ProcessDistBlock(pir::Block* block) {
       auto result = op_item->result(i);
       result.set_type(CastToLocalType(result.type()));
     }
+
+    for (size_t i = 0; i < op_item->num_operands(); ++i) {
+      auto input = op_item->operand_source(i);
+      if (IsDistType(input.type())) {
+        input.set_type(CastToLocalType(input.type()));
+      }
+    }
+
     if (op_item->isa<DataOp>()) {
       auto dense_tensor_type =
           op_item->result(0).type().dyn_cast<pir::DenseTensorType>();
@@ -157,7 +165,7 @@ void ProcessDistBlock(pir::Block* block) {
 
 /* Verification:
     1. no operator has not OperatorDistAttr.
-    2. all Values (Results) are DenseTensorType.
+    2. all Values are DenseTensorType.
     3. no shard_tensor / reshard in block.
 */
 void VerifyDenseBlock(pir::Block* block) {
@@ -169,6 +177,15 @@ void VerifyDenseBlock(pir::Block* block) {
 
       PADDLE_ENFORCE_EQ(
           IsDistType(result.type()),
+          false,
+          common::errors::PreconditionNotMet(
+              "Block op [%s] still contain dist type.", op_item->name()));
+    }
+
+    for (size_t i = 0; i < op_item->num_operands(); ++i) {
+      auto input = op_item->operand_source(i);
+      PADDLE_ENFORCE_EQ(
+          IsDistType(input.type()),
           false,
           common::errors::PreconditionNotMet(
               "Block op [%s] still contain dist type.", op_item->name()));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->


Fix the dist2dense pass when the input needs to be cast to dense, as shown below.

<img width="1552" alt="1eaba9029d5ce901292da6c60f4daa1c" src="https://github.com/user-attachments/assets/a6509a8d-7ca8-45bd-8c44-a34d6b7d98fe">

The kwargs-type inputs will cause error when run `pm.run(ir_program)`

![e3c3b713b7598a747dc8ad80d7137bc6](https://github.com/user-attachments/assets/0bf69841-1b33-45ec-9dce-b69904a7c68b)


Pcard-76459


