### PR TITLE
[CINN] refine create_array and array_write_ infersymbolicshape

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -1506,7 +1506,7 @@ bool CreateArrayOp::InferSymbolicShape(
   } else {
     // If empty array(Value)'s dims is changed by array_write_, we can use it.
     std::vector<symbol::DimExpr> shape_hints;
-    for (size_t i = 0; i < out_dims.size(); ++i) {
+    for (int i = 0; i < out_dims.size(); ++i) {
       int dim = out_dims[i];
       if (dim > 0) {
         shape_hints.push_back(dim);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- refine create_array and array_write_ infersymbolicshape
- create_array
  ```
  
  ```
- array_write_
  ```

  ```