### PR TITLE
[CodeStyle][UP031] Use f-string instead of percent format in some uts (part24)

### DIFF
--- a/test/cinn/test_efficientnet.py
+++ b/test/cinn/test_efficientnet.py
@@ -76,8 +76,7 @@ class TestLoadEfficientNetModel(unittest.TestCase):
         end5 = time.perf_counter()
 
         print(
-            "Repeat %d times, average Executor.run() time is: %.3f ms"
-            % (repeat, (end5 - end4) * 1000 / repeat)
+            f"Repeat {repeat} times, average Executor.run() time is: {(end5 - end4) * 1000 / repeat:.3f} ms"
         )
         a_t.from_numpy(x_data, self.target)
         out.from_numpy(np.zeros(out.shape(), dtype='float32'), self.target)

--- a/test/cinn/test_facedet.py
+++ b/test/cinn/test_facedet.py
@@ -79,8 +79,7 @@ class TestLoadFaceDetModel(unittest.TestCase):
             self.executor.run()
         end5 = time.perf_counter()
         print(
-            "Repeat %d times, average Executor.run() time is: %.3f ms"
-            % (repeat, (end5 - end4) * 1000 / repeat)
+            f"Repeat {repeat} times, average Executor.run() time is: {(end5 - end4) * 1000 / repeat:.3f} ms"
         )
 
         a_t.from_numpy(x_data, self.target)

--- a/test/cinn/test_mobilenetv1.py
+++ b/test/cinn/test_mobilenetv1.py
@@ -77,8 +77,7 @@ class TestLoadMobilenetV1Model(unittest.TestCase):
             self.executor.run()
         end5 = time.perf_counter()
         print(
-            "Repeat %d times, average Executor.run() time is: %.3f ms"
-            % (repeat, (end5 - end4) * 1000 / repeat)
+            f"Repeat {repeat} times, average Executor.run() time is: {(end5 - end4) * 1000 / repeat:.3f} ms"
         )
 
         a_t.from_numpy(x_data, self.target)

--- a/test/cinn/test_mobilenetv2.py
+++ b/test/cinn/test_mobilenetv2.py
@@ -79,8 +79,7 @@ class TestLoadResnetModel(unittest.TestCase):
             self.executor.run()
         end5 = time.perf_counter()
         print(
-            "Repeat %d times, average Executor.run() time is: %.3f ms"
-            % (repeat, (end5 - end4) * 1000 / repeat)
+            f"Repeat {repeat} times, average Executor.run() time is: {(end5 - end4) * 1000 / repeat:.3f} ms"
         )
 
         a_t.from_numpy(x_data, self.target)

--- a/test/cinn/test_resnet18.py
+++ b/test/cinn/test_resnet18.py
@@ -79,8 +79,7 @@ class TestLoadResnetModel(unittest.TestCase):
             self.executor.run()
         end5 = time.perf_counter()
         print(
-            "Repeat %d times, average Executor.run() time is: %.3f ms"
-            % (repeat, (end5 - end4) * 1000 / repeat)
+            f"Repeat {repeat} times, average Executor.run() time is: {(end5 - end4) * 1000 / repeat:.3f} ms"
         )
 
         a_t.from_numpy(x_data, self.target)

--- a/test/cinn/test_resnet50.py
+++ b/test/cinn/test_resnet50.py
@@ -83,8 +83,7 @@ class TestLoadResnet50Model(unittest.TestCase):
             self.executor.run()
         end5 = time.perf_counter()
         print(
-            "Repeat %d times, average Executor.run() time is: %.3f ms"
-            % (repeat, (end5 - end4) * 1000 / repeat)
+            f"Repeat {repeat} times, average Executor.run() time is: {(end5 - end4) * 1000 / repeat:.3f} ms"
         )
 
         a_t.from_numpy(x_data, self.target)

--- a/test/cinn/test_squeezenet.py
+++ b/test/cinn/test_squeezenet.py
@@ -77,8 +77,7 @@ class TestLoadSqueezeNetModel(unittest.TestCase):
             self.executor.run()
         end5 = time.perf_counter()
         print(
-            "Repeat %d times, average Executor.run() time is: %.3f ms"
-            % (repeat, (end5 - end4) * 1000 / repeat)
+            f"Repeat {repeat} times, average Executor.run() time is: {(end5 - end4) * 1000 / repeat:.3f} ms"
         )
 
         a_t.from_numpy(x_data, self.target)

--- a/test/collective/process_group_nccl_pir.py
+++ b/test/collective/process_group_nccl_pir.py
@@ -44,7 +44,7 @@ class TestProcessGroupFp32(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         device_id = paddle.distributed.ParallelEnv().dev_id
-        paddle.set_device('gpu:%d' % device_id)
+        paddle.set_device(f'gpu:{device_id}')
 
         assert paddle.distributed.is_available()
 

--- a/test/cpp/inference/api/full_ILSVRC2012_val_preprocess.py
+++ b/test/cpp/inference/api/full_ILSVRC2012_val_preprocess.py
@@ -96,9 +96,7 @@ def download_concat(cache_folder, zip_path):
 def print_processbar(done_percentage):
     done_filled = done_percentage * '='
     empty_filled = (100 - done_percentage) * ' '
-    sys.stdout.write(
-        "\r[%s%s]%d%%" % (done_filled, empty_filled, done_percentage)
-    )
+    sys.stdout.write(f"\r[{done_filled}{empty_filled}]{done_percentage}%")
     sys.stdout.flush()
 
 

--- a/test/cpp/inference/api/full_pascalvoc_test_preprocess.py
+++ b/test/cpp/inference/api/full_pascalvoc_test_preprocess.py
@@ -158,9 +158,7 @@ def convert_pascalvoc_local2bin(args):
 def print_processbar(done_percentage):
     done_filled = done_percentage * '='
     empty_filled = (100 - done_percentage) * ' '
-    sys.stdout.write(
-        "\r[%s%s]%d%%" % (done_filled, empty_filled, done_percentage)
-    )
+    sys.stdout.write(f"\r[{done_filled}{empty_filled}]{done_percentage}%")
     sys.stdout.flush()
 
 

--- a/test/cpp_extension/test_cpp_extension_setup.py
+++ b/test/cpp_extension/test_cpp_extension_setup.py
@@ -42,9 +42,9 @@ class TestCppExtensionSetupInstall(unittest.TestCase):
         custom_egg_path = [
             x for x in os.listdir(site_dir) if 'custom_cpp_extension' in x
         ]
-        assert len(custom_egg_path) == 1, "Matched egg number is %d." % len(
-            custom_egg_path
-        )
+        assert (
+            len(custom_egg_path) == 1
+        ), f"Matched egg number is {len(custom_egg_path)}."
         sys.path.append(os.path.join(site_dir, custom_egg_path[0]))
         #################################
 

--- a/test/cpp_extension/test_mixed_extension_setup.py
+++ b/test/cpp_extension/test_mixed_extension_setup.py
@@ -112,9 +112,9 @@ class TestCppExtensionSetupInstall(unittest.TestCase):
         custom_egg_path = [
             x for x in os.listdir(site_dir) if 'mix_relu_extension' in x
         ]
-        assert len(custom_egg_path) == 1, "Matched egg number is %d." % len(
-            custom_egg_path
-        )
+        assert (
+            len(custom_egg_path) == 1
+        ), f"Matched egg number is {len(custom_egg_path)}."
         sys.path.append(os.path.join(site_dir, custom_egg_path[0]))
         #################################
 

--- a/test/custom_op/test_custom_relu_op_setup.py
+++ b/test/custom_op/test_custom_relu_op_setup.py
@@ -166,9 +166,9 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
         custom_egg_path = [
             x for x in os.listdir(site_dir) if 'custom_relu_module_setup' in x
         ]
-        assert len(custom_egg_path) == 1, "Matched egg number is %d." % len(
-            custom_egg_path
-        )
+        assert (
+            len(custom_egg_path) == 1
+        ), f"Matched egg number is {len(custom_egg_path)}."
         sys.path.append(os.path.join(site_dir, custom_egg_path[0]))
 
         # usage: import the package directly

--- a/test/custom_op/test_custom_relu_op_xpu_setup.py
+++ b/test/custom_op/test_custom_relu_op_xpu_setup.py
@@ -75,9 +75,9 @@ class TestNewCustomOpXpuSetUpInstall(unittest.TestCase):
             for x in os.listdir(site_dir)
             if 'custom_relu_xpu_module_setup' in x
         ]
-        assert len(custom_egg_path) == 1, "Matched egg number is %d." % len(
-            custom_egg_path
-        )
+        assert (
+            len(custom_egg_path) == 1
+        ), f"Matched egg number is {len(custom_egg_path)}."
         sys.path.append(os.path.join(site_dir, custom_egg_path[0]))
 
         # usage: import the package directly

--- a/test/custom_op/test_inference_gap_setup.py
+++ b/test/custom_op/test_inference_gap_setup.py
@@ -57,9 +57,9 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
             custom_egg_path = [
                 x for x in os.listdir(site_dir) if 'gap_op_setup' in x
             ]
-            assert len(custom_egg_path) == 1, "Matched egg number is %d." % len(
-                custom_egg_path
-            )
+            assert (
+                len(custom_egg_path) == 1
+            ), f"Matched egg number is {len(custom_egg_path)}."
             sys.path.append(os.path.join(site_dir, custom_egg_path[0]))
 
             # usage: import the package directly

--- a/test/custom_runtime/process_group_xccl.py
+++ b/test/custom_runtime/process_group_xccl.py
@@ -49,7 +49,7 @@ class TestProcessGroupFp32(unittest.TestCase):
 
     def test_create_process_group_xccl(self):
         device_id = paddle.distributed.ParallelEnv().dev_id
-        paddle.set_device('custom_cpu:%d' % device_id)
+        paddle.set_device(f'custom_cpu:{device_id}')
 
         pg = init_process_group()
 

--- a/test/custom_runtime/test_collective_process_group_xccl.py
+++ b/test/custom_runtime/test_collective_process_group_xccl.py
@@ -70,7 +70,7 @@ def start_local_trainers(
 
         print(f"start trainer proc:{cmd} env:{proc_env}")
 
-        fn = open("workerlog.%d" % idx, "a")
+        fn = open(f"workerlog.{idx}", "a")
         proc = subprocess.Popen(
             cmd.split(" "), env=current_env, stdout=fn, stderr=fn
         )

--- a/test/deprecated/custom_op/test_custom_raw_op_kernel_op_deprecated.py
+++ b/test/deprecated/custom_op/test_custom_raw_op_kernel_op_deprecated.py
@@ -38,9 +38,9 @@ def prepare_module_path():
     else:
         site_dir = site.getsitepackages()[0]
     custom_egg_path = [x for x in os.listdir(site_dir) if MODULE_NAME in x]
-    assert len(custom_egg_path) == 1, "Matched egg number is %d." % len(
-        custom_egg_path
-    )
+    assert (
+        len(custom_egg_path) == 1
+    ), f"Matched egg number is {len(custom_egg_path)}."
     sys.path.append(os.path.join(site_dir, custom_egg_path[0]))
 
 

--- a/test/dygraph_to_static/bert_dygraph_model.py
+++ b/test/dygraph_to_static/bert_dygraph_model.py
@@ -153,7 +153,7 @@ class EncoderLayer(Layer):
         for i in range(n_layer):
             self._encoder_sublayers.append(
                 self.add_sublayer(
-                    'esl_%d' % i,
+                    f'esl_{i}',
                     EncoderSubLayer(
                         hidden_act,
                         n_head,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

继 #65585 part19 后再次对 %x 形式 format 替换，因为 Ruff 0.8[^1] UP031 检查又有修改，现在只要是 %x 的形式都会抛出 UP031，即便没有自动修复，而有自动修复的之前已经全部修复过了，剩下的都是没有自动修复的，需要手动修复

> [!CAUTION]
>
> 相关地方均为手动逐个修复，需要仔细 review！

### Related links

- #70031
- #70033
- #70034
- #70035

PCard-66972

[^1]: [Ruff 0.8 release notes](https://github.com/astral-sh/ruff/releases/tag/0.8.0)