### PR TITLE
[SOT][3.13] Support `CALL_KW` in python 3.13

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -370,7 +370,7 @@ class OpcodeExecutorBase:
         self.guard_fn = None
         self._name = "Executor"
         self._call_shape: tuple[str, ...] | None = (
-            None  # store kwnames for Python 3.11+
+            None  # store kwnames for Python 3.11 and 3.12
         )
         self._prepare_virtual_env()
         self.stop_state = None
@@ -1158,12 +1158,13 @@ class OpcodeExecutorBase:
         assert isinstance(instr.arg, int)
         self._call_shape = self._co_consts[instr.arg].get_py_value()
 
-    def call(self, instr: Instruction):
-        assert isinstance(instr.arg, int)
-        assert instr.arg + 2 <= len(self.stack)
-        is_method = not isinstance(self.stack.peek[instr.arg + 2], NullVariable)
-        total_args = instr.arg + int(is_method)
-        kwnames = self._call_shape if self._call_shape is not None else []
+    def call_impl(
+        self, num_args: int, kwnames_getter: Callable[[], tuple[str, ...]]
+    ):
+        kwnames = kwnames_getter()
+        assert num_args + 2 <= len(self.stack)
+        is_method = not isinstance(self.stack.peek[num_args + 2], NullVariable)
+        total_args = num_args + int(is_method)
         n_kwargs = len(kwnames)
         n_positional_args = total_args - n_kwargs
         kwargs_list = self.stack.pop_n(n_kwargs)
@@ -1176,11 +1177,30 @@ class OpcodeExecutorBase:
         self.stack.push(fn(*args, **kwargs))
         self._call_shape = None
 
+    def call(self, instr: Instruction):
+        assert isinstance(instr.arg, int)
+        self.call_impl(
+            instr.arg,
+            lambda: (self._call_shape if self._call_shape is not None else ()),
+        )
+
     CALL = (
         call_break_graph_decorator(push_n=1)(call)
         if sys.version_info >= (3, 12)
         else call
     )
+
+    @call_break_graph_decorator(push_n=1)
+    def CALL_KW(self, instr: Instruction):
+        assert isinstance(instr.arg, int)
+
+        def get_kwnames():
+            kwnames_var = self.stack.pop()
+            assert isinstance(kwnames_var, TupleVariable)
+            kwnames = kwnames_var.get_py_value()
+            return kwnames
+
+        self.call_impl(instr.arg, get_kwnames)
 
     @call_break_graph_decorator(push_n=1)
     def CALL_FUNCTION(self, instr: Instruction):
@@ -2018,7 +2038,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
             var_loader.load(stack_arg)
 
         # 5. run the break CALL with origin python
-        # NOTE(SigureMo): In Python 3.11，we need generate KW_NAMES if the call shape is not None.
+        # NOTE(SigureMo): In Python 3.11 and 3.12，we need generate KW_NAMES if the call shape is not None.
         self._graph.pycode_gen.gen_kw_names(self._call_shape)
         self._graph.pycode_gen.extend_instrs(
             self._instructions[cur_index:next_index]

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -821,8 +821,10 @@ class PyCodeGen:
     def gen_kw_names(self, kw_names: tuple[str, ...] | None):
         if kw_names is None:
             return
-        if sys.version_info < (3, 11):
-            raise InnerError("gen_kw_names is not supported before python3.11")
+        if sys.version_info < (3, 11) or sys.version_info >= (3, 13):
+            raise InnerError(
+                "gen_kw_names is only supported in Python 3.11 and 3.12"
+            )
         if kw_names not in self._code_options["co_consts"]:
             self._code_options["co_consts"].append(kw_names)
         idx = self._code_options["co_consts"].index(kw_names)

--- a/test/sot/skip_files_py313
+++ b/test/sot/skip_files_py313
@@ -1,6 +1,4 @@
-test/sot/test_03_tuple.py
 test/sot/test_04_list.py
-test/sot/test_06_call_function.py
 test/sot/test_11_jumps.py
 test/sot/test_12_for_loop.py
 test/sot/test_13_make_function.py
@@ -12,7 +10,6 @@ test/sot/test_18_tensor_method.py
 test/sot/test_19_closure.py
 test/sot/test_21_global.py
 test/sot/test_analysis_inputs.py
-test/sot/test_binary_operator_tracker.py
 test/sot/test_break_graph.py
 test/sot/test_builtin_bool.py
 test/sot/test_builtin_dispatch.py
@@ -20,7 +17,6 @@ test/sot/test_builtin_map.py
 test/sot/test_builtin_range.py
 test/sot/test_builtin_zip.py
 test/sot/test_call_object.py
-test/sot/test_constant_graph.py
 test/sot/test_dtype.py
 test/sot/test_dup_top.py
 test/sot/test_enumerate.py
@@ -29,14 +25,12 @@ test/sot/test_inplace_api.py
 test/sot/test_min_graph_size.py
 test/sot/test_model_switch_training.py
 test/sot/test_numpy.py
-test/sot/test_numpy_var_if.py
+test/sot/test_resume_cache.py
 test/sot/test_side_effects.py
 test/sot/test_simulate_initialize.py
 test/sot/test_sot_cost_model.py
 test/sot/test_sot_dynamic_shape.py
-test/sot/test_sot_exception.py
 test/sot/test_sot_export.py
 test/sot/test_sot_resnet.py
 test/sot/test_sot_resnet50_backward.py
 test/sot/test_str_format.py
-test/sot/test_tensor_dtype_in_guard.py


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

Python 3.13 支持 `CALL_KW` 模拟

- #69246
- #69245

PCard-66972