### PR TITLE
[Auto Parallel] handle partial status propagate for `add_n`

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/add_n.cc
+++ b/paddle/phi/infermeta/spmd_rules/add_n.cc
@@ -54,14 +54,36 @@ SpmdInfo AddNInferSpmd(
   std::vector<int64_t> dims_mapping =
       GetDimsMappingForAxes(axes, axis_to_dim_map);
 
+  // Infer partial status from inputs
+  // Note: Now only supports cases where all inputs have same
+  // partial status, then output will have the same one.
+  bool all_input_partial_same = true;
+  paddle::flat_hash_map<int64_t, ReduceType> partial_status;
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    TensorDistAttr input_dist_attr_src = inputs[i].dist_attr();
+    if (input_dist_attr_src.is_partial()) {
+      auto input_partial_status = input_dist_attr_src.partial_status();
+      if (i == 0) {
+        partial_status = input_partial_status;
+      } else if (partial_status != input_partial_status) {
+        all_input_partial_same = false;
+        break;
+      }
+    } else {
+      all_input_partial_same = false;
+      break;
+    }
+  }
   std::vector<TensorDistAttr> inputs_spmd_info;
   for (const auto& input : inputs) {
     TensorDistAttr dist_attr_dst =
         CopyTensorDistAttrForOutput(input.dist_attr());
     dist_attr_dst.set_dims_mapping(dims_mapping);
+    if (all_input_partial_same) {
+      dist_attr_dst.set_partial_status(partial_status);
+    }
     inputs_spmd_info.push_back(dist_attr_dst);
   }
-  // Handle input tensor partial(TODO)
 
   return {{inputs_spmd_info}, {inputs_spmd_info[0]}};
 }

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -726,5 +726,8 @@ PD_REGISTER_SPMD_RULE(pad,
 PD_REGISTER_SPMD_RULE(nonzero,
                       PD_INFER_SPMD(phi::distributed::NonZeroInferSpmd),
                       PD_INFER_SPMD(phi::distributed::NonZeroInferSpmdReverse));
+
+// add_n
+PD_REGISTER_SPMD_RULE(add_n, PD_INFER_SPMD(phi::distributed::AddNInferSpmd));
 }  // namespace distributed
 }  // namespace phi

--- a/test/auto_parallel/spmd_rules/CMakeLists.txt
+++ b/test/auto_parallel/spmd_rules/CMakeLists.txt
@@ -43,7 +43,9 @@ if(WITH_DISTRIBUTE)
                   test_fused_dropout_add_rule)
   py_test_modules(test_logsumexp_rule MODULES test_logsumexp_rule)
   py_test_modules(test_nonzero_rule MODULES test_nonzero_rule)
-  py_test_modules(test_add_n_rule MODULES test_add_n_rule)
+  if(NOT WITH_ROCM)
+    py_test_modules(test_add_n_rule MODULES test_add_n_rule)
+  endif()
   # End of unittests WITH single card WITHOUT timeout
 
 endif()

--- a/test/auto_parallel/spmd_rules/CMakeLists.txt
+++ b/test/auto_parallel/spmd_rules/CMakeLists.txt
@@ -43,6 +43,7 @@ if(WITH_DISTRIBUTE)
                   test_fused_dropout_add_rule)
   py_test_modules(test_logsumexp_rule MODULES test_logsumexp_rule)
   py_test_modules(test_nonzero_rule MODULES test_nonzero_rule)
+  py_test_modules(test_add_n_rule MODULES test_add_n_rule)
   # End of unittests WITH single card WITHOUT timeout
 
 endif()

--- a/test/auto_parallel/spmd_rules/test_add_n_rule.py
+++ b/test/auto_parallel/spmd_rules/test_add_n_rule.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from paddle.distributed.auto_parallel.static.dist_attribute import (
+    DistTensorSpec,
+    TensorDistAttr,
+)
+from paddle.distributed.fleet import auto
+from paddle.framework import core
+
+
+class TestAddNSPMDRule(unittest.TestCase):
+    """
+    Unit tests for add_n spmd rule.
+    """
+
+    def setUp(self):
+        self.rule1 = core.get_phi_spmd_rule("add_n")
+        process_mesh = auto.ProcessMesh(mesh=[[0, 1], [2, 3]])
+        self.x_shape = [16, 16, 16]
+        self.x_tensor_dist_attr = TensorDistAttr()
+        self.x_tensor_dist_attr.process_mesh = process_mesh
+
+        self.y_shape = [16, 16, 16]
+        self.y_tensor_dist_attr = TensorDistAttr()
+        self.y_tensor_dist_attr.process_mesh = process_mesh
+
+        self.output_shape = [16, 16, 16]
+        self.output_tensor_dist_attr = TensorDistAttr()
+        self.output_tensor_dist_attr.process_mesh = process_mesh
+
+    def test_infer_forward(self):
+        # [0, -1, -1], [-1, -1, -1] (x,y) -->
+        # [0, -1, -1], [0, -1, -1] (x, y)
+        # [0, -1, -1] (output)
+        self.x_dist_tensor_spec = DistTensorSpec(
+            self.x_shape, self.x_tensor_dist_attr
+        )
+        self.x_dist_tensor_spec.set_dims_mapping([0, -1, -1])
+        self.y_dist_tensor_spec = DistTensorSpec(
+            self.y_shape, self.y_tensor_dist_attr
+        )
+        self.y_dist_tensor_spec.set_dims_mapping([0, -1, -1])
+
+        infered_dist_attr = self.rule1.infer_forward(
+            [self.x_dist_tensor_spec, self.y_dist_tensor_spec]
+        )
+
+        self.assertEqual(len(infered_dist_attr), 2)
+        infered_input_dist_attr = infered_dist_attr[0]
+        infered_output_dist_attr = infered_dist_attr[1]
+
+        self.assertEqual(len(infered_input_dist_attr), 1)
+        self.assertEqual(len(infered_input_dist_attr[0]), 2)
+        self.assertEqual(len(infered_output_dist_attr), 1)
+
+        self.assertEqual(
+            infered_input_dist_attr[0][0].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(
+            infered_input_dist_attr[0][1].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [0, -1, -1])
+
+        # [0, -1, -1], [-1, -1, -1] (x, y) partial_dim=[1] -->
+        # [0, -1, -1], [0, -1, -1]  (x, y) partial_dim=[1]
+        # [0, -1, -1] (output) partial_dim=[1]
+        self.x_tensor_dist_attr._set_partial_dims([1])
+        self.x_dist_tensor_spec = DistTensorSpec(
+            self.x_shape, self.x_tensor_dist_attr
+        )
+        self.x_dist_tensor_spec.set_dims_mapping([0, -1, -1])
+        self.y_tensor_dist_attr._set_partial_dims([1])
+        self.y_dist_tensor_spec = DistTensorSpec(
+            self.y_shape, self.y_tensor_dist_attr
+        )
+        self.y_dist_tensor_spec.set_dims_mapping([-1, -1, -1])
+
+        infered_dist_attr = self.rule1.infer_forward(
+            [self.x_dist_tensor_spec, self.y_dist_tensor_spec]
+        )
+
+        self.assertEqual(len(infered_dist_attr), 2)
+        infered_input_dist_attr = infered_dist_attr[0]
+        infered_output_dist_attr = infered_dist_attr[1]
+
+        self.assertEqual(len(infered_input_dist_attr), 1)
+        self.assertEqual(len(infered_input_dist_attr[0]), 2)
+        self.assertEqual(len(infered_output_dist_attr), 1)
+
+        self.assertEqual(
+            infered_input_dist_attr[0][0].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(infered_input_dist_attr[0][0]._is_partial(), True)
+        self.assertEqual(infered_input_dist_attr[0][0]._partial_dims(), {1})
+
+        self.assertEqual(
+            infered_input_dist_attr[0][1].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(infered_input_dist_attr[0][1]._is_partial(), True)
+        self.assertEqual(infered_input_dist_attr[0][1]._partial_dims(), {1})
+
+        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_output_dist_attr[0]._is_partial(), True)
+        self.assertEqual(infered_output_dist_attr[0]._partial_dims(), {1})
+
+        # [0, -1, -1] partial_dim=[0], [-1, -1, -1]partial_dim=[1] (x,y)  -->
+        # [0, -1, -1], [0, -1, -1] (x, y)
+        # [0, -1, -1] (output)
+        self.x_tensor_dist_attr._clean_partial_dims([1])
+        self.x_tensor_dist_attr._set_partial_dims([0])
+        self.x_dist_tensor_spec = DistTensorSpec(
+            self.x_shape, self.x_tensor_dist_attr
+        )
+        self.x_dist_tensor_spec.set_dims_mapping([0, -1, -1])
+
+        self.y_tensor_dist_attr._clean_partial_dims([1])
+        self.y_tensor_dist_attr._set_partial_dims([1])
+        self.y_dist_tensor_spec = DistTensorSpec(
+            self.y_shape, self.y_tensor_dist_attr
+        )
+        self.y_dist_tensor_spec.set_dims_mapping([-1, -1, -1])
+
+        infered_dist_attr = self.rule1.infer_forward(
+            [self.x_dist_tensor_spec, self.y_dist_tensor_spec]
+        )
+
+        self.assertEqual(len(infered_dist_attr), 2)
+        infered_input_dist_attr = infered_dist_attr[0]
+        infered_output_dist_attr = infered_dist_attr[1]
+
+        self.assertEqual(len(infered_input_dist_attr), 1)
+        self.assertEqual(len(infered_input_dist_attr[0]), 2)
+        self.assertEqual(len(infered_output_dist_attr), 1)
+
+        self.assertEqual(
+            infered_input_dist_attr[0][0].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(infered_input_dist_attr[0][0]._is_partial(), False)
+
+        self.assertEqual(
+            infered_input_dist_attr[0][1].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(infered_input_dist_attr[0][1]._is_partial(), False)
+
+        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_output_dist_attr[0]._is_partial(), False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
为 `add_n` 算子添加 `partial` 状态的切分推导：当所有输入都有相同的 `partial` 状态，则输出也包含 相同的 `partial` 状态，并为其增加切分推导的单测
动手与静半：这会影响到部分 `reshard` 插入位置，可能导致部分 动手 与 静半 单测的算子执行顺序产生差异，进而造成合理的精度误差：

- 动手会先执行通信算子(eg：`all_reduce`， `reduce_scatter` 等)再执行 `add_n`
- 静半会先执行 `add_n` 再执行通信算子

动半与静半：动半 反向中插入的 `GradNodeAccumulation` 也会引发精度误差，在设备间是会先进行通信同步，再进行累积。因此，同样会与静半 单测的算子执行顺序产生差异，造成精度误差。


因此，增加对部分相关单测 `baseline` 的修改

PCard-88057