### PR TITLE
[Distributed] support profiling begining steps only for online analyze

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import os
+
 import paddle
 from paddle import framework
 from paddle.autograd import no_grad
@@ -36,6 +38,10 @@ from ...utils.hybrid_parallel_util import (
 from ...utils.log_util import logger, sync_rotate_logger
 from ...utils.mix_precision_utils import MixPrecisionOptimizer
 
+g_profile_optimizer_details_steps = int(
+    os.getenv("FLAGS_profile_optimizer_details_steps", "0")
+)
+
 __all__ = []
 
 
@@ -45,9 +51,11 @@ class HybridParallelClipGrad:
         self._hcg = hcg
         self.not_sharding_stage1 = True
         self._timers = timers
+        self.processed_steps = 0
 
     def _global_norm(self, global_norm_var_dist, global_norm_var_not_dist):
-        sync_rotate_logger().info("Starting to calculate global norm.")
+        if self.processed_steps < g_profile_optimizer_details_steps:
+            sync_rotate_logger().info("Starting to calculate global norm.")
         # sharding first
         sharding_flag = self._hcg.get_sharding_parallel_world_size() > 1
         dp_flag = self._hcg.get_data_parallel_world_size() > 1
@@ -97,7 +105,9 @@ class HybridParallelClipGrad:
                 group=self._hcg.get_pipe_parallel_group(),
             )
 
-        sync_rotate_logger().info("Finished calculating global norm.")
+        if self.processed_steps < g_profile_optimizer_details_steps:
+            sync_rotate_logger().info("Finished calculating global norm.")
+        self.processed_steps += 1
 
     @no_grad()
     def _dygraph_clip(self, params_grads):
@@ -351,6 +361,7 @@ class HybridParallelOptimizer:
                             item["grad_clip"] = HybridParallelClipGrad(
                                 inner_opt._grad_clip, hcg, self._timers
                             )
+        self.processed_steps = 0
 
     def _set_all_gather_overlap_forward(
         self, all_gather_overlap_forward, layers=None
@@ -397,7 +408,8 @@ class HybridParallelOptimizer:
         return False
 
     def _step(self, parameters_list):
-        sync_rotate_logger().info("Starting hybridoptimizer step")
+        if self.processed_steps < g_profile_optimizer_details_steps:
+            sync_rotate_logger().info("Starting hybridoptimizer step")
 
         mp_group = self._hcg.get_model_parallel_group()
         src_rank = self._hcg.get_model_parallel_group_src_rank()
@@ -434,14 +446,16 @@ class HybridParallelOptimizer:
                     p.grad, src_rank, mp_group, mp_configs.sync_mode
                 )
 
-        sync_rotate_logger().info("Starting mp grad sync")
+        if self.processed_steps < g_profile_optimizer_details_steps:
+            sync_rotate_logger().info("Starting mp grad sync")
 
         # Grad sync before opt
         if mp_group.nranks > 1 and mp_configs and mp_configs.sync_grad:
             for p in params:
                 syc_grad(p)
 
-        sync_rotate_logger().info("Finished mp grad sync")
+        if self.processed_steps < g_profile_optimizer_details_steps:
+            sync_rotate_logger().info("Finished mp grad sync")
 
         self._inner_opt.step()
 
@@ -504,7 +518,9 @@ class HybridParallelOptimizer:
         if mp_group.nranks > 1 and mp_configs and mp_configs.sync_moment:
             for p in params:
                 syc_moment(p)
-        sync_rotate_logger().info("Finishing hybridoptimizer step")
+        if self.processed_steps < g_profile_optimizer_details_steps:
+            sync_rotate_logger().info("Finishing hybridoptimizer step")
+        self.processed_steps += 1
 
     def _hybrid_sync_grad(self, parameter_list):
         dp_parameter_list = parameter_list

--- a/python/paddle/distributed/fleet/utils/log_util.py
+++ b/python/paddle/distributed/fleet/utils/log_util.py
@@ -15,7 +15,6 @@
 import logging
 import os
 import subprocess
-from distutils.util import strtobool
 from logging.handlers import RotatingFileHandler
 
 import paddle
@@ -84,9 +83,8 @@ class DistributedLogger(logging.Logger):
         super().__init__(name, level)
 
     def info(self, msg, *args, **kwargs):
-        if strtobool(os.getenv('FLAGS_distributed_debug_logger', '0')):
-            paddle.device.synchronize()
-            super().info(f"Distributed Debug: {msg}", *args, **kwargs)
+        paddle.device.synchronize()
+        super().info(f"Distributed Debug: {msg}", *args, **kwargs)
 
 
 def get_rotate_file_logger(log_level, name='root'):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
set FLAGS_profile_pipeline_details_steps/FLAGS_profile_optimizer_details_steps to N to get N steps detailed profiling infos on pipeline/sharding_optimizer after training process is launched (with cost of performance)
```
export FLAGS_profile_pipeline_details_steps=5
export FLAGS_profile_optimizer_details_steps=10
```