### PR TITLE
Fix `paddle.distribution.LKJCholesky.sample()` when concentration is 1-D 易用性提升

### DIFF
--- a/python/paddle/distribution/lkj_cholesky.py
+++ b/python/paddle/distribution/lkj_cholesky.py
@@ -341,9 +341,7 @@ class LKJCholesky(distribution.Distribution):
         if sample_shape != (1,):
             output_shape = list(sample_shape)
 
-        if tuple(self.concentration.shape) != () and tuple(
-            self.concentration.shape
-        ) != (1,):
+        if tuple(self.concentration.shape) != ():
             output_shape.extend(self.concentration.shape)
 
         output_shape.extend([self.dim, self.dim])

--- a/python/paddle/distribution/lkj_cholesky.py
+++ b/python/paddle/distribution/lkj_cholesky.py
@@ -120,6 +120,7 @@ def tril_matrix_to_vec(mat: Tensor, diag: int = 0) -> Tensor:
     out_shape += (vec_len,)
 
     # Use the mask to index the lower triangular elements from the input matrix
+    tril_mask = paddle.broadcast_to(tril_mask, mat.shape)
     vec = paddle.masked_select(mat, tril_mask).reshape(out_shape)
     return vec
 

--- a/test/distribution/test_distribution_lkj_cholesky.py
+++ b/test/distribution/test_distribution_lkj_cholesky.py
@@ -42,6 +42,15 @@ paddle.seed(2024)
                 min=0,
             ),
         ),
+        (
+            'one-dim2',
+            parameterize.xrand(
+                (1,),
+                dtype='float32',
+                max=1.0,
+                min=0,
+            ),
+        ),
     ],
 )
 class TestLKJCholeskyShape(unittest.TestCase):

--- a/test/distribution/test_distribution_lkj_cholesky.py
+++ b/test/distribution/test_distribution_lkj_cholesky.py
@@ -34,6 +34,15 @@ paddle.seed(2024)
     (parameterize.TEST_CASE_NAME, 'concentration'),
     [
         (
+            'zero-dim',
+            parameterize.xrand(
+                (1,),
+                dtype='float32',
+                max=1.0,
+                min=0,
+            ).reshape([]),
+        ),
+        (
             'one-dim',
             parameterize.xrand(
                 (2,),
@@ -55,10 +64,10 @@ paddle.seed(2024)
 )
 class TestLKJCholeskyShape(unittest.TestCase):
     def gen_cases(self):
-        extra_shape = (
-            len(self.concentration),
-            self._paddle_lkj_cholesky.dim,
-            self._paddle_lkj_cholesky.dim,
+        extra_shape = []
+        extra_shape.extend(self.concentration.shape)
+        extra_shape.extend(
+            [self._paddle_lkj_cholesky.dim, self._paddle_lkj_cholesky.dim]
         )
         cases = [
             {

--- a/test/distribution/test_distribution_lkj_cholesky_static.py
+++ b/test/distribution/test_distribution_lkj_cholesky_static.py
@@ -36,6 +36,15 @@ paddle.seed(2024)
     (parameterize.TEST_CASE_NAME, 'concentration'),
     [
         (
+            'zerp-dim',
+            parameterize.xrand(
+                (1,),
+                dtype='float32',
+                max=1.0,
+                min=0,
+            ).reshape([]),
+        ),
+        (
             'one-dim',
             parameterize.xrand(
                 (2,),
@@ -79,10 +88,10 @@ class TestLKJCholeskyShape(unittest.TestCase):
             }
 
     def gen_cases(self):
-        extra_shape = (
-            len(self.concentration),
-            self._paddle_lkj_cholesky.dim,
-            self._paddle_lkj_cholesky.dim,
+        extra_shape = []
+        extra_shape.extend(self.concentration.shape)
+        extra_shape.extend(
+            [self._paddle_lkj_cholesky.dim, self._paddle_lkj_cholesky.dim]
         )
         cases = [
             {

--- a/test/distribution/test_distribution_lkj_cholesky_static.py
+++ b/test/distribution/test_distribution_lkj_cholesky_static.py
@@ -44,6 +44,15 @@ paddle.seed(2024)
                 min=0,
             ),
         ),
+        (
+            'one-dim2',
+            parameterize.xrand(
+                (1,),
+                dtype='float64',
+                max=1.0,
+                min=0,
+            ),
+        ),
     ],
 )
 class TestLKJCholeskyShape(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 `concentration ` 是 1-D tensor 时 sample 方法返回值的维度问题。（无不兼容问题）