### PR TITLE
[Auto Parallel] Fix bug caused by supporting if in auto_parallel

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/pir_pass.py
+++ b/python/paddle/distributed/auto_parallel/static/pir_pass.py
@@ -408,17 +408,17 @@ class RemovePasses:
             if op.name() == "dist_op.moe_sub_mesh_tensors":
                 replace_moe_sub_mesh_tensors(op)
                 continue
-            if op.name() == "dist_op.moe_global_mesh_tensor":
+            elif op.name() == "dist_op.moe_global_mesh_tensor":
                 replace_moe_global_mesh_tensor(op)
                 continue
-            if op.name() == "cf.tuple_push":
+            elif op.name() == "cf.tuple_push":
                 stack_create_op = op.operand_source(0).get_defining_op()
                 if stack_create_op.result(2).use_empty():
                     op.erase()
                 continue
-            if op.name() == "cf.yield":
+            elif op.name() == "cf.yield":
                 continue
-            if op.name() in partition_skip_op_list:
+            elif op.name() in partition_skip_op_list:
                 can_delete = True
                 for val in op.results():
                     if not val.use_empty():
@@ -426,6 +426,7 @@ class RemovePasses:
                 if can_delete:
                     op.erase()
                 continue
+
             if cur_rank not in op.dist_attr.process_mesh.process_ids:
                 op.erase()
             elif op.name() == "dist_op.reshard":

--- a/python/paddle/distributed/auto_parallel/static/utils.py
+++ b/python/paddle/distributed/auto_parallel/static/utils.py
@@ -1107,7 +1107,8 @@ def _complete_op_dist_attr(program, block=None):
                     operand_attrs.append(pir.Attribute())
                 else:
                     operand_attrs.append(tmp_attr)
-                    meshes.append(tmp_attr.process_mesh)
+                    if tmp_attr.process_mesh not in meshes:
+                        meshes.append(tmp_attr.process_mesh)
 
             for result in op.results():
                 tmp_attr = result.dist_attr()
@@ -1115,7 +1116,8 @@ def _complete_op_dist_attr(program, block=None):
                     result_attrs.append(pir.Attribute())
                 else:
                     result_attrs.append(tmp_attr)
-                    meshes.append(tmp_attr.process_mesh)
+                    if tmp_attr.process_mesh not in meshes:
+                        meshes.append(tmp_attr.process_mesh)
             if len(meshes) > 0:
                 if len(meshes) == 1:
                     mesh = meshes[0]

--- a/python/paddle/distributed/auto_parallel/static/utils.py
+++ b/python/paddle/distributed/auto_parallel/static/utils.py
@@ -1117,7 +1117,10 @@ def _complete_op_dist_attr(program, block=None):
                     result_attrs.append(tmp_attr)
                     meshes.append(tmp_attr.process_mesh)
             if len(meshes) > 0:
-                mesh = merge_process_meshes(meshes)
+                if len(meshes) == 1:
+                    mesh = meshes[0]
+                else:
+                    mesh = merge_process_meshes(meshes)
                 op.dist_attr = pir.create_op_dist_attribute(
                     mesh,
                     operand_attrs,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

1. 当 meshes 长度为 1 的时候不进行合并操作，这样 op 中不会出现下面的错误 mesh shape

修复前：
<img width="561" alt="e3833131ededd6f537851046de16bae7" src="https://github.com/user-attachments/assets/71ffb512-023b-4fd8-b6b4-7cbdc3288e52">
修复后：
<img width="557" alt="036254d33847b53a447807e8b1c3b319" src="https://github.com/user-attachments/assets/60262617-e10d-4ac7-bc0b-4a1a6018e3a0">

2. 在 partition 中恢复原来跳过 partition_skip_op_list 的逻辑，否则会插入预期外的 reshard 进而导致在 vpp 场景下补全 backward op 的时候报错

Pcard-76459
