### PR TITLE
[CINN] Fix reduce anchor fusion with same loop but different reduce axis

### DIFF
--- a/paddle/cinn/operator_fusion/policy/iters_fusion_policy.cc
+++ b/paddle/cinn/operator_fusion/policy/iters_fusion_policy.cc
@@ -165,6 +165,13 @@ ItersFusionPolicy::SearchTransformRouteFromReduce2Reduce(
     auto [source_flatten_iters, source_reduce_iters] = SplitReduceIters(source);
     auto [target_flatten_iters, target_reduce_iters] = SplitReduceIters(target);
 
+    if (AnyFirstInSecond(source_reduce_iters, target_flatten_iters) ||
+        AnyFirstInSecond(target_reduce_iters, source_flatten_iters)) {
+      VLOG(4) << "Exist reduce iters in one ReduceOp found in the flatten "
+                 "iters in another ReduceOp.";
+      return std::nullopt;
+    }
+
     ItersTransformRoute route;
     // 1. Apply ReuseItersTransform
     const auto flatten_reuse_iters_transform =

--- a/test/ir/pir/cinn/test_anchor_fusion.py
+++ b/test/ir/pir/cinn/test_anchor_fusion.py
@@ -263,6 +263,19 @@ class TestAnchorFusion(unittest.TestCase):
 
         self.check_accuracy_and_kernel_num(init, func)
 
+    def test_reduce_cant_anchor_fusion(self):
+        def func(x):
+            a = x * 2
+            b = paddle.max(a, axis=2, keepdim=True)
+            c = paddle.max(a, axis=3, keepdim=True)
+            return a, b, c
+
+        def init():
+            x = paddle.rand((4, 256, 16, 16), dtype="float16")
+            return (x,)
+
+        self.check_accuracy_and_kernel_num(init, func, kernel_num=2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- Fix reduce anchor fusion with same loop but different reduce axis