### PR TITLE
[SOT][3.13] Use `instr.line_number` instead of `instr.starts_line` in Python 3.13

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -84,7 +84,7 @@ def convert_instruction(instr: dis.Instruction) -> Instruction:
         instr.arg,
         instr.argval,
         instr.offset,
-        instr.starts_line,
+        instr.line_number if sys.version_info >= (3, 13) else instr.starts_line,
         instr.is_jump_target,
         jump_to=None,
         is_generated=False,

--- a/python/paddle/static/nn/control_flow.py
+++ b/python/paddle/static/nn/control_flow.py
@@ -681,7 +681,7 @@ def assign_skip_lod_tensor_array(input, output):
 
 
 def create_fake_value_for_undefined_var(while_op, value):
-    # Create a fake value for create WhileOp, it's type will be reset after body is executed.
+    # Create a fake value for create WhileOp, and set its type and stop_gradient as next_var
     stop_gradient = value.stop_gradient
     fake_value = paddle.full(shape=value.shape, dtype=value.dtype, fill_value=0)
     fake_value_op = fake_value.get_defining_op()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

3.13 下使用 `instr.line_number` 而不是 `instr.starts_line`，可以查看相关变动 https://docs.python.org/3/library/dis.html#dis.Instruction

PCard-66972