### PR TITLE
[PIR][oneDNN][BF16] Generalize shape check function

### DIFF
--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
@@ -33,6 +33,20 @@
 #include "paddle/pir/include/core/operation.h"
 
 namespace {
+
+bool CheckIfknownShape(pir::Operation* op, size_t index) {
+  bool is_from_tensor = false;
+  std::vector<int64_t> shape = paddle::dialect::ParseValueShape(
+      op->operand_source(index), &is_from_tensor);
+  size_t num_minus = 0;
+  for (auto i : shape) {
+    if (i == -1) num_minus++;
+  }
+  // If all dims are -1, then the shape is actually unknown.
+  if (num_minus == shape.size()) return false;
+  return true;
+}
+
 class OneDNNBf16PlacementPattern : public pir::RewritePattern {
  public:
   explicit OneDNNBf16PlacementPattern(pir::IrContext* context)
@@ -141,17 +155,16 @@ class OneDNNBf16PlacementPattern : public pir::RewritePattern {
       }
     }
 
-    // Workaround for reshape when shape is unknown
+    // Workaround for reshape & slice when shape is unknown
+    // TODO: Since we can't distinguish when IntArray is produced by Combine,
+    // currently we fix it in a specific way. In future, we may think out a more
+    // generalized method
     if (op_name == "onednn_op.reshape_" || op_name == "onednn_op.reshape") {
-      bool is_from_tensor = false;
-      std::vector<int64_t> shape = paddle::dialect::ParseValueShape(
-          op->operand_source(1), &is_from_tensor);
-      int num_minus = 0;
-      for (auto i : shape) {
-        if (i == -1) num_minus++;
-      }
-      if (num_minus > 1 || (num_minus == 1 && shape.size() == 1)) return false;
+      return CheckIfknownShape(op, 1);
+    } else if (op_name == "onednn_op.slice") {
+      return CheckIfknownShape(op, 1) && CheckIfknownShape(op, 2);
     }
+
     return true;
   }
 

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
@@ -156,9 +156,9 @@ class OneDNNBf16PlacementPattern : public pir::RewritePattern {
     }
 
     // Workaround for reshape & slice when shape is unknown
-    // TODO: Since we can't distinguish when IntArray is produced by Combine,
-    // currently we fix it in a specific way. In future, we may think out a more
-    // generalized method
+    // TODO(Xinyi): Since we can't distinguish when IntArray is produced by
+    // Combine, currently we fix it in a specific way. In future, we may think
+    // out a more generalized method
     if (op_name == "onednn_op.reshape_" || op_name == "onednn_op.reshape") {
       return CheckIfknownShape(op, 1);
     } else if (op_name == "onednn_op.slice") {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Like #68903, we also found another op would cause error due to unknown shape. The root cause is that the shape of `VectorType` can't be distinguished when `IntArray` is produced by **Combine**.
Here I generalized the check function to check if shape is unknown. And in future, we may think out a more generalized method to deal with all possibly impacted ops.