### PR TITLE
[AutoParallel]:fix FLAGS_log_memory_stats wrong log

### DIFF
--- a/paddle/phi/core/memory/allocation/stat_allocator.h
+++ b/paddle/phi/core/memory/allocation/stat_allocator.h
@@ -31,14 +31,6 @@ class StatAllocator : public Allocator {
 
  protected:
   void FreeImpl(phi::Allocation* allocation) override {
-    if (phi::is_cpu_place(allocation->place()) ||
-        phi::is_cuda_pinned_place(allocation->place())) {
-      HOST_MEMORY_STAT_UPDATE(
-          Allocated, allocation->place().GetDeviceId(), -allocation->size());
-    } else {
-      DEVICE_MEMORY_STAT_UPDATE(
-          Allocated, allocation->place().GetDeviceId(), -allocation->size());
-    }
     platform::RecordMemEvent(allocation->ptr(),
                              allocation->place(),
                              allocation->size(),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Deprecations

### Description
<!-- Describe what you’ve done -->
开启FLAGS_log_memory_stats时会记录每个op结束后的memory_allocated , memory_resvered
在当前，memory_allocated的更新放在最外层的allocator：stat_allocator。在某些显存延迟释放的情况下会造成当前的memory_allocated 与实际不准的记录。
Pcard-67164