### PR TITLE
[Prim][Pir] Using concat instead of padding when axes.size() is 1

### DIFF
--- a/test/legacy_test/test_slice_op.py
+++ b/test/legacy_test/test_slice_op.py
@@ -101,6 +101,46 @@ class TestCase2(TestSliceOp):
         self.out = self.input[-3:3, 0:100, :, 2:-1]
 
 
+class TestCase3(TestSliceOp):
+    def config(self):
+        self.input = np.random.random([4, 4, 5, 6]).astype("float64")
+        self.starts = [-3]
+        self.ends = [3]
+        self.axes = [0]
+        self.infer_flags = [1, 1, 1]
+        self.out = self.input[-3:3, :, :, :]
+
+
+class TestCase4(TestSliceOp):
+    def config(self):
+        self.input = np.random.random([3, 4, 5, 6]).astype("float64")
+        self.starts = [0]
+        self.ends = [4]
+        self.axes = [1]
+        self.infer_flags = [1, 1, 1]
+        self.out = self.input[:, :, :, :]
+
+
+class TestCase5(TestSliceOp):
+    def config(self):
+        self.input = np.random.random([3, 4, 5, 6]).astype("float64")
+        self.starts = [0]
+        self.ends = [2]
+        self.axes = [1]
+        self.infer_flags = [1, 1, 1]
+        self.out = self.input[:, 0:2, :, :]
+
+
+class TestCase6(TestSliceOp):
+    def config(self):
+        self.input = np.random.random([3, 4, 5, 6]).astype("float64")
+        self.starts = [2]
+        self.ends = [4]
+        self.axes = [1]
+        self.infer_flags = [1, 1, 1]
+        self.out = self.input[:, 2:4, :, :]
+
+
 class TestSliceZerosShapeTensor(OpTest):
     def setUp(self):
         self.op_type = "slice"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
Others
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->


### Description
当只取一个轴做 slice 时，反向 slice_grad 使用 concat 优化。
pcard-66975
<!-- Describe what you’ve done -->
