### PR TITLE
fix: typo in dimension error message | recevied ->  received  

### DIFF
--- a/paddle/cinn/runtime/buffer.h
+++ b/paddle/cinn/runtime/buffer.h
@@ -87,7 +87,7 @@ class Buffer {
     PADDLE_ENFORCE_EQ(shape_.ndims(),
                       1,
                       ::common::errors::InvalidArgument(
-                          "Expected shape has 1 dimension, but recevied %d.",
+                          "Expected shape has 1 dimension, but received %d.",
                           shape_.ndims()));
     return static_cast<T*>(data_)[i0];
   }
@@ -95,7 +95,7 @@ class Buffer {
     PADDLE_ENFORCE_EQ(shape_.ndims(),
                       2,
                       ::common::errors::InvalidArgument(
-                          "Expected shape has 2 dimensions, but recevied %d.",
+                          "Expected shape has 2 dimensions, but received %d.",
                           shape_.ndims()));
     return static_cast<T*>(data_)[i0 * shape_[0] + i1];
   }
@@ -103,7 +103,7 @@ class Buffer {
     PADDLE_ENFORCE_EQ(shape_.ndims(),
                       3,
                       ::common::errors::InvalidArgument(
-                          "Expected shape has 3 dimensions, but recevied %d.",
+                          "Expected shape has 3 dimensions, but received %d.",
                           shape_.ndims()));
     return static_cast<T*>(
         data_)[i0 * shape_[1] * shape_[2] + i1 * shape_[2] + i2];


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Bug fixes

### Description

修正了 `PADDLE_ENFORCE_EQ` 中的错误提示信息，将 "recevied" 更正为 "received"。

---

HappyOpenSource