### PR TITLE
[PIR] refine lookup_table translator

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -1194,30 +1194,12 @@ struct EmbeddingOpTranscriber : public OpTranscriber {
       const auto& output_vars = op_desc.Output("Out");
       const auto& output_name = output_vars[0];
 
-      const dialect::DenseTensorType& out_tensor_type = std::get<1>(out_info);
       pir::Value& out_value = std::get<2>(out_info);
-
-      ValueInfo ids_info = GetTensorInfoByVarName(
-          op_desc, op_desc.Input("Ids", true), param_map, "Ids");
-      const std::vector<int64_t>& ids_shape = std::get<0>(ids_info);
-
-      ValueInfo w_info = GetTensorInfoByVarName(
-          op_desc, op_desc.Input("W", true), param_map, "W");
-
-      const std::vector<int64_t>& w_shape = std::get<0>(w_info);
-
-      std::vector<int64_t> out_new_shape(
-          ids_shape.begin(), ids_shape.begin() + ids_shape.size() - 1);
-      out_new_shape.insert(out_new_shape.end(), w_shape[1]);
-
       pir::Builder builder(ctx, operation->GetParent());
-      dialect::ReshapeOp reshape_op_out =
-          builder.Build<dialect::ReshapeOp>(out_value, out_new_shape);
-      pir::Value out_new = reshape_op_out.out();
-      VLOG(6) << "[" << op_desc.Type() << "] out_shape change from "
-              << out_tensor_type.dims() << " to "
-              << common::make_ddim(out_new_shape);
-
+      std::vector<int64_t> axis = {-2};
+      dialect::SqueezeOp squeeze_op_out =
+          builder.Build<dialect::SqueezeOp>(out_value, axis);
+      pir::Value out_new = squeeze_op_out.out();
       param_map->PushValue(output_name,
                            VariableDefiningInfo(out_new, false, -1));
     }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
lookup_table与lookup_table_v2行为上有差别，lookup_table已经废弃。在PHI和PIR下都在使用lookup_table_v2。因此需要给lookup_table 加一个OpTranslator转译他们的行为差异。
差异点在于v2输出的Tensor的shape比v1的多一个1，在倒数第二维度。
因此使用SqueezeOp将1去掉，即：lookup_table_v2+squeeze=lookup_table

之所以不使用reshape的原因在于，reshape记录了固定维度信息。但lookup_table的输入可能是动态shape。

Pcard-67164