### PR TITLE
[CINN] Fix bug of unit loops in GetLoops

### DIFF
--- a/paddle/cinn/ir/ir_analyzer/ir_analyzer.cc
+++ b/paddle/cinn/ir/ir_analyzer/ir_analyzer.cc
@@ -93,9 +93,6 @@ std::vector<Expr> GetLoops(const std::vector<Expr>& exprs, const Expr& block) {
     }
   }
 
-  if (result.empty()) {
-    result.push_back(AddUnitLoop(exprs, block));
-  }
   return result;
 }
 

--- a/paddle/cinn/ir/schedule/ir_schedule_util.h
+++ b/paddle/cinn/ir/schedule/ir_schedule_util.h
@@ -1234,8 +1234,7 @@ struct FindLoopsVisitor {
       Visit(&(expr->As<ir::For>()->body));
       father_loops.pop_back();
     } else if (expr->As<ir::ScheduleBlockRealize>()) {
-      if (!expr->As<ir::ScheduleBlockRealize>()->iter_values.empty() &&
-          (*expr == block_)) {
+      if (*expr == block_) {
         result = father_loops;
         visit_end = true;
         return;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
Fix the bug that the `GetLoops` failed to match a given block (and even changed the schedule graph) when the loop's extend was 1.

Example:
```go
serial for (i, 0, 1) {
  serial for (j, 0, 1) {
    ScheduleBlock(var_1) {
      var_1[0] = var_0[0]
    }
  }
}
```

Pcard-85711