### PR TITLE
[PIR] speed up set device id

### DIFF
--- a/paddle/cinn/hlir/framework/pir_compiler.cc
+++ b/paddle/cinn/hlir/framework/pir_compiler.cc
@@ -22,6 +22,7 @@
 #include "paddle/cinn/utils/multi_threading.h"
 #include "paddle/common/enforce.h"
 #include "paddle/common/flags.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
 
 PD_DECLARE_bool(enable_cinn_compile_cache);
 PD_DECLARE_int64(cinn_compile_thread_num);

--- a/paddle/cinn/runtime/arch_device.h
+++ b/paddle/cinn/runtime/arch_device.h
@@ -22,6 +22,7 @@
 #include "paddle/cinn/common/target.h"
 #include "paddle/cinn/runtime/backend_api.h"
 #include "paddle/common/enforce.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
 
 namespace cinn::runtime {
 
@@ -62,7 +63,7 @@ void SetArchDevice(const common::Target& target,
                           ::common::errors::InvalidArgument(
                               "Required device_id should have value, but "
                               "received std::nullopt."));
-        cudaSetDevice(device_id.value());
+        phi::backends::gpu::SetDeviceId(device_id.value());
 #endif
       },
       [&](common::HygonDCUArchHIP) -> void {

--- a/paddle/cinn/runtime/cuda/cuda_module.cc
+++ b/paddle/cinn/runtime/cuda/cuda_module.cc
@@ -28,6 +28,7 @@
 #include "paddle/cinn/runtime/flags.h"
 #include "paddle/cinn/utils/profiler.h"
 #include "paddle/common/enforce.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
 
 namespace cinn {
 namespace runtime {
@@ -48,7 +49,7 @@ CUDAModule::CUDAModule(const std::string& data, Kind kind)
   // TODO(Superjomn) Determine whether to initialize all the devices.
   int current_device_id;
   cudaGetDevice(&current_device_id);
-  cudaSetDevice(current_device_id);
+  phi::backends::gpu::SetDeviceId(current_device_id);
   cuDeviceGet(&device_, current_device_id);
   cuCtxGetCurrent(&context_);
   cuDevicePrimaryCtxRetain(&context_, device_);
@@ -172,7 +173,7 @@ CUDAModule::~CUDAModule() {
   for (int i = 0; i < module_per_card_.size(); i++) {
     auto* module = module_per_card_[i];
     if (module) {
-      CUDA_CALL(cudaSetDevice(i));
+      phi::backends::gpu::SetDeviceId(i);
       CUDA_DRIVER_CALL(cuModuleUnload(module));
     }
   }

--- a/paddle/cinn/runtime/hip/hip_backend_api.cc
+++ b/paddle/cinn/runtime/hip/hip_backend_api.cc
@@ -26,7 +26,7 @@ HIPBackendAPI* HIPBackendAPI::Global() {
 }
 
 void HIPBackendAPI::set_device(int device_id) {
-  HIP_CHECK(hipSetDevice(device_id));
+  phi::backends::gpu::SetDeviceId(device_id);
 }
 
 int HIPBackendAPI::get_device() {

--- a/paddle/cinn/runtime/hip/hip_module.cc
+++ b/paddle/cinn/runtime/hip/hip_module.cc
@@ -35,7 +35,7 @@ HIPModule::HIPModule(const std::string& data) : data_(data) {
 
   int current_device_id;
   hipGetDevice(&current_device_id);
-  hipSetDevice(current_device_id);
+  phi::backends::gpu::SetDeviceId(current_device_id);
   hipDeviceGet(&device_, current_device_id);
   hipCtxGetCurrent(&context_);
   hipDevicePrimaryCtxRetain(&context_, device_);
@@ -98,7 +98,7 @@ HIPModule::~HIPModule() {
   for (int i = 0; i < module_per_card_.size(); i++) {
     auto* module = module_per_card_[i];
     if (module) {
-      HIP_CHECK(hipSetDevice(i));
+      phi::backends::gpu::SetDeviceId(i);
       HIP_DRIVER_CHECK(hipModuleUnload(module));
     }
   }

--- a/paddle/cinn/utils/profiler.cc
+++ b/paddle/cinn/utils/profiler.cc
@@ -26,6 +26,7 @@
 #include "paddle/cinn/backends/cuda_util.h"
 #endif
 #include <chrono>
+#include "paddle/phi/backends/gpu/gpu_info.h"
 
 PD_DECLARE_int32(cinn_profiler_state);
 
@@ -95,10 +96,10 @@ void SynchronizeAllDevice() {
   int count;
   CUDA_CALL(cudaGetDeviceCount(&count));
   for (int i = 0; i < count; i++) {
-    CUDA_CALL(cudaSetDevice(i));
+    phi::backends::gpu::SetDeviceId(i);
     CUDA_CALL(cudaDeviceSynchronize());
   }
-  CUDA_CALL(cudaSetDevice(current_device_id));
+  phi::backends::gpu::SetDeviceId(current_device_id);
 #endif
 }
 

--- a/paddle/fluid/framework/fleet/heter_ps/gpu_graph_utils.h
+++ b/paddle/fluid/framework/fleet/heter_ps/gpu_graph_utils.h
@@ -24,6 +24,7 @@
 #include "paddle/common/enforce.h"
 #include "paddle/common/flags.h"
 #include "paddle/fluid/platform/enforce.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
 
 COMMON_DECLARE_bool(gpugraph_debug_gpu_memory);
 
@@ -82,7 +83,7 @@ inline std::vector<int> shuffle_int_vector(int n) {
 class CudaDeviceRestorer {
  public:
   CudaDeviceRestorer() { cudaGetDevice(&dev_); }
-  ~CudaDeviceRestorer() { cudaSetDevice(dev_); }
+  ~CudaDeviceRestorer() { phi::backends::gpu::SetDeviceId(dev_); }
 
  private:
   int dev_;
@@ -96,7 +97,7 @@ inline void debug_gpu_memory_info(int gpu_id, const char* desc) {
 
   size_t avail{0};
   size_t total{0};
-  cudaSetDevice(gpu_id);
+  phi::backends::gpu::SetDeviceId(gpu_id);
   auto err = cudaMemGetInfo(&avail, &total);
   PADDLE_ENFORCE_EQ(err,
                     cudaSuccess,
@@ -125,7 +126,7 @@ inline void debug_gpu_memory_info(const char* desc) {
   size_t avail{0};
   size_t total{0};
   for (int i = 0; i < device_num; ++i) {
-    cudaSetDevice(i);
+    phi::backends::gpu::SetDeviceId(i);
     auto err = cudaMemGetInfo(&avail, &total);
     PADDLE_ENFORCE_EQ(
         err,
@@ -153,7 +154,7 @@ inline void show_gpu_mem(const char* desc) {
   size_t avail{0};
   size_t total{0};
   for (int i = 0; i < device_num; ++i) {
-    cudaSetDevice(i);
+    phi::backends::gpu::SetDeviceId(i);
     auto err = cudaMemGetInfo(&avail, &total);
     PADDLE_ENFORCE_EQ(
         err,

--- a/paddle/fluid/framework/fleet/ps_gpu_wrapper.cc
+++ b/paddle/fluid/framework/fleet/ps_gpu_wrapper.cc
@@ -2266,7 +2266,7 @@ void PSGPUWrapper::HbmToSparseTable() {
                                    int i, size_t once_gpu_copy) {
     platform::Timer tm;
     tm.Start();
-    PADDLE_ENFORCE_GPU_SUCCESS(cudaSetDevice(this->resource_->dev_id(i)));
+    phi::backends::gpu::SetDeviceId(this->resource_->dev_id(i));
     auto stream = this->resource_->local_stream(i, 0);
 
     size_t total_len = 0;

--- a/paddle/fluid/inference/api/helper.h
+++ b/paddle/fluid/inference/api/helper.h
@@ -453,7 +453,7 @@ static inline void DisplayMemoryInfo(phi::Place place,
                                      const std::string &hint) {
 #ifdef PADDLE_WITH_CUDA
   // size_t free, total;
-  // cudaSetDevice(place.GetDeviceId());
+  // phi::backends::gpu::SetDeviceId(place.GetDeviceId());
   // cudaMemGetInfo(&free, &total);
   // VLOG(1) << "[" << ToMegaBytes(total - free) << "MB/" << ToMegaBytes(total)
   // << "MB]";

--- a/paddle/phi/backends/gpu/cuda/cuda_info.cc
+++ b/paddle/phi/backends/gpu/cuda/cuda_info.cc
@@ -245,6 +245,11 @@ const gpuDeviceProp &GetDeviceProperties(int id) {
 }
 
 void SetDeviceId(int id) {
+  static int last_id = -1;
+  if (last_id == id) {
+    return;
+  }
+
   // TODO(qijun): find a better way to cache the cuda device count
   PADDLE_ENFORCE_LT(id,
                     GetGPUDeviceCount(),
@@ -254,6 +259,7 @@ void SetDeviceId(int id) {
                         id,
                         GetGPUDeviceCount()));
   PADDLE_RETRY_CUDA_SUCCESS(cudaSetDevice(id));
+  last_id = id;
   VLOG(4) << "SetDeviceId " << id;
 }
 

--- a/paddle/phi/backends/gpu/rocm/rocm_info.cc
+++ b/paddle/phi/backends/gpu/rocm/rocm_info.cc
@@ -241,6 +241,11 @@ const gpuDeviceProp &GetDeviceProperties(int id) {
 }
 
 void SetDeviceId(int id) {
+  static int last_id = -1;
+  if (last_id == id) {
+    return;
+  }
+
   // TODO(qijun): find a better way to cache the cuda device count
   PADDLE_ENFORCE_LT(id,
                     GetGPUDeviceCount(),
@@ -250,6 +255,7 @@ void SetDeviceId(int id) {
                         id,
                         GetGPUDeviceCount()));
   PADDLE_RETRY_CUDA_SUCCESS(hipSetDevice(id));
+  last_id = id;
 }
 
 void GpuMemcpyAsync(void *dst,

--- a/paddle/phi/backends/xpu/xpu_info.cc
+++ b/paddle/phi/backends/xpu/xpu_info.cc
@@ -101,11 +101,16 @@ int GetXPUCurrentDeviceId() {
 }
 
 void SetXPUDeviceId(int id) {
+  static int last_id = -1;
+  if (last_id == id) {
+    return;
+  }
   PADDLE_ENFORCE_LT(
       id,
       GetXPUDeviceCount(),
       common::errors::InvalidArgument("id must less than XPU count"));
   PADDLE_ENFORCE_XPU_SUCCESS(xpu_set_device(id));
+  last_id = id;
 }
 
 static inline std::vector<std::string> Split(std::string const& original,

--- a/paddle/phi/backends/xpu/xpu_info.cc
+++ b/paddle/phi/backends/xpu/xpu_info.cc
@@ -101,16 +101,11 @@ int GetXPUCurrentDeviceId() {
 }
 
 void SetXPUDeviceId(int id) {
-  static int last_id = -1;
-  if (last_id == id) {
-    return;
-  }
   PADDLE_ENFORCE_LT(
       id,
       GetXPUDeviceCount(),
       common::errors::InvalidArgument("id must less than XPU count"));
   PADDLE_ENFORCE_XPU_SUCCESS(xpu_set_device(id));
-  last_id = id;
 }
 
 static inline std::vector<std::string> Split(std::string const& original,

--- a/paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.cc
+++ b/paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.cc
@@ -115,7 +115,7 @@ void CUDAVirtualMemAllocator::FreeImpl(phi::Allocation* allocation) {
   int prev_id;
   cudaGetDevice(&prev_id);
   if (prev_id != place_.device) {
-    cudaSetDevice(place_.device);
+    phi::backends::gpu::SetDeviceId(place_.device);
   }
 
   auto result = phi::dynload::cuMemUnmap(iter->first, iter->second.second);
@@ -129,7 +129,7 @@ void CUDAVirtualMemAllocator::FreeImpl(phi::Allocation* allocation) {
   }
 
   if (prev_id != place_.device) {
-    cudaSetDevice(prev_id);
+    phi::backends::gpu::SetDeviceId(prev_id);
   }
 
   virtual_2_physical_map_.erase(iter);

--- a/paddle/phi/core/platform/collective_helper.cc
+++ b/paddle/phi/core/platform/collective_helper.cc
@@ -174,11 +174,7 @@ void NCCLCommContext::CreateNCCLCommMultiTrainer(
   {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclGroupStart());
     for (int i = 0; i < kDevices; i++) {
-#ifdef PADDLE_WITH_HIP
-      PADDLE_ENFORCE_GPU_SUCCESS(hipSetDevice(i));
-#else
-      PADDLE_ENFORCE_GPU_SUCCESS(cudaSetDevice(i));
-#endif
+      phi::backends::gpu::SetDeviceId(i);
       phi::dynload::ncclCommInitRank(
           comms + i, kDevices * ntrainers, *nccl_id, train_id * kDevices + i);
       VLOG(1) << "ncclCommInitRank: " << i;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance 

### Description
<!-- Describe what you’ve done -->
通过火焰图发现，PIR执行器每个Instruction都调用SetDeviceID影响调度性能尝试优化。且发现：Program InterpretorCore、动态图、老动态图均如此处理。是否可行需验证。

优化前：
![D518FA42ECF01B85A020788D8724B89C](https://github.com/user-attachments/assets/62926036-af71-4af3-bd8d-7393266ce55f)


优化后：
![C013F8A6631B7B2F14EE4A0C659B4C24](https://github.com/user-attachments/assets/529043b0-cac8-4be1-a64d-264d1587a9a6)

PirInterpreter::Run优化不明显，经测试，是第一次调用耗时很长导致的。

Pcard-67164
