### PR TITLE
[Prim][PIR] Change `tile_grad` implementation

### DIFF
--- a/test/legacy_test/test_tile_op.py
+++ b/test/legacy_test/test_tile_op.py
@@ -159,6 +159,24 @@ class TestTileOpRank4(TestTileOpRank1):
         )
 
 
+class TestTileOpRank5(TestTileOpRank1):
+    def init_data(self):
+        self.ori_shape = (2, 2, 2, 2, 6)
+        self.repeat_times = (2, 3, 4, 5, 7)
+
+    def if_enable_cinn(self):
+        self.check_cinn = True
+
+
+class TestTileOpRank6(TestTileOpRank1):
+    def init_data(self):
+        self.ori_shape = (2, 2, 2, 2, 2, 6)
+        self.repeat_times = (2, 2, 3, 4, 5, 7)
+
+    def if_enable_cinn(self):
+        self.check_cinn = True
+
+
 # Situation 2: repeat_times is a list (with tensor)
 # CINN not support repeat_times is a tensor now
 class TestTileOpRank1_tensor_attr(OpTest):

--- a/test/legacy_test/test_tile_op.py
+++ b/test/legacy_test/test_tile_op.py
@@ -161,7 +161,7 @@ class TestTileOpRank4(TestTileOpRank1):
 
 class TestTileOpRank5(TestTileOpRank1):
     def init_data(self):
-        self.ori_shape = (2, 2, 2, 2, 6)
+        self.ori_shape = (4, 2, 2, 2, 6)
         self.repeat_times = (2, 3, 4, 5, 7)
 
     def if_enable_cinn(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
Others
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->


### Description
将`tile_grad`计算改为`reshape and sum` 

pcard-66975
<!-- Describe what you’ve done -->
