### PR TITLE
fix FLAGS_enable_pir_api when enable_new_ir

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -388,6 +388,8 @@ AnalysisPredictor::AnalysisPredictor(const AnalysisConfig &config)
   if (FLAGS_enable_pir_api) {
     config_.EnableNewExecutor(true);
     config_.EnableNewIR(true);
+  } else {
+    config_.EnableNewIR(false);
   }
   if (config_.new_executor_enabled()) {
     config_.EnableMemoryOptim(false);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-71500
Fixed the issue where the PIR Pass log is still printed when the high-priority FLAGS_enable_pir_api environment variable takes effect.