### PR TITLE
[Experiment][Dy2St] Make `to_static` can be cache with special attrs on class instance

### DIFF
--- a/paddle/phi/api/lib/tensor_method.cc
+++ b/paddle/phi/api/lib/tensor_method.cc
@@ -92,6 +92,11 @@ void Tensor::copy_(const Tensor &src,
     return;
   }
 
+  if (src.place().GetType() == AllocationType::UNDEFINED) {
+    VLOG(8) << "Src place is UNDEFINED, skip copy";
+    return;
+  }
+
   VLOG(3) << "Deep copy Tensor from " << src.name() << " to " << name();
   if (initialized()) {
     PADDLE_ENFORCE_EQ(dtype(),

--- a/paddle/phi/api/lib/tensor_method.cc
+++ b/paddle/phi/api/lib/tensor_method.cc
@@ -92,11 +92,6 @@ void Tensor::copy_(const Tensor &src,
     return;
   }
 
-  if (src.place().GetType() == AllocationType::UNDEFINED) {
-    VLOG(8) << "Src place is UNDEFINED, skip copy";
-    return;
-  }
-
   VLOG(3) << "Deep copy Tensor from " << src.name() << " to " << name();
   if (initialized()) {
     PADDLE_ENFORCE_EQ(dtype(),

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -336,7 +336,6 @@ class CacheKey:
     @staticmethod
     def hash_class_instance(class_instance):
         if not hasattr(class_instance.__class__, "__cache_attrs__"):
-            print(class_instance.__class__)
             return (ClassInstanceHashType.INSTANCE_ID, class_instance)
         attrs = tuple(
             getattr(class_instance, attr)

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -20,6 +20,7 @@ import os
 import threading
 import warnings
 import weakref
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
 
 from typing_extensions import ParamSpec, Self
@@ -247,6 +248,11 @@ def convert_to_static(function):
         return static_func
 
 
+class ClassInstanceHashType(Enum):
+    ATTR_ONLY = 0
+    INSTANCE_ID = 1
+
+
 class CacheKey:
     """
     Cached key for ProgramCache.
@@ -327,17 +333,32 @@ class CacheKey:
             class_instance,
         )
 
+    @staticmethod
+    def hash_class_instance(class_instance):
+        if not hasattr(class_instance.__class__, "__cache_attrs__"):
+            print(class_instance.__class__)
+            return (ClassInstanceHashType.INSTANCE_ID, class_instance)
+        attrs = tuple(
+            getattr(class_instance, attr)
+            for attr in class_instance.__class__.__cache_attrs__
+        )
+        return (ClassInstanceHashType.ATTR_ONLY, *attrs)
+
+    @staticmethod
+    def hash_function_spec(function_spec):
+        return (function_spec._input_spec, function_spec._dygraph_function)
+
     def __hash__(self):
         error_msg = "Arguments to a `@paddle.jit.to_static` must be a hashable Python objects (or nested structures of these types)."
         with_hook = self.kwargs.get("with_hook", False)
         is_train = self.kwargs.get("is_train", False)
         return hash(
             (
-                id(self.function_spec),
+                CacheKey.hash_function_spec(self.function_spec),
                 make_hashable(self.input_args_with_spec, error_msg),
                 make_hashable(self.input_kwargs_with_spec, error_msg),
                 self._spec_names_id,
-                self.class_instance,
+                CacheKey.hash_class_instance(self.class_instance),
                 with_hook,
                 is_train,
                 self._pir_flags,
@@ -404,7 +425,8 @@ class StaticFunction(Generic[_InputT, _RetT]):
 
         self._input_spec = input_spec
         self._function_spec = FunctionSpec(function, input_spec)
-        self._program_cache = ProgramCache()
+        # self._program_cache = ProgramCache()
+        self._program_cache = ProgramTranslator()._program_cache
         self._descriptor_cache = weakref.WeakKeyDictionary()
         # Note: Hold a reference to ProgramTranslator for switching `enable_to_static`.
         self._program_trans = ProgramTranslator()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

实验，支持通过 `__cache_attrs__` 声明只有部分属性需要作为 cache key

比如如下用法

```python
class BottleNeck(nn.Layer):
    __cache_attrs__ = ["a_channel", "s_channel"]

    def __init__(self, a_channel, s_channel):
        super(BottleNeck, self).__init__()
        self.a_channel = a_channel
        self.s_channel = s_channel
        self.adaln = AdaLN(a_channel, s_channel)
        self.ctb = ConditionedTransitionBlock(a_channel, s_channel)

    def forward(self, a, s):
        a += self.adaln(a, s)
        a += self.ctb(a, s)
        return a
```