### PR TITLE
[CINN]add side effective for group op

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
@@ -31,7 +31,9 @@ namespace cinn {
 namespace dialect {
 
 class IR_API GroupOp
-    : public pir::Op<GroupOp, paddle::dialect::InferSymbolicShapeInterface> {
+    : public pir::Op<GroupOp,
+                     paddle::dialect::InferSymbolicShapeInterface,
+                     pir::SideEffectTrait> {
  public:
   using Op::Op;
   static const char *name() { return "cinn_op.group"; }


### PR DESCRIPTION
### PR Category
CINN

### PR Types
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-76996

给group op注册side effective， 防止一个具备side effective 的op，被放入到 group op中， dce 被group op直接清理