### PR TITLE
[CINN] Fix kernel place selection for dynamic shape

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -328,7 +328,8 @@ bool CanRunOnCpuKernel(const std::vector<::pir::Value>& vec_inputs,
 
     if (out.type().isa<DenseTensorType>()) {
       auto type = out.type().dyn_cast<DenseTensorType>();
-      if (phi::product(type.dims()) > 4) {
+      if (::common::contain_unknown_dim(type.dims()) ||
+          phi::product(type.dims()) > 4) {
         can_run_cpu = false;
         break;
       }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
Add one more condition to the `CanRunOnCpuKernel` judgement. We shouldn't place the kernel on CPU if its output has dynamic shape.

Pcard-85711