### PR TITLE
[XPU] fused rope support none sin/cos and refactor code

### DIFF
--- a/paddle/phi/kernels/fusion/xpu/fused_rope_grad_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_rope_grad_kernel.cc
@@ -18,6 +18,21 @@
 
 namespace phi {
 namespace fusion {
+#define LAUNCH_XPU_FUSED_ROPE_GRAD(XPUType, SinCosType)                 \
+  XPUFusedRopeImpl<XPUType, SinCosType, Context>(dev_ctx,               \
+                                                 dout_q,                \
+                                                 dout_k,                \
+                                                 dout_v,                \
+                                                 sin,                   \
+                                                 cos,                   \
+                                                 position_ids,          \
+                                                 use_neox_rotary_style, \
+                                                 time_major,            \
+                                                 rotary_emb_base,       \
+                                                 dq,                    \
+                                                 dk,                    \
+                                                 dv);
+
 template <typename T, typename Context>
 void FusedRopeGradKernel(const Context& dev_ctx,
                          const paddle::optional<DenseTensor>& sin,
@@ -45,162 +60,30 @@ void FusedRopeGradKernel(const Context& dev_ctx,
                     common::errors::InvalidArgument(
                         "The head_dim of input must be a multiple of 2."));
   xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
-
-  int64_t sin_cos_len = batch_size * seq_len * head_dim;
-  if (use_neox_rotary_style) {
-    auto* sin_data = RAII_GUARD.alloc_l3_or_gm<XPUType>(sin_cos_len);
-    auto* cos_data = RAII_GUARD.alloc_l3_or_gm<XPUType>(sin_cos_len);
-    if (sin.get_ptr() && cos.get_ptr()) {
-      PADDLE_ENFORCE_EQ(sin.get_ptr()->dims(),
-                        cos.get_ptr()->dims(),
-                        common::errors::InvalidArgument(
-                            "The dims of sin and cos must be the same. But "
-                            "received sin's dims is {%s}, cos's dims is {%s}.",
-                            sin.get_ptr()->dims(),
-                            cos.get_ptr()->dims()));
-    }
-    XPUGetSinCosData<XPUType, Context>(
-        dev_ctx, sin, position_ids, sin_data, batch_size, seq_len, head_dim);
-    XPUGetSinCosData<XPUType, Context>(
-        dev_ctx, cos, position_ids, cos_data, batch_size, seq_len, head_dim);
-    if (!dout_k.get_ptr()) {
-      auto* dq_data = reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(dq));
-      int ret = xpu::rotary_embedding_v3_single_grad<XPUType, XPUType>(
-          dev_ctx.x_context(),
-          reinterpret_cast<const XPUType*>(dout_q.data<T>()),
-          cos_data,
-          sin_data,
-          dq_data,
-          batch_size,
-          seq_len,
-          num_heads,
-          head_dim,
-          {seq_len * num_heads * head_dim, num_heads * head_dim, head_dim, 1});
-      PADDLE_ENFORCE_XDNN_SUCCESS(ret, "rotary_embedding_v3_single_grad");
+  dev_ctx.template Alloc<T>(dq) if (dout_k) { dev_ctx.template Alloc<T>(dk); }
+  if (dout_v) {
+    dev_ctx.template Alloc<T>(dv);
+  }
+  if (sin && cos) {
+    PADDLE_ENFORCE_EQ(sin->dims(),
+                      cos->dims(),
+                      common::errors::InvalidArgument(
+                          "The dims of sin and cos must be the same. But "
+                          "received sin's dims is {%s}, cos's dims is {%s}.",
+                          sin->dims(),
+                          cos->dims()));
+    if (sin->dtype() == phi::DataType::FLOAT32) {
+      LAUNCH_XPU_FUSED_ROPE_GRAD(XPUType, float);
     } else {
-      int64_t num_heads_k = dout_k->dims()[2];
-      auto* dq_data = reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(dq));
-      auto* dk_data = reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(dk));
-      int ret = xpu::rotary_embedding_v3_grad<XPUType, XPUType>(
-          dev_ctx.x_context(),
-          reinterpret_cast<const XPUType*>(dout_q.data<T>()),
-          reinterpret_cast<const XPUType*>(dout_k->data<T>()),
-          cos_data,
-          sin_data,
-          dq_data,
-          dk_data,
-          batch_size,
-          seq_len,
-          num_heads,
-          head_dim,
-          {seq_len * num_heads * head_dim, num_heads * head_dim, head_dim, 1},
-          {seq_len * num_heads_k * head_dim,
-           num_heads_k * head_dim,
-           head_dim,
-           1},
-          num_heads_k);
-      PADDLE_ENFORCE_XDNN_SUCCESS(ret, "rotary_embedding_v3_grad");
-    }
-    if (dout_v.get_ptr()) {
-      int64_t num_heads_v = dout_v->dims()[2];
-      auto* dv_data = reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(dv));
-      int ret = xpu::rotary_embedding_v3_single_grad<XPUType, XPUType>(
-          dev_ctx.x_context(),
-          reinterpret_cast<const XPUType*>(dout_v->data<T>()),
-          cos_data,
-          sin_data,
-          dv_data,
-          batch_size,
-          seq_len,
-          num_heads_v,
-          head_dim,
-          {seq_len * num_heads_v * head_dim,
-           num_heads_v * head_dim,
-           head_dim,
-           1});
-      PADDLE_ENFORCE_XDNN_SUCCESS(ret, "rotary_embedding_v3_single_grad");
+      PADDLE_ENFORCE_EQ(
+          phi::CppTypeToDtype<T>::Type(),
+          sin->dtype(),
+          common::errors::InvalidArgument(
+              "The embedding dtype and sin/cos dtype mismatched."));
+      LAUNCH_XPU_FUSED_ROPE_GRAD(XPUType, XPUType);
     }
   } else {
-    auto* sin_data = RAII_GUARD.alloc_l3_or_gm<XPUType>(sin_cos_len);
-    auto* cos_data = RAII_GUARD.alloc_l3_or_gm<XPUType>(sin_cos_len);
-    if (sin.get_ptr() && cos.get_ptr()) {
-      PADDLE_ENFORCE_EQ(sin.get_ptr()->dims(),
-                        cos.get_ptr()->dims(),
-                        common::errors::InvalidArgument(
-                            "The dims of sin and cos must be the same. But "
-                            "received sin's dims is {%s}, cos's dims is {%s}.",
-                            sin.get_ptr()->dims(),
-                            cos.get_ptr()->dims()));
-    }
-    XPUGetSinCosData<XPUType, Context>(
-        dev_ctx, sin, position_ids, sin_data, batch_size, seq_len, head_dim);
-    XPUGetSinCosData<XPUType, Context>(
-        dev_ctx, cos, position_ids, cos_data, batch_size, seq_len, head_dim);
-    if (head_dim * sizeof(T) <= 1024 && head_dim % 64 == 0 && dout_k) {
-      int64_t num_heads_k = dout_k->dims()[2];
-      auto* dq_data = reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(dq));
-      auto* dk_data = reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(dk));
-      int ret = xpu::rotary_no_freqs_qk_embedding_v2_grad<XPUType>(
-          dev_ctx.x_context(),
-          reinterpret_cast<const XPUType*>(dout_q.data<T>()),
-          reinterpret_cast<const XPUType*>(dout_k->data<T>()),
-          sin_data,
-          cos_data,
-          dq_data,
-          dk_data,
-          {batch_size, seq_len, num_heads, head_dim},
-          {batch_size, seq_len, 1, head_dim},
-          {seq_len * num_heads * head_dim, num_heads * head_dim, head_dim, 1},
-          {seq_len * head_dim, head_dim, head_dim, 1},
-          num_heads_k);
-      PADDLE_ENFORCE_XDNN_SUCCESS(ret, "rotary_no_freqs_qk_embedding_v2_grad");
-    } else {
-      auto* dq_data = reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(dq));
-      XPUFusedRotaryHalf<XPUType, Context>(
-          dev_ctx,
-          reinterpret_cast<const XPUType*>(dout_q.data<T>()),
-          sin_data,
-          cos_data,
-          dq_data,
-          batch_size,
-          seq_len,
-          num_heads,
-          head_dim,
-          true);
-
-      if (dout_k.get_ptr()) {
-        int64_t num_heads_k = dout_k->dims()[2];
-        auto* dk_data =
-            reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(dk));
-        XPUFusedRotaryHalf<XPUType, Context>(
-            dev_ctx,
-            reinterpret_cast<const XPUType*>(dout_k->data<T>()),
-            sin_data,
-            cos_data,
-            dk_data,
-            batch_size,
-            seq_len,
-            num_heads_k,
-            head_dim,
-            true);
-      }
-    }
-
-    if (dout_v.get_ptr()) {
-      int64_t num_heads_v = dout_v->dims()[2];
-      auto* dv_data = reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(dv));
-      XPUFusedRotaryHalf<XPUType, Context>(
-          dev_ctx,
-          reinterpret_cast<const XPUType*>(dout_v->data<T>()),
-          sin_data,
-          cos_data,
-          dv_data,
-          batch_size,
-          seq_len,
-          num_heads_v,
-          head_dim,
-          true);
-    }
+    LAUNCH_XPU_FUSED_ROPE_GRAD(XPUType, float);
   }
 }
 }  // namespace fusion

--- a/paddle/phi/kernels/fusion/xpu/fused_rope_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_rope_kernel.cc
@@ -18,20 +18,21 @@
 
 namespace phi {
 namespace fusion {
-#define LAUNCH_XPU_FUSED_ROPE(XPUType, SinCosType)                 \
-  XPUFusedRopeImpl<XPUType, float, Context>(dev_ctx,               \
-                                            q,                     \
-                                            k,                     \
-                                            v,                     \
-                                            sin,                   \
-                                            cos,                   \
-                                            position_ids,          \
-                                            use_neox_rotary_style, \
-                                            time_major,            \
-                                            rotary_emb_base,       \
-                                            out_q,                 \
-                                            out_k,                 \
-                                            out_v);
+#define LAUNCH_XPU_FUSED_ROPE(T, SCT)                      \
+  XPUFusedRopeImpl<T, SCT, Context>(dev_ctx,               \
+                                    q,                     \
+                                    k,                     \
+                                    v,                     \
+                                    sin,                   \
+                                    cos,                   \
+                                    position_ids,          \
+                                    use_neox_rotary_style, \
+                                    time_major,            \
+                                    false,                 \
+                                    rotary_emb_base,       \
+                                    out_q,                 \
+                                    out_k,                 \
+                                    out_v);
 template <typename T, typename Context>
 void FusedRopeKernel(const Context& dev_ctx,
                      const DenseTensor& q,
@@ -46,23 +47,6 @@ void FusedRopeKernel(const Context& dev_ctx,
                      DenseTensor* out_q,
                      DenseTensor* out_k,
                      DenseTensor* out_v) {
-  using XPUType = typename XPUTypeTrait<T>::Type;
-  if (q.numel() <= 0) {
-    return;
-  }
-  PADDLE_ENFORCE_EQ(
-      time_major,
-      false,
-      common::errors::InvalidArgument("time_major is not supported in xpu"));
-  int64_t batch_size = q.dims()[0];
-  int64_t seq_len = q.dims()[1];
-  int64_t num_heads = q.dims()[2];
-  int64_t head_dim = q.dims()[3];
-  PADDLE_ENFORCE_EQ(head_dim % 2,
-                    0,
-                    common::errors::InvalidArgument(
-                        "The head_dim of input must be a multiple of 2."));
-
   dev_ctx.template Alloc<T>(out_q);
   if (k) {
     dev_ctx.template Alloc<T>(out_k);
@@ -80,19 +64,19 @@ void FusedRopeKernel(const Context& dev_ctx,
                           sin.get_ptr()->dims(),
                           cos.get_ptr()->dims()));
     // For user provided sin/cos, we use the dtype as is.
-    if (sin->dtype() == phi::DateType::FLOAT32) {
-      LAUNCH_XPU_FUSED_ROPE(XPUType, float);
+    if (sin->dtype() == phi::DataType::FLOAT32) {
+      LAUNCH_XPU_FUSED_ROPE(T, float);
     } else {
       PADDLE_ENFORCE_EQ(
-          phi::CppTypeToDtype<T>::Type(),
+          phi::CppTypeToDataType<T>::Type(),
           sin->dtype(),
           common::errors::InvalidArgument(
               "The embedding dtype and sin/cos dtype mismatched."));
-      LAUNCH_XPU_FUSED_ROPE(XPUType, XPUType);
+      LAUNCH_XPU_FUSED_ROPE(T, T);
     }
   } else {
     // For generated sin/cos, we use fp32 all.
-    LAUNCH_XPU_FUSED_ROPE(XPUType, float);
+    LAUNCH_XPU_FUSED_ROPE(T, float);
   }
 }
 }  // namespace fusion

--- a/paddle/phi/kernels/fusion/xpu/fused_rope_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_rope_kernel.cc
@@ -55,14 +55,14 @@ void FusedRopeKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(out_v);
   }
 
-  if (sin.get_ptr() && cos.get_ptr()) {
-    PADDLE_ENFORCE_EQ(sin.get_ptr()->dims(),
-                      cos.get_ptr()->dims(),
+  if (sin && cos) {
+    PADDLE_ENFORCE_EQ(sin->dims(),
+                      cos->dims(),
                       common::errors::InvalidArgument(
                           "The dims of sin and cos must be the same. But "
                           "received sin's dims is {%s}, cos's dims is {%s}.",
-                          sin.get_ptr()->dims(),
-                          cos.get_ptr()->dims()));
+                          sin->dims(),
+                          cos->dims()));
     // For user provided sin/cos, we use the dtype as is.
     if (sin->dtype() == phi::DataType::FLOAT32) {
       LAUNCH_XPU_FUSED_ROPE(T, float);

--- a/paddle/phi/kernels/fusion/xpu/fused_rope_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_rope_kernel.cc
@@ -18,7 +18,20 @@
 
 namespace phi {
 namespace fusion {
-
+#define LAUNCH_XPU_FUSED_ROPE(XPUType, SinCosType)                 \
+  XPUFusedRopeImpl<XPUType, float, Context>(dev_ctx,               \
+                                            q,                     \
+                                            k,                     \
+                                            v,                     \
+                                            sin,                   \
+                                            cos,                   \
+                                            position_ids,          \
+                                            use_neox_rotary_style, \
+                                            time_major,            \
+                                            rotary_emb_base,       \
+                                            out_q,                 \
+                                            out_k,                 \
+                                            out_v);
 template <typename T, typename Context>
 void FusedRopeKernel(const Context& dev_ctx,
                      const DenseTensor& q,
@@ -49,169 +62,37 @@ void FusedRopeKernel(const Context& dev_ctx,
                     0,
                     common::errors::InvalidArgument(
                         "The head_dim of input must be a multiple of 2."));
-  xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
 
-  int64_t sin_cos_len = batch_size * seq_len * head_dim;
-  if (use_neox_rotary_style) {
-    auto* sin_data = RAII_GUARD.alloc_l3_or_gm<XPUType>(sin_cos_len);
-    auto* cos_data = RAII_GUARD.alloc_l3_or_gm<XPUType>(sin_cos_len);
-    if (sin.get_ptr() && cos.get_ptr()) {
-      PADDLE_ENFORCE_EQ(sin.get_ptr()->dims(),
-                        cos.get_ptr()->dims(),
-                        common::errors::InvalidArgument(
-                            "The dims of sin and cos must be the same. But "
-                            "received sin's dims is {%s}, cos's dims is {%s}.",
-                            sin.get_ptr()->dims(),
-                            cos.get_ptr()->dims()));
-    }
-    XPUGetSinCosData<XPUType, Context>(
-        dev_ctx, sin, position_ids, sin_data, batch_size, seq_len, head_dim);
-    XPUGetSinCosData<XPUType, Context>(
-        dev_ctx, cos, position_ids, cos_data, batch_size, seq_len, head_dim);
-    if (!k) {
-      auto* outq_data =
-          reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(out_q));
-      int ret = xpu::rotary_embedding_v3_single<XPUType, XPUType>(
-          dev_ctx.x_context(),
-          reinterpret_cast<const XPUType*>(q.data<T>()),
-          cos_data,
-          sin_data,
-          outq_data,
-          batch_size,
-          seq_len,
-          num_heads,
-          head_dim,
-          {seq_len * num_heads * head_dim, num_heads * head_dim, head_dim, 1});
-      PADDLE_ENFORCE_XDNN_SUCCESS(ret, "rotary_embedding_v3_single");
+  dev_ctx.template Alloc<T>(out_q);
+  if (k) {
+    dev_ctx.template Alloc<T>(out_k);
+  }
+  if (v) {
+    dev_ctx.template Alloc<T>(out_v);
+  }
+
+  if (sin.get_ptr() && cos.get_ptr()) {
+    PADDLE_ENFORCE_EQ(sin.get_ptr()->dims(),
+                      cos.get_ptr()->dims(),
+                      common::errors::InvalidArgument(
+                          "The dims of sin and cos must be the same. But "
+                          "received sin's dims is {%s}, cos's dims is {%s}.",
+                          sin.get_ptr()->dims(),
+                          cos.get_ptr()->dims()));
+    // For user provided sin/cos, we use the dtype as is.
+    if (sin->dtype() == phi::DateType::FLOAT32) {
+      LAUNCH_XPU_FUSED_ROPE(XPUType, float);
     } else {
-      int64_t num_heads_k = k->dims()[2];
-      auto* outq_data =
-          reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(out_q));
-      auto* outk_data =
-          reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(out_k));
-      int ret = xpu::rotary_embedding_v3<XPUType, XPUType>(
-          dev_ctx.x_context(),
-          reinterpret_cast<const XPUType*>(q.data<T>()),
-          reinterpret_cast<const XPUType*>(k->data<T>()),
-          cos_data,
-          sin_data,
-          outq_data,
-          outk_data,
-          batch_size,
-          seq_len,
-          num_heads,
-          head_dim,
-          {seq_len * num_heads * head_dim, num_heads * head_dim, head_dim, 1},
-          {seq_len * num_heads_k * head_dim,
-           num_heads_k * head_dim,
-           head_dim,
-           1},
-          num_heads_k);
-      PADDLE_ENFORCE_XDNN_SUCCESS(ret, "rotary_embedding_v3");
-    }
-
-    if (v) {
-      int64_t num_heads_v = v->dims()[2];
-      auto* outv_data =
-          reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(out_v));
-      int ret = xpu::rotary_embedding_v3_single<XPUType, XPUType>(
-          dev_ctx.x_context(),
-          reinterpret_cast<const XPUType*>(v->data<T>()),
-          cos_data,
-          sin_data,
-          outv_data,
-          batch_size,
-          seq_len,
-          num_heads_v,
-          head_dim,
-          {seq_len * num_heads_v * head_dim,
-           num_heads_v * head_dim,
-           head_dim,
-           1});
-      PADDLE_ENFORCE_XDNN_SUCCESS(ret, "rotary_embedding_v3_single");
+      PADDLE_ENFORCE_EQ(
+          phi::CppTypeToDtype<T>::Type(),
+          sin->dtype(),
+          common::errors::InvalidArgument(
+              "The embedding dtype and sin/cos dtype mismatched."));
+      LAUNCH_XPU_FUSED_ROPE(XPUType, XPUType);
     }
   } else {
-    auto* sin_data = RAII_GUARD.alloc_l3_or_gm<XPUType>(sin_cos_len);
-    auto* cos_data = RAII_GUARD.alloc_l3_or_gm<XPUType>(sin_cos_len);
-    if (sin.get_ptr() && cos.get_ptr()) {
-      PADDLE_ENFORCE_EQ(sin.get_ptr()->dims(),
-                        cos.get_ptr()->dims(),
-                        common::errors::InvalidArgument(
-                            "The dims of sin and cos must be the same. But "
-                            "received sin's dims is {%s}, cos's dims is {%s}.",
-                            sin.get_ptr()->dims(),
-                            cos.get_ptr()->dims()));
-    }
-    XPUGetSinCosData<XPUType, Context>(
-        dev_ctx, sin, position_ids, sin_data, batch_size, seq_len, head_dim);
-    XPUGetSinCosData<XPUType, Context>(
-        dev_ctx, cos, position_ids, cos_data, batch_size, seq_len, head_dim);
-    if (head_dim * sizeof(T) <= 1024 && head_dim % 64 == 0 && k) {
-      int64_t num_heads_k = k->dims()[2];
-      auto* outq_data =
-          reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(out_q));
-      auto* outk_data =
-          reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(out_k));
-      int ret = xpu::rotary_no_freqs_qk_embedding_v2<XPUType>(
-          dev_ctx.x_context(),
-          reinterpret_cast<const XPUType*>(q.data<T>()),
-          reinterpret_cast<const XPUType*>(k->data<T>()),
-          sin_data,
-          cos_data,
-          outq_data,
-          outk_data,
-          {batch_size, seq_len, num_heads, head_dim},
-          {batch_size, seq_len, 1, head_dim},
-          {seq_len * num_heads * head_dim, num_heads * head_dim, head_dim, 1},
-          {seq_len * head_dim, head_dim, head_dim, 1},
-          num_heads_k);
-      PADDLE_ENFORCE_XDNN_SUCCESS(ret, "rotary_no_freqs_qk_embedding_v2");
-    } else {
-      auto* outq_data =
-          reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(out_q));
-      XPUFusedRotaryHalf<XPUType, Context>(
-          dev_ctx,
-          reinterpret_cast<const XPUType*>(q.data<T>()),
-          sin_data,
-          cos_data,
-          outq_data,
-          batch_size,
-          seq_len,
-          num_heads,
-          head_dim);
-
-      if (k) {
-        int64_t num_heads_k = k->dims()[2];
-        auto* outk_data =
-            reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(out_k));
-        XPUFusedRotaryHalf<XPUType, Context>(
-            dev_ctx,
-            reinterpret_cast<const XPUType*>(k->data<T>()),
-            sin_data,
-            cos_data,
-            outk_data,
-            batch_size,
-            seq_len,
-            num_heads_k,
-            head_dim);
-      }
-    }
-
-    if (v) {
-      int64_t num_heads_v = v->dims()[2];
-      auto* outv_data =
-          reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(out_v));
-      XPUFusedRotaryHalf<XPUType, Context>(
-          dev_ctx,
-          reinterpret_cast<const XPUType*>(v->data<T>()),
-          sin_data,
-          cos_data,
-          outv_data,
-          batch_size,
-          seq_len,
-          num_heads_v,
-          head_dim);
-    }
+    // For generated sin/cos, we use fp32 all.
+    LAUNCH_XPU_FUSED_ROPE(XPUType, float);
   }
 }
 }  // namespace fusion

--- a/paddle/phi/kernels/fusion/xpu/fused_rope_utils.h
+++ b/paddle/phi/kernels/fusion/xpu/fused_rope_utils.h
@@ -14,130 +14,418 @@
 
 #pragma once
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/common/memory_utils.h"
 
 namespace phi {
 namespace fusion {
-template <typename XPUType, typename Context>
-void XPUGetSinCosData(const Context& dev_ctx,
-                      const paddle::optional<DenseTensor>& sin_cos,
-                      const paddle::optional<DenseTensor>& position_ids,
-                      XPUType* sin_cos_data,
-                      int64_t batch_size,
-                      int64_t seq_len,
-                      int64_t head_dim) {
-  if (sin_cos.get_ptr()) {
-    auto sin_cos_dims = sin_cos.get_ptr()->dims();
-    int64_t dims_size = sin_cos_dims.size();
-    PADDLE_ENFORCE_EQ((dims_size == 2 || dims_size == 4),
+template <typename XPUType, typename SinCosType, typename Context>
+void GetSinCosByPassValue(const Context& dev_ctx,
+                          const paddle::optional<DenseTensor>& sin,
+                          const paddle::optional<DenseTensor>& cos,
+                          const paddle::optional<DenseTensor>& position_ids,
+                          SinCosType* sin_data,
+                          SinCosType* cos_data,
+                          int64_t batch_size,
+                          int64_t seq_len,
+                          int64_t head_dim) {
+  PADDLE_ENFORCE_EQ(std::is_same<XPUType, SinCosType>::value,
+                    true,
+                    common::errors::Unimplemented(
+                        "The xpu get_sin_cos_by_pass_value only supports "
+                        "sin/cos with the same type as inputs now."));
+  auto sin_cos_dims = sin->dims();
+  int64_t dims_size = sin_cos_dims.size();
+  PADDLE_ENFORCE_EQ(
+      (dims_size == 2 || dims_size == 4),
+      true,
+      common::errors::InvalidArgument("The dims of sin and cos is expected to "
+                                      "be 2 or 4, but received %d.",
+                                      dims_size));
+  if (dims_size == 4) {
+    // sin.shape: [1, seq_len, 1, head_dim]
+    PADDLE_ENFORCE_EQ((sin_cos_dims[2] == 1),
                       true,
                       common::errors::InvalidArgument(
-                          "The dims of sin and cos is expected to "
-                          "be 2 or 4, but received %d.",
-                          dims_size));
-    if (dims_size == 4) {
-      // sin.shape: [1, seq_len, 1, head_dim]
-      PADDLE_ENFORCE_EQ((sin_cos_dims[2] == 1),
-                        true,
-                        common::errors::InvalidArgument(
-                            "The num_heads of sin and cos must be 1."));
-    }
-    int sin_seq_len_dim = (dims_size) == 4 ? 1 : 0;
-    if (position_ids.get_ptr()) {
-      PADDLE_ENFORCE_EQ(
-          (sin_cos_dims[dims_size - 1] == head_dim &&
-           sin_cos_dims[sin_seq_len_dim] >= seq_len),
-          true,
-          common::errors::InvalidArgument(
-              "The seq_len of sin and cos must be greater than or equal to "
-              "this of q. The head_dim of sin and cos must be the same as this "
-              "of q."));
+                          "The num_heads of sin and cos must be 1."));
+  }
+  int sin_seq_len_dim = (dims_size) == 4 ? 1 : 0;
+  if (position_ids.get_ptr()) {
+    PADDLE_ENFORCE_EQ(
+        (sin_cos_dims[dims_size - 1] == head_dim &&
+         sin_cos_dims[sin_seq_len_dim] >= seq_len),
+        true,
+        common::errors::InvalidArgument(
+            "The seq_len of sin and cos must be greater than or equal to "
+            "this of q. The head_dim of sin and cos must be the same as this "
+            "of q."));
 
-      auto position_ids_dims = position_ids.get_ptr()->dims();
-      PADDLE_ENFORCE_EQ(position_ids_dims.size(),
-                        2,
-                        common::errors::InvalidArgument(
-                            "The dims of position_ids is expected to "
-                            "be 2, but received %d.",
-                            position_ids_dims.size()));
+    auto position_ids_dims = position_ids.get_ptr()->dims();
+    PADDLE_ENFORCE_EQ(position_ids_dims.size(),
+                      2,
+                      common::errors::InvalidArgument(
+                          "The dims of position_ids is expected to "
+                          "be 2, but received %d.",
+                          position_ids_dims.size()));
 
-      PADDLE_ENFORCE_EQ(
-          (position_ids_dims[0] == batch_size &&
-           position_ids_dims[1] == seq_len),
-          true,
-          common::errors::InvalidArgument(
-              "The batch_size and seq_len of position_ids must be the same as "
-              "those of q."));
-      using XPUTypeFp16 = typename XPUTypeTrait<phi::dtype::float16>::Type;
-      using XPUTypeBf16 = typename XPUTypeTrait<phi::dtype::bfloat16>::Type;
-      if (std::is_same<XPUType, XPUTypeBf16>::value) {
-        int ret = xpu::gather<XPUTypeFp16, int64_t>(
-            dev_ctx.x_context(),
-            reinterpret_cast<const XPUTypeFp16*>(sin_cos->data()),
-            position_ids->data<int64_t>(),
-            reinterpret_cast<XPUTypeFp16*>(sin_cos_data),
-            {seq_len, head_dim},
-            batch_size * seq_len,
-            0);
-        PADDLE_ENFORCE_XDNN_SUCCESS(ret, "gather");
-      } else {
-        int ret = xpu::gather<XPUType, int64_t>(
-            dev_ctx.x_context(),
-            reinterpret_cast<const XPUType*>(sin_cos->data()),
-            position_ids->data<int64_t>(),
-            sin_cos_data,
-            {seq_len, head_dim},
-            batch_size * seq_len,
-            0);
-        PADDLE_ENFORCE_XDNN_SUCCESS(ret, "gather");
-      }
-    } else {
-      int sin_cos_batch_size = (dims_size) == 4 ? sin_cos_dims[0] : 1;
-      int ret = xpu::broadcast<XPUType>(
-          dev_ctx.x_context(),
-          reinterpret_cast<const XPUType*>(sin_cos->data()),
-          sin_cos_data,
-          {sin_cos_batch_size, seq_len, head_dim},
-          {batch_size, seq_len, head_dim});
-      PADDLE_ENFORCE_XDNN_SUCCESS(ret, "broadcast");
-    }
+    PADDLE_ENFORCE_EQ(
+        (position_ids_dims[0] == batch_size && position_ids_dims[1] == seq_len),
+        true,
+        common::errors::InvalidArgument(
+            "The batch_size and seq_len of position_ids must be the same as "
+            "those of q."));
+
+    int ret = xpu::gather<XPUType, int64_t>(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(sin->data()),
+        position_ids->data<int64_t>(),
+        sin_data,
+        {seq_len, head_dim},
+        batch_size * seq_len,
+        0);
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, "gather");
+    int ret = xpu::gather<XPUType, int64_t>(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(cos->data()),
+        position_ids->data<int64_t>(),
+        cos_data,
+        {seq_len, head_dim},
+        batch_size * seq_len,
+        0);
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, "gather");
   } else {
-    int ret = xpu::constant(dev_ctx.x_context(),
-                            sin_cos_data,
-                            batch_size * seq_len * head_dim,
-                            static_cast<XPUType>(0.0f));
-    PADDLE_ENFORCE_XDNN_SUCCESS(ret, "constant");
+    int sin_cos_batch_size = (dims_size) == 4 ? sin_cos_dims[0] : 1;
+    int ret =
+        xpu::broadcast<XPUType>(dev_ctx.x_context(),
+                                reinterpret_cast<const XPUType*>(sin->data()),
+                                sin_data,
+                                {sin_cos_batch_size, seq_len, head_dim},
+                                {batch_size, seq_len, head_dim});
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, "broadcast");
+    int ret =
+        xpu::broadcast<XPUType>(dev_ctx.x_context(),
+                                reinterpret_cast<const XPUType*>(cos->data()),
+                                cos_data,
+                                {sin_cos_batch_size, seq_len, head_dim},
+                                {batch_size, seq_len, head_dim});
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, "broadcast");
   }
 }
 
-template <typename XPUType, typename Context>
-void XPUFusedRotaryHalf(const Context& dev_ctx,
-                        const XPUType* in_data,
-                        const XPUType* sin_data,
-                        const XPUType* cos_data,
-                        XPUType* out_data,
-                        int64_t batch_size,
-                        int64_t seq_len,
-                        int64_t num_heads,
-                        int64_t head_dim,
-                        bool is_bwd = false) {
-  auto func = &xpu::rotary_no_freqs_embedding_v2<XPUType>;
+template <typename XPUType, typename SinCosType, typename Context>
+void GetSinCosByRotaryBase(const Context& dev_ctx,
+                           SinCosType* sin_data,
+                           SinCosType* cos_data,
+                           int64_t batch_size,
+                           int64_t seq_len,
+                           int64_t head_dim,
+                           float rotary_emb_base) {
+  xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+
+  float* pos_seq_data = RAII_GUARD.alloc_l3_or_gm<float>(seq_len);
+  int ret =
+      xpu::range<float>(dev_ctx.x_context(), pos_seq_data, 0.0f, 1.0f, seq_len);
+  PADDLE_ENFORCE_XDNN_SUCCESS(ret, "range");
+  float* freqs_data = RAII_GUARD.alloc_l3_or_gm<float>(head_dim / 2);
+  ret = xpu::range<float>(
+      dev_ctx.x_context(), freqs_data, 0.0f, 2.0f / head_dim, head_dim / 2);
+  PADDLE_ENFORCE_XDNN_SUCCESS(ret, "range");
+
+  float* rotary_base_xpu_data = RAII_GUARD.alloc_l3_or_gm<float>(1);
+  memory_utils::Copy(dev_ctx.GetPlace(),
+                     rotary_base_xpu_data,
+                     phi::CPUPlace(),
+                     &rotary_emb_base,
+                     sizeof(float));
+  ret = xpu::broadcast_pow<float>(dev_ctx.x_context(),
+                                  rotary_base_xpu_data,
+                                  freqs_data,
+                                  freqs_data,
+                                  {1},
+                                  {head_dim / 2});
+  PADDLE_ENFORCE_XDNN_SUCCESS(ret, "broadcast_pow");
+  ret = xpu::reciprocal<float>(
+      dev_ctx.x_context(), freqs_data, freqs_data, head_dim / 2);
+  PADDLE_ENFORCE_XDNN_SUCCESS(ret, "reciprocal");
+
+  int64_t half_rotary_len = seq_len * head_dim / 2;
+  float* indices_half_data = RAII_GUARD.alloc_l3_or_gm<float>(half_rotary_len);
+  float* sin_fp32_half_data = RAII_GUARD.alloc_l3_or_gm<float>(half_rotary_len);
+  float* cos_fp32_half_data = RAII_GUARD.alloc_l3_or_gm<float>(half_rotary_len);
+
+  ret = xpu::broadcast_mul<float>(dev_ctx.x_context(),
+                                  pos_seq_data,
+                                  freqs_data,
+                                  indices_half_data,
+                                  {seq_len, 1},
+                                  {1, head_dim / 2});
+  PADDLE_ENFORCE_XDNN_SUCCESS(ret, "broadcast_mul");
+  ret = xpu::sin<float>(dev_ctx.x_context(),
+                        indices_half_data,
+                        sin_fp32_half_data,
+                        half_rotary_len);
+  PADDLE_ENFORCE_XDNN_SUCCESS(ret, "sin");
+  ret = xpu::cos<float>(dev_ctx.x_context(),
+                        indices_half_data,
+                        cos_fp32_half_data,
+                        half_rotary_len);
+  PADDLE_ENFORCE_XDNN_SUCCESS(ret, "cos");
+
+  SinCosType* sin_half_data = nullptr;
+  SinCosType* cos_half_data = nullptr;
+  if (!std::is_same<SinCosType, float>::value) {
+    auto* sin_half_data =
+        RAII_GUARD.alloc_l3_or_gm<SinCosType>(half_rotary_len);
+    auto* cos_half_data =
+        RAII_GUARD.alloc_l3_or_gm<SinCosType>(half_rotary_len);
+    ret = xpu::cast<float, SinCosType>(dev_ctx.x_context(),
+                                       sin_fp32_half_data,
+                                       sin_half_data,
+                                       half_rotary_len);
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, "cast");
+    ret = xpu::cast<float, SinCosType>(dev_ctx.x_context(),
+                                       cos_fp32_half_data,
+                                       cos_half_data,
+                                       half_rotary_len);
+    PADDLE_ENFORCE_XPU_SUCCESS(ret, "cast");
+  } else {
+    sin_half_data = sin_fp32_half_data;
+    cos_half_data = cos_fp32_half_data;
+  }
+  ret = xpu::concat<SinCosType>(
+      dev_ctx.x_context(),
+      {sin_half_data, sin_half_data},
+      sin_data,
+      {{seq_len, head_dim / 2}, {seq_len, head_dim / 2}},
+      1);
+  PADDLE_ENFORCE_XDNN_SUCCESS(ret, "concat");
+  ret = xpu::concat<SinCosType>(
+      dev_ctx.x_context(),
+      {cos_half_data, cos_half_data},
+      cos_data,
+      {{seq_len, head_dim / 2}, {seq_len, head_dim / 2}},
+      1);
+  PADDLE_ENFORCE_XDNN_SUCCESS(ret, "concat");
+}
+
+template <typename XPUType, typename SinCosType, typename Context>
+void XPUGetSinCosData(const Context& dev_ctx,
+                      const paddle::optional<DenseTensor>& sin,
+                      const paddle::optional<DenseTensor>& cos,
+                      const paddle::optional<DenseTensor>& position_ids,
+                      SinCosType* sin_data,
+                      SinCosType* cos_data,
+                      int64_t batch_size,
+                      int64_t seq_len,
+                      int64_t head_dim,
+                      float rotary_emb_base) {
+  if (sin_cos.get_ptr()) {
+    GetSinCosByPassValue<XPUType, SinCosType, Context>(dev_ctx,
+                                                       sin,
+                                                       cos,
+                                                       position_ids,
+                                                       sin_data,
+                                                       cos_data,
+                                                       batch_size,
+                                                       seq_len,
+                                                       head_dim);
+  } else {
+    GetSinCosByRotaryBase<XPUType, SinCosType, Context>(dev_ctx,
+                                                        sin_data,
+                                                        cos_data,
+                                                        batch_size,
+                                                        seq_len,
+                                                        head_dim,
+                                                        rotary_emb_base);
+  }
+}
+
+template <typename XPUType, typename SinCosType, typename Context>
+void XPUFusedRotaryEveryTwo(const Context& dev_ctx,
+                            const DenseTensor& in_q,
+                            const paddle::optional<DenseTensor>& in_k,
+                            const paddle::optional<DenseTensor>& in_v,
+                            const paddle::optional<DenseTensor>& sin,
+                            const paddle::optional<DenseTensor>& cos,
+                            bool time_major,
+                            bool is_bwd,
+                            DenseTensor* out_q,
+                            DenseTensor* out_k,
+                            DenseTensor* out_v) {
+  auto single_func = &xpu:: : rotary_embedding_v3_single<XPUType, SinCosType>;
+  auto fusion_func = &xpu::xpu::rotary_embedding_v3<XPUType, SinCosType>;
+  const char* single_func_name = "rotary_embedding_v3_single";
+  const char* fusion_func_name = "rotary_embedding_v3";
   if (is_bwd) {
-    func = &xpu::rotary_no_freqs_embedding_v2_grad<XPUType>;
+    single_func = &xpu:: : rotary_embedding_v3_single_grad<XPUType, SinCosType>;
+    fusion_func = &xpu::xpu::rotary_embedding_v3<XPUType, SinCosType>;
+    single_func_name = "rotary_embedding_v3_single_grad";
+    fusion_func_name = "rotary_embedding_v3_grad";
+  }
+  if (!k) {
+    int ret = single_func(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(q.data<T>()),
+        cos_data,
+        sin_data,
+        outq_data,
+        batch_size,
+        seq_len,
+        num_heads,
+        head_dim,
+        {seq_len * num_heads * head_dim, num_heads * head_dim, head_dim, 1});
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, single_func_name);
+  } else {
+    int64_t num_heads_k = k->dims()[2];
+    int ret = fusion_func<XPUType, SinCosType>(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(q.data<T>()),
+        reinterpret_cast<const XPUType*>(k->data<T>()),
+        cos_data,
+        sin_data,
+        outq_data,
+        outk_data,
+        batch_size,
+        seq_len,
+        num_heads,
+        head_dim,
+        {seq_len * num_heads * head_dim, num_heads * head_dim, head_dim, 1},
+        {seq_len * num_heads_k * head_dim, num_heads_k * head_dim, head_dim, 1},
+        num_heads_k);
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, fusion_func_name);
   }
 
-  int ret =
-      func(dev_ctx.x_context(),
-           in_data,
-           sin_data,
-           cos_data,
-           out_data,
-           {batch_size, seq_len, num_heads, head_dim},
-           {batch_size, seq_len, 1, head_dim},
-           {seq_len * num_heads * head_dim, num_heads * head_dim, head_dim, 1},
-           {seq_len * head_dim, head_dim, head_dim, 1});
-  PADDLE_ENFORCE_XDNN_SUCCESS(ret,
-                              is_bwd ? "rotary_no_freqs_embedding_v2_grad"
-                                     : "rotary_no_freqs_embedding_v2");
+  if (v) {
+    int64_t num_heads_v = v->dims()[2];
+    int ret = single_func<XPUType, XPUType>(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(v->data<T>()),
+        cos_data,
+        sin_data,
+        outv_data,
+        batch_size,
+        seq_len,
+        num_heads_v,
+        head_dim,
+        {seq_len * num_heads_v * head_dim,
+         num_heads_v * head_dim,
+         head_dim,
+         1});
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, single_func_name);
+  }
+}
+
+template <typename XPUType, typename SinCosType, typename Context>
+void XPUFusedRotaryHalf(const Context& dev_ctx,
+                        const DenseTensor& in_q,
+                        const paddle::optional<DenseTensor>& in_k,
+                        const paddle::optional<DenseTensor>& in_v,
+                        const paddle::optional<DenseTensor>& sin,
+                        const paddle::optional<DenseTensor>& cos,
+                        bool time_major,
+                        bool is_bwd,
+                        DenseTensor* out_q,
+                        DenseTensor* out_k,
+                        DenseTensor* out_v) {
+  auto single_func = &xpu::rotary_no_freqs_embedding_v2<XPUType>;
+  auto fusion_func = &xpu::rotary_no_freqs_qk_embedding_v2<XPUType>;
+  const char* single_func_name = "rotary_no_freqs_embedding_v2";
+  const char* fusion_func_name = "xpu::rotary_no_freqs_qk_embedding_v2";
+  if (is_bwd) {
+    single_func = &xpu::rotary_no_freqs_embedding_v2_grad<XPUType>;
+    fusion_func = &xpu::rotary_no_freqs_qk_embedding_v2_grad<XPUType>;
+  }
+
+  if (head_dim * sizeof(T) <= 1024 && head_dim % 64 == 0 && k) {
+    int64_t num_heads_k = k->dims()[2];
+    int ret = fusion_func(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(q.data<T>()),
+        reinterpret_cast<const XPUType*>(k->data<T>()),
+        sin_data,
+        cos_data,
+        outq_data,
+        outk_data,
+        {batch_size, seq_len, num_heads, head_dim},
+        {batch_size, seq_len, 1, head_dim},
+        {seq_len * num_heads * head_dim, num_heads * head_dim, head_dim, 1},
+        {seq_len * head_dim, head_dim, head_dim, 1},
+        num_heads_k);
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, fusion_func_name);
+  } else {
+    int ret = single_func(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(q.data<T>()),
+        sin_data,
+        cos_data,
+        outq_data,
+        {batch_size, seq_len, num_heads, head_dim},
+        {batch_size, seq_len, 1, head_dim},
+        {seq_len * num_heads * head_dim, num_heads * head_dim, head_dim, 1},
+        {seq_len * head_dim, head_dim, head_dim, 1});
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, single_func_name);
+    if (k) {
+      int64_t num_heads_k = k->dims()[2];
+      int ret = single_func(
+          dev_ctx.x_context(),
+          reinterpret_cast<const XPUType*>(k.data<T>()),
+          sin_data,
+          cos_data,
+          outk_data,
+          {batch_size, seq_len, num_heads, head_dim},
+          {batch_size, seq_len, 1, head_dim},
+          {seq_len * num_heads * head_dim, num_heads * head_dim, head_dim, 1},
+          {seq_len * head_dim, head_dim, head_dim, 1});
+      PADDLE_ENFORCE_XDNN_SUCCESS(ret, single_func_name);
+    }
+  }
+
+  if (v) {
+    int64_t num_heads_v = v->dims()[2];
+    int ret = single_func(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(v.data<T>()),
+        sin_data,
+        cos_data,
+        outv_data,
+        {batch_size, seq_len, num_heads, head_dim},
+        {batch_size, seq_len, 1, head_dim},
+        {seq_len * num_heads * head_dim, num_heads * head_dim, head_dim, 1},
+        {seq_len * head_dim, head_dim, head_dim, 1});
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, single_func_name);
+  }
+}
+template <typename XPUType, typename SinCosType, typename Context>
+void XPUFusedRopeImpl(const Context& dev_ctx,
+                      const DenseTensor& q,
+                      const paddle::optional<DenseTensor>& k,
+                      const paddle::optional<DenseTensor>& v,
+                      const paddle::optional<DenseTensor>& sin,
+                      const paddle::optional<DenseTensor>& cos,
+                      const paddle::optional<DenseTensor>& position_ids,
+                      bool use_neox_rotary_style,
+                      bool time_major,
+                      float rotary_emb_base,
+                      DenseTensor* out_q,
+                      DenseTensor* out_k,
+                      DenseTensor* out_v) {
+  int64_t sin_cos_len = batch_size * seq_len * head_dim;
+  auto* sin_data = RAII_GUARD.alloc_l3_or_gm<SinCosT>(sin_cos_len);
+  auto* cos_data = RAII_GUARD.alloc_l3_or_gm<SinCosT>(sin_cos_len);
+  XPUGetSinCosData<XPUType, SinCosType, Context>(dev_ctx,
+                                                 sin,
+                                                 position_ids,
+                                                 sin_data,
+                                                 cos_data,
+                                                 batch_size,
+                                                 seq_len,
+                                                 head_dim);
+  if (use_neox_rotary_style) {
+    XPUFusedRotaryEveryTwo<XPUType, SinCosType, Context>(
+        dev_ctx, q, k, v, sin, cos, time_major, false, out_q, out_k, out_v);
+  } else {
+    XPUFusedRotaryHalf<XPUType, SinCosType, Context>(
+        dev_ctx, q, k, v, sin, cos, time_major, false, out_q, out_k, out_v);
+  }
 }
 }  // namespace fusion
 }  // namespace phi

--- a/paddle/phi/kernels/fusion/xpu/fused_rope_utils.h
+++ b/paddle/phi/kernels/fusion/xpu/fused_rope_utils.h
@@ -50,7 +50,7 @@ void GetSinCosByPassValue(const Context& dev_ctx,
                           "The num_heads of sin and cos must be 1."));
   }
   int sin_seq_len_dim = (dims_size) == 4 ? 1 : 0;
-  if (position_ids.get_ptr()) {
+  if (position_ids) {
     PADDLE_ENFORCE_EQ(
         (sin_cos_dims[dims_size - 1] == head_dim &&
          sin_cos_dims[sin_seq_len_dim] >= seq_len),
@@ -60,7 +60,7 @@ void GetSinCosByPassValue(const Context& dev_ctx,
             "this of q. The head_dim of sin and cos must be the same as this "
             "of q."));
 
-    auto position_ids_dims = position_ids.get_ptr()->dims();
+    auto position_ids_dims = position_ids->dims();
     PADDLE_ENFORCE_EQ(position_ids_dims.size(),
                       2,
                       common::errors::InvalidArgument(
@@ -215,7 +215,7 @@ void XPUGetSinCosData(const Context& dev_ctx,
                       int64_t seq_len,
                       int64_t head_dim,
                       float rotary_emb_base) {
-  if (sin.get_ptr() && cos.get_ptr()) {
+  if (sin && cos) {
     GetSinCosByPassValue<XPUType, XPUSCType, Context>(dev_ctx,
                                                       sin,
                                                       cos,

--- a/paddle/phi/kernels/fusion/xpu/fused_rope_utils.h
+++ b/paddle/phi/kernels/fusion/xpu/fused_rope_utils.h
@@ -123,15 +123,18 @@ void GetSinCosByRotaryBase(const Context& dev_ctx,
   xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
 
   float* pos_seq_data = RAII_GUARD.alloc_l3_or_gm<float>(seq_len);
+  PADDLE_ENFORCE_XDNN_NOT_NULL(pos_seq_data);
   int ret =
       xpu::range<float>(dev_ctx.x_context(), pos_seq_data, 0.0f, 1.0f, seq_len);
   PADDLE_ENFORCE_XDNN_SUCCESS(ret, "range");
   float* freqs_data = RAII_GUARD.alloc_l3_or_gm<float>(head_dim / 2);
+  PADDLE_ENFORCE_XDNN_NOT_NULL(freqs_data);
   ret = xpu::range<float>(
       dev_ctx.x_context(), freqs_data, 0.0f, 2.0f / head_dim, head_dim / 2);
   PADDLE_ENFORCE_XDNN_SUCCESS(ret, "range");
 
   float* rotary_base_xpu_data = RAII_GUARD.alloc_l3_or_gm<float>(1);
+  PADDLE_ENFORCE_XDNN_NOT_NULL(rotary_base_xpu_data);
   memory_utils::Copy(dev_ctx.GetPlace(),
                      rotary_base_xpu_data,
                      phi::CPUPlace(),
@@ -150,8 +153,11 @@ void GetSinCosByRotaryBase(const Context& dev_ctx,
 
   int64_t half_rotary_len = seq_len * head_dim / 2;
   float* indices_half_data = RAII_GUARD.alloc_l3_or_gm<float>(half_rotary_len);
+  PADDLE_ENFORCE_XDNN_NOT_NULL(indices_half_data);
   float* sin_fp32_half_data = RAII_GUARD.alloc_l3_or_gm<float>(half_rotary_len);
+  PADDLE_ENFORCE_XDNN_NOT_NULL(sin_fp32_half_data);
   float* cos_fp32_half_data = RAII_GUARD.alloc_l3_or_gm<float>(half_rotary_len);
+  PADDLE_ENFORCE_XDNN_NOT_NULL(cos_fp32_half_data);
 
   ret = xpu::broadcast_mul<float>(dev_ctx.x_context(),
                                   pos_seq_data,
@@ -190,6 +196,8 @@ void GetSinCosByRotaryBase(const Context& dev_ctx,
     sin_half_data = reinterpret_cast<XPUSCType*>(sin_fp32_half_data);
     cos_half_data = reinterpret_cast<XPUSCType*>(cos_fp32_half_data);
   }
+  PADDLE_ENFORCE_XDNN_NOT_NULL(sin_half_data);
+  PADDLE_ENFORCE_XDNN_NOT_NULL(cos_half_data);
   ret = xpu::broadcast<XPUSCType>(dev_ctx.x_context(),
                                   sin_half_data,
                                   sin_data,
@@ -445,7 +453,9 @@ void XPUFusedRopeImpl(const Context& dev_ctx,
 
   int64_t sin_cos_len = batch_size * seq_len * head_dim;
   auto* sin_data = RAII_GUARD.alloc_l3_or_gm<XPUSCType>(sin_cos_len);
+  PADDLE_ENFORCE_XDNN_NOT_NULL(sin_data);
   auto* cos_data = RAII_GUARD.alloc_l3_or_gm<XPUSCType>(sin_cos_len);
+  PADDLE_ENFORCE_XDNN_NOT_NULL(cos_data);
   XPUGetSinCosData<XPUType, XPUSCType, Context>(dev_ctx,
                                                 sin,
                                                 cos,

--- a/test/xpu/test_fused_rotary_position_embedding_op_xpu.py
+++ b/test/xpu/test_fused_rotary_position_embedding_op_xpu.py
@@ -56,38 +56,21 @@ def mult_qkv_rotate_half(value, cos_tensor, sin_tensor):
     return query
 
 
-def get_sin_cos_tensor(seq_len, head_dim, sign=1, dtype="float32"):
+def get_sin_cos_tensor(seq_len, head_dim, dtype="float32"):
     pos_seq = paddle.arange(0, seq_len, 1).astype("float32")
     indices = paddle.arange(0, head_dim, 2).astype("float32")
 
-    indices = 1 / 10000 ** (indices / head_dim)
+    indices = 1 / (10000 ** (indices / head_dim))
     sinusoid_inp = pos_seq.unsqueeze(1) * indices.unsqueeze(0)
-
-    sin_sin = paddle.empty([seq_len * head_dim], dtype=dtype)
-    cos_cos = paddle.empty([seq_len * head_dim], dtype=dtype)
-
-    i = 0
-
-    for value in sinusoid_inp.flatten():
-        sin_sin[i * 2] = sign * paddle.sin(value)
-        cos_cos[i * 2 + 0] = paddle.cos(value)
-        sin_sin[i * 2 + 1] = paddle.sin(value)
-        cos_cos[i * 2 + 1] = paddle.cos(value)
-        i += 1
-
-    tensor_sin = paddle.reshape(
-        sin_sin,
-        [1, seq_len, 1, head_dim],
-    )
-    tensor_cos = paddle.reshape(
-        cos_cos,
-        [1, seq_len, 1, head_dim],
-    )
-
-    return tensor_sin.astype(dtype), tensor_cos.astype(dtype)
+    sinusoid_inp = paddle.concat([sinusoid_inp, sinusoid_inp], axis=-1)
+    sin = paddle.sin(sinusoid_inp)
+    cos = paddle.cos(sinusoid_inp)
+    sin = sin.astype(dtype).reshape([1, seq_len, 1, head_dim])
+    cos = cos.astype(dtype).reshape([1, seq_len, 1, head_dim])
+    return sin, cos
 
 
-def paddle_fused_rotary_position_embedding(
+def ref_rotary_position_embedding(
     init_q,
     init_k=None,
     init_v=None,
@@ -144,7 +127,7 @@ class XPUTestFusedRotaryPositionEmbedding(unittest.TestCase):
         if shape is None:
             return None
 
-        tmp = paddle.randn(shape, self.dtype)
+        tmp = paddle.uniform(shape, self.dtype, -1.0, 1.0)
         tmp.stop_gradient = False
         return tmp
 
@@ -167,7 +150,7 @@ class XPUTestFusedRotaryPositionEmbedding(unittest.TestCase):
         tensor_v = self.get_paddle_tensor(self.shape_v)
 
         tensor_sin, tensor_cos = (
-            get_sin_cos_tensor(tensor_q.shape[1], tensor_q.shape[3], 1, dtype)
+            get_sin_cos_tensor(tensor_q.shape[1], tensor_q.shape[3], dtype)
             if with_sin_cos
             else (None, None)
         )
@@ -202,9 +185,9 @@ class XPUTestFusedRotaryPositionEmbedding(unittest.TestCase):
         fw.append(out_k)
         fw.append(out_v)
         paddle.seed(seed + 1)
-        out_gq = paddle.randn(out_q.shape, self.dtype)
-        out_gk = paddle.randn(out_k.shape, self.dtype)
-        out_gv = paddle.randn(out_v.shape, self.dtype)
+        out_gq = paddle.uniform(out_q.shape, self.dtype, -1.0, 1.0)
+        out_gk = paddle.uniform(out_k.shape, self.dtype, -1.0, 1.0)
+        out_gv = paddle.uniform(out_v.shape, self.dtype, -1.0, 1.0)
 
         paddle.autograd.backward(
             [out_q, out_k, out_v], [out_gq, out_gk, out_gv], True
@@ -218,7 +201,7 @@ class XPUTestFusedRotaryPositionEmbedding(unittest.TestCase):
     def test_fused_rope(self):
         paddle.set_device('xpu')
         p_fw, p_bw = self.get_forward_backward(
-            paddle_fused_rotary_position_embedding,
+            ref_rotary_position_embedding,
             seed=self.seed,
             use_neox_rotary_style=False,
         )
@@ -235,19 +218,19 @@ class XPUTestFusedRotaryPositionEmbedding(unittest.TestCase):
                 p_bw[i].numpy(), f_bw[i].numpy(), rtol=self.rtol, atol=self.atol
             )
 
-    def test_fused_rope_with_sin_cos(self):
+    def test_fused_rope_without_sin_cos(self):
         paddle.set_device('xpu')
         p_fw, p_bw = self.get_forward_backward(
-            paddle_fused_rotary_position_embedding,
+            ref_rotary_position_embedding,
             seed=self.seed,
             with_sin_cos=True,
-            use_neox_rotary_style=False,
+            use_neox_rotary_style=True,
         )
         f_fw, f_bw = self.get_forward_backward(
             fused_rotary_position_embedding,
             seed=self.seed,
-            with_sin_cos=True,
-            use_neox_rotary_style=False,
+            with_sin_cos=False,
+            use_neox_rotary_style=True,
         )
         for i in range(len(p_fw)):
             np.testing.assert_allclose(
@@ -260,7 +243,7 @@ class XPUTestFusedRotaryPositionEmbedding(unittest.TestCase):
     def test_fused_rope_rotate_half(self):
         paddle.set_device('xpu')
         p_fw, p_bw = self.get_forward_backward(
-            paddle_fused_rotary_position_embedding,
+            ref_rotary_position_embedding,
             seed=self.seed,
             use_neox_rotary_style=False,
         )
@@ -283,7 +266,7 @@ class XPUTestFusedRotaryPositionEmbedding(unittest.TestCase):
             [[7, 5, 4, 6, 3, 1, 2, 0], [3, 1, 4, 0, 7, 6, 5, 2]]
         )
         p_fw, p_bw = self.get_forward_backward(
-            paddle_fused_rotary_position_embedding,
+            ref_rotary_position_embedding,
             seed=self.seed,
             position_ids=position_ids,
             use_neox_rotary_style=False,
@@ -308,7 +291,7 @@ class XPUTestFusedRotaryPositionEmbedding(unittest.TestCase):
             self.seed, True, self.dtype
         )
         p_fw, p_bw = self.get_forward_backward(
-            paddle_fused_rotary_position_embedding,
+            ref_rotary_position_embedding,
             seed=self.seed,
             use_neox_rotary_style=False,
         )
@@ -385,14 +368,14 @@ class XPUTestFusedRotaryPositionEmbeddingBf16_1(unittest.TestCase):
 
     def test_api(self):
         paddle.disable_static()
-        q_bf16 = paddle.randn(self.shape_q, dtype="bfloat16")
-        k_bf16 = paddle.randn(self.shape_k, dtype="bfloat16")
-        v_bf16 = paddle.randn(self.shape_v, dtype="bfloat16")
-        sin_bf16 = paddle.randn(
-            [1, self.shape_q[1], 1, self.shape_q[3]], dtype="bfloat16"
+        q_bf16 = paddle.uniform(self.shape_q, "bfloat16", -1.0, 1.0)
+        k_bf16 = paddle.uniform(self.shape_k, "bfloat16", -1.0, 1.0)
+        v_bf16 = paddle.uniform(self.shape_v, "bfloat16", -1.0, 1.0)
+        sin_bf16 = paddle.uniform(
+            [1, self.shape_q[1], 1, self.shape_q[3]], "bfloat16", -1.0, 1.0
         )
-        cos_bf16 = paddle.randn(
-            [1, self.shape_q[1], 1, self.shape_q[3]], dtype="bfloat16"
+        cos_bf16 = paddle.uniform(
+            [1, self.shape_q[1], 1, self.shape_q[3]], "bfloat16", -1.0, 1.0
         )
         q_bf16.stop_gradient = False
         k_bf16.stop_gradient = False
@@ -417,16 +400,16 @@ class XPUTestFusedRotaryPositionEmbeddingBf16_1(unittest.TestCase):
             use_neox_rotary_style=False,
         )
 
-        grad_out_q_bf16 = paddle.randn(self.shape_q, dtype="bfloat16")
-        grad_out_k_bf16 = paddle.randn(self.shape_k, dtype="bfloat16")
-        grad_out_v_bf16 = paddle.randn(self.shape_v, dtype="bfloat16")
+        grad_out_q_bf16 = paddle.uniform(self.shape_q, "bfloat16", -1.0, 1.0)
+        grad_out_k_bf16 = paddle.uniform(self.shape_k, "bfloat16", -1.0, 1.0)
+        grad_out_v_bf16 = paddle.uniform(self.shape_v, "bfloat16", -1.0, 1.0)
 
         paddle.autograd.backward(
             out_bf16, [grad_out_q_bf16, grad_out_k_bf16, grad_out_v_bf16], True
         )
         grad_bf16 = [q_bf16.grad, k_bf16.grad, v_bf16.grad]
 
-        out_fp32 = paddle_fused_rotary_position_embedding(
+        out_fp32 = ref_rotary_position_embedding(
             q_fp32,
             k_fp32,
             v_fp32,

--- a/test/xpu/test_fused_rotary_position_embedding_op_xpu.py
+++ b/test/xpu/test_fused_rotary_position_embedding_op_xpu.py
@@ -62,7 +62,7 @@ def get_sin_cos_tensor(seq_len, head_dim, dtype="float32"):
 
     indices = 1 / (10000 ** (indices / head_dim))
     sinusoid_inp = pos_seq.unsqueeze(1) * indices.unsqueeze(0)
-    sinusoid_inp = paddle.concat([sinusoid_inp, sinusoid_inp], axis=-1)
+    sinusoid_inp = paddle.stack([sinusoid_inp, sinusoid_inp], axis=-1)
     sin = paddle.sin(sinusoid_inp)
     cos = paddle.cos(sinusoid_inp)
     sin = sin.astype(dtype).reshape([1, seq_len, 1, head_dim])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
1. support fused rope with none sin/cos for XPU