### PR TITLE
Fix compilation issue with gcc13 on cpu

### DIFF
--- a/cmake/external/brpc.cmake
+++ b/cmake/external/brpc.cmake
@@ -48,6 +48,13 @@ set(prefix_path
     "${THIRD_PARTY_PATH}/install/gflags|${THIRD_PARTY_PATH}/install/leveldb|${THIRD_PARTY_PATH}/install/snappy|${THIRD_PARTY_PATH}/install/gtest|${THIRD_PARTY_PATH}/install/protobuf|${THIRD_PARTY_PATH}/install/zlib|${THIRD_PARTY_PATH}/install/glog"
 )
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION}
+                                            VERSION_GREATER_EQUAL 13.0)
+  file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/brpc/http2.h.patch
+       http2_h_patch)
+  set(BRPC_PATCH_COMMAND_GCC13 git apply ${http2_h_patch})
+endif()
+
 # If minimal .a is need, you can set  WITH_DEBUG_SYMBOLS=OFF
 ExternalProject_Add(
   extern_brpc
@@ -55,6 +62,9 @@ ExternalProject_Add(
   SOURCE_DIR ${BRPC_SOURCE_DIR}
   PREFIX ${BRPC_PREFIX_DIR}
   UPDATE_COMMAND ""
+  PATCH_COMMAND
+  COMMAND git checkout -- . && git checkout ${BRPC_TAG}
+  COMMAND ${BRPC_PATCH_COMMAND_GCC13}
   CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
              -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
              -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}

--- a/patches/brpc/http2.h.patch
+++ b/patches/brpc/http2.h.patch
@@ -1,0 +1,12 @@
+diff --git a/src/brpc/http2.h b/src/brpc/http2.h
+index 9a40d40d..5da47e60 100644
+--- a/src/brpc/http2.h
++++ b/src/brpc/http2.h
+@@ -19,6 +19,7 @@
+ #define BAIDU_RPC_HTTP2_H
+ 
+ #include "brpc/http_status_code.h"
++#include <cstdint>
+ 
+ // To baidu-rpc developers: This is a header included by user, don't depend
+ // on internal structures, use opaque pointers instead.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
OS: ubuntu20.04
GCC: 13.1.0
fix compilation issue with gcc13 on cpu
add one patch to third_party/brpc
pcard-67164