### PR TITLE
[Pir] Fix bugs in `put_along_axis` for dynamic shape handling

### DIFF
--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -2562,12 +2562,14 @@ void put_along_axis_grad(const Tensor& x,
     if (include_self == false || reduce == "assign") {
       Tensor zero_tensor = full<T>(index.shape(), 0, out_grad.dtype());
       x_grad_tmp = put_along_axis<T>(out_grad, index, zero_tensor, axis);
+      set_output<T>(x_grad_tmp, x_grad);
     } else if (reduce == "multiply" || reduce == "mul") {
       Tensor zero_tensor_x = full<T>(x.shape(), 0, x.dtype());
       Tensor one_tensor_idx = full<T>(index.shape(), 1, x.dtype());
       Tensor mask =
           put_along_axis<T>(zero_tensor_x, index, one_tensor_idx, axis);
       x_grad_tmp = where<T>(mask > zero_tensor_x, out_grad * out / x, out_grad);
+      set_output<T>(x_grad_tmp, x_grad);
     } else if (reduce == "amin" || reduce == "amax") {
       Tensor zero_tensor = full<T>(x.shape(), 0, x.dtype());
       Tensor one_tensor = full<T>(x.shape(), 1, x.dtype());
@@ -2584,6 +2586,7 @@ void put_along_axis_grad(const Tensor& x,
         num = num + put_along_axis<T>(zero_tensor, sub_index, sub_count, axis);
       }
       x_grad_tmp = zero_result * out_grad / (num + 1);
+      set_output<T>(x_grad_tmp, x_grad);
     } else if (reduce == "mean") {
       Tensor zero_tensor_x = full<T>(x.shape(), 0, x.dtype());
 
@@ -2597,9 +2600,12 @@ void put_along_axis_grad(const Tensor& x,
       }
       x_grad_tmp =
           where<T>(num > zero_tensor_x, out_grad / (num + 1), out_grad);
+      set_output<T>(x_grad_tmp, x_grad);
+    } else if (reduce == "add") {
+      by_pass<T>(out_grad, x_grad);
     }
-    set_output<T>(x_grad_tmp, x_grad);
   }
+
   if (value_grad) {
     Tensor value_grad_tmp = full<T>(index.shape(), 0, x.dtype());
     if (reduce == "assign") {

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -6343,29 +6343,21 @@ def non_negative_axis(arr, axis):
 
 
 def infer_dynamic_broadcast_shape(
-    arr_shape: Tensor, arr_shape_dim: int, indices_shape: Tensor, axis: int
+    arr_shape: Tensor, indices_shape: Tensor, axis: int
 ) -> Tensor:
     """
     Find the broadcast shape for indices when `arr` has a dynamic shape.
 
     Args:
         arr_shape (Tensor): Shape tensor of arr.
-        arr_shape_dim (int): Dimensions of arr.
         indices_shape (Tensor): Shape tensor of indices.
         axis (int): The axis to put 1d slices along.
 
     Returns:
         Tensor: The shape tensor for later broadcasting
     """
-    new_shapes = []
-    for i in range(arr_shape_dim):
-        if i == axis:
-            new_shapes.append(
-                paddle.slice(indices_shape, [0], [axis], [axis + 1])
-            )
-        else:
-            new_shapes.append(paddle.slice(arr_shape, [0], [i], [i + 1]))
-    return paddle.concat(new_shapes)
+    arr_shape[axis] = indices_shape[axis]
+    return arr_shape
 
 
 def infer_broadcast_shape(
@@ -6565,7 +6557,7 @@ def put_along_axis(
             arr_shape = paddle.shape(arr)
             indices_shape = paddle.shape(indices)
             broadcast_shape = infer_dynamic_broadcast_shape(
-                arr_shape, arr.ndim, indices_shape, axis
+                arr_shape, indices_shape, axis
             )
             values = (
                 paddle.to_tensor(values)

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -6342,6 +6342,32 @@ def non_negative_axis(arr, axis):
     return axis
 
 
+def infer_dynamic_broadcast_shape(
+    arr_shape: Tensor, arr_shape_dim: int, indices_shape: Tensor, axis: int
+) -> Tensor:
+    """
+    Find the broadcast shape for indices when `arr` has a dynamic shape.
+
+    Args:
+        arr_shape (Tensor): Shape tensor of arr.
+        arr_shape_dim (int): Dimensions of arr.
+        indices_shape (Tensor): Shape tensor of indices.
+        axis (int): The axis to put 1d slices along.
+
+    Returns:
+        Tensor: The shape tensor for later broadcasting
+    """
+    new_shapes = []
+    for i in range(arr_shape_dim):
+        if i == axis:
+            new_shapes.append(
+                paddle.slice(indices_shape, [0], [axis], [axis + 1])
+            )
+        else:
+            new_shapes.append(paddle.slice(arr_shape, [0], [i], [i + 1]))
+    return paddle.concat(new_shapes)
+
+
 def infer_broadcast_shape(
     arr: Tensor, indices: Tensor, axis: int | Tensor
 ) -> tuple[int] | None:
@@ -6525,23 +6551,45 @@ def put_along_axis(
              [60, 40, 50]])
 
     """
+
+    def has_dynamic_shape(shapes):
+        return any(shape < 0 for shape in shapes)
+
     if len(arr.shape) != len(indices.shape):
         raise ValueError(
             "`indices` and `arr` must have the same number of dimensions!"
         )
     axis = non_negative_axis(arr, axis)
     if broadcast:
-        broadcast_shape = infer_broadcast_shape(arr, indices, axis)
-        values = (
-            paddle.to_tensor(values)
-            if not isinstance(
-                values, (paddle.Tensor, paddle.pir.Value, Variable)
+        if has_dynamic_shape(arr.shape) or has_dynamic_shape(indices.shape):
+            arr_shape = paddle.shape(arr)
+            indices_shape = paddle.shape(indices)
+            broadcast_shape = infer_dynamic_broadcast_shape(
+                arr_shape, arr.ndim, indices_shape, axis
             )
-            else values
-        )
-        if broadcast_shape:
+            values = (
+                paddle.to_tensor(values)
+                if not isinstance(
+                    values, (paddle.Tensor, paddle.pir.Value, Variable)
+                )
+                else values
+            )
             indices = paddle.broadcast_to(indices, broadcast_shape)
-        values = paddle.broadcast_to(values, indices.shape)
+            values = paddle.broadcast_to(values, broadcast_shape)
+        else:
+            broadcast_shape = infer_broadcast_shape(arr, indices, axis)
+            values = (
+                paddle.to_tensor(values)
+                if not isinstance(
+                    values, (paddle.Tensor, paddle.pir.Value, Variable)
+                )
+                else values
+            )
+            if broadcast_shape:
+                indices = paddle.broadcast_to(indices, broadcast_shape)
+                values = paddle.broadcast_to(values, broadcast_shape)
+            else:
+                values = paddle.broadcast_to(values, indices.shape)
     else:
         if isinstance(values, (paddle.Tensor, paddle.pir.Value)):
             if len(indices.shape) != len(values.shape):

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -21,8 +21,16 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.framework import core
+from paddle.static import InputSpec
 
 paddle.enable_static()
+
+
+def put_along_axis_net(arr):
+    indices = paddle.to_tensor([[[[2]]]], dtype='int32', stop_gradient=False)
+    return paddle.tensor.put_along_axis(
+        arr, indices=indices, values=-4.0, axis=-2, reduce='add'
+    )
 
 
 class TestPutAlongAxisOp(OpTest):
@@ -1326,6 +1334,52 @@ class TestPutAlongAxisAPIMulUint8(unittest.TestCase):
             np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.001)
 
         run(paddle.CUDAPlace(0))
+
+
+class TestPutAlongAxisDynamicShape(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2024)
+        self.net = put_along_axis_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+        self.dtype = "float32"
+        self.input_specs = [
+            InputSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=self.dtype,
+                stop_gradient=False,
+            )
+        ]
+        self.arr = np.random.random([10, 10, 10, 10]).astype(self.dtype)
+
+    def train(self, net, to_static):
+        arr = paddle.to_tensor(self.arr, stop_gradient=False)
+        if to_static:
+            build_strategy = paddle.static.BuildStrategy()
+            build_strategy.build_cinn_pass = self.enable_cinn
+            net = paddle.jit.to_static(
+                net,
+                input_spec=self.input_specs,
+                build_strategy=build_strategy,
+                full_graph=True,
+            )
+
+        res = net(arr)
+        res.backward()
+        arr_grad = arr.gradient()
+        return res, arr_grad
+
+    def test_dynamic_static(self):
+        st_out, st_grads = self.train(self.net, to_static=True)
+        dy_out, dy_grads = self.train(self.net, to_static=False)
+
+        for ref, actual in zip(dy_out, st_out):
+            np.testing.assert_allclose(
+                ref, actual, rtol=self.tol, atol=self.tol
+            )
+
+        for dr, d in zip(dy_grads, st_grads):
+            np.testing.assert_allclose(dr, d, rtol=self.tol, atol=self.tol)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
Bug fixes
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->


### Description
- 修复静态shape下，`put_along_axis` 在 `reduce=add`时x_grad缺失的bug
- 修复动态shape下，`put_along_axis_grad`精度问题
   - 由于在输入`arr`是动态shape下，`indices`无法获得broadcast的精确维度。
   - 在python层加入获取broadcast维度的处理。

Pcard-66975
<!-- Describe what you’ve done -->
