### PR TITLE
[AutoParallel] Refine chunk_id setting method for send op

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/same_status_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/same_status_reshard_func.py
@@ -55,8 +55,44 @@ class SameStatusReshardFunction(ReshardFunction):
         for src, dst in zip(src_mesh.process_ids, dst_mesh.process_ids):
             if src == cur_global_rank:
                 chunk_id = -1
-                if src_value.get_defining_op().dist_attr:
-                    chunk_id = src_value.get_defining_op().dist_attr.chunk_id
+                if src_value.get_defining_op().name() == "pd_op.add_n":
+                    add_n_op = src_value.get_defining_op()
+                    combine_op = add_n_op.operand_source(0).get_defining_op()
+                    combine_op_chunk_id_list = []
+                    for input in combine_op.operands():
+                        if input.source().get_defining_op().dist_attr:
+                            combine_op_chunk_id_list.append(
+                                input.source()
+                                .get_defining_op()
+                                .dist_attr.chunk_id
+                            )
+                        else:
+                            combine_op_chunk_id_list.append(-1)
+                    # check combine_op operands chunk_id equal
+                    assert all(
+                        x == combine_op_chunk_id_list[0]
+                        for x in combine_op_chunk_id_list
+                    )
+
+                    assert all(
+                        x == combine_op_chunk_id_list[0]
+                        for x in combine_op_chunk_id_list
+                    ), "combine_op's operands has different chunk_id."
+                    chunk_id = combine_op_chunk_id_list[0]
+                    # reset add_n chunk_id
+                    add_n_op.dist_attr = (
+                        paddle.base.libpaddle.pir.create_op_dist_attribute(
+                            add_n_op.dist_attr.process_mesh,
+                            add_n_op.dist_attr.operands(),
+                            add_n_op.dist_attr.results(),
+                            chunk_id,
+                        )
+                    )
+                else:
+                    if src_value.get_defining_op().dist_attr:
+                        chunk_id = (
+                            src_value.get_defining_op().dist_attr.chunk_id
+                        )
 
                 comm_group = new_process_group([src, dst], group_type="p2p")
                 paddle._C_ops.send_v2(

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/same_status_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/same_status_reshard_func.py
@@ -72,11 +72,6 @@ class SameStatusReshardFunction(ReshardFunction):
                     assert all(
                         x == combine_op_chunk_id_list[0]
                         for x in combine_op_chunk_id_list
-                    )
-
-                    assert all(
-                        x == combine_op_chunk_id_list[0]
-                        for x in combine_op_chunk_id_list
                     ), "combine_op's operands has different chunk_id."
                     chunk_id = combine_op_chunk_id_list[0]
                     # reset add_n chunk_id

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/same_status_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/same_status_reshard_func.py
@@ -55,7 +55,13 @@ class SameStatusReshardFunction(ReshardFunction):
         for src, dst in zip(src_mesh.process_ids, dst_mesh.process_ids):
             if src == cur_global_rank:
                 chunk_id = -1
-                if src_value.get_defining_op().name() == "pd_op.add_n":
+                if (
+                    src_value.get_defining_op().name() == "pd_op.add_n"
+                    and src_value.get_defining_op()
+                    .operand_source(0)
+                    .get_defining_op()
+                    == "builtin.combine"
+                ):
                     add_n_op = src_value.get_defining_op()
                     combine_op = add_n_op.operand_source(0).get_defining_op()
                     combine_op_chunk_id_list = []

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/same_status_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/same_status_reshard_func.py
@@ -60,6 +60,7 @@ class SameStatusReshardFunction(ReshardFunction):
                     and src_value.get_defining_op()
                     .operand_source(0)
                     .get_defining_op()
+                    .name()
                     == "builtin.combine"
                 ):
                     add_n_op = src_value.get_defining_op()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Refine chunk_id setting method for send op
Pcard-73145