### PR TITLE
[Paddle Tensor No.23] 新增`TensorA[mask] = TensorB`

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1864,21 +1864,8 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
             mesh, self->tensor, transed_sub_tensor, value_tensor);
       }
 
-      if (transed_index.size() == 1 &&
-          transed_index[0].dtype() == phi::DataType::BOOL &&
-          transed_index[0].shape().size() == self->tensor.shape().size()) {
-        if (value_tensor.shape() != self->tensor.shape()) {
-          value_tensor = expand_ad_func(value_tensor, self->tensor.shape());
-        }
-        transed_sub_tensor =
-            where__ad_func(logical_not_ad_func(transed_index[0]),
-                           transed_sub_tensor,
-                           value_tensor);
-      } else {
-        transed_sub_tensor =
-            index_put__ad_func(transed_sub_tensor, transed_index, value_tensor);
-      }
-
+      transed_sub_tensor =
+          index_put__ad_func(transed_sub_tensor, transed_index, value_tensor);
       if (out_is_view) {
         // NOTE(zoooo0820): if out_is_view is true, it is a case of
         // combined-indexing setitem, i.e. firstly we get a view of

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1863,9 +1863,19 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
         ConvertAllInputsToDistTensor(
             mesh, self->tensor, transed_sub_tensor, value_tensor);
       }
-
-      transed_sub_tensor =
-          index_put__ad_func(transed_sub_tensor, transed_index, value_tensor);
+      if (transed_index.size() == 1 &&
+          transed_index[0].dtype() == phi::DataType::BOOL &&
+          transed_index[0].shape().size() == self->tensor.shape().size() &&
+          value_tensor.numel() == 1) {
+        value_tensor = expand_ad_func(value_tensor, self->tensor.shape());
+        transed_sub_tensor =
+            where__ad_func(logical_not_ad_func(transed_index[0]),
+                           transed_sub_tensor,
+                           value_tensor);
+      } else {
+        transed_sub_tensor =
+            index_put__ad_func(transed_sub_tensor, transed_index, value_tensor);
+      }
       if (out_is_view) {
         // NOTE(zoooo0820): if out_is_view is true, it is a case of
         // combined-indexing setitem, i.e. firstly we get a view of

--- a/test/indexing/test_setitem.py
+++ b/test/indexing/test_setitem.py
@@ -533,6 +533,28 @@ class TestSetitemInDygraph(unittest.TestCase):
         else:
             np.testing.assert_equal(v.grad.numpy(), expected_v_grad)
 
+    def test_boolean_mask_scalar(self):
+        tensor_np = np.arange(2 * 3).reshape(2, 3)
+        tensor = paddle.to_tensor(tensor_np)
+        mask_np = np.array([[True, True, False], [False, True, False]])
+        mask = paddle.to_tensor(mask_np)
+        tensor[mask] = 100
+        tensor_np[mask_np] = 100
+        np.testing.assert_equal(tensor.numpy(), tensor_np)
+
+    def test_boolean_mask_tensor(self):
+        tensor_np = np.arange(2 * 3).reshape(2, 3)
+        tensor = paddle.to_tensor(tensor_np)
+        mask_np = np.array([[True, True, False], [False, True, False]]).astype(
+            'bool'
+        )
+        mask = paddle.to_tensor(mask_np)
+        value_np = np.array([100] * mask_np.sum())
+        value = paddle.to_tensor(value_np)
+        tensor[mask] = value
+        tensor_np[mask_np] = value_np
+        np.testing.assert_equal(tensor.numpy(), tensor_np)
+
 
 @unittest.skipIf(
     not core.is_compiled_with_cuda()
@@ -940,6 +962,38 @@ class TestSetitemInStatic(unittest.TestCase):
             res = self.exe.run(fetch_list=[y])
 
         np.testing.assert_allclose(res[0], np_data)
+
+    def test_boolean_mask_scalar(self):
+        tensor_np = np.arange(2 * 3).reshape(2, 3).astype('int32')
+        mask_np = np.array([[True, True, False], [False, True, False]]).astype(
+            'bool'
+        )
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
+            tensor = paddle.to_tensor(tensor_np)
+            mask = paddle.to_tensor(mask_np)
+            tensor[mask] = 100
+            res = self.exe.run(fetch_list=[tensor])
+        tensor_np[mask_np] = 100
+        np.testing.assert_equal(res[0], tensor_np)
+
+    def test_boolean_mask_tensor(self):
+        tensor_np = np.arange(2 * 3).reshape(2, 3).astype('int32')
+        mask_np = np.array([[True, True, False], [False, True, False]]).astype(
+            'bool'
+        )
+        value_np = np.array([100] * mask_np.sum()).astype('int32')
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
+            tensor = paddle.to_tensor(tensor_np)
+            mask = paddle.to_tensor(mask_np)
+            value = paddle.to_tensor(value_np)
+            tensor[mask] = value
+            res = self.exe.run(fetch_list=[tensor])
+        tensor_np[mask_np] = value_np
+        np.testing.assert_equal(res[0], tensor_np)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Paddle Tensor 规范化：修改`Tensor.__setitem__`的 C++ 实现，实现当 index 是布尔类型，且右侧的输入是 Tensor 时的计算逻辑。
