### PR TITLE
【CINN】Add SimplifyBind func for IterExpr.

### DIFF
--- a/paddle/cinn/common/iter_simplify.h
+++ b/paddle/cinn/common/iter_simplify.h
@@ -102,21 +102,97 @@ class IterMapRewriter : public ir::IRMutator<> {
                               ir::IndexExpr base,
                               ir::IndexExpr rhs);
 
-  int32_t FindIterWithExactScale(const ir::IterSum& expr,
-                                 const std::vector<bool>& skip_flag,
-                                 const ir::IndexExpr& expected_scale,
-                                 const ir::IndexExpr& match_source,
-                                 int32_t rbegin = -1,
-                                 int32_t first_possible_unit_extent_pos = 0);
+  /*!
+   * \brief This function will find the iter which has the expected scale.
+   * For example:
+   * expr:
+   *  IterSum(IterSplit(IterMark(i), scale = 32),
+   *          IterSplit(IterMark(j), scale = 8),
+   *          base = 0)                    // i * 32 + j * 8
+   * ret: `1` when expected_scale = 8
+   * ret: `0` when expected_scale = 32
+   *
+   * \param expr the input IterSum to search.
+   * \param skip_flag the flag to indicate whether a Iter should be skipped.
+   * \param match_source Whether to only match the same source.
+   * \param rbegin the last position in reverse searching. -1 means the last.
+   * \param first_possible_unit_extent_pos the first possible position of the
+   * unit extent.
+   *  \return the index of the Iter with expected scale. return -1
+   * if not found.
+   */
+  int32_t FindSplitWithExactScale(const ir::IterSum& expr,
+                                  const std::vector<bool>& skip_flag,
+                                  const ir::IndexExpr& expected_scale,
+                                  const ir::IndexExpr& match_source,
+                                  int32_t rbegin = -1,
+                                  int32_t first_possible_unit_extent_pos = 0);
 
+  /*!
+   * \brief Find the first possible position where IterSplit->extent = 1.
+   * \param expr the input IterSum to search.
+   * \return the index of the first IterSplit with extent = 1,
+   * return IterSum.args.size if not found.
+   */
   int32_t FindFirstPossibleUnitExtentIndex(const ir::IterSum& expr);
 
-  int32_t FindBaseIter(const ir::IterSum& expr,
-                       const std::vector<bool>& skip_flag,
-                       const ir::IndexExpr& match_source,
-                       int32_t rbegin = -1);
+  /*!
+   * \brief This function will find the base Iter which has the smallest scale.
+   *
+   * For example:
+   * expr:
+   *  IterSum(IterSplit(IterMark(i), scale = 32),
+   *          IterSplit(IterMark(j), scale = 8),
+   *          base = 0)                    // i * 32 + j * 8
+   *
+   * ret: `1` when match_source = nullptr
+   * ret: `0` when match_source = IterMark(i)
+   *
+   * \param expr the input IterSum to search.
+   * \param skip_flag the flag to indicate whether a Iter should be skipped.
+   * \param match_source Whether to only match the same source.
+   * \param rbegin the last position in reverse searching. -1 means the last.
+   * \return the index of the base Iter. return -1 if not found.
+   */
+  int32_t FindBaseSplit(const ir::IterSum& expr,
+                        const std::vector<bool>& skip_flag,
+                        const ir::IndexExpr& match_source,
+                        int32_t rbegin = -1);
 
+  /*!
+   * \brief TryFuse will create new IterMark and returns an aggregated IterSum
+   * that only has one IterSplit with the new IterMark.
+   *
+   * For example:
+   * expr:
+   *  IterSum(IterSplit(IterMark(i), scale = 32),
+   *          IterSplit(IterMark(j), scale = 8),
+   *          base = 0)                    // i * 32 + j * 8
+   * ret:
+   *  IterSum(IterSplit(IterMark(i * 4 + j), scale = 8),
+   *          base = 0)                    // Treat `i * 4 + j` as a IterMark
+   *
+   * \param expr the input IterSum.
+   * \return the IterSum after fused.
+   */
   std::optional<ir::IndexExpr> TryFuse(const ir::IndexExpr& expr);
+
+  /*!
+   * \brief TryFuseSameSource will simplify the IterSum by fusing IterSplits
+   * with same source. same source means the IterSplits have same IterMark.
+   *
+   * For example:
+   * expr:
+   *  IterSum(IterSplit(IterMark(f), lower = 4, ext = 8 scale = 4),
+   *          IterSplit(IterMark(f), lower = 1, ext = 4 scale = 1),
+   *          base = 0)                        // f /4 * 4 + f % 4
+   * ret:
+   *  IterSum(IterSplit(IterMark(f), scale = 1),
+   *          base = 0)                        // f
+   *
+   * \param expr the input IterSum
+   * \return the IterSum after fused.
+   */
   std::optional<ir::IndexExpr> TryFuseSameSource(const ir::IndexExpr& expr);
 
   std::unordered_map<std::string, ir::IndexExpr> var_map_;
@@ -125,5 +201,35 @@ class IterMapRewriter : public ir::IRMutator<> {
   common::SymbolicExprAnalyzer analyzer_;
 };
 
+class SimplifyBlockBinding : public ir::IRMutator<> {
+ public:
+  explicit SimplifyBlockBinding(const std::vector<ir::Var>& loop_var,
+                                const SymbolicExprAnalyzer& analyzer)
+      : loop_var_(loop_var), analyzer_(analyzer) {}
+
+  static void SimplifyBindings(ir::Expr expr,
+                               const std::vector<ir::Expr>& loop_srefs,
+                               const SymbolicExprAnalyzer& analyzer) {
+    std::vector<ir::Var> loop_var;
+    for (const ir::Expr& sref : loop_srefs) {
+      const ir::For* loop = sref.As<ir::For>();
+      loop_var.emplace_back(loop->loop_var);
+    }
+    SimplifyBlockBinding(loop_var, analyzer)(&expr);
+  }
+  void operator()(Expr* expr) { IRMutator::Visit(expr, expr); }
+
+ private:
+  void Visit(const ir::For* op, Expr* expr) override;
+
+  void Visit(const ir::ScheduleBlockRealize* op, Expr* expr) override;
+
+  std::vector<ir::Var> loop_var_;
+  common::SymbolicExprAnalyzer analyzer_;
+};
+
+void IterMapSimplify(std::vector<Expr>& indices,  // NOLINT
+                     const std::vector<cinn::ir::Var>& input_iters,
+                     const SymbolicExprAnalyzer& analyzer);
 }  // namespace common
 }  // namespace cinn

--- a/test/cpp/pir/cinn/adt/iter_simplify_test.cc
+++ b/test/cpp/pir/cinn/adt/iter_simplify_test.cc
@@ -17,6 +17,8 @@
 #include <gtest/gtest.h>
 #include "paddle/cinn/common/integer_set.h"
 #include "paddle/cinn/ir/op/ir_operators.h"
+#include "paddle/cinn/ir/schedule/ir_schedule.h"
+#include "paddle/cinn/ir/schedule/schedule_base.h"
 
 namespace cinn {
 namespace common {
@@ -431,5 +433,65 @@ TEST_F(TestIterSimplify, fuse_same_source) {
   TEST_EXPR(e6, gt3, i_j_k_fused % 8);
 }
 
+TEST_F(TestIterSimplify, SimplifyBindings) {
+  std::vector<ir::Var> block_vars;
+  std::vector<ir::Expr> iter_values;
+  std::vector<ir::Expr> shape = {Expr(2), Expr(4), Expr(8)};
+  std::vector<Var> axis_vars = cinn::common::GenDefaultAxis(3);
+
+  // Create block vars and axis vars
+  for (int i = 0; i < shape.size(); ++i) {
+    block_vars.push_back(ir::Var(Expr(0),
+                                 shape[i],
+                                 cinn::UniqName("b" + std::to_string(i)),
+                                 false,
+                                 false));
+    axis_vars[i]->is_reduce_axis = false;
+    iter_values.push_back(axis_vars[i]);
+  }
+
+  // Create ScheduleBlock body
+  ir::Expr body = ir::ScheduleBlockRealize::Make(
+      iter_values,
+      ir::ScheduleBlock::Make(block_vars, {}, {}, "Test", Expr(0)));
+
+  // Create For loops
+  for (int i = shape.size() - 1; i >= 0; --i) {
+    ir::Var loop_var = axis_vars[i];
+    ir::Expr loop_extent = shape[i];
+    body = ir::For::Make(loop_var,
+                         Expr(0),
+                         loop_extent,
+                         ir::ForType::Serial,
+                         ir::DeviceAPI::Host,
+                         ir::Block::Make({body}));
+  }
+
+  // Create ir schedule
+  ir::ModuleExpr mod_expr(std::vector<ir::Expr>({body}));
+  ir::IRSchedule ir_sch(mod_expr);
+  auto blocks = ir_sch.GetAllBlocks();
+  std::vector<ir::Expr> loops = ir_sch.GetLoops(blocks[0]);
+
+  // Apply Fuse and Split
+  ir::Expr loop_fuse = ir_sch.Fuse(loops);
+  std::vector<ir::Expr> loops_split = ir_sch.Split(loop_fuse, {2, 2, 16});
+  ir::Expr loop_fuse_2 = ir_sch.Fuse(loops_split);
+
+  // Apply SimplifyBindings
+  SimplifyBlockBinding::SimplifyBindings(loop_fuse_2, {}, analyzer);
+
+  // Check result
+  auto for_op = loop_fuse_2.As<ir::For>();
+  auto simplified_values = for_op->body.As<ir::Block>()
+                               ->stmts[0]
+                               .As<ir::ScheduleBlockRealize>()
+                               ->iter_values;
+  auto f = for_op->loop_var;
+
+  EXPECT_EQ(simplified_values[0], f / 32);
+  EXPECT_EQ(simplified_values[1], f % 32 / 8);
+  EXPECT_EQ(simplified_values[2], f % 8);
+}
 }  // namespace common
 }  // namespace cinn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
1. Add SimplifyBind func for IterExpr.
2. Change place of comment from source file to head file.

Pcard-67164