### PR TITLE
optimize hardsigmoid grad decmop

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
@@ -168,6 +168,7 @@ OTHER_PRIM_VJP_OPS = [
 CUSTOM_VJP = [
     'bce_loss_grad',
     'gelu_grad',
+    "hardsigmoid_grad",
     'hardswish_grad',
     'leaky_relu_grad',
     'mean_grad',

--- a/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
@@ -168,7 +168,7 @@ OTHER_PRIM_VJP_OPS = [
 CUSTOM_VJP = [
     'bce_loss_grad',
     'gelu_grad',
-    "hardsigmoid_grad",
+    'hardsigmoid_grad',
     'hardswish_grad',
     'leaky_relu_grad',
     'mean_grad',

--- a/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
+++ b/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
@@ -146,6 +146,7 @@ CUSTOM_VJP = [
     'dropout_grad',
     'gelu_grad',
     'group_norm_grad',
+    'ardsigmoid_grad',
     'hardswish_grad',
     'instance_norm_grad',
     'layer_norm_grad',

--- a/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
+++ b/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
@@ -146,7 +146,7 @@ CUSTOM_VJP = [
     'dropout_grad',
     'gelu_grad',
     'group_norm_grad',
-    'ardsigmoid_grad',
+    'hardsigmoid_grad',
     'hardswish_grad',
     'instance_norm_grad',
     'layer_norm_grad',

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -1811,6 +1811,24 @@ void tile_grad(const Tensor& x,
 }
 
 template <typename T>
+void hardsigmoid_grad(const Tensor& out,
+                      const Tensor& out_grad,
+                      float slope,
+                      float offset,
+                      Tensor* x_grad) {
+  if (x_grad) {
+    Tensor zeros = full_scalar<T>(0.0, out.dtype());
+    Tensor one = full_scalar<T>(1.0, out.dtype());
+    auto mask_gt = greater_than<T>(out, zeros);
+    auto mask_lt = less_than<T>(out, one);
+    auto mask = bitwise_and<T>(mask_gt, mask_lt);
+    Tensor slope_tensor = full_scalar<T>(slope, out.dtype());
+    auto res = cast<T>(mask, out.dtype()) * slope_tensor * out_grad;
+    set_output<T>(res, x_grad);
+  }
+}
+
+template <typename T>
 void hardswish_grad(const Tensor& x, const Tensor& out_grad, Tensor* x_grad) {
   if (x_grad) {
     const Tensor offset = full_scalar<T>(3.0, x.dtype());


### PR DESCRIPTION
### PR Category
CINN

### PR Types
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-76996

优化hardsigmoid grad的反向拆分，当前hardsigmoid仅拆分了前向，反向未拆分，通规前向拆分自动推导的反向，反向会依赖前向的输入， 但是phi的 hardsigmoid grad 是依赖out，在一些任务上，依赖out 会跟后续的conv 依赖的输入是同一个变量，模型整体会更节省显存；因此直接拆分了hardsigmoid grad
