### PR TITLE
[CINN / Fusion] Add reshape product equal check for ReshapeAlignOperation

### DIFF
--- a/paddle/cinn/operator_fusion/graph_transformer/matcher.h
+++ b/paddle/cinn/operator_fusion/graph_transformer/matcher.h
@@ -226,8 +226,20 @@ struct TransposeOpMatcher {
 
 struct ReshapeOpMatcher {
   bool operator()(const PatternGraph& graph, const PatternNodePtr& node) {
+    const auto check_shape_product_equal = [&]() -> bool {
+      auto iters_manager = graph.iters_fusion_policy()->iters_manager();
+      const auto in_shape =
+          iters_manager->GetValueSymbols(node->sink_op()->operand_source(0));
+      const auto out_shape =
+          iters_manager->GetValueSymbols(node->sink_op()->result(0));
+      const auto in_rank = in_shape.size();
+      const auto out_rank = out_shape.size();
+      return ShapeProductEqual(in_shape, out_shape, 0, in_rank, 0, out_rank);
+    };
+
     return node->ops().size() == 1 &&
-           node->sink_op()->name() == "cinn_op.reshape";
+           node->sink_op()->name() == "cinn_op.reshape" &&
+           check_shape_product_equal();
   }
 };
 

--- a/paddle/cinn/operator_fusion/graph_transformer/operation.h
+++ b/paddle/cinn/operator_fusion/graph_transformer/operation.h
@@ -319,23 +319,6 @@ struct ReshapeAlignInputOperation {
             *(node->fusion_iters().input_values.begin()));
     const auto output_iters = node->fusion_iters().loop_iters;
 
-    const auto input_shape =
-        graph->iters_fusion_policy()->iters_manager()->GetIterSymbols(
-            input_iters);
-    const auto output_shape =
-        graph->iters_fusion_policy()->iters_manager()->GetIterSymbols(
-            output_iters);
-
-    const auto in_rank = input_shape.size();
-    const auto out_rank = output_shape.size();
-    if (!ShapeProductEqual(
-            input_shape, output_shape, 0, in_rank, 0, out_rank)) {
-      VLOG(4) << "Skip ReshapeAlign because the shape product is not equal: "
-              << cinn::utils::Join(input_shape, ",") << " vs "
-              << cinn::utils::Join(output_shape, ",");
-      return;
-    }
-
     // Sink reshape
     MergeTrivialPatternOperation()(graph, node);
 
@@ -352,6 +335,12 @@ struct ReshapeAlignInputOperation {
         graph->iters_fusion_policy()->GetLoopDims(aligned_fusion_iters)));
     sinked_node->set_fusion_iters(aligned_fusion_iters);
 
+    const auto input_shape =
+        graph->iters_fusion_policy()->iters_manager()->GetIterSymbols(
+            input_iters);
+    const auto output_shape =
+        graph->iters_fusion_policy()->iters_manager()->GetIterSymbols(
+            output_iters);
     FusionInstrPtr instr = std::make_shared<ReshapeAlignInstr>(
         origin_id, output_shape, input_shape, sinked_node->id());
     sinked_node->AppendInstr(instr);

--- a/paddle/cinn/operator_fusion/graph_transformer/operation.h
+++ b/paddle/cinn/operator_fusion/graph_transformer/operation.h
@@ -319,6 +319,23 @@ struct ReshapeAlignInputOperation {
             *(node->fusion_iters().input_values.begin()));
     const auto output_iters = node->fusion_iters().loop_iters;
 
+    const auto input_shape =
+        graph->iters_fusion_policy()->iters_manager()->GetIterSymbols(
+            input_iters);
+    const auto output_shape =
+        graph->iters_fusion_policy()->iters_manager()->GetIterSymbols(
+            output_iters);
+
+    const auto in_rank = input_shape.size();
+    const auto out_rank = output_shape.size();
+    if (!ShapeProductEqual(
+            input_shape, output_shape, 0, in_rank, 0, out_rank)) {
+      VLOG(4) << "Skip ReshapeAlign because the shape product is not equal: "
+              << cinn::utils::Join(input_shape, ",") << " vs "
+              << cinn::utils::Join(output_shape, ",");
+      return;
+    }
+
     // Sink reshape
     MergeTrivialPatternOperation()(graph, node);
 
@@ -335,12 +352,6 @@ struct ReshapeAlignInputOperation {
         graph->iters_fusion_policy()->GetLoopDims(aligned_fusion_iters)));
     sinked_node->set_fusion_iters(aligned_fusion_iters);
 
-    const auto input_shape =
-        graph->iters_fusion_policy()->iters_manager()->GetIterSymbols(
-            input_iters);
-    const auto output_shape =
-        graph->iters_fusion_policy()->iters_manager()->GetIterSymbols(
-            output_iters);
     FusionInstrPtr instr = std::make_shared<ReshapeAlignInstr>(
         origin_id, output_shape, input_shape, sinked_node->id());
     sinked_node->AppendInstr(instr);

--- a/paddle/cinn/operator_fusion/pattern_graph.h
+++ b/paddle/cinn/operator_fusion/pattern_graph.h
@@ -55,7 +55,7 @@ class PatternGraph {
   }
   const std::vector<pir::Value>& outputs() const { return outputs_; }
   const PolicyManager& policy_manager() const { return policy_manager_; }
-  std::shared_ptr<ItersFusionPolicy> iters_fusion_policy() {
+  const std::shared_ptr<ItersFusionPolicy>& iters_fusion_policy() const {
     return policy_manager_.template GetPolicy<ItersFusionPolicy>();
   }
 

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.cc
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.cc
@@ -295,6 +295,11 @@ std::vector<symbol::DimExpr> FusionItersManager::GetIterSymbols(
   return result;
 }
 
+std::vector<symbol::DimExpr> FusionItersManager::GetValueSymbols(
+    const pir::Value& value) {
+  return GetIterSymbols(GetValueIters(value));
+}
+
 symbol::DimExpr FusionItersManager::GetReduceDimsProduct(
     const FusionItersSignature& sig) {
   symbol::DimExpr result = 1;

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.h
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/fusion_iters.h
@@ -52,6 +52,7 @@ struct FusionItersManager {
   std::vector<std::string> GetValueIters(const pir::Value& value);
   symbol::DimExpr GetIterSymbol(const std::string& iter);
   std::vector<symbol::DimExpr> GetIterSymbols(const FusionIters& iters);
+  std::vector<symbol::DimExpr> GetValueSymbols(const pir::Value& value);
   symbol::DimExpr GetReduceDimsProduct(const FusionItersSignature& sig);
 
   auto related_iters_map() const { return related_iters_; }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- Add reshape product equal check for ReshapeAlignOperation