### PR TITLE
Clean collective_helper in cmake [fluid_ops] 

### DIFF
--- a/paddle/fluid/distributed/collective/CMakeLists.txt
+++ b/paddle/fluid/distributed/collective/CMakeLists.txt
@@ -19,13 +19,12 @@ if(WITH_NCCL OR WITH_RCCL)
   cc_library(
     process_group_nccl
     SRCS process_group_nccl.cc common.cc
-    DEPS process_group phi common collective_helper device_context
-         ${DEVICE_EVENT_LIBS})
+    DEPS process_group phi ${DEVICE_EVENT_LIBS})
 
   cc_library(
     async_load
     SRCS async_load.cc
-    DEPS device_context phi common ${DEVICE_EVENT_LIBS})
+    DEPS phi ${DEVICE_EVENT_LIBS})
 
 endif()
 
@@ -33,21 +32,21 @@ if(WITH_XPU_BKCL)
   cc_library(
     process_group_bkcl
     SRCS process_group_bkcl.cc bkcl_tools.cc common.cc
-    DEPS process_group phi common collective_helper device_context)
+    DEPS process_group phi)
 endif()
 
 if(WITH_MPI)
   cc_library(
     process_group_mpi
     SRCS process_group_mpi.cc mpi_tools.cc common.cc
-    DEPS collective_helper device_context)
+    DEPS phi)
 endif()
 
 if(WITH_CUSTOM_DEVICE)
   cc_library(
     process_group_custom
     SRCS process_group_custom.cc custom_ccl_tools.cc common.cc
-    DEPS process_group phi common collective_helper device_context)
+    DEPS process_group phi)
 endif()
 
 set(COMM_UTILS_DEPS process_group)

--- a/paddle/fluid/distributed/fleet_executor/CMakeLists.txt
+++ b/paddle/fluid/distributed/fleet_executor/CMakeLists.txt
@@ -38,7 +38,6 @@ cc_library(
        fleet_executor_desc_proto
        interceptor_message_proto
        task_loop_thread_pool
-       collective_helper
        executor_gc_helper
        op_registry
        phi

--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -574,7 +574,6 @@ if(WITH_DISTRIBUTE)
            data_set.cc
       DEPS fleet_wrapper
            op_registry
-           device_context
            scope
            framework_proto
            trainer_desc_proto
@@ -588,7 +587,6 @@ if(WITH_DISTRIBUTE)
            lod_rank_table
            feed_fetch_method
            feed_hook
-           collective_helper
            ${GLOB_DISTRIBUTE_DEPS}
            graph_to_program_pass
            variable_helper

--- a/paddle/fluid/framework/ir/CMakeLists.txt
+++ b/paddle/fluid/framework/ir/CMakeLists.txt
@@ -19,7 +19,7 @@ cc_library(
 cc_library(
   graph_helper
   SRCS graph_helper.cc
-  DEPS graph program_utils collective_helper) #
+  DEPS graph program_utils phi) #
 cc_library(
   pass
   SRCS pass.cc

--- a/paddle/fluid/imperative/CMakeLists.txt
+++ b/paddle/fluid/imperative/CMakeLists.txt
@@ -93,12 +93,11 @@ if(NOT WIN32)
     cc_library(
       imperative_all_reduce
       SRCS all_reduce.cc
-      DEPS collective_helper device_context selected_rows_utils tensor)
+      DEPS phi selected_rows_utils tensor)
     cc_library(
       nccl_context
       SRCS nccl_context.cc
-      DEPS collective_helper device_context imperative_all_reduce
-           var_type_traits)
+      DEPS phi imperative_all_reduce var_type_traits)
     if(WITH_NCCL)
       nv_library(
         reducer
@@ -116,7 +115,7 @@ if(NOT WIN32)
     cc_library(
       bkcl_context
       SRCS bkcl_context.cc
-      DEPS collective_helper device_context tensor var_type_traits)
+      DEPS phi tensor var_type_traits)
     cc_library(
       reducer
       SRCS reducer.cc
@@ -126,7 +125,7 @@ if(NOT WIN32)
     cc_library(
       xccl_context
       SRCS xccl_context.cc
-      DEPS collective_helper device_context tensor var_type_traits)
+      DEPS phi tensor var_type_traits)
     if(NOT
        (WITH_NCCL
         OR WITH_RCCL
@@ -145,7 +144,7 @@ if(NOT WIN32)
     cc_library(
       heter_ccl_context
       SRCS heter_ccl_context.cc
-      DEPS collective_helper device_context tensor var_type_traits)
+      DEPS phi tensor var_type_traits)
   endif()
   cc_library(
     data_loader
@@ -156,7 +155,7 @@ if(WITH_GLOO)
   cc_library(
     imperative_gloo_context
     SRCS gloo_context.cc
-    DEPS collective_helper device_context tensor var_type_traits)
+    DEPS phi tensor var_type_traits)
   if(WIN32
      OR (NOT
          (WITH_NCCL

--- a/paddle/fluid/operators/collective/CMakeLists.txt
+++ b/paddle/fluid/operators/collective/CMakeLists.txt
@@ -31,14 +31,13 @@ register_operators(
   ${COLLECTIVE_DEPS})
 
 if(WITH_NCCL OR WITH_RCCL)
-  set(COLLECTIVE_DEPS ${COLLECTIVE_DEPS} nccl_common collective_helper phi
-                      common)
+  set(COLLECTIVE_DEPS ${COLLECTIVE_DEPS} nccl_common phi)
   op_library(c_gen_nccl_id_op DEPS ${COLLECTIVE_DEPS})
   op_library(gen_nccl_id_op DEPS ${COLLECTIVE_DEPS})
 endif()
 
 if(WITH_XPU_BKCL)
-  set(COLLECTIVE_DEPS ${COLLECTIVE_DEPS} collective_helper)
+  set(COLLECTIVE_DEPS ${COLLECTIVE_DEPS} phi)
   op_library(c_gen_bkcl_id_op DEPS ${COLLECTIVE_DEPS})
   op_library(gen_bkcl_id_op DEPS ${COLLECTIVE_DEPS})
 endif()

--- a/paddle/fluid/platform/CMakeLists.txt
+++ b/paddle/fluid/platform/CMakeLists.txt
@@ -67,11 +67,6 @@ cc_library(
        phi
        common)
 
-cc_library(
-  collective_helper
-  SRCS collective_helper.cc
-  DEPS framework_proto device_context phi common)
-
 # Manage all device event library
 set(DEVICE_EVENT_LIBS)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
清理CMakeLists.txt中collective_helper 依赖，collective_helper 已迁移到 phi