### PR TITLE
[Infra] Increase `test_sot_resnet` timeout on Windows

### DIFF
--- a/test/sot/CMakeLists.txt
+++ b/test/sot/CMakeLists.txt
@@ -12,4 +12,5 @@ endforeach()
 
 if(WIN32)
   set_tests_properties(test_sot_resnet50_backward PROPERTIES TIMEOUT 420)
+  set_tests_properties(test_sot_resnet PROPERTIES TIMEOUT 200)
 endif()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

增大 `test_sot_resnet` timeout，避免 Windows-OPENBLAS 流水线超时

PCard-66972