### PR TITLE
[PIR] Add missing vjp interface for `FusedGemmEpilogueOp`

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
@@ -331,6 +331,63 @@ std::tuple<pir::Value, pir::Value> fused_gemm_epilogue(pir::Value x,
                          fused_gemm_epilogue_op.result(1));
 }
 
+std::tuple<pir::Value, pir::Value, pir::Value> fused_gemm_epilogue_grad(
+    pir::Value x,
+    pir::Value y,
+    pir::Value bias,
+    pir::Value out_grad,
+    bool trans_x,
+    bool trans_y,
+    std::string activation) {
+  // AMP Logic
+  if (egr::Controller::Instance().GetCurrentAmpAttrs()->GetAmpLevel() !=
+      paddle::imperative::AmpLevel::O0) {
+    VLOG(5) << "Check and Prepare For AMP: fused_gemm_epilogue_grad";
+    auto op_name = phi::TransToFluidOpName("fused_gemm_epilogue_grad");
+    paddle::small_vector<std::vector<pir::Value>, egr::kSlotSmallVectorSize>
+        amp_values_vector = {{x}, {y}, {bias}};
+    auto amp_dst_dtype =
+        paddle::imperative::GetAmpDestDtype(op_name, amp_values_vector);
+    auto new_x =
+        paddle::imperative::AmpAutoCast("x", x, amp_dst_dtype, op_name);
+    auto new_y =
+        paddle::imperative::AmpAutoCast("y", y, amp_dst_dtype, op_name);
+    auto new_bias =
+        paddle::imperative::AmpAutoCast("bias", bias, amp_dst_dtype, op_name);
+    auto new_out_grad = paddle::imperative::AmpAutoCast(
+        "out_grad", out_grad, amp_dst_dtype, op_name);
+
+    {
+      paddle::imperative::AutoCastGuard guard(
+          egr::Controller::Instance().GetCurrentAmpAttrs(),
+          paddle::imperative::AmpLevel::O0);
+      return paddle::dialect::fused_gemm_epilogue_grad(
+          new_x, new_y, new_bias, new_out_grad, trans_x, trans_y, activation);
+    }
+  }
+
+  // Type Promotion Logic
+  VLOG(5) << " No Type Promotion for fused_gemm_epilogue api. ";
+  pir::IrContext* ctx = pir::IrContext::Instance();
+  pir::AttributeMap attribute_map = {
+      {"trans_x", pir::BoolAttribute::get(ctx, trans_x)},
+      {"trans_y", pir::BoolAttribute::get(ctx, trans_y)},
+      {"activation", pir::StrAttribute::get(ctx, activation)}};
+  auto fused_gemm_epilogue_grad_op =
+      ApiBuilder::Instance()
+          .GetBuilder()
+          ->Build<paddle::dialect::FusedGemmEpilogueGradOp>(
+              x, y, bias, out_grad, attribute_map);
+  if (!egr::Controller::Instance().HasGrad()) {
+    SetStopGradient(fused_gemm_epilogue_grad_op.result(0),
+                    fused_gemm_epilogue_grad_op.result(1),
+                    fused_gemm_epilogue_grad_op.result(2));
+  }
+  return std::make_tuple(fused_gemm_epilogue_grad_op.result(0),
+                         fused_gemm_epilogue_grad_op.result(1),
+                         fused_gemm_epilogue_grad_op.result(2));
+}
+
 pir::Value array_pop(pir::Value input, int index) {
   if (input.type().isa<paddle::dialect::DenseTensorArrayType>()) {
     paddle::dialect::ArrayPopOp array_pop_op =

--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.h
@@ -102,6 +102,16 @@ std::tuple<pir::Value, pir::Value> fused_gemm_epilogue(pir::Value x,
                                                        bool trans_x,
                                                        bool trans_y,
                                                        std::string activation);
+
+std::tuple<pir::Value, pir::Value, pir::Value> fused_gemm_epilogue_grad(
+    pir::Value x,
+    pir::Value y,
+    pir::Value bias,
+    pir::Value out_grad,
+    bool trans_x,
+    bool trans_y,
+    std::string activation);
+
 pir::Value array_pop(pir::Value input, int index);
 
 std::vector<pir::Value> tensorrt_engine(

--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.h
@@ -106,11 +106,11 @@ std::tuple<pir::Value, pir::Value> fused_gemm_epilogue(pir::Value x,
 std::tuple<pir::Value, pir::Value, pir::Value> fused_gemm_epilogue_grad(
     pir::Value x,
     pir::Value y,
-    pir::Value bias,
+    paddle::optional<pir::Value> reserve_space,
     pir::Value out_grad,
     bool trans_x,
     bool trans_y,
-    std::string activation);
+    std::string activation_grad);
 
 pir::Value array_pop(pir::Value input, int index);
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -600,15 +600,15 @@ const char *FusedGemmEpilogueOp::attributes_name[3] = {  // NOLINT
 OpInfoTuple FusedGemmEpilogueOp::GetOpInfo() {
   std::vector<paddle::dialect::OpInputInfo> inputs = {
       paddle::dialect::OpInputInfo(
-          "x", "paddle::dialect::DenseTensorType", false, false, false, false),
+          "x", "paddle::dialect::DenseTensorType", false, false, false, true),
       paddle::dialect::OpInputInfo(
-          "y", "paddle::dialect::DenseTensorType", false, false, false, false),
+          "y", "paddle::dialect::DenseTensorType", false, false, false, true),
       paddle::dialect::OpInputInfo("bias",
                                    "paddle::dialect::DenseTensorType",
                                    false,
                                    false,
                                    false,
-                                   false)};
+                                   true)};
   std::vector<paddle::dialect::OpAttributeInfo> attributes = {
       paddle::dialect::OpAttributeInfo("trans_x", "pir::BoolAttribute", ""),
       paddle::dialect::OpAttributeInfo("trans_y", "pir::BoolAttribute", ""),
@@ -681,6 +681,7 @@ void FusedGemmEpilogueOp::Build(pir::Builder &builder,
       FusedGemmEpilogueOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
+  ::pir::PassStopGradientsDefaultly(argument);
 }
 
 void FusedGemmEpilogueOp::VerifySig() {
@@ -1005,6 +1006,7 @@ void FusedGemmEpilogueGradOp::Build(pir::Builder &builder,
       FusedGemmEpilogueGradOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
+  ::pir::PassStopGradientsDefaultly(argument);
 }
 
 void FusedGemmEpilogueGradOp::VerifySig() {}

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.h
@@ -87,6 +87,7 @@ class AddNArrayOp : public pir::Op<AddNArrayOp,
 class FusedGemmEpilogueOp : public pir::Op<FusedGemmEpilogueOp,
                                            paddle::dialect::OpYamlInfoInterface,
                                            paddle::dialect::InferMetaInterface,
+                                           paddle::dialect::VjpInterface,
                                            InferSymbolicShapeInterface> {
  public:
   using Op::Op;
@@ -108,6 +109,12 @@ class FusedGemmEpilogueOp : public pir::Op<FusedGemmEpilogueOp,
   pir::Value out() { return result(0); }
   pir::Value reserve_space() { return result(1); }
 
+  static std::vector<std::vector<pir::Value>> Vjp(
+      pir::Operation *op,
+      const std::vector<std::vector<pir::Value>> &inputs_,
+      const std::vector<std::vector<pir::Value>> &outputs,
+      const std::vector<std::vector<pir::Value>> &out_grads,
+      const std::vector<std::vector<bool>> &stop_gradients);
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op_vjp.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op_vjp.cc
@@ -300,5 +300,71 @@ std::vector<std::vector<pir::Value>> ArrayToTensorOp::Vjp(
   return res;
 }
 
+std::vector<std::vector<pir::Value>> FusedGemmEpilogueOp::Vjp(
+    pir::Operation* op,
+    const std::vector<std::vector<pir::Value>>& inputs_,
+    const std::vector<std::vector<pir::Value>>& outputs,
+    const std::vector<std::vector<pir::Value>>& out_grads,
+    const std::vector<std::vector<bool>>& stop_gradients) {
+  PADDLE_ENFORCE_EQ(
+      inputs_.size(),
+      4,
+      common::errors::InvalidArgument(
+          "fused_gemm_epilogue op's inputs size should be 4, but now is %d.",
+          inputs_.size()));
+  PADDLE_ENFORCE_EQ(
+      outputs.size(),
+      3,
+      common::errors::InvalidArgument(
+          "fused_gemm_epilogue op's outputs size should be 3, but now is %d.",
+          outputs.size()));
+
+  VLOG(6) << "Prepare inputs of fused_gemm_epilogue_grad";
+
+  Tensor x(std::make_shared<primitive::LazyTensor>(inputs_[0][0]));
+  Tensor y(std::make_shared<primitive::LazyTensor>(inputs_[1][0]));
+  Tensor reserve_space(std::make_shared<primitive::LazyTensor>(inputs_[2][0]));
+  Tensor out_grad(std::make_shared<primitive::LazyTensor>(inputs_[3][0]));
+  // Tensor x_grad(std::make_shared<primitive::LazyTensor>(out_grads[0][0]));
+  // Tensor y_grad(std::make_shared<primitive::LazyTensor>(out_grads[1][0]));
+  // Tensor bias_grad(std::make_shared<primitive::LazyTensor>(out_grads[2][0]));
+
+  VLOG(6) << "Vjp prepare Prepare attributes of fused_gemm_epilogue_grad";
+
+  std::string data_format =
+      op->attribute("data_format").dyn_cast<pir::StrAttribute>().AsString();
+  bool trans_x = op->attribute("trans_x").dyn_cast<pir::BoolAttribute>().data();
+  bool trans_y = op->attribute("trans_y").dyn_cast<pir::BoolAttribute>().data();
+  std::string activation =
+      op->attribute("activation").dyn_cast<pir::StrAttribute>().AsString();
+
+  VLOG(6) << "Vjp prepare call fused_gemm_epilogue's vjp interface";
+
+  std::vector<std::vector<Tensor>> tensor_res =
+      primitive::fused_gemm_epilogue_vjp(x,
+                                         y,
+                                         reserve_space,
+                                         out_grad,
+                                         trans_x,
+                                         trans_y,
+                                         activation,
+                                         stop_gradients);
+
+  VLOG(6) << "Vjp prepare stop gradient of fused_gemm_epilogue_grad";
+
+  std::vector<std::vector<pir::Value>> res(tensor_res.size());
+  for (size_t i = 0; i < tensor_res.size(); ++i) {
+    res[i].resize(tensor_res[i].size());
+    for (size_t j = 0; j < tensor_res[i].size(); ++j) {
+      if (tensor_res[i][j].defined()) {
+        res[i][j] = std::static_pointer_cast<primitive::LazyTensor>(
+                        tensor_res[i][j].impl())
+                        ->value();
+      }
+    }
+  }
+  return res;
+}
+
 }  // namespace dialect
 }  // namespace paddle

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op_vjp.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op_vjp.cc
@@ -325,9 +325,6 @@ std::vector<std::vector<pir::Value>> FusedGemmEpilogueOp::Vjp(
   Tensor y(std::make_shared<primitive::LazyTensor>(inputs_[1][0]));
   Tensor reserve_space(std::make_shared<primitive::LazyTensor>(inputs_[2][0]));
   Tensor out_grad(std::make_shared<primitive::LazyTensor>(inputs_[3][0]));
-  // Tensor x_grad(std::make_shared<primitive::LazyTensor>(out_grads[0][0]));
-  // Tensor y_grad(std::make_shared<primitive::LazyTensor>(out_grads[1][0]));
-  // Tensor bias_grad(std::make_shared<primitive::LazyTensor>(out_grads[2][0]));
 
   VLOG(6) << "Vjp prepare Prepare attributes of fused_gemm_epilogue_grad";
 

--- a/paddle/fluid/primitive/backend/manual/manual_backend.h
+++ b/paddle/fluid/primitive/backend/manual/manual_backend.h
@@ -39,6 +39,16 @@ Tensor embedding_grad(const Tensor& x,
                       int64_t padding_idx = -1,
                       bool sparse = false);
 
+template <typename T>
+std::tuple<Tensor, Tensor, Tensor> fused_gemm_epilogue_grad(
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& reserve_space,
+    const Tensor& out_grad,
+    bool trans_x,
+    bool trans_y,
+    const std::string& activation);
+
 }  // namespace backend
 }  // namespace primitive
 }  // namespace paddle

--- a/paddle/fluid/primitive/backend/manual/manual_backend.h
+++ b/paddle/fluid/primitive/backend/manual/manual_backend.h
@@ -43,7 +43,7 @@ template <typename T>
 std::tuple<Tensor, Tensor, Tensor> fused_gemm_epilogue_grad(
     const Tensor& x,
     const Tensor& y,
-    const Tensor& reserve_space,
+    const paddle::optional<Tensor>& reserve_space,
     const Tensor& out_grad,
     bool trans_x,
     bool trans_y,

--- a/paddle/fluid/primitive/backend/manual/manual_static_backend.cc
+++ b/paddle/fluid/primitive/backend/manual/manual_static_backend.cc
@@ -91,9 +91,9 @@ std::tuple<Tensor, Tensor, Tensor> fused_gemm_epilogue_grad<LazyTensor>(
                                                           activation);
   auto op_res_0 = std::get<0>(op_res);
   Tensor x_grad(std::make_shared<LazyTensor>(op_res_0));
-  auto op_res_1 = std::get<0>(op_res);
+  auto op_res_1 = std::get<1>(op_res);
   Tensor y_grad(std::make_shared<LazyTensor>(op_res_1));
-  auto op_res_2 = std::get<0>(op_res);
+  auto op_res_2 = std::get<2>(op_res);
   Tensor bias_grad(std::make_shared<LazyTensor>(op_res_2));
   return std::make_tuple(x_grad, y_grad, bias_grad);
 }

--- a/paddle/fluid/primitive/backend/manual/manual_static_backend.cc
+++ b/paddle/fluid/primitive/backend/manual/manual_static_backend.cc
@@ -60,6 +60,37 @@ Tensor embedding_grad<LazyTensor>(const Tensor& x,
   return out;
 }
 
+template <>
+std::tuple<Tensor, Tensor, Tensor> fused_gemm_epilogue_grad<LazyTensor>(
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& reserve_space,
+    const Tensor& out_grad,
+    bool trans_x,
+    bool trans_y,
+    const std::string& activation) {
+  pir::Value x_res = std::static_pointer_cast<LazyTensor>(x.impl())->value();
+  pir::Value y_res = std::static_pointer_cast<LazyTensor>(y.impl())->value();
+  pir::Value reserve_space_res =
+      std::static_pointer_cast<LazyTensor>(reserve_space.impl())->value();
+  pir::Value out_grad_res =
+      std::static_pointer_cast<LazyTensor>(out_grad.impl())->value();
+  auto op_res = paddle::dialect::fused_gemm_epilogue_grad(x_res,
+                                                          y_res,
+                                                          reserve_space_res,
+                                                          out_grad_res,
+                                                          trans_x,
+                                                          trans_y,
+                                                          activation);
+  auto op_res_0 = std::get<0>(op_res);
+  Tensor x_grad(std::make_shared<LazyTensor>(op_res_0));
+  auto op_res_1 = std::get<0>(op_res);
+  Tensor y_grad(std::make_shared<LazyTensor>(op_res_1));
+  auto op_res_2 = std::get<0>(op_res);
+  Tensor bias_grad(std::make_shared<LazyTensor>(op_res_2));
+  return std::make_tuple(x_grad, y_grad, bias_grad);
+}
+
 }  // namespace backend
 }  // namespace primitive
 }  // namespace paddle

--- a/paddle/fluid/primitive/backend/manual/manual_static_backend.cc
+++ b/paddle/fluid/primitive/backend/manual/manual_static_backend.cc
@@ -64,15 +64,22 @@ template <>
 std::tuple<Tensor, Tensor, Tensor> fused_gemm_epilogue_grad<LazyTensor>(
     const Tensor& x,
     const Tensor& y,
-    const Tensor& reserve_space,
+    const paddle::optional<Tensor>& reserve_space,
     const Tensor& out_grad,
     bool trans_x,
     bool trans_y,
     const std::string& activation) {
   pir::Value x_res = std::static_pointer_cast<LazyTensor>(x.impl())->value();
   pir::Value y_res = std::static_pointer_cast<LazyTensor>(y.impl())->value();
-  pir::Value reserve_space_res =
-      std::static_pointer_cast<LazyTensor>(reserve_space.impl())->value();
+  paddle::optional<pir::Value> reserve_space_res;
+  if (reserve_space) {
+    pir::Value reserve_space_res_inner;
+    reserve_space_res_inner =
+        std::static_pointer_cast<LazyTensor>(reserve_space.get().impl())
+            ->value();
+    reserve_space_res =
+        paddle::make_optional<pir::Value>(reserve_space_res_inner);
+  }
   pir::Value out_grad_res =
       std::static_pointer_cast<LazyTensor>(out_grad.impl())->value();
   auto op_res = paddle::dialect::fused_gemm_epilogue_grad(x_res,

--- a/paddle/fluid/primitive/vjp_interface/manual/manual_vjp.cc
+++ b/paddle/fluid/primitive/vjp_interface/manual/manual_vjp.cc
@@ -198,16 +198,8 @@ std::vector<std::vector<paddle::Tensor>> fused_gemm_epilogue_vjp(
   for (auto arg : stop_gradients) {
     vjp_res.push_back(std::vector<paddle::Tensor>(arg.size()));
   }
-  auto op_res = backend::fused_gemm_epilogue_grad<LazyTensor>(x,
-                                                              y,
-                                                              reserve_space,
-                                                              out_grad,
-                                                              // x_grad,
-                                                              // y_grad,
-                                                              // bias_grad,
-                                                              trans_x,
-                                                              trans_y,
-                                                              activation);
+  auto op_res = backend::fused_gemm_epilogue_grad<LazyTensor>(
+      x, y, reserve_space, out_grad, trans_x, trans_y, activation);
   vjp_res[0][0] = std::get<0>(op_res);
   vjp_res[1][0] = std::get<1>(op_res);
   vjp_res[2][0] = std::get<2>(op_res);

--- a/paddle/fluid/primitive/vjp_interface/manual/manual_vjp.cc
+++ b/paddle/fluid/primitive/vjp_interface/manual/manual_vjp.cc
@@ -185,4 +185,34 @@ std::vector<std::vector<paddle::Tensor>> fused_attention_vjp(
   return vjp_res;
 }
 
+std::vector<std::vector<paddle::Tensor>> fused_gemm_epilogue_vjp(
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& reserve_space,
+    const Tensor& out_grad,
+    bool trans_x,
+    bool trans_y,
+    const std::string& activation,
+    const std::vector<std::vector<bool>>& stop_gradients) {
+  std::vector<std::vector<paddle::Tensor>> vjp_res;
+  for (auto arg : stop_gradients) {
+    vjp_res.push_back(std::vector<paddle::Tensor>(arg.size()));
+  }
+  auto op_res = backend::fused_gemm_epilogue_grad<LazyTensor>(x,
+                                                              y,
+                                                              reserve_space,
+                                                              out_grad,
+                                                              // x_grad,
+                                                              // y_grad,
+                                                              // bias_grad,
+                                                              trans_x,
+                                                              trans_y,
+                                                              activation);
+  vjp_res[0][0] = std::get<0>(op_res);
+  vjp_res[1][0] = std::get<1>(op_res);
+  vjp_res[2][0] = std::get<2>(op_res);
+  vjp_res = ConstructVjpResultByStopGradients(vjp_res, stop_gradients);
+  return vjp_res;
+}
+
 }  // namespace paddle::primitive

--- a/paddle/fluid/primitive/vjp_interface/manual/manual_vjp.cc
+++ b/paddle/fluid/primitive/vjp_interface/manual/manual_vjp.cc
@@ -188,7 +188,7 @@ std::vector<std::vector<paddle::Tensor>> fused_attention_vjp(
 std::vector<std::vector<paddle::Tensor>> fused_gemm_epilogue_vjp(
     const Tensor& x,
     const Tensor& y,
-    const Tensor& reserve_space,
+    const paddle::optional<Tensor>& reserve_space,
     const Tensor& out_grad,
     bool trans_x,
     bool trans_y,

--- a/paddle/fluid/primitive/vjp_interface/manual/manual_vjp.h
+++ b/paddle/fluid/primitive/vjp_interface/manual/manual_vjp.h
@@ -81,5 +81,15 @@ std::vector<std::vector<paddle::Tensor>> fused_attention_vjp(
     int ring_id,
     const std::vector<std::vector<bool>>& stop_gradients);
 
+std::vector<std::vector<paddle::Tensor>> fused_gemm_epilogue_vjp(
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& reserve_space,
+    const Tensor& out_grad,
+    bool trans_x,
+    bool trans_y,
+    const std::string& activation,
+    const std::vector<std::vector<bool>>& stop_gradients);
+
 }  // namespace primitive
 }  // namespace paddle

--- a/paddle/fluid/primitive/vjp_interface/manual/manual_vjp.h
+++ b/paddle/fluid/primitive/vjp_interface/manual/manual_vjp.h
@@ -84,7 +84,7 @@ std::vector<std::vector<paddle::Tensor>> fused_attention_vjp(
 std::vector<std::vector<paddle::Tensor>> fused_gemm_epilogue_vjp(
     const Tensor& x,
     const Tensor& y,
-    const Tensor& reserve_space,
+    const paddle::optional<Tensor>& reserve_space,
     const Tensor& out_grad,
     bool trans_x,
     bool trans_y,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 `FusedGemmEpilogueOp` 缺失 `VjpInterface` 导致梯度断掉的问题

我们仍然不支持 `activation` 非 `"none"` 的情况，如果非 `"none"` 会直接报错确保不会产生精度问题

PCard-66972