### PR TITLE
[Dy2St] Cleanup no need buffer inputs in grad node

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_func.h
+++ b/paddle/fluid/eager/to_static/run_program_op_func.h
@@ -341,6 +341,12 @@ inline void pir_run_program_ad_func(
     grad_node->SetAttrMap(attrs);
 
     // Clear unused x vars
+    // NOTE(SigureMo): There are 2 kinds Tensor need to be filtered:
+    // 1. The input Tensor unused in backward block.
+    // 2. The input Tensor use meta only in backward block.
+    // We need to filter both of them.
+    // For the first kind, we can create a empty Tensor to replace it.
+    // For the second kind, we need to keep the meta only Tensor.
     auto filter_x = pir_filter_no_need_buffer_input_var_in_backward(
         pir_filter_unused_input_var_in_backward(x_tmp, "bx", attrs), attrs);
     // Set TensorWrappers

--- a/paddle/fluid/eager/to_static/run_program_op_func.h
+++ b/paddle/fluid/eager/to_static/run_program_op_func.h
@@ -139,6 +139,36 @@ static std::vector<paddle::Tensor> pir_filter_unused_input_var_in_backward(
   return filter_x;
 }
 
+static std::vector<paddle::Tensor>
+pir_filter_no_need_buffer_input_var_in_backward(
+    const std::vector<paddle::Tensor>& x,
+    const paddle::framework::AttributeMap& attrs) {
+  auto forward_inputs_values =
+      PADDLE_GET_CONST(std::vector<::pir::Value>, attrs.at("fx"));
+  auto no_need_buffers_values =
+      PADDLE_GET_CONST(std::vector<::pir::Value>, attrs.at("no_need_buffers"));
+  auto filter_x = std::vector<paddle::Tensor>(x);
+  std::deque<std::shared_ptr<paddle::memory::Allocation>>* garbages =
+      new std::deque<std::shared_ptr<paddle::memory::Allocation>>();
+  for (size_t i = 0; i < x.size(); i++) {
+    if (std::find(no_need_buffers_values.begin(),
+                  no_need_buffers_values.end(),
+                  forward_inputs_values[i]) != no_need_buffers_values.end()) {
+      auto& tensor = filter_x[i];
+      if (tensor.initialized() && tensor.is_dense_tensor()) {
+        auto copied_dense_tensor = std::make_shared<phi::DenseTensor>(
+            *std::dynamic_pointer_cast<phi::DenseTensor>(tensor.impl()));
+        garbages->emplace_back(copied_dense_tensor->MoveMemoryHolder());
+        auto fake = paddle::Tensor(
+            copied_dense_tensor, tensor.mutable_autograd_meta(), tensor.name());
+        filter_x[i] = fake;
+      }
+    }
+  }
+  delete garbages;
+  return filter_x;
+}
+
 static std::vector<paddle::Tensor> Trans2ContiguousTensors(
     const std::vector<paddle::Tensor>& tensors) {
   std::vector<paddle::Tensor> res;
@@ -311,7 +341,8 @@ inline void pir_run_program_ad_func(
     grad_node->SetAttrMap(attrs);
 
     // Clear unused x vars
-    auto filter_x = pir_filter_unused_input_var_in_backward(x_tmp, "bx", attrs);
+    auto filter_x = pir_filter_no_need_buffer_input_var_in_backward(
+        pir_filter_unused_input_var_in_backward(x_tmp, "bx", attrs), attrs);
     // Set TensorWrappers
     grad_node->SetFwdX(filter_x);
 

--- a/paddle/fluid/eager/to_static/run_program_op_func.h
+++ b/paddle/fluid/eager/to_static/run_program_op_func.h
@@ -159,9 +159,9 @@ pir_filter_no_need_buffer_input_var_in_backward(
         auto copied_dense_tensor = std::make_shared<phi::DenseTensor>(
             *std::dynamic_pointer_cast<phi::DenseTensor>(tensor.impl()));
         garbages->emplace_back(copied_dense_tensor->MoveMemoryHolder());
-        auto fake = paddle::Tensor(
+        auto meta_only_tensor = paddle::Tensor(
             copied_dense_tensor, tensor.mutable_autograd_meta(), tensor.name());
-        filter_x[i] = fake;
+        filter_x[i] = meta_only_tensor;
       }
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

动转静 grad node 会 hold 住前向输入，但对于 no need buffer 的 Tensor 而言，只需要 meta，不需要 holder，因此对于这些 no need buffer Tensor，反向 grad node hold 的 Tensor 不再是原来的 Tensor，而是 copy 后不持有 holder 的 Tensor（holder 被 Move 走了）

![dy2st-no-need-buffer-gc drawio](https://github.com/user-attachments/assets/f765087d-d675-4816-a241-142980472f4a)

如图所示，图中只表示了反向 no need buffer 的 Tensor，长度表示生命周期，`x -> y` 表示 x 持有 y 的引用，此时 y 的生命周期必然大于等于 x 的生命周期

由于这些 Tensor 还没释放（受 Python 端调度，Python 端 PyObject 引用计数到 0），就被设置到反向 GradNode，所以直到反向结束才真正释放

因此本 PR 对于这些 no need buffer Tensor，copy 了一个 Tensor，持有一个 copy 的 DenseTensor，没有 holder，这就确保了反向持有的是有 meta 但没 holder 的 Tensor

PT 同样有该问题，但没暴露，是因为 PT 的输入会多一个 cast，导致 no need buffer 的是输入 cast 后的 value 而不是输入，不是输入是没有这个问题的

修复前后显存如下

|               | Max reserved (MB) | Max allocated (MB) |
| ------------- | ----------------- | ------------------ |
| PT            | 8959.77           | 8824.07            |
| PIR (develop) | 11033.88          | 9707.65            |
| PIR (PR)      | 10053.88          | 8727.65            |

Max allocated 已经明显低于 PT（PT 没有修这个问题）

不过值得注意的是，因为 x 是 ad func 的输入，受到 Python 端 GC 调度，ad func 是不能擅自删掉它的，否则就可能导致后面使用 x 时出问题，这会导致动转静下，输入总是在整个子图执行完才 GC，而不能随 OP 执行完释放，导致对比动态图峰值显存会高一些，SOT 因为有多个子图，会有一些中间变量作为子图输入，这个问题会更加凸显一些，但这个问题目前是比较无解的

PCard-66972