### PR TITLE
[Dy2St] cuda_pinned_tensors_move_to_excepted_place move to C++

### DIFF
--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -63,7 +63,6 @@ from .utils import (
     NO_SHAPE_VAR_TYPE,
     ast_to_func,
     backend_guard,
-    cuda_pinned_tensors_move_to_excepted_place,
     func_to_source_code,
     input_specs_compatible,
     is_paddle_func,
@@ -783,7 +782,9 @@ class SymbolicStaticFunction(StaticFunction):
         from ..sot import symbolic_translate
 
         args, kwargs = self._function_spec.unified_args_and_kwargs(args, kwargs)
-        cuda_pinned_tensors_move_to_excepted_place(args)
+        if isinstance(args, dict):
+            args = flatten(args)
+        core.eager.cuda_pinned_tensors_move_to_excepted_place(args)
 
         (
             input_args_with_spec,

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -783,6 +783,6 @@ def cuda_pinned_tensors_move_to_excepted_place(inputs):
                 and value.stop_gradient
                 and value.place._equals(cuda_pinned_place)
             ):
-                var = value._copy_to(expected_place, True)
+                var = value._copy_to(expected_place, False)
                 var.stop_gradient = True
                 var._share_buffer_to(value)

--- a/test/dygraph_to_static/test_move_cuda_pinned_tensor.py
+++ b/test/dygraph_to_static/test_move_cuda_pinned_tensor.py
@@ -15,9 +15,6 @@
 import unittest
 
 import paddle
-from paddle.jit.dy2static.utils import (
-    cuda_pinned_tensors_move_to_excepted_place,
-)
 
 
 class TestCopyCudaPinnedTensors(unittest.TestCase):
@@ -33,7 +30,7 @@ class TestCopyCudaPinnedTensors(unittest.TestCase):
                 [1, 2, 3], place=paddle.CUDAPinnedPlace(), stop_gradient=True
             )
 
-            cuda_pinned_tensors_move_to_excepted_place(x)
+            paddle.base.core.eager.cuda_pinned_tensors_move_to_excepted_place(x)
             assert not x.place._equals(cuda_pinned_place)
 
             y = {
@@ -51,7 +48,9 @@ class TestCopyCudaPinnedTensors(unittest.TestCase):
                     )
                 },
             }
-            cuda_pinned_tensors_move_to_excepted_place(y)
+            paddle.base.core.eager.cuda_pinned_tensors_move_to_excepted_place(
+                paddle.utils.flatten(y)
+            )
             for var in paddle.utils.flatten(y):
                 if isinstance(var, paddle.Tensor):
                     assert not var.place._equals(cuda_pinned_place)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance 

### Description
<!-- Describe what you’ve done -->

Python端的cuda_pinned_tensors_move_to_excepted_place耗时严重，将其下沉到C++，并将blocking改为false。

使用helixfold APB子图做性能分析，cuda_pinned_tensors_move_to_excepted_place的耗时占比为5.84%：
![1732690074394](https://github.com/user-attachments/assets/9e074566-8113-49b1-9198-b4e4f7e97e85)


下沉到C++后耗时占比为：0.23%

Pcard-67164