### PR TITLE
optimize relu6 grad decmp

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
@@ -174,6 +174,7 @@ CUSTOM_VJP = [
     'minimum_grad',
     'pow_grad',
     'relu_grad',
+    'relu6_grad',
     'sigmoid_grad',
     'silu_grad',
     'softmax_grad',

--- a/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
+++ b/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
@@ -154,6 +154,7 @@ CUSTOM_VJP = [
     'minimum_grad',
     'pow_grad',
     'relu_grad',
+    'relu6_grad',
     'sigmoid_grad',
     'silu_grad',
     'softmax_grad',

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -1299,6 +1299,19 @@ void relu_grad(const Tensor& out, const Tensor& out_grad, Tensor* x_grad) {
 }
 
 template <typename T>
+void relu6_grad(const Tensor& out, const Tensor& out_grad, Tensor* x_grad) {
+  if (x_grad) {
+    Tensor zeros = full_scalar<T>(0.0, out.dtype());
+    Tensor six = full_scalar<T>(6.0, out.dtype());
+    auto mask_gt = greater_than<T>(out, zeros);
+    auto mask_lt = less_than<T>(out, six);
+    auto mask = bitwise_and<T>(mask_gt, mask_lt);
+    auto res = cast<T>(mask, out.dtype()) * out_grad;
+    set_output<T>(res, x_grad);
+  }
+}
+
+template <typename T>
 void gather_grad(const Tensor& x,
                  const Tensor& index,
                  const Tensor& out_grad,


### PR DESCRIPTION
### PR Category
CINN

### PR Types
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-76996

优化relu6 grad的反向拆分，当前relu6 仅拆分了前向，反向未拆分，通规前向拆分自动推导的反向，反向会依赖前向的输入， 但是phi的 relu6 grad 是依赖out，在一些任务上，依赖out 会跟后续的conv 依赖的输入是同一个变量，模型整体会更节省显存；因此直接拆分了relu6 grad
