### PR TITLE
[CINN] Add PRIM_FORWARD_BLOCKLIST in sub_graph test

### DIFF
--- a/test/ir/pir/cinn/sub_graphs/CMakeLists.txt
+++ b/test/ir/pir/cinn/sub_graphs/CMakeLists.txt
@@ -1,4 +1,5 @@
 if(WITH_GPU)
+  set(PRIM_FORWARD_BLOCKLIST "pd_op.dropout")
 
   file(
     GLOB DYNAMIC_BUILD_TESTS
@@ -13,6 +14,7 @@ if(WITH_GPU)
         ${CMAKE_COMMAND} -E env
         PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
         FLAGS_prim_enable_dynamic=1 FLAGS_check_infer_symbolic=1
+        FLAGS_prim_forward_blacklist=${PRIM_FORWARD_BLOCKLIST}
         FLAGS_cudnn_deterministic=true ${PYTHON_EXECUTABLE}
         ${CMAKE_CURRENT_SOURCE_DIR}/${cinn_sub_graph_test_name}.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/test/ir/pir/cinn/sub_graphs/test_sub_graph_18.py
+++ b/test/ir/pir/cinn/sub_graphs/test_sub_graph_18.py
@@ -69,8 +69,6 @@ class TestLayer(TestBase):
         )
         self.net = LayerCase
 
-    # NOTE output mismatch with prim
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/ir/pir/cinn/sub_graphs/test_sub_graph_18.py
+++ b/test/ir/pir/cinn/sub_graphs/test_sub_graph_18.py
@@ -68,8 +68,6 @@ class TestLayer(TestBase):
             paddle.rand(shape=[22, 1536, 8, 8], dtype=paddle.float32),
         )
         self.net = LayerCase
-        self.with_precision_compare = False
-        self.with_train = False
 
     # NOTE output mismatch with prim
 

--- a/test/ir/pir/cinn/sub_graphs/test_sub_graph_25.py
+++ b/test/ir/pir/cinn/sub_graphs/test_sub_graph_25.py
@@ -68,8 +68,6 @@ class TestLayer(TestBase):
             paddle.rand(shape=[11, 1280, 7, 7], dtype=paddle.float32),
         )
         self.net = LayerCase
-        self.with_precision_compare = False
-        self.with_train = False
 
 
 if __name__ == '__main__':

--- a/test/ir/pir/cinn/sub_graphs/test_sub_graph_28.py
+++ b/test/ir/pir/cinn/sub_graphs/test_sub_graph_28.py
@@ -69,8 +69,6 @@ class TestLayer(TestBase):
         )
         self.net = LayerCase
 
-    # NOTE prim + cinn lead to error
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/ir/pir/cinn/sub_graphs/test_sub_graph_28.py
+++ b/test/ir/pir/cinn/sub_graphs/test_sub_graph_28.py
@@ -68,8 +68,6 @@ class TestLayer(TestBase):
             paddle.rand(shape=[10, 320, 8, 8], dtype=paddle.float32),
         )
         self.net = LayerCase
-        self.with_precision_compare = False
-        self.with_train = False
 
     # NOTE prim + cinn lead to error
 

--- a/test/ir/pir/cinn/sub_graphs/test_sub_graph_29.py
+++ b/test/ir/pir/cinn/sub_graphs/test_sub_graph_29.py
@@ -68,8 +68,6 @@ class TestLayer(TestBase):
             paddle.rand(shape=[10, 2048, 10, 10], dtype=paddle.float32),
         )
         self.net = LayerCase
-        self.with_precision_compare = False
-        self.with_train = False
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-67164
1.  Add PRIM_FORWARD_BLOCKLIST in subgraph testing
2. Turn on the precision comparison switch for sub_graph_18, sub_graph_25, sub_graph_28, and sub_graph_29