### PR TITLE
[PIR]refine optimization ouput

### DIFF
--- a/paddle/fluid/pir/utils/name_analysis.cc
+++ b/paddle/fluid/pir/utils/name_analysis.cc
@@ -225,7 +225,6 @@ std::optional<std::string> GetCorrespondingInplaceName(pir::Operation *op) {
       pir::Operation *owner = inplace_value.defining_op();
       if (owner->isa<pir::ParameterOp>()) {
         pir::ParameterOp parameter_op = owner->dyn_cast<pir::ParameterOp>();
-        // auto value = parameter_op->result(0);
         std::string name = parameter_op.param_name();
         return name;
       }
@@ -299,11 +298,6 @@ std::optional<std::string> TryGetValueFirstName(pir::Value value) {
 
 std::string GetValueFirstName(pir::Value value) {
   auto name = TryGetValueFirstName(value);
-  if (name.has_value()) {
-    std::cout << name.value() << std::endl;
-  } else {
-    std::cout << "No value" << std::endl;
-  }
   PADDLE_ENFORCE(name.has_value(),
                  common::errors::InvalidArgument(
                      "Currently, we can only get name of Value from "

--- a/paddle/fluid/pir/utils/name_analysis.cc
+++ b/paddle/fluid/pir/utils/name_analysis.cc
@@ -248,8 +248,7 @@ std::optional<std::string> GetValueInputName(pir::Value value) {
     pir::Operation *owner = value.defining_op();
     if (owner->isa<pir::ParameterOp>()) {
       pir::ParameterOp parameter_op = owner->dyn_cast<pir::ParameterOp>();
-      std::string name = parameter_op.param_name();
-      return name;
+      name = parameter_op.param_name();
     }
   }
   return name;

--- a/paddle/fluid/pir/utils/name_analysis.cc
+++ b/paddle/fluid/pir/utils/name_analysis.cc
@@ -216,7 +216,6 @@ pir::Value GetCorrespondingInplaceValue(pir::Operation *op) {
           ->get_op_info_(op_name),
       paddle::dialect::IsLegacyOp(op_name));
   for (size_t i = 0; i < op->num_results(); ++i) {
-    pir::Value value = op->result(i);
     std::string value_name = yaml_parser.OutputNames()[i];
     if (yaml_parser.HasInplace(value_name)) {
       const std::string &inplace_name = yaml_parser.InplaceName(value_name);

--- a/paddle/fluid/pir/utils/name_analysis.cc
+++ b/paddle/fluid/pir/utils/name_analysis.cc
@@ -14,7 +14,8 @@
 
 #include "paddle/fluid/pir/utils/name_analysis.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
-
+#include "paddle/fluid/pir/dialect/operator/trait/inplace.h"
+#include "paddle/fluid/pir/dialect/operator/utils/op_yaml_info_parser.h"
 namespace pir {
 namespace utils {
 namespace name_analysis {
@@ -206,6 +207,33 @@ std::map<std::string, std::string> RenameValue(Value value,
   return rename_mapping;
 }
 
+std::optional<std::string> GetCorrespondingInplaceName(pir::Operation *op) {
+  pir::IrContext *ctx = pir::IrContext::Instance();
+  auto op_name = op->name();
+  pir::OpInfo op_info = ctx->GetRegisteredOpInfo(op_name);
+  paddle::dialect::OpYamlInfoParser yaml_parser(
+      op_info.GetInterfaceImpl<paddle::dialect::OpYamlInfoInterface>()
+          ->get_op_info_(op_name),
+      paddle::dialect::IsLegacyOp(op_name));
+  for (size_t i = 0; i < op->num_results(); ++i) {
+    pir::Value value = op->result(i);
+    std::string value_name = yaml_parser.OutputNames()[i];
+    if (yaml_parser.HasInplace(value_name)) {
+      const std::string &inplace_name = yaml_parser.InplaceName(value_name);
+      pir::Value inplace_value =
+          op->operand_source(yaml_parser.InputName2Id().at(inplace_name));
+      pir::Operation *owner = inplace_value.defining_op();
+      if (owner->isa<pir::ParameterOp>()) {
+        pir::ParameterOp parameter_op = owner->dyn_cast<pir::ParameterOp>();
+        // auto value = parameter_op->result(0);
+        std::string name = parameter_op.param_name();
+        return name;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
 std::optional<std::string> GetValueInputName(pir::Value value) {
   std::optional<std::string> name;
   if (auto block_arg = value.dyn_cast<pir::BlockArgument>()) {
@@ -220,6 +248,9 @@ std::optional<std::string> GetValueInputName(pir::Value value) {
     name = data_op.attribute<pir::StrAttribute>("name").AsString();
   } else if (auto constant_op = value.defining_op<::pir::ConstantTensorOp>()) {
     name = constant_op.tensor_name();
+  } else if (value.defining_op()->HasTrait<paddle::dialect::InplaceTrait>()) {
+    auto defining_op = value.defining_op();
+    name = GetCorrespondingInplaceName(defining_op);
   }
   return name;
 }
@@ -268,7 +299,11 @@ std::optional<std::string> TryGetValueFirstName(pir::Value value) {
 
 std::string GetValueFirstName(pir::Value value) {
   auto name = TryGetValueFirstName(value);
-
+  if (name.has_value()) {
+    std::cout << name.value() << std::endl;
+  } else {
+    std::cout << "No value" << std::endl;
+  }
   PADDLE_ENFORCE(name.has_value(),
                  common::errors::InvalidArgument(
                      "Currently, we can only get name of Value from "

--- a/paddle/fluid/pir/utils/name_analysis.h
+++ b/paddle/fluid/pir/utils/name_analysis.h
@@ -38,7 +38,7 @@ std::map<std::string, std::string> RenameValue(Value value,
                                                const std::string &new_name,
                                                Block *block);
 std::optional<std::string> GetValueInputName(pir::Value value);
-
+std::optional<std::string> GetCorrespondingInplaceName(pir::Operation *op);
 std::vector<std::string> GetValueOutputNames(pir::Value value);
 pir::Value GetOutputValueByName(const pir::Program &program,
                                 const std::string &name);

--- a/paddle/fluid/pir/utils/name_analysis.h
+++ b/paddle/fluid/pir/utils/name_analysis.h
@@ -38,7 +38,7 @@ std::map<std::string, std::string> RenameValue(Value value,
                                                const std::string &new_name,
                                                Block *block);
 std::optional<std::string> GetValueInputName(pir::Value value);
-std::optional<std::string> GetCorrespondingInplaceName(pir::Operation *op);
+pir::Value GetCorrespondingInplaceValue(pir::Operation *op);
 std::vector<std::string> GetValueOutputNames(pir::Value value);
 pir::Value GetOutputValueByName(const pir::Program &program,
                                 const std::string &name);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

1. 背景：

    自动并行场景下tensor fusion要求必须将参数也切分到与梯度相匹配的不规则切分状态，这需要调用切分算子对参数进行切分，从而导致传递给optimizer的参数不再是parameter算子的输出。更新后paramter list里的value不是parameter op的输出，没有name信息导致报错：
![image](https://github.com/user-attachments/assets/c7a8e83c-abce-4949-bdf2-4b57066c97dc)

2. 解决方法：
    当value的defining op是inplace的，通过yamlparser获取value_name对应的inplace_name，根据inplace_name获取其在op->operand_source中的index，进一步获取defining->op，返回该paramter_op的param_name信息

![image](https://github.com/user-attachments/assets/50a87f72-88ca-4f8a-b73f-44a1bc73d2a1)



pcard-67164

