### PR TITLE
`histogram/histogram_bin_edges` support float `min/max` 易用性提升

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
@@ -1088,8 +1088,8 @@ bool HistogramOpInferSymbolicShape(
   const symbol::ShapeOrDataDimExprs &input_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   int64_t bins = op->attribute<pir::Int64Attribute>("bins").data();
-  int min = op->attribute<pir::Int32Attribute>("min").data();
-  int max = op->attribute<pir::Int32Attribute>("max").data();
+  float min = op->attribute<pir::FloatAttribute>("min").data();
+  float max = op->attribute<pir::FloatAttribute>("max").data();
   PADDLE_ENFORCE_GE(bins,
                     1,
                     common::errors::InvalidArgument(
@@ -1100,7 +1100,7 @@ bool HistogramOpInferSymbolicShape(
       max,
       min,
       common::errors::InvalidArgument("max must be larger or equal to min."
-                                      "But received max is %d, min is %d",
+                                      "But received max is %f, min is %f",
                                       max,
                                       min));
   if (op->operand_source(1)) {

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -2257,8 +2257,8 @@ void HingeLossInferMeta(const MetaTensor& logits,
 void HistogramInferMeta(const MetaTensor& input,
                         const MetaTensor& weight,
                         int64_t bins,
-                        int min,
-                        int max,
+                        float min,
+                        float max,
                         bool density,
                         MetaTensor* out) {
   PADDLE_ENFORCE_GE(bins,
@@ -2271,7 +2271,7 @@ void HistogramInferMeta(const MetaTensor& input,
       max,
       min,
       common::errors::InvalidArgument("max must be larger or equal to min."
-                                      "But received max is %d, min is %d",
+                                      "But received max is %f, min is %f",
                                       max,
                                       min));
   if (weight) {

--- a/paddle/phi/infermeta/binary.h
+++ b/paddle/phi/infermeta/binary.h
@@ -418,8 +418,8 @@ void HingeLossInferMeta(const MetaTensor& logits,
 void HistogramInferMeta(const MetaTensor& input,
                         const MetaTensor& weight,
                         int64_t bins,
-                        int min,
-                        int max,
+                        float min,
+                        float max,
                         bool density,
                         MetaTensor* out);
 

--- a/paddle/phi/kernels/cpu/histogram_kernel.cc
+++ b/paddle/phi/kernels/cpu/histogram_kernel.cc
@@ -26,8 +26,8 @@ void HistogramKernel(const Context& dev_ctx,
                      const DenseTensor& input,
                      const paddle::optional<DenseTensor>& weight,
                      int64_t bins,
-                     int min,
-                     int max,
+                     float min,
+                     float max,
                      bool density,
                      DenseTensor* output) {
   auto& nbins = bins;

--- a/paddle/phi/kernels/gpu/histogram_kernel.cu
+++ b/paddle/phi/kernels/gpu/histogram_kernel.cu
@@ -140,8 +140,8 @@ void HistogramKernel(const Context& dev_ctx,
                      const DenseTensor& input,
                      const paddle::optional<DenseTensor>& weight,
                      int64_t bins,
-                     int min,
-                     int max,
+                     float min,
+                     float max,
                      bool density,
                      DenseTensor* output) {
   auto& nbins = bins;

--- a/paddle/phi/kernels/histogram_kernel.h
+++ b/paddle/phi/kernels/histogram_kernel.h
@@ -22,8 +22,8 @@ void HistogramKernel(const Context& dev_ctx,
                      const DenseTensor& input,
                      const paddle::optional<DenseTensor>& weight,
                      int64_t bins,
-                     int min,
-                     int max,
+                     float min,
+                     float max,
                      bool density,
                      DenseTensor* output);
 

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -2526,7 +2526,7 @@
   backward: hinge_loss_grad
 
 - op : histogram
-  args : (Tensor input, Tensor weight, int64_t bins = 100, int min = 0, int max = 0, bool density = false)
+  args : (Tensor input, Tensor weight, int64_t bins = 100, float min = 0.0, float max = 0.0, bool density = false)
   output : Tensor(out)
   infer_meta :
     func : HistogramInferMeta

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2483,8 +2483,8 @@ def bmm(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
 def histogram(
     input: Tensor,
     bins: int = 100,
-    min: int = 0,
-    max: int = 0,
+    min: float = 0.0,
+    max: float = 0.0,
     weight: Tensor | None = None,
     density: bool = False,
     name: str | None = None,
@@ -2497,8 +2497,8 @@ def histogram(
         input (Tensor): A Tensor with shape :math:`[N_1, N_2,..., N_k]` . The data type of the input Tensor
             should be float32, float64, int32, int64.
         bins (int, optional): number of histogram bins. Default: 100.
-        min (int, optional): lower end of the range (inclusive). Default: 0.
-        max (int, optional): upper end of the range (inclusive). Default: 0.
+        min (float, optional): lower end of the range (inclusive). Default: 0.0.
+        max (float, optional): upper end of the range (inclusive). Default: 0.0.
         weight (Tensor, optional): If provided, it must have the same shape as input. Each value in input contributes its associated
             weight towards the bin count (instead of 1). Default: None.
         density (bool, optional): If False, the result will contain the count (or total weight) in each bin. If True, the result is the
@@ -2519,6 +2519,11 @@ def histogram(
             Tensor(shape=[4], dtype=int64, place=Place(cpu), stop_gradient=True,
             [0, 2, 1, 0])
     """
+    if isinstance(min, int):
+        min = float(min)
+    if isinstance(max, int):
+        max = float(max)
+
     if in_dynamic_or_pir_mode():
         return _C_ops.histogram(input, weight, bins, min, max, density)
     else:
@@ -2560,8 +2565,8 @@ def histogram(
 def histogram_bin_edges(
     input: Tensor,
     bins: int = 100,
-    min: int = 0,
-    max: int = 0,
+    min: float = 0.0,
+    max: float = 0.0,
     name: str | None = None,
 ) -> Tensor:
     """
@@ -2571,8 +2576,8 @@ def histogram_bin_edges(
     Args:
         input (Tensor): The data type of the input Tensor should be float32, float64, int32, int64.
         bins (int, optional): number of histogram bins.
-        min (int, optional): lower end of the range (inclusive). Default: 0.
-        max (int, optional): upper end of the range (inclusive). Default: 0.
+        min (float, optional): lower end of the range (inclusive). Default: 0.0.
+        max (float, optional): upper end of the range (inclusive). Default: 0.0.
         name (str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
 
     Returns:
@@ -2589,6 +2594,11 @@ def histogram_bin_edges(
             Tensor(shape=[5], dtype=float32, place=Place(cpu), stop_gradient=True,
             [0.        , 0.75000000, 1.50000000, 2.25000000, 3.        ])
     """
+    if isinstance(min, int):
+        min = float(min)
+    if isinstance(max, int):
+        max = float(max)
+
     check_type(input, 'input', (Variable), 'histogram_bin_edges')
     check_dtype(
         input.dtype,
@@ -2597,13 +2607,13 @@ def histogram_bin_edges(
         'histogram_bin_edges',
     )
     check_type(bins, 'bins', int, 'histogram_bin_edges')
-    if max == 0 and min == 0:
+    if max == 0.0 and min == 0.0:
         min = paddle.min(input)
         max = paddle.max(input)
     else:
         if max < min:
             raise ValueError("max must be larger than min in range parameter")
-    if (min - max) == 0:
+    if (min - max) == 0.0:
         max = max + 0.5
         min = min - 0.5
     return paddle.linspace(min, max, bins + 1, name=name)

--- a/test/legacy_test/test_histogram_bin_edges_op.py
+++ b/test/legacy_test/test_histogram_bin_edges_op.py
@@ -62,5 +62,15 @@ class TestHistogramBinEdgesOpTest1(TestHistogramBinEdgesOp):
         )
 
 
+class TestHistogramBinEdgesOpTest2(TestHistogramBinEdgesOp):
+    def setUp(self):
+        self.x = np.random.randn(5, 20).astype('float32')
+        self.bin = 10
+        self.range = (0.2, 0.9)
+        self.out = np.histogram_bin_edges(
+            self.x, bins=self.bin, range=self.range
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_histogram_op.py
+++ b/test/legacy_test/test_histogram_op.py
@@ -108,7 +108,7 @@ class TestHistogramOpError(unittest.TestCase):
             )
             paddle.histogram(input=input_value, bins=1, min=-np.inf, max=5)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             self.run_network(net_func)
 
     def test_input_range_error(self):
@@ -298,6 +298,16 @@ class TestHistogramOp_ZeroDim(TestHistogram):
         self.bins = 5
         self.min = 1
         self.max = 5
+        self.density = False
+        self.is_weight = False
+
+
+class TestHistogramOpAPIWithFloatminMax(TestHistogram):
+    def init_test_case(self):
+        self.in_shape = (10, 12)
+        self.bins = 4
+        self.min = 2.2
+        self.max = 4.5
         self.density = False
         self.is_weight = False
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
min/max 参数支持 float 类型。
另外对于输出类型和 torch 不一致的问题，要修改则存在不兼容问题，而且感觉 paddle 的输出类型更合理一些，所以建议改一下api的转换策略。