### PR TITLE
[DCU] warpctc support gfx926 and gfx928

### DIFF
--- a/patches/warpctc/CMakeLists.txt.rocm.patch
+++ b/patches/warpctc/CMakeLists.txt.rocm.patch
@@ -8,3 +8,19 @@
      add_definitions(-DWARPCTC_WITH_HIP)
      include(hip)
  endif(WITH_ROCM)
+
+--- a/cmake/hip.cmake
++++ b/cmake/hip.cmake
+@@ -64,8 +64,12 @@ set(HIP_CLANG_FLAGS ${HIP_CXX_FLAGS})
+ # host linker to link.
+ list(APPEND HIP_HCC_FLAGS -fno-gpu-rdc)
+ list(APPEND HIP_HCC_FLAGS --amdgpu-target=gfx906)
++list(APPEND HIP_HCC_FLAGS --amdgpu-target=gfx926)
++list(APPEND HIP_HCC_FLAGS --amdgpu-target=gfx928)
+ list(APPEND HIP_CLANG_FLAGS -fno-gpu-rdc)
+ list(APPEND HIP_CLANG_FLAGS --amdgpu-target=gfx906)
++list(APPEND HIP_CLANG_FLAGS --amdgpu-target=gfx926)
++list(APPEND HIP_CLANG_FLAGS --amdgpu-target=gfx928)
+ 
+ 
+ if(HIP_COMPILER STREQUAL clang)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
warpctc support gfx926 and gfx928