### PR TITLE
Adding nccl_async_time_profiler

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1603,6 +1603,19 @@ PHI_DEFINE_EXPORTED_bool(enable_async_trace,
 
 PHI_DEFINE_EXPORTED_int32(async_trace_count, 5, "collective async trace count");
 
+/**
+ * ProcessGroupNCCL related FLAG
+ * Name: enable_async_time_profiler
+ * Since Version:
+ * Value Range: bool, default=false
+ * Example:
+ * Note: enable nccl async time profiler.
+ */
+
+PHI_DEFINE_EXPORTED_bool(enable_async_time_profiler,
+                         false,
+                         "enable collective async time profiler");
+
 PHI_DEFINE_EXPORTED_bool(
     use_auto_growth_pinned_allocator,
     false,

--- a/paddle/fluid/distributed/collective/process_group.cc
+++ b/paddle/fluid/distributed/collective/process_group.cc
@@ -13,12 +13,27 @@
 // limitations under the License.
 
 #include "paddle/fluid/distributed/collective/process_group.h"
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
+#include "paddle/common/flags.h"
+#include "paddle/phi/core/distributed/comm_async_time_profiler.h"
+
+COMMON_DECLARE_bool(enable_async_time_profiler);
+#endif
 
 namespace paddle::distributed {
 
 bool ProcessGroup::Task::IsCompleted() {
   std::lock_guard<std::mutex> lock(mutex_);
   return is_completed_;
+}
+
+std::unordered_map<int, float> ProcessGroup::GetProfiles() {
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
+  if (FLAGS_enable_async_time_profiler) {
+    return phi::distributed::CommAsyncTimeProfiler::GetInstance().GetProfiles();
+  }
+#endif
+  return {};
 }
 
 ProcessGroup::ProcessGroup(int rank, int size, int gid)

--- a/paddle/fluid/distributed/collective/process_group.h
+++ b/paddle/fluid/distributed/collective/process_group.h
@@ -100,6 +100,8 @@ class ProcessGroup {
            std::string(", backend: ") + GetBackendName();
   }
 
+  static std::unordered_map<int, float> GetProfiles();
+
   virtual std::string GetBackendName() const = 0;
 
   virtual phi::DeviceContext* GetDeviceContext(
@@ -506,6 +508,7 @@ class ProcessGroup {
   int rank_;
   int size_;
   int gid_;
+  bool profile_enabled_{false};
 };
 
 class ProcessGroupIdMap

--- a/paddle/fluid/pybind/distributed_py.cc
+++ b/paddle/fluid/pybind/distributed_py.cc
@@ -1242,7 +1242,10 @@ void BindDistributed(py::module *m) {
               py::arg("src"),
               py::arg("num"),
               py::arg("id"),
-              py::call_guard<py::gil_scoped_release>());
+              py::call_guard<py::gil_scoped_release>())
+          .def_static("get_profiles",
+                      distributed::ProcessGroup::GetProfiles,
+                      py::call_guard<py::gil_scoped_release>());
 
 #if defined(PADDLE_WITH_RCCL) || defined(PADDLE_WITH_NCCL)
   py::class_<distributed::ProcessGroupNCCL,

--- a/paddle/phi/core/distributed/CMakeLists.txt
+++ b/paddle/phi/core/distributed/CMakeLists.txt
@@ -8,6 +8,8 @@ if(WITH_NCCL OR WITH_RCCL)
   list(APPEND DISTRIBUTED_COMMON_SRCS comm_task_manager.cc)
   list(APPEND DISTRIBUTED_COMMON_SRCS nccl_comm_context.cc nccl_comm_task.cc
        nccl_tools.cc)
+  list(APPEND DISTRIBUTED_COMMON_SRCS comm_async_time_profiler.cc
+       comm_async_recorder.cc)
 endif()
 
 if(WITH_GLOO)

--- a/paddle/phi/core/distributed/comm_async_recorder.cc
+++ b/paddle/phi/core/distributed/comm_async_recorder.cc
@@ -1,0 +1,128 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <glog/logging.h>
+
+#include "paddle/common/macros.h"
+#include "paddle/phi/backends/gpu/gpu_decls.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
+#include "paddle/phi/core/distributed/comm_async_recorder.h"
+#include "paddle/phi/core/distributed/nccl_tools.h"
+
+namespace phi {
+namespace distributed {
+
+CommAsyncRecorder::CommAsyncRecorder(const phi::Place& place,
+                                     int gid,
+                                     gpuStream_t stream)
+    : place_(place), gid_(gid), nccl_stream_(stream), is_start_(false) {
+#ifdef PADDLE_WITH_CUDA
+  CUDA_CHECK(cudaEventCreate(&nccl_start_event_));
+  CUDA_CHECK(cudaEventCreate(&nccl_end_event_));
+#else  // PADDLE_WITH_HIP
+  HIP_CHECK(hipEventCreate(&nccl_start_event_));
+  HIP_CHECK(hipEventCreate(&nccl_end_event_));
+#endif
+}
+
+void CommAsyncRecorder::EventDestroy() {
+  backends::gpu::GPUDeviceGuard guard(place_.device);
+#ifdef PADDLE_WITH_CUDA
+  CUDA_CHECK(cudaEventDestroy(nccl_start_event_));
+  CUDA_CHECK(cudaEventDestroy(nccl_end_event_));
+#else  // PADDLE_WITH_HIP
+  HIP_CHECK(hipEventDestroy(nccl_start_event_));
+  HIP_CHECK(hipEventDestroy(nccl_end_event_));
+#endif
+}
+
+void CommAsyncRecorder::StartRecord() {
+  backends::gpu::GPUDeviceGuard guard(place_.device);
+#ifdef PADDLE_WITH_CUDA
+  CUDA_CHECK(cudaEventRecord(nccl_start_event_, nccl_stream_));
+#else  // PADDLE_WITH_HIP
+  HIP_CHECK(hipEventRecord(nccl_start_event_, nccl_stream_));
+#endif
+}
+
+void CommAsyncRecorder::EndRecord() {
+  backends::gpu::GPUDeviceGuard guard(place_.device);
+#ifdef PADDLE_WITH_CUDA
+  CUDA_CHECK(cudaEventRecord(nccl_end_event_, nccl_stream_));
+#else  // PADDLE_WITH_HIP
+  HIP_CHECK(hipEventRecord(nccl_end_event_, nccl_stream_));
+#endif
+}
+
+bool CommAsyncRecorder::QueryEnd() const { return EventQuery(nccl_end_event_); }
+
+bool CommAsyncRecorder::QueryStart() const {
+  return EventQuery(nccl_start_event_);
+}
+
+void CommAsyncRecorder::Start() {
+  if (IsStart()) {
+    return;
+  }
+  is_start_ = true;
+}
+
+float CommAsyncRecorder::RecordTime() const {
+  float elapsedTime = 0.f;
+#ifdef PADDLE_WITH_CUDA
+  CUDA_CHECK(
+      cudaEventElapsedTime(&elapsedTime, nccl_start_event_, nccl_end_event_));
+#else  // PADDLE_WITH_HIP
+  HIP_CHECK(
+      hipEventElapsedTime(&elapsedTime, nccl_start_event_, nccl_end_event_));
+#endif
+  return elapsedTime;
+}
+
+bool CommAsyncRecorder::EventQuery(gpuEvent_t event) const {
+#ifdef PADDLE_WITH_CUDA
+  CUDA_CHECK(cudaGetLastError());
+  cudaError_t ret = cudaEventQuery(event);
+  if (ret == cudaSuccess) {
+    return true;
+  } else if (ret != cudaErrorNotReady) {
+    CUDA_CHECK(ret);
+  } else {
+    // ignore and clear the error if not ready
+    CUDA_CHECK(cudaGetLastError());
+  }
+#else  // PADDLE_WITH_HIP
+  HIP_CHECK(hipGetLastError());
+  hipError_t ret = hipEventQuery(event);
+  if (ret == hipSuccess) {
+    return true;
+  } else if (ret != hipErrorNotReady) {
+    HIP_CHECK(ret);
+  } else {
+    // ignore and clear the error if not ready
+    HIP_CHECK(hipGetLastError());
+  }
+#endif
+  return false;
+}
+
+void CommAsyncRecorder::SynchronizeAllRecorders() {
+#ifdef PADDLE_WITH_CUDA
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaDeviceSynchronize());
+#else  // PADDLE_WITH_HIP
+  PADDLE_ENFORCE_GPU_SUCCESS(hipDeviceSynchronize());
+#endif
+}
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/core/distributed/comm_async_recorder.h
+++ b/paddle/phi/core/distributed/comm_async_recorder.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include "paddle/phi/backends/gpu/gpu_decls.h"
+#include "paddle/phi/core/distributed/utils.h"
+#include "paddle/phi/core/enforce.h"
+
+#if defined(PADDLE_WITH_RCCL)
+#include "paddle/phi/backends/dynload/rccl.h"
+#else
+#include "paddle/phi/backends/dynload/nccl.h"
+#endif
+
+namespace phi {
+namespace distributed {
+
+class CommAsyncRecorder {
+ public:
+  CommAsyncRecorder(const phi::Place& place, int gid, gpuStream_t stream);
+  ~CommAsyncRecorder() = default;
+
+  float GetTime() const;
+  void StartRecord();
+  void EndRecord();
+  bool QueryEnd() const;
+  bool QueryStart() const;
+  bool IsStart() const { return is_start_; }
+  void Start();
+
+  int GetGid() const { return gid_; }
+
+  float RecordTime() const;
+  bool EventQuery(gpuEvent_t event) const;
+  void EventDestroy();
+
+  static void SynchronizeAllRecorders();
+
+ private:
+  phi::Place place_;
+  int gid_;
+  gpuStream_t nccl_stream_;
+
+  gpuEvent_t nccl_start_event_;
+  gpuEvent_t nccl_end_event_;
+
+  bool is_start_;
+
+ private:
+  DISABLE_COPY_AND_ASSIGN(CommAsyncRecorder);
+};
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/core/distributed/comm_async_time_profiler.cc
+++ b/paddle/phi/core/distributed/comm_async_time_profiler.cc
@@ -1,0 +1,99 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <thread>
+
+#include "paddle/common/macros.h"
+#include "paddle/phi/core/distributed/comm_async_recorder.h"
+#include "paddle/phi/core/distributed/comm_async_time_profiler.h"
+
+namespace phi {
+namespace distributed {
+
+thread_local std::list<std::shared_ptr<CommAsyncRecorder>>
+    CommAsyncTimeProfiler::recorders_list_;
+
+CommAsyncTimeProfiler::CommAsyncTimeProfiler() : terminated_(false) {
+  loop_thread_ = std::thread(
+      &phi::distributed::CommAsyncTimeProfiler::RecordTimeLoop, this);
+}
+
+CommAsyncTimeProfiler::~CommAsyncTimeProfiler() { Stop(); }
+
+void CommAsyncTimeProfiler::UpdateGroupInfo(int gid, float recorder_time) {
+  profiling_infos_[gid] += recorder_time;
+}
+
+void CommAsyncTimeProfiler::ResetGroupInfo() {
+  for (auto& p : profiling_infos_) {
+    p.second = 0.f;
+  }
+}
+
+std::unordered_map<int, float> CommAsyncTimeProfiler::GetProfiles() {
+  CommAsyncRecorder::SynchronizeAllRecorders();
+  while (!recorders_list_.empty()) {
+    CheckAndUpdateProfilingInfos();
+  }
+
+  std::unique_lock<std::mutex> recoders_lk(recoders_mutex_);
+  std::unordered_map<int, float> ret(profiling_infos_);
+  ResetGroupInfo();
+  return ret;
+}
+
+void CommAsyncTimeProfiler::AddRecorder(
+    std::shared_ptr<CommAsyncRecorder> recorder) {
+  if (!terminated_.load()) {
+    recorders_list_.push_back(std::move(recorder));
+  }
+}
+
+void CommAsyncTimeProfiler::Stop() {
+  terminated_.store(true);
+  if (loop_thread_.joinable()) {
+    loop_thread_.join();
+  }
+}
+
+void CommAsyncTimeProfiler::CheckAndUpdateProfilingInfos() {
+  std::unique_lock<std::mutex> recoders_lk(recoders_mutex_);
+  for (auto iter = recorders_list_.begin(); iter != recorders_list_.end();) {
+    auto recorder = *iter;
+    if (!recorder->IsStart() && recorder->QueryStart()) {
+      // event start
+      recorder->Start();
+    }
+    if (recorder->IsStart() && recorder->QueryEnd()) {
+      // event end
+      float recorder_time = recorder->RecordTime();
+      UpdateGroupInfo(recorder->GetGid(), recorder_time);
+      recorder->EventDestroy();
+      iter = recorders_list_.erase(iter);
+    } else {
+      ++iter;
+    }
+  }
+}
+
+void CommAsyncTimeProfiler::RecordTimeLoop() {
+  while (!terminated_.load()) {
+    CheckAndUpdateProfilingInfos();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+}
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/core/distributed/comm_async_time_profiler.h
+++ b/paddle/phi/core/distributed/comm_async_time_profiler.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "paddle/phi/core/enforce.h"
+
+namespace phi {
+namespace distributed {
+
+class CommAsyncRecorder;
+
+class CommAsyncTimeProfiler {
+ public:
+  CommAsyncTimeProfiler();
+
+  ~CommAsyncTimeProfiler();
+
+  static CommAsyncTimeProfiler& GetInstance() {
+    static CommAsyncTimeProfiler instance;
+    return instance;
+  }
+
+  void Stop();
+  void AddRecorder(std::shared_ptr<CommAsyncRecorder> recorder);
+
+  std::unordered_map<int, float> GetProfiles();
+
+ private:
+  void RecordTimeLoop();
+  void CheckAndUpdateProfilingInfos();
+  void UpdateGroupInfo(int gid, float recorder_time);
+  void ResetGroupInfo();
+
+ private:
+  std::atomic<bool> terminated_;
+  std::mutex recoders_mutex_;
+  std::thread loop_thread_;
+  std::unordered_map<int, float> profiling_infos_;  // key:gid, value:time(ms)
+
+  static thread_local std::list<std::shared_ptr<CommAsyncRecorder>>
+      recorders_list_;  // to lock free
+};
+
+}  // namespace distributed
+}  // namespace phi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others
### Description
<!-- Describe what you’ve done -->
通信组性能监控

用法：
环境中 export FLAGS_enable_async_time_profiler=True

```python
import paddle
import paddle.distributed as dist
from paddle import framework
import time


# python -m paddle.distributed.launch --gpus-0,1,2,3,4,5,6,7 --log_dir logs demo.py
if __name__ == "__main__":
    dist.init_parallel_env()

    group = dist.new_group(range(dist.get_world_size()))

    tensor = paddle.ones(shape=[10000, 10000, 10], dtype='float32')
    for i in range(10):
        paddle.distributed.all_reduce(tensor, group=group, sync_op=True)
        
        time.sleep(1)   # simulation of other operations

        # get all profiling infos, key:gid, value:comm_time(ms)
        infos = framework.core.ProcessGroup.get_profiles()
        print(infos)

```