### PR TITLE
[CodeStyle][UP031] Use f-string instead of percent format in legacy uts (part29)

### DIFF
--- a/test/ir/pass_test.py
+++ b/test/ir/pass_test.py
@@ -166,17 +166,9 @@ class PassTest(unittest.TestCase):
                 offset = np.argmax(diff_mat > atol)
                 self.assertTrue(
                     is_allclose,
-                    "Output (name: %s, shape: %s, dtype: %s) has diff at %s. The maximum diff is %e, first error element is %d, expected %e, but got %e"
-                    % (
-                        self.fetch_list[i].name,
-                        str(self.fetch_list[i].shape),
-                        self.fetch_list[i].dtype,
-                        str(place),
-                        max_diff,
-                        offset,
-                        a.flatten()[offset],
-                        b.flatten()[offset],
-                    ),
+                    f"Output (name: {self.fetch_list[i].name}, shape: {self.fetch_list[i].shape!s}, dtype: {self.fetch_list[i].dtype}) "
+                    f"has diff at {place!s}. The maximum diff is {max_diff:e}, first error element is {offset}, "
+                    f"expected {a.flatten()[offset].item():e}, but got {b.flatten()[offset].item():e}",
                 )
 
     def _check_fused_ops(self, program):

--- a/test/legacy_test/auto_parallel_op_test.py
+++ b/test/legacy_test/auto_parallel_op_test.py
@@ -512,14 +512,8 @@ class AutoParallelForwardChecker:
                     atol=self.rtol,
                     err_msg=(
                         'Check eager auto parallel failed. Mismatch between eager auto parallel outputs '
-                        'and eager outputs on %s, the eager forward output tensor\'s index is : %d \n'
-                        'eager auto parallel output tensor:\n%s\n eager output tensor:\n%s\n'
-                        % (
-                            str(self.place),
-                            i,
-                            actual_ret[i],
-                            self.eager_forward_desire[i],
-                        )
+                        f'and eager outputs on {self.place!s}, the eager forward output tensor\'s index is : {i} \n'
+                        f'eager auto parallel output tensor:\n{actual_ret[i]}\n eager output tensor:\n{self.eager_forward_desire[i]}\n'
                     ),
                 )
 
@@ -731,14 +725,8 @@ class AutoParallelGradChecker(AutoParallelForwardChecker):
                     atol=self.rtol,
                     err_msg=(
                         'Check eager auto parallel failed. Mismatch between eager auto parallel outputs '
-                        'and eager outputs on %s, the eager forward output tensor\'s index is : %d \n'
-                        'eager auto parallel output tensor:\n%s\n eager output tensor:\n%s\n'
-                        % (
-                            str(self.place),
-                            i,
-                            actual_forward_res[i],
-                            self.eager_forward_desire[i],
-                        )
+                        f'and eager outputs on {self.place!s}, the eager forward output tensor\'s index is : {i} \n'
+                        f'eager auto parallel output tensor:\n{actual_forward_res[i]}\n eager output tensor:\n{self.eager_forward_desire[i]}\n'
                     ),
                 )
 
@@ -757,14 +745,8 @@ class AutoParallelGradChecker(AutoParallelForwardChecker):
                     atol=self.rtol,
                     err_msg=(
                         'Check eager auto parallel backward failed. Mismatch between eager auto parallel grad outputs '
-                        'and eager grad outputs on %s, the eager grad output tensor\'s index is : %d \n'
-                        'eager auto parallel grad output tensor:\n%s\n eager grad output tensor:\n%s\n'
-                        % (
-                            str(self.place),
-                            i,
-                            actual_grad_res[i],
-                            self.eager_grad_desire[i],
-                        )
+                        f'and eager grad outputs on {self.place!s}, the eager grad output tensor\'s index is : {i} \n'
+                        f'eager auto parallel grad output tensor:\n{actual_grad_res[i]}\n eager grad output tensor:\n{self.eager_grad_desire[i]}\n'
                     ),
                 )
 

--- a/test/legacy_test/ctr_dataset_reader.py
+++ b/test/legacy_test/ctr_dataset_reader.py
@@ -119,8 +119,8 @@ def prepare_data():
     res = list(res)
     dnn_input_dim = res[0]
     lr_input_dim = res[1]
-    logger.info('dnn input dim: %d' % dnn_input_dim)
-    logger.info('lr input dim: %d' % lr_input_dim)
+    logger.info(f'dnn input dim: {dnn_input_dim}')
+    logger.info(f'lr input dim: {lr_input_dim}')
 
     return dnn_input_dim, lr_input_dim, train_file_path
 

--- a/test/legacy_test/dist_ctr.py
+++ b/test/legacy_test/dist_ctr.py
@@ -71,7 +71,7 @@ class TestDistCTR2x2(TestDistRunnerBase):
                 weight_attr=base.ParamAttr(
                     initializer=paddle.nn.initializer.Constant(value=0.01)
                 ),
-                name='dnn-fc-%d' % i,
+                name=f'dnn-fc-{i}',
             )
             dnn_out = fc
 

--- a/test/legacy_test/dist_ctr_reader.py
+++ b/test/legacy_test/dist_ctr_reader.py
@@ -168,6 +168,6 @@ def load_data_meta():
     ), err_info
     res = map(int, [_.split(':')[1] for _ in lines])
     res = list(res)
-    logger.info('dnn input dim: %d' % res[0])
-    logger.info('lr input dim: %d' % res[1])
+    logger.info(f'dnn input dim: {res[0]}')
+    logger.info(f'lr input dim: {res[1]}')
     return res

--- a/test/legacy_test/dist_fleet_ctr.py
+++ b/test/legacy_test/dist_fleet_ctr.py
@@ -120,7 +120,7 @@ class TestDistCTR2x2(FleetDistRunnerBase):
                 weight_attr=base.ParamAttr(
                     initializer=paddle.nn.initializer.Constant(value=0.01)
                 ),
-                name='dnn-fc-%d' % i,
+                name=f'dnn-fc-{i}',
             )
             dnn_out = fc
 

--- a/test/legacy_test/dist_fleet_heter_pipeline_ctr.py
+++ b/test/legacy_test/dist_fleet_heter_pipeline_ctr.py
@@ -107,7 +107,7 @@ class TestHeterPipelinePsCTR2x2(FleetDistHeterRunnerBase):
                     weight_attr=base.ParamAttr(
                         initializer=paddle.nn.initializer.Constant(value=0.01)
                     ),
-                    name='dnn-fc-%d' % i,
+                    name=f'dnn-fc-{i}',
                 )
                 dnn_out = fc
 

--- a/test/legacy_test/dist_fleet_sparse_embedding_ctr.py
+++ b/test/legacy_test/dist_fleet_sparse_embedding_ctr.py
@@ -112,7 +112,7 @@ class TestDistCTR2x2(FleetDistRunnerBase):
                 weight_attr=base.ParamAttr(
                     initializer=paddle.nn.initializer.Constant(value=0.01)
                 ),
-                name='dnn-fc-%d' % i,
+                name=f'dnn-fc-{i}',
             )
             dnn_out = fc
 

--- a/test/legacy_test/dist_test_utils.py
+++ b/test/legacy_test/dist_test_utils.py
@@ -25,4 +25,4 @@ def silentremove(filename):
 
 
 def remove_ps_flag(pid):
-    silentremove("/tmp/paddle.%d.port" % pid)
+    silentremove(f"/tmp/paddle.{pid}.port")

--- a/test/legacy_test/fleet_heter_ps_training.py
+++ b/test/legacy_test/fleet_heter_ps_training.py
@@ -100,7 +100,7 @@ def net(batch_size=4, lr=0.01):
                 weight_attr=base.ParamAttr(
                     initializer=paddle.nn.initializer.Constant(value=0.01)
                 ),
-                name='dnn-fc-%d' % i,
+                name=f'dnn-fc-{i}',
             )
             dnn_out = fc
 

--- a/test/legacy_test/fleet_ps_training.py
+++ b/test/legacy_test/fleet_ps_training.py
@@ -51,6 +51,5 @@ elif fleet.is_worker():
             program=fleet.main_program, feed=gen_data(), fetch_list=[cost.name]
         )
         print(
-            "worker_index: %d, step%d cost = %f"
-            % (fleet.worker_index(), i, cost_val[0])
+            f"worker_index: {fleet.worker_index()}, step{i} cost = {cost_val[0]:f}"
         )

--- a/test/legacy_test/gradient_checker.py
+++ b/test/legacy_test/gradient_checker.py
@@ -717,8 +717,8 @@ def get_static_double_grad(
     if x_init:
         if len(x_init) != len(x):
             raise ValueError(
-                'len(x_init) (=%d) is not the same'
-                ' as len(x) (= %d)' % (len(x_init), len(x))
+                f'len(x_init) (={len(x_init)}) is not the same'
+                f' as len(x) (={len(x)})'
             )
         # init variable in main program
         for var, arr in zip(x, x_init):
@@ -836,8 +836,8 @@ def get_pir_static_double_grad(
     if x_init:
         if len(x_init) != len(x):
             raise ValueError(
-                'len(x_init) (=%d) is not the same'
-                ' as len(x) (= %d)' % (len(x_init), len(x))
+                f'len(x_init) (={len(x_init)}) is not the same'
+                f' as len(x) (={len(x)})'
             )
         # init variable in main program
         for var, arr in zip(x, x_init):
@@ -1028,9 +1028,8 @@ def double_grad_check_for_dygraph(
         ):
             msg = (
                 'Check eager double result fail. Mismatch between static_graph double grad '
-                'and eager double grad on %s, the output double grad tensor\'s index is : %d \n'
-                'static:%s\n eager:%s\n'
-                % (str(place), i, static_double_grad[i], eager_double_grad[i])
+                f'and eager double grad on {place!s}, the output double grad tensor\'s index is : {i} \n'
+                f'static:{static_double_grad[i]}\n eager:{eager_double_grad[i]}\n'
             )
             return fail_test(msg)
 
@@ -1293,8 +1292,7 @@ def triple_grad_check_for_dygraph(
         ):
             msg = (
                 'Check eager double result fail. Mismatch between static_graph double grad '
-                'and eager double grad on %s, the output double grad tensor\'s index is : %d \n'
-                'static:%s\n eager:%s\n'
-                % (str(place), i, static_triple_grad[i], eager_triple_grad[i])
+                f'and eager double grad on {place!s}, the output double grad tensor\'s index is : {i} \n'
+                f'static:{static_triple_grad[i]}\n eager:{eager_triple_grad[i]}\n'
             )
             return fail_test(msg)

--- a/test/legacy_test/nets.py
+++ b/test/legacy_test/nets.py
@@ -496,34 +496,30 @@ def scaled_dot_product_attention(
     if not (len(queries.shape) == len(keys.shape) == len(values.shape) == 3):
         raise ValueError(
             "Inputs queries, keys and values should all be 3-D tensors."
-            "But received len(queries.shape) = %d, "
-            "len(keys.shape) = %d, len(values.shape) = %d."
-            % (len(queries.shape), len(keys.shape), len(values.shape))
+            f"But received len(queries.shape) = {len(queries.shape)}, "
+            f"len(keys.shape) = {len(keys.shape)}, len(values.shape) = {len(values.shape)}."
         )
 
     if queries.shape[-1] != keys.shape[-1]:
         raise ValueError(
             "The hidden size of queries and keys should be the same."
-            "But received queries' hidden size = %d and keys' hidden size = %d."
-            % (queries.shape[-1], keys.shape[-1])
+            f"But received queries' hidden size = {queries.shape[-1]} and keys' hidden size = {keys.shape[-1]}."
         )
     if keys.shape[-2] != values.shape[-2]:
         raise ValueError(
             "The max sequence length in value batch and in key batch "
             "should be the same. But received max sequence length in value batch "
-            "= %d, in key batch = %d." % (values.shape[-2], keys.shape[-2])
+            f"= {values.shape[-2]}, in key batch = {keys.shape[-2]}."
         )
     if keys.shape[-1] % num_heads != 0:
         raise ValueError(
-            "The hidden size of keys (%d) must be divisible "
-            "by the number of attention heads (%d)."
-            % (keys.shape[-1], num_heads)
+            f"The hidden size of keys ({keys.shape[-1]}) must be divisible "
+            f"by the number of attention heads ({num_heads})."
         )
     if values.shape[-1] % num_heads != 0:
         raise ValueError(
-            "The hidden size of values (%d) must be divisible "
-            "by the number of attention heads (%d)."
-            % (values.shape[-1], num_heads)
+            f"The hidden size of values ({values.shape[-1]}) must be divisible "
+            f"by the number of attention heads ({num_heads})."
         )
 
     def __compute_qkv(queries, keys, values, num_heads):

--- a/test/legacy_test/op.py
+++ b/test/legacy_test/op.py
@@ -90,8 +90,7 @@ class OpDescCreationMethod:
 
             if not input_parameter.duplicable and len(input_arguments) > 1:
                 raise ValueError(
-                    "Input %s expects only one input, but %d are given."
-                    % (input_parameter.name, len(input_arguments))
+                    f"Input {input_parameter.name} expects only one input, but {len(input_arguments)} are given."
                 )
 
             ipt = op_desc.inputs.add()
@@ -105,8 +104,7 @@ class OpDescCreationMethod:
 
             if not output_parameter.duplicable and len(output_arguments) > 1:
                 raise ValueError(
-                    "Output %s expects only one output, but %d are given."
-                    % (output_parameter.name, len(output_arguments))
+                    f"Output {output_parameter.name} expects only one output, but {len(output_arguments)} are given."
                 )
 
             out = op_desc.outputs.add()

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -3046,19 +3046,9 @@ class OpTest(unittest.TestCase):
                 def err_msg():
                     offset = np.argmax(diff_mat > max_relative_error)
                     return (
-                        "Operator %s error, %s variable %s (shape: %s, dtype: %s) max gradient diff %e over limit %e, "
-                        "the first error element is %d, expected %e, but got %e."
-                    ) % (
-                        self.op_type,
-                        msg_prefix,
-                        name,
-                        str(a.shape),
-                        self.dtype,
-                        max_diff,
-                        max_relative_error,
-                        offset,
-                        a.flatten()[offset],
-                        b.flatten()[offset],
+                        f"Operator {self.op_type} error, {msg_prefix} variable {name} (shape: {a.shape!s}, dtype: {self.dtype}) "
+                        f"max gradient diff {max_diff:e} over limit {max_relative_error:e}, "
+                        f"the first error element is {offset}, expected {a.flatten()[offset].item():e}, but got {b.flatten()[offset].item():e}."
                     )
 
                 self.assertLessEqual(max_diff, max_relative_error, err_msg())

--- a/test/legacy_test/prim_op_test.py
+++ b/test/legacy_test/prim_op_test.py
@@ -120,9 +120,9 @@ class OpTestUtils:
             return isinstance(a, Empty)
 
         def get_default(idx, defaults):
-            assert not isinstance(defaults[idx], Empty), (
-                "%d-th params of python api don't have default value." % idx
-            )
+            assert not isinstance(
+                defaults[idx], Empty
+            ), f"{idx}-th params of python api don't have default value."
             return defaults[idx]
 
         def to_defaults_list(params, defaults):
@@ -703,15 +703,10 @@ class PrimForwardChecker:
                 atol=self.fw_comp_atol,
                 err_msg=(
                     'Check static comp forward api out failed. Mismatch between static comp '
-                    'and eager on %s, when enable_fw_comp is %s,the forward api out tensor\'s index is : %d \n'
-                    'static comp forward api out tensor:\n%s\n eager forward api out tensor:\n%s\n'
-                    % (
-                        str(self.place),
-                        self.enable_fw_comp,
-                        i,
-                        ret[i],
-                        self.eager_desire[i],
-                    )
+                    f'and eager on {self.place!s}, when enable_fw_comp is {self.enable_fw_comp},'
+                    f'the forward api out tensor\'s index is : {i} \n'
+                    f'static comp forward api out tensor:\n{ret[i]}\n '
+                    f'eager forward api out tensor:\n{self.eager_desire[i]}\n'
                 ),
             )
         with dygraph_guard():
@@ -788,15 +783,10 @@ class PrimForwardChecker:
                     atol=atol,
                     err_msg=(
                         'Check jit comp forward api out failed. Mismatch between jit comp '
-                        'and eager on %s, when enable_fw_comp is %s,the forward api out tensor\'s index is : %d \n'
-                        'jit comp forward api out tensor:\n%s\n eager forward api out tensor:\n%s\n'
-                        % (
-                            str(self.place),
-                            self.enable_fw_comp,
-                            i,
-                            ret[i],
-                            self.eager_desire[i],
-                        )
+                        f'and eager on {self.place!s}, when enable_fw_comp is {self.enable_fw_comp},'
+                        f'the forward api out tensor\'s index is : {i} \n'
+                        f'jit comp forward api out tensor:\n{ret[i]}\n '
+                        f'eager forward api out tensor:\n{self.eager_desire[i]}\n'
                     ),
                 )
             core._set_prim_forward_enabled(False)
@@ -882,17 +872,12 @@ class PrimForwardChecker:
                     rtol=rtol,
                     atol=atol,
                     err_msg=(
-                        'Check jit comp with cinn forward api out failed. Mismatch between jit comp and eager on %s, '
-                        'when enable_fw_comp is %s, enable_cinn is %s, the forward api out tensor\'s index is : %d \n'
-                        'jit comp forward api out tensor:\n%s\n eager forward api out tensor:\n%s\n'
-                        % (
-                            str(self.place),
-                            self.enable_fw_comp,
-                            core.is_compiled_with_cinn() and self.enable_cinn,
-                            i,
-                            ret[i],
-                            self.eager_desire[i],
-                        )
+                        f'Check jit comp with cinn forward api out failed. Mismatch between jit comp and eager on {self.place!s}, '
+                        f'when enable_fw_comp is {self.enable_fw_comp}, '
+                        f'enable_cinn is {core.is_compiled_with_cinn() and self.enable_cinn}, '
+                        f'the forward api out tensor\'s index is : {i} \n'
+                        f'jit comp forward api out tensor:\n{ret[i]}\n '
+                        f'eager forward api out tensor:\n{self.eager_desire[i]}\n'
                     ),
                 )
             core._set_prim_forward_enabled(False)
@@ -1084,15 +1069,9 @@ class PrimGradChecker(PrimForwardChecker):
                     atol=rtol,
                     err_msg=(
                         'Check eager comp grad out failed. Mismatch between eager comp '
-                        'and eager on %s, when enable_rev_comp is %s,the eager comp grad out tensor\'s index is : %d \n'
-                        'eager comp grad out tensor:\n%s\n eager grad out tensor:\n%s\n'
-                        % (
-                            str(self.place),
-                            self.enable_rev_comp,
-                            i,
-                            actual_ret[i],
-                            self.eager_desire[i],
-                        )
+                        f'and eager on {self.place!s}, when enable_rev_comp is {self.enable_rev_comp},'
+                        f'the eager comp grad out tensor\'s index is : {i} \n'
+                        f'eager comp grad out tensor:\n{actual_ret[i]}\n eager grad out tensor:\n{self.eager_desire[i]}\n'
                     ),
                 )
             core.set_prim_eager_enabled(False)
@@ -1204,16 +1183,9 @@ class PrimGradChecker(PrimForwardChecker):
                 atol=atol,
                 err_msg=(
                     'Check static comp grad out failed. Mismatch between static comp '
-                    'and eager on %s, when enable_fw_comp is %s,enable_rev_comp is %s,the forward api out tensor\'s index is : %d \n'
-                    'static comp grad out tensor:\n%s\n eager grad out tensor:\n%s\n'
-                    % (
-                        str(self.place),
-                        self.enable_fw_comp,
-                        self.enable_rev_comp,
-                        i,
-                        actual_ret[i],
-                        self.eager_desire[i],
-                    )
+                    f'and eager on {self.place}, when enable_fw_comp is {self.enable_fw_comp},enable_rev_comp is { self.enable_rev_comp},'
+                    f'the forward api out tensor\'s index is : {i} \n'
+                    f'static comp grad out tensor:\n{actual_ret[i]}\n eager grad out tensor:\n{self.eager_desire[i]}\n'
                 ),
             )
         core._set_prim_forward_enabled(False)
@@ -1320,16 +1292,9 @@ class PrimGradChecker(PrimForwardChecker):
                     atol=atol,
                     err_msg=(
                         'Check jit comp grad out failed. Mismatch between jit comp '
-                        'and eager on %s, when enable_fw_comp is %s, enable_rev_comp is %s,the grad out tensor\'s index is : %d \n'
-                        'jit comp grad out tensor:\n%s\n eager grad out out tensor:\n%s\n'
-                        % (
-                            str(self.place),
-                            self.enable_fw_comp,
-                            self.enable_rev_comp,
-                            i,
-                            ret[i],
-                            self.eager_desire[i],
-                        )
+                        f'and eager on {self.place!s}, when enable_fw_comp is {self.enable_fw_comp}, '
+                        f'enable_rev_comp is {self.enable_rev_comp},the grad out tensor\'s index is : {i} \n'
+                        f'jit comp grad out tensor:\n{ret[i]}\n eager grad out out tensor:\n{self.eager_desire[i]}\n'
                     ),
                 )
             core._set_prim_forward_enabled(False)
@@ -1449,17 +1414,9 @@ class PrimGradChecker(PrimForwardChecker):
                     atol=atol,
                     err_msg=(
                         'Check jit comp with cinn grad out failed. Mismatch between jit comp with cinn '
-                        'and eager on %s, when enable_fw_comp is %s, enable_rev_comp is %s, enable_cinn is %s,'
-                        'the grad out tensor\'s index is : %d ,jit comp with cinn grad out tensor:\n%s\n eager grad out out tensor:\n%s\n'
-                        % (
-                            str(self.place),
-                            self.enable_fw_comp,
-                            self.enable_rev_comp,
-                            self.enable_cinn and core.is_compiled_with_cinn(),
-                            i,
-                            ret[i],
-                            self.eager_desire[i],
-                        )
+                        f'and eager on {self.place!s}, when enable_fw_comp is {self.enable_fw_comp}, '
+                        f'enable_rev_comp is {self.enable_rev_comp}, enable_cinn is {self.enable_cinn and core.is_compiled_with_cinn()},'
+                        f'the grad out tensor\'s index is : {i} ,jit comp with cinn grad out tensor:\n{ret[i]}\n eager grad out out tensor:\n{self.eager_desire[i]}\n'
                     ),
                 )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

继 #65585 part19 后再次对 %x 形式 format 替换，因为 Ruff 0.8[^1] UP031 检查又有修改，现在只要是 %x 的形式都会抛出 UP031，即便没有自动修复，而有自动修复的之前已经全部修复过了，剩下的都是没有自动修复的，需要手动修复

> [!CAUTION]
>
> 相关地方均为手动逐个修复，需要仔细 review！

### Related links

- #70031
- #70033
- #70034
- #70035
- #70036
- #70037
- #70043
- #70044
- #70045

PCard-66972

[^1]: [Ruff 0.8 release notes](https://github.com/astral-sh/ruff/releases/tag/0.8.0)