### PR TITLE
remove use_calc_stream param [fluid_ops] c_broadcast

### DIFF
--- a/paddle/fluid/operators/collective/c_broadcast_op.cc
+++ b/paddle/fluid/operators/collective/c_broadcast_op.cc
@@ -43,10 +43,6 @@ class CBroadcastOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<int>("root", "(int default 0) root id for broadcasting.")
         .SetDefault(0);
 
-    AddAttr<bool>(
-        "use_calc_stream",
-        "(bool default false) eject CUDA operations to calculation stream.")
-        .SetDefault(false);
     AddComment(R"DOC(
 CBroadcast Operator
 

--- a/paddle/fluid/operators/collective/c_broadcast_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_broadcast_op_xpu.cc
@@ -70,10 +70,6 @@ class CBroadcastOpXPUKernel : public framework::OpKernel<T> {
       stream = comm->stream();
       VLOG(3) << "old BKCLCommContext has rid " << ring_id;
     }
-    if (ctx.Attr<bool>("use_calc_stream")) {
-      auto dev_ctx = phi::DeviceContextPool::Instance().Get(place);
-      stream = static_cast<phi::XPUContext*>(dev_ctx)->x_context()->xpu_stream;
-    }
     if (comm_ctx) {
       comm_ctx->Broadcast(out, *x, root, stream);
     } else {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
c_broadcast移除use_calc_stream参数