### PR TITLE
remove use_calc_stream param [fluid_ops] c_split

### DIFF
--- a/paddle/fluid/operators/collective/c_split_op.cc
+++ b/paddle/fluid/operators/collective/c_split_op.cc
@@ -103,10 +103,6 @@ class CSplitOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<int>("rank", "(int default 0) rank id.").SetDefault(0);
     AddAttr<int>("nranks", "(int default 1) number of ranks.").SetDefault(1);
     AddAttr<int>("ring_id", "(int default 0) ring id.").SetDefault(0);
-    AddAttr<bool>(
-        "use_calc_stream",
-        "(bool default false) eject CUDA operations to calculation stream.")
-        .SetDefault(false);
     AddAttr<bool>("use_model_parallel",
                   "(bool default false) use this op with model parallel.")
         .SetDefault(true);

--- a/paddle/fluid/operators/ops_signature/c_split_sig.cc
+++ b/paddle/fluid/operators/ops_signature/c_split_sig.cc
@@ -19,10 +19,7 @@ namespace phi {
 KernelSignature CSplitOpArgumentMapping(
     const ArgumentMappingContext& ctx UNUSED) {
   return KernelSignature(
-      "c_split",
-      {"X"},
-      {"rank", "nranks", "ring_id", "use_calc_stream", "use_model_parallel"},
-      {"Out"});
+      "c_split", {"X"}, {"rank", "nranks", "use_model_parallel"}, {"Out"});
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/c_split_kernel.h
+++ b/paddle/phi/kernels/c_split_kernel.h
@@ -23,8 +23,6 @@ void CSplitKernel(const Context& ctx,
                   const DenseTensor& x,
                   int rank,
                   int nranks,
-                  int ring_id,
-                  bool use_calc_stream,
                   bool use_model_parallel,
                   DenseTensor* out);
 

--- a/paddle/phi/kernels/cpu/c_split_kernel.cc
+++ b/paddle/phi/kernels/cpu/c_split_kernel.cc
@@ -23,8 +23,6 @@ void CSplitKernel(const Context& ctx,
                   const DenseTensor& x,
                   int rank,
                   int nranks,
-                  int ring_id,
-                  bool use_calc_stream,
                   bool use_model_parallel,
                   DenseTensor* out) {
   PADDLE_THROW(common::errors::Unavailable(

--- a/paddle/phi/kernels/gpu/c_split_kernel.cu
+++ b/paddle/phi/kernels/gpu/c_split_kernel.cu
@@ -54,8 +54,6 @@ void CSplitKernel(const Context& ctx,
                   const DenseTensor& x,
                   int rank,
                   int nranks,
-                  int ring_id,
-                  bool use_calc_stream,
                   bool use_model_parallel,
                   DenseTensor* out) {
   auto place = ctx.GetPlace();

--- a/paddle/phi/kernels/xpu/c_split_kernel.cc
+++ b/paddle/phi/kernels/xpu/c_split_kernel.cc
@@ -24,8 +24,6 @@ void CSplitKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   int rank,
                   int nranks,
-                  int ring_id,
-                  bool use_calc_stream,
                   bool use_model_parallel,
                   DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;

--- a/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
@@ -167,13 +167,14 @@
   inplace : (x -> out)
 
 - op : c_split
-  args : (Tensor x, int rank = 0, int nranks = 1, int ring_id = 0, bool use_calc_stream = false, bool use_model_parallel = true)
+  args : (Tensor x, int rank = 0, int nranks = 1, bool use_model_parallel = true, int ring_id = 0)
   output : Tensor(out)
   infer_meta :
     func : CSplitInferMeta
     param : [x, nranks]
   kernel :
     func : c_split
+    param: [x, rank, nranks, use_model_parallel]
 
 - op : coalesce_tensor_
   args : (Tensor[] input, DataType dtype, bool copy_data = false, bool set_constant = false, bool persist_output = false, float constant = 0.0, bool use_align = true, int align_size = -1, int size_of_dtype = -1, int64_t[] concated_shapes = {}, int64_t[] concated_ranks = {})

--- a/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
@@ -167,7 +167,7 @@
   inplace : (x -> out)
 
 - op : c_split
-  args : (Tensor x, int rank = 0, int nranks = 1, bool use_model_parallel = true, int ring_id = 0)
+  args : (Tensor x, int rank = 0, int nranks = 1, int ring_id = 0, bool use_model_parallel = true)
   output : Tensor(out)
   infer_meta :
     func : CSplitInferMeta

--- a/paddle/phi/ops/yaml/op_version.yaml
+++ b/paddle/phi/ops/yaml/op_version.yaml
@@ -89,6 +89,14 @@
         - add_input : ValueTensor
           comment : In order to support multi-tag task.
 
+- op : c_split
+  version :
+    - checkpoint : Upgrade c_split delete 1 attribute[use_calc_stream].
+      action :
+        - delete_attr : use_calc_stream
+          comment : eject CUDA operations to calculation stream.
+          default : false
+
 - op : clip
   version :
     - checkpoint :  Upgrade clip add a new input [Min]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
c_split移除use_calc_stream参数