### PR TITLE
[WIP][Dy2St] Record patched name to avoid rollback failures

### DIFF
--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -357,12 +357,11 @@ def convert_call(func):
         if hasattr(func, 'forward') and isinstance(func, Layer):
             try:
                 _, forward_func = unwrap_decorators(func.forward)
-                func._original_funcs['forward'] = forward_func.__func__
                 forward_func = convert_to_static(forward_func.__func__)
                 # Bound method will be convert into plain function after `convert_to_static`.
                 # So descriptor mechanism is used to bound `self` instance on function to
                 # keep it as bound method.
-                func.forward = WeakMethod(forward_func, func)
+                func._patch_method('forward', WeakMethod(forward_func, func))
             except (OSError, TypeError):
                 # NOTE: func.forward may have been decorated.
                 func_self = None if func_self else func_self

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -504,19 +504,19 @@ class StaticFunction(Generic[_InputT, _RetT]):
                 and self._dygraph_function.__name__
                 not in instance._patch_restorers
             ):
+                fn_name = self._dygraph_function.__name__
+
                 # Patch the method to instance to override the original static
                 # method.
                 def restore_method(instance):
                     object.__setattr__(
                         instance,
-                        self._dygraph_function.__name__,
+                        fn_name,
                         self._dygraph_function.__get__(instance),
                     )
 
-                instance._patch_restorers[self._dygraph_function.__name__] = (
-                    restore_method
-                )
-                self._patched_name = self._dygraph_function.__name__
+                instance._patch_restorers[fn_name] = restore_method
+                self._patched_name = fn_name
             new_static_layer._class_instance = weakref.ref(instance)
             self._descriptor_cache[instance] = new_static_layer
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

SOT layer infermeta 需要走 AST 动转静，并在结束后 rollback 回原来的函数，rollback 时候用的是 `dygraph_function.__name__`

但是在 PaddleNLP 中，部分函数是被 patch 的，`dygraph_function.__name__` 和实际 patch 的名字不一样，比如 `paddle.nn.TransformerEncoderLayer.forward = _transformer_encoder_layer_fwd`，`dygraph_function.__name__` 为 `_transformer_encoder_layer_fwd`，因此最后恢复没有恢复到 `forward`，导致后续 forward 仍然是转静后的函数

因此在 patch 时记录到底 patch 到哪个 name 上，以确保最终能正确恢复

https://github.com/PaddlePaddle/PaddleNLP/blob/a5ec6bf623ce8e68ce84e0620d1e195072b25643/paddlenlp/transformers/model_outputs.py#L362-L365

PCard-66972