### PR TITLE
[SOT] Add dispatch for dict keyword init and unary math functions

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/dispatcher.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/dispatcher.py
@@ -36,9 +36,10 @@ def format_type(type_: type[Any] | tuple[type[Any], ...]) -> str:
 
 def format_param(param: Parameter) -> str:
     kind = param.kind
-    # TODO: support VAR_KEYWORD
     if kind == inspect.Parameter.VAR_POSITIONAL:
         return f"*{format_type(param.type)}"
+    elif kind == inspect.Parameter.VAR_KEYWORD:
+        return f"**{format_type(param.type)}"
     else:
         return format_type(param.type)
 
@@ -108,6 +109,11 @@ class Parameter:
         if self.kind == inspect.Parameter.VAR_POSITIONAL:
             is_tuple = isinstance(arg, tuple)
             return is_tuple and all(isinstance(a, self.type) for a in arg)
+        elif self.kind == inspect.Parameter.VAR_KEYWORD:
+            is_dict = isinstance(arg, dict)
+            return is_dict and all(
+                isinstance(a, self.type) for a in arg.values()
+            )
         else:
             return isinstance(arg, self.type)
 

--- a/test/sot/test_05_dict.py
+++ b/test/sot/test_05_dict.py
@@ -180,6 +180,12 @@ def dict_test_fromkeys_defalut(x, y):
     return d
 
 
+@check_no_breakgraph
+def dict_keyword_init():
+    d = dict(x=1, y=2)  # noqa: C408
+    return d["x"] + d["y"]
+
+
 class TestBuildDict(TestCaseBase):
     def test_build_map(self):
         self.assert_results(build_map, 1, paddle.to_tensor(2))
@@ -258,6 +264,9 @@ class TestDictMethods(TestCaseBase):
         self.assert_results(
             dict_test_fromkeys_defalut, [1, 2, 3, 4], paddle.to_tensor(1)
         )
+
+    def test_dict_keyword_init(self):
+        self.assert_results(dict_keyword_init)
 
 
 if __name__ == "__main__":

--- a/test/sot/test_builtin_dispatch.py
+++ b/test/sot/test_builtin_dispatch.py
@@ -119,6 +119,11 @@ def test_sqrt(x: int):
     return math.sqrt(x)
 
 
+@check_no_breakgraph
+def test_log(x: int):
+    return math.log(x)
+
+
 class TestBuiltinDispatch(TestCaseBase):
     def test_dispatch_len(self):
         self.assert_results(dispatch_len, paddle.to_tensor([1, 2, 3]))
@@ -250,6 +255,9 @@ class TestBuiltinDispatch(TestCaseBase):
 
     def test_dispatch_sqrt(self):
         self.assert_results(test_sqrt, 9)
+
+    def test_dispatch_log(self):
+        self.assert_results(test_log, math.e)
 
 
 def run_getattr(x: paddle.Tensor):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

- 支持全部 unary 的 math 下的函数（如 `math.log`、`math.sqrt` 等）的 dispatch
- 支持 dict 的 keyword 初始化 `dict(x=1, y=2)` 的 dispatch

PCard-66972