### PR TITLE
[WIP][Dy2St] Use descriptor for convert a layer to avoid circular reference

### DIFF
--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -338,7 +338,7 @@ def to_static(
                 new_cls_forward = layer.__class__.forward
             else:
                 new_cls_forward = decorated(layer.__class__.forward)
-                function.__class__.forward = new_cls_forward
+                layer.__class__.forward = new_cls_forward
             new_cls_forward.add_need_convert_instance(layer)
             return layer
         else:

--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -366,12 +366,12 @@ def convert_call(func):
         if hasattr(func, 'forward') and isinstance(func, Layer):
             try:
                 _, forward_func = unwrap_decorators(func.forward)
-                func._original_funcs['forward'] = forward_func.__func__
+                func.__class__._fn_memos['forward'] = forward_func.__func__
                 forward_func = convert_to_static(forward_func)
                 # Bound method will be convert into plain function after `convert_to_static`.
                 # So descriptor mechanism is used to bound `self` instance on function to
                 # keep it as bound method.
-                func.forward = forward_func.__get__(func)
+                func.forward = forward_func
             except (OSError, TypeError):
                 # NOTE: func.forward may have been decorated.
                 func_self = None if func_self else func_self

--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -371,7 +371,7 @@ def convert_call(func):
                 # Bound method will be convert into plain function after `convert_to_static`.
                 # So descriptor mechanism is used to bound `self` instance on function to
                 # keep it as bound method.
-                func.forward = forward_func
+                func.__class__.forward = forward_func
             except (OSError, TypeError):
                 # NOTE: func.forward may have been decorated.
                 func_self = None if func_self else func_self

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -664,16 +664,15 @@ class StaticFunction(Generic[_InputT, _RetT]):
 
         def rollback_impl(class_instance, rollback_fn_name=None):
             for name, func in class_instance.__class__._fn_memos.items():
-                if not isinstance(
-                    getattr(class_instance.__class__, name), StaticFunction
-                ):
-                    continue
                 if rollback_fn_name is not None and name != rollback_fn_name:
                     continue
                 static_fn = getattr(class_instance.__class__, name)
-                static_fn.remove_need_convert_instance(class_instance)
-                if static_fn._need_convert_instances:
-                    continue
+                if isinstance(
+                    getattr(class_instance.__class__, name), StaticFunction
+                ):
+                    static_fn.remove_need_convert_instance(class_instance)
+                    if static_fn._need_convert_instances:
+                        continue
                 setattr(class_instance.__class__, name, func)
 
             for sublayer in class_instance.sublayers(include_self=False):

--- a/python/paddle/nn/quant/format.py
+++ b/python/paddle/nn/quant/format.py
@@ -20,6 +20,7 @@ import paddle
 from paddle import _C_ops, _legacy_C_ops
 from paddle.base import unique_name
 from paddle.framework import in_dynamic_mode, in_pir_mode
+from paddle.nn.layer.layers import LayerABCMeta
 
 from ..layer.layers import Layer
 
@@ -405,7 +406,7 @@ class LinearDequanter(Layer):
         )
 
 
-class ConvertibleQuantedLayer(Layer, metaclass=abc.ABCMeta):
+class ConvertibleQuantedLayer(Layer, metaclass=LayerABCMeta):
     r"""Abstract class to help convert quantized layer to inference model.
     It defines some functions to convert quantizers and observers to quantize
     or dequantize operators that maintain the quantization parameters used

--- a/python/paddle/quantization/base_observer.py
+++ b/python/paddle/quantization/base_observer.py
@@ -17,10 +17,12 @@ from __future__ import annotations
 
 import abc
 
+from paddle.nn.layer.layers import LayerABCMeta
+
 from .base_quanter import BaseQuanter
 
 
-class BaseObserver(BaseQuanter, metaclass=abc.ABCMeta):
+class BaseObserver(BaseQuanter, metaclass=LayerABCMeta):
     r"""
     Built-in observers and customized observers should extend this base observer
     and implement abstract methods.

--- a/python/paddle/quantization/base_quanter.py
+++ b/python/paddle/quantization/base_quanter.py
@@ -17,6 +17,7 @@ import abc
 from typing import TYPE_CHECKING, Any
 
 from paddle.nn import Layer
+from paddle.nn.layer.layers import LayerABCMeta
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -26,7 +27,8 @@ if TYPE_CHECKING:
     from paddle import Tensor
 
 
-class BaseQuanter(Layer, metaclass=abc.ABCMeta):
+class BaseQuanter(Layer, metaclass=LayerABCMeta):
+    # class BaseQuanter(Layer):
     r"""
     Built-in quanters and customized quanters should extend this base quanter
     and implement abstract methods.

--- a/python/paddle/quantization/base_quanter.py
+++ b/python/paddle/quantization/base_quanter.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
 
 
 class BaseQuanter(Layer, metaclass=LayerABCMeta):
-    # class BaseQuanter(Layer):
     r"""
     Built-in quanters and customized quanters should extend this base quanter
     and implement abstract methods.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

![to-static-circular-reference drawio](https://github.com/user-attachments/assets/b7a0c161-bbdb-4d89-aa67-108b754f971f)

> [!TIP]
>
> 图中 `a -> b`，表示 b 持有 a（的引用）

原来 `to_static(model)` 的实现是 `model.forward = decorated(model.forward)`，这导致了一个循环引用，即 `model.forward` 引用了 `static_fn`，`static_fn.class_instance`、`static_fn.__wrapped__.__self__` 等位置引用了 `model`

这在大多数情况也没啥问题，但在 #68743 中的 case 就会因为延迟 gc 而 OOM 了

不过仔细一想，为什么 Python 的其他「方法」没有这个问题呢？

比如 `model` 通过 `model.forward` 持有 bound method，而 bound method 又通过 `method.__self__` 持有 `model`

不过再仔细一想就很清楚了，`model` 实际并没有持有 `model.forward`，`model.forward` 是在这个 `LOAD_ATTR/LOAD_METHOD` 时候通过 `model.__class__.forward` 这个 unbound method（或者说 descriptor）通过 bind model（也就是 `model.__class__.forward.__get__(model, model.__class__)`）得到的，model 实际上并没有持有这样一个方法，而是在每次重新 bind 的，这可以通过每次得到的 bound method 的  id 都不同来验证

那么，自然也就想到我们的 static function 也用同样的方法了，对于 `to_static(model)` 来说，换成 `model.__class__.forward = decorated(model.__class__.forward)`，这样 `model.forward` 就是每次重新 bind 的结果了

不过要注意不能影响其它实例的 `forward` 方法，因此还需要加一个实例的白名单，只有 `to_static` 时候传入的实例才会用 static function bind，否则直接用原来的 dygraph function bind 得到动态图的 bound method

PCard-66972