### PR TITLE
fix LoadCombinePersistables when param_filename is empty

### DIFF
--- a/paddle/fluid/inference/io.cc
+++ b/paddle/fluid/inference/io.cc
@@ -82,11 +82,11 @@ void LoadCombinePersistables(framework::Executor* executor,
                              const std::string& dirname,
                              const std::string& param_filename,
                              bool model_from_memory = false) {
-  PADDLE_ENFORCE_EQ(
-      param_filename.empty(),
-      false,
-      common::errors::PreconditionNotMet(
-          "param_filename should not be empty when load combine params."));
+  if (param_filename.empty()) {
+    VLOG(4)
+        << "param_filename is empty when load combine params. Return directly.";
+    return;
+  }
   const framework::BlockDesc& global_block = main_program.Block(0);
 
   auto load_program = std::make_unique<framework::ProgramDesc>();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-71500