### PR TITLE
[CINN] Make tile config aware of data layout for static shape

### DIFF
--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.h
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.h
@@ -39,7 +39,6 @@ struct ScheduleConfig {
     int64_t spatial_numel;
     bool has_dynamic_spatial{false};
     bool has_dynamic_reduce{false};
-    bool is_reduce_all{false};
     bool can_apply_grid_reduce{false};
     IterSpaceType iter_space_type;
   };
@@ -47,9 +46,9 @@ struct ScheduleConfig {
   struct TileConfig {
     int64_t warp_num{1};
     int64_t tree_reduce_num{1};
+    int64_t grid_reduce_num{1};
     int64_t spatial_inner_num{1};
     ReduceMethod reduce_method{NoneReduceMethod()};
-    int64_t grid_reduce_num{1};
   };
 
   std::shared_ptr<BaseInfo> base_info;

--- a/paddle/cinn/ir/group_schedule/search/config_searcher.cc
+++ b/paddle/cinn/ir/group_schedule/search/config_searcher.cc
@@ -98,8 +98,10 @@ ScoreType WeightedSamplingTrailObjectiveFunc::operator()(
   auto tile_config_database = std::make_shared<NaiveTileConfigDatabase>();
   VLOG(3) << "Bucket_info_.space.size is " << bucket_info_.space.size();
   if (candidate.size() != 0) {
-    ScheduleConfig::TileConfig config{
-        candidate[0], candidate[1], candidate[2], NoneReduceMethod()};
+    ScheduleConfig::TileConfig config;
+    config.warp_num = candidate[0];
+    config.tree_reduce_num = candidate[1];
+    config.spatial_inner_num = candidate[2];
     tile_config_database->AddConfig(
         cinn::common::DefaultTarget(), bucket_info_, config);
     auto& schedule_config_manager = ScheduleConfigManager::Instance();

--- a/test/ir/pir/cinn/test_cinn_reduce_sum.py
+++ b/test/ir/pir/cinn/test_cinn_reduce_sum.py
@@ -72,6 +72,9 @@ class TestReduceLastAxis2(TestReduceSumBase):
         self.shape = [512, 1024]
         self.axis = -1
 
+    def prepare_atol(self):
+        self.atol = 2e-5
+
 
 class TestReduceLastDim3(TestReduceSumBase):
     def prepare_data(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Performance


### Description
This PR introduces a new approach to generating tile configs for static shapes, offering a <b>unified and logical</b> method for managing threads, blocks and loops for both SR and RS layouts (and even layouts to be supported in the future).

Instead of the old tree-style tile config, this PR adopts a three-step way to allocate GPU resources, with clear and understandable principles guiding each step:
* **Step 1:** Allocate spatial/reduce threads. This is critical for coalesced memory access. 
* **Step 2:** Allocate grid reduce blocks. This helps when the S dim is too small to provide enough parallelism.
* **Step 3:** Allocate spatial inner loops. This is to further reduce the block launching cost.

See more details in the `BuildPureStaticShapeConfig` function in `group_tile_config.cc`.
<br>

This PR mainly improves the performance (up to 100%) for cases where the S dim is small, such as:
```python
reduce(shape=[1024, 1024], axis=None)             # all reduce
reduce(shape=[32, 256, 512], axis=(1, 2))         # SR reduce
reduce(shape=[128, 28, 28, 256], axis=(0, 1, 2))  # RS reduce
```

<br>
Pcard-85711