### PR TITLE
[CINN] Skip checking infer_sym_shape for some ops

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_pass.cc
@@ -36,6 +36,17 @@ namespace ir {
 
 namespace {
 
+std::unordered_set<std::string> SKIP_CHECK_OPS = {
+    "pd_op.add",           "pd_op.subtract",     "pd_op.multiply",
+    "pd_op.divide",        "pd_op.floor_divide", "pd_op.minimum",
+    "pd_op.maximum",       "pd_op.remainder",    "pd_op.elementwise_pow",
+    "pd_op.bitwise_and",   "pd_op.bitwise_or",   "pd_op.bitwise_xor",
+    "pd_op.fmax",          "pd_op.fmin",         "pd_op.heaviside",
+    "pd_op.less_than",     "pd_op.less_equal",   "pd_op.greater_than",
+    "pd_op.greater_equal", "pd_op.equal",        "pd_op.not_equal",
+    "pd_op.logical_and",   "pd_op.logical_or",   "pd_op.logical_xor",
+    "pd_op.shape"};
+
 class BlockDimExprsAsserter {
  public:
   BlockDimExprsAsserter(const DimExprs4ValueT& func,
@@ -100,6 +111,7 @@ class BlockDimExprsAsserter {
     }();
     // skip the ops which operand and result have same shape
     if (is_same_operand_result_op) return;
+    if (SKIP_CHECK_OPS.count(op->name())) return;
 
     auto OpDimExprs4Value = GetOpDimExprs4Value(op);
     const auto& inputs = [&] {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

跳过部分op的符号推导检查，以降低模型开启符号推导检查的耗时