### PR TITLE
[Dy2St][PIR] Create fake value with 0D Tensor to avoid dynamic shape error

### DIFF
--- a/python/paddle/static/nn/control_flow.py
+++ b/python/paddle/static/nn/control_flow.py
@@ -683,7 +683,7 @@ def assign_skip_lod_tensor_array(input, output):
 def create_fake_value_for_undefined_var(while_op, value):
     # Create a fake value for create WhileOp, and set its type and stop_gradient as next_var
     stop_gradient = value.stop_gradient
-    fake_value = paddle.full(shape=value.shape, dtype=value.dtype, fill_value=0)
+    fake_value = paddle.full(shape=[], dtype=value.dtype, fill_value=0)
     fake_value_op = fake_value.get_defining_op()
     fake_value_op.move_before(while_op.as_operation())
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

#69210 里因为 create fake value 是已经知道另一个分支的 type 了，因此直接使用另一个分支的 shape 来创建 value，但 full 不支持传入动态 shape，因此会导致一系列模型挂掉

恢复原来的做法，创建 fake value 时仍然使用 0D Tensor

PCard-66972