### PR TITLE
[CINN] Support grid reduce for multiple reduces

### DIFF
--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
@@ -36,7 +36,7 @@
 #include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
 #include "paddle/pir/include/dialect/control_flow/ir/cf_op.h"
 
-PD_DECLARE_bool(group_schedule_tiling_first);
+PD_DECLARE_bool(cinn_enable_grid_reduce);
 
 namespace cinn {
 namespace hlir {
@@ -808,8 +808,10 @@ std::shared_ptr<FusionGroupInfo> GetFusionGroupInfo(
                    });
   }
 
-  group_info->can_apply_grid_reduce =
-      GetCanApplyGridReduce(op_compute_bodies, group_info->reduce_axis);
+  if (FLAGS_cinn_enable_grid_reduce) {
+    group_info->can_apply_grid_reduce =
+        GetCanApplyGridReduce(op_compute_bodies, group_info->reduce_axis);
+  }
 
   VLOG(4) << group_info->DebugPrint();
   return group_info;

--- a/paddle/cinn/ir/group_schedule/config/group_tile_util.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_util.cc
@@ -34,7 +34,6 @@ bool GetCanApplyGridReduce(const std::vector<ir::Expr>& op_compute_bodies,
   // A tensor is downstream of reduce either if it is produced by a reduce, or
   // if it has data dependency on another tensor that is downstream of reduce.
   std::unordered_set<std::string> reduce_downstream_tensor_names;
-  int reduce_count = 0;
 
   const auto IsReduceDownstream = [&](const ir::Expr& expr_block) {
     for (auto& expr_load : ChildTensorLoads(expr_block)) {
@@ -89,9 +88,6 @@ bool GetCanApplyGridReduce(const std::vector<ir::Expr>& op_compute_bodies,
     bool is_reduce_downstream = IsReduceDownstream(expr_block);
     bool output_has_reduce_axis = CheckOutputHasReduceAxis(body, expr_block);
 
-    if (is_reduce) {
-      ++reduce_count;
-    }
     if (is_reduce_downstream || is_reduce) {
       AddReduceDownstream(expr_block);
     }
@@ -104,8 +100,7 @@ bool GetCanApplyGridReduce(const std::vector<ir::Expr>& op_compute_bodies,
       return false;
     }
   }
-
-  return reduce_count == 1;
+  return true;
 }
 
 }  // namespace ir

--- a/paddle/cinn/ir/group_schedule/config/group_tile_util.h
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_util.h
@@ -19,8 +19,8 @@ namespace cinn {
 namespace ir {
 
 // Check whether we can apply grid reduce in this group.
-// We can apply grid reduce if there is exactly one reduce, and whose result is
-// not broadcasted before output.
+// We can apply grid reduce if there is no reduce-then-broadcast dependency
+// in this group.
 bool GetCanApplyGridReduce(const std::vector<ir::Expr>& op_compute_bodies,
                            const std::vector<int64_t>& reduce_axis);
 

--- a/paddle/cinn/ir/group_schedule/tactic/tile_first_general_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_first_general_tactic.cc
@@ -79,6 +79,7 @@ class TileFirstGeneralTactic final : public ScheduleTactic {
   std::vector<int32_t> vec_flatten_axis_;
   std::vector<int32_t> vec_reduce_axis_;
   std::unordered_map<std::string, std::string> map_rf_block_;
+  std::unordered_map<std::string, std::string> map_global_rf_block_;
 };
 
 void TileFirstGeneralTactic::Init(ScheduleContext* context) {
@@ -381,18 +382,45 @@ void TileFirstGeneralTactic::SplitSptialInner(ir::IRSchedule* sch,
 
 void TileFirstGeneralTactic::SplitReduceInner(ir::IRSchedule* sch,
                                               const std::string& block_id) {
+  const int64_t rd_block = context_->config.tile_config.grid_reduce_num;
+  const int64_t rd_thread = 16;
+  const int cur_reduce_axis = 2;
+
+  // [ R ] => [ rd_block*rd_thread, rd_inner ]
   auto loops = sch->GetLoops(block_id);
-  // [S(-1), S(32), R] => [S(-1), S(32), R(16), R(-1)]
-  sch->Split(loops[2], std::vector<int>{16, -1});
+  sch->Split(loops[cur_reduce_axis],
+             std::vector<int>{-1, rd_block * rd_thread});
+  loops = sch->GetLoops(block_id);
+  sch->Reorder({loops[cur_reduce_axis + 1], loops[cur_reduce_axis]});
 
   loops = sch->GetLoops(block_id);
   if (IsReductionSBlock(sch->GetBlock(block_id)) &&
       ir::GetLoopExtent(loops[2]) != 1) {
     ir::Expr rf_tensor =
-        sch->FactorizeReduction(loops[2],
-                                0,
+        sch->FactorizeReduction(loops[cur_reduce_axis],
+                                /* rf_axis = */ 0,
                                 /* with_write_back_block_init = */ false);
     map_rf_block_[block_id] = rf_tensor.as_tensor_ref()->name;
+  }
+
+  // [ rd_block*rd_thread ] => [ rd_block, rd_thread ]
+  if (rd_block > 1) {
+    loops = sch->GetLoops(block_id);
+    sch->Split(loops[cur_reduce_axis], {rd_block, rd_thread});
+
+    if (IsReductionSBlock(sch->GetBlock(block_id))) {
+      loops = sch->GetLoops(map_rf_block_[block_id]);
+      sch->Split(loops[cur_reduce_axis], {rd_block, rd_thread});
+
+      loops = sch->GetLoops(block_id);
+      ir::Expr rf_tensor =
+          sch->FactorizeReduction(loops[cur_reduce_axis],
+                                  /* rf_axis = */ 0,
+                                  /* with_write_back_block_init = */ false);
+      std::string tensor_name = rf_tensor.as_tensor_ref()->name;
+      map_global_rf_block_[block_id] = tensor_name;
+      rf_tensor.as_tensor_ref()->WithBuffer("global", "_" + tensor_name);
+    }
   }
 }
 
@@ -435,6 +463,12 @@ void TileFirstGeneralTactic::SetDiscreteReduceType(
                      ->schedule_block.As<ir::ScheduleBlock>();
     block->reduce_method = cinn::ir::DiscreteReduceMethod();
   }
+  if (map_global_rf_block_.count(block_id) > 0) {
+    auto block = sch->GetBlock(map_global_rf_block_[block_id])
+                     .As<ir::ScheduleBlockRealize>()
+                     ->schedule_block.As<ir::ScheduleBlock>();
+    block->reduce_method = cinn::ir::DiscreteReduceMethod();
+  }
 }
 
 void TileFirstGeneralTactic::BindCudaInfo(ir::IRSchedule* sch,
@@ -446,13 +480,23 @@ void TileFirstGeneralTactic::BindCudaInfo(ir::IRSchedule* sch,
   const auto DoBind = [&](const std::vector<ir::Expr>& loops) {
     sch->Bind(loops[0], "blockIdx.x");
     sch->Bind(loops[1], "threadIdx.x");
-    sch->Bind(loops[2], "threadIdx.y");
+    if (context_->config.tile_config.grid_reduce_num > 1) {
+      sch->Bind(loops[2], "blockIdx.y");
+      if (loops.size() > 3) {
+        sch->Bind(loops[3], "threadIdx.y");
+      }
+    } else {
+      sch->Bind(loops[2], "threadIdx.y");
+    }
   };
 
   DoBind(sch->GetLoops(block_id));
 
   if (map_rf_block_.count(block_id) > 0) {
     DoBind(sch->GetLoops(map_rf_block_[block_id]));
+  }
+  if (map_global_rf_block_.count(block_id) > 0) {
+    DoBind(sch->GetLoops(map_global_rf_block_[block_id]));
   }
 }
 

--- a/paddle/cinn/optim/replace_cross_block_reduction.h
+++ b/paddle/cinn/optim/replace_cross_block_reduction.h
@@ -25,11 +25,13 @@ namespace optim {
  * This pass handles the cross-block reduction properly.
  *
  * Specific transformations:
- * 1. Replaces the cross-block reduction with an external call to the
+ * 1. Reorders the schedule blocks to separate upstreams and downstreams
+ *    of cross-block reduction.
+ * 2. Replaces the cross-block reduction with an external call to the
  *    `grid_reduce` template function.
- * 2. Adds a condition check `is_last_block_done` to the reduction operation
- *    and all subsequent schedule blocks.
- * 3. Pushes global buffers (`rf` and `semaphore`) to the function’s argument
+ * 3. Adds a condition check `is_last_block_done` to the grid reduce and all
+ *    subsequent schedule blocks.
+ * 4. Pushes global buffers (`rf` and `semaphore`) to the function’s argument
  *    list.
  *
  * Example:

--- a/paddle/cinn/runtime/cuda/cuda_intrinsics_reduce.cc
+++ b/paddle/cinn/runtime/cuda/cuda_intrinsics_reduce.cc
@@ -170,6 +170,7 @@ CINN_REGISTER_HELPER(cuda_intrinsics_reduce) {
       .SetRetType<DTYPE>()                                                   \
       .AddInputType<cinn_buffer_t *>()                                       \
       .AddInputType<int>()                                                   \
+      .AddInputType<int>()                                                   \
       .End();
 
   EXPAND_REDUCE_INT32_REGISTER_MARCO(REGISTER_GRID_REDUCE_FUNC_IMPL)

--- a/paddle/cinn/runtime/flags.cc
+++ b/paddle/cinn/runtime/flags.cc
@@ -72,6 +72,10 @@ PD_DEFINE_bool(cinn_measure_kernel_time,
                BoolFromEnv("FLAGS_cinn_measure_kernel_time", false),
                "Whether to enable schedule config search mode.");
 
+PD_DEFINE_bool(cinn_enable_grid_reduce,
+               BoolFromEnv("FLAGS_cinn_enable_grid_reduce", true),
+               "Whether to enable the grid reduce method.");
+
 PD_DEFINE_bool(cinn_use_op_fusion,
                BoolFromEnv("FLAGS_cinn_use_op_fusion", true),
                "Whether to use op fusion pass.");

--- a/test/cpp/pir/cinn/replace_cross_block_reduction_test.cc
+++ b/test/cpp/pir/cinn/replace_cross_block_reduction_test.cc
@@ -78,7 +78,7 @@ TEST(CrossBlockReductionReplacer, SRLayout) {
             ScheduleBlock(B)
             {
               i0_0, i1 = axis.bind(i, reduce_k)
-              B[i0_0] = cinn_grid_reduce_sum_fp32(Tensor(A, [8,16]), 1)
+              B[i0_0] = cinn_grid_reduce_sum_fp32(Tensor(A, [8,16]), 1, i0_0)
             }
           }
         }
@@ -166,7 +166,7 @@ TEST(CrossBlockReductionReplacer, RSLayout) {
               ScheduleBlock(B)
               {
                 i0_0, i1_0, i2 = axis.bind(i, j, reduce_k)
-                B[i0_0, i1_0] = cinn_grid_reduce_max_fp32(Tensor(A, [8,4,32]), 32)
+                B[i0_0, i1_0] = cinn_grid_reduce_max_fp32(Tensor(A, [8,4,32]), 32, ((32 * i0_0) + i1_0))
               }
             }
           }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Improvements


### Description
This PR mainly adds grid reduce support for fusion groups that have multiple reduces. To achieve this, this PR adds a `CrossBlockReductionReorderer` pass that separates the upstream and downstream schedule blocks of grid reduce. We can then insert a fence (`update_semaphore`) between the last upstream block and the first grid reduce block.

After the `CrossBlockReductionReorderer` pass, the compute graph is like:
```python
ScheduleBlock(root)
{
  ScheduleBlock(upstream_1)
  ScheduleBlock(upstream_2)
  ...
  # add fence here
  ScheduleBlock(grid_reduce_1)
  ScheduleBlock(grid_reduce_2)
  ...
  ScheduleBlock(downstream_1)
  ScheduleBlock(downstream_2)
  ...
}
```

This PR also adds tiling support for RS layout.

pcard-85711
