### PR TITLE
[CodeStyle][UP031] Use f-string instead of percent format in legacy uts (part28)

### DIFF
--- a/test/legacy_test/test_cholesky_op.py
+++ b/test/legacy_test/test_cholesky_op.py
@@ -114,8 +114,8 @@ class TestCholeskyOp(OpTest):
             if x_init:
                 if len(x_init) != len(root):
                     raise ValueError(
-                        'len(x_init) (=%d) is not the same'
-                        ' as len(x) (= %d)' % (len(x_init), len(root))
+                        f'len(x_init) (={len(x_init)}) is not the same'
+                        f' as len(x) (={len(root)})'
                     )
                 # init variable in main program
                 for var, arr in zip(root, x_init):

--- a/test/legacy_test/test_collect_fpn_proposals_op.py
+++ b/test/legacy_test/test_collect_fpn_proposals_op.py
@@ -23,12 +23,12 @@ class TestCollectFPNProposalstOp(OpTest):
         self.init_test_case()
         self.make_rois()
         self.scores_input = [
-            ('y%d' % i, (self.scores[i].reshape(-1, 1), self.rois_lod[i]))
+            (f'y{i}', (self.scores[i].reshape(-1, 1), self.rois_lod[i]))
             for i in range(self.num_level)
         ]
         self.rois, self.lod = self.calc_rois_collect()
         inputs_x = [
-            ('x%d' % i, (self.roi_inputs[i][:, 1:], self.rois_lod[i]))
+            (f'x{i}', (self.roi_inputs[i][:, 1:], self.rois_lod[i]))
             for i in range(self.num_level)
         ]
         self.inputs = {
@@ -107,16 +107,16 @@ class TestCollectFPNProposalstOpWithRoisNum(TestCollectFPNProposalstOp):
         self.init_test_case()
         self.make_rois()
         self.scores_input = [
-            ('y%d' % i, (self.scores[i].reshape(-1, 1), self.rois_lod[i]))
+            (f'y{i}', (self.scores[i].reshape(-1, 1), self.rois_lod[i]))
             for i in range(self.num_level)
         ]
         self.rois, self.lod = self.calc_rois_collect()
         inputs_x = [
-            ('x%d' % i, (self.roi_inputs[i][:, 1:], self.rois_lod[i]))
+            (f'x{i}', (self.roi_inputs[i][:, 1:], self.rois_lod[i]))
             for i in range(self.num_level)
         ]
         rois_num_per_level = [
-            ('rois%d' % i, np.array(self.rois_lod[i][0]).astype('int32'))
+            (f'rois{i}', np.array(self.rois_lod[i][0]).astype('int32'))
             for i in range(self.num_level)
         ]
 

--- a/test/legacy_test/test_collective_api_base.py
+++ b/test/legacy_test/test_collective_api_base.py
@@ -280,10 +280,10 @@ class TestDistBase(unittest.TestCase):
         tr0_cmd = tr_cmd % (self._python_interp, model_file)
         tr1_cmd = tr_cmd % (self._python_interp, model_file)
         path0 = os.path.join(
-            self.temp_dir.name, "/tmp/tr0_err_%d.log" % os.getpid()
+            self.temp_dir.name, f"/tmp/tr0_err_{os.getpid()}.log"
         )
         path1 = os.path.join(
-            self.temp_dir.name, "/tmp/tr1_err_%d.log" % os.getpid()
+            self.temp_dir.name, f"/tmp/tr1_err_{os.getpid()}.log"
         )
         tr0_pipe = open(path0, "w")
         tr1_pipe = open(path1, "w")

--- a/test/legacy_test/test_dist_base.py
+++ b/test/legacy_test/test_dist_base.py
@@ -225,7 +225,7 @@ class TestDistRunnerBase:
         )
 
         device_id = int(os.getenv("FLAGS_selected_gpus", "0"))
-        eprint(type(self).__name__, "device_id: %d." % device_id)
+        eprint(type(self).__name__, f"device_id: {device_id}.")
         place = base.CUDAPlace(device_id)
 
         exe = base.Executor(place)
@@ -775,7 +775,7 @@ class TestParallelDyGraphRunnerBase:
                 if step_id % 10 == 0:
                     print_to_err(
                         type(self).__name__,
-                        "loss at step %d: %f" % (step_id, loss.numpy()),
+                        f"loss at step {step_id}: {loss.numpy().item():f}",
                     )
                 out_losses.append(loss.numpy())
 
@@ -1128,9 +1128,9 @@ class TestDistBase(unittest.TestCase):
         )
 
         if batch_size != DEFAULT_BATCH_SIZE:
-            cmd += " --batch_size %d" % batch_size
+            cmd += f" --batch_size {batch_size}"
         if batch_merge_repeat > 1:
-            cmd += " --batch_merge_repeat %d" % batch_merge_repeat
+            cmd += f" --batch_merge_repeat {batch_merge_repeat}"
         if self._nccl2_reduce_layer:
             cmd += " --nccl2_reduce_layer_local_run 1"
 

--- a/test/legacy_test/test_dist_base.py
+++ b/test/legacy_test/test_dist_base.py
@@ -225,7 +225,7 @@ class TestDistRunnerBase:
         )
 
         device_id = int(os.getenv("FLAGS_selected_gpus", "0"))
-        eprint(type(self).__name__, f"device_id: {device_id}.")
+        eprint(type(self).__name__, "device_id: %d." % device_id)
         place = base.CUDAPlace(device_id)
 
         exe = base.Executor(place)

--- a/test/legacy_test/test_dist_fleet_sparse_embedding_ctr.py
+++ b/test/legacy_test/test_dist_fleet_sparse_embedding_ctr.py
@@ -231,7 +231,7 @@ class TestDistMnistAsync2x2WithGauss(TestFleetBase):
                     weight_attr=base.ParamAttr(
                         initializer=paddle.nn.initializer.Constant(value=0.01)
                     ),
-                    name='dnn-fc-%d' % i,
+                    name=f'dnn-fc-{i}',
                 )
                 dnn_out = fc
 

--- a/test/legacy_test/test_dist_hapi_model.py
+++ b/test/legacy_test/test_dist_hapi_model.py
@@ -43,7 +43,7 @@ def get_cluster_from_args(selected_gpus):
 
     trainer_endpoints = []
     for ip in node_ips:
-        trainer_endpoints.append(["%s:%d" % (ip, port) for port in free_ports])
+        trainer_endpoints.append([f"{ip}:{port}" for port in free_ports])
     return get_cluster(node_ips, node_ip, trainer_endpoints, selected_gpus)
 
 
@@ -73,9 +73,9 @@ def start_local_trainers(
             "FLAGS_selected_gpus": "{}".format(
                 ",".join([str(g) for g in t.gpus])
             ),
-            "PADDLE_TRAINER_ID": "%d" % t.rank,
-            "PADDLE_CURRENT_ENDPOINT": f"{t.endpoint}",
-            "PADDLE_TRAINERS_NUM": "%d" % cluster.trainers_nranks(),
+            "PADDLE_TRAINER_ID": str(t.rank),
+            "PADDLE_CURRENT_ENDPOINT": str(t.endpoint),
+            "PADDLE_TRAINERS_NUM": str(cluster.trainers_nranks()),
             "PADDLE_TRAINER_ENDPOINTS": ",".join(cluster.trainers_endpoints()),
         }
 

--- a/test/legacy_test/test_dist_train.py
+++ b/test/legacy_test/test_dist_train.py
@@ -46,7 +46,7 @@ class TestSendOp(unittest.TestCase):
         self.ps_timeout = 5
         self._wait_ps_ready(p.pid)
 
-        with open("/tmp/paddle.%d.port" % p.pid, "r") as fn:
+        with open(f"/tmp/paddle.{p.pid}.port", "r") as fn:
             selected_port = int(fn.readlines()[0])
         self.init_client(place, selected_port)
 
@@ -65,7 +65,7 @@ class TestSendOp(unittest.TestCase):
             try:
                 # the listen_and_serv_op would touch a file which contains the listen port
                 # on the /tmp directory until it was ready to process all the RPC call.
-                os.stat("/tmp/paddle.%d.port" % pid)
+                os.stat(f"/tmp/paddle.{pid}.port")
                 return
             except OSError:
                 start_left_time -= sleep_time
@@ -129,8 +129,8 @@ class TestSendOp(unittest.TestCase):
             #
             # BTW, `Send` is not a public API to users. So I set
             # `x.persistable = True` to be a hot fix of this unittest.
-            Send("127.0.0.1:%d" % port, [x])
-            o = Recv("127.0.0.1:%d" % port, [get_var])
+            Send(f"127.0.0.1:{port}", [x])
+            o = Recv(f"127.0.0.1:{port}", [get_var])
 
         exe = base.Executor(place)
         self.dist_out = exe.run(main, fetch_list=o)  # o is a list

--- a/test/legacy_test/test_distribute_fpn_proposals_op.py
+++ b/test/legacy_test/test_distribute_fpn_proposals_op.py
@@ -53,7 +53,7 @@ class TestDistributeFPNProposalsOp(OpTest):
             'pixel_offset': self.pixel_offset,
         }
         output = [
-            ('out%d' % i, self.rois_fpn[i]) for i in range(len(self.rois_fpn))
+            (f'out{i}', self.rois_fpn[i]) for i in range(len(self.rois_fpn))
         ]
 
         self.outputs = {
@@ -162,10 +162,10 @@ class TestDistributeFPNProposalsOpWithRoisNum(TestDistributeFPNProposalsOp):
             'pixel_offset': self.pixel_offset,
         }
         output = [
-            ('out%d' % i, self.rois_fpn[i]) for i in range(len(self.rois_fpn))
+            (f'out{i}', self.rois_fpn[i]) for i in range(len(self.rois_fpn))
         ]
         rois_num_per_level = [
-            ('rois_num%d' % i, np.array(self.rois_fpn[i][1][0]).astype('int32'))
+            (f'rois_num{i}', np.array(self.rois_fpn[i][1][0]).astype('int32'))
             for i in range(len(self.rois_fpn))
         ]
 

--- a/test/legacy_test/test_fleet_base_single.py
+++ b/test/legacy_test/test_fleet_base_single.py
@@ -151,8 +151,7 @@ class TestFleetBaseSingleRunPS(unittest.TestCase):
                     fetch_list=[avg_cost.name],
                 )
                 print(
-                    "worker_index: %d, step%d cost = %f"
-                    % (fleet.worker_index(), i, cost_val[0])
+                    f"worker_index: {fleet.worker_index()}, step{i} cost = {cost_val[0]:f}"
                 )
 
 

--- a/test/legacy_test/test_fusion_transpose_flatten_concat_op.py
+++ b/test/legacy_test/test_fusion_transpose_flatten_concat_op.py
@@ -33,7 +33,7 @@ class TestFusionTransposeFlattenConcationOp(OpTest):
         for i in range(len(self.shapes)):
             in_shape = self.shapes[i]
             a = np.random.random(in_shape).astype("float32")
-            ins.append(("x%d" % i, a))
+            ins.append((f"x{i}", a))
 
             b = a.transpose(self.trans_axis)
             flat_shape = (

--- a/test/legacy_test/test_imperative_deepcf.py
+++ b/test/legacy_test/test_imperative_deepcf.py
@@ -38,7 +38,7 @@ class DMF(paddle.nn.Layer):
         for i in range(len(self._hid_sizes)):
             self._user_layers.append(
                 self.add_sublayer(
-                    'user_layer_%d' % i,
+                    f'user_layer_{i}',
                     Linear(
                         256 if i == 0 else self._hid_sizes[i - 1],
                         self._hid_sizes[i],
@@ -47,13 +47,13 @@ class DMF(paddle.nn.Layer):
             )
             self._user_layers.append(
                 self.add_sublayer(
-                    'user_layer_act_%d' % i,
+                    f'user_layer_act_{i}',
                     paddle.nn.ReLU(),
                 )
             )
             self._item_layers.append(
                 self.add_sublayer(
-                    'item_layer_%d' % i,
+                    f'item_layer_{i}',
                     Linear(
                         256 if i == 0 else self._hid_sizes[i - 1],
                         self._hid_sizes[i],
@@ -62,7 +62,7 @@ class DMF(paddle.nn.Layer):
             )
             self._item_layers.append(
                 self.add_sublayer(
-                    'item_layer_act_%d' % i,
+                    f'item_layer_act_{i}',
                     paddle.nn.ReLU(),
                 )
             )
@@ -87,7 +87,7 @@ class MLP(paddle.nn.Layer):
         for i in range(len(self._hid_sizes)):
             self._match_layers.append(
                 self.add_sublayer(
-                    'match_layer_%d' % i,
+                    f'match_layer_{i}',
                     Linear(
                         256 * 2 if i == 0 else self._hid_sizes[i - 1],
                         self._hid_sizes[i],
@@ -96,7 +96,7 @@ class MLP(paddle.nn.Layer):
             )
             self._match_layers.append(
                 self.add_sublayer(
-                    'match_layer_act_%d' % i,
+                    f'match_layer_act_{i}',
                     paddle.nn.ReLU(),
                 )
             )
@@ -278,7 +278,7 @@ class TestDygraphDeepCF(unittest.TestCase):
             )
             exe.run(startup)
             for e in range(self.num_epoches):
-                sys.stderr.write('epoch %d\n' % e)
+                sys.stderr.write(f'epoch {e}\n')
                 for slice in range(
                     0, self.batch_size * self.num_batches, self.batch_size
                 ):
@@ -308,7 +308,7 @@ class TestDygraphDeepCF(unittest.TestCase):
             deepcf = DeepCF(num_users, num_items, matrix)
             adam = paddle.optimizer.Adam(0.01, parameters=deepcf.parameters())
             for e in range(self.num_epoches):
-                sys.stderr.write('epoch %d\n' % e)
+                sys.stderr.write(f'epoch {e}\n')
                 for slice in range(
                     0, self.batch_size * self.num_batches, self.batch_size
                 ):
@@ -344,7 +344,7 @@ class TestDygraphDeepCF(unittest.TestCase):
             adam2 = paddle.optimizer.Adam(0.01, parameters=deepcf2.parameters())
             base.set_flags({'FLAGS_sort_sum_gradient': True})
             for e in range(self.num_epoches):
-                sys.stderr.write('epoch %d\n' % e)
+                sys.stderr.write(f'epoch {e}\n')
                 for slice in range(
                     0, self.batch_size * self.num_batches, self.batch_size
                 ):
@@ -380,7 +380,7 @@ class TestDygraphDeepCF(unittest.TestCase):
             adam = paddle.optimizer.Adam(0.01, parameters=deepcf.parameters())
 
             for e in range(self.num_epoches):
-                sys.stderr.write('epoch %d\n' % e)
+                sys.stderr.write(f'epoch {e}\n')
                 for slice in range(
                     0, self.batch_size * self.num_batches, self.batch_size
                 ):

--- a/test/legacy_test/test_imperative_ptb_rnn.py
+++ b/test/legacy_test/test_imperative_ptb_rnn.py
@@ -83,7 +83,7 @@ class SimpleLSTMRNN(paddle.nn.Layer):
                     low=-self._init_scale, high=self._init_scale
                 ),
             )
-            self.weight_1_arr.append(self.add_parameter('w_%d' % i, weight_1))
+            self.weight_1_arr.append(self.add_parameter(f'w_{i}', weight_1))
             bias_1 = self.create_parameter(
                 attr=base.ParamAttr(
                     initializer=paddle.nn.initializer.Uniform(
@@ -94,7 +94,7 @@ class SimpleLSTMRNN(paddle.nn.Layer):
                 dtype="float32",
                 default_initializer=paddle.nn.initializer.Constant(0.0),
             )
-            self.bias_arr.append(self.add_parameter('b_%d' % i, bias_1))
+            self.bias_arr.append(self.add_parameter(f'b_{i}', bias_1))
 
     def forward(self, input_embedding, init_hidden=None, init_cell=None):
         self.cell_array = []

--- a/test/legacy_test/test_imperative_resnet.py
+++ b/test/legacy_test/test_imperative_resnet.py
@@ -198,7 +198,7 @@ class ResNet(paddle.nn.Layer):
             shortcut = False
             for i in range(depth[block]):
                 bottleneck_block = self.add_sublayer(
-                    'bb_%d_%d' % (block, i),
+                    f'bb_{block}_{i}',
                     BottleneckBlock(
                         num_channels=(
                             num_channels[block]

--- a/test/legacy_test/test_imperative_save_load_v2.py
+++ b/test/legacy_test/test_imperative_save_load_v2.py
@@ -57,7 +57,7 @@ class SimpleLSTMRNN(paddle.nn.Layer):
                     low=-self._init_scale, high=self._init_scale
                 ),
             )
-            self.weight_1_arr.append(self.add_parameter('w_%d' % i, weight_1))
+            self.weight_1_arr.append(self.add_parameter(f'w_{i}', weight_1))
             bias_1 = self.create_parameter(
                 attr=base.ParamAttr(
                     initializer=paddle.nn.initializer.Uniform(
@@ -68,7 +68,7 @@ class SimpleLSTMRNN(paddle.nn.Layer):
                 dtype="float32",
                 default_initializer=paddle.nn.initializer.Constant(0.0),
             )
-            self.bias_arr.append(self.add_parameter('b_%d' % i, bias_1))
+            self.bias_arr.append(self.add_parameter(f'b_{i}', bias_1))
 
     def forward(self, input_embedding, init_hidden=None, init_cell=None):
         self.cell_array = []

--- a/test/legacy_test/test_imperative_se_resnext.py
+++ b/test/legacy_test/test_imperative_se_resnext.py
@@ -263,7 +263,7 @@ class SeResNeXt(paddle.nn.Layer):
             shortcut = False
             for i in range(depth[block]):
                 bottleneck_block = self.add_sublayer(
-                    'bb_%d_%d' % (block, i),
+                    f'bb_{block}_{i}',
                     BottleneckBlock(
                         num_channels=num_channels,
                         num_filters=num_filters[block],

--- a/test/legacy_test/test_imperative_transformer_sorted_gradient.py
+++ b/test/legacy_test/test_imperative_transformer_sorted_gradient.py
@@ -643,7 +643,7 @@ class EncoderLayer(Layer):
         for i in range(n_layer):
             self._encoder_sublayers.append(
                 self.add_sublayer(
-                    'esl_%d' % i,
+                    f'esl_{i}',
                     EncoderSubLayer(
                         n_head,
                         d_key,
@@ -922,7 +922,7 @@ class DecoderLayer(Layer):
         for i in range(n_layer):
             self._decoder_sub_layers.append(
                 self.add_sublayer(
-                    'dsl_%d' % i,
+                    f'dsl_{i}',
                     DecoderSubLayer(
                         n_head,
                         d_key,

--- a/test/legacy_test/test_listen_and_serv_op.py
+++ b/test/legacy_test/test_listen_and_serv_op.py
@@ -147,7 +147,7 @@ class TestListenAndServOp(unittest.TestCase):
             try:
                 # the listen_and_serv_op would touch a file which contains the listen port
                 # on the /tmp directory until it was ready to process all the RPC call.
-                os.stat("/tmp/paddle.%d.port" % pid)
+                os.stat(f"/tmp/paddle.{pid}.port")
                 return
             except OSError:
                 start_left_time -= sleep_time

--- a/test/legacy_test/test_parallel_dygraph_dataparallel.py
+++ b/test/legacy_test/test_parallel_dygraph_dataparallel.py
@@ -43,7 +43,7 @@ def get_cluster_from_args(selected_devices):
 
     trainer_endpoints = []
     for ip in node_ips:
-        trainer_endpoints.append(["%s:%d" % (ip, port) for port in free_ports])
+        trainer_endpoints.append([f"{ip}:{port}" for port in free_ports])
     return get_cluster(node_ips, node_ip, trainer_endpoints, selected_devices)
 
 
@@ -65,9 +65,9 @@ def start_local_trainers_cpu(
     for rank_id, endpoint in enumerate(trainer_endpoints):
         proc_env = {
             "PADDLE_DISTRI_BACKEND": "gloo",
-            "PADDLE_TRAINER_ID": "%d" % rank_id,
-            "PADDLE_CURRENT_ENDPOINT": f"{endpoint}",
-            "PADDLE_TRAINERS_NUM": "%d" % n_rank,
+            "PADDLE_TRAINER_ID": str(rank_id),
+            "PADDLE_CURRENT_ENDPOINT": str(endpoint),
+            "PADDLE_TRAINERS_NUM": str(n_rank),
             "PADDLE_TRAINER_ENDPOINTS": ",".join(trainer_endpoints),
         }
 
@@ -121,9 +121,9 @@ def start_local_trainers(
             f"FLAGS_selected_{accelerator_type}s": "{}".format(
                 ",".join([str(g) for g in t.gpus])
             ),
-            "PADDLE_TRAINER_ID": "%d" % t.rank,
-            "PADDLE_CURRENT_ENDPOINT": f"{t.endpoint}",
-            "PADDLE_TRAINERS_NUM": "%d" % cluster.trainers_nranks(),
+            "PADDLE_TRAINER_ID": str(t.rank),
+            "PADDLE_CURRENT_ENDPOINT": str(t.endpoint),
+            "PADDLE_TRAINERS_NUM": str(cluster.trainers_nranks()),
             "PADDLE_TRAINER_ENDPOINTS": ",".join(cluster.trainers_endpoints()),
         }
 

--- a/test/legacy_test/test_parallel_dygraph_dataparallel_cpuonly.py
+++ b/test/legacy_test/test_parallel_dygraph_dataparallel_cpuonly.py
@@ -42,7 +42,7 @@ def get_cluster_from_args(selected_gpus):
 
     trainer_endpoints = []
     for ip in node_ips:
-        trainer_endpoints.append(["%s:%d" % (ip, port) for port in free_ports])
+        trainer_endpoints.append([f"{ip}:{port}" for port in free_ports])
     return get_cluster(node_ips, node_ip, trainer_endpoints, selected_gpus)
 
 
@@ -65,9 +65,9 @@ def start_local_trainers(
     procs = []
     for t in pod.trainers:
         proc_env = {
-            "PADDLE_TRAINER_ID": "%d" % t.rank,
-            "PADDLE_CURRENT_ENDPOINT": f"{t.endpoint}",
-            "PADDLE_TRAINERS_NUM": "%d" % cluster.trainers_nranks(),
+            "PADDLE_TRAINER_ID": str(t.rank),
+            "PADDLE_CURRENT_ENDPOINT": str(t.endpoint),
+            "PADDLE_TRAINERS_NUM": str(cluster.trainers_nranks()),
             "PADDLE_TRAINER_ENDPOINTS": ",".join(cluster.trainers_endpoints()),
             "MASTER_ADDR": "127.0.0.1",
             "MASTER_PORT": "6170",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

继 #65585 part19 后再次对 %x 形式 format 替换，因为 Ruff 0.8[^1] UP031 检查又有修改，现在只要是 %x 的形式都会抛出 UP031，即便没有自动修复，而有自动修复的之前已经全部修复过了，剩下的都是没有自动修复的，需要手动修复

> [!CAUTION]
>
> 相关地方均为手动逐个修复，需要仔细 review！

### Related links

- #70031
- #70033
- #70034
- #70035
- #70036
- #70037
- #70043
- #70044

PCard-66972

[^1]: [Ruff 0.8 release notes](https://github.com/astral-sh/ruff/releases/tag/0.8.0)