### PR TITLE
[Auto Parallelfix attn_mask spmd rules

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/flash_attention.cc
+++ b/paddle/phi/infermeta/spmd_rules/flash_attention.cc
@@ -274,6 +274,9 @@ SpmdInfo FlashAttInferSpmd(const DistMetaTensor& q,
   if (!IsEmpty(attn_mask_shape)) {
     attn_mask_dist_attr_dst =
         MapDims(attn_mask_dist_attr, axis_to_dim_map, attn_mask_axes);
+    if (attn_mask_shape[1] == 1) {
+      attn_mask_dist_attr_dst = UnShardTensorDims(attn_mask_dist_attr_dst, {1});
+    }
   }
 
   // TODO(liuzhenhai): process fixed_seed
@@ -527,6 +530,9 @@ SpmdInfo FlashAttInferSpmdReverse(const DistMetaTensor& q,
   if (!IsEmpty(attn_mask_shape)) {
     attn_mask_dist_attr_dst =
         MapDims(attn_mask_dist_attr, axis_to_dim_map, attn_mask_axes);
+    if (attn_mask_shape[1] == 1) {
+      attn_mask_dist_attr_dst = UnShardTensorDims(attn_mask_dist_attr_dst, {1});
+    }
   }
 
   // TODO(liuzhenhai): process fixed_seed
@@ -800,6 +806,9 @@ SpmdInfo FlashAttGradInferSpmd(const DistMetaTensor& q,
   if (!IsEmpty(attn_mask_shape)) {
     attn_mask_dist_attr_dst =
         MapDims(attn_mask_dist_attr, axis_to_dim_map, attn_mask_axes);
+    if (attn_mask_shape[1] == 1) {
+      attn_mask_dist_attr_dst = UnShardTensorDims(attn_mask_dist_attr_dst, {1});
+    }
   }
 
   // TODO(liuzhenhai): process seed and  attn_mask


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-73145
修复fa算子切分推导的bug，当attn_mask的num_head维度为1的时候，不进行切分，避免空tensor的出现。
<img width="1268" alt="image" src="https://github.com/user-attachments/assets/986c227e-9c60-4bc5-928a-60cabbaf64b9">

