### PR TITLE
[SOT][3.13] Support new method layout

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -503,7 +503,7 @@ class FunctionGraph:
         log(3, f"call paddle.api : {func.__name__}", "\n")
 
         def message_handler(*args, **kwargs):
-            return f"Call paddle_api error: {func.__name__}, may be not a operator api ?"
+            return f"Call paddle_api error: {func.__name__}, may be not a operator api?"
 
         return inner_error_default_handler(self.symbolic_call, message_handler)(
             InferMetaCache(),
@@ -525,7 +525,7 @@ class FunctionGraph:
         """
 
         def message_handler(*args, **kwargs):
-            return f"Call tensor_method error: Tensor.{method_name}, may be not a valid operator api ?"
+            return f"Call tensor_method error: Tensor.{method_name}, may be not a valid operator api?"
 
         return inner_error_default_handler(self.symbolic_call, message_handler)(
             InferMetaCache(),
@@ -547,7 +547,7 @@ class FunctionGraph:
         """
 
         def message_handler(*args, **kwargs):
-            return f"Call symbolic_method error: Symbolic.{method_name}, may be not a valid operator api ?"
+            return f"Call symbolic_method error: Symbolic.{method_name}, may be not a valid operator api?"
 
         return inner_error_default_handler(self.symbolic_call, message_handler)(
             InferMetaCache(),
@@ -585,7 +585,7 @@ class FunctionGraph:
             )
 
         def message_handler(*args, **kwargs):
-            return f"Call paddle layer error: {layer}, may be not a valid paddle layer ?"
+            return f"Call paddle layer error: {layer}, may be not a valid paddle layer?"
 
         return inner_error_default_handler(self.symbolic_call, message_handler)(
             infer_meta_fn, compute_fn, layer, False, *args, **kwargs

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -116,6 +116,9 @@ SUPPORT_COMPARE_OP = {
     "BAD": operator_BAD,
 }
 
+# In Python 3.13, the method layout is changed, and a NULL will be pushed after the value.
+NULL_AFTER_VALUE = sys.version_info >= (3, 13)
+
 
 @dataclass
 class Stop:
@@ -837,7 +840,7 @@ class OpcodeExecutorBase:
         if sys.version_info >= (3, 11):
             push_null = namei & 1
             namei >>= 1
-        if push_null:
+        if push_null and not NULL_AFTER_VALUE:
             self.stack.push(NullVariable())
         name = self._code.co_names[namei]
         if name in self._globals.keys():
@@ -847,6 +850,8 @@ class OpcodeExecutorBase:
         else:
             raise InnerError(f"{name} not in globals and builtins")
         self.stack.push(value)
+        if push_null and NULL_AFTER_VALUE:
+            self.stack.push(NullVariable())
 
     def load_method(self, method_name):
         method_name_var = ConstantVariable.wrap_literal(
@@ -867,8 +872,11 @@ class OpcodeExecutorBase:
             self.stack.push(obj)
         else:
             # unbound method, push the dummy and the function
-            self.stack.push(NullVariable())
+            if not NULL_AFTER_VALUE:
+                self.stack.push(NullVariable())
             self.stack.push(method)
+            if NULL_AFTER_VALUE:
+                self.stack.push(NullVariable())
 
     def LOAD_METHOD(self, instr: Instruction):
         method_name = self._code.co_names[instr.arg]
@@ -1285,8 +1293,11 @@ class OpcodeExecutorBase:
         assert isinstance(args_variable, (TupleVariable, ListVariable))
         args = args_variable.get_wrapped_items()
 
+        if sys.version_info >= (3, 11) and NULL_AFTER_VALUE:
+            null = self.stack.pop()
+            assert isinstance(null, NullVariable)
         fn = self.stack.pop()
-        if sys.version_info >= (3, 11):
+        if sys.version_info >= (3, 11) and not NULL_AFTER_VALUE:
             null = self.stack.pop()
             assert isinstance(null, NullVariable)
         ret = fn(*args, **kwargs)

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1158,15 +1158,15 @@ class OpcodeExecutorBase:
         assert isinstance(instr.arg, int)
         self._call_shape = self._co_consts[instr.arg].get_py_value()
 
-    def call_impl(
+    def call_impl_py312_minus(
         self,
-        num_args: int,
-        kwnames_getter: Callable[[OpcodeExecutor], tuple[str, ...]],
+        instr: Instruction,
     ):
-        kwnames = kwnames_getter(self)
-        assert num_args + 2 <= len(self.stack)
-        is_method = not isinstance(self.stack.peek[num_args + 2], NullVariable)
-        total_args = num_args + int(is_method)
+        assert isinstance(instr.arg, int)
+        assert instr.arg + 2 <= len(self.stack)
+        is_method = not isinstance(self.stack.peek[instr.arg + 2], NullVariable)
+        total_args = instr.arg + int(is_method)
+        kwnames = self._call_shape if self._call_shape is not None else ()
         n_kwargs = len(kwnames)
         n_positional_args = total_args - n_kwargs
         kwargs_list = self.stack.pop_n(n_kwargs)
@@ -1179,32 +1179,63 @@ class OpcodeExecutorBase:
         self.stack.push(fn(*args, **kwargs))
         self._call_shape = None
 
-    def call(self, instr: Instruction):
-        assert isinstance(instr.arg, int)
-        self.call_impl(
-            instr.arg,
-            lambda exe: (
-                exe._call_shape if exe._call_shape is not None else ()
-            ),
-        )
+    def call_impl_py313_plus(
+        self,
+        num_args: int,
+        kwnames_getter: Callable[[OpcodeExecutorBase], tuple[str, ...]],
+    ):
+        kwnames = kwnames_getter(self)
+        assert num_args + 2 <= len(self.stack)
+        args = self.stack.pop_n(num_args)
+        self_or_null = self.stack.pop()
+        callable = self.stack.pop()
 
-    CALL = (
-        call_break_graph_decorator(push_n=1)(call)
-        if sys.version_info >= (3, 12)
-        else call
-    )
+        if not isinstance(self_or_null, NullVariable):
+            args = [self_or_null, *args]
+        if isinstance(self_or_null, NullVariable) and isinstance(
+            callable, MethodVariable
+        ):
+            unbound_method = callable.fn
+            self_var = callable.bound_instance
+            args = [self_var, *args]
+            callable = unbound_method
+
+        n_positional_args = len(args) - len(kwnames)
+        kwargs_list = args[n_positional_args:]
+        args = args[:n_positional_args]
+        kwargs = dict(zip(kwnames, kwargs_list))
+        self.stack.push(callable(*args, **kwargs))
+
+    if sys.version_info >= (3, 13):
+
+        @call_break_graph_decorator(push_n=1)
+        def CALL(self, instr: Instruction):
+            assert isinstance(instr.arg, int)
+
+            self.call_impl_py313_plus(instr.arg, lambda exe: ())
+
+    elif sys.version_info >= (3, 12):
+
+        @call_break_graph_decorator(push_n=1)
+        def CALL(self, instr: Instruction):
+            self.call_impl_py312_minus(instr)
+
+    else:
+
+        def CALL(self, instr: Instruction):
+            self.call_impl_py312_minus(instr)
 
     @call_break_graph_decorator(push_n=1)
     def CALL_KW(self, instr: Instruction):
         assert isinstance(instr.arg, int)
 
-        def get_kwnames(exe: OpcodeExecutor):
+        def get_kwnames(exe: OpcodeExecutorBase):
             kwnames_var = exe.stack.pop()
             assert isinstance(kwnames_var, TupleVariable)
             kwnames = kwnames_var.get_py_value()
             return kwnames
 
-        self.call_impl(instr.arg, get_kwnames)
+        self.call_impl_py313_plus(instr.arg, get_kwnames)
 
     @call_break_graph_decorator(push_n=1)
     def CALL_FUNCTION(self, instr: Instruction):

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -681,6 +681,11 @@ class PyCodeGen:
         null_var = self.global_null_variable
         return self.gen_load_object(null_var, "___null_var", push_null=False)
 
+    def gen_push_null(self):
+        if sys.version_info < (3, 11):
+            raise InnerError("gen_push_null is only supported in Python 3.11+")
+        return self.add_instr("PUSH_NULL")
+
     def gen_load_fast(self, name):
         """
         Generate the bytecode for loading a local variable.

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import operator
+import sys
 import types
 from functools import cached_property, reduce
 from typing import TYPE_CHECKING, Any
@@ -1205,6 +1206,9 @@ class NullVariable(VariableBase):
         return func(*args[1:], **kwargs)
 
     def reconstruct(self, codegen: PyCodeGen):
+        if sys.version_info >= (3, 13):
+            codegen.gen_push_null()
+            return
         codegen.gen_load_null_variable()
 
 

--- a/python/paddle/jit/sot/utils/exceptions.py
+++ b/python/paddle/jit/sot/utils/exceptions.py
@@ -61,7 +61,7 @@ def inner_error_default_handler(func, message_fn):
                 traceback.format_exception(type(e), e, e.__traceback__)
             )
             raise InnerError(
-                f"{message}.\nOrigin Exception is: \n {origin_exception_message}"
+                f"{message}\nOrigin Exception is: \n {origin_exception_message}"
             ) from e
 
     return impl

--- a/test/sot/skip_files_py313
+++ b/test/sot/skip_files_py313
@@ -1,12 +1,9 @@
-test/sot/test_04_list.py
 test/sot/test_11_jumps.py
 test/sot/test_12_for_loop.py
 test/sot/test_13_make_function.py
 test/sot/test_14_operators.py
 test/sot/test_15_slice.py
-test/sot/test_16_paddle_api.py
 test/sot/test_17_paddle_layer.py
-test/sot/test_18_tensor_method.py
 test/sot/test_19_closure.py
 test/sot/test_21_global.py
 test/sot/test_analysis_inputs.py
@@ -16,11 +13,8 @@ test/sot/test_builtin_dispatch.py
 test/sot/test_builtin_map.py
 test/sot/test_builtin_range.py
 test/sot/test_builtin_zip.py
-test/sot/test_call_object.py
-test/sot/test_dtype.py
 test/sot/test_dup_top.py
 test/sot/test_enumerate.py
-test/sot/test_guard_user_defined_fn.py
 test/sot/test_inplace_api.py
 test/sot/test_min_graph_size.py
 test/sot/test_model_switch_training.py


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

为 SOT Python 3.13 支持新的 method layout

在 Python 3.13 之前，CALL 的两种 layout 分别如下：

```
function layout: [NULL, callable, arg1, arg2, ...]
method layout:   [method, self, arg1, arg2, ...]
```

相关内容可以参考 https://github.com/PaddlePaddle/PaddleSOT/blob/develop/docs/compat/python311/CALL.md

3.13 对其进行了统一

```
function layout: [callable, NULL, arg1, arg2, ...]
method layout:   [method, self, arg1, arg2, ...]
i.e.
                 [callable, self_or_null, arg1, arg2, ...]
```

这样栈上各个位置的元素语义也更加清晰了

相应地，`LOAD_GLOBAL`、`LOAD_ATTR`（原 `LOAD_METHOD`）融合 `PUSH_NULL` 后的语义也变了，是先 push value 后 push null，之前是先 push null 后 push value，因此相关模拟也都需要适配

- #69246
- #69245

PCard-66972