### PR TITLE
[XPU] fix xpu compile dependency

### DIFF
--- a/paddle/fluid/imperative/CMakeLists.txt
+++ b/paddle/fluid/imperative/CMakeLists.txt
@@ -6,7 +6,7 @@ cc_library(
   var_helper
   SRCS var_helper.cc type_defs.cc
   DEPS tensor phi common)
-if(WITH_XPU)
+if(WITH_XPU_BKCL)
   cc_library(
     prepared_operator
     SRCS prepared_operator.cc


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
在 https://github.com/PaddlePaddle/Paddle/pull/69229 中，给`prepared_operator`增加了`process_group_bkcl`的依赖。接下游用户反馈，在仅开了`WITH_XPU`而没有开`WITH_XPU_BKCL`的情况下，会编译不过。排查发现给`prepared_operator`增加依赖这件事应该仅在开BKCL的情况下生效。进一步排查发现，XPU下面对于`prepared_operator`不需要特殊的依赖，可以放到`ELSE`里面。
