### PR TITLE
[XPU] disable use_stride_kernel for XPU

### DIFF
--- a/paddle/phi/core/kernel_factory.cc
+++ b/paddle/phi/core/kernel_factory.cc
@@ -28,9 +28,17 @@
 #include "paddle/phi/core/compat/op_utils.h"
 #include "paddle/utils/string/string_helper.h"
 
+#ifdef PADDLE_WITH_XPU
+// There is a significant performance degradation for using stride kernel on
+// XPU, so we disable it by default.
+PHI_DEFINE_EXPORTED_bool(use_stride_kernel,
+                         false,
+                         "Whether to use stride kernel if op support stride.");
+#else
 PHI_DEFINE_EXPORTED_bool(use_stride_kernel,
                          true,
                          "Whether to use stride kernel if op support stride.");
+#endif
 
 COMMON_DECLARE_int32(low_precision_op_list);
 COMMON_DECLARE_bool(enable_api_kernel_fallback);

--- a/paddle/phi/kernels/reshape_kernel.cc
+++ b/paddle/phi/kernels/reshape_kernel.cc
@@ -64,11 +64,13 @@ void ReshapeKernel<phi::XPUContext>(const XPUContext& dev_ctx,
   auto* src_ptr = x.data();
   auto* dst_ptr = out->data();
   auto size = x.numel() * phi::SizeOf(x.dtype());
-  int ret = xpu::copy(dev_ctx.x_context(),
-                      reinterpret_cast<const int8_t*>(src_ptr),
-                      reinterpret_cast<int8_t*>(dst_ptr),
-                      size);
-  PADDLE_ENFORCE_XDNN_SUCCESS(ret, "copy");
+  if (size > 0) {
+    int ret = xpu::copy(dev_ctx.x_context(),
+                        reinterpret_cast<const int8_t*>(src_ptr),
+                        reinterpret_cast<int8_t*>(dst_ptr),
+                        size);
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, "copy");
+  }
   out->Resize(dims);
   out->ResetLoD(x.lod());
 }

--- a/paddle/phi/kernels/xpu/diagonal_kernel.cc
+++ b/paddle/phi/kernels/xpu/diagonal_kernel.cc
@@ -31,6 +31,14 @@ void DiagonalKernel(const Context& dev_ctx,
   std::vector<int64_t> xshape = common::vectorize<int64_t>(x.dims());
   std::vector<int64_t> yshape = common::vectorize<int64_t>(out->dims());
 
+  if (axis1 < 0) {
+    axis1 += xshape.size();
+  }
+
+  if (axis2 < 0) {
+    axis2 += xshape.size();
+  }
+
   int r = xpu::diagonal(dev_ctx.x_context(),
                         reinterpret_cast<const XPUType*>(x.data<T>()),
                         reinterpret_cast<XPUType*>(out_data),

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -523,20 +523,23 @@ endif()
 
 list(REMOVE_ITEM TEST_OPS "test_stride")
 list(REMOVE_ITEM TEST_OPS "test_graph_reindex")
+if(WITH_XPU)
+  # XPU disables stride by default, so we turn on the flag
+  # manually to pass some stride tests.
+  set(STRIDE_TESTS test_as_strided test_index_select_strided test_tensor_unfold)
+  foreach(STRIDE_TEST_OP ${STRIDE_TESTS})
+    list(REMOVE_ITEM TEST_OPS ${STRIDE_TEST_OP})
+    py_test_modules(${STRIDE_TEST_OP} MODULES ${STRIDE_TEST_OP} ENVS
+                    FLAGS_use_stride_kernel=true)
+  endforeach()
+endif()
 if(WITH_COVERAGE)
   list(REMOVE_ITEM TEST_OPS test_weight_decay)
   list(REMOVE_ITEM TEST_OPS test_cuda_graphed_layer)
   list(REMOVE_ITEM TEST_OPS test_cuda_graph_partial_graph_static_run)
 endif()
 foreach(TEST_OP ${TEST_OPS})
-  if(WITH_XPU)
-    # Because XPU disables stride kernel by default,
-    # we turn it on here to pass some stride tests.
-    py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS
-                    FLAGS_use_stride_kernel=true)
-  else()
-    py_test_modules(${TEST_OP} MODULES ${TEST_OP})
-  endif()
+  py_test_modules(${TEST_OP} MODULES ${TEST_OP})
 endforeach()
 py_test_modules(
   test_imperative_ocr_attention_model MODULES

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -529,7 +529,14 @@ if(WITH_COVERAGE)
   list(REMOVE_ITEM TEST_OPS test_cuda_graph_partial_graph_static_run)
 endif()
 foreach(TEST_OP ${TEST_OPS})
-  py_test_modules(${TEST_OP} MODULES ${TEST_OP})
+  if(WITH_XPU)
+    # Because XPU disables stride kernel by default,
+    # we turn it on here to pass some stride tests.
+    py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS
+                    FLAGS_use_stride_kernel=true)
+  else()
+    py_test_modules(${TEST_OP} MODULES ${TEST_OP})
+  endif()
 endforeach()
 py_test_modules(
   test_imperative_ocr_attention_model MODULES


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Because the use_stride_kernel=True on XPU would cause significant performance degradation, we disable it by default.