### PR TITLE
[PIR] Add delete assert op pass and use it before apply cinn pass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -61,7 +61,6 @@
 #include "paddle/fluid/pir/transforms/build_cinn_pass.h"
 #include "paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.h"
 #include "paddle/fluid/pir/transforms/general/dead_code_elimination_pass.h"
-#include "paddle/fluid/pir/transforms/general/delete_assert_op_pass.h"
 #include "paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.h"
 
 COMMON_DECLARE_bool(cinn_specify_input_dynamic_dim);

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -61,6 +61,7 @@
 #include "paddle/fluid/pir/transforms/build_cinn_pass.h"
 #include "paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.h"
 #include "paddle/fluid/pir/transforms/general/dead_code_elimination_pass.h"
+#include "paddle/fluid/pir/transforms/general/delete_assert_op_pass.h"
 #include "paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.h"
 
 COMMON_DECLARE_bool(cinn_specify_input_dynamic_dim);

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -866,7 +866,7 @@ void AnalysisPredictor::OptimizeInferencePirProgram() {
       return pass_manager;
     };
 
-    if (config_.cinn_enabled() && !config_.custom_pass_only) {
+    if (config_.cinn_enabled() && !config_.custom_pass_only_) {
       ::pir::PassManager delete_assert_op_pm(::pir::IrContext::Instance(),
                                              config_.pm_opt_level_);
       delete_assert_op_pm.AddPass(

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -866,6 +866,14 @@ void AnalysisPredictor::OptimizeInferencePirProgram() {
       return pass_manager;
     };
 
+    if (config_.cinn_enabled() && !config_.custom_pass_only) {
+      ::pir::PassManager delete_assert_op_pm(::pir::IrContext::Instance(),
+                                             config_.pm_opt_level_);
+      delete_assert_op_pm.AddPass(
+          pir::PassRegistry::Instance().Get("delete_assert_op_pass"));
+      delete_assert_op_pm.Run(pir_program_.get());
+    }
+
     if (config_.use_gpu() && config_.cinn_enabled()) {
       if (!config_.custom_pass_only_) {
         ::pir::PassManager fused_op_pm(::pir::IrContext::Instance(),

--- a/paddle/fluid/pir/transforms/general/delete_assert_op_pass.cc
+++ b/paddle/fluid/pir/transforms/general/delete_assert_op_pass.cc
@@ -1,0 +1,64 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/pir/transforms/general/delete_assert_op_pass.h"
+
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/pir/include/core/builtin_op.h"
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pass/pass_registry.h"
+
+namespace {
+
+class DeleteAssertOpPattern
+    : public pir::OpRewritePattern<paddle::dialect::AssertOp> {
+ public:
+  using pir::OpRewritePattern<paddle::dialect::AssertOp>::OpRewritePattern;
+  bool MatchAndRewrite(
+      paddle::dialect::AssertOp op,
+      pir::PatternRewriter& rewriter) const override {  // NOLINT
+    rewriter.EraseOp(op);
+    return true;
+  }
+};
+
+class DeleteAssertOpPass : public pir::PatternRewritePass {
+ public:
+  DeleteAssertOpPass() : pir::PatternRewritePass("delete_assert_op_pass", 1) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext* context) override {
+    pir::RewritePatternSet ps(context);
+    ps.Add<DeleteAssertOpPattern>(context);
+    return ps;
+  }
+
+  bool CanApplyOn(pir::Operation* op) const override {
+    return op->isa<::pir::ModuleOp>() && op->num_regions() > 0;
+  }
+
+ private:
+  pir::FrozenRewritePatternSet patterns_;
+};
+
+}  // namespace
+
+namespace pir {
+
+std::unique_ptr<pir::Pass> CreateDeleteAssertOpPass() {
+  return std::make_unique<DeleteAssertOpPass>();
+}
+
+}  // namespace pir
+
+REGISTER_IR_PASS(delete_assert_op_pass, DeleteAssertOpPass);

--- a/paddle/fluid/pir/transforms/general/delete_assert_op_pass.h
+++ b/paddle/fluid/pir/transforms/general/delete_assert_op_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/core/dll_decl.h"
+
+namespace pir {
+
+class Pass;
+
+IR_API std::unique_ptr<Pass> CreateDeleteAssertOpPass();
+
+}  // namespace pir

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -51,6 +51,7 @@ USE_PIR_PASS(horizontal_fuse_pass);
 USE_PIR_PASS(auto_layout_simplify_pass);
 USE_PIR_PASS(auto_layout_pass);
 USE_PIR_PASS(common_subexpression_elimination_pass);
+USE_PIR_PASS(delete_assert_op_pass);
 USE_PIR_PASS(add_shadow_output_after_dead_parameter_pass);
 
 #ifdef PADDLE_WITH_DNNL

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -62,8 +62,10 @@ def apply_general_passes(
     program, *, enable_cse=True, enable_delete_assert_op=True
 ):
     pm = paddle.pir.PassManager(2)
-    pm.add_pass("common_subexpression_elimination_pass", {})
-    pm.add_pass("delete_assert_op_pass", {})
+    if enable_cse:
+        pm.add_pass("common_subexpression_elimination_pass", {})
+    if enable_delete_assert_op:
+        pm.add_pass("delete_assert_op_pass", {})
     pm.run(program)
 
 

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -58,6 +58,15 @@ def get_value_name(value):
     return value.name
 
 
+def apply_general_passes(
+    program, *, enable_cse=True, enable_delete_assert_op=True
+):
+    pm = paddle.pir.PassManager(2)
+    pm.add_pass("common_subexpression_elimination_pass", {})
+    pm.add_pass("delete_assert_op_pass", {})
+    pm.run(program)
+
+
 class NestSequence:
     """
     A wrapper class that easily to flatten and restore the nest structure of
@@ -698,8 +707,14 @@ class PartialProgramLayer:
                     pm, forward_program
                 )
                 pm.run(forward_program)
-                if cse_is_enabled():
-                    paddle.base.libpaddle.pir.apply_cse_pass(forward_program)
+
+                apply_general_passes(
+                    forward_program,
+                    enable_cse=cse_is_enabled(),
+                    enable_delete_assert_op=cinn_is_enabled(
+                        self._build_strategy, self._backend
+                    ),
+                )
 
                 # if-else pass
                 if cinn_is_enabled(self._build_strategy, self._backend):
@@ -786,9 +801,20 @@ class PartialProgramLayer:
                             forward_matched_value, kw_value
                         )
 
-                if cse_is_enabled():
-                    paddle.base.libpaddle.pir.apply_cse_pass(forward_program)
-                    paddle.base.libpaddle.pir.apply_cse_pass(backward_program)
+                apply_general_passes(
+                    forward_program,
+                    enable_cse=cse_is_enabled(),
+                    enable_delete_assert_op=cinn_is_enabled(
+                        self._build_strategy, self._backend
+                    ),
+                )
+                apply_general_passes(
+                    backward_program,
+                    enable_cse=cse_is_enabled(),
+                    enable_delete_assert_op=cinn_is_enabled(
+                        self._build_strategy, self._backend
+                    ),
+                )
                 if cinn_is_enabled(self._build_strategy, self._backend):
                     paddle.base.libpaddle.pir.apply_cinn_pass(forward_program)
                     init_backward_program_shape_analysis(

--- a/test/ir/pir/test_delete_assert_op_pass.py
+++ b/test/ir/pir/test_delete_assert_op_pass.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from contextlib import contextmanager
+
+import paddle
+
+paddle.enable_static()
+
+
+@contextmanager
+def program_scope_guard():
+    place = paddle.framework.core.Place()
+    place.set_place(paddle.CPUPlace())
+    new_scope = paddle.static.Scope()
+    main_program = paddle.static.Program()
+    with paddle.static.scope_guard(new_scope):
+        with paddle.static.program_guard(main_program):
+            yield main_program
+
+
+def walk_block(block, fn):
+    for op in block.ops:
+        fn(op)
+        for subblock in op.blocks():
+            walk_block(subblock, fn)
+
+
+def count_op(program, op_name):
+    count = 0
+
+    def count_fn(op):
+        nonlocal count
+        if op.name() == op_name:
+            count += 1
+
+    walk_block(program.global_block(), count_fn)
+    return count
+
+
+class AssertOpCountEqualMixin:
+    def assert_op_count_equal(self, program, op_count_map):
+        for op_name, expected_count in op_count_map.items():
+            actual_count = count_op(program, op_name)
+            self.assertEqual(
+                actual_count,
+                expected_count,
+                msg=f"Expect program has {expected_count} {op_name}, but got {actual_count} {op_name}",
+            )
+
+
+def apply_delete_assert_op_pass(program):
+    pm = paddle.pir.PassManager(2)
+    pm.add_pass("delete_assert_op_pass", {})
+    pm.run(program)
+
+
+class TestDeleteAssertOpBasic(unittest.TestCase, AssertOpCountEqualMixin):
+    def test_basic(self):
+        with program_scope_guard() as main_program:
+            # Inputs
+            x1 = paddle.static.data("x1", [2, 2], dtype="float32")
+            x2 = paddle.static.data("x2", [2, 2], dtype="float32")
+
+            # Computation
+            cond = x1 == x2
+            data = [x1, x2]
+            summarize = 2
+            paddle.static.nn.control_flow.Assert(cond, data, summarize)
+
+            # ApplyPass
+            self.assert_op_count_equal(
+                main_program, {"pd_op.assert": 1, "builtin.combine": 1}
+            )
+            apply_delete_assert_op_pass(main_program)
+            self.assert_op_count_equal(
+                main_program, {"pd_op.assert": 0, "builtin.combine": 0}
+            )
+
+    def test_basic2(self):
+        with program_scope_guard() as main_program:
+            # Inputs
+            x = paddle.static.data("x1", [], dtype="bool")
+
+            # Computation
+            cond = x
+            data = []
+            summarize = 0
+            paddle.static.nn.control_flow.Assert(cond, data, summarize)
+
+            self.assert_op_count_equal(
+                main_program, {"pd_op.assert": 1, "builtin.combine": 1}
+            )
+            apply_delete_assert_op_pass(main_program)
+            self.assert_op_count_equal(
+                main_program, {"pd_op.assert": 0, "builtin.combine": 0}
+            )
+
+
+class TestDeleteAssertOpSubBlock(unittest.TestCase, AssertOpCountEqualMixin):
+    def test_subblock(self):
+        with program_scope_guard() as main_program:
+            # Inputs
+            x1 = paddle.static.data("x1", [2, 2], dtype="int32")
+            x2 = paddle.static.data("x2", [2, 2], dtype="int32")
+            cond = paddle.static.data("cond", [], dtype="bool")
+            loop_var = paddle.static.data("i", [], dtype="int32")
+
+            def computation(x1, x2):
+                paddle.static.nn.control_flow.Assert(cond, [], 0)
+
+            # Assert in global block
+            computation(x1, x2)
+
+            # Assert in subblock
+            def loop_body(loop_var):
+                computation(x1, x2)
+                return [loop_var + 1]
+
+            def get_cond(loop_var):
+                return cond
+
+            paddle.static.nn.while_loop(get_cond, loop_body, [loop_var])
+
+            self.assert_op_count_equal(
+                main_program, {"pd_op.assert": 2, "builtin.combine": 2}
+            )
+            apply_delete_assert_op_pass(main_program)
+            self.assert_op_count_equal(
+                main_program, {"pd_op.assert": 0, "builtin.combine": 0}
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

添加 pass 用于删除 `AssertOp`，目前会在 CINN 场景使用，在 `apply_cinn_pass` 前调用

### TODOs

- [x] add unittest

PCard-66972