### PR TITLE
[Inference] config.delete_pass api can delete inplace_pass and fix a bug in replace_fetch_with_shadow_output_pass

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1097,7 +1097,8 @@ bool AnalysisPredictor::SaveOrLoadPirParameters(bool for_save) {
         std::string fetch_name =
             op->attribute("name").dyn_cast<pir::StrAttribute>().AsString();
         idx2fetches_[idx] = fetch_name;
-        fetch_name2shapes_[fetch_name] = pir::GetShapeFromValue(op->operand_source(0));
+        fetch_name2shapes_[fetch_name] =
+            pir::GetShapeFromValue(op->operand_source(0));
       }
     } else if (op->isa<paddle::dialect::DataOp>() ||
                op->isa<paddle::dialect::FeedOp>()) {

--- a/paddle/fluid/inference/api/analysis_predictor.h
+++ b/paddle/fluid/inference/api/analysis_predictor.h
@@ -578,9 +578,11 @@ class AnalysisPredictor : public PaddlePredictor {
   std::map<std::string, size_t> feed_names_;
   // Sorted according to the idx.
   std::map<size_t, std::string> idx2feeds_;
+  std::map<std::string, std::vector<int64_t>> feed_name2shapes_;
   std::vector<framework::OpDesc *> fetches_;
   std::vector<pir::Operation *> pir_fetches_;
   std::map<size_t, std::string> idx2fetches_;
+  std::map<std::string, std::vector<int64_t>> fetch_name2shapes_;
 
   phi::DataType model_precision_{phi::DataType::FLOAT32};
 

--- a/paddle/fluid/pir/transforms/general/inplace_pass.cc
+++ b/paddle/fluid/pir/transforms/general/inplace_pass.cc
@@ -88,6 +88,10 @@ bool CanDoInplace(const std::unordered_set<pir::Value>& eager_dels,
     return false;
   }
 
+  // for (auto it = output.use_begin(); it != output.use_end(); ++it) {
+  //   if(it->owner()->isa<pir::ShadowOutputOp>() || )
+  // }
+
   if (input.type().isa<TensorType>() && output.type().isa<TensorType>()) {
     auto input_alloc_tensor_type = input.type().dyn_cast<TensorType>();
     auto output_alloc_tensor_type = output.type().dyn_cast<TensorType>();

--- a/paddle/fluid/pir/transforms/general/inplace_pass.cc
+++ b/paddle/fluid/pir/transforms/general/inplace_pass.cc
@@ -88,10 +88,6 @@ bool CanDoInplace(const std::unordered_set<pir::Value>& eager_dels,
     return false;
   }
 
-  // for (auto it = output.use_begin(); it != output.use_end(); ++it) {
-  //   if(it->owner()->isa<pir::ShadowOutputOp>() || )
-  // }
-
   if (input.type().isa<TensorType>() && output.type().isa<TensorType>()) {
     auto input_alloc_tensor_type = input.type().dyn_cast<TensorType>();
     auto output_alloc_tensor_type = output.type().dyn_cast<TensorType>();

--- a/paddle/fluid/pir/transforms/general/replace_fetch_with_shadow_output_pass.cc
+++ b/paddle/fluid/pir/transforms/general/replace_fetch_with_shadow_output_pass.cc
@@ -15,6 +15,7 @@
 #include "paddle/fluid/pir/transforms/general/replace_fetch_with_shadow_output_pass.h"
 
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/utils/general_functions.h"
 #include "paddle/pir/include/core/builtin_op.h"
 #include "paddle/pir/include/pass/pass.h"
 #include "paddle/pir/include/pass/pass_registry.h"
@@ -28,6 +29,10 @@ class ReplaceFetchWithShadowOutputPattern
   bool MatchAndRewrite(
       paddle::dialect::FetchOp op,
       pir::PatternRewriter& rewriter) const override {  // NOLINT
+    if (pir::GetDefiningOpForInput(op, 0)->HasAttribute("name")) {
+      // DataOp/FeedOp
+      return false;
+    }
     rewriter.Build<pir::ShadowOutputOp>(
         op->operand_source(0),
         op->attributes().at("name").dyn_cast<pir::StrAttribute>().AsString());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
- config.delete_pass api can delete inplace_pass
- fix a bug in replace_fetch_with_shadow_output_pass

pcard-71500