### PR TITLE
[CodeStyle][UP031] Use f-string instead of percent format in some uts (part27)

### DIFF
--- a/test/legacy_test/test_meshgrid_op.py
+++ b/test/legacy_test/test_meshgrid_op.py
@@ -76,10 +76,8 @@ class TestMeshgridOp(OpTest):
             out_reshape[i] = self.shape[i]
             out_temp = np.reshape(ins[i], out_reshape)
             outs.append(np.broadcast_to(out_temp, self.shape))
-        self.inputs = {'X': [('x%d' % i, ins[i]) for i in range(len(ins))]}
-        self.outputs = {
-            'Out': [('out%d' % i, outs[i]) for i in range(len(outs))]
-        }
+        self.inputs = {'X': [(f'x{i}', ins[i]) for i in range(len(ins))]}
+        self.outputs = {'Out': [(f'out{i}', outs[i]) for i in range(len(outs))]}
 
     def get_x_shape(self):
         return [100, 200]
@@ -141,13 +139,13 @@ class TestMeshgridOpBFP16OP(TestMeshgridOp):
             outs.append(np.broadcast_to(out_temp, self.shape))
         self.inputs = {
             'X': [
-                ('x%d' % i, convert_float_to_uint16(ins[i]))
+                (f'x{i}', convert_float_to_uint16(ins[i]))
                 for i in range(len(ins))
             ]
         }
         self.outputs = {
             'Out': [
-                ('out%d' % i, convert_float_to_uint16(outs[i]))
+                (f'out{i}', convert_float_to_uint16(outs[i]))
                 for i in range(len(outs))
             ]
         }
@@ -440,10 +438,8 @@ class TestMeshGrid_ZeroDim(TestMeshgridOp):
             out_reshape[i] = self.shape[i]
             out_temp = np.reshape(ins[i], out_reshape)
             outs.append(np.broadcast_to(out_temp, self.shape))
-        self.inputs = {'X': [('x%d' % i, ins[i]) for i in range(len(ins))]}
-        self.outputs = {
-            'Out': [('out%d' % i, outs[i]) for i in range(len(outs))]
-        }
+        self.inputs = {'X': [(f'x{i}', ins[i]) for i in range(len(ins))]}
+        self.outputs = {'Out': [(f'out{i}', outs[i]) for i in range(len(outs))]}
 
     def get_x_shape(self):
         return [1, 2, 3]

--- a/test/legacy_test/test_rnn_decode_api.py
+++ b/test/legacy_test/test_rnn_decode_api.py
@@ -423,7 +423,7 @@ class EncoderCell(SimpleRNNCell):
         for i in range(num_layers):
             self.lstm_cells.append(
                 self.add_sublayer(
-                    "lstm_%d" % i,
+                    f"lstm_{i}",
                     LSTMCell(
                         input_size=input_size if i == 0 else hidden_size,
                         hidden_size=hidden_size,

--- a/test/legacy_test/test_split_op.py
+++ b/test/legacy_test/test_split_op.py
@@ -38,7 +38,7 @@ class TestSplitOp(OpTest):
             self.inputs = {'X': convert_float_to_uint16(x)}
             self.outputs = {
                 'Out': [
-                    ('out%d' % i, convert_float_to_uint16(out[i]))
+                    (f'out{i}', convert_float_to_uint16(out[i]))
                     for i in range(len(out))
                 ]
             }
@@ -47,7 +47,7 @@ class TestSplitOp(OpTest):
             out = np.split(x, [2, 3], axis)
             self.inputs = {'X': x}
             self.outputs = {
-                'Out': [('out%d' % i, out[i]) for i in range(len(out))]
+                'Out': [(f'out{i}', out[i]) for i in range(len(out))]
             }
         self.attrs = {'axis': axis, 'sections': [2, 1, 2]}
 
@@ -90,7 +90,7 @@ class TestSplitWithNumOp(OpTest):
             out = np.split(self.x, self.indices_or_sections, self.axis)
             self.outputs = {
                 'Out': [
-                    ('out%d' % i, convert_float_to_uint16(out[i]))
+                    (f'out{i}', convert_float_to_uint16(out[i]))
                     for i in range(len(out))
                 ]
             }
@@ -98,7 +98,7 @@ class TestSplitWithNumOp(OpTest):
             self.inputs = {'X': self.x}
             out = np.split(self.x, self.indices_or_sections, self.axis)
             self.outputs = {
-                'Out': [('out%d' % i, out[i]) for i in range(len(out))]
+                'Out': [(f'out{i}', out[i]) for i in range(len(out))]
             }
 
     def init_data(self):
@@ -145,7 +145,7 @@ class TestSplitOp_AxisTensor(OpTest):
         self.attrs = {'sections': self.sections, 'num': self.num}
 
         out = np.split(self.x, self.indices_or_sections, self.axis)
-        self.outputs = {'Out': [('out%d' % i, out[i]) for i in range(len(out))]}
+        self.outputs = {'Out': [(f'out{i}', out[i]) for i in range(len(out))]}
 
     def init_data(self):
         self.x = np.random.random((4, 5, 6)).astype(self.dtype)
@@ -192,7 +192,7 @@ class TestSplitOp_SectionsTensor(OpTest):
         }
 
         out = np.split(self.x, self.indices_or_sections, self.axis)
-        self.outputs = {'Out': [('out%d' % i, out[i]) for i in range(len(out))]}
+        self.outputs = {'Out': [(f'out{i}', out[i]) for i in range(len(out))]}
 
     def init_data(self):
         self.x = np.random.random((4, 5, 6)).astype(self.dtype)
@@ -232,7 +232,7 @@ class TestSplitOp_unk_section(OpTest):
         }
 
         out = np.split(self.x, self.indices_or_sections, self.axis)
-        self.outputs = {'Out': [('out%d' % i, out[i]) for i in range(len(out))]}
+        self.outputs = {'Out': [(f'out{i}', out[i]) for i in range(len(out))]}
 
     def init_data(self):
         self.x = np.random.random((4, 5, 6)).astype(self.dtype)

--- a/test/legacy_test/test_static_save_load.py
+++ b/test/legacy_test/test_static_save_load.py
@@ -68,7 +68,7 @@ class SimpleLSTMRNN(paddle.nn.Layer):
                     low=-self._init_scale, high=self._init_scale
                 ),
             )
-            self.weight_1_arr.append(self.add_parameter('w_%d' % i, weight_1))
+            self.weight_1_arr.append(self.add_parameter(f'w_{i}', weight_1))
             bias_1 = self.create_parameter(
                 attr=base.ParamAttr(
                     initializer=paddle.nn.initializer.Uniform(
@@ -79,7 +79,7 @@ class SimpleLSTMRNN(paddle.nn.Layer):
                 dtype="float32",
                 default_initializer=paddle.nn.initializer.Constant(0.0),
             )
-            self.bias_arr.append(self.add_parameter('b_%d' % i, bias_1))
+            self.bias_arr.append(self.add_parameter(f'b_{i}', bias_1))
 
     def forward(self, input_embedding, init_hidden=None, init_cell=None):
         self.cell_array = []

--- a/test/legacy_test/test_unbind_op.py
+++ b/test/legacy_test/test_unbind_op.py
@@ -179,11 +179,11 @@ class TestUnbindOp(OpTest):
         self.attrs = {'axis': self.axis}
         self.setAxis()
         self.outputs = {
-            'Out': [('out%d' % i, self.out[i]) for i in range(len(self.out))]
+            'Out': [(f'out{i}', self.out[i]) for i in range(len(self.out))]
         }
         self.python_api = paddle.unbind
         self.public_python_api = paddle.unbind
-        self.python_out_sig = ['out%d' % i for i in range(len(self.out))]
+        self.python_out_sig = [f'out{i}' for i in range(len(self.out))]
 
     def get_dtype(self):
         return "float64"
@@ -338,9 +338,9 @@ class TestUnbindFP16Op(OpTest):
         self.inputs = {'X': x}
         self.attrs = {'axis': self.axis}
         self.outputs = {
-            'Out': [('out%d' % i, self.out[i]) for i in range(len(self.out))]
+            'Out': [(f'out{i}', self.out[i]) for i in range(len(self.out))]
         }
-        self.python_out_sig = ['out%d' % i for i in range(len(self.out))]
+        self.python_out_sig = [f'out{i}' for i in range(len(self.out))]
 
     def outReshape(self):
         self.out[0] = self.out[0].reshape((2, 2))
@@ -371,11 +371,11 @@ class TestUnbindBF16Op(OpTest):
         self.attrs = {'axis': self.axis}
         self.outputs = {
             'Out': [
-                ('out%d' % i, convert_float_to_uint16(self.out[i]))
+                (f'out{i}', convert_float_to_uint16(self.out[i]))
                 for i in range(len(self.out))
             ]
         }
-        self.python_out_sig = ['out%d' % i for i in range(len(self.out))]
+        self.python_out_sig = [f'out{i}' for i in range(len(self.out))]
 
     def outReshape(self):
         self.out[0] = self.out[0].reshape((2, 2))

--- a/test/mkldnn/test_split_bf16_mkldnn_op.py
+++ b/test/mkldnn/test_split_bf16_mkldnn_op.py
@@ -60,7 +60,7 @@ class TestSplitSectionsBF16OneDNNOp(OpTest):
             self.inputs['SectionsTensorList'] = self.sections_tensor_list
 
         self.outputs = {
-            'Out': [('out%d' % i, self.out[i]) for i in range(len(self.out))]
+            'Out': [(f'out{i}', self.out[i]) for i in range(len(self.out))]
         }
 
     def test_check_output(self):

--- a/test/prim/model/test_resnet_cinn.py
+++ b/test/prim/model/test_resnet_cinn.py
@@ -145,16 +145,11 @@ def run(model, data_loader, optimizer, mode):
 
             end_time = time.time()
             print(
-                "[%s]epoch %d | batch step %d, loss %0.8f, acc1 %0.3f, acc5 %0.3f, time %f"
-                % (
-                    mode,
-                    epoch,
-                    batch_id,
-                    avg_loss,
-                    total_acc1.numpy() / total_sample,
-                    total_acc5.numpy() / total_sample,
-                    end_time - start_time,
-                )
+                f"[{mode}]epoch {epoch} | batch step {batch_id}, "
+                f"loss {avg_loss:0.8f}, "
+                f"acc1 {total_acc1.numpy() / total_sample:0.3f}, "
+                f"acc5 {total_acc5.numpy() / total_sample:0.3f}, "
+                f"time {end_time - start_time:f}"
             )
             if batch_id >= end_step:
                 break

--- a/test/prim/model/test_resnet_prim.py
+++ b/test/prim/model/test_resnet_prim.py
@@ -159,16 +159,11 @@ def run(model, data_loader, optimizer, mode):
 
             end_time = time.time()
             print(
-                "[%s]epoch %d | batch step %d, loss %0.8f, acc1 %0.3f, acc5 %0.3f, time %f"
-                % (
-                    mode,
-                    epoch,
-                    batch_id,
-                    avg_loss,
-                    total_acc1.numpy() / total_sample,
-                    total_acc5.numpy() / total_sample,
-                    end_time - start_time,
-                )
+                f"[{mode}]epoch {epoch} | batch step {batch_id}, "
+                f"loss {avg_loss:0.8f}, "
+                f"acc1 {total_acc1.numpy() / total_sample:0.3f}, "
+                f"acc5 {total_acc5.numpy() / total_sample:0.3f}, "
+                f"time {end_time - start_time:f}"
             )
             if batch_id >= end_step:
                 break

--- a/test/prim/model/test_resnet_prim_cinn.py
+++ b/test/prim/model/test_resnet_prim_cinn.py
@@ -146,16 +146,11 @@ def run(model, data_loader, optimizer, mode):
 
             end_time = time.time()
             print(
-                "[%s]epoch %d | batch step %d, loss %0.8f, acc1 %0.3f, acc5 %0.3f, time %f"
-                % (
-                    mode,
-                    epoch,
-                    batch_id,
-                    avg_loss,
-                    total_acc1.numpy() / total_sample,
-                    total_acc5.numpy() / total_sample,
-                    end_time - start_time,
-                )
+                f"[{mode}]epoch {epoch} | batch step {batch_id}, "
+                f"loss {avg_loss:0.8f}, "
+                f"acc1 {total_acc1.numpy() / total_sample:0.3f}, "
+                f"acc5 {total_acc5.numpy() / total_sample:0.3f}, "
+                f"time {end_time - start_time:f}"
             )
             if batch_id >= end_step:
                 break

--- a/test/ps/fl_ps_trainer.py
+++ b/test/ps/fl_ps_trainer.py
@@ -126,8 +126,7 @@ def fl_ps_train():
             )
             end_time = time.time()
             print(
-                "trainer epoch %d finished, use time=%d\n"
-                % ((epoch), end_time - start_time)
+                f"trainer epoch {epoch} finished, use time={end_time - start_time}\n"
             )
         exe.close()
         _runtime_handle._stop_worker()

--- a/test/ps/ps_dnn_model.py
+++ b/test/ps/ps_dnn_model.py
@@ -63,11 +63,11 @@ class DNNLayer(nn.Layer):
                     )
                 ),
             )
-            self.add_sublayer('linear_%d' % i, linear)
+            self.add_sublayer(f'linear_{i}', linear)
             self._mlp_layers.append(linear)
             if acts[i] == 'relu':
                 act = paddle.nn.ReLU()
-                self.add_sublayer('act_%d' % i, act)
+                self.add_sublayer(f'act_{i}', act)
                 self._mlp_layers.append(act)
 
     def forward(self, sparse_inputs, dense_inputs):
@@ -151,10 +151,10 @@ class FlDNNLayer(nn.Layer):
                     )
                 ),
             )
-            self.add_sublayer('linear_%d' % i, linear)
+            self.add_sublayer(f'linear_{i}', linear)
             self._mlp_layers_a.append(linear)
             act = paddle.nn.ReLU()
-            self.add_sublayer('act_%d' % i, act)
+            self.add_sublayer(f'act_{i}', act)
             self._mlp_layers_a.append(act)
 
         # part_b fc
@@ -170,10 +170,10 @@ class FlDNNLayer(nn.Layer):
                     )
                 ),
             )
-            self.add_sublayer('linear_%d' % i, linear)
+            self.add_sublayer(f'linear_{i}', linear)
             self._mlp_layers_b.append(linear)
             act = paddle.nn.ReLU()
-            self.add_sublayer('act_%d' % i, act)
+            self.add_sublayer(f'act_{i}', act)
             self._mlp_layers_b.append(act)
 
         # top fc
@@ -189,10 +189,10 @@ class FlDNNLayer(nn.Layer):
                     )
                 ),
             )
-            self.add_sublayer('linear_%d' % i, linear)
+            self.add_sublayer(f'linear_{i}', linear)
             self._mlp_layers_top.append(linear)
             act = paddle.nn.ReLU()
-            self.add_sublayer('act_%d' % i, act)
+            self.add_sublayer(f'act_{i}', act)
             self._mlp_layers_top.append(act)
 
     def bottom_a_layer(self, sparse_inputs):

--- a/test/xpu/process_group_bkcl.py
+++ b/test/xpu/process_group_bkcl.py
@@ -44,7 +44,7 @@ class TestProcessGroupFp32(unittest.TestCase):
 
     def test_create_process_group_bkcl(self):
         device_id = paddle.distributed.ParallelEnv().dev_id
-        paddle.set_device('xpu:%d' % device_id)
+        paddle.set_device(f'xpu:{device_id}')
 
         pg = init_process_group()
         sys.stdout.write(

--- a/test/xpu/test_collective_api_base.py
+++ b/test/xpu/test_collective_api_base.py
@@ -274,10 +274,10 @@ class TestDistBase(unittest.TestCase):
         tr0_cmd = tr_cmd % (self._python_interp, model_file)
         tr1_cmd = tr_cmd % (self._python_interp, model_file)
         path0 = os.path.join(
-            self.temp_dir.name, "/tmp/tr0_err_%d.log" % os.getpid()
+            self.temp_dir.name, f"/tmp/tr0_err_{os.getpid()}.log"
         )
         path1 = os.path.join(
-            self.temp_dir.name, "/tmp/tr1_err_%d.log" % os.getpid()
+            self.temp_dir.name, f"/tmp/tr1_err_{os.getpid()}.log"
         )
         tr0_pipe = open(path0, "w")
         tr1_pipe = open(path1, "w")

--- a/test/xpu/test_distribute_fpn_proposals_op_xpu.py
+++ b/test/xpu/test_distribute_fpn_proposals_op_xpu.py
@@ -69,8 +69,7 @@ class XPUTestDistributeFPNProposalsOp(XPUOpTestWrapper):
                 'pixel_offset': self.pixel_offset,
             }
             output = [
-                ('out%d' % i, self.rois_fpn[i])
-                for i in range(len(self.rois_fpn))
+                (f'out{i}', self.rois_fpn[i]) for i in range(len(self.rois_fpn))
             ]
 
             self.outputs = {
@@ -180,12 +179,11 @@ class XPUTestDistributeFPNProposalsOp(XPUOpTestWrapper):
                 'pixel_offset': self.pixel_offset,
             }
             output = [
-                ('out%d' % i, self.rois_fpn[i])
-                for i in range(len(self.rois_fpn))
+                (f'out{i}', self.rois_fpn[i]) for i in range(len(self.rois_fpn))
             ]
             rois_num_per_level = [
                 (
-                    'rois_num%d' % i,
+                    f'rois_num{i}',
                     np.array(self.rois_fpn[i][1][0]).astype('int32'),
                 )
                 for i in range(len(self.rois_fpn))

--- a/test/xpu/test_meshgrid_op_xpu.py
+++ b/test/xpu/test_meshgrid_op_xpu.py
@@ -66,9 +66,9 @@ class XPUTestMeshGridOp(XPUOpTestWrapper):
 
         def set_inputs(self):
             ins, outs = self.init_test_data()
-            self.inputs = {'X': [('x%d' % i, ins[i]) for i in range(len(ins))]}
+            self.inputs = {'X': [(f'x{i}', ins[i]) for i in range(len(ins))]}
             self.outputs = {
-                'Out': [('out%d' % i, outs[i]) for i in range(len(outs))]
+                'Out': [(f'out{i}', outs[i]) for i in range(len(outs))]
             }
 
         def set_output(self):

--- a/test/xpu/test_parallel_dygraph_dataparallel.py
+++ b/test/xpu/test_parallel_dygraph_dataparallel.py
@@ -44,7 +44,7 @@ def get_cluster_from_args(selected_xpus):
 
     trainer_endpoints = []
     for ip in node_ips:
-        trainer_endpoints.append(["%s:%d" % (ip, port) for port in free_ports])
+        trainer_endpoints.append([f"{ip}:{port}" for port in free_ports])
     return get_cluster(node_ips, node_ip, trainer_endpoints, selected_xpus)
 
 
@@ -76,9 +76,9 @@ def start_local_trainers(
             "FLAGS_selected_xpus": "{}".format(
                 ",".join([str(g) for g in t.gpus])
             ),
-            "PADDLE_TRAINER_ID": "%d" % t.rank,
-            "PADDLE_CURRENT_ENDPOINT": f"{t.endpoint}",
-            "PADDLE_TRAINERS_NUM": "%d" % cluster.trainers_nranks(),
+            "PADDLE_TRAINER_ID": str(t.rank),
+            "PADDLE_CURRENT_ENDPOINT": str(t.endpoint),
+            "PADDLE_TRAINERS_NUM": str(cluster.trainers_nranks()),
             "PADDLE_TRAINER_ENDPOINTS": ",".join(cluster.trainers_endpoints()),
         }
 

--- a/test/xpu/test_split_op_xpu.py
+++ b/test/xpu/test_split_op_xpu.py
@@ -50,7 +50,7 @@ class XPUTestSplitOp(XPUOpTestWrapper):
 
             out = np.split(self.x, self.indices_or_sections, self.axis)
             self.outputs = {
-                'Out': [('out%d' % i, out[i]) for i in range(len(out))]
+                'Out': [(f'out{i}', out[i]) for i in range(len(out))]
             }
 
         def init_dtype(self):

--- a/test/xpu/test_top_k_v2_op_xpu.py
+++ b/test/xpu/test_top_k_v2_op_xpu.py
@@ -34,7 +34,7 @@ def random_unique_float(shape, dtype):
     arr = np.unique(arr)
     assert (
         arr.shape[0] >= numel
-    ), "failed to create enough unique values: %d vs %d" % (arr.shape[0], numel)
+    ), f"failed to create enough unique values: {arr.shape[0]} vs {numel}"
     arr = arr[:numel]
     np.random.shuffle(arr)
     arr = arr.reshape(shape)

--- a/test/xpu/test_unbind_op_xpu.py
+++ b/test/xpu/test_unbind_op_xpu.py
@@ -127,9 +127,7 @@ class XPUTestUnbindOP(XPUOpTestWrapper):
             self.attrs = {'axis': self.axis}
             self.setAxis()
             self.outputs = {
-                'Out': [
-                    ('out%d' % i, self.out[i]) for i in range(len(self.out))
-                ]
+                'Out': [(f'out{i}', self.out[i]) for i in range(len(self.out))]
             }
 
         def _set_op_type(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

继 #65585 part19 后再次对 %x 形式 format 替换，因为 Ruff 0.8[^1] UP031 检查又有修改，现在只要是 %x 的形式都会抛出 UP031，即便没有自动修复，而有自动修复的之前已经全部修复过了，剩下的都是没有自动修复的，需要手动修复

> [!CAUTION]
>
> 相关地方均为手动逐个修复，需要仔细 review！

### Related links

- #70031
- #70033
- #70034
- #70035
- #70036
- #70037
- #70043

PCard-66972

[^1]: [Ruff 0.8 release notes](https://github.com/astral-sh/ruff/releases/tag/0.8.0)