### PR TITLE
fix engine._parameter_name_list after fusion pass

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -718,15 +718,18 @@ class Engine:
                 mode="all",
             )
 
-        for k in self.fused_ffn_qkv.keys():
-            for fusion in self.fused_ffn_qkv[k]:
-                for after_fuse_name, before_fuse_params in fusion.items():
-                    index = self._parameter_name_list.index(
-                        before_fuse_params[0].name
-                    )
-                    self._parameter_name_list.insert(index, after_fuse_name)
-                    for before_fuse_param in before_fuse_params:
-                        self._parameter_name_list.remove(before_fuse_param.name)
+            # update self._parameter_name_list after fused_ffn_qkv, otherwise opt stage will not update fused params
+            for k in self.fused_ffn_qkv.keys():
+                for fusion in self.fused_ffn_qkv[k]:
+                    for after_fuse_name, before_fuse_params in fusion.items():
+                        index = self._parameter_name_list.index(
+                            before_fuse_params[0].name
+                        )
+                        self._parameter_name_list.insert(index, after_fuse_name)
+                        for before_fuse_param in before_fuse_params:
+                            self._parameter_name_list.remove(
+                                before_fuse_param.name
+                            )
 
         forward_op_start_idx = 0
         backward_op_start_idx = -1

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -718,6 +718,16 @@ class Engine:
                 mode="all",
             )
 
+        for k in self.fused_ffn_qkv.keys():
+            for fusion in self.fused_ffn_qkv[k]:
+                for after_fuse_name, before_fuse_params in fusion.items():
+                    index = self._parameter_name_list.index(
+                        before_fuse_params[0].name
+                    )
+                    self._parameter_name_list.insert(index, after_fuse_name)
+                    for before_fuse_param in before_fuse_params:
+                        self._parameter_name_list.remove(before_fuse_param.name)
+
         forward_op_start_idx = 0
         backward_op_start_idx = -1
         opt_op_start_idx = -1


### PR DESCRIPTION
### PR Category
Auto Parallel


### PR Types
Bug fixes


### Description
Pcard-76459
静半需要和动手精度对齐，grad clip中param累加的顺序需要保证跟动手相同，因此需要给优化器设置优化的param_list，但是经过fuse_qkv_ffn pass之后Program中qkv和ffn的matmul算子被融合，param也更换名称，而engine._parameter_name_list从没有fuse的动态图获取param_name_list，导致最终优化器优化的param里面没有fuse过后的param
