### PR TITLE
[CINN] Fix horizontal fusion with reduce dim equals one

### DIFF
--- a/test/ir/pir/cinn/test_reduce_fusion.py
+++ b/test/ir/pir/cinn/test_reduce_fusion.py
@@ -185,6 +185,20 @@ class TestReduceFusion(unittest.TestCase):
 
         self.check_accuracy_and_kernel_num(init, func, kernel_num=1)
 
+    def test_horizontal_fusion_with_reduce_dim_equals_one(self):
+        def func(x):
+            a = x + 1
+            a = paddle.max(a, axis=[0])
+            b = x * 2
+            b = paddle.max(b, axis=[2])
+            return a, b
+
+        def init():
+            x = paddle.rand((1, 32, 8), dtype='float32')
+            return (x,)
+
+        self.check_accuracy_and_kernel_num(init, func)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- Fix horizontal fusion with reduce dim equals one