### PR TITLE
[Auto Parallel] fix enable_delay_scale_loss for static auto parallel …

### DIFF
--- a/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
+++ b/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
@@ -636,6 +636,94 @@ def parse_program(
     return grad_to_gradient_merge
 
 
+def _find_trival_optimizer_ops(block):
+    optimizer_ops = []
+    for op in block.ops:
+        if "adam" in op.name() or "sgd" in op.name():
+            optimizer_ops.append(op)
+    return optimizer_ops
+
+
+def _get_prev_op(block, optimizer_op):
+    found = False
+    for op in reversed(block.ops):
+        if found:
+            return op
+        if op.id == optimizer_op.id:
+            found = True
+    return None
+
+
+def _insert_scale_op_after(target_value, optimizer_op, scale, bias=0.0):
+    scaled_grad = paddle._C_ops.scale_(target_value, scale, bias, False)
+
+    scale_op = scaled_grad.get_defining_op()
+    scale_op.op_role = int(OpRole.Optimize)
+
+    full_op = scale_op.operand_source(1).get_defining_op()
+    assert (
+        full_op.name() == "pd_op.full"
+    ), f"The defining op of the scale value should be `pd_op.full`, but got {full_op.name()}"
+    full_op.op_role = int(OpRole.Optimize)
+
+    if "adam" in optimizer_op.name():
+        optimizer_op.operand(1).set_source(scaled_grad)
+    elif "sgd" in optimizer_op.name():
+        optimizer_op.operand(2).set_source(scaled_grad)
+
+
+def _append_scale_op_before_comm(block, new_params_to_grads, k_steps):
+    for op in reversed(block.ops):
+        if op.op_role == int(OpRole.Backward):
+            paddle.pir.set_insertion_point_after(op)
+            break
+        for _, new_grad in new_params_to_grads:
+            new_grad = paddle._C_ops.scale_(new_grad, 1.0 / k_steps, 0.0, False)
+
+            scale_op = new_grad.get_defining_op()
+            scale_op.op_role = int(OpRole.Optimize)
+
+            full_op = scale_op.operand_source(1).get_defining_op()
+            assert (
+                full_op.name() == "pd_op.full"
+            ), f"The defining op of the scale value should be `pd_op.full`, but got {full_op.name()}"
+            full_op.op_role = int(OpRole.Optimize)
+    paddle.pir.set_insertion_point_to_block_end(block)
+
+
+def _append_scale_op_after_comm(block, optimizer_ops, k_steps):
+    for optimizer_op in optimizer_ops:
+        target_value = None
+        if "adam" in optimizer_op.name():  # adam and adamw are included
+            target_value = optimizer_op.operand_source(1)
+        elif "sgd" in optimizer_op.name():
+            target_value = optimizer_op.operand_source(2)
+        else:
+            raise NotImplementedError(
+                f"We yet support adamw, adam and sgd, but got {optimizer_op.name()}"
+            )
+        assert (
+            target_value is not None
+        ), "target_value is not expected to be None"
+        insertion_point = target_value.get_defining_op()
+        if insertion_point is None:
+            # target_value is a gradient_merge_var, which hasn't defining_op
+            # so we find the prev op of optimizer_op, inserting a scale op behind.
+            insertion_point = _get_prev_op(block, optimizer_op)
+        paddle.pir.set_insertion_point_after(insertion_point)
+        _insert_scale_op_after(target_value, optimizer_op, 1.0 / k_steps)
+    paddle.pir.set_insertion_point_to_block_end(block)
+
+
+def _pir_append_scale_op(program, new_params_to_grads, k_steps):
+    block = program.global_block()
+    optimizer_ops = _find_trival_optimizer_ops(block)
+    if len(optimizer_ops) > 0:
+        _append_scale_op_after_comm(block, optimizer_ops, k_steps)
+    else:
+        _append_scale_op_before_comm(block, new_params_to_grads, k_steps)
+
+
 def _pir_parse_program(
     main_program,
     startup_program,
@@ -657,22 +745,7 @@ def _pir_parse_program(
 
     # step3: append scale op
     if avg:
-        main_block = main_program.global_block()
-        for op in reversed(main_block.ops):
-            if op.op_role == int(OpRole.Backward):
-                paddle.pir.set_insertion_point_after(op)
-                break
-        for _, new_grad in new_params_to_grads:
-            new_grad = paddle._C_ops.scale_(new_grad, 1.0 / k_steps, 0.0, False)
-
-            scale_op = new_grad.get_defining_op()
-            scale_op.op_role = int(OpRole.Optimize)
-
-            full_op = scale_op.operand_source(1).get_defining_op()
-            assert (
-                full_op.name() == "pd_op.full"
-            ), f"The defining op of the scale value should be `pd_op.full`, but got {full_op.name()}"
-            full_op.op_role = int(OpRole.Optimize)
+        _pir_append_scale_op(main_program, new_params_to_grads, k_steps)
 
 
 @register_pass("auto_parallel_gradient_merge_pass")


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复动静半自动并行中，针对enable_delay_scale_loss的行为。在自动并行中，默认使用enable_delay_scale_loss的逻辑。
动态图手动的enable_delay_scale_loss的逻辑中，会先在sp/dp/sharding并行组对grad进行规约，再对规约的结果除以acc的step数。但目前自动并行的实现中，先对每个add的grad除以acc的step数，再在sp/dp/sharding并行组对grad进行规约。这种做法在grad较小时会有数值精度损失的风险。

因此，本pr：
**（1）适配动态图自动并行的逻辑，强制在优化器更新前触发通信，然后对梯度进行scale**
**（2）适配静态图自动并行的逻辑，适配auto_parallel_gradient_merge_pass，将grad的scale移动到reduce通信后进行**

Pcard-76459