### PR TITLE
Add sync_comm_stream double type [fluid_ops] 

### DIFF
--- a/paddle/phi/kernels/gpu/sync_comm_stream_kernel.cu
+++ b/paddle/phi/kernels/gpu/sync_comm_stream_kernel.cu
@@ -14,5 +14,9 @@
 
 #include "paddle/phi/kernels/impl/sync_comm_stream_kernel_impl.h"
 
-PD_REGISTER_KERNEL(
-    sync_comm_stream, GPU, ALL_LAYOUT, phi::SyncCommStreamKernel, float) {}
+PD_REGISTER_KERNEL(sync_comm_stream,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::SyncCommStreamKernel,
+                   float,
+                   double) {}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/66744#issuecomment-2378730970
sync_comm_stream 增加 double类型支持