### PR TITLE
[SOT] Use tuple `InputSpec` to avoid type check error

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -433,7 +433,7 @@ class FunctionGraph:
         symbolic_inputs = self._find_tensor_inputs(input_names)
         compiled_fn = self.sir_ctx.compile_fn(
             statement_ir.name,
-            [var.meta.to_input_spec() for var in symbolic_inputs],
+            tuple(var.meta.to_input_spec() for var in symbolic_inputs),
             **self._kwargs,
         )
         return compiled_fn, (statement_ir, symbolic_inputs, symbolic_outputs)

--- a/python/paddle/jit/sot/symbolic/compile_cache.py
+++ b/python/paddle/jit/sot/symbolic/compile_cache.py
@@ -104,7 +104,10 @@ class FallbackWrapper:
     def graph_size(self):
         if self.partial_program is None:
             input_spec = convert_meta_to_input_spec(
-                [self.SIR.symbol_meta_map[symbol] for symbol in self.SIR.inputs]
+                tuple(
+                    self.SIR.symbol_meta_map[symbol]
+                    for symbol in self.SIR.inputs
+                )
             )
             (
                 self.concrete_program,
@@ -181,7 +184,7 @@ class CompileSIRCache(Cache, metaclass=Singleton):
         self,
         context: SymbolicTraceContext,
         sir_name: str,
-        input_spec: list[InputSpec],
+        input_spec: tuple[InputSpec, ...],
         **kwargs,
     ):
         """
@@ -204,7 +207,7 @@ class CompileSIRCache(Cache, metaclass=Singleton):
         self,
         context: SymbolicTraceContext,
         sir_name: str,
-        input_spec: list[InputSpec],
+        input_spec: tuple[InputSpec, ...],
         **kwargs,
     ):
         """

--- a/python/paddle/jit/sot/symbolic/symbolic_context.py
+++ b/python/paddle/jit/sot/symbolic/symbolic_context.py
@@ -156,7 +156,9 @@ class SymbolicTraceContext:
 
         return DummyFunc()
 
-    def compile_fn(self, sir_name: str, input_spec: list[InputSpec], **kwargs):
+    def compile_fn(
+        self, sir_name: str, input_spec: tuple[InputSpec, ...], **kwargs
+    ):
         """
         start compile and return the python function, which must can be to_static without errors.
         """


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

开启动态 shape 后设置的 input spec 是 list，但实际上 SOT 的输入都是 tuple，会导致 input spec 检查逻辑挂掉（log 4 下直接挂），因此统一使用 tuple 作为 input spec 输入类型

PCard-66972