### PR TITLE
Support numpy scalar as input type case

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1363,7 +1363,7 @@ def eye(
             assert len(attr.shape) == 0 or (
                 len(attr.shape) == 1 and attr.shape[0] in [1, -1]
             )
-        elif not isinstance(attr, int) or attr < 0:
+        elif not np.isscalar(attr) or attr < 0:
             raise TypeError(f"{message} should be a non-negative int.")
 
     _check_attr(num_rows, "num_rows")

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1363,7 +1363,7 @@ def eye(
             assert len(attr.shape) == 0 or (
                 len(attr.shape) == 1 and attr.shape[0] in [1, -1]
             )
-        elif not np.isscalar(attr) or attr < 0:
+        elif not isinstance(attr, (int, np.integer)) or attr < 0:
             raise TypeError(f"{message} should be a non-negative int.")
 
     _check_attr(num_rows, "num_rows")

--- a/test/legacy_test/test_eye_op.py
+++ b/test/legacy_test/test_eye_op.py
@@ -94,7 +94,7 @@ class TestEyeOp2(OpTest):
 class TestEyeOp3(OpTest):
     def setUp(self):
         '''
-        Test eye op with specified shape
+        Test eye op with np.int32 scalar
         '''
         self.python_api = paddle.eye
         self.op_type = "eye"

--- a/test/legacy_test/test_eye_op.py
+++ b/test/legacy_test/test_eye_op.py
@@ -91,6 +91,22 @@ class TestEyeOp2(OpTest):
         self.check_output(check_pir=True)
 
 
+class TestEyeOp3(OpTest):
+    def setUp(self):
+        '''
+        Test eye op with specified shape
+        '''
+        self.python_api = paddle.eye
+        self.op_type = "eye"
+
+        self.inputs = {}
+        self.attrs = {'num_rows': np.int32(99), 'num_columns': np.int32(1)}
+        self.outputs = {'Out': np.eye(99, 1, dtype=float)}
+
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
+
 class API_TestTensorEye(unittest.TestCase):
 
     def test_static_out(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-75624

允许np.dtype类型的标量作为eye的参数

相关PR：<https://github.com/deepmodeling/deepmd-kit/pull/4302>