### PR TITLE
[AutoParallel] Fix empty shape in einsum

### DIFF
--- a/paddle/phi/api/lib/api_gen_utils.cc
+++ b/paddle/phi/api/lib/api_gen_utils.cc
@@ -805,6 +805,13 @@ void SetReplicatedDistAttrForOutput(
     phi::distributed::DistTensor* out,
     const phi::distributed::ProcessMesh& process_mesh) {
   if (out) {
+    if (out->dims().size() == -1 || out->dims().size() == 0) {
+      if (out->local_dims().size() != -1 && out->local_dims().size() != 0) {
+        out->unsafe_set_dims(out->local_dims());
+        VLOG(3)
+            << "DistTensor out has empty shape, use its local value's shape";
+      }
+    }
     // For inplace output, we also need to set replicated dist attr
     auto dist_attr =
         phi::distributed::TensorDistAttr(common::vectorize(out->dims()));

--- a/paddle/phi/api/lib/data_transform.cc
+++ b/paddle/phi/api/lib/data_transform.cc
@@ -779,7 +779,7 @@ ReshardApiInputToKernelInput(phi::DeviceContext* dev_ctx,
     if (tensor_in) {
       phi::distributed::DistTensor* dist_tensor =
           static_cast<phi::distributed::DistTensor*>(tensor_in.get());
-      VLOG(4) << "ReshardIsNeededWithPartial"
+      VLOG(4) << "ReshardIsNeededWithPartial "
               << ReshardIsNeededWithPartial(dist_tensor->dist_attr(),
                                             dist_attr);
       if (ReshardIsNeededWithPartial(dist_tensor->dist_attr(), dist_attr)) {

--- a/paddle/phi/kernels/impl/einsum_impl.h
+++ b/paddle/phi/kernels/impl/einsum_impl.h
@@ -519,8 +519,12 @@ DenseTensor PerformContraction(
                                                   label2type);
       trans_t = PerformTranspose<T, Context>(
           dev_ctx, reduct_t, perm, reordered_all_labels, label2type);
-      if (cache[operand_idx] != nullptr)
+      if (cache[operand_idx] != nullptr) {
         cache[operand_idx]->ShareBufferWith(trans_t);
+        cache[operand_idx]->Resize(trans_t.dims());
+        VLOG(5) << "Set dims of cache[" << operand_idx
+                << "]: " << trans_t.dims();
+      }
     }
     auto mul_dims = GetShapeByType<int>(
         all_labels, label2type, perm, label2shape, {LabelType::Batch});


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
The shape of 'inner_cache' ouput in 'einsum' op is not infered, so it is empty. 
It result in error in auto_parallel, this PR fixes it by using local shape in replicated case.
Pcard-76459