### PR TITLE
add backward decomp for logsumexp and trunc

### DIFF
--- a/paddle/fluid/primitive/codegen/gen.py
+++ b/paddle/fluid/primitive/codegen/gen.py
@@ -76,6 +76,7 @@ UNARY_PRIM_VJP_OPS = [
     'sin_grad',
     'cos_grad',
     'tanh_grad',
+    'trunc_grad',
     'square_grad',
 ]
 
@@ -126,6 +127,7 @@ OTHER_PRIM_VJP_OPS = [
     'unsqueeze_grad',
     'where_grad',
     'logcumsumexp_grad',
+    'logsumexp_grad',
 ]
 
 # whole vjp list of primitive op vjp

--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -2892,64 +2892,103 @@ void logsumexp_grad(const Tensor& x,
                     bool keepdim,
                     bool reduce_all,
                     Tensor* x_grad) {
-  if (!x_grad) {
-    return;
-  }
-
-  std::vector<int64_t> x_dim = common::vectorize<int64_t>(x.dims());
-  int64_t axis_size = axis.size();
-  int64_t x_dim_size = x_dim.size();
-  reduce_all = false;
-
-  if (reduce_all || axis_size == 0 || axis_size == x_dim_size) {
-    reduce_all = true;
-  } else {
+  if (x_grad) {
+    int64_t axis_size = axis.size();
+    int64_t x_dim_size = x.dims().size();
     reduce_all = false;
-  }
 
-  auto x_grad_tmp = Tensor();
+    if (reduce_all || axis_size == 0 || axis_size == x_dim_size) {
+      reduce_all = true;
+    } else {
+      reduce_all = false;
+    }
 
-  if (x_dim_size == 1) {
-    x_grad_tmp = expand<T>(out_grad, IntArray(x_dim)) * exp<T>(x - out);
-  } else {
-    if (!keepdim) {
-      auto axis_ = std::vector<int64_t>();
-      if (reduce_all) {
-        for (int64_t i = 0; i < x_dim_size; i++) {
-          axis_.push_back(i);
-        }
+    auto x_grad_tmp = Tensor();
+
+    if (has_dynamic_shape(x.shape())) {
+      Tensor x_shape = shape<T>(x);
+      if (x_dim_size == 1) {
+        x_grad_tmp = backend::expand<T>(out_grad, x_shape) * exp<T>(x - out);
       } else {
-        axis_ = axis.GetData();
-        for (int64_t i = 0; i < axis_size; i++) {
-          if (axis[i] < 0) {
-            axis_[i] = axis[i] + x_dim_size;
+        if (!keepdim) {
+          auto axis_ = std::vector<int64_t>();
+          if (reduce_all) {
+            for (int64_t i = 0; i < x_dim_size; i++) {
+              axis_.push_back(i);
+            }
+          } else {
+            axis_ = axis.GetData();
+            for (int64_t i = 0; i < axis_size; i++) {
+              if (axis[i] < 0) {
+                axis_[i] = axis[i] + x_dim_size;
+              }
+            }
           }
+          Tensor out_grad_shape = shape<T>(out_grad);
+          size_t total_shape_size = out_grad.shape().size() + axis_.size();
+          std::vector<Tensor> result_shape;
+          size_t j = 0, k = 0;
+          Tensor ones = backend::full<T>({1}, 1, x_shape.dtype());
+          for (size_t i = 0; i < total_shape_size; i++) {
+            if (j < axis_.size() && axis_[j] == int64_t(i)) {
+              result_shape.push_back(ones);
+              j++;
+            } else {
+              result_shape.push_back(get_slice<T>(out_grad_shape, int64_t(k)));
+              k++;
+            }
+          }
+          auto out_ = backend::reshape<T>(out, concat<T>(result_shape));
+          auto softmax = exp<T>(x - backend::expand<T>(out_, x_shape));
+
+          auto out_grad_ =
+              backend::reshape<T>(out_grad, concat<T>(result_shape));
+          x_grad_tmp = backend::expand<T>(out_grad_, x_shape) * softmax;
+        } else {
+          x_grad_tmp = backend::expand<T>(out_grad, x_shape) * exp<T>(x - out);
         }
       }
-
-      auto out_shape = get_unsqueeze_dims(out, axis_);
-      auto out_ = reshape<T>(out, out_shape);
-      auto softmax = exp<T>(x - expand<T>(out_, IntArray(x_dim)));
-
-      auto out_grad_shape = get_unsqueeze_dims(out_grad, axis_);
-      auto out_grad_ = reshape<T>(out_grad, out_grad_shape);
-      x_grad_tmp = expand<T>(out_grad_, IntArray(x_dim)) * softmax;
     } else {
-      x_grad_tmp = expand<T>(out_grad, IntArray(x_dim)) * exp<T>(x - out);
-    }
-  }
+      std::vector<int64_t> x_dim = common::vectorize<int64_t>(x.dims());
+      if (x_dim_size == 1) {
+        x_grad_tmp = expand<T>(out_grad, IntArray(x_dim)) * exp<T>(x - out);
+      } else {
+        if (!keepdim) {
+          auto axis_ = std::vector<int64_t>();
+          if (reduce_all) {
+            for (int64_t i = 0; i < x_dim_size; i++) {
+              axis_.push_back(i);
+            }
+          } else {
+            axis_ = axis.GetData();
+            for (int64_t i = 0; i < axis_size; i++) {
+              if (axis[i] < 0) {
+                axis_[i] = axis[i] + x_dim_size;
+              }
+            }
+          }
+          auto out_shape = get_unsqueeze_dims(out, axis_);
+          auto out_ = reshape<T>(out, out_shape);
+          auto softmax = exp<T>(x - expand<T>(out_, IntArray(x_dim)));
 
-  set_output<T>(x_grad_tmp, x_grad);
+          auto out_grad_shape = get_unsqueeze_dims(out_grad, axis_);
+          auto out_grad_ = reshape<T>(out_grad, out_grad_shape);
+          x_grad_tmp = expand<T>(out_grad_, IntArray(x_dim)) * softmax;
+        } else {
+          x_grad_tmp = expand<T>(out_grad, IntArray(x_dim)) * exp<T>(x - out);
+        }
+      }
+    }
+    set_output<T>(x_grad_tmp, x_grad);
+  }
 }
 
 template <typename T>
 void trunc_grad(const Tensor& out_grad, Tensor* x_grad) {
   if (!x_grad) {
-    return;
+    Tensor zero_tensor = full<T>(out_grad.shape(), 0.0, out_grad.dtype());
+    set_output<T>(zero_tensor, x_grad);
   }
-
-  Tensor zero_tensor = full<T>(out_grad.shape(), 0.0, out_grad.dtype());
-  set_output<T>(zero_tensor, x_grad);
 }
 
 }  // namespace details

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -89,8 +89,9 @@ ALLOW_DYNAMIC_SHAPE_VJP_OPS = [
     "pd_op.swish",
     "pd_op.tanh",
     "pd_op.topk",
-    "pd_op.unsqueeze",
     "pd_op.transpose",
+    "pd_op.trunc",
+    "pd_op.unsqueeze",
     "pd_op.where",
 ]
 

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -55,6 +55,7 @@ ALLOW_DYNAMIC_SHAPE_VJP_OPS = [
     "pd_op.leaky_relu",
     "pd_op.log",
     "pd_op.logcumsumexp",
+    "pd_op.logsumexp",
     "pd_op.matmul",
     "pd_op.max",
     "pd_op.maximum",

--- a/test/legacy_test/test_logsumexp.py
+++ b/test/legacy_test/test_logsumexp.py
@@ -171,24 +171,25 @@ class TestLogsumexp_FP16(TestLogsumexp):
         self.dtype = 'float16'
 
     def test_check_output(self):
-        ref_x = self.inputs['X'].astype(np.float32)
-        out_ref = ref_logsumexp(ref_x)
-        paddle.disable_static()
-        x = self.inputs['X'].astype(np.float16)
-        tensor_x = paddle.to_tensor(x)
-        out_pad = logsumexp_wrapper(tensor_x)
-        paddle.enable_static()
-        np.testing.assert_allclose(
-            out_pad.numpy(), out_ref, rtol=1e-03, atol=1e-08
+        place = core.CUDAPlace(0)
+        self.check_output_with_place(
+            place,
+            check_pir=True,
+            check_prim_pir=True,
         )
 
     def test_check_grad(self):
-        self.__class__.dtype = self.dtype
-        ref_x = self.inputs['X'].astype(np.float32)
-        ref_x_grad = logsumexp_ref_grad(ref_x)
-        x = self.inputs['X'].astype(np.float16)
-        x_grad = logsumexp_op_grad(x)
-        np.testing.assert_allclose(x_grad, ref_x_grad, rtol=1e-03, atol=1e-05)
+        place = core.CUDAPlace(0)
+        self.check_grad_with_place(
+            place,
+            ['X'],
+            'Out',
+            check_pir=True,
+            check_prim_pir=True,
+        )
+
+    def set_attrs_addition(self):
+        pass
 
 
 @unittest.skipIf(

--- a/test/legacy_test/test_logsumexp.py
+++ b/test/legacy_test/test_logsumexp.py
@@ -19,7 +19,6 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
-from paddle.pir_utils import test_with_pir_api
 
 
 def ref_logsumexp(x, axis=None, keepdim=False, reduce_all=False):
@@ -58,7 +57,7 @@ def logsumexp_ref_grad(x):
 class TestLogsumexp(OpTest):
     def setUp(self):
         self.op_type = 'logsumexp'
-        self.prim_op_type = "comp"
+        self.prim_op_type = "prim"
         self.python_api = logsumexp_wrapper
         self.public_python_api = logsumexp_wrapper
         self.shape = [2, 3, 4, 5]
@@ -220,11 +219,21 @@ class TestLogsumexpBF16Op(TestLogsumexp):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place, check_pir=True)
+        self.check_output_with_place(
+            place,
+            check_pir=True,
+            check_prim_pir=True,
+        )
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
-        self.check_grad_with_place(place, ['X'], 'Out', check_pir=True)
+        self.check_grad_with_place(
+            place,
+            ['X'],
+            'Out',
+            check_pir=True,
+            check_prim_pir=True,
+        )
 
     def set_attrs(self):
         pass
@@ -234,7 +243,6 @@ class TestLogsumexpBF16Op(TestLogsumexp):
 
 
 class TestLogsumexpError(unittest.TestCase):
-    @test_with_pir_api
     def test_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):
             self.assertRaises(TypeError, paddle.logsumexp, 1)
@@ -267,7 +275,6 @@ class TestLogsumexpAPI(unittest.TestCase):
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=1e-05)
         paddle.enable_static()
 
-    @test_with_pir_api
     def test_api(self):
         self.api_case()
         self.api_case(2)

--- a/test/legacy_test/test_logsumexp.py
+++ b/test/legacy_test/test_logsumexp.py
@@ -199,7 +199,9 @@ class TestLogsumexp_FP16(TestLogsumexp):
 class TestLogsumexpBF16Op(TestLogsumexp):
     def setUp(self):
         self.op_type = 'logsumexp'
+        self.prim_op_type = "prim"
         self.python_api = logsumexp_wrapper
+        self.public_python_api = logsumexp_wrapper
         self.dtype = np.uint16
         self.shape = [2, 3, 4, 5]
         self.axis = [-1]

--- a/test/legacy_test/test_trunc_op.py
+++ b/test/legacy_test/test_trunc_op.py
@@ -19,7 +19,6 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
-from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -27,7 +26,7 @@ paddle.enable_static()
 class TestTruncOp(OpTest):
     def setUp(self):
         self.op_type = "trunc"
-        self.prim_op_type = "comp"
+        self.prim_op_type = "prim"
         self.python_api = paddle.trunc
         self.public_python_api = paddle.trunc
         self.init_dtype_type()
@@ -78,7 +77,6 @@ class TestTruncAPI(unittest.TestCase):
         self.x = np.random.random((20, 20)).astype(np.float32)
         self.place = paddle.CPUPlace()
 
-    @test_with_pir_api
     def test_api_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -98,7 +96,6 @@ class TestTruncAPI(unittest.TestCase):
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=1e-08)
         paddle.enable_static()
 
-    @test_with_pir_api
     def test_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', [20, 20], 'bool')

--- a/test/legacy_test/test_trunc_op.py
+++ b/test/legacy_test/test_trunc_op.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -26,7 +27,9 @@ paddle.enable_static()
 class TestTruncOp(OpTest):
     def setUp(self):
         self.op_type = "trunc"
+        self.prim_op_type = "comp"
         self.python_api = paddle.trunc
+        self.public_python_api = paddle.trunc
         self.init_dtype_type()
         np.random.seed(2021)
         self.inputs = {'X': np.random.random((20, 20)).astype(self.dtype)}
@@ -36,10 +39,19 @@ class TestTruncOp(OpTest):
         self.dtype = np.float64
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(
+            check_pir=True,
+            check_prim_pir=True,
+        )
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', numeric_grad_delta=1e-5, check_pir=True)
+        self.check_grad(
+            ['X'],
+            'Out',
+            numeric_grad_delta=1e-5,
+            check_pir=True,
+            check_prim_pir=True,
+        )
 
 
 class TestFloatTruncOp(TestTruncOp):
@@ -66,6 +78,7 @@ class TestTruncAPI(unittest.TestCase):
         self.x = np.random.random((20, 20)).astype(np.float32)
         self.place = paddle.CPUPlace()
 
+    @test_with_pir_api
     def test_api_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -85,6 +98,7 @@ class TestTruncAPI(unittest.TestCase):
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=1e-08)
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', [20, 20], 'bool')

--- a/test/prim/pir_prim/test_prim_sub_graph_klmno_backward_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_klmno_backward_dynamic_shape.py
@@ -39,6 +39,22 @@ def logcumsumexp_net3(x):
     return paddle.logcumsumexp(x, axis=-1)
 
 
+def logsumexp_net1(x):
+    return paddle.logsumexp(x)
+
+
+def logsumexp_net2(x):
+    return paddle.logsumexp(x, keepdim=False)
+
+
+def logsumexp_net3(x):
+    return paddle.logsumexp(x, axis=-1, keepdim=False)
+
+
+def logsumexp_net4(x):
+    return paddle.logsumexp(x, axis=[0, 2], keepdim=False)
+
+
 def matmul_net(x, y):
     return paddle.matmul(x, y)
 
@@ -139,6 +155,71 @@ class TestPrimLogcumsumexpWithGrad3(TestPrimBaseWithGrad):
         self.init_x_shape = [None, None, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = logcumsumexp_net3
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimLogsumexpWithGrad1(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.logsumexp_grad"
+        self.dtype = "float32"
+        self.x_shape = [1000]
+        self.init_x_shape = [None]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = logsumexp_net1
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimLogsumexpWithGrad2(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.logsumexp_grad"
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 40]
+        self.init_x_shape = [None, None, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = logsumexp_net2
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimLogsumexpWithGrad3(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.logsumexp_grad"
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 40]
+        self.init_x_shape = [None, None, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = logsumexp_net1
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimLogsumexpWithGrad4(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.logsumexp_grad"
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 40]
+        self.init_x_shape = [None, None, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = logsumexp_net3
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimLogsumexpWithGrad5(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.logsumexp_grad"
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 40]
+        self.init_x_shape = [None, None, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = logsumexp_net4
         self.enable_cinn = False
         self.tol = 1e-6
 

--- a/test/prim/pir_prim/test_prim_sub_graph_pqrst_backward_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_pqrst_backward_dynamic_shape.py
@@ -178,6 +178,10 @@ def transpose_net(x):
     return paddle.transpose(x, perm=[0, 3, 1, 2])
 
 
+def trunc_net(x):
+    return paddle.trunc(x)
+
+
 class TestPrimPadWithGrad(TestPrimBaseWithGrad):
     def setUp(self):
         np.random.seed(2023)
@@ -1087,6 +1091,19 @@ class TestPrimTransposeWithGrad(TestPrimBaseWithGrad):
         self.init_x_shape = [None, None, None, 70]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = transpose_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimTruncWithGrad(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.trunc_grad"
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 40]
+        self.init_x_shape = [None, None, None]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = trunc_net
         self.enable_cinn = False
         self.tol = 1e-6
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others


### Description
<!-- Describe what you’ve done -->
反向拆解 logsumexp, trunc

pcard-66975
