### PR TITLE
[PIR]Refine switch ir

### DIFF
--- a/python/paddle/pir_utils.py
+++ b/python/paddle/pir_utils.py
@@ -18,6 +18,7 @@ from paddle.framework.dtype import bind_datatype, bind_vartype
 
 
 def _switch_to_pir_():
+    bind_datatype()
     paddle.base.framework.global_var._use_pir_api_ = True
     paddle.framework.set_flags({"FLAGS_enable_pir_in_executor": True})
     paddle.pir.register_paddle_dialect()
@@ -39,6 +40,7 @@ def _switch_to_pir_():
 
 
 def _switch_to_old_ir_():
+    bind_vartype()
     paddle.base.framework.global_var._use_pir_api_ = False
     paddle.framework.set_flags({"FLAGS_enable_pir_in_executor": False})
 
@@ -71,7 +73,6 @@ class IrGuard:
         if not self.old_flag:
             paddle.framework.set_flags({"FLAGS_enable_pir_api": True})
             paddle.base.framework.global_var._use_pir_api_ = True
-            bind_datatype()
             self._switch_to_pir()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -80,7 +81,6 @@ class IrGuard:
         if not self.old_flag:
             paddle.framework.set_flags({"FLAGS_enable_pir_api": False})
             paddle.base.framework.global_var._use_pir_api_ = False
-            bind_vartype()
             self._switch_to_old_ir()
 
     def _switch_to_pir(self):
@@ -111,8 +111,6 @@ class OldIrGuard:
             paddle.enable_static()
         if self.old_flag:
             paddle.framework.set_flags({"FLAGS_enable_pir_api": False})
-            paddle.base.framework.global_var._use_pir_api_ = False
-            bind_vartype()
             _switch_to_old_ir_()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -120,8 +118,6 @@ class OldIrGuard:
             paddle.disable_static()
         if self.old_flag:
             paddle.framework.set_flags({"FLAGS_enable_pir_api": True})
-            paddle.base.framework.global_var._use_pir_api_ = True
-            bind_datatype()
             _switch_to_pir_()
 
 
@@ -132,15 +128,11 @@ class DygraphPirGuard:
         ]
         if not self.old_flag:
             paddle.framework.set_flags({"FLAGS_enable_pir_api": True})
-            paddle.base.framework.global_var._use_pir_api_ = True
-            bind_datatype()
             self._switch_to_pir()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if not self.old_flag:
             paddle.framework.set_flags({"FLAGS_enable_pir_api": False})
-            paddle.base.framework.global_var._use_pir_api_ = False
-            bind_vartype()
             self._switch_to_old_ir()
 
     def _switch_to_pir(self):
@@ -168,15 +160,11 @@ class DygraphOldIrGuard:
         ]
         if self.old_flag:
             paddle.framework.set_flags({"FLAGS_enable_pir_api": False})
-            paddle.base.framework.global_var._use_pir_api_ = False
-            bind_vartype()
             _switch_to_old_ir_()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.old_flag:
             paddle.framework.set_flags({"FLAGS_enable_pir_api": True})
-            paddle.base.framework.global_var._use_pir_api_ = True
-            bind_datatype()
             _switch_to_pir_()
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
pcard-67164
Refine switch ir
pir_utils中IrGuard和OldIrGuard在调用switch_to_xx_ir前有部分重复逻辑，还有部分逻辑可以合并到switch函数中。整理后在switch函数调用前只需要修改flag即可。