### PR TITLE
[0-size Tensor] Support creating 0-size parameter and correct data_ptr

### DIFF
--- a/python/paddle/base/layer_helper_base.py
+++ b/python/paddle/base/layer_helper_base.py
@@ -360,8 +360,8 @@ class LayerHelperBase:
             return None
         assert isinstance(attr, ParamAttr)
         for i, size in enumerate(shape):
-            assert size > 0, (
-                "Expected every dim's size to be larger than 0, "
+            assert size >= 0, (
+                "Expected every dim's size to be larger than or equal to 0, "
                 f"but the size of the {i}-th dim is {size}"
             )
         # set global dtype

--- a/test/legacy_test/test_deform_conv2d.py
+++ b/test/legacy_test/test_deform_conv2d.py
@@ -321,27 +321,5 @@ class TestDeformConv2DWithGroups(TestDeformConv2D):
         self.no_bias = False
 
 
-class TestDeformConv2DError(unittest.TestCase):
-
-    def test_input_error(self):
-        def test_input_rank_error():
-            paddle.enable_static()
-            x = paddle.static.data(name='error_x_1', shape=[0], dtype='float32')
-            offset = paddle.static.data(
-                name='error_offset_1', shape=[0], dtype='float32'
-            )
-            mask = paddle.static.data(
-                name='error_mask_1', shape=[0, 0, 0], dtype='float32'
-            )
-            out = paddle.vision.ops.DeformConv2D(
-                in_channels=0,
-                out_channels=0,
-                kernel_size=0,
-                deformable_groups=0,
-            )(x, offset, mask)
-
-        self.assertRaises(AssertionError, test_input_rank_error)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_deformable_conv_op.py
+++ b/test/legacy_test/test_deformable_conv_op.py
@@ -405,23 +405,6 @@ class TestModulatedDeformableConvInvalidInput(unittest.TestCase):
 
         self.assertRaises(TypeError, test_invalid_offset)
 
-        def test_invalid_filter():
-            paddle.enable_static()
-            input = paddle.static.data(
-                name='input_filter', shape=[None, 3, 32, 32], dtype='float32'
-            )
-            offset = paddle.static.data(
-                name='offset_filter', shape=[None, 3, 32, 32], dtype='float32'
-            )
-            mask = paddle.static.data(
-                name='mask_filter', shape=[None, 3, 32, 32], dtype='float32'
-            )
-            loss = paddle.vision.ops.DeformConv2D(
-                in_channels=input.shape[1], out_channels=4, kernel_size=0
-            )(input, offset, mask)
-
-        self.assertRaises(AssertionError, test_invalid_filter)
-
         def test_invalid_groups():
             paddle.enable_static()
             input = paddle.static.data(

--- a/test/legacy_test/test_parameter.py
+++ b/test/legacy_test/test_parameter.py
@@ -75,6 +75,22 @@ class ParameterChecks(unittest.TestCase):
             pram_copy2 = copy.deepcopy(param, memo)
             self.assertEqual(id(param_copy), id(pram_copy2))
 
+    def test_create_0_size_param(self):
+        with guard():
+            shape = [0, 4]
+            for dtype in [
+                paddle.float32,
+                paddle.float64,
+            ]:
+                zero_size_param = paddle.create_parameter(
+                    shape,
+                    dtype,
+                )
+                self.assertEqual(zero_size_param.shape, shape)
+                self.assertEqual(zero_size_param.data_ptr(), 0)
+                # strides will be same with shape for 0-size tensor in paddle
+                self.assertEqual(zero_size_param.strides, shape)
+
     def func_exception(self):
         b = main_program.global_block()
         with self.assertRaises(ValueError):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-75624

支持创建0-size参数，并且规范了0-size参数的data_ptr()返回值，从None改为0