### PR TITLE
fix core: auto growth allocator add release lock

### DIFF
--- a/paddle/phi/core/memory/allocation/auto_growth_best_fit_allocator.h
+++ b/paddle/phi/core/memory/allocation/auto_growth_best_fit_allocator.h
@@ -46,6 +46,7 @@ class AutoGrowthBestFitAllocator : public Allocator {
 
   // Release the memory block which is not used in pool.
   uint64_t ReleaseImpl(const phi::Place &place) override {
+    std::lock_guard<SpinLock> guard(spinlock_);
     return FreeIdleChunks();
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Inference

### PR Types
Bug fixes


### Description
AutoGrowthBestFitAllocator作为默认的显存分配器，它是进程级的，在创建predictor时会调用ReleaseImpl释放空闲的chunks，但是ReleaseImpl不是线程安全的，如果此时其他predictor正在分配或者释放显存，会导致进程core；
所以修复方式是：参考FreeImpl和AllocateImpl接口实现，在ReleaseImpl中添加自旋锁，防止并发错误。
