### PR TITLE
[Paddle TensorRT No.9-10] Add `pd_op.(argmin,argsort)` converter

### DIFF
--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -1755,6 +1755,7 @@ class TrtOpMarkerPass : public pir::PatternRewritePass {
     ps.Add(std::make_unique<MulticlassNms3OpPattern>(context));
     ps.Add(std::make_unique<ArgmaxOpPattern>(context));
     ps.Add(std::make_unique<ArgminOpPattern>(context));
+    ps.Add(std::make_unique<ArgsortOpPattern>(context));
     ps.Add(std::make_unique<MaxOpPattern>(context));
     ps.Add(std::make_unique<MinOpPattern>(context));
     ps.Add(std::make_unique<AllOpPattern>(context));

--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -1311,10 +1311,9 @@ class ArgsortOpPattern
     if (axis < 0) {
       axis += x_shape.size();
     }
-    if (x_shape[axis] > 3840 || x_shape[axis] < 0) {
+    if (x_shape[axis] > 3840) {
       VLOG(3) << "In pd_op.argsort,the axis dim of input should be less than "
-                 "3840 and greater "
-                 "than 0 in Tensorrt";
+                 "3840";
       return false;
     }
     op->set_attribute(kCanRunTrtAttr, rewriter.bool_attr(true));

--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -1305,7 +1305,7 @@ class ArgsortOpPattern
       }
     }
     pir::Value x = op.x();
-    auto x_type = pir::GetDataTypeFromValue(x);
+    auto x_type = x.type().dyn_cast<paddle::dialect::DenseTensorType>();
     auto x_shape = x_type.dims();
     int axis = op->attribute<pir::Int32Attribute>("axis").data();
     if (axis < 0) {

--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -1233,8 +1233,7 @@ class ArgmaxOpPattern
     if (axis == 0 || flatten ||
         (dtype != phi::DataType::INT32 && dtype != phi::DataType::INT64)) {
       VLOG(3) << "Skipping TRT conversion in pd_op.argmax: axis is zero, "
-                 "flatten is True, or "
-                 "dtype isn't int32/int64";
+                 "flatten is True, or dtype isn't int32/int64";
       return false;
     }
     op->set_attribute(kCanRunTrtAttr, rewriter.bool_attr(true));
@@ -1277,8 +1276,7 @@ class ArgminOpPattern
     if (axis == 0 || flatten ||
         (dtype != phi::DataType::INT32 && dtype != phi::DataType::INT64)) {
       VLOG(3) << "Skipping TRT conversion in pd_op.argmin: axis is zero, "
-                 "flatten is True, or "
-                 "dtype isn't int32/int64";
+                 "flatten is True, or dtype isn't int32/int64";
       return false;
     }
 
@@ -1312,8 +1310,8 @@ class ArgsortOpPattern
       axis += x_shape.size();
     }
     if (x_shape[axis] > 3840) {
-      VLOG(3) << "In pd_op.argsort,the axis dim of input should be less than "
-                 "3840";
+      VLOG(3)
+          << "In pd_op.argsort,the axis dim of input should be less than 3840";
       return false;
     }
     op->set_attribute(kCanRunTrtAttr, rewriter.bool_attr(true));

--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -1276,7 +1276,7 @@ class ArgminOpPattern
   }
 };
 
-class ArgsortPattern
+class ArgsortOpPattern
     : public pir::OpRewritePattern<paddle::dialect::ArgsortOp> {
  public:
   using pir::OpRewritePattern<paddle::dialect::ArgsortOp>::OpRewritePattern;

--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -1234,7 +1234,7 @@ class ArgmaxOpPattern
         (dtype != phi::DataType::INT32 && dtype != phi::DataType::INT64)) {
       VLOG(3) << "Skipping TRT conversion in pd_op.argmax: axis is zero, "
                  "flatten is True, or "
-                 "dtype is int32/int64";
+                 "dtype isn't int32/int64";
       return false;
     }
     op->set_attribute(kCanRunTrtAttr, rewriter.bool_attr(true));
@@ -1278,7 +1278,7 @@ class ArgminOpPattern
         (dtype != phi::DataType::INT32 && dtype != phi::DataType::INT64)) {
       VLOG(3) << "Skipping TRT conversion in pd_op.argmin: axis is zero, "
                  "flatten is True, or "
-                 "dtype is int32/int64";
+                 "dtype isn't int32/int64";
       return false;
     }
 

--- a/python/paddle/tensorrt/impls/search.py
+++ b/python/paddle/tensorrt/impls/search.py
@@ -118,7 +118,7 @@ def argsort_converter(network, paddle_op, inputs):
     if in_rank == 1:
         unsqueeze_shape = trt.Dims([1, -1])
         input_tensor = trt_reshape(
-            network, input_tensor, unsqueeze_shape, is_shape_tensor=True
+            network, input_tensor, unsqueeze_shape, is_shape_tensor=False
         )
         axis = 1
     if need_cast:
@@ -131,9 +131,9 @@ def argsort_converter(network, paddle_op, inputs):
     indices = topk_layer.get_output(1)
     if in_rank == 1:
         squeeze_shape = trt.Dims([-1])
-        out = trt_reshape(network, out, squeeze_shape, is_shape_tensor=True)
+        out = trt_reshape(network, out, squeeze_shape, is_shape_tensor=False)
         indices = trt_reshape(
-            network, indices, squeeze_shape, is_shape_tensor=True
+            network, indices, squeeze_shape, is_shape_tensor=False
         )
     out_tensor = trt_cast(network, out, in_type)
     indices_tensor = trt_cast(network, indices, indices.dtype)

--- a/python/paddle/tensorrt/impls/search.py
+++ b/python/paddle/tensorrt/impls/search.py
@@ -128,7 +128,7 @@ def argsort_converter(network, paddle_op, inputs):
     k_tensor = get_shape_tensor_element(network, shape, axis, True)
     topk_layer.set_input(1, k_tensor)
     out = topk_layer.get_output(0)
-    indices = topk_layer.get_ouput(1)
+    indices = topk_layer.get_output(1)
     if in_rank == 1:
         squeeze_shape = trt.Dims([-1])
         out = trt_reshape(network, out, squeeze_shape, is_shape_tensor=True)

--- a/python/paddle/tensorrt/impls/search.py
+++ b/python/paddle/tensorrt/impls/search.py
@@ -66,6 +66,56 @@ def argmax_converter(network, paddle_op, inputs):
         return squeeze_layer.get_output(0)
 
 
+@converter_registry.register("pd_op.argmin", trt_version="8.x")
+def argmin_converter(network, paddle_op, inputs):
+    x = inputs[0]
+    input_dims = x.shape
+    rank = len(input_dims)
+    axis = int(
+        paddle_op.operands()[1]
+        .source()
+        .get_defining_op()
+        .attrs()
+        .get("value", -1)
+    )
+    keepdims = paddle_op.attrs()["keepdims"]
+
+    if axis < 0:
+        axis += rank
+
+    topk_layer = network.add_topk(
+        input=x, op=trt.TopKOperation.Min, k=1, axes=(1 << axis)
+    )
+
+    if keepdims:
+        return topk_layer.get_output(1)
+    else:
+        squeeze_layer = network.add_shuffle(topk_layer.get_output(1))
+        output_dims = []
+        for i in range(len(input_dims)):
+            if i == axis:
+                continue
+            output_dims.append(input_dims[i])
+        squeeze_layer.reshape_dims = tuple(output_dims)
+        return squeeze_layer.get_output(0)
+
+
+@converter_registry.register("pd_op.argsort", trt_version="8.x")
+def argsort_converter(network, paddle_op, inputs):
+    input_tensor = inputs[0]
+    input_shape = input_tensor.shape
+    # The following two attributes is judged in Marker Pass.
+    # Default value maybe redundant.
+    axis = paddle_op.attrs().get("axis", -1)
+    descending = paddle_op.attrs().get("descending", False)
+    if axis < 0:
+        axis += len(input_shape)
+    topk_op = trt.TopKOperation.MAX if descending else trt.TopKOperation.MIN
+    k = input_shape[axis]
+    topk_layer = network.add_topk(input_tensor, topk_op, k, 1 << axis)
+    return topk_layer.get_output(1)
+
+
 @converter_registry.register("pd_op.topk", trt_version="8.x")
 def topk_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]

--- a/test/tensorrt/test_converter_search.py
+++ b/test/tensorrt/test_converter_search.py
@@ -35,16 +35,19 @@ class TestArgmaxTRTPattern(TensorRTBaseTest):
         self.check_trt_result()
 
 
-class TestArgminCase1TRTPattern(TensorRTBaseTest):
+class TestArgminTRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.argmin
         self.api_args = {
-            "x": np.random.randn(2, 3).astype(np.float32),
+            "x": np.random.randn(2, 3).astype("float32"),
             "axis": -1,
         }
         self.program_config = {"feed_list": ["x"]}
         self.min_shape = {"x": [1, 3]}
         self.max_shape = {"x": [5, 3]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
 
 
 class TestWhereTRTPatternCase1(TensorRTBaseTest):
@@ -63,26 +66,11 @@ class TestWhereTRTPatternCase1(TensorRTBaseTest):
         self.check_trt_result()
 
 
-class TestArgminCase2TRTPattern(TensorRTBaseTest):
-    def setUp(self):
-        self.python_api = paddle.argmin
-        self.api_args = {
-            "x": np.random.randn(2, 3).astype(np.int64),
-            "axis": -1,
-        }
-        self.program_config = {"feed_list": ["x"]}
-        self.min_shape = {"x": [1, 3]}
-        self.max_shape = {"x": [5, 3]}
-
-    def test_trt_result(self):
-        self.check_trt_result()
-
-
 class TestArgsortCase1TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.argsort
         self.api_args = {
-            "x": np.random.randn(2, 3).astype(np.float32),
+            "x": np.random.randn(2, 3).astype("float32"),
             "axis": -1,
         }
         self.program_config = {"feed_list": ["x"]}
@@ -97,7 +85,7 @@ class TestArgsortCase2TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.argsort
         self.api_args = {
-            "x": np.random.randn(2, 3).astype(np.int64),
+            "x": np.random.randn(2, 3).astype("int64"),
             "axis": -1,
         }
         self.program_config = {"feed_list": ["x"]}
@@ -112,13 +100,16 @@ class TestArgsortCase3TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.argsort
         self.api_args = {
-            "x": np.random.randn(2, 3).astype(np.int64),
+            "x": np.random.randn(2, 3).astype("float32"),
             "axis": -1,
             "descending": True,
         }
         self.program_config = {"feed_list": ["x"]}
         self.min_shape = {"x": [1, 3]}
         self.max_shape = {"x": [5, 3]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
 
 
 class TestWhereTRTPatternCase2(TensorRTBaseTest):

--- a/test/tensorrt/test_converter_search.py
+++ b/test/tensorrt/test_converter_search.py
@@ -35,6 +35,82 @@ class TestArgmaxTRTPattern(TensorRTBaseTest):
         self.check_trt_result()
 
 
+class TestArgminCase1TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argmin
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype(np.float32),
+            "axis": -1,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1, 3]}
+        self.max_shape = {"x": [5, 3]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
+class TestArgminCase2TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argmin
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype(np.int64),
+            "axis": -1,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1, 3]}
+        self.max_shape = {"x": [5, 3]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
+class TestArgsortCase1TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argsort
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype(np.float32),
+            "axis": -1,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1, 3]}
+        self.max_shape = {"x": [5, 3]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
+class TestArgsortCase2TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argsort
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype(np.int64),
+            "axis": -1,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1, 3]}
+        self.max_shape = {"x": [5, 3]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
+class TestArgsortCase3TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argsort
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype(np.int64),
+            "axis": -1,
+            "descending": True,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1, 3]}
+        self.max_shape = {"x": [5, 3]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
 class TestTopkCase1TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.topk

--- a/test/tensorrt/test_converter_search.py
+++ b/test/tensorrt/test_converter_search.py
@@ -20,11 +20,11 @@ from tensorrt_test_base import TensorRTBaseTest
 import paddle
 
 
-class TestArgmaxTRTPattern(TensorRTBaseTest):
+class TestArgmaxCase1TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.argmax
         self.api_args = {
-            "x": np.random.randn(2, 3).astype(np.float32),
+            "x": np.random.randn(2, 3).astype("float32"),
             "axis": -1,
         }
         self.program_config = {"feed_list": ["x"]}
@@ -35,7 +35,53 @@ class TestArgmaxTRTPattern(TensorRTBaseTest):
         self.check_trt_result()
 
 
-class TestArgminTRTPattern(TensorRTBaseTest):
+class TestArgmaxCase2TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argmax
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype("int64"),
+            "axis": -1,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.target_marker_op = "pd_op.argmax"
+
+    def test_trt_result(self):
+        # test input's dtype
+        self.check_marker(expected_result=False)
+
+
+class TestArgmaxCase3TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argmax
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype("float32"),
+            "axis": 0,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.target_marker_op = "pd_op.argmax"
+
+    def test_trt_result(self):
+        # test axis
+        self.check_marker(expected_result=False)
+
+
+class TestArgmaxCase4TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argmax
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype("float32"),
+            "axis": -1,
+            "dtype": "float32",
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.target_marker_op = "pd_op.argmax"
+
+    def test_trt_result(self):
+        # test dtype attr
+        self.check_marker(expected_result=False)
+
+
+class TestArgminCase1TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.argmin
         self.api_args = {
@@ -48,6 +94,52 @@ class TestArgminTRTPattern(TensorRTBaseTest):
 
     def test_trt_result(self):
         self.check_trt_result()
+
+
+class TestArgminCase2TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argmin
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype("int64"),
+            "axis": -1,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.target_marker_op = "pd_op.argmin"
+
+    def test_trt_result(self):
+        # test input's dtype
+        self.check_marker(expected_result=False)
+
+
+class TestArgminCase3TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argmin
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype("float32"),
+            "axis": 0,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.target_marker_op = "pd_op.argmin"
+
+    def test_trt_result(self):
+        # test axis
+        self.check_marker(expected_result=False)
+
+
+class TestArgminCase4TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argmin
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype("float32"),
+            "axis": -1,
+            "dtype": "float32",
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.target_marker_op = "pd_op.argmin"
+
+    def test_trt_result(self):
+        # test dtype attr
+        self.check_marker(expected_result=False)
 
 
 class TestWhereTRTPatternCase1(TensorRTBaseTest):
@@ -85,6 +177,21 @@ class TestArgsortCase2TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.argsort
         self.api_args = {
+            "x": np.random.randn(2).astype("float32"),
+            "axis": -1,
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1]}
+        self.max_shape = {"x": [5]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
+class TestArgsortCase3TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argsort
+        self.api_args = {
             "x": np.random.randn(2, 3).astype("int64"),
             "axis": -1,
         }
@@ -96,20 +203,19 @@ class TestArgsortCase2TRTPattern(TensorRTBaseTest):
         self.check_trt_result()
 
 
-class TestArgsortCase3TRTPattern(TensorRTBaseTest):
+class TestArgsortCase4TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.argsort
         self.api_args = {
             "x": np.random.randn(2, 3).astype("float32"),
-            "axis": -1,
-            "descending": True,
+            "axis": 3940,
         }
         self.program_config = {"feed_list": ["x"]}
-        self.min_shape = {"x": [1, 3]}
-        self.max_shape = {"x": [5, 3]}
+        self.target_marker_op = "pd_op.argsort"
 
     def test_trt_result(self):
-        self.check_trt_result()
+        # test axis attr
+        self.check_marker(expected_result=False)
 
 
 class TestWhereTRTPatternCase2(TensorRTBaseTest):

--- a/test/tensorrt/test_converter_search.py
+++ b/test/tensorrt/test_converter_search.py
@@ -65,22 +65,6 @@ class TestArgmaxCase3TRTPattern(TensorRTBaseTest):
         self.check_marker(expected_result=False)
 
 
-class TestArgmaxCase4TRTPattern(TensorRTBaseTest):
-    def setUp(self):
-        self.python_api = paddle.argmax
-        self.api_args = {
-            "x": np.random.randn(2, 3).astype("float32"),
-            "axis": -1,
-            "dtype": "float32",
-        }
-        self.program_config = {"feed_list": ["x"]}
-        self.target_marker_op = "pd_op.argmax"
-
-    def test_trt_result(self):
-        # test dtype attr
-        self.check_marker(expected_result=False)
-
-
 class TestArgminCase1TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.argmin
@@ -123,22 +107,6 @@ class TestArgminCase3TRTPattern(TensorRTBaseTest):
 
     def test_trt_result(self):
         # test axis
-        self.check_marker(expected_result=False)
-
-
-class TestArgminCase4TRTPattern(TensorRTBaseTest):
-    def setUp(self):
-        self.python_api = paddle.argmin
-        self.api_args = {
-            "x": np.random.randn(2, 3).astype("float32"),
-            "axis": -1,
-            "dtype": "float32",
-        }
-        self.program_config = {"feed_list": ["x"]}
-        self.target_marker_op = "pd_op.argmin"
-
-    def test_trt_result(self):
-        # test dtype attr
         self.check_marker(expected_result=False)
 
 
@@ -207,8 +175,8 @@ class TestArgsortCase4TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.argsort
         self.api_args = {
-            "x": np.random.randn(2, 3).astype("float32"),
-            "axis": 3940,
+            "x": np.random.randn(2, 4000).astype("float32"),
+            "axis": 1,
         }
         self.program_config = {"feed_list": ["x"]}
         self.target_marker_op = "pd_op.argsort"

--- a/test/tensorrt/test_converter_search.py
+++ b/test/tensorrt/test_converter_search.py
@@ -65,6 +65,21 @@ class TestArgmaxCase3TRTPattern(TensorRTBaseTest):
         self.check_marker(expected_result=False)
 
 
+class TestArgmaxCase4TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argmin
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype("float32"),
+            "axis": np.random.randn(1).astype("int64"),
+        }
+        self.program_config = {"feed_list": ["x", "axis"]}
+        self.target_marker_op = "pd_op.argmax"
+
+    def test_trt_result(self):
+        # test axis Value
+        self.check_marker(expected_result=False)
+
+
 class TestArgminCase1TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.argmin
@@ -107,6 +122,21 @@ class TestArgminCase3TRTPattern(TensorRTBaseTest):
 
     def test_trt_result(self):
         # test axis
+        self.check_marker(expected_result=False)
+
+
+class TestArgminCase4TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.argmin
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype("float32"),
+            "axis": np.random.randn(1).astype("int64"),
+        }
+        self.program_config = {"feed_list": ["x", "axis"]}
+        self.target_marker_op = "pd_op.argmin"
+
+    def test_trt_result(self):
+        # test axis Value
         self.check_marker(expected_result=False)
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->


- 新增了 pd_op.argmix Marker 和 Converter
- 新增了 pd_op.argsort Marker 和 Converter

- links: https://github.com/PaddlePaddle/Paddle/issues/69178