### PR TITLE
[CINN]Revert the infer symbolic shape interface of pd_op.slice op

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
@@ -39,8 +39,6 @@ class FusionOpPattern : public pir::OpRewritePattern<cinn::dialect::FusionOp> {
     ::pir::IrContext* ctx = ::pir::IrContext::Instance();
     auto* program = fusion_op->GetParentProgram();
     auto& shape_analysis = pir::ShapeAnalysisManager::Instance().Get(program);
-    VLOG(4) << "Program before lowering: \n"
-            << pir::CustomPrintHelper(*program, shape_analysis.PrintHook());
 
     // TODO(zhangyuqin1998): Replace pir::Group with a new structure
     OpLoweringGroupPtr group = GetGroup(fusion_op);

--- a/paddle/cinn/hlir/framework/pir/utils.cc
+++ b/paddle/cinn/hlir/framework/pir/utils.cc
@@ -352,8 +352,7 @@ bool CauseNewSymbolicShape(const ::pir::Operation& op) {
   if (!HaveUnkDim(op)) {
     return false;
   }
-  auto& shape_analysis = ::pir::ShapeAnalysisManager::Instance().Get(
-      const_cast<::pir::Operation&>(op).GetParentProgram());
+
   std::unordered_set<std::string> input_exprs = [&]() {
     std::unordered_set<std::string> res;
     for (const auto& input_value : op.operands_source()) {

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -3227,23 +3227,65 @@ bool ShuffleChannelOpInferSymbolicShape(
 bool SliceOpInferSymbolicShape(pir::Operation *op,
                                pir::InferSymbolicShapeContext *infer_context) {
   pir::Value operand_source = op->operand_source(0);
-  pir::Value operand_starts = op->operand_source(1);
-  pir::Value operand_ends = op->operand_source(2);
   pir::Value res = op->result(0);
 
-  const symbol::ShapeOrDataDimExprs &starts_shape_data =
-      infer_context->GetShapeOrDataForValue(operand_starts);
-  const symbol::ShapeOrDataDimExprs &ends_shape_data =
-      infer_context->GetShapeOrDataForValue(operand_ends);
-
   std::vector<int64_t> axes_vec = details::GetVectorAttr(op, "axes");
-
-  ExprVec starts = slice_utils::GetExprVecFromData(starts_shape_data);
-  ExprVec ends = slice_utils::GetExprVecFromData(ends_shape_data);
-
   std::vector<int64_t> infer_flags = details::GetVectorAttr(op, "infer_flags");
   const std::vector<int64_t> decrease_axis =
       details::GetVectorAttr(op, "decrease_axis");
+
+  auto GetExprVec = [&](std::vector<symbol::DimExpr> *expr_vec,
+                        const int &operand_idx,
+                        const std::string &attr_name) -> bool {
+    if (op->operand_source(operand_idx)) {
+      const symbol::ShapeOrDataDimExprs &se_shape_data =
+          infer_context->GetShapeOrDataForValue(
+              op->operand_source(operand_idx));
+      if (slice_utils::GetExprVecOfStartEnd(se_shape_data, expr_vec)) {
+        return true;
+      }
+      PADDLE_ENFORCE_EQ(
+          se_shape_data.shape().at(0).isa<std::int64_t>() &&
+              (static_cast<int64_t>(axes_vec.size()) ==
+               se_shape_data.shape().at(0).dyn_cast<std::int64_t>()),
+          true,
+          common::errors::InvalidArgument(
+              "The size of axes must equal size of starts and ends."));
+      return false;
+    } else {
+      if (op->attributes().find(attr_name) != op->attributes().end()) {
+        const std::vector<int64_t> se_raw =
+            paddle::dialect::details::GetVectorAttr(op, attr_name);
+        for (const int64_t &se : se_raw) {
+          expr_vec->push_back(symbol::DimExpr{se});
+        }
+        return true;
+      }
+      return false;
+    }
+  };
+
+  std::vector<symbol::DimExpr> starts;
+  std::vector<symbol::DimExpr> ends;
+  if (!GetExprVec(&starts, 1, "starts") || !GetExprVec(&ends, 2, "ends")) {
+    const auto &in_shapeordata =
+        infer_context->GetShapeOrDataForValue(op->operand_source(0));
+    // NOTE(gongshaotian): When there is no data value in the starts and ends
+    // parameters, only the shape value is processed regardless of whether the
+    // input has a data value, and the  data value is no longer processed.
+    std::vector<symbol::DimExpr> out_shape = in_shapeordata.shape();
+    for (size_t i = 0; i < axes_vec.size(); i++) {
+      int64_t axis = axes_vec[i];
+      out_shape[axis] = infer_context->GetNextSymName();
+    }
+    ExprVec out_dims = paddle::dialect::slice_utils::GetDecreasedDims(
+        out_shape, decrease_axis);
+    infer_context->SetShapeOrDataForValue(
+        res,
+        symbol::ShapeOrDataDimExprs{
+            symbol::TensorShapeOrDataDimExprs(out_dims)});
+    return true;
+  }
 
   infer_context->SetShapeOrDataForValue(
       res,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
+ revert PR https://github.com/PaddlePaddle/Paddle/pull/69503 中slice op的符号推导修改