### PR TITLE
[XPU] support track rng state on XPU

### DIFF
--- a/python/paddle/distributed/fleet/layers/mpu/random.py
+++ b/python/paddle/distributed/fleet/layers/mpu/random.py
@@ -64,7 +64,7 @@ class RNGStatesTracker:
             # switch index to name
             paddle.incubate.set_rng_state(self.states_[name], use_index=True)
             # export the saved state
-            states[name] = paddle.get_cuda_rng_state()
+            states[name] = paddle.get_rng_state()
         paddle.incubate.set_rng_state(orig_rng_state_index, use_index=True)
         return states
 
@@ -76,7 +76,7 @@ class RNGStatesTracker:
             # switch index to name
             paddle.incubate.set_rng_state(self.states_[name], use_index=True)
             # set the state to saved state
-            paddle.set_cuda_rng_state(states[name])
+            paddle.set_rng_state(states[name])
 
         paddle.incubate.set_rng_state(orig_rng_state_index, use_index=True)
 


### PR DESCRIPTION
### PR Category
Custom Device


### PR Types
New features


### Description
将RNGStatesTracker中的paddle.get_cuda_rng_state()、paddle.set_cuda_rng_state()修改为通用接口paddle.get_rng_state()、paddle.set_rng_state()以支持XPU等其他device
