### PR TITLE
roi_align_grad boxes_num support int64

### DIFF
--- a/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc
@@ -97,13 +97,24 @@ void RoiAlignGradKernel(const Context& dev_ctx,
   int boxes_batch_size = 0;
   if (boxes_num) {
     boxes_batch_size = static_cast<int>(boxes_num->numel());
-    auto* boxes_num_data = boxes_num->data<int>();
-    int start = 0;
-    for (int n = 0; n < boxes_batch_size; ++n) {
-      for (int i = start; i < start + boxes_num_data[n]; ++i) {
-        box_batch_id_data[i] = n;
+    if (boxes_num->dtype() == phi::DataType::INT64) {
+      auto* boxes_num_data = boxes_num->data<int64_t>();
+      int64_t start = 0;
+      for (int64_t n = 0; n < boxes_batch_size; ++n) {
+        for (int64_t i = start; i < start + boxes_num_data[n]; ++i) {
+          box_batch_id_data[i] = n;
+        }
+        start += boxes_num_data[n];
       }
-      start += boxes_num_data[n];
+    } else if (boxes_num->dtype() == phi::DataType::INT32) {
+      auto* boxes_num_data = boxes_num->data<int>();
+      int start = 0;
+      for (int n = 0; n < boxes_batch_size; ++n) {
+        for (int i = start; i < start + boxes_num_data[n]; ++i) {
+          box_batch_id_data[i] = n;
+        }
+        start += boxes_num_data[n];
+      }
     }
   } else {
     auto boxes_lod = boxes.lod().back();

--- a/paddle/phi/kernels/xpu/roi_align_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/roi_align_grad_kernel.cc
@@ -50,16 +50,30 @@ void RoiAlignGradKernel(const Context& dev_ctx,
   int* cpu_lod = nullptr;
   if (boxes_num) {
     rois_batch_size = boxes_num->numel();
-    std::vector<int> rois_num_list(rois_batch_size);
-    memory_utils::Copy(cplace,
-                       rois_num_list.data(),
-                       xplace,
-                       boxes_num->data<int>(),
-                       sizeof(int) * rois_batch_size);
-    cpu_lod = new int[rois_batch_size + 1];
-    cpu_lod[0] = 0;
-    for (int i = 0; i < rois_batch_size; i++) {
-      cpu_lod[i + 1] = cpu_lod[i] + rois_num_list[i];
+    if (boxes_num->dtype() == phi::DataType::INT64) {
+      std::vector<int64_t> rois_num_list(rois_batch_size);
+      memory_utils::Copy(cplace,
+                         rois_num_list.data(),
+                         xplace,
+                         boxes_num->data<int64_t>(),
+                         sizeof(int64_t) * rois_batch_size);
+      cpu_lod = new int[rois_batch_size + 1];
+      cpu_lod[0] = 0;
+      for (int64_t i = 0; i < rois_batch_size; i++) {
+        cpu_lod[i + 1] = cpu_lod[i] + rois_num_list[i];
+      }
+    } else if (boxes_num->dtype() == phi::DataType::INT32) {
+      std::vector<int> rois_num_list(rois_batch_size);
+      memory_utils::Copy(cplace,
+                         rois_num_list.data(),
+                         xplace,
+                         boxes_num->data<int>(),
+                         sizeof(int) * rois_batch_size);
+      cpu_lod = new int[rois_batch_size + 1];
+      cpu_lod[0] = 0;
+      for (int i = 0; i < rois_batch_size; i++) {
+        cpu_lod[i + 1] = cpu_lod[i] + rois_num_list[i];
+      }
     }
   } else {
     auto rois_lod = boxes.lod().back();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->

https://github.com/PaddlePaddle/Paddle/pull/69589 后，模型里传入一些算子的input变为int64类型。可以通过模型中将其cast成int32，也可以让算子支持int64。支持int64更合理，可以让不兼容升级影响范围更小。

https://github.com/PaddlePaddle/Paddle/pull/69829 支持了一批，没有支持全。本PR补充roi_align_grad的boxes_num支持int64。


Pcard-67164