### PR TITLE
[Prim] Mark `reduce_as` no need `target` buffer and use `by_pass` in both dynamic and static shape branch

### DIFF
--- a/paddle/common/ddim.cc
+++ b/paddle/common/ddim.cc
@@ -282,6 +282,18 @@ DDim ComputeCompatibleDim(const DDim& dim1, const DDim& dim2) {
   return make_ddim(result);
 }
 
+bool AreDimsWithDynamicShapeCompatible(const DDim& dim1, const DDim& dim2) {
+  if (dim1.size() != dim2.size()) {
+    return false;
+  }
+  for (int i = 0; i < dim1.size(); ++i) {
+    if (dim1[i] >= 0 && dim2[i] >= 0 && dim1[i] != dim2[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace common
 
 namespace std {

--- a/paddle/common/ddim.h
+++ b/paddle/common/ddim.h
@@ -234,6 +234,9 @@ TEST_API DDim stride(const DDim& ddim);
 
 TEST_API DDim stride_numel(const DDim& ddim);
 
+TEST_API bool AreDimsWithDynamicShapeCompatible(const DDim& dim1,
+                                                const DDim& dim2);
+
 TEST_API DDim ComputeCompatibleDim(const DDim& dim1, const DDim& dim2);
 
 }  // namespace common

--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -20,6 +20,7 @@
 
 #include <math.h>
 #include <vector>
+#include "paddle/common/ddim.h"
 #include "paddle/fluid/prim/api/generated_prim/prim_generated_api.h"
 #include "paddle/fluid/primitive/type/lazy_tensor.h"
 #include "paddle/fluid/primitive/utils/utils.h"
@@ -655,37 +656,36 @@ void add_grad(const Tensor& x,
               Tensor* dx,
               Tensor* dy) {
   if (dy) {
-    if (has_dynamic_shape(y.shape()) || has_dynamic_shape(out_grad.shape())) {
-      auto dy_tmp = reduce_as<T>(out_grad, y);
-      set_output<T>(dy_tmp, dy);
-    } else {
-      if (out_grad.dims() != y.dims()) {
+    if (!common::AreDimsWithDynamicShapeCompatible(out_grad.dims(), y.dims())) {
+      if (has_dynamic_shape(y.shape()) || has_dynamic_shape(out_grad.shape())) {
+        auto dy_tmp = reduce_as<T>(out_grad, y);
+        set_output<T>(dy_tmp, dy);
+      } else {
         phi::DDim reduce_dim =
             get_reduce_dims_from_out(out_grad.dims(), y.dims());
         auto dy_reduce_res =
             out_grad.sum(common::vectorize(reduce_dim), y.dtype(), false);
         auto dy_tmp = reshape<T>(dy_reduce_res, common::vectorize(y.dims()));
         set_output<T>(dy_tmp, dy);
-
-      } else {
-        by_pass<T>(out_grad, dy);
       }
+    } else {
+      by_pass<T>(out_grad, dy);
     }
   }
   if (dx) {
-    if (has_dynamic_shape(x.shape()) || has_dynamic_shape(out_grad.shape())) {
-      auto dx_tmp = reduce_as<T>(out_grad, x);
-      set_output<T>(dx_tmp, dx);
-    } else {
-      if (out_grad.dims() != x.dims()) {
+    if (!common::AreDimsWithDynamicShapeCompatible(out_grad.dims(), x.dims())) {
+      if (has_dynamic_shape(x.shape()) || has_dynamic_shape(out_grad.shape())) {
+        auto dx_tmp = reduce_as<T>(out_grad, x);
+        set_output<T>(dx_tmp, dx);
+      } else {
         auto reduce_dim = get_reduce_dims_from_out(out_grad.dims(), x.dims());
         auto dx_reduce_res =
             out_grad.sum(common::vectorize(reduce_dim), x.dtype(), false);
         auto dx_tmp = reshape<T>(dx_reduce_res, common::vectorize(x.dims()));
         set_output<T>(dx_tmp, dx);
-      } else {
-        by_pass<T>(out_grad, dx);
       }
+    } else {
+      by_pass<T>(out_grad, dx);
     }
   }
 }

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -3875,6 +3875,7 @@
     func : reduce_as
     data_type : x
   backward : reduce_as_grad
+  no_need_buffer : target
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : reduce_scatter


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

#68302 默认开启动态 shape 后，QA 反馈 PPTSM 开 CINN 显存增加超 5%，初步分析现象如下

| mem (MB) | 动态 shape | 静态 shape |
| - | - | - |
| dy2st | 892 | 892 |
| prim | 927 | 831 |
| prim (forward only) | 1949 | 1949 |
| prim (backward only) | 927 | 831 |
| CINN | 927 | 830 |

根据现象可以发现，开组合后动态 shape 显存是明显高于静态 shape 的，CINN 作为下游同样会高，进一步可以发现是反向拆解动态 shape 会明显高一些

经过分析发现有两个问题

- add 反向拆解动态 shape 分支用的 `reduce_as` 没有给 `target` 标记 `no_need_buffer`，但这里只需要 meta 信息，不需要 holder，修复后显存从 927 降低到 890 左右（和动转静基线差不多，也就是说静态 shape 下拆解后显存得到了额外优化才到 830，但动态 shape 下没有这部分优化）
- 仍然是 add 反向拆解，动态 shape 下永远不会走 `by_pass`，导致显存升高，修改后可以命中，显存降回 830 左右，与静态 shape 拆解基本打平

### TODOs

- subtract 等使用 `by_pass` 的 OP 修复

PCard-66972