### PR TITLE
[CINN] Refine infer symbol shape for block_arg in shape_optimization_pass

### DIFF
--- a/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
+++ b/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
@@ -391,10 +391,11 @@ void InferSymExprForAllValues(ModuleOp module_op) {
         std::unordered_map<pir::Value, symbol::ShapeOrDataDimExprs>
             symbol_shape_map;
         for (const auto& [_, value] : module_op.block().kwargs()) {
-          if (infer_context->HasShapeOrDataForValue(value)) {
-            symbol_shape_map.emplace(
-                value, infer_context->GetShapeOrDataForValue(value));
+          if (!infer_context->HasShapeOrDataForValue(value)) {
+            infer_context->SetSymbolForValueByStaticShape(value);
           }
+          symbol_shape_map.emplace(
+              value, infer_context->GetShapeOrDataForValue(value));
         }
         return symbol_shape_map;
       }();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix infer symbol shape for block_args bug in shape_optimization_pass: some values in startup_program may pass to main_program by block_args.
Pcard-67164
