### PR TITLE
[SOT][3.13] Support non-breakgraph for loop

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
@@ -319,7 +319,8 @@ class OpcodeInlineExecutor(OpcodeExecutorBase):
                 self._lasti = self.indexof(instr.jump_to)
                 if sys.version_info >= (3, 12):
                     assert self._instructions[self._lasti].opname == "END_FOR"
-                    self._lasti += 1
+                    skip_n_instrs = 2 if sys.version_info >= (3, 13) else 1
+                    self._lasti += skip_n_instrs
 
         else:
             self._graph.remove_global_guarded_variable(iterator)

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -43,6 +43,7 @@ from ..instruction_utils import (
     apply_instr_pass,
     calc_stack_effect,
     gen_instr,
+    get_instruction_size,
     instrs_info,
     modify_instrs,
     modify_vars,
@@ -215,13 +216,6 @@ def to_byte(num):
     if num < 0:
         num += 256
     return num
-
-
-def get_instruction_size(instr: Instruction) -> int:
-    cache_size = 0
-    if sys.version_info >= (3, 11):
-        cache_size = PYOPCODE_CACHE_SIZE.get(instr.opname, 0)
-    return 2 * (cache_size + 1)
 
 
 def create_linetable_calculator(firstlineno: int):
@@ -933,6 +927,11 @@ class PyCodeGen:
         direction: JumpDirection = JumpDirection.FORWARD,
         suffix: PopJumpCond = PopJumpCond.NONE,
     ) -> Instruction:
+        if sys.version_info >= (3, 13) and suffix in [
+            PopJumpCond.TRUE,
+            PopJumpCond.FALSE,
+        ]:
+            self.add_instr("TO_BOOL")
         if sys.version_info >= (3, 11) and sys.version_info < (3, 12):
             return self.add_instr(
                 f"POP_JUMP_{direction.value}_IF_{suffix.value}", jump_to=jump_to

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -49,7 +49,6 @@ from ..instruction_utils import (
     modify_vars,
 )
 from ..instruction_utils.opcode_info import (
-    PYOPCODE_CACHE_SIZE,
     UNCONDITIONAL_JUMP,
     JumpDirection,
     PopJumpCond,

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/__init__.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/__init__.py
@@ -20,6 +20,7 @@ from .instruction_utils import (  # noqa: F401
     calc_stack_effect,
     convert_instruction,
     gen_instr,
+    get_instruction_size,
     get_instructions,
     instrs_info,
     modify_extended_args,

--- a/test/sot/skip_files_py313
+++ b/test/sot/skip_files_py313
@@ -5,12 +5,10 @@ test/sot/test_14_operators.py
 test/sot/test_15_slice.py
 test/sot/test_17_paddle_layer.py
 test/sot/test_19_closure.py
-test/sot/test_21_global.py
 test/sot/test_analysis_inputs.py
 test/sot/test_break_graph.py
 test/sot/test_builtin_bool.py
 test/sot/test_builtin_dispatch.py
-test/sot/test_builtin_map.py
 test/sot/test_builtin_range.py
 test/sot/test_builtin_zip.py
 test/sot/test_dup_top.py


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

SOT Python 3.13 支持基本的非打断场景 for-loop

Python 3.13 对 `END_FOR` 进行了改动，3.12 `END_FOR` 等价于两个 `POP_TOP`，因此只需要一个 `END_FOR` 即可，而 3.13 下 `END_FOR` 只等价于一个 `POP_TOP`，因此需要额外一个 `POP_TOP` 来维持栈平衡

即

```python
# 3.12
    FOR_ITER    to L1
    ...
L1: END_FOR

# 3.13
    FOR_ITER    to L1
    ...
L1: END_FOR
    POP_TOP
```

相关区域需要适配

> [!TIP]
>
> 3.13 `dis.dis` 默认显示如上所示的 Label 形式的跳转，而隐藏了 offset，但为了确认生成指令的问题，可以在 `dis.dis` 传入 `show_offsets=True` 来开启

另外就是 3.13 下 `JUMP_BACKWARD` 有一个 inline cache，而 `JUMP_FORWARD` 没有，我们是先 `reset_offset` 后 `relocate_jump_target` 的，`relocate_jump_target` 可能会将 `JUMP_FORWARD` 改为 `JUMP_BACKWARD`（或反之），这就会导致 offset 异常，跳转计算出错

因此需要确保 `relocate_jump_target` 里出现反转跳转方向时，需要重新 `reset_offset`，以确保计算的跳转方向是正确的

打断场景待支持，目前会发生段错误

- #69246
- #69245

PCard-66972