### PR TITLE
[XPU] fix c_concat op

### DIFF
--- a/paddle/fluid/distributed/collective/process_group_bkcl.cc
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.cc
@@ -622,6 +622,15 @@ std::shared_ptr<ProcessGroupBKCL> ProcessGroupBKCL::CreateProcessGroupBKCL(
   return process_group;
 }
 
+phi::distributed::BKCLCommContext* ProcessGroupBKCL::GetOrCreateCommContext(
+    const Place& place, CommType comm_type) {
+  const auto& key = GetKeyFromPlace(place);
+  if (place_to_comm_ctx_.find(key) == place_to_comm_ctx_.end()) {
+    CreateBKCLEnvCache(place, key);
+  }
+  return GetCommContext();
+}
+
 phi::distributed::BKCLCommContext* ProcessGroupBKCL::GetCommContext() {
   const auto& comm_context_manager =
       phi::distributed::CommContextManager::GetInstance();

--- a/paddle/fluid/distributed/collective/process_group_bkcl.h
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.h
@@ -154,6 +154,9 @@ class ProcessGroupBKCL : public ProcessGroupWithStream {
 
   BKCLContext_t BKCLComm(const Place& place) const;
 
+  phi::distributed::BKCLCommContext* GetOrCreateCommContext(
+      const Place& place, CommType comm_type = CommType::UNKNOWN);
+
  private:
   std::shared_ptr<ProcessGroupBKCL::BKCLTask> CreateTask(const Place& place,
                                                          int rank,

--- a/paddle/fluid/imperative/CMakeLists.txt
+++ b/paddle/fluid/imperative/CMakeLists.txt
@@ -20,7 +20,8 @@ if(WITH_XPU)
          data_transform
          phi
          common
-         var_helper)
+         var_helper
+         process_group_bkcl)
 elseif(WITH_NCCL OR WITH_RCCL)
   cc_library(
     prepared_operator


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
发现之前的某个PR https://github.com/PaddlePaddle/Paddle/pull/68610 修改了`c_concat`算子，包括XPU下的算子。但是在修改`paddle/fluid/imperative/prepared_operator.cc`文件的时候，只改了NCCL和RCCL的逻辑，没有改XPU的逻辑，导致XPU下的若干分布式单测跑不过。

本PR修复了此问题。感谢 @xiaocizhang 提供指导以及部分代码。

TODO(@houj04)：等腾出手来，完善分布式单测的执行机制，避免“被别人改坏”。