### PR TITLE
[Eager] skip copy if place is undefined

### DIFF
--- a/paddle/phi/api/lib/tensor_method.cc
+++ b/paddle/phi/api/lib/tensor_method.cc
@@ -92,6 +92,11 @@ void Tensor::copy_(const Tensor &src,
     return;
   }
 
+  if (src.place().GetType() == AllocationType::UNDEFINED) {
+    VLOG(8) << "Src place is UNDEFINED, skip copy";
+    return;
+  }
+
   VLOG(3) << "Deep copy Tensor from " << src.name() << " to " << name();
   if (initialized()) {
     PADDLE_ENFORCE_EQ(dtype(),

--- a/test/legacy_test/test_lazy_init.py
+++ b/test/legacy_test/test_lazy_init.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import unittest
 
 import numpy as np
@@ -210,6 +211,25 @@ class TestXavierUniform(TestUniform):
     def set_initializer(self):
         self.w_initializer = XavierUniform()
         self.b_initializer = XavierUniform()
+
+
+class SubNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.linear = paddle.nn.Linear(10, 10)
+
+
+class DemoNet(paddle.nn.Layer):
+    def __init__(self):
+        sub_net = SubNet()
+        sub_net_deepcopy = copy.deepcopy(sub_net)
+
+
+class TestDeepCopyLazyInitializedParam(unittest.TestCase):
+    def test_deepcopy_lazy_initialized_param(self):
+        paddle.disable_static()
+        with LazyGuard():
+            demo_net = DemoNet()
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_lazy_init.py
+++ b/test/legacy_test/test_lazy_init.py
@@ -213,23 +213,18 @@ class TestXavierUniform(TestUniform):
         self.b_initializer = XavierUniform()
 
 
-class SubNet(paddle.nn.Layer):
+class LinearNet(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.linear = paddle.nn.Linear(10, 10)
-
-
-class DemoNet(paddle.nn.Layer):
-    def __init__(self):
-        sub_net = SubNet()
-        sub_net_deepcopy = copy.deepcopy(sub_net)
 
 
 class TestDeepCopyLazyInitializedParam(unittest.TestCase):
     def test_deepcopy_lazy_initialized_param(self):
         paddle.disable_static()
         with LazyGuard():
-            demo_net = DemoNet()
+            net = LinearNet()
+            copy.deepcopy(net)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#68862 会导致 LazyGuard 下的初始化的 parameter `has_allocation` 是 True，因为确实初始化了 holder，但是 `initialized` 是 False，特别的是，此时的 place 是 undefined

```python
from copy import deepcopy

import paddle
from paddle import nn


class SubNet(nn.Layer):
    def __init__(self):
        super().__init__()
        self.proj = nn.Linear(10, 10)


class DemoNet(nn.Layer):
    def __init__(self):
        sub_net = SubNet()
        breakpoint()
        sub_net_deepcopy = deepcopy(sub_net)


# python demo.py
if __name__ == "__main__":
    with paddle.LazyGuard():
        model = DemoNet()
```

因此将 place 是 undefined 的情况也跳过

PCard-66972