### PR TITLE
[AutoParallel]:fix vpp error when use acc

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1461,15 +1461,10 @@ void BindValue(py::module *m) {
               return py::cast<py::none>(Py_None);
             }
           })
-      .def("_clone",
-           [](Value self) {
-             // Return a new value owned by python side
-             return self;
-           })
-      .def("_equal", [](Value &self, Value &other) {
+      .def("_clone", [](Value self) {
         // Return a new value owned by python side
-        return self == other;
-      });
+        return self;
+      })
 }
 
 void BindOpOperand(py::module *m) {

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1464,7 +1464,7 @@ void BindValue(py::module *m) {
       .def("_clone", [](Value self) {
         // Return a new value owned by python side
         return self;
-      })
+      });
 }
 
 void BindOpOperand(py::module *m) {

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1461,9 +1461,14 @@ void BindValue(py::module *m) {
               return py::cast<py::none>(Py_None);
             }
           })
-      .def("_clone", [](Value self) {
+      .def("_clone",
+           [](Value self) {
+             // Return a new value owned by python side
+             return self;
+           })
+      .def("_equal", [](Value &self, Value &other) {
         // Return a new value owned by python side
-        return self;
+        return self == other;
       });
 }
 

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -837,7 +837,7 @@ class Engine:
         # TODO(hitywt) Step 3.2: Reshard Pass
         #   resolute the reshard op into special collective operation.
         #   collect the communicator created during resolution.
-        ReshardPasses.apply_reshard_pass(dist_program)
+        ReshardPasses.apply_reshard_pass(dist_program, global_params_grads)
 
         # Note(luchang): When using VPP pipeline pass, we need to split the whole graph into
         # multiple chunks and adjust the process mesh accordingly. Here, we need to store the

--- a/python/paddle/distributed/auto_parallel/static/pir_pass.py
+++ b/python/paddle/distributed/auto_parallel/static/pir_pass.py
@@ -324,7 +324,7 @@ class ReshardPasses:
                     op.result(0).replace_all_uses_with(var)
                     if global_params_grads is not None:
                         for idx, (p, g) in enumerate(global_params_grads):
-                            if g is not None and g._equal(op.result(0)):
+                            if g is not None and g.is_same(op.result(0)):
                                 global_params_grads[idx] = (p, var)
                     op.erase()
                     continue
@@ -351,7 +351,7 @@ class ReshardPasses:
                 if op.result(0).use_empty():
                     if global_params_grads is not None:
                         for idx, (p, g) in enumerate(global_params_grads):
-                            if g is not None and g._equal(op.result(0)):
+                            if g is not None and g.is_same(op.result(0)):
                                 global_params_grads[idx] = (
                                     (p, out_value)
                                     if out_value is not None

--- a/python/paddle/distributed/auto_parallel/static/pir_pass.py
+++ b/python/paddle/distributed/auto_parallel/static/pir_pass.py
@@ -324,7 +324,7 @@ class ReshardPasses:
                     op.result(0).replace_all_uses_with(var)
                     if global_params_grads is not None:
                         for idx, (p, g) in enumerate(global_params_grads):
-                            if g._equal(op.result(0)):
+                            if g is not None and g._equal(op.result(0)):
                                 global_params_grads[idx] = (p, var)
                     op.erase()
                     continue
@@ -351,7 +351,7 @@ class ReshardPasses:
                 if op.result(0).use_empty():
                     if global_params_grads is not None:
                         for idx, (p, g) in enumerate(global_params_grads):
-                            if g._equal(op.result(0)):
+                            if g is not None and g._equal(op.result(0)):
                                 global_params_grads[idx] = (
                                     (p, out_value)
                                     if out_value is not None

--- a/python/paddle/distributed/auto_parallel/static/pir_pass.py
+++ b/python/paddle/distributed/auto_parallel/static/pir_pass.py
@@ -303,7 +303,7 @@ class ReshardPasses:
             op.erase()
 
     @staticmethod
-    def reshard_op_pass(dist_program, block=None):
+    def reshard_op_pass(dist_program, global_params_grads=None, block=None):
         if block is None:
             block = dist_program.global_block()
         for op in block.ops:
@@ -322,6 +322,10 @@ class ReshardPasses:
 
                 if src_dist_attr == dst_dist_attr:
                     op.result(0).replace_all_uses_with(var)
+                    if global_params_grads is not None:
+                        for idx, (p, g) in enumerate(global_params_grads):
+                            if g._equal(op.result(0)):
+                                global_params_grads[idx] = (p, var)
                     op.erase()
                     continue
 
@@ -345,13 +349,21 @@ class ReshardPasses:
                     op.result(0).replace_all_uses_with(out_value)
 
                 if op.result(0).use_empty():
+                    if global_params_grads is not None:
+                        for idx, (p, g) in enumerate(global_params_grads):
+                            if g._equal(op.result(0)):
+                                global_params_grads[idx] = (
+                                    (p, out_value)
+                                    if out_value is not None
+                                    else (p, var)
+                                )
                     op.erase()
 
     @staticmethod
-    def apply_reshard_pass(dist_program):
+    def apply_reshard_pass(dist_program, global_params_grads=None):
         ReshardPasses.decompose_reshard_pass(dist_program)
         ReshardPasses.fold_reshard_pass(dist_program)
-        ReshardPasses.reshard_op_pass(dist_program)
+        ReshardPasses.reshard_op_pass(dist_program, global_params_grads)
 
 
 # Replace the specific MoE-related dist op with the


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
当param_grad的defined_op是reshard时，需要在reshard_op.erase时候将grad替换成reshare value
Pcard-67164