### PR TITLE
[XPU] fix gather_nd on zero-dim index

### DIFF
--- a/paddle/phi/kernels/cpu/gather_nd_kernel.cc
+++ b/paddle/phi/kernels/cpu/gather_nd_kernel.cc
@@ -26,7 +26,7 @@ void GatherNdKernel(const Context &ctx,
                     const DenseTensor &index,
                     DenseTensor *out) {
   ctx.template Alloc<T>(out);
-  if (x.numel() == 0) return;
+  if (x.numel() == 0 || out->numel() == 0) return;
   if (index.dims()[0] == 0 && index.numel() == 0) return;
   auto index_type = index.dtype();
   bool index_type_match =

--- a/paddle/phi/kernels/gpu/gather_nd_kernel.cu
+++ b/paddle/phi/kernels/gpu/gather_nd_kernel.cu
@@ -27,7 +27,7 @@ void GatherNdKernel(const Context &ctx,
                     const DenseTensor &index,
                     DenseTensor *out) {
   ctx.template Alloc<T>(out);
-  if (x.numel() == 0) return;
+  if (x.numel() == 0 || out->numel() == 0) return;
   if (index.dims()[0] == 0 && index.numel() == 0) return;
   const auto &index_type = index.dtype();
   bool index_type_match =

--- a/paddle/phi/kernels/xpu/gather_nd_kernel.cc
+++ b/paddle/phi/kernels/xpu/gather_nd_kernel.cc
@@ -27,9 +27,8 @@ void GatherNdKernel(const Context &ctx,
   using XPUType = typename XPUTypeTrait<T>::Type;
   ctx.template Alloc<T>(out);
 
-  if (x.numel() == 0) {
-    return;
-  }
+  if (x.numel() == 0 || out->numel() == 0) return;
+  if (index.dims()[0] == 0 && index.numel() == 0) return;
 
   if (index.numel() == 0) {
     auto index_dims = index.dims();

--- a/test/xpu/test_gather_nd_op_xpu.py
+++ b/test/xpu/test_gather_nd_op_xpu.py
@@ -178,5 +178,29 @@ support_types = get_xpu_op_support_types('gather_nd')
 for stype in support_types:
     create_test_class(globals(), XPUTestGatherNd, stype)
 
+
+class TestZeroDimIndex(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+        # shape of x: [2, 3, 2]
+        self.x = paddle.to_tensor(
+            [[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]
+        )
+
+    def test_1(self):
+        index = np.zeros((0, 1)).astype("int")
+        index = paddle.to_tensor(index)
+        output = paddle.gather_nd(self.x, index)
+        self.assertEqual(output.numel().numpy(), 0)
+        self.assertEqual(output.shape, [0, 3, 2])
+
+    def test_2(self):
+        index = np.zeros((2, 0, 1)).astype("int")
+        index = paddle.to_tensor(index)
+        output = paddle.gather_nd(self.x, index)
+        self.assertEqual(output.numel().numpy(), 0)
+        self.assertEqual(output.shape, [2, 0, 3, 2])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/xpu/test_gather_nd_op_xpu.py
+++ b/test/xpu/test_gather_nd_op_xpu.py
@@ -178,5 +178,30 @@ support_types = get_xpu_op_support_types('gather_nd')
 for stype in support_types:
     create_test_class(globals(), XPUTestGatherNd, stype)
 
+
+class TestZeroDimIndex(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+        # shape of x: [2, 3, 2]
+        self.x = paddle.to_tensor(
+            [[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]
+        )
+
+    def test_1(self):
+        index = np.zeros((0, 1)).astype("int")
+        index = paddle.to_tensor(index)
+        output = paddle.gather_nd(self.x, index)
+        self.assertEqual(output.numel().numpy(), 0)
+        self.assertEqual(output.shape, [0, 3, 2])
+
+    def test_2(self):
+        index = np.zeros((2, 0, 1)).astype("int")
+        index = paddle.to_tensor(index)
+        output = paddle.gather_nd(self.x, index)
+        print("houjue debug:", output)
+        self.assertEqual(output.numel().numpy(), 0)
+        self.assertEqual(output.shape, [2, 0, 3, 2])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
接用户反馈，在`gather_nd`算子中，如果输入的`index`的形状中含有不在末尾的0，就会报错。
本PR同步了CPU和GPU和XPU下面的early return逻辑，并且增加了某些奇怪形状的单测。
