### PR TITLE
【Hackathon 7th No.18】为稀疏计算添加复数支持2 -part

### DIFF
--- a/paddle/phi/kernels/sparse/cpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/elementwise_kernel.cc
@@ -401,7 +401,9 @@ PD_REGISTER_KERNEL(multiply_csr_csr,
                    double,
                    int16_t,
                    int,
-                   int64_t) {
+                   int64_t,
+                   complex64,
+                   complex128) {
   kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_CSR);
   kernel->InputAt(1).SetDataLayout(phi::DataLayout::SPARSE_CSR);
 }
@@ -414,7 +416,9 @@ PD_REGISTER_KERNEL(multiply_coo_coo,
                    double,
                    int16_t,
                    int,
-                   int64_t) {
+                   int64_t,
+                   complex64,
+                   complex128) {
   kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
   kernel->InputAt(1).SetDataLayout(phi::DataLayout::SPARSE_COO);
 }
@@ -427,7 +431,9 @@ PD_REGISTER_KERNEL(divide_csr_csr,
                    double,
                    int16_t,
                    int,
-                   int64_t) {
+                   int64_t,
+                   complex64,
+                   complex128) {
   kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_CSR);
   kernel->InputAt(1).SetDataLayout(phi::DataLayout::SPARSE_CSR);
 }
@@ -440,7 +446,9 @@ PD_REGISTER_KERNEL(divide_coo_coo,
                    double,
                    int16_t,
                    int,
-                   int64_t) {
+                   int64_t,
+                   complex64,
+                   complex128) {
   kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
   kernel->InputAt(1).SetDataLayout(phi::DataLayout::SPARSE_COO);
 }

--- a/python/paddle/sparse/binary.py
+++ b/python/paddle/sparse/binary.py
@@ -274,8 +274,8 @@ def add(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         out = x + y
 
     Args:
-        x (Tensor): the input tensor, it's data type should be float32, float64, int32, int64.
-        y (Tensor): the input tensor, it's data type should be float32, float64, int32, int64.
+        x (Tensor): the input tensor, it's data type should be float32, float64, int32, int64, complex64, complex128.
+        y (Tensor): the input tensor, it's data type should be float32, float64, int32, int64, complex64, complex128.
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
@@ -325,8 +325,8 @@ def subtract(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         out = x - y
 
     Args:
-        x (Tensor): the input tensor, it's data type should be float32, float64, int32, int64.
-        y (Tensor): the input tensor, it's data type should be float32, float64, int32, int64.
+        x (Tensor): the input tensor, it's data type should be float32, float64, int32, int64, complex64, complex128.
+        y (Tensor): the input tensor, it's data type should be float32, float64, int32, int64, complex64, complex128.
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
@@ -373,8 +373,8 @@ def multiply(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         out = x * y
 
     Args:
-        x (Tensor): the input tensor, it's data type should be float32, float64, int32, int64.
-        y (Tensor): the input tensor, it's data type should be float32, float64, int32, int64.
+        x (Tensor): the input tensor, it's data type should be float32, float64, int32, int64, complex64, complex128.
+        y (Tensor): the input tensor, it's data type should be float32, float64, int32, int64, complex64, complex128.
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
@@ -424,8 +424,8 @@ def divide(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         out = x / y
 
     Args:
-        x (Tensor): the input tensor, it's data type should be float32, float64, int32, int64.
-        y (Tensor): the input tensor, it's data type should be float32, float64, int32, int64.
+        x (Tensor): the input tensor, it's data type should be float32, float64, int32, int64, complex64, complex128.
+        y (Tensor): the input tensor, it's data type should be float32, float64, int32, int64, complex64, complex128.
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:

--- a/test/legacy_test/test_sparse_elementwise_op.py
+++ b/test/legacy_test/test_sparse_elementwise_op.py
@@ -21,7 +21,6 @@ import paddle
 from paddle.base.framework import in_pir_mode
 
 op_list = [__add__, __sub__, __mul__, __truediv__]
-op_list_complex = [__add__, __sub__]
 
 
 def get_actual_res(x, y, op):
@@ -226,7 +225,7 @@ class TestSparseElementWiseAPI(unittest.TestCase):
 class TestSparseElementWiseAPIComplex(unittest.TestCase):
     def setUp(self):
         np.random.seed(2022)
-        self.op_list = op_list_complex
+        self.op_list = op_list
         self.csr_shape = [8, 10]
         self.coo_shape = [3, 7, 2, 9]
         self.support_dtypes = ['complex64', 'complex128']
@@ -738,19 +737,36 @@ class TestSparseMulStaticAPI(unittest.TestCase):
         np.random.seed(2022)
         self.op_list = op_list
         self.coo_shape = [4, 8, 3, 5]
-        self.support_dtypes = ['float32', 'float64', 'int32', 'int64']
+        self.support_dtypes = [
+            'float32',
+            'float64',
+            'int32',
+            'int64',
+            'complex64',
+            'complex128',
+        ]
 
     def test_coo(self):
         if in_pir_mode():
             sparse_dim = len(self.coo_shape) - 1
             op = __mul__
             for dtype in self.support_dtypes:
-                x = np.random.randint(-255, 255, size=self.coo_shape).astype(
-                    dtype
-                )
-                y = np.random.randint(-255, 255, size=self.coo_shape).astype(
-                    dtype
-                )
+                if 'complex' in dtype:
+                    x = np.vectorize(complex)(
+                        np.random.randint(-255, 255, size=self.coo_shape),
+                        np.random.randint(-255, 255, size=self.coo_shape),
+                    ).astype(dtype)
+                    y = np.vectorize(complex)(
+                        np.random.randint(-255, 255, size=self.coo_shape),
+                        np.random.randint(-255, 255, size=self.coo_shape),
+                    ).astype(dtype)
+                else:
+                    x = np.random.randint(
+                        -255, 255, size=self.coo_shape
+                    ).astype(dtype)
+                    y = np.random.randint(
+                        -255, 255, size=self.coo_shape
+                    ).astype(dtype)
 
                 self.dense_x = paddle.to_tensor(
                     x, dtype=dtype, stop_gradient=True
@@ -839,19 +855,36 @@ class TestSparseDivStaticAPI(unittest.TestCase):
         np.random.seed(2022)
         self.op_list = op_list
         self.coo_shape = [4, 8, 3, 5]
-        self.support_dtypes = ['float32', 'float64', 'int32', 'int64']
+        self.support_dtypes = [
+            'float32',
+            'float64',
+            'int32',
+            'int64',
+            'complex64',
+            'complex128',
+        ]
 
     def test_coo(self):
         if in_pir_mode():
             sparse_dim = len(self.coo_shape) - 1
             op = __truediv__
             for dtype in self.support_dtypes:
-                x = np.random.randint(-255, 255, size=self.coo_shape).astype(
-                    dtype
-                )
-                y = np.random.randint(-255, 255, size=self.coo_shape).astype(
-                    dtype
-                )
+                if 'complex' in dtype:
+                    x = np.vectorize(complex)(
+                        np.random.randint(-255, 255, size=self.coo_shape),
+                        np.random.randint(-255, 255, size=self.coo_shape),
+                    ).astype(dtype)
+                    y = np.vectorize(complex)(
+                        np.random.randint(-255, 255, size=self.coo_shape),
+                        np.random.randint(-255, 255, size=self.coo_shape),
+                    ).astype(dtype)
+                else:
+                    x = np.random.randint(
+                        -255, 255, size=self.coo_shape
+                    ).astype(dtype)
+                    y = np.random.randint(
+                        -255, 255, size=self.coo_shape
+                    ).astype(dtype)
 
                 self.dense_x = paddle.to_tensor(
                     x, dtype=dtype, stop_gradient=True


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
multiply_coo_coo, multiply_csr_csr, divide_coo_coo, divide_csr_csr 支持 complex64/complex128