### PR TITLE
[Inference] Remove fleetexe in Predictor

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -585,9 +585,6 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   CP_MEMBER(ipu_custom_ops_info_);
   CP_MEMBER(ipu_custom_patterns_);
 
-  // fleet exe related
-  CP_MEMBER(dist_config_);
-
   // custom device related.
   CP_MEMBER(use_custom_device_);
   CP_MEMBER(custom_device_type_);

--- a/paddle/fluid/inference/api/analysis_predictor.h
+++ b/paddle/fluid/inference/api/analysis_predictor.h
@@ -33,10 +33,6 @@
 #include "paddle/phi/core/platform/device/gpu/gpu_types.h"
 #include "paddle/utils/string/printf.h"
 
-#if defined(PADDLE_WITH_DISTRIBUTE) && defined(PADDLE_WITH_PSCORE)
-#include "paddle/fluid/distributed/fleet_executor/fleet_executor.h"
-#endif
-
 #ifdef PADDLE_WITH_TESTING
 #include <gtest/gtest.h>
 #include <gtest/gtest_prod.h>
@@ -513,55 +509,6 @@ class AnalysisPredictor : public PaddlePredictor {
   std::string GetOptimizedModelPath();
   void ClearExtraParams();
 
-#if defined(PADDLE_WITH_DISTRIBUTE) && defined(PADDLE_WITH_PSCORE)
-  // fleet exe related
-
-  ///
-  /// \brief prepare for fleet executor to run
-  ///
-  /// Used in AnalysisPredictor::Init(),
-  ///
-  bool PrepareFleetExecutor();
-
-  ///
-  /// \brief init NCCL env for multi gpus inference
-  ///
-  /// Used in AnalysisPredictor::PrepareFleetExecutor()
-  ///
-  bool CommInit();
-
-  ///
-  /// \brief read the config to init NCCL env
-  ///
-  /// Used in AnalysisPredictor::CommInit()
-  ///
-  /// \param[in] ring_id_to_ranks: a ptr to ring_id_to_ranks
-  /// \param[in] rank_to_ring_ids: a ptr to rank_to_ring_ids
-  ///
-  bool LoadConverterConfig(
-      std::map<int64_t, std::vector<int64_t>> *ring_id_to_ranks,
-      std::map<int64_t, std::vector<int64_t>> *rank_to_ring_ids);
-
-  ///
-  /// \brief add ops and run them with NaiveExecutor to init NCCL env
-  ///
-  /// Used in AnalysisPredictor::CommInit()
-  ///
-  /// \param[in] tmp_var_name: var name to hold NCCL unique id
-  /// \param[in] nranks: number of ranks in one comm group
-  /// \param[in] rank: relative rank of current rank in the comm group
-  /// \param[in] peer_endpoints: group's peers' endpoints
-  /// \param[in] block: the block to insert comm ops
-  /// \param[in] ring_id: the ring id to be used to init NCCL env
-  ///
-  void InsertCommOp(std::string tmp_var_name,
-                    int nranks,
-                    int rank,
-                    const std::vector<std::string> &peer_endpoints,
-                    framework::BlockDesc *block,
-                    int ring_id);
-#endif
-
  private:
   AnalysisConfig config_;
   std::unique_ptr<Argument> argument_ = nullptr;
@@ -613,12 +560,6 @@ class AnalysisPredictor : public PaddlePredictor {
   std::map<phi::Place, std::shared_future<std::unique_ptr<phi::DeviceContext>>>
       device_contexts_;
 
-#if defined(PADDLE_WITH_DISTRIBUTE) && defined(PADDLE_WITH_PSCORE)
-  // fleet executor related
-  distributed::FleetExecutorDesc executor_desc_;
-  std::shared_ptr<distributed::FleetExecutor> fleet_exe_;
-  std::shared_ptr<distributed::TaskNode> task_node_;
-#endif
   friend class paddle_infer::experimental::InternalUtils;
 };
 

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -120,54 +120,6 @@ struct PD_INFER_DECL XpuConfig {
   std::map<std::string, int> quant_post_dynamic_weight_methods;
 };
 
-struct DistConfig {
-  bool use_dist_model() const { return use_dist_model_; }
-  void EnableDistModel(bool use_dist_model) {
-    use_dist_model_ = use_dist_model;
-  }
-
-  std::vector<std::string> trainer_endpoints() const {
-    return trainer_endpoints_;
-  }
-
-  std::string current_endpoint() const { return current_endpoint_; }
-
-  void SetEndpoints(const std::vector<std::string>& trainer_endpoints,
-                    const std::string& current_endpoint) {
-    trainer_endpoints_ = trainer_endpoints;
-    current_endpoint_ = current_endpoint;
-  }
-
-  int64_t nranks() const { return nranks_; }
-
-  int64_t rank() const { return rank_; }
-
-  void SetRanks(int64_t nranks, int64_t rank) {
-    nranks_ = nranks;
-    rank_ = rank;
-  }
-
-  std::string comm_init_config() const { return comm_init_config_; }
-
-  void SetCommInitConfig(const std::string& comm_init_config) {
-    comm_init_config_ = comm_init_config;
-  }
-
-  void SetCarrierId(const std::string& carrier_id) { carrier_id_ = carrier_id; }
-
-  std::string carrier_id() const { return carrier_id_; }
-
- protected:
-  // DistModel Inference related
-  bool use_dist_model_{false};  // whether use DistModel or not
-  std::vector<std::string> trainer_endpoints_{};  // all trainers' endpoints
-  std::string current_endpoint_{};                // current trainer's endpoint
-  int64_t nranks_{1};               // total ranks (number of trainers)
-  int64_t rank_{0};                 // rank
-  std::string comm_init_config_{};  // converter config path
-  std::string carrier_id_{"inference"};
-};
-
 ///
 /// \brief configuration manager for AnalysisPredictor.
 /// \since 1.7.0
@@ -1106,12 +1058,6 @@ struct PD_INFER_DECL AnalysisConfig {
   ///
   std::string Summary();
 
-  void SetDistConfig(const DistConfig& dist_config) {
-    dist_config_ = dist_config;
-  }
-
-  const DistConfig& dist_config() const { return dist_config_; }
-
   ///
   /// \brief Set a list of operators that do not support mixed precision. This
   /// interface is in the experimental stage and may change in the future. Note
@@ -1364,9 +1310,6 @@ struct PD_INFER_DECL AnalysisConfig {
   bool save_optimized_model_{false};
   std::string opt_cache_dir_;
   friend class paddle_infer::experimental::InternalUtils;
-
-  // fleet exe related
-  DistConfig dist_config_{};
 
   // jit engine related
   // NOTE(Aureliue84): In case of Predictor in JITLayer, program is from outer

--- a/paddle/fluid/inference/api/paddle_inference_api.h
+++ b/paddle/fluid/inference/api/paddle_inference_api.h
@@ -46,7 +46,6 @@ namespace paddle_infer {
 
 using PrecisionType = paddle::AnalysisConfig::Precision;
 using Config = paddle::AnalysisConfig;
-using DistConfig = paddle::DistConfig;
 using XpuConfig = paddle::XpuConfig;
 
 ///

--- a/paddle/fluid/inference/paddle_inference.map
+++ b/paddle/fluid/inference/paddle_inference.map
@@ -34,7 +34,6 @@
 			*paddle::PaddleTensor*;
 			*paddle::UpdateDllFlag*;
 			*paddle::MakeCipher*;
-			*paddle::DistConfig*;
 			*paddle::DefaultGPUPlace*;
 			*paddle::ResourceManager*;
 			*paddle::GPUContextResource*;

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -1018,24 +1018,7 @@ void BindAnalysisConfig(py::module *m) {
            py::arg("custom_pass_only") = false)
       .def("set_optimization_level",
            &AnalysisConfig::SetOptimizationLevel,
-           py::arg("opt_level") = 2)
-      .def("set_dist_config", &AnalysisConfig::SetDistConfig)
-      .def("dist_config", &AnalysisConfig::dist_config);
-
-  py::class_<DistConfig>(*m, "DistConfig")
-      .def(py::init<>())
-      .def("set_carrier_id", &DistConfig::SetCarrierId)
-      .def("set_comm_init_config", &DistConfig::SetCommInitConfig)
-      .def("set_endpoints", &DistConfig::SetEndpoints)
-      .def("set_ranks", &DistConfig::SetRanks)
-      .def("enable_dist_model", &DistConfig::EnableDistModel)
-      .def("carrier_id", &DistConfig::carrier_id)
-      .def("current_endpoint", &DistConfig::current_endpoint)
-      .def("trainer_endpoints", &DistConfig::trainer_endpoints)
-      .def("nranks", &DistConfig::nranks)
-      .def("rank", &DistConfig::rank)
-      .def("comm_init_config", &DistConfig::comm_init_config)
-      .def("use_dist_model", &DistConfig::use_dist_model);
+           py::arg("opt_level") = 2);
 }
 
 void BindXpuConfig(py::module *m) {

--- a/test/cpp/inference/api/analyzer_dist_model_xpu_tester.cc
+++ b/test/cpp/inference/api/analyzer_dist_model_xpu_tester.cc
@@ -30,11 +30,6 @@ TEST(test_dist_model_xpu, dist_model_xpu) {
                   FLAGS_infer_model + "/__params__");
   config.EnableXpu();
   config.SetXpuDeviceId(0);
-  DistConfig dist_config;
-  dist_config.SetRanks(1, 0);
-  dist_config.EnableDistModel(true);
-  dist_config.SetEndpoints({""}, "");
-  config.SetDistConfig(dist_config);
 
   auto predictor = paddle_infer::CreatePredictor(config);
   int batch_size = 1;

--- a/test/ir/inference/test_trt_c_allreduce_infer_script.py
+++ b/test/ir/inference/test_trt_c_allreduce_infer_script.py
@@ -19,7 +19,6 @@ import tempfile
 import numpy as np
 
 import paddle
-from paddle.base import core
 from paddle.distributed import fleet
 from paddle.inference import Config, PrecisionType, create_predictor
 
@@ -66,12 +65,6 @@ def run(op_type, precision):
     current_endpoint = "127.0.0.1:600" + str(fleet.worker_index())
     trainer_endpoints = ["127.0.0.1:6000", "127.0.0.1:6001"]
 
-    dist_config = core.DistConfig()
-    dist_config.set_carrier_id("inference")
-    dist_config.set_endpoints(trainer_endpoints, current_endpoint)
-    dist_config.set_ranks(nranks, fleet.worker_index())
-    dist_config.enable_dist_model(True)
-
     with tempfile.TemporaryDirectory(prefix="allreduce_") as tmpdir:
         paddle.static.save_inference_model(
             os.path.join(tmpdir, "model"),
@@ -86,7 +79,6 @@ def run(op_type, precision):
         )
         config.enable_memory_optim()
         config.enable_use_gpu(1000, fleet.worker_index())
-        config.set_dist_config(dist_config)
         config.enable_tensorrt_engine(
             workspace_size=1 << 30,
             max_batch_size=1,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
Pcard-71500 
Use new executor instead of  fleetexe in Predictor for inference multi-gpus 

NOTE: config.dist_config is no longer in use.