### PR TITLE
Modify FetchList to PhiVector type [fluid_ops] 

### DIFF
--- a/paddle/fluid/framework/feed_fetch_type.h
+++ b/paddle/fluid/framework/feed_fetch_type.h
@@ -25,22 +25,25 @@ namespace paddle {
 namespace framework {
 using FeedType =
     paddle::variant<phi::DenseTensor, Strings, phi::SparseCooTensor>;
+using FetchType = paddle::variant<phi::DenseTensor,
+                                  phi::TensorArray,
+                                  framework::Vocab,
+                                  phi::SparseCooTensor>;
 
 template <>
 struct PhiVectorType<FeedType> {
   const char *type_name = "PhiVectorFeedType";
 };
 
-using FeedList = paddle::framework::PhiVector<FeedType>;
+template <>
+struct PhiVectorType<FetchType> {
+  const char *type_name = "PhiVectorFetchType";
+};
 
-using FetchType = paddle::variant<phi::DenseTensor,
-                                  phi::TensorArray,
-                                  framework::Vocab,
-                                  phi::SparseCooTensor>;
-using FetchList = std::vector<FetchType>;
+using FeedList = paddle::framework::PhiVector<FeedType>;
+using FetchList = paddle::framework::PhiVector<FetchType>;
 
 using FetchUnmergedList = std::vector<std::vector<FetchType>>;
-using FetchResultType = paddle::variant<FetchList, FetchUnmergedList>;
 
 inline bool data_is_lod_tensor(const FetchType &data) {
   if (data.type() == typeid(phi::DenseTensor)) {

--- a/paddle/fluid/framework/phi_tensor_base_vector.h
+++ b/paddle/fluid/framework/phi_tensor_base_vector.h
@@ -69,6 +69,10 @@ class PhiVector : public phi::ExtendedTensor,
 
   void emplace_back(const T& feed_data) { data_.emplace_back(feed_data); }
 
+  void emplace_back() { data_.emplace_back(); }
+
+  void push_back(const T& feed_data) { data_.push_back(feed_data); }
+
   void pop_back() { data_.pop_back(); }
 
   const T& operator[](size_t index) const { return data_[index]; }

--- a/paddle/fluid/framework/type_info.cc
+++ b/paddle/fluid/framework/type_info.cc
@@ -53,4 +53,5 @@ template class TypeInfoTraits<phi::TensorBase,
                               paddle::dialect::IrSparseCooTensor>;
 template class TypeInfoTraits<phi::TensorBase,
                               paddle::dialect::IrSparseCsrTensor>;
+template class TypeInfoTraits<phi::TensorBase, paddle::framework::FetchList>;
 }  // namespace phi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
修改 FetchList 为 PhiVector 类型，可以从ExtendedTensor继承作为kernel参数