### PR TITLE
Only ResultDataType of type flaot is processed in AMP.

### DIFF
--- a/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
@@ -408,21 +408,7 @@ class AutoMixedPrecisionPass : public pir::Pass {
     auto type = result.type();
     if (type.isa<paddle::dialect::DenseTensorType>()) {
       auto dense_type = type.dyn_cast<paddle::dialect::DenseTensorType>();
-      auto new_type = paddle::dialect::DenseTensorType::get(
-          context,
-          paddle::dialect::TransToIrDataType(precision, context),
-          dense_type.dims(),
-          dense_type.data_layout(),
-          dense_type.lod(),
-          dense_type.offset());
-      result.set_type(new_type);
-    } else if (type.isa<pir::VectorType>()) {
-      auto vec_type = type.dyn_cast<pir::VectorType>();
-      auto output_num = vec_type.size();
-      std::vector<pir::Type> results_type(output_num);
-      for (size_t idx = 0; idx < output_num; ++idx) {
-        auto dense_type =
-            vec_type[idx].dyn_cast<paddle::dialect::DenseTensorType>();
+      if (IsDenseTensorTypeFloat(dense_type)) {
         auto new_type = paddle::dialect::DenseTensorType::get(
             context,
             paddle::dialect::TransToIrDataType(precision, context),
@@ -430,7 +416,27 @@ class AutoMixedPrecisionPass : public pir::Pass {
             dense_type.data_layout(),
             dense_type.lod(),
             dense_type.offset());
-        results_type[idx] = new_type;
+        result.set_type(new_type);
+      }
+    } else if (type.isa<pir::VectorType>()) {
+      auto vec_type = type.dyn_cast<pir::VectorType>();
+      auto output_num = vec_type.size();
+      std::vector<pir::Type> results_type(output_num);
+      for (size_t idx = 0; idx < output_num; ++idx) {
+        auto dense_type =
+            vec_type[idx].dyn_cast<paddle::dialect::DenseTensorType>();
+        if (IsDenseTensorTypeFloat(dense_type)) {
+          auto new_type = paddle::dialect::DenseTensorType::get(
+              context,
+              paddle::dialect::TransToIrDataType(precision, context),
+              dense_type.dims(),
+              dense_type.data_layout(),
+              dense_type.lod(),
+              dense_type.offset());
+          results_type[idx] = new_type;
+        } else {
+          results_type[idx] = dense_type;
+        }
       }
       auto new_vec_type = pir::VectorType::get(context, results_type);
       result.set_type(new_vec_type);
@@ -794,14 +800,6 @@ class AutoMixedPrecisionPass : public pir::Pass {
               {4, "saved_variance"}}},
             {"pd_op.layer_norm", {{1, "mean"}, {2, "variance"}}},
             {"pd_op.instance_norm", {{1, "mean"}, {2, "variance"}}}};
-
-    if (op->name() == "pd_op.clip") {
-      pir::Value input_value = op->operand_source(0);
-      pir::Type input_dtype = pir::GetDataTypeFromValue(input_value);
-      if (!input_dtype.isa<pir::Float32Type>()) {
-        return true;
-      }
-    }
 
     auto it = op_output_indices.find(op->name());
     if (it != op_output_indices.end()) {

--- a/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
@@ -795,6 +795,14 @@ class AutoMixedPrecisionPass : public pir::Pass {
             {"pd_op.layer_norm", {{1, "mean"}, {2, "variance"}}},
             {"pd_op.instance_norm", {{1, "mean"}, {2, "variance"}}}};
 
+    if (op->name() == "pd_op.clip") {
+      pir::Value input_value = op->operand_source(0);
+      pir::Type input_dtype = pir::GetDataTypeFromValue(input_value);
+      if (!input_dtype.isa<pir::Float32Type>()) {
+        return true;
+      }
+    }
+
     auto it = op_output_indices.find(op->name());
     if (it != op_output_indices.end()) {
       const auto& index_pairs = it->second;


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
Fix bug caused by AMP before moving to CINN. The DenseTensorType of the Value to be converted is 16 only if it is a float type.
![image](https://github.com/user-attachments/assets/c4accf4c-41c0-4391-83e2-45842989f52f)

Pcard-67164