### PR TITLE
[CINN] Fix decomposition of split op and fix fusion bug

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -562,7 +562,7 @@ class SplitOpPattern : public pir::OpRewritePattern<paddle::dialect::SplitOp> {
     const auto &OnlyUsedBySplitOrSlice = [&]() -> bool {
       for (auto it = op.out().use_begin(); it != op.out().use_end();) {
         const pir::Operation *downstream_op = (it++)->owner();
-        if (!downstream_op->isa<::pir::SliceOp>() ||
+        if (!downstream_op->isa<::pir::SliceOp>() &&
             !downstream_op->isa<::pir::SplitOp>()) {
           return false;
         }

--- a/paddle/cinn/operator_fusion/pattern_graph.h
+++ b/paddle/cinn/operator_fusion/pattern_graph.h
@@ -38,6 +38,7 @@ class PatternGraph {
   void ReduceTreeGrown();
   void ReduceTree_Trivial_Fusion();
   void LiftToItersPermutationPattern();
+  void LimitedAnchorFusion();
   void ItersPermutationFusion();
   void SplitRecomputePattern();
   std::vector<PatternNodePtr> ReturnFusionResults();

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.h
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.h
@@ -153,4 +153,6 @@ using ItersTransform = std::variant<IdentityItersTransform,
                                     ReuseItersTransform>;
 using ItersTransformRoute = std::vector<ItersTransform>;
 
+enum ItersTransformType { Identity, TransposeIters, AppendIters, ReuseIters };
+
 }  // namespace cinn::fusion

--- a/paddle/cinn/operator_fusion/policy/iters_fusion_policy.cc
+++ b/paddle/cinn/operator_fusion/policy/iters_fusion_policy.cc
@@ -95,9 +95,10 @@ std::optional<ItersTransform> ItersFusionPolicy::GetReuseItersTransform(
       GatherFirstNotInSecond(target_iters, shared_iters);
 
   if (!source_unique_iters.empty() && !target_unique_iters.empty()) {
-    if (!FLAGS_enable_reuse_iters_in_fusion) {
-      VLOG(4) << "Can not reuse iters in fusion, because of FLAGS_enable_"
-                 "reuse_iters_in_fusion is false.";
+    if (!transform_strategy_[ItersTransformType::ReuseIters] ||
+        !FLAGS_enable_reuse_iters_in_fusion) {
+      VLOG(4) << "Can not reuse iters in fusion, because of ReuseIters "
+                 "transform is disabled.";
       return std::nullopt;
     }
     std::unordered_map<std::string, std::string> reuse_target_to_source;
@@ -158,9 +159,10 @@ ItersFusionPolicy::SearchTransformRouteFromReduce2Reduce(
     if (source_flatten_iters == target_flatten_iters &&
         source_reduce_iters == target_reduce_iters) {
       return route;
-    } else if (!FLAGS_enable_transpose_iters_in_fusion) {
-      VLOG(4) << "Can not transpose iters in fusion, because of FLAGS_"
-                 "enable_transpose_iters_in_fusion is false.";
+    } else if (!transform_strategy_[ItersTransformType::TransposeIters] ||
+               !FLAGS_enable_transpose_iters_in_fusion) {
+      VLOG(4) << "Can not transpose iters in fusion, because of TransposeIters "
+                 "transform is disabled.";
       return std::nullopt;
     } else if (source_flatten_iters != target_flatten_iters &&
                source_reduce_iters == target_reduce_iters) {
@@ -285,9 +287,10 @@ std::optional<ItersTransformRoute> ItersFusionPolicy::SearchItersTransformRoute(
   // if exist iters in target can not find in source
   FusionIters appended_source_iters = reused_source_iters;
   if (!reused_target_unique_iters.empty()) {
-    if (!FLAGS_enable_append_iters_in_fusion) {
-      VLOG(4) << "Can not append iters in fusion, because of FLAGS_enable_"
-                 "append_iters_in_fusion is false.";
+    if (!transform_strategy_[ItersTransformType::AppendIters] ||
+        !FLAGS_enable_append_iters_in_fusion) {
+      VLOG(4) << "Can not append iters in fusion, because of AppendIters "
+                 "tranform is disabled.";
       return std::nullopt;
     }
     std::vector<int32_t> append_axis;
@@ -318,9 +321,10 @@ std::optional<ItersTransformRoute> ItersFusionPolicy::SearchItersTransformRoute(
   // 4. Apply TransposeItersTransform
   // if source iters after reuse and append are not equal to target
   if (appended_source_iters != target_iters) {
-    if (!FLAGS_enable_transpose_iters_in_fusion) {
-      VLOG(4) << "Can not transpose iters in fusion, because of FLAGS_enable_"
-                 "transpose_iters_in_fusion is false.";
+    if (!transform_strategy_[ItersTransformType::TransposeIters] ||
+        !FLAGS_enable_transpose_iters_in_fusion) {
+      VLOG(4) << "Can not transpose iters in fusion, because of "
+                 "TransposeIters tranform is disabled";
       return std::nullopt;
     }
     const auto perm =

--- a/paddle/cinn/operator_fusion/policy/iters_fusion_policy.h
+++ b/paddle/cinn/operator_fusion/policy/iters_fusion_policy.h
@@ -46,6 +46,17 @@ struct ItersFusionPolicy final : public PolicyBase {
   std::pair<std::vector<symbol::DimExpr>, std::vector<bool>> GetLoopDims(
       const FusionItersSignature& sig);
 
+  ItersFusionPolicy* DisableStrategy(ItersTransformType type) {
+    transform_strategy_[type] = false;
+    return this;
+  }
+  ItersFusionPolicy* EnableAllStrategies() {
+    for (auto& kv : transform_strategy_) {
+      kv.second = true;
+    }
+    return this;
+  }
+
  private:
   std::optional<ItersTransform> GetReuseItersTransform(
       FusionIters* source_iters, const FusionIters& target_iters);
@@ -59,6 +70,13 @@ struct ItersFusionPolicy final : public PolicyBase {
   using NodeRouteMap = std::unordered_map<PatternNodePtr, ItersTransformRoute>;
   std::unordered_map<PatternNodePtr, NodeRouteMap> routes_;
   std::shared_ptr<FusionItersManager> iters_manager_;
+
+  std::unordered_map<ItersTransformType, bool> transform_strategy_ = {
+      {ItersTransformType::Identity, true},
+      {ItersTransformType::TransposeIters, true},
+      {ItersTransformType::ReuseIters, true},
+      {ItersTransformType::AppendIters, true},
+  };
 };
 
 std::string DebugStrItersTransformRoute(const ItersTransformRoute& route);

--- a/test/ir/pir/cinn/test_anchor_fusion.py
+++ b/test/ir/pir/cinn/test_anchor_fusion.py
@@ -115,20 +115,14 @@ class TestAnchorFusion(unittest.TestCase):
         self.check_accuracy_and_kernel_num(init, func)
 
     def test_append_iters_fusion(self):
-        #       T
+        #       R
         #     /   \
         #    S     B
-        #   / \   / \
-        #  S   B S   T
         def func(x):
-            x = x * 2
-            a = x[0, :]  # shape=[64, 128]
-            b = paddle.expand(x, [16, 32, 64, 128])
-            c = a[:, 0]  # shape=[64]
-            d = paddle.expand(a, [8, 16, 32, 64, 128])
-            e = b[0, :, 0, :]  # shape=[32,128]
-            f = paddle.exp(b)
-            return c, d, e, f
+            x = paddle.sum(x, axis=0)
+            a = x[0, :]  # shape=[128]
+            b = paddle.expand(x, [32, 64, 128])
+            return a, b
 
         def init():
             x = paddle.rand((32, 64, 128))
@@ -256,6 +250,18 @@ class TestAnchorFusion(unittest.TestCase):
             return (x,)
 
         self.check_accuracy_and_kernel_num(init, func, kernel_num=1)
+
+    def test_split_fusion(self):
+        def func(x):
+            x = x * 2
+            a, b = paddle.split(x, num_or_sections=[2, 1], axis=1)
+            return a, b
+
+        def init():
+            x = paddle.rand((1, 3, 192, 288))
+            return (x,)
+
+        self.check_accuracy_and_kernel_num(init, func)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- 修复 Split Op 拆解成 2 个 Slice Op
- 修改多下游融合策略：只开启 Identity 和 TransposeIters 的多下游融合 + Sink 剩下的 Trivial + 开启全策略的多下游融合