### PR TITLE
[CINN] Remove batch_norm fusion kernels num check

### DIFF
--- a/test/ir/pir/cinn/test_anchor_fusion.py
+++ b/test/ir/pir/cinn/test_anchor_fusion.py
@@ -249,7 +249,7 @@ class TestAnchorFusion(unittest.TestCase):
             x = paddle.rand((128, 2048, 7, 7))
             return (x,)
 
-        self.check_accuracy_and_kernel_num(init, func, kernel_num=1)
+        self.check_accuracy_and_kernel_num(init, func)
 
     def test_split_fusion(self):
         def func(x):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes
### Description
<!-- Describe what you’ve done -->
Pcard-76996
- Remove batch_norm fusion kernels num check