### PR TITLE
[SOT] Add inline call codeobj to global guard

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
@@ -163,7 +163,8 @@ class OpcodeInlineExecutor(OpcodeExecutorBase):
         self._fn_var = fn_variable
         self.return_value: VariableBase | None = None
         self._fn_value = fn_variable.value
-        super().__init__(fn_variable.get_code(), fn_variable.graph)
+        self._code_var = fn_variable.get_code()
+        super().__init__(self._code_var.value, fn_variable.graph)
         self._name = "Inline"
         self._prepare_locals(*args, **kwargs)
         self._prepare_closure()
@@ -273,6 +274,7 @@ class OpcodeInlineExecutor(OpcodeExecutorBase):
         """
         Execute the inline call of the function.
         """
+        self._graph.add_global_guarded_variable(self._code_var)
         self.run()
         assert self.return_value is not None
         return self.return_value

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -119,8 +119,11 @@ class FunctionVariable(CallableVariable):
     def get_py_value(self, allow_tensor=False):
         return self.value
 
-    def get_code(self) -> types.CodeType:
-        return self.value.__code__
+    def get_code(self) -> VariableBase:
+        code_obj_var = VariableFactory.from_value(
+            self.value.__code__, self.graph, GetAttrTracker(self, "__code__")
+        )
+        return code_obj_var
 
     def bind(self, instance: VariableBase, name: str):
         method_var = MethodVariable(

--- a/test/sot/test_06_call_function.py
+++ b/test/sot/test_06_call_function.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-from test_case_base import TestCaseBase
+from test_case_base import (
+    TestCaseBase,
+    test_instruction_translator_cache_context,
+)
 
 import paddle
 
@@ -148,6 +151,31 @@ class TestCall(TestCaseBase):
 
     def test_call8(self):
         self.assert_results(foo_8, paddle.to_tensor(9))
+
+
+def apply_fn(fn, x):
+    return fn(x)
+
+
+def fn1(x):
+    return x + 1
+
+
+def fn2(x):
+    return x - 1
+
+
+class TestApplyDifferentFunctions(TestCaseBase):
+    def test_apply_fn(self):
+        x = 1
+        with test_instruction_translator_cache_context() as ctx:
+            self.assertEqual(ctx.translate_count, 0)
+            self.assert_results(apply_fn, fn1, x)
+            self.assertEqual(ctx.translate_count, 1)
+            self.assert_results(apply_fn, fn2, x)
+            self.assertEqual(ctx.translate_count, 2)
+            self.assert_results(apply_fn, fn1, x)
+            self.assertEqual(ctx.translate_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

因为我们现在并不会将 inline call 的 codeobj 加入到 guard 中，因此在调用不同函数时是有可能错误命中 guard 的

比如

```python
def apply_fn(fn, x):
    return fn(x)


def fn1(x):
    return x + 1


def fn2(x):
    return x - 1

static_fn = paddle.jit.to_static(apply_fn, full_graph=False)
static_fn(fn1, 1)
static_fn(fn2, 1)
```

这里的 guard 是没有函数的 codeobj 的

因此在 inline call 时将其添加到 global guard 中，确保会 guard 住这个 code

PCard-66972