### PR TITLE
[PIR] Fix shape mismatch bug in Save&Load

### DIFF
--- a/paddle/fluid/pir/serialize_deserialize/src/ir_deserialize.cc
+++ b/paddle/fluid/pir/serialize_deserialize/src/ir_deserialize.cc
@@ -215,8 +215,8 @@ pir::Operation* ProgramReader::ReadParameterOp(Json* op_json) {
   // prepare opinfo
   pir::OpInfo op_info = ctx_->GetRegisteredOpInfo(pir::ParameterOp::name());
   // deserialize op
-  pir::Operation* op =
-      Operation::Create(inputs, attributes, output_types, op_info);
+  pir::Operation* op = Operation::Create(
+      inputs, attributes, output_types, op_info, 0, {}, false);
 
   id_value_map[value_id_] = op->result(0);
   VLOG(4) << "Finish Read Operation " << op->name() << ".";
@@ -295,8 +295,8 @@ pir::Operation* ProgramReader::ReadOp(Json* op_json) {
     num_regions = op_json->at(REGIONS).size();
   }
   // deserialize op
-  pir::Operation* op =
-      Operation::Create(inputs, attributes, output_types, op_info, num_regions);
+  pir::Operation* op = Operation::Create(
+      inputs, attributes, output_types, op_info, num_regions, {}, false);
 
   // deserialize op's regions
   if (op_json->contains(REGIONS)) {

--- a/paddle/pir/src/core/builtin_op.cc
+++ b/paddle/pir/src/core/builtin_op.cc
@@ -360,7 +360,7 @@ void CombineOp::VerifySig() const {
           input_num));
 
   // forall i in inputs.size(): inputs[i].type == outputs[0][i].type
-  for (auto i = 0; i < input_num; ++i) {
+  for (uint64_t i = 0; i < input_num; ++i) {
     auto type = (*this)->operand(i).type();
     PADDLE_ENFORCE_EQ(
         (output_type[i] == type ||

--- a/paddle/pir/src/core/builtin_op.cc
+++ b/paddle/pir/src/core/builtin_op.cc
@@ -25,7 +25,7 @@ namespace pir {
 const char *ModuleOp::attributes_name[attributes_num] = {"program"};  // NOLINT
 
 bool IsDynamicShapeTypeEqual(Type type1, Type type2) {
-  // Only support DenseTensorType now 
+  // Only support DenseTensorType now
   bool are_equal = false;
   if (type1.isa<DenseTensorType>() && type2.isa<DenseTensorType>()) {
     auto type_l = type1.dyn_cast<DenseTensorType>();

--- a/paddle/pir/src/core/builtin_op.cc
+++ b/paddle/pir/src/core/builtin_op.cc
@@ -360,7 +360,7 @@ void CombineOp::VerifySig() const {
           input_num));
 
   // forall i in inputs.size(): inputs[i].type == outputs[0][i].type
-  for (size_t i = 0; i < input_num; ++i) {
+  for (int i = 0; i < input_num; ++i) {
     auto type = (*this)->operand(i).type();
     PADDLE_ENFORCE_EQ(
         (output_type[i] == type ||

--- a/paddle/pir/src/core/builtin_op.cc
+++ b/paddle/pir/src/core/builtin_op.cc
@@ -26,13 +26,13 @@ const char *ModuleOp::attributes_name[attributes_num] = {"program"};  // NOLINT
 
 bool IsDynamicShapeTypeEqual(Type type1, Type type2) {
   // Only support DenseTensorType now
+  bool are_equal = false;
   if (type1.isa<DenseTensorType>() && type2.isa<DenseTensorType>()) {
     auto type_l = type1.dyn_cast<DenseTensorType>();
     auto type_r = type2.dyn_cast<DenseTensorType>();
     auto vec1 = type_l.dims();
     auto vec2 = type_r.dims();
     if (vec1.size() != vec2.size()) return false;
-    bool are_equal = false;
     for (auto i = 0; i < vec1.size(); ++i) {
       are_equal = ((vec1[i] == -1 || vec2[i] == -1) || (vec1[i] == vec2[i])) |
                   are_equal;
@@ -42,6 +42,7 @@ bool IsDynamicShapeTypeEqual(Type type1, Type type2) {
                              type_l.lod() == type_r.lod() &&
                              type_l.offset() == type_r.offset() && are_equal);
   }
+  bool are_equal;
 }
 
 void PassStopGradientsDefaultly(OperationArgument &argument) {  // NOLINT

--- a/paddle/pir/src/core/builtin_op.cc
+++ b/paddle/pir/src/core/builtin_op.cc
@@ -37,10 +37,10 @@ bool IsDynamicShapeTypeEqual(Type type1, Type type2) {
       are_equal = ((vec1[i] == -1 || vec2[i] == -1) || (vec1[i] == vec2[i])) |
                   are_equal;
     }
-    return {type_l.dtype() == type_r.dtype() &&
-            type_l.data_layout() == type_r.data_layout() &&
-            type_l.lod() == type_r.lod() &&
-            type_l.offset() == type_r.offset() && are_equal};
+    return static_cast<bool>(type_l.dtype() == type_r.dtype() &&
+                             type_l.data_layout() == type_r.data_layout() &&
+                             type_l.lod() == type_r.lod() &&
+                             type_l.offset() == type_r.offset() && are_equal);
   }
 }
 

--- a/paddle/pir/src/core/builtin_op.cc
+++ b/paddle/pir/src/core/builtin_op.cc
@@ -33,7 +33,7 @@ bool IsDynamicShapeTypeEqual(Type type1, Type type2) {
     auto vec2 = type_r.dims();
     if (vec1.size() != vec2.size()) return false;
     bool are_equal = false;
-    for (size_t i = 0; i < vec1.size(); ++i) {
+    for (auto i = 0; i < vec1.size(); ++i) {
       are_equal = ((vec1[i] == -1 || vec2[i] == -1) || (vec1[i] == vec2[i])) |
                   are_equal;
     }
@@ -360,7 +360,7 @@ void CombineOp::VerifySig() const {
           input_num));
 
   // forall i in inputs.size(): inputs[i].type == outputs[0][i].type
-  for (int i = 0; i < input_num; ++i) {
+  for (auto i = 0; i < input_num; ++i) {
     auto type = (*this)->operand(i).type();
     PADDLE_ENFORCE_EQ(
         (output_type[i] == type ||

--- a/paddle/pir/src/core/builtin_op.cc
+++ b/paddle/pir/src/core/builtin_op.cc
@@ -25,7 +25,7 @@ namespace pir {
 const char *ModuleOp::attributes_name[attributes_num] = {"program"};  // NOLINT
 
 bool IsDynamicShapeTypeEqual(Type type1, Type type2) {
-  // Only support DenseTensorType now
+  // Only support DenseTensorType now 
   bool are_equal = false;
   if (type1.isa<DenseTensorType>() && type2.isa<DenseTensorType>()) {
     auto type_l = type1.dyn_cast<DenseTensorType>();

--- a/paddle/pir/src/core/builtin_op.cc
+++ b/paddle/pir/src/core/builtin_op.cc
@@ -24,6 +24,26 @@ namespace pir {
 
 const char *ModuleOp::attributes_name[attributes_num] = {"program"};  // NOLINT
 
+bool IsDynamicShapeTypeEqual(Type type1, Type type2) {
+  // Only support DenseTensorType now
+  if (type1.isa<DenseTensorType>() && type2.isa<DenseTensorType>()) {
+    auto type_l = type1.dyn_cast<DenseTensorType>();
+    auto type_r = type2.dyn_cast<DenseTensorType>();
+    auto vec1 = type_l.dims();
+    auto vec2 = type_r.dims();
+    if (vec1.size() != vec2.size()) return false;
+    bool are_equal = false;
+    for (size_t i = 0; i < vec1.size(); ++i) {
+      are_equal = ((vec1[i] == -1 || vec2[i] == -1) || (vec1[i] == vec2[i])) |
+                  are_equal;
+    }
+    return {type_l.dtype() == type_r.dtype() &&
+            type_l.data_layout() == type_r.data_layout() &&
+            type_l.lod() == type_r.lod() &&
+            type_l.offset() == type_r.offset() && are_equal};
+  }
+}
+
 void PassStopGradientsDefaultly(OperationArgument &argument) {  // NOLINT
   VLOG(10) << "Builder construction stop gradient for OpResults.";
   bool stop_gradient = true;
@@ -343,8 +363,9 @@ void CombineOp::VerifySig() const {
   for (size_t i = 0; i < input_num; ++i) {
     auto type = (*this)->operand(i).type();
     PADDLE_ENFORCE_EQ(
-        output_type[i],
-        type,
+        (output_type[i] == type ||
+         IsDynamicShapeTypeEqual(output_type[i], type)),
+        true,
         common::errors::InvalidArgument("The type %s of outputs[0][%d] must be "
                                         "equal to type %s of inputs[%d].",
                                         output_type[i],

--- a/paddle/pir/src/core/builtin_op.cc
+++ b/paddle/pir/src/core/builtin_op.cc
@@ -42,7 +42,7 @@ bool IsDynamicShapeTypeEqual(Type type1, Type type2) {
                              type_l.lod() == type_r.lod() &&
                              type_l.offset() == type_r.offset() && are_equal);
   }
-  bool are_equal;
+  return are_equal;
 }
 
 void PassStopGradientsDefaultly(OperationArgument &argument) {  // NOLINT


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
报错：
![28ea8cc2203b9025f3e498c2103cc8e0](https://github.com/user-attachments/assets/4e53ba1a-9307-4242-8cef-0d23999653d1)

错误分析：
Combine op的verify函数要求输入输出的type相等，但后续执行时，while改变了输出的shape（yield变量与原有变量shape不一致时设为-1）。该模型后续的Pass中存在Verify调用，造成错误。

方案：
考虑到不能直接关闭Pass的Verify，目前解决方法是添加Combine op针对动态shape的判等，但未来还需要支持更多op和type