### PR TITLE
[CINN]Slice_op is not supported to enter CINN when there is no data in the parameters

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
@@ -39,8 +39,6 @@ class FusionOpPattern : public pir::OpRewritePattern<cinn::dialect::FusionOp> {
     ::pir::IrContext* ctx = ::pir::IrContext::Instance();
     auto* program = fusion_op->GetParentProgram();
     auto& shape_analysis = pir::ShapeAnalysisManager::Instance().Get(program);
-    VLOG(4) << "Program before lowering: \n"
-            << pir::CustomPrintHelper(*program, shape_analysis.PrintHook());
 
     // TODO(zhangyuqin1998): Replace pir::Group with a new structure
     OpLoweringGroupPtr group = GetGroup(fusion_op);

--- a/paddle/cinn/hlir/framework/pir/utils.cc
+++ b/paddle/cinn/hlir/framework/pir/utils.cc
@@ -352,8 +352,7 @@ bool CauseNewSymbolicShape(const ::pir::Operation& op) {
   if (!HaveUnkDim(op)) {
     return false;
   }
-  auto& shape_analysis = ::pir::ShapeAnalysisManager::Instance().Get(
-      const_cast<::pir::Operation&>(op).GetParentProgram());
+
   std::unordered_set<std::string> input_exprs = [&]() {
     std::unordered_set<std::string> res;
     for (const auto& input_value : op.operands_source()) {

--- a/paddle/cinn/hlir/framework/pir/utils.cc
+++ b/paddle/cinn/hlir/framework/pir/utils.cc
@@ -363,12 +363,13 @@ bool CauseNewSymbolicShape(const ::pir::Operation& op) {
         has_data = has_data && item.data().has_value();
       }
       return has_data;
-    } else if (shape_or_data.isa<symbol::ShapeOrDataDimExprs>) {
+    } else if (shape_or_data.isa<symbol::TensorShapeOrDataDimExprs>()) {
       return shape_or_data.data().has_value();
     }
     PADDLE_THROW(::common::errors::InvalidArgument(
         "The starts and ends parameters of pd_op.slice currently only support "
-        "two types: TensorListShapeOrDataDimExprs and ShapeOrDataDimExprs"));
+        "two types: TensorListShapeOrDataDimExprs and "
+        "TensorShapeOrDataDimExprs"));
   };
 
   const auto& IsProcessableSlice = [&]() -> bool {

--- a/paddle/cinn/hlir/framework/pir/utils.cc
+++ b/paddle/cinn/hlir/framework/pir/utils.cc
@@ -353,33 +353,35 @@ bool CauseNewSymbolicShape(const ::pir::Operation& op) {
   auto& shape_analysis = ::pir::ShapeAnalysisManager::Instance().Get(
       const_cast<::pir::Operation&>(op).GetParentProgram());
 
-  const auto& isProcessableSlice = [&]() -> bool {
+  const auto& HasData =
+      [&](const symbol::ShapeOrDataDimExprs& shape_or_data) -> bool {
+    if (shape_or_data.isa<symbol::TensorListShapeOrDataDimExprs>()) {
+      bool has_data = true;
+      const symbol::TensorListShapeOrDataDimExprs& list =
+          shape_or_data.dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
+      for (const auto& item : list) {
+        has_data = has_data && item.data().has_value();
+      }
+      return has_data;
+    } else if (shape_or_data.isa<symbol::ShapeOrDataDimExprs>) {
+      return shape_or_data.data().has_value();
+    }
+    PADDLE_THROW(::common::errors::InvalidArgument(
+        "The starts and ends parameters of pd_op.slice currently only support "
+        "two types: TensorListShapeOrDataDimExprs and ShapeOrDataDimExprs"));
+  };
+
+  const auto& IsProcessableSlice = [&]() -> bool {
     const ::pir::Value& starts_value = op.operand_source(1);
     const ::pir::Value& ends_value = op.operand_source(2);
     const symbol::ShapeOrDataDimExprs& starts_shape_data =
         shape_analysis.GetShapeOrDataForValue(starts_value);
     const symbol::ShapeOrDataDimExprs& ends_shape_data =
         shape_analysis.GetShapeOrDataForValue(ends_value);
-
-    const auto& HasData =
-        [&](const symbol::ShapeOrDataDimExprs& se_shape_data) -> bool {
-      if (se_shape_data.isa<symbol::TensorListShapeOrDataDimExprs>()) {
-        bool has_data = true;
-        const symbol::TensorListShapeOrDataDimExprs& list =
-            se_shape_data.dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
-        for (const auto& item : list) {
-          has_data = has_data && item.data().has_value();
-        }
-        return has_data;
-      }
-
-      return se_shape_data.data().has_value();
-    };
-
     return HasData(starts_shape_data) && HasData(ends_shape_data);
   };
 
-  if (op.isa<paddle::dialect::SliceOp>() && !isProcessableSlice()) {
+  if (op.isa<paddle::dialect::SliceOp>() && !IsProcessableSlice()) {
     return true;
   }
 

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
@@ -19,11 +19,11 @@
 namespace paddle::dialect::slice_utils {
 
 inline bool GetExprVecOfStartEnd(
-    const symbol::ShapeOrDataDimExprs &se_shape_data,
+    const symbol::ShapeOrDataDimExprs &shape_or_data,
     std::vector<symbol::DimExpr> *expr_vec) {
-  if (se_shape_data.isa<TensorListExprs>()) {
+  if (shape_or_data.isa<TensorListExprs>()) {
     TensorListExprs list =
-        se_shape_data.dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
+        shape_or_data.dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
     for (size_t i = 0; i < list.size(); i++) {
       PADDLE_ENFORCE_EQ(list.at(i).data().has_value(),
                         true,
@@ -34,12 +34,16 @@ inline bool GetExprVecOfStartEnd(
       }
     }
     return true;
-  } else {
-    if (se_shape_data.data().has_value()) {
-      *expr_vec = se_shape_data.data().value();
+  } else if (shape_or_data.isa<symbol::ShapeOrDataDimExprs>) {
+    if (shape_or_data.data().has_value()) {
+      *expr_vec = shape_or_data.data().value();
       return true;
     }
     return false;
+  } else {
+    PADDLE_THROW(::common::errors::InvalidArgument(
+        "The starts and ends parameters of pd_op.slice currently only support "
+        "two types: TensorListShapeOrDataDimExprs and ShapeOrDataDimExprs"));
   }
 }
 

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
@@ -34,7 +34,7 @@ inline bool GetExprVecOfStartEnd(
       }
     }
     return true;
-  } else if (shape_or_data.isa<symbol::ShapeOrDataDimExprs>) {
+  } else if (shape_or_data.isa<symbol::TensorShapeOrDataDimExprs>()) {
     if (shape_or_data.data().has_value()) {
       *expr_vec = shape_or_data.data().value();
       return true;
@@ -43,7 +43,8 @@ inline bool GetExprVecOfStartEnd(
   } else {
     PADDLE_THROW(::common::errors::InvalidArgument(
         "The starts and ends parameters of pd_op.slice currently only support "
-        "two types: TensorListShapeOrDataDimExprs and ShapeOrDataDimExprs"));
+        "two types: TensorListShapeOrDataDimExprs and "
+        "TensorShapeOrDataDimExprs"));
   }
 }
 

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -3227,23 +3227,65 @@ bool ShuffleChannelOpInferSymbolicShape(
 bool SliceOpInferSymbolicShape(pir::Operation *op,
                                pir::InferSymbolicShapeContext *infer_context) {
   pir::Value operand_source = op->operand_source(0);
-  pir::Value operand_starts = op->operand_source(1);
-  pir::Value operand_ends = op->operand_source(2);
   pir::Value res = op->result(0);
 
-  const symbol::ShapeOrDataDimExprs &starts_shape_data =
-      infer_context->GetShapeOrDataForValue(operand_starts);
-  const symbol::ShapeOrDataDimExprs &ends_shape_data =
-      infer_context->GetShapeOrDataForValue(operand_ends);
-
   std::vector<int64_t> axes_vec = details::GetVectorAttr(op, "axes");
-
-  ExprVec starts = slice_utils::GetExprVecFromData(starts_shape_data);
-  ExprVec ends = slice_utils::GetExprVecFromData(ends_shape_data);
-
   std::vector<int64_t> infer_flags = details::GetVectorAttr(op, "infer_flags");
   const std::vector<int64_t> decrease_axis =
       details::GetVectorAttr(op, "decrease_axis");
+
+  auto GetExprVec = [&](std::vector<symbol::DimExpr> *expr_vec,
+                        const int &operand_idx,
+                        const std::string &attr_name) -> bool {
+    if (op->operand_source(operand_idx)) {
+      const symbol::ShapeOrDataDimExprs &se_shape_data =
+          infer_context->GetShapeOrDataForValue(
+              op->operand_source(operand_idx));
+      if (slice_utils::GetExprVecOfStartEnd(se_shape_data, expr_vec)) {
+        return true;
+      }
+      PADDLE_ENFORCE_EQ(
+          se_shape_data.shape().at(0).isa<std::int64_t>() &&
+              (static_cast<int64_t>(axes_vec.size()) ==
+               se_shape_data.shape().at(0).dyn_cast<std::int64_t>()),
+          true,
+          common::errors::InvalidArgument(
+              "The size of axes must equal size of starts and ends."));
+      return false;
+    } else {
+      if (op->attributes().find(attr_name) != op->attributes().end()) {
+        const std::vector<int64_t> se_raw =
+            paddle::dialect::details::GetVectorAttr(op, attr_name);
+        for (const int64_t &se : se_raw) {
+          expr_vec->push_back(symbol::DimExpr{se});
+        }
+        return true;
+      }
+      return false;
+    }
+  };
+
+  std::vector<symbol::DimExpr> starts;
+  std::vector<symbol::DimExpr> ends;
+  if (!GetExprVec(&starts, 1, "starts") || !GetExprVec(&ends, 2, "ends")) {
+    const auto &in_shapeordata =
+        infer_context->GetShapeOrDataForValue(op->operand_source(0));
+    // NOTE(gongshaotian): When there is no data value in the starts and ends
+    // parameters, only the shape value is processed regardless of whether the
+    // input has a data value, and the  data value is no longer processed.
+    std::vector<symbol::DimExpr> out_shape = in_shapeordata.shape();
+    for (size_t i = 0; i < axes_vec.size(); i++) {
+      int64_t axis = axes_vec[i];
+      out_shape[axis] = infer_context->GetNextSymName();
+    }
+    ExprVec out_dims = paddle::dialect::slice_utils::GetDecreasedDims(
+        out_shape, decrease_axis);
+    infer_context->SetShapeOrDataForValue(
+        res,
+        symbol::ShapeOrDataDimExprs{
+            symbol::TensorShapeOrDataDimExprs(out_dims)});
+    return true;
+  }
 
   infer_context->SetShapeOrDataForValue(
       res,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
+ In stage IsSupportInCinn(), intercept pd_op.slice without data area in the start and end parameters
+ Refine the symbolic interface of SliceOp. Enable it to handle situations where data in the data area is empty in special circumstances

Associated reverted PR: https://github.com/PaddlePaddle/Paddle/pull/69503
Difference from Reverted PR：
+ Determine the type of supplementary TensorListExprs
+ Split the modified parts