### PR TITLE
[Comm] Switch c_reduce_* in fluid to reduce in phi

### DIFF
--- a/paddle/fluid/framework/hogwild_worker.cc
+++ b/paddle/fluid/framework/hogwild_worker.cc
@@ -24,6 +24,7 @@ limitations under the License. */
 #include "paddle/fluid/operators/controlflow/conditional_block_op_helper.h"
 #include "paddle/fluid/operators/isfinite_op.h"
 #include "paddle/fluid/platform/lodtensor_printer.h"
+#include "paddle/phi/common/reduce_type.h"
 #include "paddle/phi/core/distributed/comm_context_manager.h"
 #include "paddle/phi/core/platform/cpu_helper.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
@@ -786,8 +787,10 @@ void HogwildWorker::CreateThreadOperators(const ProgramDesc &program) {
     op_names_.push_back(op_name);
     ops_.emplace_back(OpRegistry::CreateOp(*op_desc));
     // change to device stream
-    if (op_name == "c_broadcast" || op_name == "c_reduce_sum" ||
-        op_name == "c_allreduce_sum") {
+    if (op_name == "c_broadcast" || op_name == "c_allreduce_sum" ||
+        (op_name == "reduce" &&
+         op_desc->GetAttrIfExists<int>("reduce_type") ==
+             static_cast<int>(phi::ReduceType::kRedSum))) {
       ops_[op_index]->SetAttr("use_calc_stream", true);
     }
     op_index++;

--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
@@ -22,6 +22,7 @@
 #include "paddle/fluid/framework/new_executor/instruction/phi_kernel_instruction.h"
 #include "paddle/fluid/framework/new_executor/interpreter/interpreter_util.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/phi/common/reduce_type.h"
 
 PHI_DEFINE_EXPORTED_bool(
     add_dependency_for_communication_op,
@@ -1259,7 +1260,8 @@ void DependencyBuilderSimplify::SetSameStream() {
   // for sharing
   for (size_t i = start_index_; i < op_num_; i++) {
     std::string op_name = _ops_ptr->at(i)->Type();
-    if (op_name == "c_reduce_sum") {
+    if (op_name == "reduce" && _ops_ptr->at(i)->Attr<int>("reduce_type") ==
+                                   static_cast<int>(phi::ReduceType::kRedSum)) {
       _ops_ptr->at(i)->SetAttr(use_calc_stream, true);
       for (auto it : _ops_ptr->at(i)->Inputs()) {
         for (auto var : it.second) {

--- a/paddle/phi/kernels/gpu/reduce_kernel.cu
+++ b/paddle/phi/kernels/gpu/reduce_kernel.cu
@@ -270,6 +270,9 @@ void ReduceKernel(const Context& dev_ctx,
     case ReduceType::kRedProd:
       red_type = ncclProd;
       break;
+    case ReduceType::kRedAvg:
+      red_type = ncclAvg;
+      break;
   }
   comm_ctx->Reduce(out, x, red_type, root, stream);
 #else

--- a/paddle/phi/kernels/gpu/reduce_kernel.cu
+++ b/paddle/phi/kernels/gpu/reduce_kernel.cu
@@ -270,9 +270,11 @@ void ReduceKernel(const Context& dev_ctx,
     case ReduceType::kRedProd:
       red_type = ncclProd;
       break;
+#if NCCL_VERSION_CODE >= 21000
     case ReduceType::kRedAvg:
       red_type = ncclAvg;
       break;
+#endif
   }
   comm_ctx->Reduce(out, x, red_type, root, stream);
 #else

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -745,17 +745,6 @@
     data_type : dtype
   traits : paddle::dialect::ForwardOnlyTrait
 
-- op : reduce
-  args : (Tensor x, int ring_id = 0, int root_id = 0, int reduce_type = 0)
-  output : Tensor(out)
-  infer_meta :
-    func : DistReduceInferMeta
-    param: [x]
-  kernel :
-    func : reduce
-    param: [x, root_id, reduce_type]
-  traits : paddle::dialect::ForwardOnlyTrait
-
 - op : remainder
   args : (Tensor x, Tensor y, int axis = -1)
   output : Tensor (out)

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -3976,6 +3976,18 @@
   backward : reciprocal_grad
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
+- op : reduce
+  args : (Tensor x, int ring_id = 0, int root_id = 0, int reduce_type = 0)
+  output : Tensor(out)
+  infer_meta :
+    func : DistReduceInferMeta
+    param: [x]
+  kernel :
+    func : reduce
+    param: [x, root_id, reduce_type]
+  traits : paddle::dialect::ForwardOnlyTrait
+  inplace : (x -> out)
+
 - op : reduce_as
   args : (Tensor x, Tensor target)
   output : Tensor(out)

--- a/python/paddle/decomposition/recompute.py
+++ b/python/paddle/decomposition/recompute.py
@@ -147,7 +147,7 @@ COMPUTE_INTENSIVE_OPS: list[str] = [
     "pd_op.softmax",
     "pd_op.c_allreduce_sum_",
     "pd_op.c_broadcast_",
-    "pd_op.c_reduce_sum_",
+    "pd_op.reduce_",
 ]
 
 AGGRESSIVE_RECOMPUTATION = False

--- a/python/paddle/distributed/auto_parallel/static/operators/common.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/common.py
@@ -17,6 +17,7 @@ import logging
 import warnings
 
 import paddle
+import paddle.distributed as dist
 from paddle.base.log_helper import get_logger
 from paddle.distributed.fleet.meta_optimizers.common import OP_ROLE_KEY, OpRole
 
@@ -669,14 +670,16 @@ def is_data_parallel_scale_op(op):
 
 
 def is_data_parallel_reduce_op(op):
+    is_allreduce_op = op.type in [
+        "c_allreduce_sum",
+        "c_allreduce_avg",
+    ]
+    is_reduce_op = op.type == "reduce" and op.desc.attr("reduce_type") in [
+        dist.ReduceOp.SUM,
+        dist.ReduceOp.AVG,
+    ]
     return (
-        op.type
-        in [
-            "c_allreduce_sum",
-            "c_allreduce_avg",
-            "c_reduce_sum",
-            "c_reduce_avg",
-        ]
+        (is_allreduce_op or is_reduce_op)
         and op.desc.has_attr("op_namescope")
         and ParallelMode.DataParallel in op.desc.attr("op_namescope")
     )

--- a/python/paddle/distributed/communication/reduce.py
+++ b/python/paddle/distributed/communication/reduce.py
@@ -178,49 +178,22 @@ def reduce(
     gdst = dst if group is None else group.get_group_rank(dst)
     assert gdst >= 0, "dst rank out of group, need global rank"
 
-    if op == ReduceOp.SUM:
-        return paddle._legacy_C_ops.c_reduce_sum(
+    if (
+        op == ReduceOp.SUM
+        or op == ReduceOp.MAX
+        or op == ReduceOp.MIN
+        or op == ReduceOp.PROD
+        or op == ReduceOp.AVG
+    ):
+        return paddle._C_ops.reduce(
             tensor,
             tensor,
-            'use_calc_stream',
-            use_calc_stream,
             'ring_id',
             ring_id,
             'root_id',
             gdst,
-        )
-    elif op == ReduceOp.MAX:
-        return paddle._legacy_C_ops.c_reduce_max(
-            tensor,
-            tensor,
-            'use_calc_stream',
-            use_calc_stream,
-            'ring_id',
-            ring_id,
-            'root_id',
-            gdst,
-        )
-    elif op == ReduceOp.MIN:
-        return paddle._legacy_C_ops.c_reduce_min(
-            tensor,
-            tensor,
-            'use_calc_stream',
-            use_calc_stream,
-            'ring_id',
-            ring_id,
-            'root_id',
-            gdst,
-        )
-    elif op == ReduceOp.PROD:
-        return paddle._legacy_C_ops.c_reduce_prod(
-            tensor,
-            tensor,
-            'use_calc_stream',
-            use_calc_stream,
-            'ring_id',
-            ring_id,
-            'root_id',
-            gdst,
+            'reduce_type',
+            op,
         )
     else:
         raise ValueError(f"Unknown parameter: {op}.")

--- a/python/paddle/distributed/communication/stream/reduce.py
+++ b/python/paddle/distributed/communication/stream/reduce.py
@@ -51,7 +51,7 @@ def _reduce_in_dygraph(
 
 
 def _reduce_in_static_mode(
-    tensor, dst_rank_in_group, op, group, sync_op, use_calc_stream
+    tensor, dst_rank_in_group, reduce_type, group, sync_op, use_calc_stream
 ):
     data_feeder.check_variable_and_dtype(
         tensor,
@@ -69,18 +69,18 @@ def _reduce_in_static_mode(
         'reduce',
     )
 
-    op_type = _get_reduce_op(op, "reduce")
+    op_type = "reduce"
     ring_id = 0 if group is None else group.id
 
     helper = framework.LayerHelper(op_type, **locals())
     helper.append_op(
         type=op_type,
-        inputs={'X': [tensor]},
-        outputs={'Out': [tensor]},
+        inputs={'x': [tensor]},
+        outputs={'out': [tensor]},
         attrs={
             'ring_id': ring_id,
-            'use_calc_stream': sync_op,
             'root_id': dst_rank_in_group,
+            'reduce_type': int(reduce_type),
         },
     )
 

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding/utils.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding/utils.py
@@ -165,10 +165,9 @@ def check_allreduce_sum(block, shard, sharding_ring_id, dp_ring_id=-1):
                 var_name = op.desc.input_arg_names()[0]
                 ring_id = op.desc.attr("ring_id")
                 if ring_id == sharding_ring_id:
-                    assert op.type == "reduce" and op.desc.attr(
-                        "reduce_type"
-                    ) == str(
-                        dist.ReduceOp.SUM
+                    assert (
+                        op.type == "reduce"
+                        and op.desc.attr("reduce_type") == dist.ReduceOp.SUM
                     ), "Grad in Sharding group should be reduce rather than allreduce"
                     if var_name in vars_status:
                         _status = vars_status[var_name]
@@ -566,7 +565,7 @@ def insert_fused_reduce_ops(
                     'ring_id': ring_id,
                     'root_id': root_id,
                     'reduce_type': int(dist.ReduceOp.SUM),
-                    'op_role': op_role,
+                    OP_ROLE_KEY: op_role,
                 },
             )
             if not use_calc_stream:

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding/utils.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding/utils.py
@@ -564,7 +564,7 @@ def insert_fused_reduce_ops(
                 attrs={
                     'ring_id': ring_id,
                     'root_id': root_id,
-                    'reduce_type': int(dist.ReduceOp.SUM),
+                    'reduce_type': dist.ReduceOp.SUM,
                     OP_ROLE_KEY: op_role,
                 },
             )
@@ -636,7 +636,7 @@ def insert_reduce_ops(
             attrs={
                 'ring_id': ring_id,
                 'root_id': root_id,
-                'reduce_type': int(dist.ReduceOp.SUM),
+                'reduce_type': dist.ReduceOp.SUM,
                 OP_ROLE_KEY: op_role,
             },
         )

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding/utils.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding/utils.py
@@ -16,6 +16,7 @@ import re
 from functools import reduce
 
 import paddle
+import paddle.distributed as dist
 from paddle.distributed.fleet.meta_optimizers.common import (
     OP_ROLE_KEY,
     OpRole,
@@ -117,7 +118,10 @@ def check_allreduce_sum(block, shard, sharding_ring_id, dp_ring_id=-1):
 
     for idx, op in enumerate(block.ops):
         # sharding use both allreduce and reduce to sync grad
-        if op.type == "c_allreduce_sum" or op.type == "c_reduce_sum":
+        if op.type == "c_allreduce_sum" or (
+            op.type == "reduce"
+            and op.desc.attr("reduce_type") == dist.ReduceOp.SUM
+        ):
             if not op.all_attrs()["use_calc_stream"]:
                 ring_id = op.desc.attr("ring_id")
                 var_name = op.desc.input_arg_names()[0]
@@ -153,13 +157,18 @@ def check_allreduce_sum(block, shard, sharding_ring_id, dp_ring_id=-1):
                 ):
                     dp_grads_status[var_name] = 1
         # check sharding allreduce and  reduce but skip megatron allreduce
-        elif op.type == "c_allreduce_sum" or op.type == "c_reduce_sum":
+        elif op.type == "c_allreduce_sum" or (
+            op.type == "reduce"
+            and op.desc.attr("reduce_type") == dist.ReduceOp.SUM
+        ):
             if not op.all_attrs()["use_calc_stream"]:
                 var_name = op.desc.input_arg_names()[0]
                 ring_id = op.desc.attr("ring_id")
                 if ring_id == sharding_ring_id:
-                    assert (
-                        op.type == "c_reduce_sum"
+                    assert op.type == "reduce" and op.desc.attr(
+                        "reduce_type"
+                    ) == str(
+                        dist.ReduceOp.SUM
                     ), "Grad in Sharding group should be reduce rather than allreduce"
                     if var_name in vars_status:
                         _status = vars_status[var_name]
@@ -550,14 +559,14 @@ def insert_fused_reduce_ops(
         for fused_var in fused_vars:
             block._insert_op_without_sync(
                 insert_idx + insert_num,
-                type='c_reduce_sum',
-                inputs={'X': fused_var},
-                outputs={'Out': fused_var},
+                type='reduce',
+                inputs={'x': fused_var},
+                outputs={'out': fused_var},
                 attrs={
                     'ring_id': ring_id,
                     'root_id': root_id,
-                    'use_calc_stream': use_calc_stream,
-                    OP_ROLE_KEY: op_role,
+                    'reduce_type': int(dist.ReduceOp.SUM),
+                    'op_role': op_role,
                 },
             )
             if not use_calc_stream:
@@ -622,13 +631,13 @@ def insert_reduce_ops(
             grad_in_this_device.append(var)
         block._insert_op_without_sync(
             insert_idx,
-            type='c_reduce_sum',
-            inputs={'X': var},
-            outputs={'Out': var},
+            type='reduce',
+            inputs={'x': var},
+            outputs={'out': var},
             attrs={
                 'ring_id': ring_id,
                 'root_id': root_id,
-                'use_calc_stream': use_calc_stream,
+                'reduce_type': int(dist.ReduceOp.SUM),
                 OP_ROLE_KEY: op_role,
             },
         )

--- a/python/paddle/distributed/passes/auto_parallel_grad_clip.py
+++ b/python/paddle/distributed/passes/auto_parallel_grad_clip.py
@@ -17,6 +17,7 @@ from functools import reduce
 import numpy as np
 
 import paddle
+import paddle.distributed as dist
 from paddle.distributed.fleet.meta_optimizers.common import OP_ROLE_KEY, OpRole
 
 from ..auto_parallel.process_mesh import ProcessMesh
@@ -252,10 +253,14 @@ class ClipHelper:
                 return False
 
         for op in self.block.ops:
-            if op.type in [
-                "c_reduce_sum",
-                "c_allreduce_sum",
-            ] and not is_data_parallel_reduce_op(op):
+            if (
+                op.type == "c_allreduce_sum"
+                or (
+                    op.type == "reduce"
+                    and op.desc.attr("reduce_type") == dist.ReduceOp.SUM
+                )
+                and not is_data_parallel_reduce_op(op)
+            ):
                 return False
             if op.type in ["send_v2", "recv_v2"]:
                 return False

--- a/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
+++ b/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import Any
 
 import paddle
+import paddle.distributed as dist
 from paddle.distributed.auto_parallel.process_mesh import ProcessMesh
 from paddle.distributed.auto_parallel.static.operators.common import (
     is_data_parallel_reduce_op,
@@ -400,7 +401,10 @@ def _move_reduce_to_optimizer_ops_block(
             reduce_op_desc._set_attr(OP_ROLE_KEY, OpRole.Optimize)
             removed_op_idx.append(idx)
 
-            if op.type in ["c_allreduce_sum", "c_reduce_sum"]:
+            if op.type == "c_allreduce_sum" or (
+                op.type == "reduce"
+                and op.attr("reduce_type") == dist.ReduceOp.SUM
+            ):
                 scale_index = idx + 1
                 while scale_index < len(main_block.ops):
                     if is_data_parallel_scale_op(main_block.ops[scale_index]):

--- a/python/paddle/distributed/passes/auto_parallel_sharding.py
+++ b/python/paddle/distributed/passes/auto_parallel_sharding.py
@@ -1554,7 +1554,7 @@ def _insert_reduce_op(
     root_id,
     dist_context,
     reduce_type,
-    op_role,
+    op_role=OpRole.Backward,
 ):
     assert (
         root_id >= 0
@@ -1567,7 +1567,7 @@ def _insert_reduce_op(
         attrs={
             'ring_id': ring_id,
             'root_id': root_id,
-            'reduce_type': int(reduce_type),
+            'reduce_type': reduce_type,
             OP_ROLE_KEY: op_role,
         },
     )

--- a/python/paddle/distributed/passes/auto_parallel_sharding.py
+++ b/python/paddle/distributed/passes/auto_parallel_sharding.py
@@ -538,15 +538,13 @@ class ShardingPass(PassBase):
             if _is_param_grad_allreduce_op(op, main_block):
                 if op.type == "c_allreduce_sum" or (
                     op.type == "reduce"
-                    and op.attr("reduce_type") == str(dist.ReduceOp.SUM)
+                    and op.attr("reduce_type") == dist.ReduceOp.SUM
                 ):
                     reduce_op_type = "reduce"
                     reduce_type = dist.ReduceOp.SUM
-                    op_role = op.attr("op_role")
                 else:
                     reduce_op_type = "reduce"
                     reduce_type = dist.ReduceOp.AVG
-                    op_role = op.attr("op_role")
                 input_name = op.input_arg_names[0]
                 base_name = _get_base_name_from_grad_name(input_name)
                 sharding_info = self.varname_to_sharding_info[base_name]
@@ -559,7 +557,6 @@ class ShardingPass(PassBase):
                     sharding_info.get_var_rank(base_name),
                     self._dist_context,
                     reduce_type,
-                    op_role,
                 )
                 if (
                     not self.sharding_hybrid_dp
@@ -1465,9 +1462,8 @@ class ShardingPass(PassBase):
                             attrs={
                                 'ring_id': inter_node_group.id,
                                 'root_id': inter_node_dst,
-                                'reduce_type': int(dist.ReduceOp.SUM),
+                                'reduce_type': dist.ReduceOp.SUM,
                                 OP_ROLE_KEY: OpRole.Backward,
-                                'op_role': OpRole.Backward,
                             },
                         )
                         new_op._set_attr(

--- a/python/paddle/distributed/passes/auto_parallel_sharding.py
+++ b/python/paddle/distributed/passes/auto_parallel_sharding.py
@@ -16,6 +16,7 @@ import logging
 from functools import reduce
 
 import paddle
+import paddle.distributed as dist
 from paddle.distributed.auto_parallel.static.operators.common import (
     ParallelMode,
     is_data_parallel_reduce_op,
@@ -535,11 +536,20 @@ class ShardingPass(PassBase):
         dp_ring_ids = [group.id for group in self.dp_groups]
         for idx, op in reversed(list(enumerate(main_block.ops))):
             if _is_param_grad_allreduce_op(op, main_block):
-                reduce_op_type = (
-                    "c_reduce_sum"
-                    if op.type in ["c_allreduce_sum", "c_reduce_sum"]
-                    else "c_reduce_avg"
-                )
+                if op.type == "c_allreduce_sum":
+                    reduce_op_type = "reduce"
+                    reduce_type = dist.ReduceOp.SUM
+                    op_role = op.attr("op_role")
+                elif op.type == "reduce" and op.attr("reduce_type") == str(
+                    dist.ReduceOp.SUM
+                ):
+                    reduce_op_type = "reduce"
+                    reduce_type = dist.ReduceOp.SUM
+                    op_role = op.attr("op_role")
+                else:
+                    reduce_op_type = "reduce"
+                    reduce_type = dist.ReduceOp.AVG
+                    op_role = op.attr("op_role")
                 input_name = op.input_arg_names[0]
                 base_name = _get_base_name_from_grad_name(input_name)
                 sharding_info = self.varname_to_sharding_info[base_name]
@@ -551,6 +561,8 @@ class ShardingPass(PassBase):
                     sharding_info.group.id,
                     sharding_info.get_var_rank(base_name),
                     self._dist_context,
+                    reduce_type,
+                    op_role,
                 )
                 if (
                     not self.sharding_hybrid_dp
@@ -991,10 +1003,13 @@ class ShardingPass(PassBase):
         while i < len(ops):
             op = ops[i]
             if is_data_parallel_reduce_op(op):
-                assert op.type in [
-                    "c_reduce_avg",
-                    "c_reduce_sum",
-                ], "Sharding should reduce grad first and than allreduce if Hybrid Sharding with Data-Parallel"
+                is_reduce = op.type == "reduce" and op.attr("reduce_type") in [
+                    dist.ReduceOp.AVG,
+                    dist.ReduceOp.SUM,
+                ]
+                assert (
+                    is_reduce
+                ), "Sharding should reduce grad first and than allreduce if Hybrid Sharding with Data-Parallel"
 
                 grad_name = op.output_arg_names[0]
                 param_name = _get_base_name_from_grad_name(grad_name)
@@ -1308,7 +1323,8 @@ class ShardingPass(PassBase):
                 # increase in memory usage. For more details, see the code of StreamSafeCUDAAllocator.
                 # This issue should be fixed using CUDAMallocAsyncAllocator in the future.
                 if (
-                    op.type == "c_reduce_avg"
+                    op.type == "reduce"
+                    and op.attr("reduce_type") == dist.ReduceOp.AVG
                     and not grad_group.is_in_local_shard
                     and not self.get_attr("gradient_sync_after_accumulate")
                 ):
@@ -1419,7 +1435,10 @@ class ShardingPass(PassBase):
             # update program
             for idx, op in reversed(list(enumerate(block.ops))):
                 if is_data_parallel_reduce_op(op):
-                    assert op.type == "c_reduce_sum"
+                    assert (
+                        op.type == "reduce"
+                        and op.attr("reduce_type") == dist.ReduceOp.SUM
+                    )
                     grad_comm_stream_idx = grad_comm_op_to_stream_idx[op]
                     inter_node_group = inter_node_groups[grad_comm_stream_idx]
                     intra_node_group = intra_node_groups[grad_comm_stream_idx]
@@ -1441,16 +1460,17 @@ class ShardingPass(PassBase):
                         inter_node_dst = dst_rank // nranks_per_node
                         new_op = block._insert_op_without_sync(
                             idx + 1,
-                            type='c_reduce_sum',
-                            inputs={"X": reduce_varname},
+                            type='reduce',
+                            inputs={"x": reduce_varname},
                             outputs={
-                                "Out": reduce_varname,
+                                "out": reduce_varname,
                             },
                             attrs={
                                 'ring_id': inter_node_group.id,
                                 'root_id': inter_node_dst,
-                                'use_calc_stream': True,
+                                'reduce_type': int(dist.ReduceOp.SUM),
                                 OP_ROLE_KEY: OpRole.Backward,
+                                'op_role': OpRole.Backward,
                             },
                         )
                         new_op._set_attr(
@@ -1540,8 +1560,8 @@ def _insert_reduce_op(
     ring_id,
     root_id,
     dist_context,
-    op_role=OpRole.Backward,
-    use_calc_stream=True,
+    reduce_type,
+    op_role,
 ):
     assert (
         root_id >= 0
@@ -1549,12 +1569,12 @@ def _insert_reduce_op(
     new_op = block._insert_op_without_sync(
         insert_idx,
         type=op_type,
-        inputs={'X': [reduce_var]},
-        outputs={'Out': [reduce_var]},
+        inputs={'x': [reduce_var]},
+        outputs={'out': [reduce_var]},
         attrs={
             'ring_id': ring_id,
             'root_id': root_id,
-            'use_calc_stream': use_calc_stream,
+            'reduce_type': int(reduce_type),
             OP_ROLE_KEY: op_role,
         },
     )

--- a/python/paddle/distributed/passes/auto_parallel_sharding.py
+++ b/python/paddle/distributed/passes/auto_parallel_sharding.py
@@ -536,12 +536,9 @@ class ShardingPass(PassBase):
         dp_ring_ids = [group.id for group in self.dp_groups]
         for idx, op in reversed(list(enumerate(main_block.ops))):
             if _is_param_grad_allreduce_op(op, main_block):
-                if op.type == "c_allreduce_sum":
-                    reduce_op_type = "reduce"
-                    reduce_type = dist.ReduceOp.SUM
-                    op_role = op.attr("op_role")
-                elif op.type == "reduce" and op.attr("reduce_type") == str(
-                    dist.ReduceOp.SUM
+                if op.type == "c_allreduce_sum" or (
+                    op.type == "reduce"
+                    and op.attr("reduce_type") == str(dist.ReduceOp.SUM)
                 ):
                     reduce_op_type = "reduce"
                     reduce_type = dist.ReduceOp.SUM

--- a/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_vpp.py
+++ b/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_vpp.py
@@ -14,6 +14,7 @@
 
 import logging
 
+import paddle.distributed as dist
 from paddle.base import core
 from paddle.distributed.auto_parallel.static.operators.common import (
     is_data_parallel_reduce_op,
@@ -210,7 +211,10 @@ class PipelineVirtualPipelinePass(PipelinePassBase):
                     global_grad_to_comm_op[op_input_names[0]] = [op]
                     remove_op_ids.append(idx)
 
-                if op.type in ["c_allreduce_sum", "c_reduce_sum"]:
+                if op.type == "c_allreduce_sum" or (
+                    op.type == "reduce"
+                    and op.desc.attr('reduce_type') == dist.ReduceOp.SUM
+                ):
                     scale_index = idx + 1
                     if scale_index < len(len(ops)):
                         if is_data_parallel_scale_op(ops[scale_index]):

--- a/test/collective/collective_reduce_op_calc_stream.py
+++ b/test/collective/collective_reduce_op_calc_stream.py
@@ -18,6 +18,7 @@ from legacy_test.test_collective_base import (
 )
 
 import paddle
+import paddle.distributed as dist
 from paddle import base
 from paddle.base import core
 
@@ -45,14 +46,14 @@ class TestCollectiveReduce(TestCollectiveRunnerBase):
                 stop_gradient=False,
             )
             main_prog.global_block().append_op(
-                type="c_reduce_sum",
-                inputs={'X': tindata},
+                type="reduce",
+                inputs={'x': tindata},
                 attrs={
                     'ring_id': ring_id,
-                    'use_calc_stream': True,
                     'root_id': rootid,
+                    'reduce_type': int(dist.ReduceOp.SUM),
                 },
-                outputs={'Out': toutdata},
+                outputs={'out': toutdata},
             )
             main_prog.global_block().append_op(
                 type="c_sync_comm_stream",

--- a/test/collective/collective_reduce_op_calc_stream.py
+++ b/test/collective/collective_reduce_op_calc_stream.py
@@ -50,7 +50,7 @@ class TestCollectiveReduce(TestCollectiveRunnerBase):
                 inputs={'x': tindata},
                 attrs={
                     'ring_id': ring_id,
-                    'reduce_type': int(dist.ReduceOp.SUM),
+                    'reduce_type': dist.ReduceOp.SUM,
                     'root_id': rootid,
                 },
                 outputs={'out': toutdata},

--- a/test/collective/collective_reduce_op_calc_stream.py
+++ b/test/collective/collective_reduce_op_calc_stream.py
@@ -50,8 +50,8 @@ class TestCollectiveReduce(TestCollectiveRunnerBase):
                 inputs={'x': tindata},
                 attrs={
                     'ring_id': ring_id,
-                    'root_id': rootid,
                     'reduce_type': int(dist.ReduceOp.SUM),
+                    'root_id': rootid,
                 },
                 outputs={'out': toutdata},
             )

--- a/test/collective/test_collective_reduce_api.py
+++ b/test/collective/test_collective_reduce_api.py
@@ -58,7 +58,7 @@ class TestCollectiveReduceAPI(TestDistBase):
                         need_envs={"USE_COMM_CONTEXT": "1"},
                     )
 
-    def test_reduce_nccl_with_new_comm(self):
+    def test_reduce_nccl_with_new_comm_pir(self):
         dtypes_to_test = [
             "float16",
             "float32",
@@ -78,6 +78,9 @@ class TestCollectiveReduceAPI(TestDistBase):
                         "nccl",
                         dtype=dtype,
                         reduce_type=red_type,
+                        need_envs={
+                            "FLAGS_enable_pir_in_executor": "1",
+                        },
                     )
 
     def test_reduce_bkcl(self):

--- a/test/deprecated/legacy_test/test_auto_parallel_mapper_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_mapper_deprecated.py
@@ -20,6 +20,7 @@ import unittest
 import numpy as np
 
 import paddle
+import paddle.distributed as dist
 import paddle.nn.functional as F
 from paddle import base, nn, static, utils
 from paddle.base import core
@@ -623,10 +624,14 @@ class TestAutoParallelMapper(unittest.TestCase):
             self.assertEqual(get_comm_volume(allgather_op, 0, 1), 400)
             self.assertIsNone(get_comm_volume(allgather_op, 0, 0))
             reduce_op = train_program.global_block().append_op(
-                type="c_reduce_sum",
-                inputs={'X': input},
-                attrs={'ring_id': ring_id, 'root_id': root_id},
-                outputs={'Out': output},
+                type="reduce",
+                inputs={'x': input},
+                attrs={
+                    'ring_id': ring_id,
+                    'root_id': root_id,
+                    'reduce_type': int(dist.ReduceOp.SUM),
+                },
+                outputs={'out': output},
             )
             self.assertIsNone(get_comm_volume(reduce_op, 0, 1))
             self.assertEqual(get_comm_volume(reduce_op, 1, 0), 400)

--- a/test/deprecated/legacy_test/test_auto_parallel_mapper_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_mapper_deprecated.py
@@ -629,7 +629,7 @@ class TestAutoParallelMapper(unittest.TestCase):
                 attrs={
                     'ring_id': ring_id,
                     'root_id': root_id,
-                    'reduce_type': int(dist.ReduceOp.SUM),
+                    'reduce_type': dist.ReduceOp.SUM,
                 },
                 outputs={'out': output},
             )

--- a/test/xpu/test_collective_reduce_xpu.py
+++ b/test/xpu/test_collective_reduce_xpu.py
@@ -37,7 +37,7 @@ class TestCollectiveReduceAPI(TestDistBase):
         "run test when having at least 2 XPUs.",
     )
     def test_reduce(self):
-        support_types = get_xpu_op_support_types('c_reduce_sum')
+        support_types = get_xpu_op_support_types('reduce')
         for dtype in support_types:
             self.check_with_place(
                 "collective_reduce_api.py",
@@ -50,7 +50,7 @@ class TestCollectiveReduceAPI(TestDistBase):
         "run test when having at least 2 XPUs.",
     )
     def test_reduce_dygraph(self):
-        support_types = get_xpu_op_support_types('c_reduce_sum')
+        support_types = get_xpu_op_support_types('reduce')
         for dtype in support_types:
             self.check_with_place(
                 "collective_reduce_api_dygraph.py",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements


### Description
<!-- Describe what you’ve done -->
1、switch `c_reduce_*` in fluid to `reduce` in phi. The replaced OP is in  the set below:
`c_reduce_avg`
`c_reduce_max`
`c_reduce_min`
`c_reduce_prod`
`c_reduce_sum`
2、switch c_reduce_* in fluid to reduce in phi in some left tests

- https://github.com/PaddlePaddle/Paddle/pull/68814

PCard-85618

