### PR TITLE
[XPU] Add KL3 Support for fc_xpu and Fix Top-P Sampling Flag

### DIFF
--- a/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
@@ -76,7 +76,7 @@ void FcXPUKernelImpl(const Context& ctx,
     act.hard_sigmoid_slope = act_alpha;
   }
   int r = 0;
-
+#ifdef PADDLE_WITH_XPU_XRE5
   if (std::is_same<XPUTypeX, XPUTypeOut>::value &&
       std::is_same<XPUTypeW, T_GEMM>::value &&
       !std::is_same<T_W, int8_t>::value) {
@@ -108,7 +108,7 @@ void FcXPUKernelImpl(const Context& ctx,
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "fc_xpu");
     return;
   }
-
+#endif
   auto* scale_max_data = scale_max.get_ptr() == nullptr
                              ? nullptr
                              : scale_max.get_ptr()->data<float>();

--- a/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
@@ -78,7 +78,7 @@ void FcXPUKernelImpl(const Context& ctx,
   int r = 0;
 
   if (std::is_same<XPUTypeX, XPUTypeOut>::value &&
-      std::is_same<XPUTypeW, XPUTypeOut>::value &&
+      std::is_same<XPUTypeW, T_GEMM>::value &&
       !std::is_same<T_W, int8_t>::value) {
     r = baidu::xpu::xblas::
         fc_fusion<XPUTypeX, XPUTypeW, XPUTypeOut, T_GEMM>(  // TX, TW. TY TGEMM

--- a/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
@@ -15,9 +15,7 @@
 #include "glog/logging.h"
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
-#ifdef PADDLE_WITH_XPU_XHPC
 #include "xblas/cublasLt.h"
-#endif
 
 namespace phi {
 namespace fusion {
@@ -79,7 +77,6 @@ void FcXPUKernelImpl(const Context& ctx,
   }
   int r = 0;
 
-#ifdef PADDLE_WITH_XPU_XHPC
   if (std::is_same<XPUTypeX, XPUTypeOut>::value &&
       std::is_same<XPUTypeW, XPUTypeOut>::value &&
       !std::is_same<XPUTypeW, int8_t>::value) {
@@ -111,7 +108,7 @@ void FcXPUKernelImpl(const Context& ctx,
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "fc_xpu");
     return;
   }
-#endif
+
   auto* scale_max_data = scale_max.get_ptr() == nullptr
                              ? nullptr
                              : scale_max.get_ptr()->data<float>();

--- a/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
@@ -79,7 +79,7 @@ void FcXPUKernelImpl(const Context& ctx,
 
   if (std::is_same<XPUTypeX, XPUTypeOut>::value &&
       std::is_same<XPUTypeW, XPUTypeOut>::value &&
-      !std::is_same<XPUTypeW, int8_t>::value) {
+      !std::is_same<T_W, int8_t>::value) {
     r = baidu::xpu::xblas::
         fc_fusion<XPUTypeX, XPUTypeW, XPUTypeOut, T_GEMM>(  // TX, TW. TY TGEMM
             ctx.x_context(),                                // ctx

--- a/paddle/phi/kernels/xpu/top_p_sampling_kernel.cc
+++ b/paddle/phi/kernels/xpu/top_p_sampling_kernel.cc
@@ -26,7 +26,7 @@ PHI_DEFINE_EXPORTED_bool(xpu_top_p_sampling_use_fp16,
                          false,
                          "use fp16 to improve the inference performance of "
                          "top_p_sampling xpu kernel");
-PHI_DEFINE_EXPORTED_bool(
+PHI_DEFINE_EXPORTED_int32(
     xpu_top_p_sampling_heuristic_threshold,
     20,
     "threshold of heuristic method used for xpu_top_p_sampling, default 20; if "


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
- 新增fc_xpu昆仑3加速
- 修复top p中flag的类型：xpu_top_p_sampling_heuristic_threshold
Pcard-71500