### PR TITLE
fix fused_layer_norm fused_rms_norm outputs

### DIFF
--- a/python/paddle/incubate/nn/functional/fused_layer_norm.py
+++ b/python/paddle/incubate/nn/functional/fused_layer_norm.py
@@ -123,7 +123,6 @@ def fused_layer_norm(
             quant_max_bound,
             quant_min_bound,
         )
-
     helper = LayerHelper('fused_layernorm', **locals())
     out = None
     if quant_scale <= 0:

--- a/python/paddle/incubate/nn/functional/fused_layer_norm.py
+++ b/python/paddle/incubate/nn/functional/fused_layer_norm.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, overload
 
 import paddle
 from paddle import _C_ops
-from paddle.framework import LayerHelper, in_dynamic_mode, in_pir_mode
+from paddle.framework import LayerHelper, in_dynamic_or_pir_mode
 
 if TYPE_CHECKING:
     from paddle import Tensor
@@ -108,8 +108,7 @@ def fused_layer_norm(
             >>> epsilon = 1e-6
             >>> paddle_layernorm = paddle.incubate.nn.functional.fused_layer_norm(paddle_x, paddle_weight, paddle_bias, epsilon, 1)
     """
-
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.fused_bias_residual_layernorm(
             x,
             bias,
@@ -124,22 +123,6 @@ def fused_layer_norm(
             quant_max_bound,
             quant_min_bound,
         )
-    elif in_pir_mode():
-        out, residual_out, _, _ = _C_ops.fused_bias_residual_layernorm(
-            x,
-            bias,
-            residual,
-            norm_weight,
-            norm_bias,
-            epsilon,
-            residual_alpha,
-            begin_norm_axis,
-            quant_scale,
-            quant_round_type,
-            quant_max_bound,
-            quant_min_bound,
-        )
-        return (out, residual_out) if residual is not None else out
 
     helper = LayerHelper('fused_layernorm', **locals())
     out = None
@@ -183,4 +166,4 @@ def fused_layer_norm(
         },
         outputs=outputs_dict,
     )
-    return (out, residual_out) if residual is not None else out
+    return (out, residual_out)

--- a/python/paddle/incubate/nn/functional/fused_rms_norm.py
+++ b/python/paddle/incubate/nn/functional/fused_rms_norm.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, overload
 
 import paddle
 from paddle import _C_ops
-from paddle.framework import LayerHelper, in_dynamic_mode, in_pir_mode
+from paddle.framework import LayerHelper, in_dynamic_or_pir_mode
 
 if TYPE_CHECKING:
     from paddle import Tensor
@@ -102,7 +102,7 @@ def fused_rms_norm(
             >>> epsilon = 1e-6
             >>> paddle_rmsnorm = paddle.incubate.nn.functional.fused_rms_norm(paddle_x, paddle_weight, paddle_bias, epsilon, 1)
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.rms_norm(
             x,
             bias,
@@ -116,21 +116,6 @@ def fused_rms_norm(
             quant_max_bound,
             quant_min_bound,
         )
-    if in_pir_mode():
-        out, residual_out = _C_ops.rms_norm(
-            x,
-            bias,
-            residual,
-            norm_weight,
-            norm_bias,
-            epsilon,
-            begin_norm_axis,
-            quant_scale,
-            quant_round_type,
-            quant_max_bound,
-            quant_min_bound,
-        )
-        return (out, residual_out) if residual is not None else out
     helper = LayerHelper('rms_norm', **locals())
     out = None
     if quant_scale <= 0:
@@ -167,4 +152,4 @@ def fused_rms_norm(
         },
         outputs=outputs_dict,
     )
-    return (out, residual_out) if residual is not None else out
+    return (out, residual_out)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
fix fused_layer_norm fused_rms_norm outputs in dynamic, pir, static mode