### PR TITLE
[PIR] Fix op mutable attribute use wrong dtype

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -542,7 +542,7 @@ def GenBuildOutputs(
                                   .attribute("value")
                                   .dyn_cast<paddle::dialect::ScalarAttribute>()
                                   .data()
-                                  .to<int>());
+                                  .to<{dtype}>());
   }}
   else {{
     {name} = phi::Scalar(-1);

--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -1300,9 +1300,6 @@ def AutoCodeGen(
         # get op mutable attribute
         op_mutable_attribute_name_list = op_info.mutable_attribute_name_list
         op_mutable_attribute_type_list = op_info.mutable_attribute_type_list
-        print(
-            "op_mutable_attribute_type_list: ", op_mutable_attribute_type_list
-        )
         # get op attribute
         op_attribute_name_list = op_info.attribute_name_list
         op_attribute_type_list = op_info.attribute_type_list
@@ -1583,10 +1580,6 @@ def AutoCodeGen(
                         op_non_mutable_attribute_build_arg_type_list,
                         op_non_mutable_attribute_default_value_list,
                         muta_attr_is_input=False,
-                    )
-                    print(
-                        "op_mutable_attribute_type_list: ",
-                        op_mutable_attribute_type_list,
                     )
                     if len(op_attribute_name_list) > 0:
                         (

--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -1300,6 +1300,9 @@ def AutoCodeGen(
         # get op mutable attribute
         op_mutable_attribute_name_list = op_info.mutable_attribute_name_list
         op_mutable_attribute_type_list = op_info.mutable_attribute_type_list
+        print(
+            "op_mutable_attribute_type_list: ", op_mutable_attribute_type_list
+        )
         # get op attribute
         op_attribute_name_list = op_info.attribute_name_list
         op_attribute_type_list = op_info.attribute_type_list
@@ -1580,6 +1583,10 @@ def AutoCodeGen(
                         op_non_mutable_attribute_build_arg_type_list,
                         op_non_mutable_attribute_default_value_list,
                         muta_attr_is_input=False,
+                    )
+                    print(
+                        "op_mutable_attribute_type_list: ",
+                        op_mutable_attribute_type_list,
                     )
                     if len(op_attribute_name_list) > 0:
                         (

--- a/paddle/fluid/pir/dialect/op_generator/op_infermeta_func_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_infermeta_func_gen.py
@@ -351,7 +351,7 @@ def GenBuildOutputsPart2(
                                   .attribute("value")
                                   .dyn_cast<paddle::dialect::ScalarAttribute>()
                                   .data()
-                                  .to<int>());
+                                  .to<{dtype}>());
   }}
   else {{
     {name} = phi::Scalar(-1);

--- a/paddle/phi/ops/yaml/inconsistent/update_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/update_ops.yaml
@@ -4,7 +4,7 @@
 # the dynamic graph is simultaneously upgraded, the operators in this file will be migrated to paddle/phi/ops/yaml/ops.yaml.
 
 - op : arange
-  args : (Scalar(double) start, Scalar(double) end, Scalar(double) step, DataType dtype=DataType::FLOAT64, Place place=CPUPlace())
+  args : (Scalar start, Scalar end, Scalar step, DataType dtype=DataType::FLOAT64, Place place=CPUPlace())
   output : Tensor(out)
   infer_meta :
     func : ArangeInferMeta
@@ -14,6 +14,5 @@
     param : [start, end, step]
     data_type : dtype
     backend : place
-  support_tensor : [start, end, step]
   interfaces : paddle::dialect::InferSymbolicShapeInterface
   traits : paddle::dialect::ForwardOnlyTrait

--- a/paddle/phi/ops/yaml/inconsistent/update_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/update_ops.yaml
@@ -4,7 +4,7 @@
 # the dynamic graph is simultaneously upgraded, the operators in this file will be migrated to paddle/phi/ops/yaml/ops.yaml.
 
 - op : arange
-  args : (Scalar start, Scalar end, Scalar step, DataType dtype=DataType::FLOAT64, Place place=CPUPlace())
+  args : (Scalar(double) start, Scalar(double) end, Scalar(double) step, DataType dtype=DataType::FLOAT64, Place place=CPUPlace())
   output : Tensor(out)
   infer_meta :
     func : ArangeInferMeta

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -239,6 +239,16 @@
     {start : Start, end : End, step : Step}
   outputs :
     out : Out
+  scalar:
+    start:
+      data_type : double
+      support_tensor : true
+    end:
+      data_type : double
+      support_tensor : true
+    step:
+      data_type : double
+      support_tensor : true
 
 - op : argmax(arg_max)
   inputs :

--- a/test/legacy_test/test_arange.py
+++ b/test/legacy_test/test_arange.py
@@ -229,5 +229,13 @@ class TestArangeImperative(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestArangeStatic(unittest.TestCase):
+    def test_infermeta(self):
+        paddle.enable_static()
+        x = paddle.arange(0, 1 + 0.005, 0.005)
+        self.assertEqual(x.shape, [201])
+        paddle.disable_static()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 PIR 可变 attribute OP infermeta 时硬编码成 int 的问题，修复 arange 无法感知可变 attribute 的问题

PCard-66972