### PR TITLE
[SOT] Use trace run in SOT mode

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -674,7 +674,7 @@ inline void RunProgramAPI(
           program_id,
           global_inner_scope,
           place_hash_key,
-          false);  // Simply pass false in PT mode
+          /*used_for_sot=*/false);  // Simply pass false in PT mode
     } else {
       interpreter_core =
           paddle::framework::CreateProgramInterpreterCoreInfoToCache(
@@ -841,7 +841,7 @@ inline void RunProgramGradAPI(
           program_id,
           global_inner_scope,
           place_hash_key,
-          false);  // Simply pass false for PT mode
+          /*used_for_sot=*/false);  // Simply pass false in PT mode
     } else {
       interpreter_core =
           paddle::framework::CreateProgramInterpreterCoreInfoToCache(

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -389,6 +389,10 @@ inline void PirRunProgramAPI(
     is_test = PADDLE_GET_CONST(bool, attrs.at("is_test"));
   }
   int64_t program_id = PADDLE_GET_CONST(int64_t, attrs.at("program_id"));
+  bool in_sot_mode = false;
+  if (attrs.count("in_sot_mode")) {
+    in_sot_mode = PADDLE_GET_CONST(bool, attrs.at("in_sot_mode"));
+  }
   auto place = egr::Controller::Instance().GetExpectedPlace();
 
   // NOTE(chenweihang): In order not to add new variable type, use vector
@@ -467,7 +471,8 @@ inline void PirRunProgramAPI(
         /*is_grad=*/false,
         program_id,
         global_inner_scope,
-        place_hash_key);
+        place_hash_key,
+        in_sot_mode);
     // Step 3. get all eager gc vars (skip_names = backward_inputs -
     // no_need_buffers + outputs)
     std::vector<std::string> skip_names;
@@ -668,7 +673,8 @@ inline void RunProgramAPI(
           /*is_grad=*/false,
           program_id,
           global_inner_scope,
-          place_hash_key);
+          place_hash_key,
+          false);  // Simply pass false in PT mode
     } else {
       interpreter_core =
           paddle::framework::CreateProgramInterpreterCoreInfoToCache(
@@ -834,7 +840,8 @@ inline void RunProgramGradAPI(
           /*is_grad=*/true,
           program_id,
           global_inner_scope,
-          place_hash_key);
+          place_hash_key,
+          false);  // Simply pass false for PT mode
     } else {
       interpreter_core =
           paddle::framework::CreateProgramInterpreterCoreInfoToCache(
@@ -956,6 +963,11 @@ inline void PirRunProgramGradAPI(
 
   int64_t program_id = PADDLE_GET_CONST(int64_t, attrs.at("program_id"));
 
+  bool in_sot_mode = false;
+  if (attrs.count("in_sot_mode")) {
+    in_sot_mode = PADDLE_GET_CONST(bool, attrs.at("in_sot_mode"));
+  }
+
   auto place = egr::Controller::Instance().GetExpectedPlace();
   VLOG(2) << "RunProgramGradOp use interpretercore to execute program.";
 
@@ -1016,7 +1028,8 @@ inline void PirRunProgramGradAPI(
         /*is_grad=*/true,
         program_id,
         global_inner_scope,
-        place_hash_key);
+        place_hash_key,
+        in_sot_mode);
     // share threadpool
     // NOTE(zhiqiu): this only works interpreter_core is executed strictly
     // after the related fwd_interpreter_core.

--- a/paddle/fluid/framework/executor_cache.cc
+++ b/paddle/fluid/framework/executor_cache.cc
@@ -143,7 +143,8 @@ std::shared_ptr<InterpreterCore> CreatePirInterpreterCoreInfoToCache(
     bool is_grad,
     int64_t program_id,
     framework::Scope *scope,
-    const int64_t &place_hash_key) {
+    const int64_t &place_hash_key,
+    bool used_for_sot) {
   auto &cache = framework::InterpreterCoreInfoCache::Instance();
   if (cache.Size() > 256000u /* max_cached_size*/) {
     PADDLE_THROW(common::errors::Fatal(
@@ -153,6 +154,7 @@ std::shared_ptr<InterpreterCore> CreatePirInterpreterCoreInfoToCache(
   interpreter::ExecutionConfig execution_config;
   execution_config.create_local_scope = false;
   execution_config.used_for_jit = true;
+  execution_config.used_for_sot = used_for_sot;
 
   std::shared_ptr<InterpreterCore> core = nullptr;
 

--- a/paddle/fluid/framework/executor_cache.h
+++ b/paddle/fluid/framework/executor_cache.h
@@ -159,7 +159,8 @@ std::shared_ptr<InterpreterCore> CreatePirInterpreterCoreInfoToCache(
     bool is_grad,
     int64_t program_id,
     framework::Scope* scope,
-    const int64_t& place_hash_key);
+    const int64_t& place_hash_key,
+    bool used_for_sot);
 
 std::unique_ptr<::pir::Program> ApplyIrPass(::pir::Program* program,
                                             phi::Place place);

--- a/paddle/fluid/framework/new_executor/interpreter/execution_config.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/execution_config.cc
@@ -140,6 +140,7 @@ void ExecutionConfig::Log(int log_level) {
           << "used_for_cinn = " << used_for_cinn << "\n"
           << "used_for_control_flow_op = " << used_for_control_flow_op << "\n"
           << "used_for_jit = " << used_for_jit << "\n"
+          << "used_for_sot = " << used_for_sot << "\n"
           << "device_num_threads = " << device_num_threads << "\n"
           << "host_num_threads = " << host_num_threads << "\n";
 

--- a/paddle/fluid/framework/new_executor/interpreter/execution_config.h
+++ b/paddle/fluid/framework/new_executor/interpreter/execution_config.h
@@ -29,6 +29,7 @@ struct ExecutionConfig {
   bool used_for_cinn{false};
   bool used_for_control_flow_op{false};
   bool used_for_jit{false};
+  bool used_for_sot{false};
   bool used_for_inference{false};
 
   size_t device_num_threads{0};

--- a/paddle/fluid/framework/new_executor/pir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.cc
@@ -110,6 +110,15 @@ void RecordLowPrecisionOp(const InstructionBase* instr_node) {
   }
 }
 
+bool UseTraceRun(const ExecutionConfig& execution_config,
+                 size_t onednn_op_num,
+                 size_t sync_op_num) {
+  return FLAGS_enable_pir_in_executor_trace_run || onednn_op_num ||
+         execution_config.used_for_inference || execution_config.used_for_sot ||
+         ((execution_config.used_for_jit || execution_config.used_for_cinn) &&
+          (sync_op_num == 0));
+}
+
 PirInterpreter::PirInterpreter(const phi::Place& place,
                                const std::vector<std::string>& fetch_var_names,
                                const ::pir::Block* ir_block,
@@ -1496,10 +1505,7 @@ paddle::framework::FetchList PirInterpreter::Run(
     PreAnalysis();
     VLOG(4) << "Done PreAnalysis";
 
-    if (FLAGS_enable_pir_in_executor_trace_run || onednn_op_num_ ||
-        execution_config_.used_for_inference ||
-        ((execution_config_.used_for_jit || execution_config_.used_for_cinn) &&
-         (sync_op_num_ == 0))) {
+    if (UseTraceRun(execution_config_, onednn_op_num_, sync_op_num_)) {
       LOG_FIRST_N(INFO, 1) << "pir interpreter is running by trace mode ...";
       TraceRunImpl();
     } else {
@@ -1511,10 +1517,7 @@ paddle::framework::FetchList PirInterpreter::Run(
     is_build_ = true;
     is_shared_results_build_ = true;
   } else {
-    if (FLAGS_enable_pir_in_executor_trace_run || onednn_op_num_ ||
-        execution_config_.used_for_inference ||
-        ((execution_config_.used_for_jit || execution_config_.used_for_cinn) &&
-         (sync_op_num_ == 0))) {
+    if (UseTraceRun(execution_config_, onednn_op_num_, sync_op_num_)) {
       TraceRunImpl();
     } else {
       MultiThreadRunImpl();
@@ -1581,10 +1584,7 @@ FetchList PirInterpreter::Run(const std::vector<std::string>& feed_names,
     VLOG(4) << "Done PreAnalysis";
 
     // Run
-    if (FLAGS_enable_pir_in_executor_trace_run || onednn_op_num_ ||
-        execution_config_.used_for_inference ||
-        ((execution_config_.used_for_jit || execution_config_.used_for_cinn) &&
-         (sync_op_num_ == 0))) {
+    if (UseTraceRun(execution_config_, onednn_op_num_, sync_op_num_)) {
       LOG_FIRST_N(INFO, 1) << "pir interpreter is running by trace mode ...";
       TraceRunImpl();
     } else {
@@ -1596,10 +1596,7 @@ FetchList PirInterpreter::Run(const std::vector<std::string>& feed_names,
     is_build_ = true;
     is_shared_results_build_ = true;
   } else {
-    if (FLAGS_enable_pir_in_executor_trace_run || onednn_op_num_ ||
-        execution_config_.used_for_inference ||
-        ((execution_config_.used_for_jit || execution_config_.used_for_cinn) &&
-         (sync_op_num_ == 0))) {
+    if (UseTraceRun(execution_config_, onednn_op_num_, sync_op_num_)) {
       TraceRunImpl();
     } else {
       MultiThreadRunImpl();

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -1177,7 +1177,8 @@ void ConstructAttrMapForRunProgram(
     } else if (std::set<std::string>({"forward_program", "backward_program"})
                    .count(key)) {
       CastPyArg2AttrIRProgram(obj, attrs, key, op_type, arg_pos);
-    } else if (std::set<std::string>({"is_test", "use_interpretorcore"})
+    } else if (std::set<std::string>(
+                   {"is_test", "use_interpretorcore", "in_sot_mode"})
                    .count(key)) {
       CastPyArg2AttrBoolean(obj, attrs, key, op_type, arg_pos);
     } else if (std::set<std::string>({"start_op_index",

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -592,7 +592,7 @@ class PartialProgramLayer:
         """
         in_vars = self._prepare_inputs(inputs)
         out_vars = self._prepare_outputs()
-        attrs = self._prepare_attributes()
+        attrs = self._prepare_attributes(in_sot_mode=False)
         _legacy_C_ops.pir_run_program(
             self._valid_vars(in_vars),
             self._valid_vars(self._params),
@@ -611,7 +611,7 @@ class PartialProgramLayer:
         In sot, inputs and outputs of partial program only contain tensors, so we can skip some step to speed up
         """
         out_vars = self._prepare_outputs()
-        attrs = self._prepare_attributes()
+        attrs = self._prepare_attributes(in_sot_mode=True)
         _legacy_C_ops.pir_run_program(
             self._valid_vars(inputs),
             self._valid_vars(self._params),
@@ -1055,7 +1055,7 @@ class PartialProgramLayer:
             (backward_start_op_index, backward_end_op_index),
         )
 
-    def _prepare_attributes(self):
+    def _prepare_attributes(self, in_sot_mode=False):
         attrs = [
             'forward_program',
             self.program.forward_program,
@@ -1065,6 +1065,8 @@ class PartialProgramLayer:
             not self.training,
             'program_id',
             self.program_id,
+            'in_sot_mode',
+            in_sot_mode,
         ]
         for key, val in self.program.program_attr.items():
             attrs.append(key)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

根据 benchmark 测得的数据，SOT 下 trace run 性能表现相对会更优些，因此 SOT 下默认 trace run，避免多线程带来更多的开销

PT 不修改，只改 PIR 理想态

PCard-66972