### PR TITLE
[Fix] Fix remainder_grad for integer dtype

### DIFF
--- a/test/legacy_test/test_elementwise_mod_op.py
+++ b/test/legacy_test/test_elementwise_mod_op.py
@@ -298,10 +298,10 @@ class TestElementwiseDygraph(unittest.TestCase):
                     x_shape = [2, 1, 4, 1]
                     y_shape = [1, 3, 1, 5]
                     # x_shape = y_shape
-                    x_np = np.random.uniform(0, 1000, x_shape).astype(dtype)
+                    x_np = np.random.uniform(-1000, 1000, x_shape).astype(dtype)
                     # make sure all element in y is non-zero
                     x_np[x_np == 0] = -1
-                    y_np = np.random.uniform(0, 1000, y_shape).astype(dtype)
+                    y_np = np.random.uniform(-1000, 1000, y_shape).astype(dtype)
                     # make sure all element in y is non-zero
                     y_np[np.isclose(y_np, 0)] = -1
                     z_np = np.remainder(x_np, y_np)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-75624

修复remainder_grad在负整数下，将整数除法改为向下整除，防止计算结果错误。对应地，单测的随机数据范围扩大到负数