### PR TITLE
[CINN] Fix some CINN bug in AutoParallel

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.h
@@ -842,7 +842,7 @@ class TEST_API ArrayPopOp
       pir::AttributeMap *p_attributes);
 };
 
-class ShareVarOp : public pir::Op<ShareVarOp> {
+class ShareVarOp : public pir::Op<ShareVarOp, pir::SideEffectTrait> {
  public:
   using Op::Op;
   static const char *name() { return "pd_op.share_var"; }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix some bug in AutoParallel:
- ShareVarOp is SideEffect, should not delete by dead_code_eliminate pass.

Pcard-67164