### PR TITLE
[CINN] Adjust tile config parameters based on model benchmarks

### DIFF
--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -201,7 +201,8 @@ TileConfigMap BuildPureStaticShapeConfig(
   if (last_dim == "R") {
     rd_thread_num = 32;
     int64_t remain_reduce_numel = CeilDiv(reduce_numel, 32);
-    if (remain_reduce_numel <= 8 && spatial_numel > 1) {
+    if ((remain_reduce_numel <= 8 && spatial_numel > 1) ||
+        (spatial_numel > remain_reduce_numel * 128)) {
       sp_thread_num = Trim(spatial_numel, 1, 8);
       reduce_method = WarpReduceMethod();
     } else {
@@ -247,7 +248,7 @@ TileConfigMap BuildPureStaticShapeConfig(
       return 1;
     }
     int64_t expected = spatial_numel / (sm_count * 4);
-    return CeilPow2(Trim(expected, 1, 32));
+    return CeilPow2(Trim(expected, 1, 4));
   }();
 
   int64_t sp_upper_bound = base_info->spatial_numel > 1 ? kMaxNumel : 1;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Performance


### Description
Adjust two key parameters in TileConfig based on recent end-to-end model benchmark results.

**Change 1:**
Add one more condition for using WarpReduce. This improves performance for huge-S-small-R cases, such as:
```python
reduce(shape=[128, 197, 768] axis=2)
reduce(shape=[32, 512, 56, 56], axis=(2, 3))
```

**Change 2:**
Set tighter limit on spatial inner loop number (from 32 to 4). This prevents performance degradation in Transpose and certain element-wise operations.
**Note:** this change doesn't imply that 32 is inherently a worse choice than 4; rather, it is due to the lack of support for scheduling Transpose, and 4 is currently the optimal choice for nvcc to do just acceptable optimization.

Pcard-85711