### PR TITLE
[CINN] Temporarily disable the IfFusion backend pass

### DIFF
--- a/paddle/cinn/optim/optimize.cc
+++ b/paddle/cinn/optim/optimize.cc
@@ -102,8 +102,9 @@ ir::LoweredFunc Optimize(ir::LoweredFunc fn,
   Simplify(&copied->body);
   VLOG(10) << "After Optimize Simplify:" << copied;
 
-  IfFusion(&copied->body);
-  VLOG(10) << "After Optimize IfFusion" << copied;
+  // TODO(liangshuhao): this pass may unexpectedly remove schedule blocks, and
+  // it actually doesn't contribute to performance, so temporarily disabled.
+  // IfFusion(&copied->body);
 
   VectorizeForTrans(&copied->body);
   VLOG(10) << "After Optimize vectorize" << copied;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN

### PR Types
Bug fixes


### Description
`IfFusion`在合入 #69417 之后出现错误移除一些ScheduleBlock的情况，导致生成的CUDA Kernel不完整。由于`IfFusion`的功能下层编译器也能做，我们当前做`IfFusion`只是为了让IR更简洁，对性能无影响，所以这个PR暂时禁用`IfFusion`，等修复好再启用。

Pcard-85711
