### PR TITLE
fix saved_tensors_hook bug

### DIFF
--- a/paddle/fluid/eager/tensor_wrapper.h
+++ b/paddle/fluid/eager/tensor_wrapper.h
@@ -171,13 +171,13 @@ class TensorWrapper {
       if (intermidiate_tensor_.is_dense_tensor()) {
         VLOG(6) << "intermidiate_tensor_ is DenseTensor";
         static_cast<phi::DenseTensor*>(intermidiate_tensor_.impl().get())
-            ->ResetHolder(src_dense_tensor->MoveMemoryHolder());
+            ->ResetHolder(src_dense_tensor->Holder());
       } else if (intermidiate_tensor_.is_dist_tensor()) {
         VLOG(6) << "intermidiate_tensor_ is DistTensor";
         static_cast<phi::distributed::DistTensor*>(
             intermidiate_tensor_.impl().get())
             ->unsafe_mutable_value()
-            ->ResetHolder(src_dense_tensor->MoveMemoryHolder());
+            ->ResetHolder(src_dense_tensor->Holder());
       } else {
         PADDLE_THROW(
             common::errors::Fatal("Unrecognized intermidiate_tensor_ type for "


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复一个saved_tensors_hooks的bug。
如果一个Tensor在unpack时多次提供给框架。由于move。第二次获得的将是一个空Tensor。

Pcard-67164