### PR TITLE
support load merged checkpoint

### DIFF
--- a/python/paddle/distributed/checkpoint/load_state_dict.py
+++ b/python/paddle/distributed/checkpoint/load_state_dict.py
@@ -552,7 +552,6 @@ def load_state_dict(
             process_group,
             use_dist,
         )
-        print('rank_to_files', rank_to_files)
 
         if len(missing_keys) > 0:
             logger.warning(
@@ -806,7 +805,7 @@ def load_merged_state_dict(path: str, prefix=None, unique_id=-1, offload=False):
     metadata_files, local_data_files = get_checkpoint_files(
         path, unique_id=unique_id
     )
-    print(metadata_files, local_data_files, flush=1)
+
     metadata_list = []
     for file in metadata_files:
         metadata_list.append(paddle.load(os.path.join(path, file)))
@@ -818,7 +817,6 @@ def load_merged_state_dict(path: str, prefix=None, unique_id=-1, offload=False):
             tensor_key,
             local_tensor_meta,
         ) in metadata.state_dict_metadata.items():
-            print(tensor_key, local_tensor_meta)
             if prefix is None or tensor_key.startswith(prefix):
                 global_shape = compute_global_shape(local_tensor_meta)
                 t = paddle.zeros(global_shape, dtype=local_tensor_meta[0].dtype)

--- a/python/paddle/distributed/checkpoint/load_state_dict.py
+++ b/python/paddle/distributed/checkpoint/load_state_dict.py
@@ -53,6 +53,9 @@ PATH_TO_CHECKPOINT_FILES: dict[str, tuple[list, list]] = {}
 
 
 def get_checkpoint_files(path, use_cache=True, unique_id=-1):
+    # if unique_id is -1, all file ends with .metadata and .distcp is returned
+    if unique_id == -1:
+        unique_id = ''
     global PATH_TO_CHECKPOINT_FILES
     if use_cache and path in PATH_TO_CHECKPOINT_FILES:
         return PATH_TO_CHECKPOINT_FILES[path]
@@ -64,7 +67,7 @@ def get_checkpoint_files(path, use_cache=True, unique_id=-1):
     ]
     assert (
         len(metadata_files) > 0
-    ), f"No metadata file found in the checkpoint directory:{path}."
+    ), f"No metadata file ends with '{unique_id}.metadata' found in the checkpoint directory: {path}."
     local_data_files = [
         file
         for file in accessible_files
@@ -72,7 +75,7 @@ def get_checkpoint_files(path, use_cache=True, unique_id=-1):
     ]
     assert (
         len(local_data_files) > 0
-    ), f"No data file found in the checkpoint directory:{path}."
+    ), f"No data file ends with '{unique_id}.distcp' found in the checkpoint directory:{path}."
     if use_cache:
         PATH_TO_CHECKPOINT_FILES[path] = (metadata_files, local_data_files)
     return (metadata_files, local_data_files)
@@ -539,7 +542,9 @@ def load_state_dict(
         if use_dist:
             check_unique_id(unique_id, process_group)
 
-        metadata_files, local_data_files = get_checkpoint_files(path)
+        metadata_files, local_data_files = get_checkpoint_files(
+            path, unique_id=unique_id
+        )
 
         metadata_list = []
         for file in metadata_files:

--- a/python/paddle/distributed/checkpoint/save_state_dict.py
+++ b/python/paddle/distributed/checkpoint/save_state_dict.py
@@ -24,8 +24,10 @@ from paddle.distributed.fleet.utils.log_util import logger
 
 from .metadata import LocalTensorIndex, LocalTensorMetadata, Metadata
 from .utils import (
+    check_unique_id,
     compute_local_shape_and_global_offset,
     flatten_state_dict,
+    get_max_id,
 )
 
 if TYPE_CHECKING:
@@ -74,18 +76,6 @@ def copy_dict_to_cpu(nested_dict):
         else:
             new_dict[key] = value
     return new_dict
-
-
-def check_file_name(file_name, process_group):
-    all_unique_id = []
-    unique_id = int(file_name.split(".")[0].split("_")[1])
-    paddle.distributed.all_gather_object(
-        all_unique_id, unique_id, process_group
-    )
-    for id in all_unique_id[1:]:
-        assert (
-            id == all_unique_id[0]
-        ), f"id:{id} !=  all_unique_id[0]:{file_name}"
 
 
 def merge_state_dict_metadata(global_state_dict_metadata):
@@ -147,6 +137,7 @@ def save_state_dict(
     path: str,
     process_group: Group | None = None,
     coordinator_rank: int = 0,
+    unique_id: int = -1,
     async_save: bool = False,
 ) -> None:
     """
@@ -156,9 +147,11 @@ def save_state_dict(
         state_dict(Dict[str, paddle.Tensor]): The state_dict to save.
         path(str): The directory to save state_dict.
         process_group(paddle.distributed.collective.Group): ProcessGroup to be used for cross-rank synchronization. Use the default process group which contains all cards.
-        coordinator_rank(int): The rank used to save non distributed values. Rank0 is used by default.
+        coordinator_rank(int): The rank used to save non distributed values. Rank 0 is used by default.
+        unique_id(int): The unique id of ckeckpoint, used to distinguish between different checkpoint versions. Default is -1, in which case the id 0 when save for the first time and increased by 1 each time when calling save_state_dict in the same path.
         async_save(bool): Async save the state_dict, default is False.
 
+        Note: If there is already checkpoint in
     Examples:
         .. code-block:: python
 
@@ -193,16 +186,21 @@ def save_state_dict(
             # Init the default global process group
             paddle.distributed.init_parallel_env()
 
-        unique_id = 0
-        file_name = ""
-        while True:
-            file_name = f"{paddle.distributed.get_rank()}_{unique_id}.distcp"
-            if not os.path.exists(os.path.join(path, file_name)):
-                break
-            unique_id += 1
-        logger.debug(f"file_name:{file_name}")
+        assert (
+            unique_id >= -1
+        ), f"unique_id should be >= -1, but got {unique_id}"
+
+        if unique_id == -1:
+            max_unique_id = get_max_id(path)
+            unique_id = max_unique_id + 1
+            logger.debug(f"Max unique id: {max_unique_id}")
+
         if use_dist:
-            check_file_name(file_name, process_group)
+            check_unique_id(unique_id, process_group)
+
+        file_name = f"{paddle.distributed.get_rank()}_{unique_id}.distcp"
+        logger.debug(f"The checkpoint is saved to file_name:{file_name}")
+
         metadata = Metadata()
         local_state_dict = {}
         local_state_dict_metadata = {}

--- a/python/paddle/distributed/checkpoint/utils.py
+++ b/python/paddle/distributed/checkpoint/utils.py
@@ -129,7 +129,7 @@ def get_max_id(path):
         match = pattern.match(file)
         if match:
             numbers.append(int(match.group(2)))
-    return max(numbers) if numbers else -1
+    return max(numbers) if numbers else None
 
 
 def check_unique_id(unique_id, process_group):

--- a/python/paddle/distributed/checkpoint/utils.py
+++ b/python/paddle/distributed/checkpoint/utils.py
@@ -14,6 +14,8 @@
 from __future__ import annotations
 
 import copy
+import os
+import re
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -117,3 +119,23 @@ def unflatten_state_dict(flat_state_dict, mapping):
         tmp[key_tuple[-1]] = value
 
     return state_dict
+
+
+def get_max_id(path):
+    numbers = []
+    pattern = re.compile(r"^(\d+)_(\d+)\.distcp$")
+    files = os.listdir(path)
+    for file in files:
+        match = pattern.match(file)
+        if match:
+            numbers.append(int(match.group(2)))
+    return max(numbers) if numbers else -1
+
+
+def check_unique_id(unique_id, process_group):
+    all_unique_id = []
+    paddle.distributed.all_gather_object(
+        all_unique_id, unique_id, process_group
+    )
+    for id in all_unique_id[1:]:
+        assert id == all_unique_id[0], f"id:{id} !=  all_unique_id[0]"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
- support load merged checkpoint
- fix the checkpoint version management problem:
  - allow user to specify unique_id, and when the specified unique_id is exists, the existing checkpoint will be overwrite
  - allow user to delete ckpt in given path
  - fix load checkpoint from multiple version


usage:
```
import paddle
import paddle.distributed as dist

ckpt_path='checkpoints/llama3.1_pretrain_ckpts/checkpoint-2/dist_ckpt'
print('maxid', dist.checkpoint.utils.get_max_id('checkpoints/llama3.1_pretrain_ckpts/checkpoint-2/dist_ckpt'))

unsharded_state_dict = dist.checkpoint.load_state_dict.load_merged_state_dict(ckpt_path, offload=1) # load unsharded checkpoint
print(f"unsharded_state_dict:{unsharded_state_dict}")
```

Pcard-76459