### PR TITLE
[CINN] Fix the InferSymbolic bug  of pd_op.minimum 

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/element_wise_binary.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/element_wise_binary.cc
@@ -147,6 +147,17 @@ bool FloorDivideOpInferSymbolicShape(
       });
 }
 
+bool MinimumOpInferSymbolicShape(
+    pir::Operation *op, pir::InferSymbolicShapeContext *infer_context) {
+  return InferSymbolicShapeElementWiseBinary(
+      op,
+      infer_context,
+      [](const symbol::DimExpr &x, const symbol::DimExpr &y) {
+        symbol::DimExprBuilder builder;
+        return builder.Min(x, y);
+      });
+}
+
 OP_ELEMENT_WISE_BINARY(Add_)
 OP_ELEMENT_WISE_BINARY(BitwiseAnd)
 OP_ELEMENT_WISE_BINARY(BitwiseAnd_)
@@ -186,7 +197,6 @@ OP_ELEMENT_WISE_BINARY(LogicalOr_)
 OP_ELEMENT_WISE_BINARY(LogicalXor)
 OP_ELEMENT_WISE_BINARY(LogicalXor_)
 OP_ELEMENT_WISE_BINARY(Maximum)
-OP_ELEMENT_WISE_BINARY(Minimum)
 OP_ELEMENT_WISE_BINARY(MultiplySr)
 OP_ELEMENT_WISE_BINARY(MultiplySr_)
 OP_ELEMENT_WISE_BINARY(Multiply_)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
+ add MinimumOpInferSymbolicShape