### PR TITLE
Fix pylayer op incorrect run into fused_passes branch

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -970,7 +970,10 @@ class Engine:
             )
             self._job_plan = core.Plan(jobs, type_to_program)
 
-        if self._strategy.fused_passes.fused_passes_list is not None:
+        if (
+            self._strategy.fused_passes.fused_passes_list is not None
+            and self._strategy.fused_passes.fused_passes_list
+        ):
             pm = pir.PassManager()
             for p in self._strategy.fused_passes.fused_passes_list:
                 # Temporary implementation, it will be refined when auto_parallel refactored

--- a/test/auto_parallel/pylayer.py
+++ b/test/auto_parallel/pylayer.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import paddle
+import paddle.distributed as dist
+from paddle import nn
+from paddle.autograd import PyLayer
+from paddle.io import DataLoader
+
+
+class DemoPyLayer(PyLayer):
+    @staticmethod
+    def forward(ctx, x):
+        ctx.save_for_backward(x)
+        y = paddle.tanh(x)
+
+        return y
+
+    @staticmethod
+    def backward(ctx, dy):
+        (x,) = ctx.saved_tensor()
+        grad = dy * (1 - paddle.square(x))
+        return grad
+
+
+class DemoNet(nn.Layer):
+    def __init__(self, mesh):
+        super().__init__()
+        self.mesh = mesh
+        self.linear1 = paddle.nn.Linear(16, 16)
+
+    def forward(self, x):
+        x = dist.shard_tensor(x, self.mesh, [dist.Shard(0)])  # shard tensor
+        y = self.linear1(x)
+        return DemoPyLayer.apply(y)
+
+
+class RandomDataset(paddle.io.Dataset):
+    def __init__(self, images, labels, num_samples):
+        self.images = images
+        self.labels = labels
+        self.num_samples = num_samples
+
+    def __getitem__(self, idx):
+        return self.images[idx], self.labels[idx]
+
+    def __len__(self):
+        return self.num_samples
+
+
+def test_pylayer():
+    mesh = dist.ProcessMesh([0], dim_names=['x'])
+    images = np.random.rand(4, 16).astype('float32')
+    labels = np.random.rand(4, 16).astype('float32')
+    dataset = RandomDataset(images, labels, 4)
+    loader = DataLoader(dataset, batch_size=4)
+
+    layer = DemoNet(mesh)
+    opt = paddle.optimizer.SGD(learning_rate=0.1, parameters=layer.parameters())
+    mse_loss = paddle.nn.loss.MSELoss()
+    epoch = 2
+
+    # to static
+    dist_model = dist.to_static(layer, loader, mse_loss, opt)
+    dist_model.train()
+    for batch_id, data in enumerate(loader()):
+        img, label = data
+        label.stop_gradient = True
+        loss = dist_model(img, label)
+
+
+class DemoPyLayerCustom(PyLayer):
+    @staticmethod
+    def forward(ctx, x, y, z):
+        ctx.save_for_backward(x, y, z)
+        x1 = paddle.tanh(x)
+        y1 = paddle.tanh(y)
+        z1 = paddle.tanh(z)
+        return x1 + y1 + z1
+
+    @staticmethod
+    def backward(ctx, grad):
+        x, y, z = ctx.saved_tensor()
+        x_grad = grad * (1 - paddle.square(x))
+        y_grad = grad * (1 - paddle.square(y))
+        return x_grad, y_grad, None
+
+
+class DemoNetCustom(nn.Layer):
+    def __init__(self, mesh):
+        super().__init__()
+        self.mesh = mesh
+        self.linear1 = paddle.nn.Linear(16, 16)
+        self.linear2 = paddle.nn.Linear(16, 16)
+        self.linear3 = paddle.nn.Linear(16, 16)
+
+    def forward(self, x):
+        x = dist.shard_tensor(x, self.mesh, [dist.Shard(0)])  # shard tensor
+        x = self.linear1(x)
+        y = self.linear2(x)
+        z = self.linear3(x)
+        z.stop_gradient = True
+        out = DemoPyLayerCustom.apply(x, y, z)
+        return out
+
+
+def test_pylayer_custom_op():
+    mesh = dist.ProcessMesh([0], dim_names=['x'])
+    images = np.random.rand(4, 16).astype('float32')
+    labels = np.random.rand(4, 16).astype('float32')
+    dataset = RandomDataset(images, labels, 4)
+    loader = DataLoader(dataset, batch_size=4)
+
+    layer = DemoNetCustom(mesh)
+    opt = paddle.optimizer.SGD(learning_rate=0.1, parameters=layer.parameters())
+    mse_loss = paddle.nn.loss.MSELoss()
+    epoch = 2
+
+    # to static
+    dist_model = dist.to_static(layer, loader, mse_loss, opt)
+    dist_model.train()
+    for batch_id, data in enumerate(loader()):
+        img, label = data
+        label.stop_gradient = True
+        loss = dist_model(img, label)

--- a/test/auto_parallel/test_pylayer.py
+++ b/test/auto_parallel/test_pylayer.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import collective.test_communication_api_base as test_base
+
+
+class TestReshardAPI(test_base.CommunicationTestDistBase):
+    def setUp(self):
+        super().setUp(num_of_devices=2, timeout=120)
+        self._default_envs = {
+            "shape": "(4, 16)",
+            "dtype": "float32",
+            "seeds": str(self._seeds),
+            "shard": "0",
+        }
+        self._changeable_envs = {
+            "backend": ["cpu", "gpu"],
+        }
+
+    def test_reshard_api(self):
+        envs_list = test_base.gen_product_envs_list(
+            self._default_envs, self._changeable_envs
+        )
+        for envs in envs_list:
+            self.run_test_case(
+                "pylayer.py",
+                user_defined_envs=envs,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix pylayer op incorrect run into fused_passes branch and raise:
` ValueError: (InvalidArgument) The 0 element's push type (pd_dist.tensor<4x16xf32, mesh_shape:[1],process_ids:[0],dims_mappings:[0,-1]>) isn't equal to pop type (builtin.tensor<4x16xf32>) `
Pcard-73145