### PR TITLE
【CINN】Add TryFuseSameSource func for IterExpr.

### DIFF
--- a/paddle/cinn/common/iter_simplify.cc
+++ b/paddle/cinn/common/iter_simplify.cc
@@ -98,7 +98,6 @@ void IterMapRewriter::Visit(const ir::Add* op, Expr* expr) {
   }
 
   Expr ret = ir::ir_utils::IRCopy(ToIterSum(a));
-
   ir::IterSum* ret_sum = ret.As<ir::IterSum>();
 
   if (auto b_sum = b.As<ir::IterSum>()) {
@@ -124,7 +123,7 @@ void IterMapRewriter::Visit(const ir::Sub* op, Expr* expr) {
   }
   if (!IsIterExpr(a, b)) return;
 
-  Expr ret = ToIterSum(a);
+  Expr ret = ir::ir_utils::IRCopy(ToIterSum(a));
   ir::IterSum* ret_sum = ret.As<ir::IterSum>();
 
   if (auto b_sum = b.As<ir::IterSum>()) {
@@ -235,7 +234,8 @@ void IterMapRewriter::Visit(const ir::Mod* op, Expr* expr) {
   *expr = ret;
 }
 
-Expr IterMapRewriter::PreprocessDividend(const Expr& dividend) {
+ir::IndexExpr IterMapRewriter::PreprocessDividend(
+    const ir::IndexExpr& dividend) {
   if (dividend.As<ir::IterSplit>()) {
     return ir::IterSum::Make({dividend}, ir::Zero(dividend.type()));
   } else if (auto sum = dividend.As<ir::IterSum>()) {
@@ -252,13 +252,13 @@ Expr IterMapRewriter::PreprocessDividend(const Expr& dividend) {
   } else {
     PADDLE_THROW(
         ::common::errors::InvalidArgument("Expect dividend is IterExpr."));
-    return Expr();
+    return ir::IndexExpr();
   }
 }
 
-ir::Expr IterMapRewriter::SplitDivConst(ir::Expr lhs_expr,
-                                        ir::IndexExpr base,
-                                        ir::IndexExpr rhs) {
+ir::IndexExpr IterMapRewriter::SplitDivConst(ir::IndexExpr lhs_expr,
+                                             ir::IndexExpr base,
+                                             ir::IndexExpr rhs) {
   // (lhs_expr + base) // rhs
   if (IsOne(rhs)) {
     if (IsZero(base)) return lhs_expr;
@@ -324,9 +324,9 @@ ir::Expr IterMapRewriter::SplitDivConst(ir::Expr lhs_expr,
                             : ir::IterSum::Make({new_split}, base / rhs);
 }
 
-ir::Expr IterMapRewriter::SplitModConst(ir::Expr lhs_expr,
-                                        ir::IndexExpr base,
-                                        ir::IndexExpr rhs) {
+ir::IndexExpr IterMapRewriter::SplitModConst(ir::IndexExpr lhs_expr,
+                                             ir::IndexExpr base,
+                                             ir::IndexExpr rhs) {
   // (lhs_expr + base) % rhs
   if (IsOne(rhs)) {
     return ir::Zero(lhs_expr.type());
@@ -369,55 +369,81 @@ ir::Expr IterMapRewriter::SplitModConst(ir::Expr lhs_expr,
   return ir::IterSplit::Make(lhs->source, lhs->lower_factor, rhs, lhs->scale);
 }
 
+/*!
+ * \brief Find the first possible position where IterSplit->extent = 1.
+ * \param expr the input IterSum to search.
+ * \return the index of the first IterSplit with extent = 1,
+ * return IterSum.args.size if not found.
+ */
 int32_t IterMapRewriter::FindFirstPossibleUnitExtentIndex(
     const ir::IterSum& expr) {
-  for (size_t i = 0; i < expr.args.size(); ++i) {
-    if (IsOne(expr.args[i].As<ir::IterSplit>()->extent))
-      return static_cast<int32_t>(i);
+  for (int32_t i = 0; i < expr.args.size(); ++i) {
+    if (IsOne(expr.args[i].As<ir::IterSplit>()->extent)) return i;
   }
   return static_cast<int32_t>(expr.args.size());
 }
 
+/*!
+ * \brief FindIterWithExactScale find the iter which has the expected scale.
+ * \param expr the input IterSum to search.
+ * \param skip_flag the flag to indicate whether a Iter should be skipped.
+ * \param match_source Whether to only match the same source.
+ * \param rbegin the last position in reverse searching. -1 means the last.
+ * \param first_possible_unit_extent_pos the first possible position of ext = 1.
+ * \return the index of the Iter with expected scale. return -1 if not found.
+ */
 int32_t IterMapRewriter::FindIterWithExactScale(
     const ir::IterSum& expr,
     const std::vector<bool>& skip_flag,
     const ir::IndexExpr& expected_scale,
-    const ir::Expr& match_source,
+    const ir::IndexExpr& match_source,
     int32_t rbegin,
     int32_t first_possible_unit_extent_pos) {
   if (rbegin == -1) {
     rbegin = static_cast<int32_t>(expr.args.size()) - 1;
   }
   int32_t matched_pos = -1;
-  // use reverse search, as smallest scale usually are near the end.
+  // Use reverse search, as smallest scale usually are near the end.
   for (int32_t j = rbegin; j >= 0; --j) {
     if (skip_flag[j]) continue;
     auto split = expr.args[j].As<ir::IterSplit>();
     if (match_source.defined() && match_source != split->source) continue;
     const ir::IndexExpr& cur_scale = split->scale;
-    // for bijective mapping, the matched scale must equal to expected scale
     if (ProveEQ(cur_scale, expected_scale, analyzer_)) {
       if (IsOne(split->extent)) return j;
+      // We prefer the unit extent Iter. just search when extent != 1.
       if (matched_pos == -1) {
         matched_pos = j;
       }
+      // There is no unit extent in front of first_possible_unit_extent_pos,
+      // so just return.
       if (j <= first_possible_unit_extent_pos) return matched_pos;
     }
   }
   return matched_pos;
 }
 
+/*!
+ * \brief FindBaseIter will find the base Iter which has the smallest scale.
+ * \param expr the input IterSum to search.
+ * \param skip_flag the flag to indicate whether a Iter should be skipped.
+ * \param match_source Whether to only match the same source.
+ * \param rbegin the last position in reverse searching. -1 means the last.
+ * \return the index of the base Iter. return -1 if not found.
+ */
 int32_t IterMapRewriter::FindBaseIter(const ir::IterSum& expr,
                                       const std::vector<bool>& skip_flag,
-                                      const ir::Expr& match_source,
+                                      const ir::IndexExpr& match_source,
                                       int32_t rbegin) {
   if (rbegin == -1) {
     rbegin = static_cast<int>(expr.args.size()) - 1;
   }
 
-  int base_index = -1;
+  int32_t base_index = -1;
   int64_t min_const_scale = 0;
 
+  // Compare the const scale size, use reverse search, as smallest scale usually
+  // are near the end.
   for (int32_t i = rbegin; i >= 0; --i) {
     if (skip_flag[i]) continue;
     auto split = expr.args[i].As<ir::IterSplit>();
@@ -425,17 +451,20 @@ int32_t IterMapRewriter::FindBaseIter(const ir::IterSum& expr,
     if (const auto* op = split->scale.As<ir::IntImm>()) {
       if (base_index == -1 || op->value < min_const_scale) {
         min_const_scale = op->value;
-        base_index = static_cast<int>(i);
+        base_index = i;
       } else if (op->value == min_const_scale) {
         if (IsOne(split->extent) &&
             !IsOne(expr.args[base_index].As<ir::IterSplit>()->extent)) {
-          base_index = static_cast<int32_t>(i);
+          base_index = i;
         }
       }
     }
   }
+
+  // Finded! return the base index.
   if (base_index != -1) return base_index;
 
+  // If not found const scale, compare the symbole length in scale.
   int32_t min_reduce_size = 0;
   for (int32_t i = rbegin; i >= 0; --i) {
     if (skip_flag[i]) continue;
@@ -446,32 +475,61 @@ int32_t IterMapRewriter::FindBaseIter(const ir::IterSum& expr,
     UnpackReduction<ir::Mul>(split->scale, fcollect);
     if (base_index == -1 || reduce_size < min_reduce_size) {
       min_reduce_size = reduce_size;
-      base_index = static_cast<int32_t>(i);
+      base_index = i;
     }
   }
   return base_index;
 }
 
-std::optional<Expr> IterMapRewriter::TryFuse(const ir::Expr& expr) {
+/*!
+ * \brief TryFuse will create new IterMark and returns an aggregated Iter.
+ *
+ * For example:
+ * inp:
+ *  IterSum(IterSplit(IterMark(i), scale = 32),
+ *          IterSplit(IterMark(j), scale = 8),
+ *          base = 0)                        // i * 32 + j * 8
+ * ret:
+ *  IterSum(IterSplit(IterMark(i * 4 + j), scale = 8),
+ *          base = 0)                        // Treat `i * 4 + j` as a IterMark
+ *
+ * \param expr the input IterSum.
+ * \return the IterSum after fused.
+ */
+std::optional<ir::IndexExpr> IterMapRewriter::TryFuse(
+    const ir::IndexExpr& expr) {
   auto iter_sum = expr.As<ir::IterSum>();
   if (!iter_sum) return std::nullopt;
   if (iter_sum->args.size() <= 1) return std::nullopt;
-  // TODO(liuruyan): fuse iter with same source.
 
+  // Fuse Iter with same source. e.g. i_j_fused / 4 * 4 + i_j_fused % 4
+  if (auto opt = TryFuseSameSource(expr)) {
+    auto sum = opt.value().As<ir::IterSum>();
+    if (sum->args.size() <= 1) {
+      return opt.value();
+    }
+  }
+
+  // Select iter with smallest scale as base iter.
   std::vector<bool> visited(iter_sum->args.size(), false);
   int base_index = FindBaseIter(*iter_sum, visited, ir::IndexExpr(), -1);
   if (base_index == -1) return std::nullopt;
   ir::IndexExpr base_scale =
       iter_sum->args[base_index].As<ir::IterSplit>()->scale;
 
-  std::vector<ir::Expr> grouped_iters;
+  std::vector<ir::IndexExpr> grouped_iters;
 
-  ir::IndexExpr expected_extra_base = ir::Zero(iter_sum->type());
-  ir::IndexExpr tail_extent = ir::Zero(iter_sum->type());
   ir::IndexExpr expected_scale = base_scale;
   int first_possible_unit_extent_pos =
       FindFirstPossibleUnitExtentIndex(*iter_sum);
 
+  // Find iter with same scale as expected_scale and update expected_scale.
+  // e.g. i * 32 + j * 8 + k * 1, Extent(i, j, k) = 2, 4, 8.
+  // first base_index = 2, expected_scale = 1. means select k as base iter.
+  // then matched_pos = 2, expected_scale = 8 * 1 = 8. means match k.
+  // then matched_pos = 1, expected_scale = 8 * 4 = 32. means match j.
+  // finally matched_pos = 0, expected_scale = 32 * 2 = 64. means match i.
+  // if match failed, indicates that expr is illegal and cannot be merged.
   for (size_t i = 0; i < iter_sum->args.size(); ++i) {
     ir::IndexExpr matched_scale{nullptr};
     int matched_pos =
@@ -482,22 +540,25 @@ std::optional<Expr> IterMapRewriter::TryFuse(const ir::Expr& expr) {
                                         ir::IndexExpr(),
                                         -1,
                                         first_possible_unit_extent_pos);
-    if (matched_pos != -1) matched_scale = expected_scale;
-
+    // If not found iter with expected scale, return nullopt.
     if (matched_pos == -1) return std::nullopt;
 
+    matched_scale = expected_scale;
     visited[matched_pos] = true;
     auto arg_copy = ir::ir_utils::IRCopy(iter_sum->args[matched_pos]);
     auto arg = arg_copy.As<ir::IterSplit>();
     arg->scale = arg->scale / base_scale;
     grouped_iters.push_back(arg_copy);
+
+    // Update expected_scale = matched_split->scale * matched_split->extent
     expected_scale = MulAndNormalize(
         iter_sum->args[matched_pos].As<ir::IterSplit>()->extent, matched_scale);
   }
   std::reverse(grouped_iters.begin(), grouped_iters.end());
-  Expr grouped_sum =
+  ir::IndexExpr grouped_sum =
       ir::IterSum::Make(grouped_iters, ir::Zero(iter_sum->type()));
 
+  // If the iter is already fused, return it directly.
   auto it = sum_fuse_map_.find(grouped_sum);
   if (it != sum_fuse_map_.end()) {
     return ir::IterSum::Make({ir::IterSplit::Make(it->second, base_scale)},
@@ -511,7 +572,100 @@ std::optional<Expr> IterMapRewriter::TryFuse(const ir::Expr& expr) {
   }
 }
 
-Expr IterMapRewriter::ToIterSum(const Expr& expr) {
+/*!
+ * \brief TryFuseSameSource will simplify the IterSum by fusing iterators with.
+ *
+ * For example:
+ * inp:
+ *  IterSum(IterSplit(IterMark(f), lower = 4, ext = 8 scale = 4),
+ *          IterSplit(IterMark(f), lower = 1, ext = 4 scale = 1),
+ *          base = 0)                        // f /4 * 4 + f % 4
+ * ret:
+ *  IterSum(IterSplit(IterMark(f), scale = 1),
+ *          base = 0)                        // f
+ *
+ * \param expr the input IterSum
+ * \return the IterSum after fused.
+ */
+std::optional<ir::IndexExpr> IterMapRewriter::TryFuseSameSource(
+    const ir::IndexExpr& expr) {
+  auto iter_sum = expr.As<ir::IterSum>();
+  if (!iter_sum) return std::nullopt;
+  if (iter_sum->args.size() <= 1) return std::nullopt;
+
+  // Only for IterMark
+  std::unordered_map<ir::IndexExpr, int32_t> hit_count;
+
+  bool has_overlap = false;
+  // Check if the iterators have overlap, just return nullopt if not.
+  for (auto&& split : iter_sum->args) {
+    auto mark = split.As<ir::IterSplit>()->source;
+    auto it = hit_count.find(mark);
+    if (it != hit_count.end()) {
+      ++it->second;
+      has_overlap = true;
+    } else {
+      hit_count[mark] = 1;
+    }
+  }
+  if (!has_overlap) return std::nullopt;
+
+  std::vector<bool> visited(iter_sum->args.size(), false);
+  // Only for IterSplit
+  std::vector<ir::IndexExpr> reverse_flattened_iters;
+
+  int first_possible_unit_extent_pos =
+      FindFirstPossibleUnitExtentIndex(*iter_sum);
+
+  // Start eliminating the iterators
+  for (int rend = static_cast<int32_t>(iter_sum->args.size()) - 1; rend >= 0;) {
+    auto split = iter_sum->args[rend].As<ir::IterSplit>();
+    if (visited[rend]) {
+      --rend;
+      continue;
+    }
+    if (hit_count.at(split->source) == 1) {
+      reverse_flattened_iters.push_back(iter_sum->args[rend]);
+      visited[rend] = true;
+      --rend;
+      continue;
+    }
+    int matched_index = FindBaseIter(*iter_sum, visited, split->source, rend);
+    visited[matched_index] = true;
+    auto split_copy = ir::ir_utils::IRCopy(iter_sum->args[matched_index]);
+    auto rhs_iter = split_copy.As<ir::IterSplit>();
+
+    // Eliminate the lhs iterators when meets the following conditions:
+    // 1. The lhs has the same source as the rhs.
+    // 2. lhs->scale == rhs->extent * rhs->scale.
+    // 3. lhs->lower_factor == rhs->lower_factor * rhs->extent.
+    while (true) {
+      ir::IndexExpr lhs_scale =
+          MulAndNormalize(rhs_iter->extent, rhs_iter->scale);
+      matched_index = FindIterWithExactScale(*iter_sum,
+                                             visited,
+                                             lhs_scale,
+                                             rhs_iter->source,
+                                             rend,
+                                             first_possible_unit_extent_pos);
+      if (matched_index == -1) break;
+      auto lhs_iter = iter_sum->args[matched_index].As<ir::IterSplit>();
+      ir::IndexExpr lhs_lower_factor =
+          MulAndNormalize(rhs_iter->lower_factor, rhs_iter->extent);
+      if (!ProveEQ(lhs_iter->lower_factor, lhs_lower_factor, analyzer_)) break;
+      visited[matched_index] = true;
+
+      rhs_iter->extent = MulAndNormalize(lhs_iter->extent, rhs_iter->extent);
+    }
+    reverse_flattened_iters.push_back(split_copy);
+  }
+  std::reverse(reverse_flattened_iters.begin(), reverse_flattened_iters.end());
+  auto simplified_sum =
+      ir::IterSum::Make(reverse_flattened_iters, iter_sum->base);
+  return simplified_sum;
+}
+
+ir::IndexExpr IterMapRewriter::ToIterSum(const ir::IndexExpr& expr) {
   if (expr.As<ir::IterSum>()) {
     return expr;
   } else if (auto split = expr.As<ir::IterSplit>()) {
@@ -526,7 +680,7 @@ Expr IterMapRewriter::ToIterSum(const Expr& expr) {
 void IterMapRewriter::AddToLhs(ir::IterSum* lhs,
                                const ir::IterSplit& rhs,
                                int sign) {
-  auto rhs_expr = ir::ir_utils::IRCopy(Expr(&Reference(&rhs)));
+  auto rhs_expr = ir::IndexExpr(ir::ir_utils::IRCopy(Expr(&Reference(&rhs))));
   for (auto&& lvalue : lhs->args) {
     if (lvalue == rhs_expr) {
       auto lsplit = lvalue.As<ir::IterSplit>();

--- a/paddle/cinn/common/iter_simplify.h
+++ b/paddle/cinn/common/iter_simplify.h
@@ -84,7 +84,7 @@ class IterMapRewriter : public ir::IRMutator<> {
   void Visit(const ir::Mod* op, Expr* expr) override;
 
  private:
-  static Expr ToIterSum(const Expr& expr);
+  static ir::IndexExpr ToIterSum(const ir::IndexExpr& expr);
 
   static void AddToLhs(ir::IterSum* lhs, const ir::IterSplit& rhs, int sign);
 
@@ -92,16 +92,20 @@ class IterMapRewriter : public ir::IRMutator<> {
 
   static void MulToLhs(ir::IterSum* lhs, const ir::IndexExpr& rhs);
 
-  Expr PreprocessDividend(const Expr& dividend);
+  ir::IndexExpr PreprocessDividend(const ir::IndexExpr& dividend);
 
-  Expr SplitDivConst(Expr lhs, ir::IndexExpr base, ir::IndexExpr rhs);
+  ir::IndexExpr SplitDivConst(ir::IndexExpr lhs,
+                              ir::IndexExpr base,
+                              ir::IndexExpr rhs);
 
-  Expr SplitModConst(Expr lhs, ir::IndexExpr base, ir::IndexExpr rhs);
+  ir::IndexExpr SplitModConst(ir::IndexExpr lhs,
+                              ir::IndexExpr base,
+                              ir::IndexExpr rhs);
 
   int32_t FindIterWithExactScale(const ir::IterSum& expr,
                                  const std::vector<bool>& skip_flag,
                                  const ir::IndexExpr& expected_scale,
-                                 const Expr& match_source,
+                                 const ir::IndexExpr& match_source,
                                  int32_t rbegin = -1,
                                  int32_t first_possible_unit_extent_pos = 0);
 
@@ -109,14 +113,15 @@ class IterMapRewriter : public ir::IRMutator<> {
 
   int32_t FindBaseIter(const ir::IterSum& expr,
                        const std::vector<bool>& skip_flag,
-                       const Expr& match_source,
+                       const ir::IndexExpr& match_source,
                        int32_t rbegin = -1);
 
-  std::optional<Expr> TryFuse(const Expr& expr);
+  std::optional<ir::IndexExpr> TryFuse(const ir::IndexExpr& expr);
+  std::optional<ir::IndexExpr> TryFuseSameSource(const ir::IndexExpr& expr);
 
   std::unordered_map<std::string, ir::IndexExpr> var_map_;
   std::vector<ir::IterMark> input_marks_;
-  std::unordered_map<Expr, Expr> sum_fuse_map_;
+  std::unordered_map<ir::IndexExpr, ir::IndexExpr> sum_fuse_map_;
   common::SymbolicExprAnalyzer analyzer_;
 };
 

--- a/paddle/cinn/ir/ir.cc
+++ b/paddle/cinn/ir/ir.cc
@@ -320,12 +320,12 @@ void _Var_::Verify() const {
                         "A valid name is required to identify the variable."));
 }
 
-Expr IterMark::Make(const Expr &source, const IndexExpr &extent) {
+IndexExpr IterMark::Make(const IndexExpr &source, const IndexExpr &extent) {
   auto *n = make_shared<IterMark>();
   n->source = source;
   n->extent = extent;
   n->set_type(source.type());
-  return Expr(n);
+  return IndexExpr(n);
 }
 
 IterMark &IterMark::operator=(const IterMark &other) {
@@ -334,20 +334,20 @@ IterMark &IterMark::operator=(const IterMark &other) {
   extent = other.extent;
   return *this;
 }
-Expr IterSplit::Make(const Expr &source,
-                     const IndexExpr &lower_factor,
-                     const IndexExpr &extent,
-                     const IndexExpr &scale) {
+IndexExpr IterSplit::Make(const IndexExpr &source,
+                          const IndexExpr &lower_factor,
+                          const IndexExpr &extent,
+                          const IndexExpr &scale) {
   auto *n = make_shared<IterSplit>();
   n->set_type(source.type());
   n->source = source;
   n->lower_factor = lower_factor;
   n->extent = extent;
   n->scale = scale;
-  return Expr(n);
+  return IndexExpr(n);
 }
 
-Expr IterSplit::Make(const Expr &source) {
+IndexExpr IterSplit::Make(const IndexExpr &source) {
   auto *n = make_shared<IterSplit>();
   auto source_mark = source.As<IterMark>();
   n->set_type(source.type());
@@ -355,10 +355,10 @@ Expr IterSplit::Make(const Expr &source) {
   n->extent = source_mark->extent;
   n->lower_factor = One(source.type()).as_index();
   n->scale = One(source.type()).as_index();
-  return Expr(n);
+  return IndexExpr(n);
 }
 
-Expr IterSplit::Make(const Expr &source, const IndexExpr &scale) {
+IndexExpr IterSplit::Make(const IndexExpr &source, const IndexExpr &scale) {
   auto *n = make_shared<IterSplit>();
   auto source_mark = source.As<IterMark>();
   n->set_type(source.type());
@@ -366,7 +366,7 @@ Expr IterSplit::Make(const Expr &source, const IndexExpr &scale) {
   n->extent = source_mark->extent;
   n->lower_factor = One(source.type()).as_index();
   n->scale = scale;
-  return Expr(n);
+  return IndexExpr(n);
 }
 IterSplit &IterSplit::operator=(const IterSplit &other) {
   this->set_type(other.type());
@@ -377,12 +377,13 @@ IterSplit &IterSplit::operator=(const IterSplit &other) {
   return *this;
 }
 
-Expr IterSum::Make(const std::vector<Expr> &args, const IndexExpr &base) {
+IndexExpr IterSum::Make(const std::vector<IndexExpr> &args,
+                        const IndexExpr &base) {
   auto *n = make_shared<IterSum>();
   n->set_type(base.type());
   n->args = std::move(args);
   n->base = base;
-  return Expr(n);
+  return IndexExpr(n);
 }
 
 void Mul::Verify() const { BinaryNodeVerify(a(), b(), "Mul"); }

--- a/paddle/cinn/ir/ir.h
+++ b/paddle/cinn/ir/ir.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include "paddle/common/enforce.h"
 
+#include "paddle/cinn/adt/adt.h"
 #include "paddle/cinn/common/shared.h"
 #include "paddle/cinn/common/type.h"
 #include "paddle/cinn/ir/function_base.h"
@@ -1038,6 +1039,10 @@ struct IndexExpr : public Expr {
 #undef DEFINE_OPERATOR
 };
 
+// TODO(liujinnan): Essentially IterExpr is not IndexExpr, so it does not
+// satisfy the `is_index` and `as_index` method. IterExpr is temporarily held by
+// IndexExpr, it will be separated later.
+
 /**
  * \brief IterMark is a special ExprNode, which can be used to mark ther entire
  * ierator. source is a IterSum or iterator. extent is the extent of the
@@ -1050,9 +1055,9 @@ struct IterMark : public ExprNode<IterMark> {
   }
   IterMark& operator=(const IterMark& other);
 
-  static Expr Make(const Expr& source, const IndexExpr& extent);
+  static IndexExpr Make(const IndexExpr& source, const IndexExpr& extent);
   Type type() const { return source.type(); }
-  Expr source;
+  IndexExpr source;
   IndexExpr extent;
   static const IrNodeTy _node_type_ = IrNodeTy::IterMark;
 };
@@ -1074,15 +1079,15 @@ struct IterSplit : public ExprNode<IterSplit> {
 
   IterSplit& operator=(const IterSplit& other);
 
-  static Expr Make(const Expr& source,
-                   const IndexExpr& lower_factor,
-                   const IndexExpr& extent,
-                   const IndexExpr& scale);
-  static Expr Make(const Expr& source, const IndexExpr& scale);
-  static Expr Make(const Expr& source);
+  static IndexExpr Make(const IndexExpr& source,
+                        const IndexExpr& lower_factor,
+                        const IndexExpr& extent,
+                        const IndexExpr& scale);
+  static IndexExpr Make(const IndexExpr& source, const IndexExpr& scale);
+  static IndexExpr Make(const IndexExpr& source);
 
   Type type() const { return source.type(); }
-  Expr source;
+  IndexExpr source;
   IndexExpr lower_factor;
   IndexExpr extent;
   IndexExpr scale;
@@ -1096,9 +1101,10 @@ struct IterSplit : public ExprNode<IterSplit> {
 struct IterSum : public ExprNode<IterSum> {
  public:
   IterSum() = default;
-  static Expr Make(const std::vector<Expr>& args, const IndexExpr& base);
+  static IndexExpr Make(const std::vector<IndexExpr>& args,
+                        const IndexExpr& base);
   Type type() const { return base.type(); }
-  std::vector<Expr> args;
+  std::vector<IndexExpr> args;
   IndexExpr base;
   static const IrNodeTy _node_type_ = IrNodeTy::IterSum;
 };
@@ -1237,6 +1243,66 @@ template <>
 struct hash<cinn::ir::Var> {
   std::size_t operator()(const cinn::ir::Var& var) const {
     return std::hash<std::string>()(var->name);
+  }
+};
+
+// Author(liujinnan):
+// Because IRCopy will create a new copy, cannot simply use
+// IRNode* here, otherwise it will cause the following error:
+// hash(a) != hash(b) s.t. a = IRCopy(b)
+// IterExpr is temporarily held by IndexExpr.
+template <>
+struct hash<cinn::ir::IndexExpr> {
+  size_t operator()(const cinn::ir::IndexExpr& x) const {
+    switch (x.node_type()) {
+      case cinn::ir::IrNodeTy::_Var_:
+        return std::hash<std::string>()(x.as_var()->name);
+      case cinn::ir::IrNodeTy::IntImm:
+        return std::hash<int>()(x.as_int64());
+      case cinn::ir::IrNodeTy::IterMark: {
+        auto iter_mark = x.As<cinn::ir::IterMark>();
+        auto hash_source = std::hash<cinn::ir::IndexExpr>()(iter_mark->source);
+        auto hash_extent = std::hash<cinn::ir::IndexExpr>()(iter_mark->extent);
+        return cinn::adt::hash_combine(hash_source, hash_extent);
+      }
+      case cinn::ir::IrNodeTy::IterSplit: {
+        auto iter_split = x.As<cinn::ir::IterSplit>();
+        auto hash_source = std::hash<cinn::ir::IndexExpr>()(iter_split->source);
+        auto hash_lower_facort =
+            std::hash<cinn::ir::IndexExpr>()(iter_split->lower_factor);
+        auto hash_extent = std::hash<cinn::ir::IndexExpr>()(iter_split->extent);
+        auto hash_scale = std::hash<cinn::ir::IndexExpr>()(iter_split->scale);
+        auto hash_res = cinn::adt::hash_combine(hash_source, hash_lower_facort);
+        hash_res = cinn::adt::hash_combine(hash_res, hash_extent);
+        hash_res = cinn::adt::hash_combine(hash_res, hash_scale);
+        return hash_res;
+      }
+      case cinn::ir::IrNodeTy::IterSum: {
+        auto iter_sum = x.As<cinn::ir::IterSum>();
+        auto hash_res = std::hash<cinn::ir::IndexExpr>()(iter_sum->base);
+        for (auto&& iter_mark : iter_sum->args) {
+          hash_res = cinn::adt::hash_combine(
+              hash_res, std::hash<cinn::ir::IndexExpr>()(iter_mark));
+        }
+        return hash_res;
+      }
+      case cinn::ir::IrNodeTy::Add:
+        [[fallthrough]];
+      case cinn::ir::IrNodeTy::Sub:
+        [[fallthrough]];
+      case cinn::ir::IrNodeTy::Mul:
+        [[fallthrough]];
+      case cinn::ir::IrNodeTy::Div:
+        [[fallthrough]];
+      case cinn::ir::IrNodeTy::Mod: {
+        auto hash_lhs =
+            std::hash<cinn::ir::IndexExpr>()(x.get()->operand(0).as_index());
+        auto hash_rhs =
+            std::hash<cinn::ir::IndexExpr>()(x.get()->operand(1).as_index());
+        return cinn::adt::hash_combine(hash_lhs, hash_rhs);
+      }
+    }
+    ::common::errors::InvalidArgument("Unsupported index expr type.");
   }
 };
 }  // namespace std

--- a/paddle/cinn/ir/utils/ir_compare.cc
+++ b/paddle/cinn/ir/utils/ir_compare.cc
@@ -24,7 +24,7 @@ namespace ir {
 
 namespace ir_utils {
 bool EqualIntImmm(const Expr& lhs, const Expr& rhs) {
-  if (lhs == rhs) return true;
+  if (lhs.get() == rhs.get()) return true;
   if (auto* plhs = lhs.As<ir::IntImm>()) {
     auto* prhs = rhs.As<ir::IntImm>();
     return plhs->type() == prhs->type() && plhs->value == prhs->value;
@@ -425,7 +425,8 @@ bool IrEqualVisitor::Visit(const IterSum* lhs, const Expr* other) {
   for (size_t i = 0; i < lhs->args.size(); ++i) {
     if (!Compare(lhs->args.at(i), rhs->args.at(i))) return false;
   }
-  return Compare(lhs->base, rhs->base);
+  return EqualIntImmm(lhs->base, rhs->base) ? true
+                                            : Compare(lhs->base, rhs->base);
 }
 
 bool IRCompare(const Expr& lhs, const Expr& rhs, bool allow_name_suffix_diff) {

--- a/paddle/cinn/ir/utils/ir_copy.cc
+++ b/paddle/cinn/ir/utils/ir_copy.cc
@@ -472,7 +472,7 @@ struct IRCopyVisitor : public ir::IRVisitorRequireReImpl<Expr> {
     return IterSplit::Make(source, lower_factor, extent, scale);
   }
   Expr Visit(const ir::IterSum* op) override {
-    std::vector<Expr> args;
+    std::vector<IndexExpr> args;
     for (const auto& v : op->args) {
       args.push_back(Visit(&v));
     }

--- a/test/cpp/pir/cinn/adt/iter_simplify_test.cc
+++ b/test/cpp/pir/cinn/adt/iter_simplify_test.cc
@@ -378,5 +378,58 @@ TEST_F(TestIterSimplify, fuse_not_same_source) {
   EXPECT_ANY_THROW(rewriter.Rewrite(&e3));
 }
 
+TEST_F(TestIterSimplify, fuse_same_source) {
+  IterMapRewriter rewriter{{i, j, k, i_j_k_fused}, analyzer};
+  IterMapToExprNormalizer normalizer{analyzer};
+
+  auto gt1 = ITER_SUM(ITER_SPLIT(ITER_MARK_VAR(i_j_k_fused),
+                                 ir::IndexExpr(32),
+                                 ir::IndexExpr(2),
+                                 ir::IndexExpr(1)));
+  auto gt2 = ITER_SUM(ITER_SPLIT(ITER_MARK_VAR(i_j_k_fused),
+                                 ir::IndexExpr(8),
+                                 ir::IndexExpr(4),
+                                 ir::IndexExpr(1)));
+  auto gt3 = ITER_SUM(ITER_SPLIT(ITER_MARK_VAR(i_j_k_fused),
+                                 ir::IndexExpr(1),
+                                 ir::IndexExpr(8),
+                                 ir::IndexExpr(1)));
+  auto gt4 = ITER_SUM(ITER_SPLIT(ITER_MARK_VAR(i_j_k_fused),
+                                 ir::IndexExpr(32),
+                                 ir::IndexExpr(2),
+                                 ir::IndexExpr(1)),
+                      ITER_SPLIT(ITER_MARK_VAR(i_j_k_fused),
+                                 ir::IndexExpr(32),
+                                 ir::IndexExpr(1),
+                                 ir::IndexExpr(1)));
+
+  ir::Expr e1 = (i_j_k_fused / 16 / 2 * 32 + i_j_k_fused / 16 % 2 * 16 +
+                 i_j_k_fused % 16) /
+                8 / 4;
+  ir::Expr e2 =
+      (i_j_k_fused / 32 * 32 + i_j_k_fused / 16 % 2 * 16 + i_j_k_fused % 16) /
+      8 % 4;
+  ir::Expr e3 =
+      (i_j_k_fused / 32 * 32 + i_j_k_fused / 16 % 2 * 16 + i_j_k_fused % 16) %
+      8;
+
+  ir::Expr e4 =
+      ((i_j_k_fused / 16) / 2) +
+      ((((i_j_k_fused % 16) / 8) + (2 * ((i_j_k_fused / 16) % 2))) / 4);
+  ir::Expr e5 = (((i_j_k_fused % 16) / 8) + ((4 * ((i_j_k_fused / 16) / 2)) +
+                                             (2 * ((i_j_k_fused / 16) % 2)))) %
+                4;
+  ir::Expr e6 = ((i_j_k_fused % 16) + ((32 * ((i_j_k_fused / 16) / 2)) +
+                                       (16 * ((i_j_k_fused / 16) % 2)))) %
+                8;
+
+  TEST_EXPR(e1, gt1, i_j_k_fused / 32);
+  TEST_EXPR(e2, gt2, i_j_k_fused % 32 / 8);
+  TEST_EXPR(e3, gt3, i_j_k_fused % 8);
+  TEST_EXPR(e4, gt4, i_j_k_fused / 32);
+  TEST_EXPR(e5, gt2, i_j_k_fused % 32 / 8);
+  TEST_EXPR(e6, gt3, i_j_k_fused % 8);
+}
+
 }  // namespace common
 }  // namespace cinn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
1. Change Expr to IndexExpr in func of IterExpr.
2. Add TryFuseSameSource func for simplify the iter when comes from same source.
```
(i_j_k_fused / 16 / 2 * 32 + i_j_k_fused / 16 % 2 * 16 +  i_j_k_fused % 16) / 8
=====>
i_j_k_fused / 8
```
3. Add comment for TryFuse and TryFuseSameSource.
4. Add Hash func for IndexExpr.

Pcard-67164
