### PR TITLE
[SOT] Add a quick output restore implementation in SOT call

### DIFF
--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -96,7 +96,7 @@ class NestSequence:
 
     def restore(self, tensor_result_list):
         """
-        Restores the nested sequence from value list.
+        Restores the nested sequence from tenosr list.
         """
         assert len(self._var_list) == len(tensor_result_list)
 

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -94,21 +94,29 @@ class NestSequence:
             variable_list.append(value)
         return variable_map, variable_list
 
-    def restore(self, value_list):
+    def restore(self, tensor_result_list):
         """
         Restores the nested sequence from value list.
         """
-        assert len(self._var_list) == len(value_list)
+        assert len(self._var_list) == len(tensor_result_list)
 
-        def to_value(x):
+        def to_tensor_result(x):
             if isinstance(x, Value):
-                return value_list[self._var_map[x]]
+                return tensor_result_list[self._var_map[x]]
             return x
 
         return paddle.utils.pack_sequence_as(
             self._raw_input,
-            list(map(to_value, paddle.utils.flatten(self._raw_input))),
+            list(map(to_tensor_result, paddle.utils.flatten(self._raw_input))),
         )
+
+    @cached_property
+    def quick_index_map(self):
+        assert all(isinstance(v, Value) for v in self._raw_input)
+        return [self._var_map[v] for v in self._raw_input]
+
+    def quick_restore(self, tensor_list):
+        return [tensor_list[idx] for idx in self.quick_index_map]
 
     def __getitem__(self, item):
         return self._var_list[item]
@@ -623,8 +631,7 @@ class PartialProgramLayer:
             self._cuda_graph_vec,
             *attrs,
         )
-        restored_nest_out = self._restore_out(out_vars)
-        return restored_nest_out
+        return self._outputs.quick_restore(out_vars)
 
     @cached_property
     def origin_runnable_program(self) -> RunnableProgram:

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -112,8 +112,11 @@ class NestSequence:
 
     @cached_property
     def quick_index_map(self):
-        assert all(isinstance(v, Value) for v in self._raw_input)
-        return [self._var_map[v] for v in self._raw_input]
+        raw_inputs = self._raw_input
+        if len(raw_inputs) == 1:
+            raw_inputs = raw_inputs[0]
+        assert all(isinstance(v, Value) for v in raw_inputs)
+        return [self._var_map[v] for v in raw_inputs]
 
     def quick_restore(self, tensor_list):
         return [tensor_list[idx] for idx in self.quick_index_map]

--- a/test/sot/test_sot_call.py
+++ b/test/sot/test_sot_call.py
@@ -24,7 +24,8 @@ def simple_case(x, y):
     a = x[0]
     b = x[1]
     c = paddle.reshape(y, [a, b])
-    return c
+    # This case use full graph mode, we need to return a list to keep same as SOT
+    return [c]
 
 
 class TestSotCall(TestCaseBase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

PIR 下 SOT call 添加一个快速的输出恢复方式，因为 SOT 下输出永远是线性的 list，因此不需要复杂的输出恢复逻辑，使用简单的 list index map，并提前 build，以降低此部分的开销

PCard-66972