### PR TITLE
Fix distribution API with 0-D input parameters 易用性提升 -part2

### DIFF
--- a/python/paddle/distribution/bernoulli.py
+++ b/python/paddle/distribution/bernoulli.py
@@ -146,7 +146,7 @@ class Bernoulli(exponential_family.ExponentialFamily):
         """
         return paddle.multiply(self.probs, (1 - self.probs))
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Sample from Bernoulli distribution.
 
         Args:
@@ -194,7 +194,7 @@ class Bernoulli(exponential_family.ExponentialFamily):
             return paddle.bernoulli(self.probs.expand(shape), name=name)
 
     def rsample(
-        self, shape: Sequence[int] = (), temperature: float = 1.0
+        self, shape: Sequence[int] = [], temperature: float = 1.0
     ) -> Tensor:
         """Sample from Bernoulli distribution (reparameterized).
 

--- a/python/paddle/distribution/beta.py
+++ b/python/paddle/distribution/beta.py
@@ -145,7 +145,7 @@ class Beta(exponential_family.ExponentialFamily):
         """
         return self._dirichlet.log_prob(paddle.stack([value, 1.0 - value], -1))
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Sample from beta distribution with sample shape.
 
         Args:

--- a/python/paddle/distribution/binomial.py
+++ b/python/paddle/distribution/binomial.py
@@ -126,7 +126,7 @@ class Binomial(distribution.Distribution):
         """
         return self.total_count * self.probs * (1 - self.probs)
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate binomial samples of the specified shape. The final shape would be ``shape+batch_shape`` .
 
         Args:

--- a/python/paddle/distribution/categorical.py
+++ b/python/paddle/distribution/categorical.py
@@ -148,11 +148,11 @@ class Categorical(distribution.Distribution):
         dist_sum = paddle.sum(self.logits, axis=-1, keepdim=True)
         self._prob = self.logits / dist_sum
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate samples of the specified shape.
 
         Args:
-            shape (list, optional): Shape of the generated samples.
+            shape (Sequence[int], optional): Shape of the generated samples.
 
         Returns:
             Tensor: A tensor with prepended dimensions shape.
@@ -179,7 +179,7 @@ class Categorical(distribution.Distribution):
         """
         name = self.name + '_sample'
         if not in_dynamic_mode():
-            check_type(shape, 'shape', (list), 'sample')
+            check_type(shape, 'shape', (list, tuple), 'sample')
 
         num_samples = np.prod(np.array(shape))
 

--- a/python/paddle/distribution/cauchy.py
+++ b/python/paddle/distribution/cauchy.py
@@ -122,7 +122,7 @@ class Cauchy(distribution.Distribution):
         raise ValueError("Cauchy distribution has no stddev.")
 
     def sample(
-        self, shape: Sequence[int] = (), name: str | None = None
+        self, shape: Sequence[int] = [], name: str | None = None
     ) -> Tensor:
         """Sample from Cauchy distribution.
 
@@ -172,7 +172,7 @@ class Cauchy(distribution.Distribution):
             return self.rsample(shape, name)
 
     def rsample(
-        self, shape: Sequence[int] = (), name: str | None = None
+        self, shape: Sequence[int] = [], name: str | None = None
     ) -> Tensor:
         """Sample from Cauchy distribution (reparameterized).
 

--- a/python/paddle/distribution/continuous_bernoulli.py
+++ b/python/paddle/distribution/continuous_bernoulli.py
@@ -245,7 +245,7 @@ class ContinuousBernoulli(distribution.Distribution):
             self._cut_support_region(), propose, taylor_expansion
         )
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate Continuous Bernoulli samples of the specified shape. The final shape would be ``sample_shape + batch_shape``.
 
         Args:
@@ -257,7 +257,7 @@ class ContinuousBernoulli(distribution.Distribution):
         with paddle.no_grad():
             return self.rsample(shape)
 
-    def rsample(self, shape: Sequence[int] = ()) -> Tensor:
+    def rsample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate Continuous Bernoulli samples of the specified shape. The final shape would be ``sample_shape + batch_shape``.
 
         Args:

--- a/python/paddle/distribution/dirichlet.py
+++ b/python/paddle/distribution/dirichlet.py
@@ -111,11 +111,11 @@ class Dirichlet(exponential_family.ExponentialFamily):
             concentration0.pow(2) * (concentration0 + 1)
         )
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Sample from dirichlet distribution.
 
         Args:
-            shape (Sequence[int], optional): Sample shape. Defaults to empty tuple.
+            shape (Sequence[int], optional): Sample shape. Defaults to empty list.
         """
         shape = shape if isinstance(shape, tuple) else tuple(shape)
         return _dirichlet(self.concentration.expand(self._extend_shape(shape)))

--- a/python/paddle/distribution/distribution.py
+++ b/python/paddle/distribution/distribution.py
@@ -95,11 +95,11 @@ class Distribution:
         """Variance of distribution"""
         raise NotImplementedError
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Sampling from the distribution."""
         raise NotImplementedError
 
-    def rsample(self, shape: Sequence[int] = ()) -> Tensor:
+    def rsample(self, shape: Sequence[int] = []) -> Tensor:
         """reparameterized sample"""
         raise NotImplementedError
 

--- a/python/paddle/distribution/exponential.py
+++ b/python/paddle/distribution/exponential.py
@@ -107,7 +107,7 @@ class Exponential(exponential_family.ExponentialFamily):
         """
         return self.rate.pow(-2)
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate samples of the specified shape.
 
         Args:
@@ -119,7 +119,7 @@ class Exponential(exponential_family.ExponentialFamily):
         with paddle.no_grad():
             return self.rsample(shape)
 
-    def rsample(self, shape: Sequence[int] = ()) -> Tensor:
+    def rsample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate reparameterized samples of the specified shape.
 
         Args:

--- a/python/paddle/distribution/gamma.py
+++ b/python/paddle/distribution/gamma.py
@@ -177,7 +177,7 @@ class Gamma(exponential_family.ExponentialFamily):
             + (1.0 - self.concentration) * paddle.digamma(self.concentration)
         )
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate samples of the specified shape.
 
         Args:
@@ -189,7 +189,7 @@ class Gamma(exponential_family.ExponentialFamily):
         with paddle.no_grad():
             return self.rsample(shape)
 
-    def rsample(self, shape: Sequence[int] = ()) -> Tensor:
+    def rsample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate reparameterized samples of the specified shape.
 
         Args:

--- a/python/paddle/distribution/geometric.py
+++ b/python/paddle/distribution/geometric.py
@@ -195,7 +195,7 @@ class Geometric(distribution.Distribution):
                 f"Expected type of k is number.Real|framework.Variable|Value, but got {type(k)}"
             )
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Sample from Geometric distribution with sample shape.
 
         Args:
@@ -221,7 +221,7 @@ class Geometric(distribution.Distribution):
         with paddle.no_grad():
             return self.rsample(shape)
 
-    def rsample(self, shape: Sequence[int] = ()) -> Tensor:
+    def rsample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate samples of the specified shape.
 
         Args:

--- a/python/paddle/distribution/gumbel.py
+++ b/python/paddle/distribution/gumbel.py
@@ -266,8 +266,7 @@ class Gumbel(TransformedDistribution):
     def rsample(self, shape: Sequence[int] = ()) -> Tensor:
         """reparameterized sample
         Args:
-            shape (Sequence[int], optional): 1D `int32`. Shape of the generated samples.
-                Defaults to ().
+            shape (Sequence[int], optional): 1D `int32`. Shape of the generated samples. Defaults to ().
 
         Returns:
             Tensor: A tensor with prepended dimensions shape.The data type is float32.

--- a/python/paddle/distribution/gumbel.py
+++ b/python/paddle/distribution/gumbel.py
@@ -250,11 +250,11 @@ class Gumbel(TransformedDistribution):
         """
         return paddle.log(self.scale) + 1 + np.euler_gamma
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Sample from ``Gumbel``.
 
         Args:
-            shape (Sequence[int], optional): The sample shape. Defaults to ().
+            shape (Sequence[int], optional): The sample shape. Defaults to [].
 
         Returns:
             Tensor: A tensor with prepended dimensions shape.The data type is float32.
@@ -263,10 +263,10 @@ class Gumbel(TransformedDistribution):
         with paddle.no_grad():
             return self.rsample(shape)
 
-    def rsample(self, shape: Sequence[int] = ()) -> Tensor:
+    def rsample(self, shape: Sequence[int] = []) -> Tensor:
         """reparameterized sample
         Args:
-            shape (Sequence[int], optional): 1D `int32`. Shape of the generated samples. Defaults to ().
+            shape (Sequence[int], optional): 1D `int32`. Shape of the generated samples. Defaults to [].
 
         Returns:
             Tensor: A tensor with prepended dimensions shape.The data type is float32.

--- a/python/paddle/distribution/gumbel.py
+++ b/python/paddle/distribution/gumbel.py
@@ -250,7 +250,7 @@ class Gumbel(TransformedDistribution):
         """
         return paddle.log(self.scale) + 1 + np.euler_gamma
 
-    def sample(self, shape: Sequence[int]) -> Tensor:
+    def sample(self, shape: Sequence[int] = ()) -> Tensor:
         """Sample from ``Gumbel``.
 
         Args:
@@ -263,10 +263,11 @@ class Gumbel(TransformedDistribution):
         with paddle.no_grad():
             return self.rsample(shape)
 
-    def rsample(self, shape: Sequence[int]) -> Tensor:
+    def rsample(self, shape: Sequence[int] = ()) -> Tensor:
         """reparameterized sample
         Args:
-            shape (Sequence[int]): 1D `int32`. Shape of the generated samples.
+            shape (Sequence[int], optional): 1D `int32`. Shape of the generated samples.
+                Defaults to ().
 
         Returns:
             Tensor: A tensor with prepended dimensions shape.The data type is float32.

--- a/python/paddle/distribution/independent.py
+++ b/python/paddle/distribution/independent.py
@@ -89,7 +89,7 @@ class Independent(distribution.Distribution):
     def variance(self) -> Tensor:
         return self._base.variance
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         return self._base.sample(shape)
 
     def log_prob(self, value: Tensor) -> Tensor:

--- a/python/paddle/distribution/laplace.py
+++ b/python/paddle/distribution/laplace.py
@@ -307,7 +307,8 @@ class Laplace(distribution.Distribution):
         r"""Generate samples of the specified shape.
 
         Args:
-            shape(tuple[int]): The shape of generated samples.
+            shape(Sequence[int], optional): The shape of generated samples.
+                Defaults to ().
 
         Returns:
             Tensor: A sample tensor that fits the Laplace distribution.
@@ -326,11 +327,12 @@ class Laplace(distribution.Distribution):
         with paddle.no_grad():
             return self.rsample(shape)
 
-    def rsample(self, shape: Sequence[int]) -> Tensor:
+    def rsample(self, shape: Sequence[int] = ()) -> Tensor:
         r"""Reparameterized sample.
 
         Args:
-            shape(tuple[int]): The shape of generated samples.
+            shape(Sequence[int], optional): The shape of generated samples.
+                Defaults to ().
 
         Returns:
             Tensor: A sample tensor that fits the Laplace distribution.

--- a/python/paddle/distribution/laplace.py
+++ b/python/paddle/distribution/laplace.py
@@ -303,12 +303,12 @@ class Laplace(distribution.Distribution):
 
         return loc - scale * (term).sign() * paddle.log1p(-2 * term.abs())
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         r"""Generate samples of the specified shape.
 
         Args:
             shape(Sequence[int], optional): The shape of generated samples.
-                Defaults to ().
+                Defaults to [].
 
         Returns:
             Tensor: A sample tensor that fits the Laplace distribution.
@@ -327,12 +327,12 @@ class Laplace(distribution.Distribution):
         with paddle.no_grad():
             return self.rsample(shape)
 
-    def rsample(self, shape: Sequence[int] = ()) -> Tensor:
+    def rsample(self, shape: Sequence[int] = []) -> Tensor:
         r"""Reparameterized sample.
 
         Args:
             shape(Sequence[int], optional): The shape of generated samples.
-                Defaults to ().
+                Defaults to [].
 
         Returns:
             Tensor: A sample tensor that fits the Laplace distribution.

--- a/python/paddle/distribution/lkj_cholesky.py
+++ b/python/paddle/distribution/lkj_cholesky.py
@@ -316,7 +316,7 @@ class LKJCholesky(distribution.Distribution):
         r = r * z1m_cumprod_sqrt_shifted
         return r
 
-    def sample(self, sample_shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, sample_shape: Sequence[int] = []) -> Tensor:
         """Generate a sample using the specified sampling method."""
         if not isinstance(sample_shape, Sequence):
             raise TypeError('sample shape must be Sequence object.')

--- a/python/paddle/distribution/multinomial.py
+++ b/python/paddle/distribution/multinomial.py
@@ -150,11 +150,11 @@ class Multinomial(distribution.Distribution):
             + (value * logits).sum(-1)
         )
 
-    def sample(self, shape: Iterable[int] = ()) -> Tensor:
+    def sample(self, shape: Iterable[int] = []) -> Tensor:
         """draw sample data from multinomial distribution
 
         Args:
-            sample_shape (tuple, optional): [description]. Defaults to ().
+            sample_shape (list|tuple, optional): [description]. Defaults to [].
         """
         if not isinstance(shape, Iterable):
             raise TypeError('sample shape must be Iterable object.')

--- a/python/paddle/distribution/multivariate_normal.py
+++ b/python/paddle/distribution/multivariate_normal.py
@@ -207,7 +207,7 @@ class MultivariateNormal(distribution.Distribution):
             .expand(self._batch_shape + self._event_shape)
         )
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate Multivariate Normal samples of the specified shape. The final shape would be ``sample_shape + batch_shape + event_shape``.
 
         Args:
@@ -219,7 +219,7 @@ class MultivariateNormal(distribution.Distribution):
         with paddle.no_grad():
             return self.rsample(shape)
 
-    def rsample(self, shape: Sequence[int] = ()) -> Tensor:
+    def rsample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate Multivariate Normal samples of the specified shape. The final shape would be ``sample_shape + batch_shape + event_shape``.
 
         Args:

--- a/python/paddle/distribution/normal.py
+++ b/python/paddle/distribution/normal.py
@@ -272,7 +272,7 @@ class Normal(distribution.Distribution):
         """
         return self.scale.pow(2)
 
-    def sample(self, shape: Sequence[int] = (), seed: int = 0) -> Tensor:
+    def sample(self, shape: Sequence[int] = [], seed: int = 0) -> Tensor:
         """Generate samples of the specified shape.
 
         Args:
@@ -325,7 +325,7 @@ class Normal(distribution.Distribution):
             else:
                 return output
 
-    def rsample(self, shape: Sequence[int] = ()) -> Tensor:
+    def rsample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate reparameterized samples of the specified shape.
 
         Args:

--- a/python/paddle/distribution/poisson.py
+++ b/python/paddle/distribution/poisson.py
@@ -73,8 +73,8 @@ class Poisson(distribution.Distribution):
             >>> rv2 = Poisson(paddle.to_tensor([[1000.,40.],[7.,10.]]))
             >>> print(rv1.kl_divergence(rv2))
             Tensor(shape=[2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [[864.80285645, 0.          ],
-             [0.06825157  , 1.53426421  ]])
+            [[864.80499268, 0.          ],
+             [0.06825146  , 1.53426409  ])
     """
 
     rate: Tensor

--- a/python/paddle/distribution/poisson.py
+++ b/python/paddle/distribution/poisson.py
@@ -118,7 +118,7 @@ class Poisson(distribution.Distribution):
         """
         return self.rate
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate poisson samples of the specified shape. The final shape would be ``shape+batch_shape`` .
 
         Args:

--- a/python/paddle/distribution/poisson.py
+++ b/python/paddle/distribution/poisson.py
@@ -59,7 +59,7 @@ class Poisson(distribution.Distribution):
 
             >>> print(rv.sample([3]))
             Tensor(shape=[3], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [35., 35., 30.])
+            [32., 27., 25.])
 
             >>> print(rv.mean)
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,

--- a/python/paddle/distribution/poisson.py
+++ b/python/paddle/distribution/poisson.py
@@ -74,7 +74,7 @@ class Poisson(distribution.Distribution):
             >>> print(rv1.kl_divergence(rv2))
             Tensor(shape=[2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
             [[864.80499268, 0.          ],
-             [0.06825146  , 1.53426409  ])
+             [0.06825146  , 1.53426409  ]])
     """
 
     rate: Tensor

--- a/python/paddle/distribution/poisson.py
+++ b/python/paddle/distribution/poisson.py
@@ -58,18 +58,16 @@ class Poisson(distribution.Distribution):
             >>> rv = Poisson(paddle.to_tensor(30.0))
 
             >>> print(rv.sample([3]))
-            Tensor(shape=[3, 1], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [[35.],
-             [35.],
-             [30.]])
+            Tensor(shape=[3], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [35., 35., 30.])
 
             >>> print(rv.mean)
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
             30.)
 
             >>> print(rv.entropy())
-            Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [3.11671066])
+            Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
+            3.11671066)
 
             >>> rv1 = Poisson(paddle.to_tensor([[30.,40.],[8.,5.]]))
             >>> rv2 = Poisson(paddle.to_tensor([[1000.,40.],[7.,10.]]))
@@ -86,10 +84,7 @@ class Poisson(distribution.Distribution):
         self.dtype = paddle.get_default_dtype()
         self.rate = self._to_tensor(rate)
 
-        if self.rate.shape == []:
-            batch_shape = (1,)
-        else:
-            batch_shape = self.rate.shape
+        batch_shape = self.rate.shape
         super().__init__(batch_shape)
 
     def _to_tensor(self, rate: float | Tensor) -> Tensor:

--- a/python/paddle/distribution/poisson.py
+++ b/python/paddle/distribution/poisson.py
@@ -67,7 +67,7 @@ class Poisson(distribution.Distribution):
 
             >>> print(rv.entropy())
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
-            3.11671066)
+            3.11671519)
 
             >>> rv1 = Poisson(paddle.to_tensor([[30.,40.],[8.,5.]]))
             >>> rv2 = Poisson(paddle.to_tensor([[1000.,40.],[7.,10.]]))

--- a/python/paddle/distribution/student_t.py
+++ b/python/paddle/distribution/student_t.py
@@ -194,7 +194,7 @@ class StudentT(distribution.Distribution):
         )
         return var
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate StudentT samples of the specified shape. The final shape would be ``shape+batch_shape`` .
 
         Args:

--- a/python/paddle/distribution/transformed_distribution.py
+++ b/python/paddle/distribution/transformed_distribution.py
@@ -106,11 +106,11 @@ class TransformedDistribution(distribution.Distribution):
             ],
         )
 
-    def sample(self, shape: Sequence[int] = ()) -> Tensor:
+    def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Sample from ``TransformedDistribution``.
 
         Args:
-            shape (Sequence[int], optional): The sample shape. Defaults to ().
+            shape (Sequence[int], optional): The sample shape. Defaults to [].
 
         Returns:
             [Tensor]: The sample result.
@@ -120,11 +120,11 @@ class TransformedDistribution(distribution.Distribution):
             x = t.forward(x)
         return x
 
-    def rsample(self, shape: Sequence[int] = ()) -> Tensor:
+    def rsample(self, shape: Sequence[int] = []) -> Tensor:
         """Reparameterized sample from ``TransformedDistribution``.
 
         Args:
-            shape (Sequence[int], optional): The sample shape. Defaults to ().
+            shape (Sequence[int], optional): The sample shape. Defaults to [].
 
         Returns:
             [Tensor]: The sample result.

--- a/python/paddle/distribution/uniform.py
+++ b/python/paddle/distribution/uniform.py
@@ -194,11 +194,12 @@ class Uniform(distribution.Distribution):
 
         super().__init__(self.low.shape)
 
-    def sample(self, shape: list[int], seed: int = 0) -> Tensor:
+    def sample(self, shape: Sequence[int] = (), seed: int = 0) -> Tensor:
         """Generate samples of the specified shape.
 
         Args:
-            shape (list): 1D `int32`. Shape of the generated samples.
+            shape (Sequence[int], optional): 1D `int32`. Shape of the generated samples.
+                Defaults to ().
             seed (int): Python integer number.
 
         Returns:
@@ -206,9 +207,9 @@ class Uniform(distribution.Distribution):
 
         """
         if not in_dynamic_mode():
-            check_type(shape, 'shape', (list), 'sample')
+            check_type(shape, 'shape', (list, tuple), 'sample')
             check_type(seed, 'seed', (int), 'sample')
-
+        shape = list(shape)
         name = self.name + '_sample'
         batch_shape = list((self.low + self.high).shape)
         if -1 in batch_shape:

--- a/python/paddle/distribution/uniform.py
+++ b/python/paddle/distribution/uniform.py
@@ -194,12 +194,12 @@ class Uniform(distribution.Distribution):
 
         super().__init__(self.low.shape)
 
-    def sample(self, shape: Sequence[int] = (), seed: int = 0) -> Tensor:
+    def sample(self, shape: Sequence[int] = [], seed: int = 0) -> Tensor:
         """Generate samples of the specified shape.
 
         Args:
             shape (Sequence[int], optional): 1D `int32`. Shape of the generated samples.
-                Defaults to ().
+                Defaults to [].
             seed (int): Python integer number.
 
         Returns:

--- a/test/distribution/test_distribution_poisson.py
+++ b/test/distribution/test_distribution_poisson.py
@@ -27,6 +27,7 @@ from paddle.distribution import Poisson
 @parameterize.parameterize_cls(
     (parameterize.TEST_CASE_NAME, 'rate'),
     [
+        ('zero-dim', np.array(100.0).astype('float64')),
         ('one-dim', np.array([100.0]).astype('float64')),
         # bondary case and extreme case (`scipy.stats.poisson.entropy` cannot converge for very extreme cases such as rate=10000.0)
         ('multi-dim', np.array([0.0, 1000.0]).astype('float32')),
@@ -129,6 +130,17 @@ class TestPoissonProbs(unittest.TestCase):
 @parameterize.parameterize_cls(
     (parameterize.TEST_CASE_NAME, 'rate_1', 'rate_2'),
     [
+        (
+            'zero-dim',
+            parameterize.xrand((1,), min=1, max=20)
+            .astype('int32')
+            .astype('float64')
+            .reshape([]),
+            parameterize.xrand((1,), min=1, max=20)
+            .astype('int32')
+            .astype('float64')
+            .reshape([]),
+        ),
         (
             'one-dim',
             parameterize.xrand((1,), min=1, max=20)

--- a/test/distribution/test_distribution_poisson_static.py
+++ b/test/distribution/test_distribution_poisson_static.py
@@ -32,6 +32,7 @@ paddle.enable_static()
 @parameterize.parameterize_cls(
     (parameterize.TEST_CASE_NAME, 'rate'),
     [
+        ('zero-dim', np.array(1000.0).astype('float32')),
         ('one-dim', np.array([1000.0]).astype('float32')),
         (
             'multi-dim',
@@ -164,6 +165,17 @@ class TestPoissonProbs(unittest.TestCase):
 @parameterize.parameterize_cls(
     (parameterize.TEST_CASE_NAME, 'rate_1', 'rate_2'),
     [
+        (
+            'zero-dim',
+            parameterize.xrand((1,), min=1, max=20)
+            .astype('int32')
+            .astype('float32')
+            .reshape([]),
+            parameterize.xrand((1,), min=1, max=20)
+            .astype('int32')
+            .astype('float32')
+            .reshape([]),
+        ),
         (
             'multi-dim',
             parameterize.xrand((2, 3), min=1, max=20)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
1. `paddle.distribution.Poisson` 修复 0-D 参数输入；
2. 将 distribution API 的 sample/rsample 方法默认值全部替换为 `[]` 。