### PR TITLE
add cf.stack_create、cf.tuple_push op to always_forward_ops

### DIFF
--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -8468,7 +8468,12 @@ def auto_complete_op_role(program, op_role):
         yield
     finally:
         if paddle.framework.in_pir_mode() and is_dist_block(block):
-            always_forward_ops = ["pd_op.data", "builtin.parameter"]
+            always_forward_ops = [
+                "pd_op.data",
+                "builtin.parameter",
+                "cf.stack_create",
+                "cf.tuple_push",
+            ]
             set_op_roles(block, op_role, always_forward_ops)
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
add cf.stack_create、cf.tuple_push op to always_forward_ops

### Other
Pcard-67164