### PR TITLE
[CINN] Fix the InferSymbolic bug of pd_op.ceil

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
@@ -49,8 +49,6 @@ OP_SAME_OPERANDS_AND_RESULT(Hardtanh_)
 OP_SAME_OPERANDS_AND_RESULT(Bernoulli)
 OP_SAME_OPERANDS_AND_RESULT(BitwiseNot)
 OP_SAME_OPERANDS_AND_RESULT(BitwiseNot_)
-OP_SAME_OPERANDS_AND_RESULT(Ceil)
-OP_SAME_OPERANDS_AND_RESULT(Ceil_)
 OP_SAME_OPERANDS_AND_RESULT(Celu)
 OP_SAME_OPERANDS_AND_RESULT(Clip)
 OP_SAME_OPERANDS_AND_RESULT(Clip_)
@@ -282,6 +280,19 @@ bool ArgsortOpInferSymbolicShape(
   infer_context->SetShapeOrDataForValue(op->result(0), operand_shape_or_data);
   infer_context->SetShapeOrDataForValue(op->result(1), operand_shape_or_data);
   return true;
+}
+
+bool CeilOpInferSymbolicShape(pir::Operation *op,
+                              pir::InferSymbolicShapeContext *infer_context) {
+  const symbol::ShapeOrDataDimExprs &operand_shape_or_data =
+      infer_context->GetShapeOrDataForValue(op->operand_source(0));
+  infer_context->SetShapeOrDataForValue(op->result(0), operand_shape_or_data);
+  return true;
+}
+
+bool Ceil_OpInferSymbolicShape(pir::Operation *op,
+                               pir::InferSymbolicShapeContext *infer_context) {
+  return CeilOpInferSymbolicShape(op, infer_context);
 }
 
 }  // namespace paddle::dialect


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
+ add InferSymbolicShape interface of `ceil` and `ceil_` op 