### PR TITLE
[SOT] Extract `FrameProxy` to separate file `frame_proxy.h` and `frame_proxy.c`

### DIFF
--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -140,6 +140,7 @@ set(PYBIND_SRCS
     auto_parallel_py.cc
     sot/eval_frame_tools.cc
     sot/cpython_internals.c
+    sot/frame_proxy.c
     sot/eval_frame.c
     sot/guards.cc
     op_callstack_utils.cc

--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -119,6 +119,7 @@ void BindGuard(pybind11::module *m) {
 void BindSot(pybind11::module *m) {
 #if SOT_IS_SUPPORTED
   PyInit__eval_frame();
+  PyInit__frame_proxy();
   m->def(
       "set_eval_frame",
       [](const py::object &py_func) {

--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -119,7 +119,9 @@ void BindGuard(pybind11::module *m) {
 void BindSot(pybind11::module *m) {
 #if SOT_IS_SUPPORTED
   PyInit__eval_frame();
+#if PY_3_11_PLUS
   PyInit__frame_proxy();
+#endif
   m->def(
       "set_eval_frame",
       [](const py::object &py_func) {

--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -22,6 +22,7 @@ limitations under the License. */
 #include "paddle/fluid/jit/serializer.h"
 #include "paddle/fluid/pybind/sot/eval_frame.h"
 #include "paddle/fluid/pybind/sot/eval_frame_tools.h"
+#include "paddle/fluid/pybind/sot/frame_proxy.h"
 #include "paddle/fluid/pybind/sot/guards.h"
 #include "paddle/fluid/pybind/sot/macros.h"
 #include "paddle/phi/common/data_type.h"

--- a/paddle/fluid/pybind/sot/cpython_internals.c
+++ b/paddle/fluid/pybind/sot/cpython_internals.c
@@ -14,9 +14,11 @@ limitations under the License. */
 
 #include "paddle/fluid/pybind/sot/cpython_internals.h"
 
-#include <frameobject.h>
-
 #if SOT_IS_SUPPORTED
+
+#if !PY_3_11_PLUS
+#include <frameobject.h>
+#endif
 
 #if PY_3_11_PLUS
 #include <internal/pycore_code.h>
@@ -682,7 +684,7 @@ static void Internal_take_ownership(PyFrameObject *f,
     } else {
       f->f_back = (PyFrameObject *)Py_NewRef(back);
     }
-#if PY_VERSION_HEX < PY_3_12_0_HEX
+#if !PY_3_12_PLUS
     frame->previous = NULL;
 #endif
   }

--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -21,7 +21,6 @@ limitations under the License. */
 #include "paddle/fluid/pybind/sot/frame_proxy.h"
 
 #include <Python.h>
-#include <frameobject.h>
 
 #if PY_3_8_PLUS && PY_VERSION_HEX < PY_3_9_0_HEX
 #define Py_BUILD_CORE  // internal/pycore_pymem.h need this macro
@@ -36,9 +35,6 @@ limitations under the License. */
 #include <pystate.h>
 
 #if PY_3_11_PLUS
-// To avoid the error: undefined symbol: _PyFrame_GetFrameObject, all we need is
-// to redefine this function based source code in python3.11. The advantage is
-// that we don't need any modification in eval_frame functions.
 #define CALL_STAT_INC(name) ((void)0)
 
 #endif

--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -22,12 +22,12 @@ limitations under the License. */
 
 #include <Python.h>
 
-#if PY_3_8_PLUS && PY_VERSION_HEX < PY_3_9_0_HEX
+#if PY_3_8_PLUS && !PY_3_9_PLUS
 #define Py_BUILD_CORE  // internal/pycore_pymem.h need this macro
 #include <internal/pycore_pystate.h>
 #undef Py_BUILD_CORE
 #endif
-#if PY_VERSION_HEX < PY_3_11_0_HEX
+#if !PY_3_11_PLUS
 #include <code.h>
 #endif
 

--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -18,7 +18,7 @@ limitations under the License. */
 
 #include "paddle/fluid/pybind/sot/cpython_internals.h"
 #include "paddle/fluid/pybind/sot/eval_frame_tools.h"
-#include "paddle/fluid/pybind/sot/frame.h"
+#include "paddle/fluid/pybind/sot/frame_proxy.h"
 
 #include <Python.h>
 #include <frameobject.h>
@@ -39,100 +39,8 @@ limitations under the License. */
 // To avoid the error: undefined symbol: _PyFrame_GetFrameObject, all we need is
 // to redefine this function based source code in python3.11. The advantage is
 // that we don't need any modification in eval_frame functions.
-typedef _PyInterpreterFrame FrameObject;
 #define CALL_STAT_INC(name) ((void)0)
 
-#define DECLARE_PROXY_PROPERTY(name)                        \
-  static PyObject *PyInterpreterFrameProxy_property_##name( \
-      PyInterpreterFrameProxy *self, void *closure) {       \
-    Py_XINCREF(self->frame->name);                          \
-    return (PyObject *)self->frame->name;                   \
-  }
-
-// clang-format off
-#define REGISTER_PROXY_PROPERTY(property_name, func_name) \
-  { #property_name, (getter)PyInterpreterFrameProxy_property_##func_name, NULL, NULL, NULL }
-// clang-format on
-
-#if PY_3_13_PLUS
-DECLARE_PROXY_PROPERTY(f_executable)
-#else
-DECLARE_PROXY_PROPERTY(f_code)
-#endif
-#if PY_3_13_PLUS
-static PyObject *PyInterpreterFrameProxy_property_f_locals(
-    PyInterpreterFrameProxy *self, void *closure) {
-  Py_XINCREF(self->locals);
-  return self->locals;
-}
-#else
-DECLARE_PROXY_PROPERTY(f_locals)
-#endif
-DECLARE_PROXY_PROPERTY(f_globals)
-DECLARE_PROXY_PROPERTY(f_builtins)
-
-// Refer to
-// https://github.com/python/cpython/blob/9414ddf91898892f3f6a672ae946931ee4b3ceb7/Objects/frameobject.c#L953-L961
-static PyObject *PyInterpreterFrameProxy_method_repr(
-    PyInterpreterFrameProxy *self) {
-#if PY_3_13_PLUS
-  int lineno = Internal_PyUnstable_InterpreterFrame_GetLine(self->frame);
-#else
-  int lineno = Internal_PyInterpreterFrame_GetLine(self->frame);
-#endif
-  PyCodeObject *code = PyFrame_GET_CODE(self->frame);
-  return PyUnicode_FromFormat(
-      "<PyInterpreterFrameProxy at %p, file %R, line %d, code %S>",
-      self,
-      code->co_filename,
-      lineno,
-      code->co_name);
-}
-
-static PyGetSetDef PyInterpreterFrameProxy_properties[] = {
-#if PY_3_13_PLUS
-    REGISTER_PROXY_PROPERTY(f_code, f_executable),
-#else
-    REGISTER_PROXY_PROPERTY(f_code, f_code),
-#endif
-    REGISTER_PROXY_PROPERTY(f_locals, f_locals),
-    REGISTER_PROXY_PROPERTY(f_globals, f_globals),
-    REGISTER_PROXY_PROPERTY(f_builtins, f_builtins),
-    {NULL} /* Sentinel */
-};
-
-// clang-format off
-static PyTypeObject PyInterpreterFrameProxyType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "paddle.framework.core.PyInterpreterFrameProxy",
-    .tp_doc = PyDoc_STR("A proxy object for _PyInterpreterFrame, "
-                        "it's only define all properties we need."),
-    .tp_repr = (reprfunc)PyInterpreterFrameProxy_method_repr,
-    .tp_basicsize = sizeof(PyInterpreterFrameProxy),
-    .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
-    .tp_getset = PyInterpreterFrameProxy_properties,
-};
-// clang-format on
-
-PyInterpreterFrameProxy *PyInterpreterFrameProxy_New(
-    _PyInterpreterFrame *frame) {
-  PyTypeObject *type = &PyInterpreterFrameProxyType;
-  PyInterpreterFrameProxy *self =
-      (PyInterpreterFrameProxy *)type->tp_alloc(type, 0);
-  if (!self) {
-    // VLOG(7) << "Failed to allocate PyInterpreterFrameProxy";
-    return NULL;
-  }
-  self->frame = frame;
-#if PY_3_13_PLUS
-  self->locals = NULL;
-#endif
-  return self;
-}
-
-#else
-typedef PyFrameObject FrameObject;
 #endif
 
 #ifdef _WIN32
@@ -544,13 +452,6 @@ PyMODINIT_FUNC PyInit__eval_frame() {
 
   Py_INCREF(Py_None);
   eval_frame_callback_set(Py_None);
-
-#if PY_3_11_PLUS
-  if (PyType_Ready(&PyInterpreterFrameProxyType) < 0) {
-    // VLOG(7) << "PyInterpreterFrameProxyType has not been ready!";
-  }
-  Py_INCREF(&PyInterpreterFrameProxyType);
-#endif
 
   return NULL;
 }

--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -18,6 +18,7 @@ limitations under the License. */
 
 #include "paddle/fluid/pybind/sot/cpython_internals.h"
 #include "paddle/fluid/pybind/sot/eval_frame_tools.h"
+#include "paddle/fluid/pybind/sot/frame.h"
 
 #include <Python.h>
 #include <frameobject.h>
@@ -40,18 +41,6 @@ limitations under the License. */
 // that we don't need any modification in eval_frame functions.
 typedef _PyInterpreterFrame FrameObject;
 #define CALL_STAT_INC(name) ((void)0)
-
-// clang-format off
-// Define a proxy PyObject to access _PyInterpreterFrame's properties.
-// It will be passed as an argument to the eval frame's callback.
-typedef struct PyInterpreterFrameProxy {
-  PyObject_HEAD
-  _PyInterpreterFrame *frame;
-  #if PY_3_13_PLUS
-  PyObject* locals;
-  #endif
-} PyInterpreterFrameProxy;
-// clang-format on
 
 #define DECLARE_PROXY_PROPERTY(name)                        \
   static PyObject *PyInterpreterFrameProxy_property_##name( \

--- a/paddle/fluid/pybind/sot/eval_frame_tools.h
+++ b/paddle/fluid/pybind/sot/eval_frame_tools.h
@@ -19,20 +19,10 @@ extern "C" {
 #endif
 
 #include <Python.h>
-#include <frameobject.h>
+#include "paddle/fluid/pybind/sot/frame_proxy.h"
 #include "paddle/fluid/pybind/sot/macros.h"
 
 #if SOT_IS_SUPPORTED
-
-#if PY_3_11_PLUS
-#if PY_3_13_PLUS
-#define Py_BUILD_CORE
-#endif
-#include <internal/pycore_frame.h>
-typedef _PyInterpreterFrame FrameObject;
-#else
-typedef PyFrameObject FrameObject;
-#endif
 
 int need_skip(FrameObject* frame);
 int is_code_without_graph(PyCodeObject* code);

--- a/paddle/fluid/pybind/sot/frame.h
+++ b/paddle/fluid/pybind/sot/frame.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <Python.h>
+
+#include "paddle/fluid/pybind/sot/macros.h"
+
+#if SOT_IS_SUPPORTED
+
+#if PY_3_11_PLUS
+// clang-format off
+// Define a proxy PyObject to access _PyInterpreterFrame's properties.
+// It will be passed as an argument to the eval frame's callback.
+typedef struct PyInterpreterFrameProxy {
+  PyObject_HEAD
+  _PyInterpreterFrame *frame;
+  #if PY_3_13_PLUS
+  PyObject* locals;
+  #endif
+} PyInterpreterFrameProxy;
+// clang-format on
+#endif
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/paddle/fluid/pybind/sot/frame_proxy.c
+++ b/paddle/fluid/pybind/sot/frame_proxy.c
@@ -17,7 +17,6 @@ limitations under the License. */
 
 #if SOT_IS_SUPPORTED
 #include <Python.h>
-#include <frameobject.h>
 
 #if PY_3_11_PLUS
 

--- a/paddle/fluid/pybind/sot/frame_proxy.c
+++ b/paddle/fluid/pybind/sot/frame_proxy.c
@@ -1,0 +1,125 @@
+/* Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/pybind/sot/frame_proxy.h"
+#include "paddle/fluid/pybind/sot/macros.h"
+
+#if SOT_IS_SUPPORTED
+#include <Python.h>
+
+#if PY_3_11_PLUS
+
+#define DECLARE_PROXY_PROPERTY(name)                        \
+  static PyObject *PyInterpreterFrameProxy_property_##name( \
+      PyInterpreterFrameProxy *self, void *closure) {       \
+    Py_XINCREF(self->frame->name);                          \
+    return (PyObject *)self->frame->name;                   \
+  }
+
+// clang-format off
+#define REGISTER_PROXY_PROPERTY(property_name, func_name) \
+  { #property_name, (getter)PyInterpreterFrameProxy_property_##func_name, NULL, NULL, NULL }
+// clang-format on
+
+#if PY_3_13_PLUS
+DECLARE_PROXY_PROPERTY(f_executable)
+#else
+DECLARE_PROXY_PROPERTY(f_code)
+#endif
+#if PY_3_13_PLUS
+static PyObject *PyInterpreterFrameProxy_property_f_locals(
+    PyInterpreterFrameProxy *self, void *closure) {
+  Py_XINCREF(self->locals);
+  return self->locals;
+}
+#else
+DECLARE_PROXY_PROPERTY(f_locals)
+#endif
+DECLARE_PROXY_PROPERTY(f_globals)
+DECLARE_PROXY_PROPERTY(f_builtins)
+
+// Refer to
+// https://github.com/python/cpython/blob/9414ddf91898892f3f6a672ae946931ee4b3ceb7/Objects/frameobject.c#L953-L961
+static PyObject *PyInterpreterFrameProxy_method_repr(
+    PyInterpreterFrameProxy *self) {
+#if PY_3_13_PLUS
+  int lineno = Internal_PyUnstable_InterpreterFrame_GetLine(self->frame);
+#else
+  int lineno = Internal_PyInterpreterFrame_GetLine(self->frame);
+#endif
+  PyCodeObject *code = PyFrame_GET_CODE(self->frame);
+  return PyUnicode_FromFormat(
+      "<PyInterpreterFrameProxy at %p, file %R, line %d, code %S>",
+      self,
+      code->co_filename,
+      lineno,
+      code->co_name);
+}
+
+static PyGetSetDef PyInterpreterFrameProxy_properties[] = {
+#if PY_3_13_PLUS
+    REGISTER_PROXY_PROPERTY(f_code, f_executable),
+#else
+    REGISTER_PROXY_PROPERTY(f_code, f_code),
+#endif
+    REGISTER_PROXY_PROPERTY(f_locals, f_locals),
+    REGISTER_PROXY_PROPERTY(f_globals, f_globals),
+    REGISTER_PROXY_PROPERTY(f_builtins, f_builtins),
+    {NULL} /* Sentinel */
+};
+
+// clang-format off
+static PyTypeObject PyInterpreterFrameProxyType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "paddle.framework.core.PyInterpreterFrameProxy",
+    .tp_doc = PyDoc_STR("A proxy object for _PyInterpreterFrame, "
+                        "it's only define all properties we need."),
+    .tp_repr = (reprfunc)PyInterpreterFrameProxy_method_repr,
+    .tp_basicsize = sizeof(PyInterpreterFrameProxy),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_getset = PyInterpreterFrameProxy_properties,
+};
+// clang-format on
+
+PyInterpreterFrameProxy *PyInterpreterFrameProxy_New(
+    _PyInterpreterFrame *frame) {
+  PyTypeObject *type = &PyInterpreterFrameProxyType;
+  PyInterpreterFrameProxy *self =
+      (PyInterpreterFrameProxy *)type->tp_alloc(type, 0);
+  if (!self) {
+    // VLOG(7) << "Failed to allocate PyInterpreterFrameProxy";
+    return NULL;
+  }
+  self->frame = frame;
+#if PY_3_13_PLUS
+  self->locals = NULL;
+#endif
+  return self;
+}
+
+PyMODINIT_FUNC PyInit__frame_proxy() {
+#if PY_3_11_PLUS
+  if (PyType_Ready(&PyInterpreterFrameProxyType) < 0) {
+    // VLOG(7) << "PyInterpreterFrameProxyType has not been ready!";
+  }
+  Py_INCREF(&PyInterpreterFrameProxyType);
+#endif
+
+  return NULL;
+}
+
+#endif
+
+#endif

--- a/paddle/fluid/pybind/sot/frame_proxy.c
+++ b/paddle/fluid/pybind/sot/frame_proxy.c
@@ -17,6 +17,7 @@ limitations under the License. */
 
 #if SOT_IS_SUPPORTED
 #include <Python.h>
+#include <frameobject.h>
 
 #if PY_3_11_PLUS
 

--- a/paddle/fluid/pybind/sot/frame_proxy.c
+++ b/paddle/fluid/pybind/sot/frame_proxy.c
@@ -110,13 +110,10 @@ PyInterpreterFrameProxy *PyInterpreterFrameProxy_New(
 }
 
 PyMODINIT_FUNC PyInit__frame_proxy() {
-#if PY_3_11_PLUS
   if (PyType_Ready(&PyInterpreterFrameProxyType) < 0) {
     // VLOG(7) << "PyInterpreterFrameProxyType has not been ready!";
   }
   Py_INCREF(&PyInterpreterFrameProxyType);
-#endif
-
   return NULL;
 }
 

--- a/paddle/fluid/pybind/sot/frame_proxy.h
+++ b/paddle/fluid/pybind/sot/frame_proxy.h
@@ -18,6 +18,7 @@ extern "C" {
 #endif
 
 #include <Python.h>
+#include <frameobject.h>
 #include "paddle/fluid/pybind/sot/cpython_internals.h"
 #include "paddle/fluid/pybind/sot/macros.h"
 

--- a/paddle/fluid/pybind/sot/frame_proxy.h
+++ b/paddle/fluid/pybind/sot/frame_proxy.h
@@ -19,11 +19,15 @@ extern "C" {
 
 #include <Python.h>
 
+#include "internal/pycore_frame.h"
+#include "paddle/fluid/pybind/sot/cpython_internals.h"
 #include "paddle/fluid/pybind/sot/macros.h"
 
 #if SOT_IS_SUPPORTED
 
 #if PY_3_11_PLUS
+typedef _PyInterpreterFrame FrameObject;
+
 // clang-format off
 // Define a proxy PyObject to access _PyInterpreterFrame's properties.
 // It will be passed as an argument to the eval frame's callback.
@@ -35,6 +39,13 @@ typedef struct PyInterpreterFrameProxy {
   #endif
 } PyInterpreterFrameProxy;
 // clang-format on
+
+PyInterpreterFrameProxy *PyInterpreterFrameProxy_New(
+    _PyInterpreterFrame *frame);
+PyMODINIT_FUNC PyInit__frame_proxy();
+
+#else
+typedef PyFrameObject FrameObject;
 #endif
 
 #endif

--- a/paddle/fluid/pybind/sot/frame_proxy.h
+++ b/paddle/fluid/pybind/sot/frame_proxy.h
@@ -18,11 +18,14 @@ extern "C" {
 #endif
 
 #include <Python.h>
-#include <frameobject.h>
 #include "paddle/fluid/pybind/sot/cpython_internals.h"
 #include "paddle/fluid/pybind/sot/macros.h"
 
 #if SOT_IS_SUPPORTED
+
+#if !PY_3_11_PLUS
+#include <frameobject.h>
+#endif
 
 #if PY_3_11_PLUS
 

--- a/paddle/fluid/pybind/sot/frame_proxy.h
+++ b/paddle/fluid/pybind/sot/frame_proxy.h
@@ -18,14 +18,18 @@ extern "C" {
 #endif
 
 #include <Python.h>
-
-#include "internal/pycore_frame.h"
 #include "paddle/fluid/pybind/sot/cpython_internals.h"
 #include "paddle/fluid/pybind/sot/macros.h"
 
 #if SOT_IS_SUPPORTED
 
 #if PY_3_11_PLUS
+
+#if PY_3_13_PLUS
+#define Py_BUILD_CORE
+#endif
+#include <internal/pycore_frame.h>
+
 typedef _PyInterpreterFrame FrameObject;
 
 // clang-format off

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -20,7 +20,7 @@ limitations under the License. */
 #include <Python.h>
 #include <frameobject.h>
 
-#if !defined(PyObject_CallOneArg) && PY_VERSION_HEX < PY_3_9_0_HEX
+#if !defined(PyObject_CallOneArg) && !PY_3_9_PLUS
 static inline PyObject* PyObject_CallOneArg(PyObject* func, PyObject* arg) {
   return PyObject_CallFunctionObjArgs(func, arg, NULL);
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->
把 PyInterpreterFrameProxy 抽离到单独的文件