### PR TITLE
[Infra][3.8] Use `pkg_resources` in Python 3.8

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -595,6 +595,7 @@ from .utils.dlpack import (
 # CINN has to set a flag to include a lib
 if is_compiled_with_cinn():
     import os
+    import sys
     from importlib import resources
 
     package_dir = os.path.dirname(os.path.abspath(__file__))
@@ -603,8 +604,17 @@ if is_compiled_with_cinn():
     if os.path.exists(cuh_file):
         os.environ.setdefault('runtime_include_dir', runtime_include_dir)
 
-    data_file_path = resources.files('paddle.cinn_config')
-    os.environ['CINN_CONFIG_PATH'] = str(data_file_path)
+    if sys.version_info >= (3, 9):
+
+        data_file_path = resources.files('paddle.cinn_config')
+        os.environ['CINN_CONFIG_PATH'] = str(data_file_path)
+    else:
+        import pkg_resources
+
+        data_file_path = pkg_resources.resource_filename(
+            'paddle.cinn_config', ''
+        )
+        os.environ['CINN_CONFIG_PATH'] = data_file_path
 
 if __is_metainfo_generated and is_compiled_with_cuda():
     import os


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#69130 会导致 Python 3.8 挂掉，因为 `importlib.resources.files` 是 Python 3.9 添加的[^1]

因此 Python 3.8 回退到原来的写法，后续 Python 3.8 退场可以直接删除

PCard-66972

[^1]: https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files