### PR TITLE
[CodeStyle][UP031] Use f-string instead of percent format in tools (part26)

### DIFF
--- a/tools/CrossStackProfiler/CspFileReader.py
+++ b/tools/CrossStackProfiler/CspFileReader.py
@@ -281,7 +281,7 @@ class FileReader:
         return self.getFileName("dcgm", groupId, gpuId, tmpPath)
 
     def getFileName(self, name, groupId, gpuId, tmpPath="./tmp"):
-        return os.path.join(tmpPath, "%s_%d_%d.json" % (name, groupId, gpuId))
+        return os.path.join(tmpPath, f"{name}_{groupId}_{gpuId}.json")
 
     def getOpInfoDict(self, groupId, gpuId, tmpPath="./tmp"):
         return self.getDict("opinfo", groupId, gpuId, tmpPath)

--- a/tools/CrossStackProfiler/CspFileReader.py
+++ b/tools/CrossStackProfiler/CspFileReader.py
@@ -292,7 +292,7 @@ class FileReader:
     def getDict(self, name, groupId, gpuId, tmpPath="./tmp"):
         fileName = self.getFileName(name, groupId, gpuId, tmpPath)
         if not os.path.isfile(fileName):
-            raise OSError(f"[{fileName}] is not existed!")
+            raise OSError(f"[{fileName}] does not existed!")
 
         data = {}
         with open(fileName, "r") as rf:

--- a/tools/CrossStackProfiler/CspReporter.py
+++ b/tools/CrossStackProfiler/CspReporter.py
@@ -89,8 +89,7 @@ class CspReporter:
     def _checkArgs(self):
         if self._trainerNum % self._groupSize != 0:
             raise Exception(
-                "Input args error: trainerNum[%d] %% groupSize[%d] != 0"
-                % (self._trainerNum, self._groupSize)
+                f"Input args error: trainerNum[{self._trainerNum}] %% groupSize[{self._groupSize}] != 0"
             )
 
     def _init_logger(self):
@@ -217,16 +216,14 @@ class CspReporter:
             subproc.start()
             pidList.append(subproc.pid)
             self._logger.info(
-                "[traceFile]: process [%d] has been started, total task num is %d ..."
-                % (subproc.pid, 1)
+                f"[traceFile]: process [{subproc.pid}] has been started, total task num is {1} ..."
             )
 
         for t in processPool:
             t.join()
             pidList.remove(t.pid)
             self._logger.info(
-                "[traceFile]: process [%d] has exited! remained %d process!"
-                % (t.pid, len(pidList))
+                f"[traceFile]: process [{t.pid}] has exited! remained {len(pidList)} process!"
             )
 
     def generateTraceFile(self, processNum=8):
@@ -244,15 +241,13 @@ class CspReporter:
             subproc.start()
             pidList.append(subproc.pid)
             self._logger.info(
-                "[GroupTraceFile]: process [%d] has been started, total task num is %d ..."
-                % (subproc.pid, 1)
+                f"[GroupTraceFile]: process [{subproc.pid}] has been started, total task num is {1} ..."
             )
         for t in processPool:
             t.join()
             pidList.remove(t.pid)
             self._logger.info(
-                "[GroupTraceFile]: process [%d] has exited! remained %d process!"
-                % (t.pid, len(pidList))
+                f"[GroupTraceFile]: process [{t.pid}] has exited! remained {len(pidList)} process!"
             )
 
 

--- a/tools/CrossStackProfiler/DCGMFileReader.py
+++ b/tools/CrossStackProfiler/DCGMFileReader.py
@@ -39,9 +39,7 @@ class dcgmFileReader(FileReader):
             return self._parseTask(fileFist)
 
         else:
-            self._logger.info(
-                "using [%d] process to do this work!" % processNum
-            )
+            self._logger.info(f"using [{processNum}] process to do this work!")
             processPool = []
             pidList = []
 
@@ -61,16 +59,14 @@ class dcgmFileReader(FileReader):
                 subproc.start()
                 pidList.append(subproc.pid)
                 self._logger.info(
-                    "[DCGM reader]: process [%d] has been started, total task num is %d ..."
-                    % (subproc.pid, len(processPool))
+                    f"[DCGM reader]: process [{subproc.pid}] has been started, total task num is {len(processPool)} ..."
                 )
 
             for t in processPool:
                 t.join()
                 pidList.remove(t.pid)
                 self._logger.info(
-                    "[DCGM reader]: process [%d] has exited! remained %d process!"
-                    % (t.pid, len(pidList))
+                    f"[DCGM reader]: process [{t.pid}] has exited! remained {len(pidList)} process!"
                 )
 
             isFistProcess = True
@@ -169,8 +165,7 @@ class dcgmFileReader(FileReader):
         self, groupId, gpuId, dcgm_data, pid_map, q=None
     ):
         self._logger.info(
-            "Begin to generate dcgm info, groupId = %d, gpuID = %d ..."
-            % (groupId, gpuId)
+            f"Begin to generate dcgm info, groupId = {groupId}, gpuID = {gpuId} ..."
         )
 
         gpuDcgmData = dcgm_data[dcgm_data['Entity'].isin([gpuId])]
@@ -198,7 +193,7 @@ class dcgmFileReader(FileReader):
                 di['ts'] = self._align_ts(int(row['ts']))
                 # di['ts'] = int(row['ts'])
                 di['cat'] = metric
-                di['tid'] = "%d_%d" % (groupId, trainerId)
+                di['tid'] = f"{groupId}_{trainerId}"
                 di['ph'] = "C"
                 di['id'] = trainerId
 
@@ -244,16 +239,14 @@ class dcgmFileReader(FileReader):
             subproc.start()
             pidList.append(subproc.pid)
             self._logger.info(
-                "[DCGM info]: process [%d] has been started, total task num is %d ..."
-                % (subproc.pid, 1)
+                f"[DCGM info]: process [{subproc.pid}] has been started, total task num is {1} ..."
             )
 
         for t in processPool:
             t.join()
             pidList.remove(t.pid)
             self._logger.info(
-                "[DCGM info]: process [%d] has exited! remained %d process!"
-                % (t.pid, len(pidList))
+                f"[DCGM info]: process [{t.pid}] has exited! remained {len(pidList)} process!"
             )
 
         dcgmInfo = {}

--- a/tools/CrossStackProfiler/NetFileReader.py
+++ b/tools/CrossStackProfiler/NetFileReader.py
@@ -33,14 +33,14 @@ class netFileReader(FileReader):
         metaInfo['name'] = 'process_name'
         metaInfo['ph'] = 'M'
         metaInfo['pid'] = tx_pid
-        metaInfo['args'] = {'name': "%02d_tx" % tx_pid}
+        metaInfo['args'] = {'name': f"{tx_pid:02}_tx"}
 
         traceEventList.append(metaInfo)
         metaInfo = {}
         metaInfo['name'] = 'process_name'
         metaInfo['ph'] = 'M'
         metaInfo['pid'] = rx_pid
-        metaInfo['args'] = {'name': "%02d_rx" % rx_pid}
+        metaInfo['args'] = {'name': f"{rx_pid:02}_rx"}
 
         traceEventList.append(metaInfo)
 
@@ -98,16 +98,14 @@ class netFileReader(FileReader):
             subproc.start()
             pidList.append(subproc.pid)
             self._logger.info(
-                "[Net info]: process [%d] has been started, total task num is %d ..."
-                % (subproc.pid, len(processPool))
+                f"[Net info]: process [{subproc.pid}] has been started, total task num is {len(processPool)} ..."
             )
 
         for t in processPool:
             t.join()
             pidList.remove(t.pid)
             self._logger.info(
-                "[Net info]: process [%d] has exited! remained %d process!"
-                % (t.pid, len(pidList))
+                f"[Net info]: process [{t.pid}] has exited! remained {len(pidList)} process!"
             )
 
         traceInfo = {}

--- a/tools/CrossStackProfiler/ProfileFileReader.py
+++ b/tools/CrossStackProfiler/ProfileFileReader.py
@@ -43,7 +43,7 @@ class profileFileReader(FileReader):
 
         for fileName in taskList:
             rankId = self.getRankId(fileName)
-            profile_dict["trainerRank.%03d" % (rankId)] = self._parseSingleFile(
+            profile_dict[f"trainerRank.{rankId:03}"] = self._parseSingleFile(
                 fileName
             )
             self._logger.info(f"I finish processing {fileName}!")
@@ -147,8 +147,7 @@ class profileFileReader(FileReader):
         fileFist = self.getFileListByGroup(groupId)
 
         self._logger.info(
-            "using [%d] process to do this work, total task num is %d!"
-            % (processNum, len(fileFist))
+            f"using [{processNum}] process to do this work, total task num is {len(fileFist)}!"
         )
         processPool = []
         pidList = []
@@ -169,16 +168,14 @@ class profileFileReader(FileReader):
             subproc.start()
             pidList.append(subproc.pid)
             self._logger.info(
-                "[pipeline info]: process [%d] has been started, total task num is %d ..."
-                % (subproc.pid, len(task))
+                f"[pipeline info]: process [{subproc.pid}] has been started, total task num is {len(task)} ..."
             )
 
         for t in processPool:
             t.join()
             pidList.remove(t.pid)
             self._logger.info(
-                "[pipeline info]: process [%d] has exited! remained %d process!"
-                % (t.pid, len(pidList))
+                f"[pipeline info]: process [{t.pid}] has exited! remained {len(pidList)} process!"
             )
 
         pipeLineInfo = {}
@@ -187,9 +184,7 @@ class profileFileReader(FileReader):
         metaInfo['name'] = 'process_name'
         metaInfo['ph'] = 'M'
         metaInfo['pid'] = 0
-        metaInfo['args'] = {
-            'name': "%02d_pipeLineInfo" % PIPELINEINFO_TRACE_NUM
-        }
+        metaInfo['args'] = {'name': f"{PIPELINEINFO_TRACE_NUM:02}_pipeLineInfo"}
 
         for t in processPool:
             for k, v in q.get().items():
@@ -220,13 +215,12 @@ class profileFileReader(FileReader):
                         # -1 device id represents CUDA API(RunTime) call.(e.g. cudaLaunch, cudaMemcpy)
                         if event.device_id == -1:
                             chrome_trace.emit_pid(
-                                "%02d_%s:cuda_api" % (lineNum, k), pid
+                                f"{lineNum:02}_{k}:cuda_api", pid
                             )
                             lineNum = lineNum + 1
                         else:
                             chrome_trace.emit_pid(
-                                "%02d_%s:cpu:block:%d"
-                                % (lineNum, k, event.device_id),
+                                f"{lineNum:02}_{k}:cpu:block:{event.device_id}",
                                 pid,
                             )
                             lineNum = lineNum + 1
@@ -238,8 +232,7 @@ class profileFileReader(FileReader):
 
                             devices[(k, event.device_id, "GPUKernel")] = pid
                             chrome_trace.emit_pid(
-                                "%02d_%s:gpu:%d"
-                                % (lineNum, k, event.device_id),
+                                f"{lineNum:02}_{k}:gpu:{event.device_id}",
                                 pid,
                             )
                             lineNum = lineNum + 1
@@ -255,8 +248,7 @@ class profileFileReader(FileReader):
 
                             mem_devices[(k, mevent.device_id, "GPU")] = pid
                             chrome_trace.emit_pid(
-                                "%02d_memory usage on %s:gpu:%d"
-                                % (lineNum, k, mevent.device_id),
+                                f"{lineNum:02}_memory usage on {k}:gpu:{mevent.device_id}",
                                 pid,
                             )
                             lineNum = lineNum + 1
@@ -267,8 +259,7 @@ class profileFileReader(FileReader):
 
                         mem_devices[(k, mevent.device_id, "CPU")] = pid
                         chrome_trace.emit_pid(
-                            "%02d_memory usage on %s:cpu:%d"
-                            % (lineNum, k, mevent.device_id),
+                            f"{lineNum:02}_memory usage on {k}:cpu:{mevent.device_id}",
                             pid,
                         )
                         lineNum = lineNum + 1
@@ -286,8 +277,7 @@ class profileFileReader(FileReader):
                                 (k, mevent.device_id, "CUDAPinnedPlace")
                             ] = pid
                             chrome_trace.emit_pid(
-                                "%02d_memory usage on %s:cudapinnedplace:%d"
-                                % (lineNum, k, mevent.device_id),
+                                f"{lineNum:02}_memory usage on {k}:cudapinnedplace:{mevent.device_id}",
                                 pid,
                             )
                             lineNum = lineNum + 1
@@ -297,7 +287,7 @@ class profileFileReader(FileReader):
 
                     mem_devices[(k, 0, "CPU")] = pid
                     chrome_trace.emit_pid(
-                        "%02d_memory usage on %s:cpu:%d" % (lineNum, k, 0), pid
+                        f"{lineNum:02}_memory usage on {k}:cpu:{0}", pid
                     )
                     lineNum = lineNum + 1
                 if (k, 0, "GPU") not in mem_devices:
@@ -307,7 +297,7 @@ class profileFileReader(FileReader):
 
                     mem_devices[(k, 0, "GPU")] = pid
                     chrome_trace.emit_pid(
-                        "%02d_memory usage on %s:gpu:%d" % (lineNum, k, 0), pid
+                        f"{lineNum:02}_memory usage on {k}:gpu:{0}", pid
                     )
                     lineNum = lineNum + 1
                 if (k, 0, "CUDAPinnedPlace") not in mem_devices:
@@ -316,8 +306,7 @@ class profileFileReader(FileReader):
 
                     mem_devices[(k, 0, "CUDAPinnedPlace")] = pid
                     chrome_trace.emit_pid(
-                        "%02d_memory usage on %s:cudapinnedplace:%d"
-                        % (lineNum, k, 0),
+                        f"{lineNum:02}_memory usage on {k}:cudapinnedplace:{0}",
                         pid,
                     )
                     lineNum = lineNum + 1
@@ -484,16 +473,14 @@ class profileFileReader(FileReader):
             subproc.start()
             pidList.append(subproc.pid)
             self._logger.info(
-                "[op info]: process [%d] has been started, total task num is %d ..."
-                % (subproc.pid, 1)
+                f"[op info]: process [{subproc.pid}] has been started, total task num is {1} ..."
             )
 
         for t in processPool:
             t.join()
             pidList.remove(t.pid)
             self._logger.info(
-                "[op info]: process [%d] has exited! remained %d process!"
-                % (t.pid, len(pidList))
+                f"[op info]: process [{t.pid}] has exited! remained {len(pidList)} process!"
             )
 
         opInfo = {}

--- a/tools/continuous_integration/bisect.py
+++ b/tools/continuous_integration/bisect.py
@@ -113,7 +113,7 @@ while True:
     # Clean builds and compile.
     # We assume mainline commits should always compile.
     os.chdir(args.build_dir)
-    sys.stdout.write('eval commit %d/%d: %s\n' % (pick_idx, len(commits), pick))
+    sys.stdout.write(f'eval commit {pick_idx}/{len(commits)}: {pick}\n')
     # Link error can happen without complete clean up.
     cmd = (
         'rm -rf * && '

--- a/tools/timeline.py
+++ b/tools/timeline.py
@@ -151,14 +151,14 @@ class Timeline:
                             self._chrome_trace.emit_pid(f"{k}:cuda_api", pid)
                         else:
                             self._chrome_trace.emit_pid(
-                                "%s:cpu:block:%d" % (k, event.device_id), pid
+                                f"{k}:cpu:block:{event.device_id}", pid
                             )
                 elif event.type == profiler_pb2.Event.GPUKernel:
                     if (k, event.device_id, "GPUKernel") not in self._devices:
                         pid = self._allocate_pid()
                         self._devices[(k, event.device_id, "GPUKernel")] = pid
                         self._chrome_trace.emit_pid(
-                            "%s:gpu:%d" % (k, event.device_id), pid
+                            f"{k}:gpu:{event.device_id}", pid
                         )
             if not hasattr(profile_pb, "mem_events"):
                 continue
@@ -168,7 +168,7 @@ class Timeline:
                         pid = self._allocate_pid()
                         self._mem_devices[(k, mevent.device_id, "GPU")] = pid
                         self._chrome_trace.emit_pid(
-                            "memory usage on %s:gpu:%d" % (k, mevent.device_id),
+                            f"memory usage on {k}:gpu:{mevent.device_id}",
                             pid,
                         )
                 elif mevent.place == profiler_pb2.MemEvent.CPUPlace:
@@ -176,7 +176,7 @@ class Timeline:
                         pid = self._allocate_pid()
                         self._mem_devices[(k, mevent.device_id, "CPU")] = pid
                         self._chrome_trace.emit_pid(
-                            "memory usage on %s:cpu:%d" % (k, mevent.device_id),
+                            f"memory usage on {k}:cpu:{mevent.device_id}",
                             pid,
                         )
                 elif mevent.place == profiler_pb2.MemEvent.CUDAPinnedPlace:
@@ -190,27 +190,26 @@ class Timeline:
                             (k, mevent.device_id, "CUDAPinnedPlace")
                         ] = pid
                         self._chrome_trace.emit_pid(
-                            "memory usage on %s:cudapinnedplace:%d"
-                            % (k, mevent.device_id),
+                            f"memory usage on {k}:cudapinnedplace:{mevent.device_id}",
                             pid,
                         )
                 if (k, 0, "CPU") not in self._mem_devices:
                     pid = self._allocate_pid()
                     self._mem_devices[(k, 0, "CPU")] = pid
                     self._chrome_trace.emit_pid(
-                        "memory usage on %s:cpu:%d" % (k, 0), pid
+                        f"memory usage on {k}:cpu:{0}", pid
                     )
                 if (k, 0, "GPU") not in self._mem_devices:
                     pid = self._allocate_pid()
                     self._mem_devices[(k, 0, "GPU")] = pid
                     self._chrome_trace.emit_pid(
-                        "memory usage on %s:gpu:%d" % (k, 0), pid
+                        f"memory usage on {k}:gpu:{0}", pid
                     )
                 if (k, 0, "CUDAPinnedPlace") not in self._mem_devices:
                     pid = self._allocate_pid()
                     self._mem_devices[(k, 0, "CUDAPinnedPlace")] = pid
                     self._chrome_trace.emit_pid(
-                        "memory usage on %s:cudapinnedplace:%d" % (k, 0), pid
+                        f"memory usage on {k}:cudapinnedplace:{0}", pid
                     )
 
     def _allocate_events(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

继 #65585 part19 后再次对 %x 形式 format 替换，因为 Ruff 0.8[^1] UP031 检查又有修改，现在只要是 %x 的形式都会抛出 UP031，即便没有自动修复，而有自动修复的之前已经全部修复过了，剩下的都是没有自动修复的，需要手动修复

> [!CAUTION]
>
> 相关地方均为手动逐个修复，需要仔细 review！

### Related links

- #70031
- #70033
- #70034
- #70035
- #70036
- #70037

PCard-66972

[^1]: [Ruff 0.8 release notes](https://github.com/astral-sh/ruff/releases/tag/0.8.0)