### PR TITLE
[bug fix] remove lock in AuroGrowth FreeImpl

### DIFF
--- a/paddle/phi/core/memory/allocation/auto_growth_best_fit_allocator.h
+++ b/paddle/phi/core/memory/allocation/auto_growth_best_fit_allocator.h
@@ -46,7 +46,8 @@ class AutoGrowthBestFitAllocator : public Allocator {
 
   // Release the memory block which is not used in pool.
   uint64_t ReleaseImpl(const phi::Place &place) override {
-    std::lock_guard<SpinLock> guard(spinlock_);
+    // TODO(vivienfanghuagood): the next line may cause the process to deadlock.
+    // std::lock_guard<SpinLock> guard(spinlock_);
     return FreeIdleChunks();
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes


### Description
<!-- Describe what you’ve done -->
pcard-71500

When calling the AutoGrowth Allocator, distributed training will be stuck due to the lock in Release, although the cause is unknown. Therefore, the lock has been temporarily removed. 
TODO: In the future, we will recover it after finding out the real cause of the crash.
