### PR TITLE
[Paddle TensorRT] add pd_op.split_with_num converter

### DIFF
--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -88,6 +88,13 @@ class Pool2dOpPattern
         op->attribute<pir::BoolAttribute>(kCanRunTrtAttr).data()) {
       return false;
     }
+    paddle::dialect::FullIntArrayOp full_int_array_op =
+        pir::GetDefiningOpForInput(op, 1)
+            ->dyn_cast<paddle::dialect::FullIntArrayOp>();
+    if (!full_int_array_op) {
+      VLOG(3) << "Cannot find FullIntArrayOp";
+      return false;
+    }
     auto padding_attr = op->attribute<pir::ArrayAttribute>("paddings");
     std::vector<int32_t> paddings;
     for (const auto &attr : padding_attr.AsVector()) {
@@ -121,28 +128,19 @@ class Pool2dOpPattern
           if (!op->attribute<pir::BoolAttribute>("global_pooling").data()) {
             if (op->HasAttribute("exclusive")) {
               if (op->attribute<pir::BoolAttribute>("exclusive").data()) {
-                paddle::dialect::FullIntArrayOp full_int_array_op =
-                    pir::GetDefiningOpForInput(op, 1)
-                        ->dyn_cast<paddle::dialect::FullIntArrayOp>();
-                if (!full_int_array_op) {
-                  VLOG(3) << "Cannot find FullIntArrayOp";
-                  return false;
-                } else {
-                  auto attr_value =
-                      full_int_array_op->attribute<pir::ArrayAttribute>(
-                          "value");
-                  std::vector<int64_t> kernel_size;
-                  for (const auto &attr : attr_value.AsVector()) {
-                    kernel_size.push_back(
-                        attr.dyn_cast<pir::Int64Attribute>().data());
-                  }
-                  for (size_t i = 0; i < kernel_size.size(); ++i) {
-                    if (kernel_size[i] <= paddings[i]) {
-                      VLOG(3) << "the padding size should be less than the "
-                                 "filter size "
-                                 "for exclusive-counting pooling.";
-                      return false;
-                    }
+                auto attr_value =
+                    full_int_array_op->attribute<pir::ArrayAttribute>("value");
+                std::vector<int64_t> kernel_size;
+                for (const auto &attr : attr_value.AsVector()) {
+                  kernel_size.push_back(
+                      attr.dyn_cast<pir::Int64Attribute>().data());
+                }
+                for (size_t i = 0; i < kernel_size.size(); ++i) {
+                  if (kernel_size[i] <= paddings[i]) {
+                    VLOG(3) << "the padding size should be less than the "
+                               "filter size "
+                               "for exclusive-counting pooling.";
+                    return false;
                   }
                 }
               }
@@ -852,33 +850,38 @@ class SplitWithNumOpPattern
         op->attribute<pir::BoolAttribute>(kCanRunTrtAttr).data()) {
       return false;
     }
-    paddle::dialect::FullOp full_op =
-        pir::GetDefiningOpForInput(op, 1)->dyn_cast<paddle::dialect::FullOp>();
-    if (!full_op) {
-      VLOG(3) << "Can not find full op";
+
+    pir::Value axis_tensor = op.operand_source(1);
+    if (!axis_tensor) {
+      VLOG(3) << "pd_op.split_with_num can not find axis input";
       return false;
-    } else {
-      auto axis = full_op->attribute<paddle::dialect::ScalarAttribute>("value")
+    }
+    if (pir::GetDefiningOpForInput(op, 1)
+            ->isa<paddle::dialect::FullIntArrayOp>()) {
+      paddle::dialect::FullIntArrayOp full_int_array_op =
+          pir::GetDefiningOpForInput(op, 1)
+              ->dyn_cast<paddle::dialect::FullIntArrayOp>();
+      auto axis = full_int_array_op
+                      ->attribute<paddle::dialect::ScalarAttribute>("value")
                       .data()
                       .to<int>();
       auto x_shape = op.operand_source(0)
                          .type()
                          .dyn_cast<paddle::dialect::DenseTensorType>()
                          .dims();
-      auto out_vector_type = op.result(0).type().dyn_cast<pir::VectorType>();
 
       axis += (axis < 0) ? x_shape.size() : 0;
       if (x_shape[axis] == -1) {
         VLOG(3) << "The (" << axis << ") dim of input should not be -1";
         return false;
       }
-
       if (!op->HasAttribute("num")) {
         VLOG(3) << "split_with_num op must has num attributes";
         return false;
       }
       int num = op->attribute<pir::Int32Attribute>("num").data();
       std::vector<int64_t> output_lengths;
+
       if (num > 0) {
         int64_t in_axis_dim = x_shape[axis];
         if (in_axis_dim % num != 0) {
@@ -892,14 +895,15 @@ class SplitWithNumOpPattern
           output_lengths.push_back(out_axis_dim);
         }
       }
-
+      auto out_vector_type = op.result(0).type().dyn_cast<pir::VectorType>();
       if (out_vector_type.size() != output_lengths.size()) {
         VLOG(3) << "The output_length should be equal to the output size.";
         return false;
       }
-      op->set_attribute(kCanRunTrtAttr, rewriter.bool_attr(true));
-      return true;
     }
+
+    op->set_attribute(kCanRunTrtAttr, rewriter.bool_attr(true));
+    return true;
   }
 };
 class GreaterEqualOpPattern

--- a/python/paddle/tensorrt/converter.py
+++ b/python/paddle/tensorrt/converter.py
@@ -172,6 +172,9 @@ class PaddleToTensorRTConverter:
                 value_to_trt_tensor[value.id] = input_tensor
 
         for op in operations:
+            # Adding marker labels to builtin ops facilitates convert processing, but they ultimately do not enter the TensorRT subgraph.
+            if op.name() == "builtin.split":
+                continue
             operands = []
             for operand in op.operands():
                 source = operand.source()
@@ -202,7 +205,18 @@ class PaddleToTensorRTConverter:
 
             trt_outs = self.convert(network, op, operands)
 
+            results = []
+
             for idx, result in enumerate(op.results()):
+                if result.is_combine():
+                    used_ops = result.all_used_ops()
+                    for use_op in used_ops:
+                        if use_op.name() == "builtin.split":
+                            split_outputs = use_op.results()
+                            results.extend(split_outputs)
+                else:
+                    results.append(result)
+            for idx, result in enumerate(results):
                 if idx < len(trt_outs):
                     value_to_trt_tensor[result.id] = trt_outs[idx]
                 else:
@@ -406,14 +420,10 @@ class PaddleToTensorRTConverter:
                     f"Converter for {op_name} not implemented."
                 )
             outs = converter_func(network, paddle_op, inputs)
-        if isinstance(outs, tuple):
-            return outs
-        elif isinstance(outs, trt.ITensor):
+        if isinstance(outs, trt.ITensor):
             return (outs,)
         else:
-            raise TypeError(
-                f"Expected outputs to be a tuple or ITensor, but got {type(outs)}"
-            )
+            return outs
 
     def convert_program_to_trt(self):
         for op in self.program.global_block().ops:

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -132,26 +132,13 @@ def get_positive_dim(dim, dim_size):
     return dim
 
 
-def add_elementwise_layer(network, paddle_op, inputs, op_type):
-    weight_shape = paddle_op.operands()[1].source().shape
-    input_shape = paddle_op.operands()[0].source().shape
-
-    weight_tensor = inputs[1]
-    input_tensor = inputs[0]
-    if type(inputs[1]) == trt.Weights:
-        weight_tensor = network.add_constant(
-            weight_shape, inputs[1]
-        ).get_output(0)
-    if type(inputs[0]) == trt.Weights:
-        input_tensor = network.add_constant(input_shape, inputs[0]).get_output(
-            0
-        )
+def add_elementwise_layer(network, lhs_val, rhs_val, op_type):
     lhs_val, rhs_val = broadcast(
         network,
-        input_tensor,
-        weight_tensor,
-        input_tensor.name,
-        weight_tensor.name,
+        lhs_val,
+        rhs_val,
+        lhs_val.name,
+        rhs_val.name,
     )
     layer = network.add_elementwise(lhs_val, rhs_val, op_type)
     return layer.get_output(0)
@@ -175,6 +162,11 @@ def get_shape_tensor_element(network, x, index):
     return gather_layer.get_output(0)
 
 
+def trt_less(network, a, b):
+    layer = network.add_elementwise(a, b, trt.ElementWiseOperation.LESS)
+    return layer.get_output(0)
+
+
 def trt_sum(network, a, b):
     layer = network.add_elementwise(a, b, trt.ElementWiseOperation.SUM)
     return layer.get_output(0)
@@ -192,4 +184,52 @@ def trt_sub(network, a, b):
 
 def trt_min(network, a, b):
     layer = network.add_elementwise(a, b, trt.ElementWiseOperation.MIN)
+    return layer.get_output(0)
+
+
+def trt_mul(network, a, b):
+    layer = network.add_elementwise(a, b, trt.ElementWiseOperation.PROD)
+    return layer.get_output(0)
+
+
+def trt_div(network, a, b):
+    layer = network.add_elementwise(a, b, trt.ElementWiseOperation.DIV)
+    return layer.get_output(0)
+
+
+def trt_floor_div(network, a, b):
+    layer = network.add_elementwise(a, b, trt.ElementWiseOperation.FLOOR_DIV)
+    return layer.get_output(0)
+
+
+def trt_equal(network, a, b):
+    layer = network.add_elementwise(a, b, trt.ElementWiseOperation.EQUAL)
+    return layer.get_output(0)
+
+
+def get_shape_with_dynamic_shape(network, shape, input_val):
+    input_shape = network.add_shape(input_val).get_output(0)
+    scale_layer = network.add_constant(
+        input_shape.shape, np.ascontiguousarray(shape, dtype=np.int32)
+    )
+    scale_res = scale_layer.get_output(0)
+
+    length = input_shape.shape[0]
+    zero_layer = network.add_constant(
+        input_shape.shape, trt.Weights(np.zeros(length, dtype=np.int32))
+    )
+
+    condition_val = add_elementwise_layer(
+        network,
+        scale_res,
+        zero_layer.get_output(0),
+        trt.ElementWiseOperation.LESS,
+    )
+    select_layer = network.add_select(condition_val, input_shape, scale_res)
+    return select_layer.get_output(0)
+
+
+def cast_tensor(network, input_tensor, dtype):
+    layer = network.add_identity(input_tensor)
+    layer.set_output_type(0, dtype)
     return layer.get_output(0)

--- a/test/tensorrt/tensorrt_test_base.py
+++ b/test/tensorrt/tensorrt_test_base.py
@@ -21,6 +21,7 @@ import paddle
 from paddle.base import core
 from paddle.tensorrt.converter import PaddleToTensorRTConverter
 from paddle.tensorrt.util import (
+    mark_buitlin_op,
     run_pir_pass,
     warmup_shape_infer,
 )
@@ -150,7 +151,10 @@ class TensorRTBaseTest(unittest.TestCase):
             # init all parameter
             exe.run(startup_program)
             fetch_num = len(fetch_list)
-            fetch_index = [v.index() for v in fetch_list]
+            if isinstance(fetch_list[0], list):
+                fetch_index = [i for i, v in enumerate(fetch_list)]
+            else:
+                fetch_index = [v.index() for v in fetch_list]
             output_expected = self.run_program(main_program, fetch_list)
 
             min_shape_data = dict()  # noqa: C408
@@ -196,6 +200,9 @@ class TensorRTBaseTest(unittest.TestCase):
 
             # run pir pass(including some fusion pass and trt_op_marker_pass)
             main_program = run_pir_pass(main_program, partition_mode=False)
+
+            # Adding marker labels to builtin ops facilitates convert processing, but they ultimately do not enter the TensorRT subgraph.
+            mark_buitlin_op(main_program)
 
             # run trt_sub_graph_extract_pass()
             program_with_trt = run_pir_pass(main_program, partition_mode=True)

--- a/test/tensorrt/test_converter_manipulation.py
+++ b/test/tensorrt/test_converter_manipulation.py
@@ -113,5 +113,53 @@ class TestSliceWithInputStartTRTPattern(TensorRTBaseTest):
         self.check_trt_result()
 
 
+class TestSplitWithNumTRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.split
+        self.api_args = {
+            "x": np.random.randn(3, 9, 5).astype(np.float32),
+            "num_or_sections": 3,
+            "axis": 1,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1, 9, 5]}
+        self.max_shape = {"x": [3, 9, 5]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
+class TestSplitWithNumAxisTRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.split
+        self.api_args = {
+            "x": np.random.randn(3, 9, 5).astype(np.float32),
+            "num_or_sections": 3,
+            "axis": np.array([1]).astype("int32"),
+        }
+        self.program_config = {"feed_list": ["x", "axis"]}
+        self.min_shape = {"x": [1, 9, 5]}
+        self.max_shape = {"x": [3, 9, 5]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
+class TestSplitWithNumNegativeAxisTRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.split
+        self.api_args = {
+            "x": np.random.randn(3, 9, 5).astype(np.float32),
+            "num_or_sections": 3,
+            "axis": -2,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1, 9, 5]}
+        self.max_shape = {"x": [3, 9, 5]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
card-71500
添加了pd_op.split_with_num的converter，修改了pd_op.split_with_num的Marker,同时补全了了converter中对于trt算子的输出为list情况的缺失