### PR TITLE
[CINN]fix arange op decomp bug

### DIFF
--- a/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
@@ -31,6 +31,7 @@
     backend : place
   data_transform :
     support_trans_dtype : start, end, step
+  traits : paddle::dialect::ForwardOnlyTrait
 
 - op : assign
   args : (Tensor x)

--- a/paddle/phi/ops/yaml/inconsistent/update_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/update_ops.yaml
@@ -16,3 +16,4 @@
     backend : place
   support_tensor : [start, end, step]
   interfaces : paddle::dialect::InferSymbolicShapeInterface
+  traits : paddle::dialect::ForwardOnlyTrait


### PR DESCRIPTION
### PR Category
CINN

### PR Types
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-76996

通过注册 only forwad trait的方式， 修复arange op 组合算子拆分的错误
