### PR TITLE
[SOT][3.13] Adapt for `f_lasti` usage in `test_analysis_inputs`

### DIFF
--- a/test/sot/skip_files_py313
+++ b/test/sot/skip_files_py313
@@ -1,7 +1,6 @@
 test/sot/test_11_jumps.py
 test/sot/test_12_for_loop.py
 test/sot/test_19_closure.py
-test/sot/test_analysis_inputs.py
 test/sot/test_break_graph.py
 test/sot/test_min_graph_size.py
 test/sot/test_numpy.py

--- a/test/sot/test_analysis_inputs.py
+++ b/test/sot/test_analysis_inputs.py
@@ -24,6 +24,9 @@ from paddle.jit.sot.opcode_translator.instruction_utils import (
     calc_offset_from_bytecode_offset,
     get_instructions,
 )
+from paddle.jit.sot.opcode_translator.instruction_utils.opcode_info import (
+    PYOPCODE_CACHE_SIZE,
+)
 
 
 def assert_inputs_equals(instruction_offset: int, expected_inputs: set[str]):
@@ -33,8 +36,11 @@ def assert_inputs_equals(instruction_offset: int, expected_inputs: set[str]):
     assert test_frame is not None
 
     instructions = get_instructions(test_frame.f_code)
+    current_offset = test_frame.f_lasti
+    if sys.version_info >= (3, 13):
+        current_offset += PYOPCODE_CACHE_SIZE.get("CALL") * 2
     current_instr_idx = calc_offset_from_bytecode_offset(
-        test_frame.f_lasti + 2, instructions
+        current_offset + 2, instructions
     )
     reads, writes = analysis_used_names(
         instructions, current_instr_idx + instruction_offset


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

Python 3.13 `f_lasti` 变动适配，3.13 的 `f_lasti` 需要自行跳过 inline cache

- #69246
- #69245

PCard-66972