### PR TITLE
[Infra][3.13] replace `pkg_resources` with `importlib.resources`

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -583,6 +583,7 @@ from .tensor.to_string import set_printoptions
 # CINN has to set a flag to include a lib
 if is_compiled_with_cinn():
     import os
+    from importlib import resources
 
     package_dir = os.path.dirname(os.path.abspath(__file__))
     runtime_include_dir = os.path.join(package_dir, "libs")
@@ -590,10 +591,8 @@ if is_compiled_with_cinn():
     if os.path.exists(cuh_file):
         os.environ.setdefault('runtime_include_dir', runtime_include_dir)
 
-    import pkg_resources
-
-    data_file_path = pkg_resources.resource_filename('paddle.cinn_config', '')
-    os.environ['CINN_CONFIG_PATH'] = data_file_path
+    data_file_path = resources.files('paddle.cinn_config').joinpath('')
+    os.environ['CINN_CONFIG_PATH'] = str(data_file_path)
 
 if __is_metainfo_generated and is_compiled_with_cuda():
     import os

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -591,7 +591,7 @@ if is_compiled_with_cinn():
     if os.path.exists(cuh_file):
         os.environ.setdefault('runtime_include_dir', runtime_include_dir)
 
-    data_file_path = resources.files('paddle.cinn_config').joinpath('')
+    data_file_path = resources.files('paddle.cinn_config')
     os.environ['CINN_CONFIG_PATH'] = str(data_file_path)
 
 if __is_metainfo_generated and is_compiled_with_cuda():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

Python 3.13 debug 版下 import paddle 出现如下 warning

```
python
Python 3.13.0+ (heads/3.13:5c040550820, Nov  2 2024, 15:45:05) [Clang 16.0.0 (clang-1600.0.26.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import paddle
/Users/nyakku/Projects/Paddle/.venv/lib/python3.13/site-packages/setuptools/command/easy_install.py:41: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources
/Users/nyakku/Projects/Paddle/.venv/lib/python3.13/site-packages/astor/op_util.py:92: DeprecationWarning: ast.Num is deprecated and will be removed in Python 3.14; use ast.Constant instead
  precedence_data = dict((getattr(ast, x, None), z) for x, y, z in op_data)
>>> 
```

- `astor` 会在后续 3.8 退场时移除
- 本 PR 移除 paddle 内的 `pkg_resources`，但使用的 setuptools 仍然会使用 `pkg_resources`

PCard-66972