### PR TITLE
[PIR]delete some flags

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -61,7 +61,6 @@
 COMMON_DECLARE_bool(cinn_specify_input_dynamic_dim);
 COMMON_DECLARE_string(cinn_input_dynamic_dim_spec_file);
 COMMON_DECLARE_bool(print_ir);
-COMMON_DECLARE_bool(pir_debug);
 COMMON_DECLARE_bool(disable_dyshape_in_train);
 COMMON_DECLARE_bool(enable_cinn_accuracy_check);
 COMMON_DECLARE_bool(enable_fuse_parallel_matmul_pass);
@@ -279,7 +278,7 @@ void ApplyCinnPass(::pir::Program* program,
   LOG(INFO) << "FusionOp count before lowering : *****[ "
             << GetOpCount<cinn::dialect::FusionOp>(program->module_op())
             << " ]*****";
-  if (FLAGS_pir_debug) {
+  if (FLAGS_print_ir) {
     auto& shape_analysis = pir::ShapeAnalysisManager::Instance().Get(program);
     std::cout << "Program before lowering: \n"
               << pir::CustomPrintHelper(*program, shape_analysis.PrintHook())

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1668,9 +1668,6 @@ PHI_DEFINE_EXPORTED_int32(
 
 PHI_DEFINE_EXPORTED_bool(print_ir, false, "Whether print ir debug str.");
 
-PHI_DEFINE_EXPORTED_bool(pir_debug,
-                         false,
-                         "Whether print more pir debug info.");
 PHI_DEFINE_EXPORTED_bool(
     prim_skip_dynamic,
     true,

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -40,7 +40,6 @@
 
 COMMON_DECLARE_bool(enable_pir_with_pt_in_dy2st);
 COMMON_DECLARE_bool(enable_pir_in_executor);
-COMMON_DECLARE_bool(print_ir);
 COMMON_DECLARE_bool(use_mkldnn);
 
 namespace details {
@@ -424,19 +423,6 @@ inline void PirRunProgramAPI(
   std::shared_ptr<::pir::Program> backward_program = PADDLE_GET_CONST(
       std::shared_ptr<::pir::Program>, attrs.at("backward_program"));
 
-  if (FLAGS_print_ir) {
-    std::ostringstream print_stream;
-    print_stream << "ForwardProgram is :\n";
-    forward_program->Print(print_stream);
-    if (!is_test) {
-      print_stream << "BackwardProgram is:\n";
-      backward_program->Print(print_stream);
-    } else {
-      print_stream << "BackwardProgram is empty in test mode.\n";
-    }
-    std::cout << "Program (fwd | bwd): \n" << print_stream.str() << std::endl;
-  }
-
   VLOG(10) << is_test << program_id;
 
   auto &cache = paddle::framework::InterpreterCoreInfoCache::Instance();
@@ -459,12 +445,6 @@ inline void PirRunProgramAPI(
     // Step 2. create new interpretercore
     auto passed_kernel_program =
         paddle::framework::ApplyIrPass(forward_program.get(), place);
-    if (FLAGS_print_ir) {
-      std::ostringstream print_stream;
-      print_stream << "LoweredProgram( AfterPass ) is :\n";
-      passed_kernel_program->Print(print_stream);
-      std::cout << print_stream.str() << std::endl;
-    }
     interpreter_core = paddle::framework::CreatePirInterpreterCoreInfoToCache(
         std::move(passed_kernel_program),
         place,
@@ -1016,12 +996,6 @@ inline void PirRunProgramGradAPI(
     passed_kernel_program = paddle::framework::ApplyRemoveShadowFeedPass(
         std::move(passed_kernel_program), new_block, place, global_inner_scope);
 
-    if (FLAGS_print_ir) {
-      std::ostringstream print_stream;
-      print_stream << "LoweredProgram( AfterPass | Backward ) is :\n";
-      passed_kernel_program->Print(print_stream);
-      std::cout << print_stream.str() << std::endl;
-    }
     interpreter_core = paddle::framework::CreatePirInterpreterCoreInfoToCache(
         std::move(passed_kernel_program),
         place,

--- a/paddle/fluid/pir/dialect/distributed/transforms/dist_to_dense_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/dist_to_dense_pass.cc
@@ -194,10 +194,6 @@ void VerifyDenseBlock(pir::Block* block) {
 }
 
 void DistToDensePass(pir::Program* prog) {
-  if (FLAGS_print_ir) {
-    VLOG(0) << "IR before DistToDense Pass = " << *prog;
-  }
-
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<OperatorDialect>();
   ctx->GetOrRegisterDialect<DistDialect>();

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -41,8 +41,6 @@ using pir::TuplePopOp;
 using pir::TuplePushOp;
 constexpr char kStopGradientAttrName[] = "stop_gradient";  // NOLINT
 
-COMMON_DECLARE_bool(pir_debug);
-
 namespace paddle::dialect {
 
 void IfOp::Build(pir::Builder &builder,             // NOLINT
@@ -171,7 +169,7 @@ void IfOp::Print(pir::IrPrinter &printer) {
   printer.PrintOpResult(*op);
   os << " = \"" << name() << "\"";
 
-  if (VLOG_IS_ON(1) || FLAGS_pir_debug) {
+  if (VLOG_IS_ON(1)) {
     os << " [id:" << op->id() << "]";
   }
 
@@ -428,7 +426,7 @@ void WhileOp::Print(pir::IrPrinter &printer) {
   auto op = operation();
   printer.PrintOpResult(*op);
   os << " = \"" << name() << "\"";
-  if (VLOG_IS_ON(1) || FLAGS_pir_debug) {
+  if (VLOG_IS_ON(1)) {
     os << " [id:" << op->id() << "]";
   }
   os << " (cond=";

--- a/paddle/fluid/pir/dialect/operator/ir/manual_pylayer_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_pylayer_op.cc
@@ -36,8 +36,6 @@ paddle::dialect::PyLayerOp
 #include "paddle/pir/include/dialect/control_flow/ir/cf_op.h"
 #include "paddle/pir/include/dialect/control_flow/ir/cf_type.h"
 
-COMMON_DECLARE_bool(pir_debug);
-
 namespace paddle {
 namespace dialect {
 
@@ -121,7 +119,7 @@ void PyLayerOp::Print(pir::IrPrinter &printer) {
   printer.PrintOpResult(*op);
   os << " = pd_op.pylayer";
 
-  if (VLOG_IS_ON(1) || FLAGS_pir_debug) {
+  if (VLOG_IS_ON(1)) {
     os << " [id:" << op->id() << "]";
   }
 

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -3531,10 +3531,6 @@ void ProcessBlock(
 
 std::unique_ptr<pir::Program> PdOpLowerToKernelPass(pir::Program* prog,
                                                     phi::Place place) {
-  if (FLAGS_print_ir) {
-    std::cout << "IR before lowering = " << *prog << std::endl;
-  }
-
   auto program = std::make_unique<pir::Program>(pir::IrContext::Instance());
 
   auto block = prog->block();

--- a/paddle/pir/src/core/ir_printer.cc
+++ b/paddle/pir/src/core/ir_printer.cc
@@ -29,8 +29,6 @@
 #include "paddle/pir/include/core/utils.h"
 #include "paddle/pir/include/core/value.h"
 
-COMMON_DECLARE_bool(pir_debug);
-
 namespace pir {
 
 namespace {
@@ -192,7 +190,7 @@ void IrPrinter::PrintOperationWithNoRegion(const Operation& op) {
 
   os << " \"" << op.name() << "\"";
 
-  if (VLOG_IS_ON(1) || FLAGS_pir_debug) {
+  if (VLOG_IS_ON(1)) {
     os << " [id:" << op.id() << "]";
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
此PR作用：

- 将FLAGS_pir_debug(打印op id信息)合并到FLAGS_print_ir里，公用一个FLAG，删除FLAGS_pir_debug
- 删除动转静下的打印的冗余的ir program信息
- paddle代码里存在许多before pass打印了program信息，after pass又打印了一遍，有很多重复的program打印，现在只打印after pass之后的program信息

pcard-67164