### PR TITLE
[AutoParallel][PIR] remove src place type check when changing the dst place of the shadow feed op

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -3057,16 +3057,7 @@ void RemoveRedundantMemcpyAfterShadowFeed(pir::Block* block,
         }
       }
 
-      pir::Value shadow_source = it->operand_source(0);
-      if (!shadow_source.type().isa<AllocatedDenseTensorType>()) {
-        continue;
-      }
-      auto var_src_place =
-          shadow_source.type()
-              .dyn_cast<paddle::dialect::AllocatedDenseTensorType>();
-
-      if (shadow_value.use_count() >= 1 &&
-          phi::is_cpu_place(var_src_place.place())) {
+      if (shadow_value.use_count() >= 1) {
         bool all_use_is_scalar = true;
         for (auto use_it = shadow_value.use_begin();
              use_it != shadow_value.use_end();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
删除对于 src place 的 check，因为还没到执行阶段获取不到具体的 place

Pcard-76459