### PR TITLE
fix setitem grad bug

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1899,6 +1899,7 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
         if (require_any_grad) {
           paddle::Tensor transback_sub_tensor =
               transpose_ad_func(transed_sub_tensor, trans_back_dim);
+
           const auto& values_tmp =
               (require_any_grad && transback_sub_tensor.is_dense_tensor() &&
                !std::dynamic_pointer_cast<phi::DenseTensor>(
@@ -1913,7 +1914,10 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
                         transback_sub_tensor.mutable_autograd_meta(),
                         transback_sub_tensor.name())
                   : transback_sub_tensor;
-
+          if (!x_autograd_meta) {
+            VLOG(3) << "x_autograd_meta is null and requires_any_grad is true";
+            x_autograd_meta = egr::EagerUtils::autograd_meta(&self->tensor);
+          }
           grad_node = std::shared_ptr<SetValueWithTensorGradNode>(
               new SetValueWithTensorGradNode(1, 2));  // NOLINT
           grad_node->SetAttribute_starts(slice_starts);
@@ -1933,11 +1937,10 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
           // SetGradOutMeta & SetEdges
           grad_node->SetGradOutMeta(self->tensor, 0);
           grad_node->SetGradOutMeta(transback_sub_tensor, 1);
-          if (x_autograd_meta) {
-            egr::EagerUtils::SetOutRankWithSlot(x_autograd_meta, 0);
-            egr::EagerUtils::SetHistory(x_autograd_meta, grad_node);
-          }
           grad_node->SetGradInMeta(self->tensor, 0);
+
+          egr::EagerUtils::SetOutRankWithSlot(x_autograd_meta, 0);
+          egr::EagerUtils::SetHistory(x_autograd_meta, grad_node);
         }
       } else {
         self->tensor.set_autograd_meta(

--- a/test/indexing/test_setitem.py
+++ b/test/indexing/test_setitem.py
@@ -316,7 +316,8 @@ class TestSetitemInDygraph(unittest.TestCase):
             x = paddle.cast(x, dtype='float32')
         np.testing.assert_allclose(x.numpy(), np_data)
 
-    def test_inplace_with_stride(self):
+    def test_inplace_with_stride_bwd_1(self):
+        # combined-setitem case for X with stop_graident=False
         np_v = np.random.randn(3, 1).astype(self.ndtype)
         if self.dtype == 'bfloat16':
             np_v = convert_uint16_to_float(convert_float_to_uint16(np_v))
@@ -336,6 +337,166 @@ class TestSetitemInDygraph(unittest.TestCase):
         loss.backward()
 
         expected_v_grad = np.ones((3, 1)) * 5.0
+        if self.dtype == 'bfloat16':
+            np.testing.assert_allclose(
+                v.grad.cast('float32').numpy(), expected_v_grad
+            )
+        elif self.dtype == 'bool':
+            np.testing.assert_equal(
+                v.grad.numpy(), expected_v_grad.astype('bool')
+            )
+        else:
+            np.testing.assert_equal(v.grad.numpy(), expected_v_grad)
+
+    def test_inplace_with_stride_bwd_2(self):
+        # combined-setitem case for X with stop_graident=True
+        np_v = np.random.randn(3, 1).astype(self.ndtype)
+        if self.dtype == 'bfloat16':
+            np_v = convert_uint16_to_float(convert_float_to_uint16(np_v))
+        if self.dtype == 'complex64' or self.dtype == 'complex128':
+            np_v = np_v + 1j * np_v
+        v = paddle.to_tensor(np_v, dtype=self.dtype)
+        v.stop_gradient = False
+        vv = v
+
+        zero = paddle.randn((3, 3, 5))
+        zero.stop_gradient = False
+
+        zero1 = paddle.zeros_like(zero)
+        zero1[1, paddle.to_tensor([2, 0, 1])] = vv
+
+        loss = zero1.sum()
+        loss.backward()
+
+        expected_v_grad = np.ones((3, 1)) * 5.0
+        if self.dtype == 'bfloat16':
+            np.testing.assert_allclose(
+                v.grad.cast('float32').numpy(), expected_v_grad
+            )
+        elif self.dtype == 'bool':
+            np.testing.assert_equal(
+                v.grad.numpy(), expected_v_grad.astype('bool')
+            )
+        else:
+            np.testing.assert_equal(v.grad.numpy(), expected_v_grad)
+
+    def test_inplace_with_stride_bwd_3(self):
+        # advanced-setitem case for X with stop_graident=False
+        np_v = np.random.randn(3, 3, 1).astype(self.ndtype)
+        if self.dtype == 'bfloat16':
+            np_v = convert_uint16_to_float(convert_float_to_uint16(np_v))
+        if self.dtype == 'complex64' or self.dtype == 'complex128':
+            np_v = np_v + 1j * np_v
+        v = paddle.to_tensor(np_v, dtype=self.dtype)
+        v.stop_gradient = False
+        vv = v
+
+        zero = paddle.randn((3, 3, 5))
+        zero.stop_gradient = False
+
+        zero1 = zero * 1
+        zero1[paddle.to_tensor([2, 0, 1])] = vv
+
+        loss = zero1.sum()
+        loss.backward()
+
+        expected_v_grad = np.ones((3, 3, 1)) * 5.0
+        if self.dtype == 'bfloat16':
+            np.testing.assert_allclose(
+                v.grad.cast('float32').numpy(), expected_v_grad
+            )
+        elif self.dtype == 'bool':
+            np.testing.assert_equal(
+                v.grad.numpy(), expected_v_grad.astype('bool')
+            )
+        else:
+            np.testing.assert_equal(v.grad.numpy(), expected_v_grad)
+
+    def test_inplace_with_stride_bwd_4(self):
+        # advanced-setitem case for X with stop_graident=True
+        np_v = np.random.randn(3, 3, 1).astype(self.ndtype)
+        if self.dtype == 'bfloat16':
+            np_v = convert_uint16_to_float(convert_float_to_uint16(np_v))
+        if self.dtype == 'complex64' or self.dtype == 'complex128':
+            np_v = np_v + 1j * np_v
+        v = paddle.to_tensor(np_v, dtype=self.dtype)
+        v.stop_gradient = False
+        vv = v
+
+        zero = paddle.randn((3, 3, 5))
+        zero.stop_gradient = False
+
+        zero1 = paddle.zeros_like(zero)
+        zero1[paddle.to_tensor([2, 0, 1])] = vv
+
+        loss = zero1.sum()
+        loss.backward()
+
+        expected_v_grad = np.ones((3, 3, 1)) * 5.0
+        if self.dtype == 'bfloat16':
+            np.testing.assert_allclose(
+                v.grad.cast('float32').numpy(), expected_v_grad
+            )
+        elif self.dtype == 'bool':
+            np.testing.assert_equal(
+                v.grad.numpy(), expected_v_grad.astype('bool')
+            )
+        else:
+            np.testing.assert_equal(v.grad.numpy(), expected_v_grad)
+
+    def test_basic_setitem_bwd_1(self):
+        # basic-setitem case for X with stop_graident=False
+        np_v = np.random.randn(5).astype(self.ndtype)
+        if self.dtype == 'bfloat16':
+            np_v = convert_uint16_to_float(convert_float_to_uint16(np_v))
+        if self.dtype == 'complex64' or self.dtype == 'complex128':
+            np_v = np_v + 1j * np_v
+        v = paddle.to_tensor(np_v, dtype=self.dtype)
+        v.stop_gradient = False
+        vv = v
+
+        zero = paddle.randn((3, 3, 5))
+        zero.stop_gradient = False
+
+        zero1 = zero * 1
+        zero1[2, 1:3, :] = vv
+
+        loss = zero1.sum()
+        loss.backward()
+
+        expected_v_grad = np.ones((5,)) * 2.0
+        if self.dtype == 'bfloat16':
+            np.testing.assert_allclose(
+                v.grad.cast('float32').numpy(), expected_v_grad
+            )
+        elif self.dtype == 'bool':
+            np.testing.assert_equal(
+                v.grad.numpy(), expected_v_grad.astype('bool')
+            )
+        else:
+            np.testing.assert_equal(v.grad.numpy(), expected_v_grad)
+
+    def test_basic_setitem_bwd_2(self):
+        # basic-setitem case for X with stop_graident=True
+        np_v = np.random.randn(5).astype(self.ndtype)
+        if self.dtype == 'bfloat16':
+            np_v = convert_uint16_to_float(convert_float_to_uint16(np_v))
+        if self.dtype == 'complex64' or self.dtype == 'complex128':
+            np_v = np_v + 1j * np_v
+        v = paddle.to_tensor(np_v, dtype=self.dtype)
+        v.stop_gradient = False
+        vv = v
+
+        zero = paddle.randn((3, 3, 5))
+        zero.stop_gradient = False
+
+        zero1 = paddle.zeros_like(zero)
+        zero1[2, 1:3, :] = vv
+
+        loss = zero1.sum()
+        loss.backward()
+
+        expected_v_grad = np.ones((5,)) * 2.0
         if self.dtype == 'bfloat16':
             np.testing.assert_allclose(
                 v.grad.cast('float32').numpy(), expected_v_grad


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
This PR is similar to https://github.com/PaddlePaddle/Paddle/pull/68520 ;  For advanced / combined setitem, if input Tensor's `stop_gradient=True`, the values grad will be lossed.

**Advanced setitem** case has been fixed at https://github.com/PaddlePaddle/Paddle/pull/65881
This PR is to
1. fix **Combined setitem** mentioned above
2. add unittests  for **input.stop_gradient=True/False** in basic/advanced/combined setitem .

Pcard-67164