### PR TITLE
[PHI] Skip infer shape for crop op if not given shape dims

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -785,10 +785,6 @@ void CropInferMeta(const MetaTensor& x,
   for (int i = 0; i < static_cast<int>(shape_dims.size()); ++i) {
     if (shape_dims[i] > 0) {
       out_dims[i] = static_cast<int64_t>(shape_dims[i]);
-    } else {
-      if (shape_dims[i] == -1 && offsets_vec[i] != -1 && x_dim[i] != -1) {
-        out_dims[i] = x_dim[i] - static_cast<int64_t>(offsets_vec[i]);
-      }
     }
   }
   out->set_dims(common::make_ddim(out_dims));

--- a/test/legacy_test/test_crop_tensor_op.py
+++ b/test/legacy_test/test_crop_tensor_op.py
@@ -289,6 +289,23 @@ class TestCropTensorException(unittest.TestCase):
         self.assertRaises(TypeError, input_dtype)
 
 
+class TestCropWithUnknownShape(unittest.TestCase):
+    def test_crop_with_unknown_shape(self):
+        main_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program):
+            x = paddle.static.data(name='x', shape=[-1, 4, 4], dtype='float32')
+            shape = paddle.static.data(name='shape', shape=[3], dtype='int32')
+            out = paddle.crop(x, shape=shape, offsets=[1, 1, 1])
+            exe = paddle.static.Executor(paddle.CPUPlace())
+            x_np = np.random.random((4, 4, 4)).astype('float32')
+            shape_np = np.array([2, 2, 2]).astype('int32')
+            (out_np,) = exe.run(
+                feed={'x': x_np, 'shape': shape_np}, fetch_list=[out]
+            )
+            self.assertEqual(out.shape, [-1, -1, -1])
+            self.assertEqual(out_np.shape, (2, 2, 2))
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

移除 crop op infermeta 中，未知参数 shape 但知道 offset 的时候的 infer shape 逻辑，因为这样完全是错误的

```python
x = ... # shape = [10, 10]
shape = paddle.to_tensor([6, 6]) # 注意是静态图，这里数值是未知的
crop(x, shape, offset=[2, 2])
```

这里原本是 crop 中间的 6x6，但原有逻辑会 infer 出来 [10-2 ,10-2]，明显是错误的，这里并不清楚 shape 数值，此时 infermeta 应该是 [-1, -1]，虽然推不出来，但至少不是错的

cc @megemini 

PCard-66972