### PR TITLE
[Dy2St] Use weakref for layer instance conversion to avoid circular reference

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/helper.py
+++ b/python/paddle/distributed/auto_parallel/static/helper.py
@@ -64,9 +64,10 @@ class ProxyLayer(Layer):
 
         # Consider ProxyLayer as not Paddle inner function because it contains
         # user-defined layer.
-        as_not_paddle_func(
-            inspect.getmodule(ProxyLayer).__name__ + ".ProxyLayer.forward"
-        )
+        for fn_name in ["_train", "_eval", "_predict"]:
+            as_not_paddle_func(
+                f"{inspect.getmodule(ProxyLayer).__name__}.ProxyLayer.{fn_name}"
+            )
 
     @paddle.jit.not_to_static
     def append_loss_to_shadow_output(self, mode):

--- a/python/paddle/distributed/auto_parallel/static/helper.py
+++ b/python/paddle/distributed/auto_parallel/static/helper.py
@@ -65,7 +65,7 @@ class ProxyLayer(Layer):
         # Consider ProxyLayer as not Paddle inner function because it contains
         # user-defined layer.
         as_not_paddle_func(
-            inspect.getmodule(ProxyLayer).__name__ + ".ProxyLayer"
+            inspect.getmodule(ProxyLayer).__name__ + ".ProxyLayer.forward"
         )
 
     @paddle.jit.not_to_static

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -1270,7 +1270,7 @@ def save(
                 )
                 concrete_program = static_function.concrete_program
 
-                if static_function._class_instance is None:
+                if static_function.class_instance is None:
                     warnings.warn(
                         f'`jit.save` will only save the `Program`, not the parameters. If you have to save the parameters, please make sure that {layer} is a member function of `paddle.nn.Layer` and the saved parameters are in `state_dict`'
                     )
@@ -1280,9 +1280,9 @@ def save(
         if isinstance(inner_layer, Layer):
             dygraph_state_dict = inner_layer.to_static_state_dict()
         elif isinstance(attr_func, StaticFunction):
-            if static_func._class_instance:
+            if static_func.class_instance:
                 dygraph_state_dict = (
-                    static_func._class_instance.to_static_state_dict()
+                    static_func.class_instance.to_static_state_dict()
                 )
 
         if dygraph_state_dict:
@@ -1776,9 +1776,9 @@ def set_dynamic_shape(variable, shape_list):
 
 def get_ast_static_function(function):
     if isinstance(function, SymbolicStaticFunction):
-        if function._class_instance:
+        if function.class_instance:
             dygraph_function = types.MethodType(
-                function._dygraph_function, function._class_instance
+                function._dygraph_function, function.class_instance
             )
         else:
             dygraph_function = function._dygraph_function

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -133,7 +133,8 @@ def copy_decorator_attrs(original_func, decorated_obj):
 
     decorated_obj.__name__ = original_func.__name__
     decorated_obj._decorator_name = decorator_name
-    decorated_obj.__wrapped__ = original_func
+    if not inspect.ismethod(original_func):
+        decorated_obj.__wrapped__ = original_func
     decorated_obj.__doc__ = original_func.__doc__
     if hasattr(original_func, "__module__"):
         decorated_obj.__module__ = original_func.__module__

--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -22,7 +22,6 @@ import logging
 import os
 import pdb  # noqa: T100
 import re
-import weakref
 from typing import TYPE_CHECKING, Any, Callable
 
 import numpy
@@ -43,7 +42,7 @@ from .program_translator import (
     convert_to_static,
     unwrap_decorators,
 )
-from .utils import is_builtin, is_paddle_func
+from .utils import WeakMethod, is_builtin, is_paddle_func
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -52,17 +51,6 @@ __all__ = []
 
 
 translator_logger = TranslatorLogger()
-
-
-class WeakMethod:
-    def __init__(self, fn, instance):
-        self.fn = fn
-        self.instance = weakref.ref(instance)
-
-    def __call__(self, *args, **kwargs):
-        if self.instance() is None:
-            raise RuntimeError("The object has been destroyed")
-        return self.fn(self.instance(), *args, **kwargs)
 
 
 class ConversionOptions:

--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -192,15 +192,6 @@ def is_unsupported(func):
             )
             return True
 
-    # NOTE: should be placed before `is_paddle_func`
-    # The api(s) should be considered as plain function and convert
-    # them into static layer code.
-    from paddle.nn import Sequential
-
-    PADDLE_NEED_CONVERT_APIS = [Sequential]
-    if type(func) in PADDLE_NEED_CONVERT_APIS:
-        return False
-
     if is_paddle_func(func):
         translator_logger.log(
             2,

--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -22,6 +22,7 @@ import logging
 import os
 import pdb  # noqa: T100
 import re
+import weakref
 from typing import TYPE_CHECKING, Any, Callable
 
 import numpy
@@ -371,7 +372,7 @@ def convert_call(func):
                 # Bound method will be convert into plain function after `convert_to_static`.
                 # So descriptor mechanism is used to bound `self` instance on function to
                 # keep it as bound method.
-                func.forward = forward_func.__get__(func)
+                func.forward = weakref.WeakMethod(forward_func.__get__(func))
             except (OSError, TypeError):
                 # NOTE: func.forward may have been decorated.
                 func_self = None if func_self else func_self

--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -367,7 +367,7 @@ def convert_call(func):
             try:
                 _, forward_func = unwrap_decorators(func.forward)
                 func._original_funcs['forward'] = forward_func.__func__
-                forward_func = convert_to_static(forward_func)
+                forward_func = convert_to_static(forward_func.__func__)
                 # Bound method will be convert into plain function after `convert_to_static`.
                 # So descriptor mechanism is used to bound `self` instance on function to
                 # keep it as bound method.

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -364,7 +364,7 @@ def unwrap_decorators(func):
         if isinstance(cur, StaticFunction):
             decorators.append(cur)
             # Note: if `cur` is a method, keep it as bound method of class.
-            instance = cur._class_instance
+            instance = cur.class_instance
             if instance is not None:
                 cur = cur.dygraph_function.__get__(instance)
             else:
@@ -388,14 +388,14 @@ class StaticFunction(Generic[_InputT, _RetT]):
 
         if inspect.ismethod(function):
             self._dygraph_function = function.__func__
-            self._class_instance = function.__self__
+            self._class_instance = weakref.ref(function.__self__)
 
-            if not hasattr(self._class_instance, '_original_funcs'):
+            if not hasattr(self.class_instance, '_original_funcs'):
                 raise TypeError(
                     "When using 'to_static' to convert method of a class, "
                     "please ensure the class inherits from nn.Layer"
                 )
-            self._class_instance._original_funcs[function.__name__] = (
+            self.class_instance._original_funcs[function.__name__] = (
                 self._dygraph_function
             )
         else:
@@ -417,8 +417,8 @@ class StaticFunction(Generic[_InputT, _RetT]):
 
     def _get_debug_name(self) -> str:
         try:
-            if self._class_instance:
-                self._debug_name = self._class_instance.__class__.__name__
+            if self.class_instance:
+                self._debug_name = self.class_instance.__class__.__name__
             else:
                 self._debug_name = self._dygraph_function.__name__
         except Exception:
@@ -431,8 +431,8 @@ class StaticFunction(Generic[_InputT, _RetT]):
 
     def train(self) -> None:
         if (
-            isinstance(self._class_instance, layers.Layer)
-            and self._class_instance.training is False
+            isinstance(self.class_instance, layers.Layer)
+            and self.class_instance.training is False
         ):
             raise RuntimeError(
                 f"Failed to switch train mode. {self.dygraph_function} is a Layer's method, "
@@ -442,8 +442,8 @@ class StaticFunction(Generic[_InputT, _RetT]):
 
     def eval(self) -> None:
         if (
-            isinstance(self._class_instance, layers.Layer)
-            and self._class_instance.training is True
+            isinstance(self.class_instance, layers.Layer)
+            and self.class_instance.training is True
         ):
             raise RuntimeError(
                 f"Failed to switch eval mode. {self.dygraph_function} is a Layer's method, "
@@ -488,7 +488,7 @@ class StaticFunction(Generic[_InputT, _RetT]):
                 instance._original_funcs[self._dygraph_function.__name__] = (
                     self._dygraph_function
                 )
-            new_static_layer._class_instance = instance
+            new_static_layer._class_instance = weakref.ref(instance)
             self._descriptor_cache[instance] = new_static_layer
 
         return self._descriptor_cache[instance]
@@ -535,13 +535,13 @@ class StaticFunction(Generic[_InputT, _RetT]):
         return self._perform_call(*args, **kwargs)
 
     def _is_train_mode(self) -> bool:
-        if self._class_instance is not None:
-            if not hasattr(self._class_instance, 'training'):
+        if self.class_instance is not None:
+            if not hasattr(self.class_instance, 'training'):
                 raise TypeError(
                     "When using 'to_static' to convert method of a class, "
                     "please ensure the class inherits from nn.Layer"
                 )
-            return self._class_instance.training
+            return self.class_instance.training
         else:
             return self._training
 
@@ -585,12 +585,22 @@ class StaticFunction(Generic[_InputT, _RetT]):
         raise NotImplementedError("Not implemented yet.")
 
     @property
+    def class_instance(self):
+        if self._class_instance is None:
+            return None
+        if self._class_instance() is None:
+            raise RuntimeError(
+                "The instance of class has been deleted, please re-create the instance."
+            )
+        return self._class_instance()
+
+    @property
     def dygraph_function(self) -> Callable[_InputT, _RetT]:
         """
         Returns the original decorated function.
         """
-        if self._class_instance is not None:
-            return self._dygraph_function.__get__(self._class_instance)
+        if self.class_instance is not None:
+            return self._dygraph_function.__get__(self.class_instance)
         else:
             return self._dygraph_function
 
@@ -645,23 +655,23 @@ class StaticFunction(Generic[_InputT, _RetT]):
             for sublayer in class_instance.sublayers(include_self=False):
                 rollback_impl(sublayer)
 
-        if self._class_instance is None:
+        if self.class_instance is None:
             return self._dygraph_function
 
         # only rollback sub-functions on path of top _dygraph_function
         func_name = self._dygraph_function.__name__
         assert (
-            func_name in self._class_instance._original_funcs
-        ), f"Not Found function '{func_name}' in class '{self._class_instance.__class__}'."
-        func = self._class_instance._original_funcs[func_name]
+            func_name in self.class_instance._original_funcs
+        ), f"Not Found function '{func_name}' in class '{self.class_instance.__class__}'."
+        func = self.class_instance._original_funcs[func_name]
         setattr(
-            self._class_instance, func_name, func.__get__(self._class_instance)
+            self.class_instance, func_name, func.__get__(self.class_instance)
         )
 
-        for sublayer in self._class_instance.sublayers(include_self=False):
+        for sublayer in self.class_instance.sublayers(include_self=False):
             rollback_impl(sublayer)
 
-        return getattr(self._class_instance, func_name)
+        return getattr(self.class_instance, func_name)
 
     def __deepcopy__(self, memo):
         """
@@ -695,17 +705,15 @@ class StaticFunction(Generic[_InputT, _RetT]):
 
         Please attention that original 'net' will unwrap @to_static and rollback into simple Layer.
         """
-        if self._class_instance is not None:
-            net_name = type(self._class_instance).__name__
+        if self.class_instance is not None:
+            net_name = type(self.class_instance).__name__
             logging_utils.log(
                 level=-1,
                 msg=f"Not recommend to deepcopy '{net_name}' decorated with @to_static, it has side effect that will"
                 f" rollback into original state before @to_static. Please deepcopy '{net_name}' before applying @to_static.",
             )
             self.rollback()
-            return self._dygraph_function.__get__(
-                memo[id(self._class_instance)]
-            )
+            return self._dygraph_function.__get__(memo[id(self.class_instance)])
         else:
             return self._dygraph_function
 
@@ -771,8 +779,8 @@ class SymbolicStaticFunction(StaticFunction):
             training=self._is_train_mode(),
             backend=backend,
         )
-        if self._class_instance is not None:
-            args = (self._class_instance, *args)
+        if self.class_instance is not None:
+            args = (self.class_instance, *args)
         return traced_fun(*args, **kwargs)
 
     @property
@@ -831,8 +839,8 @@ class ASTStaticFunction(StaticFunction[_InputT, _RetT]):
                 *args, **kwargs, is_train=self._is_train_mode()
             )
             # 2. synchronize self.training attribute.
-            if isinstance(self._class_instance, layers.Layer):
-                partial_program_layer.training = self._class_instance.training
+            if isinstance(self.class_instance, layers.Layer):
+                partial_program_layer.training = self.class_instance.training
             else:
                 partial_program_layer.training = self._training
 
@@ -899,7 +907,7 @@ class ASTStaticFunction(StaticFunction[_InputT, _RetT]):
             self._function_spec,
             input_args_with_spec,
             input_kwargs_with_spec,
-            self._class_instance,
+            self.class_instance,
             **self._kwargs,
             with_hook=with_hook,
             is_train=is_train,

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -257,24 +257,33 @@ def is_paddle_func(func, ignore_white_list=True):
         return (module.__name__ + '.' + func_name) in AS_NOT_INNER_FUNC_LIST
 
     try:
+        print(f"---- func 1 {func}", flush=True)
         if isinstance(func, paddle.nn.Layer):
             func = func.forward
+        print(f"---- func 2 {func}", flush=True)
         if isinstance(
             func, paddle.jit.dy2static.program_translator.StaticFunction
         ):
             func = func.dygraph_function
+        print(f"---- func 3 {func}", flush=True)
         if isinstance(func, functools.partial):
             func = func.func
+        print(f"---- func 4 {func}", flush=True)
         if inspect.ismethod(func):
             func = func.__func__
+        print(f"---- func 5 {func}", flush=True)
         func_name = getattr(func, '__name__', None)
         if inspect.ismethod(func) or inspect.isfunction(func):
             func_name = func.__qualname__
 
+        print(f"---- func 6 {func}", flush=True)
         m = inspect.getmodule(func)
+        print(f"---- module 7 {m}", flush=True)
         flag = m is not None and m.__name__.startswith(PADDLE_MODULE_PREFIX)
+        print(f"---- flag 8 {flag}", flush=True)
         if ignore_white_list:
             flag = flag and not in_white_list(m, func_name)
+        print(f"---- in_white_list 9 {in_white_list(m, func_name)}", flush=True)
 
         return flag
     except Exception:

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -257,33 +257,24 @@ def is_paddle_func(func, ignore_white_list=True):
         return (module.__name__ + '.' + func_name) in AS_NOT_INNER_FUNC_LIST
 
     try:
-        print(f"---- func 1 {func}", flush=True)
         if isinstance(func, paddle.nn.Layer):
             func = func.forward
-        print(f"---- func 2 {func}", flush=True)
         if isinstance(
             func, paddle.jit.dy2static.program_translator.StaticFunction
         ):
             func = func.dygraph_function
-        print(f"---- func 3 {func}", flush=True)
         if isinstance(func, functools.partial):
             func = func.func
-        print(f"---- func 4 {func}", flush=True)
         if inspect.ismethod(func):
             func = func.__func__
-        print(f"---- func 5 {func}", flush=True)
         func_name = getattr(func, '__name__', None)
         if inspect.ismethod(func) or inspect.isfunction(func):
             func_name = func.__qualname__
 
-        print(f"---- func 6 {func}", flush=True)
         m = inspect.getmodule(func)
-        print(f"---- module 7 {m}", flush=True)
         flag = m is not None and m.__name__.startswith(PADDLE_MODULE_PREFIX)
-        print(f"---- flag 8 {flag}", flush=True)
         if ignore_white_list:
             flag = flag and not in_white_list(m, func_name)
-        print(f"---- in_white_list 9 {in_white_list(m, func_name)}", flush=True)
 
         return flag
     except Exception:

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -259,6 +259,10 @@ def is_paddle_func(func, ignore_white_list=True):
     try:
         if isinstance(func, paddle.nn.Layer):
             func = func.forward
+        if isinstance(
+            func, paddle.jit.dy2static.program_translator.StaticFunction
+        ):
+            func = func.dygraph_function
         if isinstance(func, functools.partial):
             func = func.func
         if inspect.ismethod(func):

--- a/python/paddle/tensorrt/export.py
+++ b/python/paddle/tensorrt/export.py
@@ -480,9 +480,9 @@ def convert(function=None, input_spec=None, config=None, **kwargs):
         if isinstance(inner_layer, Layer):
             dygraph_state_dict = inner_layer.to_static_state_dict()
         elif isinstance(attr_func, StaticFunction):
-            if static_func._class_instance:
+            if static_func.class_instance:
                 dygraph_state_dict = (
-                    static_func._class_instance.to_static_state_dict()
+                    static_func.class_instance.to_static_state_dict()
                 )
         if dygraph_state_dict:
             #  we maintain the mapping of variable name to

--- a/test/dygraph_to_static/test_circular_reference.py
+++ b/test/dygraph_to_static/test_circular_reference.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/dygraph_to_static/test_circular_reference.py
+++ b/test/dygraph_to_static/test_circular_reference.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+
+from dygraph_to_static_utils import Dy2StTestBase
+
+import paddle
+from paddle import nn
+
+
+class MyConv2D(nn.Layer):
+    def __init__(self, in_channels, out_channels, kernel_size, stride, padding):
+        super().__init__()
+        self.inner_conv = nn.Conv2D(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+        )
+
+    def forward(self, x):
+        return self.inner_conv(x)
+
+
+class ExampleCNN(nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = MyConv2D(
+            in_channels=3, out_channels=64, kernel_size=3, stride=1, padding=1
+        )
+        self.pool = nn.MaxPool2D(kernel_size=2, stride=2, padding=0)
+        self.conv2 = nn.Conv2D(
+            in_channels=64, out_channels=128, kernel_size=3, stride=1, padding=1
+        )
+        self.conv3 = nn.Conv2D(
+            in_channels=128,
+            out_channels=256,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+        )
+        self.fc1 = nn.Linear(256 * 28 * 28, 10)
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        x = self.pool(self.relu(self.conv1(x)))
+        x = self.pool(self.relu(self.conv2(x)))
+        x = self.pool(self.relu(self.conv3(x)))
+        x = paddle.flatten(x, start_axis=1)
+        x = self.fc1(x)
+        return x
+
+
+class TestCircularReference(Dy2StTestBase):
+    def test_circular_reference(self):
+        model = ExampleCNN()
+        model_ref_before_to_static = sys.getrefcount(model)
+        inner_model_ref_before_to_static = sys.getrefcount(model.conv1)
+        paddle.jit.to_static(model)
+        model_ref_after_to_static = sys.getrefcount(model)
+        inner_model_ref_after_to_static = sys.getrefcount(model.conv1)
+        # NOTE(SigureMo): The reference count of `model` must be the same before and after `to_static`.
+        # Otherwise, it may cause memory leak.
+        self.assertEqual(model_ref_before_to_static, model_ref_after_to_static)
+        self.assertEqual(
+            inner_model_ref_before_to_static, inner_model_ref_after_to_static
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/dygraph_to_static/test_convert_call.py
+++ b/test/dygraph_to_static/test_convert_call.py
@@ -20,7 +20,7 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_ast_only,
-    test_legacy_and_pir,
+    test_pir_only,
 )
 
 import paddle
@@ -98,7 +98,7 @@ class TestRecursiveCall1(Dy2StTestBase):
             res = self.dyfunc(self.input).numpy()
         return res
 
-    @test_legacy_and_pir
+    @test_pir_only
     def test_transformed_static_result(self):
         self.init_test_func()
         static_res = self.get_static_output()
@@ -187,7 +187,7 @@ class TestRecursiveCall2(Dy2StTestBase):
         with enable_to_static_guard(True):
             return self._run()
 
-    @test_legacy_and_pir
+    @test_pir_only
     def test_transformed_static_result(self):
         self.set_func()
         dygraph_res = self.get_dygraph_output()
@@ -230,14 +230,14 @@ class TestNotToConvert(TestRecursiveCall2):
         paddle.jit.not_to_static(self.net.sum)
         self.dygraph_func = paddle.jit.to_static(self.net.outer)
 
-    @test_legacy_and_pir
+    @test_pir_only
     def test_conversion_options(self):
         self.set_func()
         options = getattr(self.net.sum, CONVERSION_OPTIONS, None)
         self.assertIsNotNone(options)
         self.assertTrue(options.not_convert)
 
-    @test_legacy_and_pir
+    @test_pir_only
     def test_code(self):
         self.set_func()
         # check 'if statement' is not converted
@@ -253,7 +253,7 @@ class TestNotToConvert2(TestRecursiveCall2):
         paddle.jit.not_to_static(self.net.sum)
         self.dygraph_func = paddle.jit.to_static(self.net.sum)
 
-    @test_legacy_and_pir
+    @test_pir_only
     def test_conversion_options(self):
         self.set_func()
         options = getattr(self.net.sum, CONVERSION_OPTIONS, None)
@@ -261,7 +261,7 @@ class TestNotToConvert2(TestRecursiveCall2):
         self.assertTrue(options.not_convert)
 
     @test_ast_only
-    @test_legacy_and_pir
+    @test_pir_only
     def test_code(self):
         self.set_func()
         self.dygraph_func = paddle.jit.to_static(self.net.sum)
@@ -279,7 +279,7 @@ def forward(self, x):
 
 class TestConvertPaddleAPI(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pir
+    @test_pir_only
     def test_functional_api(self):
         func = paddle.nn.functional.relu
         func = paddle.jit.to_static(func)
@@ -287,7 +287,7 @@ class TestConvertPaddleAPI(Dy2StTestBase):
         self.assertIn("if in_dynamic_or_pir_mode()", func.code)
 
     @test_ast_only
-    @test_legacy_and_pir
+    @test_pir_only
     def test_class_api(self):
         bn = paddle.nn.SyncBatchNorm(2)
         paddle.jit.to_static(bn)
@@ -295,7 +295,7 @@ class TestConvertPaddleAPI(Dy2StTestBase):
         self.assertIn("if in_dynamic_or_pir_mode()", bn.forward.code)
 
     @test_ast_only
-    @test_legacy_and_pir
+    @test_pir_only
     def test_class_patch_api(self):
         paddle.nn.SyncBatchNorm.forward = forward
         bn = paddle.nn.SyncBatchNorm(2)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

要解决的问题同 #68815，但方案不同，本 PR 通过解除 static function 对 class instance 的强引用来解除循环引用

#68815 实现有点恶心，特别是与动态图的边界，以及内部的 API 转换（`convert_call`）并不是用 `to_static` 而是直接 `convert_to_static`，如果不是 `StaticFunction` 就没办法用之前的 bind 方案了，重构起来成本就高了，因此暂时恢复旧的解除引用方案

虽然但是，现在的改法也很恶心，`convert_call` 好恶心

closes #68815

PCard-66972