### PR TITLE
[AutoParallel] Decompose Reshard Pass

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/pir_pass.py
+++ b/python/paddle/distributed/auto_parallel/static/pir_pass.py
@@ -211,6 +211,51 @@ def apply_partition_pass(program):
 
 
 class ReshardPasses:
+
+    @staticmethod
+    def atomic_reshard_pass(dist_program):
+        # split composed reshard op into atomic reshard ops, which would increase the oppotunity of reshard Re-Use in following fold_reshard_pass.
+        del_ops = []
+        for op in dist_program.global_block().ops:
+            if op.name() != 'dist_op.reshard':
+                continue
+            input = op.operand_source(0)
+            result = op.result(0)
+
+            # split the reshard compose p2p and collective into one p2p reshard and one collective reshard.
+            if (
+                input.dist_attr().process_mesh
+                != result.dist_attr().process_mesh
+            ):
+                if (
+                    input.dist_attr().placements
+                    != result.dist_attr().placements
+                ):
+                    ref_op_role = op.op_role
+                    with pir_op_role_guard(ref_op_role):
+                        intermediate_dist_attr = copy_dist_attr_with_new_member(
+                            input.dist_attr(),
+                            new_process_mesh=result.dist_attr().process_mesh,
+                        )
+                        intermediate_dist_type = (
+                            paddle.base.libpaddle.pir.cvt_to_dist_type(
+                                input.type(), intermediate_dist_attr
+                            )
+                        )
+                        paddle.pir.set_insertion_point(op)
+                        intermediate_var = paddle._C_ops.reshard_v2(
+                            input, intermediate_dist_attr
+                        )
+                        new_reshard_result = paddle._C_ops.reshard_v2(
+                            intermediate_var, result.dist_attr()
+                        )
+                        result.replace_all_uses_with(new_reshard_result)
+                        del_ops.append(op)
+
+        for op in del_ops:
+            _logger.info(f"[Reshard Pass] atomic composed reshard op: {op!s}")
+            op.erase()
+
     @staticmethod
     def fold_reshard_pass(dist_program):
         del_ops = []
@@ -282,6 +327,7 @@ class ReshardPasses:
 
     @staticmethod
     def apply_reshard_pass(dist_program, params_grads=[]):
+        ReshardPasses.atomic_reshard_pass(dist_program)
         ReshardPasses.fold_reshard_pass(dist_program)
         ReshardPasses.reshard_op_pass(dist_program, params_grads)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

Pcard-67164

Before this PR, the reshard op in program might compose multiple "atomic" operations, which make it difficult for Reusing reshard in later fold_reshard_pass.

In this PR, we decompose the reshard into multiple atomic operations, which increase the opportunity of re-using.


Before PR | ![image](https://github.com/user-attachments/assets/bf963bba-7bd6-4e93-b105-752107ef3b3b)
-- | --
 After PR  |  ![image](https://github.com/user-attachments/assets/1c14ae00-40f7-413b-8b76-7cddb832ced5)









