### PR TITLE
[Auto Parallel] only shard parameters that is not dist

### DIFF
--- a/python/paddle/distributed/auto_parallel/intermediate/parallel_base.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/parallel_base.py
@@ -149,7 +149,7 @@ class ParallelModel:
     def _shard_all_param(self, model):
         param_name_to_shard_param = {}
 
-        def shard_layer_param(name, layer):
+        def shard_layer_param(layer):
             if self.pp_parallelizer is not None:
                 assert hasattr(layer, "pipeline_stage_index")
             for param_name in list(layer._parameters.keys()):
@@ -178,7 +178,7 @@ class ParallelModel:
                         setattr(layer, param_name, param)
 
         for name, layer in model.named_sublayers():
-            shard_layer_param(name, layer)
+            shard_layer_param(layer)
 
 
 def parallelize_model_and_optimizer(model, optimizer=None):

--- a/python/paddle/distributed/auto_parallel/intermediate/parallel_base.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/parallel_base.py
@@ -149,45 +149,36 @@ class ParallelModel:
     def _shard_all_param(self, model):
         param_name_to_shard_param = {}
 
-        def shard_layer_param(layer):
+        def shard_layer_param(name, layer):
             if self.pp_parallelizer is not None:
                 assert hasattr(layer, "pipeline_stage_index")
-            layer_attrs = dir(layer)
-            for layer_attr in layer_attrs:
-                if getattr(layer, layer_attr) is not None and is_tensor(
-                    getattr(layer, layer_attr)
-                ):
-                    layer_tensor = getattr(layer, layer_attr)
-                    if not layer_tensor.is_dist():
-                        tensor_name = layer_tensor.name
-                        if tensor_name in param_name_to_shard_param:
-                            setattr(
-                                layer,
-                                layer_attr,
-                                param_name_to_shard_param[tensor_name],
-                            )
-                        else:
-                            ipp = (
-                                layer.pipeline_stage_index
-                                if hasattr(layer, "pipeline_stage_index")
-                                else 0
-                            )
-                            mesh = self.get_mesh(ipp)
-                            layer_tensor = dist.shard_tensor(
-                                layer_tensor,
-                                mesh,
-                                [
-                                    dist.Replicate()
-                                    for _ in range(len(mesh._shape))
-                                ],
-                            )
-                            param_name_to_shard_param[tensor_name] = (
-                                layer_tensor
-                            )
-                            setattr(layer, layer_attr, layer_tensor)
+            for param_name in list(layer._parameters.keys()):
+                param = getattr(layer, param_name)
+                if param is not None and not param.is_dist():
+                    param_full_name = param.name
+                    if param_full_name in param_name_to_shard_param:
+                        setattr(
+                            layer,
+                            param_name,
+                            param_name_to_shard_param[param_full_name],
+                        )
+                    else:
+                        ipp = (
+                            layer.pipeline_stage_index
+                            if hasattr(layer, "pipeline_stage_index")
+                            else 0
+                        )
+                        mesh = self.get_mesh(ipp)
+                        param = dist.shard_tensor(
+                            param,
+                            mesh,
+                            [dist.Replicate() for _ in range(len(mesh._shape))],
+                        )
+                        param_name_to_shard_param[param_full_name] = param
+                        setattr(layer, param_name, param)
 
         for name, layer in model.named_sublayers():
-            shard_layer_param(layer)
+            shard_layer_param(name, layer)
 
 
 def parallelize_model_and_optimizer(model, optimizer=None):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
 Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-73145
只将未标记的参数标记成全复制，而不是layer内的全部tensor，避免动转静报错