### PR TITLE
[CINN] Add fusion result loop alignment check

### DIFF
--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
@@ -1041,6 +1041,25 @@ ir::Expr ReshapeLoop(const ir::Expr& root,
   return copied;
 }
 
+bool CheckLoopAlignment(const std::vector<ir::Expr>& roots) {
+  if (roots.size() < 2) {
+    return true;
+  }
+  const auto base_loop_vars = GetAllLoopVars(roots[0]);
+  for (size_t i = 1; i < roots.size(); ++i) {
+    const auto loop_vars = GetAllLoopVars(roots[i]);
+    bool loop_equal = fusion::VectorEqual(
+        base_loop_vars, loop_vars, [](const ir::Var& lhs, const ir::Var& rhs) {
+          return lhs->upper_bound == rhs->upper_bound &&
+                 lhs->lower_bound == rhs->lower_bound;
+        });
+    if (!loop_equal) {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace trivial_fusion_detail
 }  // namespace pir
 }  // namespace framework

--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
@@ -1061,8 +1061,12 @@ void CheckLoopAlignment(const std::vector<ir::Expr>& roots) {
   if (roots.size() < 2) return;
 
   auto var_equal = [](const ir::Var& lhs, const ir::Var& rhs) {
-    return lhs->upper_bound == rhs->upper_bound &&
-           lhs->lower_bound == rhs->lower_bound;
+    auto index_equal = [](const ir::Expr& lhs, const ir::Expr& rhs) -> bool {
+      return lhs.is_index() && rhs.is_index() ? lhs.as_index() == rhs.as_index()
+                                              : lhs == rhs;
+    };
+    return index_equal(lhs->upper_bound, rhs->upper_bound) &&
+           index_equal(lhs->lower_bound, rhs->lower_bound);
   };
 
   int base_loop_idx = -1;

--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.h
@@ -301,7 +301,7 @@ ir::Expr ReshapeLoop(const ir::Expr& root,
                      const std::vector<symbol::DimExpr>& in_shape,
                      const std::vector<symbol::DimExpr>& out_shape);
 
-bool CheckLoopAlignment(const std::vector<ir::Expr>& roots);
+void CheckLoopAlignment(const std::vector<ir::Expr>& roots);
 
 }  // namespace trivial_fusion_detail
 }  // namespace pir

--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.h
@@ -301,6 +301,8 @@ ir::Expr ReshapeLoop(const ir::Expr& root,
                      const std::vector<symbol::DimExpr>& in_shape,
                      const std::vector<symbol::DimExpr>& out_shape);
 
+bool CheckLoopAlignment(const std::vector<ir::Expr>& roots);
+
 }  // namespace trivial_fusion_detail
 }  // namespace pir
 }  // namespace framework

--- a/paddle/cinn/operator_fusion/fusion_interface.cc
+++ b/paddle/cinn/operator_fusion/fusion_interface.cc
@@ -39,6 +39,13 @@ std::vector<ir::Expr> OperationFusion(
       FusionInterpreter(fusion_tracker_ptr, ops, initialized_lowered_op);
   auto output = interpreter.Run();
 
+  PADDLE_ENFORCE(
+      cinn::hlir::framework::pir::trivial_fusion_detail::CheckLoopAlignment(
+          output),
+      ::common::errors::InvalidArgument(
+          "CheckLoopAlignment Failed for fusion result: \n%s",
+          cinn::utils::Join(output, "\n")));
+
   VLOG(4) << "Fusion Result: output size is " << output.size();
   for (const auto& expr : output) {
     VLOG(4) << expr;

--- a/paddle/cinn/operator_fusion/fusion_interface.cc
+++ b/paddle/cinn/operator_fusion/fusion_interface.cc
@@ -19,6 +19,7 @@
 #include "paddle/cinn/operator_fusion/fusion_tracker/interpreter.h"
 #include "paddle/cinn/operator_fusion/utils.h"
 
+COMMON_DECLARE_bool(enable_fusion_result_check);
 namespace cinn::fusion {
 
 std::vector<ir::Expr> OperationFusion(
@@ -39,7 +40,10 @@ std::vector<ir::Expr> OperationFusion(
       FusionInterpreter(fusion_tracker_ptr, ops, initialized_lowered_op);
   auto output = interpreter.Run();
 
-  cinn::hlir::framework::pir::trivial_fusion_detail::CheckLoopAlignment(output);
+  if (FLAGS_enable_fusion_result_check) {
+    cinn::hlir::framework::pir::trivial_fusion_detail::CheckLoopAlignment(
+        output);
+  }
 
   VLOG(4) << "Fusion Result: output size is " << output.size();
   for (const auto& expr : output) {

--- a/paddle/cinn/operator_fusion/fusion_interface.cc
+++ b/paddle/cinn/operator_fusion/fusion_interface.cc
@@ -39,12 +39,7 @@ std::vector<ir::Expr> OperationFusion(
       FusionInterpreter(fusion_tracker_ptr, ops, initialized_lowered_op);
   auto output = interpreter.Run();
 
-  PADDLE_ENFORCE(
-      cinn::hlir::framework::pir::trivial_fusion_detail::CheckLoopAlignment(
-          output),
-      ::common::errors::InvalidArgument(
-          "CheckLoopAlignment Failed for fusion result: \n%s",
-          cinn::utils::Join(output, "\n")));
+  cinn::hlir::framework::pir::trivial_fusion_detail::CheckLoopAlignment(output);
 
   VLOG(4) << "Fusion Result: output size is " << output.size();
   for (const auto& expr : output) {

--- a/paddle/cinn/operator_fusion/utils.h
+++ b/paddle/cinn/operator_fusion/utils.h
@@ -139,6 +139,27 @@ std::vector<T> FilterVector(const std::vector<T>& first, const F& func) {
   return result;
 }
 
+template <typename T, typename F = std::function<bool(T, T)>>
+bool VectorEqual(const std::vector<T>& first,
+                 const std::vector<T>& second,
+                 const F& func = nullptr) {
+  if (first.size() != second.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < first.size(); ++i) {
+    if (func) {
+      if (!func(first[i], second[i])) {
+        return false;
+      }
+    } else {
+      if (first[i] != second[i]) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 template <class A, class B>
 std::vector<B> MapVector(const std::vector<A>& as,
                          const std::function<B(A)>& func) {

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1370,6 +1370,16 @@ PHI_DEFINE_EXPORTED_bool(enable_fusion_fallback,
                          "Whether enable fallback fusion ops in cinn.");
 
 /**
+ * CINN fusion result check FLAG
+ * Name: FLAGS_enable_fusion_result_check
+ * Since Version: 3.0 beta
+ * Value Range: bool, default=false
+ */
+PHI_DEFINE_EXPORTED_bool(enable_fusion_result_check,
+                         false,
+                         "Whether enable fusion result check in cinn.");
+
+/**
  * CINN TransposeItesr transform fusion FLAG
  * Name: FLAGS_enable_transpose_iters_in_fusion
  * Since Version: 3.0 beta

--- a/test/cpp/pir/shape_dialect/constraints_manager_test.cc
+++ b/test/cpp/pir/shape_dialect/constraints_manager_test.cc
@@ -61,4 +61,18 @@ TEST(ConstraintsManager, BroadcastableCstr) {
   ASSERT_TRUE(cstr_mgr.IsBroadcastable(sym_expr_0, int_expr));
 }
 
+TEST(ConstraintsManager, Case1) {
+  // BC(S0, S1) == S2 => BC(S0, S2) == S2
+  ConstraintsManager cstr_mgr;
+  DimExpr s0 = DimExpr("S0");
+  DimExpr s1 = DimExpr("S1");
+  DimExpr s2 = DimExpr("S2");
+  DimExpr bc_s0_s1 = Broadcast<DimExpr>{{s0, s1}};
+  cstr_mgr.AddEqCstr(bc_s0_s1, s2);
+  cstr_mgr.AddBroadcastableCstr(s0, s1);
+  DimExpr bc_s0_s2 = Broadcast<DimExpr>{{s0, s2}};
+  cstr_mgr.AddBroadcastableCstr(s0, s2);
+  ASSERT_TRUE(cstr_mgr.IsEqual(bc_s0_s2, s2));
+}
+
 }  // namespace symbol::test


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- 添加 Fusion Result 循环对齐检查
- 该 PR 可能会导致一些模型报错，因此添加了 FLAGS_enable_fusion_result_check，默认关闭