### PR TITLE
[CodeStyle][UP031] Use f-string instead of percent format in some framework dirs (part20)

### DIFF
--- a/paddle/phi/kernels/sparse/gpu/cutlass_generator/gather_gemm_scatter_operation.py
+++ b/paddle/phi/kernels/sparse/gpu/cutlass_generator/gather_gemm_scatter_operation.py
@@ -158,7 +158,7 @@ struct ${operation_name} {
             'opcode_class': OpcodeClassTag[
                 operation.tile_description.math_instruction.opcode_class
             ],
-            'arch': "cutlass::arch::Sm%d" % operation.arch,
+            'arch': f"cutlass::arch::Sm{operation.arch}",
             'threadblock_shape_m': str(
                 operation.tile_description.threadblock_shape[0]
             ),

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -632,25 +632,14 @@ def amp_guard(
                 if (dtype == 'float16') and not _is_gpu_float16_supported():
                     prop = paddle.device.cuda.get_device_capability()
                     warnings.warn(
-                        "For float16, amp only support NVIDIA GPU with Compute Capability 7.0 or higher, current GPU is: %s, with Compute Capability: %d.%d."
-                        % (
-                            paddle.device.cuda.get_device_name(),
-                            prop[0],
-                            prop[1],
-                        )
+                        f"For float16, amp only support NVIDIA GPU with Compute Capability 7.0 or higher, current GPU is: {paddle.device.cuda.get_device_name()}, with Compute Capability: {prop[0]}.{prop[1]}."
                     )
                     enable = False
                 elif (dtype == 'bfloat16') and not _is_gpu_bfloat16_supported():
                     prop = paddle.device.cuda.get_device_capability()
                     cuda_version = paddle.version.cuda()
                     warnings.warn(
-                        "For bfloat16, amp only support NVIDIA GPU with Compute Capability 8.0 or higher and CUDA Version 11.0 or higher, current GPU is: %s, with Compute Capability: %d.%d, current CUDA Version is: %s."
-                        % (
-                            paddle.device.cuda.get_device_name(),
-                            prop[0],
-                            prop[1],
-                            cuda_version,
-                        )
+                        f"For bfloat16, amp only support NVIDIA GPU with Compute Capability 8.0 or higher and CUDA Version 11.0 or higher, current GPU is: {paddle.device.cuda.get_device_name()}, with Compute Capability: {prop[0]}.{prop[1]}, current CUDA Version is: {cuda_version}."
                     )
                     enable = False
 

--- a/python/paddle/amp/debugging.py
+++ b/python/paddle/amp/debugging.py
@@ -471,8 +471,7 @@ def _print_operator_stats(op_count_dict: dict[str, str | list[int]]) -> None:
                     f"Input {value} is expected to be a list of str, but received {type(value)}."
                 )
             print(
-                "  %-40s|  %-17s|  %-17s|  %-17s|  %-17s"
-                % (op_type, called[0], called[1], called[2], called[3])
+                f"  {op_type:<40}|  {called[0]:<17}|  {called[1]:<17}|  {called[2]:<17}|  {called[3]:<17}"
             )
             total_ops += 1
     print("<{:-^120}>\n".format(" op count: " + str(total_ops) + " "))

--- a/python/paddle/audio/features/layers.py
+++ b/python/paddle/audio/features/layers.py
@@ -412,7 +412,7 @@ class MFCC(nn.Layer):
         super().__init__()
         assert (
             n_mfcc <= n_mels
-        ), 'n_mfcc cannot be larger than n_mels: %d vs %d' % (n_mfcc, n_mels)
+        ), f'n_mfcc cannot be larger than n_mels: {n_mfcc} vs {n_mels}'
         self._log_melspectrogram = LogMelSpectrogram(
             sr=sr,
             n_fft=n_fft,

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -233,13 +233,11 @@ def prepare_grad_outputs(grad_outputs, outputs, state):
         else:
             if output.shape != grad.shape:
                 raise ValueError(
-                    "The shape of grad_output[%d] %s should be the same as the shape of output[%d] %s"
-                    % (i, str(grad.shape), i, str(output.shape))
+                    f"The shape of grad_output[{i}] {grad.shape} should be the same as the shape of output[{i}] {output.shape}"
                 )
             if output.dtype != grad.dtype:
                 warnings.warn(
-                    "The dtype of grad_output[%d] %s is not same as the dtype of output[%d] %s"
-                    % (i, str(grad.dtype), i, str(output.dtype))
+                    f"The dtype of grad_output[{i}] {grad.dtype} is not same as the dtype of output[{i}] {output.dtype}"
                 )
             feedop = grad.get_defining_op()
             update_bwdop_structure(

--- a/python/paddle/base/backward.py
+++ b/python/paddle/base/backward.py
@@ -1146,7 +1146,7 @@ def _append_backward_ops_with_checkpoints_(
             grad_to_var.update(op_grad_to_var)
 
         ff_ops = ops[segment[0] : segment[1]]
-        var_suffix = ".subprog_%d" % i
+        var_suffix = f".subprog_{i}"
 
         for op in ff_ops:
             if op.has_attr("sub_block"):

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -76,8 +76,7 @@ class TensorHookRemoveHelper:
                 return True
             else:
                 warnings.warn(
-                    "The backward hook (ID: %d) of Tensor `%s` you want to remove does not exist or has been removed."
-                    % (self._hook_id, tensor.name),
+                    f"The backward hook (ID: {self._hook_id}) of Tensor `{tensor.name}` you want to remove does not exist or has been removed.",
                     RuntimeWarning,
                 )
         return False

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -270,9 +270,8 @@ def check_feed_shape_type(var, feed, num_places=1):
         diff_shape = core.diff_tensor_shape(feed, var.desc, num_places)
         if diff_shape is not None:
             raise ValueError(
-                'The fed Variable %r should have dimensions = %d, shape = '
-                '%r, but received fed shape %r on each device'
-                % (var.name, len(var.shape), var.shape, diff_shape)
+                f'The fed Variable {var.name!r} should have dimensions = {len(var.shape)}, shape = '
+                f'{var.shape!r}, but received fed shape {diff_shape!r} on each device'
             )
         if not dtype_is_compatible_with(feed._dtype(), var.dtype):
             var_dtype_format = (
@@ -318,9 +317,8 @@ def pir_check_feed_shape_type(feed, name, target_shape, dtype, num_places=1):
     diff_shape = core.diff_tensor_shape(feed, target_shape, num_places)
     if diff_shape is not None:
         warnings.warn(
-            'The fed Variable %r should have dimensions = %d, shape = '
-            '%r, but received fed shape %r on each device'
-            % (name, len(target_shape), target_shape, diff_shape)
+            f'The fed Variable {name!r} should have dimensions = {len(target_shape)}, shape = '
+            f'{target_shape!r}, but received fed shape {diff_shape!r} on each device'
         )
     if not dtype_is_compatible_with(feed._dtype(), dtype):
         var_dtype_format = (
@@ -2277,13 +2275,11 @@ class Executor:
         if filelist_length < pipeline_num:
             pipeline_num = filelist_length
             print(
-                "Pipeline training: setting the pipeline num to %d is enough because there are only %d files"
-                % (filelist_length, filelist_length)
+                f"Pipeline training: setting the pipeline num to {filelist_length} is enough because there are only {filelist_length} files"
             )
         if filelist_length < pipeline_num * pipeline_opt["concurrency_list"][0]:
             print(
-                "Pipeline training: setting the 1st element in concurrency_list to %d is enough because there are only %d files"
-                % (filelist_length // pipeline_num, filelist_length)
+                f"Pipeline training: setting the 1st element in concurrency_list to {filelist_length // pipeline_num} is enough because there are only {filelist_length} files"
             )
             pipeline_opt["concurrency_list"][0] = (
                 filelist_length // pipeline_num

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -1173,7 +1173,7 @@ class NameScope:
             self._children[prefix] = [new_child]
         else:
             new_child = NameScope(
-                prefix + "_%d" % len(self._children[prefix]), self
+                f"{prefix}_{len(self._children[prefix])}", self
             )
             self._children[prefix].append(new_child)
         return new_child
@@ -1264,7 +1264,7 @@ class NameStruct:
             self._children[prefix] = [new_child]
         else:
             new_child = NameStruct(
-                prefix + "_%d" % len(self._children[prefix]), self
+                f"{prefix}_{len(self._children[prefix])}", self
             )
             self._children[prefix].append(new_child)
         return new_child
@@ -3315,8 +3315,7 @@ class Operator:
                             in_args = [in_args]
                         if not in_proto.duplicable and len(in_args) > 1:
                             raise ValueError(
-                                "Input %s expects only one input, but %d are given."
-                                % (in_proto.name, len(in_args))
+                                f"Input {in_proto.name} expects only one input, but {len(in_args)} are given."
                             )
                         in_arg_names = []
                         for index, arg in enumerate(in_args):
@@ -3370,8 +3369,7 @@ class Operator:
                         out_args = [out_args]
                     if not out_proto.duplicable and len(out_args) > 1:
                         raise ValueError(
-                            "Output %s expects only one output, but %d are given."
-                            % (out_proto.name, len(out_args))
+                            f"Output {out_proto.name} expects only one output, but {len(out_args)} are given."
                         )
                     out_arg_names = []
                     for arg in out_args:
@@ -4327,9 +4325,8 @@ class Block:
         )
         if with_details:
             re_add_indent = re.compile(r"\n(.)")
-            res_str = "blocks {\n  idx: %d\n  parent_idx: %d" % (
-                self.idx,
-                self.parent_idx,
+            res_str = (
+                f"blocks {{\n  idx: {self.idx}\n  parent_idx: {self.parent_idx}"
             )
             for var in list(self.vars.values()):
                 res_str += "\n  vars {{\n    {}  }}".format(

--- a/python/paddle/base/layer_helper.py
+++ b/python/paddle/base/layer_helper.py
@@ -111,9 +111,7 @@ class LayerHelper(LayerHelperBase):
             if dtype is None:
                 dtype = each.dtype
             elif dtype != each.dtype:
-                raise ValueError(
-                    "Data Type mismatch: %d to %d" % (dtype, each.dtype)
-                )
+                raise ValueError(f"Data Type mismatch: {dtype} to {each.dtype}")
         return dtype
 
     def get_parameter(self, name: str) -> Tensor:

--- a/python/paddle/base/variable_index.py
+++ b/python/paddle/base/variable_index.py
@@ -297,8 +297,7 @@ def parse_index(x, indices):
                 # the unpack size would cause error.
                 # We raises IndexError here to support grammar like `a, b = var`
                 raise IndexError(
-                    "slice_item %d at dim %d should be >= 0 and < x.shape[%d]: %d"
-                    % (slice_item, dim, dim, x.shape[dim])
+                    f"slice_item {slice_item} at dim {dim} should be >= 0 and < x.shape[{dim}]: {x.shape[dim]}"
                 )
             # not calculate result to reduce call times for slice OP.
             decrease_axes.append(dim)

--- a/python/paddle/dataset/flowers.py
+++ b/python/paddle/dataset/flowers.py
@@ -114,7 +114,7 @@ def reader_creator(
 
         img2label = {}
         for i in indexes:
-            img = "jpg/image_%05d.jpg" % i
+            img = f"jpg/image_{i:05}.jpg"
             img2label[img] = labels[i - 1]
 
         tf = tarfile.open(data_file)

--- a/python/paddle/dataset/image.py
+++ b/python/paddle/dataset/image.py
@@ -97,7 +97,7 @@ def batch_images_from_tar(
                 output = {'label': labels, 'data': data}
                 pickle.dump(
                     output,
-                    open('%s/batch_%d' % (out_path, file_id), 'wb'),
+                    open(f'{out_path}/batch_{file_id}', 'wb'),
                     protocol=2,
                 )
                 file_id += 1
@@ -106,7 +106,7 @@ def batch_images_from_tar(
     if len(data) > 0:
         output = {'label': labels, 'data': data}
         pickle.dump(
-            output, open('%s/batch_%d' % (out_path, file_id), 'wb'), protocol=2
+            output, open(f'{out_path}/batch_{file_id}', 'wb'), protocol=2
         )
 
     with open(meta_file, mode='a') as meta:

--- a/python/paddle/dataset/movielens.py
+++ b/python/paddle/dataset/movielens.py
@@ -61,11 +61,7 @@ class MovieInfo:
         ]
 
     def __str__(self):
-        return "<MovieInfo id(%d), title(%s), categories(%s)>" % (
-            self.index,
-            self.title,
-            self.categories,
-        )
+        return f"<MovieInfo id({self.index}), title({self.title}), categories({self.categories})>"
 
     def __repr__(self):
         return self.__str__()
@@ -89,12 +85,8 @@ class UserInfo:
         return [self.index, 0 if self.is_male else 1, self.age, self.job_id]
 
     def __str__(self):
-        return "<UserInfo id(%d), gender(%s), age(%d), job(%d)>" % (
-            self.index,
-            "M" if self.is_male else "F",
-            age_table[self.age],
-            self.job_id,
-        )
+        gender = "M" if self.is_male else "F"
+        return f"<UserInfo id({self.index}), gender({gender}), age({age_table[self.age]}), job({self.job_id})>"
 
     def __repr__(self):
         return str(self)

--- a/python/paddle/dataset/wmt16.py
+++ b/python/paddle/dataset/wmt16.py
@@ -73,7 +73,7 @@ def __build_dict(tar_file, dict_size, save_path, lang):
 
 def __load_dict(tar_file, dict_size, lang, reverse=False):
     dict_path = os.path.join(
-        paddle.dataset.common.DATA_HOME, "wmt16/%s_%d.dict" % (lang, dict_size)
+        paddle.dataset.common.DATA_HOME, f"wmt16/{lang}_{dict_size}.dict"
     )
     if not os.path.exists(dict_path) or (
         len(open(dict_path, "rb").readlines()) != dict_size
@@ -349,7 +349,7 @@ def get_dict(lang, dict_size, reverse=False):
         dict_size = min(dict_size, TOTAL_DE_WORDS)
 
     dict_path = os.path.join(
-        paddle.dataset.common.DATA_HOME, "wmt16/%s_%d.dict" % (lang, dict_size)
+        paddle.dataset.common.DATA_HOME, f"wmt16/{lang}_{dict_size}.dict"
     )
     assert os.path.exists(dict_path), "Word dictionary does not exist. "
     "Please invoke paddle.dataset.wmt16.train/test/validation first "


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

继 #65585 part19 后再次对 %x 形式 format 替换，因为 Ruff 0.8[^1] UP031 检查又有修改，现在只要是 %x 的形式都会抛出 UP031，即便没有自动修复，而有自动修复的之前已经全部修复过了，剩下的都是没有自动修复的，需要手动修复

> [!CAUTION]
>
> 相关地方均为手动逐个修复，需要仔细 review！

PCard-66972

[^1]: [Ruff 0.8 release notes](https://github.com/astral-sh/ruff/releases/tag/0.8.0)