### PR TITLE
[AutoParallel] Fix CI bug by disabling nd_mesh_alltoall reshard

### DIFF
--- a/test/auto_parallel/test_moe_utils.py
+++ b/test/auto_parallel/test_moe_utils.py
@@ -30,7 +30,12 @@ class TestSemiAutoParallelMoEUtils(test_base.CommunicationTestDistBase):
 
     def test_moe_utils(self):
         envs_list = test_base.gen_product_envs_list(
-            {"dtype": "float32", "seed": "2024"}, {"backend": ["gpu"]}
+            {
+                "dtype": "float32",
+                "seed": "2024",
+                "FLAGS_enable_moe_utils": "true",
+            },
+            {"backend": ["gpu"]},
         )
         for envs in envs_list:
             self.run_test_case(

--- a/test/auto_parallel/test_moe_utils.py
+++ b/test/auto_parallel/test_moe_utils.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
 
-sys.path.append("..")
 import collective.test_communication_api_base as test_base
 
 


### PR DESCRIPTION
### PR Category
Auto Parallel


### PR Types
Bug fixes

### Description
Pcard-67164

Fix the auto parallel CI bug in PaddleNLP by adding a flag to disable nd_mesh_all2all_reshard by default.
