### PR TITLE
AMP skip clip operator output type modification

### DIFF
--- a/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
@@ -795,6 +795,14 @@ class AutoMixedPrecisionPass : public pir::Pass {
             {"pd_op.layer_norm", {{1, "mean"}, {2, "variance"}}},
             {"pd_op.instance_norm", {{1, "mean"}, {2, "variance"}}}};
 
+    if (op->name() == "pd_op.clip") {
+      pir::Value input_value = op->operand_source(0);
+      pir::Type input_dtype = pir::GetDataTypeFromValue(input_value);
+      if (!input_dtype.isa<pir::Float32Type>()) {
+        return true;
+      }
+    }
+
     auto it = op_output_indices.find(op->name());
     if (it != op_output_indices.end()) {
       const auto& index_pairs = it->second;


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Performance

### Description
Fix bug caused by AMP before moving to CINN. The output should not be converted from int64 to float16 for the clip arithmetic.
![image](https://github.com/user-attachments/assets/f94907be-c7e6-4172-9bf0-76cfcacac274)


Pcard-67164