### PR TITLE
[SOT] fix sot syncbn mean varience

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_func.h
+++ b/paddle/fluid/eager/to_static/run_program_op_func.h
@@ -16,6 +16,7 @@
 
 #include <vector>
 
+#include "paddle/fluid/eager/api/generated/eager_generated/backwards/nodes.h"
 #include "paddle/fluid/eager/api/manual/eager_manual/nodes/nodes.h"
 #include "paddle/fluid/eager/autograd_meta.h"
 #include "paddle/fluid/eager/eager_tensor.h"
@@ -330,7 +331,9 @@ inline void pir_run_program_ad_func(
       if (p_autograd_tensor) {
         auto sync_bn_node = std::dynamic_pointer_cast<SyncBatchNormGradNode>(
             p_autograd_tensor->GetMutableGradNode());
-        if (!sync_bn_node) {
+        auto bn_node = std::dynamic_pointer_cast<BatchNormGradNode>(
+            p_autograd_tensor->GetMutableGradNode());
+        if (!sync_bn_node && !bn_node) {
           params_except_mean_variance.emplace_back(tensor);
         }
       } else {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
batch_norm和sync_batch_norm的mean varience，不需要SetGradOutMeta。否则会连边到上一个step的batch_nome node。
Pcard-67164