### PR TITLE
Fix vpp warmup step bug

### DIFF
--- a/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_vpp.py
+++ b/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_vpp.py
@@ -84,9 +84,12 @@ class PipelineVirtualPipelinePass(PipelinePassBase):
             return virtual_pp_stage
 
         total_num_steps = accumulate_steps * num_model_chunks
-        warmup_steps = (num_stages - stage_id - 1) * 2
-        warmup_steps += (num_model_chunks - 1) * num_stages
-        warmup_steps = min(warmup_steps, total_num_steps)
+        if accumulate_steps == num_stages:
+            warmup_steps = total_num_steps
+        else:
+            warmup_steps = (num_stages - stage_id - 1) * 2
+            warmup_steps += (num_model_chunks - 1) * num_stages
+            warmup_steps = min(warmup_steps, total_num_steps)
 
         steady_steps = total_num_steps - warmup_steps
         real_split_backward = (


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
Bug fixes


### Description
<!-- Describe what you’ve done -->
Pcard-76459
修复PR https://github.com/PaddlePaddle/Paddle/pull/69728 引入的vpp调度问题，在acc_step==pp_degree场景下保持wramup逻辑不变（退化到FThenB编排）。