### PR TITLE
[PIR] Make get PIR flag from env logic more robust

### DIFF
--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -214,14 +214,12 @@ class GlobalThreadLocal(threading.local):
         self._dygraph_tracer_ = _dygraph_tracer_
         tmp_flags = os.environ.get("FLAGS_enable_pir_api")
         if tmp_flags is not None:
-            if (
-                tmp_flags == "0"
-                or tmp_flags == 0
-                or tmp_flags == "False"
-                or not tmp_flags
-            ):
-                tmp_flags = False
-            set_flags({"FLAGS_enable_pir_api": bool(tmp_flags)})
+            set_flags(
+                {
+                    "FLAGS_enable_pir_api": tmp_flags.lower()
+                    in ['n', 'no', 'f', 'false', 'off', '0']
+                }
+            )
         self._use_pir_api_ = get_flags("FLAGS_enable_pir_api")[
             "FLAGS_enable_pir_api"
         ]

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -217,7 +217,7 @@ class GlobalThreadLocal(threading.local):
             set_flags(
                 {
                     "FLAGS_enable_pir_api": tmp_flags.lower()
-                    in ['n', 'no', 'f', 'false', 'off', '0']
+                    not in ['n', 'no', 'f', 'false', 'off', '0']
                 }
             )
         self._use_pir_api_ = get_flags("FLAGS_enable_pir_api")[

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -212,14 +212,18 @@ class GlobalThreadLocal(threading.local):
         self._in_sot_simulation_mode_ = False
         self._functional_dygraph_context_manager = None
         self._dygraph_tracer_ = _dygraph_tracer_
-        tmp_flags = os.environ.get("FLAGS_enable_pir_api")
-        if tmp_flags is not None:
-            set_flags(
-                {
-                    "FLAGS_enable_pir_api": tmp_flags.lower()
-                    not in ['n', 'no', 'f', 'false', 'off', '0']
-                }
-            )
+        env_pir_enabled = os.environ.get("FLAGS_enable_pir_api")
+
+        if env_pir_enabled is not None:
+            pir_enabled = env_pir_enabled.lower() not in [
+                'n',
+                'no',
+                'f',
+                'false',
+                'off',
+                '0',
+            ]
+            set_flags({"FLAGS_enable_pir_api": pir_enabled})
         self._use_pir_api_ = get_flags("FLAGS_enable_pir_api")[
             "FLAGS_enable_pir_api"
         ]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

从环境变量读取应该考虑的情况更加充分，比如 `false`

copy 之前写的逻辑

https://github.com/PaddlePaddle/Paddle/blob/418fcf1d970646145d5ed25514da79837f9936b7/python/paddle/utils/environments.py#L25-L32

cc. @yuanlehome 

PCard-66972