### PR TITLE
[Paddle Tensorrt] add pd_op.stride_slice converter

### DIFF
--- a/paddle/fluid/framework/new_executor/collect_shape_manager.h
+++ b/paddle/fluid/framework/new_executor/collect_shape_manager.h
@@ -68,8 +68,6 @@ class CollectShapeManager {
     is_shape_range_info_ready_ = false;
   }
 
-  bool IsShapeRangeInfoReady() const { return is_shape_range_info_ready_; }
-
  private:
   CollectShapeManager() {}
   std::unordered_map<pir::Value, pir::Value> op_value2kernel_value_;

--- a/paddle/fluid/framework/new_executor/collect_shape_manager.h
+++ b/paddle/fluid/framework/new_executor/collect_shape_manager.h
@@ -55,6 +55,21 @@ class CollectShapeManager {
                                               bool is_shape_tensor,
                                               ShapeMode shape_mode);
 
+  void ClearShapeInfo() {
+    shape_info_.clear();
+    shape_tensor_info_.clear();
+    min_shapes_.clear();
+    max_shapes_.clear();
+    opt_shapes_.clear();
+    min_values_.clear();
+    max_values_.clear();
+    opt_values_.clear();
+    op_value2kernel_value_.clear();
+    is_shape_range_info_ready_ = false;
+  }
+
+  bool IsShapeRangeInfoReady() const { return is_shape_range_info_ready_; }
+
  private:
   CollectShapeManager() {}
   std::unordered_map<pir::Value, pir::Value> op_value2kernel_value_;

--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -1646,6 +1646,7 @@ class TrtOpMarkerPass : public pir::PatternRewritePass {
     ps.Add(std::make_unique<BilinearInterpV2Pattern>(context));
     ps.Add(std::make_unique<NearestInterV2Pattern>(context));
     ps.Add(std::make_unique<StackOpPattern>(context));
+    ps.Add(std::make_unique<TanhOpPattern>(context));
     ps.Add(std::make_unique<FullWithTensorPattern>(context));
     ps.Add(std::make_unique<StridedSliceOpPattern>(context));
     return ps;

--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -1646,8 +1646,8 @@ class TrtOpMarkerPass : public pir::PatternRewritePass {
     ps.Add(std::make_unique<BilinearInterpV2Pattern>(context));
     ps.Add(std::make_unique<NearestInterV2Pattern>(context));
     ps.Add(std::make_unique<StackOpPattern>(context));
-    ps.Add(std::make_unique<TanhOpPattern>(context));
     ps.Add(std::make_unique<FullWithTensorPattern>(context));
+    ps.Add(std::make_unique<StridedSliceOpPattern>(context));
     return ps;
   }
 };

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3279,6 +3279,7 @@ All parameter, weight, gradient are variables in Paddle.
            bool is_shape_tensor,
            paddle::framework::ShapeMode shape_mode) -> py::list {
           py::list res;
+
           paddle::framework::CollectShapeManager::Instance()
               .StatisticShapeRangeInfo();
           auto shape_result =
@@ -3289,6 +3290,9 @@ All parameter, weight, gradient are variables in Paddle.
           }
           return res;
         });
+  m.def("clear_shape_info", []() {
+    paddle::framework::CollectShapeManager::Instance().ClearShapeInfo();
+  });
 
 #if defined(PADDLE_WITH_PSLIB) && !defined(PADDLE_WITH_HETERPS)
   BindHeterWrapper(&m);

--- a/python/paddle/tensorrt/converter.py
+++ b/python/paddle/tensorrt/converter.py
@@ -441,3 +441,5 @@ class PaddleToTensorRTConverter:
                     orin_out_values[o_i].replace_all_uses_with(new_out[o_i])
 
                 self.program.global_block().remove_op(op)
+        # Call clear_shape_info to clear the previous shape information
+        clear_shape_info()

--- a/python/paddle/tensorrt/converter.py
+++ b/python/paddle/tensorrt/converter.py
@@ -262,7 +262,6 @@ class PaddleToTensorRTConverter:
                         value, False, paddle.base.core.ShapeMode.kMAX
                     )
                     if trt_input.is_shape_tensor:
-                        print("它是shape_tensor了吧")
                         min_value = get_value_shape_range_info(
                             value, True, paddle.base.core.ShapeMode.kMIN
                         )

--- a/python/paddle/tensorrt/converter.py
+++ b/python/paddle/tensorrt/converter.py
@@ -261,6 +261,7 @@ class PaddleToTensorRTConverter:
                         value, False, paddle.base.core.ShapeMode.kMAX
                     )
                     if trt_input.is_shape_tensor:
+                        print("它是shape_tensor了吧")
                         min_value = get_value_shape_range_info(
                             value, True, paddle.base.core.ShapeMode.kMIN
                         )
@@ -270,13 +271,14 @@ class PaddleToTensorRTConverter:
                         max_value = get_value_shape_range_info(
                             value, True, paddle.base.core.ShapeMode.kMAX
                         )
-                _logger.info(f"set min_shape of {value} as {min_shape}")
-                _logger.info(f"set opt_shape of {value} as {opt_shape}")
-                _logger.info(f"set max_shape of {value} as {max_shape}")
-                profile.set_shape(
-                    input_name, min=min_shape, opt=opt_shape, max=max_shape
-                )
-                if trt_input.is_shape_tensor:
+                if not trt_input.is_shape_tensor:
+                    _logger.info(f"set min_shape of {value} as {min_shape}")
+                    _logger.info(f"set opt_shape of {value} as {opt_shape}")
+                    _logger.info(f"set max_shape of {value} as {max_shape}")
+                    profile.set_shape(
+                        input_name, min=min_shape, opt=opt_shape, max=max_shape
+                    )
+                else:
                     _logger.info(
                         f"set min_value of shape input: {value} as {min_value}"
                     )

--- a/python/paddle/tensorrt/converter.py
+++ b/python/paddle/tensorrt/converter.py
@@ -410,8 +410,7 @@ class PaddleToTensorRTConverter:
                     "opt_value": orin_opt_value,
                     "max_value": orin_max_value,
                 }
-        # Call clear_shape_info to clear the previous shape information
-        clear_shape_info()
+
         return out
 
     def convert(self, network, paddle_op, inputs):
@@ -441,5 +440,5 @@ class PaddleToTensorRTConverter:
                     orin_out_values[o_i].replace_all_uses_with(new_out[o_i])
 
                 self.program.global_block().remove_op(op)
-        # Call clear_shape_info to clear the previous shape information
+        # # Call clear_shape_info to clear the previous shape information
         clear_shape_info()

--- a/python/paddle/tensorrt/converter.py
+++ b/python/paddle/tensorrt/converter.py
@@ -26,7 +26,7 @@ trt_plugin_lib.initLibNvInferPlugins(None, "")
 
 import paddle
 from paddle import pir
-from paddle.base.core import get_value_shape_range_info
+from paddle.base.core import clear_shape_info, get_value_shape_range_info
 from paddle.base.log_helper import get_logger
 
 from .impls.activation import *  # noqa: F403
@@ -123,6 +123,7 @@ class PaddleToTensorRTConverter:
 
     def convert_subgraph_to_trt(self, program, group_op):
         _logger.info(f"start process {group_op}")
+
         operations = next(iter(group_op.blocks())).ops
         input_values, output_values = self.find_graph_inputs_outputs(group_op)
         builder = trt.Builder(trt.Logger(trt.Logger.ERROR))
@@ -410,7 +411,8 @@ class PaddleToTensorRTConverter:
                     "opt_value": orin_opt_value,
                     "max_value": orin_max_value,
                 }
-
+        # Call clear_shape_info to clear the previous shape information
+        clear_shape_info()
         return out
 
     def convert(self, network, paddle_op, inputs):

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -504,13 +504,30 @@ def add_cast_reduce_layer(network, paddle_op, inputs, op_type):
     return layer.get_output(0)
 
 
-def fix_negative_indices(network, input_shape, indices):
-    rank = len(input_shape.shape)
-    zero_tensor = add_1D_constant_layer(network, [0] * rank)
-    minus_one_tensor = add_1D_constant_layer(network, [-1] * rank)
+def fix_negative_index(network, shape_tensor, index_tensor, axis):
+    # 获取对应轴的维度大小
+    dim_i = get_shape_tensor_element(network, shape_tensor, axis)
 
-    min_indices_zero = trt_min(network, indices, zero_tensor)
-    sign = trt_max(network, min_indices_zero, minus_one_tensor)
-    sub = trt_mul(network, sign, input_shape)
-    fixed_indices = trt_sub(network, indices, sub)
-    return fixed_indices
+    # 判断索引是否为负数
+    zero_tensor = network.add_constant(
+        (1,), np.array([0], dtype=np.int32)
+    ).get_output(0)
+    is_neg = network.add_elementwise(
+        index_tensor, zero_tensor, trt.ElementWiseOperation.LESS
+    ).get_output(0)
+
+    # 如果索引为负数，修正为 index + dim
+    neg_index = network.add_elementwise(
+        index_tensor, dim_i, trt.ElementWiseOperation.SUM
+    ).get_output(0)
+
+    # 使用逻辑运算符模拟 select 操作
+    cond_tensor = network.add_activation(
+        is_neg, trt.ActivationType.STEP
+    ).get_output(0)
+
+    fixed_index = network.add_elementwise(
+        neg_index, index_tensor, trt.ElementWiseOperation.SELECT, cond_tensor
+    ).get_output(0)
+
+    return fixed_index

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -734,54 +734,93 @@ def strided_slice_converter(network, paddle_op, inputs):
 
     trt_start_dims = [0] * nchw_input_dims
     trt_size_dims = [input_shape[i] for i in range(nchw_input_dims)]
-    trt_end_dims = [0] * nchw_input_dims
     trt_step_dims = [1] * nchw_input_dims
 
     has_neg_indices = False
+    trt_start_tensors = []
+    trt_end_tensors = []
+    trt_stride_tensors = []
+
     for i, axis in enumerate(axes):
-        trt_start_dims[axis] = starts[i]
-        trt_end_dims[axis] = ends[i]
-        trt_step_dims[axis] = strides[i]
-        trt_size_dims[axis] = max(
-            0, (ends[i] - starts[i] + strides[i] - 1) // strides[i]
-        )
-        if starts[i] < 0 or ends[i] < 0:
-            has_neg_indices = True
+        if isinstance(starts, trt.ITensor):
+            start_tensor = get_shape_tensor_element(network, starts, i)
+        else:
+            start_tensor = add_1D_constant_layer(network, [starts[i]])
+
+        if isinstance(ends, trt.ITensor):
+            end_tensor = get_shape_tensor_element(network, ends, i)
+        else:
+            end_tensor = add_1D_constant_layer(network, [ends[i]])
+
+        if isinstance(strides, trt.ITensor):
+            stride_tensor = get_shape_tensor_element(network, strides, i)
+        else:
+            stride_tensor = add_1D_constant_layer(network, [strides[i]])
+
+        zero_tensor = add_1D_constant_layer(network, [0])
+
+        if isinstance(starts, trt.ITensor) or isinstance(ends, trt.ITensor):
+            is_start_neg = trt_less(network, start_tensor, zero_tensor)
+            is_end_neg = trt_less(network, end_tensor, zero_tensor)
+            temp_has_neg = network.add_elementwise(
+                is_start_neg, is_end_neg, trt.ElementWiseOperation.OR
+            ).get_output(0)
+            if not has_neg_indices:
+                has_neg_indices = temp_has_neg
+            else:
+                has_neg_indices = network.add_elementwise(
+                    has_neg_indices, temp_has_neg, trt.ElementWiseOperation.OR
+                ).get_output(0)
+        else:
+            if starts[i] < 0 or ends[i] < 0:
+                has_neg_indices = True
+
+        trt_start_tensors.append(start_tensor)
+        trt_end_tensors.append(end_tensor)
+        trt_stride_tensors.append(stride_tensor)
+
+    # Concatenate the tensors for start, end, and strides
+    start_tensor = network.add_concatenation(trt_start_tensors).get_output(0)
+    end_tensor = network.add_concatenation(trt_end_tensors).get_output(0)
+    step_tensor = network.add_concatenation(trt_stride_tensors).get_output(0)
 
     shape_tensor = network.add_shape(input_tensor).get_output(0)
-    start_tensor = add_1D_constant_layer(network, trt_start_dims)
 
-    if has_neg_indices:
+    if has_neg_indices is True:
         start_tensor = fix_negative_indices(network, shape_tensor, start_tensor)
-
-    end_vec_tensor = []
-    for i in range(len(trt_end_dims)):
-        end_vec_tensor.append(
-            get_shape_tensor_element(network, shape_tensor, i)
+    elif isinstance(has_neg_indices, trt.ITensor):
+        fixed_start_tensor = fix_negative_indices(
+            network, shape_tensor, start_tensor
         )
+        start_tensor = network.add_select(
+            condition=has_neg_indices,
+            then_input=fixed_start_tensor,
+            else_input=start_tensor,
+        ).get_output(0)
 
-    for i, axis in enumerate(axes):
-        if ends[i] >= 0:
-            end_vec_tensor[axis] = network.add_constant(
-                (1,), np.array([ends[i]], dtype=np.int32)
-            ).get_output(0)
-        else:
-            adjusted_end = network.add_constant(
-                (1,), np.array([ends[i]], dtype=np.int32)
-            ).get_output(0)
-            end_vec_tensor[axis] = trt_sum(
-                network, end_vec_tensor[axis], adjusted_end
-            )
+    # Process end_tensor similarly to handle negative indices
+    if has_neg_indices is True:
+        end_tensor = fix_negative_indices(network, shape_tensor, end_tensor)
+    elif isinstance(has_neg_indices, trt.ITensor):
+        fixed_end_tensor = fix_negative_indices(
+            network, shape_tensor, end_tensor
+        )
+        end_tensor = network.add_select(
+            condition=has_neg_indices,
+            then_input=fixed_end_tensor,
+            else_input=end_tensor,
+        ).get_output(0)
 
-    concat_end_tensor = network.add_concatenation(end_vec_tensor).get_output(0)
-    min_tensor = trt_min(network, concat_end_tensor, shape_tensor)
+    # Compute min_tensor
+    min_tensor = trt_min(network, end_tensor, shape_tensor)
+    # Correct size_tensor calculation
     size_tensor = trt_sub(network, start_tensor, min_tensor)
 
-    zero_t = add_1D_constant_layer(network, [0] * nchw_input_dims)
-    step_tensor = add_1D_constant_layer(network, trt_step_dims)
+    # floor_div_tensor computation
     floor_div_tensor = trt_floor_div(network, size_tensor, step_tensor)
-    size_tensor = trt_sub(network, zero_t, floor_div_tensor)
+    size_tensor = trt_sub(network, zero_tensor, floor_div_tensor)
 
+    # Create the slice layer
     layer = network.add_slice(
         input_tensor, trt_start_dims, trt_size_dims, trt_step_dims
     )

--- a/setup.py
+++ b/setup.py
@@ -2025,6 +2025,7 @@ def get_setup_parameters():
         'paddle.decomposition',
         'paddle._typing',
         'paddle._typing.libs',
+        'paddle.tensorrt',
     ]
 
     paddle_bins = ''

--- a/test/tensorrt/test_converter_manipulation.py
+++ b/test/tensorrt/test_converter_manipulation.py
@@ -385,15 +385,15 @@ class TestStrideSliceCase1TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.strided_slice
         self.api_args = {
-            "x": np.random.random([3, 4, 5, 6]).astype("float32"),
+            "x": np.random.random([3, 4, 10]).astype("float32"),
             "axes": [0, 1, 2],
             "starts": [1, 0, 2],
             "ends": [2, 3, 4],
             "strides": [1, 1, 1],
         }
         self.program_config = {"feed_list": ["x"]}
-        self.min_shape = {"x": [1, 4, 5, 6]}
-        self.max_shape = {"x": [5, 4, 5, 6]}
+        self.min_shape = {"x": [1, 4, 10]}
+        self.max_shape = {"x": [5, 4, 10]}
 
     def test_trt_result(self):
         self.check_trt_result()
@@ -403,15 +403,15 @@ class TestStrideSliceCase2TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.strided_slice
         self.api_args = {
-            "x": np.random.random([3, 4, 5, 6]).astype("int32"),
+            "x": np.random.random([3, 4, 10]).astype("int32"),
             "axes": [0, 1, 2],
             "starts": [1, 0, 2],
             "ends": [2, 3, 4],
             "strides": [1, 1, 1],
         }
         self.program_config = {"feed_list": ["x"]}
-        self.min_shape = {"x": [1, 4, 5, 6]}
-        self.max_shape = {"x": [5, 4, 5, 6]}
+        self.min_shape = {"x": [1, 4, 10]}
+        self.max_shape = {"x": [5, 4, 10]}
 
     def test_trt_result(self):
         self.check_trt_result()

--- a/test/tensorrt/test_converter_manipulation.py
+++ b/test/tensorrt/test_converter_manipulation.py
@@ -453,6 +453,7 @@ class TestStrideSliceCase4TRTPattern(TensorRTBaseTest):
         for i in range(100):  # 运行100次
             print(f"Running test iteration {i+1}")
             self.check_trt_result()
+            # clear_shape_info()
 
 
 class TestStrideSliceCase5TRTPattern(TensorRTBaseTest):

--- a/test/tensorrt/test_converter_manipulation.py
+++ b/test/tensorrt/test_converter_manipulation.py
@@ -453,5 +453,23 @@ class TestStrideSliceCase4TRTPattern(TensorRTBaseTest):
         self.check_trt_result()
 
 
+class TestStrideSliceCase5TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.strided_slice
+        self.api_args = {
+            "x": np.random.random([3, 4, 10]).astype("float32"),
+            "axes": [0, 1, 2],
+            "starts": np.array([0, -1, 0]).astype("int32"),
+            "ends": np.array([2, -3, 5]).astype("int32"),
+            "strides": np.array([1, -1, 1]).astype("int32"),
+        }
+        self.program_config = {"feed_list": ["x", "starts", "ends", "strides"]}
+        self.min_shape = {"x": [1, 4, 10]}
+        self.max_shape = {"x": [5, 4, 10]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/tensorrt/test_converter_manipulation.py
+++ b/test/tensorrt/test_converter_manipulation.py
@@ -439,18 +439,20 @@ class TestStrideSliceCase4TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.strided_slice
         self.api_args = {
-            "x": np.random.random([3, 4, 10]).astype("float32"),
+            "x": np.random.random([5, 5, 5]).astype("float32"),
             "axes": [0, 1, 2],
-            "starts": np.array([0, 1, 0]).astype("int32"),
-            "ends": np.array([2, 3, 5]).astype("int32"),
+            "starts": np.array([1, 0, 0]).astype("int32"),
+            "ends": np.array([2, 1, 3]).astype("int32"),
             "strides": np.array([1, 1, 1]).astype("int32"),
         }
         self.program_config = {"feed_list": ["x", "starts", "ends", "strides"]}
-        self.min_shape = {"x": [1, 4, 10]}
-        self.max_shape = {"x": [5, 4, 10]}
+        self.min_shape = {"x": [1, 5, 5]}
+        self.max_shape = {"x": [6, 5, 5]}
 
     def test_trt_result(self):
-        self.check_trt_result()
+        for i in range(100):  # 运行100次
+            print(f"Running test iteration {i+1}")
+            self.check_trt_result()
 
 
 class TestStrideSliceCase5TRTPattern(TensorRTBaseTest):

--- a/test/tensorrt/test_converter_manipulation.py
+++ b/test/tensorrt/test_converter_manipulation.py
@@ -435,5 +435,23 @@ class TestStrideSliceCase3TRTPattern(TensorRTBaseTest):
         self.check_trt_result()
 
 
+class TestStrideSliceCase4TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.strided_slice
+        self.api_args = {
+            "x": np.random.random([3, 4, 10]).astype("float32"),
+            "axes": [0, 1, 2],
+            "starts": np.array([0, 1, 0]).astype("int32"),
+            "ends": np.array([2, 3, 5]).astype("int32"),
+            "strides": np.array([1, 1, 1]).astype("int32"),
+        }
+        self.program_config = {"feed_list": ["x", "starts", "ends", "strides"]}
+        self.min_shape = {"x": [1, 4, 10]}
+        self.max_shape = {"x": [5, 4, 10]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/tensorrt/test_converter_manipulation.py
+++ b/test/tensorrt/test_converter_manipulation.py
@@ -450,10 +450,7 @@ class TestStrideSliceCase4TRTPattern(TensorRTBaseTest):
         self.max_shape = {"x": [6, 5, 5]}
 
     def test_trt_result(self):
-        for i in range(100):  # 运行100次
-            print(f"Running test iteration {i+1}")
-            self.check_trt_result()
-            # clear_shape_info()
+        self.check_trt_result()
 
 
 class TestStrideSliceCase5TRTPattern(TensorRTBaseTest):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
card-71500
添加pd_op.stride_slice 输入start,end,stride为pir::value的情况，另外修改setup.py，开启with_pip_tensorrt=on时，直接跑trt单测报错 No module named 'paddle.tensorrt ,并解决了单测随机挂的现象，解决了collect_shape_range_info中对于shape收集后没有清理shape信息，导致缓存后跑多轮会出现shape信息混乱的bug