### PR TITLE
[Prim][PIR] Add back_decomp and support dynamic shape for korn_grad

### DIFF
--- a/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
+++ b/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
@@ -93,6 +93,7 @@ BINARY_PRIM_VJP_OPS = [
     'fmax_grad',
     'fmin_grad',
     'dot_grad',
+    'kron_grad',
 ]
 
 OTHER_PRIM_VJP_OPS = [

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -2919,132 +2919,283 @@ void kron_grad(const Tensor& x,
                Tensor* x_grad,
                Tensor* y_grad) {
   if (x_grad) {
-    auto x_shape = x.shape();
-    auto y_shape = y.shape();
-
-    auto diff = std::abs(static_cast<int>(x_shape.size()) -
-                         static_cast<int>(y_shape.size()));
-    for (int i = 0; i < diff; i++) {
-      if (x_shape.size() > y_shape.size()) {
-        y_shape.insert(y_shape.begin(), 1);
-      } else {
-        x_shape.insert(x_shape.begin(), 1);
-      }
-    }
-
-    auto x_ = reshape<T>(x, x_shape);
-    auto y_ = reshape<T>(y, y_shape);
-
-    // tile
-    std::vector<int64_t> x_dim = common::vectorize<int64_t>(x_.dims());
-    auto y_tile = tile<T>(y_, x_dim);
-
-    auto out_grad_tmp = y_tile * out_grad;
-
-    std::vector<int64_t> out_grad_shape(out_grad_tmp.shape());
-
-    if (x_dim.size() != 0) {
-      while (true) {
-        std::vector<int64_t> expand_shape(out_grad_tmp.shape());
-
-        int num_reduce = 0;
-        while (x_dim.size() != 0 && expand_shape.size() <= 8) {
-          int64_t repeat = x_dim.back();
-          int64_t orig_size = out_grad_shape.back() / repeat;
-          size_t out_grad_last_index = out_grad_shape.size() - 1;
-
-          expand_shape[out_grad_last_index] = repeat;
-          expand_shape.insert(
-              expand_shape.begin() + out_grad_shape.size(), 1, orig_size);
-
-          x_dim.pop_back();
-          out_grad_shape.pop_back();
-          ++num_reduce;
-        }
-
-        int64_t axis = static_cast<int64_t>(out_grad_shape.size()) + 1;
-        std::vector<int64_t> reduce_axes;
-        for (int i = 0; i < num_reduce; ++i) {
-          reduce_axes.push_back(axis);
-          axis += 2;
-        }
-
-        out_grad_tmp = reshape<T>(out_grad_tmp, expand_shape);
-        out_grad_tmp = sum<T>(out_grad_tmp, reduce_axes);
-
-        if (x_dim.size() == 0) {
-          break;
+    Tensor zero = full<T>({1}, 0, DataType::INT32);
+    Tensor x_grad_tmp;
+    if (has_dynamic_shape(x.shape()) || has_dynamic_shape(y.shape())) {
+      Tensor x_ = x;
+      Tensor y_ = y;
+      auto diff = std::abs(static_cast<int>(x.dims().size()) -
+                           static_cast<int>(y.dims().size()));
+      while (diff--) {
+        if (x_.dims().size() > y_.dims().size()) {
+          y_ = backend::unsqueeze<T>(y_, zero);
+        } else {
+          x_ = backend::unsqueeze<T>(x_, zero);
         }
       }
+
+      // tile
+      std::vector<Tensor> x_shape_vec;
+      for (int64_t i = 0; i < x_.dims().size(); ++i) {
+        auto x_shape_slice = get_slice<T>(shape<T>(x_), i);
+        x_shape_vec.push_back(x_shape_slice);
+      }
+
+      auto y_tile = backend::tile<T>(y_, shape<T>(x_));
+
+      auto out_grad_tmp = y_tile * out_grad;
+
+      std::vector<Tensor> out_grad_shape_vec;
+      for (int64_t i = 0; i < out_grad.dims().size(); ++i) {
+        auto out_grad_shape_slice = get_slice<T>(shape<T>(out_grad), i);
+        out_grad_shape_vec.push_back(out_grad_shape_slice);
+      }
+      if (x_shape_vec.size() != 0) {
+        while (true) {
+          std::vector<Tensor> expand_shape_vec;
+          for (int64_t i = 0; i < out_grad_tmp.dims().size(); ++i) {
+            auto expand_shape = get_slice<T>(shape<T>(out_grad_tmp), i);
+            expand_shape_vec.push_back(expand_shape);
+          }
+          int num_reduce = 0;
+          while (x_shape_vec.size() != 0 && expand_shape_vec.size() <= 8) {
+            Tensor repeat = x_shape_vec.back();
+            auto orig_size =
+                cast<T>(out_grad_shape_vec.back() / repeat, DataType::INT32);
+            size_t out_grad_last_index = out_grad_shape_vec.size() - 1;
+            expand_shape_vec[out_grad_last_index] = repeat;
+            expand_shape_vec.insert(
+                expand_shape_vec.begin() + out_grad_shape_vec.size(),
+                orig_size);
+
+            x_shape_vec.pop_back();
+            out_grad_shape_vec.pop_back();
+            ++num_reduce;
+          }
+
+          int axis = static_cast<int>(out_grad_shape_vec.size()) + 1;
+          std::vector<Tensor> reduce_axes_vec;
+          for (int i = 0; i < num_reduce; ++i) {
+            reduce_axes_vec.push_back(full<T>({1}, axis, DataType::INT32));
+            axis += 2;
+          }
+
+          out_grad_tmp =
+              backend::reshape<T>(out_grad_tmp, concat<T>(expand_shape_vec));
+          out_grad_tmp =
+              backend::sum<T>(out_grad_tmp, concat<T>(reduce_axes_vec));
+          if (x_shape_vec.size() == 0) {
+            break;
+          }
+        }
+      }
+      x_grad_tmp = backend::reshape<T>(out_grad_tmp, shape<T>(x));
+    } else {
+      auto x_shape = x.shape();
+      auto y_shape = y.shape();
+
+      auto diff = std::abs(static_cast<int>(x_shape.size()) -
+                           static_cast<int>(y_shape.size()));
+      for (int i = 0; i < diff; i++) {
+        if (x_shape.size() > y_shape.size()) {
+          y_shape.insert(y_shape.begin(), 1);
+        } else {
+          x_shape.insert(x_shape.begin(), 1);
+        }
+      }
+
+      auto x_ = reshape<T>(x, x_shape);
+      auto y_ = reshape<T>(y, y_shape);
+
+      // tile
+      std::vector<int64_t> x_dim = common::vectorize<int64_t>(x_.dims());
+      auto y_tile = tile<T>(y_, x_dim);
+
+      auto out_grad_tmp = y_tile * out_grad;
+
+      std::vector<int64_t> out_grad_shape(out_grad_tmp.shape());
+
+      if (x_dim.size() != 0) {
+        while (true) {
+          std::vector<int64_t> expand_shape(out_grad_tmp.shape());
+
+          int num_reduce = 0;
+          while (x_dim.size() != 0 && expand_shape.size() <= 8) {
+            int64_t repeat = x_dim.back();
+            int64_t orig_size = out_grad_shape.back() / repeat;
+            size_t out_grad_last_index = out_grad_shape.size() - 1;
+
+            expand_shape[out_grad_last_index] = repeat;
+            expand_shape.insert(
+                expand_shape.begin() + out_grad_shape.size(), 1, orig_size);
+
+            x_dim.pop_back();
+            out_grad_shape.pop_back();
+            ++num_reduce;
+          }
+
+          int64_t axis = static_cast<int64_t>(out_grad_shape.size()) + 1;
+          std::vector<int64_t> reduce_axes;
+          for (int i = 0; i < num_reduce; ++i) {
+            reduce_axes.push_back(axis);
+            axis += 2;
+          }
+
+          out_grad_tmp = reshape<T>(out_grad_tmp, expand_shape);
+          out_grad_tmp = sum<T>(out_grad_tmp, reduce_axes);
+
+          if (x_dim.size() == 0) {
+            break;
+          }
+        }
+      }
+      x_grad_tmp = reshape<T>(out_grad_tmp, x.shape());
     }
-    Tensor x_grad_tmp = reshape<T>(out_grad_tmp, x.shape());
     set_output<T>(x_grad_tmp, x_grad);
   }
-
   if (y_grad) {
+    Tensor zero = full<T>({1}, 0, DataType::INT32);
     auto x_cast = ConverToMT<T>(x);
     auto out_grad_cast = ConverToMT<T>(out_grad);
+    Tensor out_grad_tmp;
+    Tensor y_grad_tmp;
 
-    auto x_shape = x_cast.shape();
-    auto y_shape = y.shape();
-
-    auto diff = std::abs(static_cast<int>(x_shape.size()) -
-                         static_cast<int>(y_shape.size()));
-    for (int i = 0; i < diff; i++) {
-      if (x_shape.size() > y_shape.size()) {
-        y_shape.insert(y_shape.begin(), 1);
-      } else {
-        x_shape.insert(x_shape.begin(), 1);
-      }
-    }
-
-    auto x_ = reshape<T>(x_cast, x_shape);
-
-    std::vector<int64_t> x_dim = common::vectorize<int64_t>(x_.dims());
-    for (size_t i = 0; i < x_dim.size(); ++i) {
-      x_ = repeat_interleave<T>(x_, y_shape[i], i);
-    }
-
-    std::vector<int64_t> out_grad_shape(out_grad_cast.shape());
-    Tensor out_grad_tmp = out_grad_cast * x_;
-
-    if (x_dim.size() != 0) {
-      while (true) {
-        std::vector<int64_t> expand_shape(out_grad_tmp.shape());
-
-        int num_reduce = 0;
-        while (x_dim.size() != 0 && expand_shape.size() <= 8) {
-          int64_t repeat = x_dim.back();
-          int64_t orig_size = out_grad_shape.back() / repeat;
-          size_t out_grad_last_index = out_grad_shape.size() - 1;
-
-          expand_shape[out_grad_last_index] = repeat;
-          expand_shape.insert(
-              expand_shape.begin() + out_grad_shape.size(), 1, orig_size);
-
-          x_dim.pop_back();
-          out_grad_shape.pop_back();
-          ++num_reduce;
-        }
-
-        int64_t axis = static_cast<int64_t>(out_grad_shape.size());
-        std::vector<int64_t> reduce_axes;
-        for (int i = 0; i < num_reduce; ++i) {
-          reduce_axes.push_back(axis);
-          axis += 2;
-        }
-
-        out_grad_tmp = reshape<T>(out_grad_tmp, expand_shape);
-        out_grad_tmp = sum<T>(out_grad_tmp, reduce_axes);
-
-        if (x_dim.size() == 0) {
-          break;
+    if (has_dynamic_shape(x_cast.shape()) || has_dynamic_shape(y.shape())) {
+      Tensor x_ = x_cast;
+      Tensor y_ = y;
+      auto diff = std::abs(static_cast<int>(x_cast.dims().size()) -
+                           static_cast<int>(y.dims().size()));
+      while (diff--) {
+        if (x_.dims().size() > y_.dims().size()) {
+          y_ = backend::unsqueeze<T>(y_, zero);
+        } else {
+          x_ = backend::unsqueeze<T>(x_, zero);
         }
       }
+
+      std::vector<Tensor> x_shape_vec;
+      for (int64_t i = 0; i < x_.dims().size(); ++i) {
+        auto x_shape_slice = get_slice<T>(shape<T>(x_), i);
+        x_shape_vec.push_back(x_shape_slice);
+      }
+
+      for (int64_t i = 0; i < x_.dims().size(); ++i) {
+        auto y_shape_slice = get_slice<T>(shape<T>(y_), i);
+        auto x_shape_slice = get_slice<T>(shape<T>(x_), i);
+        auto y_shape_tile = backend::tile<T>(y_shape_slice, x_shape_slice);
+        x_ = backend::repeat_interleave_with_tensor_index<T>(
+            x_, y_shape_tile, i);
+      }
+      out_grad_tmp = out_grad_cast * x_;
+
+      std::vector<Tensor> out_grad_shape_vec;
+      for (int64_t i = 0; i < out_grad.dims().size(); ++i) {
+        auto out_grad_shape_slice = get_slice<T>(shape<T>(out_grad_cast), i);
+        out_grad_shape_vec.push_back(out_grad_shape_slice);
+      }
+
+      if (x_shape_vec.size() != 0) {
+        while (true) {
+          std::vector<Tensor> expand_shape_vec;
+          for (int64_t i = 0; i < out_grad_tmp.dims().size(); ++i) {
+            auto expand_shape = get_slice<T>(shape<T>(out_grad_tmp), i);
+            expand_shape_vec.push_back(expand_shape);
+          }
+          int num_reduce = 0;
+          while (x_shape_vec.size() != 0 && expand_shape_vec.size() <= 8) {
+            auto repeat = x_shape_vec.back();
+            auto orig_size =
+                cast<T>(out_grad_shape_vec.back() / repeat, DataType::INT32);
+            size_t out_grad_last_index = out_grad_shape_vec.size() - 1;
+            expand_shape_vec[out_grad_last_index] = repeat;
+            expand_shape_vec.insert(
+                expand_shape_vec.begin() + out_grad_shape_vec.size(),
+                orig_size);
+
+            x_shape_vec.pop_back();
+            out_grad_shape_vec.pop_back();
+            ++num_reduce;
+          }
+          int axis = static_cast<int>(out_grad_shape_vec.size());
+          std::vector<Tensor> reduce_axes_vec;
+          for (int i = 0; i < num_reduce; ++i) {
+            reduce_axes_vec.push_back(full<T>({1}, axis, DataType::INT32));
+            axis += 2;
+          }
+          out_grad_tmp =
+              backend::reshape<T>(out_grad_tmp, concat<T>(expand_shape_vec));
+          out_grad_tmp =
+              backend::sum<T>(out_grad_tmp, concat<T>(reduce_axes_vec));
+
+          if (x_shape_vec.size() == 0) {
+            break;
+          }
+        }
+      }
+      y_grad_tmp = backend::reshape<T>(
+          ConverToOrig<T>(out_grad_tmp, out_grad.dtype()), shape<T>(y));
+    } else {
+      auto x_shape = x_cast.shape();
+      auto y_shape = y.shape();
+
+      auto diff = std::abs(static_cast<int>(x_shape.size()) -
+                           static_cast<int>(y_shape.size()));
+      for (int i = 0; i < diff; i++) {
+        if (x_shape.size() > y_shape.size()) {
+          y_shape.insert(y_shape.begin(), 1);
+        } else {
+          x_shape.insert(x_shape.begin(), 1);
+        }
+      }
+
+      auto x_ = reshape<T>(x_cast, x_shape);
+
+      std::vector<int64_t> x_dim = common::vectorize<int64_t>(x_.dims());
+      for (size_t i = 0; i < x_dim.size(); ++i) {
+        x_ = repeat_interleave<T>(x_, y_shape[i], i);
+      }
+      out_grad_tmp = out_grad_cast * x_;
+
+      std::vector<int64_t> out_grad_shape(out_grad_cast.shape());
+
+      if (x_dim.size() != 0) {
+        while (true) {
+          std::vector<int64_t> expand_shape(out_grad_tmp.shape());
+
+          int num_reduce = 0;
+          while (x_dim.size() != 0 && expand_shape.size() <= 8) {
+            int64_t repeat = x_dim.back();
+            int64_t orig_size = out_grad_shape.back() / repeat;
+            size_t out_grad_last_index = out_grad_shape.size() - 1;
+
+            expand_shape[out_grad_last_index] = repeat;
+            expand_shape.insert(
+                expand_shape.begin() + out_grad_shape.size(), 1, orig_size);
+
+            x_dim.pop_back();
+            out_grad_shape.pop_back();
+            ++num_reduce;
+          }
+
+          int64_t axis = static_cast<int64_t>(out_grad_shape.size());
+          std::vector<int64_t> reduce_axes;
+          for (int i = 0; i < num_reduce; ++i) {
+            reduce_axes.push_back(axis);
+            axis += 2;
+          }
+
+          out_grad_tmp = reshape<T>(out_grad_tmp, expand_shape);
+          out_grad_tmp = sum<T>(out_grad_tmp, reduce_axes);
+
+          if (x_dim.size() == 0) {
+            break;
+          }
+        }
+      }
+      y_grad_tmp = reshape<T>(ConverToOrig<T>(out_grad_tmp, out_grad.dtype()),
+                              y.shape());
     }
-    set_output<T>(
-        reshape<T>(ConverToOrig<T>(out_grad_tmp, out_grad.dtype()), y.shape()),
-        y_grad);
+    set_output<T>(y_grad_tmp, y_grad);
   }
 }
 

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -2952,7 +2952,7 @@ void kron_grad(const Tensor& x,
         std::vector<int> split_vec(static_cast<int>(x_shape[i]),
                                    static_cast<int>(y_shape[i]));
         std::vector<Tensor> block_split =
-            split<T>(block, IntArray(split_vec), i);
+            split<T>(block, IntArray(split_vec), static_cast<int>(i));
 
         for (auto& b : block_split) {
           tmp_block.push_back(b);

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -2918,111 +2918,136 @@ void kron_grad(const Tensor& x,
                const Tensor& out_grad,
                Tensor* x_grad,
                Tensor* y_grad) {
-  if (x_grad && y_grad) {
-    // auto vector_x = split<T>(backend::flatten<T>(x, 0, -1), {x.numel()}, -1);
-    std::vector<Tensor> vector_x;
-    auto flat_x = backend::flatten<T>(x, 0, -1);
-    for (int i = 0; i < x.numel(); i++) {
-      vector_x.push_back(get_slice_vec<T>(flat_x, i, i + 1));  // 逐元素切片
-    }
-    // auto vector_y = split<T>(backend::flatten<T>(y, 0, -1), {y.numel()}, 0);
-    std::vector<Tensor> vector_y;
-    auto flat_y = backend::flatten<T>(y, 0, -1);
-    for (int i = 0; i < y.numel(); i++) {
-      vector_y.push_back(get_slice_vec<T>(flat_y, i, i + 1));  // 逐元素切片
-    }
-    // auto vector_out_grad = split<T>(backend::flatten<T>(out_grad, 0, -1),
-    // {out_grad.numel()}, -1);
-
-    std::vector<Tensor> vector_out_grad;
-    auto flat_out_grad = backend::flatten<T>(out_grad, 0, -1);
-    for (int i = 0; i < out_grad.numel(); i++) {
-      vector_out_grad.push_back(
-          get_slice_vec<T>(flat_out_grad, i, i + 1));  // 逐元素切片
-    }
+  if (x_grad) {
+    auto x_shape = x.shape();
+    auto y_shape = y.shape();
+    auto out_grad_shape = out_grad.shape();
 
     Tensor x_ = x;
     Tensor y_ = y;
-    int64_t x_dim_size = x.dims().size();
-    int64_t y_dim_size = y.dims().size();
-    auto diff = std::abs(x_dim_size - y_dim_size);
-    if (diff != 0) {
-      std::vector<int64_t> range_diff(diff);
-      for (int64_t i = 0; i < diff; i++) {
-        range_diff[i] = i;
-      }
-
-      if (x_dim_size < y_dim_size) {
-        x_ = unsqueeze<T>(x, IntArray(range_diff));
-      } else if (x_dim_size > y_dim_size) {
-        y_ = unsqueeze<T>(y, IntArray(range_diff));
-      }
-    }
-
-    std::vector<Tensor> x_grad_data(x.numel(), full_scalar<T>(0.0, x.dtype()));
-    std::vector<Tensor> y_grad_data(y.numel(), full_scalar<T>(0.0, y.dtype()));
-
-    // 计算stride信息
-    int64_t size = x_.shape().size();
-    auto x_stride = std::vector<int>(size, 0);
-    auto y_stride = std::vector<int>(size, 0);
-    auto out_grad_stride = std::vector<int>(size, 0);
-
-    x_stride[size - 1] = 1;
-    y_stride[size - 1] = 1;
-    out_grad_stride[size - 1] = 1;
-
-    for (int64_t i = size - 2; i >= 0; i--) {
-      x_stride[i] = x_stride[i + 1] * x_.shape()[i + 1];
-      y_stride[i] = y_stride[i + 1] * y_.shape()[i + 1];
-      out_grad_stride[i] = out_grad_stride[i + 1] * out_grad.shape()[i + 1];
-    }
-
-    // auto* out_grad_data = out_grad.data<float>();
-    // auto* y_data = y_.data<float>();
-    std::vector<Tensor> x_grad_tmp_;
-    std::vector<Tensor> y_grad_tmp_;
-
-    // 计算Kronecker积的梯度
-    for (int64_t i = 0; i < out_grad.numel(); i++) {
-      auto idx = i;
-      auto x_idx = 0;
-      auto y_idx = 0;
-
-      for (int64_t j = 0; j < size; j++) {
-        auto pos_j = idx / out_grad_stride[j];
-        idx = idx % out_grad_stride[j];
-        auto pos_xj = pos_j / y_.shape()[j];
-        auto pos_yj = pos_j % y_.shape()[j];
-        x_idx += x_stride[j] * pos_xj;
-        y_idx += y_stride[j] * pos_yj;
-      }
-      if (x_grad_data[x_idx].defined() && vector_out_grad[i].defined() &&
-          vector_y[y_idx].defined()) {
-        x_grad_data[x_idx] =
-            x_grad_data[x_idx] + vector_out_grad[i] * vector_y[y_idx];
+    auto diff = std::abs(static_cast<int>(x_shape.size()) -
+                         static_cast<int>(y_shape.size()));
+    for (int i = 0; i < diff; i++) {
+      if (x_shape.size() > y_shape.size()) {
+        y_shape.insert(y_shape.begin(), 1);
       } else {
-        PADDLE_THROW(::common::errors::InvalidArgument(
-            "One of the tensors in x_grad_data, vector_out_grad or vector_y is "
-            "not defined."));
+        x_shape.insert(x_shape.begin(), 1);
       }
+    }
+    x_ = expand<T>(x, x_shape);
+    y_ = expand<T>(y, y_shape);
 
-      if (y_grad_data[y_idx].defined() && vector_out_grad[i].defined() &&
-          vector_x[x_idx].defined()) {
-        y_grad_data[y_idx] =
-            y_grad_data[y_idx] + vector_out_grad[i] * vector_x[x_idx];
-      } else {
-        PADDLE_THROW(::common::errors::InvalidArgument(
-            "One of the tensors in y_grad_data, vector_out_grad or vector_x is "
-            "not defined."));
+    std::vector<int64_t> y_dim = common::vectorize<int64_t>(y_.dims());
+
+    // split out_grad into blocks
+    std::vector<int64_t> block_shape(out_grad_shape.size());
+    for (size_t i = 0; i < block_shape.size(); i++) {
+      block_shape[i] = out_grad_shape[i] / y_shape[i];
+    }
+
+    std::vector<int64_t> new_shape;
+    for (size_t i = 0; i < out_grad_shape.size(); i++) {
+      new_shape.push_back(block_shape[i]);
+      new_shape.push_back(y_shape[i]);
+    }
+    auto new_out_grad = reshape<T>(out_grad, new_shape);
+
+    // transpose out_grad
+    std::vector<size_t> permute_order;
+    for (size_t i = 0; i < out_grad_shape.size(); ++i) {
+      permute_order.push_back(i * 2);
+    }
+    for (size_t i = 0; i < out_grad_shape.size(); ++i) {
+      permute_order.push_back(i * 2 + 1);
+    }
+
+    std::vector<int> permute_order_int(permute_order.begin(),
+                                       permute_order.end());
+    auto transposed_out_grad = transpose<T>(new_out_grad, permute_order_int);
+
+    // unsqueeze
+    y_dim.insert(y_dim.begin(), -1);
+    auto blocks = reshape<T>(transposed_out_grad, y_dim);
+
+    std::vector<size_t> range;
+    for (size_t i = 0; i <= y_shape.size(); i++) {
+      if (i != 0) {
+        range.push_back(i);
       }
     }
 
-    Tensor x_grad_tmp = reshape<T>(concat<T>(x_grad_data), x.shape());
-    Tensor y_grad_tmp = reshape<T>(concat<T>(y_grad_data), y.shape());
+    std::vector<int> range_int(range.begin(), range.end());
+    auto sum_tensor = sum<T>(blocks * y_, IntArray(range_int));
+    auto x_grad_tmp = reshape<T>(sum_tensor, x.shape());
 
     set_output<T>(x_grad_tmp, x_grad);
-    set_output<T>(y_grad_tmp, y_grad);
+  }
+
+  if (y_grad) {
+    auto x_cast = ConverToMT<T>(x);
+    auto out_grad_cast = ConverToMT<T>(out_grad);
+
+    auto x_shape = x_cast.shape();
+    auto y_shape = y.shape();
+
+    auto diff = std::abs(static_cast<int>(x_shape.size()) -
+                         static_cast<int>(y_shape.size()));
+    for (int i = 0; i < diff; i++) {
+      if (x_shape.size() > y_shape.size()) {
+        y_shape.insert(y_shape.begin(), 1);
+      } else {
+        x_shape.insert(x_shape.begin(), 1);
+      }
+    }
+
+    auto x_ = expand<T>(x_cast, x_shape);
+
+    std::vector<int64_t> x_dim = common::vectorize<int64_t>(x_.dims());
+    std::vector<int64_t> out_grad_shape(out_grad_cast.shape());
+    Tensor out_grad_tmp = out_grad_cast;
+
+    if (x_dim.size() != 0) {
+      while (true) {
+        std::vector<int64_t> expand_shape(out_grad_tmp.shape());
+
+        int num_reduce = 0;
+        while (x_dim.size() != 0 && expand_shape.size() <= 8) {
+          int64_t repeat = x_dim.back();
+          int64_t orig_size = out_grad_shape.back() / repeat;
+          size_t out_grad_last_index = out_grad_shape.size() - 1;
+
+          expand_shape[out_grad_last_index] = repeat;
+          expand_shape.insert(
+              expand_shape.begin() + out_grad_shape.size(), 1, orig_size);
+
+          x_dim.pop_back();
+          out_grad_shape.pop_back();
+          ++num_reduce;
+        }
+
+        int64_t axis = static_cast<int64_t>(out_grad_shape.size());
+        std::vector<int64_t> reduce_axes;
+        for (int i = 0; i < num_reduce; ++i) {
+          reduce_axes.push_back(axis);
+          axis += 2;
+        }
+
+        auto x_tmp_dim = common::vectorize<int64_t>(x_.dims());
+        for (size_t i = 0; i < x_tmp_dim.size(); ++i) {
+          x_ = repeat_interleave<T>(x_, y_shape[i], i);
+        }
+
+        out_grad_tmp = reshape<T>(out_grad_tmp * x_, expand_shape);
+        out_grad_tmp = sum<T>(out_grad_tmp, reduce_axes);
+
+        if (x_dim.size() == 0) {
+          break;
+        }
+      }
+    }
+    set_output<T>(
+        reshape<T>(ConverToOrig<T>(out_grad_tmp, out_grad.dtype()), y.shape()),
+        y_grad);
   }
 }
 

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -53,6 +53,7 @@ ALLOW_DYNAMIC_SHAPE_VJP_OPS = [
     "pd_op.gather_nd",
     "pd_op.gelu",
     "pd_op.hardswish",
+    "pd_op.kron",
     "pd_op.kthvalue",
     "pd_op.layer_norm",
     "pd_op.leaky_relu",

--- a/test/legacy_test/test_kron_op.py
+++ b/test/legacy_test/test_kron_op.py
@@ -105,7 +105,7 @@ class TestKronOp4(TestKronOp):
         self.public_python_api = paddle.kron
         self.dtype = self._init_dtype()
         x = np.random.uniform(size=(5, 5, 5)).astype(self.dtype)
-        y = np.random.uniform(size=(2, 5, 4, 5)).astype(self.dtype)
+        y = np.random.uniform(size=(2, 3, 4, 2, 2, 3)).astype(self.dtype)
         out_ref = np.kron(x, y)
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': out_ref}
@@ -118,7 +118,7 @@ class TestKronOp5(TestKronOp):
         self.python_api = paddle.kron
         self.public_python_api = paddle.kron
         self.dtype = self._init_dtype()
-        x = np.random.uniform(size=(2, 3, 4, 5)).astype(self.dtype)
+        x = np.random.uniform(size=(2, 3, 4, 3, 2, 2)).astype(self.dtype)
         y = np.random.uniform(size=(10, 10)).astype(self.dtype)
         out_ref = np.kron(x, y)
         self.inputs = {'X': x, 'Y': y}

--- a/test/legacy_test/test_kron_op.py
+++ b/test/legacy_test/test_kron_op.py
@@ -104,8 +104,8 @@ class TestKronOp4(TestKronOp):
         self.python_api = paddle.kron
         self.public_python_api = paddle.kron
         self.dtype = self._init_dtype()
-        x = np.random.uniform(size=(5, 10, 5, 5)).astype(self.dtype)
-        y = np.random.uniform(size=(10, 5, 4, 5)).astype(self.dtype)
+        x = np.random.uniform(size=(5, 5, 5)).astype(self.dtype)
+        y = np.random.uniform(size=(2, 5, 4, 5)).astype(self.dtype)
         out_ref = np.kron(x, y)
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': out_ref}
@@ -118,8 +118,8 @@ class TestKronOp5(TestKronOp):
         self.python_api = paddle.kron
         self.public_python_api = paddle.kron
         self.dtype = self._init_dtype()
-        x = np.random.uniform(size=(2, 3, 4, 5, 4)).astype(self.dtype)
-        y = np.random.uniform(size=(2, 2, 4, 5, 4)).astype(self.dtype)
+        x = np.random.uniform(size=(2, 3, 4, 5)).astype(self.dtype)
+        y = np.random.uniform(size=(2, 10, 4)).astype(self.dtype)
         out_ref = np.kron(x, y)
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': out_ref}

--- a/test/legacy_test/test_kron_op.py
+++ b/test/legacy_test/test_kron_op.py
@@ -118,8 +118,22 @@ class TestKronOp5(TestKronOp):
         self.python_api = paddle.kron
         self.public_python_api = paddle.kron
         self.dtype = self._init_dtype()
-        x = np.random.uniform(size=(2, 3, 4, 3, 2, 2)).astype(self.dtype)
+        x = np.random.uniform(size=(2, 3, 4, 3, 2)).astype(self.dtype)
         y = np.random.uniform(size=(10, 10)).astype(self.dtype)
+        out_ref = np.kron(x, y)
+        self.inputs = {'X': x, 'Y': y}
+        self.outputs = {'Out': out_ref}
+
+
+class TestKronOp6(TestKronOp):
+    def setUp(self):
+        self.op_type = "kron"
+        self.prim_op_type = "prim"
+        self.python_api = paddle.kron
+        self.public_python_api = paddle.kron
+        self.dtype = self._init_dtype()
+        x = np.random.uniform(size=(10, 10, 2)).astype(self.dtype)
+        y = np.random.uniform(size=(2, 3, 4, 3, 2)).astype(self.dtype)
         out_ref = np.kron(x, y)
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': out_ref}

--- a/test/legacy_test/test_kron_op.py
+++ b/test/legacy_test/test_kron_op.py
@@ -26,7 +26,9 @@ from paddle.base import core
 class TestKronOp(OpTest):
     def setUp(self):
         self.op_type = "kron"
+        self.prim_op_type = "prim"
         self.python_api = paddle.kron
+        self.public_python_api = paddle.kron
         self.dtype = self._init_dtype()
         x = np.random.uniform(size=(10, 10)).astype(self.dtype)
         y = np.random.uniform(size=(10, 10)).astype(self.dtype)
@@ -41,19 +43,38 @@ class TestKronOp(OpTest):
         self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
+        self.check_grad(
+            ['X', 'Y'],
+            'Out',
+            check_pir=True,
+            check_prim_pir=True,
+        )
 
     def test_check_grad_ignore_x(self):
-        self.check_grad(['Y'], 'Out', no_grad_set=set('X'), check_pir=True)
+        self.check_grad(
+            ['Y'],
+            'Out',
+            no_grad_set=set('X'),
+            check_pir=True,
+            check_prim_pir=True,
+        )
 
     def test_check_grad_ignore_y(self):
-        self.check_grad(['X'], 'Out', no_grad_set=set('Y'), check_pir=True)
+        self.check_grad(
+            ['X'],
+            'Out',
+            no_grad_set=set('Y'),
+            check_pir=True,
+            check_prim_pir=True,
+        )
 
 
 class TestKronOp2(TestKronOp):
     def setUp(self):
         self.op_type = "kron"
+        self.prim_op_type = "prim"
         self.python_api = paddle.kron
+        self.public_python_api = paddle.kron
         self.dtype = self._init_dtype()
         x = np.random.uniform(size=(5, 5, 4)).astype(self.dtype)
         y = np.random.uniform(size=(10, 10)).astype(self.dtype)
@@ -65,7 +86,9 @@ class TestKronOp2(TestKronOp):
 class TestKronOp3(TestKronOp):
     def setUp(self):
         self.op_type = "kron"
+        self.prim_op_type = "prim"
         self.python_api = paddle.kron
+        self.public_python_api = paddle.kron
         self.dtype = self._init_dtype()
         x = np.random.uniform(size=(10, 10)).astype(self.dtype)
         y = np.random.uniform(size=(5, 5, 4)).astype(self.dtype)
@@ -87,7 +110,9 @@ class TestKronFP16Op(TestKronOp):
 class TestKronBF16Op(TestKronOp):
     def setUp(self):
         self.op_type = "kron"
+        self.prim_op_type = "prim"
         self.python_api = paddle.kron
+        self.public_python_api = paddle.kron
         self.dtype = np.uint16
         self.np_dtype = "float32"
         x = np.random.uniform(size=(10, 10)).astype(self.np_dtype)
@@ -106,17 +131,31 @@ class TestKronBF16Op(TestKronOp):
 
     def test_check_grad(self):
         self.check_grad_with_place(
-            self.place, ['X', 'Y'], 'Out', check_pir=True
+            self.place,
+            ['X', 'Y'],
+            'Out',
+            check_pir=True,
+            check_prim_pir=True,
         )
 
     def test_check_grad_ignore_x(self):
         self.check_grad_with_place(
-            self.place, ['Y'], 'Out', no_grad_set=set('X'), check_pir=True
+            self.place,
+            ['Y'],
+            'Out',
+            no_grad_set=set('X'),
+            check_pir=True,
+            check_prim_pir=True,
         )
 
     def test_check_grad_ignore_y(self):
         self.check_grad_with_place(
-            self.place, ['X'], 'Out', no_grad_set=set('Y'), check_pir=True
+            self.place,
+            ['X'],
+            'Out',
+            no_grad_set=set('Y'),
+            check_pir=True,
+            check_prim_pir=True,
         )
 
 

--- a/test/legacy_test/test_kron_op.py
+++ b/test/legacy_test/test_kron_op.py
@@ -119,7 +119,7 @@ class TestKronOp5(TestKronOp):
         self.public_python_api = paddle.kron
         self.dtype = self._init_dtype()
         x = np.random.uniform(size=(2, 3, 4, 5)).astype(self.dtype)
-        y = np.random.uniform(size=(2, 10, 4)).astype(self.dtype)
+        y = np.random.uniform(size=(10, 10)).astype(self.dtype)
         out_ref = np.kron(x, y)
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': out_ref}

--- a/test/legacy_test/test_kron_op.py
+++ b/test/legacy_test/test_kron_op.py
@@ -77,7 +77,7 @@ class TestKronOp2(TestKronOp):
         self.public_python_api = paddle.kron
         self.dtype = self._init_dtype()
         x = np.random.uniform(size=(5, 5, 4)).astype(self.dtype)
-        y = np.random.uniform(size=(10, 10)).astype(self.dtype)
+        y = np.random.uniform(size=(100)).astype(self.dtype)
         out_ref = np.kron(x, y)
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': out_ref}
@@ -92,6 +92,34 @@ class TestKronOp3(TestKronOp):
         self.dtype = self._init_dtype()
         x = np.random.uniform(size=(10, 10)).astype(self.dtype)
         y = np.random.uniform(size=(5, 5, 4)).astype(self.dtype)
+        out_ref = np.kron(x, y)
+        self.inputs = {'X': x, 'Y': y}
+        self.outputs = {'Out': out_ref}
+
+
+class TestKronOp4(TestKronOp):
+    def setUp(self):
+        self.op_type = "kron"
+        self.prim_op_type = "prim"
+        self.python_api = paddle.kron
+        self.public_python_api = paddle.kron
+        self.dtype = self._init_dtype()
+        x = np.random.uniform(size=(5, 10, 5, 5)).astype(self.dtype)
+        y = np.random.uniform(size=(10, 5, 4, 5)).astype(self.dtype)
+        out_ref = np.kron(x, y)
+        self.inputs = {'X': x, 'Y': y}
+        self.outputs = {'Out': out_ref}
+
+
+class TestKronOp5(TestKronOp):
+    def setUp(self):
+        self.op_type = "kron"
+        self.prim_op_type = "prim"
+        self.python_api = paddle.kron
+        self.public_python_api = paddle.kron
+        self.dtype = self._init_dtype()
+        x = np.random.uniform(size=(2, 3, 4, 5, 4)).astype(self.dtype)
+        y = np.random.uniform(size=(2, 2, 4, 5, 4)).astype(self.dtype)
         out_ref = np.kron(x, y)
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': out_ref}

--- a/test/prim/pir_prim/test_prim_sub_graph_klmno_backward_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_klmno_backward_dynamic_shape.py
@@ -24,6 +24,10 @@ from test_prim_sub_graph_backward_dynamic_shape import (
 import paddle
 
 
+def kron_net(x, y):
+    return paddle.kron(x, y)
+
+
 def kthvalue_net1(x):
     return paddle.kthvalue(x, k=2)[0]
 
@@ -134,6 +138,54 @@ def minimum_net(x, y):
 
 def multiply_net(x, y):
     return x * y
+
+
+class TestPrimKronWithGrad1(TestPrimTwoWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.kron"
+        self.dtype = "float32"
+        self.x_shape = [10, 10]
+        self.init_x_shape = [None, None]
+        self.y_shape = [5, 5, 4]
+        self.init_y_shape = [None, None, None]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = kron_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimKronWithGrad2(TestPrimTwoWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.kron"
+        self.dtype = "float32"
+        self.x_shape = [10, 10]
+        self.init_x_shape = [None, None]
+        self.y_shape = [5, 5, 4, 3, 2]
+        self.init_y_shape = [None, None, None, None, None]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = kron_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimKronWithGrad3(TestPrimTwoWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.kron"
+        self.dtype = "float32"
+        self.x_shape = [5, 5, 4, 3, 5, 6]
+        self.init_x_shape = [None, None, None, None, None, None]
+        self.y_shape = [3, 5, 4]
+        self.init_y_shape = [None, None, None]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+        self.net = kron_net
+        self.enable_cinn = False
+        self.tol = 1e-6
 
 
 class TestPrimKthvalueWithGrad1(TestPrimBaseWithGrad):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
反向拆解kron_grad，并添加动态shape支持