### PR TITLE
[Dy2St][PIR] Add error for PyLayer setattr in to static mode

### DIFF
--- a/python/paddle/jit/dy2static/py_layer.py
+++ b/python/paddle/jit/dy2static/py_layer.py
@@ -32,6 +32,18 @@ class StaticPyLayerContext:
             self.tuple_push_op_name = "cf.tuple_push"
             self.tuple_pop_op_name = "cf.tuple_pop"
 
+    def __setattr__(self, attr: str, value: object):
+        attr_allow_list = ["saved_vars"]
+        if (
+            in_pir_mode()
+            and attr not in attr_allow_list
+            and isinstance(value, pir.Value)
+        ):
+            raise AttributeError(
+                f"ctx.{attr} = tensor is not allowed in static mode, please use `ctx.save_for_backward(tensor)` instead."
+            )
+        super().__setattr__(attr, value)
+
     def save_for_backward(self, *tensors):
         if in_pir_mode():
             current_insert_point = pir.get_current_insertion_point()

--- a/python/paddle/jit/dy2static/py_layer.py
+++ b/python/paddle/jit/dy2static/py_layer.py
@@ -48,19 +48,19 @@ class StaticPyLayerContext:
                 For example:
 
                     >>> class ExamplePyLayer(PyLayer):
-                    ... @staticmethod
-                    ... def forward(ctx, x):
-                    ...     # ctx.x = x  # This is not allowed in static mode, Replace it with `ctx.save_for_backward(x)`
-                    ...     ctx.save_for_backward(x)
-                    ...     x1 = paddle.tanh(x)
-                    ...     return x1
+                    ...     @staticmethod
+                    ...     def forward(ctx, x):
+                    ...         # ctx.x = x  # This is not allowed in static mode, Replace it with `ctx.save_for_backward(x)`
+                    ...         ctx.save_for_backward(x)
+                    ...         x1 = paddle.tanh(x)
+                    ...         return x1
 
-                    ... @staticmethod
-                    ... def backward(ctx, grad):
-                    ...     # x = ctx.x  # Same as above, replace it with `x, = ctx.saved_tensor()`
-                    ...     x, = ctx.saved_tensor()
-                    ...     x_grad = grad * (1 - paddle.square(x))
-                    ...     return x_grad
+                    ...     @staticmethod
+                    ...     def backward(ctx, grad):
+                    ...         # x = ctx.x  # Same as above, replace it with `x, = ctx.saved_tensor()`
+                    ...         x, = ctx.saved_tensor()
+                    ...         x_grad = grad * (1 - paddle.square(x))
+                    ...         return x_grad
                 """
                 )
             )

--- a/python/paddle/jit/dy2static/py_layer.py
+++ b/python/paddle/jit/dy2static/py_layer.py
@@ -43,7 +43,7 @@ class StaticPyLayerContext:
             raise AttributeError(
                 textwrap.dedent(
                     f"""\
-                ctx.{attr} = tensor is not allowed in static mode, please use `ctx.save_for_backward(tensor)` instead.
+                `ctx.{attr} = tensor` is not allowed in static mode, please use `ctx.save_for_backward(tensor)` instead.
 
                 For example:
 

--- a/test/dygraph_to_static/test_pylayer.py
+++ b/test/dygraph_to_static/test_pylayer.py
@@ -815,7 +815,7 @@ class TestPyLayerWrongUsage(unittest.TestCase):
         x = paddle.to_tensor(np.random.random((1, 784)).astype('float32'))
         with self.assertRaisesRegex(
             AttributeError,
-            r"ctx.x = tensor is not allowed in static mode, please use `ctx.save_for_backward\(tensor\)` instead.",
+            r"`ctx.x = tensor` is not allowed in static mode, please use `ctx.save_for_backward\(tensor\)` instead.",
         ):
             static_layer(x)
 

--- a/test/dygraph_to_static/test_pylayer.py
+++ b/test/dygraph_to_static/test_pylayer.py
@@ -785,5 +785,40 @@ class TestPyLayerJitSaveLoad(unittest.TestCase):
         np.testing.assert_array_equal(train_layer_result, infer_layer_result)
 
 
+class PyLayerWrongUsage(PyLayer):
+    @staticmethod
+    def forward(ctx, x):
+        ctx.x = x
+        x1 = paddle.tanh(x)
+        return x1
+
+    @staticmethod
+    def backward(ctx, grad):
+        x = ctx.x
+        x_grad = grad * (1 - paddle.square(x))
+        return x_grad
+
+
+class PyLayerWrongUsageWrapper(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.layer = PyLayerWrongUsage()
+
+    def forward(self, x):
+        return PyLayerWrongUsage.apply(x)
+
+
+class TestPyLayerWrongUsage(unittest.TestCase):
+    def test_wrong_usage(self):
+        layer = PyLayerWrongUsageWrapper()
+        static_layer = paddle.jit.to_static(layer, full_graph=True)
+        x = paddle.to_tensor(np.random.random((1, 784)).astype('float32'))
+        with self.assertRaisesRegex(
+            AttributeError,
+            r"ctx.x = tensor is not allowed in static mode, please use `ctx.save_for_backward\(tensor\)` instead.",
+        ):
+            static_layer(x)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

`ctx.x = x` 这种动态化的行为并不适合静态化，动态图虽然能跑，但其实是不规范的，因此在转静时如果发现有类似用法，会报错提示这种用法可能产生问题，并推荐使用 `ctx.save_for_backward`

```
Traceback (most recent call last):
  File "/workspace/Paddle/test.py", line 65, in <module>
    out = layer(img)
  File "/workspace/Paddle/build/python/paddle/nn/layer/layers.py", line 1532, in __call__
    return self.forward(*inputs, **kwargs)
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/program_translator.py", line 535, in __call__
    return self._perform_call(*args, **kwargs)
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/program_translator.py", line 863, in _perform_call
    error_data.raise_new_exception()
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/error.py", line 454, in raise_new_exception
    raise new_exception from None
AttributeError: In transformed code:

    File "/workspace/Paddle/test.py", line 31, in forward
        out = DemoPyLayer.apply(x)
    File "/workspace/Paddle/test.py", line 11, in forward
        @staticmethod
        def forward(ctx, x):
            ctx.x = x
            ~~~~~~~~~ <--- HERE
            # ctx.save_for_backward(x)
            x1 = paddle.tanh(x)

    File "/workspace/Paddle/build/python/paddle/jit/dy2static/py_layer.py", line 43, in __setattr__
        raise AttributeError(

    AttributeError: `ctx.x = tensor` is not allowed in static mode, please use `ctx.save_for_backward(tensor)` instead.

For example:

    >>> class ExamplePyLayer(PyLayer):
    ...     @staticmethod
    ...     def forward(ctx, x):
    ...         # ctx.x = x  # This is not allowed in static mode, Replace it with `ctx.save_for_backward(x)`
    ...         ctx.save_for_backward(x)
    ...         x1 = paddle.tanh(x)
    ...         return x1

    ...     @staticmethod
    ...     def backward(ctx, grad):
    ...         # x = ctx.x  # Same as above, replace it with `x, = ctx.saved_tensor()`
    ...         x, = ctx.saved_tensor()
    ...         x_grad = grad * (1 - paddle.square(x))
    ...         return x_grad
```

PCard-66972