### PR TITLE
[CodeStyle][UP031] Use f-string instead of percent format in some framework dirs (part23)

### DIFF
--- a/python/paddle/hapi/model_summary.py
+++ b/python/paddle/hapi/model_summary.py
@@ -466,7 +466,7 @@ def summary_string(model, input_size=None, dtypes=None, input=None):
             except:
                 layer_idx = len(summary)
 
-            m_key = "%s-%i" % (class_name, layer_idx + 1)
+            m_key = f"{class_name}-{layer_idx + 1}"
             summary[m_key] = OrderedDict()
 
             try:

--- a/python/paddle/hapi/progressbar.py
+++ b/python/paddle/hapi/progressbar.py
@@ -129,7 +129,7 @@ class ProgressBar:
                 bar_chars += '.' * (self._width - prog_width)
                 bar_chars += ']'
             else:
-                bar_chars = self.name + ' %3d' % current_num
+                bar_chars = f'{self.name} {current_num:3}'
 
             self._total_width = len(bar_chars)
             sys.stdout.write(bar_chars)
@@ -149,15 +149,13 @@ class ProgressBar:
             if self._num is not None and current_num < self._num:
                 eta = time_per_unit * (self._num - current_num)
                 if eta > 3600:
-                    eta_format = '%d:%02d:%02d' % (
-                        eta // 3600,
-                        (eta % 3600) // 60,
-                        eta % 60,
+                    eta_format = (
+                        f'{eta // 3600}:{(eta % 3600) // 60:02}:{eta % 60:02}'
                     )
                 elif eta > 60:
-                    eta_format = '%d:%02d' % (eta // 60, eta % 60)
+                    eta_format = f'{eta // 60}:{eta % 60:02}'
                 else:
-                    eta_format = '%ds' % eta
+                    eta_format = f'{eta}s'
 
                 info += f' - ETA: {eta_format}'
 
@@ -183,7 +181,7 @@ class ProgressBar:
                     self._num,
                 )
             else:
-                count = self.name + ' %3d' % current_num
+                count = f'{self.name} {current_num:3}'
             info = count + info
 
             for k, val in values:

--- a/python/paddle/jit/translated_layer.py
+++ b/python/paddle/jit/translated_layer.py
@@ -51,7 +51,7 @@ def _load_program_desc(model_file_path):
     program_desc = core.ProgramDesc(program_desc_str)
     if not core._is_program_version_supported(program_desc._version()):
         raise ValueError(
-            "Unsupported program version: %d\n" % program_desc._version()
+            f"Unsupported program version: {program_desc._version()}\n"
         )
     return program_desc
 

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -101,12 +101,11 @@ def dice_loss(
     ), "The rank of input should be greater than or equal to 2."
     assert len(input.shape) == len(label.shape), (
         "The rank of input and label should be equal, "
-        "but received input: %d, label: %d."
-        % (len(input.shape), len(label.shape))
+        f"but received input: {len(input.shape)}, label: {len(label.shape)}."
     )
     assert label.shape[-1] == 1, (
         "The last dimension of label should be 1, "
-        "but received %d." % label.shape[-1]
+        f"but received {label.shape[-1]}."
     )
     assert (
         input.shape[:-1] == label.shape[:-1]

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -246,8 +246,7 @@ class LayerObjectHelper(LayerHelperBase):
                 dtype = each.dtype
             elif dtype != each.dtype:
                 raise ValueError(
-                    "Data Type mismatch: %d to %d in %s"
-                    % (dtype, each.dtype, self.name)
+                    f"Data Type mismatch: {dtype} to {each.dtype} in {self.name}"
                 )
         return dtype
 

--- a/python/paddle/nn/layer/transformer.py
+++ b/python/paddle/nn/layer/transformer.py
@@ -70,9 +70,9 @@ def _convert_param_attr_to_list(param_attr, n):
         list: A list composed of each including cell's `param_attr`.
     """
     if isinstance(param_attr, (list, tuple)):
-        assert len(param_attr) == n, (
-            "length of param_attr should be %d when it is a list/tuple" % n
-        )
+        assert (
+            len(param_attr) == n
+        ), f"length of param_attr should be {n} when it is a list/tuple"
         param_attrs = []
         for attr in param_attr:
             if isinstance(attr, bool):

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -692,9 +692,7 @@ def deserialize_program(data: bytes) -> Program:
     """
     program = Program.parse_from_string(data)
     if not core._is_program_version_supported(program._version()):
-        raise ValueError(
-            "Unsupported program version: %d\n" % program._version()
-        )
+        raise ValueError(f"Unsupported program version: {program._version()}\n")
     return program
 
 

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2066,21 +2066,19 @@ def diag_embed(
             f"But received Input's dimensional: {len(input_shape)}.\n"
         )
 
-        assert np.abs(dim1) <= len(input_shape), (
-            "Dim1 is out of range (expected to be in range of [%d, %d], but got %d).\n"
-            % (-(len(input_shape) + 1), len(input_shape), dim1)
-        )
+        assert np.abs(dim1) <= len(
+            input_shape
+        ), f"Dim1 is out of range (expected to be in range of [{-(len(input_shape) + 1)}, {len(input_shape)}], but got {dim1}).\n"
 
-        assert np.abs(dim2) <= len(input_shape), (
-            "Dim2 is out of range (expected to be in range of [%d, %d], but got %d).\n"
-            % (-(len(input_shape) + 1), len(input_shape), dim2)
-        )
+        assert np.abs(dim2) <= len(
+            input_shape
+        ), f"Dim2 is out of range (expected to be in range of [{-(len(input_shape) + 1)}, {len(input_shape)}], but got {dim2}).\n"
 
         dim1_ = dim1 if dim1 >= 0 else len(input_shape) + dim1 + 1
         dim2_ = dim2 if dim2 >= 0 else len(input_shape) + dim2 + 1
         assert dim1_ != dim2_, (
             "dim1 and dim2 cannot be the same dimension."
-            "But received dim1 = %d, dim2 = %d\n" % (dim1, dim2)
+            f"But received dim1 = {dim1}, dim2 = {dim2}\n"
         )
 
     __check_input(input, offset, dim1, dim2)

--- a/python/paddle/tensor/einsum.py
+++ b/python/paddle/tensor/einsum.py
@@ -838,10 +838,9 @@ def parse_fake_shape(
         1. ori_label is the original labels, not aligned by '....'
         2. if the '...' is evaluated to empty list, there is no '.' in label
         """
-        assert len(op.shape) == len(label), (
-            "length of shape and length of label must be the same, but received %d != %d"
-            % (len(op.shape), len(label))
-        )
+        assert len(op.shape) == len(
+            label
+        ), f"length of shape and length of label must be the same, but received {len(op.shape)} != {len(label)}"
         fakes = [s for i, (l, s) in enumerate(zip(label, op.shape))]
         fakes = list(map(abs, fakes))  # make -1 -> 1
         if '.' in ori_label:
@@ -913,7 +912,7 @@ def einsum_v2(equation: str, *operands: Tensor) -> Tensor:
         var_list.append(gen_einsum_op(eq, *var_s))
     assert (
         len(var_list) == 1
-    ), "There must be one elements in list, but received %d." % len(var_list)
+    ), f"There must be one elements in list, but received {len(var_list)}."
     return var_list[0]
 
 

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -162,8 +162,8 @@ def transpose(
             if dim >= len(x.shape):
                 raise ValueError(
                     "Each element in Input(perm) should be less than Input(x)'s dimension, "
-                    "but %d-th element in Input(perm) is %d which exceeds Input(x)'s "
-                    "dimension %d." % (idx, perm[idx], len(x.shape))
+                    f"but {idx}-th element in Input(perm) is {perm[idx]} which exceeds Input(x)'s "
+                    f"dimension {len(x.shape)}."
                 )
 
         helper = LayerHelper('transpose', **locals())
@@ -5560,7 +5560,7 @@ def histogramdd(
         check_type(ranges, 'ranges', (list, tuple), 'histogramdd')
         assert D * 2 == len(
             ranges
-        ), "The length of ranges list must be %d\n" % (D * 2)
+        ), f"The length of ranges list must be {D * 2}\n"
 
     check_type(density, 'density', bool, 'histogramdd')
 
@@ -5574,9 +5574,7 @@ def histogramdd(
     if weights is not None:
         weights = weights.astype(x.dtype)
         reshaped_weights = weights.reshape([N])
-        assert reshaped_weights.shape[0] == N, (
-            "The size of weight must be %d" % N
-        )
+        assert reshaped_weights.shape[0] == N, f"The size of weight must be {N}"
     # ranges
     __check_ranges(D, ranges)
     if ranges is None:
@@ -5599,13 +5597,13 @@ def histogramdd(
     if isinstance(bins, (int, list)):  # int or int[]
         if isinstance(bins, int):
             bins = [bins] * D
-        assert len(bins) == D, (
-            "The length of bins must be %d when bins is a list.\n" % D
-        )
+        assert (
+            len(bins) == D
+        ), f"The length of bins must be {D} when bins is a list.\n"
         for idx, r in enumerate(ranges):
             if not isinstance(bins[idx], int):
                 raise ValueError(
-                    "The type of %d-th element in bins list must be int." % idx
+                    f"The type of {idx}-th element in bins list must be int."
                 )
             e = paddle.linspace(r[0], r[1], bins[idx] + 1, x.dtype)
             edges.append(e)
@@ -5931,19 +5929,17 @@ def diagonal(
             axis1_ = axis1 if axis1 >= 0 else len(input_shape) + axis1
             axis2_ = axis2 if axis2 >= 0 else len(input_shape) + axis2
 
-            assert axis1_ < len(input_shape), (
-                "The argument axis1 is out of range (expected to be in range of [%d, %d], but got %d).\n"
-                % (-(len(input_shape)), len(input_shape) - 1, axis1)
-            )
+            assert axis1_ < len(
+                input_shape
+            ), f"The argument axis1 is out of range (expected to be in range of [{-(len(input_shape))}, {len(input_shape) - 1}], but got {axis1}).\n"
 
-            assert axis2_ < len(input_shape), (
-                "The argument axis2 is out of range (expected to be in range of [%d, %d], but got %d).\n"
-                % (-(len(input_shape)), len(input_shape) - 1, axis2)
-            )
+            assert axis2_ < len(
+                input_shape
+            ), f"The argument axis2 is out of range (expected to be in range of [{-(len(input_shape))}, {len(input_shape) - 1}], but got {axis2}).\n"
 
             assert axis1_ != axis2_, (
                 "axis1 and axis2 cannot be the same axis."
-                "But received axis1 = %d, axis2 = %d\n" % (axis1, axis2)
+                f"But received axis1 = {axis1}, axis2 = {axis2}\n"
             )
 
         __check_input(x, offset, axis1, axis2)

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -613,8 +613,8 @@ def transpose(
             if dim >= len(x.shape):
                 raise ValueError(
                     "Each element in Input(perm) should be less than Input(x)'s dimension, "
-                    "but %d-th element in Input(perm) is %d which exceeds Input(x)'s "
-                    "dimension %d." % (idx, perm[idx], len(x.shape))
+                    f"but {idx}-th element in Input(perm) is {perm[idx]} which exceeds Input(x)'s "
+                    f"dimension {len(x.shape)}."
                 )
 
         helper = LayerHelper('transpose', **locals())
@@ -748,7 +748,7 @@ def shard_index(
     helper = LayerHelper(op_type, **locals())
     if shard_id < 0 or shard_id >= nshards:
         raise ValueError(
-            'The shard_id(%d) should be in [0, %d)' % (shard_id, nshards)
+            f'The shard_id({shard_id}) should be in [0, {nshards})'
         )
 
     out = helper.create_variable_for_type_inference(dtype=input.dtype)
@@ -2788,8 +2788,7 @@ def split(
                 assert input_shape[dim] % num_or_sections == 0, (
                     "The input's size along the split dimension "
                     "must be evenly divisible by Attr(num_or_sections). "
-                    "But %d is not evenly divisible by %d. "
-                    % (num_or_sections, input_shape[dim])
+                    f"But {num_or_sections} is not evenly divisible by {input_shape[dim]}. "
                 )
             return _C_ops.split_with_num(input, num_or_sections, dim)
         else:
@@ -2848,8 +2847,7 @@ def split(
                     if dim_size == -1:
                         assert unk_dim_idx == -1, (
                             "Only one value of 'num_or_section' in split can "
-                            "be -1. But received num_or_section[%d] is also -1."
-                            % idx
+                            f"be -1. But received num_or_section[{idx}] is also -1."
                         )
                         unk_dim_idx = idx
                     temp_out = helper.create_variable_for_type_inference(
@@ -2875,8 +2873,7 @@ def split(
                 assert input_shape[dim] % num_or_sections == 0, (
                     "The input's size along the split dimension "
                     "must be evenly divisible by Attr(num_or_sections). "
-                    "But %d is not evenly divisible by %d. "
-                    % (num_or_sections, input_shape[dim])
+                    f"But {num_or_sections} is not evenly divisible by {input_shape[dim]}. "
                 )
             num = num_or_sections
         else:
@@ -4953,14 +4950,13 @@ def reshape(x: Tensor, shape: ShapeLike, name: str | None = None) -> Tensor:
                 if dim_size == -1:
                     assert unk_dim_idx == -1, (
                         "Only one dimension value of 'shape' in reshape can "
-                        "be -1. But received shape[%d] is also -1.\n"
+                        f"be -1. But received shape[{dim_idx}] is also -1.\n"
                         "\n\t# N = x.shape()[2]\t\t# N is an int. "
                         "(NOT recommend under @to_static)\n\tN = paddle.shape(x)[2]\t\t"
                         "# N is a Tensor. (Recommend)\n\tz = paddle.reshape([N, -1, 4])"
                         "\t# z.shape is [-1, -1, 4]\n\n"
                         "    If your target shape in Reshape represents dynamic shape, "
                         "please turn it into a Tensor under @to_static. See above example for details."
-                        % dim_idx
                     )
                     unk_dim_idx = dim_idx
                 elif dim_size == 0:
@@ -4968,15 +4964,13 @@ def reshape(x: Tensor, shape: ShapeLike, name: str | None = None) -> Tensor:
                         assert dim_idx < len(x.shape), (
                             "The index of 0 in `shape` must be less than "
                             "the input tensor X's dimensions. "
-                            "But received shape[%d] = 0, X's dimensions = %d."
-                            % (dim_idx, len(x.shape))
+                            f"But received shape[{dim_idx}] = 0, X's dimensions = {len(x.shape)}."
                         )
                 else:
                     assert dim_size > 0, (
                         "Each dimension value of 'shape' in reshape must not "
                         "be negative except one unknown dimension. "
-                        "But received shape[%d] = %s."
-                        % (dim_idx, str(dim_size))
+                        f"But received shape[{dim_idx}] = {dim_size!s}."
                     )
         return attrs_shape
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2365,8 +2365,8 @@ def mm(input: Tensor, mat2: Tensor, name: str | None = None) -> Tensor:
                     raise ValueError(
                         "When the matrix is larger than 2 dimensions, the higher "
                         "dimensional values of the two matrices need to be equal. "
-                        "But received x_shape[%d] != y_shape[%d]. X's shape: %s, "
-                        "Y's shape: %s.\n" % (i, i, x_shape, y_shape)
+                        f"But received x_shape[{i}] != y_shape[{i}]. X's shape: {x_shape}, "
+                        f"Y's shape: {y_shape}.\n"
                     )
 
     __check_input(input, mat2)
@@ -2890,8 +2890,8 @@ def inverse(x: Tensor, name: str | None = None) -> Tensor:
             if len(x.shape) < 2:
                 raise ValueError(
                     "The input of inverse is expected to be a Tensor whose number "
-                    "of dimensions is no less than 2. But received: %d, "
-                    "x's shape: %s." % (len(x.shape), x.shape)
+                    f"of dimensions is no less than 2. But received: {len(x.shape)}, "
+                    f"x's shape: {x.shape}."
                 )
 
         _check_input(x)
@@ -3956,19 +3956,17 @@ def trace(
         axis1_ = axis1 if axis1 >= 0 else len(input_shape) + axis1
         axis2_ = axis2 if axis2 >= 0 else len(input_shape) + axis2
 
-        assert (0 <= axis1_) and (axis1_ < len(input_shape)), (
-            "The argument axis1 is out of range (expected to be in range of [%d, %d], but got %d).\n"
-            % (-(len(input_shape)), len(input_shape) - 1, axis1)
-        )
+        assert (0 <= axis1_) and (
+            axis1_ < len(input_shape)
+        ), f"The argument axis1 is out of range (expected to be in range of [{-(len(input_shape))}, {len(input_shape) - 1}], but got {axis1}).\n"
 
-        assert (0 <= axis2_) and (axis2_ < len(input_shape)), (
-            "The argument axis2 is out of range (expected to be in range of [%d, %d], but got %d).\n"
-            % (-(len(input_shape)), len(input_shape) - 1, axis2)
-        )
+        assert (0 <= axis2_) and (
+            axis2_ < len(input_shape)
+        ), f"The argument axis2 is out of range (expected to be in range of [{-(len(input_shape))}, {len(input_shape) - 1}], but got {axis2}).\n"
 
         assert axis1_ != axis2_, (
             "axis1 and axis2 cannot be the same axis."
-            "But received axis1 = %d, axis2 = %d\n" % (axis1, axis2)
+            f"But received axis1 = {axis1}, axis2 = {axis2}\n"
         )
 
     if in_dynamic_or_pir_mode():
@@ -7206,7 +7204,7 @@ def vander(
     if x.dim() != 1:
         raise ValueError(
             "The input of x is expected to be a 1-D Tensor."
-            "But now the dims of Input(X) is %d." % x.dim()
+            f"But now the dims of Input(X) is {x.dim()}."
         )
 
     if n is None:

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -263,9 +263,9 @@ def trt_reshape(network, input, new_shape, name="", is_shape_tensor=False):
 
 # Get element tensor of 1D shape tensor
 def get_shape_tensor_element(network, x, index, is_scalar=False):
-    assert index >= 0, (
-        "The index should be greater or equal than 0, but got %d" % index
-    )
+    assert (
+        index >= 0
+    ), f"The index should be greater or equal than 0, but got {index}"
     index_tensor = add_1D_constant_layer(network, index, is_scalar=is_scalar)
     gather_layer = network.add_gather(input=x, indices=index_tensor, axis=0)
     return gather_layer.get_output(0)

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -193,10 +193,9 @@ def unsqueeze_converter(network, paddle_op, inputs):
     x = inputs[0]
     input_dims = x.shape
     axes = paddle_op.operands()[1].source().get_defining_op().attrs()["value"]
-    assert len(axes) > 0, (
-        "axes size should be > 0 in when convert unsqueeze op in TensorRT, but received len(axes) = %d."
-        % (len(axes))
-    )
+    assert (
+        len(axes) > 0
+    ), f"axes size should be > 0 in when convert unsqueeze op in TensorRT, but received len(axes) = {len(axes)}."
 
     should_unsqueeze = [False] * (len(input_dims) + len(axes))
     cur_out_rank = len(input_dims)
@@ -352,10 +351,7 @@ def slice_converter(network, paddle_op, inputs):
         starts = starts_op.attrs()["value"]
         assert len(starts) == len(
             axes
-        ), "The size of this starts: %d must be equal to the axes: %d." % (
-            len(starts),
-            len(axes),
-        )
+        ), f"The size of this starts: {len(starts)} must be equal to the axes: {len(axes)}."
         for idx in range(len(axes)):
             if starts[idx] < 0:
                 starts_tensor[axes[idx]] = trt_max(
@@ -388,10 +384,7 @@ def slice_converter(network, paddle_op, inputs):
         ends = ends_op.attrs()["value"]
         assert len(ends) == len(
             axes
-        ), "The size of this ends: %d must be equal to the axes: %d." % (
-            len(ends),
-            len(axes),
-        )
+        ), f"The size of this ends: {len(ends)} must be equal to the axes: {len(axes)}."
         for idx in range(len(axes)):
             if ends[idx] < 0:
                 ends_tensor[axes[idx]] = trt_max(

--- a/python/paddle/text/datasets/movielens.py
+++ b/python/paddle/text/datasets/movielens.py
@@ -59,11 +59,7 @@ class MovieInfo:
         ]
 
     def __str__(self) -> str:
-        return "<MovieInfo id(%d), title(%s), categories(%s)>" % (
-            self.index,
-            self.title,
-            self.categories,
-        )
+        return f"<MovieInfo id({self.index}), title({self.title}), categories({self.categories})>"
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -97,12 +93,8 @@ class UserInfo:
         ]
 
     def __str__(self) -> str:
-        return "<UserInfo id(%d), gender(%s), age(%d), job(%d)>" % (
-            self.index,
-            "M" if self.is_male else "F",
-            age_table[self.age],
-            self.job_id,
-        )
+        gender = "M" if self.is_male else "F"
+        return f"<UserInfo id({self.index}), gender({gender}), age({age_table[self.age]}), job({self.job_id})>"
 
     def __repr__(self) -> str:
         return str(self)

--- a/python/paddle/text/datasets/wmt16.py
+++ b/python/paddle/text/datasets/wmt16.py
@@ -192,7 +192,7 @@ class WMT16(Dataset):
     def _load_dict(self, lang, dict_size, reverse=False):
         dict_path = os.path.join(
             paddle.dataset.common.DATA_HOME,
-            "wmt16/%s_%d.dict" % (lang, dict_size),
+            f"wmt16/{lang}_{dict_size}.dict",
         )
         dict_found = False
         if os.path.exists(dict_path):
@@ -331,7 +331,7 @@ class WMT16(Dataset):
 
         dict_path = os.path.join(
             paddle.dataset.common.DATA_HOME,
-            "wmt16/%s_%d.dict" % (lang, dict_size),
+            f"wmt16/{lang}_{dict_size}.dict",
         )
         assert os.path.exists(dict_path), "Word dictionary does not exist. "
         "Please invoke paddle.dataset.wmt16.train/test/validation first "

--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -225,8 +225,7 @@ def custom_write_stub(resource, pyfile):
         for op_name in new_custom_ops:
             api_content.append(_custom_api_content(op_name))
         print(
-            "Received len(custom_op) =  %d, using custom operator"
-            % len(new_custom_ops)
+            f"Received len(custom_op) = {len(new_custom_ops)}, using custom operator"
         )
 
     with open(pyfile, 'w') as f:

--- a/python/paddle/utils/layers_utils.py
+++ b/python/paddle/utils/layers_utils.py
@@ -228,8 +228,7 @@ def pack_sequence_as(structure, flat_sequence):
     if not is_sequence(structure):
         if len(flat_sequence) != 1:
             raise ValueError(
-                "Structure is a scalar but len(flat_sequence) == %d > 1"
-                % len(flat_sequence)
+                f"Structure is a scalar but len(flat_sequence) == {len(flat_sequence)} > 1"
             )
         return flat_sequence[0]
     flat_structure = flatten(structure)

--- a/python/paddle/vision/datasets/flowers.py
+++ b/python/paddle/vision/datasets/flowers.py
@@ -194,7 +194,7 @@ class Flowers(Dataset[Tuple["_ImageDataType", "npt.NDArray[np.int64]"]]):
     ) -> tuple[_ImageDataType, npt.NDArray[np.int64]]:
         index = self.indexes[idx]
         label = np.array([self.labels[index - 1]])
-        img_name = "jpg/image_%05d.jpg" % index
+        img_name = f"jpg/image_{index:05}.jpg"
         image = os.path.join(self.data_path, img_name)
         if self.backend == 'pil':
             image = Image.open(image)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

继 #65585 part19 后再次对 %x 形式 format 替换，因为 Ruff 0.8[^1] UP031 检查又有修改，现在只要是 %x 的形式都会抛出 UP031，即便没有自动修复，而有自动修复的之前已经全部修复过了，剩下的都是没有自动修复的，需要手动修复

> [!CAUTION]
>
> 相关地方均为手动逐个修复，需要仔细 review！

### Related links

- #70031
- #70033
- #70034

PCard-66972

[^1]: [Ruff 0.8 release notes](https://github.com/astral-sh/ruff/releases/tag/0.8.0)