### PR TITLE
[SOT][3.13] fix get `frame.f_locals` segmentation fault

### DIFF
--- a/paddle/fluid/pybind/sot/cpython_internals.h
+++ b/paddle/fluid/pybind/sot/cpython_internals.h
@@ -40,7 +40,7 @@ static int Internal_PyFrame_OpAlreadyRan(_PyInterpreterFrame *frame,
                                          int opcode,
                                          int oparg);
 #if PY_3_13_PLUS
-PyObject *Internal_PyFrame_GetLocals(_PyInterpreterFrame *frame);
+PyObject *get_framelocals_mapping(_PyInterpreterFrame *frame);
 #else
 int Internal_PyFrame_FastToLocalsWithError(_PyInterpreterFrame *frame);
 #endif

--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -354,7 +354,7 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
   // _PyFrame_FastToLocalsWithError directly. But this is an internal API, so we
   // copy many code from CPython project into our project.
 #if PY_3_13_PLUS
-  PyObject *f_locals = Internal_PyFrame_GetLocals(frame);
+  PyObject *f_locals = get_framelocals_mapping(frame);
   if (f_locals == NULL) {
 #else
   if (Internal_PyFrame_FastToLocalsWithError(frame) < 0) {

--- a/test/sot/skip_files_py313
+++ b/test/sot/skip_files_py313
@@ -5,3 +5,4 @@ test/sot/test_break_graph.py
 test/sot/test_min_graph_size.py
 test/sot/test_numpy.py
 test/sot/test_resume_cache.py
+test/sot/test_simulate_initialize.py

--- a/test/sot/skip_files_py313
+++ b/test/sot/skip_files_py313
@@ -5,4 +5,3 @@ test/sot/test_break_graph.py
 test/sot/test_min_graph_size.py
 test/sot/test_numpy.py
 test/sot/test_resume_cache.py
-test/sot/test_simulate_initialize.py


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

* 修复获取`frame.f_locals` 段错误的情况 (`PyFrame_GetLocals` 只是返回了一个 proxy 结构， 而不是我们想要的 f_locals 的 variables)

### TODO
* closure 部分, 这里主要涉及到两个字节码`MAKE_FUNCTION` 和 `SET_FUNCTION_ATTRIBUTE`. 现在的问题是如果我要在 `MAKE_FUNCTION` 创建 func, 就会遇到 `ValueError: func1 requires closure of length 1, not 0` 因为 3.13 是在 `SET_FUNCTION_ATTRIBUTE` 设置 func 相关的属性。

* 部分单测在 debug 版本下会出现 assert 错误, 都是 `POP_JUMP_IF_FALSE` 中的 `assert(PyBool_Check(cond));`
	* test/sot/test_14_operators.py
	* test/sot/test_dtype.py
	* test/sot/test_inplace_api.py

### 相关链接
- #69246
- #69245
