### PR TITLE
[Inference] Some effective methods to reduce the loading time of models

### DIFF
--- a/paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.cc
@@ -23,6 +23,7 @@
 #include "paddle/fluid/framework/scope.h"
 #include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/fluid/platform/enforce.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/framework/framework.pb.h"
@@ -74,7 +75,11 @@ void IrParamsSyncAmongDevicesPass::CopyParamsToGpu(Argument *argument) {
     reserve_cpu_weights = true;
   }
 
+  phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
+  phi::DeviceContext *dev_ctx = pool.Get(place);
+
   std::unordered_set<std::string> visited;
+  std::vector<phi::DenseTensor *> dense_tensors;
   for (auto *node : paddle::framework::ir::TopologySortOperations(graph)) {
     if (!node->IsOp()) continue;
     if (node->Op()->Type() == "feed" || node->Op()->Type() == "fetch") continue;
@@ -95,13 +100,58 @@ void IrParamsSyncAmongDevicesPass::CopyParamsToGpu(Argument *argument) {
           var,
           common::errors::PreconditionNotMet("The var should not be nullptr"));
       if (var->IsType<phi::DenseTensor>()) {
-        auto *t = var->GetMutable<phi::DenseTensor>();
-        auto var_data_type = var_node->Var()->GetDataType();
-        VLOG(5) << "var_name is " << var_name << ", data type is "
-                << var_data_type;
-        paddle::framework::TensorCopySync(*t, place, t);
+        dense_tensors.push_back(var->GetMutable<phi::DenseTensor>());
       }
     }
+  }
+
+  if (dense_tensors.empty()) return;
+
+  size_t num_threads = 8;
+  const size_t chunk_size =
+      std::max(static_cast<size_t>(1), dense_tensors.size() / num_threads);
+  num_threads = std::min(num_threads, dense_tensors.size() / chunk_size);
+  const size_t remains_size = dense_tensors.size() % num_threads;
+
+  auto sync_nodes = [&](const std::vector<phi::DenseTensor *> &tensors) {
+    cudaStream_t stream;
+    cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);
+    for (auto *t : tensors) {
+      auto t_tmp = *t;
+      void *src_ptr = t_tmp.data();
+      t->Resize(t->dims());
+
+      void *dst_ptr = nullptr;
+      dst_ptr = dev_ctx->Alloc(t, t->dtype());
+      phi::memory_utils::Copy(place,
+                              dst_ptr,
+                              phi::CPUPlace(),
+                              src_ptr,
+                              t->numel() * phi::SizeOf(t->dtype()),
+                              stream);
+    }
+    cudaStreamSynchronize(stream);
+    cudaStreamDestroy(stream);
+  };
+
+  std::vector<std::future<void>> futures;
+  for (size_t i = 0; i < num_threads; ++i) {
+    auto start_it = dense_tensors.begin() + i * chunk_size;
+    auto end_it = start_it + chunk_size;
+    futures.push_back(
+        std::async(std::launch::async,
+                   sync_nodes,
+                   std::vector<phi::DenseTensor *>(start_it, end_it)));
+  }
+  if (remains_size > 0) {
+    futures.push_back(std::async(
+        std::launch::async,
+        sync_nodes,
+        std::vector<phi::DenseTensor *>(
+            dense_tensors.rbegin(), dense_tensors.rbegin() + remains_size)));
+  }
+  for (auto &future : futures) {
+    future.wait();
   }
 }
 #endif

--- a/paddle/fluid/inference/io.cc
+++ b/paddle/fluid/inference/io.cc
@@ -140,11 +140,15 @@ void LoadSeparatePersistables(framework::Executor* executor,
   }
 
   size_t num_threads = 8;
-  size_t chunk_size = (persistable_vars.size() + num_threads - 1) / num_threads;
+  size_t chunk_size = std::max(1UL, persistable_vars.size() / num_threads);
+  num_threads = std::min(num_threads, persistable_vars.size() / chunk_size);
   VLOG(4) << "Start Load with multi-thread: " << num_threads
           << " chund size: " << chunk_size;
 
   auto load_handler = [&](const std::vector<framework::VarDesc*>& vars) {
+    if (vars.empty()) {
+      return;
+    }
     auto load_program = std::make_unique<framework::ProgramDesc>();
     auto load_block = load_program->MutableBlock(0);
 

--- a/paddle/fluid/inference/io.cc
+++ b/paddle/fluid/inference/io.cc
@@ -76,16 +76,21 @@ bool IsPersistable(const framework::VarDesc* var) {
   return false;
 }
 
-void LoadPersistables(framework::Executor* executor,
-                      framework::Scope* scope,
-                      const framework::ProgramDesc& main_program,
-                      const std::string& dirname,
-                      const std::string& param_filename,
-                      bool model_from_memory = false) {
+void LoadCombinePersistables(framework::Executor* executor,
+                             framework::Scope* scope,
+                             const framework::ProgramDesc& main_program,
+                             const std::string& dirname,
+                             const std::string& param_filename,
+                             bool model_from_memory = false) {
+  PADDLE_ENFORCE_EQ(
+      param_filename.empty(),
+      false,
+      common::errors::PreconditionNotMet(
+          "param_filename should not be empty when load combine params."));
   const framework::BlockDesc& global_block = main_program.Block(0);
 
-  framework::ProgramDesc* load_program = new framework::ProgramDesc();
-  framework::BlockDesc* load_block = load_program->MutableBlock(0);
+  auto load_program = std::make_unique<framework::ProgramDesc>();
+  auto load_block = load_program->MutableBlock(0);
   std::vector<std::string> param_list;
 
   for (auto* var : global_block.AllVars()) {
@@ -105,35 +110,84 @@ void LoadPersistables(framework::Executor* executor,
       }
 
       new_var->SetPersistable(true);
-
-      if (!param_filename.empty()) {
-        param_list.push_back(new_var->Name());
-      } else {
-        // append_op
-        framework::OpDesc* op = load_block->AppendOp();
-        op->SetType("load");
-        op->SetOutput("Out", {new_var->Name()});
-        op->SetAttr("file_path", {dirname + "/" + new_var->Name()});
-        op->CheckAttrs();
-      }
+      param_list.push_back(new_var->Name());
     }
   }
 
-  if (!param_filename.empty()) {
-    // sort param_list to have consistent ordering
-    std::sort(param_list.begin(), param_list.end());
-    // append just the load_combine op
-    framework::OpDesc* op = load_block->AppendOp();
-    op->SetType("load_combine");
-    op->SetOutput("Out", param_list);
-    op->SetAttr("file_path", {param_filename});
-    op->SetAttr("model_from_memory", {model_from_memory});
-    op->CheckAttrs();
-  }
+  // sort param_list to have consistent ordering
+  std::sort(param_list.begin(), param_list.end());
+  // append just the load_combine op
+  framework::OpDesc* op = load_block->AppendOp();
+  op->SetType("load_combine");
+  op->SetOutput("Out", param_list);
+  op->SetAttr("file_path", {param_filename});
+  op->SetAttr("model_from_memory", {model_from_memory});
+  op->CheckAttrs();
 
   executor->Run(*load_program, scope, 0, true, true);
+}
 
-  delete load_program;
+void LoadSeparatePersistables(framework::Executor* executor,
+                              framework::Scope* scope,
+                              const framework::ProgramDesc& main_program,
+                              const std::string& dirname) {
+  const framework::BlockDesc& global_block = main_program.Block(0);
+  std::vector<framework::VarDesc*> persistable_vars;
+  for (auto* var : global_block.AllVars()) {
+    if (IsPersistable(var)) {
+      persistable_vars.push_back(var);
+    }
+  }
+
+  size_t num_threads = 8;
+  size_t chunk_size = (persistable_vars.size() + num_threads - 1) / num_threads;
+  VLOG(4) << "Start Load with multi-thread: " << num_threads
+          << " chund size: " << chunk_size;
+
+  auto load_handler = [&](const std::vector<framework::VarDesc*>& vars) {
+    auto load_program = std::make_unique<framework::ProgramDesc>();
+    auto load_block = load_program->MutableBlock(0);
+
+    for (auto* var : vars) {
+      VLOG(4) << "persistable variable's name: " << var->Name();
+
+      framework::VarDesc* new_var = load_block->Var(var->Name());
+      new_var->SetShape(var->GetShape());
+      new_var->SetDataType(var->GetDataType());
+      auto var_type = var->GetType();
+      new_var->SetType(var_type);
+
+      if ((var_type !=
+           framework::proto::VarType::Type::VarType_Type_SELECTED_ROWS) &&
+          (var_type != framework::proto::VarType::VOCAB)) {
+        new_var->SetLoDLevel(var->GetLoDLevel());
+      }
+
+      new_var->SetPersistable(true);
+
+      // append_op
+      framework::OpDesc* op = load_block->AppendOp();
+      op->SetType("load");
+      op->SetOutput("Out", {new_var->Name()});
+      op->SetAttr("file_path", {dirname + "/" + new_var->Name()});
+      op->CheckAttrs();
+    }
+    executor->Run(*load_program, scope, 0, true, true);
+  };
+
+  std::vector<std::future<void>> futures;
+  for (size_t i = 0; i < num_threads; ++i) {
+    auto start_it = persistable_vars.begin() + i * chunk_size;
+    auto end_it =
+        (i == num_threads - 1) ? persistable_vars.end() : start_it + chunk_size;
+    futures.push_back(
+        std::async(std::launch::async,
+                   load_handler,
+                   std::vector<framework::VarDesc*>(start_it, end_it)));
+  }
+  for (auto& future : futures) {
+    future.wait();
+  }
 }
 
 std::unique_ptr<framework::ProgramDesc> Load(framework::Executor* executor,
@@ -148,12 +202,7 @@ std::unique_ptr<framework::ProgramDesc> Load(framework::Executor* executor,
       new framework::ProgramDesc(program_desc_str));
 
   // model_from_memory is false in separate parameters.
-  LoadPersistables(executor,
-                   scope,
-                   *main_program,
-                   dirname,
-                   "",
-                   false /* model_from_memory */);
+  LoadSeparatePersistables(executor, scope, *main_program, dirname);
   return main_program;
 }
 
@@ -169,12 +218,12 @@ std::unique_ptr<framework::ProgramDesc> Load(framework::Executor* executor,
       new framework::ProgramDesc(program_desc_str));
 
   if (load_params) {
-    LoadPersistables(executor,
-                     scope,
-                     *main_program,
-                     "",
-                     param_filename,
-                     false /* model_from_memory */);
+    LoadCombinePersistables(executor,
+                            scope,
+                            *main_program,
+                            "",
+                            param_filename,
+                            false /* model_from_memory */);
   }
   return main_program;
 }
@@ -187,12 +236,12 @@ std::unique_ptr<framework::ProgramDesc> LoadFromMemory(
   std::unique_ptr<framework::ProgramDesc> main_program(
       new framework::ProgramDesc(prog_buffer));
 
-  LoadPersistables(executor,
-                   scope,
-                   *main_program,
-                   "",
-                   param_buffer,
-                   true /* model_filename */);
+  LoadCombinePersistables(executor,
+                          scope,
+                          *main_program,
+                          "",
+                          param_buffer,
+                          true /* model_filename */);
   return main_program;
 }
 

--- a/paddle/fluid/inference/io.cc
+++ b/paddle/fluid/inference/io.cc
@@ -138,6 +138,9 @@ void LoadSeparatePersistables(framework::Executor* executor,
       persistable_vars.push_back(var);
     }
   }
+  if (persistable_vars.empty()) {
+    return;
+  }
 
   size_t num_threads = 8;
   size_t chunk_size =

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -100,6 +100,7 @@ if TYPE_CHECKING:
         skip_forward: NotRequired[bool]
         input_names_after_prune: NotRequired[list[str]]
         skip_prune_program: NotRequired[bool]
+        separate_parameters: NotRequired[bool]
 
     class _LoadOptions(TypedDict):
         model_filename: NotRequired[str]
@@ -436,6 +437,9 @@ class _SaveLoadConfig:
         # in the scene of llm-inference, pruning program can cause unexpectable result, an option to skip prune is necessary
         self.skip_prune_program = False
 
+        # if True, the params will be saved separately in multiple files.
+        self.separate_parameters = False
+
     @property
     def output_spec(self):
         return self._output_spec
@@ -511,6 +515,7 @@ def _parse_save_configs(configs: _SaveOptions) -> _SaveLoadConfig:
         "skip_forward",
         "input_names_after_prune",
         "skip_prune_program",
+        "separate_parameters",
     ]
 
     # input check
@@ -531,6 +536,7 @@ def _parse_save_configs(configs: _SaveOptions) -> _SaveLoadConfig:
         "input_names_after_prune", None
     )
     inner_config.skip_prune_program = configs.get("skip_prune_program", False)
+    inner_config.separate_parameters = configs.get("separate_parameters", False)
 
     return inner_config
 
@@ -1422,6 +1428,7 @@ def save(
                 program=clone_program,
                 clip_extra=configs.clip_extra,
                 skip_prune_program=configs.skip_prune_program,
+                separate_parameters=configs.separate_parameters,
             )
 
         if combine_params:

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -620,7 +620,14 @@ def save_inference_model(
         legacy_format=legacy_format,
     )
 
-    save_to_file(model_path, program_bytes)
+    save_to_file(
+        (
+            os.path.join(os.path.dirname(model_path), "__model__")
+            if kwargs.get('separate_parameters', False)
+            else model_path
+        ),
+        program_bytes,
+    )
 
     vars = list(filter(is_persistable, program.list_vars()))
 
@@ -637,7 +644,11 @@ def save_inference_model(
             dirname=save_dirname,
             main_program=program,
             predicate=is_persistable,
-            filename=params_filename,
+            filename=(
+                None
+                if kwargs.get('separate_parameters', False)
+                else params_filename
+            ),
         )
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
pcard-71500

- jit.save support option of separate_parameters
- ir_graph_build_pass support multi threads
- ir_params_sync_among_devices_pass support multi threads and multi streams

使用时模型保存与加载方式需要改变：
1. 模型需要重新导出，导出时paddle.jit.save api新增separate_parameters=True参数
2. config = paddle.inference.Config(model_path) 直接传入模型文件所在目录path即可

TODO：
- support pir