### PR TITLE
Revert "[CINN] Make slice op not enter CINN when there is no data in the parameters"

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
@@ -39,6 +39,8 @@ class FusionOpPattern : public pir::OpRewritePattern<cinn::dialect::FusionOp> {
     ::pir::IrContext* ctx = ::pir::IrContext::Instance();
     auto* program = fusion_op->GetParentProgram();
     auto& shape_analysis = pir::ShapeAnalysisManager::Instance().Get(program);
+    VLOG(4) << "Program before lowering: \n"
+            << pir::CustomPrintHelper(*program, shape_analysis.PrintHook());
 
     // TODO(zhangyuqin1998): Replace pir::Group with a new structure
     OpLoweringGroupPtr group = GetGroup(fusion_op);

--- a/paddle/cinn/hlir/framework/pir/utils.cc
+++ b/paddle/cinn/hlir/framework/pir/utils.cc
@@ -349,29 +349,11 @@ bool CauseNewSymbolicShape(const ::pir::Operation& op) {
   if (FLAGS_disable_dyshape_in_train) {
     return false;
   }
-
-  auto& shape_analysis = ::pir::ShapeAnalysisManager::Instance().Get(
-      const_cast<::pir::Operation&>(op).GetParentProgram());
-
-  const auto& isProcessableSlice = [&]() -> bool {
-    const ::pir::Value& starts_value = op.operand_source(1);
-    const ::pir::Value& ends_value = op.operand_source(2);
-    const symbol::ShapeOrDataDimExprs& starts_shape_data =
-        shape_analysis.GetShapeOrDataForValue(starts_value);
-    const symbol::ShapeOrDataDimExprs& ends_shape_data =
-        shape_analysis.GetShapeOrDataForValue(ends_value);
-    return starts_shape_data.data().has_value() &&
-           ends_shape_data.data().has_value();
-  };
-
-  if (op.isa<paddle::dialect::SliceOp>() && !isProcessableSlice()) {
-    return true;
-  }
-
   if (!HaveUnkDim(op)) {
     return false;
   }
-
+  auto& shape_analysis = ::pir::ShapeAnalysisManager::Instance().Get(
+      const_cast<::pir::Operation&>(op).GetParentProgram());
   std::unordered_set<std::string> input_exprs = [&]() {
     std::unordered_set<std::string> res;
     for (const auto& input_value : op.operands_source()) {

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/element_wise_binary.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/element_wise_binary.cc
@@ -147,17 +147,6 @@ bool FloorDivideOpInferSymbolicShape(
       });
 }
 
-bool MinimumOpInferSymbolicShape(
-    pir::Operation *op, pir::InferSymbolicShapeContext *infer_context) {
-  return InferSymbolicShapeElementWiseBinary(
-      op,
-      infer_context,
-      [](const symbol::DimExpr &x, const symbol::DimExpr &y) {
-        symbol::DimExprBuilder builder;
-        return builder.Min(x, y);
-      });
-}
-
 OP_ELEMENT_WISE_BINARY(Add_)
 OP_ELEMENT_WISE_BINARY(BitwiseAnd)
 OP_ELEMENT_WISE_BINARY(BitwiseAnd_)
@@ -197,6 +186,7 @@ OP_ELEMENT_WISE_BINARY(LogicalOr_)
 OP_ELEMENT_WISE_BINARY(LogicalXor)
 OP_ELEMENT_WISE_BINARY(LogicalXor_)
 OP_ELEMENT_WISE_BINARY(Maximum)
+OP_ELEMENT_WISE_BINARY(Minimum)
 OP_ELEMENT_WISE_BINARY(MultiplySr)
 OP_ELEMENT_WISE_BINARY(MultiplySr_)
 OP_ELEMENT_WISE_BINARY(Multiply_)

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
@@ -49,6 +49,8 @@ OP_SAME_OPERANDS_AND_RESULT(Hardtanh_)
 OP_SAME_OPERANDS_AND_RESULT(Bernoulli)
 OP_SAME_OPERANDS_AND_RESULT(BitwiseNot)
 OP_SAME_OPERANDS_AND_RESULT(BitwiseNot_)
+OP_SAME_OPERANDS_AND_RESULT(Ceil)
+OP_SAME_OPERANDS_AND_RESULT(Ceil_)
 OP_SAME_OPERANDS_AND_RESULT(Celu)
 OP_SAME_OPERANDS_AND_RESULT(Clip)
 OP_SAME_OPERANDS_AND_RESULT(Clip_)
@@ -253,13 +255,13 @@ bool ScaleOpInferSymbolicShape(pir::Operation *op,
     return GetOptionalAttributeData("scale");
   };
 
-  if (operand_shape_or_data.data().has_value()) {
+  if (operand_shape_or_data.data()) {
     const std::optional<symbol::DimExpr> &opt_scale = GetOptionalScaleData();
     const std::optional<symbol::DimExpr> &opt_bias =
         GetOptionalAttributeData("bias");
     if (opt_scale && opt_bias) {
       std::vector<symbol::DimExpr> data;
-      for (auto &val : operand_shape_or_data.data().value()) {
+      for (auto &val : *(operand_shape_or_data.data())) {
         data.push_back(val * (opt_scale.value()) + (opt_bias.value()));
       }
       SetOutputWithShapeAndData(data);
@@ -280,19 +282,6 @@ bool ArgsortOpInferSymbolicShape(
   infer_context->SetShapeOrDataForValue(op->result(0), operand_shape_or_data);
   infer_context->SetShapeOrDataForValue(op->result(1), operand_shape_or_data);
   return true;
-}
-
-bool CeilOpInferSymbolicShape(pir::Operation *op,
-                              pir::InferSymbolicShapeContext *infer_context) {
-  const symbol::ShapeOrDataDimExprs &operand_shape_or_data =
-      infer_context->GetShapeOrDataForValue(op->operand_source(0));
-  infer_context->SetShapeOrDataForValue(op->result(0), operand_shape_or_data);
-  return true;
-}
-
-bool Ceil_OpInferSymbolicShape(pir::Operation *op,
-                               pir::InferSymbolicShapeContext *infer_context) {
-  return CeilOpInferSymbolicShape(op, infer_context);
 }
 
 }  // namespace paddle::dialect

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -3227,66 +3227,23 @@ bool ShuffleChannelOpInferSymbolicShape(
 bool SliceOpInferSymbolicShape(pir::Operation *op,
                                pir::InferSymbolicShapeContext *infer_context) {
   pir::Value operand_source = op->operand_source(0);
+  pir::Value operand_starts = op->operand_source(1);
+  pir::Value operand_ends = op->operand_source(2);
   pir::Value res = op->result(0);
 
+  const symbol::ShapeOrDataDimExprs &starts_shape_data =
+      infer_context->GetShapeOrDataForValue(operand_starts);
+  const symbol::ShapeOrDataDimExprs &ends_shape_data =
+      infer_context->GetShapeOrDataForValue(operand_ends);
+
   std::vector<int64_t> axes_vec = details::GetVectorAttr(op, "axes");
+
+  ExprVec starts = slice_utils::GetExprVecFromData(starts_shape_data);
+  ExprVec ends = slice_utils::GetExprVecFromData(ends_shape_data);
+
   std::vector<int64_t> infer_flags = details::GetVectorAttr(op, "infer_flags");
   const std::vector<int64_t> decrease_axis =
       details::GetVectorAttr(op, "decrease_axis");
-
-  auto GetExprVec = [&](std::vector<symbol::DimExpr> *expr_vec,
-                        const int &operand_idx,
-                        const std::string &attr_name) -> bool {
-    if (op->operand_source(operand_idx)) {
-      const symbol::ShapeOrDataDimExprs &se_shape_data =
-          infer_context->GetShapeOrDataForValue(
-              op->operand_source(operand_idx));
-      if (se_shape_data.data().has_value()) {
-        *expr_vec = se_shape_data.data().value();
-        return true;
-      }
-      PADDLE_ENFORCE_EQ(
-          se_shape_data.shape().at(0).isa<std::int64_t>() &&
-              (static_cast<int64_t>(axes_vec.size()) ==
-               se_shape_data.shape().at(0).dyn_cast<std::int64_t>()),
-          true,
-          common::errors::InvalidArgument(
-              "The size of axes must equal size of starts and ends."));
-      return false;
-    } else {
-      if (op->attributes().find(attr_name) != op->attributes().end()) {
-        const std::vector<int64_t> se_raw =
-            paddle::dialect::details::GetVectorAttr(op, attr_name);
-        for (const int64_t &se : se_raw) {
-          expr_vec->push_back(symbol::DimExpr{se});
-        }
-        return true;
-      }
-      return false;
-    }
-  };
-
-  std::vector<symbol::DimExpr> starts;
-  std::vector<symbol::DimExpr> ends;
-  if (!GetExprVec(&starts, 1, "starts") || !GetExprVec(&ends, 2, "ends")) {
-    const auto &in_shapeordata =
-        infer_context->GetShapeOrDataForValue(op->operand_source(0));
-    // NOTE(gongshaotian): When there is no data value in the starts and ends
-    // parameters, only the shape value is processed regardless of whether the
-    // input has a data value, and the  data value is no longer processed.
-    std::vector<symbol::DimExpr> out_shape = in_shapeordata.shape();
-    for (size_t i = 0; i < axes_vec.size(); i++) {
-      int64_t axis = axes_vec[i];
-      out_shape[axis] = infer_context->GetNextSymName();
-    }
-    ExprVec out_dims = paddle::dialect::slice_utils::GetDecreasedDims(
-        out_shape, decrease_axis);
-    infer_context->SetShapeOrDataForValue(
-        res,
-        symbol::ShapeOrDataDimExprs{
-            symbol::TensorShapeOrDataDimExprs(out_dims)});
-    return true;
-  }
 
   infer_context->SetShapeOrDataForValue(
       res,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Reverts PaddlePaddle/Paddle#69503