### PR TITLE
[SOT] Prohibit treating instances of `BooleanEnvironmentVariable` directly as boolean values

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -98,7 +98,7 @@ class FasterStringifiedExpression(StringifiedExpression):
         free_vars: dict[str, Any],
     ):
         self.faster_guard = faster_guard
-        if ENV_SOT_ENABLE_FASTER_GUARD:
+        if ENV_SOT_ENABLE_FASTER_GUARD.get():
             original_expr_template = expr_template
             guard_cls_name = faster_guard.__class__.__name__
             guard_name = f"{guard_cls_name}_{id(faster_guard)}"

--- a/python/paddle/utils/environments.py
+++ b/python/paddle/utils/environments.py
@@ -86,6 +86,12 @@ class BooleanEnvironmentVariable(EnvironmentVariable[bool]):
         assert isinstance(value, bool), "value must be a boolean"
         os.environ[self.name] = str(value).lower()
 
+    def __bool__(self) -> bool:
+        raise ValueError(
+            "BooleanEnvironmentVariable does not support bool(), "
+            "please use get() instead."
+        )
+
 
 class IntegerEnvironmentVariable(EnvironmentVariable[int]):
     def __init__(self, name: str, default: int):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

禁止将 BooleanEnvironmentVariable 的实例直接当成bool值防止出现意外情况