### PR TITLE
[Dy2st] Temporarily add actual functional ops to blacklist for SOT to trace down, enhancing trace ability. 

### DIFF
--- a/python/paddle/jit/sot/utils/paddle_api_config.py
+++ b/python/paddle/jit/sot/utils/paddle_api_config.py
@@ -116,7 +116,14 @@ break_graph_tensor_method = {
     # TODO: Browse all possible functions and make prior judgments.
 }
 
-not_supported_paddle_layer = {paddle.nn.RNN}
+not_supported_paddle_layer = {
+    paddle.nn.RNN,
+    paddle.nn.LayerNorm,
+    paddle.nn.Softmax,
+    paddle.nn.Linear,
+    paddle.nn.Dropout,
+    paddle.nn.AlphaDropout,
+}
 
 
 def is_not_supported_paddle_layer(layer_class):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
 Improvements

### Description
<!-- Describe what you’ve done -->
Temporarily add actual functional ops to blacklist for SOT to trace down, enhancing trace ability. In case of Helixfold3, it can make SOT able to reuse subgraphs that contains pure functional ops.

It is possible that this blacklist need further augmentations

pcard-76996