### PR TITLE
Adapt python op converters covered in paddle-3-beta2 for TRT 10

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
@@ -233,6 +233,12 @@ static phi::DataType TRT2PaddleDataType(nvinfer1::DataType type) {
       return phi::DataType::FLOAT16;
     case nvinfer1::DataType::kINT8:
       return phi::DataType::INT8;
+#if IS_TRT_VERSION_GE(9000)
+    case nvinfer1::DataType::kINT64:
+      VLOG(4) << "get nvinfer1::DataType::kINT64 from TRT op, and will output "
+                 "to paddle. Does the downstream paddle op here support int64?";
+      return phi::DataType::INT64;
+#endif
 #if IS_TRT_VERSION_GE(7000)
     case nvinfer1::DataType::kBOOL:
       return phi::DataType::BOOL;

--- a/python/paddle/tensorrt/converter.py
+++ b/python/paddle/tensorrt/converter.py
@@ -448,6 +448,9 @@ class PaddleToTensorRTConverter:
                 config.set_flag(trt.BuilderFlag.PREFER_PRECISION_CONSTRAINTS)
 
         trt_engine = builder.build_serialized_network(network, config)
+        assert (
+            trt_engine is not None
+        ), 'Failed to build engine. please see ERROR log from trt.Logger'
         trt_params = paddle.base.libpaddle.TRTEngineParams()
         trt_params.min_input_shape = min_shape_map
         trt_params.max_input_shape = max_shape_map

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -25,6 +25,8 @@ if parent_dir not in sys.path:
     sys.path.append(parent_dir)
 
 
+from tensorrt import INetworkDefinition, ITensor
+
 from paddle.base.log_helper import get_logger
 
 _logger = get_logger(
@@ -243,9 +245,17 @@ def trt_cast(network, input, dtype):
     return identity_layer.get_output(0)
 
 
-def trt_shape(network, input):
+def trt_shape(network: INetworkDefinition, input: ITensor) -> ITensor:
+    """
+    Add a IShapeLayer to get the shape of `input` ITensor.
+    This includes a workaround that casting the shape result(int64) from TRT10 back to int32.
+    Many existing paddle op kernels only support input shape tensor as int32
+    , to make TRT op more compatible with other paddle op, we cast back to int32.
+    NOTE: please remove this workaround when all paddle op supports shape tensor in int64
+    """
     shape_layer = network.add_shape(input)
     if version_list[0] >= 10:  # trt_version >=10
+        # workaround
         return trt_cast(network, shape_layer.get_output(0), trt.int32)
     return shape_layer.get_output(0)
 

--- a/python/paddle/tensorrt/impls/activation.py
+++ b/python/paddle/tensorrt/impls/activation.py
@@ -35,9 +35,9 @@ activation_type_map = {
 }
 
 
-@converter_registry.register("pd_op.relu", trt_version="8.x")
-@converter_registry.register("pd_op.tanh", trt_version="8.x")
-@converter_registry.register("pd_op.sigmoid", trt_version="8.x")
+@converter_registry.register("pd_op.relu", trt_version="trt_version_ge=8.0")
+@converter_registry.register("pd_op.tanh", trt_version="trt_version_ge=8.0")
+@converter_registry.register("pd_op.sigmoid", trt_version="trt_version_ge=8.0")
 def activation_converter(network, paddle_op, inputs):
     layer = network.add_activation(
         inputs[0], activation_type_map[paddle_op.name()]
@@ -45,7 +45,7 @@ def activation_converter(network, paddle_op, inputs):
     return layer.get_output(0)
 
 
-@converter_registry.register("pd_op.softmax", trt_version="8.x")
+@converter_registry.register("pd_op.softmax", trt_version="trt_version_ge=8.0")
 def softmax_converter(network, paddle_op, inputs):
     axis = paddle_op.attrs().get("axis", 0)
     if axis < 0:
@@ -56,7 +56,7 @@ def softmax_converter(network, paddle_op, inputs):
     return softmax_layer.get_output(0)
 
 
-@converter_registry.register("pd_op.gelu", trt_version="8.x")
+@converter_registry.register("pd_op.gelu", trt_version="trt_version_ge=8.0")
 def gelu_converter(network, paddle_op, inputs):
     input_val = inputs[0]
     approximate = paddle_op.attrs()["approximate"]
@@ -79,7 +79,9 @@ def gelu_converter(network, paddle_op, inputs):
     return layer.get_output(0)
 
 
-@converter_registry.register("pd_op.hardsigmoid", trt_version="8.x")
+@converter_registry.register(
+    "pd_op.hardsigmoid", trt_version="trt_version_ge=8.0"
+)
 def hardsigmoid_converter(network, paddle_op, inputs):
     x = inputs[0]
     slope = paddle_op.attrs()["slope"]
@@ -92,7 +94,9 @@ def hardsigmoid_converter(network, paddle_op, inputs):
     return hardsigmoid_layer.get_output(0)
 
 
-@converter_registry.register("pd_op.hardswish", trt_version="8.x")
+@converter_registry.register(
+    "pd_op.hardswish", trt_version="trt_version_ge=8.0"
+)
 def hardswish_converter(network, paddle_op, inputs):
     x = inputs[0]
     threshold = 6.0

--- a/python/paddle/tensorrt/impls/attribute.py
+++ b/python/paddle/tensorrt/impls/attribute.py
@@ -12,17 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from paddle.tensorrt.converter_utils import trt_shape
 from paddle.tensorrt.register import converter_registry
 
 
-@converter_registry.register("pd_op.shape", trt_version="8.x")
+@converter_registry.register("pd_op.shape", trt_version="trt_version_ge=8.0")
 def shape_converter(network, paddle_op, inputs):
-    input_tensor = inputs[0]
-    shape_layer = network.add_shape(input_tensor)
-    return shape_layer.get_output(0)
+    return trt_shape(network, inputs[0])
 
 
-@converter_registry.register("pd_op.shape64", trt_version="8.x")
+@converter_registry.register("pd_op.shape64", trt_version="trt_version_ge=8.0")
 def shape64_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]
     shape_layer = network.add_shape(input_tensor)

--- a/python/paddle/tensorrt/impls/common.py
+++ b/python/paddle/tensorrt/impls/common.py
@@ -16,7 +16,7 @@
 import numpy as np
 import tensorrt as trt
 
-from paddle.tensorrt.converter_utils import get_shape_tensor_element
+from paddle.tensorrt.converter_utils import get_shape_tensor_element, trt_shape
 from paddle.tensorrt.register import converter_registry
 from paddle.tensorrt.util import get_trt_version_list
 
@@ -48,7 +48,9 @@ def dropout_converter(network, paddle_op, inputs):
     return scale_layer.get_output(0)
 
 
-@converter_registry.register("pd_op.bilinear_interp", trt_version="8.x")
+@converter_registry.register(
+    "pd_op.bilinear_interp", trt_version="trt_version_ge=8.0"
+)
 def bilinear_interp_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]
     data_format = paddle_op.attrs().get("data_format")
@@ -139,7 +141,7 @@ def bilinear_interp_converter(network, paddle_op, inputs):
     else:
         if outsize_tensor is not None:
             outsize_itensors = []
-            input_shape_tensor = network.add_shape(input_tensor).get_output(0)
+            input_shape_tensor = trt_shape(network, input_tensor)
             batch_dim = get_shape_tensor_element(network, input_shape_tensor, 0)
             outsize_itensors.append(batch_dim)
             if data_format == "NCHW":
@@ -162,7 +164,9 @@ def bilinear_interp_converter(network, paddle_op, inputs):
     return resize_layer.get_output(0)
 
 
-@converter_registry.register("pd_op.nearest_interp", trt_version="8.x")
+@converter_registry.register(
+    "pd_op.nearest_interp", trt_version="trt_version_ge=8.0"
+)
 def nearest_interp_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]
     data_format = paddle_op.attrs().get("data_format")
@@ -254,7 +258,7 @@ def nearest_interp_converter(network, paddle_op, inputs):
         )
     if outsize_tensor is not None:
         outsize_itensors = []
-        input_shape_tensor = network.add_shape(input_tensor).get_output(0)
+        input_shape_tensor = trt_shape(network, input_tensor)
         batch_dim = get_shape_tensor_element(network, input_shape_tensor, 0)
         outsize_itensors.append(batch_dim)
         if data_format == "NCHW":

--- a/python/paddle/tensorrt/impls/conv.py
+++ b/python/paddle/tensorrt/impls/conv.py
@@ -18,7 +18,7 @@ from paddle.tensorrt.register import converter_registry
 
 
 @converter_registry.register("pd_op.depthwise_conv2d", trt_version="8.x")
-@converter_registry.register("pd_op.conv2d", trt_version="8.x")
+@converter_registry.register("pd_op.conv2d", trt_version="trt_version_ge=8.0")
 @converter_registry.register("pd_op.conv2d_transpose", trt_version="8.x")
 @converter_registry.register(
     "pd_op.depthwise_conv2d_transpose", trt_version="8.x"

--- a/python/paddle/tensorrt/impls/creation.py
+++ b/python/paddle/tensorrt/impls/creation.py
@@ -29,7 +29,9 @@ from paddle.tensorrt.converter_utils import (
 from paddle.tensorrt.register import converter_registry
 
 
-@converter_registry.register("pd_op.full_int_array", trt_version="8.x")
+@converter_registry.register(
+    "pd_op.full_int_array", trt_version="trt_version_ge=8.0"
+)
 def full_int_array_converter(network, paddle_op, inputs):
     value = paddle_op.attrs()["value"]
     if len(value) == 0:
@@ -39,7 +41,7 @@ def full_int_array_converter(network, paddle_op, inputs):
     return full_int_array_layer.get_output(0)
 
 
-@converter_registry.register("pd_op.full", trt_version="8.x")
+@converter_registry.register("pd_op.full", trt_version="trt_version_ge=8.0")
 def full_converter(network, paddle_op, inputs):
     shape = paddle_op.attrs()["shape"]
     value = paddle_op.attrs().get("value", 1.0)

--- a/python/paddle/tensorrt/impls/linalg.py
+++ b/python/paddle/tensorrt/impls/linalg.py
@@ -25,7 +25,7 @@ from paddle.tensorrt.converter_utils import (
 from paddle.tensorrt.register import converter_registry
 
 
-@converter_registry.register("pd_op.matmul", trt_version="8.x")
+@converter_registry.register("pd_op.matmul", trt_version="trt_version_ge=8.0")
 def matmul_converter(network, paddle_op, inputs):
     weight_shape = paddle_op.operands()[1].source().shape
     transpose_x = paddle_op.attrs()["transpose_x"]
@@ -61,7 +61,9 @@ def matmul_converter(network, paddle_op, inputs):
     return out.get_output(0)
 
 
-@converter_registry.register("pd_op.transpose", trt_version="8.x")
+@converter_registry.register(
+    "pd_op.transpose", trt_version="trt_version_ge=8.0"
+)
 def transpose_converter(network, paddle_op, inputs):
     perm = paddle_op.attrs()["perm"]
     transposed_tensor = network.add_shuffle(inputs[0])

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -44,7 +44,7 @@ from paddle.tensorrt.register import converter_registry
 from ..util import get_trt_version_list
 
 
-@converter_registry.register("pd_op.reshape", trt_version="8.x")
+@converter_registry.register("pd_op.reshape", trt_version="trt_version_ge=8.0")
 def reshape_converter(network, paddle_op, inputs):
     x = inputs[0]
     is_constant_shape = False
@@ -87,7 +87,7 @@ def gather_nd_converter(network, paddle_op, inputs):
     return non_zero_layer.get_output(0)
 
 
-@converter_registry.register("pd_op.flatten", trt_version="8.x")
+@converter_registry.register("pd_op.flatten", trt_version="trt_version_ge=8.0")
 def flatten_converter(network, paddle_op, inputs):
     input_val = inputs[0]
     input_val_shape = paddle_op.operands()[0].source().shape
@@ -172,7 +172,7 @@ def flatten_converter(network, paddle_op, inputs):
 
 
 # In the converter, pd_op.concat has three inputs, because builtin.combine has two inputs.
-@converter_registry.register("pd_op.concat", trt_version="8.x")
+@converter_registry.register("pd_op.concat", trt_version="trt_version_ge=8.0")
 def concat_converter(network, paddle_op, inputs):
     input_tensors = inputs[0]
     axis_tensor = inputs[1]
@@ -187,8 +187,12 @@ def concat_converter(network, paddle_op, inputs):
     return concat_layer.get_output(0)
 
 
-@converter_registry.register("pd_op.unsqueeze", trt_version="8.x")
-@converter_registry.register("pd_op.unsqueeze_", trt_version="8.x")
+@converter_registry.register(
+    "pd_op.unsqueeze", trt_version="trt_version_ge=8.0"
+)
+@converter_registry.register(
+    "pd_op.unsqueeze_", trt_version="trt_version_ge=8.0"
+)
 def unsqueeze_converter(network, paddle_op, inputs):
     x = inputs[0]
     input_dims = x.shape
@@ -236,8 +240,8 @@ def unsqueeze_converter(network, paddle_op, inputs):
     return layer.get_output(0)
 
 
-@converter_registry.register("pd_op.squeeze", trt_version="8.x")
-@converter_registry.register("pd_op.squeeze_", trt_version="8.x")
+@converter_registry.register("pd_op.squeeze", trt_version="trt_version_ge=8.0")
+@converter_registry.register("pd_op.squeeze_", trt_version="trt_version_ge=8.0")
 def squeeze_converter(network, paddle_op, inputs):
     input_val = inputs[0]
     input_shape = input_val.shape

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -265,7 +265,7 @@ def squeeze_converter(network, paddle_op, inputs):
     return layer.get_output(0)
 
 
-@converter_registry.register("pd_op.expand", trt_version="8.x")
+@converter_registry.register("pd_op.expand", trt_version="trt_version_ge=8.0")
 def expand_converter(network, paddle_op, inputs):
     input = inputs[0]
     input_dims = input.shape
@@ -287,7 +287,9 @@ def expand_converter(network, paddle_op, inputs):
     return trt_expand(network, input, rank, shape_tensor, shape_rank)
 
 
-@converter_registry.register("pd_op.expand_as", trt_version="8.x")
+@converter_registry.register(
+    "pd_op.expand_as", trt_version="trt_version_ge=8.0"
+)
 def expand_as_converter(network, paddle_op, inputs):
     input = inputs[0]
     input_dims = input.shape
@@ -333,7 +335,7 @@ def cast_converter(network, paddle_op, inputs):
     return cast_layer.get_output(0)
 
 
-@converter_registry.register("pd_op.slice", trt_version="8.x")
+@converter_registry.register("pd_op.slice", trt_version="trt_version_ge=8.0")
 def slice_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]
     axes = paddle_op.attrs()["axes"]
@@ -341,7 +343,7 @@ def slice_converter(network, paddle_op, inputs):
 
     starts_op = paddle_op.operands()[1].source().get_defining_op()
     ends_op = paddle_op.operands()[2].source().get_defining_op()
-    input_shape_tensor = network.add_shape(input_tensor).get_output(0)
+    input_shape_tensor = trt_shape(network, input_tensor)
     input_rank = len(input_tensor.shape)
 
     starts_tensor = []

--- a/python/paddle/tensorrt/impls/math.py
+++ b/python/paddle/tensorrt/impls/math.py
@@ -30,15 +30,15 @@ from paddle.tensorrt.converter_utils import (
 from paddle.tensorrt.register import converter_registry
 
 
-@converter_registry.register("pd_op.add", trt_version="8.x")
-@converter_registry.register("pd_op.add_", trt_version="8.x")
+@converter_registry.register("pd_op.add", trt_version="trt_version_ge=8.0")
+@converter_registry.register("pd_op.add_", trt_version="trt_version_ge=8.0")
 def add_converter(network, paddle_op, inputs):
     return add_elementwise_layer(
         network, paddle_op, inputs, trt.ElementWiseOperation.SUM
     )
 
 
-@converter_registry.register("pd_op.scale", trt_version="8.x")
+@converter_registry.register("pd_op.scale", trt_version="trt_version_ge=8.0")
 def scale_converter(network, paddle_op, inputs):
     scale = paddle_op.operands()[1].source().get_defining_op().attrs()["value"]
     bias = paddle_op.attrs().get("bias", 0.0)

--- a/python/paddle/tensorrt/impls/math.py
+++ b/python/paddle/tensorrt/impls/math.py
@@ -59,7 +59,7 @@ def scale_converter(network, paddle_op, inputs):
     return scale_layer.get_output(0)
 
 
-@converter_registry.register("pd_op.max", trt_version="8.x")
+@converter_registry.register("pd_op.max", trt_version="trt_version_ge=8.0")
 def max_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]
     axis = paddle_op.operands()[1].source().get_defining_op().attrs()["value"]
@@ -84,21 +84,21 @@ def max_converter(network, paddle_op, inputs):
     return layer.get_output(0)
 
 
-@converter_registry.register("pd_op.divide", trt_version="8.x")
+@converter_registry.register("pd_op.divide", trt_version="trt_version_ge=8.0")
 def divide_converter(network, paddle_op, inputs):
     return add_elementwise_layer(
         network, paddle_op, inputs, trt.ElementWiseOperation.DIV
     )
 
 
-@converter_registry.register("pd_op.subtract", trt_version="8.x")
+@converter_registry.register("pd_op.subtract", trt_version="trt_version_ge=8.0")
 def substract_converter(network, paddle_op, inputs):
     return add_elementwise_layer(
         network, paddle_op, inputs, trt.ElementWiseOperation.SUB
     )
 
 
-@converter_registry.register("pd_op.multiply", trt_version="8.x")
+@converter_registry.register("pd_op.multiply", trt_version="trt_version_ge=8.0")
 def multiply_converter(network, paddle_op, inputs):
     return add_elementwise_layer(
         network, paddle_op, inputs, trt.ElementWiseOperation.PROD

--- a/python/paddle/tensorrt/impls/norm.py
+++ b/python/paddle/tensorrt/impls/norm.py
@@ -66,8 +66,12 @@ def layernorm_converter(network, paddle_op, inputs):
     return layer_norm.get_output(0)
 
 
-@converter_registry.register("pd_op.batch_norm", trt_version="8.x")
-@converter_registry.register("pd_op.batch_norm_", trt_version="8.x")
+@converter_registry.register(
+    "pd_op.batch_norm", trt_version="trt_version_ge=8.0"
+)
+@converter_registry.register(
+    "pd_op.batch_norm_", trt_version="trt_version_ge=8.0"
+)
 def batch_norm_converter(network, paddle_op, inputs):
     input_tensor, mean, variance, scale, bias = inputs
     scale_shape = paddle_op.operands()[3].source().shape

--- a/python/paddle/tensorrt/impls/ops.py
+++ b/python/paddle/tensorrt/impls/ops.py
@@ -22,8 +22,8 @@ ops_type_map = {
 }
 
 
-@converter_registry.register("pd_op.sqrt", trt_version="8.x")
-@converter_registry.register("pd_op.sqrt_", trt_version="8.x")
+@converter_registry.register("pd_op.sqrt", trt_version="trt_version_ge=8.0")
+@converter_registry.register("pd_op.sqrt_", trt_version="trt_version_ge=8.0")
 @converter_registry.register("pd_op.floor", trt_version="8.x")
 def sqrt_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]

--- a/python/paddle/tensorrt/impls/others.py
+++ b/python/paddle/tensorrt/impls/others.py
@@ -35,7 +35,9 @@ _logger = get_logger(
 )
 
 
-@converter_registry.register("pd_op.multiclass_nms3", trt_version="8.x")
+@converter_registry.register(
+    "pd_op.multiclass_nms3", trt_version="trt_version_ge=8.0"
+)
 def multiclass_nms3_converter(network, paddle_op, inputs):
     bboxes = inputs[0]
     scores = inputs[1]

--- a/python/paddle/tensorrt/impls/pooling.py
+++ b/python/paddle/tensorrt/impls/pooling.py
@@ -18,7 +18,7 @@ import tensorrt as trt
 from paddle.tensorrt.register import converter_registry
 
 
-@converter_registry.register("pd_op.pool2d", trt_version="8.x")
+@converter_registry.register("pd_op.pool2d", trt_version="trt_version_ge=8.0")
 def pool2d_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]
 

--- a/python/paddle/tensorrt/impls/search.py
+++ b/python/paddle/tensorrt/impls/search.py
@@ -35,7 +35,7 @@ def non_zero_converter(network, paddle_op, inputs):
     return non_zero_layer.get_output(0)
 
 
-@converter_registry.register("pd_op.argmax", trt_version="8.x")
+@converter_registry.register("pd_op.argmax", trt_version="trt_version_ge=8.0")
 def argmax_converter(network, paddle_op, inputs):
     x = inputs[0]
     input_dims = x.shape

--- a/python/paddle/tensorrt/impls/stat.py
+++ b/python/paddle/tensorrt/impls/stat.py
@@ -18,7 +18,7 @@ from paddle.tensorrt.converter_utils import get_axes_for_reduce_op
 from paddle.tensorrt.register import converter_registry
 
 
-@converter_registry.register("pd_op.mean", trt_version="8.x")
+@converter_registry.register("pd_op.mean", trt_version="trt_version_ge=8.0")
 def mean_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]
     keep_dim = paddle_op.attrs().get("keepdim")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

- Added support for TRT 10.0 since 
   - some deprecated APIs were removed or (NOTE: we have a mapping table to help developer migrate code [here](https://docs.nvidia.com/deeplearning/tensorrt/migration-guide/index.html))
   - some interfaces are refined in TRT10


細節主要分為:
 (1) ~~[build TRT engine](https://docs.nvidia.com/deeplearning/tensorrt/api/python_api/infer/Core/Builder.html#tensorrt.Builder)相關的改動~~(PR審核期間，Paddle內部已移除deprecated `build_engine`, see [commit:d4e1784b](https://github.com/anderson101866/Paddle/commit/d4e1784b8caa2473247b1583b539873a7dfa971b#diff-960cee3e52e89684ae51c3727e3a120ad17749a58955693113d2129ee323b787R442)) 、以及 
 (2) [Layer](https://docs.nvidia.com/deeplearning/tensorrt/api/python_api/infer/Graph/Layers.html)相關的改動
    - 其中(1)為一次性的改動engine建置過程；而 **後續python op converter開發者僅需專注(2)** 的部分，專注TRT 10的介面變化

(1)的部分請參考`python/paddle/tensorrt/converter.py`的改動，很簡單。可以參考上文[deprecated API的表格](https://docs.nvidia.com/deeplearning/tensorrt/migration-guide/index.html)
(2)的部分包括:

-   TRT10的[IShapeLayer](https://docs.nvidia.com/deeplearning/tensorrt/api/python_api/infer/Graph/Layers.html#tensorrt.IShapeLayer)從此擴展為INT64的介面，以適應形狀大的Tensor。
    - 已知某些paddle op的輸入`shape_tensor`只有int32版本，因此TRT上/下游的paddle op實作INT64之前，只得套用現有的workaround (see: `python/paddle/tensorrt/converter_utils.py` 統一轉換成較窄的int32，直到paddle正式支援int64 shape

- TRT10對於pool layer僅支援nd的介面，移除2d介面 (同樣可參考上文的[deprecated API表格](https://docs.nvidia.com/deeplearning/tensorrt/migration-guide/index.html))
    - ~~see `python/paddle/tensorrt/impls/pooling.py`, `add_pooling`/`stride`/`padding`等介面移除~~
      然而此PR合併前，Paddle內部已於`pooling.py`中移除2d介面，see [commit:6043c7f3](https://github.com/anderson101866/Paddle/commit/6043c7f382021b2ce1c1c0a9fd8153dedb18556c#diff-da593382ac700b90bc2c41f11ba23d78307edc8db1ba7ddfb54d7f9d022a0fcd)
- 其餘改動，僅是驗證現有paddle-3.0.0-beta2有的單元測試有覆蓋的op，將支援版本限制放鬆
    - `trt_version="8.x"` -> `trt_version="trt_version_ge=8.0"`
