### PR TITLE
[CINN]clear module optimize pass

### DIFF
--- a/paddle/cinn/ir/module.cc
+++ b/paddle/cinn/ir/module.cc
@@ -100,8 +100,6 @@ Module Module::Builder::Build() {
   }
 
   auto res = ir::Module(module_.get());
-
-  res = optim::Optimize(res, module_->target);
   return res;
 }
 

--- a/paddle/cinn/optim/lower_intrin.h
+++ b/paddle/cinn/optim/lower_intrin.h
@@ -37,7 +37,7 @@ static const std::set<std::string> kIntrinsicCalls{
  *
  * Notes: only support cpu currently.
  */
-void LowerIntrin(ir::Module m, Target target);
+void LowerIntrin(ir::Expr *expr, Target target);
 
 }  // namespace optim
 }  // namespace cinn

--- a/paddle/cinn/optim/optimize.cc
+++ b/paddle/cinn/optim/optimize.cc
@@ -112,19 +112,10 @@ ir::LoweredFunc Optimize(ir::LoweredFunc fn,
   Simplify(&copied->body);
   VLOG(10) << "After Optimize Simplify" << copied;
 
-  return copied;
-}
-
-ir::Module Optimize(const ir::Module& module, const Target& target) {
-  auto copied = ir::ir_utils::IRCopy(module);
-
-  RemoveScheduleBlock(copied);
+  RemoveScheduleBlock(&copied->body);
   VLOG(10) << "After RemoveScheduleBlock:" << copied;
-  LowerFunctionCallBindVars(copied);
-  VLOG(10) << "After LowerFunctionCallBindVars:" << copied;
-  CallArgListToPodValue(copied);
-  VLOG(10) << "After CallArgListToPodValue:" << copied;
-  LowerIntrin(copied, target);
+
+  LowerIntrin(&copied->body, target);
   VLOG(10) << "After LowerIntrin:" << copied;
 
   return copied;

--- a/paddle/cinn/optim/remove_schedule_block.cc
+++ b/paddle/cinn/optim/remove_schedule_block.cc
@@ -23,7 +23,7 @@ namespace cinn {
 namespace optim {
 
 struct ScheduleBlockRemover : public ir::IRMutator<Expr*> {
-  void operator()(ir::Module m) { IRMutator::Visit(m.As<ir::_Module_>()); }
+  void operator()(Expr* expr) { ir::IRMutator<ir::Expr*>::Visit(expr, expr); }
 
  private:
   void Visit(const ir::ScheduleBlockRealize* op, Expr* expr) override {
@@ -57,7 +57,7 @@ struct ScheduleBlockRemover : public ir::IRMutator<Expr*> {
   }
 };
 
-void RemoveScheduleBlock(ir::Module m) { ScheduleBlockRemover()(m); }
+void RemoveScheduleBlock(ir::Expr* expr) { ScheduleBlockRemover()(expr); }
 
 }  // namespace optim
 }  // namespace cinn

--- a/paddle/cinn/optim/remove_schedule_block.h
+++ b/paddle/cinn/optim/remove_schedule_block.h
@@ -27,7 +27,7 @@ namespace optim {
 /**
  * Remove schedule block.
  */
-void RemoveScheduleBlock(ir::Module m);
+void RemoveScheduleBlock(ir::Expr *expr);
 
 }  // namespace optim
 }  // namespace cinn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR clears some useless backend passes and move some passes from module optimize to function optimize as CINN does not have cross function optimization.