### PR TITLE
【SCU】【Paddle Tensor 第二期 常用API复数类型支持No.1】添加 `all` 函数复数类型支持

### DIFF
--- a/paddle/phi/kernels/cpu/reduce_all_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_all_kernel.cc
@@ -33,7 +33,7 @@ void AllRawKernel(const Context& dev_ctx,
                   bool reduce_all,
                   DenseTensor* out) {
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
-   phi::BoolReduceKernel<Context, T, phi::funcs::AllFunctor<T>>(
+  phi::BoolReduceKernel<CPUContext, T, phi::funcs::AllFunctor<T>>(
       dev_ctx, x, dims, keep_dim, reduce_all, out);
 }
 

--- a/paddle/phi/kernels/cpu/reduce_all_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_all_kernel.cc
@@ -14,8 +14,8 @@
 
 #include "paddle/phi/kernels/reduce_all_kernel.h"
 
-#include "paddle/phi/common/complex.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/common/complex.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cpu/reduce.h"
 #include "paddle/phi/kernels/funcs/reduce_functor.h"
@@ -32,9 +32,9 @@ void AllRawKernel(const Context& dev_ctx,
                   bool keep_dim,
                   bool reduce_all,
                   DenseTensor* out) {
-    reduce_all = recompute_reduce_all(x, dims, reduce_all);
-    phi::BoolReduceKernel<Context, T, phi::funcs::AllFunctor<T>>(
-        dev_ctx, x, dims, keep_dim, reduce_all, out);
+  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+   phi::BoolReduceKernel<Context, T, phi::funcs::AllFunctor<T>>(
+      dev_ctx, x, dims, keep_dim, reduce_all, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/reduce_all_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_all_kernel.cc
@@ -14,10 +14,14 @@
 
 #include "paddle/phi/kernels/reduce_all_kernel.h"
 
+#include "paddle/phi/common/complex.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cpu/reduce.h"
 #include "paddle/phi/kernels/funcs/reduce_functor.h"
+
+using complex64 = ::phi::dtype::complex<float>;
+using complex128 = ::phi::dtype::complex<double>;
 
 namespace phi {
 
@@ -28,9 +32,9 @@ void AllRawKernel(const Context& dev_ctx,
                   bool keep_dim,
                   bool reduce_all,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
-  phi::BoolReduceKernel<CPUContext, T, phi::funcs::AllFunctor>(
-      dev_ctx, x, dims, keep_dim, reduce_all, out);
+    reduce_all = recompute_reduce_all(x, dims, reduce_all);
+    phi::BoolReduceKernel<Context, T, phi::funcs::AllFunctor<T>>(
+        dev_ctx, x, dims, keep_dim, reduce_all, out);
 }
 
 }  // namespace phi
@@ -43,6 +47,8 @@ PD_REGISTER_KERNEL(all_raw,
                    double,
                    int,
                    int64_t,
-                   bool) {
+                   bool,
+                   complex64,
+                   complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
 }

--- a/paddle/phi/kernels/funcs/reduce_functor.h
+++ b/paddle/phi/kernels/funcs/reduce_functor.h
@@ -102,7 +102,9 @@ template <>
 struct AllFunctor<std::complex<float>> {
   template <typename DeviceContext, typename X, typename Y, typename Dim>
   void operator()(const DeviceContext& place, X* x, Y* y, const Dim& dim) {
-    auto to_bool = [](const std::complex<float>& v) { return v.real() != 0 || v.imag() != 0; };
+    auto to_bool = [](const std::complex<float>& v) {
+      return v.real() != 0 || v.imag() != 0;
+    };
     y->device(place) = x->unaryExpr(to_bool).all(dim);
   }
 };

--- a/paddle/phi/kernels/funcs/reduce_functor.h
+++ b/paddle/phi/kernels/funcs/reduce_functor.h
@@ -98,26 +98,13 @@ struct AllFunctor {
   }
 };
 
-template <>
-struct AllFunctor<std::complex<float>> {
-  template <typename DeviceContext, typename X, typename Y, typename Dim>
-  void operator()(const DeviceContext& place, X* x, Y* y, const Dim& dim) {
-    auto to_bool = [](const std::complex<float>& v) {
-      return v.real() != 0 || v.imag() != 0;
-    };
-    y->device(place) = x->unaryExpr(to_bool).all(dim);
-  }
-};
-
-template <>
-struct AllFunctor<std::complex<double>> {
-  template <typename DeviceContext, typename X, typename Y, typename Dim>
-  void operator()(const DeviceContext& place, X* x, Y* y, const Dim& dim) {
-    auto to_bool = [](const std::complex<double>& v) {
-      return v.real() != 0 || v.imag() != 0;
-    };
-    y->device(place) = x->unaryExpr(to_bool).all(dim);
-  }
+template<typename T>
+struct AllFunctor<std::complex<T>> {
+    template <typename DeviceContext, typename X, typename Y, typename Dim>
+    void operator()(const DeviceContext& place, X* x, Y* y, const Dim& dim) {
+        auto to_bool = [](const std::complex<T>& v) { return v.real() != 0 || v.imag() != 0; };
+        y->device(place) = x->unaryExpr(to_bool).all(dim);
+    }
 };
 
 //////// Any Functor ///////

--- a/paddle/phi/kernels/funcs/reduce_functor.h
+++ b/paddle/phi/kernels/funcs/reduce_functor.h
@@ -17,6 +17,7 @@
 #include "paddle/common/macros.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
+#include "paddle/phi/common/complex.h"
 namespace phi {
 namespace funcs {
 
@@ -89,10 +90,29 @@ struct MinFunctor {
 };
 
 //////// All Functor ///////
+template<typename T>
 struct AllFunctor {
   template <typename DeviceContext, typename X, typename Y, typename Dim>
   void operator()(const DeviceContext& place, X* x, Y* y, const Dim& dim) {
     y->device(place) = x->all(dim);
+  }
+};
+
+template<>
+struct AllFunctor<std::complex<float>> {
+  template <typename DeviceContext, typename X, typename Y, typename Dim>
+  void operator()(const DeviceContext& place, X* x, Y* y, const Dim& dim) {
+    auto to_bool = [](const std::complex<float>& v) { return v.real() != 0 || v.imag() != 0; };
+    y->device(place) = x->unaryExpr(to_bool).all(dim);
+  }
+};
+
+template<>
+struct AllFunctor<std::complex<double>> {
+  template <typename DeviceContext, typename X, typename Y, typename Dim>
+  void operator()(const DeviceContext& place, X* x, Y* y, const Dim& dim) {
+    auto to_bool = [](const std::complex<double>& v) { return v.real() != 0 || v.imag() != 0; };
+    y->device(place) = x->unaryExpr(to_bool).all(dim);
   }
 };
 

--- a/paddle/phi/kernels/funcs/reduce_functor.h
+++ b/paddle/phi/kernels/funcs/reduce_functor.h
@@ -98,13 +98,15 @@ struct AllFunctor {
   }
 };
 
-template<typename T>
+template <typename T>
 struct AllFunctor<std::complex<T>> {
-    template <typename DeviceContext, typename X, typename Y, typename Dim>
-    void operator()(const DeviceContext& place, X* x, Y* y, const Dim& dim) {
-        auto to_bool = [](const std::complex<T>& v) { return v.real() != 0 || v.imag() != 0; };
-        y->device(place) = x->unaryExpr(to_bool).all(dim);
-    }
+  template <typename DeviceContext, typename X, typename Y, typename Dim>
+  void operator()(const DeviceContext& place, X* x, Y* y, const Dim& dim) {
+    auto to_bool = [](const std::complex<T>& v) {
+      return v.real() != 0 || v.imag() != 0;
+    };
+    y->device(place) = x->unaryExpr(to_bool).all(dim);
+  }
 };
 
 //////// Any Functor ///////

--- a/paddle/phi/kernels/funcs/reduce_functor.h
+++ b/paddle/phi/kernels/funcs/reduce_functor.h
@@ -15,9 +15,9 @@
 #pragma once
 
 #include "paddle/common/macros.h"
+#include "paddle/phi/common/complex.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
-#include "paddle/phi/common/complex.h"
 namespace phi {
 namespace funcs {
 
@@ -90,7 +90,7 @@ struct MinFunctor {
 };
 
 //////// All Functor ///////
-template<typename T>
+template <typename T>
 struct AllFunctor {
   template <typename DeviceContext, typename X, typename Y, typename Dim>
   void operator()(const DeviceContext& place, X* x, Y* y, const Dim& dim) {
@@ -98,7 +98,7 @@ struct AllFunctor {
   }
 };
 
-template<>
+template <>
 struct AllFunctor<std::complex<float>> {
   template <typename DeviceContext, typename X, typename Y, typename Dim>
   void operator()(const DeviceContext& place, X* x, Y* y, const Dim& dim) {
@@ -107,11 +107,13 @@ struct AllFunctor<std::complex<float>> {
   }
 };
 
-template<>
+template <>
 struct AllFunctor<std::complex<double>> {
   template <typename DeviceContext, typename X, typename Y, typename Dim>
   void operator()(const DeviceContext& place, X* x, Y* y, const Dim& dim) {
-    auto to_bool = [](const std::complex<double>& v) { return v.real() != 0 || v.imag() != 0; };
+    auto to_bool = [](const std::complex<double>& v) {
+      return v.real() != 0 || v.imag() != 0;
+    };
     y->device(place) = x->unaryExpr(to_bool).all(dim);
   }
 };

--- a/paddle/phi/kernels/kps/reduce_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_kernel.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <limits>
+#include "paddle/phi/common/complex.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/gpu/reduce.h"
@@ -28,6 +29,9 @@
 #ifndef PADDLE_WITH_XPU_KP
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #endif
+
+using complex64 = ::phi::dtype::complex<float>;
+using complex128 = ::phi::dtype::complex<double>;
 
 namespace phi {
 
@@ -307,7 +311,9 @@ PD_REGISTER_KERNEL(all_raw,
                    double,
                    int,
                    int64_t,
-                   bool) {
+                   bool,
+                   complex64,
+                   complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
 }
 

--- a/paddle/phi/kernels/primitive/functor_primitives.h
+++ b/paddle/phi/kernels/primitive/functor_primitives.h
@@ -83,6 +83,17 @@ struct IdentityFunctor {
   }
 };
 
+template <typename T>
+struct IdentityFunctor<phi::dtype::complex<T>, bool> {
+  HOSTDEVICE inline IdentityFunctor() {}
+
+  HOSTDEVICE explicit inline IdentityFunctor(int n) {}
+
+  HOSTDEVICE inline bool operator()(const phi::dtype::complex<T>& x) const {
+    return x.real != 0 || x.imag != 0;
+  }
+};
+
 /**
  * @brief Default unary div functor. Divide by a constant
  */

--- a/paddle/phi/kernels/reduce_all_kernel.cc
+++ b/paddle/phi/kernels/reduce_all_kernel.cc
@@ -15,7 +15,11 @@
 #include "paddle/phi/kernels/reduce_all_kernel.h"
 
 #include "paddle/phi/backends/all_context.h"
+#include "paddle/phi/common/complex.h"
 #include "paddle/phi/core/kernel_registry.h"
+
+using complex64 = ::phi::dtype::complex<float>;
+using complex128 = ::phi::dtype::complex<double>;
 
 namespace phi {
 
@@ -39,13 +43,13 @@ void AllKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    all, CPU, ALL_LAYOUT, phi::AllKernel, float, double, int, int64_t, bool) {
+    all, CPU, ALL_LAYOUT, phi::AllKernel, float, double, int, int64_t, bool, complex64, complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
 }
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 PD_REGISTER_KERNEL(
-    all, GPU, ALL_LAYOUT, phi::AllKernel, float, double, int, int64_t, bool) {
+    all, GPU, ALL_LAYOUT, phi::AllKernel, float, double, int, int64_t, bool, complex64, complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
 }
 #endif

--- a/paddle/phi/kernels/reduce_all_kernel.cc
+++ b/paddle/phi/kernels/reduce_all_kernel.cc
@@ -42,14 +42,32 @@ void AllKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(
-    all, CPU, ALL_LAYOUT, phi::AllKernel, float, double, int, int64_t, bool, complex64, complex128) {
+PD_REGISTER_KERNEL(all,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::AllKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t,
+                   bool,
+                   complex64,
+                   complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
 }
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-PD_REGISTER_KERNEL(
-    all, GPU, ALL_LAYOUT, phi::AllKernel, float, double, int, int64_t, bool, complex64, complex128) {
+PD_REGISTER_KERNEL(all,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::AllKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t,
+                   bool,
+                   complex64,
+                   complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
 }
 #endif

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -4972,7 +4972,7 @@ def all(
     Computes the ``logical and`` of tensor elements over the given dimension.
 
     Args:
-        x (Tensor): An N-D Tensor, the input data type should be 'bool', 'float32', 'float64', 'int32', 'int64'.
+        x (Tensor): An N-D Tensor, the input data type should be 'bool', 'float32', 'float64', 'int32', 'int64', 'complex64', 'complex128'.
         axis (int|list|tuple|None, optional): The dimensions along which the ``logical and`` is compute. If
             :attr:`None`, and all elements of :attr:`x` and return a
             Tensor with a single element, otherwise must be in the
@@ -5038,7 +5038,7 @@ def all(
             'reduce_all': reduce_all,
         }
         check_variable_and_dtype(
-            x, 'x', ['bool', 'float32', 'float64', 'int32', 'int64'], 'all'
+            x, 'x', ['bool', 'float32', 'float64', 'int32', 'int64', 'complex64', 'complex128'], 'all'
         )
         check_type(axis, 'axis', (int, list, tuple, type(None)), 'all')
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5047,9 +5047,9 @@ def all(
                 'int32',
                 'int64',
                 'complex64',
-                'complex128'
+                'complex128',
             ],
-            'all'
+            'all',
         )
         check_type(axis, 'axis', (int, list, tuple, type(None)), 'all')
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5038,7 +5038,18 @@ def all(
             'reduce_all': reduce_all,
         }
         check_variable_and_dtype(
-            x, 'x', ['bool', 'float32', 'float64', 'int32', 'int64', 'complex64', 'complex128'], 'all'
+            x,
+            'x',
+            [
+                'bool',
+                'float32',
+                'float64',
+                'int32',
+                'int64',
+                'complex64',
+                'complex128'
+            ],
+            'all'
         )
         check_type(axis, 'axis', (int, list, tuple, type(None)), 'all')
 

--- a/test/legacy_test/test_reduce_op.py
+++ b/test/legacy_test/test_reduce_op.py
@@ -998,6 +998,62 @@ class TestAllComplex128Op(OpTest):
         self.check_output(check_pir=True)
 
 
+class TestAllComplex128OpInf(TestAllComplex128Op):
+    def setUp(self):
+        super().setUp()
+        real_part = np.full((2, 5, 3, 2, 2, 3, 4, 2), np.inf)
+        imag_part = np.full((2, 5, 3, 2, 2, 3, 4, 2), np.inf)
+        self.inputs['X'] = (real_part + 1j * imag_part).astype("complex128")
+        self.outputs['Out'] = np.expand_dims(
+            np.all(self.inputs['X'], axis=self.attrs['dim']), axis=5
+        )
+
+
+class TestAllComplex128OpNegInf(TestAllComplex128Op):
+    def setUp(self):
+        super().setUp()
+        real_part = np.full((2, 5, 3, 2, 2, 3, 4, 2), -np.inf)
+        imag_part = np.full((2, 5, 3, 2, 2, 3, 4, 2), -np.inf)
+        self.inputs['X'] = (real_part + 1j * imag_part).astype("complex128")
+        self.outputs['Out'] = np.expand_dims(
+            np.all(self.inputs['X'], axis=self.attrs['dim']), axis=5
+        )
+
+
+class TestAllComplex128OpNan(TestAllComplex128Op):
+    def setUp(self):
+        super().setUp()
+        real_part = np.full((2, 5, 3, 2, 2, 3, 4, 2), np.nan)
+        imag_part = np.full((2, 5, 3, 2, 2, 3, 4, 2), np.nan)
+        self.inputs['X'] = (real_part + 1j * imag_part).astype("complex128")
+        self.outputs['Out'] = np.expand_dims(
+            np.all(self.inputs['X'], axis=self.attrs['dim']), axis=5
+        )
+
+
+class TestAllComplex128OpZero(TestAllComplex128Op):
+    def setUp(self):
+        super().setUp()
+        real_part = np.zeros((2, 5, 3, 2, 2, 3, 4, 2))
+        imag_part = np.zeros((2, 5, 3, 2, 2, 3, 4, 2))
+        self.inputs['X'] = (real_part + 1j * imag_part).astype("complex128")
+        self.outputs['Out'] = np.expand_dims(
+            np.all(self.inputs['X'], axis=self.attrs['dim']), axis=5
+        )
+
+
+class TestAllComplex128OpMixed(TestAllComplex128Op):
+    def setUp(self):
+        super().setUp()
+        special_values = np.array([np.inf, -np.inf, np.nan, 0], dtype=np.float64)
+        real_part = np.random.choice(special_values, (2, 5, 3, 2, 2, 3, 4, 2))
+        imag_part = np.random.choice(special_values, (2, 5, 3, 2, 2, 3, 4, 2))
+        self.inputs['X'] = (real_part + 1j * imag_part).astype("complex128")
+        self.outputs['Out'] = np.expand_dims(
+            np.all(self.inputs['X'], axis=self.attrs['dim']), axis=5
+        )
+
+
 class TestAllOpError(unittest.TestCase):
 
     def test_errors(self):

--- a/test/legacy_test/test_reduce_op.py
+++ b/test/legacy_test/test_reduce_op.py
@@ -1027,7 +1027,9 @@ class TestAllComplex64OpZero(TestAllComplex64Op):
 class TestAllComplex64OpMixed(TestAllComplex64Op):
     def setUp(self):
         super().setUp()
-        special_values = np.array([np.inf, -np.inf, np.nan, 0], dtype=np.float64)
+        special_values = np.array(
+            [np.inf, -np.inf, np.nan, 0], dtype=np.float64
+        )
         real_part = np.random.choice(special_values, (2, 5, 3, 2, 2, 3, 4, 2))
         imag_part = np.random.choice(special_values, (2, 5, 3, 2, 2, 3, 4, 2))
         self.inputs['X'] = (real_part + 1j * imag_part).astype("complex64")
@@ -1101,7 +1103,9 @@ class TestAllComplex128OpZero(TestAllComplex128Op):
 class TestAllComplex128OpMixed(TestAllComplex128Op):
     def setUp(self):
         super().setUp()
-        special_values = np.array([np.inf, -np.inf, np.nan, 0], dtype=np.float64)
+        special_values = np.array(
+            [np.inf, -np.inf, np.nan, 0], dtype=np.float64
+        )
         real_part = np.random.choice(special_values, (2, 5, 3, 2, 2, 3, 4, 2))
         imag_part = np.random.choice(special_values, (2, 5, 3, 2, 2, 3, 4, 2))
         self.inputs['X'] = (real_part + 1j * imag_part).astype("complex128")

--- a/test/legacy_test/test_reduce_op.py
+++ b/test/legacy_test/test_reduce_op.py
@@ -966,8 +966,10 @@ class TestAllComplex64Op(OpTest):
     def setUp(self):
         self.op_type = "reduce_all"
         self.python_api = paddle.all
+        real_part = np.random.uniform(-1, 1, (2, 5, 3, 2, 2, 3, 4, 2))
+        imag_part = np.random.uniform(-1, 1, (2, 5, 3, 2, 2, 3, 4, 2))
         self.inputs = {
-            'X': np.random.randint(0, 2, (2, 5, 3, 2, 2, 3, 4, 2)).astype(
+            'X': (real_part + 1j * imag_part).astype(
                 "complex64"
             )
         }
@@ -986,8 +988,10 @@ class TestAllComplex128Op(OpTest):
     def setUp(self):
         self.op_type = "reduce_all"
         self.python_api = paddle.all
+        real_part = np.random.uniform(-1, 1, (2, 5, 3, 2, 2, 3, 4, 2))
+        imag_part = np.random.uniform(-1, 1, (2, 5, 3, 2, 2, 3, 4, 2))
         self.inputs = {
-            'X': np.random.randint(0, 2, (2, 5, 3, 2, 2, 3, 4, 2)).astype(
+            'X': (real_part + 1j * imag_part).astype(
                 "complex128"
             )
         }

--- a/test/legacy_test/test_reduce_op.py
+++ b/test/legacy_test/test_reduce_op.py
@@ -980,6 +980,62 @@ class TestAllComplex64Op(OpTest):
         self.check_output(check_pir=True)
 
 
+class TestAllComplex640pInf(TestAllComplex64Op):
+    def setUp(self):
+        super().setUp()
+        real_part = np.full((2, 5, 3, 2, 2, 3, 4, 2), np.inf)
+        imag_part = np.full((2, 5, 3, 2, 2, 3, 4, 2), np.inf)
+        self.inputs['X'] = (real_part + 1j * imag_part).astype("complex64")
+        self.outputs['Out'] = np.expand_dims(
+            np.all(self.inputs['X'], axis=self.attrs['dim']), axis=5
+        )
+
+
+class TestAllComplex640pNegInf(TestAllComplex64Op):
+    def setUp(self):
+        super().setUp()
+        real_part = np.full((2, 5, 3, 2, 2, 3, 4, 2), -np.inf)
+        imag_part = np.full((2, 5, 3, 2, 2, 3, 4, 2), -np.inf)
+        self.inputs['X'] = (real_part + 1j * imag_part).astype("complex64")
+        self.outputs['Out'] = np.expand_dims(
+            np.all(self.inputs['X'], axis=self.attrs['dim']), axis=5
+        )
+
+
+class TestAllComplex64OpNan(TestAllComplex64Op):
+    def setUp(self):
+        super().setUp()
+        real_part = np.full((2, 5, 3, 2, 2, 3, 4, 2), np.nan)
+        imag_part = np.full((2, 5, 3, 2, 2, 3, 4, 2), np.nan)
+        self.inputs['X'] = (real_part + 1j * imag_part).astype("complex64")
+        self.outputs['Out'] = np.expand_dims(
+            np.all(self.inputs['X'], axis=self.attrs['dim']), axis=5
+        )
+
+
+class TestAllComplex64OpZero(TestAllComplex64Op):
+    def setUp(self):
+        super().setUp()
+        real_part = np.zeros((2, 5, 3, 2, 2, 3, 4, 2))
+        imag_part = np.zeros((2, 5, 3, 2, 2, 3, 4, 2))
+        self.inputs['X'] = (real_part + 1j * imag_part).astype("complex64")
+        self.outputs['Out'] = np.expand_dims(
+            np.all(self.inputs['X'], axis=self.attrs['dim']), axis=5
+        )
+
+
+class TestAllComplex64OpMixed(TestAllComplex64Op):
+    def setUp(self):
+        super().setUp()
+        special_values = np.array([np.inf, -np.inf, np.nan, 0], dtype=np.float64)
+        real_part = np.random.choice(special_values, (2, 5, 3, 2, 2, 3, 4, 2))
+        imag_part = np.random.choice(special_values, (2, 5, 3, 2, 2, 3, 4, 2))
+        self.inputs['X'] = (real_part + 1j * imag_part).astype("complex64")
+        self.outputs['Out'] = np.expand_dims(
+            np.all(self.inputs['X'], axis=self.attrs['dim']), axis=5
+        )
+
+
 class TestAllComplex128Op(OpTest):
     def setUp(self):
         self.op_type = "reduce_all"

--- a/test/legacy_test/test_reduce_op.py
+++ b/test/legacy_test/test_reduce_op.py
@@ -962,6 +962,46 @@ class TestAll8DOpWithKeepDim(OpTest):
         self.check_output(check_pir=True)
 
 
+class TestAllComplex64Op(OpTest):
+    def setUp(self):
+        self.op_type = "reduce_all"
+        self.python_api = paddle.all
+        self.inputs = {
+            'X': np.random.randint(0, 2, (2, 5, 3, 2, 2, 3, 4, 2)).astype(
+                "complex64"
+            )
+        }
+        self.attrs = {'dim': (5,), 'keep_dim': True}
+        self.outputs = {
+            'Out': np.expand_dims(
+                self.inputs['X'].all(axis=self.attrs['dim']), axis=5
+            )
+        }
+
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
+
+class TestAllComplex128Op(OpTest):
+    def setUp(self):
+        self.op_type = "reduce_all"
+        self.python_api = paddle.all
+        self.inputs = {
+            'X': np.random.randint(0, 2, (2, 5, 3, 2, 2, 3, 4, 2)).astype(
+                "complex128"
+            )
+        }
+        self.attrs = {'dim': (5,), 'keep_dim': True}
+        self.outputs = {
+            'Out': np.expand_dims(
+                self.inputs['X'].all(axis=self.attrs['dim']), axis=5
+            )
+        }
+
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
+
 class TestAllOpError(unittest.TestCase):
 
     def test_errors(self):

--- a/test/legacy_test/test_reduce_op.py
+++ b/test/legacy_test/test_reduce_op.py
@@ -968,11 +968,7 @@ class TestAllComplex64Op(OpTest):
         self.python_api = paddle.all
         real_part = np.random.uniform(-1, 1, (2, 5, 3, 2, 2, 3, 4, 2))
         imag_part = np.random.uniform(-1, 1, (2, 5, 3, 2, 2, 3, 4, 2))
-        self.inputs = {
-            'X': (real_part + 1j * imag_part).astype(
-                "complex64"
-            )
-        }
+        self.inputs = {'X': (real_part + 1j * imag_part).astype("complex64")}
         self.attrs = {'dim': (5,), 'keep_dim': True}
         self.outputs = {
             'Out': np.expand_dims(
@@ -990,11 +986,7 @@ class TestAllComplex128Op(OpTest):
         self.python_api = paddle.all
         real_part = np.random.uniform(-1, 1, (2, 5, 3, 2, 2, 3, 4, 2))
         imag_part = np.random.uniform(-1, 1, (2, 5, 3, 2, 2, 3, 4, 2))
-        self.inputs = {
-            'X': (real_part + 1j * imag_part).astype(
-                "complex128"
-            )
-        }
+        self.inputs = {'X': (real_part + 1j * imag_part).astype("complex128")}
         self.attrs = {'dim': (5,), 'keep_dim': True}
         self.outputs = {
             'Out': np.expand_dims(


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
`all` 添加复数类型支持
![Screenshot 2024-12-06 at 20 49 17](https://github.com/user-attachments/assets/298e75e8-2a13-4394-b6b2-9f321e526cf2)
![Screenshot 2024-12-06 at 20 49 06](https://github.com/user-attachments/assets/1c9d91f5-8a58-49e6-99fc-6e73afa90e6c)
