### PR TITLE
SlogDeterminant kernel support complex 易用性提升

### DIFF
--- a/paddle/phi/kernels/cpu/slogdeterminant_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/slogdeterminant_grad_kernel.cc
@@ -22,4 +22,6 @@ PD_REGISTER_KERNEL(slogdet_grad,
                    ALL_LAYOUT,
                    phi::SlogDeterminantGradKernel,
                    float,
-                   double) {}
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/cpu/slogdeterminant_kernel.cc
+++ b/paddle/phi/kernels/cpu/slogdeterminant_kernel.cc
@@ -17,5 +17,11 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/slogdeterminant_kernel_impl.h"
 
-PD_REGISTER_KERNEL(
-    slogdet, CPU, ALL_LAYOUT, phi::SlogDeterminantKernel, float, double) {}
+PD_REGISTER_KERNEL(slogdet,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::SlogDeterminantKernel,
+                   float,
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/gpu/slogdeterminant_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/slogdeterminant_grad_kernel.cu
@@ -22,4 +22,6 @@ PD_REGISTER_KERNEL(slogdet_grad,
                    ALL_LAYOUT,
                    phi::SlogDeterminantGradKernel,
                    float,
-                   double) {}
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/gpu/slogdeterminant_kernel.cu
+++ b/paddle/phi/kernels/gpu/slogdeterminant_kernel.cu
@@ -12,10 +12,241 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "glog/logging.h"
+
+#include "paddle/phi/common/complex.h"
+#include "paddle/phi/core/enforce.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/kernels/determinant_kernel.h"
+#include "paddle/phi/kernels/funcs/blas/blas.h"
+#include "paddle/phi/kernels/impl/determinant_kernel_impl.h"
 #include "paddle/phi/kernels/slogdeterminant_kernel.h"
 
-#include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/impl/slogdeterminant_kernel_impl.h"
+namespace phi {
 
-PD_REGISTER_KERNEL(
-    slogdet, GPU, ALL_LAYOUT, phi::SlogDeterminantKernel, float, double) {}
+// T is not complex
+template <typename T>
+T sign(T val) {
+  return static_cast<T>(T(0) < val) - (val < T(0));
+}
+
+// T is complex
+template <typename T>
+T sign(T det, T modulus) {
+  return det / modulus;
+}
+
+template <typename T, typename Context>
+struct SlogDeterminantFunctor {
+  void operator()(const Context& dev_ctx,
+                  const DenseTensor& input,
+                  int64_t rank,
+                  int64_t batch_count,
+                  DenseTensor* output) {
+    std::vector<T> input_vec;
+    std::vector<T> sign_vec;
+    std::vector<T> log_vec;
+    std::vector<T> output_vec;
+    phi::TensorToVector(input, dev_ctx, &input_vec);
+    for (int64_t i = 0; i < batch_count; ++i) {  // maybe can be parallel
+      auto begin_iter = input_vec.begin() + i * rank * rank;
+      auto end_iter = input_vec.begin() + (i + 1) * rank * rank;
+      std::vector<T> sub_vec(begin_iter,
+                             end_iter);  // get every square matrix data
+      typename detail::EigenMatrix<T>::MatrixType matrix(rank, rank);
+      for (int64_t i = 0; i < rank; ++i) {
+        for (int64_t j = 0; j < rank; ++j) {
+          matrix(i, j) = sub_vec[rank * i + j];
+        }
+      }
+      VLOG(2) << "det value: " << matrix.determinant();
+      VLOG(2) << "matrix val: " << matrix;
+      auto det_val = matrix.determinant();
+      sign_vec.push_back(sign(det_val));
+      det_val >= 0
+          ? log_vec.push_back(std::log(det_val))
+          : log_vec.push_back(std::log(std::abs(
+                det_val)));  // for computing log value of a negative value.
+    }
+    // merge sign_vec and log_vec as final output_vec
+    output_vec.insert(output_vec.end(), sign_vec.begin(), sign_vec.end());
+    output_vec.insert(output_vec.end(), log_vec.begin(), log_vec.end());
+    phi::TensorFromVector(output_vec, dev_ctx, output);
+  }
+};
+
+template <typename T>
+__global__ void GetSlogDetFromLUComplex(const T* lu_data,
+                                        const int* ipiv,
+                                        int64_t n,
+                                        int64_t batch_size,
+                                        T* out_data) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (idx < batch_size) {
+    int offset_lu = idx * n * n;
+    int offset_ipiv = idx * n;
+    T det_val = T(1.0, 0.0);
+    T negative = T(-1.0, 0.0);
+    for (int i = 0; i < n; ++i) {
+      det_val *= lu_data[offset_lu + i * n + i];
+      if (ipiv[offset_ipiv + i] != i + 1) {
+        det_val *= negative;
+      }
+    }
+    T abs_det = static_cast<T>(abs(det_val));
+    T sign = det_val / abs_det;
+    T log_abs_det = log(abs_det);
+    out_data[idx] = sign;
+    out_data[idx + batch_size] = log_abs_det;
+  }
+}
+
+template <typename T, typename Context>
+struct SlogDeterminantFunctor<phi::dtype::complex<T>, Context> {
+  void operator()(const Context& dev_ctx,
+                  const DenseTensor& input,
+                  int64_t rank,
+                  int64_t batch_count,
+                  DenseTensor* output) {
+#ifndef PADDLE_WITH_HIP
+    phi::Allocator::AllocationPtr tmp_gpu_mat_data;
+    const phi::dtype::complex<T>* gpu_mat =
+        input.data<phi::dtype::complex<T>>();
+    // Copy all elements of input matrix A to a temporary memory space to
+    // avoid being overriden by getrf.
+    tmp_gpu_mat_data = phi::memory_utils::Alloc(
+        dev_ctx.GetPlace(),
+        input.numel() * sizeof(phi::dtype::complex<T>),
+        phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
+    memory_utils::Copy(dev_ctx.GetPlace(),
+                       tmp_gpu_mat_data->ptr(),
+                       dev_ctx.GetPlace(),
+                       input.data(),
+                       input.numel() * sizeof(phi::dtype::complex<T>),
+                       dev_ctx.stream());
+    gpu_mat = reinterpret_cast<const phi::dtype::complex<T>*>(
+        tmp_gpu_mat_data->ptr());
+
+    std::vector<const phi::dtype::complex<T>*> cpu_ptrs(batch_count);
+    for (int i = 0; i < batch_count; ++i) {
+      cpu_ptrs[i] = gpu_mat + i * rank * rank;
+    }
+
+    // num_ints is for pivot (rank * batch_count) and info (batch_count)
+    int num_ints = batch_count * (rank + 1);
+    size_t total_bytes =
+        batch_count * sizeof(phi::dtype::complex<T>*) + num_ints * sizeof(int);
+    phi::Allocator::AllocationPtr tmp_gpu_ptrs_data = phi::memory_utils::Alloc(
+        dev_ctx.GetPlace(),
+        total_bytes,
+        phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
+    memory_utils::Copy(dev_ctx.GetPlace(),
+                       tmp_gpu_ptrs_data->ptr(),
+                       phi::CPUPlace(),
+                       static_cast<void*>(cpu_ptrs.data()),
+                       cpu_ptrs.size() * sizeof(phi::dtype::complex<T>*),
+                       dev_ctx.stream());
+
+    phi::dtype::complex<T>** gpu_mat_ptr =
+        reinterpret_cast<phi::dtype::complex<T>**>(tmp_gpu_ptrs_data->ptr());
+    int* gpu_info_ptr = reinterpret_cast<int*>(gpu_mat_ptr + cpu_ptrs.size());
+    int* pivot_data = gpu_info_ptr + batch_count;
+
+    auto blas = phi::funcs::GetBlas<Context, phi::dtype::complex<T>>(dev_ctx);
+    // This function performs the LU factorization of each matrix A by the
+    // equation P * A = L * U. L and U are written back to original matrix A,
+    // and diagonal elements of L are discarded.
+    blas.BatchedGETRF(rank, gpu_mat_ptr, pivot_data, gpu_info_ptr, batch_count);
+    phi::dtype::complex<T>* out_data =
+        dev_ctx.template Alloc<phi::dtype::complex<T>>(output);
+    int block_size = std::min(256, dev_ctx.GetMaxThreadsPerBlock());
+    dim3 dim_block(block_size);
+    dim3 num_blocks((batch_count + block_size - 1) / block_size);
+    GetSlogDetFromLUComplex<phi::dtype::complex<T>><<<num_blocks, dim_block>>>(
+        gpu_mat, pivot_data, rank, batch_count, out_data);
+#else
+    using MatrixType =
+        Eigen::Matrix<std::complex<T>, Eigen::Dynamic, Eigen::Dynamic>;
+    std::vector<phi::dtype::complex<T>> input_vec;
+    std::vector<phi::dtype::complex<T>> sign_vec;
+    std::vector<phi::dtype::complex<T>> log_vec;
+    std::vector<phi::dtype::complex<T>> output_vec;
+    phi::TensorToVector(input, dev_ctx, &input_vec);
+    for (int64_t i = 0; i < batch_count; ++i) {  // maybe can be parallel
+      auto begin_iter = input_vec.begin() + i * rank * rank;
+      auto end_iter = input_vec.begin() + (i + 1) * rank * rank;
+      std::vector<phi::dtype::complex<T>> sub_vec(
+          begin_iter,
+          end_iter);  // get every square matrix data
+      MatrixType matrix(rank, rank);
+      for (int64_t i = 0; i < rank; ++i) {
+        for (int64_t j = 0; j < rank; ++j) {
+          matrix(i, j) = static_cast<std::complex<T>>(sub_vec[rank * i + j]);
+        }
+      }
+      VLOG(2) << "det value: " << matrix.determinant();
+      VLOG(2) << "matrix val: " << matrix;
+      std::complex<T> det_val = matrix.determinant();
+      T abs_det_val = std::abs(det_val);
+      sign_vec.push_back(static_cast<phi::dtype::complex<T>>(
+          sign(det_val, static_cast<std::complex<T>>(abs_det_val))));
+      log_vec.push_back(
+          static_cast<phi::dtype::complex<T>>(std::log(abs_det_val)));
+    }
+    // merge sign_vec and log_vec as final output_vec
+    output_vec.insert(output_vec.end(), sign_vec.begin(), sign_vec.end());
+    output_vec.insert(output_vec.end(), log_vec.begin(), log_vec.end());
+    phi::TensorFromVector(output_vec, dev_ctx, output);
+#endif
+  }
+};
+
+template <typename T, typename Context>
+void SlogDeterminantKernel(const Context& dev_ctx,
+                           const DenseTensor& x,
+                           DenseTensor* out) {
+  auto input_dim = common::vectorize(x.dims());
+  auto input_dim_size = input_dim.size();
+
+  auto batch_count = detail::GetBatchCount(x.dims());
+  VLOG(2) << "input dim:" << x.dims();
+  PADDLE_ENFORCE_GE(
+      input_dim_size,
+      2,
+      errors::InvalidArgument(
+          "the input matrix dimension size should greater than 2."));
+  PADDLE_ENFORCE_EQ(
+      input_dim[input_dim_size - 1],
+      input_dim[input_dim_size - 2],
+      errors::InvalidArgument("the input matrix should be square matrix."));
+  auto rank = input_dim[input_dim_size - 1];  // square matrix length
+  SlogDeterminantFunctor<T, Context>()(dev_ctx, x, rank, batch_count, out);
+  std::vector<int> output_dim_vec(input_dim.begin(), input_dim.end() - 2);
+  if (input_dim.size() == static_cast<size_t>(2)) {
+    // when input is a two-dimension matrix, The det value is a number.
+    output_dim_vec = {};
+  }
+  output_dim_vec.insert(output_dim_vec.begin(),
+                        2);  // make the output dims as same as numpy
+  auto output_dims = common::make_ddim(output_dim_vec);
+  out->Resize(output_dims);
+  VLOG(2) << "output dim:" << out->dims();
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(slogdet,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::SlogDeterminantKernel,
+                   float,
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2774,9 +2774,13 @@ def slogdet(x: Tensor, name: str | None = None) -> Tensor:
     Calculates the sign and natural logarithm of the absolute value of a square matrix's or batches square matrices' determinant.
     The determinant can be computed with ``sign * exp`` (logabsdet).
 
-    Supports input of float, double.
+    Supports input of float, double, complex64, complex128.
 
-    Note that for matrices that have zero determinant, this returns ``(0, -inf)``.
+    Notes:
+        1. For matrices that have zero determinant, this returns ``(0, -inf)``.
+
+        2. For matrices with complex value, the :math:`abs(det)` is the modulus of the determinant,
+        and therefore :math:`sign = det / abs(det)`.
 
     Args:
         x (Tensor): the batch of matrices of size :math:`(*, n, n)`
@@ -2786,7 +2790,8 @@ def slogdet(x: Tensor, name: str | None = None) -> Tensor:
 
     Returns:
         y (Tensor), A tensor containing the sign of the determinant and the natural logarithm
-        of the absolute value of determinant, respectively.
+        of the absolute value of determinant, respectively. The output shape is :math:`(2, *)`,
+        where math:`*` is one or more batch dimensions of the input `x`.
 
     Examples:
         .. code-block:: python
@@ -2804,7 +2809,12 @@ def slogdet(x: Tensor, name: str | None = None) -> Tensor:
     if in_dynamic_or_pir_mode():
         return _C_ops.slogdet(x)
     else:
-        check_dtype(x.dtype, 'Input', ['float32', 'float64'], 'slogdet')
+        check_dtype(
+            x.dtype,
+            'Input',
+            ['float32', 'float64', 'complex64', 'complex128'],
+            'slogdet',
+        )
 
         input_shape = list(x.shape)
         assert len(input_shape) >= 2, (

--- a/test/legacy_test/test_determinant_op.py
+++ b/test/legacy_test/test_determinant_op.py
@@ -166,7 +166,43 @@ class TestDeterminantAPI(unittest.TestCase):
         paddle.enable_static()
 
 
-class TestDeterminantAPIComplex(TestDeterminantAPI):
+def determinant_complex_numeric_grad_single_batch(
+    x, n, delta=0.005, det_out_grad=np.array(1 + 0j)
+):
+    # an naive implementation of numeric_grad with single batch input x
+    # the output of det for complex matrix is always complex, so det_out_grad
+    # should be a+bj, where a and b are arbitrary real numbers
+    dx = []
+    for i in range(n):
+        for j in range(n):
+            xp = x.copy()
+            xn = x.copy()
+            xpj = x.copy()
+            xnj = x.copy()
+            xp[i, j] += delta
+            xn[i, j] -= delta
+            xpj[i, j] += delta * 1j
+            xnj[i, j] -= delta * 1j
+            yp = np.linalg.det(xp)
+            yn = np.linalg.det(xn)
+            ypj = np.linalg.det(xpj)
+            ynj = np.linalg.det(xnj)
+            df_over_dr = (yp - yn) / delta / 2
+            df_over_di = (ypj - ynj) / delta / 2
+            dl_over_du, dl_over_dv = det_out_grad.real, det_out_grad.imag
+            du_over_dr, dv_over_dr = df_over_dr.real, df_over_dr.imag
+            du_over_di, dv_over_di = df_over_di.real, df_over_di.imag
+            dl_over_dr = np.sum(
+                dl_over_du * du_over_dr + dl_over_dv * dv_over_dr
+            )
+            dl_over_di = np.sum(
+                dl_over_du * du_over_di + dl_over_dv * dv_over_di
+            )
+            dx.append(dl_over_dr + 1j * dl_over_di)
+    return np.array(dx).reshape([n, n])
+
+
+class TestDeterminantAPIComplex(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
         self.dtype = np.complex64
@@ -175,9 +211,71 @@ class TestDeterminantAPIComplex(TestDeterminantAPI):
             np.random.random(self.shape), np.random.random(self.shape)
         ).astype(self.dtype)
         self.place = paddle.CPUPlace()
+        self.out_grad = (
+            np.array([1 - 0.5j] * 2 * 1 * 4 * 3)
+            .reshape(2, 1, 4, 3)
+            .astype(self.dtype)
+        )
+        self.x_grad_ref_dy = self.get_numeric_grad(
+            self.x, self.shape, self.out_grad
+        )
+        self.x_grad_ref_st = self.get_numeric_grad(self.x, self.shape)
+
+    def get_numeric_grad(self, x, shape, out_grad=None):
+        n = shape[-1]
+        flatten_x = x.reshape([-1, n, n])
+        n_batch = flatten_x.shape[0]
+        grad = []
+        if out_grad is None:
+            for b in range(n_batch):
+                grad.append(
+                    determinant_complex_numeric_grad_single_batch(
+                        flatten_x[b], n
+                    )
+                )
+        else:
+            flatten_grad = out_grad.reshape([-1])
+            for b in range(n_batch):
+                grad.append(
+                    determinant_complex_numeric_grad_single_batch(
+                        flatten_x[b], n, det_out_grad=flatten_grad[b]
+                    )
+                )
+        return np.array(grad).reshape(shape)
+
+    def test_api_static(self):
+        paddle.enable_static()
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.static.data('X', self.shape, dtype=self.dtype)
+            x.stop_gradient = False
+            out_value = paddle.linalg.det(x)
+            x_grad = paddle.static.gradients([out_value], x)
+            exe = paddle.static.Executor(self.place)
+            (out_np, x_grad_np) = exe.run(
+                feed={'X': self.x}, fetch_list=[out_value, x_grad]
+            )
+        out_ref = np.linalg.det(self.x)
+
+        np.testing.assert_allclose(out_np, out_ref, rtol=0.001)
+        self.assertEqual(out_np.shape, out_ref.shape)
+        self.assertEqual(tuple(out_value.shape), out_ref.shape)
+        np.testing.assert_allclose(x_grad_np, self.x_grad_ref_st, rtol=0.001)
+
+    def test_api_dygraph(self):
+        paddle.disable_static(self.place)
+        x_tensor = paddle.to_tensor(self.x)
+        x_tensor.stop_gradient = False
+        out = paddle.linalg.det(x_tensor)
+        out.backward(paddle.to_tensor(self.out_grad))
+        out_ref = np.linalg.det(self.x)
+        np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.001)
+        np.testing.assert_allclose(
+            x_tensor.grad.numpy(), self.x_grad_ref_dy, rtol=0.001
+        )
+        paddle.enable_static()
 
 
-class TestDeterminantAPIComplex2(TestDeterminantAPI):
+class TestDeterminantAPIComplex2(TestDeterminantAPIComplex):
     def setUp(self):
         np.random.seed(0)
         self.dtype = np.complex128
@@ -186,6 +284,13 @@ class TestDeterminantAPIComplex2(TestDeterminantAPI):
             np.random.random(self.shape), np.random.random(self.shape)
         ).astype(self.dtype)
         self.place = paddle.CPUPlace()
+        self.out_grad = (
+            np.array([0.5 + 1.2j] * 3 * 3).reshape(3, 3).astype(self.dtype)
+        )
+        self.x_grad_ref_dy = self.get_numeric_grad(
+            self.x, self.shape, self.out_grad
+        )
+        self.x_grad_ref_st = self.get_numeric_grad(self.x, self.shape)
 
 
 class TestSlogDeterminantOp(OpTest):
@@ -244,6 +349,135 @@ class TestSlogDeterminantAPI(unittest.TestCase):
         out_ref = np.array(np.linalg.slogdet(self.x))
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.001)
         paddle.enable_static()
+
+
+def slogdeterminant_complex_numeric_grad_single_batch(
+    x, n, delta=0.005, logabsdet_out_grad=np.array(1 + 0j)
+):
+    # an naive implementation of numeric_grad with single batch input x
+    # the output of logabsdet is always real, so logabsdet_out_grad
+    # should be a+0j, where a is an arbitrary real number
+    dx = []
+    for i in range(n):
+        for j in range(n):
+            xp = x.copy()
+            xn = x.copy()
+            xpj = x.copy()
+            xnj = x.copy()
+            xp[i, j] += delta
+            xn[i, j] -= delta
+            xpj[i, j] += delta * 1j
+            xnj[i, j] -= delta * 1j
+            _, yp = np.linalg.slogdet(xp)
+            _, yn = np.linalg.slogdet(xn)
+            _, ypj = np.linalg.slogdet(xpj)
+            _, ynj = np.linalg.slogdet(xnj)
+            df_over_dr = (yp - yn) / delta / 2
+            df_over_di = (ypj - ynj) / delta / 2
+            dl_over_du, dl_over_dv = (
+                logabsdet_out_grad.real,
+                logabsdet_out_grad.imag,
+            )
+            du_over_dr, dv_over_dr = df_over_dr.real, df_over_dr.imag
+            du_over_di, dv_over_di = df_over_di.real, df_over_di.imag
+            dl_over_dr = np.sum(
+                dl_over_du * du_over_dr + dl_over_dv * dv_over_dr
+            )
+            dl_over_di = np.sum(
+                dl_over_du * du_over_di + dl_over_dv * dv_over_di
+            )
+            dx.append(dl_over_dr + 1j * dl_over_di)
+    return np.array(dx).reshape([n, n])
+
+
+class TestSlogDeterminantAPIComplex(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(0)
+        self.shape = [3, 3, 5, 5]
+        self.dtype = np.complex64
+        self.x = np.vectorize(complex)(
+            np.random.random(self.shape), np.random.random(self.shape)
+        ).astype(self.dtype)
+        self.places = [paddle.CPUPlace()]
+        if paddle.base.core.is_compiled_with_cuda():
+            self.places.append(paddle.CUDAPlace(0))
+        self.out_grad = (
+            np.array([1 + 0j, 1 + 0j] * 3 * 3)
+            .reshape(2, 3, 3)
+            .astype(self.dtype)
+        )
+        self.x_grad_ref_dy = self.get_numeric_grad(
+            self.x, self.shape, self.out_grad
+        )
+        self.x_grad_ref_st = self.get_numeric_grad(self.x, self.shape)
+
+    def get_numeric_grad(self, x, shape, out_grad=None):
+        n = shape[-1]
+        flatten_x = x.reshape([-1, n, n])
+        n_batch = flatten_x.shape[0]
+        grad = []
+        if out_grad is None:
+            for b in range(n_batch):
+                grad.append(
+                    slogdeterminant_complex_numeric_grad_single_batch(
+                        flatten_x[b], n
+                    )
+                )
+        else:
+            flatten_grad = out_grad.reshape([-1, 2])
+            for b in range(n_batch):
+                grad.append(
+                    slogdeterminant_complex_numeric_grad_single_batch(
+                        flatten_x[b], n, logabsdet_out_grad=flatten_grad[b][1]
+                    )
+                )
+        return np.array(grad).reshape(shape)
+
+    def test_api_static(self):
+        for place in self.places:
+            paddle.enable_static()
+            with paddle.static.program_guard(paddle.static.Program()):
+                x = paddle.static.data('X', self.shape, self.dtype)
+                x.stop_gradient = False
+                out = paddle.linalg.slogdet(x)
+                x_grad = paddle.static.gradients(out, x)
+                exe = paddle.static.Executor(place)
+                res = exe.run(feed={'X': self.x}, fetch_list=[out, x_grad])
+            out_ref = np.array(np.linalg.slogdet(self.x))
+            np.testing.assert_allclose(res[0], out_ref, rtol=0.001)
+            np.testing.assert_allclose(res[1], self.x_grad_ref_st, rtol=0.001)
+
+    def test_api_dygraph(self):
+        for place in self.places:
+            paddle.disable_static(place)
+            x_tensor = paddle.to_tensor(self.x)
+            x_tensor.stop_gradient = False
+            out = paddle.linalg.slogdet(x_tensor)
+            out.backward(paddle.to_tensor(self.out_grad))
+            out_ref = np.array(np.linalg.slogdet(self.x))
+            np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.001)
+            np.testing.assert_allclose(
+                x_tensor.grad.numpy(), self.x_grad_ref_dy, rtol=0.001
+            )
+            paddle.enable_static()
+
+
+class TestSlogDeterminantAPIComplex2(TestSlogDeterminantAPIComplex):
+    def setUp(self):
+        np.random.seed(0)
+        self.shape = [6, 5, 5]
+        self.dtype = np.complex128
+        self.x = np.vectorize(complex)(
+            np.random.random(self.shape), np.random.random(self.shape)
+        ).astype(self.dtype)
+        self.places = [paddle.CPUPlace()]
+        if paddle.base.core.is_compiled_with_cuda():
+            self.places.append(paddle.CUDAPlace(0))
+        self.out_grad = np.array([3 + 0j, 3 + 0j] * 6).reshape(2, 6)
+        self.x_grad_ref_dy = self.get_numeric_grad(
+            self.x, self.shape, self.out_grad
+        )
+        self.x_grad_ref_st = self.get_numeric_grad(self.x, self.shape)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
SlogDeterminant kernel 支持complex64/complex128
修改方法与 https://github.com/PaddlePaddle/Paddle/pull/68390 相同，因为 slogdeterminant_grad_kernel 中的计算本身支持复数，所以不需要修改。

另外根据 slogdeterminant_grad_kernel 的计算推导结果重新修复了 determinant_grad ，并测试了 out_grad 不是 1+0j 而是任意复数的情况。