### PR TITLE
[Serde] Clear scope after jit save

### DIFF
--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -1509,6 +1509,7 @@ def save(
             extra_var_info_path = path + INFER_PARAMS_INFO_SUFFIX
             with open(extra_var_info_path, 'wb') as f:
                 pickle.dump(extra_var_info, f, protocol=2)
+    scope.erase(scope.local_var_names())
 
 
 @dygraph_only


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

save 最后清理掉 scope 里的 var，以免 save 过程会 hold 住 parameter

```python
def export(model):
    model = copy.deepcopy(model)
    print([p.name for p in model.parameters()])
    model.eval()
    print("before jit to_static", sys.getrefcount(model))
    model = paddle.jit.to_static(
        model,
        input_spec=[
            paddle.static.InputSpec(
                shape=[None] + [3, 224, 224], dtype='float32'
            )
        ],
        full_graph=True,
    )
    save_path = os.path.join("test_export", "inference")
    paddle.jit.save(model, save_path)
```

避免上述代码显存持续升高的问题

> [!NOTE]
>
> model 在传入 `to_static` 会有一些循环引用，比如 model 持有 StaticFunction(model.forward)，而 static_function 里又有多处持有 model，因此目前建议在 `export(model)` 后调用一下 `gc.collect()` 来清理掉循环引用

PCard-66972