### PR TITLE
[SOT][3.13] support `FORMAT_SIMPLE` opcode in python3.13

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1262,7 +1262,7 @@ class OpcodeExecutorBase:
         # in python3.13, the offset is 5
         if sys.version_info >= (3, 13):
             cmp_op_index >>= 1
-        # TODO 3.13修改了COMPARE_OP的行为，需要进一步适配，并且加入了TO_BOOL
+        # TODO 3.13 modified the behavior related to TO_BOOL, needs further modification
         op = dis.cmp_op[cmp_op_index]
         right, left = self.stack.pop(), self.stack.pop()
         self.stack.push(
@@ -1540,15 +1540,17 @@ class OpcodeExecutorBase:
 
     def FORMAT_SIMPLE(self, instr: Instruction):
         value = self.stack.pop()
-        assert (
-            value is not None
-        ), "value passed to FORMAT_SIMPLE must be a valid object!"
-        if isinstance(value, ConstantVariable):
+
+        if isinstance(value, ConstantVariable) and isinstance(value, str):
+            self.stack.push(value)
+
+        elif isinstance(value, ConstantVariable):
             result = value.get_py_value()
-            result = result.__format__("")
+            result = format(result, "")
             self.stack.push(
                 ConstantVariable(result, self._graph, DummyTracker([value]))
             )
+            return
         else:
             raise FallbackError(f"Do not support format {type(value)} now")
 

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1534,6 +1534,20 @@ class OpcodeExecutorBase:
         else:
             raise FallbackError(f"Do not support format {type(value)} now")
 
+    def FORMAT_SIMPLE(self, instr: Instruction):
+        value = self.stack.pop()
+        assert value is not None, "value passed to FORMAT_SIMPLE must be a valid object!"
+
+        if isinstance(value, ConstantVariable):
+            result = value.get_py_value().__format__("")
+            self.stack.push(
+                ConstantVariable(result, self._graph, DummyTracker([value]))
+            )
+        else:
+            raise FallbackError(
+                f"Do not support format {type(value)} now"
+            )
+    
     # NOTE: This operation will generate SideEffects, and the mechanism has not been completed yet
     def DICT_UPDATE(self, instr: Instruction):
         dict_value = self.stack.pop()

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1534,20 +1534,6 @@ class OpcodeExecutorBase:
         else:
             raise FallbackError(f"Do not support format {type(value)} now")
 
-    def FORMAT_SIMPLE(self, instr: Instruction):
-        value = self.stack.pop()
-        assert value is not None, "value passed to FORMAT_SIMPLE must be a valid object!"
-
-        if isinstance(value, ConstantVariable):
-            result = value.get_py_value().__format__("")
-            self.stack.push(
-                ConstantVariable(result, self._graph, DummyTracker([value]))
-            )
-        else:
-            raise FallbackError(
-                f"Do not support format {type(value)} now"
-            )
-    
     # NOTE: This operation will generate SideEffects, and the mechanism has not been completed yet
     def DICT_UPDATE(self, instr: Instruction):
         dict_value = self.stack.pop()

--- a/test/sot/skip_files_py313
+++ b/test/sot/skip_files_py313
@@ -1,7 +1,6 @@
 test/sot/test_03_tuple.py
 test/sot/test_04_list.py
 test/sot/test_06_call_function.py
-test/sot/test_09_f_string.py
 test/sot/test_11_jumps.py
 test/sot/test_12_for_loop.py
 test/sot/test_13_make_function.py

--- a/test/sot/skip_files_py313
+++ b/test/sot/skip_files_py313
@@ -10,7 +10,6 @@ test/sot/test_16_paddle_api.py
 test/sot/test_17_paddle_layer.py
 test/sot/test_18_tensor_method.py
 test/sot/test_19_closure.py
-test/sot/test_20_string.py
 test/sot/test_21_global.py
 test/sot/test_analysis_inputs.py
 test/sot/test_binary_operator_tracker.py


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
python3.13支持`FORMAT_SIMPLE` opcode
https://github.com/PaddlePaddle/Paddle/issues/69246
https://github.com/PaddlePaddle/Paddle/issues/69245