### PR TITLE
[PIR] refine ir_backward

### DIFF
--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -80,21 +80,24 @@ def append_full_like(float_value, copy_value, value, state, backward_ops):
             full_like_op = value_grad.get_defining_op()
             backward_ops_ = [full_like_op]
         elif copy_value.is_combine():
-            values = paddle._C_ops.builtin_split(copy_value)
-            value_grad = []
-            backward_ops_ = []
-            backward_ops_.append(values[0].get_defining_op())
-            for v in values:
-                grad = paddle.full_like(
-                    v,
-                    float_value,
-                    dtype=v.dtype,
-                )
-                value_grad.append(grad)
-                full_like_op = grad.get_defining_op()
-                full_op = full_like_op.operand_source(1).get_defining_op()
-                backward_ops_.append(full_like_op)
-                backward_ops_.append(full_op)
+            raise ValueError(
+                "This kind of scene, where VectorType grad be fulled with zeros should not occur."
+            )
+            # values = paddle._C_ops.builtin_split(copy_value)
+            # value_grad = []
+            # backward_ops_ = []
+            # backward_ops_.append(values[0].get_defining_op())
+            # for v in values:
+            #     grad = paddle.full_like(
+            #         v,
+            #         float_value,
+            #         dtype=v.dtype,
+            #     )
+            #     value_grad.append(grad)
+            #     full_like_op = grad.get_defining_op()
+            #     full_op = full_like_op.operand_source(1).get_defining_op()
+            #     backward_ops_.append(full_like_op)
+            #     backward_ops_.append(full_op)
         else:
             value_grad = paddle.full_like(
                 copy_value,
@@ -247,6 +250,8 @@ def prepare_grad_outputs(grad_outputs, outputs, state):
         if output in visited_output:
             continue
         for opresult in output.get_defining_op().results():
+            if opresult.is_combine():
+                continue
             if opresult in state.value_to_valuegrad:
                 visited_output.add(opresult)
                 continue


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

![183746084abc481e48e44d8a5ba955e](https://github.com/user-attachments/assets/1e5f18d9-fa3b-42df-9ed6-679689849114)

对于上图场景中的state，不在prepare_grad_outputs时，为state做补0动作。在rnn_grad时会完成正确的梯度的传递。传递方式是添加combine op。

Pcard-67164