### PR TITLE
[Inference] 确保常量折叠pass中执行器执行前的pd_op_lower_to_kernel_pass阶段不会改变算子的输出数据类型

### DIFF
--- a/paddle/fluid/pir/transforms/general/constant_folding_pass.cc
+++ b/paddle/fluid/pir/transforms/general/constant_folding_pass.cc
@@ -402,7 +402,7 @@ class ConstantFoldingPattern : public pir::RewritePattern {
       std::string output_var_name =
           "constant_folding@_" + ss.str() + std::to_string((*suffix_)++);
 
-      builder.Build<pir::ShadowOutputOp>(cast_op->result(0), output_var_name);
+      builder.Build<pir::ShadowOutputOp>(cast_op.result(0), output_var_name);
       output_var_names.push_back(output_var_name);
     }
 

--- a/paddle/fluid/pir/transforms/general/constant_folding_pass.cc
+++ b/paddle/fluid/pir/transforms/general/constant_folding_pass.cc
@@ -26,6 +26,7 @@
 #include "paddle/fluid/pir/dialect/operator/ir/op_dialect.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/dialect/operator/utils/utils.h"
 #include "paddle/fluid/pir/transforms/pd_op_to_kernel_pass.h"
 #include "paddle/fluid/pir/utils/general_functions.h"
 
@@ -389,6 +390,11 @@ class ConstantFoldingPattern : public pir::RewritePattern {
       if (!op_copy->result(i) || !op_copy->result(i).type()) {
         continue;
       }
+
+      auto cast_op = builder.Build<paddle::dialect::CastOp>(
+          op_copy->result(i),
+          paddle::dialect::GetValueDataType(op_copy->result(i)));
+
       std::stringstream ss;
       ss << std::chrono::high_resolution_clock::now()
                 .time_since_epoch()
@@ -396,7 +402,7 @@ class ConstantFoldingPattern : public pir::RewritePattern {
       std::string output_var_name =
           "constant_folding@_" + ss.str() + std::to_string((*suffix_)++);
 
-      builder.Build<pir::ShadowOutputOp>(op_copy->result(i), output_var_name);
+      builder.Build<pir::ShadowOutputOp>(cast_op->result(0), output_var_name);
       output_var_names.push_back(output_var_name);
     }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-71500

通过插入一个冗余的cast算子，确保常量折叠pass中执行器执行前的pd_op_lower_to_kernel_pass阶段不会改变算子的输出数据类型（由于类型提升机制）。