### PR TITLE
Add backward_decomp and support dynamic shape for kthvalue_grad

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -88,6 +88,7 @@ _INFERMETA_NEED_META_CONFIG = {
     'CropInferMeta',
     'EigvalsInferMeta',
     'FractionalMaxPoolInferMeta',
+    'KthvalueInferMeta',
     'MaxPoolWithIndexInferMeta',
     'MaxPoolV2InferMeta',
     'MultinomialInferMeta',

--- a/paddle/fluid/primitive/codegen/gen.py
+++ b/paddle/fluid/primitive/codegen/gen.py
@@ -128,6 +128,7 @@ OTHER_PRIM_VJP_OPS = [
     'where_grad',
     'logcumsumexp_grad',
     'logsumexp_grad',
+    'kthvalue_grad',
 ]
 
 # whole vjp list of primitive op vjp

--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -143,7 +143,7 @@ void divide_grad(const Tensor& x,
     } else {
       set_output<T>(dy_res, dy);
     }
-  }  // indicate we will compute dy
+  }  // indicate we willshape<T>(put compute dy
   if (dx) {
     // dx = (1/y) * dout
     auto dx_res = out_grad / y;
@@ -2943,13 +2943,12 @@ void kthvalue_grad(const Tensor& x,
       axis += x.dims().size();
     }
 
-    const int64_t x_dim_size = x.dims().size();
     Tensor zero_tensor;
     Tensor x_grad_tmp;
     if (has_dynamic_shape(x.shape())) {
       zero_tensor = backend::full_with_tensor<T>(shape<T>(x), 0, x.dtype());
 
-      if (x_dim_size == 1 || keepdim) {
+      if (keepdim) {
         x_grad_tmp =
             backend::put_along_axis<T>(zero_tensor, indices, out_grad, axis);
       } else {
@@ -2963,7 +2962,7 @@ void kthvalue_grad(const Tensor& x,
       }
     } else {
       zero_tensor = full<T>(common::vectorize(x.dims()), 0, x.dtype());
-      if (x_dim_size == 1 || keepdim) {
+      if (keepdim) {
         x_grad_tmp = put_along_axis<T>(zero_tensor, indices, out_grad, axis);
       } else {
         auto axis_ = std::vector<int64_t>(1, axis);

--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -2932,90 +2932,42 @@ void kthvalue_grad(const Tensor& x,
                    bool keepdim,
                    Tensor* x_grad) {
   if (x_grad) {
+    // put_along_axis doesn't support zero dim
+    if (x.dims().size() == 0) {
+      by_pass<T>(out_grad, x_grad);
+      return;
+    }
+
+    // function `put_along_axis` requires a non-negative axis
+    if (axis < 0) {
+      axis += x.dims().size();
+    }
+
+    Tensor zero_tensor;
     Tensor x_grad_tmp;
-    // LOG(INFO) << "zrt";
-
     if (has_dynamic_shape(x.shape())) {
-      const Tensor x_shape = shape<T>(x);
-      const Tensor zero_tensor =
-          backend::full_with_tensor<T>(x_shape, 0.0, x.dtype());
-      const int64_t x_dim_size = x.dims().size();
-
-      if (axis < 0) {
-        axis += x_dim_size;
-      }
-      auto x_axis = std::vector<int64_t>();
-      for (int64_t i = 0; i < x_dim_size; i++) {
-        if (i != axis) {
-          x_axis.push_back(i);
-        }
-      }
-      std::vector<int64_t> x_range_tmp(x.dims()[axis]);
-      for (int64_t i = 0; i < x.dims()[axis]; i++) {
-        x_range_tmp[i] = i;
-      }
-      auto x_range = backend::full_int_array<T>(x_range_tmp);
-      auto x_range_shape = get_unsqueeze_dims<T>(shape<T>(x_range), x_axis);
-      auto x_range_ = backend::reshape<T>(x_range, x_range_shape);
-      auto x_indices = backend::expand<T>(x_range_, x_shape);
-
-      if (x_dim_size == 0 || x_dim_size == 1 || keepdim) {
-        auto out_grad_tmp = backend::expand<T>(out_grad, x_shape);
-        auto indices_tmp = backend::expand<T>(indices, x_shape);
-        auto mask = equal<T>(x_indices, indices_tmp);
-        x_grad_tmp = where<T>(mask, out_grad_tmp, zero_tensor);
-      } else {
+      zero_tensor = backend::full_with_tensor<T>(shape<T>(x), 0, x.dtype());
+      if (!keepdim) {
         auto axis_ = std::vector<int64_t>(1, axis);
         auto out_grad_shape = get_unsqueeze_dims<T>(shape<T>(out_grad), axis_);
         auto out_grad_ = backend::reshape<T>(out_grad, out_grad_shape);
         auto indices_shape = get_unsqueeze_dims(shape<T>(indices), axis_);
         auto indices_ = backend::reshape<T>(indices, indices_shape);
-        auto out_grad_tmp = backend::expand<T>(out_grad_, x_shape);
-        auto indices_tmp = backend::expand<T>(indices_, x_shape);
-        auto mask = equal<T>(x_indices, indices_tmp);
-        x_grad_tmp = where<T>(mask, out_grad_tmp, zero_tensor);
+        x_grad_tmp = put_along_axis<T>(zero_tensor, indices_, out_grad_, axis);
+      } else {
+        x_grad_tmp = put_along_axis<T>(zero_tensor, indices, out_grad, axis);
       }
     } else {
-      auto zero_tensor = full<T>(common::vectorize(x.dims()), 0.0, x.dtype());
-      std::vector<int64_t> x_dim = common::vectorize<int64_t>(x.dims());
-      int64_t x_dim_size = x_dim.size();
-
-      if (axis < 0) {
-        axis += x_dim_size;
-      }
-
-      auto x_axis = std::vector<int64_t>();
-      for (int64_t i = 0; i < x_dim_size; i++) {
-        if (i != axis) {
-          x_axis.push_back(i);
-        }
-      }
-
-      std::vector<int64_t> x_range_tmp(x_dim[axis]);
-      for (int64_t i = 0; i < x_dim[axis]; i++) {
-        x_range_tmp[i] = i;
-      }
-      auto x_range = full_int_array<T>(x_range_tmp);
-      // x_range=[0,1]    x_axis=[0,2]
-      auto x_range_shape = get_unsqueeze_dims(x_range, x_axis);
-      auto x_range_ = reshape<T>(x_range, x_range_shape);
-      auto x_indices = expand<T>(x_range_, IntArray(x_dim));
-
-      if (x_dim_size == 0 || x_dim_size == 1 || keepdim) {
-        auto out_grad_tmp = out_grad.expand(IntArray(x_dim));
-        auto indices_tmp = indices.expand(IntArray(x_dim));
-        auto mask = equal<T>(x_indices, indices_tmp);
-        x_grad_tmp = where<T>(mask, out_grad_tmp, zero_tensor);
-      } else {
+      zero_tensor = full<T>(common::vectorize(x.dims()), 0, x.dtype());
+      if (!keepdim) {
         auto axis_ = std::vector<int64_t>(1, axis);
         auto out_grad_shape = get_unsqueeze_dims(out_grad, axis_);
         auto out_grad_ = reshape<T>(out_grad, out_grad_shape);
         auto indices_shape = get_unsqueeze_dims(indices, axis_);
         auto indices_ = reshape<T>(indices, indices_shape);
-        auto out_grad_tmp = out_grad_.expand(IntArray(x_dim));
-        auto indices_tmp = indices_.expand(IntArray(x_dim));
-        auto mask = equal<T>(x_indices, indices_tmp);
-        x_grad_tmp = where<T>(mask, out_grad_tmp, zero_tensor);
+        x_grad_tmp = put_along_axis<T>(zero_tensor, indices_, out_grad_, axis);
+      } else {
+        x_grad_tmp = put_along_axis<T>(zero_tensor, indices, out_grad, axis);
       }
     }
     set_output<T>(x_grad_tmp, x_grad);

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -52,6 +52,7 @@ ALLOW_DYNAMIC_SHAPE_VJP_OPS = [
     "pd_op.gather_nd",
     "pd_op.gelu",
     "pd_op.hardswish",
+    "pd_op.kthvalue",
     "pd_op.leaky_relu",
     "pd_op.log",
     "pd_op.logcumsumexp",

--- a/test/legacy_test/test_kthvalue_op.py
+++ b/test/legacy_test/test_kthvalue_op.py
@@ -49,7 +49,7 @@ class TestKthvalueOp(OpTest):
         self.python_api = paddle.kthvalue
         self.public_python_api = paddle.kthvalue
         self.init_dtype()
-        self.input_data = np.random.random((2, 1, 2, 4, 10)).astype(self.dtype)
+        self.input_data = np.random.random([2, 1, 2, 4, 10]).astype(self.dtype)
         self.init_args()
         self.inputs = {'X': self.input_data}
         self.attrs = {'k': self.k, 'axis': self.axis}
@@ -65,7 +65,7 @@ class TestKthvalueOp(OpTest):
     def test_check_grad(self):
         paddle.enable_static()
         self.check_grad(
-            {'X'},
+            ['X'],
             'Out',
             check_pir=True,
             check_prim_pir=True,
@@ -92,7 +92,7 @@ class TestKthvalueOpWithKeepdim(OpTest):
         self.prim_op_type = "prim"
         self.python_api = paddle.kthvalue
         self.public_python_api = paddle.kthvalue
-        self.input_data = np.random.random((1, 3, 2, 4, 10)).astype(self.dtype)
+        self.input_data = np.random.random([1, 3, 2, 4, 10]).astype(self.dtype)
         self.inputs = {'X': self.input_data}
         self.attrs = {'k': self.k, 'axis': self.axis, 'keepdim': True}
         output, indices = cal_kthvalue(
@@ -107,7 +107,7 @@ class TestKthvalueOpWithKeepdim(OpTest):
     def test_check_grad(self):
         paddle.enable_static()
         self.check_grad(
-            {'X'},
+            ['X'],
             'Out',
             check_pir=True,
             check_prim_pir=True,

--- a/test/legacy_test/test_kthvalue_op.py
+++ b/test/legacy_test/test_kthvalue_op.py
@@ -45,7 +45,9 @@ class TestKthvalueOp(OpTest):
 
     def setUp(self):
         self.op_type = "kthvalue"
+        self.prim_op_type = "prim"
         self.python_api = paddle.kthvalue
+        self.public_python_api = paddle.kthvalue
         self.init_dtype()
         self.input_data = np.random.random((2, 1, 2, 4, 10)).astype(self.dtype)
         self.init_args()
@@ -62,7 +64,12 @@ class TestKthvalueOp(OpTest):
 
     def test_check_grad(self):
         paddle.enable_static()
-        self.check_grad({'X'}, 'Out', check_pir=True)
+        self.check_grad(
+            {'X'},
+            'Out',
+            check_pir=True,
+            check_prim_pir=True,
+        )
 
 
 class TestKthvalueOpFp16(TestKthvalueOp):
@@ -82,7 +89,9 @@ class TestKthvalueOpWithKeepdim(OpTest):
         self.init_args()
         self.init_dtype()
         self.op_type = "kthvalue"
+        self.prim_op_type = "prim"
         self.python_api = paddle.kthvalue
+        self.public_python_api = paddle.kthvalue
         self.input_data = np.random.random((1, 3, 2, 4, 10)).astype(self.dtype)
         self.inputs = {'X': self.input_data}
         self.attrs = {'k': self.k, 'axis': self.axis, 'keepdim': True}
@@ -97,7 +106,12 @@ class TestKthvalueOpWithKeepdim(OpTest):
 
     def test_check_grad(self):
         paddle.enable_static()
-        self.check_grad({'X'}, 'Out', check_pir=True)
+        self.check_grad(
+            {'X'},
+            'Out',
+            check_pir=True,
+            check_prim_pir=True,
+        )
 
 
 class TestKthvalueOpWithKeepdimFp16(TestKthvalueOpWithKeepdim):

--- a/test/prim/pir_prim/test_prim_sub_graph_klmno_backward_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_klmno_backward_dynamic_shape.py
@@ -24,15 +24,15 @@ import paddle
 
 
 def kthvalue_net1(x):
-    return paddle.kthvalue(x, k=2)
+    return paddle.kthvalue(x, k=2)[0]
 
 
 def kthvalue_net2(x):
-    return paddle.kthvalue(x, k=1, axis=1)
+    return paddle.kthvalue(x, k=1, axis=1)[0]
 
 
 def kthvalue_net3(x):
-    return paddle.kthvalue(x, k=1, axis=1, keepdim=True)
+    return paddle.kthvalue(x, k=1, axis=1, keepdim=True)[0]
 
 
 def leaky_relu_net(x):

--- a/test/prim/pir_prim/test_prim_sub_graph_klmno_backward_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_klmno_backward_dynamic_shape.py
@@ -23,6 +23,18 @@ from test_prim_sub_graph_backward_dynamic_shape import (
 import paddle
 
 
+def kthvalue_net1(x):
+    return paddle.kthvalue(x, k=2)
+
+
+def kthvalue_net2(x):
+    return paddle.kthvalue(x, k=1, axis=1)
+
+
+def kthvalue_net3(x):
+    return paddle.kthvalue(x, k=1, axis=1, keepdim=True)
+
+
 def leaky_relu_net(x):
     return paddle.nn.functional.leaky_relu(x)
 
@@ -105,6 +117,58 @@ def minimum_net(x, y):
 
 def multiply_net(x, y):
     return x * y
+
+
+class TestPrimKthvalueWithGrad1(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.kthvalue_grad"
+        self.dtype = "float32"
+        self.x_shape = [30]
+        self.init_x_shape = [None]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = kthvalue_net1
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimKthvalueWithGrad2(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.kthvalue_grad"
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 40]
+        self.init_x_shape = [None, None, None]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = kthvalue_net1
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimKthvalueWithGrad3(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.kthvalue_grad"
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 40]
+        self.init_x_shape = [None, None, None]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = kthvalue_net2
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimKthvalueWithGrad4(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.kthvalue_grad"
+        self.dtype = "float32"
+        self.x_shape = [30, 200, 40]
+        self.init_x_shape = [None, None, None]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = kthvalue_net3
+        self.enable_cinn = False
+        self.tol = 1e-6
 
 
 class TestPrimLeakyReluWithGrad(TestPrimBaseWithGrad):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
反向拆解kthvalue_grad算子，并添加支持动态shape 