### PR TITLE
[Inference]Remove scale when export pir model

### DIFF
--- a/test/legacy_test/test_cumsum_op.py
+++ b/test/legacy_test/test_cumsum_op.py
@@ -610,7 +610,6 @@ class TestTensorAxis(unittest.TestCase):
                 exe = paddle.static.Executor(self.place)
                 exe.run(startup_prog)
                 static_out = exe.run(feed={'x': np_x}, fetch_list=[out])
-
                 # run infer
                 paddle.static.save_inference_model(
                     self.save_path, [x], [out], exe, program=main_prog

--- a/test/legacy_test/test_cumsum_op.py
+++ b/test/legacy_test/test_cumsum_op.py
@@ -623,7 +623,7 @@ class TestTensorAxis(unittest.TestCase):
 
                 self.assertEqual(
                     len(load_program.global_block().ops),
-                    11,
+                    9,
                 )
                 print(load_program)
                 self.assertEqual(

--- a/test/legacy_test/test_save_inference_model_conditional_op.py
+++ b/test/legacy_test/test_save_inference_model_conditional_op.py
@@ -104,12 +104,12 @@ class TestConditionalOp(unittest.TestCase):
         paddle.enable_static()
         if paddle.framework.use_pir_api():
             program = GetPirModelOp(model_file + ".json")
-            self.assertEqual(program.global_block().ops[-4].name(), "pd_op.add")
+            self.assertEqual(program.global_block().ops[-2].name(), "pd_op.add")
             self.assertEqual(
-                program.global_block().ops[-5].result(1).shape, [1, 3, -1, -1]
+                program.global_block().ops[-3].result(1).shape, [1, 3, -1, -1]
             )
             self.assertEqual(
-                program.global_block().ops[-5].name(), "pd_op.while"
+                program.global_block().ops[-3].name(), "pd_op.while"
             )
         else:
             right_pdmodel = {
@@ -142,9 +142,9 @@ class TestConditionalOp(unittest.TestCase):
         paddle.enable_static()
         if paddle.framework.use_pir_api():
             program = GetPirModelOp(model_file + ".json")
-            self.assertEqual(program.global_block().ops[-4].name(), "pd_op.add")
+            self.assertEqual(program.global_block().ops[-2].name(), "pd_op.add")
             self.assertEqual(
-                program.global_block().ops[-5].name(), "pd_op.while"
+                program.global_block().ops[-3].name(), "pd_op.while"
             )
         else:
             right_pdmodel = {
@@ -185,8 +185,6 @@ class TestConditionalOp(unittest.TestCase):
                 "pd_op.cast",
                 "pd_op.greater_than",
                 "pd_op.if",
-                "pd_op.full",
-                "pd_op.scale",
                 "pd_op.fetch",
             ]
             i = 0

--- a/test/legacy_test/test_static_save_load.py
+++ b/test/legacy_test/test_static_save_load.py
@@ -1189,8 +1189,6 @@ class TestSaveLoadInferenceModel(unittest.TestCase):
                     [
                         'pd_op.data',
                         'pd_op.add',
-                        'pd_op.full',
-                        'pd_op.scale',
                         'pd_op.fetch',
                     ],
                 )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
card-71500
在导出pir模型的过程中，删除最后添加scale算子的操作