### PR TITLE
fix stack_grad bug when index offset > int32_t

### DIFF
--- a/paddle/phi/kernels/funcs/stack_and_unstack.h
+++ b/paddle/phi/kernels/funcs/stack_and_unstack.h
@@ -121,7 +121,7 @@ __global__ void UnStackCudaKernel(const T* __restrict__ input,
 
   IndexT offset = blockIdx.x * blockDim.x + threadIdx.x;
   if (each_dim_size == 1) {
-    for (; offset < numel; offset += blockDim.x * gridDim.x) {
+    for (; offset < numel && offset >= 0; offset += blockDim.x * gridDim.x) {
       auto col_divmod_rslt = col_divmoder.div_mod(offset);
 
       IndexT i = offset / split_dim_with_out_col;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-70459