### PR TITLE
[Lod][fluid_ops] Revert "recursive_sequence_lengths"

### DIFF
--- a/paddle/fluid/pybind/tensor.cc
+++ b/paddle/fluid/pybind/tensor.cc
@@ -633,32 +633,6 @@ void BindTensor(pybind11::module &m) {  // NOLINT
                     >>> print(t.lod())
                     [[0, 2, 5]]
            )DOC")
-      // Set above comments of set_lod.
-      .def(
-          "recursive_sequence_lengths",
-          [](phi::DenseTensor &self) -> std::vector<std::vector<size_t>> {
-            // output the length-based lod info
-            LoD lod = phi::ConvertToLengthBasedLoD(self.lod());
-            std::vector<std::vector<size_t>> new_lod;
-            new_lod.reserve(lod.size());
-            std::copy(lod.begin(), lod.end(), std::back_inserter(new_lod));
-            return new_lod;
-          },
-          R"DOC(
-           Return the recursive sequence lengths corresponding to of the LodD
-           of the Tensor.
-           Returns:
-                list[list[int]]: The recursive sequence lengths.
-           Examples:
-                .. code-block:: python
-                    >>> import paddle
-                    >>> import numpy as np
-                    >>> t = paddle.framework.core.Tensor()
-                    >>> t.set(np.ndarray([5, 30]), paddle.CPUPlace())
-                    >>> t.set_recursive_sequence_lengths([[2, 3]])
-                    >>> print(t.recursive_sequence_lengths())
-                    [[2, 3]]
-           )DOC")
       .def("_as_type",
            [](const phi::DenseTensor &self,
               paddle::framework::proto::VarType::Type type) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Reverts PaddlePaddle/Paddle#69551

PaddleCustomDevice 已升级为最新paddle，所以移除recursive_sequence_lengths