### PR TITLE
[SOT][3.11] Fix `gen_dup_top` generated `COPY` instruction with wrong oparg setting

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -899,7 +899,7 @@ class PyCodeGen:
 
     def gen_dup_top(self):
         if sys.version_info >= (3, 11):
-            return self.add_instr("COPY", arg=0)
+            return self.add_instr("COPY", arg=1)
         return self.add_instr("DUP_TOP")
 
     def gen_swap(self, n):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 #68938 中的 COPY arg 错误
