### PR TITLE
[CINN] Complete the op_role and chunk_id attributes of the operator in decompose process

### DIFF
--- a/paddle/pir/include/core/builder.h
+++ b/paddle/pir/include/core/builder.h
@@ -195,9 +195,7 @@ OpTy Builder::Build(Args &&...args) {
 
 class BuilderAttrGuard {
  public:
-  BuilderAttrGuard(std::shared_ptr<pir::Builder> builder,
-                   int op_role,
-                   int chunk_id);
+  BuilderAttrGuard(std::shared_ptr<Builder> builder, int op_role, int chunk_id);
 
   ~BuilderAttrGuard();
 
@@ -206,7 +204,7 @@ class BuilderAttrGuard {
   BuilderAttrGuard &operator=(const BuilderAttrGuard &guard) = delete;
 
  private:
-  std::shared_ptr<pir::Builder> builder_;
+  std::shared_ptr<Builder> builder_;
   int pre_op_role_ = -1;
   int pre_chunk_id_ = -1;
 };

--- a/paddle/pir/include/core/builder.h
+++ b/paddle/pir/include/core/builder.h
@@ -193,4 +193,22 @@ OpTy Builder::Build(Args &&...args) {
   return OpTy(op);
 }
 
+class BuilderAttrGuard {
+ public:
+  BuilderAttrGuard(std::shared_ptr<pir::Builder> builder,
+                   int op_role,
+                   int chunk_id);
+
+  ~BuilderAttrGuard();
+
+  // forbid copy and operator=
+  BuilderAttrGuard(const BuilderAttrGuard &guard) = delete;
+  BuilderAttrGuard &operator=(const BuilderAttrGuard &guard) = delete;
+
+ private:
+  std::shared_ptr<pir::Builder> builder_;
+  int pre_op_role_ = -1;
+  int pre_chunk_id_ = -1;
+};
+
 }  // namespace pir

--- a/paddle/pir/src/core/builder.cc
+++ b/paddle/pir/src/core/builder.cc
@@ -106,7 +106,7 @@ TensorNameAttribute Builder::tensor_name_attr(const std::string &value) {
   return TensorNameAttribute::get(context_, value);
 }
 
-BuilderAttrGuard::BuilderAttrGuard(std::shared_ptr<pir::Builder> builder,
+BuilderAttrGuard::BuilderAttrGuard(std::shared_ptr<Builder> builder,
                                    int op_role,
                                    int chunk_id)
     : builder_(builder),

--- a/paddle/pir/src/core/builder.cc
+++ b/paddle/pir/src/core/builder.cc
@@ -106,4 +106,23 @@ TensorNameAttribute Builder::tensor_name_attr(const std::string &value) {
   return TensorNameAttribute::get(context_, value);
 }
 
+BuilderAttrGuard::BuilderAttrGuard(std::shared_ptr<pir::Builder> builder,
+                                   int op_role,
+                                   int chunk_id)
+    : builder_(builder),
+      pre_op_role_(builder_->op_role()),
+      pre_chunk_id_(builder_->chunk_id()) {
+  if (pre_op_role_ != op_role) {
+    builder_->set_op_role(op_role);
+  }
+  if (pre_chunk_id_ != chunk_id) {
+    builder_->set_chunk_id(chunk_id);
+  }
+}
+
+BuilderAttrGuard::~BuilderAttrGuard() {  // NOLINT
+  builder_->set_op_role(pre_op_role_);
+  builder_->set_chunk_id(pre_chunk_id_);
+}
+
 }  // namespace pir

--- a/test/prim/pir_prim/test_decomp_op.py
+++ b/test/prim/pir_prim/test_decomp_op.py
@@ -38,6 +38,11 @@ def get_ir_program():
             y_s = paddle.mean(y_s)
             y_s = paddle.tanh(y_s)
         pir_program = pir.translate_to_pir(main_program.desc)
+
+        all_ops = pir_program.global_block().ops
+        for op in all_ops:
+            op.op_role = 1
+
         return pir_program
 
 
@@ -67,6 +72,10 @@ class TestBuildOp(unittest.TestCase):
                     'pd_op.divide',
                     'pd_op.tanh',
                 ],
+            )
+            op_role_list = [op.op_role for op in pir_program.global_block().ops]
+            self.assertEqual(
+                all(op_role == 1 for op_role in op_role_list), True
             )
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Complete the op_role and chunk_id attributes of the operator in decompose process.
Pcard-67164