### PR TITLE
[Dy2St] fix ast error when reset shadowfeed dst place type

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -3060,12 +3060,15 @@ void RemoveRedundantMemcpyAfterShadowFeed(pir::Block* block,
       }
 
       pir::Value shadow_source = it->operand_source(0);
-      auto val_src_place =
+      if (!shadow_source.type().isa<AllocatedDenseTensorType>()) {
+        continue;
+      }
+      auto var_src_place =
           shadow_source.type()
-              .dyn_cast<paddle::dialect::AllocatedDenseTensorType>()
-              .place();
+              .dyn_cast<paddle::dialect::AllocatedDenseTensorType>();
 
-      if (shadow_value.use_count() >= 1 || val_src_place == phi::CPUPlace()) {
+      if (shadow_value.use_count() >= 1 &&
+          phi::is_cpu_place(var_src_place.place())) {
         bool all_use_is_scalar = true;
         for (auto use_it = shadow_value.use_begin();
              use_it != shadow_value.use_end();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复重置 shadow feed op 的 dst type 逻辑引起的动转静错误
Pcard-76459
