### PR TITLE
[CINN] Add loop fuse interface

### DIFF
--- a/paddle/cinn/optim/merge_block_utils.cc
+++ b/paddle/cinn/optim/merge_block_utils.cc
@@ -337,10 +337,14 @@ void MoveScheduleBlock(const ir::Expr& src,
 }
 
 ir::Expr LoopFusion(const ir::Expr& src, const ir::Expr& dst) {
-  VLOG(6) << "loop src: \n" << src;
-  VLOG(6) << "loop dst: \n" << dst;
+  VLOG(6) << "LoopFusion src: \n" << src;
+  VLOG(6) << "LoopFusion dst: \n" << dst;
   ir::Expr fused_loop = LoopFusionHelper(src, dst);
-  VLOG(6) << "fused loop: \n" << fused_loop;
+  if (fused_loop != nullptr) {
+    VLOG(6) << "Fused loop: \n" << fused_loop;
+  } else {
+    VLOG(6) << "Not supported for those loops!";
+  }
   return fused_loop;
 }
 

--- a/paddle/cinn/optim/merge_block_utils.cc
+++ b/paddle/cinn/optim/merge_block_utils.cc
@@ -17,6 +17,9 @@
 #include "paddle/cinn/common/cas.h"
 #include "paddle/cinn/ir/ir_mutator.h"
 #include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/utils/ir_copy.h"
+#include "paddle/cinn/optim/replace_var_with_expr.h"
+
 #include "paddle/common/enforce.h"
 
 namespace cinn {
@@ -57,6 +60,247 @@ struct ForInfoAnalyzer : public ir::IRMutator<Expr*> {
       for_to_children_;
 };
 
+struct ForVarExtent {
+  ir::Var loop_var;
+  ir::Expr extent;
+};
+
+ir::Expr ReplaceSbrIter(const ir::ScheduleBlockRealize* sbr,
+                        const std::vector<ForVarExtent>& src_vars,
+                        const std::vector<ForVarExtent>& dst_vars) {
+  auto ConstructForVarReplaceMap =
+      [&](const std::vector<ForVarExtent>& lhs_extents,
+          const std::vector<ForVarExtent>& rhs_extents)
+      -> std::unordered_map<ir::Var, ir::Var> {
+    std::unordered_map<ir::Var, ir::Var> ret;
+    std::unordered_set<std::size_t> visited_rhs_index;
+    for (const auto& [lhs_var, lhs_extent] : lhs_extents) {
+      for (std::size_t i = 0; i < rhs_extents.size(); ++i) {
+        const auto& [rhs_var, rhs_extent] = rhs_extents[i];
+        if (cinn::common::AutoSimplify(ir::Sub::Make(lhs_extent, rhs_extent)) ==
+                ir::Expr(0) &&
+            visited_rhs_index.count(i) == 0) {
+          ret[lhs_var] = rhs_var;
+          visited_rhs_index.insert(i);
+          break;
+        }
+      }
+    }
+    return ret;
+  };
+
+  std::unordered_map<cinn::ir::Var, cinn::ir::Var> for_var_map =
+      ConstructForVarReplaceMap(src_vars, dst_vars);
+  std::vector<ir::Expr> new_iter_values;
+  for (const ir::Expr& iter_value : sbr->iter_values) {
+    ir::Expr new_iter_value = ir::ir_utils::IRCopy(iter_value);
+    for (const auto& [lhs_var, rhs_var] : for_var_map) {
+      ReplaceVarWithExpr(
+          &new_iter_value, lhs_var, ir::ir_utils::IRCopy(rhs_var));
+    }
+    new_iter_values.push_back(new_iter_value);
+  }
+  return ir::ScheduleBlockRealize::Make(
+      new_iter_values, ir::ir_utils::IRCopy(sbr->schedule_block));
+}
+
+struct MoveScheduleBlockMutator : public ir::IRMutator<Expr*> {
+ public:
+  MoveScheduleBlockMutator(const std::string& src, const std::string& dst)
+      : src_(src), dst_(dst) {}
+
+  void operator()(ir::Expr* expr) { ir::IRMutator<>::Visit(expr, expr); }
+
+ private:
+  void Visit(const ir::Block* op, ir::Expr* expr) {
+    auto InsertRootAndRemoveCurrentStmts = [&](ir::Block* current_block) {
+      if (block_to_new_stmts_.find(current_block) !=
+          block_to_new_stmts_.end()) {
+        current_block->stmts = block_to_new_stmts_[current_block];
+      }
+      while (!insert_root_schedule_blocks_.empty()) {
+        VLOG(6) << "Insert to root block: "
+                << insert_root_schedule_blocks_.back();
+        root_block_->stmts.insert(root_block_->stmts.begin(),
+                                  insert_root_schedule_blocks_.back());
+        insert_root_schedule_blocks_.pop_back();
+      }
+    };
+
+    auto* node = expr->As<ir::Block>();
+    current_block_ = node;
+    ir::IRMutator<>::Visit(op, expr);
+    InsertRootAndRemoveCurrentStmts(node);
+  }
+
+  void Visit(const ir::ScheduleBlockRealize* op, ir::Expr* expr) override {
+    auto* sbr_node = expr->As<ir::ScheduleBlockRealize>();
+    current_sbr_ = sbr_node;
+    const auto* sb_node = sbr_node->schedule_block.As<ir::ScheduleBlock>();
+    if (sb_node->name == dst_) {
+      root_block_ = current_block_;
+      root_for_var_extents_ = for_var_extents_;
+    }
+    ir::IRMutator<>::Visit(op, expr);
+  }
+
+  void Visit(const ir::For* op, ir::Expr* expr) {
+    auto* node = expr->As<ir::For>();
+    for_var_extents_.push_back({node->loop_var, node->extent});
+    ir::IRMutator<>::Visit(op, expr);
+    for_var_extents_.pop_back();
+  }
+
+  void Visit(const ir::Store* op, ir::Expr* expr) {
+    auto* node = expr->As<ir::Store>();
+    ir::Expr sb = ir::ir_utils::IRCopy(current_sbr_->schedule_block);
+    ir::ScheduleBlock* sb_node = sb.As<ir::ScheduleBlock>();
+    if (sb_node->name == src_) {
+      MoveAfter();
+    }
+  }
+
+  void MoveAfter() {
+    // Merge current sbr to root block.
+    insert_root_schedule_blocks_.push_back(
+        ReplaceSbrIter(current_sbr_, for_var_extents_, root_for_var_extents_));
+
+    // Record and will remove current sbr later.
+    block_to_new_stmts_[current_block_] = [&]() -> std::vector<ir::Expr> {
+      std::vector<ir::Expr> new_stmts;
+      for (const ir::Expr& expr : current_block_->stmts) {
+        if (expr.As<ir::ScheduleBlockRealize>()) {
+          const ir::Expr sb = ir::ir_utils::IRCopy(
+              expr.As<ir::ScheduleBlockRealize>()->schedule_block);
+          const ir::ScheduleBlock* sb_node = sb.As<ir::ScheduleBlock>();
+          if (sb_node->name == src_) {
+            continue;
+          }
+        }
+        new_stmts.push_back(expr);
+      }
+      return new_stmts;
+    }();
+  }
+
+  std::vector<ForVarExtent> for_var_extents_;
+  std::vector<ForVarExtent> root_for_var_extents_;
+  std::vector<ir::Expr> insert_root_schedule_blocks_;
+  std::unordered_map<ir::Block*, std::vector<ir::Expr>> block_to_new_stmts_;
+
+  ir::Block* root_block_;
+  ir::Block* current_block_;
+  ir::ScheduleBlockRealize* current_sbr_;
+  const std::string& src_;
+  const std::string& dst_;
+};
+
+struct EmptyBlockRemover : public ir::IRMutator<Expr*> {
+ public:
+  void operator()(ir::Expr* expr) { ir::IRMutator<>::Visit(expr, expr); }
+
+ private:
+  void Visit(const ir::Block* op, ir::Expr* expr) {
+    auto* node = expr->As<ir::Block>();
+    std::unordered_set<int> need_remove_ids;
+    for (int i = 0; i < node->stmts.size(); ++i) {
+      if (IsEmptyBlock(node->stmts[i]) || IsEmptyFor(node->stmts[i])) {
+        need_remove_ids.insert(i);
+      }
+    }
+    if (!need_remove_ids.empty()) {
+      node->stmts = [&] {
+        std::vector<ir::Expr> new_stmts;
+        for (int i = 0; i < node->stmts.size(); ++i) {
+          if (need_remove_ids.count(i) == 0) {
+            new_stmts.push_back(node->stmts[i]);
+          }
+        }
+        return new_stmts;
+      }();
+    }
+    ir::IRMutator<>::Visit(op, expr);
+  }
+
+  bool IsEmptyBlock(const ir::Expr& expr) {
+    const auto* block_node = expr.As<ir::Block>();
+    if (block_node == nullptr) return false;
+    for (const auto& stmt : block_node->stmts) {
+      if (!IsEmptyBlock(stmt)) return false;
+    }
+    return true;
+  }
+
+  bool IsEmptyFor(const ir::Expr& expr) {
+    const auto* for_node = expr.As<ir::For>();
+    if (for_node == nullptr) return false;
+    return IsEmptyBlock(for_node->body);
+  }
+};
+
+ir::Expr LoopFusionHelper(const ir::Expr& src, const ir::Expr& dst) {
+  std::vector<ForVarExtent> src_for_vars;
+  std::vector<ForVarExtent> dst_for_vars;
+
+  auto FuseLoop = [&](const ir::Expr& src, const ir::Expr& dst) -> ir::Expr {
+    const auto* src_node = src.As<ir::For>();
+    const auto* dst_node = dst.As<ir::For>();
+    ir::Expr fused_loop = ir::ir_utils::IRCopy(dst);
+    auto* fused_loop_node = fused_loop.As<ir::For>();
+
+    src_for_vars.push_back({src_node->loop_var, src_node->extent});
+    dst_for_vars.push_back({dst_node->loop_var, dst_node->extent});
+    ir::Expr fused_body = LoopFusionHelper(src_node->body, dst_node->body);
+    dst_for_vars.pop_back();
+    src_for_vars.pop_back();
+
+    if (fused_body == nullptr) return nullptr;
+    fused_loop_node->body = fused_body;
+    return fused_loop;
+  };
+
+  auto FuseBlock = [&](const ir::Expr& src, const ir::Expr& dst) -> ir::Expr {
+    const auto* src_node = src.As<ir::Block>();
+    const auto* dst_node = dst.As<ir::Block>();
+    ir::Expr fused_block = ir::ir_utils::IRCopy(dst);
+    auto* fused_block_node = fused_block.As<ir::Block>();
+    // currently support block has only one stmt.
+    if (src_node->stmts.size() > 1 || dst_node->stmts.size() > 1) {
+      return nullptr;
+    }
+    PADDLE_ENFORCE_EQ(src_node->stmts.size(),
+                      dst_node->stmts.size(),
+                      ::common::errors::InvalidArgument(
+                          "The stmts size in block should be equal."));
+
+    for (size_t i = 0; i < dst_node->stmts.size(); ++i) {
+      if (src_node->stmts[i].As<ir::ScheduleBlockRealize>() &&
+          dst_node->stmts[i].As<ir::ScheduleBlockRealize>()) {
+        fused_block_node->stmts.push_back(
+            ReplaceSbrIter(src_node->stmts[i].As<ir::ScheduleBlockRealize>(),
+                           src_for_vars,
+                           dst_for_vars));
+        continue;
+      }
+      ir::Expr fused_body =
+          LoopFusionHelper(src_node->stmts[i], dst_node->stmts[i]);
+      if (fused_body == nullptr) {
+        return nullptr;
+      }
+      fused_block_node->stmts[i] = fused_body;
+    }
+    return fused_block;
+  };
+
+  if (src.As<ir::For>() && dst.As<ir::For>()) {
+    return FuseLoop(src, dst);
+  }
+  if (src.As<ir::Block>() && dst.As<ir::Block>()) {
+    return FuseBlock(src, dst);
+  }
+  return nullptr;
+}
+
 }  // namespace
 
 bool CanMergeBlocks(const ir::For* first,
@@ -72,6 +316,21 @@ bool CanMergeBlocks(const ir::For* first,
   const auto first_inner_for_list = Get(&first_expr);
   const auto second_inner_for_list = Get(&second_expr);
   return IsEqual(first_inner_for_list, second_inner_for_list);
+}
+
+void MoveScheduleBlock(const std::string& src,
+                       const std::string& dst,
+                       ir::Expr* root) {
+  MoveScheduleBlockMutator(src, dst)(root);
+  EmptyBlockRemover()(root);
+}
+
+ir::Expr LoopFusion(const ir::Expr& src, const ir::Expr& dst) {
+  VLOG(6) << "loop src: \n" << src;
+  VLOG(6) << "loop dst: \n" << dst;
+  ir::Expr fused_loop = LoopFusionHelper(src, dst);
+  VLOG(6) << "fused loop: \n" << fused_loop;
+  return fused_loop;
 }
 
 }  // namespace optim

--- a/paddle/cinn/optim/merge_block_utils.cc
+++ b/paddle/cinn/optim/merge_block_utils.cc
@@ -19,7 +19,6 @@
 #include "paddle/cinn/ir/ir_printer.h"
 #include "paddle/cinn/ir/utils/ir_copy.h"
 #include "paddle/cinn/optim/replace_var_with_expr.h"
-
 #include "paddle/common/enforce.h"
 
 namespace cinn {
@@ -264,8 +263,8 @@ ir::Expr LoopFusionHelper(const ir::Expr& src, const ir::Expr& dst) {
     const auto* dst_node = dst.As<ir::Block>();
     ir::Expr fused_block = ir::ir_utils::IRCopy(dst);
     auto* fused_block_node = fused_block.As<ir::Block>();
-    // currently support block has only one stmt.
-    if (src_node->stmts.size() > 1 || dst_node->stmts.size() > 1) {
+    // currently support blocks have equal stmt size.
+    if (src_node->stmts.size() != dst_node->stmts.size()) {
       return nullptr;
     }
     PADDLE_ENFORCE_EQ(src_node->stmts.size(),

--- a/paddle/cinn/optim/merge_block_utils.cc
+++ b/paddle/cinn/optim/merge_block_utils.cc
@@ -59,37 +59,10 @@ struct ForInfoAnalyzer : public ir::IRMutator<Expr*> {
       for_to_children_;
 };
 
-struct ForVarExtent {
-  ir::Var loop_var;
-  ir::Expr extent;
-};
-
-ir::Expr ReplaceSbrIter(const ir::ScheduleBlockRealize* sbr,
-                        const std::vector<ForVarExtent>& src_vars,
-                        const std::vector<ForVarExtent>& dst_vars) {
-  auto ConstructForVarReplaceMap =
-      [&](const std::vector<ForVarExtent>& lhs_extents,
-          const std::vector<ForVarExtent>& rhs_extents)
-      -> std::unordered_map<ir::Var, ir::Var> {
-    std::unordered_map<ir::Var, ir::Var> ret;
-    std::unordered_set<std::size_t> visited_rhs_index;
-    for (const auto& [lhs_var, lhs_extent] : lhs_extents) {
-      for (std::size_t i = 0; i < rhs_extents.size(); ++i) {
-        const auto& [rhs_var, rhs_extent] = rhs_extents[i];
-        if (cinn::common::AutoSimplify(ir::Sub::Make(lhs_extent, rhs_extent)) ==
-                ir::Expr(0) &&
-            visited_rhs_index.count(i) == 0) {
-          ret[lhs_var] = rhs_var;
-          visited_rhs_index.insert(i);
-          break;
-        }
-      }
-    }
-    return ret;
-  };
-
-  std::unordered_map<cinn::ir::Var, cinn::ir::Var> for_var_map =
-      ConstructForVarReplaceMap(src_vars, dst_vars);
+// Replace bind values in ScheduleBlockRealize using `for_var_map`.
+ir::Expr ReplaceSbrIter(
+    const ir::ScheduleBlockRealize* sbr,
+    const std::unordered_map<ir::Var, ir::Var>& for_var_map) {
   std::vector<ir::Expr> new_iter_values;
   for (const ir::Expr& iter_value : sbr->iter_values) {
     ir::Expr new_iter_value = ir::ir_utils::IRCopy(iter_value);
@@ -103,9 +76,11 @@ ir::Expr ReplaceSbrIter(const ir::ScheduleBlockRealize* sbr,
       new_iter_values, ir::ir_utils::IRCopy(sbr->schedule_block));
 }
 
+// Need to check dependency when dependency analysis tools are complete.
 struct MoveScheduleBlockMutator : public ir::IRMutator<Expr*> {
  public:
-  MoveScheduleBlockMutator(const ir::Expr& src, const ir::Expr& dst)
+  MoveScheduleBlockMutator(const ir::ScheduleBlock* src,
+                           const ir::ScheduleBlock* dst)
       : src_(src), dst_(dst) {}
 
   void operator()(ir::Expr* expr) { ir::IRMutator<>::Visit(expr, expr); }
@@ -125,7 +100,7 @@ struct MoveScheduleBlockMutator : public ir::IRMutator<Expr*> {
             if (expr.As<ir::ScheduleBlockRealize>()) {
               auto* sbr = expr.As<ir::ScheduleBlockRealize>();
               auto* sb = sbr->schedule_block.As<ir::ScheduleBlock>();
-              if (sb->name == dst_.As<ir::ScheduleBlock>()->name) {
+              if (sb->name == dst_->name) {
                 VLOG(6) << "Insert to root block: "
                         << insert_root_schedule_block_;
                 new_stmts.push_back(insert_root_schedule_block_);
@@ -148,33 +123,42 @@ struct MoveScheduleBlockMutator : public ir::IRMutator<Expr*> {
     auto* sbr_node = expr->As<ir::ScheduleBlockRealize>();
     current_sbr_ = sbr_node;
     const auto* sb_node = sbr_node->schedule_block.As<ir::ScheduleBlock>();
-    if (sb_node->name == dst_.As<ir::ScheduleBlock>()->name) {
+    if (sb_node->name == dst_->name) {
       root_block_ = current_block_;
-      root_for_var_extents_ = for_var_extents_;
+      root_for_vars_ = for_vars_;
+    }
+    if (sb_node->name == src_->name) {
+      MoveAfter();
     }
     ir::IRMutator<>::Visit(op, expr);
   }
 
   void Visit(const ir::For* op, ir::Expr* expr) {
     auto* node = expr->As<ir::For>();
-    for_var_extents_.push_back({node->loop_var, node->extent});
+    for_vars_.push_back(node->loop_var);
     ir::IRMutator<>::Visit(op, expr);
-    for_var_extents_.pop_back();
-  }
-
-  void Visit(const ir::Store* op, ir::Expr* expr) {
-    auto* node = expr->As<ir::Store>();
-    ir::Expr sb = ir::ir_utils::IRCopy(current_sbr_->schedule_block);
-    ir::ScheduleBlock* sb_node = sb.As<ir::ScheduleBlock>();
-    if (sb_node->name == src_.As<ir::ScheduleBlock>()->name) {
-      MoveAfter();
-    }
+    for_vars_.pop_back();
   }
 
   void MoveAfter() {
+    auto ConstructForVarReplaceMap = [&](const std::vector<ir::Var>& lhs_vars,
+                                         const std::vector<ir::Var>& rhs_vars)
+        -> std::unordered_map<ir::Var, ir::Var> {
+      PADDLE_ENFORCE_EQ(lhs_vars.size(),
+                        rhs_vars.size(),
+                        ::common::errors::InvalidArgument(
+                            "The for vars size should be equal."));
+      std::unordered_map<ir::Var, ir::Var> ret;
+      for (std::size_t i = 0; i < lhs_vars.size(); ++i) {
+        const auto& rhs_var = rhs_vars[i];
+        ret[lhs_vars[i]] = rhs_var;
+      }
+      return ret;
+    };
+
     // Merge current sbr to root block.
-    insert_root_schedule_block_ =
-        ReplaceSbrIter(current_sbr_, for_var_extents_, root_for_var_extents_);
+    insert_root_schedule_block_ = ReplaceSbrIter(
+        current_sbr_, ConstructForVarReplaceMap(for_vars_, root_for_vars_));
 
     // Record and will remove current sbr later.
     block_to_new_stmts_[current_block_] = [&]() -> std::vector<ir::Expr> {
@@ -184,7 +168,7 @@ struct MoveScheduleBlockMutator : public ir::IRMutator<Expr*> {
           const ir::Expr sb = ir::ir_utils::IRCopy(
               expr.As<ir::ScheduleBlockRealize>()->schedule_block);
           const ir::ScheduleBlock* sb_node = sb.As<ir::ScheduleBlock>();
-          if (sb_node->name == src_.As<ir::ScheduleBlock>()->name) {
+          if (sb_node->name == src_->name) {
             continue;
           }
         }
@@ -194,16 +178,16 @@ struct MoveScheduleBlockMutator : public ir::IRMutator<Expr*> {
     }();
   }
 
-  std::vector<ForVarExtent> for_var_extents_;
-  std::vector<ForVarExtent> root_for_var_extents_;
+  std::vector<ir::Var> for_vars_;
+  std::vector<ir::Var> root_for_vars_;
   std::unordered_map<ir::Block*, std::vector<ir::Expr>> block_to_new_stmts_;
 
   ir::Block* root_block_{nullptr};
   ir::Block* current_block_{nullptr};
   ir::ScheduleBlockRealize* current_sbr_{nullptr};
   ir::Expr insert_root_schedule_block_{nullptr};
-  const ir::Expr& src_;
-  const ir::Expr& dst_;
+  const ir::ScheduleBlock* src_;
+  const ir::ScheduleBlock* dst_;
 };
 
 struct EmptyBlockRemover : public ir::IRMutator<Expr*> {
@@ -249,68 +233,74 @@ struct EmptyBlockRemover : public ir::IRMutator<Expr*> {
   }
 };
 
-ir::Expr LoopFusionHelper(const ir::Expr& src, const ir::Expr& dst) {
-  std::vector<ForVarExtent> src_for_vars;
-  std::vector<ForVarExtent> dst_for_vars;
+struct LoopFusionFunctor {
+ public:
+  ir::Expr FuseTwoLoops(const ir::For* src, const ir::For* dst) {
+    return LoopFusionImpl(src, dst);
+  }
 
-  auto FuseLoop = [&](const ir::Expr& src, const ir::Expr& dst) -> ir::Expr {
-    const auto* src_node = src.As<ir::For>();
-    const auto* dst_node = dst.As<ir::For>();
-    ir::Expr fused_loop = ir::ir_utils::IRCopy(dst);
+ private:
+  ir::Expr LoopFusionImpl(const ir::Expr& src, const ir::Expr& dst) {
+    // Need to check dependency when dependency analysis tools are complete.
+    if (src.As<ir::For>() && dst.As<ir::For>()) {
+      return LoopFusionImpl(src.As<ir::For>(), dst.As<ir::For>());
+    }
+    if (src.As<ir::Block>() && dst.As<ir::Block>()) {
+      return LoopFusionImpl(src.As<ir::Block>(), dst.As<ir::Block>());
+    }
+    return nullptr;
+  }
+
+  ir::Expr LoopFusionImpl(const ir::For* src, const ir::For* dst) {
+    ir::Expr fused_loop = ir::For::Make(dst->loop_var,
+                                        dst->min,
+                                        dst->extent,
+                                        dst->for_type(),
+                                        dst->device_api,
+                                        dst->body,
+                                        dst->vectorize_info(),
+                                        dst->bind_info());
     auto* fused_loop_node = fused_loop.As<ir::For>();
 
-    src_for_vars.push_back({src_node->loop_var, src_node->extent});
-    dst_for_vars.push_back({dst_node->loop_var, dst_node->extent});
-    ir::Expr fused_body = LoopFusionHelper(src_node->body, dst_node->body);
-    dst_for_vars.pop_back();
-    src_for_vars.pop_back();
+    src_to_dst_for_vars_[src->loop_var] = dst->loop_var;
+    ir::Expr fused_body = LoopFusionImpl(src->body, dst->body);
 
     if (fused_body == nullptr) return nullptr;
     fused_loop_node->body = fused_body;
     return fused_loop;
-  };
+  }
 
-  auto FuseBlock = [&](const ir::Expr& src, const ir::Expr& dst) -> ir::Expr {
-    const auto* src_node = src.As<ir::Block>();
-    const auto* dst_node = dst.As<ir::Block>();
-    ir::Expr fused_block = ir::ir_utils::IRCopy(dst);
+  ir::Expr LoopFusionImpl(const ir::Block* src, const ir::Block* dst) {
+    ir::Expr fused_block = ir::Block::Make(dst->stmts);
     auto* fused_block_node = fused_block.As<ir::Block>();
-    // currently support blocks have equal stmt size.
-    if (src_node->stmts.size() != dst_node->stmts.size()) {
+    // Currently support blocks have equal stmts size.
+    if (src->stmts.size() != dst->stmts.size()) {
       return nullptr;
     }
-    PADDLE_ENFORCE_EQ(src_node->stmts.size(),
-                      dst_node->stmts.size(),
+    PADDLE_ENFORCE_EQ(src->stmts.size(),
+                      dst->stmts.size(),
                       ::common::errors::InvalidArgument(
                           "The stmts size in block should be equal."));
 
-    for (size_t i = 0; i < dst_node->stmts.size(); ++i) {
-      if (src_node->stmts[i].As<ir::ScheduleBlockRealize>() &&
-          dst_node->stmts[i].As<ir::ScheduleBlockRealize>()) {
+    for (size_t i = 0; i < dst->stmts.size(); ++i) {
+      if (src->stmts[i].As<ir::ScheduleBlockRealize>() &&
+          dst->stmts[i].As<ir::ScheduleBlockRealize>()) {
         fused_block_node->stmts.push_back(
-            ReplaceSbrIter(src_node->stmts[i].As<ir::ScheduleBlockRealize>(),
-                           src_for_vars,
-                           dst_for_vars));
+            ReplaceSbrIter(src->stmts[i].As<ir::ScheduleBlockRealize>(),
+                           src_to_dst_for_vars_));
         continue;
       }
-      ir::Expr fused_body =
-          LoopFusionHelper(src_node->stmts[i], dst_node->stmts[i]);
+      ir::Expr fused_body = LoopFusionImpl(src->stmts[i], dst->stmts[i]);
       if (fused_body == nullptr) {
         return nullptr;
       }
       fused_block_node->stmts[i] = fused_body;
     }
     return fused_block;
-  };
+  }
 
-  if (src.As<ir::For>() && dst.As<ir::For>()) {
-    return FuseLoop(src, dst);
-  }
-  if (src.As<ir::Block>() && dst.As<ir::Block>()) {
-    return FuseBlock(src, dst);
-  }
-  return nullptr;
-}
+  std::unordered_map<ir::Var, ir::Var> src_to_dst_for_vars_;
+};
 
 }  // namespace
 
@@ -329,19 +319,18 @@ bool CanMergeBlocks(const ir::For* first,
   return IsEqual(first_inner_for_list, second_inner_for_list);
 }
 
-void MoveScheduleBlock(const ir::Expr& src,
-                       const ir::Expr& dst,
+void MoveScheduleBlock(const ir::ScheduleBlock* src,
+                       const ir::ScheduleBlock* dst,
                        ir::Expr* root) {
   MoveScheduleBlockMutator(src, dst)(root);
   EmptyBlockRemover()(root);
 }
 
-ir::Expr LoopFusion(const ir::Expr& src, const ir::Expr& dst) {
-  VLOG(6) << "LoopFusion src: \n" << src;
-  VLOG(6) << "LoopFusion dst: \n" << dst;
-  ir::Expr fused_loop = LoopFusionHelper(src, dst);
+ir::Expr LoopFusion(const ir::For* src, const ir::For* dst) {
+  VLOG(6) << "Begin LoopFusion: \n";
+  ir::Expr fused_loop = LoopFusionFunctor().FuseTwoLoops(src, dst);
   if (fused_loop != nullptr) {
-    VLOG(6) << "Fused loop: \n" << fused_loop;
+    VLOG(6) << "After LoopFusion, Fused loop: \n" << fused_loop;
   } else {
     VLOG(6) << "Not supported for those loops!";
   }

--- a/paddle/cinn/optim/merge_block_utils.h
+++ b/paddle/cinn/optim/merge_block_utils.h
@@ -67,8 +67,8 @@ bool CanMergeBlocks(const ir::For* first,
                     const ForEqualFunc& IsEqual);
 
 // Move schedule block src after schedule block dst.
-void MoveScheduleBlock(const std::string& src,
-                       const std::string& dst,
+void MoveScheduleBlock(const ir::Expr& src,
+                       const ir::Expr& dst,
                        ir::Expr* root);
 
 // Fuse two loop, src -> dst.

--- a/paddle/cinn/optim/merge_block_utils.h
+++ b/paddle/cinn/optim/merge_block_utils.h
@@ -66,13 +66,59 @@ bool CanMergeBlocks(const ir::For* first,
                     const ir::For* second,
                     const ForEqualFunc& IsEqual);
 
-// Move schedule block src after schedule block dst.
-void MoveScheduleBlock(const ir::Expr& src,
-                       const ir::Expr& dst,
+/**
+ * \brief Move schedule block src after schedule block dst, without checking
+ * dependency.
+ * @param src The src ScheduleBlock.
+ * @param dst The dst ScheduleBlock.
+ * @param root The root Expr.
+ */
+void MoveScheduleBlock(const ir::ScheduleBlock* src,
+                       const ir::ScheduleBlock* dst,
                        ir::Expr* root);
 
-// Fuse two loop, src -> dst. Return `nullptr` if not supported.
-ir::Expr LoopFusion(const ir::Expr& src, const ir::Expr& dst);
+/**
+ * \brief Fuse two loop, `src` -> `dst`, remains ScheduleBlock order. Return
+ * `nullptr` if not supported. Currently support loop struct having exactly the
+ * same extents without IfThenElse.
+ * @param src The first loop.
+ * @param dst The second loop.
+ * @return Return fused loop or `nullptr` if not supported.
+ */
+/**
+ * Example 1: LoopFusion(loop_src, loop_dst)
+ * loop(loop_dst)
+ *   for(i, 0, 10)
+ *     for(j, 0, 10)
+ *        B[i,j] = A[i,j]
+ *
+ * loop(loop_src)
+ *   for(i, 0, 10)
+ *     for(j, 0, 10)
+ *        C[i,j] = A[i,j]
+ * =>
+ * Return value:
+ * loop(loop_fused)
+ *   for(i, 0, 10)
+ *     for(j, 0, 10)
+ *        B[i,j] = A[i,j]
+ *        C[i,j] = A[i,j]
+ *
+ * Example 2: LoopFusion(loop_src, loop_dst)
+ * loop(loop_dst)
+ *   for(i, 0, 10)
+ *     for(j, 0, 10)
+ *        B[i,j] = A[i,j]
+ *
+ * loop(loop_src)
+ *   for(i, 0, 3)
+ *     for(j, 0, 4)
+ *        C[i,j] = A[i,j]
+ * =>
+ * Return value:
+ * `nullptr`
+ */
+ir::Expr LoopFusion(const ir::For* src, const ir::For* dst);
 
 }  // namespace optim
 }  // namespace cinn

--- a/paddle/cinn/optim/merge_block_utils.h
+++ b/paddle/cinn/optim/merge_block_utils.h
@@ -66,5 +66,13 @@ bool CanMergeBlocks(const ir::For* first,
                     const ir::For* second,
                     const ForEqualFunc& IsEqual);
 
+// Move schedule block src after schedule block dst.
+void MoveScheduleBlock(const std::string& src,
+                       const std::string& dst,
+                       ir::Expr* root);
+
+// Fuse two loop, src -> dst.
+ir::Expr LoopFusion(const ir::Expr& src, const ir::Expr& dst);
+
 }  // namespace optim
 }  // namespace cinn

--- a/paddle/cinn/optim/merge_block_utils.h
+++ b/paddle/cinn/optim/merge_block_utils.h
@@ -71,7 +71,7 @@ void MoveScheduleBlock(const ir::Expr& src,
                        const ir::Expr& dst,
                        ir::Expr* root);
 
-// Fuse two loop, src -> dst.
+// Fuse two loop, src -> dst. Return `nullptr` if not supported.
 ir::Expr LoopFusion(const ir::Expr& src, const ir::Expr& dst);
 
 }  // namespace optim

--- a/test/cpp/pir/cinn/adt/merge_block_utils_test.cc
+++ b/test/cpp/pir/cinn/adt/merge_block_utils_test.cc
@@ -143,7 +143,7 @@ TEST(ForInfo, ForInfoNotEqual) {
 TEST(ForInfo, ForMerge) {
   ir::Expr for_loop1 = MakeForLoops({2, 3, 4}, 0);
   ir::Expr for_loop2 = MakeForLoops({2, 3, 4}, 0);
-  ir::Expr fuse_loop = LoopFusion(for_loop1, for_loop2);
+  ir::Expr fuse_loop = LoopFusion(for_loop1.As<ir::For>(), for_loop2.As<ir::For>());
   EXPECT_TRUE(CanMergeBlocks(
       for_loop1.As<ir::For>(), fuse_loop.As<ir::For>(), IsBlockForAllEqual));
   EXPECT_TRUE(CanMergeBlocks(

--- a/test/cpp/pir/cinn/adt/merge_block_utils_test.cc
+++ b/test/cpp/pir/cinn/adt/merge_block_utils_test.cc
@@ -53,7 +53,8 @@ ir::Expr MakeForLoops(const std::vector<int> extents, int index) {
                                           std::vector<Expr>(),
                                           "block",
                                           ir::Expr(0));
-    return sb;
+    ir::Expr sbr = ir::ScheduleBlockRealize::Make({}, sb);
+    return sbr;
   }
 
   ir::Expr extent = ir::Expr(extents.at(index));
@@ -137,6 +138,16 @@ TEST(ForInfo, ForInfoNotEqual) {
   TestHelper2({{10, 5}, {4, 7}}, {{10, 5}, {4, 3}}, false);
   TestHelper2(
       {{10, 5, 3}, {4, 7, 9}, {2, 8}}, {{10, 5, 3}, {4, 7, 9}, {2, 7}}, false);
+}
+
+TEST(ForInfo, ForMerge) {
+  ir::Expr for_loop1 = MakeForLoops({2, 3, 4}, 0);
+  ir::Expr for_loop2 = MakeForLoops({2, 3, 4}, 0);
+  ir::Expr fuse_loop = LoopFusion(for_loop1, for_loop2);
+  EXPECT_TRUE(CanMergeBlocks(
+      for_loop1.As<ir::For>(), fuse_loop.As<ir::For>(), IsBlockForAllEqual));
+  EXPECT_TRUE(CanMergeBlocks(
+      for_loop2.As<ir::For>(), fuse_loop.As<ir::For>(), IsBlockForAllEqual));
 }
 
 }  // namespace

--- a/test/cpp/pir/cinn/adt/merge_block_utils_test.cc
+++ b/test/cpp/pir/cinn/adt/merge_block_utils_test.cc
@@ -143,7 +143,8 @@ TEST(ForInfo, ForInfoNotEqual) {
 TEST(ForInfo, ForMerge) {
   ir::Expr for_loop1 = MakeForLoops({2, 3, 4}, 0);
   ir::Expr for_loop2 = MakeForLoops({2, 3, 4}, 0);
-  ir::Expr fuse_loop = LoopFusion(for_loop1.As<ir::For>(), for_loop2.As<ir::For>());
+  ir::Expr fuse_loop =
+      LoopFusion(for_loop1.As<ir::For>(), for_loop2.As<ir::For>());
   EXPECT_TRUE(CanMergeBlocks(
       for_loop1.As<ir::For>(), fuse_loop.As<ir::For>(), IsBlockForAllEqual));
   EXPECT_TRUE(CanMergeBlocks(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

[CINN] Add loop fuse interface

move schedule block without checking dependency.

```
schedule block dst: var_0_rf__reduce_init = 0
...
schedule block src: var_1_rf__reduce_init = 0
```

->

```
schedule block dst: var_0_rf__reduce_init = 0
schedule block src: var_1_rf__reduce_init = 0
...
```

loop fuse. Currently  can fuse loop which only  containing for or block.

```
for i in (0, 2):
  for j in (0, 3):
    s1
for i in (0, 2):
  for j in (0, 3):
    s2
```

->

```
for i in (0, 2):
  for j in (0, 3):
    s1
    s2
```

Pcard-67164
