### PR TITLE
[Inference] fused_flash_attn_pass support mixed precision

### DIFF
--- a/paddle/fluid/pir/transforms/gpu/fused_flash_attn_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_flash_attn_pass.cc
@@ -29,10 +29,13 @@ namespace {
 class FlashAttnPatternQscaleWithMask : public paddle::drr::DrrPatternBase {
  private:
   bool softmax_with_cast_;
+  bool enable_gpu_mixed_;
 
  public:
-  explicit FlashAttnPatternQscaleWithMask(bool softmax_with_cast)
-      : softmax_with_cast_(softmax_with_cast) {}
+  explicit FlashAttnPatternQscaleWithMask(bool softmax_with_cast,
+                                          bool enable_gpu_mixed)
+      : softmax_with_cast_(softmax_with_cast),
+        enable_gpu_mixed_(enable_gpu_mixed) {}
 
   std::string name() const override { return "FlashAttnPatternQscaleWithMask"; }
 
@@ -99,53 +102,54 @@ class FlashAttnPatternQscaleWithMask : public paddle::drr::DrrPatternBase {
     src.Tensor("out") = o_transpose(src.Tensor("context_matmul_out"));
 
     // Constraints
-    src.AddConstraint([](const paddle::drr::MatchContext &match_ctx) -> bool {
-      auto q_dtype = pir::GetDataTypeFromValue(match_ctx.Tensor("q"));
-      if (!q_dtype.isa<pir::Float16Type>() &&
-          !q_dtype.isa<pir::BFloat16Type>()) {
-        return false;
-      }
-      // softmax
-      const auto &softmax_axis = match_ctx.Attr<int>("softmax_axis");
-      if (softmax_axis != -1 && softmax_axis != 3) return false;
-      // matmul transpose
-      bool matmul_qk_transpose_x =
-          match_ctx.Attr<bool>("matmul_qk_transpose_x");
-      bool matmul_qk_transpose_y =
-          match_ctx.Attr<bool>("matmul_qk_transpose_y");
-      if (matmul_qk_transpose_x || matmul_qk_transpose_y) return false;
+    src.AddConstraint(
+        [this](const paddle::drr::MatchContext &match_ctx) -> bool {
+          auto q_dtype = pir::GetDataTypeFromValue(match_ctx.Tensor("q"));
+          if (!this->enable_gpu_mixed_ && !q_dtype.isa<pir::Float16Type>() &&
+              !q_dtype.isa<pir::BFloat16Type>()) {
+            return false;
+          }
+          // softmax
+          const auto &softmax_axis = match_ctx.Attr<int>("softmax_axis");
+          if (softmax_axis != -1 && softmax_axis != 3) return false;
+          // matmul transpose
+          bool matmul_qk_transpose_x =
+              match_ctx.Attr<bool>("matmul_qk_transpose_x");
+          bool matmul_qk_transpose_y =
+              match_ctx.Attr<bool>("matmul_qk_transpose_y");
+          if (matmul_qk_transpose_x || matmul_qk_transpose_y) return false;
 
-      bool matmul_o_transpose_x =
-          match_ctx.Attr<bool>("context_matmul_transpose_x");
-      bool matmul_o_transpose_y =
-          match_ctx.Attr<bool>("context_matmul_transpose_y");
-      if (matmul_o_transpose_x || matmul_o_transpose_y) return false;
-      // tensor shape
-      auto q_transpose_out =
-          pir::GetShapeFromValue(match_ctx.Tensor("q_transpose_out"));
-      auto k_transpose_out =
-          pir::GetShapeFromValue(match_ctx.Tensor("k_transpose_out"));
-      auto v_transpose_out =
-          pir::GetShapeFromValue(match_ctx.Tensor("v_transpose_out"));
-      if (q_transpose_out.size() != 4 || k_transpose_out.size() != 4 ||
-          v_transpose_out.size() != 4 ||
-          !(q_transpose_out.at(0) == k_transpose_out.at(0) &&
-            k_transpose_out.at(0) == v_transpose_out.at(0)) ||
-          !(q_transpose_out.at(1) == k_transpose_out.at(1) &&
-            k_transpose_out.at(1) == v_transpose_out.at(1)) ||
-          !(q_transpose_out.at(3) == k_transpose_out.at(3) &&
-            k_transpose_out.at(3) == v_transpose_out.at(3))) {
-        return false;
-      }
-      // mask's shape [bs, 1, seq_len, seq_len]
-      auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
-      if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
-          mask_add.at(0) != q_transpose_out.at(0)) {
-        return false;
-      }
+          bool matmul_o_transpose_x =
+              match_ctx.Attr<bool>("context_matmul_transpose_x");
+          bool matmul_o_transpose_y =
+              match_ctx.Attr<bool>("context_matmul_transpose_y");
+          if (matmul_o_transpose_x || matmul_o_transpose_y) return false;
+          // tensor shape
+          auto q_transpose_out =
+              pir::GetShapeFromValue(match_ctx.Tensor("q_transpose_out"));
+          auto k_transpose_out =
+              pir::GetShapeFromValue(match_ctx.Tensor("k_transpose_out"));
+          auto v_transpose_out =
+              pir::GetShapeFromValue(match_ctx.Tensor("v_transpose_out"));
+          if (q_transpose_out.size() != 4 || k_transpose_out.size() != 4 ||
+              v_transpose_out.size() != 4 ||
+              !(q_transpose_out.at(0) == k_transpose_out.at(0) &&
+                k_transpose_out.at(0) == v_transpose_out.at(0)) ||
+              !(q_transpose_out.at(1) == k_transpose_out.at(1) &&
+                k_transpose_out.at(1) == v_transpose_out.at(1)) ||
+              !(q_transpose_out.at(3) == k_transpose_out.at(3) &&
+                k_transpose_out.at(3) == v_transpose_out.at(3))) {
+            return false;
+          }
+          // mask's shape [bs, 1, seq_len, seq_len]
+          auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
+          if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
+              mask_add.at(0) != q_transpose_out.at(0)) {
+            return false;
+          }
 
-      return true;
-    });
+          return true;
+        });
 
     //
     // Result Pattern.
@@ -175,10 +179,13 @@ class FlashAttnPatternQscaleWithMask : public paddle::drr::DrrPatternBase {
 class FlashAttnPatternOutscaleWithMask : public paddle::drr::DrrPatternBase {
  private:
   bool softmax_with_cast_;
+  bool enable_gpu_mixed_;
 
  public:
-  explicit FlashAttnPatternOutscaleWithMask(bool softmax_with_cast)
-      : softmax_with_cast_(softmax_with_cast) {}
+  explicit FlashAttnPatternOutscaleWithMask(bool softmax_with_cast,
+                                            bool enable_gpu_mixed)
+      : softmax_with_cast_(softmax_with_cast),
+        enable_gpu_mixed_(enable_gpu_mixed) {}
 
  public:
   std::string name() const override {
@@ -246,53 +253,54 @@ class FlashAttnPatternOutscaleWithMask : public paddle::drr::DrrPatternBase {
     src.Tensor("out") = o_transpose(src.Tensor("context_matmul_out"));
 
     // Constraints
-    src.AddConstraint([](const paddle::drr::MatchContext &match_ctx) -> bool {
-      auto q_dtype = pir::GetDataTypeFromValue(match_ctx.Tensor("q"));
-      if (!q_dtype.isa<pir::Float16Type>() &&
-          !q_dtype.isa<pir::BFloat16Type>()) {
-        return false;
-      }
-      // softmax
-      const auto &softmax_axis = match_ctx.Attr<int>("softmax_axis");
-      if (softmax_axis != -1 && softmax_axis != 3) return false;
-      // matmul transpose
-      bool matmul_qk_transpose_x =
-          match_ctx.Attr<bool>("matmul_qk_transpose_x");
-      bool matmul_qk_transpose_y =
-          match_ctx.Attr<bool>("matmul_qk_transpose_y");
-      if (matmul_qk_transpose_x || matmul_qk_transpose_y) return false;
+    src.AddConstraint(
+        [this](const paddle::drr::MatchContext &match_ctx) -> bool {
+          auto q_dtype = pir::GetDataTypeFromValue(match_ctx.Tensor("q"));
+          if (!this->enable_gpu_mixed_ && !q_dtype.isa<pir::Float16Type>() &&
+              !q_dtype.isa<pir::BFloat16Type>()) {
+            return false;
+          }
+          // softmax
+          const auto &softmax_axis = match_ctx.Attr<int>("softmax_axis");
+          if (softmax_axis != -1 && softmax_axis != 3) return false;
+          // matmul transpose
+          bool matmul_qk_transpose_x =
+              match_ctx.Attr<bool>("matmul_qk_transpose_x");
+          bool matmul_qk_transpose_y =
+              match_ctx.Attr<bool>("matmul_qk_transpose_y");
+          if (matmul_qk_transpose_x || matmul_qk_transpose_y) return false;
 
-      bool matmul_o_transpose_x =
-          match_ctx.Attr<bool>("context_matmul_transpose_x");
-      bool matmul_o_transpose_y =
-          match_ctx.Attr<bool>("context_matmul_transpose_y");
-      if (matmul_o_transpose_x || matmul_o_transpose_y) return false;
-      // tensor shape
-      auto q_transpose_out =
-          pir::GetShapeFromValue(match_ctx.Tensor("q_transpose_out"));
-      auto k_transpose_out =
-          pir::GetShapeFromValue(match_ctx.Tensor("k_transpose_out"));
-      auto v_transpose_out =
-          pir::GetShapeFromValue(match_ctx.Tensor("v_transpose_out"));
-      if (q_transpose_out.size() != 4 || k_transpose_out.size() != 4 ||
-          v_transpose_out.size() != 4 ||
-          !(q_transpose_out.at(0) == k_transpose_out.at(0) &&
-            k_transpose_out.at(0) == v_transpose_out.at(0)) ||
-          !(q_transpose_out.at(1) == k_transpose_out.at(1) &&
-            k_transpose_out.at(1) == v_transpose_out.at(1)) ||
-          !(q_transpose_out.at(3) == k_transpose_out.at(3) &&
-            k_transpose_out.at(3) == v_transpose_out.at(3))) {
-        return false;
-      }
-      // mask's shape [bs, 1, seq_len, seq_len]
-      auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
-      if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
-          mask_add.at(0) != q_transpose_out.at(0)) {
-        return false;
-      }
+          bool matmul_o_transpose_x =
+              match_ctx.Attr<bool>("context_matmul_transpose_x");
+          bool matmul_o_transpose_y =
+              match_ctx.Attr<bool>("context_matmul_transpose_y");
+          if (matmul_o_transpose_x || matmul_o_transpose_y) return false;
+          // tensor shape
+          auto q_transpose_out =
+              pir::GetShapeFromValue(match_ctx.Tensor("q_transpose_out"));
+          auto k_transpose_out =
+              pir::GetShapeFromValue(match_ctx.Tensor("k_transpose_out"));
+          auto v_transpose_out =
+              pir::GetShapeFromValue(match_ctx.Tensor("v_transpose_out"));
+          if (q_transpose_out.size() != 4 || k_transpose_out.size() != 4 ||
+              v_transpose_out.size() != 4 ||
+              !(q_transpose_out.at(0) == k_transpose_out.at(0) &&
+                k_transpose_out.at(0) == v_transpose_out.at(0)) ||
+              !(q_transpose_out.at(1) == k_transpose_out.at(1) &&
+                k_transpose_out.at(1) == v_transpose_out.at(1)) ||
+              !(q_transpose_out.at(3) == k_transpose_out.at(3) &&
+                k_transpose_out.at(3) == v_transpose_out.at(3))) {
+            return false;
+          }
+          // mask's shape [bs, 1, seq_len, seq_len]
+          auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
+          if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
+              mask_add.at(0) != q_transpose_out.at(0)) {
+            return false;
+          }
 
-      return true;
-    });
+          return true;
+        });
 
     //
     // Result Pattern.
@@ -322,10 +330,13 @@ class FlashAttnPatternOutscaleWithMask : public paddle::drr::DrrPatternBase {
 class FlashAttnPatternOutscaleNoMask : public paddle::drr::DrrPatternBase {
  private:
   bool softmax_with_cast_;
+  bool enable_gpu_mixed_;
 
  public:
-  explicit FlashAttnPatternOutscaleNoMask(bool softmax_with_cast)
-      : softmax_with_cast_(softmax_with_cast) {}
+  explicit FlashAttnPatternOutscaleNoMask(bool softmax_with_cast,
+                                          bool enable_gpu_mixed)
+      : softmax_with_cast_(softmax_with_cast),
+        enable_gpu_mixed_(enable_gpu_mixed) {}
 
  public:
   std::string name() const override { return "FlashAttnPatternOutscaleNoMask"; }
@@ -382,47 +393,48 @@ class FlashAttnPatternOutscaleNoMask : public paddle::drr::DrrPatternBase {
     src.Tensor("out") = o_transpose(src.Tensor("context_matmul_out"));
 
     // Constraints
-    src.AddConstraint([](const paddle::drr::MatchContext &match_ctx) -> bool {
-      auto q_dtype = pir::GetDataTypeFromValue(match_ctx.Tensor("q"));
-      if (!q_dtype.isa<pir::Float16Type>() &&
-          !q_dtype.isa<pir::BFloat16Type>()) {
-        return false;
-      }
-      // softmax
-      const auto &softmax_axis = match_ctx.Attr<int>("softmax_axis");
-      if (softmax_axis != -1 && softmax_axis != 3) return false;
-      // matmul transpose
-      bool matmul_qk_transpose_x =
-          match_ctx.Attr<bool>("matmul_qk_transpose_x");
-      bool matmul_qk_transpose_y =
-          match_ctx.Attr<bool>("matmul_qk_transpose_y");
-      if (matmul_qk_transpose_x || !matmul_qk_transpose_y) return false;
+    src.AddConstraint(
+        [this](const paddle::drr::MatchContext &match_ctx) -> bool {
+          auto q_dtype = pir::GetDataTypeFromValue(match_ctx.Tensor("q"));
+          if (!this->enable_gpu_mixed_ && !q_dtype.isa<pir::Float16Type>() &&
+              !q_dtype.isa<pir::BFloat16Type>()) {
+            return false;
+          }
+          // softmax
+          const auto &softmax_axis = match_ctx.Attr<int>("softmax_axis");
+          if (softmax_axis != -1 && softmax_axis != 3) return false;
+          // matmul transpose
+          bool matmul_qk_transpose_x =
+              match_ctx.Attr<bool>("matmul_qk_transpose_x");
+          bool matmul_qk_transpose_y =
+              match_ctx.Attr<bool>("matmul_qk_transpose_y");
+          if (matmul_qk_transpose_x || !matmul_qk_transpose_y) return false;
 
-      bool matmul_o_transpose_x =
-          match_ctx.Attr<bool>("context_matmul_transpose_x");
-      bool matmul_o_transpose_y =
-          match_ctx.Attr<bool>("context_matmul_transpose_y");
-      if (matmul_o_transpose_x || matmul_o_transpose_y) return false;
-      // tensor shape
-      auto q_transpose_out =
-          pir::GetShapeFromValue(match_ctx.Tensor("q_transpose_out"));
-      auto k_transpose_out =
-          pir::GetShapeFromValue(match_ctx.Tensor("k_transpose_out"));
-      auto v_transpose_out =
-          pir::GetShapeFromValue(match_ctx.Tensor("v_transpose_out"));
-      if (q_transpose_out.size() != 4 || k_transpose_out.size() != 4 ||
-          v_transpose_out.size() != 4 ||
-          !(q_transpose_out.at(0) == k_transpose_out.at(0) &&
-            k_transpose_out.at(0) == v_transpose_out.at(0)) ||
-          !(q_transpose_out.at(1) == k_transpose_out.at(1) &&
-            k_transpose_out.at(1) == v_transpose_out.at(1)) ||
-          !(q_transpose_out.at(3) == k_transpose_out.at(3) &&
-            k_transpose_out.at(3) == v_transpose_out.at(3))) {
-        return false;
-      }
+          bool matmul_o_transpose_x =
+              match_ctx.Attr<bool>("context_matmul_transpose_x");
+          bool matmul_o_transpose_y =
+              match_ctx.Attr<bool>("context_matmul_transpose_y");
+          if (matmul_o_transpose_x || matmul_o_transpose_y) return false;
+          // tensor shape
+          auto q_transpose_out =
+              pir::GetShapeFromValue(match_ctx.Tensor("q_transpose_out"));
+          auto k_transpose_out =
+              pir::GetShapeFromValue(match_ctx.Tensor("k_transpose_out"));
+          auto v_transpose_out =
+              pir::GetShapeFromValue(match_ctx.Tensor("v_transpose_out"));
+          if (q_transpose_out.size() != 4 || k_transpose_out.size() != 4 ||
+              v_transpose_out.size() != 4 ||
+              !(q_transpose_out.at(0) == k_transpose_out.at(0) &&
+                k_transpose_out.at(0) == v_transpose_out.at(0)) ||
+              !(q_transpose_out.at(1) == k_transpose_out.at(1) &&
+                k_transpose_out.at(1) == v_transpose_out.at(1)) ||
+              !(q_transpose_out.at(3) == k_transpose_out.at(3) &&
+                k_transpose_out.at(3) == v_transpose_out.at(3))) {
+            return false;
+          }
 
-      return true;
-    });
+          return true;
+        });
 
     //
     // Result Pattern.
@@ -448,7 +460,13 @@ class FlashAttnPatternOutscaleNoMask : public paddle::drr::DrrPatternBase {
 
 // slice qkv
 class TransposeSliceFlashAttnPattern : public paddle::drr::DrrPatternBase {
+ private:
+  bool enable_gpu_mixed_;
+
  public:
+  explicit TransposeSliceFlashAttnPattern(bool enable_gpu_mixed)
+      : enable_gpu_mixed_(enable_gpu_mixed) {}
+
   std::string name() const override { return "TransposeSliceFlashAttnPattern"; }
 
   void operator()(paddle::drr::DrrPatternContext *ctx) const override {
@@ -526,46 +544,47 @@ class TransposeSliceFlashAttnPattern : public paddle::drr::DrrPatternBase {
     src.Tensor("out") = o_transpose(src.Tensor("context_matmul_out"));
 
     // Constraints
-    src.AddConstraint([](const paddle::drr::MatchContext &match_ctx) -> bool {
-      auto q_dtype = pir::GetDataTypeFromValue(match_ctx.Tensor("q"));
-      if (!q_dtype.isa<pir::Float16Type>() &&
-          !q_dtype.isa<pir::BFloat16Type>()) {
-        return false;
-      }
-      // softmax
-      const auto &softmax_axis = match_ctx.Attr<int>("softmax_axis");
-      if (softmax_axis != -1 && softmax_axis != 3) return false;
-      // matmul transpose
-      bool matmul_qk_transpose_x =
-          match_ctx.Attr<bool>("matmul_qk_transpose_x");
-      bool matmul_qk_transpose_y =
-          match_ctx.Attr<bool>("matmul_qk_transpose_y");
-      if (matmul_qk_transpose_x || matmul_qk_transpose_y) return false;
+    src.AddConstraint(
+        [this](const paddle::drr::MatchContext &match_ctx) -> bool {
+          auto q_dtype = pir::GetDataTypeFromValue(match_ctx.Tensor("q"));
+          if (!this->enable_gpu_mixed_ && !q_dtype.isa<pir::Float16Type>() &&
+              !q_dtype.isa<pir::BFloat16Type>()) {
+            return false;
+          }
+          // softmax
+          const auto &softmax_axis = match_ctx.Attr<int>("softmax_axis");
+          if (softmax_axis != -1 && softmax_axis != 3) return false;
+          // matmul transpose
+          bool matmul_qk_transpose_x =
+              match_ctx.Attr<bool>("matmul_qk_transpose_x");
+          bool matmul_qk_transpose_y =
+              match_ctx.Attr<bool>("matmul_qk_transpose_y");
+          if (matmul_qk_transpose_x || matmul_qk_transpose_y) return false;
 
-      bool matmul_o_transpose_x =
-          match_ctx.Attr<bool>("context_matmul_transpose_x");
-      bool matmul_o_transpose_y =
-          match_ctx.Attr<bool>("context_matmul_transpose_y");
-      if (matmul_o_transpose_x || matmul_o_transpose_y) return false;
-      // tensor shape
-      auto q = pir::GetShapeFromValue(match_ctx.Tensor("q"));
-      auto k = pir::GetShapeFromValue(match_ctx.Tensor("k"));
-      auto v = pir::GetShapeFromValue(match_ctx.Tensor("v"));
-      if (q.size() != 4 || k.size() != 4 || v.size() != 4 ||
-          !(q.at(0) == k.at(0) && k.at(0) == v.at(0)) ||
-          !(q.at(1) == k.at(1) && k.at(1) == v.at(1)) ||
-          !(q.at(3) == k.at(3) && k.at(3) == v.at(3))) {
-        return false;
-      }
-      // mask's shape [bs, 1, seq_len, seq_len]
-      auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
-      if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
-          mask_add.at(0) != q.at(0)) {
-        return false;
-      }
+          bool matmul_o_transpose_x =
+              match_ctx.Attr<bool>("context_matmul_transpose_x");
+          bool matmul_o_transpose_y =
+              match_ctx.Attr<bool>("context_matmul_transpose_y");
+          if (matmul_o_transpose_x || matmul_o_transpose_y) return false;
+          // tensor shape
+          auto q = pir::GetShapeFromValue(match_ctx.Tensor("q"));
+          auto k = pir::GetShapeFromValue(match_ctx.Tensor("k"));
+          auto v = pir::GetShapeFromValue(match_ctx.Tensor("v"));
+          if (q.size() != 4 || k.size() != 4 || v.size() != 4 ||
+              !(q.at(0) == k.at(0) && k.at(0) == v.at(0)) ||
+              !(q.at(1) == k.at(1) && k.at(1) == v.at(1)) ||
+              !(q.at(3) == k.at(3) && k.at(3) == v.at(3))) {
+            return false;
+          }
+          // mask's shape [bs, 1, seq_len, seq_len]
+          auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
+          if (mask_add.size() != 4 || mask_add.at(1) != 1 ||
+              mask_add.at(0) != q.at(0)) {
+            return false;
+          }
 
-      return true;
-    });
+          return true;
+        });
 
     //
     // Result Pattern.
@@ -606,15 +625,27 @@ class FusedFlashAttnPass : public pir::PatternRewritePass {
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
-    ps.Add(paddle::drr::Create<FlashAttnPatternQscaleWithMask>(context, true));
-    ps.Add(paddle::drr::Create<FlashAttnPatternQscaleWithMask>(context, false));
-    ps.Add(
-        paddle::drr::Create<FlashAttnPatternOutscaleWithMask>(context, true));
-    ps.Add(
-        paddle::drr::Create<FlashAttnPatternOutscaleWithMask>(context, false));
-    ps.Add(paddle::drr::Create<FlashAttnPatternOutscaleNoMask>(context, true));
-    ps.Add(paddle::drr::Create<FlashAttnPatternOutscaleNoMask>(context, false));
-    ps.Add(paddle::drr::Create<TransposeSliceFlashAttnPattern>(context));
+    bool enable_gpu_mixed = false;
+    if (Has("enable_gpu_mixed")) {
+      enable_gpu_mixed = Get<bool>("enable_gpu_mixed");
+    }
+
+    LOG(INFO) << "liuyuanle: " << enable_gpu_mixed;
+
+    ps.Add(paddle::drr::Create<FlashAttnPatternQscaleWithMask>(
+        context, true, enable_gpu_mixed));
+    ps.Add(paddle::drr::Create<FlashAttnPatternQscaleWithMask>(
+        context, false, enable_gpu_mixed));
+    ps.Add(paddle::drr::Create<FlashAttnPatternOutscaleWithMask>(
+        context, true, enable_gpu_mixed));
+    ps.Add(paddle::drr::Create<FlashAttnPatternOutscaleWithMask>(
+        context, false, enable_gpu_mixed));
+    ps.Add(paddle::drr::Create<FlashAttnPatternOutscaleNoMask>(
+        context, true, enable_gpu_mixed));
+    ps.Add(paddle::drr::Create<FlashAttnPatternOutscaleNoMask>(
+        context, false, enable_gpu_mixed));
+    ps.Add(paddle::drr::Create<TransposeSliceFlashAttnPattern>(
+        context, enable_gpu_mixed));
     return ps;
   }
 

--- a/paddle/fluid/pir/transforms/gpu/fused_flash_attn_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_flash_attn_pass.cc
@@ -630,8 +630,6 @@ class FusedFlashAttnPass : public pir::PatternRewritePass {
       enable_gpu_mixed = Get<bool>("enable_gpu_mixed");
     }
 
-    LOG(INFO) << "liuyuanle: " << enable_gpu_mixed;
-
     ps.Add(paddle::drr::Create<FlashAttnPatternQscaleWithMask>(
         context, true, enable_gpu_mixed));
     ps.Add(paddle::drr::Create<FlashAttnPatternQscaleWithMask>(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-71500

修复 https://github.com/PaddlePaddle/Paddle/pull/69011 导致的SD模型性能退化问题。