### PR TITLE
[DLPACK] Setting device_id in FromDLPACK

### DIFF
--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -908,7 +908,7 @@ phi::DenseTensor TensorFromDLPack(DLManagedTensor* src, Deleter deleter) {
   if (src->dl_tensor.device.device_type == kDLCPU) {
     place = phi::CPUPlace();
   } else if (src->dl_tensor.device.device_type == kDLCUDA) {
-    place = phi::GPUPlace();
+    place = phi::GPUPlace(src->dl_tensor.device.device_id);
   } else if (src->dl_tensor.device.device_type == kDLCUDAHost) {
     place = phi::GPUPinnedPlace();
   } else {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-75624

Issued in <https://github.com/NVIDIA/warp/pull/318#issuecomment-2383404576>, `device_id` should be set in `TensorFromDLPack` when in GPU env.
cc @shi-eric

before:

``` py
import paddle

x_gpu2 = paddle.randn([2, 2]).to(device='gpu:2')

t_gpu2 = paddle.utils.dlpack.to_dlpack(x_gpu2)

x_gpu2_ref = paddle.utils.dlpack.from_dlpack(t_gpu2)

print(x_gpu2.place, x_gpu2_ref.place)
Place(gpu:2) Place(gpu:0) # device_id of x_gpu2_ref.place is not not set correctly
```

after fixing:

``` py
import paddle

x_gpu2 = paddle.randn([2, 2]).to(device='gpu:2')

t_gpu2 = paddle.utils.dlpack.to_dlpack(x_gpu2)

x_gpu2_ref = paddle.utils.dlpack.from_dlpack(t_gpu2)

print(x_gpu2.place, x_gpu2_ref.place)
Place(gpu:2) Place(gpu:2) # x_gpu2_ref.place is same as x_gpu2
```