### PR TITLE
[XPU] fix missed link to xpuml in local build

### DIFF
--- a/tools/xpu/pack_paddle_dependence.sh
+++ b/tools/xpu/pack_paddle_dependence.sh
@@ -142,6 +142,8 @@ function local_assemble() {
 
       cp -r ${LOCAL_PATH}/${XHPC_DIR_NAME}/xpudnn/include/* xpu/include/xhpc/xpudnn
       cp -r ${LOCAL_PATH}/${XHPC_DIR_NAME}/xpudnn/so/libxpu_dnn.so xpu/lib/
+      # FIXME(yangjianbang): 待bkcl增加RPATH后, 删除以下代码
+      patchelf --set-rpath '$ORIGIN/' xpu/lib/libbkcl.so
     fi
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
1. set rpath for libbkcl.so in local build
