### PR TITLE
[Prim][Pir] Delete with `expand_with_tensor` and `reshape_with_tensor`

### DIFF
--- a/paddle/fluid/primitive/backend/manual/manual_prim_backend.h
+++ b/paddle/fluid/primitive/backend/manual/manual_prim_backend.h
@@ -36,9 +36,6 @@ Tensor full_with_tensor(const Tensor& shape,
                         Place place = Place());
 
 template <typename T>
-Tensor reshape_with_tensor(const Tensor& x, const Tensor& shape);
-
-template <typename T>
 Tensor arange_with_tensor(const Tensor& start,
                           const Tensor& end,
                           const Tensor& step,

--- a/paddle/fluid/primitive/backend/manual/manual_prim_backend.h
+++ b/paddle/fluid/primitive/backend/manual/manual_prim_backend.h
@@ -39,9 +39,6 @@ template <typename T>
 Tensor reshape_with_tensor(const Tensor& x, const Tensor& shape);
 
 template <typename T>
-Tensor expand_with_tensor(const Tensor& x, const Tensor& shape);
-
-template <typename T>
 Tensor arange_with_tensor(const Tensor& start,
                           const Tensor& end,
                           const Tensor& step,

--- a/paddle/fluid/primitive/backend/manual/manual_static_prim_backend.cc
+++ b/paddle/fluid/primitive/backend/manual/manual_static_prim_backend.cc
@@ -49,16 +49,6 @@ Tensor full_with_tensor<LazyTensor>(const Tensor& shape,
 }
 
 template <>
-Tensor reshape_with_tensor<LazyTensor>(const Tensor& x, const Tensor& shape) {
-  pir::Value x_res = std::static_pointer_cast<LazyTensor>(x.impl())->value();
-  pir::Value shape_res =
-      std::static_pointer_cast<LazyTensor>(shape.impl())->value();
-  auto op_res = paddle::dialect::reshape(x_res, shape_res);
-  Tensor out(std::make_shared<LazyTensor>(op_res));
-  return out;
-}
-
-template <>
 Tensor arange_with_tensor<LazyTensor>(const Tensor& start,
                                       const Tensor& end,
                                       const Tensor& step,

--- a/paddle/fluid/primitive/backend/manual/manual_static_prim_backend.cc
+++ b/paddle/fluid/primitive/backend/manual/manual_static_prim_backend.cc
@@ -59,16 +59,6 @@ Tensor reshape_with_tensor<LazyTensor>(const Tensor& x, const Tensor& shape) {
 }
 
 template <>
-Tensor expand_with_tensor<LazyTensor>(const Tensor& x, const Tensor& shape) {
-  pir::Value x_res = std::static_pointer_cast<LazyTensor>(x.impl())->value();
-  pir::Value shape_res =
-      std::static_pointer_cast<LazyTensor>(shape.impl())->value();
-  auto op_res = paddle::dialect::expand(x_res, shape_res);
-  Tensor out(std::make_shared<LazyTensor>(op_res));
-  return out;
-}
-
-template <>
 Tensor arange_with_tensor<LazyTensor>(const Tensor& start,
                                       const Tensor& end,
                                       const Tensor& step,

--- a/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
@@ -778,15 +778,13 @@ std::tuple<Tensor, Tensor, Tensor> instance_norm_decomp(
 
     Tensor scale_cast;
     if (scale) {
-      scale_cast =
-          backend::reshape_with_tensor<T>(scale.get(), slice_shape_tensor);
+      scale_cast = backend::reshape<T>(scale.get(), slice_shape_tensor);
       scale_cast = ConverToMT<T>(scale_cast);
       out = out * scale_cast;
     }
     Tensor bias_cast;
     if (bias) {
-      bias_cast =
-          backend::reshape_with_tensor<T>(bias.get(), slice_shape_tensor);
+      bias_cast = backend::reshape<T>(bias.get(), slice_shape_tensor);
       bias_cast = ConverToMT<T>(bias_cast);
       out = out + bias_cast;
     }
@@ -1354,7 +1352,7 @@ std::vector<Tensor> unstack_decomp(const Tensor& x, int axis, const int num) {
     }
     const Tensor new_shape = concat<T>(new_shape_vec);
     std::transform(res.begin(), res.end(), res.begin(), [&](Tensor& x) {
-      return backend::reshape_with_tensor<T>(x, new_shape);
+      return backend::reshape<T>(x, new_shape);
     });
   } else {
     std::vector<int64_t> new_shape;

--- a/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
@@ -483,7 +483,7 @@ std::vector<Tensor> meshgrid_decomp(const std::vector<Tensor>& x) {
 
     for (int64_t i = 0; i < rank; i++) {
       if (tar_shape[i] == 1) {
-        res.push_back(backend::expand_with_tensor<T>(x[i], tar_tensor_shape));
+        res.push_back(backend::expand<T>(x[i], tar_tensor_shape));
       } else {
         std::vector<int64_t> unsqueeze_dim;
         for (int64_t k = 0; k < rank; k++) {
@@ -491,8 +491,8 @@ std::vector<Tensor> meshgrid_decomp(const std::vector<Tensor>& x) {
             unsqueeze_dim.push_back(k);
           }
         }
-        res.push_back(backend::expand_with_tensor<T>(
-            unsqueeze<T>(x[i], unsqueeze_dim), tar_tensor_shape));
+        res.push_back(backend::expand<T>(unsqueeze<T>(x[i], unsqueeze_dim),
+                                         tar_tensor_shape));
       }
     }
 
@@ -927,8 +927,8 @@ Tensor clip_decomp(const Tensor& x, const Tensor& min, const Tensor& max) {
   }
 
   if (has_dynamic_shape(x.shape())) {
-    min_reshape = backend::expand_with_tensor<T>(min_reshape, shape<T>(x));
-    max_reshape = backend::expand_with_tensor<T>(max_reshape, shape<T>(x));
+    min_reshape = backend::expand<T>(min_reshape, shape<T>(x));
+    max_reshape = backend::expand<T>(max_reshape, shape<T>(x));
   } else {
     min_reshape = expand<T>(min_reshape, x.shape());
     max_reshape = expand<T>(max_reshape, x.shape());
@@ -1219,8 +1219,8 @@ Tensor index_sample_decomp(const Tensor& x, const Tensor& index) {
       backend::arange_with_tensor<T>(start, index_dim, step, index.dtype()),
       tmp_shape);
 
-  auto index_res = reshape<T>(
-      backend::expand_with_tensor<T>(arange_tmp, shape<T>(index)), tmp_shape);
+  auto index_res =
+      reshape<T>(backend::expand<T>(arange_tmp, shape<T>(index)), tmp_shape);
   auto index_ = reshape<T>(index, tmp_shape);
   auto concat_res = concat<T>({index_res, index_}, 1);
   auto res = backend::reshape<T>(gather_nd<T>(x, concat_res), shape<T>(index));

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -366,7 +366,7 @@ void reduce_as_grad(const Tensor& x,
     return;
   }
   if (has_dynamic_shape(x.shape()) || has_dynamic_shape(out_grad.shape())) {
-    auto x_grad_tmp = backend::expand_with_tensor<T>(out_grad, shape<T>(x));
+    auto x_grad_tmp = backend::expand<T>(out_grad, shape<T>(x));
     set_output<T>(x_grad_tmp, x_grad);
   } else {
     std::vector<int64_t> x_dim = common::vectorize<int64_t>(x.dims());
@@ -1909,7 +1909,7 @@ void prod_grad(const Tensor& x,
       std::vector<int> transpose_dim, origin_position;
       std::vector<Tensor> transpose_shape, cumprod_shape;
       if (x_dim_size == 1) {
-        out_grad_tmp = backend::expand_with_tensor<T>(out_grad, x_dim);
+        out_grad_tmp = backend::expand<T>(out_grad, x_dim);
       } else {
         if (!keep_dim) {
           auto axis_ = std::vector<int64_t>();
@@ -1928,9 +1928,9 @@ void prod_grad(const Tensor& x,
           Tensor out_grad_shape =
               get_unsqueeze_dims<T>(shape<T>(out_grad), axis_);
           Tensor out_grad_ = backend::reshape<T>(out_grad, out_grad_shape);
-          out_grad_tmp = backend::expand_with_tensor<T>(out_grad_, x_dim);
+          out_grad_tmp = backend::expand<T>(out_grad_, x_dim);
         } else {
-          out_grad_tmp = backend::expand_with_tensor<T>(out_grad, x_dim);
+          out_grad_tmp = backend::expand<T>(out_grad, x_dim);
         }
       }
       if (reduce_all) {
@@ -2619,7 +2619,7 @@ void dot_grad(const Tensor& x,
     auto out_grad_shape =
         get_unsqueeze_dims<T>(shape<T>(out_grad_), {out_grad_dim_size});
     out_grad_ = backend::reshape<T>(out_grad_, out_grad_shape);
-    out_grad_ = backend::expand_with_tensor<T>(out_grad_, shape<T>(x));
+    out_grad_ = backend::expand<T>(out_grad_, shape<T>(x));
   } else {
     std::vector<int64_t> x_dim = common::vectorize<int64_t>(x.dims());
     auto out_grad_shape = get_unsqueeze_dims(out_grad, {out_grad_dim_size});

--- a/paddle/fluid/primitive/decomp_utils/decomp_utils.h
+++ b/paddle/fluid/primitive/decomp_utils/decomp_utils.h
@@ -351,7 +351,7 @@ class LayerNormDecompHelper {
     if (static_norm_shape_) {
       return reshape<T>(s, normlized_shape_);
     } else {
-      return backend::reshape_with_tensor<T>(
+      return backend::reshape<T>(
           s, get_slice_vec<T>(shape<T>(x), begin_norm_axis_, x_rank_));
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
Others
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->


### Description
Pcard-66975
删除 `expand_with_tensor` and `reshape_with_tensor`，这两个API可以使用现有的`expand` 和 `reshape` 代替
<!-- Describe what you’ve done -->
