### PR TITLE
bump pybind11 version from `v2.12.0` to `v2.13.6`

### DIFF
--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -27,7 +27,7 @@ set(PYBIND_PATCH_COMMAND "")
 if(LINUX
    AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
    AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
-  set(PYBIND_TAG v2.12.0)
+  set(PYBIND_TAG v2.13.6)
   file(TO_NATIVE_PATH
        ${PADDLE_SOURCE_DIR}/patches/pybind/detail/internals.h.patch native_dst)
   # Note: [Why calling some `git` commands before `patch`?]

--- a/patches/pybind/detail/internals.h.patch
+++ b/patches/pybind/detail/internals.h.patch
@@ -1,22 +1,22 @@
 diff --git a/include/pybind11/detail/internals.h b/include/pybind11/detail/internals.h
-index c1047e4a..e09a6495 100644
+index 232bc32d..b6491c11 100644
 --- a/include/pybind11/detail/internals.h
 +++ b/include/pybind11/detail/internals.h
-@@ -193,11 +193,18 @@ struct internals {
+@@ -203,11 +203,18 @@ struct internals {
+     PyTypeObject *static_property_type;
      PyTypeObject *default_metaclass;
      PyObject *instance_base;
- #if defined(WITH_THREAD)
 +#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ <= 8
-+#pragma GCC diagnostic push
-+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
++#    pragma GCC diagnostic push
++#    pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 +#endif
      // Unused if PYBIND11_SIMPLE_GIL_MANAGEMENT is defined:
      PYBIND11_TLS_KEY_INIT(tstate)
- #    if PYBIND11_INTERNALS_VERSION > 4
+ #if PYBIND11_INTERNALS_VERSION > 4
      PYBIND11_TLS_KEY_INIT(loader_life_support_tls_key)
- #    endif // PYBIND11_INTERNALS_VERSION > 4
+ #endif // PYBIND11_INTERNALS_VERSION > 4
 +#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ <= 8
-+#pragma GCC diagnostic pop
++#    pragma GCC diagnostic pop
 +#endif
      // Unused if PYBIND11_SIMPLE_GIL_MANAGEMENT is defined:
      PyInterpreterState *istate = nullptr;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Change pybind11 from v2.12.0 to 2.13.6
pcard-67164
