### PR TITLE
[PIR] Fix `check_view_api_used_by_inplace`

### DIFF
--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -120,6 +120,13 @@ def check_view_api_used_by_inplace(program: paddle.pir.Program) -> None:
         a = transpose(b)
         b.add_(c)
     """
+    # TODO(ooooo): Deal with these inplace ops
+    skipped_inplace_ops = [
+        "pd_op.set_value_",
+        "pd_op.set_value_with_tensor_",
+        # It willn't change tensor imdeiately,but it's ouput is dangerous.
+        "pd_op.share_data_",
+    ]
 
     def val_is_used_by_stride_op(op, val):
         return op.name() in framework.stride_ops and op.operand_source(
@@ -139,13 +146,7 @@ def check_view_api_used_by_inplace(program: paddle.pir.Program) -> None:
             if val_is_used_by_stride_op(op, value):
                 uesd_by_stride_ops.append(op)
             if is_used_by_inplace_op(op, value, inplace_info):
-                # TODO(ooooo): Deal with these inplace ops
-                if (
-                    op.name() == "pd_op.set_value_"
-                    or op.name() == "pd_op.set_value_with_tensor_"
-                    # It willn't change tensor imdeiately,but it's ouput is dangerous.
-                    or op.name() == "pd_op.share_data_"
-                ):
+                if op.name() in skipped_inplace_ops:
                     continue
                 if value.get_defining_op().name() in framework.stride_ops:
                     show_op_callstack(op)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/PaddleDetection/blob/0914611178e9db34e746a351c7fc090048eeebc0/ppdet/modeling/losses/ssd_loss.py#L115

- 修复检查逻辑， value.detach 使用的 `pd_op.share_data_` 不会和其他 inplace api 一样立刻修改显存
- 但是产生的新的 Value 在逻辑上是不保证安全的，因为之后可能会被其他 inplace api 使用，也修改了之前的显存，目前的检查没有包含这种情况（现在只是跳过了

```python
z = paddle.squeeze(x,-1)
y = x.detach() #不会立刻导致 z 的显存变化
# y.add_(xxx) ，就会导致 z 的显存变化

```