### PR TITLE
[PIR][oneDNN] Delete extra placement pattern for fc

### DIFF
--- a/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
@@ -189,7 +189,6 @@ class OneDNNPlacementPass : public pir::PatternRewritePass {
     patternCreator.CreatePatterns<paddle::dialect::SqueezeGrad_Op>(ps);
     patternCreator.CreatePatterns<paddle::dialect::TanhGradOp>(ps);
     patternCreator.CreatePatterns<paddle::dialect::TanhGrad_Op>(ps);
-    patternCreator.CreatePatterns<paddle::dialect::FcOp>(ps);
     patternCreator.CreatePatterns<paddle::dialect::FusionGruOp>(ps);
     patternCreator.CreatePatterns<paddle::dialect::AddNOp>(ps);
     patternCreator.CreatePatterns<paddle::dialect::Cast_Op>(ps);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
 Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Delete extra placement pattern for Fc, since former pass `fc_onednn_enable_pass` already filtered feasible Fc ops. Extra pattern may introduce error such what `ConvNeXt_tiny_infer` met. In the future, we will check if limits on Fc has been resolved and see if it's possible extend the scope to convert fc for performance improvement.
