### PR TITLE
c_softmax_with_cross_entropy_op supports multiple label values

### DIFF
--- a/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op.cc
+++ b/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op.cc
@@ -53,11 +53,12 @@ class CSoftmaxWithCrossEntropyOp : public framework::OperatorWithKernel {
       }
     }
 
-    PADDLE_ENFORCE_EQ(
+    PADDLE_ENFORCE_GE(
         labels_dims[logits_rank - 1],
         1UL,
         common::errors::InvalidArgument(
-            "the last dimension of Input(Label) should be 1."
+            "the last dimension of Input(Label) should be greater than or "
+            "equal to 1."
             "But received: the last dimension of Input(Label) is [%d],"
             "the last dimension is [%d]",
             labels_dims[logits_rank - 1],

--- a/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
+++ b/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
@@ -440,6 +440,7 @@ def _c_softmax_with_cross_entropy(
         )
     if input_dims - 1 == label_dims:
         label = paddle.unsqueeze(label, axis=-1)
+        label_shape = list(label.shape)
     if label_shape[-1] < 1 or label_shape[-1] > input_shape[-1] * nranks:
         raise ValueError(
             f'Expected label_shape[-1] >= 1 and label_shape[-1] <= input_shape[-1] * nranks\

--- a/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
+++ b/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
@@ -429,8 +429,10 @@ def _c_softmax_with_cross_entropy(
         else group.nranks
     )
 
-    input_dims = len(list(logits.shape))
-    label_dims = len(list(label.shape))
+    input_shape = list(logits.shape)
+    label_shape = list(label.shape)
+    input_dims = len(input_shape)
+    label_dims = len(label_shape)
     if input_dims - 1 != label_dims and input_dims != label_dims:
         raise ValueError(
             f'Expected input_dims - 1 = label_dims or input_dims == label_dims\
@@ -438,6 +440,11 @@ def _c_softmax_with_cross_entropy(
         )
     if input_dims - 1 == label_dims:
         label = paddle.unsqueeze(label, axis=-1)
+    if label_shape[-1] < 1 or label_shape[-1] > input_shape[-1] * nranks:
+        raise ValueError(
+            f'Expected label_shape[-1] >= 1 and label_shape[-1] <= input_shape[-1] * nranks\
+             (got label_shape[-1] = {label_shape[-1]}, input_shape[-1] = {input_shape[-1]})'
+        )
 
     if in_dynamic_mode():
         softmax, loss = _legacy_C_ops.c_softmax_with_cross_entropy(

--- a/test/legacy_test/c_softmax_with_cross_entropy_op.py
+++ b/test/legacy_test/c_softmax_with_cross_entropy_op.py
@@ -74,7 +74,7 @@ class TestCSoftmaxWithCrossEntropy(unittest.TestCase):
         strategy = fleet.DistributedStrategy()
         strategy.tensor_parallel = True
         strategy.tensor_parallel_configs = {'tensor_parallel_degree': 2}
-    
+
     def test_model(self, data_type="float32"):
         rank = fleet.worker_index()
 
@@ -139,15 +139,17 @@ class TestCSoftmaxWithCrossEntropy(unittest.TestCase):
 
         # get data that is shared by both ranks
         np.random.seed(os.getuid())
-        
+
         C = 4
 
         label = []
         for _ in range(self.batch_size):
-            tmp = np.random.choice(range(0, self.num_class), size=C, replace=False)
+            tmp = np.random.choice(
+                range(0, self.num_class), size=C, replace=False
+            )
             label.append(tmp)
         label = np.array(label)
-        print("label", label)
+
         ignore_index = -100
 
         local_elements = int(self.num_class / 2)
@@ -192,7 +194,7 @@ class TestCSoftmaxWithCrossEntropy(unittest.TestCase):
         for i in range(len(label)):
             for c in label[i]:
                 need_label[i][c] = prob
-        
+
         need_loss = cross_entropy(
             need_softmax, need_label, True, 1, ignore_index=ignore_index
         )

--- a/test/legacy_test/c_softmax_with_cross_entropy_op.py
+++ b/test/legacy_test/c_softmax_with_cross_entropy_op.py
@@ -67,14 +67,15 @@ def softmax_with_cross_entropy_grad(softmax, label, loss_grad, axis):
 
 
 class TestCSoftmaxWithCrossEntropy(unittest.TestCase):
-    def test_model(self, data_type="float32"):
+    def setUp(self):
         self.num_class = 1000
         self.batch_size = 1024
         fleet.init(is_collective=True)
         strategy = fleet.DistributedStrategy()
         strategy.tensor_parallel = True
         strategy.tensor_parallel_configs = {'tensor_parallel_degree': 2}
-
+    
+    def test_model(self, data_type="float32"):
         rank = fleet.worker_index()
 
         # get data that is shared by both ranks
@@ -122,6 +123,78 @@ class TestCSoftmaxWithCrossEntropy(unittest.TestCase):
         need_softmax = np.apply_along_axis(stable_softmax, 1, inputs)
         need_loss = cross_entropy(
             need_softmax, label, False, 1, ignore_index=ignore_index
+        )
+
+        softmax = np.concatenate(
+            (softmax_list[0].numpy(), softmax_list[1].numpy()), axis=1
+        )
+
+        # compare results
+        rtol = 1e-6
+        np.testing.assert_allclose(loss.numpy(), need_loss, rtol=rtol)
+        np.testing.assert_allclose(softmax, need_softmax, rtol=rtol)
+
+    def test_model_soft_label(self, data_type="float32"):
+        rank = fleet.worker_index()
+
+        # get data that is shared by both ranks
+        np.random.seed(os.getuid())
+        
+        C = 4
+
+        label = []
+        for _ in range(self.batch_size):
+            tmp = np.random.choice(range(0, self.num_class), size=C, replace=False)
+            label.append(tmp)
+        label = np.array(label)
+        print("label", label)
+        ignore_index = -100
+
+        local_elements = int(self.num_class / 2)
+        # get input data for rank 0
+        np.random.seed(0)
+        input0 = np.random.uniform(
+            low=-40.0, high=40.0, size=(self.batch_size, local_elements)
+        ).astype(data_type)
+
+        # get input data for rank 1
+        np.random.seed(1)
+        input1 = np.random.uniform(
+            low=-40.0, high=40.0, size=(self.batch_size, local_elements)
+        ).astype(data_type)
+
+        # get combined input data
+        inputs = np.concatenate((input0, input1), axis=1)
+
+        if rank == 0:
+            loss, softmax = _c_softmax_with_cross_entropy(
+                paddle.to_tensor(input0),
+                paddle.to_tensor(label),
+                ignore_index=ignore_index,
+                return_softmax=True,
+            )
+        else:
+            loss, softmax = _c_softmax_with_cross_entropy(
+                paddle.to_tensor(input1),
+                paddle.to_tensor(label),
+                ignore_index=ignore_index,
+                return_softmax=True,
+            )
+        paddle.device.cuda.synchronize()
+        softmax_list = []
+        paddle.distributed.all_gather(softmax_list, softmax)
+
+        # calculate analytic result
+        need_softmax = np.apply_along_axis(stable_softmax, 1, inputs)
+        prob = 1.0 / C
+        need_label = np.zeros_like(inputs)
+
+        for i in range(len(label)):
+            for c in label[i]:
+                need_label[i][c] = prob
+        
+        need_loss = cross_entropy(
+            need_softmax, need_label, True, 1, ignore_index=ignore_index
         )
 
         softmax = np.concatenate(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
ParallelCrossEntropy 支持多标签分类
c_softmax_with_cross_entropy_op 的label参数支持shape=[B, S, C]，其中1 <= C <= vocab_size
Pcard-87604