### PR TITLE
[CINN] Fix reshape fusion with dynamic shape

### DIFF
--- a/paddle/cinn/operator_fusion/graph_transformer/matcher.h
+++ b/paddle/cinn/operator_fusion/graph_transformer/matcher.h
@@ -226,8 +226,19 @@ struct TransposeOpMatcher {
 
 struct ReshapeOpMatcher {
   bool operator()(const PatternGraph& graph, const PatternNodePtr& node) {
+    auto has_dynamic_shape = [](const PatternNodePtr& node) {
+      const auto in_value = node->sink_op()->operand_source(0);
+      const auto out_value = node->sink_op()->result(0);
+      const auto in_shape = GetDimExprsFromValue(in_value);
+      const auto out_shape = GetDimExprsFromValue(out_value);
+      return GetShapeProduct(in_shape, 0, in_shape.size())
+                 .isa<std::int64_t>() &&
+             GetShapeProduct(out_shape, 0, out_shape.size())
+                 .isa<std::int64_t>();
+    };
     return node->ops().size() == 1 &&
-           node->sink_op()->name() == "cinn_op.reshape";
+           node->sink_op()->name() == "cinn_op.reshape" &&
+           has_dynamic_shape(node);
   }
 };
 

--- a/paddle/cinn/operator_fusion/utils.cc
+++ b/paddle/cinn/operator_fusion/utils.cc
@@ -177,22 +177,24 @@ std::vector<std::pair<size_t, size_t>> GetNonBroadCastDims(pir::Operation* op) {
   return res;
 }
 
+symbol::DimExpr GetShapeProduct(const std::vector<symbol::DimExpr>& shape,
+                                int start,
+                                int end) {
+  symbol::DimExpr product(1);
+  for (int i = start; i < end; ++i) {
+    product = product * shape[i];
+  }
+  return symbol::SimplifyDimExpr(product);
+}
+
 bool ShapeProductEqual(const std::vector<symbol::DimExpr>& in_shape,
                        const std::vector<symbol::DimExpr>& out_shape,
                        int in_start,
                        int in_end,
                        int out_start,
                        int out_end) {
-  symbol::DimExpr in_product(1);
-  symbol::DimExpr out_product(1);
-  for (int i = in_start; i < in_end; ++i) {
-    in_product = in_product * in_shape[i];
-  }
-  for (int i = out_start; i < out_end; ++i) {
-    out_product = out_product * out_shape[i];
-  }
-  return symbol::SimplifyDimExpr(in_product) ==
-         symbol::SimplifyDimExpr(out_product);
+  return GetShapeProduct(in_shape, in_start, in_end) ==
+         GetShapeProduct(out_shape, out_start, out_end);
 }
 
 std::vector<std::pair<int, int>> PartionReshapeAxes(

--- a/paddle/cinn/operator_fusion/utils.h
+++ b/paddle/cinn/operator_fusion/utils.h
@@ -642,6 +642,10 @@ std::vector<Int> ArangeVector(Int start, Int end, Int step = 1) {
   return res;
 }
 
+symbol::DimExpr GetShapeProduct(const std::vector<symbol::DimExpr>& shape,
+                                int start,
+                                int end);
+
 bool ShapeProductEqual(const std::vector<symbol::DimExpr>& in_shape,
                        const std::vector<symbol::DimExpr>& out_shape,
                        int in_start,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- 目前动态 Shape 有些问题（前端看到的 shape 和后端 lower 时的 shape 不一致）导致 ReshapeOp 融合报错，目前先禁止包含动态 shape 的 ReshapeOp 融合