### PR TITLE
[CINN] fix CINN build group op insert bug

### DIFF
--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -706,10 +706,6 @@ pir::Operation* FindInsertPoint(const GroupOpsVec& group_ops,
     }
   }
 
-  std::cout << "group_ops.front()... " << first_op->id() << " "
-            << first_op->name() << std::endl;
-  std::cout << "group_ops.back()... " << insert_point_op->id() << " "
-            << insert_point_op->name() << std::endl;
   auto begin = first_op->operator Block::ConstIterator();
   auto end = ++(insert_point_op->operator Block::ConstIterator());
   const std::unordered_set<pir::Value> outputs_set(outputs.begin(),

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -683,9 +683,35 @@ pir::Operation* FindInsertPoint(const GroupOpsVec& group_ops,
                                 const std::vector<pir::Value>& outputs) {
   // Regard last op as insert position if there are no downstream ops between in
   // group_ops.
+  pir::Operation* first_op = group_ops.front();
   pir::Operation* insert_point_op = group_ops.back();
-  auto begin = group_ops.front()->operator Block::ConstIterator();
-  auto end = ++(group_ops.back()->operator Block::ConstIterator());
+  auto order_info =
+      [&]() -> std::unordered_map<const pir::Operation*, int64_t> {
+    std::unordered_map<const pir::Operation*, int64_t> map;
+    // initialize the position index with block size by default.
+    auto block = insert_point_op->GetParent();
+    int64_t order = 0;
+    for (auto& op : *block) {
+      map[&op] = order++;
+    }
+    return map;
+  }();
+
+  for (auto* op : group_ops) {
+    if (order_info.at(op) > order_info.at(insert_point_op)) {
+      insert_point_op = op;
+    }
+    if (order_info.at(op) < order_info.at(first_op)) {
+      first_op = op;
+    }
+  }
+
+  std::cout << "group_ops.front()... " << first_op->id() << " "
+            << first_op->name() << std::endl;
+  std::cout << "group_ops.back()... " << insert_point_op->id() << " "
+            << insert_point_op->name() << std::endl;
+  auto begin = first_op->operator Block::ConstIterator();
+  auto end = ++(insert_point_op->operator Block::ConstIterator());
   const std::unordered_set<pir::Value> outputs_set(outputs.begin(),
                                                    outputs.end());
   const std::unordered_set<const pir::Operation*> group_ops_set(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

#### 问题表现：
![image](https://github.com/user-attachments/assets/d7e268a2-ee35-4801-98b3-ef346c4907fd)


#### 原因分析：
如下图，红色为被划分到同一个 group 中的 op ，黑色为下游 op。示意图中省略了其他无关 op，只示意这些 op在 program 中的相对位置。

在构建 group op 时，插入逻辑可参考[PR62529](https://github.com/PaddlePaddle/Paddle/pull/62529)，需要寻找*第一个下游 op* 。
![image](https://github.com/user-attachments/assets/1d5c10f8-c110-4d74-af2b-f84adf68c676)

在原来的 program 中，第一个下游 op 为 op3。

构建过程中， op5 的下游存在其他 group op（称为group2） 中的 op，将 op5 连同其上游 op 插入了 group2 第一个下游 op 之前，这个插入点同时也在 op1 之前。该所以经历变化后，op5 和 op4 相对于 op123 的一维执行顺序发生了变化。

目前的逻辑中，找第一个下游 op 是从 VecGroupOp 的 begin 开始遍历计算图，到 end 为止。但如图所示，VecGroupOp 的 begin其实发生了变化。这导致现有逻辑下，第一个下游 op 没有找准。

原来的计算图没有这类问题，可能是因为 recompute 引入了 op4--op5 这样，有共同下游但没有共同上游的分支。

另外，兄弟节点合并也有可能导致同一个 group op 中存在无公共节点的两棵树。

#### 修复：
遍历 VecGroupOp，重新获取其 begin 和 end。