### PR TITLE
[Dy2St] Record patched name to avoid rollback failures

### DIFF
--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -335,6 +335,7 @@ def to_static(
                 logging_utils.warn(
                     f"`{class_name}.forward` has already been decorated somewhere. It will be redecorated to replace previous one."
                 )
+            function._original_funcs["forward"] = function.forward
             function.forward = decorated(function.forward)
             return function
         else:

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -1759,6 +1759,12 @@ class Layer:
                 if name in d:
                     del d[name]
 
+        if isinstance(
+            value, paddle.jit.dy2static.program_translator.StaticFunction
+        ):
+            object.__setattr__(self, name, value)
+            value._patched_name = name
+            return
         if isinstance(getattr(type(self), name, None), property):
             object.__setattr__(self, name, value)
         params = self.__dict__.get('_parameters', None)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

SOT layer infermeta 需要走 AST 动转静，并在结束后 rollback 回原来的函数，rollback 时候用的是 `dygraph_function.__name__`

但是在 PaddleNLP 中，部分函数是被 patch 的，`dygraph_function.__name__` 和实际 patch 的名字不一样，比如 `paddle.nn.TransformerEncoderLayer.forward = _transformer_encoder_layer_fwd`，`dygraph_function.__name__` 为 `_transformer_encoder_layer_fwd`，因此最后恢复没有恢复到 `forward`，导致后续 forward 仍然是转静后的函数

因此在 patch 时记录到底 patch 到哪个 name 上，以确保最终能正确恢复

https://github.com/PaddlePaddle/PaddleNLP/blob/a5ec6bf623ce8e68ce84e0620d1e195072b25643/paddlenlp/transformers/model_outputs.py#L362-L365

同 #69936，但只是临时解决方案，因为 #69936 有一些坑还不太好解决

PCard-66972