### PR TITLE
【BUPT】[CodeStyle][Typos][B-2] Fix typos (`beacuse`, `becasue`, `Becasue`, `becuase`)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -26,10 +26,6 @@ UE = "UE"
 unpacket = "unpacket"
 
 # These words need to be fixed
-beacuse = 'beacuse'
-becasue = 'becasue'
-Becasue = 'Becasue'
-becuase = 'becuase'
 blokc = 'blokc'
 blcok = 'blcok'
 bootom = 'bootom'

--- a/paddle/cinn/common/simplify_special_pattern.cc
+++ b/paddle/cinn/common/simplify_special_pattern.cc
@@ -30,7 +30,7 @@ std::optional<ir::IndexExpr> DivMulAddModCornerCase(const ir::IndexExpr& lhs,
   auto rhsMod = rhs.As<ir::Mod>();
   if (!lhsMul || !rhsMod) return std::nullopt;
 
-  // Why inner is lhs of Mul? beacuse we sort by expr length, and the length of
+  // Why inner is lhs of Mul? because we sort by expr length, and the length of
   // inner is longer in this case.
   auto inner = lhsMul->a().as_index();
   auto mult_outer = lhsMul->b().as_index();

--- a/paddle/phi/kernels/gpudnn/conv_cudnn_v7.h
+++ b/paddle/phi/kernels/gpudnn/conv_cudnn_v7.h
@@ -163,7 +163,7 @@ struct SearchAlgorithmBase<ConvKind::kForward> {
           perf_results, workspace_size_limit, &result);
 #else
       VLOG(3) << "Fallback to non-v7 method to find conv algorithm "
-                 "becasue the workspace size request("
+                 "because the workspace size request("
               << result.workspace_size << ") exceeds the limit("
               << workspace_size_limit << ")";
       PADDLE_ENFORCE_GPU_SUCCESS(
@@ -346,7 +346,7 @@ struct SearchAlgorithmBase<ConvKind::kBackwardData> {
       ChooseAlgoByWorkspace<PerfT, AlgoT>(
           perf_results, workspace_size_limit, &result);
 #else
-      VLOG(1) << "Fallback to non-v7 method to find conv algorithm becasue "
+      VLOG(1) << "Fallback to non-v7 method to find conv algorithm because "
                  "the workspace size request("
               << result.workspace_size << ") exceeds the limit("
               << workspace_size_limit << ")";
@@ -518,7 +518,7 @@ struct SearchAlgorithmBase<ConvKind::kBackwardFilter> {
       ChooseAlgoByWorkspace<PerfT, AlgoT>(
           perf_results, workspace_size_limit, &result);
 #else
-      VLOG(1) << "Fallback to non-v7 method to find conv algorithm becasue "
+      VLOG(1) << "Fallback to non-v7 method to find conv algorithm because "
                  "the workspace size request("
               << result.workspace_size << ") exceeds the limit("
               << workspace_size_limit << ")";

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -700,7 +700,7 @@ class StaticFunction(Generic[_InputT, _RetT]):
     def __deepcopy__(self, memo):
         """
         Customized behavior for copy.deepcopy, return original decorated function instead
-        of a new StaticFunction Object. StaticFunction itself is not copyable becuase it's
+        of a new StaticFunction Object. StaticFunction itself is not copyable because it's
         associated with class_instance.
 
         We add __deepcopy__ here only for the following usage:

--- a/test/legacy_test/test_assign_pos_op.py
+++ b/test/legacy_test/test_assign_pos_op.py
@@ -43,7 +43,7 @@ def count(x, upper_num):
 
 
 # why defining the assert function specially?
-# Becasue assign_pos_op is multithread-op, which can make the order of numbers
+# Because assign_pos_op is multithread-op, which can make the order of numbers
 # in each counter(bin) is random. But the numbers set is certain in each counter(bin).
 np_allclose = np.allclose
 

--- a/test/legacy_test/test_assign_pos_op_dygraph.py
+++ b/test/legacy_test/test_assign_pos_op_dygraph.py
@@ -42,7 +42,7 @@ def count(x, upper_num):
 
 
 # why defining the assert function specially?
-# Becasue assign_pos_op is multithread-op, which can make the order of numbers
+# Because assign_pos_op is multithread-op, which can make the order of numbers
 # in each counter(bin) is random. But the numbers set is certain in each counter(bin).
 np_allclose = np.allclose
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

Fix:

- becuase (-> because)
- Becasue (-> Because)
- becasue (-> because)
- beacuse (-> because)