### PR TITLE
【CINN】 Decoupling relationship between 'FLAGS_enable_dist_prim_all' and 'FLAGS_enable_auto_recompute'

### DIFF
--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -1223,7 +1223,7 @@ class _ExecutorCache:
                 decomp.decompose_dist_program(program)
 
         if core._enable_auto_recompute():
-            print("apply auto_recompute in executor", flush=True)
+            logging.info("apply auto_recompute in executor")
             program = decomp.auto_recompute_pir_program(program, None)
 
         if in_cinn_mode():

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -1220,12 +1220,11 @@ class _ExecutorCache:
 
         if core._enable_dist_prim_all():
             with decomp.prim_guard():
-                pir_grad_var_to_var = decomp.decompose_dist_program(program)
-            if core._enable_auto_recompute():
-                print("apply auto_recompute in executor", flush=True)
-                program = decomp.auto_recompute_pir_program(
-                    program, pir_grad_var_to_var
-                )
+                decomp.decompose_dist_program(program)
+
+        if core._enable_auto_recompute():
+            print("apply auto_recompute in executor", flush=True)
+            program = decomp.auto_recompute_pir_program(program, None)
 
         if in_cinn_mode():
             apply_cinn_pass(program)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Decoupling relationship between 'FLAGS_enable_dist_prim_all' and 'FLAGS_enable_auto_recompute'