### PR TITLE
[Kernel] Support negative and add necessary boundary check for `take_along_axis`

### DIFF
--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cc
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cc
@@ -140,12 +140,64 @@ struct cpu_gather_scatter_functor {
           // multiply the replaced_select_dim_size.
           int64_t replace_index_self, replace_index_src;
           if (is_scatter_like) {
+            // scatter
+            PADDLE_ENFORCE_GE(
+                index,
+                -self_select_dim_size,
+                common::errors::OutOfRange(
+                    "Variable value (index) of OP(take_along_axis) "
+                    "expected >= %d and < %d, but got %ld."
+                    "Please check the input "
+                    "value.",
+                    -self_select_dim_size,
+                    self_select_dim_size,
+                    index));
+            PADDLE_ENFORCE_LT(
+                index,
+                self_select_dim_size,
+                common::errors::OutOfRange(
+                    "Variable value (index) of OP(take_along_axis) "
+                    "expected >= %d and < %d, but got %ld."
+                    "Please check the input "
+                    "value.",
+                    -self_select_dim_size,
+                    self_select_dim_size,
+                    index));
+            if (index < 0) {
+              index += self_select_dim_size;
+            }
             replace_index_self = k + index * outer_dim_size_self +
                                  i * outer_dim_size_self * self_select_dim_size;
 
             replace_index_src = k + j * outer_dim_size_src +
                                 i * outer_dim_size_src * src_select_dim_size;
           } else {
+            // gather
+            PADDLE_ENFORCE_GE(
+                index,
+                -src_select_dim_size,
+                common::errors::OutOfRange(
+                    "Variable value (index) of OP(take_along_axis) "
+                    "expected >= %ld and < %ld, but got %ld. "
+                    "Please check the input "
+                    "value.",
+                    -src_select_dim_size,
+                    src_select_dim_size,
+                    index));
+            PADDLE_ENFORCE_LT(
+                index,
+                src_select_dim_size,
+                common::errors::OutOfRange(
+                    "Variable value (index) of OP(take_along_axis) "
+                    "expected >= %ld and < %ld, but got %ld. "
+                    "Please check the input "
+                    "value.",
+                    -src_select_dim_size,
+                    src_select_dim_size,
+                    index));
+            if (index < 0) {
+              index += src_select_dim_size;
+            }
             replace_index_self = index_idx;
 
             replace_index_src = k + index * outer_dim_size_src +

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -144,12 +144,38 @@ __global__ void ScatterAssignGPUKernel(tensor_t* self_data,
   // index matrix has different shape with self matrix or src matrix.
   int64_t replace_index_self, replace_index_src;
   if (is_scatter_like) {
+    // scatter
+    PADDLE_ENFORCE(
+        index >= -self_select_dim_size && index < self_select_dim_size,
+        "The index is out of bounds, "
+        "please check whether the index and "
+        "input's shape meet the requirements. It should "
+        "be greater or equal to [%d] and less than [%d], but received [%ld]",
+        -self_select_dim_size,
+        self_select_dim_size,
+        (int64_t)index);
+    if (index < 0) {
+      index += self_select_dim_size;
+    }
     replace_index_self = k + index * outer_dim_size_self +
                          i * outer_dim_size_self * self_select_dim_size;
 
     replace_index_src = k + j * outer_dim_size_src +
                         i * outer_dim_size_src * src_select_dim_size;
   } else {
+    // gather
+    PADDLE_ENFORCE(
+        index >= -src_select_dim_size && index < src_select_dim_size,
+        "The index is out of bounds, "
+        "please check whether the index and "
+        "input's shape meet the requirements. It should "
+        "be greater or equal to [%d] and less than [%d], but received [%d]",
+        -src_select_dim_size,
+        src_select_dim_size,
+        (int32_t)index);
+    if (index < 0) {
+      index += src_select_dim_size;
+    }
     replace_index_self = tid;
 
     replace_index_src = k + index * outer_dim_size_src +
@@ -219,12 +245,38 @@ __global__ void GatherScatterGPUKernel(tensor_t* self_data,
   // index matrix has different shape with self matrix or src matrix.
   int64_t replace_index_self, replace_index_src;
   if (is_scatter_like) {
+    // scatter
+    PADDLE_ENFORCE(
+        index >= -self_select_dim_size && index < self_select_dim_size,
+        "The index is out of bounds, "
+        "please check whether the index and "
+        "input's shape meet the requirements. It should "
+        "be greater or equal to [%d] and less than [%d], but received [%ld]",
+        -self_select_dim_size,
+        self_select_dim_size,
+        (int64_t)index);
+    if (index < 0) {
+      index += self_select_dim_size;
+    }
     replace_index_self = k + index * outer_dim_size_self +
                          i * outer_dim_size_self * self_select_dim_size;
 
     replace_index_src = k + j * outer_dim_size_src +
                         i * outer_dim_size_src * src_select_dim_size;
   } else {
+    // gather
+    PADDLE_ENFORCE(
+        index >= -src_select_dim_size && index < src_select_dim_size,
+        "The index is out of bounds, "
+        "please check whether the index and "
+        "input's shape meet the requirements. It should "
+        "be greater or equal to [%d] and less than [%d], but received [%d]",
+        -src_select_dim_size,
+        src_select_dim_size,
+        (int32_t)index);
+    if (index < 0) {
+      index += src_select_dim_size;
+    }
     replace_index_self = tid;
 
     replace_index_src = k + index * outer_dim_size_src +
@@ -292,12 +344,38 @@ __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
   // index matrix has different shape with self matrix or src matrix.
   int64_t replace_index_self, replace_index_src;
   if (is_scatter_like) {
+    // scatter
+    PADDLE_ENFORCE(
+        index >= -self_select_dim_size && index < self_select_dim_size,
+        "The index is out of bounds, "
+        "please check whether the index and "
+        "input's shape meet the requirements. It should "
+        "be greater or equal to [%d] and less than [%d], but received [%ld]",
+        -self_select_dim_size,
+        self_select_dim_size,
+        (int64_t)index);
+    if (index < 0) {
+      index += self_select_dim_size;
+    }
     replace_index_self = k + index * outer_dim_size_self +
                          i * outer_dim_size_self * self_select_dim_size;
 
     replace_index_src = k + j * outer_dim_size_src +
                         i * outer_dim_size_src * src_select_dim_size;
   } else {
+    // gather
+    PADDLE_ENFORCE(
+        index >= -src_select_dim_size && index < src_select_dim_size,
+        "The index is out of bounds, "
+        "please check whether the index and "
+        "input's shape meet the requirements. It should "
+        "be greater or equal to [%d] and less than [%d], but received [%d]",
+        -src_select_dim_size,
+        src_select_dim_size,
+        (int32_t)index);
+    if (index < 0) {
+      index += src_select_dim_size;
+    }
     replace_index_self = tid;
 
     replace_index_src = k + index * outer_dim_size_src +

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -6444,11 +6444,6 @@ def take_along_axis(
                     f"Size does not match at dimension {i} expected index {indices.shape} to be smaller than self {arr.shape} apart from dimension {axis}"
                 )
 
-        axis_max_size = arr.shape[axis]
-        if in_dynamic_mode() and not (indices < axis_max_size).all():
-            raise RuntimeError(
-                f"one of element of indices is out of bounds for dimension {axis} with size {axis_max_size}"
-            )
     if in_dynamic_or_pir_mode():
         return _C_ops.take_along_axis(arr, indices, axis)
     else:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-75624

1. 为 `take_along_axis` 支持负数索引
2. 在 kernel 中添加边界检查，移除 python 中的边界检查（减少不必要的判断）
3. 更新对应单测，所有单测的`indices`范围从手动设置的非负数改为随机整数