### PR TITLE
[draft] comm_init_op_fix

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1478,6 +1478,13 @@ void AnalysisPredictor::InsertCommOp(
     ss << ep << ", ";
   }
   VLOG(3) << ss.str();
+  // Q(chenhuan09): Is ‘endpoints_str’ necessary?
+  // For instance, if there are 2 ranks in the group:
+  // 127.0.0.1:6070/127.0.0.1:6071 ‘endpoints_str_rank1’ would be:
+  // “127.0.0.1:6070,127.0.0.1:6071” ‘endpoints_str_rank2’ would be:
+  // “127.0.0.1:6071,127.0.0.1:6070” And ‘endpoints_str’ is the hash_key in
+  // ‘CreateBKCLCommContext’/‘CreateXCCLCommContext’, which could lead to
+  // inconsistency in ‘unique_key’.
   std::string endpoints_str = config_.dist_config().current_endpoint();
   for (const auto &peer : peer_endpoints) {
     endpoints_str += "," + peer;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- bug fix：endpoint_str在kl3分布式中会导致算子初始化失败，具体原因是‘CreateBKCLCommContext’的‘unique_key’不一致
