### PR TITLE
【CINN】Add const for parameter of IRcopy and AutoSimplify

### DIFF
--- a/paddle/cinn/common/cas.cc
+++ b/paddle/cinn/common/cas.cc
@@ -34,13 +34,14 @@ namespace common {
 using namespace ir;  // NOLINT
 
 Expr AutoSimplify(
-    Expr u,
+    const Expr& u,
     const absl::flat_hash_map<std::string, CasInterval>& var_intervals) {
   VLOG(7) << "Begin AutoSimplify: " << u;
-  if (u.type().is_float()) {
-    return u;
+  Expr copied = ir::ir_utils::IRCopy(u);
+  if (copied.type().is_float()) {
+    return copied;
   }
-  u = detail::ConvertCinnToCAS(u);
+  copied = detail::ConvertCinnToCAS(copied);
   absl::flat_hash_map<std::string, CasInterval> s_var_intervals;
   for (auto& item : var_intervals) {
     if (item.second.e_l.defined() && item.second.e_r.defined()) {
@@ -52,10 +53,10 @@ Expr AutoSimplify(
                               CasInterval(item.second.l, item.second.r));
     }
   }
-  u = CasSimplify(u, s_var_intervals);
-  u = detail::ConvertCasToCinn(u);
-  VLOG(7) << "End AutoSimplify " << u;
-  return u;
+  copied = CasSimplify(copied, s_var_intervals);
+  copied = detail::ConvertCasToCinn(copied);
+  VLOG(7) << "End AutoSimplify " << copied;
+  return copied;
 }
 
 int gcd(int a, int b) {
@@ -1761,8 +1762,8 @@ Expr ConvertCinnToCAS(Expr expr) {
     }
   };
 
-  Mutator()(&copied);
-  return copied;
+  Mutator()(&expr);
+  return expr;
 }
 
 /**

--- a/paddle/cinn/common/cas.cc
+++ b/paddle/cinn/common/cas.cc
@@ -1644,7 +1644,6 @@ bool CASasSymbol(Expr expr) {
 
 Expr ConvertCinnToCAS(Expr expr) {
   VLOG(7) << "Begin ConvertCinnToCAS " << expr;
-  Expr copied = ir::ir_utils::IRCopy(expr);
   struct Mutator : public ir::IRMutator<ir::Expr*> {
     void operator()(Expr* expr) { Visit(expr); }
     void Visit(Expr* expr) { ir::IRMutator<>::Visit(expr, expr); }
@@ -1848,7 +1847,6 @@ Expr ReplaceMaxToConstant(Expr expr) {
 
 Expr ConvertCasToCinn(Expr expr) {
   VLOG(7) << "Begin ConvertCasToCinn : " << expr;
-  Expr copied = ir::ir_utils::IRCopy(expr);
 
   struct Mutator : ir::IRMutator<Expr*> {
     void operator()(Expr* expr) { Visit(expr); }
@@ -1943,8 +1941,8 @@ Expr ConvertCasToCinn(Expr expr) {
     }
   };
 
-  Mutator()(&copied);
-  return copied;
+  Mutator()(&expr);
+  return expr;
 }
 
 bool IsExprCasCompatible(Expr expr) {

--- a/paddle/cinn/common/cas.h
+++ b/paddle/cinn/common/cas.h
@@ -95,7 +95,7 @@ struct CasInterval {
 using cas_intervals_t = absl::flat_hash_map<std::string, CasInterval>;
 
 Expr AutoSimplify(
-    Expr u,
+    const Expr& u,
     const absl::flat_hash_map<std::string, CasInterval>& var_intervals = {});
 
 //! Simplify a CAS expression.

--- a/paddle/cinn/ir/utils/ir_copy.cc
+++ b/paddle/cinn/ir/utils/ir_copy.cc
@@ -550,7 +550,7 @@ Expr IRCopyVisitor::Visit(const ir::intrinsics::BuiltinIntrin* op) {
       op->name, op->args, op->id, op->arg_nums, op->type());
 }
 }  // namespace
-Expr IRCopy(Expr x, bool copy_buffer_node) {
+Expr IRCopy(const Expr& x, bool copy_buffer_node) {
   IRCopyVisitor visitor(copy_buffer_node);
   auto copied = visitor.Visit(&x);
   return copied;

--- a/paddle/cinn/ir/utils/ir_copy.h
+++ b/paddle/cinn/ir/utils/ir_copy.h
@@ -28,7 +28,7 @@ class ModuleExpr;
 namespace ir_utils {
 
 //! Shallow copy an expression.
-Expr IRCopy(Expr x, bool copy_buffer_node = true);
+Expr IRCopy(const Expr& x, bool copy_buffer_node = true);
 
 std::vector<Expr> IRCopy(const std::vector<Expr>& x,
                          bool copy_buffer_node = true);

--- a/paddle/cinn/pybind/optim.cc
+++ b/paddle/cinn/pybind/optim.cc
@@ -43,7 +43,7 @@ void BindSimplify(py::module* m) {
       py::arg("expr"));
 
   m->def("ir_copy",
-         py::overload_cast<Expr, bool>(&ir::ir_utils::IRCopy),
+         py::overload_cast<const Expr&, bool>(&ir::ir_utils::IRCopy),
          py::arg("x"),
          py::arg("copy_buffer_node") = true);
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Security

### Description
<!-- Describe what you’ve done -->
Add `const` for parameter of IRcopy and AutoSimplify.
Pcard-67164