### PR TITLE
Fix bugs in GPU-phi-kernel in function CommonGradBroadcastCUDA

### DIFF
--- a/paddle/phi/kernels/funcs/elementwise_grad_base.h
+++ b/paddle/phi/kernels/funcs/elementwise_grad_base.h
@@ -1513,10 +1513,13 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
     VLOG(3) << "CommonBroadcast can_split_y:" << can_split_y
             << " can_split_x:" << can_split_x;
     // if both x and y into fast path then return
-    if (fast_broadcast_x && fast_broadcast_y) {
-      fast_broadcast = true;
-    }
-    if (can_split_y && can_split_x && fast_broadcast) return;
+
+    //* It's possible that some bugs are a result of early returns, comment out
+    // the code for checking.
+    // if (fast_broadcast_x && fast_broadcast_y) {
+    //   fast_broadcast = true;
+    // }
+    // if (can_split_y && can_split_x && fast_broadcast) return;
   }
 
   // Should remove memory copy, use reg instead.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
Bug fixes
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->


### Description
paddle.pow(x, y)，当前例如x形状为`(1, 2, 1, 3)`，y形状为`(1, 2, 3)`时，GPU版本的计算与CPU不一致。
修复 `fast_broadcast` 为真时提前退出的问题，这可能导致 pow_grad 在适用于广播维度的元素上出现精度异常。

pcard-66975
<!-- Describe what you’ve done -->
