### PR TITLE
[AutoParallel]:fix fused_dropout_add bug

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/fused_dropout_add.cc
+++ b/paddle/phi/infermeta/spmd_rules/fused_dropout_add.cc
@@ -77,7 +77,9 @@ SpmdInfo FusedDropoutAddSpmd(const DistMetaTensor& x,
                              const std::string& mode,
                              int seed,
                              bool fix_seed) {
-  return FusedDropoutAddSpmdBase(x, y);
+  auto dropout_info = FusedDropoutAddSpmdBase(x, y);
+  dropout_info.first.push_back(seed_tensor.dist_attr());
+  return dropout_info;
 }
 
 SpmdInfo FusedDropoutAddSpmdReverse(const DistMetaTensor& x,

--- a/paddle/phi/kernels/fusion/gpu/fused_dropout_add_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_dropout_add_grad_kernel.cu
@@ -263,5 +263,5 @@ PD_REGISTER_KERNEL(fused_dropout_add_grad,
                    double,
                    phi::dtype::bfloat16,
                    phi::dtype::float16) {
-  kernel->InputAt(0).SetBackend(phi::Backend::ALL_BACKEND);  // seed_offset
+  kernel->InputAt(0).SetBackend(phi::Backend::CPU);  // seed_offset
 }

--- a/paddle/phi/kernels/fusion/gpu/fused_dropout_add_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_dropout_add_kernel.cu
@@ -274,5 +274,7 @@ PD_REGISTER_KERNEL(fused_dropout_add,
                    double,
                    phi::dtype::bfloat16,
                    phi::dtype::float16) {
+  kernel->OutputAt(0).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->OutputAt(1).SetDataType(phi::DataType::INT64);
+  kernel->OutputAt(1).SetBackend(phi::Backend::CPU);
 }

--- a/paddle/phi/kernels/fusion/gpu/fused_dropout_add_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_dropout_add_kernel.cu
@@ -274,7 +274,5 @@ PD_REGISTER_KERNEL(fused_dropout_add,
                    double,
                    phi::dtype::bfloat16,
                    phi::dtype::float16) {
-  kernel->OutputAt(0).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->OutputAt(1).SetDataType(phi::DataType::INT64);
-  kernel->OutputAt(1).SetBackend(phi::Backend::CPU);
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes 
### Description
<!-- Describe what you’ve done -->
fused_dropout_add spmdinfo 的长度应该和op的输入输出长度一致。fused_dropout_add 的输入seed的backend应该固定为cpu
pcard-73145