### PR TITLE
[inference] fix_no_load non_persistable

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1157,6 +1157,7 @@ bool AnalysisPredictor::SaveOrLoadPirParameters(bool for_save) {
             "Only support parameter data of type DenseTensor."));
       }
     }
+    // we only load params which are persistable(means TRUE parameters))
     auto *tensor_temp = var->GetMutable<phi::DenseTensor>();
     if (value.attribute("persistable")
             .dyn_cast<::pir::BoolAttribute>()

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1128,7 +1128,7 @@ bool AnalysisPredictor::SaveOrLoadPirParameters(bool for_save) {
               return a.first < b.first;
             });
 
-  std::vector<std::string> param_names;
+  std::vector<std::string> param_names, filter_param_names;
   std::vector<pir::Value> vars;
   for (const auto &pair : param_name_var_pairs) {
     param_names.emplace_back(pair.first);
@@ -1158,7 +1158,15 @@ bool AnalysisPredictor::SaveOrLoadPirParameters(bool for_save) {
       }
     }
     auto *tensor_temp = var->GetMutable<phi::DenseTensor>();
-    tensor_out.push_back(tensor_temp);
+    if (value.attribute("persistable")
+            .dyn_cast<::pir::BoolAttribute>()
+            .data()) {
+      tensor_out.push_back(tensor_temp);
+      filter_param_names.emplace_back(param_names[i]);
+    } else {
+      VLOG(3) << param_names[i]
+              << " persistable is false, will ignore it when load variables.";
+    }
   }
 
   if (for_save) {
@@ -1171,7 +1179,7 @@ bool AnalysisPredictor::SaveOrLoadPirParameters(bool for_save) {
     LOG(INFO) << "Optimized params saved to " << optimized_params;
   } else {
     pir::LoadCombineFunction(
-        config_.params_file(), param_names, &tensor_out, false, place_);
+        config_.params_file(), filter_param_names, &tensor_out, false, place_);
   }
   return true;
 }

--- a/paddle/fluid/pir/transforms/general/params_sync_among_devices_pass.cc
+++ b/paddle/fluid/pir/transforms/general/params_sync_among_devices_pass.cc
@@ -65,7 +65,13 @@ class ParamsSyncAmongDevicesPass : public pir::Pass {
     auto& block = module_op.block();
     int64_t num_rewrites_{0};
     for (auto& inner_op : block) {
-      if (inner_op.isa<pir::ParameterOp>()) {
+      if (inner_op.isa<pir::ParameterOp>() && inner_op.num_results() > 0) {
+        auto var = inner_op.result(0);
+        auto bool_attr =
+            var.attribute<::pir::BoolAttribute>(kAttrIsPersistable);
+        if (!bool_attr || !bool_attr.data()) {
+          continue;
+        }
         std::string param_name = inner_op.attributes()
                                      .at("parameter_name")
                                      .dyn_cast<pir::StrAttribute>()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes


### Description
<!-- Describe what you’ve done -->
pcard-71500
When the parameter  is non_persistable, predictor will ignore when loading it.
