### PR TITLE
Revert "[CINN] Add InferSymbolicShape Interface for  `add_n_array` op"

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -592,27 +592,6 @@ std::vector<pir::Type> AddNArrayOp::InferMeta(
   return argument_outputs;
 }
 
-bool AddNArrayOp::InferSymbolicShape(
-    pir::InferSymbolicShapeContext *infer_context) {
-  // The inputs for add_n_array op is defined by builtin.combine.
-  // We use the combine op's inputs to infer the output shape.
-  pir::CombineOp combine_op =
-      inputs().defining_op()->dyn_cast<pir::CombineOp>();
-  // Try to get the infer result as much as possible.
-  for (size_t i = 0; i < combine_op.num_operands(); i++) {
-    if (infer_context->HasShapeOrDataForValue(combine_op.operand_source(i))) {
-      auto out_shape_or_data =
-          infer_context->GetShapeOrDataForValue(combine_op.operand_source(i))
-              .dyn_cast<symbol::RankedTensorArrayShapeOrDataDimExprs>();
-      infer_context->SetShapeOrDataForValue(
-          out(), symbol::ShapeOrDataDimExprs{out_shape_or_data});
-      return true;
-    }
-  }
-  PADDLE_THROW(common::errors::InvalidArgument(
-      "At least one operand of CombineOp should have shape or data."));
-}
-
 const char *FusedGemmEpilogueOp::attributes_name[3] = {  // NOLINT
     "trans_x",
     "trans_y",
@@ -1516,7 +1495,6 @@ std::vector<pir::Type> CreateArrayOp::InferMeta(
 
 bool CreateArrayOp::InferSymbolicShape(
     pir::InferSymbolicShapeContext *infer_context) {
-  // TODO(ooooo): Try to use output type's dims to decide.
   infer_context->SetShapeOrDataForValue(
       out(),
       symbol::ShapeOrDataDimExprs{symbol::RankedTensorArrayShapeOrDataDimExprs(
@@ -2187,12 +2165,6 @@ bool ArrayWrite_Op::InferSymbolicShape(
   const auto &x_shape = infer_context->GetShapeOrDataForValue(x()).shape();
   infer_context->SetShapeOrDataForValue(
       out(),
-      symbol::ShapeOrDataDimExprs{
-          symbol::RankedTensorArrayShapeOrDataDimExprs(x_shape)});
-  // update array's shape as x's shape.
-  // TOOD(ooooo) Do not change if shape is set by custom, similar to infer_meta
-  infer_context->SetShapeOrDataForValue(
-      array(),
       symbol::ShapeOrDataDimExprs{
           symbol::RankedTensorArrayShapeOrDataDimExprs(x_shape)});
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.h
@@ -61,11 +61,9 @@ class TEST_API AddN_Op
   bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
 };
 
-class AddNArrayOp
-    : public pir::Op<AddNArrayOp,
-                     paddle::dialect::OpYamlInfoInterface,
-                     paddle::dialect::InferMetaInterface,
-                     paddle::dialect::InferSymbolicShapeInterface> {
+class AddNArrayOp : public pir::Op<AddNArrayOp,
+                                   paddle::dialect::OpYamlInfoInterface,
+                                   paddle::dialect::InferMetaInterface> {
  public:
   using Op::Op;
   static const char *name() { return "pd_op.add_n_array"; }
@@ -84,7 +82,6 @@ class AddNArrayOp
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
       pir::AttributeMap *p_attributes);
-  bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
 };
 
 class FusedGemmEpilogueOp : public pir::Op<FusedGemmEpilogueOp,

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -49,47 +49,25 @@ struct CombineOpInferSymbolicShapeInterfaceModel
     : public InferSymbolicShapeInterface::Concept {
   static inline bool InferSymbolicShape(
       pir::Operation* op, pir::InferSymbolicShapeContext* infer_context) {
-    if (op->operand(0).type().dyn_cast<DenseTensorType>()) {
-      const auto shape_data_list = [&] {
-        symbol::TensorListShapeOrDataDimExprs shape_data_list;
-        for (size_t i = 0; i < op->num_operands(); ++i) {
-          PADDLE_ENFORCE_NOT_NULL(
-              op->operand(i).type().dyn_cast<DenseTensorType>(),
-              common::errors::InvalidArgument(
-                  "The operand at index %d must be a DenseTensorArray. "
-                  "Currently InferSymbolicShape of CombineOp only accepts "
-                  "inputs that are either all DenseTensors or all "
-                  "DenseTensorArrays.",
-                  i));
-          shape_data_list.emplace_back(
-              infer_context->GetShapeOrDataForValue(op->operand_source(i))
-                  .dyn_cast<symbol::TensorShapeOrDataDimExprs>());
-        }
-        return shape_data_list;
-      }();
-      symbol::ShapeOrDataDimExprs shape_data{shape_data_list};
-      infer_context->SetShapeOrDataForValue(op->result(0), shape_data);
-      return true;
-    } else if (op->operand(0).type().dyn_cast<DenseTensorArrayType>()) {
-      // Note: Return NullShapeOrDataDimExpr for CombineOp with all
-      // DenseTensorArrayType. The logic is designed for add_n_array op.
-      // TODO(ooooo): Actually RankedTensorArrayListShapeOrDataDimExprs is
-      // better.
+    const auto shape_data_list = [&] {
+      symbol::TensorListShapeOrDataDimExprs shape_data_list;
       for (size_t i = 0; i < op->num_operands(); ++i) {
         PADDLE_ENFORCE_NOT_NULL(
-            op->operand(i).type().dyn_cast<DenseTensorArrayType>(),
+            op->operand(i).type().dyn_cast<DenseTensorType>(),
             common::errors::InvalidArgument(
-                "The operand at index %d must be a DenseTensorArray. Currently "
-                "InferSymbolicShape of CombineOp only accepts inputs that are "
-                "either all DenseTensors or all DenseTensorArrays.",
-                i));
+                "Currently InferSymbolicShape of CombineOp only support "
+                "DenseTensorType."));
+
+        shape_data_list.emplace_back(
+            infer_context->GetShapeOrDataForValue(op->operand_source(i))
+                .dyn_cast<symbol::TensorShapeOrDataDimExprs>());
       }
-      return true;
-    } else {
-      PADDLE_THROW(common::errors::InvalidArgument(
-          "Currently InferSymbolicShape of CombineOp only accepts "
-          "inputs that are either all DenseTensors or all DenseTensorArrays."));
-    }
+      return shape_data_list;
+    }();
+
+    symbol::ShapeOrDataDimExprs shape_data{shape_data_list};
+    infer_context->SetShapeOrDataForValue(op->result(0), shape_data);
+    return true;
   }
 
   CombineOpInferSymbolicShapeInterfaceModel()


### PR DESCRIPTION
Reverts PaddlePaddle/Paddle#69698

如果推导的时候涉及 add_n_array，会有对 op 输出有没有全部设置符号信息的检查
![图片](https://github.com/user-attachments/assets/2328812f-fb30-42d0-b279-ee800e58266b)
