### PR TITLE
[CINN] Add program id to compilation cache key

### DIFF
--- a/paddle/cinn/hlir/framework/pir/fusion_info.h
+++ b/paddle/cinn/hlir/framework/pir/fusion_info.h
@@ -90,6 +90,17 @@ class FusionOpInfo {
   std::map<size_t, OpDepInfo> inner_deps_;
 };
 
+class ProgramInfo {
+ public:
+  explicit ProgramInfo(const ::pir::Program &program);
+
+  std::size_t hash() const;
+  friend std::ostream &operator<<(std::ostream &os, const ProgramInfo &info);
+
+ private:
+  uint64_t id_;
+};
+
 class FusionInfo {
   using IntArgsMap = std::map<int, CINNKernelInfo::SymbolArgBindInfo>;
 
@@ -109,9 +120,11 @@ class FusionInfo {
  private:
   void ParseOpInfos(const OpLoweringGroup &group);
   void ParseInputDimExprs(const OpLoweringGroup &group);
+  void ParseProgramInfo(const OpLoweringGroup &group);
 
   std::vector<FusionOpInfo> op_infos_;
   std::vector<::symbol::ShapeOrDataDimExprs> input_dim_exprs_;
+  std::shared_ptr<ProgramInfo> program_info_;
   std::size_t cached_hash_value_{0};
 
   // Used to make same subgraphs have unique FusionInfo while
@@ -149,10 +162,11 @@ namespace std {
     }                                                              \
   };
 
-REGISTER_STD_HASH(AttributeInfo);
-REGISTER_STD_HASH(ValueInfo);
-REGISTER_STD_HASH(OperationInfo);
+REGISTER_STD_HASH(AttributeInfo)
+REGISTER_STD_HASH(ValueInfo)
+REGISTER_STD_HASH(OperationInfo)
 REGISTER_STD_HASH(OpDepInfo)
-REGISTER_STD_HASH(FusionOpInfo);
+REGISTER_STD_HASH(FusionOpInfo)
+REGISTER_STD_HASH(ProgramInfo)
 REGISTER_STD_HASH(FusionInfo)
 }  // namespace std


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

不同 program 符号信息独立，因此跨 program 符号信息相同并不能保证约束一样，会导致错误命中 cache

因此将 program id 添加到编译 cache key 中使得 cache 根据 Program 隔离

Pcard-67164