### PR TITLE
[PIR save/load]Fix save combine memory

### DIFF
--- a/paddle/phi/kernels/impl/save_combine_kernel_impl.h
+++ b/paddle/phi/kernels/impl/save_combine_kernel_impl.h
@@ -58,29 +58,10 @@ inline void SaveToMemory(const std::string& file_path,
 }
 
 template <typename T, typename Context>
-void SaveCombineTensorKernel(const Context& dev_ctx,
-                             const std::vector<const phi::DenseTensor*>& x,
-                             const std::string& file_path,
-                             bool overwrite,
-                             bool save_as_fp16,
-                             bool save_to_memory,
-                             phi::ExtendedTensor* out) {
-  std::string* y = nullptr;
-  if (out != nullptr) {
-    auto raw_out = static_cast<RawTensor*>(out);
-    y = raw_out->GetMutable<std::string>();
-  }
-
-  bool is_present = FileExists(file_path);
-  if (is_present && !overwrite) {
-    PADDLE_THROW(common::errors::PreconditionNotMet(
-        "%s exists! Cannot save_combine to it when overwrite is set to "
-        "false.",
-        file_path,
-        overwrite));
-  }
-
-  std::ostringstream ss;
+void SerializeCombineTensor(const Context& dev_ctx,
+                            const std::vector<const phi::DenseTensor*>& x,
+                            bool save_as_fp16,
+                            std::ostream& ss) {
   PADDLE_ENFORCE_GT(x.size(),
                     0UL,
                     common::errors::InvalidArgument(
@@ -114,8 +95,40 @@ void SaveCombineTensorKernel(const Context& dev_ctx,
       SerializeToStream(ss, tensor, dev_ctx);
     }
   }
+}
 
-  SaveToMemory(file_path, ss, save_to_memory, y);
+template <typename T, typename Context>
+void SaveCombineTensorKernel(const Context& dev_ctx,
+                             const std::vector<const phi::DenseTensor*>& x,
+                             const std::string& file_path,
+                             bool overwrite,
+                             bool save_as_fp16,
+                             bool save_to_memory,
+                             phi::ExtendedTensor* out) {
+  std::string* y = nullptr;
+  if (out != nullptr) {
+    auto raw_out = static_cast<RawTensor*>(out);
+    y = raw_out->GetMutable<std::string>();
+  }
+
+  bool is_present = FileExists(file_path);
+  if (is_present && !overwrite) {
+    PADDLE_THROW(common::errors::PreconditionNotMet(
+        "%s exists! Cannot save_combine to it when overwrite is set to "
+        "false.",
+        file_path,
+        overwrite));
+  }
+
+  if (save_to_memory) {
+    std::ostringstream ss;
+    SerializeCombineTensor<T>(dev_ctx, x, save_as_fp16, ss);
+    SaveToMemory(file_path, ss, save_to_memory, y);
+  } else {
+    std::ofstream fout(file_path, std::ios::binary);
+    SerializeCombineTensor<T>(dev_ctx, x, save_as_fp16, fout);
+    fout.close();
+  }
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/impl/save_combine_kernel_impl.h
+++ b/paddle/phi/kernels/impl/save_combine_kernel_impl.h
@@ -125,7 +125,12 @@ void SaveCombineTensorKernel(const Context& dev_ctx,
     SerializeCombineTensor<T>(dev_ctx, x, save_as_fp16, ss);
     SaveToMemory(file_path, ss, save_to_memory, y);
   } else {
+    MkDirRecursively(DirName(file_path).c_str());
     std::ofstream fout(file_path, std::ios::binary);
+    PADDLE_ENFORCE_EQ(static_cast<bool>(fout),
+                      true,
+                      common::errors::Unavailable(
+                          "Cannot open %s to save variables.", file_path));
     SerializeCombineTensor<T>(dev_ctx, x, save_as_fp16, fout);
     fout.close();
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
pcard-67164
Fix save combine memory
save_combine存储参数时为保持save_to_memory参数的处理逻辑一致，会统一使用`ostringstream` 进行序列化，之后根据保存到内存或是文件中再做区分。这样在写入文件时再次构造`ofstream` 导致最大内存占用为参数量大小的二倍，在参数量大的模型上会造成OOM。
修改了旧IR `SaveCombineTensorKernel`  和PIR `SaveCombineFunction` 中的序列化逻辑，其中`SaveCombineTensorKernel` 中根据是否保存到内存中创建不同的二进制流传入序列化函数，避免二次内存占用。