### PR TITLE
[Prim] Support take along axis double grad

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -83,6 +83,7 @@ prim_white_list = [
     "index_put_double_grad",
     "gather_nd_double_grad",
     "reshape_double_grad",
+    "take_along_axis_double_grad",
 ]
 
 # white ops list whose kernel can automatically do type promotion.

--- a/paddle/fluid/pir/dialect/op_generator/vjp_interface_black_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/vjp_interface_black_list.py
@@ -35,4 +35,5 @@ vjp_interface_black_list = [
     'bmm_grad',
     'index_put_grad',
     'gather_nd_grad',
+    'take_along_axis_grad',
 ]

--- a/paddle/fluid/prim/api/api.yaml
+++ b/paddle/fluid/prim/api/api.yaml
@@ -53,3 +53,4 @@
 - index_put
 - isnan
 - isfinite
+- take_along_axis

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -1072,5 +1072,20 @@ void reshape_double_grad(const Tensor& grad_out,
   }
 }
 
+template <typename T>
+void take_along_axis_double_grad(const Tensor& indices,
+                                 const Tensor& grad_arr_grad,
+                                 int axis,
+                                 Tensor* grad_out_grad) {
+  if (grad_out_grad) {
+    if (axis < 0) {
+      axis += grad_arr_grad.dims().size();
+    }
+    // ddout = take_along_axis(ddx, index)
+    auto grad_out_grad_tmp = take_along_axis<T>(grad_arr_grad, indices, axis);
+    set_output<T>(grad_out_grad_tmp, grad_out_grad);
+  }
+}
+
 }  // namespace prim
 }  // namespace paddle

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -3277,6 +3277,15 @@
     data_type : out_grad
   optional : reserve_space
 
+- backward_op : take_along_axis_double_grad
+  forward : take_along_axis_grad (Tensor arr, Tensor indices, Tensor grad_out, int axis) -> Tensor(grad_arr)
+  args : (Tensor indices, Tensor grad_arr_grad, int axis)
+  output : Tensor(grad_out_grad)
+  infer_meta :
+    func : TakeAlongAxisInferMeta
+    param : [grad_arr_grad, indices, axis]
+  composite : take_along_axis_double_grad(indices, grad_arr_grad, axis, grad_out_grad)
+
 - backward_op : take_along_axis_grad
   forward : take_along_axis (Tensor arr, Tensor indices, int axis) -> Tensor(out)
   args : (Tensor arr, Tensor indices, Tensor out_grad, int axis)
@@ -3286,6 +3295,7 @@
     param : [arr]
   kernel :
     func : take_along_axis_grad
+  backward : take_along_axis_double_grad
 
 - backward_op : tan_grad
   forward : tan (Tensor x) -> Tensor(out)

--- a/test/prim/prim/vjp/eager/test_comp_eager_take_along_axis_double_grad.py
+++ b/test/prim/prim/vjp/eager/test_comp_eager_take_along_axis_double_grad.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,100 +18,36 @@ import numpy as np
 import parameterized as param
 
 import paddle
-from paddle.base import core
 
 
 @param.parameterized_class(
     ('arr', 'indices', 'axis', 'cotangent', 'dtype'),
     [
         (
-            np.random.rand(4, 3, 2),  # arr
-            np.array([[0, 1], [2, 1]], dtype=np.int64),  # indices
+            np.random.randn(4, 3, 2),  # arr
+            np.random.randint(0, 3, size=(1, 3, 2)),  # indices
             1,  # axis
-            np.random.rand(4, 2, 2),  # cotangent
+            np.random.rand(1, 3, 2),  # cotangent
             np.float32,  # dtype
         ),
-        # 可以添加更多测试用例
     ],
 )
 class TestTakeAlongAxisTanhDoubleGrad(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        core.set_prim_eager_enabled(True)
-        cls.arr = cls.arr.astype(cls.dtype)
-        if cls.cotangent is not None:
-            cls.cotangent = cls.cotangent.astype(cls.dtype)
-
-    @classmethod
-    def tearDownClass(cls):
-        core.set_prim_eager_enabled(False)
-
     def test_take_along_axis_tanh_double_grad(self):
-        def actual(arr, indices, axis, cotangent):
-            arr = paddle.to_tensor(arr)
-            arr.stop_gradient = False
-            indices = paddle.to_tensor(indices)
-
-            # 复合函数：take_along_axis后接tanh
-            def composite_func(x):
-                taken = paddle.take_along_axis(x, indices, axis)
-                return paddle.tanh(taken)
-
-            # 计算一阶导数
-            first_grad = paddle.grad(
-                composite_func(arr), arr, paddle.to_tensor(cotangent)
-            )[0]
-            first_grad.stop_gradient = False
-
-            # 计算二阶导数
-            second_grad = paddle.grad(
-                first_grad, arr, paddle.to_tensor(cotangent)
-            )[0]
-
-            return second_grad
-
-        def desired(arr, indices, axis, cotangent):
-            # 使用numpy计算参考结果
-            def numpy_composite_grad(x):
-                # 先计算take_along_axis
-                taken = np.take_along_axis(x, indices, axis)
-                # tanh的二阶导数是 -2 * tanh(x) * (1 - tanh(x)^2)
-                tanh_x = np.tanh(taken)
-                second_derivative = -2 * tanh_x * (1 - tanh_x**2)
-
-                # 创建与输入相同形状的零数组
-                result = np.zeros_like(arr)
-
-                # 将二阶导数放回原始位置
-                # 这里需要考虑cotangent的影响
-                if axis == 1:
-                    for i in range(indices.shape[0]):
-                        for j in range(indices.shape[1]):
-                            result[:, indices[i, j], :] += (
-                                second_derivative[:, i, :] * cotangent[:, i, :]
-                            )
-
-                return result
-
-            return numpy_composite_grad(arr)
-
-        np.testing.assert_allclose(
-            actual=actual(self.arr, self.indices, self.axis, self.cotangent),
-            desired=desired(self.arr, self.indices, self.axis, self.cotangent),
-            rtol=1e-5,
-            atol=1e-5,
+        arr_tensor = paddle.to_tensor(
+            self.arr, dtype=self.dtype, stop_gradient=False
         )
+        indices_tensor = paddle.to_tensor(self.indices, dtype="int64")
+        dout_tensor = paddle.to_tensor(
+            self.cotangent, dtype=self.dtype, stop_gradient=False
+        )
+        out = paddle.take_along_axis(arr_tensor, indices_tensor, axis=self.axis)
 
-    def test_stop_gradients(self):
-        with self.assertRaises(ValueError):
-            arr = paddle.to_tensor(self.arr)
-            arr.stop_gradient = True
-            indices = paddle.to_tensor(self.indices)
-            return paddle.grad(
-                paddle.tanh(paddle.take_along_axis(arr, indices, self.axis)),
-                arr,
-                paddle.to_tensor(self.cotangent),
-            )
+        out = paddle.tanh(out)
+
+        dx = paddle.grad(out, arr_tensor, dout_tensor, create_graph=True)[0]
+
+        ddx = paddle.grad(dx, dout_tensor, create_graph=True)[0]
 
 
 if __name__ == '__main__':

--- a/test/prim/prim/vjp/eager/test_comp_eager_take_along_axis_double_grad.py
+++ b/test/prim/prim/vjp/eager/test_comp_eager_take_along_axis_double_grad.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import parameterized as param
+
+import paddle
+from paddle.base import core
+
+
+@param.parameterized_class(
+    ('arr', 'indices', 'axis', 'cotangent', 'dtype'),
+    [
+        (
+            np.random.rand(4, 3, 2),  # arr
+            np.array([[0, 1], [2, 1]], dtype=np.int64),  # indices
+            1,  # axis
+            np.random.rand(4, 2, 2),  # cotangent
+            np.float32,  # dtype
+        ),
+        # 可以添加更多测试用例
+    ],
+)
+class TestTakeAlongAxisTanhDoubleGrad(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        core.set_prim_eager_enabled(True)
+        cls.arr = cls.arr.astype(cls.dtype)
+        if cls.cotangent is not None:
+            cls.cotangent = cls.cotangent.astype(cls.dtype)
+
+    @classmethod
+    def tearDownClass(cls):
+        core.set_prim_eager_enabled(False)
+
+    def test_take_along_axis_tanh_double_grad(self):
+        def actual(arr, indices, axis, cotangent):
+            arr = paddle.to_tensor(arr)
+            arr.stop_gradient = False
+            indices = paddle.to_tensor(indices)
+
+            # 复合函数：take_along_axis后接tanh
+            def composite_func(x):
+                taken = paddle.take_along_axis(x, indices, axis)
+                return paddle.tanh(taken)
+
+            # 计算一阶导数
+            first_grad = paddle.grad(
+                composite_func(arr), arr, paddle.to_tensor(cotangent)
+            )[0]
+            first_grad.stop_gradient = False
+
+            # 计算二阶导数
+            second_grad = paddle.grad(
+                first_grad, arr, paddle.to_tensor(cotangent)
+            )[0]
+
+            return second_grad
+
+        def desired(arr, indices, axis, cotangent):
+            # 使用numpy计算参考结果
+            def numpy_composite_grad(x):
+                # 先计算take_along_axis
+                taken = np.take_along_axis(x, indices, axis)
+                # tanh的二阶导数是 -2 * tanh(x) * (1 - tanh(x)^2)
+                tanh_x = np.tanh(taken)
+                second_derivative = -2 * tanh_x * (1 - tanh_x**2)
+
+                # 创建与输入相同形状的零数组
+                result = np.zeros_like(arr)
+
+                # 将二阶导数放回原始位置
+                # 这里需要考虑cotangent的影响
+                if axis == 1:
+                    for i in range(indices.shape[0]):
+                        for j in range(indices.shape[1]):
+                            result[:, indices[i, j], :] += (
+                                second_derivative[:, i, :] * cotangent[:, i, :]
+                            )
+
+                return result
+
+            return numpy_composite_grad(arr)
+
+        np.testing.assert_allclose(
+            actual=actual(self.arr, self.indices, self.axis, self.cotangent),
+            desired=desired(self.arr, self.indices, self.axis, self.cotangent),
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
+    def test_stop_gradients(self):
+        with self.assertRaises(ValueError):
+            arr = paddle.to_tensor(self.arr)
+            arr.stop_gradient = True
+            indices = paddle.to_tensor(self.indices)
+            return paddle.grad(
+                paddle.tanh(paddle.take_along_axis(arr, indices, self.axis)),
+                arr,
+                paddle.to_tensor(self.cotangent),
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

Pcard-75624

1. 将`take_along_axis`加入动态图基础算子，从而支持`take_along_axis_double_grad`，并设置其为默认动态图二阶微分

related PR: <https://github.com/deepmodeling/deepmd-kit/pull/4302>，#69385

精度验证脚本(pytorch 不支持broadcast，因此设置paddle的broadcast为False)：

``` py
import numpy as np
import torch
import paddle

arr_shape = [19, 91, 78]
indices_shape = [19, 91, 78]

for axis in range(-len(arr_shape), len(arr_shape)):
    arr_np = np.random.randn(*arr_shape).astype("float32")
    indices_np = np.random.randint(-arr_shape[axis], arr_shape[axis], size=indices_shape).astype("int64")

    # paddle
    arr_pd = paddle.to_tensor(arr_np, "float32", stop_gradient=False)
    indices_pd = paddle.to_tensor(indices_np, "int64")

    out_pd = paddle.take_along_axis(arr_pd, indices_pd, axis=axis, broadcast=False)

    dout_np = np.random.randn(*out_pd.shape).astype(arr_np.dtype)
    dout_pd = paddle.to_tensor(dout_np, arr_pd.dtype, stop_gradient=False)
    dx_pd = paddle.grad(out_pd, arr_pd, dout_pd, create_graph=True)[0]

    ddx_np = np.random.randn(*dx_pd.shape)
    ddx_pd = paddle.to_tensor(ddx_np, arr_pd.dtype, stop_gradient=False)
    ddout_pd = paddle.grad(dx_pd, dout_pd, ddx_pd, create_graph=True)[0]

    # torch
    arr_pt = torch.from_numpy(arr_np).cuda().requires_grad_(True)
    indices_pt = torch.from_numpy(indices_np).cuda()

    out_pt = torch.gather(arr_pt, axis, indices_pt)

    dout_pt = torch.from_numpy(dout_np).cuda().requires_grad_(True)
    dx_pt = torch.autograd.grad(out_pt, arr_pt, dout_pt, create_graph=True)[0]

    ddx_pt = torch.from_numpy(ddx_np).cuda().requires_grad_(True)
    ddout_pt = torch.autograd.grad(dx_pt, dout_pt, ddx_pt, create_graph=True)[0]

    # check output
    np.testing.assert_allclose(out_pd.numpy(), out_pt.cpu().detach().numpy())
    # check 1-order grad
    np.testing.assert_allclose(dx_pd.numpy(), dx_pt.cpu().detach().numpy(), 1e-6, 1e-6)
    # check 2-order grad
    np.testing.assert_allclose(ddout_pd.numpy(), ddout_pt.cpu().detach().numpy(), 1e-6, 1e-6)
```