### PR TITLE
Bug fix amp

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -865,6 +865,8 @@ void AnalysisPredictor::OptimizeInferencePirProgram() {
 
         if (config_.enable_gpu_mixed_) {
           AddAutoMixedPrecisionPass(fused_op_pm);
+          fused_op_pm.AddPass(
+              pir::PassRegistry::Instance().Get("transfer_layout_pass"));
         }
 
         fused_op_pm.Run(pir_program_.get());
@@ -994,14 +996,14 @@ void AnalysisPredictor::OptimizeInferencePirProgram() {
   if (config_.enable_gpu_mixed_) {
     if (!config_.cinn_enabled()) {
       AddAutoMixedPrecisionPass(basic_pass_pm);
-    }
 
-    auto transfer_layout_pass = ::pir::CreateTransferLayoutPass();
-    if (std::find(config_.deleted_passes_.begin(),
-                  config_.deleted_passes_.end(),
-                  transfer_layout_pass->name()) ==
-        config_.deleted_passes_.end()) {
-      basic_pass_pm.AddPass(std::move(transfer_layout_pass));
+      auto transfer_layout_pass = ::pir::CreateTransferLayoutPass();
+      if (std::find(config_.deleted_passes_.begin(),
+                    config_.deleted_passes_.end(),
+                    transfer_layout_pass->name()) ==
+          config_.deleted_passes_.end()) {
+        basic_pass_pm.AddPass(std::move(transfer_layout_pass));
+      }
     }
   }
   auto common_subexpression_elimination_pass =

--- a/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
@@ -793,8 +793,7 @@ class AutoMixedPrecisionPass : public pir::Pass {
               {3, "saved_mean"},
               {4, "saved_variance"}}},
             {"pd_op.layer_norm", {{1, "mean"}, {2, "variance"}}},
-            {"pd_op.instance_norm", {{1, "mean"}, {2, "variance"}}},
-            {"pd_op.clip", {{0, "out"}}}};
+            {"pd_op.instance_norm", {{1, "mean"}, {2, "variance"}}}};
 
     auto it = op_output_indices.find(op->name());
     if (it != op_output_indices.end()) {

--- a/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
@@ -795,6 +795,14 @@ class AutoMixedPrecisionPass : public pir::Pass {
             {"pd_op.layer_norm", {{1, "mean"}, {2, "variance"}}},
             {"pd_op.instance_norm", {{1, "mean"}, {2, "variance"}}}};
 
+    if (op->name() == "pd_op.clip") {
+      pir::Value input_value = op->operand_source(0);
+      pir::Type input_dtype = pir::GetDataTypeFromValue(input_value);
+      if (!input_dtype.isa<pir::Float32Type>()) {
+        return true;
+      }
+    }
+
     auto it = op_output_indices.find(op->name());
     if (it != op_output_indices.end()) {
       const auto& index_pairs = it->second;

--- a/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
@@ -793,7 +793,8 @@ class AutoMixedPrecisionPass : public pir::Pass {
               {3, "saved_mean"},
               {4, "saved_variance"}}},
             {"pd_op.layer_norm", {{1, "mean"}, {2, "variance"}}},
-            {"pd_op.instance_norm", {{1, "mean"}, {2, "variance"}}}};
+            {"pd_op.instance_norm", {{1, "mean"}, {2, "variance"}}},
+            {"pd_op.clip", {{0, "out"}}}};
 
     auto it = op_output_indices.find(op->name());
     if (it != op_output_indices.end()) {


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Performance

### Description
Fix bug caused by AMP before moving to CINN. The output should not be converted from int64 to float16 for the clip arithmetic.
![image](https://github.com/user-attachments/assets/755fc479-e17a-4766-aff4-75a96b7743c8)

image

Pcard-67164