### PR TITLE
[inference] disable tf32 when inference test run

### DIFF
--- a/test/dygraph_to_static/predictor_utils.py
+++ b/test/dygraph_to_static/predictor_utils.py
@@ -20,6 +20,8 @@ from paddle import base
 from paddle.base.core import AnalysisConfig, create_paddle_predictor
 from paddle.framework import use_pir_api
 
+os.environ['NVIDIA_TF32_OVERRIDE'] = '0'
+
 
 class PredictorTools:
     '''
@@ -55,7 +57,7 @@ class PredictorTools:
         config.switch_specify_input_names(True)
         config.switch_use_feed_fetch_ops(False)
         config.enable_memory_optim()
-        config.disable_glog_info()
+        # config.disable_glog_info()
         # TODO: set it to True after PaddleInference fix the precision error
         # in CUDA11
         config.switch_ir_optim(False)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes


### Description
<!-- Describe what you’ve done -->
pcard-71500

In devices such as a100, TF32 precision calculations will cause some unit tests to fail, so just turn off it.