### PR TITLE
[Static] Set mask.stop_gradient to True in `masked_fill_`

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -6331,6 +6331,7 @@ def masked_fill_(
         value = paddle.full([], value, x.dtype)
 
     mask = paddle.logical_not(mask)
+    mask.stop_gradient = True
     out = paddle.where_(mask, x, value)
     return out
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Pcard-75624

`masked_fill_`接受的`mask.stop_gradient`可能会被设置为False，因此将其手动设置为True，避免后续的调用被assert检测。比较运算产生的布尔类型stop_gradient不能为False。
![image](https://github.com/user-attachments/assets/e6d072da-1ad4-41a4-b641-acc9675d1ef6)
