### PR TITLE
[CodeStyle][UP031] Use f-string instead of percent format in uts (part31)

### DIFF
--- a/python/paddle/hapi/callbacks.py
+++ b/python/paddle/hapi/callbacks.py
@@ -446,7 +446,7 @@ class ProgBarLogger(Callback):
         self.epoch = epoch
         self.train_step = 0
         if self.epochs and self._is_print():
-            print('Epoch %d/%d' % (epoch + 1, self.epochs))
+            print(f'Epoch {epoch + 1}/{self.epochs}')
         self.train_progbar = ProgressBar(num=self.steps, verbose=self.verbose)
 
         self._train_timer['batch_start_time'] = time.time()
@@ -624,14 +624,14 @@ class ProgBarLogger(Callback):
         logs = logs or {}
         if self._is_print() and (self.eval_steps is not None):
             self._updates(logs, 'eval')
-            print('Eval samples: %d' % (self.evaled_samples))
+            print(f'Eval samples: {self.evaled_samples}')
 
     def on_predict_end(self, logs: _CallbackLogs | None = None) -> None:
         logs = logs or {}
         if self._is_print():
             if self.test_step % self.log_freq != 0 or self.verbose == 1:
                 self._updates(logs, 'test')
-            print('Predict samples: %d' % (self.tested_samples))
+            print(f'Predict samples: {self.tested_samples}')
 
 
 class ModelCheckpoint(Callback):
@@ -962,7 +962,7 @@ class EarlyStopping(Callback):
         if self.wait_epoch >= self.patience:
             self.model.stop_training = True
             if self.verbose > 0:
-                print('Epoch %d: Early stopping.' % (self.stopped_epoch + 1))
+                print(f'Epoch {self.stopped_epoch + 1}: Early stopping.')
                 if self.save_best_model and self.save_dir is not None:
                     print(
                         'Best checkpoint has been saved at {}'.format(
@@ -1448,8 +1448,8 @@ class ReduceLROnPlateau(Callback):
                         and paddle.distributed.ParallelEnv().local_rank == 0
                     ):
                         print(
-                            '\nEpoch %d: ReduceLROnPlateau reducing learning '
-                            'rate to %s.' % (self.epoch + 1, new_lr)
+                            f'\nEpoch {self.epoch + 1}: ReduceLROnPlateau reducing learning '
+                            f'rate to {new_lr}.'
                         )
                     self.cooldown_counter = self.cooldown
                     self.wait = 0

--- a/test/collective/fleet/hybrid_parallel_qat.py
+++ b/test/collective/fleet/hybrid_parallel_qat.py
@@ -68,7 +68,7 @@ def get_cluster_from_args(selected_gpus):
 
     trainer_endpoints = []
     for ip in node_ips:
-        trainer_endpoints.append(["%s:%d" % (ip, port) for port in free_ports])
+        trainer_endpoints.append([f"{ip}:{port}" for port in free_ports])
     return get_cluster(node_ips, node_ip, trainer_endpoints, selected_gpus)
 
 

--- a/test/collective/fleet/parallel_dygraph_se_resnext.py
+++ b/test/collective/fleet/parallel_dygraph_se_resnext.py
@@ -276,7 +276,7 @@ class SeResNeXt(paddle.nn.Layer):
             shortcut = False
             for i in range(depth[block]):
                 bottleneck_block = self.add_sublayer(
-                    'bb_%d_%d' % (block, i),
+                    f'bb_{block}_{i}',
                     BottleneckBlock(
                         num_channels=num_channels,
                         num_filters=num_filters[block],

--- a/test/collective/fleet/parallel_dygraph_transformer.py
+++ b/test/collective/fleet/parallel_dygraph_transformer.py
@@ -464,7 +464,7 @@ class EncoderLayer(Layer):
         for i in range(n_layer):
             self._encoder_sublayers.append(
                 self.add_sublayer(
-                    'esl_%d' % i,
+                    f'esl_{i}',
                     EncoderSubLayer(
                         n_head,
                         d_key,
@@ -739,7 +739,7 @@ class DecoderLayer(Layer):
         for i in range(n_layer):
             self._decoder_sub_layers.append(
                 self.add_sublayer(
-                    'dsl_%d' % i,
+                    f'dsl_{i}',
                     DecoderSubLayer(
                         n_head,
                         d_key,

--- a/test/collective/fleet/test_parallel_dygraph_qat.py
+++ b/test/collective/fleet/test_parallel_dygraph_qat.py
@@ -43,7 +43,7 @@ def get_cluster_from_args(selected_gpus):
 
     trainer_endpoints = []
     for ip in node_ips:
-        trainer_endpoints.append(["%s:%d" % (ip, port) for port in free_ports])
+        trainer_endpoints.append([f"{ip}:{port}" for port in free_ports])
     return get_cluster(node_ips, node_ip, trainer_endpoints, selected_gpus)
 
 

--- a/test/collective/fleet/test_recv_save_op.py
+++ b/test/collective/fleet/test_recv_save_op.py
@@ -85,13 +85,13 @@ class TestListenAndServOp(unittest.TestCase):
             try:
                 # the listen_and_serv_op would touch a file which contains the listen port
                 # on the /tmp directory until it was ready to process all the RPC call.
-                os.stat("/tmp/paddle.%d.port" % pid)
+                os.stat(f"/tmp/paddle.{pid}.port")
                 return
             except OSError:
                 start_left_time -= sleep_time
 
     def _get_pserver_port(self, pid):
-        with open("/tmp/paddle.%d.port" % pid, 'r') as f:
+        with open(f"/tmp/paddle.{pid}.port", 'r') as f:
             port = int(f.read().strip())
         return port
 

--- a/test/collective/process_group_nccl.py
+++ b/test/collective/process_group_nccl.py
@@ -43,7 +43,7 @@ class TestProcessGroupFp32(unittest.TestCase):
 
     def test_create_process_group_nccl(self):
         device_id = paddle.distributed.ParallelEnv().dev_id
-        paddle.set_device('gpu:%d' % device_id)
+        paddle.set_device(f'gpu:{device_id}')
 
         assert paddle.distributed.is_available()
 

--- a/test/custom_runtime/test_collective_process_group_xccl.py
+++ b/test/custom_runtime/test_collective_process_group_xccl.py
@@ -109,7 +109,7 @@ def get_cluster_from_args(selected_gpus):
 
     trainer_endpoints = []
     for ip in node_ips:
-        trainer_endpoints.append(["%s:%d" % (ip, port) for port in free_ports])
+        trainer_endpoints.append([f"{ip}:{port}" for port in free_ports])
     return get_cluster(node_ips, node_ip, trainer_endpoints, selected_gpus)
 
 

--- a/test/deprecated/ir/pass_test.py
+++ b/test/deprecated/ir/pass_test.py
@@ -166,17 +166,7 @@ class PassTest(unittest.TestCase):
                 offset = np.argmax(diff_mat > atol)
                 self.assertTrue(
                     is_allclose,
-                    "Output (name: %s, shape: %s, dtype: %s) has diff at %s. The maximum diff is %e, first error element is %d, expected %e, but got %e"
-                    % (
-                        self.fetch_list[i].name,
-                        str(self.fetch_list[i].shape),
-                        self.fetch_list[i].dtype,
-                        str(place),
-                        max_diff,
-                        offset,
-                        a.flatten()[offset],
-                        b.flatten()[offset],
-                    ),
+                    f"Output (name: {self.fetch_list[i].name}, shape: {self.fetch_list[i].shape!s}, dtype: {self.fetch_list[i].dtype}) has diff at {place!s}. The maximum diff is {max_diff}, first error element is {offset}, expected {a.flatten()[offset]}, but got {b.flatten()[offset]}",
                 )
 
     def _check_fused_ops(self, program):

--- a/test/deprecated/ir/pass_test.py
+++ b/test/deprecated/ir/pass_test.py
@@ -166,7 +166,10 @@ class PassTest(unittest.TestCase):
                 offset = np.argmax(diff_mat > atol)
                 self.assertTrue(
                     is_allclose,
-                    f"Output (name: {self.fetch_list[i].name}, shape: {self.fetch_list[i].shape!s}, dtype: {self.fetch_list[i].dtype}) has diff at {place!s}. The maximum diff is {max_diff}, first error element is {offset}, expected {a.flatten()[offset]}, but got {b.flatten()[offset]}",
+                    f"Output (name: {self.fetch_list[i].name}, shape: {self.fetch_list[i].shape!s}, dtype: {self.fetch_list[i].dtype}) has diff at {place!s}. "
+                    f"The maximum diff is {max_diff:e}, first error element is {offset}, "
+                    f"expected {a.flatten()[offset].item():e}, "
+                    f"but got {b.flatten()[offset].item():e}",
                 )
 
     def _check_fused_ops(self, program):

--- a/test/deprecated/legacy_test/auto_parallel_op_test.py
+++ b/test/deprecated/legacy_test/auto_parallel_op_test.py
@@ -512,15 +512,9 @@ class AutoParallelForwardChecker:
                     rtol=self.atol,
                     atol=self.rtol,
                     err_msg=(
-                        'Check eager auto parallel failed. Mismatch between eager auto parallel outputs '
-                        'and eager outputs on %s, the eager forward output tensor\'s index is : %d \n'
-                        'eager auto parallel output tensor:\n%s\n eager output tensor:\n%s\n'
-                        % (
-                            str(self.place),
-                            i,
-                            actual_ret[i],
-                            self.eager_forward_desire[i],
-                        )
+                        f"Check eager auto parallel failed. Mismatch between eager auto parallel outputs "
+                        f"and eager outputs on {self.place!s}. The eager forward output tensor's index is : {i} \n"
+                        f"eager auto parallel output tensor:\n{actual_ret[i]}\n eager output tensor:\n{self.eager_forward_desire[i]}\n"
                     ),
                 )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

继 #65585 part19 后再次对 %x 形式 format 替换，因为 Ruff 0.8[^1] UP031 检查又有修改，现在只要是 %x 的形式都会抛出 UP031，即便没有自动修复，而有自动修复的之前已经全部修复过了，剩下的都是没有自动修复的，需要手动修复

> [!CAUTION]
>
> 相关地方均为手动逐个修复，需要仔细 review！

### Related links

- #70031
- #70033
- #70034
- #70035
- #70036
- #70037
- #70043
- #70044
- #70045
- #70046
- #70084

[^1]: [Ruff 0.8 release notes](https://github.com/astral-sh/ruff/releases/tag/0.8.0)