### PR TITLE
【GCU】modify concat infermeta

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -1247,7 +1247,7 @@ void ConcatInferMeta(const std::vector<const MetaTensor*>& x,
                     common::errors::InvalidArgument(
                         "The size of input meta vector should be greater"
                         "than 0."));
-  if (axis_scalar.FromTensor()) {
+  if (axis_scalar.FromTensor() && !config.is_runtime) {
     auto out_dims =
         common::make_ddim(std::vector<int>(x.at(0)->dims().size(), -1));
     out->set_dims(out_dims);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164

concat infer Meta当axis 是tensor的时候，应该在执行期跳过-1的shape 处理，采用下面的推导逻辑