### PR TITLE
[SOT][3.13] fix `GetLocals` free error in `eval_custom_code` and clean `cpython_internals.c` some `_PyFrame_GetCode`

### DIFF
--- a/paddle/fluid/pybind/sot/cpython_internals.c
+++ b/paddle/fluid/pybind/sot/cpython_internals.c
@@ -703,7 +703,9 @@ static void Internal_take_ownership(PyFrameObject *f,
   Py_ssize_t size =
       ((char *)&frame->localsplus[frame->stacktop]) - (char *)frame;
 
+#if PY_3_12_PLUS
   Py_INCREF(PyFrame_GET_CODE(frame));
+#endif
 
   memcpy((_PyInterpreterFrame *)f->_f_frame_data, frame, size);
   frame = (_PyInterpreterFrame *)f->_f_frame_data;

--- a/paddle/fluid/pybind/sot/cpython_internals.c
+++ b/paddle/fluid/pybind/sot/cpython_internals.c
@@ -695,24 +695,6 @@ static inline PyFrameObject *Internal_PyFrame_GetFrameObject(
   return Internal_PyFrame_MakeAndSetFrameObject(frame);
 }
 
-// static inline bool
-// Internal_PyFrame_IsIncomplete(_PyInterpreterFrame *frame)
-// {
-//     if (frame->owner == FRAME_OWNED_BY_CSTACK) {
-//         return true;
-//     }
-//     PyTypeObject *type = Py_TYPE(frame);  // 获取对象的类型
-//     if (type && type->tp_name) {
-//         printf("[Internal_take_ownership] Type of object: %s\n",
-//         type->tp_name);
-//     }else{
-//         printf("[Internal_take_ownership] Type of object: unknown\n");
-//     }
-//     return frame->owner != FRAME_OWNED_BY_GENERATOR &&
-//         frame->instr_ptr < _PyCode_CODE(_PyFrame_GetCode(frame)) +
-//         _PyFrame_GetCode(frame)->_co_firsttraceable;
-// }
-
 static void Internal_take_ownership(PyFrameObject *f,
                                     _PyInterpreterFrame *frame) {
 #if PY_3_12_PLUS
@@ -807,22 +789,14 @@ void Internal_PyFrame_Clear(_PyInterpreterFrame *frame) {
 #else
   assert(PyThreadState_GET()->cframe->current_frame != frame);
 #endif
-  printf("[Internal_PyFrame_ClearExceptCode] frame->owner: %d\n", frame->owner);
-  printf("[Internal_PyFrame_ClearExceptCode] frame_obj: %p\n",
-         frame->frame_obj);
   if (frame->frame_obj) {
     PyFrameObject *f = frame->frame_obj;
     frame->frame_obj = NULL;
     if (Py_REFCNT(f) > 1) {
-      printf(
-          "[Internal_PyFrame_ClearExceptCode] frame object refcnt > 1 : %zd\n",
-          Py_REFCNT(f));
       Internal_take_ownership(f, frame);
       Py_DECREF(f);
       return;
     }
-    printf("[Internal_PyFrame_ClearExceptCode] frame object refcnt: %zd\n",
-           Py_REFCNT(f));
     Py_DECREF(f);
   }
 #if PY_3_13_PLUS

--- a/paddle/fluid/pybind/sot/cpython_internals.c
+++ b/paddle/fluid/pybind/sot/cpython_internals.c
@@ -124,8 +124,6 @@ static void Internal_clear_thread_frame(PyThreadState *tstate,
          tstate->datastack_top);
   tstate->c_recursion_remaining--;
   assert(frame->frame_obj == NULL || frame->frame_obj->f_frame == frame);
-  printf("[Internal_clear_thread_frame] opname: %s\n",
-         PyUnicode_AsUTF8(PyFrame_GET_CODE(frame)->co_name));
   Internal_PyFrame_ClearExceptCode(frame);
 #if PY_3_13_PLUS
   Py_DECREF(frame->f_executable);
@@ -287,7 +285,6 @@ PyObject *Internal_PyFrame_GetLocals(_PyInterpreterFrame *frame) {
     return Py_NewRef(frame->f_locals);
   }
 
-  printf("[Internal_PyFrame_GetLocals] frame: %p\n", frame);
   PyFrameObject *f = Internal_PyFrame_GetFrameObject(frame);
 
   return Internal_PyFrameLocalsProxy_New(f);

--- a/paddle/fluid/pybind/sot/cpython_internals.c
+++ b/paddle/fluid/pybind/sot/cpython_internals.c
@@ -49,11 +49,7 @@ int Internal_PyUnstable_InterpreterFrame_GetLine(_PyInterpreterFrame *frame) {
 int Internal_PyInterpreterFrame_GetLine(_PyInterpreterFrame *frame) {
 #endif
   int addr = _PyInterpreterFrame_LASTI(frame) * sizeof(_Py_CODEUNIT);
-#if PY_3_13_PLUS
-  return PyCode_Addr2Line(_PyFrame_GetCode(frame), addr);
-#else
-  return PyCode_Addr2Line(frame->f_code, addr);
-#endif
+  return PyCode_Addr2Line(PyFrame_GET_CODE(frame), addr);
 }
 
 static int Internal_PyFrame_OpAlreadyRan(_PyInterpreterFrame *frame,
@@ -62,15 +58,14 @@ static int Internal_PyFrame_OpAlreadyRan(_PyInterpreterFrame *frame,
   // This only works when opcode is a non-quickened form:
   assert(_PyOpcode_Deopt[opcode] == opcode);
   int check_oparg = 0;
+  for (_Py_CODEUNIT *instruction = _PyCode_CODE(PyFrame_GET_CODE(frame));
 #if PY_3_13_PLUS
-  for (_Py_CODEUNIT *instruction = _PyCode_CODE(_PyFrame_GetCode(frame));
        instruction < frame->instr_ptr;
-       instruction++) {
 #else
-  for (_Py_CODEUNIT *instruction = _PyCode_CODE(frame->f_code);
        instruction < frame->prev_instr;
-       instruction++) {
 #endif
+       instruction++) {
+
 #if PY_3_12_PLUS
     int check_opcode = _PyOpcode_Deopt[instruction->op.code];
     check_oparg |= instruction->op.arg;
@@ -225,9 +220,9 @@ bool Internal_PyFrame_HasHiddenLocals(_PyInterpreterFrame *frame) {
 
   return false;
 }
-static PyObject *framelocalsproxy_new(PyTypeObject *type,
-                                      PyObject *args,
-                                      PyObject *kwds) {
+static PyObject *Internal_framelocalsproxy_new(PyTypeObject *type,
+                                               PyObject *args,
+                                               PyObject *kwds) {
   if (PyTuple_GET_SIZE(args) != 1) {
     PyErr_Format(PyExc_TypeError,
                  "FrameLocalsProxy expected 1 argument, got %zd",
@@ -265,8 +260,8 @@ PyObject *Internal_PyFrameLocalsProxy_New(PyFrameObject *frame) {
     return NULL;
   }
 
-  PyObject *proxy =
-      (PyObject *)framelocalsproxy_new(&PyFrameLocalsProxy_Type, args, NULL);
+  PyObject *proxy = (PyObject *)Internal_framelocalsproxy_new(
+      &PyFrameLocalsProxy_Type, args, NULL);
   Py_DECREF(args);
   return proxy;
 }
@@ -634,11 +629,7 @@ PyFrameObject *Internal_PyFrame_MakeAndSetFrameObject(
   PyErr_Fetch(&error_type, &error_value, &error_traceback);
 #endif
 
-#if PY_3_13_PLUS
-  PyFrameObject *f = Internal_PyFrame_New_NoTrack(_PyFrame_GetCode(frame));
-#else
-  PyFrameObject *f = Internal_PyFrame_New_NoTrack(frame->f_code);
-#endif
+  PyFrameObject *f = Internal_PyFrame_New_NoTrack(PyFrame_GET_CODE(frame));
   if (f == NULL) {
 #if PY_3_12_PLUS
     Py_XDECREF(exc);
@@ -712,24 +703,20 @@ static void Internal_take_ownership(PyFrameObject *f,
   Py_ssize_t size =
       ((char *)&frame->localsplus[frame->stacktop]) - (char *)frame;
 
-#if PY_3_13_PLUS
-  Py_INCREF(_PyFrame_GetCode(frame));
-#elif PY_3_12_PLUS
-  Py_INCREF(frame->f_code);
-#endif
+  Py_INCREF(PyFrame_GET_CODE(frame));
 
   memcpy((_PyInterpreterFrame *)f->_f_frame_data, frame, size);
   frame = (_PyInterpreterFrame *)f->_f_frame_data;
   f->f_frame = frame;
   frame->owner = FRAME_OWNED_BY_FRAME_OBJECT;
   if (_PyFrame_IsIncomplete(frame)) {
-// This may be a newly-created generator or coroutine frame. Since it's
-// dead anyways, just pretend that the first RESUME ran:
+    // This may be a newly-created generator or coroutine frame. Since it's
+    // dead anyways, just pretend that the first RESUME ran:
+    PyCodeObject *code = PyFrame_GET_CODE(frame);
+
 #if PY_3_13_PLUS
-    PyCodeObject *code = _PyFrame_GetCode(frame);
     frame->instr_ptr = _PyCode_CODE(code) + code->_co_firsttraceable + 1;
 #else
-    PyCodeObject *code = frame->f_code;
     frame->prev_instr = _PyCode_CODE(code) + code->_co_firsttraceable;
 #endif
   }
@@ -792,13 +779,9 @@ void Internal_PyFrame_Clear(_PyInterpreterFrame *frame) {
    * to have cleared the enclosing generator, if any. */
   assert(frame->owner != FRAME_OWNED_BY_GENERATOR ||
          _PyFrame_GetGenerator(frame)->gi_frame_state == FRAME_CLEARED);
-// GH-99729: Clearing this frame can expose the stack (via finalizers). It's
-// crucial that this frame has been unlinked, and is no longer visible:
-#if PY_3_13_PLUS
+  // GH-99729: Clearing this frame can expose the stack (via finalizers). It's
+  // crucial that this frame has been unlinked, and is no longer visible:
   assert(PyThreadState_GET()->current_frame != frame);
-#else
-  assert(PyThreadState_GET()->cframe->current_frame != frame);
-#endif
   if (frame->frame_obj) {
     PyFrameObject *f = frame->frame_obj;
     frame->frame_obj = NULL;

--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -137,7 +137,9 @@ PyInterpreterFrameProxy *PyInterpreterFrameProxy_New(
     return NULL;
   }
   self->frame = frame;
+#if PY_3_13_PLUS
   self->locals = NULL;
+#endif
   return self;
 }
 

--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -47,7 +47,9 @@ typedef _PyInterpreterFrame FrameObject;
 typedef struct PyInterpreterFrameProxy {
   PyObject_HEAD
   _PyInterpreterFrame *frame;
+  #if PY_3_13_PLUS
   PyObject* locals;
+  #endif
 } PyInterpreterFrameProxy;
 // clang-format on
 

--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -73,7 +73,6 @@ DECLARE_PROXY_PROPERTY(f_code)
 #if PY_3_13_PLUS
 static PyObject *PyInterpreterFrameProxy_property_f_locals(
     PyInterpreterFrameProxy *self, void *closure) {
-  // PyObject *f_locals = Internal_PyFrame_GetLocals(self->frame);
   Py_XINCREF(self->locals);
   return self->locals;
 }

--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -349,11 +349,15 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
   // _PyFrame_FastToLocalsWithError directly. But this is an internal API, so we
   // copy many code from CPython project into our project.
 #if PY_3_13_PLUS
-  Internal_PyFrame_GetLocals(frame);
+  PyObject *f_locals = Internal_PyFrame_GetLocals(frame);
+  if (f_locals == NULL) {
 #else
   if (Internal_PyFrame_FastToLocalsWithError(frame) < 0) {
+#endif
     return NULL;
   }
+#if PY_3_13_PLUS
+  Py_DECREF(f_locals);
 #endif
 #else
   if (frame->f_code->co_flags & 0x20) {

--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -394,7 +394,6 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
 
   // get code & disable_eval_frame
   if (need_skip(frame)) {
-    printf("[_custom_eval_frame] skip frame\n");
     Py_INCREF(Py_None);
     code = Py_None;
     Py_INCREF(Py_False);
@@ -402,17 +401,17 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
   } else {
     /* should calculate guards here if we want */
 #if PY_3_11_PLUS
-    PyInterpreterFrameProxy *frame_ = PyInterpreterFrameProxy_New(frame);
-    if (frame_ == NULL) {
+    PyInterpreterFrameProxy *frame_proxy = PyInterpreterFrameProxy_New(frame);
+    if (frame_proxy == NULL) {
 #if PY_3_13_PLUS
       Py_DECREF(f_locals);
 #endif
       return NULL;
     }
 #if PY_3_13_PLUS
-    frame_->locals = f_locals;
+    frame_proxy->locals = f_locals;
 #endif
-    PyObject *args = Py_BuildValue("(O)", frame_);
+    PyObject *args = Py_BuildValue("(O)", frame_proxy);
 #else
     PyObject *args = Py_BuildValue("(O)", frame);
 #endif
@@ -420,7 +419,6 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
     Py_DECREF(args);
     if (result == NULL) {
 #if PY_3_12_PLUS
-      printf("[_custom_eval_frame] result is NULL\n");
 #if PY_3_13_PLUS
       Py_DECREF(f_locals);
       Internal_PyEval_FrameClearAndPop(tstate, frame);
@@ -430,8 +428,6 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
 #endif
       return NULL;
     }
-    printf("[_custom_eval_frame] result: %s\n",
-           PyUnicode_AsUTF8(PyObject_Repr(result)));
     code = PyObject_GetAttrString(result, "code");
     disable_eval_frame = PyObject_GetAttrString(result, "disable_eval_frame");
     Py_DECREF(result);

--- a/test/sot/skip_files_py313
+++ b/test/sot/skip_files_py313
@@ -23,8 +23,6 @@ test/sot/test_builtin_range.py
 test/sot/test_builtin_zip.py
 test/sot/test_call_object.py
 test/sot/test_constant_graph.py
-test/sot/test_dataclass.py
-test/sot/test_delete_fast.py
 test/sot/test_dtype.py
 test/sot/test_dup_top.py
 test/sot/test_enumerate.py
@@ -36,7 +34,6 @@ test/sot/test_numpy.py
 test/sot/test_numpy_var_if.py
 test/sot/test_side_effects.py
 test/sot/test_simulate_initialize.py
-test/sot/test_sir_rollback.py
 test/sot/test_sot_cost_model.py
 test/sot/test_sot_dynamic_shape.py
 test/sot/test_sot_exception.py


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

* 清理了一些`_PyFrame_GetCode`
* ~~在`_custom_eval_frame` 方法中使用了`GetLocals`导致 `frame` 变成了一个 proxy, 并且`Py_NewRef`了, 这就导致了后续在`ClearAndPop` 的时候 `IsIncomplete` 错误. 而事实是我们在创建一个新的`frame`时也用不上`f_locals`(直接传了个NULL创建的)~~
* 让`f_locals`直接与`FrameProxy`绑定, 这样不会在`FrameProxy_property_f_locals`再次生成一个新的 proxy，并且好处是现在可以在 `_custom_eval_frame` 管理`f_locals`


#### 相关pr
* #69246
* #69245

