### PR TITLE
fix conv2d_grad error in auto parallel training

### DIFF
--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/conv2d_nodes.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/conv2d_nodes.cc
@@ -80,6 +80,13 @@ Conv2dGradNodeFinal::operator()(
       (out_metas[1].empty() || out_metas[1][0].IsStopGradient())
           ? nullptr
           : &returns[1][0];
+
+  // Set DistAttr of Out Tensor for semi-auto parallel
+  if (IsRunAutoParallel()) {
+    egr::EagerUtils::SetGradOutputDistAttr(
+        out_metas, {0, 1}, api_output_0, api_output_1);
+  }
+
   // Runtime check if we need next grad
   bool trace_backward = egr::Controller::Instance().HasGrad() && create_graph;
 

--- a/test/auto_parallel/semi_auto_parallel_for_conv2d.py
+++ b/test/auto_parallel/semi_auto_parallel_for_conv2d.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from semi_auto_parallel_util import SemiAutoParallelTestBase
+
+import paddle
+import paddle.distributed as dist
+
+
+class TestConv2dApiForSemiAutoParallel(SemiAutoParallelTestBase):
+    def __init__(self):
+        super().__init__()
+
+    def check_placements(self, output, expected_placements):
+        assert (
+            output.placements == expected_placements
+        ), f"{output.placements}  vs {expected_placements}"
+
+    def test_conv2d_shard(self):
+        shapes = ([8, 3, 8, 8], [6, 3, 3, 3], [6])
+        specs = (['x', None, None], [None], [None])
+        inputs, outputs = self.runfunc_and_check(
+            inputs_shape=shapes,
+            inputs_specs=specs,
+            op_func=paddle.nn.functional.conv2d,
+            # Todo(jeff41404): the spmd rule of conv2d_grad is fixing, after that, we can set with_backward to True.
+            with_backward=False,
+        )
+        self.check_placements(outputs, [dist.Shard(0)])
+
+    def run_test_case(self):
+        if self._backend == "cpu":
+            paddle.set_device("cpu")
+        elif self._backend == "gpu":
+            paddle.set_device("gpu:" + str(dist.get_rank()))
+        else:
+            raise ValueError("Only support cpu or gpu backend.")
+
+        self.test_conv2d_shard()
+
+
+if __name__ == '__main__':
+    TestConv2dApiForSemiAutoParallel().run_test_case()

--- a/test/auto_parallel/test_semi_auto_parallel_basic.py
+++ b/test/auto_parallel/test_semi_auto_parallel_basic.py
@@ -58,6 +58,16 @@ class TestSemiAutoParallelBasic(test_base.CommunicationTestDistBase):
                 user_defined_envs=envs,
             )
 
+    def test_conv2d_api(self):
+        envs_list = test_base.gen_product_envs_list(
+            self._default_envs, self._changeable_envs
+        )
+        for envs in envs_list:
+            self.run_test_case(
+                "semi_auto_parallel_for_conv2d.py",
+                user_defined_envs=envs,
+            )
+
     def test_layernorm_api(self):
         envs_list = test_base.gen_product_envs_list(
             self._default_envs, self._changeable_envs


### PR DESCRIPTION
### PR Category
Auto Parallel

### PR Types
Bug fixes

### Description
pcard-87125
When training model in auto parallel, if there is `paddle.nn.Conv2D` in the network and its parameters need to be trained, an error occurs when calculating the gradient in backward.
![image](https://github.com/user-attachments/assets/52ecbe13-197a-4e95-97e3-04b9cfa1526b)
The following simple program can reproduce this issue: 
```python
# -*- coding: UTF-8 -*-
import numpy as np
import paddle
# 导入动态图半自动接口
from paddle.distributed import ProcessMesh, shard_dataloader, shard_optimizer, ShardingStage1
# 导入数据加载和数据保存接口
from paddle.io import Dataset, BatchSampler, DataLoader

epoch = 5  #训练迭代次数
batch_num = 100 #每次迭代的 batch 数
batch_size = 32 #训练批次大小
class_dim = 10
in_channels = 4
out_channels = 8

# 设置数据读取器
class RandomDataset(Dataset):
    def __init__(self, num_samples):
        self.num_samples = num_samples

    def __getitem__(self, idx):
        image = np.random.random([4, 32, 32]).astype('float32')
        label = np.random.randint(0, class_dim - 1, (1, )).astype('int64')
        return image, label

    def __len__(self):
        return self.num_samples

# 模型网络
class SimpleNet(paddle.nn.Layer):
    def __init__(self, input_size, inner_size, output_size):
        super().__init__()
        self.conv2d = paddle.nn.Conv2D(in_channels, out_channels, kernel_size=2, stride=1, bias_attr=False)
        self.linear = paddle.nn.Linear(out_channels*31*31, class_dim)
        self.relu = paddle.nn.ReLU()

    def forward(self, x):
        x = self.conv2d(x).flatten(1)
        x = self.linear(x)
        x = self.relu(x)
        return x

# 设置mesh
world_process_mesh = ProcessMesh([0, 1], dim_names=["dp"])

# 设置训练函数
def train_model():
    model = SimpleNet(input_size=256, inner_size=102400, output_size=class_dim)
    loss_func = paddle.nn.CrossEntropyLoss()
    optimizer = paddle.optimizer.AdamW(learning_rate=0.001, parameters=model.parameters())

    # 设置dataset和dataloader，用于并行训练
    dataset = RandomDataset(batch_num * batch_size)
    # 设置批采样器，用于数据并行训练
    sampler = BatchSampler(dataset,
                        batch_size=batch_size,shuffle=False, drop_last=True)
    train_loader = DataLoader(dataset,
                            batch_sampler=sampler,
                            num_workers=1)
    dist_dataloader = shard_dataloader(dataloader=train_loader, meshes=world_process_mesh, shard_dims="dp")
    dist_opt = shard_optimizer(optimizer, ShardingStage1(world_process_mesh))

    for eop in range(epoch):
        model.train()

        for batch_id, data in enumerate(dist_dataloader()):
            img, label = data
            label.stop_gradient = True

            out = model(img)
            avg_loss = loss_func(input=out, label=label)

            avg_loss.backward()   # will report error
            dist_opt.step()
            model.clear_gradients()

            if batch_id % 5 == 0:
                print("[Epoch %d, batch %d] loss: %.5f" % (eop, batch_id, np.array(avg_loss)))
# 启动训练
if __name__ == '__main__':
    train_model()
```
this PR will fix this issue.