### PR TITLE
[SOT] Fix for breakgraph load same variable with different name

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1775,7 +1775,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
             extra_store_vars: for iterator, we need store the holder if it is a Tensor
         """
         store_vars = list(OrderedSet(list(stack) + extra_store_vars))
-        store_var_info = {var.id: None for var in stack}
+        store_var_info = {var.id: [] for var in stack}
 
         for name in restore_names:
             _var = self.get_var(name, allow_undefined=True)
@@ -1783,7 +1783,8 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 continue
             if _var not in stack:
                 store_vars.append(_var)
-            store_var_info[_var.id] = name
+            store_var_info.setdefault(_var.id, [])
+            store_var_info[_var.id].append(name)
 
         compile_graph_result = self._graph.compile_graph(*store_vars)
         graph_fn, _ = compile_graph_result
@@ -2169,6 +2170,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         )
 
         for name in loop_body_inputs[:-1]:
+            # var_loader.load(self.get_var(name))
             self._graph.pycode_gen.gen_load(name)
 
         # this is the _break_flag

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -935,6 +935,11 @@ class PyCodeGen:
                     "shift_n is not supported before python3.11"
                 )
 
+    def gen_dup_top(self):
+        if sys.version_info >= (3, 11):
+            return self.add_instr("COPY", arg=0)
+        return self.add_instr("DUP_TOP")
+
     def gen_swap(self, n):
         if sys.version_info >= (3, 11):
             self.add_instr("SWAP", arg=n)

--- a/test/sot/test_12_for_loop.py
+++ b/test/sot/test_12_for_loop.py
@@ -321,5 +321,24 @@ class TestArange(TestCaseBase):
         self.assert_results(for_arange, x)
 
 
+def for_break_with_load_same_consts(x: paddle.Tensor):
+    y = None
+    z = None
+    for i in [1, 2, 3]:
+        if y is None:
+            y = i
+        if z is None:
+            z = i
+        x += y + z
+        sot.psdb.breakgraph()
+    return x
+
+
+class TestForBreakWithLoadSameConsts(TestCaseBase):
+    def test_for_break_with_load_same_consts(self):
+        x = paddle.to_tensor(1)
+        self.assert_results(for_break_with_load_same_consts, x)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

对于相同的对象，比如 `None`，我们在模拟执行也是相同的 Variable，也就是说这个 Variable 拥有不同的 name，因此在 store 的时候，`store_var_info: dict[str, str]`（`var.id -> name`），这样的 `store_var_info` 是无法表示拥有多个 name 的 Variable 的，因此使用 `store_var_info: dict[str, list[str]]` 来表示 Variable 可能拥有多个 name，当然，如果它拥有多个 name，在 store 时候就应该为每个 name store，需要 dup top 一下再进行 store

PCard-66972