### PR TITLE
[SOT][Faster Guard] test faster guard in separate cache

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -81,6 +81,18 @@ class OpcodeExecutorCache(metaclass=Singleton):
         self.translate_count = 0
         self.code_symbolic_inputs.clear()
 
+    def dump_state(self):
+        return {
+            "cache": self.cache,
+            "translate_count": self.translate_count,
+            "code_symbolic_inputs": self.code_symbolic_inputs,
+        }
+
+    def load_state(self, state):
+        self.cache = state["cache"]
+        self.translate_count = state["translate_count"]
+        self.code_symbolic_inputs = state["code_symbolic_inputs"]
+
     def __call__(self, frame: types.FrameType, **kwargs) -> CustomCode:
         code: types.CodeType = frame.f_code
         if code not in self.cache:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

目前 `test_with_faster_guard` 所装饰的 case 原 guard 和 faster guard 共享 cache，大概率会导致后测的 faster guard 测不到，因此在跑 faster guard 时候使用独立的 cache，以确保能跑到

这里原来想简单地使用 `test_instruction_translator_cache_context` 来 clear，但是这是有 side effect 的，会导致原来 case 的行为变掉，可能会导致奇怪的问题

PCard-66972