### PR TITLE
[Prim][Pir] Fixed add scalar bug in Batchnorm forward decomposition

### DIFF
--- a/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
@@ -275,6 +275,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
 
   std::vector<int64_t> x_dim = x_cast.shape();
   std::vector<int64_t> stats_shape;
+  Tensor eps = full_scalar<T>(epsilon, x_cast.dtype());
 
   Tensor x_hat;
   Tensor batch_mean;
@@ -283,7 +284,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
     batch_mean = mean_decomp<T>(x_cast, reduce_axes, true);
     auto temp = mean_decomp<T>(x_cast * x_cast, reduce_axes, true);
     auto batch_var = temp - batch_mean * batch_mean;
-    inv_std = rsqrt<T>(batch_var + epsilon);
+    inv_std = rsqrt<T>(batch_var + eps);
 
     x_hat = (x_cast - batch_mean) * inv_std;
 
@@ -298,7 +299,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
     assign_out_<T>(run_var_, run_var);
   } else {
     x_hat = (x_cast - reshape<T>(run_mean, scale_bias_new_shape)) *
-            rsqrt<T>(reshape<T>(run_var, scale_bias_new_shape) + epsilon);
+            rsqrt<T>(reshape<T>(run_var, scale_bias_new_shape) + eps);
 
     run_mean_ = run_mean;
     run_var_ = run_var;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
Bug fixes
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->


### Description
修复标量与张量在动态shape下进行加法时的广播异常问题
Pcard-66975
<!-- Describe what you’ve done -->
