### PR TITLE
【CINN】Bug fix in IterExpr

### DIFF
--- a/paddle/cinn/ir/schedule/factorize_reduction.h
+++ b/paddle/cinn/ir/schedule/factorize_reduction.h
@@ -139,9 +139,10 @@ class ReduceBlockCreater {
       bool is_rf_loop = rf_loop_.As<For>()->loop_var->name ==
                         original_loops_[i].As<For>()->loop_var->name;
       // Skip non rf reduction loops of write back block.
-      if (!is_rf_block_ && !is_spatial_loop && !is_rf_loop) {
-        continue;
-      }
+      // Author(liujinnan): Temporarily skip inspection.
+      // if (!is_rf_block_ && !is_spatial_loop && !is_rf_loop) {
+      //   continue;
+      // }
       // Add reduce init block.
       if (!has_add_init_block && is_spatial_loop && with_init) {
         body = Block::Make({new_init_block_realize_, body});

--- a/paddle/cinn/ir/schedule/factorize_reduction.h
+++ b/paddle/cinn/ir/schedule/factorize_reduction.h
@@ -132,17 +132,22 @@ class ReduceBlockCreater {
     std::vector<Expr> new_loops(num_loops);
     Expr body = new_update_block_realize_;
     bool has_add_init_block = false;
+    // `is_inside_rf_loop` is used to skip loop inside rf_loop.
+    bool is_inside_rf_loop = true;
     for (int i = num_loops - 1; i >= 0; --i) {
       bool is_spatial_loop =
           new_spatial_loop_var_names_.count(
               original_loops_[i].As<For>()->loop_var->name) > 0;
       bool is_rf_loop = rf_loop_.As<For>()->loop_var->name ==
                         original_loops_[i].As<For>()->loop_var->name;
+      // Outter loop should not skip.
+      if (is_rf_loop) {
+        is_inside_rf_loop = false;
+      }
       // Skip non rf reduction loops of write back block.
-      // Author(liujinnan): Temporarily skip inspection.
-      // if (!is_rf_block_ && !is_spatial_loop && !is_rf_loop) {
-      //   continue;
-      // }
+      if (!is_rf_block_ && is_inside_rf_loop && !is_spatial_loop) {
+        continue;
+      }
       // Add reduce init block.
       if (!has_add_init_block && is_spatial_loop && with_init) {
         body = Block::Make({new_init_block_realize_, body});

--- a/paddle/cinn/optim/ir_simplify.cc
+++ b/paddle/cinn/optim/ir_simplify.cc
@@ -474,6 +474,7 @@ void Simplify(Expr* expr) {
   mutator(expr);
 
   ReplaceFracWithDivMutator()(expr);
+  VLOG(3) << "End Simplify " << *expr;
 }
 
 void SimplifyCast(Expr* expr) { SimplifyCastMutator()(expr); }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
fix bug:
```
InvalidArgumentError: Dividend can't be written as a single fused IterSum
```

Pcard-67164