### PR TITLE
[Auto Parallel] Add the CheckAndUpdateUnknownGlobalShape stage in dis…

### DIFF
--- a/paddle/phi/api/lib/api_gen_utils.cc
+++ b/paddle/phi/api/lib/api_gen_utils.cc
@@ -813,7 +813,7 @@ void SetReplicatedDistAttrForOutput(
   }
 }
 
-void CheckAndBackfillGlobalShape(phi::distributed::DistTensor* out) {
+void CheckAndUpdateUnknownGlobalShape(phi::distributed::DistTensor* out) {
   if (out && out->defined()) {
     auto dist_dims = out->dims();
     auto local_dims = out->local_dims();

--- a/paddle/phi/api/lib/api_gen_utils.cc
+++ b/paddle/phi/api/lib/api_gen_utils.cc
@@ -813,7 +813,7 @@ void SetReplicatedDistAttrForOutput(
   }
 }
 
-void CheckAndSBackfillGlobalShape(phi::distributed::DistTensor* out) {
+void CheckAndBackfillGlobalShape(phi::distributed::DistTensor* out) {
   if (out && out->defined()) {
     auto dist_dims = out->dims();
     auto local_dims = out->local_dims();

--- a/paddle/phi/api/lib/api_gen_utils.h
+++ b/paddle/phi/api/lib/api_gen_utils.h
@@ -188,7 +188,7 @@ void SetReplicatedDistAttrForOutput(
     phi::distributed::DistTensor* out,
     const phi::distributed::ProcessMesh& process_mesh);
 
-void CheckAndSBackfillGlobalShape(phi::distributed::DistTensor* out);
+void CheckAndBackfillGlobalShape(phi::distributed::DistTensor* out);
 
 }  // namespace experimental
 }  // namespace paddle

--- a/paddle/phi/api/lib/api_gen_utils.h
+++ b/paddle/phi/api/lib/api_gen_utils.h
@@ -188,5 +188,7 @@ void SetReplicatedDistAttrForOutput(
     phi::distributed::DistTensor* out,
     const phi::distributed::ProcessMesh& process_mesh);
 
+void CheckAndSBackfillGlobalShape(phi::distributed::DistTensor* out);
+
 }  // namespace experimental
 }  // namespace paddle

--- a/paddle/phi/api/lib/api_gen_utils.h
+++ b/paddle/phi/api/lib/api_gen_utils.h
@@ -188,7 +188,7 @@ void SetReplicatedDistAttrForOutput(
     phi::distributed::DistTensor* out,
     const phi::distributed::ProcessMesh& process_mesh);
 
-void CheckAndBackfillGlobalShape(phi::distributed::DistTensor* out);
+void CheckAndUpdateUnknownGlobalShape(phi::distributed::DistTensor* out);
 
 }  // namespace experimental
 }  // namespace paddle


### PR DESCRIPTION
…t_api_gen to avoid errors caused by unfilled global shape

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

In op such as `nonzero`, the output shape is set to -1 by the infer_meta_fn. This shape is then determined within the kernel. Therefore, we need to inspect and backfill the global shape after the kernel call.

In the newly added `CheckAndUpdateUnknownGlobalShape ` function, we check whether the global_shape contains -1. If it does, we replace it with the corresponding value from local_shape.

