### PR TITLE
[Custom Device] fix c_comm_init_op and c_gen_xccl_id_op

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1686,7 +1686,7 @@ PHI_DEFINE_EXPORTED_string(
     "It controls the forward blacklist ops not to be decomposed.");
 
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL) || \
-    defined(PADDLE_WITH_XPU_BKCL)
+    defined(PADDLE_WITH_XPU_BKCL) || defined(PADDLE_WITH_CUSTOM_DEVICE)
 /**
  * Communication library related FLAG
  * Name: FLAGS_dynamic_static_unified_comm


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Custom Device


### PR Types
Bug fixes


### Description
![image](https://github.com/user-attachments/assets/47e7562e-a3d9-4325-b30d-b62ec9a77bb0)

fix c_comm_init_op and c_gen_xccl_id_op for custom device，in c_comm_init_op CreateXCCLCommContext was called with FLAGS_dynamic_static_unified_comm set or not; c_gen_xccl_id_op seems should be implemented for current logic, 
