### PR TITLE
[CINN] Set smaller size limit for local buffer

### DIFF
--- a/paddle/cinn/optim/eliminate_common_global_memory_read.cc
+++ b/paddle/cinn/optim/eliminate_common_global_memory_read.cc
@@ -191,7 +191,7 @@ struct GlobalTensorInfoCollector : public ir::IRMutator<Expr*> {
       VLOG(6) << "Total buffer size: " << size;
       common::cas_intervals_t var_intervals;
       common::SymbolicExprAnalyzer analyzer(var_intervals);
-      std::optional<bool> prove_gt = analyzer.ProveGT(size, ir::Expr(128));
+      std::optional<bool> prove_gt = analyzer.ProveGT(size, ir::Expr(8));
       return prove_gt.value_or(false);
     };
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Performance


### Description
`EliminateCommonGlobalMemoryRead`里面设置的 local buffer 的大小上限太大（128个元素），经常使得 local buffer 被溢出到全局内存，导致性能严重下降

这个PR暂时将上限改成8个元素观察效果，这是我在BatchNorm上实验发现让寄存器不溢出的最大值；这个pass的更优实现应该分析目标硬件的寄存器数量、配置的线程数、输入的变量数等来综合分析上限

另外，loop fusion 完成后，`EliminateCommonGlobalMemoryRead`的必要性将大大降低，因为很多缓存的需求就没有了，到时候可以更精细地研究这个pass的阈值设置

Pcard-85711