### PR TITLE
[Inference] dce pass should not delete control flow op and inplace op

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.h
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.h
@@ -46,6 +46,11 @@ inline bool IsCustomOp(pir::Operation* op) {
   return op_name.find("custom_op") != op_name.npos;
 }
 
+inline bool IsInplaceOp(pir::Operation* op) {
+  std::string op_name = op->name();
+  return op_name.back() == '_';
+}
+
 inline bool IsTensorRTOp(pir::Operation* op) {
   std::string op_name = op->name();
   return op_name == "pd_op.tensorrt_engine";

--- a/paddle/fluid/pir/transforms/general/dead_code_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/dead_code_elimination_pass.cc
@@ -16,6 +16,7 @@
 #include <cstdint>
 
 #include "paddle/fluid/framework/scope.h"
+#include "paddle/fluid/pir/dialect/operator/ir/control_flow_op.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_dialect.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 
@@ -56,8 +57,9 @@ class DeadCodeEliminationPass : public pir::Pass {
                std::vector<std::string>* deleted_vars) {
     std::vector<pir::Operation*> deleted_ops;
     for (auto& op : block) {
-      if (op.num_regions() > 0 || op.HasTrait<pir::SideEffectTrait>() ||
+      if (op.HasTrait<pir::SideEffectTrait>() ||
           op.isa<paddle::dialect::DataOp>() ||
+          op.isa<paddle::dialect::WhileOp>() ||
           paddle::dialect::IsCustomOp(&op) ||
           paddle::dialect::IsInplaceOp(&op)) {
         continue;

--- a/paddle/fluid/pir/transforms/general/dead_code_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/dead_code_elimination_pass.cc
@@ -56,9 +56,10 @@ class DeadCodeEliminationPass : public pir::Pass {
                std::vector<std::string>* deleted_vars) {
     std::vector<pir::Operation*> deleted_ops;
     for (auto& op : block) {
-      if (op.HasTrait<pir::SideEffectTrait>() ||
+      if (op.num_regions() > 0 || op.HasTrait<pir::SideEffectTrait>() ||
           op.isa<paddle::dialect::DataOp>() ||
-          paddle::dialect::IsCustomOp(&op)) {
+          paddle::dialect::IsCustomOp(&op) ||
+          paddle::dialect::IsInplaceOp(&op)) {
         continue;
       }
       if (op.use_empty()) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-71500

dce pass should not delete while op and inplace op.