### PR TITLE
paddle.logsumexp support int tensor 易用性提升

### DIFF
--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -943,6 +943,13 @@ void InstanceNormDoubleGradInferMeta(const MetaTensor& x,
   }
 }
 
+void IntInFloatOutInferMeta(const MetaTensor& x,
+                            const MetaTensor& out,
+                            MetaTensor* x_grad) {
+  x_grad->share_meta(x);
+  x_grad->set_dtype(out.dtype());
+}
+
 void InverseGradInferMeta(const MetaTensor& out,
                           const MetaTensor& dout,
                           MetaTensor* dx) {

--- a/paddle/phi/infermeta/backward.h
+++ b/paddle/phi/infermeta/backward.h
@@ -348,6 +348,10 @@ void InstanceNormDoubleGradInferMeta(const MetaTensor& x,
                                      MetaTensor* dscale,
                                      MetaTensor* ddy);
 
+void IntInFloatOutInferMeta(const MetaTensor& x,
+                            const MetaTensor& out,
+                            MetaTensor* x_grad);
+
 void InverseGradInferMeta(const MetaTensor& out,
                           const MetaTensor& dout,
                           MetaTensor* dx);

--- a/paddle/phi/kernels/cpu/logsumexp_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/logsumexp_grad_kernel.cc
@@ -18,5 +18,11 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/logsumexp_grad_kernel_impl.h"
 
-PD_REGISTER_KERNEL(
-    logsumexp_grad, CPU, ALL_LAYOUT, phi::LogsumexpGradKernel, float, double) {}
+PD_REGISTER_KERNEL(logsumexp_grad,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::LogsumexpGradKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t) {}

--- a/paddle/phi/kernels/cpu/logsumexp_kernel.cc
+++ b/paddle/phi/kernels/cpu/logsumexp_kernel.cc
@@ -18,5 +18,11 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/logsumexp_kernel_impl.h"
 
-PD_REGISTER_KERNEL(
-    logsumexp, CPU, ALL_LAYOUT, phi::LogsumexpKernel, float, double) {}
+PD_REGISTER_KERNEL(logsumexp,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::LogsumexpKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t) {}

--- a/paddle/phi/kernels/gpu/logsumexp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/logsumexp_grad_kernel.cu
@@ -25,5 +25,7 @@ PD_REGISTER_KERNEL(logsumexp_grad,
                    phi::LogsumexpGradKernel,
                    float,
                    double,
+                   int,
+                   int64_t,
                    phi::dtype::float16,
                    phi::dtype::bfloat16) {}

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -1880,11 +1880,12 @@
   args : (Tensor x, Tensor out, Tensor out_grad, int[] axis,  bool keepdim,  bool reduce_all)
   output : Tensor(x_grad)
   infer_meta :
-    func : UnchangedInferMeta
-    param: [x]
+    func : IntInFloatOutInferMeta
+    param: [x, out]
     spmd_rule : LogSumExpGradInferSpmd
   kernel :
     func : logsumexp_grad
+    data_type : x
 
 - backward_op : lp_pool2d_grad
   forward : lp_pool2d(Tensor x, IntArray kernel_size, int[] strides = {1,1}, int[] paddings = {0,0}, bool ceil_mode = false, bool exclusive = true, str data_format = "NCHW", str pooling_type = "", bool global_pooling = false, bool adaptive = false, str padding_algorithm = "EXPLICIT", float norm_type = 0.0f) -> Tensor(out)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2752,8 +2752,8 @@ def logsumexp(
        logsumexp(x) = \log\sum exp(x)
 
     Args:
-        x (Tensor): The input Tensor with data type float16, float32 or float64, which
-            have no more than 4 dimensions.
+        x (Tensor): The input Tensor with data type float16, float32, float64,
+            int32 or int64, which have no more than 4 dimensions.
         axis (int|list|tuple|None, optional): The axis along which to perform
             logsumexp calculations. ``axis`` should be int, list(int) or
             tuple(int). If ``axis`` is a list/tuple of dimension(s), logsumexp
@@ -2798,7 +2798,10 @@ def logsumexp(
         return _C_ops.logsumexp(x, axis, keepdim, reduce_all)
     else:
         check_variable_and_dtype(
-            x, 'x', ['float16', 'float32', 'float64', 'uint16'], 'logsumexp'
+            x,
+            'x',
+            ['float16', 'float32', 'float64', 'uint16', 'int32', 'int64'],
+            'logsumexp',
         )
 
         helper = LayerHelper('logsumexp', **locals())

--- a/test/legacy_test/test_logsumexp.py
+++ b/test/legacy_test/test_logsumexp.py
@@ -327,52 +327,6 @@ class TestLogsumexpAPI(unittest.TestCase):
         self.shape = [2, 3, 4, 5]
         self.dtype = "float32"
         self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.base.core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
-
-    def api_case(self, axis=None, keepdim=False):
-        out_ref = ref_logsumexp(self.x, axis, keepdim)
-        with paddle.static.program_guard(paddle.static.Program()):
-            x = paddle.static.data('X', self.shape, self.dtype)
-            out = paddle.logsumexp(x, axis, keepdim)
-            exe = paddle.static.Executor(self.place)
-            res = exe.run(feed={'X': self.x}, fetch_list=[out])
-        np.testing.assert_allclose(res[0], out_ref, rtol=1e-05)
-
-        paddle.disable_static(self.place)
-        x = paddle.to_tensor(self.x)
-        out = paddle.logsumexp(x, axis, keepdim)
-        np.testing.assert_allclose(out.numpy(), out_ref, rtol=1e-05)
-        paddle.enable_static()
-
-    def test_api(self):
-        self.api_case()
-        self.api_case(2)
-        self.api_case([-1])
-        self.api_case([2, -3])
-        self.api_case((0, 1, -1))
-        self.api_case(keepdim=True)
-
-    def test_alias(self):
-        paddle.disable_static(self.place)
-        x = paddle.to_tensor(self.x)
-        out1 = paddle.logsumexp(x)
-        out2 = paddle.tensor.logsumexp(x)
-        out3 = paddle.tensor.math.logsumexp(x)
-        out_ref = ref_logsumexp(self.x)
-        for out in [out1, out2, out3]:
-            np.testing.assert_allclose(out.numpy(), out_ref, rtol=1e-05)
-        paddle.enable_static()
-
-
-class TestLogsumexpAPI2(TestLogsumexpAPI):
-    def setUp(self):
-        self.shape = [3, 2, 4, 5]
-        self.dtype = "int32"
-        self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.places = [paddle.CPUPlace()]
         if paddle.base.core.is_compiled_with_cuda():
             self.places.append(paddle.CUDAPlace(0))
@@ -398,6 +352,14 @@ class TestLogsumexpAPI2(TestLogsumexpAPI):
             np.testing.assert_allclose(x_grad, x_grad_ref, rtol=1e-05)
             paddle.enable_static()
 
+    def test_api(self):
+        self.api_case()
+        self.api_case(2)
+        self.api_case([-1])
+        self.api_case([2, -3])
+        self.api_case((0, 1, -1))
+        self.api_case(keepdim=True)
+
     def test_alias(self):
         paddle.disable_static(paddle.CPUPlace())
         x = paddle.to_tensor(self.x)
@@ -410,14 +372,126 @@ class TestLogsumexpAPI2(TestLogsumexpAPI):
         paddle.enable_static()
 
 
-class TestLogsumexpAPI3(TestLogsumexpAPI2):
+class TestLogsumexpAPIInt(TestLogsumexpAPI):
     def setUp(self):
-        self.shape = [3, 4, 2, 5]
+        self.shape = [3, 2, 4, 5]
+        self.dtype = "int32"
+        self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        self.places = [paddle.CPUPlace()]
+        if paddle.base.core.is_compiled_with_cuda():
+            self.places.append(paddle.CUDAPlace(0))
+
+
+class TestLogsumexpAPIInt2(TestLogsumexpAPI):
+    def setUp(self):
+        self.shape = [3, 4, 2]
+        self.dtype = "int32"
+        self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        self.places = [paddle.CPUPlace()]
+        if paddle.base.core.is_compiled_with_cuda():
+            self.places.append(paddle.CUDAPlace(0))
+
+    def test_api(self):
+        self.api_case()
+        self.api_case(2)
+        self.api_case([-1])
+        self.api_case([2, -2])
+        self.api_case((0, 1, -1))
+        self.api_case(keepdim=True)
+
+
+class TestLogsumexpAPIInt3(TestLogsumexpAPI):
+    def setUp(self):
+        self.shape = [3, 4]
         self.dtype = "int64"
         self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.places = [paddle.CPUPlace()]
         if paddle.base.core.is_compiled_with_cuda():
             self.places.append(paddle.CUDAPlace(0))
+
+    def test_api(self):
+        self.api_case()
+        self.api_case(1)
+        self.api_case([-1])
+        self.api_case((0, -1))
+        self.api_case(keepdim=True)
+
+
+class TestLogsumexpAPIInt4(TestLogsumexpAPI):
+    def setUp(self):
+        self.shape = [8]
+        self.dtype = "int64"
+        self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        self.places = [paddle.CPUPlace()]
+        if paddle.base.core.is_compiled_with_cuda():
+            self.places.append(paddle.CUDAPlace(0))
+
+    def test_api(self):
+        self.api_case()
+        self.api_case(0)
+        self.api_case([-1])
+        self.api_case(keepdim=True)
+
+
+class TestLogsumexpAPI2(TestLogsumexpAPI):
+    def setUp(self):
+        self.shape = [3, 2, 4, 5]
+        self.dtype = "float64"
+        self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        self.places = [paddle.CPUPlace()]
+        if paddle.base.core.is_compiled_with_cuda():
+            self.places.append(paddle.CUDAPlace(0))
+
+
+class TestLogsumexpAPI3(TestLogsumexpAPI):
+    def setUp(self):
+        self.shape = [3, 4, 2]
+        self.dtype = "float32"
+        self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        self.places = [paddle.CPUPlace()]
+        if paddle.base.core.is_compiled_with_cuda():
+            self.places.append(paddle.CUDAPlace(0))
+
+    def test_api(self):
+        self.api_case()
+        self.api_case(2)
+        self.api_case([-1])
+        self.api_case([2, -2])
+        self.api_case((0, 1, -1))
+        self.api_case(keepdim=True)
+
+
+class TestLogsumexpAPI4(TestLogsumexpAPI):
+    def setUp(self):
+        self.shape = [3, 4]
+        self.dtype = "float32"
+        self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        self.places = [paddle.CPUPlace()]
+        if paddle.base.core.is_compiled_with_cuda():
+            self.places.append(paddle.CUDAPlace(0))
+
+    def test_api(self):
+        self.api_case()
+        self.api_case(1)
+        self.api_case([-1])
+        self.api_case((0, -1))
+        self.api_case(keepdim=True)
+
+
+class TestLogsumexpAPI5(TestLogsumexpAPI):
+    def setUp(self):
+        self.shape = [8]
+        self.dtype = "float64"
+        self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        self.places = [paddle.CPUPlace()]
+        if paddle.base.core.is_compiled_with_cuda():
+            self.places.append(paddle.CUDAPlace(0))
+
+    def test_api(self):
+        self.api_case()
+        self.api_case(0)
+        self.api_case([-1])
+        self.api_case(keepdim=True)
 
 
 # Test logsumexp bug


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
增加 int32/int64 数据类型支持，当输入是整数类型时，前向计算输出的类型为 float32，反向计算梯度的类型为 float32。