### PR TITLE
[Auto Parallel] fix reshape_grad spmd bug && complete moe_combine spm…

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/moe_combine.cc
+++ b/paddle/phi/infermeta/spmd_rules/moe_combine.cc
@@ -158,7 +158,7 @@ SpmdInfo MoECombineBwdInferSpmd(const DistMetaTensor& x,
   // step 1 : infer sharding
   std::string x_axes = "sh", combine_weights_axes = "sk",
               scatter_index_axes = "sk", grad_y_axes = "sh", grad_x_axes = "sh",
-              grad_combine_weights_axes = "sk";
+              grad_combine_weights_axes = "sk", grad_scatter_index_axes = "sk";
   std::unordered_map<std::string, int64_t> axis_to_dim_map =
       ShardingMergeForTensors(
           {{x_axes, x_dims_mapping_src},
@@ -173,6 +173,8 @@ SpmdInfo MoECombineBwdInferSpmd(const DistMetaTensor& x,
       GetDimsMappingForAxes(grad_x_axes, axis_to_dim_map);
   std::vector<int64_t> grad_combine_weights_dims_mapping =
       GetDimsMappingForAxes(grad_combine_weights_axes, axis_to_dim_map);
+  std::vector<int64_t> grad_scatter_index_dims_mapping =
+      GetDimsMappingForAxes(grad_scatter_index_axes, axis_to_dim_map);
 
   TensorDistAttr x_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
   TensorDistAttr combine_weights_dist_attr_dst =
@@ -184,6 +186,8 @@ SpmdInfo MoECombineBwdInferSpmd(const DistMetaTensor& x,
   TensorDistAttr grad_x_dist_attr_dst =
       CopyTensorDistAttrForOutput(grad_y_dist_attr_src);
   TensorDistAttr grad_combine_weights_dist_attr_dst =
+      CopyTensorDistAttrForOutput(grad_y_dist_attr_src);
+  TensorDistAttr grad_scatter_index_dist_attr_dst =
       CopyTensorDistAttrForOutput(grad_y_dist_attr_src);
 
   x_dist_attr_dst.set_dims_mapping(
@@ -197,6 +201,8 @@ SpmdInfo MoECombineBwdInferSpmd(const DistMetaTensor& x,
   grad_x_dist_attr_dst.set_dims_mapping(grad_x_dims_mapping);
   grad_combine_weights_dist_attr_dst.set_dims_mapping(
       grad_combine_weights_dims_mapping);
+  grad_scatter_index_dist_attr_dst.set_dims_mapping(
+      grad_scatter_index_dims_mapping);
 
   // Step 2: Log messages
   LOG_SPMD_INPUT(x);
@@ -210,7 +216,9 @@ SpmdInfo MoECombineBwdInferSpmd(const DistMetaTensor& x,
            combine_weights_dist_attr_dst,
            scatter_index_dist_attr_dst,
            grad_y_dist_attr_dst},
-          {grad_x_dist_attr_dst, grad_combine_weights_dist_attr_dst}};
+          {grad_x_dist_attr_dst,
+           grad_combine_weights_dist_attr_dst,
+           grad_scatter_index_dist_attr_dst}};
 }
 
 }  // namespace distributed

--- a/paddle/phi/infermeta/spmd_rules/reshape.cc
+++ b/paddle/phi/infermeta/spmd_rules/reshape.cc
@@ -336,14 +336,10 @@ SpmdInfo ReshapeGradInferSpmd(const DistMetaTensor& x,
   const auto& x_dist_dst = PADDLE_GET_CONST(TensorDistAttr, tmp.first[0]);
   const auto& out_grad_dist_dst =
       PADDLE_GET_CONST(TensorDistAttr, tmp.second[0]);
+  if (x_dist_dst.dims_mapping() != x_dist_tmp.dims_mapping()) {
+    x_dist_tmp.set_dims_mapping(x_dist_dst.dims_mapping());
+  }
   return {{x_dist_tmp, out_grad_dist_dst}, {x_dist_dst}};
-}
-
-SpmdInfo StaticReshapeGradInferSpmd(const DistMetaTensor& x,
-                                    const DistMetaTensor& out_grad) {
-  std::vector<int64_t> out_grad_shape = common::vectorize(out_grad.dims());
-  auto tmp = ReshapeInferSpmd(x, out_grad_shape);
-  return {{tmp.first[0], tmp.second[0]}, {tmp.first[0]}};
 }
 
 }  // namespace phi::distributed

--- a/paddle/phi/infermeta/spmd_rules/reshape.h
+++ b/paddle/phi/infermeta/spmd_rules/reshape.h
@@ -35,8 +35,5 @@ SpmdInfo ReshapeInferSpmdDynamic(const DistMetaTensor& x,
 SpmdInfo ReshapeGradInferSpmd(const DistMetaTensor& x_shape,
                               const DistMetaTensor& out_grad);
 
-SpmdInfo StaticReshapeGradInferSpmd(const DistMetaTensor& x,
-                                    const DistMetaTensor& out_grad);
-
 }  // namespace distributed
 }  // namespace phi

--- a/test/cpp/auto_parallel/moe_combine_spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/moe_combine_spmd_rule_test.cc
@@ -121,7 +121,7 @@ TEST(MoECombineSPMDRule, test_moe_combine_spmd) {
   // replicated case, backward
   input_dims_mappings = {{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}};
   expected_dims_mappings = {{{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}},
-                            {{-1, -1}, {-1, -1}}};
+                            {{-1, -1}, {-1, -1}, {-1, -1}}};
   test_moe_combine_spmd(
       backward_input_shapes, input_dims_mappings, expected_dims_mappings, true);
 
@@ -134,7 +134,7 @@ TEST(MoECombineSPMDRule, test_moe_combine_spmd) {
   // mp case, backward
   input_dims_mappings = {{1, -1}, {1, -1}, {-1, -1}, {1, -1}};
   expected_dims_mappings = {{{1, -1}, {1, -1}, {1, -1}, {1, -1}},
-                            {{1, -1}, {1, -1}}};
+                            {{1, -1}, {1, -1}, {1, -1}}};
   test_moe_combine_spmd(
       backward_input_shapes, input_dims_mappings, expected_dims_mappings, true);
 }


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复reshape_grad切分推导问题；完善moe_combine切分推导
Pcard-73145