### PR TITLE
Fix random failure in test_trt_convert_strided_slice

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/slice_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/slice_op.cc
@@ -47,7 +47,9 @@ class SliceOpConverter : public OpConverter {
     auto* shape_tensor = Shape(input);
     nvinfer1::Dims trt_start_dims;
     trt_start_dims.nbDims = input_dims.nbDims;
-    memset(trt_start_dims.d, 0, sizeof(int32_t) * input_dims.nbDims);
+    memset(trt_start_dims.d,
+           0,
+           sizeof(trt_start_dims.d[0]) * nvinfer1::Dims::MAX_DIMS);
     nvinfer1::Dims trt_size_dims = trt_start_dims;
     nvinfer1::Dims trt_step_dims = trt_start_dims;
     for (int i = 0; i < trt_step_dims.nbDims; i++) trt_step_dims.d[i] = 1;

--- a/paddle/fluid/inference/tensorrt/convert/strided_slice_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/strided_slice_op.cc
@@ -46,7 +46,9 @@ class StridedSliceOpConverter : public OpConverter {
     auto nchw_input_dims = input->getDimensions();
     nvinfer1::Dims trt_start_dims;
     trt_start_dims.nbDims = nchw_input_dims.nbDims;
-    memset(trt_start_dims.d, 0, sizeof(int32_t) * nchw_input_dims.nbDims);
+    memset(trt_start_dims.d,
+           0,
+           sizeof(trt_start_dims.d[0]) * nvinfer1::Dims::MAX_DIMS);
     nvinfer1::Dims trt_size_dims = trt_start_dims;
     nvinfer1::Dims trt_end_dims = trt_start_dims;
     nvinfer1::Dims trt_step_dims = trt_start_dims;


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->


The test will produce several error log like:
API Usage Error (Tensor slice_output_data_subgraph_4 has axis 3 with inherently negative length. Proven upper bound is -111894960. Network must have an instance where axis has non-negative length.)

, which is uninitialized memory issue due to TRT10 alias Dims to Dims64,
 but TRT8 alias Dims to Dims32.

### Reproduce
Run unittest `test_trt_convert_strided_slice` with TRT 10. It'll fail with high probability

---
這個commit 專注C++ TRT converter的改動，也就是現況正在應用的版本。
過去舊有的代碼，以`int32_t`寫死初始化的memset大小。造成TRT10介面更動時代碼無法自動適應。會因uninitialized memory造成random issue。

In short，此commit修正兩個潛在的TRT10問題
