### PR TITLE
[Bug Fixes]fix bug of kernel on defalult stream

### DIFF
--- a/paddle/phi/kernels/gpu/unique_consecutive_functor.h
+++ b/paddle/phi/kernels/gpu/unique_consecutive_functor.h
@@ -48,6 +48,11 @@ static void UniqueConsecutiveFlattenedCUDATensor(const Context& context,
                                                  int64_t num_input,
                                                  DenseTensor* inverse,
                                                  DenseTensor* counts) {
+#ifdef PADDLE_WITH_CUDA
+  const auto& exec_policy = thrust::cuda::par.on(context.stream());
+#else
+  const auto& exec_policy = thrust::hip::par.on(context.stream());
+#endif
   // 0. Preparation
   DenseTensor in_hat;
   phi::Copy(context, in, context.GetPlace(), false, &in_hat);
@@ -57,19 +62,18 @@ static void UniqueConsecutiveFlattenedCUDATensor(const Context& context,
   sorted_indices.Resize(common::make_ddim({num_input}));
   auto sorted_indices_data = context.template Alloc<IndexT>(&sorted_indices);
   thrust::sequence(
-      thrust::device, sorted_indices_data, sorted_indices_data + num_input);
+      exec_policy, sorted_indices_data, sorted_indices_data + num_input);
   // 1. Calculate op result: 'out'
   DenseTensor range;
   range.Resize(common::make_ddim({num_input + 1}));
   auto range_data_ptr = context.template Alloc<IndexT>(&range);
-  thrust::sequence(
-      thrust::device, range_data_ptr, range_data_ptr + num_input + 1);
+  thrust::sequence(exec_policy, range_data_ptr, range_data_ptr + num_input + 1);
   phi::Copy(context, in_hat, context.GetPlace(), false, out);
   int num_out;
   auto out_data = context.template Alloc<InT>(out);
   num_out =
       thrust::unique_by_key(
-          thrust::device, out_data, out_data + num_input, range_data_ptr, equal)
+          exec_policy, out_data, out_data + num_input, range_data_ptr, equal)
           .first -
       out_data;
   out->Resize(common::make_ddim({num_out}));
@@ -81,18 +85,18 @@ static void UniqueConsecutiveFlattenedCUDATensor(const Context& context,
     DenseTensor inv_loc;
     inv_loc.Resize(common::make_ddim({num_input}));
     auto inv_loc_data_ptr = context.template Alloc<IndexT>(&inv_loc);
-    thrust::adjacent_difference(thrust::device,
+    thrust::adjacent_difference(exec_policy,
                                 in_data_hat,
                                 in_data_hat + num_input,
                                 inv_loc_data_ptr,
                                 not_equal);
     thrust::device_ptr<IndexT> inv_loc_data_dev(inv_loc_data_ptr);
     inv_loc_data_dev[0] = 0;  // without device_ptr, segmentation fault
-    thrust::inclusive_scan(thrust::device,
+    thrust::inclusive_scan(exec_policy,
                            inv_loc_data_ptr,
                            inv_loc_data_ptr + num_input,
                            inv_loc_data_ptr);
-    thrust::scatter(thrust::device,
+    thrust::scatter(exec_policy,
                     inv_loc_data_ptr,
                     inv_loc_data_ptr + num_input,
                     sorted_indices_data,
@@ -103,10 +107,10 @@ static void UniqueConsecutiveFlattenedCUDATensor(const Context& context,
     counts->Resize(common::make_ddim({num_out}));
     auto count_data = context.template Alloc<IndexT>(counts);
     // init 'count_data' as 0
-    thrust::fill(thrust::device, count_data, count_data + num_out, 0);
+    thrust::fill(exec_policy, count_data, count_data + num_out, 0);
     thrust::device_ptr<IndexT> range_data_ptr_dev(range_data_ptr);
     range_data_ptr_dev[num_out] = num_input;
-    thrust::adjacent_difference(thrust::device,
+    thrust::adjacent_difference(exec_policy,
                                 range_data_ptr + 1,
                                 range_data_ptr + num_out + 1,
                                 count_data);
@@ -173,6 +177,11 @@ static void ComputeUniqueConsecutiveDims(const Context& context,
                                          int64_t row,
                                          DenseTensor* inverse,
                                          DenseTensor* counts) {
+#ifdef PADDLE_WITH_CUDA
+  const auto& exec_policy = thrust::cuda::par.on(context.stream());
+#else
+  const auto& exec_policy = thrust::hip::par.on(context.stream());
+#endif
   // 1. inverse indices: 'inverse'
   DenseTensor tmp;
   if (!inverse) {
@@ -184,18 +193,16 @@ static void ComputeUniqueConsecutiveDims(const Context& context,
   DenseTensor inv_loc;
   inv_loc.Resize(common::make_ddim({row}));
   auto inv_loc_data_ptr = context.template Alloc<IndexT>(&inv_loc);
-  thrust::adjacent_difference(thrust::device,
+  thrust::adjacent_difference(exec_policy,
                               sorted_indices_data,
                               sorted_indices_data + row,
                               inv_loc_data_ptr,
                               not_equal);
   thrust::device_ptr<IndexT> inv_loc_data_dev(inv_loc_data_ptr);
   inv_loc_data_dev[0] = 0;
-  thrust::inclusive_scan(thrust::device,
-                         inv_loc_data_ptr,
-                         inv_loc_data_ptr + row,
-                         inv_loc_data_ptr);
-  thrust::scatter(thrust::device,
+  thrust::inclusive_scan(
+      exec_policy, inv_loc_data_ptr, inv_loc_data_ptr + row, inv_loc_data_ptr);
+  thrust::scatter(exec_policy,
                   inv_loc_data_ptr,
                   inv_loc_data_ptr + row,
                   sorted_indices_data,
@@ -205,9 +212,9 @@ static void ComputeUniqueConsecutiveDims(const Context& context,
   DenseTensor range;
   range.Resize(common::make_ddim({row + 1}));
   auto range_data_ptr = context.template Alloc<IndexT>(&range);
-  thrust::sequence(thrust::device, range_data_ptr, range_data_ptr + row + 1);
+  thrust::sequence(exec_policy, range_data_ptr, range_data_ptr + row + 1);
   int num_out;
-  num_out = thrust::unique_by_key(thrust::device,
+  num_out = thrust::unique_by_key(exec_policy,
                                   sorted_indices_data,
                                   sorted_indices_data + row,
                                   range_data_ptr,
@@ -222,11 +229,9 @@ static void ComputeUniqueConsecutiveDims(const Context& context,
   if (return_counts) {
     counts->Resize(common::make_ddim({num_out}));
     auto count_data = context.template Alloc<IndexT>(counts);
-    thrust::fill(thrust::device, count_data, count_data + row, 0);
-    thrust::adjacent_difference(thrust::device,
-                                range_data_ptr + 1,
-                                range_data_ptr + row + 1,
-                                count_data);
+    thrust::fill(exec_policy, count_data, count_data + row, 0);
+    thrust::adjacent_difference(
+        exec_policy, range_data_ptr + 1, range_data_ptr + row + 1, count_data);
   }
 }
 
@@ -386,8 +391,7 @@ static void UniqueConsecutiveDimsCUDATensor(const Context& context,
 
   // 2. Calculate 'inverse', 'counts'
   // Init index
-  thrust::sequence(
-      thrust::device, sorted_indices_data, sorted_indices_data + row);
+  thrust::sequence(exec_policy, sorted_indices_data, sorted_indices_data + row);
   ComputeUniqueConsecutiveDims<Context, InT, IndexT>(
       context,
       &sorted_indices,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-71500

修复bug：使用thrust::device指定defalut stream，推理切换stream时候导致这些算子在不同的stream上，容易导致偶发性core
