### PR TITLE
remove fold maipulation shadow output check

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/fold_manipulation_ops_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/fold_manipulation_ops_pass.cc
@@ -67,14 +67,6 @@ bool RemoveOp(pir::Operation* op,
     }
     return GetDims(input) == GetDims(output);
   };
-  const auto& UsedByShadowOutput = [&](const pir::Value& value) -> bool {
-    for (auto it = value.use_begin(); it != value.use_end(); ++it) {
-      if (it->owner()->isa<pir::ShadowOutputOp>()) {
-        return true;
-      }
-    }
-    return false;
-  };
 
   const auto& IsSameDataType = [&]() -> bool {
     return paddle::dialect::TransToPhiDataType(
@@ -90,7 +82,6 @@ bool RemoveOp(pir::Operation* op,
   const auto CanRemove = [&]() -> bool {
     if (!IsSameShape()) return false;
     if (check_dtype && !IsSameDataType()) return false;
-    if (UsedByShadowOutput(input) && UsedByShadowOutput(output)) return false;
     return true;
   };
 


### PR DESCRIPTION
### PR Category
CINN

### PR Types
Bug Fixes

### Description
<!-- Describe what you’ve done -->
pcard-76996

移除fold_manipulation_ops_pass pass 中关于 shadow output 的限制（如果一个op 输入和输出都是shadow的输入，则这个op 不能被删除）
这个限制存在的问题是，当前一个op 被放进group 中之后，输出就会从shadow output变成yield，fold_manipulation_ops_pass pass依然会删除，进而引发新的错误