### PR TITLE
fix the bug for create_shaped_type fucntion.

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1595,7 +1595,7 @@ void BindType(py::module *m) {
       });
 
   m->def("create_shaped_type",
-         [](Type &type, const std::vector<int> &shape) -> Type {
+         [](Type &type, const std::vector<int64_t> &shape) -> Type {
            if (type.isa<DenseTensorType>()) {
              DenseTensorType src_type = type.dyn_cast<DenseTensorType>();
              DenseTensorType dst_type =

--- a/test/ir/pir/test_build_op.py
+++ b/test/ir/pir/test_build_op.py
@@ -55,6 +55,8 @@ class TestBuildOp(unittest.TestCase):
                 .name(),
                 "pd_op.tanh",
             )
+        paddle.pir.create_shaped_type(tanh_out.type(), [3148873728])
+        paddle.pir.create_shaped_type(tanh_out.type(), [1])
 
 
 class TestBuildOp2(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
- fix the bug for create_shaped_type fucntion.
 The shapes' elements of "create_shaped_type" maybe exceeds of int32_t, so rectify its type to int64_t。
### Other
Pcard-67164