### PR TITLE
[SOT][3.13] Use `GetLocals` to avoid `SystemError` when get locals from proxy frame

### DIFF
--- a/paddle/fluid/pybind/sot/cpython_internals.h
+++ b/paddle/fluid/pybind/sot/cpython_internals.h
@@ -39,7 +39,9 @@ int Internal_PyInterpreterFrame_GetLine(_PyInterpreterFrame *frame);
 static int Internal_PyFrame_OpAlreadyRan(_PyInterpreterFrame *frame,
                                          int opcode,
                                          int oparg);
-#if !PY_3_13_PLUS
+#if PY_3_13_PLUS
+PyObject *Internal_PyFrame_GetLocals(_PyInterpreterFrame *frame);
+#else
 int Internal_PyFrame_FastToLocalsWithError(_PyInterpreterFrame *frame);
 #endif
 PyFrameObject *Internal_PyFrame_New_NoTrack(PyCodeObject *code);

--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -67,7 +67,16 @@ DECLARE_PROXY_PROPERTY(f_executable)
 #else
 DECLARE_PROXY_PROPERTY(f_code)
 #endif
+#if PY_3_13_PLUS
+static PyObject *PyInterpreterFrameProxy_property_f_locals(
+    PyInterpreterFrameProxy *self, void *closure) {
+  PyObject *f_locals = Internal_PyFrame_GetLocals(self->frame);
+  Py_XINCREF(f_locals);
+  return f_locals;
+}
+#else
 DECLARE_PROXY_PROPERTY(f_locals)
+#endif
 DECLARE_PROXY_PROPERTY(f_globals)
 DECLARE_PROXY_PROPERTY(f_builtins)
 
@@ -339,7 +348,9 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
   // original frame. So we pass a PyInterpreterFrame to
   // _PyFrame_FastToLocalsWithError directly. But this is an internal API, so we
   // copy many code from CPython project into our project.
-#if !PY_3_13_PLUS
+#if PY_3_13_PLUS
+  Internal_PyFrame_GetLocals(frame);
+#else
   if (Internal_PyFrame_FastToLocalsWithError(frame) < 0) {
     return NULL;
   }

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
@@ -46,7 +46,7 @@ class PopJumpCond(Enum):
 
 def _get_pyopcode_cache_size() -> dict[str, int]:
     if sys.version_info >= (3, 11) and sys.version_info < (3, 12):
-        # Cache for some opcodes, it's for Python 3.11+
+        # Cache for some opcodes, it's for Python 3.11
         # https://github.com/python/cpython/blob/3.11/Include/internal/pycore_opcode.h#L41-L53
         return {
             "BINARY_SUBSCR": 4,
@@ -62,7 +62,7 @@ def _get_pyopcode_cache_size() -> dict[str, int]:
             "CALL": 4,
         }
     elif sys.version_info >= (3, 12) and sys.version_info < (3, 13):
-        # Cache for some opcodes, it's for Python 3.12+
+        # Cache for some opcodes, it's for Python 3.12
         # https://github.com/python/cpython/blob/3.12/Include/internal/pycore_opcode.h#L34-L47
         return {
             "BINARY_SUBSCR": 1,
@@ -78,7 +78,31 @@ def _get_pyopcode_cache_size() -> dict[str, int]:
             "LOAD_SUPER_ATTR": 1,
             "CALL": 3,
         }
-    elif sys.version_info >= (3, 13):
+    elif sys.version_info >= (3, 13) and sys.version_info < (3, 14):
+        # Cache for some opcodes, it's for Python 3.13
+        # https://github.com/python/cpython/blob/3.13/Include/internal/pycore_opcode_metadata.h#L1598-L1618
+        return {
+            "JUMP_BACKWARD": 1,
+            "TO_BOOL": 3,
+            "BINARY_SUBSCR": 1,
+            "STORE_SUBSCR": 1,
+            "SEND": 1,
+            "UNPACK_SEQUENCE": 1,
+            "STORE_ATTR": 4,
+            "LOAD_GLOBAL": 4,
+            "LOAD_SUPER_ATTR": 1,
+            "LOAD_ATTR": 9,
+            "COMPARE_OP": 1,
+            "CONTAINS_OP": 1,
+            "POP_JUMP_IF_TRUE": 1,
+            "POP_JUMP_IF_FALSE": 1,
+            "POP_JUMP_IF_NONE": 1,
+            "POP_JUMP_IF_NOT_NONE": 1,
+            "FOR_ITER": 1,
+            "CALL": 3,
+            "BINARY_OP": 1,
+        }
+    elif sys.version_info >= (3, 14):
         raise NotImplementedError(
             f"Need to supplement cache operation code, for Python {sys.version_info}"
         )

--- a/test/sot/test_01_basic.py
+++ b/test/sot/test_01_basic.py
@@ -17,7 +17,6 @@ import unittest
 from test_case_base import TestCaseBase
 
 import paddle
-from paddle.jit.sot.utils import strict_mode_guard
 
 
 def foo(x: int, y: paddle.Tensor):
@@ -27,19 +26,6 @@ def foo(x: int, y: paddle.Tensor):
 class TestBasic(TestCaseBase):
     def test_simple(self):
         self.assert_results(foo, 1, paddle.to_tensor(2))
-
-
-def numpy_add(x, y):
-    out = paddle.to_tensor(x.numpy() + y.numpy())
-    return out
-
-
-class TestNumpyAdd(TestCaseBase):
-    @strict_mode_guard(False)
-    def test_numpy_add(self):
-        x = paddle.to_tensor([2])
-        y = paddle.to_tensor([3])
-        self.assert_results(numpy_add, x, y)
 
 
 if __name__ == "__main__":

--- a/test/sot/test_numpy.py
+++ b/test/sot/test_numpy.py
@@ -21,24 +21,35 @@ import paddle
 from paddle.jit.sot.utils import strict_mode_guard
 
 
-def foo(x, y):
+def numpy_add(x, y):
+    out = paddle.to_tensor(x.numpy() + y.numpy())
+    return out
+
+
+def tensor_add_numpy(x, y):
     ret = x + y
     return ret
 
 
 class TestNumpy(TestCaseBase):
+    @strict_mode_guard(False)
+    def test_numpy_add(self):
+        x = paddle.to_tensor([2])
+        y = paddle.to_tensor([3])
+        self.assert_results(numpy_add, x, y)
+
     def test_tensor_add_numpy_number(self):
         x = paddle.to_tensor([1.0])
         y = np.int64(2)
-        self.assert_results(foo, x, y)
-        self.assert_results(foo, y, x)
+        self.assert_results(tensor_add_numpy, x, y)
+        self.assert_results(tensor_add_numpy, y, x)
 
     @strict_mode_guard(False)
     def test_tensor_add_numpy_array(self):
         x = paddle.to_tensor([1.0])
         y = np.array(2.0)
-        self.assert_results(foo, x, y)
-        self.assert_results(foo, y, x)
+        self.assert_results(tensor_add_numpy, x, y)
+        self.assert_results(tensor_add_numpy, y, x)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

解决 #69126 中的遗留问题，`GetLocals` 到底需不需要的问题

Python 3.13 中需要，而且可能每次都需要，因为每次都要创建一个代理 locals 以进行修改

但对于我们的 frame 代理来说是否可以缓存呢？因为我们的 `frame.f_locals` 并不需要可以修改，这一点留待后续观察确认

移动 `test_numpy_add` case 到 `test_numpy` 中，不然每次从头适配的时候总是因为这个 case 导致 `test_01_basic` 在很后期才能支持

目前本 PR 至少 `test_01` 到 `test_03` 是可以直接通过了，具体通过情况待后续统计

PCard-66972