### PR TITLE
move `paddle.tensor.logic.positive` to `paddle.tensor.math.positive`

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -279,7 +279,6 @@ from .tensor.logic import (
     logical_xor_,  # noqa: F401
     not_equal,
     not_equal_,  # noqa: F401
-    positive,
 )
 from .tensor.manipulation import (
     as_complex,
@@ -500,6 +499,7 @@ from .tensor.math import (  # noqa: F401
     outer,
     polygamma,
     polygamma_,
+    positive,
     pow,
     pow_,
     prod,

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -141,7 +141,6 @@ from .logic import (  # noqa: F401
     logical_xor_,
     not_equal,
     not_equal_,
-    positive,
 )
 from .manipulation import (  # noqa: F401
     as_complex,
@@ -366,6 +365,7 @@ from .math import (  # noqa: F401
     outer,
     polygamma,
     polygamma_,
+    positive,
     pow,
     pow_,
     prod,

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -1463,38 +1463,6 @@ def bitwise_invert_(x: Tensor, name: str | None = None) -> Tensor:
     return bitwise_not_(x, name=name)
 
 
-def positive(x: Tensor) -> Tensor:
-    r"""
-    Returns the input Tensor as it is. This is used in `Tensor.__pos__`, applying the
-    unary `+` operator to the tensor.
-
-    .. math::
-        Out = +X
-
-    Args:
-        x (Tensor): The input tensor. The tensor cannot be of type bool.
-
-    Returns:
-        Tensor: A tensor with the same shape and data type as the input tensor. The returned tensor
-                is the same.
-
-    Examples:
-        .. code-block:: python
-
-            >>> import paddle
-            >>> x = paddle.to_tensor([-1, 0, 1])
-            >>> out = paddle.positive(x)
-            >>> print(out)
-            Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
-            [-1,  0,  1])
-    """
-
-    # Check if the input tensor is of bool type and raise an error
-    if x.dtype == paddle.bool:
-        raise TypeError("The `+` operator, on a bool tensor is not supported.")
-    return x
-
-
 def isclose(
     x: Tensor,
     y: Tensor,

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5644,6 +5644,38 @@ def neg_(x: Tensor, name: str | None = None) -> Tensor:
     )
 
 
+def positive(x: Tensor) -> Tensor:
+    r"""
+    Returns the input Tensor as it is. This is used in `Tensor.__pos__`, applying the
+    unary `+` operator to the tensor.
+
+    .. math::
+        Out = +X
+
+    Args:
+        x (Tensor): The input tensor. The tensor cannot be of type bool.
+
+    Returns:
+        Tensor: A tensor with the same shape and data type as the input tensor. The returned tensor
+                is the same.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+            >>> x = paddle.to_tensor([-1, 0, 1])
+            >>> out = paddle.positive(x)
+            >>> print(out)
+            Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [-1,  0,  1])
+    """
+
+    # Check if the input tensor is of bool type and raise an error
+    if x.dtype == paddle.bool:
+        raise TypeError("The `+` operator, on a bool tensor is not supported.")
+    return x
+
+
 def atan2(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     r"""
     Element-wise arctangent of x/y with consideration of the quadrant.


### PR DESCRIPTION
### PR Category
User Experience


### PR Types
Others 


### Description
将positive的定义从`python/paddle/tensor/logic.py`移动到`python/paddle/tensor/math.py`
