### PR TITLE
[PIR][oneDNN] Change opt level of oneDNN passes to 2

### DIFF
--- a/paddle/fluid/pir/transforms/onednn/conv2d_bn_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/conv2d_bn_onednn_fuse_pass.cc
@@ -294,7 +294,7 @@ class Conv2dBiasBnOneDNNFusePattern
 class Conv2dBnOneDNNFusePass : public pir::PatternRewritePass {
  public:
   Conv2dBnOneDNNFusePass()
-      : pir::PatternRewritePass("conv2d_bn_onednn_fuse_pass", 3) {}
+      : pir::PatternRewritePass("conv2d_bn_onednn_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
@@ -323,7 +323,7 @@ class Conv2dBnOneDNNFusePass : public pir::PatternRewritePass {
 class Conv2dBiasBnOneDNNFusePass : public pir::PatternRewritePass {
  public:
   Conv2dBiasBnOneDNNFusePass()
-      : pir::PatternRewritePass("conv2d_bias_bn_onednn_fuse_pass", 3) {}
+      : pir::PatternRewritePass("conv2d_bias_bn_onednn_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/conv2d_transpose_bn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/conv2d_transpose_bn_fuse_pass.cc
@@ -406,7 +406,7 @@ class Conv2dTransposeEltwiseBnOneDNNFusePattern
 class ConvTransposeEltwiseaddBnOneDNNFusePass : public pir::PatternRewritePass {
  public:
   ConvTransposeEltwiseaddBnOneDNNFusePass()
-      : pir::PatternRewritePass("conv2d_transpose_bias_bn_fuse_pass", 3) {}
+      : pir::PatternRewritePass("conv2d_transpose_bias_bn_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
@@ -419,7 +419,7 @@ class ConvTransposeEltwiseaddBnOneDNNFusePass : public pir::PatternRewritePass {
 class ConvTransposeBnOneDNNFusePass : public pir::PatternRewritePass {
  public:
   ConvTransposeBnOneDNNFusePass()
-      : pir::PatternRewritePass("conv2d_transpose_bn_fuse_pass", 3) {}
+      : pir::PatternRewritePass("conv2d_transpose_bn_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/conv_activation_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/conv_activation_onednn_fuse_pass.cc
@@ -524,7 +524,7 @@ class ConvClipFusePattern : public paddle::drr::DrrPatternBase {
 class ConvActFusePass : public pir::PatternRewritePass {
  public:
   ConvActFusePass()
-      : pir::PatternRewritePass("conv_activation_mkldnn_fuse_pass", 3) {}
+      : pir::PatternRewritePass("conv_activation_mkldnn_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/conv_bias_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/conv_bias_fuse_pass.cc
@@ -315,7 +315,7 @@ class FusedConvTransposeAddFusePattern : public paddle::drr::DrrPatternBase {
 
 class Conv2dBiasFusePass : public pir::PatternRewritePass {
  public:
-  Conv2dBiasFusePass() : pir::PatternRewritePass("conv2d_bias_fuse_pass", 3) {}
+  Conv2dBiasFusePass() : pir::PatternRewritePass("conv2d_bias_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
@@ -330,7 +330,7 @@ class Conv2dBiasFusePass : public pir::PatternRewritePass {
 class Conv2dTransposeBiasFusePass : public pir::PatternRewritePass {
  public:
   Conv2dTransposeBiasFusePass()
-      : pir::PatternRewritePass("conv2d_transpose_bias_fuse_pass", 3) {}
+      : pir::PatternRewritePass("conv2d_transpose_bias_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
@@ -342,7 +342,7 @@ class Conv2dTransposeBiasFusePass : public pir::PatternRewritePass {
 
 class Conv3dBiasFusePass : public pir::PatternRewritePass {
  public:
-  Conv3dBiasFusePass() : pir::PatternRewritePass("conv3d_bias_fuse_pass", 3) {}
+  Conv3dBiasFusePass() : pir::PatternRewritePass("conv3d_bias_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/conv_concat_activation_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/conv_concat_activation_onednn_fuse_pass.cc
@@ -964,7 +964,7 @@ class NConvConcatClipFusePattern : public paddle::drr::DrrPatternBase {
 class ConvConcatActFusePass : public pir::PatternRewritePass {
  public:
   ConvConcatActFusePass()
-      : pir::PatternRewritePass("conv_concat_activation_mkldnn_fuse_pass", 3) {}
+      : pir::PatternRewritePass("conv_concat_activation_mkldnn_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/conv_elementwise_add_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/conv_elementwise_add_onednn_fuse_pass.cc
@@ -454,7 +454,7 @@ class FusedConvBiasElementwiseAddAsYPattern
 class ConvElementwiseAddFusePass : public pir::PatternRewritePass {
  public:
   ConvElementwiseAddFusePass()
-      : pir::PatternRewritePass("conv_elementwise_add_onednn_fuse_pass", 3) {}
+      : pir::PatternRewritePass("conv_elementwise_add_onednn_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_pass.cc
@@ -2072,7 +2072,7 @@ class CastBf16Pattern : public pir::OpRewritePattern<OpType> {
 
 class CpuBfloat16Pass : public pir::PatternRewritePass {
  public:
-  CpuBfloat16Pass() : pir::PatternRewritePass("cpu_bfloat16_pass", 3) {}
+  CpuBfloat16Pass() : pir::PatternRewritePass("cpu_bfloat16_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_placement_pass.cc
@@ -448,7 +448,7 @@ class RemoveUnsupportedOpPattern : public pir::RewritePattern {
 class OneDNNPlacementBf16Pass : public pir::PatternRewritePass {
  public:
   OneDNNPlacementBf16Pass()
-      : pir::PatternRewritePass("cpu_bfloat16_placement_pass", 3) {}
+      : pir::PatternRewritePass("cpu_bfloat16_placement_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext* context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_squash_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_squash_pass.cc
@@ -392,7 +392,7 @@ class OpDequantBf16SquashPattern
 class CPUBf16QuantizeSquashPass : public pir::PatternRewritePass {
  public:
   CPUBf16QuantizeSquashPass()
-      : pir::PatternRewritePass("cpu_bf16_quantize_squash_pass", 3) {}
+      : pir::PatternRewritePass("cpu_bf16_quantize_squash_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_type_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/cpu_bfloat16_type_placement_pass.cc
@@ -145,7 +145,7 @@ class CpuBfloat16TypePattern : public pir::RewritePattern {
 class OneDNNBf16TypePass : public pir::PatternRewritePass {
  public:
   OneDNNBf16TypePass()
-      : pir::PatternRewritePass("cpu_bfloat16_type_placement_pass", 3) {}
+      : pir::PatternRewritePass("cpu_bfloat16_type_placement_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext* context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/elementwise_act_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/elementwise_act_onednn_fuse_pass.cc
@@ -261,7 +261,7 @@ class ElementwiseClipFusePattern : public paddle::drr::DrrPatternBase {
 class ElementwiseActFusePass : public pir::PatternRewritePass {
  public:
   ElementwiseActFusePass()
-      : pir::PatternRewritePass("elementwise_act_onednn_fuse_pass", 3) {}
+      : pir::PatternRewritePass("elementwise_act_onednn_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/fc_activation_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/fc_activation_fuse_pass.cc
@@ -330,7 +330,7 @@ class FusedFcClipFusePattern : public paddle::drr::DrrPatternBase {
 class FcActivationFusePass : public pir::PatternRewritePass {
  public:
   FcActivationFusePass()
-      : pir::PatternRewritePass("fc_activation_fuse_pass", 3) {}
+      : pir::PatternRewritePass("fc_activation_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/fc_onednn_enable_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/fc_onednn_enable_pass.cc
@@ -88,7 +88,7 @@ class FcOneDNNEnablePattern : public paddle::drr::DrrPatternBase {
 
 class FcOneDNNEnablePass : public pir::PatternRewritePass {
  public:
-  FcOneDNNEnablePass() : pir::PatternRewritePass("fc_onednn_enable_pass", 3) {}
+  FcOneDNNEnablePass() : pir::PatternRewritePass("fc_onednn_enable_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/matmul_activation_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/matmul_activation_fuse_pass.cc
@@ -637,7 +637,7 @@ class FusedMatmulClipFusePattern : public paddle::drr::DrrPatternBase {
 class MatmulActivationFusePass : public pir::PatternRewritePass {
  public:
   MatmulActivationFusePass()
-      : pir::PatternRewritePass("matmul_activation_fuse_pass", 3) {}
+      : pir::PatternRewritePass("matmul_activation_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.cc
@@ -189,7 +189,7 @@ class FusedMatmulElementwiseAddFusePattern
 class MatmulElementwiseAddFusePass : public pir::PatternRewritePass {
  public:
   MatmulElementwiseAddFusePass()
-      : pir::PatternRewritePass("matmul_elementwise_add_fuse_pass", 3) {}
+      : pir::PatternRewritePass("matmul_elementwise_add_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/matmul_reshape_add_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/matmul_reshape_add_pass.cc
@@ -160,7 +160,7 @@ class MatmulReshapeElementwiseAddFusePattern
 class MatmulReshapeAddFusePass : public pir::PatternRewritePass {
  public:
   MatmulReshapeAddFusePass()
-      : pir::PatternRewritePass("matmul_reshape_add_fuse_pass", 3) {}
+      : pir::PatternRewritePass("matmul_reshape_add_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/matmul_transpose_reshape_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/matmul_transpose_reshape_fuse_pass.cc
@@ -235,7 +235,7 @@ class FusedMatmulTransposeReshapeFusePattern
 class MatmulTransposeReshapeFusePass : public pir::PatternRewritePass {
  public:
   MatmulTransposeReshapeFusePass()
-      : pir::PatternRewritePass("matmul_transpose_reshape_fuse_pass", 3) {}
+      : pir::PatternRewritePass("matmul_transpose_reshape_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/onednn_placement_pass.cc
@@ -102,7 +102,7 @@ class PatternCreator {
 
 class OneDNNPlacementPass : public pir::PatternRewritePass {
  public:
-  OneDNNPlacementPass() : pir::PatternRewritePass("onednn_placement_pass", 3) {}
+  OneDNNPlacementPass() : pir::PatternRewritePass("onednn_placement_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/operator_reshape_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/operator_reshape_onednn_fuse_pass.cc
@@ -349,7 +349,7 @@ class TransposeReshapeFusePattern : public paddle::drr::DrrPatternBase {
 class OperatorReshapePass : public pir::PatternRewritePass {
  public:
   OperatorReshapePass()
-      : pir::PatternRewritePass("operator_reshape_onednn_fuse_pass", 3) {}
+      : pir::PatternRewritePass("operator_reshape_onednn_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/operator_scale_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/operator_scale_onednn_fuse_pass.cc
@@ -275,7 +275,7 @@ class OperatorScaleFusePattern : public paddle::drr::DrrPatternBase {
 class OperatorScaleFusePass : public pir::PatternRewritePass {
  public:
   OperatorScaleFusePass()
-      : pir::PatternRewritePass("operator_scale_onednn_fuse_pass", 3) {}
+      : pir::PatternRewritePass("operator_scale_onednn_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/operator_unsqueeze_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/operator_unsqueeze_onednn_fuse_pass.cc
@@ -177,7 +177,7 @@ class OperatorUnsqueezeFusePattern : public paddle::drr::DrrPatternBase {
 class OperatorUnsqueezeFusePass : public pir::PatternRewritePass {
  public:
   OperatorUnsqueezeFusePass()
-      : pir::PatternRewritePass("operator_unsqueeze_onednn_fuse_pass", 3) {}
+      : pir::PatternRewritePass("operator_unsqueeze_onednn_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/reshape_transpose_matmul_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/reshape_transpose_matmul_fuse_pass.cc
@@ -290,7 +290,7 @@ class ReshapeTransposeFusedMatmulFusePattern
 class ReshapeTransposeMatmulFusePass : public pir::PatternRewritePass {
  public:
   ReshapeTransposeMatmulFusePass()
-      : pir::PatternRewritePass("reshape_transpose_matmul_fuse_pass", 3) {}
+      : pir::PatternRewritePass("reshape_transpose_matmul_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/scale_matmul_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/scale_matmul_fuse_pass.cc
@@ -252,7 +252,7 @@ class ScaleFusedMatmulFusePattern : public paddle::drr::DrrPatternBase {
 class ScaleMatmulFusePass : public pir::PatternRewritePass {
  public:
   ScaleMatmulFusePass()
-      : pir::PatternRewritePass("scale_matmul_fuse_pass", 3) {}
+      : pir::PatternRewritePass("scale_matmul_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/self_attention_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/self_attention_fuse_pass.cc
@@ -158,7 +158,7 @@ class SelfAttentionFusePattern : public paddle::drr::DrrPatternBase {
 class SelfAttentionFusePass : public pir::PatternRewritePass {
  public:
   SelfAttentionFusePass()
-      : pir::PatternRewritePass("self_attention_fuse_pass", 3) {}
+      : pir::PatternRewritePass("self_attention_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/shuffle_channel_detect_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/shuffle_channel_detect_pass.cc
@@ -221,7 +221,7 @@ class ShuffleChannelDetectPattern : public paddle::drr::DrrPatternBase {
 class ShuffleChannelDetectPass : public pir::PatternRewritePass {
  public:
   ShuffleChannelDetectPass()
-      : pir::PatternRewritePass("shuffle_channel_detect_pass", 3) {}
+      : pir::PatternRewritePass("shuffle_channel_detect_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/softplus_activation_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/softplus_activation_fuse_pass.cc
@@ -268,7 +268,7 @@ class SoftplusClipFusePattern : public paddle::drr::DrrPatternBase {
 class SoftplusActivationFusePass : public pir::PatternRewritePass {
  public:
   SoftplusActivationFusePass()
-      : pir::PatternRewritePass("softplus_activation_fuse_pass", 3) {}
+      : pir::PatternRewritePass("softplus_activation_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/squeeze_transpose_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/squeeze_transpose_onednn_fuse_pass.cc
@@ -85,7 +85,7 @@ class SqueezeTransposePattern : public paddle::drr::DrrPatternBase {
 class SqueezeTransposePass : public pir::PatternRewritePass {
  public:
   SqueezeTransposePass()
-      : pir::PatternRewritePass("squeeze_transpose_onednn_fuse_pass", 3) {}
+      : pir::PatternRewritePass("squeeze_transpose_onednn_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Due to default opt level of PIR pass is 2, here we change opt level of oneDNN passes to 2 accordingly base on agreement from Paddle.