### PR TITLE
[PIR][oneDNN] Workaround for reshape when shape is unknown

### DIFF
--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
@@ -140,6 +140,18 @@ class OneDNNBf16PlacementPattern : public pir::RewritePattern {
         return false;
       }
     }
+
+    // Workaround for reshape when shape is unknown
+    if (op_name == "onednn_op.reshape_" || op_name == "onednn_op.reshape") {
+      bool is_from_tensor = false;
+      std::vector<int64_t> shape = paddle::dialect::ParseValueShape(
+          op->operand_source(1), &is_from_tensor);
+      int num_minus = 0;
+      for (auto i : shape) {
+        if (i == -1) num_minus++;
+      }
+      if (num_minus > 1 || (num_minus == 1 && shape.size() == 1)) return false;
+    }
     return true;
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Usually the shape of Reshape should be IntArray, while sometimes it will be DenseTensor/VectorType, which may trigger error of incompatible shape since the shape will be [-1, -1, ..., -1]. Currently we skip such case to avoid it.
