### PR TITLE
[Infra] Add `3.13` to skip coverage check labels

### DIFF
--- a/tools/get_pr_title.py
+++ b/tools/get_pr_title.py
@@ -25,6 +25,7 @@ SKIP_COVERAGE_CHECKING_LABELS = [
     "typing",
     "codestyle",
     "fluid_ops",
+    "3.13",  # SOT Python 3.13 support
 ]
 
 SKIP_DISTRIBUTE_TEST_CHECKING_LABELS = [


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

Python 3.13 相关适配跳过覆盖率检查，根据 Python 3.12 开发经验，基本每个 PR 都需要豁免

PCard-66972