### PR TITLE
Clean feed_strings kernel [fluid_ops] 

### DIFF
--- a/paddle/fluid/operators/controlflow/feed_op.cc
+++ b/paddle/fluid/operators/controlflow/feed_op.cc
@@ -198,7 +198,3 @@ REGISTER_OPERATOR(
 
 PD_REGISTER_KERNEL_FOR_ALL_BACKEND_DTYPE(
     feed_dense_tensor, ALL_LAYOUT, paddle::operators::FeedDenseTensorKernel) {}
-PD_REGISTER_KERNEL_FOR_ALL_BACKEND_DTYPE(feed_strings,
-                                         ALL_LAYOUT,
-                                         paddle::operators::FeedStringsKernel) {
-}

--- a/test/deprecated/tokenizer/test_faster_tokenizer_op_deprecated.py
+++ b/test/deprecated/tokenizer/test_faster_tokenizer_op_deprecated.py
@@ -431,16 +431,6 @@ class TestBertTokenizerOp(unittest.TestCase):
             token_type_ids, py_token_type_ids, rtol=0, atol=0.01
         )
 
-    def test_feed_string_var(self):
-        self.init_data()
-        paddle.enable_static()
-        x = paddle.static.data(
-            name="x", shape=[-1], dtype=core.VarDesc.VarType.STRINGS
-        )
-        exe = paddle.static.Executor(paddle.framework.CPUPlace())
-        exe.run(paddle.static.default_main_program(), feed={'x': self.text})
-        paddle.disable_static()
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/deprecated/tokenizer/test_faster_tokenizer_op_deprecated.py
+++ b/test/deprecated/tokenizer/test_faster_tokenizer_op_deprecated.py
@@ -314,6 +314,7 @@ class TestBertTokenizerOp(unittest.TestCase):
         )
 
     def test_no_padding(self):
+        paddle.disable_static()
         self.init_data()
         self.max_seq_len = 128
         self.pad_to_max_seq_len = False
@@ -374,6 +375,7 @@ class TestBertTokenizerOp(unittest.TestCase):
         )
 
     def test_is_split_into_words(self):
+        paddle.disable_static()
         self.init_data()
         self.is_split_into_words = True
 
@@ -397,6 +399,7 @@ class TestBertTokenizerOp(unittest.TestCase):
         )
 
     def test_inference(self):
+        paddle.disable_static()
         self.init_data()
         if not os.path.exists(self.save_path):
             os.makedirs(self.save_path, exist_ok=True)

--- a/test/deprecated/tokenizer/test_faster_tokenizer_op_deprecated.py
+++ b/test/deprecated/tokenizer/test_faster_tokenizer_op_deprecated.py
@@ -199,6 +199,7 @@ class TestBertTokenizerOp(unittest.TestCase):
         self.text_pairs_tensor = to_string_tensor(self.text_pairs, "text_pairs")
 
     def test_padding(self):
+        paddle.disable_static()
         self.init_data()
         self.max_seq_len = 128
         self.pad_to_max_seq_len = True


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
移除 feed_strings kernel

test/deprecated/tokenizer/test_faster_tokenizer_op_deprecated.py 中单测 test_feed_string_var 使用了feed_strings 所以移除