### PR TITLE
[PIR save/load]Add cf saveload and flag

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1953,3 +1953,7 @@ PHI_DEFINE_EXPORTED_bool(fused_multi_transformer_op_use_mbfmha,
 PHI_DEFINE_EXPORTED_int64(multi_block_attention_min_partition_size,
                           1024,
                           "The minimum partition size for flash decoding");
+
+PHI_DEFINE_EXPORTED_bool(save_cf_stack_op,
+                         false,
+                         "Save cf stack op for higher-order derivatives.");

--- a/paddle/fluid/pir/serialize_deserialize/src/patch_util.cc
+++ b/paddle/fluid/pir/serialize_deserialize/src/patch_util.cc
@@ -24,6 +24,7 @@
 #include "paddle/phi/common/data_type.h"
 #include "paddle/pir/include/core/builtin_attribute.h"
 #include "paddle/pir/include/core/builtin_type.h"
+#include "paddle/pir/include/dialect/control_flow/ir/cf_type.h"
 
 namespace pir {
 
@@ -168,9 +169,15 @@ std::string GetTypeName(const YAML::Node &action) {
 
 Json GetTypeJson(const YAML::Node &action) {
   Json json;
-  std::string dialect = DialectIdMap::Instance()->GetCompressDialectId(
-                            pir::BuiltinDialect::name()) +
-                        ".";
+  std::string builtin_dialect = DialectIdMap::Instance()->GetCompressDialectId(
+                                    pir::BuiltinDialect::name()) +
+                                ".";
+  std::string op_dialect = DialectIdMap::Instance()->GetCompressDialectId(
+                               paddle::dialect::OperatorDialect::name()) +
+                           ".";
+  std::string cf_dialect = DialectIdMap::Instance()->GetCompressDialectId(
+                               pir::ControlFlowDialect::name()) +
+                           ".";
   std::string type_name = "";
   if (action.IsScalar()) {
     type_name = action.as<std::string>();
@@ -181,46 +188,46 @@ Json GetTypeJson(const YAML::Node &action) {
   }
   if (type_name == "pir::BoolType") {
     VLOG(8) << "Get BoolType name.";
-    json[ID] = dialect + pir::BoolType::name();
+    json[ID] = builtin_dialect + pir::BoolType::name();
   } else if (type_name == "pir::BFloat16Type") {
     VLOG(8) << "Get BFloat16Type name.";
-    json[ID] = dialect + pir::BFloat16Type::name();
+    json[ID] = builtin_dialect + pir::BFloat16Type::name();
   } else if (type_name == "pir::Float16Type") {
     VLOG(8) << "Get Float16Type name.";
-    json[ID] = dialect + pir::Float16Type::name();
+    json[ID] = builtin_dialect + pir::Float16Type::name();
   } else if (type_name == "pir::Float32Type") {
     VLOG(8) << "Get Float32Type name.";
-    json[ID] = dialect + pir::Float32Type::name();
+    json[ID] = builtin_dialect + pir::Float32Type::name();
   } else if (type_name == "pir::Float64Type") {
     VLOG(8) << "Get Float64Type name.";
-    json[ID] = dialect + pir::Float64Type::name();
+    json[ID] = builtin_dialect + pir::Float64Type::name();
   } else if (type_name == "pir::Int8Type") {
     VLOG(8) << "Get Int8Type name.";
-    json[ID] = dialect + pir::Int8Type::name();
+    json[ID] = builtin_dialect + pir::Int8Type::name();
   } else if (type_name == "pir::UInt8Type") {
     VLOG(8) << "Get UInt8Type name.";
-    json[ID] = dialect + pir::UInt8Type::name();
+    json[ID] = builtin_dialect + pir::UInt8Type::name();
   } else if (type_name == "pir::Int16Type") {
     VLOG(8) << "Get Int16Type name.";
-    json[ID] = dialect + pir::Int16Type::name();
+    json[ID] = builtin_dialect + pir::Int16Type::name();
   } else if (type_name == "pir::Int32Type") {
     VLOG(8) << "Get Int32Type name.";
-    json[ID] = dialect + pir::Int32Type::name();
+    json[ID] = builtin_dialect + pir::Int32Type::name();
   } else if (type_name == "pir::Int64Type") {
     VLOG(8) << "Get Int64Type name.";
-    json[ID] = dialect + pir::Int64Type::name();
+    json[ID] = builtin_dialect + pir::Int64Type::name();
   } else if (type_name == "pir::IndexType") {
     VLOG(8) << "Get IndexType name.";
-    json[ID] = dialect + pir::IndexType::name();
+    json[ID] = builtin_dialect + pir::IndexType::name();
   } else if (type_name == "pir::Complex64Type") {
     VLOG(8) << "Get Complex64Type name.";
-    json[ID] = dialect + pir::Complex64Type::name();
+    json[ID] = builtin_dialect + pir::Complex64Type::name();
   } else if (type_name == "pir::Complex128Type") {
     VLOG(8) << "Get Complex128Type name.";
-    json[ID] = dialect + pir::Complex128Type::name();
+    json[ID] = builtin_dialect + pir::Complex128Type::name();
   } else if (type_name == "pir::VectorType") {
     VLOG(8) << "Get VectorType name.";
-    json[ID] = dialect + pir::VectorType::name();
+    json[ID] = builtin_dialect + pir::VectorType::name();
     json[DATA] = Json::array();
     for (size_t i = 0; i < action["default"].size(); i++) {
       YAML::Node array_value = action["default"][i];
@@ -228,7 +235,7 @@ Json GetTypeJson(const YAML::Node &action) {
     }
   } else if (type_name == "pir::DenseTensorType") {
     VLOG(8) << "Get DenseTensorType name.";
-    json[ID] = dialect + pir::DenseTensorType::name();
+    json[ID] = builtin_dialect + pir::DenseTensorType::name();
     Json content = Json::array();
     YAML::Node tensor_value = action["default"];
     content.push_back(BuildTypeJsonPatch(tensor_value[0]));
@@ -242,6 +249,15 @@ Json GetTypeJson(const YAML::Node &action) {
 
     content.push_back(tensor_value[4].as<int>());  // offset
     json[DATA] = content;
+  } else if (type_name == "pir::StackType") {
+    VLOG(8) << "Get StackType name.";
+    json[ID] = cf_dialect + pir::StackType::name();
+  } else if (type_name == "pir::InletType") {
+    VLOG(8) << "Get InletType name.";
+    json[ID] = cf_dialect + pir::InletType::name();
+  } else if (type_name == "pir::OutletType") {
+    VLOG(8) << "Get OutletType name.";
+    json[ID] = cf_dialect + pir::OutletType::name();
   }
   return json;
 }

--- a/paddle/pir/include/core/storage_manager_support.h
+++ b/paddle/pir/include/core/storage_manager_support.h
@@ -65,7 +65,8 @@ class StorageHelperBase : public BaseT {
   using InterfaceList =
       typename Filter<TypeInterfaceBase, std::tuple<TraitOrInterface...>>::Type;
 
-  static ConcreteT dyn_cast_impl(BaseT type) {
+  template <typename T>
+  static ConcreteT dyn_cast_impl(T type) {
     if (type && type.type_id() == TypeId::get<ConcreteT>()) {
       return ConcreteT(type.storage());
     }

--- a/paddle/pir/include/dialect/control_flow/ir/cf_type.h
+++ b/paddle/pir/include/dialect/control_flow/ir/cf_type.h
@@ -30,16 +30,19 @@ class IR_API StackType
     : public Type::TypeBase<StackType, ContainerType, TypeStorage> {
  public:
   using Base::Base;
+  static std::string name() { return "t_stack"; }
 };
 
 class IR_API InletType : public Type::TypeBase<InletType, Type, TypeStorage> {
  public:
   using Base::Base;
+  static std::string name() { return "t_inlet"; }
 };
 
 class IR_API OutletType : public Type::TypeBase<OutletType, Type, TypeStorage> {
  public:
   using Base::Base;
+  static std::string name() { return "t_outlet"; }
 };
 
 }  // namespace pir


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164
Add cf saveload and flag：
- 添加cf.stack_create相关op和cf type的save/load逻辑
- 新增FLAGS_save_cf_stack_op控制是否存储stack_create op。默认情况下flag=0，只有在高阶情况下需要存储stack_create op时启用FLAGS_save_cf_stack_op=1才会开启存储。