### PR TITLE
[SOT] Add dispatch for `min/max(*args)` and add `paddle.geometric` to paddle API list

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -1262,7 +1262,7 @@ def dispatch_min_star_args(*args: VariableBase):
     res = args[0]
     graph = res.graph
     for arg in args:
-        lt = BuiltinVariable(operator.gt, graph, DanglingTracker())(arg, res)
+        lt = BuiltinVariable(operator.lt, graph, DanglingTracker())(arg, res)
         if lt.get_py_value() is True:
             res = arg
     return res

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -1242,6 +1242,32 @@ Dispatcher.register(
 )
 
 
+@Dispatcher.register_decorator(max)
+def dispatch_max_star_args(*args: VariableBase):
+    if not args:
+        raise TypeError("max expected 1 arguments, got 0")
+    res = args[0]
+    graph = res.graph
+    for arg in args:
+        gt = BuiltinVariable(operator.gt, graph, DanglingTracker())(arg, res)
+        if gt.get_py_value() is True:
+            res = arg
+    return res
+
+
+@Dispatcher.register_decorator(min)
+def dispatch_min_star_args(*args: VariableBase):
+    if not args:
+        raise TypeError("min expected 1 arguments, got 0")
+    res = args[0]
+    graph = res.graph
+    for arg in args:
+        lt = BuiltinVariable(operator.gt, graph, DanglingTracker())(arg, res)
+        if lt.get_py_value() is True:
+            res = arg
+    return res
+
+
 # math functions, e.g. math.log, math.sqrt, math.sin, etc.
 def get_math_unary_functions():
     unary_fns = []

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -1245,7 +1245,7 @@ Dispatcher.register(
 @Dispatcher.register_decorator(max)
 def dispatch_max_star_args(*args: VariableBase):
     if not args:
-        raise TypeError("max expected 1 arguments, got 0")
+        raise TypeError("max expected at least 1 arguments, got 0")
     res = args[0]
     graph = res.graph
     for arg in args:
@@ -1258,7 +1258,7 @@ def dispatch_max_star_args(*args: VariableBase):
 @Dispatcher.register_decorator(min)
 def dispatch_min_star_args(*args: VariableBase):
     if not args:
-        raise TypeError("min expected 1 arguments, got 0")
+        raise TypeError("min expected at least 1 arguments, got 0")
     res = args[0]
     graph = res.graph
     for arg in args:

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
@@ -410,7 +410,7 @@ class ListVariable(ContainerVariable):
 
     def min(self):
         if len(self) == 0:
-            raise ValueError("max() arg is an empty sequence")
+            raise ValueError("min() arg is an empty sequence")
         res = self[0]
         getitem = BuiltinVariable(
             operator.getitem, self.graph, DanglingTracker()

--- a/python/paddle/jit/sot/utils/paddle_api_config.py
+++ b/python/paddle/jit/sot/utils/paddle_api_config.py
@@ -116,7 +116,7 @@ break_graph_tensor_method = {
     # TODO: Browse all possible functions and make prior judgments.
 }
 
-not_supported_paddle_layer = {paddle.nn.RNN, paddle.nn.Softmax}
+not_supported_paddle_layer = {paddle.nn.RNN}
 
 
 def is_not_supported_paddle_layer(layer_class):

--- a/python/paddle/jit/sot/utils/paddle_api_config.py
+++ b/python/paddle/jit/sot/utils/paddle_api_config.py
@@ -48,6 +48,7 @@ def get_paddle_api():
         paddle.fft,
         paddle.vision.ops,
         paddle.metric,
+        paddle.geometric,
     ]
     special_paddle_apis = [paddle.tensor.fill_constant]
     non_operator_related_apis = [
@@ -115,7 +116,7 @@ break_graph_tensor_method = {
     # TODO: Browse all possible functions and make prior judgments.
 }
 
-not_supported_paddle_layer = {paddle.nn.RNN}
+not_supported_paddle_layer = {paddle.nn.RNN, paddle.nn.Softmax}
 
 
 def is_not_supported_paddle_layer(layer_class):

--- a/test/sot/test_builtin_dispatch.py
+++ b/test/sot/test_builtin_dispatch.py
@@ -115,6 +115,16 @@ def test_ord(x: str):
 
 
 @check_no_breakgraph
+def test_min():
+    return min(9, 8, 2, 4, 1, 7, 3, 5, 6)
+
+
+@check_no_breakgraph
+def test_max():
+    return max(9, 8, 2, 4, 1, 7, 3, 5, 6)
+
+
+@check_no_breakgraph
 def test_sqrt(x: int):
     return math.sqrt(x)
 
@@ -258,6 +268,12 @@ class TestBuiltinDispatch(TestCaseBase):
 
     def test_dispatch_log(self):
         self.assert_results(test_log, math.e)
+
+    def test_dispatch_min(self):
+        self.assert_results(test_min)
+
+    def test_dispatch_max(self):
+        self.assert_results(test_max)
 
 
 def run_getattr(x: paddle.Tensor):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

- SOT 添加 `min/max(*args)` 形式的 dispatch，避免打断
- 将 `paddle.geometric` 模块添加到组网模块，避免模拟到 `_C_ops` 层导致打断

PCard-66972