### PR TITLE
Fix: PY3 Test Failed when upgrading docker images in pr#69491

### DIFF
--- a/test/cpp_extension/test_mixed_extension_setup.py
+++ b/test/cpp_extension/test_mixed_extension_setup.py
@@ -103,10 +103,12 @@ class TestCppExtensionSetupInstall(unittest.TestCase):
         cur_dir = os.path.dirname(os.path.abspath(__file__))
         # install mixed custom_op and extension
         # compile, install the custom op egg into site-packages under background
+        site_dir = site.getsitepackages()[0]
         cmd = f'cd {cur_dir} && {sys.executable} mix_relu_and_extension_setup.py install'
+        if os.name != 'nt':
+            cmd += f' --install-lib={site_dir}'
         run_cmd(cmd)
 
-        site_dir = site.getsitepackages()[0]
         custom_egg_path = [
             x for x in os.listdir(site_dir) if 'mix_relu_extension' in x
         ]

--- a/test/deprecated/custom_op/test_custom_raw_op_kernel_op_deprecated.py
+++ b/test/deprecated/custom_op/test_custom_raw_op_kernel_op_deprecated.py
@@ -54,6 +54,9 @@ class TestCustomRawReluOp(unittest.TestCase):
         path = os.path.dirname(os.path.abspath(__file__))
         path = os.path.join(path, "custom_raw_op_kernel_op_setup.py")
         cmd = [sys.executable, path, "install", "--force"]
+        if os.name != 'nt':
+            install_lib = f"--install-lib={site.getsitepackages()[0]}"
+            cmd.append(install_lib)
         cmd = " ".join([shlex.quote(c) for c in cmd])
         os.environ['MODULE_NAME'] = MODULE_NAME
         assert os.system(cmd) == 0


### PR DESCRIPTION


<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
Fix:
* test_mixed_extension_setup
* test_custom_raw_op_kernel_op_deprecated

After upgrading `setuptools` to `69.5.1` in the docker image([PR#69491](https://github.com/PaddlePaddle/Paddle/pull/69491)), the default installation location using `setup.py install` is `/usr/lib/pythonX.Y/site-packages`. However, the unit tests use `site.getsitepackages()[0]` to find the package installation location, which corresponds to the path `/usr/local/lib/pythonX.Y/dist-packages` , resulting in the installed package not being found. Therefore, manually specify `--install-lib` .”

pcard-67164