### PR TITLE
[AutoParallel] Temp fix unused params error in auto parallel

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/mix_to_dist_pass.py
+++ b/python/paddle/distributed/auto_parallel/static/mix_to_dist_pass.py
@@ -34,6 +34,12 @@ def verify_dist_block(block):
         if op.name() == "dist_op.shard_tensor":
             raise RuntimeError("Block still contain shard_tensor_op.")
         if op.dist_attr is None:
+            # Note (luchang): Temp fix, remove unused parameter 'op'.
+            # Will be removed in the future.
+            if op.name() == "builtin.parameter":
+                if op.result(0).use_empty():
+                    op.erase()
+                    continue
             raise RuntimeError(
                 f"The op {op} does not have OperatorDistAttr after Mix2Dist Pass."
             )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Pcard-76459

unused 的 param 在 mix2dist 的时候无法有分布式属性，现在动转静由于下游需求需要保留 unused 的 param，这个修改引起了 mix2dist 时候的 check 错误

本 pr 先临时 hack 一下，在分布式场景下给 unused 的 parameter 先删除，后续再讨论如何适配

相关 pr:
- https://github.com/PaddlePaddle/Paddle/pull/68442
