### PR TITLE
[Dy2St][3.13] Init AST node with all fields to avoid deprecated warning in Python3.13

### DIFF
--- a/python/paddle/utils/gast/astn.py
+++ b/python/paddle/utils/gast/astn.py
@@ -46,15 +46,16 @@ def _generate_translators(to):
                 return node
 
         def generic_visit(self, node):
-            cls = type(node).__name__
-            try:
-                new_node = getattr(to, cls)()
-            except AttributeError:
+            class_name = type(node).__name__
+            if not hasattr(to, class_name):
                 # handle nodes that are not part of the AST
                 return
-
-            for field in node._fields:
-                setattr(new_node, field, self._visit(getattr(node, field)))
+            cls = getattr(to, class_name)
+            init_fields = {
+                field: self._visit(getattr(node, field))
+                for field in node._fields
+            }
+            new_node = cls(**init_fields)
 
             for attr in node._attributes:
                 try:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

Python 3.13 下使用 AST 动转静会出现大量 DeprecatedWarning

```
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: FunctionDef.__init__ missing 1 required positional argument: 'args'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: FunctionDef.__init__ missing 1 required positional argument: 'name'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: ClassDef.__init__ missing 1 required positional argument: 'name'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Attribute.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Attribute.__init__ missing 1 required positional argument: 'attr'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Constant.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Call.__init__ missing 1 required positional argument: 'func'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: keyword.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: For.__init__ missing 1 required positional argument: 'target'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: For.__init__ missing 1 required positional argument: 'iter'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: BinOp.__init__ missing 1 required positional argument: 'right'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: BinOp.__init__ missing 1 required positional argument: 'op'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: BinOp.__init__ missing 1 required positional argument: 'left'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Subscript.__init__ missing 1 required positional argument: 'slice'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Subscript.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Compare.__init__ missing 1 required positional argument: 'left'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: AugAssign.__init__ missing 1 required positional argument: 'target'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: AugAssign.__init__ missing 1 required positional argument: 'op'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: AugAssign.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Expr.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
```

这是因为之前 gast 初始化 AST node 时候使用无参初始化，而这在未来的 Python 3.15 会直接报错

PCard-66972