### PR TITLE
[PIR save/load]Add json_to_pdmodel

### DIFF
--- a/python/paddle/jit/__init__.py
+++ b/python/paddle/jit/__init__.py
@@ -15,7 +15,7 @@
 
 from .api import (
     ignore_module,
-    json_to_pdmodel,
+    json_to_pdmodel,  # noqa: F401
     load,
     not_to_static,
     save,
@@ -35,5 +35,4 @@ __all__ = [
     'set_verbosity',
     'not_to_static',
     'enable_to_static',
-    'json_to_pdmodel',
 ]

--- a/python/paddle/jit/__init__.py
+++ b/python/paddle/jit/__init__.py
@@ -13,7 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .api import ignore_module, load, not_to_static, save, to_static
+from .api import (
+    ignore_module,
+    json_to_pdmodel,
+    load,
+    not_to_static,
+    save,
+    to_static,
+)
 from .dy2static.logging_utils import set_code_level, set_verbosity
 from .dy2static.program_translator import enable_to_static
 from .translated_layer import TranslatedLayer
@@ -28,4 +35,5 @@ __all__ = [
     'set_verbosity',
     'not_to_static',
     'enable_to_static',
+    'json_to_pdmodel',
 ]

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -1800,3 +1800,19 @@ def get_ast_static_function(function):
             )
             return ast_static_function
     return function
+
+
+def json_to_pdmodel(net, input_spec, load_path, save_path):
+    net1 = paddle.jit.load(load_path)
+    state_dict = {}
+    for val in net1.state_dict().values():
+        name = val.name[: val.name.rfind('_')]
+        state_dict[name] = val
+
+    name_state_dict = {}
+    for name, var in net.to_static_state_dict().items():
+        name_state_dict[name] = state_dict[var.name]
+
+    net.set_state_dict(name_state_dict)
+    with paddle.pir_utils.OldIrGuard():
+        paddle.jit.save(net, save_path, input_spec)

--- a/test/ir/pir/test_ir_save_load.py
+++ b/test/ir/pir/test_ir_save_load.py
@@ -370,23 +370,30 @@ class TestSaveModuleWithwhileOp(unittest.TestCase):
 
 
 class TestJsonToPdmodel(unittest.TestCase):
-    def test_json_to_pdmodel(self):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
         paddle.disable_static()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_json_to_pdmodel(self):
         net = ResNet(BottleneckBlock, 50)
         net = paddle.jit.to_static(net, full_graph=True)
-        save_path = './save1'
-        save_model = './save2'
+        save_json = os.path.join(self.temp_dir.name, 'save1')
+        save_model = os.path.join(self.temp_dir.name, 'save2')
         input_spec = [
             paddle.static.InputSpec(shape=[1, 3, 224, 224], dtype='float32')
         ]
-        paddle.jit.save(net, save_path, input_spec)
+        paddle.jit.save(net, save_json, input_spec)
 
         # load and save to pdmodel
         with paddle.pir_utils.OldIrGuard():
             input_spec = [
                 paddle.static.InputSpec(shape=[1, 3, 224, 224], dtype='float32')
             ]
-        paddle.jit.json_to_pdmodel(net, input_spec, save_path, save_model)
+        paddle.jit.json_to_pdmodel(net, input_spec, save_json, save_model)
+        self.assertTrue(os.path.exists(save_model + '.pdmodel'))
 
 
 if __name__ == '__main__':

--- a/test/ir/pir/test_ir_save_load.py
+++ b/test/ir/pir/test_ir_save_load.py
@@ -18,6 +18,8 @@ import unittest
 
 import paddle
 from paddle import base
+from paddle.vision.models import ResNet
+from paddle.vision.models.resnet import BottleneckBlock
 
 
 class TestSaveModuleWithCommonOp(unittest.TestCase):
@@ -365,6 +367,26 @@ class TestSaveModuleWithwhileOp(unittest.TestCase):
         self.check_block(
             main_program.global_block(), recover_program.global_block()
         )
+
+
+class TestJsonToPdmodel(unittest.TestCase):
+    def test_json_to_pdmodel(self):
+        paddle.disable_static()
+        net = ResNet(BottleneckBlock, 50)
+        net = paddle.jit.to_static(net, full_graph=True)
+        save_path = './save1'
+        save_model = './save2'
+        input_spec = [
+            paddle.static.InputSpec(shape=[1, 3, 224, 224], dtype='float32')
+        ]
+        paddle.jit.save(net, save_path, input_spec)
+
+        # load and save to pdmodel
+        with paddle.pir_utils.OldIrGuard():
+            input_spec = [
+                paddle.static.InputSpec(shape=[1, 3, 224, 224], dtype='float32')
+            ]
+        paddle.jit.json_to_pdmodel(net, input_spec, save_path, save_model)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
pcard-67164
Add json_to_pdmodel
需求：未适配PIR save/load的情况下，需要将存储的.json文件转存为.pdmodel文件。
解决：由于Paddle中不存在逆向转换模块，因此需要将存储的文件load回来，切换为旧IR模式，再次save为pdmodel格式。
添加API：`json_to_pdmodel(net, input_spec, load_path, save_path)`