### PR TITLE
add pd_op.min converter for PIR TRT and Add ReduceCommonOpPattern

### DIFF
--- a/python/paddle/tensorrt/impls/math.py
+++ b/python/paddle/tensorrt/impls/math.py
@@ -118,3 +118,28 @@ def multiply_converter(network, paddle_op, inputs):
     return add_elementwise_layer(
         network, paddle_op, inputs, trt.ElementWiseOperation.PROD
     )
+
+
+@converter_registry.register("pd_op.min", trt_version="8.x")
+def min_converter(network, paddle_op, inputs):
+    input_tensor = inputs[0]
+    axis = paddle_op.operands()[1].source().get_defining_op().attrs()["value"]
+    input_shape = paddle_op.operands()[0].source().shape
+    keepdim = paddle_op.attrs()["keepdim"]
+    if network.has_implicit_batch_dimension:
+        assert (
+            axis != 0
+        ), "can't reduce on axis == 0 when network has implicit batch dimension"
+    output_shape = []
+    if len(axis) == 0:
+        axis = list(range(len(input_shape)))
+    for i in range(len(axis)):
+        if axis[i] < 0:
+            axis[i] = len(input_shape) + axis[i]
+    layer = network.add_reduce(
+        input_tensor,
+        trt.ReduceOperation.MIN,
+        axes=get_axes_for_reduce_op(axis),
+        keep_dims=keepdim,
+    )
+    return layer.get_output(0)

--- a/test/tensorrt/test_converter_math.py
+++ b/test/tensorrt/test_converter_math.py
@@ -24,14 +24,12 @@ class TestMaxTRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.max
         self.api_args = {
-            "x": np.array([[0.2, 0.3, 0.5, 0.9], [0.1, 0.2, 0.6, 0.7]]).astype(
-                "float32"
-            ),
+            "x": np.random.randn(2, 4).astype(np.float32),
             "axis": [0, 1],
         }
         self.program_config = {"feed_list": ["x"]}
-        self.min_shape = {"x": [1, 4], "y": [1, 4]}
-        self.max_shape = {"x": [5, 4], "y": [5, 4]}
+        self.min_shape = {"x": [1, 4]}
+        self.max_shape = {"x": [5, 4]}
 
     def test_trt_result(self):
         self.check_trt_result()
@@ -92,6 +90,21 @@ class TestAddTRTPattern(TensorRTBaseTest):
         self.program_config = {"feed_list": ["x", "y"]}
         self.min_shape = {"x": [1, 3], "y": [1, 3]}
         self.max_shape = {"x": [5, 3], "y": [5, 3]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
+class TestMinTRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.min
+        self.api_args = {
+            "x": np.random.randn(2, 4).astype(np.float32),
+            "axis": [0, 1],
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1, 4]}
+        self.max_shape = {"x": [5, 4]}
 
     def test_trt_result(self):
         self.check_trt_result()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
pcard-71500
add pd_op.min converter for PIR TRT and Add ReduceCommonOpPattern base class to simplify code