### PR TITLE
Fix: Coverage Test Failed when upgrading docker images in pr#69491

### DIFF
--- a/test/auto_parallel/custom_op/test_semi_auto_parallel_custom_op.py
+++ b/test/auto_parallel/custom_op/test_semi_auto_parallel_custom_op.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import site
 import sys
 import unittest
 
@@ -31,9 +32,8 @@ class TestCustomOp(test_base.CommunicationTestDistBase):
         if os.name == 'nt':
             cmd = f'cd /d {cur_dir} && python custom_relu_setup.py install'
         else:
-            cmd = (
-                f'cd {cur_dir} && {sys.executable} custom_relu_setup.py install'
-            )
+            site_dir = site.getsitepackages()[0]
+            cmd = f'cd {cur_dir} && {sys.executable} custom_relu_setup.py install --install-lib={site_dir}'
         run_cmd(cmd)
 
     # test dynamic auto parallel run

--- a/test/cpp_extension/test_cpp_extension_setup.py
+++ b/test/cpp_extension/test_cpp_extension_setup.py
@@ -33,10 +33,12 @@ class TestCppExtensionSetupInstall(unittest.TestCase):
         cur_dir = os.path.dirname(os.path.abspath(__file__))
         # install general extension
         # compile, install the custom op egg into site-packages under background
+        site_dir = site.getsitepackages()[0]
         cmd = f'cd {cur_dir} && {sys.executable} cpp_extension_setup.py install'
+        if os.name != 'nt':
+            cmd += f' --install-lib={site_dir}'
         run_cmd(cmd)
 
-        site_dir = site.getsitepackages()[0]
         custom_egg_path = [
             x for x in os.listdir(site_dir) if 'custom_cpp_extension' in x
         ]

--- a/test/custom_op/test_custom_relu_op_setup.py
+++ b/test/custom_op/test_custom_relu_op_setup.py
@@ -149,9 +149,8 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
         if os.name == 'nt':
             cmd = f'cd /d {cur_dir} && python custom_relu_setup.py install'
         else:
-            cmd = (
-                f'cd {cur_dir} && {sys.executable} custom_relu_setup.py install'
-            )
+            site_dir = site.getsitepackages()[0]
+            cmd = f'cd {cur_dir} && {sys.executable} custom_relu_setup.py install --install-lib={site_dir}'
         run_cmd(cmd)
 
         # NOTE(Aurelius84): Normally, it's no need to add following codes for users.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
Fix:
* test_semi_auto_parallel_custom_op
* test_custom_relu_op_setup
* test_cpp_extension_setup

After upgrading setuptools to 69.5.1 in the docker image(https://github.com/PaddlePaddle/Paddle/pull/69491), the default installation location using setup.py install is /usr/lib/pythonX.Y/site-packages. However, the unit tests use site.getsitepackages()[0] to find the package installation location, which corresponds to the path /usr/local/lib/pythonX.Y/dist-packages , resulting in the installed package not being found. Therefore, manually specify --install-lib .

pcard-67164