### PR TITLE
[CINN] Disable some op symbol_infer check in `same_operand_with_result.cc`

### DIFF
--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -426,6 +426,7 @@ class TestSigmoid(TestActivation):
             check_pir=True,
             check_prim_pir=True,
             check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):
@@ -525,6 +526,7 @@ class TestSigmoidBF16(OpTest):
             check_pir=True,
             check_prim_pir=True,
             check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):
@@ -579,7 +581,9 @@ class TestSilu(TestActivation):
     def test_check_output(self):
         if self.dtype == np.complex64 or self.dtype == np.complex128:
             self.check_output(
-                check_pir=True, check_pir_onednn=self.check_pir_onednn
+                check_pir=True,
+                check_pir_onednn=self.check_pir_onednn,
+                check_symbol_infer=False,
             )
         else:
             self.check_output(
@@ -587,6 +591,7 @@ class TestSilu(TestActivation):
                 check_pir=True,
                 check_prim_pir=True,
                 check_pir_onednn=self.check_pir_onednn,
+                check_symbol_infer=False,
             )
 
     def test_check_grad(self):
@@ -799,7 +804,9 @@ class TestTanh(TestActivation, TestParameter):
 
     def test_check_output(self):
         self.check_output(
-            check_pir=True, check_pir_onednn=self.check_pir_onednn
+            check_pir=True,
+            check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):
@@ -1031,7 +1038,9 @@ class TestSinh(TestActivation):
 
     def test_check_output(self):
         self.check_output(
-            check_pir=True, check_pir_onednn=self.check_pir_onednn
+            check_pir=True,
+            check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):
@@ -1285,7 +1294,9 @@ class TestTanhshrink(TestActivation):
 
     def test_check_output(self):
         self.check_output(
-            check_pir=True, check_pir_onednn=self.check_pir_onednn
+            check_pir=True,
+            check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
 
@@ -1379,7 +1390,9 @@ class TestHardShrink(TestActivation):
 
     def test_check_output(self):
         self.check_output(
-            check_pir=True, check_pir_onednn=self.check_pir_onednn
+            check_pir=True,
+            check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):
@@ -1555,7 +1568,9 @@ class TestSoftshrink(TestActivation):
 
     def test_check_output(self):
         self.check_output(
-            check_pir=True, check_pir_onednn=self.check_pir_onednn
+            check_pir=True,
+            check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):
@@ -1669,6 +1684,7 @@ class TestSqrt(TestActivation, TestParameter):
             check_pir=True,
             check_prim_pir=True,
             check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
 
@@ -1705,6 +1721,7 @@ class TestSqrtPrimFp32(TestActivation):
             check_pir=True,
             check_prim_pir=True,
             check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def init_dtype(self):
@@ -1758,6 +1775,7 @@ class TestSqrtBF16(OpTest):
             check_pir=True,
             check_prim_pir=True,
             check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):
@@ -1813,6 +1831,7 @@ class TestSqrtComp(TestActivation, TestParameter):
             check_pir=True,
             check_prim_pir=True,
             check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
 
@@ -1855,6 +1874,7 @@ class TestSqrtCompFp32(TestActivation):
             check_pir=True,
             check_prim_pir=True,
             check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def init_dtype(self):
@@ -2164,7 +2184,9 @@ class TestTan(TestActivation):
 
     def test_check_output(self):
         self.check_output(
-            check_pir=True, check_pir_onednn=self.check_pir_onednn
+            check_pir=True,
+            check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):
@@ -2319,7 +2341,9 @@ class TestSin(TestActivation, TestParameter):
 
     def test_check_output(self):
         self.check_output(
-            check_pir=True, check_pir_onednn=self.check_pir_onednn
+            check_pir=True,
+            check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):
@@ -2833,6 +2857,7 @@ class TestLeakyRelu(TestActivation):
             check_pir=True,
             check_prim_pir=True,
             check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):
@@ -4356,6 +4381,7 @@ class TestSquare(TestActivation):
             check_pir=True,
             check_prim_pir=True,
             check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
 
@@ -4433,6 +4459,7 @@ class TestSquareBF16(OpTest):
             check_pir=True,
             check_prim_pir=True,
             check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):
@@ -4576,7 +4603,9 @@ class TestSTanh(TestActivation):
 
     def test_check_output(self):
         self.check_output(
-            check_pir=True, check_pir_onednn=self.check_pir_onednn
+            check_pir=True,
+            check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
 
@@ -4717,7 +4746,9 @@ class TestSoftplus(TestActivation):
 
     def test_check_output(self):
         self.check_output(
-            check_pir=True, check_pir_onednn=self.check_pir_onednn
+            check_pir=True,
+            check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):
@@ -4778,7 +4809,10 @@ class TestSoftplusBF16(OpTest):
     def test_check_output(self):
         place = core.CUDAPlace(0)
         self.check_output_with_place(
-            place, check_pir=True, check_pir_onednn=self.check_pir_onednn
+            place,
+            check_pir=True,
+            check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):
@@ -4876,13 +4910,16 @@ class TestSoftsign(TestActivation):
     def test_check_output(self):
         if self.dtype == np.complex64 or self.dtype == np.complex128:
             self.check_output(
-                check_pir=True, check_pir_onednn=self.check_pir_onednn
+                check_pir=True,
+                check_pir_onednn=self.check_pir_onednn,
+                check_symbol_infer=False,
             )
         else:
             self.check_output(
                 check_pir=True,
                 check_pir_onednn=self.check_pir_onednn,
                 check_prim_pir=True,
+                check_symbol_infer=False,
             )
 
     def test_check_grad(self):
@@ -5009,7 +5046,9 @@ class TestThresholdedRelu(TestActivation):
 
     def test_check_output(self):
         self.check_output(
-            check_pir=True, check_pir_onednn=self.check_pir_onednn
+            check_pir=True,
+            check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
 
@@ -5125,6 +5164,7 @@ class TestHardSigmoid(TestActivation):
             check_pir=True,
             check_prim_pir=True,
             check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):

--- a/test/legacy_test/test_determinant_op.py
+++ b/test/legacy_test/test_determinant_op.py
@@ -196,7 +196,7 @@ class TestSlogDeterminantOp(OpTest):
         self.outputs = {'Out': self.target}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_symbol_infer=False)
 
     def test_check_grad(self):
         # the slog det's grad value is always huge

--- a/test/legacy_test/test_gammaln_op.py
+++ b/test/legacy_test/test_gammaln_op.py
@@ -45,7 +45,7 @@ class TestGammalnOp(OpTest):
         self.dtype = np.float64
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_symbol_infer=False)
 
     def test_check_grad(self):
         self.check_grad(['x'], 'out', check_pir=True)
@@ -109,7 +109,9 @@ class TestGammalnBF16Op(OpTest):
         self.outputs = {'out': convert_float_to_uint16(out)}
 
     def test_check_output(self):
-        self.check_output_with_place(core.CUDAPlace(0), check_pir=True)
+        self.check_output_with_place(
+            core.CUDAPlace(0), check_pir=True, check_symbol_infer=False
+        )
 
     def test_check_grad(self):
         self.check_grad_with_place(

--- a/test/legacy_test/test_polygamma_op.py
+++ b/test/legacy_test/test_polygamma_op.py
@@ -204,7 +204,7 @@ class TestPolygammaOp(OpTest):
         self.target = ref_polygamma(self.inputs['x'], self.order)
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_symbol_infer=False)
 
     def test_check_grad(self):
         self.check_grad(

--- a/test/legacy_test/test_selu_op.py
+++ b/test/legacy_test/test_selu_op.py
@@ -79,7 +79,7 @@ class SeluTest(OpTest):
         self.dtype = np.float64
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_symbol_infer=False)
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out', check_pir=True)

--- a/test/legacy_test/test_sign_op.py
+++ b/test/legacy_test/test_sign_op.py
@@ -35,7 +35,7 @@ class TestSignOp(OpTest):
         self.outputs = {'Out': np.sign(self.inputs['X'])}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_symbol_infer=False)
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out', check_pir=True)
@@ -71,7 +71,9 @@ class TestSignBF16Op(OpTest):
         self.place = core.CUDAPlace(0)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_pir=True)
+        self.check_output_with_place(
+            self.place, check_pir=True, check_symbol_infer=False
+        )
 
     def test_check_grad(self):
         self.check_grad_with_place(self.place, ['X'], 'Out', check_pir=True)

--- a/test/legacy_test/test_softmax_mask_fuse_upper_triangle_op.py
+++ b/test/legacy_test/test_softmax_mask_fuse_upper_triangle_op.py
@@ -50,7 +50,9 @@ class TestSoftmaxMaskFuseOp(OpTest):
         self.outputs = {'Out': rst}
 
     def test_check_output(self):
-        self.check_output_with_place(core.CUDAPlace(0), check_pir=True)
+        self.check_output_with_place(
+            core.CUDAPlace(0), check_pir=True, check_symbol_infer=False
+        )
 
     def test_check_grad(self):
         self.check_grad_with_place(
@@ -72,7 +74,9 @@ class TestSoftmaxMaskFuseOp1(OpTest):
 
     def test_check_output(self):
         try:
-            self.check_output_with_place(core.CPUPlace(), check_pir=True)
+            self.check_output_with_place(
+                core.CPUPlace(), check_pir=True, check_symbol_infer=False
+            )
         except (NotImplementedError, RuntimeError):
             pass
 

--- a/test/legacy_test/test_softmax_op.py
+++ b/test/legacy_test/test_softmax_op.py
@@ -91,6 +91,7 @@ class TestSoftmaxOp(OpTest):
                 check_pir=True,
                 check_prim_pir=True,
                 check_pir_onednn=self.check_pir_onednn,
+                check_symbol_infer=False,
             )
         else:
             self.check_output(
@@ -98,6 +99,7 @@ class TestSoftmaxOp(OpTest):
                 check_pir=True,
                 check_prim_pir=True,
                 check_pir_onednn=self.check_pir_onednn,
+                check_symbol_infer=False,
             )
 
     def test_check_grad(self):
@@ -168,6 +170,7 @@ class TestSoftmaxOp_ZeroDim1(TestSoftmaxOp):
                 check_pir=True,
                 check_prim_pir=True,
                 check_pir_onednn=self.check_pir_onednn,
+                check_symbol_infer=False,
             )
         else:
             self.check_output(
@@ -175,6 +178,7 @@ class TestSoftmaxOp_ZeroDim1(TestSoftmaxOp):
                 check_pir=True,
                 check_prim_pir=True,
                 check_pir_onednn=self.check_pir_onednn,
+                check_symbol_infer=False,
             )
 
 
@@ -216,6 +220,7 @@ class TestSoftmaxOp_ZeroDim2(TestSoftmaxOp):
                 check_pir=True,
                 check_prim_pir=True,
                 check_pir_onednn=self.check_pir_onednn,
+                check_symbol_infer=False,
             )
         else:
             self.check_output(
@@ -223,6 +228,7 @@ class TestSoftmaxOp_ZeroDim2(TestSoftmaxOp):
                 check_pir=True,
                 check_prim_pir=True,
                 check_pir_onednn=self.check_pir_onednn,
+                check_symbol_infer=False,
             )
 
 
@@ -491,6 +497,7 @@ class TestSoftmaxBF16Op(OpTest):
             check_pir=(not self.use_mkldnn),
             check_prim_pir=(not self.use_mkldnn),
             check_pir_onednn=self.check_pir_onednn,
+            check_symbol_infer=False,
         )
 
     def test_check_grad(self):

--- a/test/legacy_test/test_tril_triu_op.py
+++ b/test/legacy_test/test_tril_triu_op.py
@@ -46,7 +46,7 @@ class TrilTriuOpDefaultTest(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_symbol_infer=False)
 
     def test_check_grad_normal(self):
         self.check_grad(['X'], 'Out', check_pir=True)

--- a/test/legacy_test/test_trunc_op.py
+++ b/test/legacy_test/test_trunc_op.py
@@ -39,8 +39,7 @@ class TestTruncOp(OpTest):
 
     def test_check_output(self):
         self.check_output(
-            check_pir=True,
-            check_prim_pir=True,
+            check_pir=True, check_prim_pir=True, check_symbol_infer=False
         )
 
     def test_check_grad(self):
@@ -125,7 +124,9 @@ class TestTruncBF16OP(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place, check_pir=True)
+        self.check_output_with_place(
+            place, check_pir=True, check_symbol_infer=False
+        )
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- 关闭 same_operand_with_result.cc 中部分算子的单测符号推导
- 减少 ci 运行时间
- 见 https://github.com/ooooo-create/Public/issues/1 中算子关闭情况