### PR TITLE
Expose header file utils.h op_compat_info.h

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_compat_info.h
+++ b/paddle/fluid/ir_adaptor/translator/op_compat_info.h
@@ -54,6 +54,26 @@ class OpNameNormalizer {
     return OpNameNormalizer;
   }
 
+  std::unordered_map<std::string, std::string> GetOpNameMappings() const {
+    return op_name_mappings;
+  }
+
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+  GetOpArgNameMappings() const {
+    return op_arg_name_mappings;
+  }
+
+  std::unordered_map<std::string,
+                     std::unordered_map<std::string, MutableAttributeInfo>>
+  GetOpMutableAttributeInfos() const {
+    return op_mutable_attribute_infos;
+  }
+
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+  GetOpMutableAttributes() const {
+    return op_mutable_attributes;
+  }
+
   std::string operator[](const std::string& op_type) {
     if (op_name_mappings.find(op_type) == op_name_mappings.end()) {
       return op_type;

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1132,7 +1132,8 @@ headers = (
     list(find_files('op_yaml_info.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/interface'))+
     list(find_files('op_yaml_info_util.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/utils/'))+
     list(find_files('op_yaml_info_parser.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/utils/'))+
-    list(find_files('utils.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/utils/')))
+    list(find_files('utils.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/utils/'))+
+    list(find_files('op_compat_info.h','@PADDLE_SOURCE_DIR@/paddle/fluid/ir_adaptor/translator/')))
 jit_layer_headers = ['layer.h', 'serializer.h', 'serializer_utils.h', 'all.h', 'function.h']
 for f in jit_layer_headers:
     headers += list(find_files(f, '@PADDLE_SOURCE_DIR@/paddle/fluid/jit', recursive=True))

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1131,7 +1131,8 @@ headers = (
     list(find_files('dense_tensor.inl','@PADDLE_SOURCE_DIR@/paddle/phi/core'))+
     list(find_files('op_yaml_info.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/interface'))+
     list(find_files('op_yaml_info_util.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/utils/'))+
-    list(find_files('op_yaml_info_parser.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/utils/')))
+    list(find_files('op_yaml_info_parser.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/utils/'))+
+    list(find_files('utils.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/utils/')))
 jit_layer_headers = ['layer.h', 'serializer.h', 'serializer_utils.h', 'all.h', 'function.h']
 for f in jit_layer_headers:
     headers += list(find_files(f, '@PADDLE_SOURCE_DIR@/paddle/fluid/jit', recursive=True))

--- a/setup.py
+++ b/setup.py
@@ -1742,16 +1742,22 @@ def get_headers():
                 paddle_source_dir + '/paddle/fluid/pir/dialect/operator/utils',
             )
         )
-        + list(  # serialize and deserialize interface headers
+        + list(  # op yaml parser interface headers
             find_files(
                 'op_yaml_info_parser.h',
                 paddle_source_dir + '/paddle/fluid/pir/dialect/operator/utils',
             )
         )
-        + list(  # serialize and deserialize interface headers
+        + list(  # pir op utils interface headers
             find_files(
                 'utils.h',
                 paddle_source_dir + '/paddle/fluid/pir/dialect/operator/utils',
+            )
+        )
+        + list(  # ir translator interface headers
+            find_files(
+                'op_compat_info.h',
+                paddle_source_dir + '/paddle/fluid/ir_adaptor/translator/',
             )
         )
     )

--- a/setup.py
+++ b/setup.py
@@ -1748,6 +1748,12 @@ def get_headers():
                 paddle_source_dir + '/paddle/fluid/pir/dialect/operator/utils',
             )
         )
+        + list(  # serialize and deserialize interface headers
+            find_files(
+                'utils.h',
+                paddle_source_dir + '/paddle/fluid/pir/dialect/operator/utils',
+            )
+        )
     )
 
     jit_layer_headers = [


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
1. Expose header file `paddle/fluid/pir/dialect/operator/utils/utils.h` and `paddle/fluid/ir_adaptor/translator/op_compat_info.h` 
2. Add getters in op_compat_info.h

pcard-67164