### PR TITLE
[CINN] Delete unused variables within the symbolic inference interface of the box coder operation

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -679,8 +679,6 @@ bool BoxCoderOpInferSymbolicShape(
   const std::string &code_type =
       op->attribute<pir::StrAttribute>("code_type").AsString();
   int axis = op->attribute<pir::Int32Attribute>("axis").data();
-  const std::vector<float> &variance =
-      paddle::dialect::details::GetVectorAttr<float>(op, "variance");
 
   PADDLE_ENFORCE_EQ(prior_box_shape.size(),
                     2,
@@ -690,7 +688,7 @@ bool BoxCoderOpInferSymbolicShape(
                         prior_box_shape.size()));
   infer_context->AddEqualCstr(prior_box_shape[1], symbol::DimExpr{4});
 
-  if (op->operand_source(1)) {
+  if (!paddle::dialect::details::IsFakeValue(op->operand_source(1))) {
     const symbol::ShapeOrDataDimExprs &prior_box_var_shape_or_data =
         infer_context->GetShapeOrDataForValue(op->operand_source(1));
     const std::vector<symbol::DimExpr> &prior_box_var_shape =


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Delete unused variables within the symbolic inference interface of the box coder operation and refine code.