### PR TITLE
[CodeStyle][UP031] Use f-string instead of percent format in dy2st uts (part25)

### DIFF
--- a/test/dygraph_to_static/darknet.py
+++ b/test/dygraph_to_static/darknet.py
@@ -124,7 +124,7 @@ class LayerWarp(paddle.nn.Layer):
         self.res_out_list = []
         for i in range(1, count):
             res_out = self.add_sublayer(
-                "basic_block_%d" % (i),
+                f"basic_block_{i}",
                 BasicBlock(ch_out * 2, ch_out, is_test=is_test),
             )
             self.res_out_list.append(res_out)
@@ -161,13 +161,13 @@ class DarkNet53_conv_body(paddle.nn.Layer):
         ch_in = [64, 128, 256, 512, 1024]
         for i, stage in enumerate(self.stages):
             conv_block = self.add_sublayer(
-                "stage_%d" % (i),
+                f"stage_{i}",
                 LayerWarp(int(ch_in[i]), 32 * (2**i), stage, is_test=is_test),
             )
             self.darknet53_conv_block_list.append(conv_block)
         for i in range(len(self.stages) - 1):
             downsample = self.add_sublayer(
-                "stage_%d_downsample" % i,
+                f"stage_{i}_downsample",
                 DownSample(
                     ch_in=32 * (2 ** (i + 1)),
                     ch_out=32 * (2 ** (i + 2)),

--- a/test/dygraph_to_static/simnet_dygraph_model.py
+++ b/test/dygraph_to_static/simnet_dygraph_model.py
@@ -345,7 +345,7 @@ class FC(paddle.nn.Layer):
             ]
             self.__w.append(
                 self.add_parameter(
-                    '_w%d' % i,
+                    f'_w{i}',
                     self.create_parameter(
                         attr=param,
                         shape=param_shape,

--- a/test/dygraph_to_static/test_bert.py
+++ b/test/dygraph_to_static/test_bert.py
@@ -147,16 +147,14 @@ class TestBert(Dy2StTestBase):
                 if step_idx % PRINT_STEP == 0:
                     if step_idx == 0:
                         print(
-                            "Step: %d, loss: %f, ppl: %f, next_sent_acc: %f"
-                            % (step_idx, loss, ppl, acc)
+                            f"Step: {step_idx}, loss: {loss:f}, ppl: {ppl:f}, next_sent_acc: {acc:f}"
                         )
                         avg_batch_time = time.time()
                     else:
                         speed = PRINT_STEP / (time.time() - avg_batch_time)
                         speed_list.append(speed)
                         print(
-                            "Step: %d, loss: %f, ppl: %f, next_sent_acc: %f, speed: %.3f steps/s"
-                            % (step_idx, loss, ppl, acc, speed)
+                            f"Step: {step_idx}, loss: {loss:f}, ppl: {ppl:f}, next_sent_acc: {acc:f}, speed: {speed:.3f} steps/s"
                         )
                         avg_batch_time = time.time()
 

--- a/test/dygraph_to_static/test_cycle_gan.py
+++ b/test/dygraph_to_static/test_cycle_gan.py
@@ -207,7 +207,7 @@ class build_generator_resnet_9blocks(paddle.nn.Layer):
         dim = 128
         for i in range(9):
             Build_Resnet_Block = self.add_sublayer(
-                "generator_%d" % (i + 1), build_resnet_block(dim)
+                f"generator_{i + 1}", build_resnet_block(dim)
             )
             self.build_resnet_block_list.append(Build_Resnet_Block)
         self.deconv0 = DeConv2D(

--- a/test/dygraph_to_static/test_mobile_net.py
+++ b/test/dygraph_to_static/test_mobile_net.py
@@ -578,18 +578,10 @@ def train_mobilenet(args, to_static):
                 train_batch_elapse = t2 - t1
                 if batch_id % args.print_step == 0:
                     print(
-                        "epoch id: %d, batch step: %d,  avg_loss %0.5f acc_top1 %0.5f acc_top5 %0.5f %2.4f sec net_t:%2.4f back_t:%2.4f read_t:%2.4f"
-                        % (
-                            eop,
-                            batch_id,
-                            avg_loss.numpy(),
-                            acc_top1.numpy(),
-                            acc_top5.numpy(),
-                            train_batch_elapse,
-                            t_end - t_start,
-                            t_end_back - t_start_back,
-                            t1 - t_last,
-                        )
+                        f"epoch id: {eop}, batch step: {batch_id}, avg_loss {avg_loss.numpy():0.5f} "
+                        f"acc_top1 {acc_top1.numpy():0.5f} acc_top5 {acc_top5.numpy():0.5f} "
+                        f"{train_batch_elapse:2.4f} sec net_t:{t_end - t_start:2.4f} "
+                        f"back_t:{t_end_back - t_start_back:2.4f} read_t:{t1 - t_last:2.4f}"
                     )
                 batch_id += 1
                 t_last = time.time()

--- a/test/dygraph_to_static/test_ptb_lm.py
+++ b/test/dygraph_to_static/test_ptb_lm.py
@@ -61,7 +61,7 @@ class SimpleLSTMRNN(paddle.nn.Layer):
                     low=-self._init_scale, high=self._init_scale
                 ),
             )
-            self.weight_1_arr.append(self.add_parameter('w_%d' % i, weight_1))
+            self.weight_1_arr.append(self.add_parameter(f'w_{i}', weight_1))
             bias_1 = self.create_parameter(
                 attr=paddle.ParamAttr(
                     initializer=paddle.nn.initializer.Uniform(
@@ -72,7 +72,7 @@ class SimpleLSTMRNN(paddle.nn.Layer):
                 dtype="float32",
                 default_initializer=paddle.nn.initializer.Constant(0.0),
             )
-            self.bias_arr.append(self.add_parameter('b_%d' % i, bias_1))
+            self.bias_arr.append(self.add_parameter(f'b_{i}', bias_1))
 
     def forward(self, input_embedding, init_hidden=None, init_cell=None):
         cell_array = []
@@ -292,20 +292,13 @@ def train():
                 if step_id % PRINT_STEP == 0:
                     if step_id == 0:
                         logging.info(
-                            "epoch %d | step %d, loss %0.3f"
-                            % (epoch_id, step_id, total_loss / total_sample)
+                            f"epoch {epoch_id} | step {step_id}, loss {total_loss / total_sample:0.3f}"
                         )
                         avg_batch_time = time.time()
                     else:
                         speed = PRINT_STEP / (time.time() - avg_batch_time)
                         logging.info(
-                            "epoch %d | step %d, loss %0.3f, speed %.3f steps/s"
-                            % (
-                                epoch_id,
-                                step_id,
-                                total_loss / total_sample,
-                                speed,
-                            )
+                            f"epoch {epoch_id} | step {step_id}, loss {total_loss / total_sample:0.3f}, speed {speed:.3f} steps/s"
                         )
                         avg_batch_time = time.time()
 

--- a/test/dygraph_to_static/test_resnet.py
+++ b/test/dygraph_to_static/test_resnet.py
@@ -177,7 +177,7 @@ class ResNet(paddle.nn.Layer):
             shortcut = False
             for i in range(depth[block]):
                 bottleneck_block = self.add_sublayer(
-                    'bb_%d_%d' % (block, i),
+                    f'bb_{block}_{i}',
                     BottleneckBlock(
                         num_channels=(
                             num_channels[block]
@@ -333,15 +333,11 @@ class ResNetHelper:
                 end_time = time.time()
                 if batch_id % 2 == 0:
                     print(
-                        "epoch %d | batch step %d, loss %0.3f, acc1 %0.3f, acc5 %0.3f, time %f"
-                        % (
-                            epoch,
-                            batch_id,
-                            total_loss.numpy() / total_sample,
-                            total_acc1.numpy() / total_sample,
-                            total_acc5.numpy() / total_sample,
-                            end_time - start_time,
-                        )
+                        f"epoch {epoch} | batch step {batch_id}, "
+                        f"loss {total_loss.numpy() / total_sample:0.3f}, "
+                        f"acc1 {total_acc1.numpy() / total_sample:0.3f}, "
+                        f"acc5 {total_acc5.numpy() / total_sample:0.3f}, "
+                        f"time {end_time - start_time:f}"
                     )
                 if batch_id == 10:
                     if to_static:

--- a/test/dygraph_to_static/test_resnet_amp.py
+++ b/test/dygraph_to_static/test_resnet_amp.py
@@ -95,15 +95,11 @@ def train(build_strategy=None):
             end_time = time.time()
             if batch_id % 2 == 0:
                 print(
-                    "epoch %d | batch step %d, loss %0.3f, acc1 %0.3f, acc5 %0.3f, time %f"
-                    % (
-                        epoch,
-                        batch_id,
-                        total_loss.numpy() / total_sample,
-                        total_acc1.numpy() / total_sample,
-                        total_acc5.numpy() / total_sample,
-                        end_time - start_time,
-                    )
+                    f"epoch {epoch} | batch step {batch_id}, "
+                    f"loss {total_loss.numpy() / total_sample:0.3f}, "
+                    f"acc1 {total_acc1.numpy() / total_sample:0.3f}, "
+                    f"acc5 {total_acc5.numpy() / total_sample:0.3f}, "
+                    f"time {end_time - start_time:f}"
                 )
             if batch_id == 10:
                 break

--- a/test/dygraph_to_static/test_resnet_pure_fp16.py
+++ b/test/dygraph_to_static/test_resnet_pure_fp16.py
@@ -98,15 +98,11 @@ def train(build_strategy=None):
             end_time = time.time()
             if batch_id % 2 == 0:
                 print(
-                    "epoch %d | batch step %d, loss %0.3f, acc1 %0.3f, acc5 %0.3f, time %f"
-                    % (
-                        epoch,
-                        batch_id,
-                        total_loss.numpy() / total_sample,
-                        total_acc1.numpy() / total_sample,
-                        total_acc5.numpy() / total_sample,
-                        end_time - start_time,
-                    )
+                    f"epoch {epoch} | batch step {batch_id}, "
+                    f"loss {total_loss.numpy() / total_sample:0.3f}, "
+                    f"acc1 {total_acc1.numpy() / total_sample:0.3f}, "
+                    f"acc5 {total_acc5.numpy() / total_sample:0.3f}, "
+                    f"time {end_time - start_time:f}"
                 )
             if batch_id == 10:
                 break

--- a/test/dygraph_to_static/test_se_resnet.py
+++ b/test/dygraph_to_static/test_se_resnet.py
@@ -295,7 +295,7 @@ class SeResNeXt(paddle.nn.Layer):
             shortcut = False
             for i in range(depth[block]):
                 bottleneck_block = self.add_sublayer(
-                    'bb_%d_%d' % (block, i),
+                    f'bb_{block}_{i}',
                     BottleneckBlock(
                         num_channels=num_channels,
                         num_filters=num_filters[block],
@@ -424,29 +424,21 @@ class TestSeResnet(Dy2StTestBase):
                     if step_id % PRINT_STEP == 0:
                         if step_id == 0:
                             logging.info(
-                                "epoch %d | step %d, loss %0.3f, acc1 %0.3f, acc5 %0.3f"
-                                % (
-                                    epoch_id,
-                                    step_id,
-                                    total_loss / total_sample,
-                                    total_acc1 / total_sample,
-                                    total_acc5 / total_sample,
-                                )
+                                f"epoch {epoch_id} | step {step_id}, "
+                                f"loss {total_loss / total_sample:0.3f}, "
+                                f"acc1 {total_acc1 / total_sample:0.3f}, "
+                                f"acc5 {total_acc5 / total_sample:0.3f}"
                             )
                             avg_batch_time = time.time()
                         else:
                             speed = PRINT_STEP / (time.time() - avg_batch_time)
                             speed_list.append(speed)
                             logging.info(
-                                "epoch %d | step %d, loss %0.3f, acc1 %0.3f, acc5 %0.3f, speed %.3f steps/s"
-                                % (
-                                    epoch_id,
-                                    step_id,
-                                    total_loss / total_sample,
-                                    total_acc1 / total_sample,
-                                    total_acc5 / total_sample,
-                                    speed,
-                                )
+                                f"epoch {epoch_id} | step {step_id}, "
+                                f"loss {total_loss / total_sample:0.3f}, "
+                                f"acc1 {total_acc1 / total_sample:0.3f}, "
+                                f"acc5 {total_acc5 / total_sample:0.3f}, "
+                                f"speed {speed:.3f} steps/s"
                             )
                             avg_batch_time = time.time()
 

--- a/test/dygraph_to_static/test_seq2seq.py
+++ b/test/dygraph_to_static/test_seq2seq.py
@@ -105,15 +105,11 @@ def train(args, attn_model=False):
             batch_times.append(batch_time)
             if batch_id % PRINT_STEP == 0:
                 print(
-                    "Batch:[%d]; Time: %.5f s; loss: %.5f; total_loss: %.5f; word num: %.5f; ppl: %.5f"
-                    % (
-                        batch_id,
-                        batch_time,
-                        loss.numpy(),
-                        total_loss.numpy(),
-                        word_count,
-                        np.exp(total_loss.numpy() / word_count),
-                    )
+                    f"Batch:[{batch_id}]; Time: {batch_time:.5f}s; "
+                    f"loss: {loss.numpy():.5f}; "
+                    f"total_loss: {total_loss.numpy():.5f}; "
+                    f"word num: {word_count:.5f}; "
+                    f"ppl: {np.exp(total_loss.numpy() / word_count):.5f}"
                 )
 
             if attn_model:

--- a/test/dygraph_to_static/test_transformer.py
+++ b/test/dygraph_to_static/test_transformer.py
@@ -132,31 +132,16 @@ def train_dygraph(args, batch_generator):
                 avg_loss.append(float(total_avg_cost))
                 if step_idx == 0:
                     logging.info(
-                        "step_idx: %d, epoch: %d, batch: %d, avg loss: %f, "
-                        "normalized loss: %f, ppl: %f"
-                        % (
-                            step_idx,
-                            pass_id,
-                            batch_id,
-                            total_avg_cost,
-                            total_avg_cost - loss_normalizer,
-                            np.exp([min(total_avg_cost, 100)]).item(),
-                        )
+                        f"step_idx: {step_idx}, epoch: {pass_id}, batch: {batch_id}, avg loss: {total_avg_cost:f}, "
+                        f"normalized loss: {total_avg_cost - loss_normalizer:f}, ppl: {np.exp([min(total_avg_cost, 100)]).item():f}"
                     )
                     avg_batch_time = time.time()
                 else:
                     logging.info(
-                        "step_idx: %d, epoch: %d, batch: %d, avg loss: %f, "
-                        "normalized loss: %f, ppl: %f, speed: %.2f steps/s"
-                        % (
-                            step_idx,
-                            pass_id,
-                            batch_id,
-                            total_avg_cost,
-                            total_avg_cost - loss_normalizer,
-                            np.exp([min(total_avg_cost, 100)]).item(),
-                            args.print_step / (time.time() - avg_batch_time),
-                        )
+                        f"step_idx: {step_idx}, epoch: {pass_id}, batch: {batch_id}, avg loss: {total_avg_cost:f}, "
+                        f"normalized loss: {total_avg_cost - loss_normalizer:f}, "
+                        f"ppl: {np.exp([min(total_avg_cost, 100)]).item():f}, "
+                        f"speed: {args.print_step / (time.time() - avg_batch_time):.2f} steps/s"
                     )
                     ce_ppl.append(np.exp([min(total_avg_cost, 100)]))
                     avg_batch_time = time.time()
@@ -258,16 +243,14 @@ def predict_dygraph(args, batch_generator):
         if step_idx % args.print_step == 0:
             if step_idx == 0:
                 logging.info(
-                    "Dygraph Predict: step_idx: %d, 1st seq_id: %d, 1st seq_score: %.2f"
-                    % (step_idx, seq_ids[0][0][0], seq_scores[0][0])
+                    f"Dygraph Predict: step_idx: {step_idx}, 1st seq_id: {seq_ids[0][0][0]}, 1st seq_score: {seq_scores[0][0]:.2f}"
                 )
                 avg_batch_time = time.time()
             else:
                 speed = args.print_step / (time.time() - avg_batch_time)
                 speed_list.append(speed)
                 logging.info(
-                    "Dygraph Predict: step_idx: %d, 1st seq_id: %d, 1st seq_score: %.2f, speed: %.3f steps/s"
-                    % (step_idx, seq_ids[0][0][0], seq_scores[0][0], speed)
+                    f"Dygraph Predict: step_idx: {step_idx}, 1st seq_id: {seq_ids[0][0][0]}, 1st seq_score: {seq_scores[0][0]:.2f}, speed: {speed:.3f} steps/s"
                 )
                 avg_batch_time = time.time()
 

--- a/test/dygraph_to_static/test_tsm.py
+++ b/test/dygraph_to_static/test_tsm.py
@@ -175,7 +175,7 @@ class TSM_ResNet(paddle.nn.Layer):
             shortcut = False
             for i in range(depth[block]):
                 bottleneck_block = self.add_sublayer(
-                    'bb_%d_%d' % (block, i),
+                    f'bb_{block}_{i}',
                     BottleneckBlock(
                         num_channels=num_channels,
                         num_filters=num_filters[block],

--- a/test/dygraph_to_static/test_word2vec.py
+++ b/test/dygraph_to_static/test_word2vec.py
@@ -89,8 +89,7 @@ vocab_size = len(word2id_freq)
 print("there are totoally %d different words in the corpus" % vocab_size)
 for _, (word, word_id) in zip(range(50), word2id_dict.items()):
     print(
-        "word %s, its id %d, its word freq %d"
-        % (word, word_id, word2id_freq[word_id])
+        f"word {word}, its id {word_id}, its word freq {word2id_freq[word_id]}"
     )
 
 
@@ -174,8 +173,7 @@ def build_data(
 dataset = build_data(corpus, word2id_dict, word2id_freq)
 for _, (center_word, target_word, label) in zip(range(50), dataset):
     print(
-        "center_word %s, target %s, label %d"
-        % (id2word_dict[center_word], id2word_dict[target_word], label)
+        f"center_word {id2word_dict[center_word]}, target {id2word_dict[target_word]}, label {label}"
     )
 
 

--- a/test/dygraph_to_static/transformer_dygraph_model.py
+++ b/test/dygraph_to_static/transformer_dygraph_model.py
@@ -51,7 +51,7 @@ class PrePostProcessLayer(Layer):
             elif cmd == "n":  # add layer normalization
                 self.functors.append(
                     self.add_sublayer(
-                        "layer_norm_%d" % len(list(self.children())),
+                        f"layer_norm_{len(list(self.children()))}",
                         paddle.nn.LayerNorm(
                             normalized_shape=d_model,
                             weight_attr=base.ParamAttr(
@@ -252,7 +252,7 @@ class Encoder(Layer):
         for i in range(n_layer):
             self.encoder_layers.append(
                 self.add_sublayer(
-                    "layer_%d" % i,
+                    f"layer_{i}",
                     EncoderLayer(
                         n_head,
                         d_key,
@@ -446,7 +446,7 @@ class Decoder(Layer):
         for i in range(n_layer):
             self.decoder_layers.append(
                 self.add_sublayer(
-                    "layer_%d" % i,
+                    f"layer_{i}",
                     DecoderLayer(
                         n_head,
                         d_key,

--- a/test/dygraph_to_static/yolov3.py
+++ b/test/dygraph_to_static/yolov3.py
@@ -228,7 +228,7 @@ class YOLOv3(paddle.nn.Layer):
         ch_in_list = [1024, 768, 384]
         for i in range(3):
             yolo_block = self.add_sublayer(
-                "yolo_detecton_block_%d" % (i),
+                f"yolo_detecton_block_{i}",
                 YoloDetectionBlock(
                     ch_in_list[i],
                     channel=512 // (2**i),
@@ -240,7 +240,7 @@ class YOLOv3(paddle.nn.Layer):
             num_filters = len(cfg.anchor_masks[i]) * (cfg.class_num + 5)
 
             block_out = self.add_sublayer(
-                "block_out_%d" % (i),
+                f"block_out_{i}",
                 paddle.nn.Conv2D(
                     in_channels=1024 // (2**i),
                     out_channels=num_filters,
@@ -259,7 +259,7 @@ class YOLOv3(paddle.nn.Layer):
             self.block_outputs.append(block_out)
             if i < 2:
                 route = self.add_sublayer(
-                    "route2_%d" % i,
+                    f"route2_{i}",
                     ConvBNLayer(
                         ch_in=512 // (2**i),
                         ch_out=256 // (2**i),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

继 #65585 part19 后再次对 %x 形式 format 替换，因为 Ruff 0.8[^1] UP031 检查又有修改，现在只要是 %x 的形式都会抛出 UP031，即便没有自动修复，而有自动修复的之前已经全部修复过了，剩下的都是没有自动修复的，需要手动修复

> [!CAUTION]
>
> 相关地方均为手动逐个修复，需要仔细 review！

### Related links

- #70031
- #70033
- #70034
- #70035
- #70036

PCard-66972

[^1]: [Ruff 0.8 release notes](https://github.com/astral-sh/ruff/releases/tag/0.8.0)