### PR TITLE
[Inference] Fix the dependency of attn_mask in FusedMT kernel

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_kernel.cu
@@ -492,11 +492,11 @@ void FusedMultiTransformerOpKernel(
     }
   }
 
-  int timestep = src_mask->dims()[3] - 1;
+  int time_step_value = out_seq_len - 1;
   int multi_block_attention_min_partition_size =
       static_cast<int>(FLAGS_multi_block_attention_min_partition_size);
   int max_num_partitions =
-      (timestep + multi_block_attention_min_partition_size - 1) /
+      (time_step_value + multi_block_attention_min_partition_size - 1) /
       multi_block_attention_min_partition_size;
 
   phi::DenseTensor partial_max_logits_tensor;
@@ -578,7 +578,7 @@ void FusedMultiTransformerOpKernel(
                                max_seq_len,
                                num_head,
                                dim_head,
-                               src_mask->dims()[3] - 1,
+                               time_step_value,
                                rotary_emb_dims,
                                1. / sqrt(dim_head),
                                mask_broadcast_num_heads,
@@ -606,7 +606,7 @@ void FusedMultiTransformerOpKernel(
                              max_seq_len,
                              num_head,
                              dim_head,
-                             src_mask->dims()[3] - 1,
+                             time_step_value,
                              rotary_emb_dims,
                              1. / sqrt(dim_head),
                              mask_broadcast_num_heads,

--- a/test/legacy_test/test_fused_multi_transformer_op.py
+++ b/test/legacy_test/test_fused_multi_transformer_op.py
@@ -926,10 +926,13 @@ class TestFusedMultiTransformerOp(OpTest):
             )
             pre_caches = []
 
-        attn_mask = paddle.static.data(
-            'src_mask', self.attn_mask.shape, self.attn_mask.dtype
-        )
-        attn_mask_feed = self.attn_mask
+        attn_mask = None
+        attn_mask_feed = None
+        if self.has_attn_mask:
+            attn_mask = paddle.static.data(
+                'src_mask', self.attn_mask.shape, self.attn_mask.dtype
+            )
+            attn_mask_feed = self.attn_mask
         epsilon = 1e-05
         ln2_epsilon = 1e-05
 
@@ -1880,7 +1883,7 @@ class TestFusedMultiTransformerOpVariableGQADecoder3(
 class TestFusedMultiTransformerOpPreCacheStatic1(TestFusedMultiTransformerOp):
     def config(self):
         super().config()
-        self.has_attn_mask = True
+        self.has_attn_mask = False
         self.x_type = np.float16
         self.weight_attr = paddle.ParamAttr(
             initializer=paddle.nn.initializer.Constant(0.0)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix the dependency of attn_mask in FusedMT kernel
Pcard-71502