### PR TITLE
[PIR-Auto-Parallel]refactor refined recompute pass in PIR mode

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -957,6 +957,10 @@ void BindOperation(py::module *m) {
                  attr_name,
                  pir::Int32Attribute::get(pir::IrContext::Instance(), val));
            })
+      .def("erase_attr",
+           [](Operation &self, std::string &attr_name) {
+             self.erase_attribute(attr_name);
+           })
       .def("attrs",
            [](Operation &self) -> py::dict {
              py::dict attrs_dict;

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -806,8 +806,9 @@ class Engine:
         apply_mix2dist_pass(dist_program)
 
         if mode == "train" and self._strategy.recompute.enable:
+            config = copy.deepcopy(self._strategy.recompute.to_dict())
             auto_parallel_recompute_pir_pass = new_pass(
-                "auto_parallel_recompute_pir", {}
+                "auto_parallel_recompute_pir", config
             )
             auto_parallel_recompute_pir_pass.apply(
                 [dist_program], [startup_program]

--- a/python/paddle/distributed/passes/auto_parallel_recompute_pir.py
+++ b/python/paddle/distributed/passes/auto_parallel_recompute_pir.py
@@ -239,6 +239,8 @@ class AutoParallelRecomputePIRPass(PassBase):
                 rc_op = op.clone(
                     value_map, paddle.pir.CloneOptions(False, True, True)
                 )
+                if rc_op.has_attr("fwd_recompute_id"):
+                    rc_op.erase_attr("fwd_recompute_id")
 
                 rc_op.set_int_attr("bwd_recompute_id", rc_id)
 

--- a/python/paddle/distributed/passes/auto_parallel_recompute_pir.py
+++ b/python/paddle/distributed/passes/auto_parallel_recompute_pir.py
@@ -73,7 +73,10 @@ class AutoParallelRecomputePIRPass(PassBase):
             if used_op.name() in dropout_ops
         )
 
-    def remove_edge_output_op(self, segment):
+    def remove_outgoing_op(self, segment):
+        # An OP is considered an outgoing OP if all of results' user OPs are not in segment.
+        # These OPs do not participate in the backward gradient computation and therefore
+        # do not need to have a recomputation during backward.
         segment_ops = [self.program_ops[idx] for idx in segment]
         segment_len = len(segment)
         for idx in range(segment_len - 1, 0, -1):
@@ -86,7 +89,7 @@ class AutoParallelRecomputePIRPass(PassBase):
                 continue
             segment.pop(idx)
             logger.info(
-                f"Segment remove edge output op: {op.name()}, which does not need recomputation."
+                f"Remove outgoing OP '{op.name()}' from the segment for recomputation, as it does not participate in the backward."
             )
         return segment
 
@@ -100,8 +103,11 @@ class AutoParallelRecomputePIRPass(PassBase):
         segment_end = {}
         max_op_id = len(self.program_ops)
         for idx, op in enumerate(self.program_ops):
+            # 1. Find the OPs marked with `fwd_recompute_id`.
             if not op.has_attr("fwd_recompute_id"):
                 continue
+            # 2. Delineate the segment range marked by `fwd_recompute_id`.
+            # Note: there may be some unmarked OPs in between.
             rc_id = op.attrs()["fwd_recompute_id"]
             if rc_id not in segment_beg:
                 segment_beg[rc_id] = max_op_id
@@ -109,18 +115,22 @@ class AutoParallelRecomputePIRPass(PassBase):
             segment_beg[rc_id] = min(segment_beg[rc_id], idx)
             segment_end[rc_id] = max(segment_end[rc_id], idx)
 
+        # 3. Aggregate all segment information into a dictionary.
+        # The key is the id of the segment, which is used to uniquely identify each segment.
+        # The value is a list of indices of the segment OPs in `self.program_ops`.
         segments = {}
-        idx = 0
         assert len(segment_beg.keys()) == len(segment_end.keys())
         for segment_id, beg_id in segment_beg.items():
             assert segment_id in segment_end.keys()
             end_id = segment_end[segment_id]
             assert beg_id <= end_id
-            segment = []
-            for p_id in range(beg_id, end_id + 1):
-                segment.append(p_id)
-            segments[idx] = self.remove_edge_output_op(segment)
-            idx += 1
+            segment = list(range(beg_id, end_id + 1))
+            # 4. Remove the outgoing OPs from the segment, as these OPs
+            # do not participate in the backward gradient computation.
+            segments[segment_id] = self.remove_outgoing_op(segment)
+            logger.info(
+                f"Segment ID {segment_id} contains {len(segment)} OPs, all of which will be recomputed."
+            )
         return segments
 
     def get_op_name(self, op):
@@ -170,30 +180,36 @@ class AutoParallelRecomputePIRPass(PassBase):
 
     def _apply_single_impl(self, main_program, startup_program, context=None):
         self.program_ops = list(main_program.global_block().ops)
-        refined_ops_patterns = self.get_attr("refined_ops_patterns")
+        # 1. Get the recompute segments information form program.
         segments = self.get_segments()
         if len(segments) == 0:
-            logger.info("No segments found in PIR recompite pass.")
+            logger.info("No segments found in PIR recompite pass, skip pass.")
             return
-
+        # 2. Get the forward and backward OPs from program.
         fwd_ops, bwd_ops = self.get_fwd_bwd_ops()
 
-        input_value = main_program.list_vars()
-        value_map = paddle.pir.IrMapping()
-        for val in input_value:
-            value_map.add(val, val)
-
+        # 3. Refine the segments based on the patterns.
+        refined_ops_patterns = self.get_attr("refined_ops_patterns")
         for refined_ops_pattern in refined_ops_patterns:
+            # 3.1 get the refined pattern information.
+            # refined_ops_patterns = pre_ops + main_ops + suf_ops
+            # `main_ops` pattern: it does not participate in backward recomputation
+            #                     and needs to be removed from the segment.
+            # `pre_ops` pattern: it serve only as markers and do require recomputation.
+            # `suf_ops` pattern: it serve only as markers and do require recomputation.
+            # `num` : it limits the maximum number of `main_ops` patterns identified
+            #         within each segment. A value of -1 represents all patterns.
             num = refined_ops_pattern['num']
-            num = (
-                num if num >= 0 else len(fwd_ops)
-            )  # 'num == -1' represents to all ops
+            num = num if num >= 0 else len(fwd_ops)
             main_ops = refined_ops_pattern['main_ops']
             pre_ops = refined_ops_pattern['pre_ops']
             suf_ops = refined_ops_pattern['suf_ops']
             pattern_ops = pre_ops + main_ops + suf_ops
 
             for rc_id in segments.keys():
+                # 3.2 Identify and mark the first 'num' patterns in each segment.
+                # The dictionary 'op_idx_map' has keys as OP information.
+                # If an OP belongs to a pattern, its value in the dictionary is marked as -1.
                 op_idx_map = {
                     self.program_ops[idx]: idx for idx in segments[rc_id]
                 }
@@ -213,12 +229,22 @@ class AutoParallelRecomputePIRPass(PassBase):
                         count=pattern_count,
                         max_count=num,
                     )
+                # 3.3 Refined segment to exclude the specified pattern.
                 refined_segment = list(set(op_idx_map.values()))
                 refined_segment.sort()
                 refined_segment = [idx for idx in refined_segment if idx != -1]
                 segments[rc_id] = refined_segment
 
+        # 4. Construct the segment for backward recomputation.
+        # 4.1 Build IrMapping to eplace forward value with backward recompute value.
+        input_value = main_program.list_vars()
+        value_map = paddle.pir.IrMapping()
+        for val in input_value:
+            value_map.add(val, val)
+
         for rc_id, segment in segments.items():
+            # 4.2 Find the insertion position for the backward segment,
+            # which should be before backward gradient computation.
             first_bwd_used_op = bwd_ops[-1]
             for idx in segment:
                 op = self.program_ops[idx]
@@ -229,27 +255,33 @@ class AutoParallelRecomputePIRPass(PassBase):
             ori_segment_outputs = backward_utils.ValueSet()
             paddle.pir.set_insertion_point(first_bwd_used_op)
 
+            # 4.3 Clone the segment OPs and replace the forward
+            # value with backward recompute value.
             for idx in segment:
                 op = self.program_ops[idx]
                 ori_segment_outputs.update(op.results())
 
+                # Random OPs should produce the same output before and after recomputation.
                 if self.is_seed_used_by_dropout(op):
                     continue
 
                 rc_op = op.clone(
                     value_map, paddle.pir.CloneOptions(False, True, True)
                 )
+                # The forward segment and the backward segment have the same segment ID.
                 if rc_op.has_attr("fwd_recompute_id"):
                     rc_op.erase_attr("fwd_recompute_id")
 
                 rc_op.set_int_attr("bwd_recompute_id", rc_id)
 
+                # Updtate attributes.
                 if first_bwd_used_op.has_attr('op_role'):
                     rc_op.set_int_attr("op_role", first_bwd_used_op.op_role)
 
                 if first_bwd_used_op.has_attr('chunk_id'):
                     rc_op.set_int_attr("chunk_id", first_bwd_used_op.chunk_id)
 
+            # 4.4 Replace the forward value with backward recompute value.
             for ori_value in ori_segment_outputs:
                 rc_value = value_map.look_up(ori_value)
                 ori_value.replace_grad_users_with(rc_value, set(bwd_ops))

--- a/python/paddle/distributed/passes/auto_parallel_recompute_pir.py
+++ b/python/paddle/distributed/passes/auto_parallel_recompute_pir.py
@@ -199,7 +199,7 @@ class AutoParallelRecomputePIRPass(PassBase):
             # `suf_ops` pattern: it serve only as markers and do require recomputation.
             # `num` : it limits the maximum number of `main_ops` patterns identified
             #         within each segment. A value of -1 represents all patterns.
-            num = refined_ops_pattern['num']
+            num = int(refined_ops_pattern['num'])
             num = num if num >= 0 else len(fwd_ops)
             main_ops = refined_ops_pattern['main_ops']
             pre_ops = refined_ops_pattern['pre_ops']

--- a/test/auto_parallel/hybrid_strategy/semi_auto_parallel_llama_model.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_parallel_llama_model.py
@@ -32,6 +32,15 @@ def is_pp_enable():
     return "pp" in global_mesh.dim_names
 
 
+def is_only_dp_enable():
+    global_mesh = dist.auto_parallel.get_mesh()
+    return (
+        "dp" in global_mesh.dim_names
+        and "mp" not in global_mesh.dim_names
+        and "pp" not in global_mesh.dim_names
+    )
+
+
 def get_mesh(pp_idx=None):
     global_mesh = dist.auto_parallel.get_mesh()
     assert global_mesh is not None, "global_mesh is not initialized!"
@@ -118,10 +127,14 @@ class LlamaAttentionAuto(nn.Layer):
             self.hidden_size,
             bias_attr=False,
         )
+        if is_only_dp_enable():
+            shard_spec = [dist.Replicate()]
+        else:
+            shard_spec = [dist.Replicate(), dist.Shard(1)]
         self.q_proj.weight = dist.shard_tensor(
             self.q_proj.weight,
             get_mesh(self.ipp),
-            [dist.Replicate(), dist.Shard(1)],
+            shard_spec,
         )
 
         self.k_proj = nn.Linear(
@@ -132,7 +145,7 @@ class LlamaAttentionAuto(nn.Layer):
         self.k_proj.weight = dist.shard_tensor(
             self.k_proj.weight,
             get_mesh(self.ipp),
-            [dist.Replicate(), dist.Shard(1)],
+            shard_spec,
         )
 
         self.v_proj = nn.Linear(
@@ -143,7 +156,7 @@ class LlamaAttentionAuto(nn.Layer):
         self.v_proj.weight = dist.shard_tensor(
             self.v_proj.weight,
             get_mesh(self.ipp),
-            [dist.Replicate(), dist.Shard(1)],
+            shard_spec,
         )
 
         self.o_proj = nn.Linear(
@@ -151,10 +164,12 @@ class LlamaAttentionAuto(nn.Layer):
             self.hidden_size,
             bias_attr=False,
         )
+        if not is_only_dp_enable():
+            shard_spec = [dist.Replicate(), dist.Shard(0)]
         self.o_proj.weight = dist.shard_tensor(
             self.o_proj.weight,
             get_mesh(self.ipp),
-            [dist.Replicate(), dist.Shard(0)],
+            shard_spec,
         )
 
         if config.rope:
@@ -312,10 +327,14 @@ class LlamaMLPAuto(nn.Layer):
         self.gate_proj = nn.Linear(
             self.hidden_size, self.intermediate_size, bias_attr=False
         )
+        if is_only_dp_enable():
+            shard_spec = [dist.Replicate()]
+        else:
+            shard_spec = [dist.Replicate(), dist.Shard(1)]
         self.gate_proj.weight = dist.shard_tensor(
             self.gate_proj.weight,
             get_mesh(self.ipp),
-            [dist.Replicate(), dist.Shard(1)],
+            shard_spec,
         )
 
         self.up_proj = nn.Linear(
@@ -324,16 +343,18 @@ class LlamaMLPAuto(nn.Layer):
         self.up_proj.weight = dist.shard_tensor(
             self.up_proj.weight,
             get_mesh(self.ipp),
-            [dist.Replicate(), dist.Shard(1)],
+            shard_spec,
         )
 
         self.down_proj = nn.Linear(
             self.intermediate_size, self.hidden_size, bias_attr=False
         )
+        if not is_only_dp_enable():
+            shard_spec = [dist.Replicate(), dist.Shard(0)]
         self.down_proj.weight = dist.shard_tensor(
             self.down_proj.weight,
             get_mesh(self.ipp),
-            [dist.Replicate(), dist.Shard(0)],
+            shard_spec,
         )
 
     def forward(self, x):
@@ -479,10 +500,14 @@ class LlamaModelAuto(nn.Layer):
             self.vocab_size,
             self.hidden_size,
         )
+        if is_only_dp_enable():
+            shard_spec = [dist.Replicate()]
+        else:
+            shard_spec = [dist.Replicate(), dist.Shard(1)]
         self.embed_tokens.weight = dist.shard_tensor(
             self.embed_tokens.weight,
             get_mesh(0),
-            [dist.Replicate(), dist.Shard(1)],
+            shard_spec,
         )
 
         def get_layer_pp_info(layer_index):
@@ -620,10 +645,14 @@ class LlamaModelAuto(nn.Layer):
             inputs_embeds.dtype,
             mesh,
         )  # [bs, 1, seq_len, seq_len]
+        if is_only_dp_enable():
+            shard_spec = [dist.Replicate()]
+        else:
+            shard_spec = [dist.Replicate() for _ in range(len(mesh._shape))]
         attention_mask = dist.shard_tensor(
             attention_mask,
             mesh,
-            [dist.Replicate() for _ in range(len(mesh._shape))],
+            shard_spec,
         )
         if not hasattr(self.config, "sep_parallel_degree"):
             self.config.sep_parallel_degree = -1
@@ -635,7 +664,7 @@ class LlamaModelAuto(nn.Layer):
             position_ids = dist.shard_tensor(
                 position_ids,
                 mesh,
-                [dist.Replicate() for _ in range(len(mesh._shape))],
+                shard_spec,
             )
 
         if self.config.use_flash_attention:
@@ -752,13 +781,17 @@ class LlamaLMHeadAuto(nn.Layer):
         self.config = config
         vocab_size = config.vocab_size
 
+        if is_only_dp_enable():
+            shard_spec = [dist.Replicate()]
+        else:
+            shard_spec = [dist.Replicate(), dist.Shard(1)]
         self.weight = dist.shard_tensor(
             self.create_parameter(
                 shape=[config.hidden_size, vocab_size],
                 dtype=paddle.get_default_dtype(),
             ),
             get_mesh(-1),
-            [dist.Replicate(), dist.Shard(1)],
+            shard_spec,
         )
 
     def forward(self, hidden_states, tensor_parallel_output=None):

--- a/test/auto_parallel/pir/CMakeLists.txt
+++ b/test/auto_parallel/pir/CMakeLists.txt
@@ -51,7 +51,7 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
     test_auto_parallel_replace_with_parallel_cross_entropy_pass
     PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 60)
   set_tests_properties(test_auto_parallel_recompute_pir_pass
-                       PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 120)
+                       PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 200)
   py_test_modules(
     test_eliminate_transpose_pass MODULES test_eliminate_transpose_pass ENVS
     FLAGS_enable_pir_in_executor=1)

--- a/test/auto_parallel/pir/CMakeLists.txt
+++ b/test/auto_parallel/pir/CMakeLists.txt
@@ -51,7 +51,7 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
     test_auto_parallel_replace_with_parallel_cross_entropy_pass
     PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 60)
   set_tests_properties(test_auto_parallel_recompute_pir_pass
-                       PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 60)
+                       PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 120)
   py_test_modules(
     test_eliminate_transpose_pass MODULES test_eliminate_transpose_pass ENVS
     FLAGS_enable_pir_in_executor=1)

--- a/test/auto_parallel/pir/auto_parallel_recompute_pir_pass_unittest.py
+++ b/test/auto_parallel/pir/auto_parallel_recompute_pir_pass_unittest.py
@@ -167,7 +167,6 @@ class TestRecomputeLlamaAuto:
             0, reduce(lambda x, y: x * y, mesh_shape, 1)
         ).reshape(mesh_shape)
         global_mesh = dist.ProcessMesh(mesh_arr, dim_names)
-        print("xxx global_mesh: ", global_mesh)
         dist.auto_parallel.set_mesh(global_mesh)
         paddle.seed(1024)
         np.random.seed(1024)

--- a/test/auto_parallel/pir/auto_parallel_recompute_pir_pass_unittest.py
+++ b/test/auto_parallel/pir/auto_parallel_recompute_pir_pass_unittest.py
@@ -222,33 +222,33 @@ class TestRecomputeLlamaAuto:
         prog_1 = model_1.dist_main_program()
         prog_2 = model_2.dist_main_program()
         prog_3 = model_3.dist_main_program()
-        base_segment_num, base_rc_op_num = self.get_recompute_message(base_prog)
-        segment_num_1, fwd_rc_op_num_1 = self.get_recompute_message(prog_1)
-        segment_num_2, fwd_rc_op_num_2 = self.get_recompute_message(prog_2)
-        segment_num_3, fwd_rc_op_num_3 = self.get_recompute_message(prog_3)
+        segment_num_base, bwd_rc_op_num_base = self.get_recompute_message(
+            base_prog
+        )
+        segment_num_1, bwd_rc_op_num_1 = self.get_recompute_message(prog_1)
+        segment_num_2, bwd_rc_op_num_2 = self.get_recompute_message(prog_2)
+        segment_num_3, bwd_rc_op_num_3 = self.get_recompute_message(prog_3)
 
         # check segment number
-        assert base_segment_num == 0
-        assert segment_num_1 == 2
-        assert segment_num_2 == 2
-        assert segment_num_3 == 2
+        assert segment_num_base == 0
+        assert segment_num_1 == 4
+        assert segment_num_2 == 4
+        assert segment_num_3 == 4
 
         # check recompute op number
-        assert base_rc_op_num == 0
-        assert fwd_rc_op_num_1 == 144
-        assert fwd_rc_op_num_2 == 102
-        assert fwd_rc_op_num_3 == 30
+        assert bwd_rc_op_num_base == 0
+        assert bwd_rc_op_num_1 == 288
+        assert bwd_rc_op_num_2 == 204
+        assert bwd_rc_op_num_3 == 60
 
         # memory check
-        # max_mem_allocated check
-        assert max_mem_allocated_1 < max_mem_allocated_2
-        assert max_mem_allocated_2 < max_mem_allocated_3
-        assert max_mem_allocated_3 < max_mem_allocated_base
-
-        # max_mem_reserved check
         assert max_mem_reserved_1 < max_mem_reserved_2
         assert max_mem_reserved_2 < max_mem_reserved_3
         assert max_mem_reserved_3 < max_mem_reserved_base
+
+        assert max_mem_allocated_1 < max_mem_allocated_2
+        assert max_mem_allocated_2 < max_mem_allocated_3
+        assert max_mem_allocated_3 < max_mem_allocated_base
 
 
 if __name__ == '__main__':

--- a/test/auto_parallel/pir/auto_parallel_recompute_pir_pass_unittest.py
+++ b/test/auto_parallel/pir/auto_parallel_recompute_pir_pass_unittest.py
@@ -225,8 +225,8 @@ class TestLlamaAuto:
 
         assert base_rc_op_num == 0
         assert fwd_rc_op_num_1 == 60
-        assert fwd_rc_op_num_2 == 204
-        assert fwd_rc_op_num_3 == 288
+        assert fwd_rc_op_num_2 == 206
+        assert fwd_rc_op_num_3 == 290
 
 
 if __name__ == '__main__':

--- a/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
+++ b/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
@@ -90,10 +90,6 @@ class TestRefinedRecomputeLlamaAuto(TestRecomputeLlamaAuto):
         assert max_mem_allocated_0 < max_mem_allocated_1
         assert max_mem_allocated_1 < max_mem_allocated_2
         assert max_mem_allocated_2 < max_mem_allocated_base
-        assert (
-            max_mem_allocated_1 - max_mem_allocated_0
-            == max_mem_allocated_2 - max_mem_allocated_1
-        )
 
 
 if __name__ == '__main__':

--- a/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
+++ b/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
@@ -12,178 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hashlib
-import os
-import sys
-
-sys.path.append("../hybrid_strategy/")
-
-import random
-from functools import reduce
-
-import numpy as np
-from semi_auto_parallel_llama_model import (
-    LlamaForCausalLMAuto,
-    LlamaPretrainingCriterionAuto,
-    get_mesh,
-)
+from auto_parallel_recompute_pir_pass_unittest import TestRecomputeLlamaAuto
 
 import paddle
-import paddle.distributed as dist
-from paddle.io import BatchSampler, DataLoader, Dataset
 
 
-class Config:
-    vocab_size = 320
-    hidden_size = 8
-    intermediate_size = 64
-    max_position_embeddings = 8
-    seq_length = 8
-
-    num_hidden_layers = 4
-    num_attention_heads = 4
-    num_key_value_heads = 4
-    initializer_range = 0.02
-    rms_norm_eps = 1e-6
-    use_cache = True
-    use_flash_attention = False
-    sequence_parallel = False
-    rope = True
-
-
-class RandomDataset(Dataset):
-    def __init__(self, seq_len, num_samples=100):
-        super().__init__()
-        self.seq_len = seq_len
-        self.num_samples = num_samples
-
-    def __getitem__(self, index):
-        input = np.full([self.seq_len], index, dtype="int64")
-        label = np.array([index] * 8)
-
-        return input, label
-
-    def __len__(self):
-        return self.num_samples
-
-
-def create_optimizer(model, lr_scheduler):
-    decay_parameters = [
-        p.name
-        for n, p in model.named_parameters()
-        if not any(nd in n for nd in ["bias", "norm"])
-    ]
-
-    def apply_decay_param_fun(x):
-        return x in decay_parameters
-
-    optimizer = paddle.optimizer.adamw.AdamW(
-        learning_rate=lr_scheduler,
-        apply_decay_param_fun=apply_decay_param_fun,
-        parameters=model.parameters(),
-        weight_decay=0.01,
-        grad_clip=paddle.nn.ClipGradByGlobalNorm(1.0),
-    )
-    return optimizer
-
-
-class TestLlamaAuto:
-    def __init__(self):
-        self.config = Config()
-        self.dp = int(os.getenv("dp"))
-        self.mp = int(os.getenv("mp"))
-        self.pp = int(os.getenv("pp"))
-
-        self.strategy = dist.Strategy()
-
-        self.run_step = 10
-
-    def prepare_llama(self, model, model_config):
-        # optimizer
-        lr_scheduler = paddle.optimizer.lr.LinearWarmup(
-            learning_rate=0.0001, warmup_steps=2, start_lr=0, end_lr=0.0001
-        )
-        optimizer = create_optimizer(model, lr_scheduler)
-        optimizer = dist.shard_optimizer(optimizer)
-
-        # dataloader
-        train_dataset = RandomDataset(model_config.seq_length)
-        train_sampler = BatchSampler(
-            train_dataset,
-            batch_size=2,
-            shuffle=True,
-            drop_last=True,
-        )
-        train_dataloader = DataLoader(
-            train_dataset,
-            batch_sampler=train_sampler,
-            num_workers=0,
-        )
-        dist_loader = dist.shard_dataloader(
-            dataloader=train_dataloader,
-            meshes=[get_mesh(0), get_mesh(1)],
-            shard_dims="dp",
-        )
-        return optimizer, dist_loader
-
-    def run_llama(self, model_config):
-        self.init_dist_env()
-        # model
-        model = LlamaForCausalLMAuto(model_config)
-        criterion = LlamaPretrainingCriterionAuto(model_config)
-
-        optimizer, dist_loader = self.prepare_llama(model, model_config)
-
-        model = dist.to_static(
-            model, dist_loader, criterion, optimizer, strategy=self.strategy
-        )
-        model.train()
-
-        md5_losses = []
-        for step, inputs in enumerate(dist_loader()):
-            if step >= self.run_step:
-                break
-            input_ids, labels = inputs
-            loss = model(input_ids, labels)
-            array_bytes = np.array(loss).tobytes()
-            md5_losses.append(hashlib.md5(array_bytes).hexdigest())
-        return md5_losses, model
-
-    def init_dist_env(self):
-        order = ["dp", "pp", "mp"]
-        dp_degree = self.dp
-        mp_degree = self.mp
-        pp_degree = self.pp
-        degree = [dp_degree, pp_degree, mp_degree]
-        mesh_dims = list(filter(lambda x: x[1] > 1, list(zip(order, degree))))
-        if not mesh_dims:
-            mesh_dims = [("dp", 1)]
-        dim_names = [mesh_dim[0] for mesh_dim in mesh_dims]
-        mesh_shape = [mesh_dim[1] for mesh_dim in mesh_dims]
-        mesh_arr = np.arange(
-            0, reduce(lambda x, y: x * y, mesh_shape, 1)
-        ).reshape(mesh_shape)
-        global_mesh = dist.ProcessMesh(mesh_arr, dim_names)
-        dist.auto_parallel.set_mesh(global_mesh)
-        paddle.seed(1024)
-        np.random.seed(1024)
-        random.seed(1024)
-
-    def check_loss(self, losses_1, losses_2):
-        np.testing.assert_equal(len(losses_1), len(losses_2))
-        for idx in range(len(losses_1)):
-            np.testing.assert_equal(losses_1[idx], losses_2[idx])
-
-    def get_recompute_message(self, program):
-        segment_num = set()
-        fwd_rc_op_num = 0
-        for block in program.blocks:
-            for op in block.ops:
-                if op.has_attr("bwd_recompute_id"):
-                    idx = op.attrs()["bwd_recompute_id"]
-                    segment_num.add(idx)
-                    fwd_rc_op_num += 1
-        return len(segment_num), fwd_rc_op_num
+class TestRefinedRecomputeLlamaAuto(TestRecomputeLlamaAuto):
 
     def run_test_cases(self):
         self.config.recompute = True
@@ -203,18 +37,15 @@ class TestLlamaAuto:
         refined_ops_pattern = self.strategy._recompute.refined_ops_patterns[0]
         refined_ops_pattern["num"] = 0
         losses_0, model_0 = self.run_llama(self.config)
-        max_mem_allocated_0 = paddle.device.cuda.max_memory_allocated()
-        max_mem_reserved_0 = paddle.device.cuda.max_memory_reserved()
+        max_mem_allocated_0, max_mem_reserved_0 = self.get_mem_message()
 
         refined_ops_pattern["num"] = 1
         losses_1, model_1 = self.run_llama(self.config)
-        max_mem_allocated_1 = paddle.device.cuda.max_memory_allocated()
-        max_mem_reserved_1 = paddle.device.cuda.max_memory_reserved()
+        max_mem_allocated_1, max_mem_reserved_1 = self.get_mem_message()
 
         refined_ops_pattern["num"] = 2
         losses_2, model_2 = self.run_llama(self.config)
-        max_mem_allocated_2 = paddle.device.cuda.max_memory_allocated()
-        max_mem_reserved_2 = paddle.device.cuda.max_memory_reserved()
+        max_mem_allocated_2, max_mem_reserved_2 = self.get_mem_message()
 
         self.config.recompute = False
         self.strategy._recompute.enable = False
@@ -232,7 +63,6 @@ class TestLlamaAuto:
         prog_0 = model_0.dist_main_program()
         prog_1 = model_1.dist_main_program()
         prog_2 = model_2.dist_main_program()
-
         segment_num_base, bwd_rc_op_num_base = self.get_recompute_message(
             base_prog
         )
@@ -273,4 +103,4 @@ class TestLlamaAuto:
 
 
 if __name__ == '__main__':
-    TestLlamaAuto().run_test_cases()
+    TestRefinedRecomputeLlamaAuto().run_test_cases()

--- a/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
+++ b/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
@@ -72,33 +72,27 @@ class TestRefinedRecomputeLlamaAuto(TestRecomputeLlamaAuto):
 
         # check segment number
         assert segment_num_base == 0
-        assert segment_num_0 == 2
-        assert segment_num_1 == 2
-        assert segment_num_2 == 2
+        assert segment_num_0 == 4
+        assert segment_num_1 == 4
+        assert segment_num_2 == 4
 
         # check recompute op number
         assert bwd_rc_op_num_base == 0
-        assert bwd_rc_op_num_0 == 144
-        assert bwd_rc_op_num_1 == 142
-        assert bwd_rc_op_num_2 == 140
+        assert bwd_rc_op_num_0 == 288
+        assert bwd_rc_op_num_1 == 284
+        assert bwd_rc_op_num_2 == 280
 
         # memory check
-        # max_mem_allocated check
+        assert max_mem_reserved_0 < max_mem_reserved_1
+        assert max_mem_reserved_1 < max_mem_reserved_2
+        assert max_mem_reserved_2 < max_mem_reserved_base
+
         assert max_mem_allocated_0 < max_mem_allocated_1
         assert max_mem_allocated_1 < max_mem_allocated_2
         assert max_mem_allocated_2 < max_mem_allocated_base
         assert (
             max_mem_allocated_1 - max_mem_allocated_0
             == max_mem_allocated_2 - max_mem_allocated_1
-        )
-
-        # max_mem_reserved check
-        assert max_mem_reserved_0 < max_mem_reserved_1
-        assert max_mem_reserved_1 < max_mem_reserved_2
-        assert max_mem_reserved_2 < max_mem_reserved_base
-        assert (
-            max_mem_reserved_1 - max_mem_reserved_0
-            == max_mem_reserved_2 - max_mem_reserved_1
         )
 
 

--- a/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
+++ b/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
@@ -196,7 +196,7 @@ class TestLlamaAuto:
             {
                 "main_ops": ["matmul"],
                 "num": -1,
-                "pre_ops": ["reshape"],
+                "pre_ops": ["multiply"],
                 "suf_ops": [],
             }
         ]
@@ -233,7 +233,7 @@ class TestLlamaAuto:
         prog_1 = model_1.dist_main_program()
         prog_2 = model_2.dist_main_program()
 
-        base_segment_num, base_bwd_rc_op_num = self.get_recompute_message(
+        segment_num_base, bwd_rc_op_num_base = self.get_recompute_message(
             base_prog
         )
         segment_num_0, bwd_rc_op_num_0 = self.get_recompute_message(prog_0)
@@ -241,16 +241,16 @@ class TestLlamaAuto:
         segment_num_2, bwd_rc_op_num_2 = self.get_recompute_message(prog_2)
 
         # check segment number
-        assert base_segment_num == 0
+        assert segment_num_base == 0
         assert segment_num_0 == 2
         assert segment_num_1 == 2
         assert segment_num_2 == 2
 
         # check recompute op number
-        assert base_bwd_rc_op_num == 0
+        assert bwd_rc_op_num_base == 0
         assert bwd_rc_op_num_0 == 144
-        assert bwd_rc_op_num_1 == 144
-        assert bwd_rc_op_num_2 == 144
+        assert bwd_rc_op_num_1 == 142
+        assert bwd_rc_op_num_2 == 140
 
         # memory check
         # max_mem_allocated check
@@ -269,11 +269,6 @@ class TestLlamaAuto:
         assert (
             max_mem_reserved_1 - max_mem_reserved_0
             == max_mem_reserved_2 - max_mem_reserved_1
-        )
-
-        assert (
-            max_mem_allocated_1 - max_mem_allocated_0
-            == max_mem_reserved_1 - max_mem_reserved_0
         )
 
 

--- a/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
+++ b/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import os
+import sys
+
+sys.path.append("../hybrid_strategy/")
+
+import random
+from functools import reduce
+
+import numpy as np
+from semi_auto_parallel_llama_model import (
+    LlamaForCausalLMAuto,
+    LlamaPretrainingCriterionAuto,
+    get_mesh,
+)
+
+import paddle
+import paddle.distributed as dist
+from paddle.io import BatchSampler, DataLoader, Dataset
+
+
+class Config:
+    vocab_size = 320
+    hidden_size = 8
+    intermediate_size = 64
+    max_position_embeddings = 8
+    seq_length = 8
+
+    num_hidden_layers = 4
+    num_attention_heads = 4
+    num_key_value_heads = 4
+    initializer_range = 0.02
+    rms_norm_eps = 1e-6
+    use_cache = True
+    use_flash_attention = False
+    sequence_parallel = False
+    rope = True
+
+
+class RandomDataset(Dataset):
+    def __init__(self, seq_len, num_samples=100):
+        super().__init__()
+        self.seq_len = seq_len
+        self.num_samples = num_samples
+
+    def __getitem__(self, index):
+        input = np.full([self.seq_len], index, dtype="int64")
+        label = np.array([index] * 8)
+
+        return input, label
+
+    def __len__(self):
+        return self.num_samples
+
+
+def create_optimizer(model, lr_scheduler):
+    decay_parameters = [
+        p.name
+        for n, p in model.named_parameters()
+        if not any(nd in n for nd in ["bias", "norm"])
+    ]
+
+    def apply_decay_param_fun(x):
+        return x in decay_parameters
+
+    optimizer = paddle.optimizer.adamw.AdamW(
+        learning_rate=lr_scheduler,
+        apply_decay_param_fun=apply_decay_param_fun,
+        parameters=model.parameters(),
+        weight_decay=0.01,
+        grad_clip=paddle.nn.ClipGradByGlobalNorm(1.0),
+    )
+    return optimizer
+
+
+class TestLlamaAuto:
+    def __init__(self):
+        self.config = Config()
+        self.dp = int(os.getenv("dp"))
+        self.mp = int(os.getenv("mp"))
+        self.pp = int(os.getenv("pp"))
+
+        self.strategy = dist.Strategy()
+
+        self.run_step = 10
+
+    def prepare_llama(self, model, model_config):
+        # optimizer
+        lr_scheduler = paddle.optimizer.lr.LinearWarmup(
+            learning_rate=0.0001, warmup_steps=2, start_lr=0, end_lr=0.0001
+        )
+        optimizer = create_optimizer(model, lr_scheduler)
+        optimizer = dist.shard_optimizer(optimizer)
+
+        # dataloader
+        train_dataset = RandomDataset(model_config.seq_length)
+        train_sampler = BatchSampler(
+            train_dataset,
+            batch_size=2,
+            shuffle=True,
+            drop_last=True,
+        )
+        train_dataloader = DataLoader(
+            train_dataset,
+            batch_sampler=train_sampler,
+            num_workers=0,
+        )
+        dist_loader = dist.shard_dataloader(
+            dataloader=train_dataloader,
+            meshes=[get_mesh(0), get_mesh(1)],
+            shard_dims="dp",
+        )
+        return optimizer, dist_loader
+
+    def run_llama(self, model_config):
+        self.init_dist_env()
+        # model
+        model = LlamaForCausalLMAuto(model_config)
+        criterion = LlamaPretrainingCriterionAuto(model_config)
+
+        optimizer, dist_loader = self.prepare_llama(model, model_config)
+
+        model = dist.to_static(
+            model, dist_loader, criterion, optimizer, strategy=self.strategy
+        )
+        model.train()
+
+        md5_losses = []
+        for step, inputs in enumerate(dist_loader()):
+            if step >= self.run_step:
+                break
+            input_ids, labels = inputs
+            loss = model(input_ids, labels)
+            array_bytes = np.array(loss).tobytes()
+            md5_losses.append(hashlib.md5(array_bytes).hexdigest())
+        return md5_losses, model
+
+    def init_dist_env(self):
+        order = ["dp", "pp", "mp"]
+        dp_degree = self.dp
+        mp_degree = self.mp
+        pp_degree = self.pp
+        degree = [dp_degree, pp_degree, mp_degree]
+        mesh_dims = list(filter(lambda x: x[1] > 1, list(zip(order, degree))))
+        if not mesh_dims:
+            mesh_dims = [("dp", 1)]
+        dim_names = [mesh_dim[0] for mesh_dim in mesh_dims]
+        mesh_shape = [mesh_dim[1] for mesh_dim in mesh_dims]
+        mesh_arr = np.arange(
+            0, reduce(lambda x, y: x * y, mesh_shape, 1)
+        ).reshape(mesh_shape)
+        global_mesh = dist.ProcessMesh(mesh_arr, dim_names)
+        dist.auto_parallel.set_mesh(global_mesh)
+        paddle.seed(1024)
+        np.random.seed(1024)
+        random.seed(1024)
+
+    def check_loss(self, losses_1, losses_2):
+        np.testing.assert_equal(len(losses_1), len(losses_2))
+        for idx in range(len(losses_1)):
+            np.testing.assert_equal(losses_1[idx], losses_2[idx])
+
+    def get_recompute_message(self, program):
+        segment_num = set()
+        fwd_rc_op_num = 0
+        for block in program.blocks:
+            for op in block.ops:
+                if op.has_attr("bwd_recompute_id"):
+                    idx = op.attrs()["bwd_recompute_id"]
+                    segment_num.add(idx)
+                    fwd_rc_op_num += 1
+        return len(segment_num), fwd_rc_op_num
+
+    def run_test_cases(self):
+        self.config.recompute = True
+        self.config.recompute_granularity = "full"
+
+        self.strategy._recompute.enable = True
+        losses_0, model_0 = self.run_llama(self.config)
+
+        self.strategy._recompute.refined_ops_patterns = [
+            {
+                "main_ops": ["matmul"],
+                "num": -1,
+                "pre_ops": ["reshape"],
+                "suf_ops": [],
+            }
+        ]
+        refined_ops_pattern = self.strategy._recompute.refined_ops_patterns[0]
+        refined_ops_pattern["num"] = 0
+        losses_0, model_0 = self.run_llama(self.config)
+        max_mem_allocated_0 = paddle.device.cuda.max_memory_allocated()
+        max_mem_reserved_0 = paddle.device.cuda.max_memory_reserved()
+
+        refined_ops_pattern["num"] = 1
+        losses_1, model_1 = self.run_llama(self.config)
+        max_mem_allocated_1 = paddle.device.cuda.max_memory_allocated()
+        max_mem_reserved_1 = paddle.device.cuda.max_memory_reserved()
+
+        refined_ops_pattern["num"] = 2
+        losses_2, model_2 = self.run_llama(self.config)
+        max_mem_allocated_2 = paddle.device.cuda.max_memory_allocated()
+        max_mem_reserved_2 = paddle.device.cuda.max_memory_reserved()
+
+        self.config.recompute = False
+        self.strategy._recompute.enable = False
+        base_losses, base_model = self.run_llama(self.config)
+        max_mem_allocated_base = paddle.device.cuda.max_memory_allocated()
+        max_mem_reserved_base = paddle.device.cuda.max_memory_reserved()
+
+        # check loss
+        self.check_loss(base_losses, losses_0)
+        self.check_loss(base_losses, losses_1)
+        self.check_loss(base_losses, losses_2)
+
+        # check program
+        base_prog = base_model.dist_main_program()
+        prog_0 = model_0.dist_main_program()
+        prog_1 = model_1.dist_main_program()
+        prog_2 = model_2.dist_main_program()
+
+        base_segment_num, base_bwd_rc_op_num = self.get_recompute_message(
+            base_prog
+        )
+        segment_num_0, bwd_rc_op_num_0 = self.get_recompute_message(prog_0)
+        segment_num_1, bwd_rc_op_num_1 = self.get_recompute_message(prog_1)
+        segment_num_2, bwd_rc_op_num_2 = self.get_recompute_message(prog_2)
+
+        # check segment number
+        assert base_segment_num == 0
+        assert segment_num_0 == 2
+        assert segment_num_1 == 2
+        assert segment_num_2 == 2
+
+        # check recompute op number
+        assert base_bwd_rc_op_num == 0
+        assert bwd_rc_op_num_0 == 144
+        assert bwd_rc_op_num_1 == 144
+        assert bwd_rc_op_num_2 == 144
+
+        # memory check
+        # max_mem_allocated check
+        assert max_mem_allocated_0 < max_mem_allocated_1
+        assert max_mem_allocated_1 < max_mem_allocated_2
+        assert max_mem_allocated_2 < max_mem_allocated_base
+        assert (
+            max_mem_allocated_1 - max_mem_allocated_0
+            == max_mem_allocated_2 - max_mem_allocated_1
+        )
+
+        # max_mem_reserved check
+        assert max_mem_reserved_0 < max_mem_reserved_1
+        assert max_mem_reserved_1 < max_mem_reserved_2
+        assert max_mem_reserved_2 < max_mem_reserved_base
+        assert (
+            max_mem_reserved_1 - max_mem_reserved_0
+            == max_mem_reserved_2 - max_mem_reserved_1
+        )
+
+        assert (
+            max_mem_allocated_1 - max_mem_allocated_0
+            == max_mem_reserved_1 - max_mem_reserved_0
+        )
+
+
+if __name__ == '__main__':
+    TestLlamaAuto().run_test_cases()

--- a/test/auto_parallel/pir/test_auto_parallel_recompute_pir_pass.py
+++ b/test/auto_parallel/pir/test_auto_parallel_recompute_pir_pass.py
@@ -19,13 +19,13 @@ import collective.test_communication_api_base as test_base
 
 class TestSemiAutoParallelLlamaACCTest(test_base.CommunicationTestDistBase):
     def setUp(self):
-        super().setUp(num_of_devices=8, timeout=200, nnode=1)
+        super().setUp(num_of_devices=2, timeout=200, nnode=1)
 
-    def test_simple_net_hybrid_strategy_recompute(self):
+    def test_simple_net_dp_strategy_recompute(self):
         _default_envs = {
             "dp": "2",
-            "mp": "2",
-            "pp": "2",
+            "mp": "1",
+            "pp": "1",
             "FLAGS_embedding_deterministic": "1",
             "FLAGS_cudnn_deterministic": "1",
         }
@@ -41,11 +41,11 @@ class TestSemiAutoParallelLlamaACCTest(test_base.CommunicationTestDistBase):
                 user_defined_envs=envs,
             )
 
-    def test_simple_net_hybrid_strategy_refined_recompute(self):
+    def test_simple_net_dp_strategy_refined_recompute(self):
         _default_envs = {
             "dp": "2",
-            "mp": "2",
-            "pp": "2",
+            "mp": "1",
+            "pp": "1",
             "FLAGS_embedding_deterministic": "1",
             "FLAGS_cudnn_deterministic": "1",
         }

--- a/test/auto_parallel/pir/test_auto_parallel_recompute_pir_pass.py
+++ b/test/auto_parallel/pir/test_auto_parallel_recompute_pir_pass.py
@@ -21,7 +21,7 @@ class TestSemiAutoParallelLlamaACCTest(test_base.CommunicationTestDistBase):
     def setUp(self):
         super().setUp(num_of_devices=8, timeout=200, nnode=1)
 
-    def test_simple_net_hybrid_strategy_acc(self):
+    def test_simple_net_hybrid_strategy_recompute(self):
         _default_envs = {
             "dp": "2",
             "mp": "2",
@@ -38,6 +38,26 @@ class TestSemiAutoParallelLlamaACCTest(test_base.CommunicationTestDistBase):
         for envs in envs_list:
             self.run_test_case(
                 "auto_parallel_recompute_pir_pass_unittest.py",
+                user_defined_envs=envs,
+            )
+
+    def test_simple_net_hybrid_strategy_refined_recompute(self):
+        _default_envs = {
+            "dp": "2",
+            "mp": "2",
+            "pp": "2",
+            "FLAGS_embedding_deterministic": "1",
+            "FLAGS_cudnn_deterministic": "1",
+        }
+        _changeable_envs = {
+            "backend": ["gpu"],
+        }
+        envs_list = test_base.gen_product_envs_list(
+            _default_envs, _changeable_envs
+        )
+        for envs in envs_list:
+            self.run_test_case(
+                "auto_parallel_refined_recompute_pir_pass_unittest.py",
                 user_defined_envs=envs,
             )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description

该 PR 是在 recompute pass( https://github.com/PaddlePaddle/Paddle/pull/69681 ) 的基础上，实现的 refined recompute，是在recompute layer 中选择一些算子不参与重计算，其开关在代码中的调用如下所示：

```python
strategy = dist.Strategy()
strategy._recompute.enable = True
strategy._recompute.refined_ops_patterns = [
            {
                "main_ops": ["matmul"],
                "num": -1,
                "pre_ops": ["multiply"],
                "suf_ops": [],
            }
        ]
...
model = dist.to_static(model, dist_loader, criterion, optimizer, strategy=strategy)
``` 
在每个layer segment 中，按照计算图拓扑结构匹配 `pattern = pre_ops + main_ops + suf_ops`，其中，pre_ops 和 suf_ops 是用于辅助匹配 main_ops 的，对于匹配到的前 num 个 main_ops，在反向时不进行重计算，当 num = -1 时，默认匹配到的 main_ops 全部不进行重计算。

其他：
PaddleNLP 中增加 refined recompute 的测试：https://github.com/PaddlePaddle/PaddleNLP/pull/9679
该实现部分参考了旧 IR 下 refined recompute实现：https://github.com/PaddlePaddle/Paddle/pull/58533 

<!-- Describe what you’ve done -->
PCard-88114
