### PR TITLE
fix the bug for tuple_push&tuple_pop while tensor numel is 0.

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
@@ -79,7 +79,9 @@ void ShareVarData(const Variable* src_var, Variable* dst_var) {
     auto* tmp_dst_tensor = dst_var->GetMutable<phi::DenseTensor>();
     if (src_tensor.numel() == 0) {
       tmp_dst_tensor->set_meta(src_tensor.meta());
-      return;
+      if (!src_tensor.IsInitialized()) {
+        return;
+      }
     }
     tmp_dst_tensor->ShareDataWith(src_tensor);
   } else if (src_var->IsType<phi::SelectedRows>()) {

--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
@@ -36,6 +36,7 @@
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/fluid/pir/dialect/operator/utils/op_yaml_info_parser.h"
 #include "paddle/fluid/pir/dialect/operator/utils/utils.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_context.h"
 #include "paddle/phi/core/meta_tensor.h"
@@ -314,6 +315,10 @@ void DeepCopyVariable(const Variable* src_var,
     // have holder. In this case we only do set_meta but not copy Tensor.
     if (src_tensor.numel() == 0) {
       tmp_dst_tensor->set_meta(src_tensor.meta());
+      if (src_tensor.IsInitialized()) {
+        tmp_dst_tensor->ResetHolder(
+            ::phi::memory_utils::AllocShared(src_tensor.place(), 0u));
+      }
       return;
     }
     if (!src_tensor.initialized()) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
fix the bug for tuple_push&tuple_pop while tensor numel is 0.

### Other
Pcard-67164