### PR TITLE
[CINN]fix generate shape convert bug

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
@@ -423,6 +423,7 @@ class FuseSingleElementShapeOpsIntoGenerateShapeOpPattern
       auto* user = iter->owner();
       if (IsSingleElementShapeOp(user, &shape_analysis)) return false;
       if (user->isa<cinn::dialect::GenerateShapeOp>()) return false;
+      if (user->isa<pir::ShadowOutputOp>()) return false;
     }
 
     return true;


### PR DESCRIPTION
### PR Category
CINN

### PR Types
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-76996

给generate shape转换的pass加一个限制，如果op 被 shadow output使用，则不转换
