### PR TITLE
[CINN] Enhance BuildCinnPass efficiency

### DIFF
--- a/paddle/fluid/pir/transforms/build_cinn_pass.cc
+++ b/paddle/fluid/pir/transforms/build_cinn_pass.cc
@@ -49,7 +49,7 @@ class BuildCinnPass : public pir::Pass {
  private:
   void ProcessBlock(pir::Block* block) {
     std::vector<GroupOpsVec> groups =
-        ::pir::SubgraphDetector(block, CompatibleInfo::IsSupportForCinn)();
+        ::pir::DetectSubGraphs(block, CompatibleInfo::IsSupportForCinn);
     AddStatistics(groups.size());
     for (auto& group_ops : groups) {
       if (group_ops.size() == 1 && group_ops[0]->name() == "pd_op.full") {

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -238,13 +238,12 @@ struct SubGraph : public std::enable_shared_from_this<SubGraph> {
   };
 
   bool substitute{true};
+  size_t min_op_id;
+  size_t max_op_id;
+  std::string name;
   std::vector<pir::Operation*> ops;
   std::unordered_set<SubGraphPtr, hash> upstreams;
   std::unordered_set<SubGraphPtr, hash> downstreams;
-
-  std::string name;
-  size_t min_op_id;
-  size_t max_op_id;
 };
 using SubGraphPtr = std::shared_ptr<SubGraph>;
 
@@ -409,9 +408,7 @@ std::vector<SubGraphPtr> SubgraphDetector::GetSubgraphList() {
   std::vector<SubGraphPtr> subgraph_list;
   for (const auto& op : sort_ops_) {
     SubGraphPtr subgraph = GetOpSubgraph(op);
-    if (subgraph_set.count(subgraph)) {
-      continue;
-    }
+    if (subgraph_set.count(subgraph)) continue;
     subgraph_set.insert(subgraph);
     subgraph_list.push_back(subgraph);
   }

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -265,6 +265,9 @@ bool CanFuseUpstream2Downstream(const SubGraphPtr& upstream,
   if (!upstream->substitute || !downstream->substitute) return false;
   auto up_downstreams = upstream->downstreams;
   up_downstreams.erase(downstream);
+  auto down_upstreams = downstream->upstreams;
+  down_upstreams.erase(upstream);
+  if (up_downstreams.empty() || down_upstreams.empty()) return true;
   for (const auto& subgraph : up_downstreams) {
     if (HasSinkRoute(subgraph, downstream)) return false;
   }

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -47,6 +47,7 @@
 #include "paddle/fluid/pir/dialect/operator/trait/onednn.h"
 #endif
 namespace pir {
+using Op2IdMap = std::unordered_map<pir::Operation*, int>;
 
 std::vector<pir::Operation*> InverselyTopologicalSort(pir::Block* block) {
   std::vector<pir::Operation*> sort_ops;
@@ -106,9 +107,8 @@ std::vector<pir::Operation*> InverselyTopologicalSort(pir::Block* block) {
   return sort_ops;
 }
 
-std::vector<pir::Operation*> GetProducerOpsReverseSort(
-    pir::Operation* op,
-    const std::unordered_map<pir::Operation*, size_t>& op2id) {
+std::vector<pir::Operation*> GetProducerOpsReverseSort(pir::Operation* op,
+                                                       const Op2IdMap& op2id) {
   std::unordered_set<pir::Operation*> producers;
 
   std::vector<pir::Operation*> vec_res;
@@ -151,30 +151,8 @@ std::unordered_set<pir::Operation*> GetProducerOps(pir::Operation* op) {
   return producers;
 }
 
-std::vector<pir::Operation*> GetProducerOpsRecursive(
-    pir::Operation* root,
-    const std::unordered_map<pir::Operation*, size_t>& op2id) {
-  std::unordered_set<pir::Operation*> visited;
-  std::deque<pir::Operation*> queue;
-  std::vector<pir::Operation*> result;
-  queue.push_back(root);
-  visited.insert(root);
-  while (!queue.empty()) {
-    pir::Operation* cur = queue.front();
-    queue.pop_front();
-    result.push_back(cur);
-    for (const auto& new_op : GetProducerOps(cur)) {
-      if (visited.count(new_op)) continue;
-      visited.insert(new_op);
-      queue.push_back(new_op);
-    }
-  }
-  return result;
-}
-
-std::unordered_set<pir::Operation*> GetConsumerOps(
-    pir::Operation* op,
-    const std::unordered_map<pir::Operation*, size_t>& op2id) {
+std::unordered_set<pir::Operation*> GetConsumerOps(pir::Operation* op,
+                                                   const Op2IdMap& op2id) {
   std::unordered_set<pir::Operation*> consumers;
 
   for (auto& result : op->results()) {
@@ -192,27 +170,6 @@ std::unordered_set<pir::Operation*> GetConsumerOps(
   return consumers;
 }
 
-std::vector<pir::Operation*> GetConsumerOpsRecursive(
-    pir::Operation* root,
-    const std::unordered_map<pir::Operation*, size_t>& op2id) {
-  std::unordered_set<pir::Operation*> visited;
-  std::deque<pir::Operation*> queue;
-  std::vector<pir::Operation*> result;
-  queue.push_back(root);
-  visited.insert(root);
-  while (!queue.empty()) {
-    pir::Operation* cur = queue.front();
-    queue.pop_front();
-    result.push_back(cur);
-    for (const auto& new_op : GetConsumerOps(cur, op2id)) {
-      if (visited.count(new_op)) continue;
-      visited.insert(new_op);
-      queue.push_back(new_op);
-    }
-  }
-  return result;
-}
-
 static std::string OpsDebugStr(std::vector<pir::Operation*> ops) {
   std::stringstream ss;
   pir::IrPrinter printer(ss);
@@ -223,352 +180,275 @@ static std::string OpsDebugStr(std::vector<pir::Operation*> ops) {
   return ss.str();
 }
 
-struct SubGraph {
-  // construct function
-  SubGraph() = default;
-  // construct function
-  SubGraph(pir::Operation* op, bool subst) : substitute(subst) { Insert(op); }
-  SubGraph(const std::unordered_set<pir::Operation*>& op, bool subst) {
-    substitute = subst;
-    for (auto& item : op) {
-      Insert(item);
-    }
-  }
-  void Insert(pir::Operation* op) {
+struct SubGraph : public std::enable_shared_from_this<SubGraph> {
+  using SubGraphPtr = std::shared_ptr<SubGraph>;
+  SubGraph() = delete;
+  SubGraph(pir::Operation* op, int id, bool subst)
+      : substitute(subst), min_op_id(id), max_op_id(id), name(UniqueId()) {
     ops.push_back(op);
-    op_set.insert(op);
+  }
 
-    auto producers = GetProducerOps(op);
-    for (auto producer : producers) {
-      input_ops.insert(producer);
+  void Merge(const SubGraphPtr& other) {
+    SubGraphPtr self = shared_from_this();
+    upstreams.insert(other->upstreams.begin(), other->upstreams.end());
+    upstreams.erase(self);
+    upstreams.erase(other);
+    downstreams.insert(other->downstreams.begin(), other->downstreams.end());
+    downstreams.erase(self);
+    downstreams.erase(other);
+    for (auto upstream : upstreams) {
+      upstream->downstreams.erase(other);
+      upstream->downstreams.insert(self);
     }
-    input_ops.erase(op);
+    for (auto downstream : downstreams) {
+      downstream->upstreams.erase(other);
+      downstream->upstreams.insert(self);
+    }
+    ops.insert(ops.begin(), other->ops.begin(), other->ops.end());
+    min_op_id = std::min(self->min_op_id, other->min_op_id);
+    max_op_id = std::max(self->max_op_id, other->max_op_id);
   }
 
-  void Print() const {
-    VLOG(4) << "SubGraph is: " << this;
-    VLOG(4) << "=============" << this;
-    VLOG(4) << OpsDebugStr(ops);
+  static std::string UniqueId() {
+    static std::atomic<size_t> counter{0};
+    return std::string("Subgraph_") + std::to_string(counter++);
   }
 
-  int depth{0};
-  int max_depth{0};
-  int min_depth{INT_MAX};
+  std::string DebugString() const {
+    std::stringstream ss;
+    ss << name << "\n" << OpsDebugStr(ops);
+    ss << "upstream: ";
+    for (const auto& subgraph : upstreams) {
+      ss << subgraph->name << ", ";
+    }
+    ss << "\ndownstream: ";
+    for (const auto& subgraph : downstreams) {
+      ss << subgraph->name << ", ";
+    }
+    return ss.str();
+  }
+
+  struct hash {
+    size_t operator()(const SubGraphPtr& subgraph) const {
+      return std::hash<std::string>()(subgraph->name);
+    }
+  };
+
   bool substitute{true};
   std::vector<pir::Operation*> ops;
-  std::unordered_set<pir::Operation*> op_set;
-  std::unordered_set<pir::Operation*> input_ops;
+  std::unordered_set<SubGraphPtr, hash> upstreams;
+  std::unordered_set<SubGraphPtr, hash> downstreams;
 
-  std::unordered_set<SubGraphPtr> producers;
-  std::unordered_set<SubGraphPtr> consumers;
+  std::string name;
+  size_t min_op_id;
+  size_t max_op_id;
+};
+using SubGraphPtr = std::shared_ptr<SubGraph>;
+
+bool HasSinkRoute(const SubGraphPtr& source, const SubGraphPtr& target) {
+  if (source == target) return true;
+  if (source->min_op_id > target->max_op_id) {
+    return false;
+  }
+  for (const auto& subgraph : source->downstreams) {
+    if (HasSinkRoute(subgraph, target)) return true;
+  }
+  return false;
+}
+
+bool HasLiftRoute(const SubGraphPtr& source, const SubGraphPtr& target) {
+  if (source == target) return true;
+  if (source->max_op_id < target->min_op_id) {
+    return false;
+  }
+  for (const auto& subgraph : source->upstreams) {
+    if (HasLiftRoute(subgraph, target)) return true;
+  }
+  return false;
+}
+
+bool CanFuseUpstream2Downstream(const SubGraphPtr& upstream,
+                                const SubGraphPtr& downstream) {
+  if (upstream == downstream) return false;
+  if (!upstream->substitute || !downstream->substitute) return false;
+  PADDLE_ENFORCE(upstream->downstreams.count(downstream) &&
+                     downstream->upstreams.count(upstream),
+                 ::common::errors::InvalidArgument(
+                     "Subgraphs to be fused must have direct relationship."));
+  auto up_downstreams = upstream->downstreams;
+  up_downstreams.erase(downstream);
+  for (const auto& subgraph : up_downstreams) {
+    if (HasSinkRoute(subgraph, downstream)) return false;
+  }
+  auto down_upstreams = downstream->upstreams;
+  down_upstreams.erase(upstream);
+  for (const auto& subgraph : down_upstreams) {
+    if (HasLiftRoute(subgraph, upstream)) return false;
+  }
+  return true;
+}
+
+bool ExistCycle(const std::vector<SubGraphPtr>& subgraph_list) {
+  std::unordered_map<SubGraphPtr, std::unordered_set<SubGraphPtr>> visited;
+  std::queue<SubGraphPtr> queue;
+  for (auto subgraph : subgraph_list) {
+    if (subgraph->downstreams.empty()) {
+      queue.push(subgraph);
+    }
+  }
+  while (!queue.empty()) {
+    auto subgraph = queue.front();
+    queue.pop();
+    for (const auto& downstream : subgraph->downstreams) {
+      if (visited.count(subgraph) && visited[subgraph].count(downstream)) {
+        return true;
+      }
+      visited[subgraph].insert(downstream);
+      queue.push(downstream);
+    }
+  }
+  return false;
+}
+
+class SubgraphDetector {
+ public:
+  SubgraphDetector(pir::Block* block, const OpClassifier& classifier);
+
+  std::vector<GroupOpsVec> operator()();
+
+ protected:
+  void SubgraphFusion();
+
+  std::vector<SubGraphPtr> GetSubgraphList();
+
+  std::vector<GroupOpsVec> BuildGroups();
+
+  pir::Operation* FindRoot(pir::Operation* op) {
+    auto root = op;
+    while (op2root_[root] != root) {
+      root = op2root_[root];
+    }
+    return root;
+  }
+
+  SubGraphPtr GetOpSubgraph(pir::Operation* op) {
+    auto root = FindRoot(op);
+    PADDLE_ENFORCE(
+        root2subgraph_.count(root),
+        ::common::errors::InvalidArgument(
+            "Can not find op in root2subgraph_: \n%s", OpsDebugStr({op})));
+    return root2subgraph_.at(root);
+  }
+
+ private:
+  Op2IdMap op2id_;
+  std::vector<pir::Operation*> sort_ops_;
+  std::unordered_map<pir::Operation*, pir::Operation*> op2root_;
+  std::unordered_map<pir::Operation*, SubGraphPtr> root2subgraph_;
 };
 
-using OpClassifier = std::function<bool(const pir::Operation&)>;
-
 SubgraphDetector::SubgraphDetector(pir::Block* block,
-                                   const OpClassifier& classifier)
-    : block_(block), op_classifier_(classifier) {
-  sort_ops_ = InverselyTopologicalSort(block_);
-  size_t index = 0;
+                                   const OpClassifier& classifier) {
+  // init sort_ops_ in reverse topo order
+  sort_ops_ = InverselyTopologicalSort(block);
+  // init op2id_ in topo order
+  int index = 0;
   for (auto& op : *block) {
+    VLOG(4) << index << " " << OpsDebugStr({&op});
     op2id_[&op] = index++;
+  }
+  // construct subgraphs and upstream/downstream relation
+  for (const auto& op : sort_ops_) {
+    bool substitute = classifier(*op);
+    auto subgraph = std::make_shared<SubGraph>(op, op2id_[op], substitute);
+    op2root_[op] = op;
+    root2subgraph_[op] = subgraph;
+  }
+  for (const auto& op : sort_ops_) {
+    auto subgraph = root2subgraph_[op];
+    for (const auto& producer : GetProducerOps(op)) {
+      if (!root2subgraph_.count(producer)) continue;
+      subgraph->upstreams.insert(root2subgraph_[producer]);
+      root2subgraph_[producer]->downstreams.insert(subgraph);
+    }
+    for (const auto& consumer : GetConsumerOps(op, op2id_)) {
+      if (!root2subgraph_.count(consumer)) continue;
+      subgraph->downstreams.insert(root2subgraph_[consumer]);
+      root2subgraph_[consumer]->upstreams.insert(subgraph);
+    }
+    VLOG(4) << "construct subgraph " << subgraph->DebugString();
   }
 }
 
 std::vector<GroupOpsVec> SubgraphDetector::operator()() {
-  DoOpFusion();
-  VLOG(4) << "Subgraph list size: " << subgraph_list_.size();
-  BuildSubGraph();
-  VLOG(4) << "Subgraph list size: " << subgraph_list_.size();
-
-  std::vector<GroupOpsVec> groups;
-  for (auto& subgraph : subgraph_list_) {
-    if (!subgraph->substitute) {
-      continue;
-    }
-
-    // sort group ops by natural increasing index.
-    std::vector<pir::Operation*> tmp_ops(subgraph->ops.begin(),
-                                         subgraph->ops.end());
-    auto& op2id = op2id_;
-    std::sort(tmp_ops.begin(),
-              tmp_ops.end(),
-              [&op2id](pir::Operation* a, pir::Operation* b) {
-                return op2id.at(a) < op2id.at(b);
-              });
-
-    groups.push_back(tmp_ops);
-  }
-
-  return groups;
+  SubgraphFusion();
+  return BuildGroups();
 }
 
-using GraphSet = std::unordered_set<SubGraphPtr>;
-static GraphSet Union(const GraphSet& upstream, const GraphSet& downstream) {
-  GraphSet unioned_set = upstream;
-  unioned_set.insert(downstream.begin(), downstream.end());
-  return unioned_set;
-}
-
-struct UnionFindSet {
-  std::unordered_map<pir::Operation*, pir::Operation*> parent;
-  std::unordered_map<pir::Operation*, SubGraphPtr> root2subgraph;
-  OpClassifier op_classifier_;
-  SubGraphPtr GetSetFromGraph(SubGraphPtr x) { return GetSetFromOp(x->ops[0]); }
-
-  pir::Operation* Find(pir::Operation* x) {
-    if (parent.find(x) == parent.end()) {
-      parent[x] = x;
-      return x;
-    }
-    if (parent[x] != x) {
-      parent[x] = Find(parent[x]);
-    }
-    return parent[x];
-  }
-
-  SubGraphPtr Union(pir::Operation* x, pir::Operation* y) {
-    auto root_x = Find(x);
-    auto root_y = Find(y);
-    if (root_x == root_y) {
-      return GetSetFromOp(root_y);
-    }
-    auto subgraph_x = GetSetFromOp(root_x);
-    auto subgraph_y = GetSetFromOp(root_y);
-    parent[root_x] = root_y;
-    // union root_x and root_y;
-    for (auto& op : subgraph_x->ops) {
-      subgraph_y->Insert(op);
-    }
-    return subgraph_y;
-  }
-
-  SubGraphPtr GetSetFromOp(pir::Operation* op) {
-    const auto& root = Find(op);
-    if (!root2subgraph.count(root)) {
-      root2subgraph[root] = std::make_shared<SubGraph>(op, op_classifier_(*op));
-    }
-    return root2subgraph[root];
-  }
-};
-
-static GraphSet Intersect(const GraphSet& upstream,
-                          const GraphSet& downstream) {
-  GraphSet intersected_set;
-  for (auto& item : upstream) {
-    if (downstream.count(item)) {
-      intersected_set.insert(item);
-    }
-  }
-  return intersected_set;
-}
-
-struct LoopDetectionMapping {
-  std::unordered_map<SubGraphPtr, std::unordered_set<SubGraphPtr>> upstreams_;
-  std::unordered_map<SubGraphPtr, std::unordered_set<SubGraphPtr>> downstreams_;
-  std::unordered_set<SubGraphPtr> all_nodes_;
-  UnionFindSet* uf_set_;
-  LoopDetectionMapping(const std::vector<pir::Operation*> sort_ops,
-                       const std::unordered_map<pir::Operation*, size_t>& op2id,
-                       UnionFindSet* uf_set) {
-    for (auto* op : sort_ops) {
-      auto producers = GetProducerOpsRecursive(op, op2id);
-      auto consumers = GetConsumerOpsRecursive(op, op2id);
-      auto op_set = uf_set->GetSetFromOp(op);
-      all_nodes_.insert(op_set);
-      for (auto producer : producers) {
-        auto producer_set = uf_set->GetSetFromOp(producer);
-        upstreams_[op_set].insert(producer_set);
-      }
-      for (auto consumer : consumers) {
-        auto consumer_set = uf_set->GetSetFromOp(consumer);
-        downstreams_[op_set].insert(consumer_set);
-      }
-    }
-    uf_set_ = uf_set;
-  }
-
-  void MergeNodes(const SubGraphPtr& first,
-                  const SubGraphPtr& second,
-                  const SubGraphPtr& merged) {
-    std::unordered_set<SubGraphPtr> merged_upstreams;
-    std::unordered_set<SubGraphPtr> merged_downstreams;
-    for (auto& item : GetUpstreamSet(first)) merged_upstreams.insert(item);
-    for (auto& item : GetUpstreamSet(second)) merged_upstreams.insert(item);
-    for (auto& item : GetDownstreamSet(first)) merged_downstreams.insert(item);
-    for (auto& item : GetDownstreamSet(second)) merged_downstreams.insert(item);
-    upstreams_[merged] = merged_upstreams;
-    downstreams_[merged] = merged_downstreams;
-    if (first != merged) {
-      upstreams_.erase(first);
-      downstreams_.erase(first);
-      all_nodes_.erase(first);
-    }
-    if (second != merged) {
-      upstreams_.erase(second);
-      downstreams_.erase(second);
-      all_nodes_.erase(second);
-    }
-    all_nodes_.insert(merged);
-  }
-  bool CanFuse(const SubGraphPtr& up, const SubGraphPtr& down) {
-    if (up == down) return false;
-    GraphSet after_fuse_upstreams =
-        Union(GetUpstreamSet(up), GetUpstreamSet(down));
-    GraphSet after_fuse_downstreams =
-        Union(GetDownstreamSet(up), GetDownstreamSet(down));
-    auto intersection = Intersect(after_fuse_upstreams, after_fuse_downstreams);
-    intersection.erase(up);
-    intersection.erase(down);
-    return intersection.size() == 0;
-  }
-
-  GraphSet GetUpstreamSet(const SubGraphPtr& cur) {
-    GraphSet res;
-    for (auto& raw_node : upstreams_[cur]) {
-      auto node = uf_set_->GetSetFromGraph(raw_node);
-      if (all_nodes_.count(node) && node != cur) res.insert(node);
-    }
-    upstreams_[cur] = res;
-    return res;
-  }
-
-  GraphSet GetDownstreamSet(const SubGraphPtr& cur) {
-    GraphSet res;
-    for (auto& raw_node : downstreams_[cur]) {
-      auto node = uf_set_->GetSetFromGraph(raw_node);
-      if (all_nodes_.count(node) && node != cur) res.insert(node);
-    }
-    downstreams_[cur] = res;
-    return res;
-  }
-};
-
-static void VLOG_LINES(const std::string& str) {
-  if (!VLOG_IS_ON(4)) return;
-#ifdef PADDLE_WITH_CINN
-  const auto& lines = cinn::utils::Split(str, "\n");
-  for (const auto& line : lines) {
-    VLOG(4) << line;
-  }
-#endif
-  return;
-}
-
-void MergeSubGraphs(Operation* op,
-                    Operation* producer,
-                    UnionFindSet& union_find,            // NOT NOLINT
-                    LoopDetectionMapping& loop_detector  // NOT NOLINT
-) {
-  if (union_find.GetSetFromOp(op) == union_find.GetSetFromOp(producer)) {
-    return;
-  }
-  if (!loop_detector.CanFuse(union_find.GetSetFromOp(producer),
-                             union_find.GetSetFromOp(op))) {
-    return;
-  }
-  // try fuse producer to sub-graph
-  auto op_graph_ptr = union_find.GetSetFromOp(op);
-  auto producer_graph_ptr = union_find.GetSetFromOp(producer);
-  union_find.Union(op, producer);
-  loop_detector.MergeNodes(
-      op_graph_ptr, producer_graph_ptr, union_find.GetSetFromOp(op));
-}
-
-void SubgraphDetector::DoOpFusion() {
-  // do fusion
-  VLOG(4) << "DoOpFusion";
-  UnionFindSet union_find;
-  union_find.op_classifier_ = op_classifier_;
-  VLOG(4) << "Do Op Fusion with sorted_ops: " << sort_ops_.size();
-  VLOG_LINES(OpsDebugStr(sort_ops_));
-  LoopDetectionMapping loop_detector(sort_ops_, op2id_, &union_find);
-
-  for (auto* op : sort_ops_) {
-    auto producers = GetProducerOpsReverseSort(op, op2id_);
-    for (auto* producer : producers) {
-      if (!op_classifier_(*op) || !op_classifier_(*producer)) {
-        continue;
-      }
-      VLOG(4) << "Start Judge: " << op->id() << " vs " << producer->id();
-
-      MergeSubGraphs(producer, op, union_find, loop_detector);
-    }
-  }
-  for (auto* op : sort_ops_) {
-    auto producers = GetProducerOpsReverseSort(op, op2id_);
-    for (auto* producer : producers) {
-      if (op_classifier_(*op) && !op_classifier_(*producer)) {
-        for (auto* consumer : GetConsumerOps(producer, op2id_)) {
-          if (op_classifier_(*consumer) &&
-              consumer->GetParent() == op->GetParent()) {
-            VLOG(4) << "Start Judge sibling nodes: " << op->id() << " vs "
-                    << consumer->id();
-            MergeSubGraphs(op, consumer, union_find, loop_detector);
-          }
+void SubgraphDetector::SubgraphFusion() {
+  // Merge related subgraphs while ensuring no cycles are created
+  for (const auto& op : sort_ops_) {
+    const auto producers = GetProducerOpsReverseSort(op, op2id_);
+    for (const auto& producer : producers) {
+      auto upstream = GetOpSubgraph(producer);
+      auto downstream = GetOpSubgraph(op);
+      std::cout << std::endl;
+      if (CanFuseUpstream2Downstream(upstream, downstream)) {
+        downstream->Merge(upstream);
+        root2subgraph_.erase(FindRoot(producer));
+        for (auto upstream_op : upstream->ops) {
+          op2root_[upstream_op] = FindRoot(op);
         }
       }
     }
   }
-
-  for (const auto& op : sort_ops_) {
-    subgraph_map_[op] = union_find.GetSetFromOp(op);
-  }
-
-  for (auto& subgraph : subgraph_map_) {
-    auto* op = subgraph.first;
-    auto* subgraph_ptr = subgraph.second.get();
-    if (union_find.Find(op) == op) {
-      VLOG(4) << "Subgraph: " << subgraph_ptr;
-      VLOG(4) << "   substitute: " << subgraph_ptr->substitute;
-      for (auto& op : subgraph_ptr->ops) {
-        VLOG(4) << "ops: " << op->name() << ", " << op->id();
-      }
-    }
-  }
 }
 
-void SubgraphDetector::BuildSubGraph() {
-  std::unordered_set<SubGraph*> subgraph_set;
-  for (auto* op : sort_ops_) {
-    PADDLE_ENFORCE_EQ(
-        subgraph_map_.count(op),
-        true,
-        common::errors::InvalidArgument("subgraph_map_ MUST contain op"));
-    auto& subgraph = subgraph_map_[op];
-    if (subgraph_set.count(subgraph.get())) {
+std::vector<SubGraphPtr> SubgraphDetector::GetSubgraphList() {
+  std::unordered_set<SubGraphPtr> subgraph_set;
+  std::vector<SubGraphPtr> subgraph_list;
+  for (const auto& op : sort_ops_) {
+    SubGraphPtr subgraph = GetOpSubgraph(op);
+    if (subgraph_set.count(subgraph)) {
       continue;
     }
-
-    subgraph_set.insert(subgraph.get());
-    subgraph_list_.push_back(subgraph);
+    subgraph_set.insert(subgraph);
+    subgraph_list.push_back(subgraph);
   }
-
-  for (auto& subgraph : subgraph_list_) {
-    for (auto& input_op : subgraph->input_ops) {
-      PADDLE_ENFORCE_EQ(
-          subgraph_map_.count(input_op),
-          true,
-          common::errors::InvalidArgument("subgraph_map_ MUST contain op"));
-      auto& producer = subgraph_map_[input_op];
-      subgraph->producers.insert(producer);
-      producer->consumers.insert(subgraph);
-    }
-  }
-
-  // init group depth.
-  for (auto& subgraph : subgraph_list_) {
-    for (auto& consumer : subgraph->consumers) {
-      // update depth.
-      subgraph->depth = std::max(subgraph->depth, consumer->depth + 1);
-    }
-    subgraph->max_depth = subgraph->depth;
-    subgraph->min_depth = subgraph->depth;
-  }
-
-  // reverse to keep fusion group in order.
-  std::reverse(subgraph_list_.begin(), subgraph_list_.end());
+  std::reverse(subgraph_list.begin(), subgraph_list.end());
+  return subgraph_list;
 }
+
+std::vector<GroupOpsVec> SubgraphDetector::BuildGroups() {
+  auto subgraph_list = GetSubgraphList();
+  VLOG(4) << "Subgraph list size: " << subgraph_list.size();
+  PADDLE_ENFORCE(!ExistCycle(subgraph_list),
+                 ::common::errors::PreconditionNotMet(
+                     "Cycle detected after SubGraph Fusion."));
+
+  std::vector<GroupOpsVec> groups;
+  for (const auto& subgraph : subgraph_list) {
+    if (!subgraph->substitute) {
+      continue;
+    }
+    // sort group ops by natural increasing index.
+    std::vector<pir::Operation*> group_ops(subgraph->ops.begin(),
+                                           subgraph->ops.end());
+    std::sort(group_ops.begin(),
+              group_ops.end(),
+              [this](pir::Operation* a, pir::Operation* b) {
+                return this->op2id_.at(a) < this->op2id_.at(b);
+              });
+    groups.push_back(group_ops);
+  }
+  return groups;
+}
+
+std::vector<GroupOpsVec> DetectSubGraphs(pir::Block* block,
+                                         const OpClassifier& classifier) {
+  return SubgraphDetector(block, classifier)();
+}
+
 std::vector<pir::Value> AnalysisOutputs(
     const GroupOpsVec& group_ops) {  // NOLINT
   // Get output by ud chain

--- a/paddle/fluid/pir/transforms/sub_graph_detector.h
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.h
@@ -29,37 +29,11 @@
 #include "paddle/pir/include/core/builder.h"
 
 namespace pir {
-
-struct SubGraph;
-using SubGraphPtr = std::shared_ptr<SubGraph>;
+using OpClassifier = std::function<bool(const pir::Operation&)>;
 using GroupOpsVec = std::vector<pir::Operation*>;
 
-class SubgraphDetector {
- public:
-  // Tell whether a node is inside a sub-graph.
-  using OpClassifier = std::function<bool(const pir::Operation&)>;
-
-  SubgraphDetector(pir::Block* block, const OpClassifier& classifier);
-
-  std::vector<GroupOpsVec> operator()();
-
- protected:
-  // Do Op Fusion
-  void DoOpFusion();
-
-  void BuildSubGraph();
-
- private:
-  pir::Block* block_;
-  OpClassifier op_classifier_;
-
-  std::vector<pir::Operation*> sort_ops_;
-  std::unordered_map<pir::Operation*, size_t> op2id_;
-  std::vector<SubGraphPtr> subgraph_list_;
-  std::unordered_map<pir::Operation*, SubGraphPtr> subgraph_map_;
-  std::unordered_map<pir::Operation*, std::unordered_map<pir::Operation*, bool>>
-      can_apply_fusion_map_;
-};
+std::vector<GroupOpsVec> DetectSubGraphs(pir::Block* block,
+                                         const OpClassifier& classifier);
 
 std::vector<pir::Value> AnalysisOutputs(const GroupOpsVec& group_ops);
 void ReplaceWithGroupOp(pir::Block* block, const GroupOpsVec& group_ops);

--- a/paddle/fluid/pir/transforms/sub_graph_extract_pass.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_extract_pass.cc
@@ -53,7 +53,7 @@ class SubGraphExtractPass : public pir::Pass {
     auto& block = module_op.block();
 
     std::vector<GroupOpsVec> groups =
-        ::pir::SubgraphDetector(&block, IsMatmulOp)();
+        ::pir::DetectSubGraphs(&block, IsMatmulOp);
     AddStatistics(groups.size());
     for (auto& group_ops : groups) {
       VLOG(4) << "current group_ops.size(): " << group_ops.size();

--- a/paddle/fluid/pir/transforms/tensorrt/trt_sub_graph_extract_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_sub_graph_extract_pass.cc
@@ -57,7 +57,7 @@ class TrtSubGraphExtractPass : public pir::Pass {
     auto& block = module_op.block();
 
     std::vector<GroupOpsVec> groups =
-        ::pir::SubgraphDetector(&block, IsSupportedByTRT)();
+        ::pir::DetectSubGraphs(&block, IsSupportedByTRT);
     AddStatistics(groups.size());
     for (auto& group_ops : groups) {
       if (group_ops.size() < static_cast<size_t>(FLAGS_trt_min_group_size)) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- 优化 BuildCinnPass 子图融合算法 + 重构规整 SubgraphDetector 相关数据结构和代码
- 之前前子图融合算法影响效率的点：判断两个 Subgraph 是否能够融合需要获取二者所有的上下游（包括间接的），然后求交集判断融合后是否存在环。
- 优化后：只需知道两个 Subgraph 的直接上下游关系，然后搜索二者之间是否存在其他路径，同时搜索的过程中利用 op 的拓扑序 id 进行剪枝
- 优化算法 + 重构代码带来的效率提升（测试机器为 A100 ）：

|  HRNet_W18_C | 前向 BuildCinnPass 耗时 | 反向 BuildCinnPass 耗时 | CINN 总耗时 |
|  ----  | ----  | ----  | ----  |
| 优化前 | 3min29s168ms | 2min37s798ms | 9min57s |
| 优化后 | 2s555ms | 814ms | 3min57s |
