### PR TITLE
【SCU】【Paddle Tensor No.24】补充 `matrix_transpose` 到  `tensor.__init__`

### DIFF
--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -500,6 +500,7 @@ tensor_method_func = [
     'bincount',
     'mv',
     'matrix_power',
+    'matrix_transpose',
     'qr',
     'householder_product',
     'pca_lowrank',


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
补充`paddle.tensor.__init__`中缺失的`matrix_transpose`。https://github.com/PaddlePaddle/Paddle/pull/69301