### PR TITLE
[Auto Parallel] fix hang caused by different process group initialization order

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/nd_mesh_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/nd_mesh_reshard_func.py
@@ -15,7 +15,9 @@
 
 import paddle
 import paddle.distributed as dist
+from paddle.distributed.auto_parallel.static.utils import split_mesh
 
+from ..process_group import new_process_group
 from .base_reshard_func import (
     ReshardFunction,
     copy_dist_attr_with_new_member,
@@ -133,7 +135,9 @@ class NdMeshReshardFunction(ReshardFunction):
             tmp_dst_type = paddle.base.libpaddle.pir.cvt_to_dist_type(
                 src_value.type(), tmp_dst_dist_attr
             )
-
+            sub_mesh_list = split_mesh(process_mesh, in_mesh_axis)
+            for sub_mesh in sub_mesh_list:
+                new_process_group(sorted(sub_mesh.process_ids))
             # get the process_mesh on specific axis
             sub_mesh = get_1D_sub_process_mesh(process_mesh, in_mesh_axis)
 
@@ -197,7 +201,9 @@ class NdMeshReshardFunction(ReshardFunction):
                 tmp_dst_type = paddle.base.libpaddle.pir.cvt_to_dist_type(
                     src_value.type(), tmp_dst_dist_attr
                 )
-
+                sub_mesh_list = split_mesh(process_mesh, partial_dim)
+                for sub_mesh in sub_mesh_list:
+                    new_process_group(sorted(sub_mesh.process_ids))
                 # get the process_mesh on specific axis
                 sub_mesh = get_1D_sub_process_mesh(process_mesh, partial_dim)
 

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/sub_to_global_mesh_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/sub_to_global_mesh_func.py
@@ -58,10 +58,7 @@ class SubToGlobalMeshFunction(ReshardFunction):
 
         cur_rank = paddle.distributed.get_rank()
 
-        group_ranks = sorted(dst_mesh.process_ids)
-        comm_group = new_process_group(group_ranks)
-
-        if cur_rank == root_rank:
+        if cur_rank in src_mesh.process_ids:
             # the root rank will broadcast the src_value to other ranks
             chunk_id = -1
             if src_value.get_defining_op().dist_attr:

--- a/python/paddle/distributed/auto_parallel/static/utils.py
+++ b/python/paddle/distributed/auto_parallel/static/utils.py
@@ -2678,3 +2678,26 @@ def split_param_func(
     else:
         # fuse_attention_ffn
         return split_fn(fused_param, split_nums, axis=-1)
+
+
+def split_mesh(global_mesh: ProcessMesh, sub_mesh_dim: int):
+    mesh_shape = global_mesh.shape
+    mesh_ndim = len(mesh_shape)
+    if sub_mesh_dim >= mesh_ndim or (
+        sub_mesh_dim < 0 and -sub_mesh_dim > mesh_ndim
+    ):
+        raise ValueError(
+            f"The sub_mesh_dim should between (-{mesh_ndim}, {mesh_ndim}]"
+        )
+    if sub_mesh_dim < 0:
+        sub_mesh_dim += mesh_ndim
+
+    process_ids = np.array(global_mesh.process_ids).reshape(mesh_shape)
+    splitted_process_ids = np.split(
+        process_ids, mesh_shape[sub_mesh_dim], axis=sub_mesh_dim
+    )
+    sub_mesh_list = []
+    for sub_process_ids in splitted_process_ids:
+        sub_mesh_list.append(ProcessMesh(sub_process_ids))
+
+    return sub_mesh_list


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复由于通信组创建顺序不同导致的hang的问题。此问题首次出现在调试allgather moe动转静测试中，具体原因如下：
目前动转静通信组的建立是在静半reshard模块中，例如：nd_mesh_reshard_func.py，创建通信组之后所有进程都要同步一次，用以避免其他的问题。所以要求全部rank创建通信组的顺序必须严格一致，否则可能导致hang。例如有4个进程[0, 1, 2, 3]，有的进程创建了[0, 2]通信组，有的进程没有，就会导致hang，moe场景恰好触发了这个case。
Pcard-73145