### PR TITLE
[Prim][Pir] Add backward decomp and support dynamic for angle_grad(not complex)

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
@@ -93,6 +93,7 @@ decomp_ops_contain_unused_output = ["squeeze", "unsqueeze"]
 GENERATE_IMPL_VJP = [
     'abs_grad',
     'add_grad',
+    'angle_grad',
     'bce_loss_grad',
     'cos_grad',
     'divide_grad',

--- a/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
+++ b/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
@@ -72,6 +72,7 @@ PRIM_VJP = [
     'add_grad',
     'amax_grad',
     'amin_grad',
+    'angle_grad',
     'argsort_grad',
     'assign_grad',
     'atan_grad',

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -3630,12 +3630,11 @@ void p_norm_grad(const Tensor& x,
   }
 }
 
-
 template <typename T>
 void angle_grad(const Tensor& x, const Tensor& out_grad, Tensor* x_grad) {
   if (x_grad) {
     if (x.dtype() != DataType::COMPLEX128 && x.dtype() != DataType::COMPLEX64) {
-      Tensor cast_x = ConverToMT<T>(x);
+      Tensor cast_x = ConvertToMT<T>(x);
       Tensor zero_tensor;
       if (has_dynamic_shape(cast_x.shape())) {
         const Tensor x_shape = shape64<T>(cast_x);
@@ -3644,7 +3643,7 @@ void angle_grad(const Tensor& x, const Tensor& out_grad, Tensor* x_grad) {
       } else {
         zero_tensor = full<T>(cast_x.shape(), 0, cast_x.dtype());
       }
-      set_output<T>(ConverToOrig<T>(zero_tensor, x.dtype()), x_grad);
+      set_output<T>(ConvertToOrig<T>(zero_tensor, x.dtype()), x_grad);
     }
   }
 }

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -3633,18 +3633,16 @@ void p_norm_grad(const Tensor& x,
 template <typename T>
 void angle_grad(const Tensor& x, const Tensor& out_grad, Tensor* x_grad) {
   if (x_grad) {
-    if (x.dtype() != DataType::COMPLEX128 && x.dtype() != DataType::COMPLEX64) {
-      Tensor cast_x = ConvertToMT<T>(x);
-      Tensor zero_tensor;
-      if (has_dynamic_shape(cast_x.shape())) {
-        const Tensor x_shape = shape64<T>(cast_x);
-        zero_tensor =
-            backend::full_with_tensor<T>(x_shape, 0.0, cast_x.dtype());
-      } else {
-        zero_tensor = full<T>(cast_x.shape(), 0, cast_x.dtype());
-      }
-      set_output<T>(ConvertToOrig<T>(zero_tensor, x.dtype()), x_grad);
+    Tensor cast_x = ConvertToMT<T>(x);
+    Tensor zero_tensor;
+    if (has_dynamic_shape(cast_x.shape())) {
+      const Tensor x_shape = shape64<T>(cast_x);
+      zero_tensor = backend::full_with_tensor<T>(
+          x_shape, 0.0, cast_x.dtype(), cast_x.place());
+    } else {
+      zero_tensor = full<T>(cast_x.shape(), 0, cast_x.dtype(), cast_x.place());
     }
+    set_output<T>(ConvertToOrig<T>(zero_tensor, x.dtype()), x_grad);
   }
 }
 

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -3642,6 +3642,7 @@ void angle_grad(const Tensor& x, const Tensor& out_grad, Tensor* x_grad) {
     } else {
       zero_tensor = full<T>(cast_x.shape(), 0, cast_x.dtype(), cast_x.place());
     }
+
     set_output<T>(ConvertToOrig<T>(zero_tensor, x.dtype()), x_grad);
   }
 }

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -3630,6 +3630,25 @@ void p_norm_grad(const Tensor& x,
   }
 }
 
+
+template <typename T>
+void angle_grad(const Tensor& x, const Tensor& out_grad, Tensor* x_grad) {
+  if (x_grad) {
+    if (x.dtype() != DataType::COMPLEX128 && x.dtype() != DataType::COMPLEX64) {
+      Tensor cast_x = ConverToMT<T>(x);
+      Tensor zero_tensor;
+      if (has_dynamic_shape(cast_x.shape())) {
+        const Tensor x_shape = shape64<T>(cast_x);
+        zero_tensor =
+            backend::full_with_tensor<T>(x_shape, 0.0, cast_x.dtype());
+      } else {
+        zero_tensor = full<T>(cast_x.shape(), 0, cast_x.dtype());
+      }
+      set_output<T>(ConverToOrig<T>(zero_tensor, x.dtype()), x_grad);
+    }
+  }
+}
+
 }  // namespace details
 }  // namespace primitive
 }  // namespace paddle

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -33,6 +33,7 @@ ALLOW_DYNAMIC_SHAPE_VJP_OPS = [
     "pd_op.add",
     "pd_op.amax",
     "pd_op.amin",
+    "pd_op.angle",
     "pd_op.argsort",
     "pd_op.assign",
     "pd_op.batch_norm_",

--- a/test/legacy_test/test_angle_op.py
+++ b/test/legacy_test/test_angle_op.py
@@ -42,6 +42,8 @@ class TestAngleOpFloat(OpTest):
     def setUp(self):
         self.op_type = "angle"
         self.python_api = paddle.angle
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.angle
         self.dtype = "float64"
         self.x = np.linspace(-5, 5, 101).astype(self.dtype)
         out_ref = np.angle(self.x)
@@ -59,6 +61,7 @@ class TestAngleOpFloat(OpTest):
                 angle_grad(self.x, np.ones_like(self.x) / self.x.size)
             ],
             check_pir=True,
+            check_prim_pir=True,
         )
 
 
@@ -66,6 +69,8 @@ class TestAngleFP16Op(TestAngleOpFloat):
     def setUp(self):
         self.op_type = "angle"
         self.python_api = paddle.angle
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.angle
         self.dtype = "float16"
         self.x = np.linspace(-5, 5, 101).astype(self.dtype)
         out_ref = np.angle(self.x)
@@ -82,6 +87,8 @@ class TestAngleBF16Op(OpTest):
     def setUp(self):
         self.op_type = "angle"
         self.python_api = paddle.angle
+        self.prim_op_type = "prim"
+        self.public_python_api = paddle.angle
         self.dtype = np.uint16
         self.np_dtype = np.float32
         self.x = np.linspace(-5, 5, 101).astype(self.np_dtype)
@@ -107,6 +114,7 @@ class TestAngleBF16Op(OpTest):
                 angle_grad(self.x, np.ones_like(self.x) / self.x.size)
             ],
             check_pir=True,
+            check_prim_pir=True,
         )
 
 

--- a/test/prim/pir_prim/test_prim_sub_graph_abcde_backward_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_abcde_backward_dynamic_shape.py
@@ -71,6 +71,10 @@ def amin_net5(x):
     return paddle.amin(x, axis=[-1, 0], keepdim=False)
 
 
+def angle_net(x):
+    return paddle.angle(x)
+
+
 def argsort_net1(x):
     return paddle.argsort(x, axis=-1)
 
@@ -491,6 +495,19 @@ class TestPrimAminWithGrad6(TestPrimBaseWithGrad):
         self.init_x_shape = [None, None, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = amin_net5
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimAngleWithGrad(TestPrimBaseWithGrad):
+    def setUp(self):
+        np.random.seed(2024)
+        self.op_name = "pd_op.angle_grad"
+        self.dtype = "float32"
+        self.x_shape = [10, 10, 10]
+        self.init_x_shape = [None, None, None]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = angle_net
         self.enable_cinn = False
         self.tol = 1e-6
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
反向拆解angle_grad实数部分，支持动态shape