### PR TITLE
some kernel support int64 input

### DIFF
--- a/paddle/phi/kernels/cpu/linspace_kernel.cc
+++ b/paddle/phi/kernels/cpu/linspace_kernel.cc
@@ -27,7 +27,12 @@ void LinspaceKernel(const Context& ctx,
                     const DenseTensor& number,
                     DataType dtype,
                     DenseTensor* out) {
-  int32_t num = number.data<int32_t>()[0];
+  int64_t num = 0;
+  if (number.dtype() == phi::DataType::INT64) {
+    num = number.data<int64_t>()[0];
+  } else if (number.dtype() == phi::DataType::INT32) {
+    num = number.data<int32_t>()[0];
+  }
   auto start_t = phi::funcs::TransDataType(ctx, start, dtype);
   auto stop_t = phi::funcs::TransDataType(ctx, stop, dtype);
 

--- a/paddle/phi/kernels/cpu/multiclass_nms3_kernel.cc
+++ b/paddle/phi/kernels/cpu/multiclass_nms3_kernel.cc
@@ -236,10 +236,20 @@ T PolyIoU(const T* box1,
 
 inline std::vector<size_t> GetNmsLodFromRoisNum(const DenseTensor* rois_num) {
   std::vector<size_t> rois_lod;
-  auto* rois_num_data = rois_num->data<int>();
-  rois_lod.push_back(static_cast<size_t>(0));
-  for (int i = 0; i < rois_num->numel(); ++i) {
-    rois_lod.push_back(rois_lod.back() + static_cast<size_t>(rois_num_data[i]));
+  if (rois_num->dtype() == phi::DataType::INT64) {
+    auto* rois_num_data = rois_num->data<int64_t>();
+    rois_lod.push_back(static_cast<size_t>(0));
+    for (int64_t i = 0; i < rois_num->numel(); ++i) {
+      rois_lod.push_back(rois_lod.back() +
+                         static_cast<size_t>(rois_num_data[i]));
+    }
+  } else if (rois_num->dtype() == phi::DataType::INT32) {
+    auto* rois_num_data = rois_num->data<int>();
+    rois_lod.push_back(static_cast<size_t>(0));
+    for (int i = 0; i < rois_num->numel(); ++i) {
+      rois_lod.push_back(rois_lod.back() +
+                         static_cast<size_t>(rois_num_data[i]));
+    }
   }
   return rois_lod;
 }

--- a/paddle/phi/kernels/cpu/roi_align_kernel.cc
+++ b/paddle/phi/kernels/cpu/roi_align_kernel.cc
@@ -217,13 +217,24 @@ void RoiAlignKernel(const Context& dev_ctx,
             "and the batch size of images is %d",
             boxes_batch_size,
             batch_size));
-    auto* boxes_num_data = boxes_num->data<int>();
-    int start = 0;
-    for (int n = 0; n < boxes_batch_size; ++n) {
-      for (int i = start; i < start + boxes_num_data[n]; ++i) {
-        roi_batch_id_data[i] = n;
+    if (boxes_num->dtype() == phi::DataType::INT64) {
+      auto* boxes_num_data = boxes_num->data<int64_t>();
+      int64_t start = 0;
+      for (int64_t n = 0; n < boxes_batch_size; ++n) {
+        for (int64_t i = start; i < start + boxes_num_data[n]; ++i) {
+          roi_batch_id_data[i] = n;
+        }
+        start += boxes_num_data[n];
       }
-      start += boxes_num_data[n];
+    } else if (boxes_num->dtype() == phi::DataType::INT32) {
+      auto* boxes_num_data = boxes_num->data<int>();
+      int start = 0;
+      for (int n = 0; n < boxes_batch_size; ++n) {
+        for (int i = start; i < start + boxes_num_data[n]; ++i) {
+          roi_batch_id_data[i] = n;
+        }
+        start += boxes_num_data[n];
+      }
     }
   } else {
     auto lod = boxes.lod();

--- a/paddle/phi/kernels/funcs/interpolate_function.h
+++ b/paddle/phi/kernels/funcs/interpolate_function.h
@@ -94,28 +94,54 @@ inline std::vector<int> get_new_shape(
                           "The shape of dimension tensor should be [1] or [],"
                           "but received d%.",
                           tensor->dims()));
+    if (tensor->dtype() == phi::DataType::INT64) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
-    if (tensor->place().GetType() == phi::AllocationType::CUSTOM) {
-      DenseTensor temp;
-      phi::Copy(*dev_ctx, *tensor, phi::CPUPlace(), true, &temp);
-      vec_new_shape.push_back(static_cast<int32_t>(*temp.data<int32_t>()));
-      continue;
-    }
+      if (tensor->place().GetType() == phi::AllocationType::CUSTOM) {
+        DenseTensor temp;
+        phi::Copy(*dev_ctx, *tensor, phi::CPUPlace(), true, &temp);
+        vec_new_shape.push_back(static_cast<int64_t>(*temp.data<int64_t>()));
+        continue;
+      }
 #endif
 #ifdef PADDLE_WITH_XPU
-    if (tensor->place().GetType() == phi::AllocationType::XPU) {
-      DenseTensor temp;
-      phi::Copy(*dev_ctx, *tensor, phi::CPUPlace(), true, &temp);
-      vec_new_shape.push_back(static_cast<int32_t>(*temp.data<int32_t>()));
-      continue;
-    }
+      if (tensor->place().GetType() == phi::AllocationType::XPU) {
+        DenseTensor temp;
+        phi::Copy(*dev_ctx, *tensor, phi::CPUPlace(), true, &temp);
+        vec_new_shape.push_back(static_cast<int64_t>(*temp.data<int64_t>()));
+        continue;
+      }
 #endif
-    if (tensor->place().GetType() == phi::AllocationType::GPU) {
-      DenseTensor temp;
-      phi::Copy(*dev_ctx, *tensor, phi::CPUPlace(), true, &temp);
-      vec_new_shape.push_back(static_cast<int32_t>(*temp.data<int32_t>()));
-    } else {
-      vec_new_shape.push_back(static_cast<int32_t>(*tensor->data<int32_t>()));
+      if (tensor->place().GetType() == phi::AllocationType::GPU) {
+        DenseTensor temp;
+        phi::Copy(*dev_ctx, *tensor, phi::CPUPlace(), true, &temp);
+        vec_new_shape.push_back(static_cast<int64_t>(*temp.data<int64_t>()));
+      } else {
+        vec_new_shape.push_back(static_cast<int64_t>(*tensor->data<int64_t>()));
+      }
+    } else if (tensor->dtype() == phi::DataType::INT32) {
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+      if (tensor->place().GetType() == phi::AllocationType::CUSTOM) {
+        DenseTensor temp;
+        phi::Copy(*dev_ctx, *tensor, phi::CPUPlace(), true, &temp);
+        vec_new_shape.push_back(static_cast<int32_t>(*temp.data<int32_t>()));
+        continue;
+      }
+#endif
+#ifdef PADDLE_WITH_XPU
+      if (tensor->place().GetType() == phi::AllocationType::XPU) {
+        DenseTensor temp;
+        phi::Copy(*dev_ctx, *tensor, phi::CPUPlace(), true, &temp);
+        vec_new_shape.push_back(static_cast<int32_t>(*temp.data<int32_t>()));
+        continue;
+      }
+#endif
+      if (tensor->place().GetType() == phi::AllocationType::GPU) {
+        DenseTensor temp;
+        phi::Copy(*dev_ctx, *tensor, phi::CPUPlace(), true, &temp);
+        vec_new_shape.push_back(static_cast<int32_t>(*temp.data<int32_t>()));
+      } else {
+        vec_new_shape.push_back(static_cast<int32_t>(*tensor->data<int32_t>()));
+      }
     }
   }
 

--- a/paddle/phi/kernels/gpu/roi_align_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_align_kernel.cu
@@ -181,19 +181,36 @@ void RoiAlignKernel(const Context& dev_ctx,
             boxes_batch_size,
             batch_size));
 
-    std::vector<int> boxes_num_list(boxes_batch_size);
-    memory_utils::Copy(cplace,
-                       boxes_num_list.data(),
-                       gplace,
-                       boxes_num->data<int>(),
-                       sizeof(int) * boxes_batch_size,
-                       0);
-    int start = 0;
-    for (int n = 0; n < boxes_batch_size; ++n) {
-      for (int i = start; i < start + boxes_num_list[n]; ++i) {
-        roi_batch_id_data[i] = n;
+    if (boxes_num->dtype() == phi::DataType::INT64) {
+      std::vector<int64_t> boxes_num_list(boxes_batch_size);
+      memory_utils::Copy(cplace,
+                         boxes_num_list.data(),
+                         gplace,
+                         boxes_num->data<int64_t>(),
+                         sizeof(int64_t) * boxes_batch_size,
+                         0);
+      int64_t start = 0;
+      for (int64_t n = 0; n < boxes_batch_size; ++n) {
+        for (int64_t i = start; i < start + boxes_num_list[n]; ++i) {
+          roi_batch_id_data[i] = n;
+        }
+        start += boxes_num_list[n];
       }
-      start += boxes_num_list[n];
+    } else if (boxes_num->dtype() == phi::DataType::INT32) {
+      std::vector<int> boxes_num_list(boxes_batch_size);
+      memory_utils::Copy(cplace,
+                         boxes_num_list.data(),
+                         gplace,
+                         boxes_num->data<int>(),
+                         sizeof(int) * boxes_batch_size,
+                         0);
+      int start = 0;
+      for (int n = 0; n < boxes_batch_size; ++n) {
+        for (int i = start; i < start + boxes_num_list[n]; ++i) {
+          roi_batch_id_data[i] = n;
+        }
+        start += boxes_num_list[n];
+      }
     }
   } else {
     auto lod = boxes.lod();

--- a/paddle/phi/kernels/xpu/linspace_kernel.cc
+++ b/paddle/phi/kernels/xpu/linspace_kernel.cc
@@ -58,7 +58,7 @@ void LinspaceKernel(const Context& ctx,
   using XPUType = typename XPUTypeTrait<T>::Type;
   T start_value = GetValueOfExpectedType<T, Context>(ctx, start);
   T stop_value = GetValueOfExpectedType<T, Context>(ctx, stop);
-  int32_t num = GetValueOfExpectedType<int32_t, Context>(ctx, number);
+  int64_t num = GetValueOfExpectedType<int64_t, Context>(ctx, number);
 
   PADDLE_ENFORCE_GT(
       num,

--- a/paddle/phi/kernels/xpu/multiclass_nms3_kernel.cc
+++ b/paddle/phi/kernels/xpu/multiclass_nms3_kernel.cc
@@ -63,16 +63,30 @@ void MultiClassNMSKernel(const Context& ctx,
     if (has_rois_num) {
       phi::DenseTensor rois_num_host;
       rois_num_host.Resize(rois_num.get_ptr()->dims());
-      ctx.template HostAlloc<int>(&rois_num_host);
-      phi::Copy(ctx,
-                *rois_num.get_ptr(),
-                rois_num_host.place(),
-                false,
-                &rois_num_host);
-      n = rois_num.get_ptr()->numel();
-      for (int i = 0; i < n; i++) {
-        rois_num_vec.push_back(rois_num_host.data<int>()[i]);
-        boxes_count += rois_num_host.data<int>()[i];
+      if (rois_num.get_ptr()->dtype() == phi::DataType::INT64) {
+        ctx.template HostAlloc<int64_t>(&rois_num_host);
+        phi::Copy(ctx,
+                  *rois_num.get_ptr(),
+                  rois_num_host.place(),
+                  false,
+                  &rois_num_host);
+        n = rois_num.get_ptr()->numel();
+        for (int64_t i = 0; i < n; i++) {
+          rois_num_vec.push_back(rois_num_host.data<int64_t>()[i]);
+          boxes_count += rois_num_host.data<int64_t>()[i];
+        }
+      } else if (rois_num.get_ptr()->dtype() == phi::DataType::INT32) {
+        ctx.template HostAlloc<int>(&rois_num_host);
+        phi::Copy(ctx,
+                  *rois_num.get_ptr(),
+                  rois_num_host.place(),
+                  false,
+                  &rois_num_host);
+        n = rois_num.get_ptr()->numel();
+        for (int i = 0; i < n; i++) {
+          rois_num_vec.push_back(rois_num_host.data<int>()[i]);
+          boxes_count += rois_num_host.data<int>()[i];
+        }
       }
     } else {
       auto lod = bboxes.lod().back();

--- a/paddle/phi/kernels/xpu/roi_align_kernel.cc
+++ b/paddle/phi/kernels/xpu/roi_align_kernel.cc
@@ -71,7 +71,7 @@ void RoiAlignKernel(const Context& dev_ctx,
                          xplace,
                          boxes_num->data<int64_t>(),
                          sizeof(int64_t) * rois_batch_size);
-      cpu_lod = new int64_t[rois_batch_size + 1];
+      cpu_lod = new int[rois_batch_size + 1];
       cpu_lod[0] = 0;
       for (int64_t i = 0; i < rois_batch_size; i++) {
         cpu_lod[i + 1] = cpu_lod[i] + rois_num_list[i];

--- a/paddle/phi/kernels/xpu/roi_align_kernel.cc
+++ b/paddle/phi/kernels/xpu/roi_align_kernel.cc
@@ -64,16 +64,30 @@ void RoiAlignKernel(const Context& dev_ctx,
             rois_batch_size,
             batch_size));
 
-    std::vector<int> rois_num_list(rois_batch_size);
-    memory_utils::Copy(cplace,
-                       rois_num_list.data(),
-                       xplace,
-                       boxes_num->data<int>(),
-                       sizeof(int) * rois_batch_size);
-    cpu_lod = new int[rois_batch_size + 1];
-    cpu_lod[0] = 0;
-    for (int i = 0; i < rois_batch_size; i++) {
-      cpu_lod[i + 1] = cpu_lod[i] + rois_num_list[i];
+    if (boxes_num->dtype() == phi::DataType::INT64) {
+      std::vector<int64_t> rois_num_list(rois_batch_size);
+      memory_utils::Copy(cplace,
+                         rois_num_list.data(),
+                         xplace,
+                         boxes_num->data<int64_t>(),
+                         sizeof(int64_t) * rois_batch_size);
+      cpu_lod = new int64_t[rois_batch_size + 1];
+      cpu_lod[0] = 0;
+      for (int64_t i = 0; i < rois_batch_size; i++) {
+        cpu_lod[i + 1] = cpu_lod[i] + rois_num_list[i];
+      }
+    } else if (boxes_num->dtype() == phi::DataType::INT32) {
+      std::vector<int> rois_num_list(rois_batch_size);
+      memory_utils::Copy(cplace,
+                         rois_num_list.data(),
+                         xplace,
+                         boxes_num->data<int>(),
+                         sizeof(int) * rois_batch_size);
+      cpu_lod = new int[rois_batch_size + 1];
+      cpu_lod[0] = 0;
+      for (int i = 0; i < rois_batch_size; i++) {
+        cpu_lod[i + 1] = cpu_lod[i] + rois_num_list[i];
+      }
     }
   } else {
     auto lod = boxes.lod();

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -396,7 +396,7 @@ def linspace(
         else:
             check_type(stop, 'stop', (int, float), 'linspace')
         if isinstance(num, paddle.pir.Value):
-            check_dtype(num.dtype, 'num', ['int32'], 'linspace')
+            check_dtype(num.dtype, 'num', ['int32', 'int64'], 'linspace')
         check_dtype(
             dtype,
             'dtype',


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->

https://github.com/PaddlePaddle/Paddle/pull/69589 后，模型里传入一些算子的input变为int64类型。可以通过模型中将其cast成int32，也可以让算子支持int64。支持int64更合理，可以让不兼容升级影响范围更小。

Pcard-67164