### PR TITLE
remove use_calc_stream param [fluid_ops] c_scatter

### DIFF
--- a/paddle/fluid/operators/collective/c_identity_op.cc
+++ b/paddle/fluid/operators/collective/c_identity_op.cc
@@ -51,10 +51,6 @@ class CIdentityOpMaker : public framework::OpProtoAndCheckerMaker {
     AddOutput("Out", "(Tensor) identity tensor.");
     AddAttr<int>("ring_id", "(int default 0) nccl communication ring id.")
         .SetDefault(0);
-    AddAttr<bool>(
-        "use_calc_stream",
-        "(bool default true) eject CUDA operations to calculation stream.")
-        .SetDefault(true);
     AddAttr<bool>("use_model_parallel",
                   "(bool default true) use this op with model parallel.")
         .SetDefault(true);

--- a/paddle/fluid/operators/ops_signature/c_identity_sig.cc
+++ b/paddle/fluid/operators/ops_signature/c_identity_sig.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
-
-#include "paddle/phi/kernels/c_identity_kernel.h"
-
-#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/compat/op_utils.h"
 
 namespace phi {
 
-template <typename T, typename Context>
-void CIdentityKernel(const Context& dev_ctx,
-                     const DenseTensor& x,
-                     bool use_model_parallel,
-                     DenseTensor* out) {
-  dev_ctx.template Alloc<T>(out);
-
-  phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+KernelSignature CIdentityOpArgumentMapping(const ArgumentMappingContext& ctx) {
+  return KernelSignature("c_identity", {"X"}, {"use_model_parallel"}, {"Out"});
 }
 
 }  // namespace phi
+
+PD_REGISTER_ARG_MAPPING_FN(c_identity, phi::CIdentityOpArgumentMapping);

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -604,7 +604,6 @@ void ClipByNormInferMeta(const MetaTensor& x, float max_norm, MetaTensor* out) {
 
 void CIdentityInferMeta(const MetaTensor& x,
                         int ring_id,
-                        bool use_calc_stream,
                         bool use_model_parallel,
                         MetaTensor* out) {
   PADDLE_ENFORCE_GE(

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -144,7 +144,6 @@ void ClipByNormInferMeta(const MetaTensor& x, float max_norm, MetaTensor* out);
 
 void CIdentityInferMeta(const MetaTensor& x,
                         int ring_id,
-                        bool use_calc_stream,
                         bool use_model_parallel,
                         MetaTensor* out);
 

--- a/paddle/phi/kernels/c_identity_kernel.h
+++ b/paddle/phi/kernels/c_identity_kernel.h
@@ -21,8 +21,6 @@ namespace phi {
 template <typename T, typename Context>
 void CIdentityKernel(const Context& dev_ctx,
                      const DenseTensor& x,
-                     int ring_id,
-                     bool use_calc_stream,
                      bool use_model_parallel,
                      DenseTensor* out);
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/c_identity_kernel.cc
+++ b/paddle/phi/kernels/cpu/c_identity_kernel.cc
@@ -22,8 +22,6 @@ namespace phi {
 template <typename T, typename Context>
 void CIdentityKernel(const Context& dev_ctx,
                      const DenseTensor& x,
-                     int ring_id,
-                     bool use_calc_stream,
                      bool use_model_parallel,
                      DenseTensor* out) {
   PADDLE_THROW(

--- a/paddle/phi/kernels/cpu/c_scatter_kernel.cc
+++ b/paddle/phi/kernels/cpu/c_scatter_kernel.cc
@@ -28,10 +28,8 @@ namespace phi {
 template <typename T, typename Context>
 void CScatterOpCPUKernel(const Context &dev_ctx,
                          const DenseTensor &x,
-                         int ring_id,
                          int root,
                          int nranks,
-                         bool use_calc_stream,
                          DenseTensor *out) {
 #if defined(PADDLE_WITH_GLOO)
   auto in = &x;

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2106,7 +2106,7 @@
   forward : mp_allreduce_sum(Tensor x, int ring_id = 0) -> Tensor(out)
   args : (Tensor out_grad, int ring_id = 0)
   output : Tensor(x_grad)
-  invoke : c_identity(out_grad, ring_id, false, false)
+  invoke : c_identity(out_grad, ring_id, false)
 
 - backward_op : multi_dot_grad
   forward : multi_dot (Tensor[] x) -> Tensor(out)

--- a/paddle/phi/ops/yaml/op_version.yaml
+++ b/paddle/phi/ops/yaml/op_version.yaml
@@ -89,6 +89,22 @@
         - add_input : ValueTensor
           comment : In order to support multi-tag task.
 
+- op : c_identity
+  version :
+    - checkpoint : Upgrade c_identity delete 1 attribute[use_calc_stream].
+      action :
+        - delete_attr : use_calc_stream
+          comment : eject CUDA operations to calculation stream.
+          default : false
+
+- op : c_scatter
+  version :
+    - checkpoint : Upgrade c_scatter delete 1 attribute[use_calc_stream].
+      action :
+        - delete_attr : use_calc_stream
+          comment : eject CUDA operations to calculation stream.
+          default : false
+
 - op : c_split
   version :
     - checkpoint : Upgrade c_split delete 1 attribute[use_calc_stream].

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -823,6 +823,7 @@
   output : Tensor(out)
   infer_meta :
     func : CScatterInferMeta
+    param : [x, ring_id, root, nranks]
   kernel :
     func : c_scatter
     param : [x, root, nranks]

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -796,12 +796,14 @@
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : c_identity
-  args : (Tensor x, int ring_id, bool use_calc_stream, bool use_model_parallel)
+  args : (Tensor x, int ring_id, bool use_model_parallel)
   output : Tensor(out)
   infer_meta :
     func : CIdentityInferMeta
+    param: [x, ring_id, use_model_parallel]
   kernel :
     func : c_identity
+    param: [x, use_model_parallel]
   inplace : (x -> out)
   traits : paddle::dialect::ForwardOnlyTrait
 
@@ -817,13 +819,14 @@
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : c_scatter
-  args : (Tensor x, int ring_id = 0, int root = 0, int nranks = 0, bool use_calc_stream = false)
+  args : (Tensor x, int ring_id = 0, int root = 0, int nranks = 0)
   output : Tensor(out)
   infer_meta :
     func : CScatterInferMeta
     param : [x, ring_id, root, nranks]
   kernel :
     func : c_scatter
+    param : [x, root, nranks]
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : c_sync_comm_stream

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -823,7 +823,6 @@
   output : Tensor(out)
   infer_meta :
     func : CScatterInferMeta
-    param : [x, ring_id, root, nranks]
   kernel :
     func : c_scatter
     param : [x, root, nranks]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
c_scatter, c_identity清理参数use_calc_stream