### PR TITLE
[Auto Parallel] parallel model and parallel optimizer

### DIFF
--- a/python/paddle/distributed/auto_parallel/intermediate/parallelize.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/parallelize.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .parallel_base import parallelize_model_and_optimizer
+from .parallel_base import ParallelOptimizer, parallelize_model_and_optimizer
 from .pipeline_parallel import pipeline_parallel
 from .sharded_data_parallel import sharded_data_parallel
 from .tensor_parallel import tensor_parallel
@@ -43,3 +43,21 @@ def parallelize(
         )
     model, optimizer = parallelize_model_and_optimizer(model, optimizer)
     return model, optimizer
+
+
+def parallelize_model(
+    model, mesh=None, dp_config=None, mp_config=None, pp_config=None
+):
+    model, _ = parallelize(model, None, mesh, dp_config, mp_config, pp_config)
+    return model
+
+
+def parallelize_optimizer(
+    model, optimizer, mesh=None, dp_config=None, mp_config=None, pp_config=None
+):
+    level = None
+    if dp_config is not None:
+        level = dp_config.get('sharding_level')
+    optimizer = ParallelOptimizer(optimizer, level)
+    optimizer = optimizer.parallelize(model.parameters())
+    return optimizer

--- a/test/auto_parallel/hybrid_strategy/parallel_api.py
+++ b/test/auto_parallel/hybrid_strategy/parallel_api.py
@@ -23,7 +23,8 @@ import paddle
 import paddle.distributed as dist
 from paddle import LazyGuard
 from paddle.distributed.auto_parallel.intermediate.parallelize import (
-    parallelize,
+    parallelize_model,
+    parallelize_optimizer,
 )
 from paddle.distributed.auto_parallel.intermediate.tensor_parallel import (
     ColWiseParallel,
@@ -262,7 +263,13 @@ class TestParallelAPI:
                         "lm_head": SequenceParallelEnd(),
                     }
             mp_config = {'parallelize_plan': plan}
-        layer, optimizer = parallelize(
+        layer = parallelize_model(
+            layer,
+            dp_config=dp_config,
+            mp_config=mp_config,
+            pp_config=pp_config,
+        )
+        optimizer = parallelize_optimizer(
             layer,
             optimizer,
             dp_config=dp_config,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
New features


### Description
Pcard-73145
parallel model and parallel optimizer

- 在PaddleNLP中，model的初始化最晚要在amp的decorate之前，也就是Trainer.__init__方法之前。因为amp decorate会真正的进行参数的cast等操作。
- 在PaddleNLP中，optimizer初始化需要传入lr scheduler，并且lr scheduler的配置的某些分支需要通过checkpoint中的resume step来获取。这就导致optimizer的初始化需要在load checkpoint之后。也就是在trainer.train中完成。
- 这就导致在PaddleNLP目前的框架体系下，model的初始化与optimizer的初始化位置无法统一，所以中层api需要两个接口分别parallelize model与optimizer。
- 未来如果PaddleNLP进行更新，譬如将optimizer与lr scheduler解耦，将optimizer的初始化提前到Trainer.__init__之中，中层api也无需使用两个接口分别parallelize model与optimizer。
