### PR TITLE
[Kernel&Prim] Fix `IndexPutCudaKernel` for thread safe and add index_put_double_grad 

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -80,6 +80,7 @@ prim_white_list = [
     "log_double_grad",
     "where_double_grad",
     "bmm_double_grad",
+    "index_put_double_grad",
 ]
 
 # white ops list whose kernel can automatically do type promotion.

--- a/paddle/fluid/pir/dialect/op_generator/vjp_interface_black_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/vjp_interface_black_list.py
@@ -33,4 +33,5 @@ vjp_interface_black_list = [
     'abs_double_grad',
     'where_grad',
     'bmm_grad',
+    'index_put_grad',
 ]

--- a/paddle/fluid/prim/api/api.yaml
+++ b/paddle/fluid/prim/api/api.yaml
@@ -50,3 +50,4 @@
 - tanh
 - sign
 - sigmoid
+- index_put

--- a/paddle/phi/kernels/gpu/index_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_kernel.cu
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/index_put_kernel.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
+#include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/funcs/index_put_utils.h"
@@ -54,7 +55,7 @@ __global__ void IndexPutCudaKernel(const T* x,
   }
 
   if (accumulate) {
-    *(out + offset) += *(vals + (idx & is_single_val_tensor));
+    phi::CudaAtomicAdd(out + offset, *(vals + (idx & is_single_val_tensor)));
   } else {
     *(out + offset) = *(vals + (idx & is_single_val_tensor));
   }

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -1553,6 +1553,18 @@
     data_type : out_grad
   inplace : (out_grad -> x_grad)
 
+- backward_op : index_put_double_grad
+  forward : index_put_grad (Tensor x, Tensor[] indices, Tensor value, Tensor out_grad, bool accumulate=false) -> Tensor(grad_x), Tensor(grad_value)
+  args : (Tensor x, Tensor[] indices, Tensor value, Tensor grad_x_grad, Tensor grad_value_grad, bool accumulate=false)
+  output : Tensor(out_grad_grad)
+  infer_meta :
+    func : UnchangedInferMeta
+    param: [x]
+  data_transform :
+    skip_transform : indices
+  composite : index_put_double_grad(x, indices, value, grad_x_grad, grad_value_grad, accumulate, out_grad_grad)
+  optional: grad_x_grad, grad_value_grad
+
 - backward_op : index_put_grad
   forward : index_put (Tensor x, Tensor[] indices, Tensor value, bool accumulate=false) -> Tensor(out)
   args : (Tensor x, Tensor[] indices, Tensor value, Tensor out_grad, bool accumulate=false)
@@ -1564,6 +1576,7 @@
     data_type : out_grad
   data_transform :
     skip_transform : indices
+  backward : index_put_double_grad
 
 - backward_op : index_sample_grad
   forward : index_sample (Tensor x, Tensor index) -> Tensor(out)

--- a/test/prim/prim/vjp/test_comp_high_grad.py
+++ b/test/prim/prim/vjp/test_comp_high_grad.py
@@ -1145,11 +1145,7 @@ class TestIndexPutHighGradCheck(unittest.TestCase):
         self.assertEqual(n_indices, self.value_shape[0])
         indices = tuple(
             [
-                paddle.randint(
-                    0,
-                    self.x_shape[i],
-                    shape=[n_indices],
-                ).to(place)
+                paddle.randint(0, self.x_shape[i], shape=[n_indices]).to(place)
                 for i in range(max(index_dim_size, 1))
             ]
         )

--- a/test/prim/prim/vjp/test_comp_high_grad.py
+++ b/test/prim/prim/vjp/test_comp_high_grad.py
@@ -1110,5 +1110,111 @@ class TestBmmHighGradCheck2(unittest.TestCase):
                         self.func_triple(p, x_stop, y_stop)
 
 
+@param.parameterized_class(
+    ('x_shape', 'indices_shape', 'value_shape'),
+    [
+        ([16], [10], [10]),
+        ([16, 16], [20, 2], [20]),
+        ([12, 13, 14], [88, 1], [88, 13, 14]),
+        ([12, 13, 14], [88, 2], [88, 14]),
+        ([12, 13, 14], [88, 3], [88]),
+    ],
+)
+class TestIndexPutHighGradCheck(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.x_shape = cls.x_shape
+        cls.indices_shape = cls.indices_shape
+        cls.value_shape = cls.value_shape
+
+    def _grad(self, y, x, order):
+        u = y
+        dx = paddle.ones_like(x)
+        for _ in range(order):
+            dx = paddle.grad(u, x, create_graph=True)[0]
+            u = dx
+        return dx
+
+    def func_double(self, place, x_stop, y_stop):
+        x = paddle.randn(self.x_shape).astype("float32").to(device=place)
+        x.stop_gradient = x_stop
+        n_indices = self.indices_shape[0]
+        index_dim_size = (
+            self.indices_shape[1] if len(self.indices_shape) > 1 else 1
+        )
+        self.assertEqual(n_indices, self.value_shape[0])
+        indices = tuple(
+            [
+                paddle.randint(
+                    0,
+                    self.x_shape[i],
+                    shape=[n_indices],
+                ).to(place)
+                for i in range(max(index_dim_size, 1))
+            ]
+        )
+        value = (
+            paddle.randn(self.value_shape).astype("float32").to(device=place)
+        )
+        value.stop_gradient = y_stop
+
+        z = paddle.index_put(x, indices, value)
+        z = paddle.tanh(z)
+
+        if not x.stop_gradient:
+            dzdx = self._grad(z, x, 2)
+        if not value.stop_gradient:
+            dzdy = self._grad(z, value, 2)
+
+    def func_triple(self, place, x_stop, y_stop):
+        x = paddle.randn(self.x_shape).astype("float32").to(device=place)
+        x.stop_gradient = x_stop
+        n_indices = self.indices_shape[0]
+        index_dim_size = (
+            self.indices_shape[1] if len(self.indices_shape) > 1 else 1
+        )
+        self.assertEqual(n_indices, self.value_shape[0])
+        indices = tuple(
+            [
+                paddle.randint(
+                    0,
+                    self.x_shape[i],
+                    shape=[n_indices],
+                ).to(place)
+                for i in range(max(index_dim_size, 1))
+            ]
+        )
+        value = (
+            paddle.randn(self.value_shape).astype("float32").to(device=place)
+        )
+        value.stop_gradient = y_stop
+
+        # wraping with tanh to enable high order gradient
+        z = paddle.index_put(paddle.tanh(x), indices, paddle.tanh(value))
+        z = paddle.tanh(z)
+
+        if not x.stop_gradient:
+            dzdx = self._grad(z, x, 3)
+        if not value.stop_gradient:
+            dzdy = self._grad(z, value, 3)
+
+    def test_high_grad(self):
+        places = []
+        if (
+            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
+            in ['1', 'true', 'on']
+            or not core.is_compiled_with_cuda()
+        ):
+            places.append(base.CPUPlace())
+        if core.is_compiled_with_cuda():
+            places.append(base.CUDAPlace(0))
+        for p in places:
+            for x_stop in [False, True]:
+                for y_stop in [False, True]:
+                    with dygraph_guard():
+                        self.func_double(p, x_stop, y_stop)
+                        self.func_triple(p, x_stop, y_stop)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-75624

Related PR: <https://github.com/deepmodeling/deepmd-kit/pull/4157>

1. 修复`IndexPutCudaKernel`线程不安全的`+=`加法，改为`phi::CudaAtomicAdd`，避免`indices`中含有重复的坐标导致结果不正确
2. 将`index_put`添加到`api.yaml`里作为基础算子，而后在`index_put_double_grad`中复用该前向算子

> [!NOTE]
> 由于gradient_checker不支持indices这一`Tuple[Tensor, ..]`输入类型，因此单测仅作覆盖率测试，精度测试与pytorch对比，如下所示（`accumulate=False`时前向计算的结果为赋值操作，具有不确定性，因此该前向结果不进行对比）
![image](https://github.com/user-attachments/assets/d1e4563b-5952-4075-9e29-bb12b5640acf)

由于使用`CudaAtomicAdd`对性能可能有影响，测试结果如下（单位：毫秒，测试100次取后80次的平均值）：

|  x.shape, indices.shape, value.shape                                 | baseline(pytorch) | "+=" | phi::CudaAtomicAdd |
| --------------------------------- | ----------------- | ---- | ------------------ |
| [16] [10] [10]                    | 0.21              | 0.09 | 0.10(+0.01)               |
| [16, 16] [20, 2] [20]             | 0.28              | 0.10 | 0.10(+0)               |
| [12, 13, 14] [88, 1] [88, 13, 14] | 0.22              | 0.17 | 0.23(+0.05)               |
| [12, 13, 14] [88, 2] [88, 14]     | 0.28              | 0.17 | 0.17(+0)               |
| [12, 13, 14] [88, 3] [88]         | 0.34              | 0.11 | 0.11(+0)               |
| [12, 13, 14] [2184, 3] [2184]        | 0.48              | 0.10 | 0.14(+0.04)               |
| [102, 103, 104] [1092624, 3] [1092624]       | 1.74              | 0.26 | 0.26(+0)              |

可以看到`CudaAtomicAdd`会略微增加计算耗时，但是不会导致算子比pytorch更慢

测试脚本如下
``` py
def test_inedx_put_grad_speed():
    import paddle
    from paddle.framework import core
    import numpy as np
    import torch
    import time

    core.set_prim_eager_enabled(True)
    core._set_prim_all_enabled(True)
    place = 'gpu'
    accumulate = True
    from tqdm import trange
    for x_shape, indices_shape, value_shape in [
        ([16], [10], [10]),
        ([16, 16], [20, 2], [20]),
        ([12, 13, 14], [88, 1], [88, 13, 14]),
        ([12, 13, 14], [88, 2], [88, 14]),
        ([12, 13, 14], [88, 3], [88]),
    ]:
        pd_list = []
        pt_list = []
        for i in trange(100):
            n_indices = indices_shape[0]
            index_dim_size = indices_shape[1] if len(indices_shape) > 1 else 1

            x_np = np.random.randn(*x_shape)
            indices_np = tuple(
                [
                    np.random.randint(0, x_shape[i], [n_indices])
                    for i in range(max(index_dim_size, 1))
                ]
            )
            value_np = np.random.randn(*value_shape).astype("float32")

            # run paddle
            x_pd = paddle.to_tensor(x_np.copy(), "float32", stop_gradient=False, place=place)
            indices_pd = [
                paddle.to_tensor(indice.copy(), "int64", stop_gradient=True, place=place)
                for indice in indices_np
            ]
            value_pd = paddle.to_tensor(value_np.copy(), "float32", stop_gradient=False, place=place)

            def paddle_forward(x_, i_, v_):
                return paddle.index_put(x_, i_, v_, accumulate=accumulate)

            paddle.device.cuda.synchronize()
            t = time.perf_counter()
            paddle_forward(x_pd, indices_pd, value_pd)
            paddle.device.cuda.synchronize()
            t = time.perf_counter() - t

            pd_list.append(t)

            # run torch
            x_pt = torch.as_tensor(x_np, dtype=torch.float32, device='cuda' if place == 'gpu' else place).requires_grad_(True)
            indices_pt = [
                torch.as_tensor(indice, dtype=torch.int64, device='cuda' if place == 'gpu' else place).requires_grad_(False)
                for indice in indices_np
            ]
            value_pt = torch.as_tensor(value_np, dtype=torch.float32, device='cuda' if place == 'gpu' else place).requires_grad_(True)

            def torch_forward(x_, i_, v_):
                return torch.index_put(x_, i_, v_, accumulate=accumulate)

            torch.cuda.synchronize()
            t = time.perf_counter()
            torch_forward(x_pt, indices_pt, value_pt)
            torch.cuda.synchronize()
            t = time.perf_counter() - t

            pt_list.append(t)

        print(x_shape, indices_shape, value_shape, f"{np.asarray(pd_list[20:]).mean() * 1000: .2f} ms")
        print(x_shape, indices_shape, value_shape, f"{np.asarray(pt_list[20:]).mean() * 1000: .2f} ms")

```

精度测试脚本如下：

``` py
def test_index_put_fwd_bwd_double_bwd():
    import paddle
    from paddle.framework import core
    import numpy as np
    import torch

    core.set_prim_eager_enabled(True)
    core._set_prim_all_enabled(True)
    for place in ['cpu', 'gpu']:
        for accumulate in [False, True]:
            for x_shape, indices_shape, value_shape in [
                ([16], [10], [10]),
                ([16, 16], [20, 2], [20]),
                ([12, 13, 14], [88, 1], [88, 13, 14]),
                ([12, 13, 14], [88, 2], [88, 14]),
                ([12, 13, 14], [88, 3], [88]),
            ]:
                n_indices = indices_shape[0]
                index_dim_size = indices_shape[1] if len(indices_shape) > 1 else 1

                x_np = np.random.randn(*x_shape)
                indices_np = tuple(
                    [
                        np.random.randint(0, x_shape[i], [n_indices])
                        for i in range(max(index_dim_size, 1))
                    ]
                )
                value_np = np.random.randn(*value_shape).astype("float32")

                # run paddle
                x_pd = paddle.to_tensor(x_np.copy(), "float32", stop_gradient=False, place=place)
                indices_pd = [
                    paddle.to_tensor(indice.copy(), "int64", stop_gradient=True, place=place)
                    for indice in indices_np
                ]
                value_pd = paddle.to_tensor(value_np.copy(), "float32", stop_gradient=False, place=place)

                out_pd = paddle.index_put(x_pd, indices_pd, value_pd, accumulate=accumulate)
                out_pd = paddle.tanh(out_pd) #
                dout_np = np.random.randn(*out_pd.shape)

                dout_pd = paddle.to_tensor(dout_np.copy(), "float32", stop_gradient=False, place=place)
                dout_pd.stop_gradient = False

                dx_pd = paddle.grad(out_pd, x_pd, dout_pd, create_graph=True)[0] #
                ddx_np = np.random.randn(*dx_pd.shape)

                dvalue_pd = paddle.grad(out_pd, x_pd, dout_pd, create_graph=True)[0] #
                ddvalue_np = np.random.randn(*dvalue_pd.shape)

                ddx_pd = paddle.to_tensor(ddx_np.copy(), "float32", stop_gradient=False, place=place)
                ddvalue_pd = paddle.to_tensor(ddvalue_np.copy(), "float32", stop_gradient=False, place=place)
                ddout1_pd = paddle.grad(dx_pd, dout_pd, ddx_pd, create_graph=True)[0] #
                ddout2_pd = paddle.grad(dvalue_pd, dout_pd, ddvalue_pd, create_graph=True)[0] #

                # run torch
                x_pt = torch.as_tensor(x_np, dtype=torch.float32, device='cuda' if place == 'gpu' else place).requires_grad_(True)
                indices_pt = [
                    torch.as_tensor(indice, dtype=torch.int64, device='cuda' if place == 'gpu' else place).requires_grad_(False)
                    for indice in indices_np
                ]
                value_pt = torch.as_tensor(value_np, dtype=torch.float32, device='cuda' if place == 'gpu' else place).requires_grad_(True)

                out_pt = torch.index_put(x_pt, indices_pt, value_pt, accumulate=accumulate)
                out_pt = torch.tanh(out_pt)

                dout_pt = torch.as_tensor(dout_np, dtype=torch.float32, device='cuda' if place == 'gpu' else place).requires_grad_(True)
                dout_pt.stop_gradient = False

                dx_pt = torch.autograd.grad(out_pt, x_pt, dout_pt, create_graph=True)[0]

                dvalue_pt = torch.autograd.grad(out_pt, x_pt, dout_pt, create_graph=True)[0]

                ddx_pt = torch.as_tensor(ddx_np.copy(), dtype=torch.float32, device='cuda' if place == 'gpu' else place).requires_grad_(True)
                ddvalue_pt = torch.as_tensor(ddvalue_np.copy(), dtype=torch.float32, device='cuda' if place == 'gpu' else place).requires_grad_(True)
                ddout1_pt = torch.autograd.grad(dx_pt, dout_pt, ddx_pt, create_graph=True)[0]
                ddout2_pt = torch.autograd.grad(dvalue_pt, dout_pt, ddvalue_pt, create_graph=True)[0]

                # compare result
                ## output
                if accumulate:
                    np.testing.assert_allclose(out_pd.numpy(), out_pt.detach().cpu().numpy(), 1e-6, 1e-6)

                ## 1-order grad
                np.testing.assert_allclose(dx_pd.numpy(), dx_pt.detach().cpu().numpy(), 2e-6, 2e-6)
                np.testing.assert_allclose(dvalue_pd.numpy(), dvalue_pt.detach().cpu().numpy(), 2e-6, 2e-6)

                ## 2-order grad
                np.testing.assert_allclose(ddout1_pd.numpy(), ddout1_pt.detach().cpu().numpy(), 2e-6, 2e-6)
                np.testing.assert_allclose(ddout2_pd.numpy(), ddout2_pt.detach().cpu().numpy(), 2e-6, 2e-6)


def index_put_fwd_bwd_double_bwd_with_accumulate_false():
    import paddle
    from paddle.framework import core
    import numpy as np
    import torch

    core.set_prim_eager_enabled(True)
    core._set_prim_all_enabled(True)

    x_shape = [3, 4]
    indices_np = [
        np.asarray([0, 1, 1, 2, 2]),
        np.asarray([1, 3, 2, 1, 0]),
    ] # N = 2, D = 4
    indices_shape = [indices_np[0].shape[0], len(indices_np)] # N x D
    n_indices = indices_shape[0]
    value_shape = [n_indices]


    x_np = np.random.randn(*x_shape)
    value_np = np.random.randn(*value_shape).astype("float32")

    for place in ['cpu', 'gpu']:
        for accumulate in [False, True]:
            # run paddle
            x_pd = paddle.to_tensor(x_np.copy(), "float32", stop_gradient=False, place=place)
            indices_pd = [
                paddle.to_tensor(indice.copy(), "int64", stop_gradient=True, place=place)
                for indice in indices_np
            ]
            value_pd = paddle.to_tensor(value_np.copy(), "float32", stop_gradient=False, place=place)

            out_pd = paddle.index_put(x_pd, indices_pd, value_pd, accumulate=accumulate)
            out_pd = paddle.tanh(out_pd) #
            dout_np = np.random.randn(*out_pd.shape)

            dout_pd = paddle.to_tensor(dout_np.copy(), "float32", stop_gradient=False, place=place)
            dout_pd.stop_gradient = False

            dx_pd = paddle.grad(out_pd, x_pd, dout_pd, create_graph=True)[0] #
            ddx_np = np.random.randn(*dx_pd.shape)

            dvalue_pd = paddle.grad(out_pd, x_pd, dout_pd, create_graph=True)[0] #
            ddvalue_np = np.random.randn(*dvalue_pd.shape)

            ddx_pd = paddle.to_tensor(ddx_np.copy(), "float32", stop_gradient=False, place=place)
            ddvalue_pd = paddle.to_tensor(ddvalue_np.copy(), "float32", stop_gradient=False, place=place)
            ddout1_pd = paddle.grad(dx_pd, dout_pd, ddx_pd, create_graph=True)[0] #
            ddout2_pd = paddle.grad(dvalue_pd, dout_pd, ddvalue_pd, create_graph=True)[0] #

            # run torch
            x_pt = torch.as_tensor(x_np.copy(), dtype=torch.float32, device='cuda' if place == 'gpu' else place).requires_grad_(True)
            indices_pt = [
                torch.as_tensor(indice.copy(), dtype=torch.int64, device='cuda' if place == 'gpu' else place).requires_grad_(False)
                for indice in indices_np
            ]
            value_pt = torch.as_tensor(value_np.copy(), dtype=torch.float32, device='cuda' if place == 'gpu' else place).requires_grad_(True)

            out_pt = torch.index_put(x_pt, indices_pt, value_pt, accumulate=accumulate)
            out_pt = torch.tanh(out_pt)

            dout_pt = torch.as_tensor(dout_np.copy(), dtype=torch.float32, device='cuda' if place == 'gpu' else place).requires_grad_(True)
            dout_pt.stop_gradient = False

            dx_pt = torch.autograd.grad(out_pt, x_pt, dout_pt, create_graph=True)[0]

            dvalue_pt = torch.autograd.grad(out_pt, x_pt, dout_pt, create_graph=True)[0]

            ddx_pt = torch.as_tensor(ddx_np.copy(), dtype=torch.float32, device='cuda' if place == 'gpu' else place).requires_grad_(True)
            ddvalue_pt = torch.as_tensor(ddvalue_np.copy(), dtype=torch.float32, device='cuda' if place == 'gpu' else place).requires_grad_(True)
            ddout1_pt = torch.autograd.grad(dx_pt, dout_pt, ddx_pt, create_graph=True)[0]
            ddout2_pt = torch.autograd.grad(dvalue_pt, dout_pt, ddvalue_pt, create_graph=True)[0]

            # compare result
            ## output
            np.testing.assert_allclose(out_pd.numpy(), out_pt.detach().cpu().numpy(), 1e-6, 1e-6)

            ## 1-order grad
            np.testing.assert_allclose(dx_pd.numpy(), dx_pt.detach().cpu().numpy(), 1e-6, 1e-6)
            np.testing.assert_allclose(dvalue_pd.numpy(), dvalue_pt.detach().cpu().numpy(), 1e-6, 1e-6)

            ## 2-order grad
            np.testing.assert_allclose(ddout1_pd.numpy(), ddout1_pt.detach().cpu().numpy(), 2e-6, 2e-6)
            np.testing.assert_allclose(ddout2_pd.numpy(), ddout2_pt.detach().cpu().numpy(), 2e-6, 2e-6)

if __name__ == "__main__":
    test_index_put_fwd_bwd_double_bwd()
    index_put_fwd_bwd_double_bwd_with_accumulate_false()

```