### PR TITLE
[CINN] Remove the hard-coded var loading in CodeGenLLVM

### DIFF
--- a/paddle/cinn/backends/codegen_invoke_module.h
+++ b/paddle/cinn/backends/codegen_invoke_module.h
@@ -43,19 +43,8 @@ class CodeGenInvokeModule : public CodeGenLLVM {
     return LowerInvokeFunc(func);
   }
 
-  llvm::Value *Visit(const ir::Call *op) override {
-    // TODO(Hongqing-work): change intrinsic name to get_value_in_kernel_args
-    if (op->name == runtime::intrinsic::get_value_in_cuda_kernel_args) {
-      return LowerParseArgsValueCall(op);
-    } else {
-      return CodeGenLLVM::Visit(op);
-    }
-  }
-
  protected:
   llvm::Value *LowerInvokeFunc(const ir::_LoweredFunc_ *func);
-
-  llvm::Value *LowerParseArgsValueCall(const ir::Call *call_ir);
 };
 
 class CodeGenHost : public CodeGenInvokeModule {
@@ -80,7 +69,7 @@ class CodeGenSwitchHost : public CodeGenInvokeModule {
   // only support call of args get function and inner case host function call
   llvm::Value *Visit(const ir::Call *op) override {
     if (op->name == runtime::intrinsic::get_value_in_cuda_kernel_args) {
-      return CodeGenInvokeModule::LowerParseArgsValueCall(op);
+      return CodeGenLLVM::Visit(op);
     } else {
       return LowerInnerCaseCall(op);
     }

--- a/paddle/cinn/backends/llvm/codegen_llvm.h
+++ b/paddle/cinn/backends/llvm/codegen_llvm.h
@@ -49,14 +49,6 @@ class LLVMIRVisitor : public ir::IRVisitorRequireReImpl<llvm::Value *> {
 #undef __m
 };
 
-/**
- * Tell whether a variable called \p \var_name will lowered to a pointer type in
- * LLVM.
- * @param var_name name of the variable.
- * @return a boolean.
- */
-bool LLVM_WillVarLowerAsPointer(const std::string &var_name);
-
 class SymbolTable {
  public:
   SymbolTable() = default;

--- a/paddle/cinn/runtime/cuda/cuda_intrinsics.cc
+++ b/paddle/cinn/runtime/cuda/cuda_intrinsics.cc
@@ -433,6 +433,14 @@ CINN_REGISTER_HELPER(cinn_cuda_host_api) {
       .AddInputType<int>()     // index
       .End();
 
+  using cinn::runtime::cuda::cinn_get_item_in_cuda_kernel_args;
+  REGISTER_EXTERN_FUNC_HELPER(cinn_get_item_in_cuda_kernel_args,
+                              cinn::common::DefaultHostTarget())
+      .SetRetType<void *>()
+      .AddInputType<void *>()  // args
+      .AddInputType<int>()     // index
+      .End();
+
   using cinn::runtime::cuda::infer_shape_set_value;
   REGISTER_EXTERN_FUNC_HELPER(infer_shape_set_value,
                               cinn::common::DefaultHostTarget())

--- a/paddle/cinn/runtime/cuda/cuda_util.cc
+++ b/paddle/cinn/runtime/cuda/cuda_util.cc
@@ -83,6 +83,11 @@ int64_t cinn_get_value_in_cuda_kernel_args(void *v_args, int idx) {
   return args[idx].operator int64_t();
 }
 
+void *cinn_get_item_in_cuda_kernel_args(void *v_args, int idx) {
+  cinn_pod_value_t *args = static_cast<cinn_pod_value_t *>(v_args);
+  return static_cast<void *>(&args[idx]);
+}
+
 void cinn_call_cuda_kernel(void *kernel_fn,
                            void *v_args,
                            int num_args,

--- a/paddle/cinn/runtime/cuda/cuda_util.h
+++ b/paddle/cinn/runtime/cuda/cuda_util.h
@@ -90,6 +90,8 @@ void cinn_call_cuda_memcpy(void* v_args,
                            void* stream = nullptr);
 
 int64_t cinn_get_value_in_cuda_kernel_args(void* v_args, int idx);
+void* cinn_get_item_in_cuda_kernel_args(void* v_args, int idx);
+
 void infer_shape_set_value(int row, int col, int64_t value, int64_t** v);
 
 /**

--- a/paddle/cinn/runtime/intrinsic.h
+++ b/paddle/cinn/runtime/intrinsic.h
@@ -106,8 +106,13 @@ static const char* call_cuda_kernel = "cinn_call_cuda_kernel";
 
 static const char* call_hip_kernel = "cinn_call_hip_kernel";
 
+static const char* call_cuda_memset = "cinn_call_cuda_memset";
+
 static const char* get_value_in_cuda_kernel_args =
     "cinn_get_value_in_cuda_kernel_args";
+
+static const char* get_item_in_cuda_kernel_args =
+    "cinn_get_item_in_cuda_kernel_args";
 
 static const char* infer_shape_set_value = "infer_shape_set_value";
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Improvements


### Description
There is no need to treat argument or pointer vars separately when loading vars in `CodeGenLLVM`. This PR removes the hard-coded parts of the` _Var_ `'s visitor, making var loading more general.

This PR also exports some intrinsic functions that rely on this PR for proper lowering.

Pcard-85711
