### PR TITLE
[Kernel] Support `take_along_axis` double grad and add necessary check

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -933,8 +933,6 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
 
         max_grad_tensor_position = -1
         for _, (_, _, pos) in backward_grad_inputs_map.items():
-            if pos <= max_fwd_input_position:
-                print(self.grad_api_contents)
             assert pos > max_fwd_input_position, AssertMessage(
                 pos, max_fwd_input_position
             )

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -83,6 +83,7 @@ prim_white_list = [
     "index_put_double_grad",
     "gather_nd_double_grad",
     "reshape_double_grad",
+    "take_along_axis_double_grad",
 ]
 
 # white ops list whose kernel can automatically do type promotion.
@@ -932,6 +933,8 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
 
         max_grad_tensor_position = -1
         for _, (_, _, pos) in backward_grad_inputs_map.items():
+            if pos <= max_fwd_input_position:
+                print(self.grad_api_contents)
             assert pos > max_fwd_input_position, AssertMessage(
                 pos, max_fwd_input_position
             )

--- a/paddle/fluid/pir/dialect/op_generator/vjp_interface_black_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/vjp_interface_black_list.py
@@ -35,4 +35,5 @@ vjp_interface_black_list = [
     'bmm_grad',
     'index_put_grad',
     'gather_nd_grad',
+    'take_along_axis_grad',
 ]

--- a/paddle/fluid/prim/api/api.yaml
+++ b/paddle/fluid/prim/api/api.yaml
@@ -53,3 +53,4 @@
 - index_put
 - isnan
 - isfinite
+- take_along_axis

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -1062,6 +1062,21 @@ void gather_nd_double_grad(const Tensor& grad_out,
 }
 
 template <typename T>
+void take_along_axis_double_grad(const Tensor& indices,
+                                 const Tensor& grad_arr_grad,
+                                 int axis,
+                                 Tensor* grad_out_grad) {
+  if (grad_out_grad) {
+    if (axis < 0) {
+      axis += grad_arr_grad.dims().size();
+    }
+    // ddout = take_along_axis(ddx, index)
+    auto grad_out_grad_tmp = take_along_axis<T>(grad_arr_grad, indices, axis);
+    set_output<T>(grad_out_grad_tmp, grad_out_grad);
+  }
+}
+
+template <typename T>
 void reshape_double_grad(const Tensor& grad_out,
                          const Tensor& grad_x_grad,
                          Tensor* grad_out_grad) {

--- a/paddle/phi/kernels/cpu/take_along_axis_kernel.cc
+++ b/paddle/phi/kernels/cpu/take_along_axis_kernel.cc
@@ -32,6 +32,20 @@ void TakeAlongAxisKernel(const Context& dev_ctx,
       dev_ctx.GetPlace().GetType() == phi::AllocationType::CPU,
       true,
       errors::PreconditionNotMet("This kernel only runs on CPU."));
+  const int x_ndim = x.dims().size();
+  PADDLE_ENFORCE_LT(
+      axis,
+      x_ndim,
+      errors::InvalidArgument(
+          "axis(%d) should be less than the x.ndim(%d).", axis, x_ndim));
+  PADDLE_ENFORCE_GE(
+      axis,
+      -x_ndim,
+      errors::InvalidArgument(
+          "axis(%d) should be larger or equal to -x.ndim(%d).", axis, -x_ndim));
+  if (axis < 0) {
+    axis += x.dims().size();
+  }
 
   out->Resize(index.dims());
   dev_ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cc
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cc
@@ -99,7 +99,7 @@ struct cpu_gather_scatter_functor {
     int64_t select_dim_size = index_dims[dim];
     // index matrix has different shape with self matrix or src matrix.
     int self_select_dim_size = self_dims[dim];
-    int src_select_dim_size = src_dims[dim];
+    int64_t src_select_dim_size = src_dims[dim];
     int64_t outer_dim_size_self = 1;
     int64_t outer_dim_size_src = 1;
     int64_t inner_dim_size = 1;
@@ -120,7 +120,29 @@ struct cpu_gather_scatter_functor {
       for (int64_t j = 0; j < select_dim_size; j++) {
         for (int64_t k = 0; k < outer_dim_size; k++) {
           int64_t index = index_data[index_idx];
-
+          PADDLE_ENFORCE_GE(index,
+                            -src_select_dim_size,
+                            common::errors::InvalidArgument(
+                                "Variable value (index) of OP(take_along_axis) "
+                                "expected >= %ld and < %ld, but got %ld. "
+                                "Please check the input "
+                                "value.",
+                                -src_select_dim_size,
+                                src_select_dim_size,
+                                index));
+          PADDLE_ENFORCE_LT(index,
+                            src_select_dim_size,
+                            common::errors::InvalidArgument(
+                                "Variable value (index) of OP(take_along_axis) "
+                                "expected >= %ld and < %ld, but got %ld. "
+                                "Please check the input "
+                                "value.",
+                                -src_select_dim_size,
+                                src_select_dim_size,
+                                index));
+          if (index < 0) {
+            index += src_select_dim_size;
+          }
           /*
             gather computation formula:
 

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cc
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cc
@@ -120,29 +120,6 @@ struct cpu_gather_scatter_functor {
       for (int64_t j = 0; j < select_dim_size; j++) {
         for (int64_t k = 0; k < outer_dim_size; k++) {
           int64_t index = index_data[index_idx];
-          PADDLE_ENFORCE_GE(index,
-                            -src_select_dim_size,
-                            common::errors::InvalidArgument(
-                                "Variable value (index) of OP(take_along_axis) "
-                                "expected >= %ld and < %ld, but got %ld. "
-                                "Please check the input "
-                                "value.",
-                                -src_select_dim_size,
-                                src_select_dim_size,
-                                index));
-          PADDLE_ENFORCE_LT(index,
-                            src_select_dim_size,
-                            common::errors::InvalidArgument(
-                                "Variable value (index) of OP(take_along_axis) "
-                                "expected >= %ld and < %ld, but got %ld. "
-                                "Please check the input "
-                                "value.",
-                                -src_select_dim_size,
-                                src_select_dim_size,
-                                index));
-          if (index < 0) {
-            index += src_select_dim_size;
-          }
           /*
             gather computation formula:
 
@@ -162,12 +139,64 @@ struct cpu_gather_scatter_functor {
           // multiply the replaced_select_dim_size.
           int64_t replace_index_self, replace_index_src;
           if (is_scatter_like) {
+            // scatter
+            PADDLE_ENFORCE_GE(
+                index,
+                -self_select_dim_size,
+                common::errors::InvalidArgument(
+                    "Variable value (index) of OP(take_along_axis) "
+                    "expected >= %ld and < %ld, but got %ld. "
+                    "Please check the input "
+                    "value.",
+                    -self_select_dim_size,
+                    self_select_dim_size,
+                    index));
+            PADDLE_ENFORCE_LT(
+                index,
+                self_select_dim_size,
+                common::errors::InvalidArgument(
+                    "Variable value (index) of OP(take_along_axis) "
+                    "expected >= %ld and < %ld, but got %ld. "
+                    "Please check the input "
+                    "value.",
+                    -self_select_dim_size,
+                    self_select_dim_size,
+                    index));
+            if (index < 0) {
+              index += self_select_dim_size;
+            }
             replace_index_self = k + index * outer_dim_size_self +
                                  i * outer_dim_size_self * self_select_dim_size;
 
             replace_index_src = k + j * outer_dim_size_src +
                                 i * outer_dim_size_src * src_select_dim_size;
           } else {
+            // gather
+            PADDLE_ENFORCE_GE(
+                index,
+                -src_select_dim_size,
+                common::errors::InvalidArgument(
+                    "Variable value (index) of OP(take_along_axis) "
+                    "expected >= %ld and < %ld, but got %ld. "
+                    "Please check the input "
+                    "value.",
+                    -src_select_dim_size,
+                    src_select_dim_size,
+                    index));
+            PADDLE_ENFORCE_LT(
+                index,
+                src_select_dim_size,
+                common::errors::InvalidArgument(
+                    "Variable value (index) of OP(take_along_axis) "
+                    "expected >= %ld and < %ld, but got %ld. "
+                    "Please check the input "
+                    "value.",
+                    -src_select_dim_size,
+                    src_select_dim_size,
+                    index));
+            if (index < 0) {
+              index += src_select_dim_size;
+            }
             replace_index_self = index_idx;
 
             replace_index_src = k + index * outer_dim_size_src +

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -127,6 +127,18 @@ __global__ void ScatterAssignGPUKernel(tensor_t* self_data,
   j = remind / outer_dim_size;
   k = remind % outer_dim_size;
   index_t index = index_data[tid];
+  PADDLE_ENFORCE(
+      index >= -src_select_dim_size && index < src_select_dim_size,
+      "The index is out of bounds, "
+      "please check whether the index and "
+      "input's shape meet the requirements. It should "
+      "be less than [%ld] and greater or equal to [%ld], but received [%d]",
+      src_select_dim_size,
+      -src_select_dim_size,
+      index);
+  if (index < 0) {
+    index += src_select_dim_size;
+  }
   /*
     gather computation formula:
 
@@ -202,6 +214,18 @@ __global__ void GatherScatterGPUKernel(tensor_t* self_data,
   j = remind / outer_dim_size;
   k = remind % outer_dim_size;
   index_t index = index_data[tid];
+  PADDLE_ENFORCE(
+      index >= -src_select_dim_size && index < src_select_dim_size,
+      "The index is out of bounds, "
+      "please check whether the index and "
+      "input's shape meet the requirements. It should "
+      "be less than [%d] and greater or equal to [%d], but received [%ld]",
+      src_select_dim_size,
+      -src_select_dim_size,
+      index);
+  if (index < 0) {
+    index += src_select_dim_size;
+  }
   /*
     gather computation formula:
 
@@ -275,6 +299,18 @@ __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
   j = remind / outer_dim_size;
   k = remind % outer_dim_size;
   index_t index = index_data[tid];
+  PADDLE_ENFORCE(
+      index >= -src_select_dim_size && index < src_select_dim_size,
+      "The index is out of bounds, "
+      "please check whether the index and "
+      "input's shape meet the requirements. It should "
+      "be less than [%ld] and greater or equal to [%ld], but received [%d]",
+      src_select_dim_size,
+      -src_select_dim_size,
+      index);
+  if (index < 0) {
+    index += src_select_dim_size;
+  }
   /*
     gather computation formula:
 

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -219,10 +219,10 @@ __global__ void GatherScatterGPUKernel(tensor_t* self_data,
       "The index is out of bounds, "
       "please check whether the index and "
       "input's shape meet the requirements. It should "
-      "be less than [%d] and greater or equal to [%d], but received [%ld]",
+      "be less than [%d] and greater or equal to [%d], but received [%d]",
       src_select_dim_size,
       -src_select_dim_size,
-      index);
+      (int32_t)index);
   if (index < 0) {
     index += src_select_dim_size;
   }

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -132,7 +132,7 @@ __global__ void ScatterAssignGPUKernel(tensor_t* self_data,
       "The index is out of bounds, "
       "please check whether the index and "
       "input's shape meet the requirements. It should "
-      "be less than [%ld] and greater or equal to [%ld], but received [%d]",
+      "be less than [%d] and greater or equal to [%d], but received [%d]",
       src_select_dim_size,
       -src_select_dim_size,
       index);
@@ -304,10 +304,10 @@ __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
       "The index is out of bounds, "
       "please check whether the index and "
       "input's shape meet the requirements. It should "
-      "be less than [%ld] and greater or equal to [%ld], but received [%d]",
+      "be less than [%d] and greater or equal to [%d], but received [%d]",
       src_select_dim_size,
       -src_select_dim_size,
-      index);
+      (int32_t)index);
   if (index < 0) {
     index += src_select_dim_size;
   }

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -127,18 +127,6 @@ __global__ void ScatterAssignGPUKernel(tensor_t* self_data,
   j = remind / outer_dim_size;
   k = remind % outer_dim_size;
   index_t index = index_data[tid];
-  PADDLE_ENFORCE(
-      index >= -src_select_dim_size && index < src_select_dim_size,
-      "The index is out of bounds, "
-      "please check whether the index and "
-      "input's shape meet the requirements. It should "
-      "be less than [%d] and greater or equal to [%d], but received [%d]",
-      src_select_dim_size,
-      -src_select_dim_size,
-      index);
-  if (index < 0) {
-    index += src_select_dim_size;
-  }
   /*
     gather computation formula:
 
@@ -156,12 +144,36 @@ __global__ void ScatterAssignGPUKernel(tensor_t* self_data,
   // index matrix has different shape with self matrix or src matrix.
   int64_t replace_index_self, replace_index_src;
   if (is_scatter_like) {
+    PADDLE_ENFORCE(
+        index >= -self_select_dim_size && index < self_select_dim_size,
+        "The index is out of bounds, "
+        "please check whether the index and "
+        "input's shape meet the requirements. It should "
+        "be greater or equal to [%d] and less than [%d], but received [%d]",
+        -self_select_dim_size,
+        self_select_dim_size,
+        index);
+    if (index < 0) {
+      index += self_select_dim_size;
+    }
     replace_index_self = k + index * outer_dim_size_self +
                          i * outer_dim_size_self * self_select_dim_size;
 
     replace_index_src = k + j * outer_dim_size_src +
                         i * outer_dim_size_src * src_select_dim_size;
   } else {
+    PADDLE_ENFORCE(
+        index >= -src_select_dim_size && index < src_select_dim_size,
+        "The index is out of bounds, "
+        "please check whether the index and "
+        "input's shape meet the requirements. It should "
+        "be greater or equal to [%d] and less than [%d], but received [%d]",
+        -src_select_dim_size,
+        src_select_dim_size,
+        index);
+    if (index < 0) {
+      index += src_select_dim_size;
+    }
     replace_index_self = tid;
 
     replace_index_src = k + index * outer_dim_size_src +
@@ -214,18 +226,6 @@ __global__ void GatherScatterGPUKernel(tensor_t* self_data,
   j = remind / outer_dim_size;
   k = remind % outer_dim_size;
   index_t index = index_data[tid];
-  PADDLE_ENFORCE(
-      index >= -src_select_dim_size && index < src_select_dim_size,
-      "The index is out of bounds, "
-      "please check whether the index and "
-      "input's shape meet the requirements. It should "
-      "be less than [%d] and greater or equal to [%d], but received [%d]",
-      src_select_dim_size,
-      -src_select_dim_size,
-      (int32_t)index);
-  if (index < 0) {
-    index += src_select_dim_size;
-  }
   /*
     gather computation formula:
 
@@ -243,12 +243,38 @@ __global__ void GatherScatterGPUKernel(tensor_t* self_data,
   // index matrix has different shape with self matrix or src matrix.
   int64_t replace_index_self, replace_index_src;
   if (is_scatter_like) {
+    // scatter
+    PADDLE_ENFORCE(
+        index >= -self_select_dim_size && index < self_select_dim_size,
+        "The index is out of bounds, "
+        "please check whether the index and "
+        "input's shape meet the requirements. It should "
+        "be greater or equal to [%d] and less than [%d], but received [%d]",
+        -self_select_dim_size,
+        self_select_dim_size,
+        (int32_t)index);
+    if (index < 0) {
+      index += self_select_dim_size;
+    }
     replace_index_self = k + index * outer_dim_size_self +
                          i * outer_dim_size_self * self_select_dim_size;
 
     replace_index_src = k + j * outer_dim_size_src +
                         i * outer_dim_size_src * src_select_dim_size;
   } else {
+    // gather
+    PADDLE_ENFORCE(
+        index >= -src_select_dim_size && index < src_select_dim_size,
+        "The index is out of bounds, "
+        "please check whether the index and "
+        "input's shape meet the requirements. It should "
+        "be greater or equal to [%d] and less than [%d], but received [%d]",
+        -src_select_dim_size,
+        src_select_dim_size,
+        (int32_t)index);
+    if (index < 0) {
+      index += src_select_dim_size;
+    }
     replace_index_self = tid;
 
     replace_index_src = k + index * outer_dim_size_src +
@@ -299,18 +325,6 @@ __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
   j = remind / outer_dim_size;
   k = remind % outer_dim_size;
   index_t index = index_data[tid];
-  PADDLE_ENFORCE(
-      index >= -src_select_dim_size && index < src_select_dim_size,
-      "The index is out of bounds, "
-      "please check whether the index and "
-      "input's shape meet the requirements. It should "
-      "be less than [%d] and greater or equal to [%d], but received [%d]",
-      src_select_dim_size,
-      -src_select_dim_size,
-      (int32_t)index);
-  if (index < 0) {
-    index += src_select_dim_size;
-  }
   /*
     gather computation formula:
 
@@ -328,12 +342,36 @@ __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
   // index matrix has different shape with self matrix or src matrix.
   int64_t replace_index_self, replace_index_src;
   if (is_scatter_like) {
+    PADDLE_ENFORCE(
+        index >= -self_select_dim_size && index < self_select_dim_size,
+        "The index is out of bounds, "
+        "please check whether the index and "
+        "input's shape meet the requirements. It should "
+        "be greater or equal to [%d] and less than [%d], but received [%d]",
+        -self_select_dim_size,
+        self_select_dim_size,
+        (int32_t)index);
+    if (index < 0) {
+      index += self_select_dim_size;
+    }
     replace_index_self = k + index * outer_dim_size_self +
                          i * outer_dim_size_self * self_select_dim_size;
 
     replace_index_src = k + j * outer_dim_size_src +
                         i * outer_dim_size_src * src_select_dim_size;
   } else {
+    PADDLE_ENFORCE(
+        index >= -src_select_dim_size && index < src_select_dim_size,
+        "The index is out of bounds, "
+        "please check whether the index and "
+        "input's shape meet the requirements. It should "
+        "be greater or equal to [%d] and less than [%d], but received [%d]",
+        -src_select_dim_size,
+        src_select_dim_size,
+        (int32_t)index);
+    if (index < 0) {
+      index += src_select_dim_size;
+    }
     replace_index_self = tid;
 
     replace_index_src = k + index * outer_dim_size_src +
@@ -676,6 +714,19 @@ __global__ void ScatterMulInputGradGPUKernel(tensor_t* grad_data,
   j = remind / outer_dim_size;
   k = remind % outer_dim_size;
   index_t index = index_data[tid];
+  PADDLE_ENFORCE(
+      index >= -grad_select_dim_size && index < grad_select_dim_size,
+      "The index is out of bounds, "
+      "please check whether the index and "
+      "input's shape meet the requirements. It should "
+      "be greater or equal to [%d] and less than [%d], but received [%d]",
+      -grad_select_dim_size,
+      grad_select_dim_size,
+      (int32_t)index);
+  if (index < 0) {
+    index += grad_select_dim_size;
+  }
+
   int64_t replace_index = k + index * outer_dim_size_grad +
                           i * outer_dim_size_grad * grad_select_dim_size;
   atomicMax(thread_ids + replace_index, tid);
@@ -712,6 +763,19 @@ __global__ void ScatterMinMaxInputGradGPUKernel(tensor_t* grad_data,
   j = remind / outer_dim_size;
   k = remind % outer_dim_size;
   index_t index = index_data[tid];
+  PADDLE_ENFORCE(
+      index >= -grad_select_dim_size && index < grad_select_dim_size,
+      "The index is out of bounds, "
+      "please check whether the index and "
+      "input's shape meet the requirements. It should "
+      "be greater or equal to [%d] and less than [%d], but received [%d]",
+      -grad_select_dim_size,
+      grad_select_dim_size,
+      (int32_t)index);
+  if (index < 0) {
+    index += grad_select_dim_size;
+  }
+
   int64_t replace_index = k + index * outer_dim_size_grad +
                           i * outer_dim_size_grad * grad_select_dim_size;
   int64_t replace_index_value =
@@ -751,8 +815,24 @@ void gpu_scatter_mul_min_max_input_grad_kernel(phi::DenseTensor self,
   int64_t index_size = index.numel();
   auto index_dims = index.dims();
   auto grad_dims = grad.dims();
+  auto grad_ndim = grad_dims.size();
   auto x_dims = x.dims();
   auto value_dims = value.dims();
+
+  PADDLE_ENFORCE_LT(
+      dim,
+      grad_ndim,
+      errors::InvalidArgument(
+          "axis(%d) should be less than the x.ndim(%d).", dim, grad_ndim));
+  PADDLE_ENFORCE_GE(dim,
+                    -grad_ndim,
+                    errors::InvalidArgument(
+                        "axis(%d) should be larger or equal to -x.ndim(%d).",
+                        dim,
+                        -grad_ndim));
+  if (dim < 0) {
+    dim += grad_ndim;
+  }
 
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
@@ -837,6 +917,19 @@ __global__ void ScatterMeanInputGradGPUKernel(tensor_t* grad_data,
   index_t index = index_data[tid];
   int64_t replace_index = k + index * outer_dim_size_grad +
                           i * outer_dim_size_grad * grad_select_dim_size;
+  PADDLE_ENFORCE(
+      index >= -grad_select_dim_size && index < grad_select_dim_size,
+      "The index is out of bounds, "
+      "please check whether the index and "
+      "input's shape meet the requirements. It should "
+      "be greater or equal to [%d] and less than [%d], but received [%d]",
+      -grad_select_dim_size,
+      grad_select_dim_size,
+      (int32_t)index);
+  if (index < 0) {
+    index += grad_select_dim_size;
+  }
+
   atomicMax(shared_mem + replace_index, tid);
   phi::CudaAtomicAdd(shared_mem + numel_grad + replace_index, 1);
   __syncthreads();
@@ -929,6 +1022,19 @@ __global__ void ScatterValueGradGPUKernel(tensor_t* grad_data,
   index_t index = index_data[tid];
   int64_t replace_index_self = k + index * outer_dim_size_self +
                                i * outer_dim_size_self * self_select_dim_size;
+  PADDLE_ENFORCE(
+      index >= -grad_select_dim_size && index < grad_select_dim_size,
+      "The index is out of bounds, "
+      "please check whether the index and "
+      "input's shape meet the requirements. It should "
+      "be greater or equal to [%d] and less than [%d], but received [%d]",
+      -grad_select_dim_size,
+      grad_select_dim_size,
+      (int32_t)index);
+  if (index < 0) {
+    index += grad_select_dim_size;
+  }
+
   atomicMax(thread_ids + replace_index_self, tid);
   __syncthreads();
 
@@ -1023,6 +1129,18 @@ __global__ void ScatterMeanValueGradGPUKernel(tensor_t* grad_data,
   index_t index = index_data[tid];
   int64_t replace_index_self = k + index * outer_dim_size_self +
                                i * outer_dim_size_self * self_select_dim_size;
+  PADDLE_ENFORCE(
+      index >= -grad_select_dim_size && index < grad_select_dim_size,
+      "The index is out of bounds, "
+      "please check whether the index and "
+      "input's shape meet the requirements. It should "
+      "be greater or equal to [%d] and less than [%d], but received [%d]",
+      -grad_select_dim_size,
+      grad_select_dim_size,
+      (int32_t)index);
+  if (index < 0) {
+    index += grad_select_dim_size;
+  }
 
   phi::CudaAtomicAdd(shared_mem + replace_index_self, 1);
   __syncthreads();
@@ -1054,6 +1172,19 @@ __global__ void ScatterAddValueGradGPUKernel(tensor_t* grad_data,
   j = remind / outer_dim_size;
   k = remind % outer_dim_size;
   index_t index = index_data[tid];
+  PADDLE_ENFORCE(
+      index >= -grad_select_dim_size && index < grad_select_dim_size,
+      "The index is out of bounds, "
+      "please check whether the index and "
+      "input's shape meet the requirements. It should "
+      "be greater or equal to [%d] and less than [%d], but received [%d]",
+      -grad_select_dim_size,
+      grad_select_dim_size,
+      (int32_t)index);
+  if (index < 0) {
+    index += grad_select_dim_size;
+  }
+
   int64_t replace_index_self = k + index * outer_dim_size_self +
                                i * outer_dim_size_self * self_select_dim_size;
   int64_t replace_index_grad = k + j * outer_dim_size_grad +
@@ -1167,6 +1298,19 @@ __global__ void ScatterMulValueGradGPUKernel(tensor_t* grad_data,
   j = remind / outer_dim_size;
   k = remind % outer_dim_size;
   index_t index = index_data[tid];
+  PADDLE_ENFORCE(
+      index >= -grad_select_dim_size && index < grad_select_dim_size,
+      "The index is out of bounds, "
+      "please check whether the index and "
+      "input's shape meet the requirements. It should "
+      "be greater or equal to [%d] and less than [%d], but received [%d]",
+      -grad_select_dim_size,
+      grad_select_dim_size,
+      (int32_t)index);
+  if (index < 0) {
+    index += grad_select_dim_size;
+  }
+
   int64_t replace_index_self = k + index * outer_dim_size_self +
                                i * outer_dim_size_self * self_select_dim_size;
   int64_t replace_index_grad = k + j * outer_dim_size_grad +
@@ -1202,6 +1346,19 @@ __global__ void ScatterMinMaxValueGradGPUKernel(tensor_t* grad_data,
   j = remind / outer_dim_size;
   k = remind % outer_dim_size;
   index_t index = index_data[tid];
+  PADDLE_ENFORCE(
+      index >= -grad_select_dim_size && index < grad_select_dim_size,
+      "The index is out of bounds, "
+      "please check whether the index and "
+      "input's shape meet the requirements. It should "
+      "be greater or equal to [%d] and less than [%d], but received [%d]",
+      -grad_select_dim_size,
+      grad_select_dim_size,
+      (int32_t)index);
+  if (index < 0) {
+    index += grad_select_dim_size;
+  }
+
   int64_t replace_index_self = k + index * outer_dim_size_self +
                                i * outer_dim_size_self * self_select_dim_size;
   int64_t replace_index_grad = k + j * outer_dim_size_grad +

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -3279,9 +3279,12 @@
 
 - backward_op : take_along_axis_double_grad
   forward : take_along_axis_grad (Tensor arr, Tensor indices, Tensor grad_out, int axis) -> Tensor(grad_arr)
-  args : (Tensor grad_arr_grad, Tensor indices, int axis)
+  args : (Tensor indices, Tensor grad_arr_grad, int axis)
   output : Tensor(grad_out_grad)
-  invoke : take_along_axis(grad_arr_grad, indices, axis)
+  infer_meta :
+    func : TakeAlongAxisInferMeta
+    param : [grad_arr_grad, indices, axis]
+  composite : take_along_axis_double_grad(indices, grad_arr_grad, axis, grad_out_grad)
 
 - backward_op : take_along_axis_grad
   forward : take_along_axis (Tensor arr, Tensor indices, int axis) -> Tensor(out)
@@ -3292,6 +3295,7 @@
     param : [arr]
   kernel :
     func : take_along_axis_grad
+  backward : take_along_axis_double_grad
 
 - backward_op : tan_grad
   forward : tan (Tensor x) -> Tensor(out)

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -3277,6 +3277,12 @@
     data_type : out_grad
   optional : reserve_space
 
+- backward_op : take_along_axis_double_grad
+  forward : take_along_axis_grad (Tensor arr, Tensor indices, Tensor grad_out, int axis) -> Tensor(grad_arr)
+  args : (Tensor grad_arr_grad, Tensor indices, int axis)
+  output : Tensor(grad_out_grad)
+  invoke : take_along_axis(grad_arr_grad, indices, axis)
+
 - backward_op : take_along_axis_grad
   forward : take_along_axis (Tensor arr, Tensor indices, int axis) -> Tensor(out)
   args : (Tensor arr, Tensor indices, Tensor out_grad, int axis)

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -3771,7 +3771,7 @@
     attrs : [bool use_mkldnn = false, bool fuse_with_relu = false]
 
 - op : take_along_axis
-  backward : take_along_axis_grad, take_along_axis_double_grad
+  backward : take_along_axis_grad
   inputs :
     {arr : Input, indices : Index}
   outputs :

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -3771,7 +3771,7 @@
     attrs : [bool use_mkldnn = false, bool fuse_with_relu = false]
 
 - op : take_along_axis
-  backward : take_along_axis_grad
+  backward : take_along_axis_grad, take_along_axis_double_grad
   inputs :
     {arr : Input, indices : Index}
   outputs :

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -6444,11 +6444,6 @@ def take_along_axis(
                     f"Size does not match at dimension {i} expected index {indices.shape} to be smaller than self {arr.shape} apart from dimension {axis}"
                 )
 
-        axis_max_size = arr.shape[axis]
-        if in_dynamic_mode() and not (indices < axis_max_size).all():
-            raise RuntimeError(
-                f"one of element of indices is out of bounds for dimension {axis} with size {axis_max_size}"
-            )
     if in_dynamic_or_pir_mode():
         return _C_ops.take_along_axis(arr, indices, axis)
     else:

--- a/test/legacy_test/test_take_along_axis_op.py
+++ b/test/legacy_test/test_take_along_axis_op.py
@@ -302,17 +302,23 @@ class TestTakeAlongAxisAPICase2(unittest.TestCase):
         indices = paddle.to_tensor([1]).astype("int32")
         # len(arr.shape) != len(indices.shape)
         with self.assertRaises(ValueError):
-            res = paddle.take_along_axis(tensorx, indices, 0, False)
+            res = paddle.take_along_axis(
+                tensorx.to("cpu"), indices.to("cpu"), 0, False
+            )
         # the element of indices out of range
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             indices = paddle.to_tensor([[100]]).astype("int32")
-            res = paddle.take_along_axis(tensorx, indices, 0, False)
+            res = paddle.take_along_axis(
+                tensorx.to("cpu"), indices.to("cpu"), 0, False
+            )
         # the shape of indices doesn't match
         with self.assertRaises(RuntimeError):
             indices = paddle.to_tensor(
                 [[1, 0, 0, 0], [1, 0, 0, 0], [1, 0, 0, 0]]
             ).astype("int32")
-            res = paddle.take_along_axis(tensorx, indices, 0, False)
+            res = paddle.take_along_axis(
+                tensorx.to("cpu"), indices.to("cpu"), 0, False
+            )
 
 
 class TestTakeAlongAxisAPICase3(unittest.TestCase):

--- a/test/legacy_test/test_take_along_axis_op.py
+++ b/test/legacy_test/test_take_along_axis_op.py
@@ -375,7 +375,7 @@ class TestTakeAlongAxisAPICase3(unittest.TestCase):
         with self.assertRaises(ValueError):
             res = paddle.take_along_axis(tensorx, indices, axis, False)
 
-        # only test cpu because gpu error can not be caught by assertRaises
+        # only test cpu below because gpu error can not be caught by assertRaises
         # the element of indices out of range
         with self.assertRaises(ValueError):
             indices = paddle.to_tensor([[100]]).astype("int32")
@@ -388,7 +388,7 @@ class TestTakeAlongAxisAPICase3(unittest.TestCase):
                 [[1, 0, 0, 0], [1, 0, 0, 0], [1, 0, 0, 0]]
             ).astype("int32")
             res = paddle.take_along_axis(
-                tensorx.cpu(), indices.cpu(), axis, False
+                tensorx.to("cpu"), indices.to("cpu"), axis, False
             )
         # the index value in indices do not in range: [-arr_shape[axis], arr_shape[axis])
         with self.assertRaises(ValueError):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-75624

1. `take_along_axis`支持动态图二阶反向组合
2. 增加 `take_along_axis`相关CPU/GPU kernel 内对axis、indices的范围检查与抛出异常逻辑，删除python端的indices范围检查（会调用多个额外的算子，较为耗时），更新对应单测