### PR TITLE
[Infra] Remove unused dependency `pygame`

### DIFF
--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -2,7 +2,6 @@ PyGithub
 coverage==5.5
 mock
 gymnasium>=1.0.0a1
-pygame==2.5.2
 hypothesis
 opencv-python>= 4.10.0.84
 visualdl==2.5.3


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

支持 Python 3.13 `pygame` 需要升级，但是 `pygame` 貌似在单测中没有用，因此尝试直接删除

PCard-66972