### PR TITLE
[CodeStyle][UP031] Use f-string instead of percent format in distributed (part30)

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/tuner/profiler.py
+++ b/python/paddle/distributed/auto_parallel/static/tuner/profiler.py
@@ -246,7 +246,7 @@ def profiler(args):
             if eval_step >= args.profile_start_step:
                 duration += end_time - start_time
 
-            print(f"step: {eval_step}, loss_print: {loss[0]}")
+            print(f"step: {eval_step}, loss_print: {loss[0]:f}")
             eval_step += 1
 
         avg_tput = (

--- a/python/paddle/distributed/auto_parallel/static/tuner/profiler.py
+++ b/python/paddle/distributed/auto_parallel/static/tuner/profiler.py
@@ -246,7 +246,7 @@ def profiler(args):
             if eval_step >= args.profile_start_step:
                 duration += end_time - start_time
 
-            print("step: %d, loss_print: %f" % (eval_step, loss[0]))
+            print(f"step: {eval_step}, loss_print: {loss[0]}")
             eval_step += 1
 
         avg_tput = (

--- a/python/paddle/distributed/fleet/cloud_utils.py
+++ b/python/paddle/distributed/fleet/cloud_utils.py
@@ -74,7 +74,7 @@ paddlecloud environment."
         ports = list(range(started_port, started_port + len(devices_per_proc)))
         trainer_endpoints = []
         for ip in node_ips:
-            trainer_endpoints.append(["%s:%d" % (ip, port) for port in ports])
+            trainer_endpoints.append([f"{ip}:{port}" for port in ports])
     else:
         trainer_endpoints_ori = trainer_endpoints.split(",")
         trainer_endpoints = []

--- a/python/paddle/distributed/fleet/elastic/manager.py
+++ b/python/paddle/distributed/fleet/elastic/manager.py
@@ -161,10 +161,10 @@ class ElasticManager:
                 node_ips, self.devices_per_proc, self.start_port
             )
             self.trainer_endpoints_list = [
-                "%s:%d" % (ip, self.start_port) for ip in node_ips
+                f"{ip}:{self.start_port}" for ip in node_ips
             ]
 
-        self.curr_host = "%s:%d" % (self.host, self.start_port)
+        self.curr_host = f"{self.host}:{self.start_port}"
         logger.info(f'start job with np={self.np}')
         logger.info(
             f"trainers={self.trainers}, trainer_endpoints_list={self.trainer_endpoints_list}"
@@ -327,7 +327,7 @@ class ElasticManager:
                 port = start_port
 
             ports = list(range(port, port + len(devices_per_proc)))
-            endpoint_list.extend(["%s:%d" % (ip, port) for port in ports])
+            endpoint_list.extend([f"{ip}:{port}" for port in ports])
 
         dist_endpoints = ','.join(endpoint_list)
         return dist_endpoints

--- a/python/paddle/distributed/fleet/launch.py
+++ b/python/paddle/distributed/fleet/launch.py
@@ -296,7 +296,7 @@ def get_cluster_from_args(args, device_mode, devices_per_proc):
 
     trainer_endpoints = []
     for ip in node_ips:
-        trainer_endpoints.append(["%s:%d" % (ip, port) for port in free_ports])
+        trainer_endpoints.append([f"{ip}:{port}" for port in free_ports])
     return get_cluster(
         node_ips, node_ip, trainer_endpoints, device_mode, devices_per_proc
     )

--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -497,9 +497,9 @@ def start_local_trainers(
     procs = []
     for idx, t in enumerate(pod.trainers):
         proc_env = {
-            "PADDLE_TRAINER_ID": "%d" % t.rank,
-            "PADDLE_CURRENT_ENDPOINT": f"{t.endpoint}",
-            "PADDLE_TRAINERS_NUM": "%d" % cluster.trainers_nranks(),
+            "PADDLE_TRAINER_ID": str(t.rank),
+            "PADDLE_CURRENT_ENDPOINT": str(t.endpoint),
+            "PADDLE_TRAINERS_NUM": str(cluster.trainers_nranks()),
             "PADDLE_TRAINER_ENDPOINTS": ",".join(cluster.trainers_endpoints()),
             "PADDLE_RANK_IN_NODE": str(idx),
             "PADDLE_LOCAL_DEVICE_IDS": ",".join(
@@ -582,9 +582,9 @@ def start_local_trainers(
                 and current_env.get("PADDLE_NEED_RANK_MAPPING").lower()
                 == "true"
             ):
-                fn = open("%s/prelaunchlog.%d" % (log_dir, idx), "a")
+                fn = open(f"{log_dir}/prelaunchlog.{idx}", "a")
             else:
-                fn = open("%s/workerlog.%d" % (log_dir, idx), "a")
+                fn = open(f"{log_dir}/workerlog.{idx}", "a")
             proc = subprocess.Popen(
                 cmd, env=current_env, stdout=fn, stderr=fn, preexec_fn=pre_fn
             )
@@ -949,7 +949,7 @@ def get_mapped_cluster_from_args_without_rank_mapping(args, device_mode):
             )
         else:
             free_ports = find_free_ports(len(node_ranks[node_rank]))
-        trainer_endpoints.append(["%s:%d" % (ip, port) for port in free_ports])
+        trainer_endpoints.append([f"{ip}:{port}" for port in free_ports])
 
     return get_mapped_cluster_without_rank_mapping(
         node_ips, node_ip, trainer_endpoints, device_mode, node_ranks
@@ -1082,7 +1082,7 @@ def get_mapped_cluster_from_args_with_rank_mapping(args, device_mode):
             )
         else:
             free_ports = find_free_ports(len(node_ranks[node_rank]))
-        trainer_endpoints.append(["%s:%d" % (ip, port) for port in free_ports])
+        trainer_endpoints.append([f"{ip}:{port}" for port in free_ports])
 
     return get_mapped_cluster_with_rank_mapping(
         node_ips,
@@ -1640,7 +1640,7 @@ class ParameterServerLauncher:
 
             if args.log_dir is not None:
                 os.makedirs(args.log_dir, exist_ok=True)
-                fn = open("%s/serverlog.%d" % (args.log_dir, idx), "w")
+                fn = open(f"{args.log_dir}/serverlog.{idx}", "w")
                 self.log_fns["server"].append(fn)
                 proc = subprocess.Popen(
                     cmd, env=current_env, stdout=fn, stderr=fn
@@ -1749,7 +1749,7 @@ class ParameterServerLauncher:
 
             if args.log_dir is not None:
                 os.makedirs(args.log_dir, exist_ok=True)
-                fn = open("%s/workerlog.%d" % (args.log_dir, idx), "w")
+                fn = open(f"{args.log_dir}/workerlog.{idx}", "w")
                 self.log_fns["worker"].append(fn)
                 proc = subprocess.Popen(
                     cmd, env=current_env, stdout=fn, stderr=fn
@@ -1818,7 +1818,7 @@ class ParameterServerLauncher:
 
             if args.log_dir is not None:
                 os.makedirs(args.log_dir, exist_ok=True)
-                fn = open("%s/coordinator.%d" % (args.log_dir, idx), "w")
+                fn = open(f"{args.log_dir}/coordinator.{idx}", "w")
                 self.log_fns["coordinator"].append(fn)
                 proc = subprocess.Popen(
                     cmd, env=current_env, stdout=fn, stderr=fn
@@ -1910,7 +1910,7 @@ class ParameterServerLauncher:
 
             if args.log_dir is not None:
                 os.makedirs(args.log_dir, exist_ok=True)
-                fn = open("%s/heterlog.%d" % (args.log_dir, idx), "w")
+                fn = open(f"{args.log_dir}/heterlog.{idx}", "w")
                 self.log_fns["heter_worker"].append(fn)
                 proc = subprocess.Popen(
                     cmd, env=current_env, stdout=fn, stderr=fn

--- a/python/paddle/distributed/ps/utils/collective_transpiler.py
+++ b/python/paddle/distributed/ps/utils/collective_transpiler.py
@@ -534,7 +534,7 @@ class MultiThread(GradAllReduce):
             print("begin to _transpile_startup_program for multi-node")
             print("current_endpoint: ", self.current_endpoint)
             print("total endpoints: ", self.endpoints)
-            print("rank: %d, ring_id: %d" % (self.rank, self.nrings))
+            print(f"rank: {self.rank}, ring_id: {self.nrings}")
             for ring_id in range(self.nrings):
                 self._init_communicator(
                     self.startup_program,

--- a/python/paddle/distributed/transpiler/collective.py
+++ b/python/paddle/distributed/transpiler/collective.py
@@ -523,7 +523,7 @@ class SingleProcessMultiThread(GradAllReduce):
             print("begin to _transpile_startup_program for multi-node")
             print("current_endpoint: ", self.current_endpoint)
             print("total endpoints: ", self.endpoints)
-            print("rank: %d, ring_id: %d" % (self.rank, self.nrings))
+            print(f"rank: {self.rank}, ring_id: {self.nrings}")
             for ring_id in range(self.nrings):
                 self._init_communicator(
                     self.startup_program,
@@ -737,7 +737,7 @@ class MultiThread(GradAllReduce):
             print("begin to _transpile_startup_program for multi-node")
             print("current_endpoint: ", self.current_endpoint)
             print("total endpoints: ", self.endpoints)
-            print("rank: %d, ring_id: %d" % (self.rank, self.nrings))
+            print(f"rank: {self.rank}, ring_id: {self.nrings}")
             for ring_id in range(self.nrings):
                 self._init_communicator(
                     self.startup_program,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

继 #65585 part19 后再次对 %x 形式 format 替换，因为 Ruff 0.8[^1] UP031 检查又有修改，现在只要是 %x 的形式都会抛出 UP031，即便没有自动修复，而有自动修复的之前已经全部修复过了，剩下的都是没有自动修复的，需要手动修复

> [!CAUTION]
>
> 相关地方均为手动逐个修复，需要仔细 review！

### Related links

- #70031
- #70033
- #70034
- #70035
- #70036
- #70037
- #70043
- #70044
- #70045
- #70046

[^1]: [Ruff 0.8 release notes](https://github.com/astral-sh/ruff/releases/tag/0.8.0)