### PR TITLE
 【Paddle Tensor No.27】 `paddle.to_tensor` 适配 `__cuda_array_interface__`

### DIFF
--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -1020,8 +1020,6 @@ void TensorFromDLPack(const ::DLTensor& dl_tensor, phi::DenseTensor* dst) {
 #endif
 }
 
-phi::DenseTensor TensorFromCudaArray() {}
-
 template <typename T>
 std::string format_tensor(const phi::DenseTensor& tensor) {
   // TODO(zhiqiu): use the print option to format tensor.

--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -878,6 +878,10 @@ phi::DataType ConvertToPDDataType(const std::string& typestr) {
       {"<i4", phi::DataType::INT32},
       {"<i8", phi::DataType::INT64},
       {"|b1", phi::DataType::BOOL},
+      // NOTE: Paddle not support uint32, uint64, uint16 yet.
+      // {"<u2", phi::DataType::UINT16},
+      // {"<u4", phi::DataType::UINT32},
+      // {"<u8", phi::DataType::UINT64},
   };
   auto it = type_map.find(typestr);
   PADDLE_ENFORCE_NE(

--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -883,7 +883,7 @@ phi::DataType ConvertToPDDataType(const std::string& typestr) {
   PADDLE_ENFORCE_NE(
       it,
       type_map.end(),
-      platform::errors::InvalidArgument("Unsupported typestr: " + typestr));
+      common::errors::InvalidArgument("Unsupported typestr: " + typestr));
   return it->second;
 }
 

--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -865,6 +865,28 @@ void DeleterBridge(phi::Allocation* alloc) {
   }
 }
 
+phi::DataType ConvertToPDDataType(const std::string& typestr) {
+  static const std::unordered_map<std::string, phi::DataType> type_map = {
+      {"<c8", phi::DataType::COMPLEX64},
+      {"<c16", phi::DataType::COMPLEX128},
+      {"<f2", phi::DataType::BFLOAT16},
+      {"<f4", phi::DataType::FLOAT32},
+      {"<f8", phi::DataType::FLOAT64},
+      {"|u1", phi::DataType::UINT8},
+      {"|i1", phi::DataType::INT8},
+      {"<i2", phi::DataType::INT16},
+      {"<i4", phi::DataType::INT32},
+      {"<i8", phi::DataType::INT64},
+      {"|b1", phi::DataType::BOOL},
+  };
+  auto it = type_map.find(typestr);
+  if (it != type_map.end()) {
+    return it->second;
+  } else {
+    throw std::invalid_argument("Unsupported typestr: " + typestr);
+  }
+}
+
 phi::DenseTensor from_blob(void* data,
                            DLManagedTensor* src,
                            const phi::DDim& shape,
@@ -997,6 +1019,8 @@ void TensorFromDLPack(const ::DLTensor& dl_tensor, phi::DenseTensor* dst) {
   PADDLE_THROW(common::errors::Unimplemented("XPUPlace is not supported"));
 #endif
 }
+
+phi::DenseTensor TensorFromCudaArray() {}
 
 template <typename T>
 std::string format_tensor(const phi::DenseTensor& tensor) {

--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -880,11 +880,11 @@ phi::DataType ConvertToPDDataType(const std::string& typestr) {
       {"|b1", phi::DataType::BOOL},
   };
   auto it = type_map.find(typestr);
-  if (it != type_map.end()) {
-    return it->second;
-  } else {
-    throw std::invalid_argument("Unsupported typestr: " + typestr);
-  }
+  PADDLE_ENFORCE_NE(
+      it,
+      type_map.end(),
+      platform::errors::InvalidArgument("Unsupported typestr: " + typestr));
+  return it->second;
 }
 
 phi::DenseTensor from_blob(void* data,

--- a/paddle/fluid/framework/tensor_util.h
+++ b/paddle/fluid/framework/tensor_util.h
@@ -53,6 +53,8 @@ class PrintOptions {
   PrintOptions() {}
 };
 
+phi::DataType ConvertToPDDataType(const std::string& typestr);
+
 TEST_API void TensorToStream(std::ostream& os,
                              const phi::DenseTensor& tensor,
                              const phi::DeviceContext& dev_ctx);

--- a/paddle/fluid/framework/tensor_util.h
+++ b/paddle/fluid/framework/tensor_util.h
@@ -122,7 +122,7 @@ phi::DenseTensor from_blob(void* data,
                            const phi::DDim& strides,
                            phi::DataType dtype,
                            const phi::Place& place,
-                           const Deleter& deleter);
+                           const std::function<void(void*)>& deleter);
 
 phi::DenseTensor TensorFromDLPack(DLManagedTensor* src,
                                   std::function<void(void*)> deleter);

--- a/paddle/fluid/framework/tensor_util.h
+++ b/paddle/fluid/framework/tensor_util.h
@@ -116,14 +116,6 @@ inline phi::DenseTensor TensorFromDLPack(const DLManagedTensor* src) {
   return TensorFromDLPack(const_cast<DLManagedTensor*>(src));
 }
 
-phi::DenseTensor from_blob(void* data,
-                           DLManagedTensor* src,
-                           const phi::DDim& shape,
-                           const phi::DDim& strides,
-                           phi::DataType dtype,
-                           const phi::Place& place,
-                           const std::function<void(void*)>& deleter);
-
 phi::DenseTensor TensorFromDLPack(DLManagedTensor* src,
                                   std::function<void(void*)> deleter);
 //

--- a/paddle/fluid/framework/tensor_util.h
+++ b/paddle/fluid/framework/tensor_util.h
@@ -116,6 +116,14 @@ inline phi::DenseTensor TensorFromDLPack(const DLManagedTensor* src) {
   return TensorFromDLPack(const_cast<DLManagedTensor*>(src));
 }
 
+phi::DenseTensor from_blob(void* data,
+                           DLManagedTensor* src,
+                           const phi::DDim& shape,
+                           const phi::DDim& strides,
+                           phi::DataType dtype,
+                           const phi::Place& place,
+                           const Deleter& deleter);
+
 phi::DenseTensor TensorFromDLPack(DLManagedTensor* src,
                                   std::function<void(void*)> deleter);
 //

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1275,12 +1275,12 @@ PYBIND11_MODULE(libpaddle, m) {
       phi::DDim ddim_shape;
       {
         std::vector<int64_t> shape;
-        py::object shape_obj = cuda_dict.get("shape", py::none());
-        if (shape_obj.is_none()) {
+        if (!cuda_dict.contains("shape")) {
           throw py::key_error(
               "The 'shape' key is missing in the __cuda_array_interface__  "
               "dict.");
         }
+        py::object shape_obj = cuda_dict["shape"];
         if (py::isinstance<py::tuple>(shape_obj) ||
             py::isinstance<py::list>(shape_obj)) {
           shape = shape_obj.cast<std::vector<int64_t>>();
@@ -1291,22 +1291,22 @@ PYBIND11_MODULE(libpaddle, m) {
       }
 
       // Extract the `obj.__cuda_array_interface__['typestr'] attribute
-      py::object typestr_obj = cuda_dict.get("typestr", py::none());
-      if (typestr_obj.is_none()) {
+      if (!cuda_dict.contains("typestr")) {
         throw py::key_error(
             "The 'typestr' key is missing in the __cuda_array_interface__  "
             "dict.");
       }
+      py::object typestr_obj = cuda_dict["typestr"];
       std::string typestr = typestr_obj.cast<std::string>();
       phi::DataType dtype = paddle::framework::ConvertToPDDataType(typestr);
 
       // Extract the `obj.__cuda_array_interface__['data']` attribute
-      py::object data_obj = cuda_dict.get("data", py::none());
-      if (data_obj.is_none()) {
+      if (!cuda_dict.contains("data")) {
         throw py::key_error(
             "The 'data' key is missing in the __cuda_array_interface__  "
             "dict.");
       }
+      py::object data_obj = cuda_dict["data"];
       py::tuple data_tuple = data_obj.cast<py::tuple>();
 
       // Data tuple(ptr_as_int, read_only_flag).

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -36,6 +36,7 @@ limitations under the License. */
 #include <utility>
 #include <vector>
 
+#include "paddle/common/ddim.h"
 #include "paddle/fluid/framework/compiled_program.h"
 #include "paddle/fluid/framework/convert_utils.h"
 #include "paddle/fluid/framework/custom_operator.h"
@@ -76,9 +77,11 @@ limitations under the License. */
 #include "paddle/fluid/prim/utils/utils.h"
 #include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/common/float16.h"
+#include "paddle/phi/common/int_array.h"
 #include "paddle/phi/core/framework/reader.h"
 #include "paddle/phi/core/memory/allocation/allocator_strategy.h"
 #include "paddle/phi/core/raw_tensor.h"
+#include "paddle/phi/core/tensor_meta.h"
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 #include "paddle/phi/core/memory/allocation/auto_growth_best_fit_allocator_v2.h"
 #include "paddle/phi/core/memory/allocation/cuda_ipc_allocator.h"
@@ -1264,91 +1267,97 @@ PYBIND11_MODULE(libpaddle, m) {
   });
 
   m.def("tensor_from_cuda_array_interface", [](py::object obj) {
-    try {
-      py::object cuda_array_interface = obj.attr("__cuda_array_interface__");
-      if (!py::isinstance<py::dict>(cuda_array_interface)) {
-        throw py::type_error("`__cuda_array_interface` must be a dict");
-      }
-      py::dict cuda_dict = cuda_array_interface.cast<py::dict>();
+    // We use CUDA Array Interface (Version 2) protocol:
+    // https://numba.pydata.org/numba-doc/dev/cuda/cuda_array_interface.html
+    py::object cuda_array_interface = obj.attr("__cuda_array_interface__");
+    PADDLE_ENFORCE_EQ(py::isinstance<py::dict>(cuda_array_interface),
+                      true,
+                      common::errors::InvalidArgument(
+                          "`__cuda_array_interface` must be a dict"));
+    py::dict cuda_dict = cuda_array_interface.cast<py::dict>();
 
-      // Extract the `obj.__cuda_array_interface__['shape']` attribute
-      phi::IntArray shapeIntArray;
-      std::vector<int64_t> shapes;
-      if (!cuda_dict.contains("shape")) {
-        throw py::key_error(
+    // Extract the `obj.__cuda_array_interface__['shape']` attribute
+    PADDLE_ENFORCE_EQ(
+        cuda_dict.contains("shape"),
+        true,
+        common::errors::InvalidArgument(
             "The 'shape' key is missing in the __cuda_array_interface__  "
-            "dict.");
-      }
-      py::object shape_obj = cuda_dict["shape"];
-      if (py::isinstance<py::tuple>(shape_obj) ||
-          py::isinstance<py::list>(shape_obj)) {
-        shapes = shape_obj.cast<std::vector<int64_t>>();
-      } else {
-        throw py::value_error("Shape must be a tuple or list");
-      }
-      shapeIntArray = phi::IntArray(shapes);
+            "dict."));
+    py::object shape_obj = cuda_dict["shape"];
+    PADDLE_ENFORCE_EQ(
+        py::isinstance<py::tuple>(shape_obj) ||
+            py::isinstance<py::list>(shape_obj),
+        true,
+        common::errors::InvalidArgument("Shape must be a tuple or list"));
+    std::vector<int64_t> shapes;
+    shapes = shape_obj.cast<std::vector<int64_t>>();
+    phi::IntArray shapeIntArray = phi::IntArray(shapes);
 
-      // Extract the `obj.__cuda_array_interface__['typestr'] attribute
-      if (!cuda_dict.contains("typestr")) {
-        throw py::key_error(
+    // Extract the `obj.__cuda_array_interface__['typestr'] attribute
+    PADDLE_ENFORCE_EQ(
+        cuda_dict.contains("typestr"),
+        true,
+        common::errors::InvalidArgument(
             "The 'typestr' key is missing in the __cuda_array_interface__  "
-            "dict.");
-      }
-      py::object typestr_obj = cuda_dict["typestr"];
-      std::string typestr = typestr_obj.cast<std::string>();
-      phi::DataType dtype = paddle::framework::ConvertToPDDataType(typestr);
+            "dict."));
+    py::object typestr_obj = cuda_dict["typestr"];
+    std::string typestr = typestr_obj.cast<std::string>();
+    phi::DataType dtype = paddle::framework::ConvertToPDDataType(typestr);
 
-      // Extract the `obj.__cuda_array_interface__['data']` attribute
-      if (!cuda_dict.contains("data")) {
-        throw py::key_error(
+    // Extract the `obj.__cuda_array_interface__['data']` attribute
+    PADDLE_ENFORCE_EQ(
+        cuda_dict.contains("data"),
+        true,
+        common::errors::InvalidArgument(
             "The 'data' key is missing in the __cuda_array_interface__  "
-            "dict.");
-      }
-      py::object data_obj = cuda_dict["data"];
-      py::tuple data_tuple = data_obj.cast<py::tuple>();
+            "dict."));
+    py::object data_obj = cuda_dict["data"];
+    py::tuple data_tuple = data_obj.cast<py::tuple>();
 
-      // Data tuple(ptr_as_int, read_only_flag).
-      // The ptr_as_int stands for data pointer but in  Python it is a integer.
-      // It need to be converted to a large enough integral type first
-      // and then convert to void*
-      void *data_ptr = reinterpret_cast<void *>(data_tuple[0].cast<intptr_t>());
-      if (data_tuple[1].cast<bool>()) {
-        throw py::value_error("Read-only array is not supported");
-      }
+    // Data tuple(ptr_as_int, read_only_flag).
+    // The ptr_as_int stands for data pointer but in Python it is a integer.
+    // It need to be converted to a large enough integral type first
+    // and then convert to void*
+    void *data_ptr = reinterpret_cast<void *>(data_tuple[0].cast<intptr_t>());
+    PADDLE_ENFORCE_NE(
+        data_tuple[1].cast<bool>(),
+        true,
+        common::errors::InvalidArgument("Read-only array is not supported"));
 
-      // Extract the `obj.__cuda_array_interface__['strides']` attribute
-      phi::IntArray stridesIntArray;
-      if (cuda_dict.contains("strides") && !cuda_dict["strides"].is_none()) {
-        std::vector<int64_t> strides_vec =
-            cuda_dict["strides"].cast<std::vector<int64_t>>();
+    // Extract the `obj.__cuda_array_interface__['strides']` attribute
+    phi::IntArray stridesIntArray;
+    if (cuda_dict.contains("strides") && !cuda_dict["strides"].is_none()) {
+      std::vector<int64_t> strides_vec =
+          cuda_dict["strides"].cast<std::vector<int64_t>>();
 
-        // __cuda_array_interface__ strides uses bytes
-        size_t element_size = phi::SizeOf(dtype);
-        for (auto &stride : strides_vec) {
-          if (stride % element_size != 0) {
-            throw py::value_error(
-                "strides must be a multiple of the element size.");
-          }
-          stride /= element_size;
-        }
-        stridesIntArray = phi::IntArray(strides_vec);
-      } else {
-        stridesIntArray = phi::IntArray(
-            phi::DenseTensorMeta::calc_strides(common::make_ddim(shapes)));
+      // __cuda_array_interface__ strides uses bytes
+      size_t element_size = phi::SizeOf(dtype);
+      for (auto &stride : strides_vec) {
+        PADDLE_ENFORCE_NE(
+            stride % element_size,
+            0,
+            common::errors::InvalidArgument(
+                "strides must be a multiple of the element size."));
+        stride /= element_size;
       }
-      return paddle::from_blob(data_ptr,
-                               shapeIntArray,
-                               stridesIntArray,
-                               dtype,
-                               phi::DataLayout::NCHW,
-                               phi::GPUPlace(),
-                               [obj](void *data) {
-                                 py::gil_scoped_acquire gil;
-                                 obj.dec_ref();
-                               });
-    } catch (const py::error_already_set &e) {
-      throw;
+      stridesIntArray = phi::IntArray(strides_vec);
+    } else {
+      DDim temp = phi::DenseTensorMeta::calc_strides(common::make_ddim(shapes));
+      int rank = temp.size();
+      const int64_t *ddim_data = temp.Get();
+      std::vector<int64_t> strides_vec(ddim_data, ddim_data + rank);
+      stridesIntArray = phi::IntArray(strides_vec);
     }
+    return paddle::from_blob(data_ptr,
+                             shapeIntArray,
+                             stridesIntArray,
+                             dtype,
+                             phi::DataLayout::NCHW,
+                             phi::GPUPlace(),
+                             [obj](void *data) {
+                               py::gil_scoped_acquire gil;
+                               obj.dec_ref();
+                             });
   });
 
   m.def("_create_loaded_parameter",

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1326,7 +1326,7 @@ PYBIND11_MODULE(libpaddle, m) {
 
         // __cuda_array_interface__ strides uses bytes
         size_t element_size = phi::SizeOf(dtype);
-        for (auto &stride : strides) {
+        for (auto &stride : strides_vec) {
           if (stride % element_size != 0) {
             throw py::value_error(
                 "strides must be a multiple of the element size.");
@@ -1335,8 +1335,7 @@ PYBIND11_MODULE(libpaddle, m) {
         }
         ddim_strides = common::make_ddim(strides_vec);
       } else {
-        ddim_strides =
-            phi::DenseTensorMeta::calc_strides(common::make_ddim(shape));
+        ddim_strides = phi::DenseTensorMeta::calc_strides(ddim_shape);
       }
       DLManagedTensor *dlMTensor = reinterpret_cast<DLManagedTensor *>(
           PyCapsule_GetPointer(obj.ptr(), "dltensor"));

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1311,7 +1311,8 @@ PYBIND11_MODULE(libpaddle, m) {
           stride *= shape[i - 1];
         }
       }
-      return paddle::from_blob(data, shape, )
+      phi::IntArray stridesIntArray(strides);
+      return paddle::from_blob(data, shapeIntArray, stridesIntArray, dtype);
     } catch (const py::error_already_set &e) {
       throw;
     } catch (const std::exception &e) {

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1342,9 +1342,10 @@ PYBIND11_MODULE(libpaddle, m) {
       }
       stridesIntArray = phi::IntArray(strides_vec);
     } else {
-      DDim temp = phi::DenseTensorMeta::calc_strides(common::make_ddim(shapes));
-      int rank = temp.size();
-      const int64_t *ddim_data = temp.Get();
+      DDim ddim_strides =
+          phi::DenseTensorMeta::calc_strides(common::make_ddim(shapes));
+      int rank = ddim_strides.size();
+      const int64_t *ddim_data = ddim_strides.Get();
       std::vector<int64_t> strides_vec(ddim_data, ddim_data + rank);
       stridesIntArray = phi::IntArray(strides_vec);
     }
@@ -1353,7 +1354,7 @@ PYBIND11_MODULE(libpaddle, m) {
                              stridesIntArray,
                              dtype,
                              phi::DataLayout::NCHW,
-                             phi::GPUPlace(),
+                             phi::Place(),
                              [obj](void *data) {
                                py::gil_scoped_acquire gil;
                                obj.dec_ref();

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1273,22 +1273,20 @@ PYBIND11_MODULE(libpaddle, m) {
 
       // Extract the `obj.__cuda_array_interface__['shape']` attribute
       phi::IntArray shapeIntArray;
-      {
-        std::vector<int64_t> shape;
-        if (!cuda_dict.contains("shape")) {
-          throw py::key_error(
-              "The 'shape' key is missing in the __cuda_array_interface__  "
-              "dict.");
-        }
-        py::object shape_obj = cuda_dict["shape"];
-        if (py::isinstance<py::tuple>(shape_obj) ||
-            py::isinstance<py::list>(shape_obj)) {
-          shape = shape_obj.cast<std::vector<int64_t>>();
-        } else {
-          throw py::value_error("Shape must be a tuple or list");
-        }
-        shapeIntArray = phi::IntArray(shape);
+      std::vector<int64_t> shapes;
+      if (!cuda_dict.contains("shape")) {
+        throw py::key_error(
+            "The 'shape' key is missing in the __cuda_array_interface__  "
+            "dict.");
       }
+      py::object shape_obj = cuda_dict["shape"];
+      if (py::isinstance<py::tuple>(shape_obj) ||
+          py::isinstance<py::list>(shape_obj)) {
+        shapes = shape_obj.cast<std::vector<int64_t>>();
+      } else {
+        throw py::value_error("Shape must be a tuple or list");
+      }
+      shapeIntArray = phi::IntArray(shapes);
 
       // Extract the `obj.__cuda_array_interface__['typestr'] attribute
       if (!cuda_dict.contains("typestr")) {
@@ -1335,8 +1333,8 @@ PYBIND11_MODULE(libpaddle, m) {
         }
         stridesIntArray = phi::IntArray(strides_vec);
       } else {
-        stridesIntArray = phi::IntArray(phi::DenseTensorMeta::calc_strides(
-            common::make_ddim(shapeIntArray)));
+        stridesIntArray = phi::IntArray(
+            phi::DenseTensorMeta::calc_strides(common::make_ddim(shapes)));
       }
       return paddle::from_blob(data_ptr,
                                shapeIntArray,

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1285,7 +1285,12 @@ PYBIND11_MODULE(libpaddle, m) {
 
       // Extract the `data.__cuda_array_interface__['data']` attribute
       py::tuple data_tuple = cuda_dict["data"].cast<py::tuple>();
-      void *data_ptr = data_tuple[0].cast<void *>();
+      /*__cuda_array_interface__ 的 data 字段是一个元组 (ptr_as_int,
+      read_only_flag)。 ptr_as_int 表示数据指针，但在 Python
+      中它是一个整数，而不是真正的指针。 需要使用 reinterpret_cast 将其转换为
+      void*，但不能直接转换。 需要先将其转换为一个足够大的整数类型（例如
+      intptr_t 或 uintptr_t），然后再转换为 void*。*/
+      void *data_ptr = reinterpret_cast<void *>(data_tuple[0].cast<intptr_t>());
       if (data_tuple[1].cast<bool>()) {
         throw py::value_error("Read-only array is not supported");
       }

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1281,7 +1281,7 @@ PYBIND11_MODULE(libpaddle, m) {
       phi::IntArray shapeIntArray(shape);
       // Extractt the `data.__cuda_array_interface__['typestr'] attribute
       std::string typestr = cuda_dict["typestr"].cast<std::string>();
-      phi::DataType dtype = paddle::framework::ConvertToDataType(typestr);
+      phi::DataType dtype = paddle::framework::ConvertToPDDataType(typestr);
 
       // Extract the `data.__cuda_array_interface__['data']` attribute
       py::tuple data_tuple = cuda_dict["data"].cast<py::tuple>();
@@ -1312,12 +1312,12 @@ PYBIND11_MODULE(libpaddle, m) {
         }
       }
       phi::IntArray stridesIntArray(strides);
-      return paddle::from_blob(data, shapeIntArray, stridesIntArray, dtype);
+      return paddle::from_blob(data_ptr, shapeIntArray, stridesIntArray, dtype);
     } catch (const py::error_already_set &e) {
       throw;
     } catch (const std::exception &e) {
       // capture other exception
-      std::string msg = "Error in tensor from cuda_array_interface";
+      std::string msg = "Error in tensor from cuda_array_interface ";
       msg += e.what();
       throw py::value_error(msg);
     }

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -928,22 +928,22 @@ def to_tensor(
             [[(1+1j), (2+0j)],
              [(3+2j), (4+0j)]])
     """
-    is_tensor = paddle.is_tensor(data)
-    if not is_tensor and hasattr(data, "__cuda_array_interface__"):
-        if not core.is_compiled_with_cuda():
-            raise RuntimeError(
-                "PaddlePaddle is not compiled with CUDA, but trying to create a Tensor from a CUDA array."
-            )
-        return core.tensor_from_cuda_array_interface(data)
-    if is_tensor:
-        warnings.warn(
-            "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach(), "
-            "rather than paddle.to_tensor(sourceTensor)."
-        )
     place = _get_paddle_place(place)
     if place is None:
         place = _current_expected_place_()
     if in_dynamic_mode():
+        is_tensor = paddle.is_tensor(data)
+        if not is_tensor and hasattr(data, "__cuda_array_interface__"):
+            if not core.is_compiled_with_cuda():
+                raise RuntimeError(
+                    "PaddlePaddle is not compiled with CUDA, but trying to create a Tensor from a CUDA array."
+                )
+            return core.tensor_from_cuda_array_interface(data)
+        if is_tensor:
+            warnings.warn(
+                "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach(), "
+                "rather than paddle.to_tensor(sourceTensor)."
+            )
         return _to_tensor_non_static(data, dtype, place, stop_gradient)
 
     # call assign for static graph

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -930,6 +930,12 @@ def to_tensor(
     place = _get_paddle_place(place)
     if place is None:
         place = _current_expected_place_()
+    if hasattr(data, "__cuda_array_interface__"):
+        if not core.is_compiled_with_cuda():
+            raise RuntimeError(
+                "PaddlePaddle is not compiled with CUDA, but trying to create a Tensor from a CUDA array."
+            )
+        return core.tensor_from_cuda_array_interface(data)
     if in_dynamic_mode():
         return _to_tensor_non_static(data, dtype, place, stop_gradient)
 

--- a/test/dygraph_to_static/test_to_tensor.py
+++ b/test/dygraph_to_static/test_to_tensor.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import warnings
 
 import numpy
 import numpy as np
@@ -226,23 +225,6 @@ class TestNestedListWithTensor(Dy2StTestBase):
         else:
             self.assertEqual(y.shape, (1, 1))
         self.assertEqual(y.dtype, paddle.int64)
-
-
-class TestCudaArrayInterface(unittest.TestCase):
-    def test_tensor2tensor_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            x = paddle.to_tensor([1, 2, 3])
-            paddle.to_tensor(x)
-            flag = False
-            for warn in w:
-                if (
-                    issubclass(warn.category, UserWarning)
-                ) and "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach(), rather than paddle.to_tensor(sourceTensor)." in str(
-                    warn.message
-                ):
-                    flag = True
-                    break
-            self.assertTrue(flag)
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_to_tensor.py
+++ b/test/dygraph_to_static/test_to_tensor.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+import warnings
 
 import numpy
 import numpy as np
@@ -225,6 +226,25 @@ class TestNestedListWithTensor(Dy2StTestBase):
         else:
             self.assertEqual(y.shape, (1, 1))
         self.assertEqual(y.dtype, paddle.int64)
+
+
+class TestCudaArrayInterface(unittest.TestCase):
+
+    def test_tensor2tensor_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            x = paddle.to_tensor([1, 2, 3])
+            paddle.to_tensor(x)
+            flag = False
+            for warn in w:
+                if (
+                    issubclass(warn.category, UserWarning)
+                ) and "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach(), rather than paddle.to_tensor(sourceTensor)." in str(
+                    warn.message
+                ):
+                    flag = True
+                    break
+
+            self.assertTrue(flag)
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_to_tensor.py
+++ b/test/dygraph_to_static/test_to_tensor.py
@@ -229,7 +229,6 @@ class TestNestedListWithTensor(Dy2StTestBase):
 
 
 class TestCudaArrayInterface(unittest.TestCase):
-
     def test_tensor2tensor_warning(self):
         with warnings.catch_warnings(record=True) as w:
             x = paddle.to_tensor([1, 2, 3])
@@ -243,7 +242,6 @@ class TestCudaArrayInterface(unittest.TestCase):
                 ):
                     flag = True
                     break
-
             self.assertTrue(flag)
 
 

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -15,6 +15,7 @@
 import copy
 import itertools
 import unittest
+import warnings
 
 import numpy as np
 from utils import dygraph_guard
@@ -1292,6 +1293,23 @@ class TestEagerTensor(unittest.TestCase):
 
                     self.assertIn("version", interface)
                     self.assertEqual(interface["version"], 2)
+
+    def test_to_tensor_from___cuda_array_interface__(self):
+        # only test warning message here for cuda tensor of other framework is not supported in Paddle test, more tests code can be referenced: https://github.com/PaddlePaddle/Paddle/pull/69913
+        with dygraph_guard():
+            with warnings.catch_warnings(record=True) as w:
+                x = paddle.to_tensor([1, 2, 3])
+                paddle.to_tensor(x)
+                flag = False
+                for warn in w:
+                    if (
+                        issubclass(warn.category, UserWarning)
+                    ) and "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach(), rather than paddle.to_tensor(sourceTensor)." in str(
+                        warn.message
+                    ):
+                        flag = True
+                        break
+                self.assertTrue(flag)
 
     def test_dlpack_device(self):
         """test Tensor.__dlpack_device__"""


### PR DESCRIPTION
### PR Category
User Experience


### PR Types
New features


### Description
paddle.to_tensor 适配 `__cuda_array_interface__`，对实现了`__cuda_array_interface__`的非`paddle.Tensor`对象（如`torch.Tensor`、`cupy.NdArray`）均可通过其`__cuda_array_interface__`接口，以零拷贝的方式转换为`paddle.Tensor`

``` python
def check_tensor_conversion(self, x, check_version = True):
    """Helper function to check tensor conversion."""
    paddle_tensor = paddle.to_tensor(x, place=paddle.CUDAPlace(0))

    self.assertEqual(x.__cuda_array_interface__["typestr"], paddle_tensor.__cuda_array_interface__["typestr"])
    self.assertEqual(x.__cuda_array_interface__["shape"], paddle_tensor.__cuda_array_interface__["shape"])
    self.assertEqual(x.__cuda_array_interface__["strides"], paddle_tensor.__cuda_array_interface__["strides"])
    self.assertEqual(x.__cuda_array_interface__["data"], paddle_tensor.__cuda_array_interface__["data"])
    if check_version:
        self.assertEqual(x.__cuda_array_interface__["version"], paddle_tensor.__cuda_array_interface__["version"])

# 测试cupy
def test_cuda_tensor_cupy(self):
    if not torch.cuda.is_available():
        return
    shapes = [[2], [2, 3], [2, 3, 4], [2, 3, 4, 5]]
    dtypes = [cp.float32, cp.float64, cp.int32, cp.int64]

    for shape in shapes:
        for dtype in dtypes:
            x = cp.random.random(tuple(shape)).astype(dtype)
            self.check_tensor_conversion(x, False)

# 测试pytorch
def test_cuda_array_torch(self):
    if not paddle.is_compiled_with_cuda():
        return  
    shapes = [[2], [2, 3], [2, 3, 4], [2, 3, 4, 5]] 
    dtypes = [np.float32, np.float64, np.int32, np.int64] 

    for shape in shapes:
        for dtype in dtypes:
            x = torch.tensor(np.random.rand(*shape).astype(dtype), device='cuda')
            self.check_tensor_conversion(x)
```
```python
# 测试0-size tensor
def test_cuda_array_exception(self):
    def test_cuda_array_zero_size():
        shape = [0]
        x = torch.tensor(np.random.rand(*shape), device='cuda')
        self.check_tensor_conversion(x)
    self.assertRaises(ValueError, test_cuda_array_zero_size)
```
```python
# 测试内存
def test_for(self):
        for i in range(100):  
            x_torch = torch.randn([2048, 1024], device='cuda')  
            x_paddle = paddle.to_tensor(x_torch) 
            print(f"{i} paddle mem: {paddle.device.cuda.max_memory_allocated() / (1 << 20):.2f} MB, torch mem: {torch.cuda.max_memory_allocated() / (1 << 20):.2f} MB")
```
```
# “测试内存”输出
0 paddle mem: 0.00 MB, torch mem: 8.00 MB
1 paddle mem: 0.00 MB, torch mem: 16.00 MB
2 paddle mem: 0.00 MB, torch mem: 16.00 MB
3 paddle mem: 0.00 MB, torch mem: 16.00 MB
4 paddle mem: 0.00 MB, torch mem: 16.00 MB
5 paddle mem: 0.00 MB, torch mem: 16.00 MB
6 paddle mem: 0.00 MB, torch mem: 16.00 MB
7 paddle mem: 0.00 MB, torch mem: 16.00 MB
8 paddle mem: 0.00 MB, torch mem: 16.00 MB
9 paddle mem: 0.00 MB, torch mem: 16.00 MB
10 paddle mem: 0.00 MB, torch mem: 16.00 MB
11 paddle mem: 0.00 MB, torch mem: 16.00 MB
12 paddle mem: 0.00 MB, torch mem: 16.00 MB
13 paddle mem: 0.00 MB, torch mem: 16.00 MB
14 paddle mem: 0.00 MB, torch mem: 16.00 MB
15 paddle mem: 0.00 MB, torch mem: 16.00 MB
16 paddle mem: 0.00 MB, torch mem: 16.00 MB
17 paddle mem: 0.00 MB, torch mem: 16.00 MB
18 paddle mem: 0.00 MB, torch mem: 16.00 MB
19 paddle mem: 0.00 MB, torch mem: 16.00 MB
20 paddle mem: 0.00 MB, torch mem: 16.00 MB
21 paddle mem: 0.00 MB, torch mem: 16.00 MB
22 paddle mem: 0.00 MB, torch mem: 16.00 MB
23 paddle mem: 0.00 MB, torch mem: 16.00 MB
24 paddle mem: 0.00 MB, torch mem: 16.00 MB
25 paddle mem: 0.00 MB, torch mem: 16.00 MB
26 paddle mem: 0.00 MB, torch mem: 16.00 MB
27 paddle mem: 0.00 MB, torch mem: 16.00 MB
28 paddle mem: 0.00 MB, torch mem: 16.00 MB
29 paddle mem: 0.00 MB, torch mem: 16.00 MB
30 paddle mem: 0.00 MB, torch mem: 16.00 MB
31 paddle mem: 0.00 MB, torch mem: 16.00 MB
32 paddle mem: 0.00 MB, torch mem: 16.00 MB
33 paddle mem: 0.00 MB, torch mem: 16.00 MB
34 paddle mem: 0.00 MB, torch mem: 16.00 MB
35 paddle mem: 0.00 MB, torch mem: 16.00 MB
36 paddle mem: 0.00 MB, torch mem: 16.00 MB
37 paddle mem: 0.00 MB, torch mem: 16.00 MB
38 paddle mem: 0.00 MB, torch mem: 16.00 MB
39 paddle mem: 0.00 MB, torch mem: 16.00 MB
40 paddle mem: 0.00 MB, torch mem: 16.00 MB
41 paddle mem: 0.00 MB, torch mem: 16.00 MB
42 paddle mem: 0.00 MB, torch mem: 16.00 MB
43 paddle mem: 0.00 MB, torch mem: 16.00 MB
44 paddle mem: 0.00 MB, torch mem: 16.00 MB
45 paddle mem: 0.00 MB, torch mem: 16.00 MB
46 paddle mem: 0.00 MB, torch mem: 16.00 MB
47 paddle mem: 0.00 MB, torch mem: 16.00 MB
48 paddle mem: 0.00 MB, torch mem: 16.00 MB
49 paddle mem: 0.00 MB, torch mem: 16.00 MB
50 paddle mem: 0.00 MB, torch mem: 16.00 MB
51 paddle mem: 0.00 MB, torch mem: 16.00 MB
52 paddle mem: 0.00 MB, torch mem: 16.00 MB
53 paddle mem: 0.00 MB, torch mem: 16.00 MB
54 paddle mem: 0.00 MB, torch mem: 16.00 MB
55 paddle mem: 0.00 MB, torch mem: 16.00 MB
56 paddle mem: 0.00 MB, torch mem: 16.00 MB
57 paddle mem: 0.00 MB, torch mem: 16.00 MB
58 paddle mem: 0.00 MB, torch mem: 16.00 MB
59 paddle mem: 0.00 MB, torch mem: 16.00 MB
60 paddle mem: 0.00 MB, torch mem: 16.00 MB
61 paddle mem: 0.00 MB, torch mem: 16.00 MB
62 paddle mem: 0.00 MB, torch mem: 16.00 MB
63 paddle mem: 0.00 MB, torch mem: 16.00 MB
64 paddle mem: 0.00 MB, torch mem: 16.00 MB
65 paddle mem: 0.00 MB, torch mem: 16.00 MB
66 paddle mem: 0.00 MB, torch mem: 16.00 MB
67 paddle mem: 0.00 MB, torch mem: 16.00 MB
68 paddle mem: 0.00 MB, torch mem: 16.00 MB
69 paddle mem: 0.00 MB, torch mem: 16.00 MB
70 paddle mem: 0.00 MB, torch mem: 16.00 MB
71 paddle mem: 0.00 MB, torch mem: 16.00 MB
72 paddle mem: 0.00 MB, torch mem: 16.00 MB
73 paddle mem: 0.00 MB, torch mem: 16.00 MB
74 paddle mem: 0.00 MB, torch mem: 16.00 MB
75 paddle mem: 0.00 MB, torch mem: 16.00 MB
76 paddle mem: 0.00 MB, torch mem: 16.00 MB
77 paddle mem: 0.00 MB, torch mem: 16.00 MB
78 paddle mem: 0.00 MB, torch mem: 16.00 MB
79 paddle mem: 0.00 MB, torch mem: 16.00 MB
80 paddle mem: 0.00 MB, torch mem: 16.00 MB
81 paddle mem: 0.00 MB, torch mem: 16.00 MB
82 paddle mem: 0.00 MB, torch mem: 16.00 MB
83 paddle mem: 0.00 MB, torch mem: 16.00 MB
84 paddle mem: 0.00 MB, torch mem: 16.00 MB
85 paddle mem: 0.00 MB, torch mem: 16.00 MB
86 paddle mem: 0.00 MB, torch mem: 16.00 MB
87 paddle mem: 0.00 MB, torch mem: 16.00 MB
88 paddle mem: 0.00 MB, torch mem: 16.00 MB
89 paddle mem: 0.00 MB, torch mem: 16.00 MB
90 paddle mem: 0.00 MB, torch mem: 16.00 MB
91 paddle mem: 0.00 MB, torch mem: 16.00 MB
92 paddle mem: 0.00 MB, torch mem: 16.00 MB
93 paddle mem: 0.00 MB, torch mem: 16.00 MB
94 paddle mem: 0.00 MB, torch mem: 16.00 MB
95 paddle mem: 0.00 MB, torch mem: 16.00 MB
96 paddle mem: 0.00 MB, torch mem: 16.00 MB
97 paddle mem: 0.00 MB, torch mem: 16.00 MB
98 paddle mem: 0.00 MB, torch mem: 16.00 MB
99 paddle mem: 0.00 MB, torch mem: 16.00 MB
```