### PR TITLE
[PIR Pass] Support hook of value replace in pir pass

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -85,6 +85,7 @@
 #include "paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_util.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/pir_to_py_code_converter.h"
 #include "paddle/cinn/hlir/framework/pir_compiler.h"
+#include "paddle/pir/include/dialect/shape/utils/shape_analysis.h"
 #endif
 
 using paddle::dialect::ApiBuilder;
@@ -2359,22 +2360,23 @@ void BindUtils(pybind11::module *m) {
 
 namespace {
 
-#ifdef PADDLE_WITH_CINN
-std::shared_ptr<pir::PassManager> CreatePassManager() {
-  pir::IrContext *ctx = pir::IrContext::Instance();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<pir::shape::ShapeDialect>();
-  auto pass_manager = std::make_shared<pir::PassManager>(ctx);
-  if (FLAGS_print_ir) {
-    pass_manager->EnableIRPrinting();
-  }
-  return pass_manager;
-}
-#endif
-
 void ApplyCinnPass(Program &program) {  // NOLINT
 #ifdef PADDLE_WITH_CINN
+  auto CreatePassManager = [&]() -> std::shared_ptr<pir::PassManager> {
+    pir::IrContext *ctx = pir::IrContext::Instance();
+    ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
+    ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
+    ctx->GetOrRegisterDialect<pir::shape::ShapeDialect>();
+    auto pass_manager = std::make_shared<pir::PassManager>(ctx);
+    if (FLAGS_print_ir) {
+      pass_manager->EnableIRPrinting();
+    }
+    auto &shape_analysis = pir::ShapeAnalysisManager::Instance().Get(&program);
+    pass_manager->SetValueReplacedHook([&](pir::Value from, pir::Value to) {
+      shape_analysis.ShareShapeOrData(from, to);
+    });
+    return pass_manager;
+  };
   cinn::dialect::ir::ApplyCinnPass(&program, CreatePassManager);
 #else
   PADDLE_THROW(common::errors::Unimplemented(
@@ -2385,6 +2387,18 @@ void ApplyCinnPass(Program &program) {  // NOLINT
 
 void CheckInferSymbolicIfNeed(Program &program) {  // NOLINT
 #ifdef PADDLE_WITH_CINN
+  auto CreatePassManager = [&]() -> std::shared_ptr<pir::PassManager> {
+    pir::IrContext *ctx = pir::IrContext::Instance();
+    ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
+    ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
+    ctx->GetOrRegisterDialect<pir::shape::ShapeDialect>();
+    auto pass_manager = std::make_shared<pir::PassManager>(ctx);
+    if (FLAGS_print_ir) {
+      pass_manager->EnableIRPrinting();
+    }
+    return pass_manager;
+  };
+  cinn::dialect::ir::ApplyCinnPass(&program, CreatePassManager);
   cinn::dialect::ir::CheckInferSymbolicIfNeed(&program, CreatePassManager);
 #else
   // Do nothing.

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -2398,7 +2398,6 @@ void CheckInferSymbolicIfNeed(Program &program) {  // NOLINT
     }
     return pass_manager;
   };
-  cinn::dialect::ir::ApplyCinnPass(&program, CreatePassManager);
   cinn::dialect::ir::CheckInferSymbolicIfNeed(&program, CreatePassManager);
 #else
   // Do nothing.

--- a/paddle/pir/include/dialect/shape/utils/shape_analysis.h
+++ b/paddle/pir/include/dialect/shape/utils/shape_analysis.h
@@ -196,6 +196,9 @@ class IR_API ShapeConstraintIRAnalysis final
   void SetShapeOrDataForValue(Value val,
                               const symbol::ShapeOrDataDimExprs& shape_or_data);
 
+  // Set ShapeOrData of `to` value by ShapeOrData of `from` value.
+  void ShareShapeOrData(Value from, Value to);
+
   bool IsEqual(const symbol::DimExpr& lhs, const symbol::DimExpr& rhs) const;
 
   bool IsGreatThanOne(const symbol::DimExpr& dim_expr) const;

--- a/paddle/pir/include/pass/pass.h
+++ b/paddle/pir/include/pass/pass.h
@@ -76,6 +76,7 @@ class IR_API Pass {
  public:
   inline static const char kParamScopeAttr[] = "__param_scope__";
   inline static const char kPlaceAttr[] = "__place__";
+  inline static const char kValueReplaceHookAttr[] = "__value_replaced_hook__";
 
   explicit Pass(const std::string& name,
                 uint8_t opt_level,

--- a/paddle/pir/include/pass/pass_manager.h
+++ b/paddle/pir/include/pass/pass_manager.h
@@ -115,6 +115,11 @@ class IR_API PassManager {
 
   void AddInstrumentation(std::unique_ptr<PassInstrumentation> pi);
 
+  void SetValueReplacedHook(
+      const std::function<void(pir::Value, pir::Value)> &hook) {
+    value_replaced_hook_ = hook;
+  }
+
  private:
   bool Initialize(IrContext *context);
 
@@ -134,6 +139,8 @@ class IR_API PassManager {
   std::unique_ptr<Pass> pass_adaptor_;
 
   std::unique_ptr<PassInstrumentor> instrumentor_;
+
+  std::function<void(pir::Value, pir::Value)> value_replaced_hook_ = nullptr;
 
   // For access member of pass_adaptor_.
   friend class detail::PassAdaptor;

--- a/paddle/pir/include/pass/pass_manager.h
+++ b/paddle/pir/include/pass/pass_manager.h
@@ -115,8 +115,7 @@ class IR_API PassManager {
 
   void AddInstrumentation(std::unique_ptr<PassInstrumentation> pi);
 
-  void SetValueReplacedHook(
-      const std::function<void(pir::Value, pir::Value)> &hook) {
+  void SetValueReplacedHook(const VALUE_REPLACED_HOOK_FUNC &hook) {
     value_replaced_hook_ = hook;
   }
 
@@ -140,7 +139,7 @@ class IR_API PassManager {
 
   std::unique_ptr<PassInstrumentor> instrumentor_;
 
-  std::function<void(pir::Value, pir::Value)> value_replaced_hook_ = nullptr;
+  VALUE_REPLACED_HOOK_FUNC value_replaced_hook_ = nullptr;
 
   // For access member of pass_adaptor_.
   friend class detail::PassAdaptor;

--- a/paddle/pir/include/pattern_rewrite/pattern_match.h
+++ b/paddle/pir/include/pattern_rewrite/pattern_match.h
@@ -302,6 +302,8 @@ class RewriterBase : public Builder {
 
   virtual void NotifyOperationInserted(Operation* op) {}
 
+  virtual void NotifyValueReplaced(Value from, Value to) {}
+
   virtual void StartRootUpdate(Operation* op) {}
 
   virtual void FinalizeRootUpdate(Operation* op) {}

--- a/paddle/pir/include/pattern_rewrite/pattern_rewrite_driver.h
+++ b/paddle/pir/include/pattern_rewrite/pattern_rewrite_driver.h
@@ -19,6 +19,8 @@
 
 namespace pir {
 
+using VALUE_REPLACED_HOOK_FUNC = std::function<void(pir::Value, pir::Value)>;
+
 class FrozenRewritePatternSet;
 
 /// This enum will control which ops will be added to the worklist during the
@@ -58,7 +60,7 @@ class IR_API GreedyRewriteConfig {
   GreedyRewriteStrictness strict_mode = GreedyRewriteStrictness::AnyOp;
 
   // Hook function for replacing the value.
-  std::function<void(pir::Value, pir::Value)> value_replaced_hook = nullptr;
+  VALUE_REPLACED_HOOK_FUNC value_replaced_hook = nullptr;
 
   static constexpr int64_t kNoLimit = -1;
 };

--- a/paddle/pir/include/pattern_rewrite/pattern_rewrite_driver.h
+++ b/paddle/pir/include/pattern_rewrite/pattern_rewrite_driver.h
@@ -57,6 +57,9 @@ class IR_API GreedyRewriteConfig {
   /// - ExistingOps: only pre-existing ops are added to the worklist.
   GreedyRewriteStrictness strict_mode = GreedyRewriteStrictness::AnyOp;
 
+  // Hook function for replacing the value.
+  std::function<void(pir::Value, pir::Value)> value_replaced_hook = nullptr;
+
   static constexpr int64_t kNoLimit = -1;
 };
 

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -613,6 +613,12 @@ void ShapeConstraintIRAnalysis::SetShapeOrDataForValue(
   context_.SetShapeOrDataForValue(val, shape_or_data);
 }
 
+void ShapeConstraintIRAnalysis::ShareShapeOrData(Value from, Value to) {
+  if (context_.HasShapeOrDataForValue(from)) {
+    context_.SetShapeOrDataForValue(to, context_.GetShapeOrDataForValue(from));
+  }
+}
+
 bool ShapeConstraintIRAnalysis::IsEqual(const symbol::DimExpr& lhs,
                                         const symbol::DimExpr& rhs) const {
   return context_.IsEqual(lhs, rhs);

--- a/paddle/pir/src/pass/pass.cc
+++ b/paddle/pir/src/pass/pass.cc
@@ -92,7 +92,7 @@ void PatternRewritePass::Run(Operation* op) {
   GreedyRewriteConfig config = InitializeConfig();
   if (Has(kValueReplaceHookAttr)) {
     config.value_replaced_hook =
-        Get<std::function<void(Value, Value)>>(kValueReplaceHookAttr);
+        Get<VALUE_REPLACED_HOOK_FUNC>(kValueReplaceHookAttr);
   }
   auto [_, num_rewrites] = ApplyPatternsGreedily(op, patterns_, config);
   AddStatistics(num_rewrites);
@@ -207,8 +207,8 @@ bool PassManager::Initialize(IrContext* context) {
   for (auto& pass : passes()) {
     if (!pass->Initialize(context)) return false;
     if (value_replaced_hook_) {
-      pass->SetNotOwned<std::function<void(pir::Value, pir::Value)>>(
-          Pass::kValueReplaceHookAttr, &value_replaced_hook_);
+      pass->SetNotOwned<VALUE_REPLACED_HOOK_FUNC>(Pass::kValueReplaceHookAttr,
+                                                  &value_replaced_hook_);
     }
   }
 

--- a/paddle/pir/src/pass/pass.cc
+++ b/paddle/pir/src/pass/pass.cc
@@ -89,8 +89,12 @@ GreedyRewriteConfig PatternRewritePass::InitializeConfig() {
 
 void PatternRewritePass::Run(Operation* op) {
   VLOG(4) << "Run PatternRewritePass: " << name();
-  auto [_, num_rewrites] =
-      ApplyPatternsGreedily(op, patterns_, InitializeConfig());
+  GreedyRewriteConfig config = InitializeConfig();
+  if (Has(kValueReplaceHookAttr)) {
+    config.value_replaced_hook =
+        Get<std::function<void(Value, Value)>>(kValueReplaceHookAttr);
+  }
+  auto [_, num_rewrites] = ApplyPatternsGreedily(op, patterns_, config);
   AddStatistics(num_rewrites);
 }
 
@@ -202,6 +206,10 @@ bool PassManager::Run(Operation* op) {
 bool PassManager::Initialize(IrContext* context) {
   for (auto& pass : passes()) {
     if (!pass->Initialize(context)) return false;
+    if (value_replaced_hook_) {
+      pass->SetNotOwned<std::function<void(pir::Value, pir::Value)>>(
+          Pass::kValueReplaceHookAttr, &value_replaced_hook_);
+    }
   }
 
   return true;

--- a/paddle/pir/src/pattern_rewrite/pattern_match.cc
+++ b/paddle/pir/src/pattern_rewrite/pattern_match.cc
@@ -126,6 +126,9 @@ void RewriterBase::ReplaceOp(Operation* op,
       new_values.size(),
       common::errors::InvalidArgument("incorrect # of replacement values"));
   op->ReplaceAllUsesWith(new_values);
+  for (uint32_t i = 0; i < op->num_results(); ++i) {
+    NotifyValueReplaced(op->result(i), new_values[i]);
+  }
 
   NotifyOperationRemoved(op);
   op->Erase();
@@ -157,9 +160,15 @@ void RewriterBase::ReplaceUseIf(Value from,
   // Use post-increment operator for iterator since set_source() will change
   // `it`.
   // TODO(zhangbopd): Add unit test for this.
+  bool replaced = false;
   for (auto it = from.use_begin(); it != from.use_end();) {
-    if (functor(*it))
+    if (functor(*it)) {
       UpdateRootInplace(it.owner(), [&]() { (it++)->set_source(to); });
+      replaced = true;
+    }
+  }
+  if (replaced) {
+    NotifyValueReplaced(from, to);
   }
 }
 

--- a/paddle/pir/src/pattern_rewrite/pattern_match.cc
+++ b/paddle/pir/src/pattern_rewrite/pattern_match.cc
@@ -144,8 +144,10 @@ void RewriterBase::EraseOp(Operation* op) {
 
 // Find uses of `from` and replace it with `to`.
 void RewriterBase::ReplaceAllUsesWith(Value from, Value to) {
-  for (auto it = from.use_begin(); it != from.use_end();)
+  for (auto it = from.use_begin(); it != from.use_end();) {
     UpdateRootInplace(it.owner(), [&]() { (it++)->set_source(to); });
+  }
+  NotifyValueReplaced(from, to);
 }
 
 // Find uses of `from` and replace them with `to` if the `functor` returns true.

--- a/paddle/pir/src/pattern_rewrite/pattern_rewrite_driver.cc
+++ b/paddle/pir/src/pattern_rewrite/pattern_rewrite_driver.cc
@@ -53,6 +53,9 @@ class GreedyPatternRewriteDriver : public pir::PatternRewriter {
         }
       }
     }
+    if (config.value_replaced_hook) {
+      value_replaced_hook_fn_ = config.value_replaced_hook;
+    }
   }
 
   std::pair<bool, int64_t> Simplify() {
@@ -156,6 +159,12 @@ class GreedyPatternRewriteDriver : public pir::PatternRewriter {
     AddToWorklist(op);
   }
 
+  void NotifyValueReplaced(pir::Value from, pir::Value to) override {
+    if (value_replaced_hook_fn_) {
+      value_replaced_hook_fn_(from, to);
+    }
+  }
+
   /// Add the given operation to the worklist.
   void AddToWorklist(pir::Operation* op) {
     if (config_.strict_mode == pir::GreedyRewriteStrictness::AnyOp ||
@@ -207,6 +216,7 @@ class GreedyPatternRewriteDriver : public pir::PatternRewriter {
   std::unordered_set<pir::Operation*> strict_mode_filtered_ops_;
   pir::Region& region_;
   pir::PatternApplicator matcher_;
+  std::function<void(pir::Value, pir::Value)> value_replaced_hook_fn_ = nullptr;
 };
 
 }  // namespace

--- a/paddle/pir/src/pattern_rewrite/pattern_rewrite_driver.cc
+++ b/paddle/pir/src/pattern_rewrite/pattern_rewrite_driver.cc
@@ -216,7 +216,7 @@ class GreedyPatternRewriteDriver : public pir::PatternRewriter {
   std::unordered_set<pir::Operation*> strict_mode_filtered_ops_;
   pir::Region& region_;
   pir::PatternApplicator matcher_;
-  VALUE_REPLACED_HOOK_FUNC value_replaced_hook_fn_ = nullptr;
+  pir::VALUE_REPLACED_HOOK_FUNC value_replaced_hook_fn_ = nullptr;
 };
 
 }  // namespace

--- a/paddle/pir/src/pattern_rewrite/pattern_rewrite_driver.cc
+++ b/paddle/pir/src/pattern_rewrite/pattern_rewrite_driver.cc
@@ -216,7 +216,7 @@ class GreedyPatternRewriteDriver : public pir::PatternRewriter {
   std::unordered_set<pir::Operation*> strict_mode_filtered_ops_;
   pir::Region& region_;
   pir::PatternApplicator matcher_;
-  std::function<void(pir::Value, pir::Value)> value_replaced_hook_fn_ = nullptr;
+  VALUE_REPLACED_HOOK_FUNC value_replaced_hook_fn_ = nullptr;
 };
 
 }  // namespace


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

为 PIR Pass 添加Value替换callback机制，在PassManager中通过设置对应hook可实现value替换时的自定义操作。