### PR TITLE
set sharding degree and sharding mesh axis in auto parallel fix shard_optimizer bug

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1050,6 +1050,10 @@ class _ShardOptimizer(Optimizer):
         ):
             self._sharding_degree = self._shard_fn._mesh.get_dim_size(0)
             self._sharding_mesh_axis = 0
+        elif (self._shard_fn._mesh is not None) and (
+            'dp' in self._shard_fn._mesh.dim_names
+        ):
+            self._sharding_degree = self._shard_fn._mesh.get_dim_size('dp')
         else:
             param_list = self._inner_opt._parameter_list
             for param in param_list:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
修复混合自动并行下sharding_degree和sharding mesh axis的设置