### PR TITLE
[Recompute] Fasten bw_ops detecting time

### DIFF
--- a/python/paddle/decomposition/recompute.py
+++ b/python/paddle/decomposition/recompute.py
@@ -383,6 +383,7 @@ def auto_recompute(
             (%11) = "pd_op.fetch" (%10) {col:(Int32)0,is_persistable:[true],name:"fetch0",stop_gradient:[false]} : (pd_op.tensor<4096x4096xf32>) -> pd_op.tensor<4096x4096xf32>
         }
     '''
+    DebugPrint("program before recompute:", program)
     # 1. find smart recompute needed saved values by min-cut algorithm
     # 1.1 classify value nodes
     import networkx as nx
@@ -630,7 +631,6 @@ def auto_recompute(
     # (TODO: wanghao107): remove it and fix model
     # saved_values = cut_value_nodes | inputs
     saved_values = cut_value_nodes
-    DebugPrint("program before recompute:", program)
     # 2.patition the joint graph by saved values.
     (
         program_after_recompute,
@@ -856,36 +856,29 @@ def classify_value_node(program, grad_outputs, fwd_op_end_idx):
         program.global_block().get_values_by_op_idx(required_fw_op_idxs)
     )
 
-    required_bw_ops = set()
-    for grad_output in grad_outputs:
-        required_bw_ops = required_bw_ops | find_child_ops(grad_output)
-        required_bw_ops.add(grad_output.get_defining_op())
-
-    required_bw_op_idxs = []
-    for idx, op in enumerate(all_ops):
-        if op in required_bw_ops:
-            required_bw_op_idxs.append(idx)
+    required_bw_op_idxs = list(range(fwd_op_end_idx + 1, len(all_ops)))
     required_bw_value_nodes = backward_utils.ValueSet(
         program.global_block().get_values_by_op_idx(required_bw_op_idxs)
     )
 
-    unclaimed_ops = {
-        op
-        for op in all_ops
-        if op not in required_fw_ops and op not in required_bw_ops
-    }
+    # TODO(chenxi67) optimize classify algorithm by using unclaimed_ops. Remove them to fasten bw_ops detecting time.
+    # unclaimed_ops = {
+    #     op
+    #     for op in all_ops
+    #     if op not in required_fw_ops and op not in required_bw_ops
+    # }
 
-    unclaimed_op_idxs = []
-    for idx, op in enumerate(all_ops):
-        if op in unclaimed_ops:
-            unclaimed_op_idxs.append(idx)
-    unclaimed_value_nodes = backward_utils.ValueSet(
-        program.global_block().get_values_by_op_idx(unclaimed_op_idxs)
-    )
+    # unclaimed_op_idxs = []
+    # for idx, op in enumerate(all_ops):
+    #     if op in unclaimed_ops:
+    #         unclaimed_op_idxs.append(idx)
+    # unclaimed_value_nodes = backward_utils.ValueSet(
+    #     program.global_block().get_values_by_op_idx(unclaimed_op_idxs)
+    # )
 
     return (
         required_fw_value_nodes,
-        required_bw_value_nodes | unclaimed_value_nodes,
+        required_bw_value_nodes,
         backward_utils.ValueSet(),
     )
 
@@ -1104,25 +1097,3 @@ def find_parent_ops(value):
         return parent_ops
 
     return _find_parent_ops(value)
-
-
-def find_child_ops(value):
-    visited = backward_utils.ValueSet()
-
-    def _find_child_ops(value):
-        child_ops = set()
-        if value in visited:
-            return child_ops
-        visited.add(value)
-        used_ops = value.all_used_ops()
-        child_ops |= set(used_ops)
-        op_results = backward_utils.ValueSet()
-        for used_op in used_ops:
-            op_results = op_results | backward_utils.ValueSet(used_op.results())
-        for op_result in op_results:
-            if not op_result.initialized():
-                continue
-            child_ops = child_ops | _find_child_ops(op_result)
-        return child_ops
-
-    return _find_child_ops(value)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
optimize classify algorithm by removing unclaimed_ops to fasten bw_ops detecting time.
