### PR TITLE
[CI] Remind re-run when auto_parallel CI exit -6

### DIFF
--- a/tools/auto_parallel/ci_auto_parallel.sh
+++ b/tools/auto_parallel/ci_auto_parallel.sh
@@ -65,8 +65,16 @@ case_list[${#case_list[*]}]=gpt-3_dygraph
 }
 
 print_info(){
-#解决异常退出-6的问题，CI中的偶现问题，无法发现
-if [[ $1 -ne 0 ]] && [[ $1 -ne 250 ]];then
+if [ $1 -eq 250 ];then
+    #解决异常退出-6的问题，CI中的偶现问题，无法复现
+    echo -e "\033[1;31m"
+    echo -e "\033[1;31m The CI execution encountered an abnormal termination with error code exit -6. \033[0m"
+    echo -e "\033[1;31m This is an intermittent issue. \033[0m"
+    echo -e "\033[1;31m Please re-run the CI. \033[0m"
+    echo -e "\033[1;31m"
+    exit 2
+fi
+if [[ $1 -ne 0 ]];then
     EXCODE=2
     if [ ! -f ${log_path}/$2 ];then
         echo -e "\033[31m run $2 CI FAIL \033"
@@ -77,7 +85,7 @@ if [[ $1 -ne 0 ]] && [[ $1 -ne 250 ]];then
     fi
     exit $EXCODE
 else
-    echo -e "\033[32m run $3 CI SUCCESS \033"
+    echo -e "\033[32m The $3 CI has completed \033"
 fi
 }
 

--- a/tools/auto_parallel/ci_auto_parallel.sh
+++ b/tools/auto_parallel/ci_auto_parallel.sh
@@ -71,23 +71,15 @@ case_list[${#case_list[*]}]=gpt-3_dygraph
 }
 
 print_info(){
-if [ $1 -eq 250 ];then
-    #解决异常退出-6的问题，CI中的偶现问题，无法复现
-    echo -e "\033[1;31m"
-    echo -e "\033[1;31m The CI execution encountered an abnormal termination with error code exit -6. \033[0m"
-    echo -e "\033[1;31m This is an intermittent issue. \033[0m"
-    echo -e "\033[1;31m Please re-run the CI. \033[0m"
-    echo -e "\033[1;31m"
-    exit 2
-fi
-if [[ $1 -ne 0 ]];then
+#解决异常退出-6的问题，CI中的偶现问题，无法发现
+if [[ $1 -ne 0 ]] && [[ $1 -ne 250 ]];then
     EXCODE=2
     if [ ! -f ${log_path}/$2 ];then
         echo -e "\033[31m run $2 CI FAIL \033"
-    else
-        mv ${log_path}/$2 ${log_path}/$2_FAIL.log
-        echo -e "\033[31m ${log_path}/$2_FAIL \033"
-        tail -70 ${log_path}/$2_FAIL.log
+else
+    mv ${log_path}/$2 ${log_path}/$2_FAIL.log
+    echo -e "\033[31m ${log_path}/$2_FAIL \033"
+    tail -70 ${log_path}/$2_FAIL.log
     fi
     exit $EXCODE
 else


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others


### Description
<!-- Describe what you’ve done -->

1. 自动并行 CI（`PR-CI-Auto-Parallel`）会出现随机的异常退出 `exit -6` 问题，这是 CI 中的偶然问题，无法复现
这会造成当前 case 后面的测试都不再执行，直接 case pass。这使得 CI 可能不能拦截到一些提交。
解决：当检测到测试 `exit -6` 时，自动 re-run 一次，如果 `exit -6` 复现，跳过该测试，使用`global_exit_250_arr`记录该测试名称，在CI结束后通过 log 提示用户，并不会造成 CI 失败

2. CI 统计 test 执行情况的`track_case_status` 函数存在运行失败 test 检测不到的 bug，有些 test 运行出错后并不会产生类似`func_name_FAIL.log`的日志文件，因此，在通过日志名字统计失败 test 的方法存在 bug。现在通过全局变量 在 `execute_func_list` 中记录每个 case 的执行结果，将每个失败测试名字通过数组记录，在 CI 结束的时候汇总输出

PCard-87521

