### PR TITLE
[cherry-pick] c_softmax_with_cross_entropy_op supports multiple label values

### DIFF
--- a/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op.cc
+++ b/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op.cc
@@ -53,11 +53,12 @@ class CSoftmaxWithCrossEntropyOp : public framework::OperatorWithKernel {
       }
     }
 
-    PADDLE_ENFORCE_EQ(
+    PADDLE_ENFORCE_GE(
         labels_dims[logits_rank - 1],
         1UL,
-        phi::errors::InvalidArgument(
-            "the last dimension of Input(Label) should be 1."
+        common::errors::InvalidArgument(
+            "the last dimension of Input(Label) should be greater than or "
+            "equal to 1."
             "But received: the last dimension of Input(Label) is [%d],"
             "the last dimension is [%d]",
             labels_dims[logits_rank - 1],

--- a/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op.cu
+++ b/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op.cu
@@ -53,21 +53,24 @@ __global__ void MaskLabelByIndex(T* predicted_logits,
                                  const int64_t end_index,
                                  const int64_t N,
                                  const int64_t D,
+                                 const int64_t C,
                                  const int nranks) {
   CUDA_KERNEL_LOOP_TYPE(i, N, int64_t) {
-    auto real_label = label[i];
-    PADDLE_ENFORCE(((real_label < D * nranks) && (real_label >= 0)) ||
-                       (real_label == ignore_index),
-                   "The index is out of bounds, "
-                   "please check whether the value of label and "
-                   "input meet the class number. It should "
-                   "be less than [%ld] or equal to [%ld], but received [%ld]",
-                   static_cast<int64_t>(D * nranks),
-                   static_cast<int64_t>(ignore_index),
-                   static_cast<int64_t>(real_label));
+    for (int j = 0; j < C; ++j) {
+      auto real_label = label[i * C + j];
+      PADDLE_ENFORCE(((real_label < D * nranks) && (real_label >= 0)) ||
+                         (real_label == ignore_index),
+                     "The index is out of bounds, "
+                     "please check whether the value of label and "
+                     "input meet the class number. It should "
+                     "be less than [%ld] or equal to [%ld], but received [%ld]",
+                     static_cast<int64_t>(D * nranks),
+                     static_cast<int64_t>(ignore_index),
+                     static_cast<int64_t>(real_label));
 
-    if (real_label >= start_index && real_label < end_index) {
-      predicted_logits[i] = logit[i * D + real_label - start_index];
+      if (real_label >= start_index && real_label < end_index) {
+        predicted_logits[i * C + j] = logit[i * D + real_label - start_index];
+      }
     }
   }
 }
@@ -78,15 +81,72 @@ __global__ void CaculateLoss(T* loss,
                              const T* sum_exp_logits,
                              const IndexT* label,
                              const int64_t ignore_index,
-                             const int64_t N) {
+                             const int64_t N,
+                             const int64_t C) {
+  const T prob = static_cast<T>(1.0 / C);
+
   CUDA_KERNEL_LOOP_TYPE(i, N, int64_t) {
-    auto real_label = static_cast<int64_t>(label[i]);
-    loss[i] = ignore_index == real_label
-                  ? static_cast<T>(0)
-                  : phi::funcs::TolerableValue<T>()(
-                        phi::funcs::TolerableValue<T>()(
-                            phi::funcs::real_log(sum_exp_logits[i])) -
-                        predict_logits[i]);
+    T tmp_loss = static_cast<T>(0);
+    int ignore_num = 0;
+    for (int j = 0; j < C; ++j) {
+      auto real_label = static_cast<int64_t>(label[i * C + j]);
+      tmp_loss += ignore_index == real_label
+                      ? static_cast<T>(0)
+                      : phi::funcs::TolerableValue<T>()(
+                            (phi::funcs::TolerableValue<T>()(
+                                 phi::funcs::real_log(sum_exp_logits[i])) -
+                             predict_logits[i * C + j]) *
+                            prob);
+      ignore_num += ignore_index == real_label ? 1 : 0;
+    }
+    loss[i] = ignore_num > 0 ? static_cast<T>(0) : tmp_loss;
+  }
+}
+
+template <typename T, typename IndexT>
+__global__ void CaculateSoftLogitsGrad(T* logits_grad,
+                                       IndexT* is_ignore,
+                                       const IndexT* labels,
+                                       const IndexT ignore_index,
+                                       const int64_t start_index,
+                                       const int64_t end_index,
+                                       const int64_t N,
+                                       const int64_t D,
+                                       const int64_t C) {
+  const T prob = static_cast<T>(1.0 / C);
+  CUDA_KERNEL_LOOP_TYPE(i, N, int64_t) {
+    is_ignore[i] = labels[i * C];
+    for (int j = 0; j < C; ++j) {
+      auto real_label = labels[i * C + j];
+      if (real_label == ignore_index) {
+        is_ignore[i] = real_label;
+      }
+      if (real_label >= start_index && real_label < end_index) {
+        int64_t idx = i * D + real_label - start_index;
+        logits_grad[idx] = logits_grad[idx] - prob;
+      }
+    }
+  }
+}
+
+template <typename T, typename IndexT>
+__global__ void SoftMaskLabelByIndexGrad(T* logits_grad,
+                                         const T* loss_grad,
+                                         const IndexT* is_ignore,
+                                         const int64_t start_index,
+                                         const int64_t end_index,
+                                         const int64_t N,
+                                         const int64_t D,
+                                         const int64_t ignore_index) {
+  CUDA_KERNEL_LOOP_TYPE(i, N * D, int64_t) {
+    auto row = i / D;
+    auto col = i % D;
+    auto lbl = static_cast<int64_t>(is_ignore[row]);
+    if (lbl == ignore_index) {
+      logits_grad[i] = static_cast<T>(0.0);
+    } else {
+      logits_grad[i] *= loss_grad[row];
+    }
   }
 }
 
@@ -189,6 +249,7 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::GPUContext, T> {
     const int axis = logits_dims.size() - 1;
     const int64_t N = phi::funcs::SizeToAxis<int64_t>(axis, logits_dims);
     const int64_t D = phi::funcs::SizeFromAxis<int64_t>(axis, logits_dims);
+    const int64_t C = phi::funcs::SizeFromAxis<int64_t>(axis, labels_dims);
 
     phi::DenseTensor logits_2d, softmax_2d, loss_2d;
     logits_2d.ShareDataWith(*logits).Resize({N, D});
@@ -234,7 +295,7 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::GPUContext, T> {
     // step 3, obtain predict target
     phi::DenseTensor predicted_logits;
     predicted_logits =
-        ctx.AllocateTmpTensor<T, phi::GPUContext>({N, 1}, dev_ctx);
+        ctx.AllocateTmpTensor<T, phi::GPUContext>({N, C}, dev_ctx);
     predicted_logits.mutable_data<T>(place);
 
     auto t = phi::EigenVector<T>::Flatten(predicted_logits);
@@ -257,6 +318,7 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::GPUContext, T> {
           end_index,
           N,
           D,
+          C,
           nranks);
     } else if (label_type == framework::proto::VarType::INT64) {
       MaskLabelByIndex<T, int64_t>
@@ -268,6 +330,7 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::GPUContext, T> {
                                                      end_index,
                                                      N,
                                                      D,
+                                                     C,
                                                      nranks);
     }
 
@@ -320,7 +383,8 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::GPUContext, T> {
                                                      sum_exp_logits.data<T>(),
                                                      labels->data<int32_t>(),
                                                      ignore_index,
-                                                     N);
+                                                     N,
+                                                     C);
     } else {
       CaculateLoss<T, int64_t>
           <<<blocks, threads, 0, dev_ctx.stream()>>>(loss_2d.data<T>(),
@@ -328,7 +392,8 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::GPUContext, T> {
                                                      sum_exp_logits.data<T>(),
                                                      labels->data<int64_t>(),
                                                      ignore_index,
-                                                     N);
+                                                     N,
+                                                     C);
     }
 
     auto eigen_sum_exp_logits =
@@ -370,6 +435,7 @@ struct CSoftmaxWithCrossEntropyProcessGroupFunctor<phi::GPUContext, T> {
     const int axis = logits_dims.size() - 1;
     const int64_t N = phi::funcs::SizeToAxis<int64_t>(axis, logits_dims);
     const int64_t D = phi::funcs::SizeFromAxis<int64_t>(axis, logits_dims);
+    const int64_t C = phi::funcs::SizeFromAxis<int64_t>(axis, labels_dims);
 
     phi::DenseTensor logits_2d, softmax_2d, loss_2d;
     logits_2d.ShareDataWith(*logits).Resize({N, D});
@@ -401,7 +467,7 @@ struct CSoftmaxWithCrossEntropyProcessGroupFunctor<phi::GPUContext, T> {
     // step 3, obtain predict target
     phi::DenseTensor predicted_logits;
     predicted_logits =
-        ctx.AllocateTmpTensor<T, phi::GPUContext>({N, 1}, dev_ctx);
+        ctx.AllocateTmpTensor<T, phi::GPUContext>({N, C}, dev_ctx);
     predicted_logits.mutable_data<T>(place);
 
     auto t = phi::EigenVector<T>::Flatten(predicted_logits);
@@ -424,6 +490,7 @@ struct CSoftmaxWithCrossEntropyProcessGroupFunctor<phi::GPUContext, T> {
           end_index,
           N,
           D,
+          C,
           nranks);
     } else if (label_type == framework::proto::VarType::INT64) {
       MaskLabelByIndex<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
@@ -435,6 +502,7 @@ struct CSoftmaxWithCrossEntropyProcessGroupFunctor<phi::GPUContext, T> {
           end_index,
           N,
           D,
+          C,
           nranks);
     }
 
@@ -462,7 +530,8 @@ struct CSoftmaxWithCrossEntropyProcessGroupFunctor<phi::GPUContext, T> {
                                                      sum_exp_logits.data<T>(),
                                                      labels->data<int32_t>(),
                                                      ignore_index,
-                                                     N);
+                                                     N,
+                                                     C);
     } else {
       CaculateLoss<T, int64_t>
           <<<blocks, threads, 0, dev_ctx.stream()>>>(loss_2d.data<T>(),
@@ -470,7 +539,8 @@ struct CSoftmaxWithCrossEntropyProcessGroupFunctor<phi::GPUContext, T> {
                                                      sum_exp_logits.data<T>(),
                                                      labels->data<int64_t>(),
                                                      ignore_index,
-                                                     N);
+                                                     N,
+                                                     C);
     }
 
     auto eigen_sum_exp_logits =
@@ -506,35 +576,97 @@ class CSoftmaxWithCrossEntropyGradCUDAKernel : public framework::OpKernel<T> {
     const int64_t N = phi::funcs::SizeToAxis<int64_t>(axis, sofrmax_dims);
     const int64_t D = phi::funcs::SizeFromAxis<int64_t>(axis, sofrmax_dims);
 
+    const auto label_dims = labels->dims();
+    const int64_t C = label_dims[axis];
+
     phi::DenseTensor logit_grad_2d;
     logit_grad_2d.ShareDataWith(*logit_grad).Resize({N, D});
 
     int64_t blocks = NumBlocks(N * D);
+    int64_t blocks_cal = NumBlocks(N);
     int threads = kNumCUDAThreads;
     const auto& label_type = framework::TransToProtoVarType(labels->dtype());
     const int64_t start_index = rank * D;
     const int64_t end_index = start_index + D;
 
     if (label_type == framework::proto::VarType::INT32) {
-      MaskLabelByIndexGrad<T, int32_t>
-          <<<blocks, threads, 0, dev_ctx.stream()>>>(logit_grad_2d.data<T>(),
-                                                     loss_grad->data<T>(),
-                                                     labels->data<int32_t>(),
-                                                     start_index,
-                                                     end_index,
-                                                     N,
-                                                     D,
-                                                     ignore_index);
+      if (C > 1) {
+        phi::DenseTensor is_ignore;
+        is_ignore = context.AllocateTmpTensor<int32_t, phi::GPUContext>(
+            {N, 1}, dev_ctx);
+
+        CaculateSoftLogitsGrad<T, int32_t>
+            <<<blocks_cal, threads, 0, dev_ctx.stream()>>>(
+                logit_grad_2d.data<T>(),
+                is_ignore.data<int32_t>(),
+                labels->data<int32_t>(),
+                ignore_index,
+                start_index,
+                end_index,
+                N,
+                D,
+                C);
+
+        SoftMaskLabelByIndexGrad<T, int32_t>
+            <<<blocks, threads, 0, dev_ctx.stream()>>>(
+                logit_grad_2d.data<T>(),
+                loss_grad->data<T>(),
+                is_ignore.data<int32_t>(),
+                start_index,
+                end_index,
+                N,
+                D,
+                ignore_index);
+      } else {
+        MaskLabelByIndexGrad<T, int32_t>
+            <<<blocks, threads, 0, dev_ctx.stream()>>>(logit_grad_2d.data<T>(),
+                                                       loss_grad->data<T>(),
+                                                       labels->data<int32_t>(),
+                                                       start_index,
+                                                       end_index,
+                                                       N,
+                                                       D,
+                                                       ignore_index);
+      }
     } else if (label_type == framework::proto::VarType::INT64) {
-      MaskLabelByIndexGrad<T, int64_t>
-          <<<blocks, threads, 0, dev_ctx.stream()>>>(logit_grad_2d.data<T>(),
-                                                     loss_grad->data<T>(),
-                                                     labels->data<int64_t>(),
-                                                     start_index,
-                                                     end_index,
-                                                     N,
-                                                     D,
-                                                     ignore_index);
+      if (C > 1) {
+        phi::DenseTensor is_ignore;
+        is_ignore = context.AllocateTmpTensor<int64_t, phi::GPUContext>(
+            {N, 1}, dev_ctx);
+
+        CaculateSoftLogitsGrad<T, int64_t>
+            <<<blocks_cal, threads, 0, dev_ctx.stream()>>>(
+                logit_grad_2d.data<T>(),
+                is_ignore.data<int64_t>(),
+                labels->data<int64_t>(),
+                ignore_index,
+                start_index,
+                end_index,
+                N,
+                D,
+                C);
+
+        SoftMaskLabelByIndexGrad<T, int64_t>
+            <<<blocks, threads, 0, dev_ctx.stream()>>>(
+                logit_grad_2d.data<T>(),
+                loss_grad->data<T>(),
+                is_ignore.data<int64_t>(),
+                start_index,
+                end_index,
+                N,
+                D,
+                ignore_index);
+      } else {
+        MaskLabelByIndexGrad<T, int64_t>
+            <<<blocks, threads, 0, dev_ctx.stream()>>>(logit_grad_2d.data<T>(),
+                                                       loss_grad->data<T>(),
+                                                       labels->data<int64_t>(),
+                                                       start_index,
+                                                       end_index,
+                                                       N,
+                                                       D,
+                                                       ignore_index);
+      }
     }
   }
 };

--- a/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op.cu
+++ b/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op.cu
@@ -53,8 +53,36 @@ __global__ void MaskLabelByIndex(T* predicted_logits,
                                  const int64_t end_index,
                                  const int64_t N,
                                  const int64_t D,
-                                 const int64_t C,
                                  const int nranks) {
+  CUDA_KERNEL_LOOP_TYPE(i, N, int64_t) {
+    auto real_label = label[i];
+    PADDLE_ENFORCE(((real_label < D * nranks) && (real_label >= 0)) ||
+                       (real_label == ignore_index),
+                   "The index is out of bounds, "
+                   "please check whether the value of label and "
+                   "input meet the class number. It should "
+                   "be less than [%ld] or equal to [%ld], but received [%ld]",
+                   static_cast<int64_t>(D * nranks),
+                   static_cast<int64_t>(ignore_index),
+                   static_cast<int64_t>(real_label));
+
+    if (real_label >= start_index && real_label < end_index) {
+      predicted_logits[i] = logit[i * D + real_label - start_index];
+    }
+  }
+}
+
+template <typename T, typename IndexT>
+__global__ void SoftMaskLabelByIndex(T* predicted_logits,
+                                     const T* logit,
+                                     const IndexT* label,
+                                     const IndexT ignore_index,
+                                     const int64_t start_index,
+                                     const int64_t end_index,
+                                     const int64_t N,
+                                     const int64_t D,
+                                     const int64_t C,
+                                     const int nranks) {
   CUDA_KERNEL_LOOP_TYPE(i, N, int64_t) {
     for (int j = 0; j < C; ++j) {
       auto real_label = label[i * C + j];
@@ -81,8 +109,26 @@ __global__ void CaculateLoss(T* loss,
                              const T* sum_exp_logits,
                              const IndexT* label,
                              const int64_t ignore_index,
-                             const int64_t N,
-                             const int64_t C) {
+                             const int64_t N) {
+  CUDA_KERNEL_LOOP_TYPE(i, N, int64_t) {
+    auto real_label = static_cast<int64_t>(label[i]);
+    loss[i] = ignore_index == real_label
+                  ? static_cast<T>(0)
+                  : phi::funcs::TolerableValue<T>()(
+                        phi::funcs::TolerableValue<T>()(
+                            phi::funcs::real_log(sum_exp_logits[i])) -
+                        predict_logits[i]);
+  }
+}
+
+template <typename T, typename IndexT>
+__global__ void CaculateSoftLoss(T* loss,
+                                 const T* predict_logits,
+                                 const T* sum_exp_logits,
+                                 const IndexT* label,
+                                 const int64_t ignore_index,
+                                 const int64_t N,
+                                 const int64_t C) {
   const T prob = static_cast<T>(1.0 / C);
 
   CUDA_KERNEL_LOOP_TYPE(i, N, int64_t) {
@@ -309,29 +355,57 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::GPUContext, T> {
     const auto& label_type = framework::TransToProtoVarType(labels->dtype());
 
     if (label_type == framework::proto::VarType::INT32) {
-      MaskLabelByIndex<T, int32_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
-          predicted_logits.data<T>(),
-          softmax_2d.data<T>(),
-          labels->data<int32_t>(),
-          static_cast<int32_t>(ignore_index),
-          start_index,
-          end_index,
-          N,
-          D,
-          C,
-          nranks);
+      if (C > 1) {
+        SoftMaskLabelByIndex<T, int32_t>
+            <<<blocks, threads, 0, dev_ctx.stream()>>>(
+                predicted_logits.data<T>(),
+                softmax_2d.data<T>(),
+                labels->data<int32_t>(),
+                static_cast<int32_t>(ignore_index),
+                start_index,
+                end_index,
+                N,
+                D,
+                C,
+                nranks);
+      } else {
+        MaskLabelByIndex<T, int32_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+            predicted_logits.data<T>(),
+            softmax_2d.data<T>(),
+            labels->data<int32_t>(),
+            static_cast<int32_t>(ignore_index),
+            start_index,
+            end_index,
+            N,
+            D,
+            nranks);
+      }
     } else if (label_type == framework::proto::VarType::INT64) {
-      MaskLabelByIndex<T, int64_t>
-          <<<blocks, threads, 0, dev_ctx.stream()>>>(predicted_logits.data<T>(),
-                                                     softmax_2d.data<T>(),
-                                                     labels->data<int64_t>(),
-                                                     ignore_index,
-                                                     start_index,
-                                                     end_index,
-                                                     N,
-                                                     D,
-                                                     C,
-                                                     nranks);
+      if (C > 1) {
+        SoftMaskLabelByIndex<T, int64_t>
+            <<<blocks, threads, 0, dev_ctx.stream()>>>(
+                predicted_logits.data<T>(),
+                softmax_2d.data<T>(),
+                labels->data<int64_t>(),
+                ignore_index,
+                start_index,
+                end_index,
+                N,
+                D,
+                C,
+                nranks);
+      } else {
+        MaskLabelByIndex<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+            predicted_logits.data<T>(),
+            softmax_2d.data<T>(),
+            labels->data<int64_t>(),
+            ignore_index,
+            start_index,
+            end_index,
+            N,
+            D,
+            nranks);
+      }
     }
 
     predicted_logits.mutable_data<T>(place);
@@ -377,23 +451,44 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::GPUContext, T> {
     }
 
     if (label_type == framework::proto::VarType::INT32) {
-      CaculateLoss<T, int32_t>
-          <<<blocks, threads, 0, dev_ctx.stream()>>>(loss_2d.data<T>(),
-                                                     predicted_logits.data<T>(),
-                                                     sum_exp_logits.data<T>(),
-                                                     labels->data<int32_t>(),
-                                                     ignore_index,
-                                                     N,
-                                                     C);
+      if (C > 1) {
+        CaculateSoftLoss<T, int32_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+            loss_2d.data<T>(),
+            predicted_logits.data<T>(),
+            sum_exp_logits.data<T>(),
+            labels->data<int32_t>(),
+            ignore_index,
+            N,
+            C);
+      } else {
+        CaculateLoss<T, int32_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+            loss_2d.data<T>(),
+            predicted_logits.data<T>(),
+            sum_exp_logits.data<T>(),
+            labels->data<int32_t>(),
+            ignore_index,
+            N);
+      }
+
     } else {
-      CaculateLoss<T, int64_t>
-          <<<blocks, threads, 0, dev_ctx.stream()>>>(loss_2d.data<T>(),
-                                                     predicted_logits.data<T>(),
-                                                     sum_exp_logits.data<T>(),
-                                                     labels->data<int64_t>(),
-                                                     ignore_index,
-                                                     N,
-                                                     C);
+      if (C > 1) {
+        CaculateSoftLoss<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+            loss_2d.data<T>(),
+            predicted_logits.data<T>(),
+            sum_exp_logits.data<T>(),
+            labels->data<int64_t>(),
+            ignore_index,
+            N,
+            C);
+      } else {
+        CaculateLoss<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+            loss_2d.data<T>(),
+            predicted_logits.data<T>(),
+            sum_exp_logits.data<T>(),
+            labels->data<int64_t>(),
+            ignore_index,
+            N);
+      }
     }
 
     auto eigen_sum_exp_logits =
@@ -481,29 +576,57 @@ struct CSoftmaxWithCrossEntropyProcessGroupFunctor<phi::GPUContext, T> {
     const auto& label_type = framework::TransToProtoVarType(labels->dtype());
 
     if (label_type == framework::proto::VarType::INT32) {
-      MaskLabelByIndex<T, int32_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
-          predicted_logits.data<T>(),
-          softmax_2d.data<T>(),
-          labels->data<int32_t>(),
-          static_cast<int32_t>(ignore_index),
-          start_index,
-          end_index,
-          N,
-          D,
-          C,
-          nranks);
+      if (C > 1) {
+        SoftMaskLabelByIndex<T, int32_t>
+            <<<blocks, threads, 0, dev_ctx.stream()>>>(
+                predicted_logits.data<T>(),
+                softmax_2d.data<T>(),
+                labels->data<int32_t>(),
+                static_cast<int32_t>(ignore_index),
+                start_index,
+                end_index,
+                N,
+                D,
+                C,
+                nranks);
+      } else {
+        MaskLabelByIndex<T, int32_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+            predicted_logits.data<T>(),
+            softmax_2d.data<T>(),
+            labels->data<int32_t>(),
+            static_cast<int32_t>(ignore_index),
+            start_index,
+            end_index,
+            N,
+            D,
+            nranks);
+      }
     } else if (label_type == framework::proto::VarType::INT64) {
-      MaskLabelByIndex<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
-          predicted_logits.data<T>(),
-          softmax_2d.data<T>(),
-          labels->data<int64_t>(),
-          static_cast<int32_t>(ignore_index),
-          start_index,
-          end_index,
-          N,
-          D,
-          C,
-          nranks);
+      if (C > 1) {
+        SoftMaskLabelByIndex<T, int64_t>
+            <<<blocks, threads, 0, dev_ctx.stream()>>>(
+                predicted_logits.data<T>(),
+                softmax_2d.data<T>(),
+                labels->data<int64_t>(),
+                static_cast<int32_t>(ignore_index),
+                start_index,
+                end_index,
+                N,
+                D,
+                C,
+                nranks);
+      } else {
+        MaskLabelByIndex<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+            predicted_logits.data<T>(),
+            softmax_2d.data<T>(),
+            labels->data<int64_t>(),
+            static_cast<int32_t>(ignore_index),
+            start_index,
+            end_index,
+            N,
+            D,
+            nranks);
+      }
     }
 
     opts.reduce_op = distributed::ReduceOp::SUM;
@@ -524,23 +647,44 @@ struct CSoftmaxWithCrossEntropyProcessGroupFunctor<phi::GPUContext, T> {
     pg->AllReduce(&sum_exp_logits, sum_exp_logits, opts, true, true);
 
     if (label_type == framework::proto::VarType::INT32) {
-      CaculateLoss<T, int32_t>
-          <<<blocks, threads, 0, dev_ctx.stream()>>>(loss_2d.data<T>(),
-                                                     predicted_logits.data<T>(),
-                                                     sum_exp_logits.data<T>(),
-                                                     labels->data<int32_t>(),
-                                                     ignore_index,
-                                                     N,
-                                                     C);
+      if (C > 1) {
+        CaculateSoftLoss<T, int32_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+            loss_2d.data<T>(),
+            predicted_logits.data<T>(),
+            sum_exp_logits.data<T>(),
+            labels->data<int32_t>(),
+            ignore_index,
+            N,
+            C);
+      } else {
+        CaculateLoss<T, int32_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+            loss_2d.data<T>(),
+            predicted_logits.data<T>(),
+            sum_exp_logits.data<T>(),
+            labels->data<int32_t>(),
+            ignore_index,
+            N);
+      }
+
     } else {
-      CaculateLoss<T, int64_t>
-          <<<blocks, threads, 0, dev_ctx.stream()>>>(loss_2d.data<T>(),
-                                                     predicted_logits.data<T>(),
-                                                     sum_exp_logits.data<T>(),
-                                                     labels->data<int64_t>(),
-                                                     ignore_index,
-                                                     N,
-                                                     C);
+      if (C > 1) {
+        CaculateSoftLoss<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+            loss_2d.data<T>(),
+            predicted_logits.data<T>(),
+            sum_exp_logits.data<T>(),
+            labels->data<int64_t>(),
+            ignore_index,
+            N,
+            C);
+      } else {
+        CaculateLoss<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+            loss_2d.data<T>(),
+            predicted_logits.data<T>(),
+            sum_exp_logits.data<T>(),
+            labels->data<int64_t>(),
+            ignore_index,
+            N);
+      }
     }
 
     auto eigen_sum_exp_logits =

--- a/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
+++ b/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
@@ -422,8 +422,10 @@ def _c_softmax_with_cross_entropy(
         else group.nranks
     )
 
-    input_dims = len(list(logits.shape))
-    label_dims = len(list(label.shape))
+    input_shape = list(logits.shape)
+    label_shape = list(label.shape)
+    input_dims = len(input_shape)
+    label_dims = len(label_shape)
     if input_dims - 1 != label_dims and input_dims != label_dims:
         raise ValueError(
             f'Expected input_dims - 1 = label_dims or input_dims == label_dims\
@@ -431,6 +433,12 @@ def _c_softmax_with_cross_entropy(
         )
     if input_dims - 1 == label_dims:
         label = paddle.unsqueeze(label, axis=-1)
+        label_shape = list(label.shape)
+    if label_shape[-1] < 1 or label_shape[-1] > input_shape[-1] * nranks:
+        raise ValueError(
+            f'Expected label_shape[-1] >= 1 and label_shape[-1] <= input_shape[-1] * nranks\
+             (got label_shape[-1] = {label_shape[-1]}, input_shape[-1] = {input_shape[-1]})'
+        )
 
     if in_dynamic_mode():
         softmax, loss = _legacy_C_ops.c_softmax_with_cross_entropy(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
develop pr：https://github.com/PaddlePaddle/Paddle/pull/69041 https://github.com/PaddlePaddle/Paddle/pull/69147
ParallelCrossEntropy 支持多标签分类
c_softmax_with_cross_entropy_op 的label参数支持shape=[B, S, C]，其中1 <= C <= vocab_size
Pcard-87604
