### PR TITLE
Fix distribution API with 0-D input parameters 易用性提升 -part1

### DIFF
--- a/python/paddle/distribution/bernoulli.py
+++ b/python/paddle/distribution/bernoulli.py
@@ -146,11 +146,11 @@ class Bernoulli(exponential_family.ExponentialFamily):
         """
         return paddle.multiply(self.probs, (1 - self.probs))
 
-    def sample(self, shape: Sequence[int]) -> Tensor:
+    def sample(self, shape: Sequence[int] = ()) -> Tensor:
         """Sample from Bernoulli distribution.
 
         Args:
-            shape (Sequence[int]): Sample shape.
+            shape (Sequence[int], optional): Sample shape.
 
         Returns:
             Tensor: Sampled data with shape `sample_shape` + `batch_shape` + `event_shape`.
@@ -193,7 +193,9 @@ class Bernoulli(exponential_family.ExponentialFamily):
         with paddle.no_grad():
             return paddle.bernoulli(self.probs.expand(shape), name=name)
 
-    def rsample(self, shape: Sequence[int], temperature: float = 1.0) -> Tensor:
+    def rsample(
+        self, shape: Sequence[int] = (), temperature: float = 1.0
+    ) -> Tensor:
         """Sample from Bernoulli distribution (reparameterized).
 
         The `rsample` is a continuously approximate of Bernoulli distribution reparameterized sample method.
@@ -204,7 +206,7 @@ class Bernoulli(exponential_family.ExponentialFamily):
             `rsample` need to be followed by a `sigmoid`, which converts samples' value to unit interval (0, 1).
 
         Args:
-            shape (Sequence[int]): Sample shape.
+            shape (Sequence[int], optional): Sample shape.
             temperature (float): temperature for rsample, must be positive.
 
         Returns:

--- a/python/paddle/distribution/binomial.py
+++ b/python/paddle/distribution/binomial.py
@@ -84,10 +84,7 @@ class Binomial(distribution.Distribution):
         self.dtype = paddle.get_default_dtype()
         self.total_count, self.probs = self._to_tensor(total_count, probs)
 
-        if self.total_count.shape == []:
-            batch_shape = (1,)
-        else:
-            batch_shape = self.total_count.shape
+        batch_shape = self.total_count.shape
         super().__init__(batch_shape)
 
     def _to_tensor(

--- a/python/paddle/distribution/categorical.py
+++ b/python/paddle/distribution/categorical.py
@@ -148,11 +148,11 @@ class Categorical(distribution.Distribution):
         dist_sum = paddle.sum(self.logits, axis=-1, keepdim=True)
         self._prob = self.logits / dist_sum
 
-    def sample(self, shape: Sequence[int]) -> Tensor:
+    def sample(self, shape: Sequence[int] = ()) -> Tensor:
         """Generate samples of the specified shape.
 
         Args:
-            shape (list): Shape of the generated samples.
+            shape (list, optional): Shape of the generated samples.
 
         Returns:
             Tensor: A tensor with prepended dimensions shape.

--- a/python/paddle/distribution/cauchy.py
+++ b/python/paddle/distribution/cauchy.py
@@ -121,14 +121,16 @@ class Cauchy(distribution.Distribution):
         """Standard Deviation of Cauchy distribution."""
         raise ValueError("Cauchy distribution has no stddev.")
 
-    def sample(self, shape: Sequence[int], name: str | None = None) -> Tensor:
+    def sample(
+        self, shape: Sequence[int] = (), name: str | None = None
+    ) -> Tensor:
         """Sample from Cauchy distribution.
 
         Note:
             `sample` method has no grad, if you want so, please use `rsample` instead.
 
         Args:
-            shape (Sequence[int]): Sample shape.
+            shape (Sequence[int], optional): Sample shape.
             name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
         Returns:
@@ -169,11 +171,13 @@ class Cauchy(distribution.Distribution):
         with paddle.no_grad():
             return self.rsample(shape, name)
 
-    def rsample(self, shape: Sequence[int], name: str | None = None) -> Tensor:
+    def rsample(
+        self, shape: Sequence[int] = (), name: str | None = None
+    ) -> Tensor:
         """Sample from Cauchy distribution (reparameterized).
 
         Args:
-            shape (Sequence[int]): Sample shape.
+            shape (Sequence[int], optional): Sample shape.
             name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
         Returns:

--- a/python/paddle/distribution/continuous_bernoulli.py
+++ b/python/paddle/distribution/continuous_bernoulli.py
@@ -118,10 +118,7 @@ class ContinuousBernoulli(distribution.Distribution):
         eps_prob = paddle.finfo(self.probs.dtype).eps
         self.probs = paddle.clip(self.probs, min=eps_prob, max=1 - eps_prob)
 
-        if self.probs.shape == []:
-            batch_shape = (1,)
-        else:
-            batch_shape = self.probs.shape
+        batch_shape = self.probs.shape
         super().__init__(batch_shape)
 
     def _to_tensor(self, probs: float | Tensor) -> Tensor:

--- a/test/distribution/test_distribution_binomial.py
+++ b/test/distribution/test_distribution_binomial.py
@@ -116,12 +116,6 @@ class TestBinomial(unittest.TestCase):
     (parameterize.TEST_CASE_NAME, 'total_count', 'probs', 'value'),
     [
         (
-            'zero-dim',
-            np.array(1000),
-            np.array(0.85).astype('float64'),
-            np.array([2.0, 55.0, 999.0]).astype('float64'),
-        ),
-        (
             'value-same-shape',
             1000,
             np.array([0.12, 0.3, 0.85]).astype('float64'),

--- a/test/distribution/test_distribution_binomial.py
+++ b/test/distribution/test_distribution_binomial.py
@@ -28,6 +28,11 @@ from paddle.distribution.binomial import Binomial
     (parameterize.TEST_CASE_NAME, 'total_count', 'probs'),
     [
         (
+            'zero-dim',
+            np.array(1000),
+            np.array(0.6),
+        ),
+        (
             'one-dim',
             1000,
             np.array([0.4]).astype('float32'),
@@ -111,6 +116,12 @@ class TestBinomial(unittest.TestCase):
     (parameterize.TEST_CASE_NAME, 'total_count', 'probs', 'value'),
     [
         (
+            'zero-dim',
+            np.array(1000),
+            np.array(0.85).astype('float64'),
+            np.array([2.0, 55.0, 999.0]).astype('float64'),
+        ),
+        (
             'value-same-shape',
             1000,
             np.array([0.12, 0.3, 0.85]).astype('float64'),
@@ -127,7 +138,7 @@ class TestBinomial(unittest.TestCase):
 class TestBinomialProbs(unittest.TestCase):
     def setUp(self):
         self._dist = Binomial(
-            total_count=self.total_count,
+            total_count=paddle.to_tensor(self.total_count),
             probs=paddle.to_tensor(self.probs),
         )
 

--- a/test/distribution/test_distribution_binomial_static.py
+++ b/test/distribution/test_distribution_binomial_static.py
@@ -33,6 +33,11 @@ paddle.enable_static()
     (parameterize.TEST_CASE_NAME, 'total_count', 'probs'),
     [
         (
+            'zero-dim',
+            np.array(1000),
+            np.array(0.6),
+        ),
+        (
             'one-dim',
             np.array([1000]),
             parameterize.xrand((1,), dtype='float32', min=0, max=1),
@@ -127,6 +132,12 @@ class TestBinomial(unittest.TestCase):
 @parameterize.parameterize_cls(
     (parameterize.TEST_CASE_NAME, 'total_count', 'probs', 'value'),
     [
+        (
+            'zero-dim',
+            np.array(1000),
+            np.array(0.85).astype('float64'),
+            np.array([2.0, 55.0, 999.0]).astype('float64'),
+        ),
         (
             'value-same-shape',
             np.array([10]).astype('int64'),

--- a/test/distribution/test_distribution_binomial_static.py
+++ b/test/distribution/test_distribution_binomial_static.py
@@ -134,9 +134,9 @@ class TestBinomial(unittest.TestCase):
     [
         (
             'zero-dim',
-            np.array(1000),
-            np.array(0.85).astype('float64'),
-            np.array([2.0, 55.0, 999.0]).astype('float64'),
+            np.array(10),
+            np.array(0.6).astype('float64'),
+            np.array([2.0, 3.0, 5.0]).astype('float64'),
         ),
         (
             'value-same-shape',

--- a/test/distribution/test_distribution_continuous_bernoulli.py
+++ b/test/distribution/test_distribution_continuous_bernoulli.py
@@ -242,6 +242,11 @@ class TestContinuousBernoulli(unittest.TestCase):
     (parameterize.TEST_CASE_NAME, 'probs', 'value'),
     [
         (
+            'zero-dim',
+            np.array(0.3).astype("float32"),
+            parameterize.xrand((5,), min=0.0, max=1.0).astype("float32"),
+        ),
+        (
             'value-same-shape',
             parameterize.xrand((5,), min=0.0, max=1.0).astype("float32"),
             parameterize.xrand((5,), min=0.0, max=1.0).astype("float32"),
@@ -297,6 +302,11 @@ class TestContinuousBernoulliProbs(unittest.TestCase):
 @parameterize.parameterize_cls(
     (parameterize.TEST_CASE_NAME, 'p_1', 'p_2'),
     [
+        (
+            'zero-dim',
+            np.array(0.2).astype("float32"),
+            np.array(0.4).astype("float32"),
+        ),
         (
             'one-dim',
             parameterize.xrand((1,), min=0.0, max=1.0).astype("float32"),

--- a/test/distribution/test_distribution_continuous_bernoulli_static.py
+++ b/test/distribution/test_distribution_continuous_bernoulli_static.py
@@ -160,6 +160,10 @@ paddle.enable_static()
     (parameterize.TEST_CASE_NAME, 'probs'),
     [
         (
+            'zero-dim',
+            np.array(0.7).astype("float32"),
+        ),
+        (
             'multi-dim',
             parameterize.xrand((1, 3), min=0.0, max=1.0).astype("float32"),
         ),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
`paddle.distribution.Binomial`，`paddle.distribution.ContinuousBernoulli` 修复 0-D 参数输入；
`paddle.distribution.Bernoulli`，`paddle.distribution.Categorical`，`paddle.distribution.Cauchy` 的 sample/rsample 方法增加默认值，与 pytorch 对齐。