### PR TITLE
[Auto Parallel] fix flash attn spmd

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/flash_attention.cc
+++ b/paddle/phi/infermeta/spmd_rules/flash_attention.cc
@@ -268,6 +268,7 @@ SpmdInfo FlashAttInferSpmd(const DistMetaTensor& q,
 
   TensorDistAttr seed_offset = fixed_seed_offset_dist_attr;
   seed_offset.set_dims_mapping({-1});
+  seed_offset.set_process_mesh(out.process_mesh());
 
   VLOG(4) << "FlashAttInferSpmd:";
   VLOG(4) << "Einsum Notation: " << q_axes << "," << k_axes << "," << v_axes


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
In the flash attention SPMD, the ‘dist_attr’ of ‘seed_offset’ is set using the ‘dist_attr’ of ‘fixed_seed_offset’. However, ‘fixed_seed_offset’ is an optional input. If ‘fixed_seed_offset’ is None, the ‘process_mesh’ in ‘dist_attr’ will be invalid, which may cause bugs in some cases.
```bash
( seed_offset , [{Name: None, Initialized: 1, Ptr: 0xbda564d0,TensorInfo: [ Type: DistTensor, Dtype: int64, Place: Place(cpu), Is_defined: true, Is_initialized: true, Shape: 2, Local Shape: 2, DistAttr: {process_mesh: {shape: [], process_ids: [], dim_names: []}, dims_mappings: [-1], ... } 
```

Pcard-76459