### PR TITLE
[PHI]fix expand as kernel bug

### DIFF
--- a/paddle/phi/kernels/gpu/expand_as_kernel.cu
+++ b/paddle/phi/kernels/gpu/expand_as_kernel.cu
@@ -27,8 +27,14 @@ template <typename T, typename Context>
 void ExpandAsKernel(const Context& ctx,
                     const DenseTensor& x,
                     const paddle::optional<DenseTensor>& y,
-                    const std::vector<int>& target_shape,
+                    const std::vector<int>& target_shape_t,
                     DenseTensor* out) {
+  std::vector<int> target_shape = target_shape_t;
+
+  if (y.get_ptr()) {
+    target_shape = phi::vectorize<int>(y.get_ptr()->dims());
+  }
+
   int rank = x.dims().size();
   int target_rank = static_cast<int>(target_shape.size());
   auto vec_in_dims = common::vectorize<int>(x.dims());


### PR DESCRIPTION
### PR Category
CINN

### PR Types
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-76996

修复 expand as kernel的bug，在expand as的输入y，不为空时， 还用 y的真实shape ，更新 target shape