### PR TITLE
Not folding assign_value op in constant_folding_pass

### DIFF
--- a/paddle/fluid/pir/drr/src/rewrite_pattern.cc
+++ b/paddle/fluid/pir/drr/src/rewrite_pattern.cc
@@ -16,7 +16,6 @@
 #include <queue>
 #include <utility>
 
-#include "glog/vlog_is_on.h"
 #include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
 #include "paddle/fluid/pir/drr/include/drr_rewrite_pattern.h"
 #include "paddle/fluid/pir/drr/src/ir_operation_factory.h"

--- a/paddle/fluid/pir/transforms/general/constant_folding_pass.cc
+++ b/paddle/fluid/pir/transforms/general/constant_folding_pass.cc
@@ -79,7 +79,8 @@ class ConstantFoldingPattern : public pir::RewritePattern {
     if (op->HasTrait<pir::SideEffectTrait>() ||
         op->isa<pir::ConstantTensorOp>() || op->isa<pir::ParameterOp>() ||
         op->isa<paddle::dialect::FeedOp>() ||
-        op->isa<paddle::dialect::DataOp>()) {
+        op->isa<paddle::dialect::DataOp>() ||
+        op->isa<paddle::dialect::AssignValueOp>()) {
       return false;
     }
 
@@ -289,8 +290,14 @@ class ConstantFoldingPattern : public pir::RewritePattern {
     for (const auto& output_var_name : output_var_names) {
       exe_config_->skip_gc_vars.insert(output_var_name);
     }
+    if (VLOG_IS_ON(3)) {
+      std::cout << "IR before lowering = " << new_program << std::endl;
+    }
     auto kernel_program =
         paddle::dialect::PdOpLowerToKernelPass(&new_program, place_);
+    if (VLOG_IS_ON(3)) {
+      std::cout << "IR after lowering = " << *kernel_program << std::endl;
+    }
     paddle::framework::InterpreterCore core(
         place_, {}, kernel_program->block(), scope_, *exe_config_);
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-71500

![image](https://github.com/user-attachments/assets/ee97e82d-e0e9-4ce8-8de5-663ebaace108)

```shell
(%1112) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<i32>
```