### PR TITLE
[Prim][PIR] Add backward_decomp and support dynamic shape for argsort_grad

### DIFF
--- a/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
+++ b/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
@@ -96,6 +96,7 @@ BINARY_PRIM_VJP_OPS = [
 ]
 
 OTHER_PRIM_VJP_OPS = [
+    'argsort_grad',
     'assign_grad',
     'atan_grad',
     'atan2_grad',

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -2889,19 +2889,26 @@ void argsort_grad(const Tensor& indices,
                   bool stable,
                   Tensor* x_grad) {
   if (x_grad) {
+    auto indices_cast = ConverToMT<T>(indices);
+    auto x_cast = ConverToMT<T>(x);
+    auto out_grad_cast = ConverToMT<T>(out_grad);
+
     if (axis < 0) {
-      axis += x.dims().size();
+      axis += x_cast.dims().size();
     }
     Tensor zero_tensor;
     auto x_grad_tmp = Tensor();
-    if (has_dynamic_shape(x.shape())) {
-      zero_tensor = backend::full_with_tensor<T>(shape<T>(x), 0, x.dtype());
+    if (has_dynamic_shape(x_cast.shape())) {
+      zero_tensor =
+          backend::full_with_tensor<T>(shape<T>(x_cast), 0, x_cast.dtype());
     } else {
-      zero_tensor = full<T>(common::vectorize(x.dims()), 0, x.dtype());
+      zero_tensor =
+          full<T>(common::vectorize(x_cast.dims()), 0, x_cast.dtype());
     }
-    x_grad_tmp = put_along_axis<T>(zero_tensor, indices, out_grad, axis);
+    x_grad_tmp =
+        put_along_axis<T>(zero_tensor, indices_cast, out_grad_cast, axis);
 
-    set_output<T>(x_grad_tmp, x_grad);
+    set_output<T>(ConverToOrig<T>(x_grad_tmp, x.dtype()), x_grad);
   }
 }
 

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -2880,6 +2880,31 @@ void kthvalue_grad(const Tensor& x,
   }
 }
 
+template <typename T>
+void argsort_grad(const Tensor& indices,
+                  const Tensor& x,
+                  const Tensor& out_grad,
+                  int axis,
+                  bool descending,
+                  bool stable,
+                  Tensor* x_grad) {
+  if (x_grad) {
+    if (axis < 0) {
+      axis += x.dims().size();
+    }
+    Tensor zero_tensor;
+    auto x_grad_tmp = Tensor();
+    if (has_dynamic_shape(x.shape())) {
+      zero_tensor = backend::full_with_tensor<T>(shape<T>(x), 0, x.dtype());
+    } else {
+      zero_tensor = full<T>(common::vectorize(x.dims()), 0, x.dtype());
+    }
+    x_grad_tmp = put_along_axis<T>(zero_tensor, indices, out_grad, axis);
+
+    set_output<T>(x_grad_tmp, x_grad);
+  }
+}
+
 }  // namespace details
 }  // namespace primitive
 }  // namespace paddle

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -31,6 +31,7 @@ from paddle.base.wrapped_decorator import signature_safe_contextmanager
 ALLOW_DYNAMIC_SHAPE_VJP_OPS = [
     "pd_op.abs",
     "pd_op.add",
+    "pd_op.argsort",
     "pd_op.assign",
     "pd_op.batch_norm_",
     "pd_op.cast",

--- a/test/legacy_test/test_argsort_op.py
+++ b/test/legacy_test/test_argsort_op.py
@@ -468,6 +468,7 @@ class TestArgsortFP16Op(OpTest):
         self.init()
         self.init_direction()
         self.op_type = "argsort"
+        self.prim_op_type = "prim"
         self.python_api = paddle.argsort
         self.public_python_api = paddle.argsort
         self.python_out_sig = ["Out"]
@@ -496,7 +497,13 @@ class TestArgsortFP16Op(OpTest):
         self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', check_dygraph=False, check_pir=True)
+        self.check_grad(
+            ['X'],
+            'Out',
+            check_dygraph=False,
+            check_pir=True,
+            check_prim_pir=True,
+        )
 
 
 class TestArgsortFP16OpDescendingTrue(TestArgsortFP16Op):
@@ -514,6 +521,7 @@ class TestArgsortBF16Op(OpTest):
         self.init()
         self.init_direction()
         self.op_type = "argsort"
+        self.prim_op_type = "prim"
         self.python_api = paddle.argsort
         self.public_python_api = paddle.argsort
         self.python_out_sig = ["Out"]
@@ -546,7 +554,12 @@ class TestArgsortBF16Op(OpTest):
     def test_check_grad(self):
         place = core.CUDAPlace(0)
         self.check_grad_with_place(
-            place, ['X'], 'Out', check_dygraph=False, check_pir=True
+            place,
+            ['X'],
+            'Out',
+            check_dygraph=False,
+            check_pir=True,
+            check_prim_pir=True,
         )
 
 

--- a/test/legacy_test/test_argsort_op.py
+++ b/test/legacy_test/test_argsort_op.py
@@ -500,7 +500,7 @@ class TestArgsortFP16Op(OpTest):
         self.check_grad(
             ['X'],
             'Out',
-            check_dygraph=False,
+            check_dygraph=True,
             check_pir=True,
             check_prim_pir=True,
         )
@@ -557,7 +557,7 @@ class TestArgsortBF16Op(OpTest):
             place,
             ['X'],
             'Out',
-            check_dygraph=False,
+            check_dygraph=True,
             check_pir=True,
             check_prim_pir=True,
         )

--- a/test/legacy_test/test_argsort_op.py
+++ b/test/legacy_test/test_argsort_op.py
@@ -500,7 +500,7 @@ class TestArgsortFP16Op(OpTest):
         self.check_grad(
             ['X'],
             'Out',
-            check_dygraph=True,
+            check_dygraph=False,
             check_pir=True,
             check_prim_pir=True,
         )
@@ -557,7 +557,7 @@ class TestArgsortBF16Op(OpTest):
             place,
             ['X'],
             'Out',
-            check_dygraph=True,
+            check_dygraph=False,
             check_pir=True,
             check_prim_pir=True,
         )

--- a/test/prim/pir_prim/test_prim_sub_graph_abcde_backward_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_abcde_backward_dynamic_shape.py
@@ -31,6 +31,14 @@ def add_net(x, y):
     return x + y
 
 
+def argsort_net1(x):
+    return paddle.argsort(x, axis=-1)
+
+
+def argsort_net2(x):
+    return paddle.argsort(x, axis=1, descending=True)
+
+
 def batch_norm_net1(x, y, z):
     var = paddle.ones([40], dtype="float32")
     mean = paddle.zeros([40], dtype='float32')
@@ -273,6 +281,32 @@ class TestPrimAddWithGrad10(TestPrimTwoWithGrad):
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.y = np.random.random(self.y_shape).astype(self.dtype)
         self.net = add_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimArgsortWithGrad1(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.argsort_grad"
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 40]
+        self.init_x_shape = [None, None, 40]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = argsort_net1
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimArgsortWithGrad2(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.argsort_grad"
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 40]
+        self.init_x_shape = [None, None, None]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = argsort_net2
         self.enable_cinn = False
         self.tol = 1e-6
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
反向拆解argsort_grad，并添加动态shape支持