### PR TITLE
[Dy2St] Infer next var type recursively in while op

### DIFF
--- a/python/paddle/static/nn/control_flow.py
+++ b/python/paddle/static/nn/control_flow.py
@@ -743,7 +743,7 @@ class LoopVar:
             return create_loop_var_like(while_op, next_var)
         if is_sequence(next_var):
             return map_structure(
-                lambda var: create_loop_var_like(while_op, var),
+                lambda var: self.infer_type_with_next_var(var, while_op),
                 next_var,
             )
         return LoopVar(self.curr_var, next_var, self.block_arg)

--- a/test/dygraph_to_static/test_loop.py
+++ b/test/dygraph_to_static/test_loop.py
@@ -470,6 +470,7 @@ def loop_with_inner_mutate_list(x):
         a = []
         a.append(x)
         a.append(x + 1)
+        a.append(None)
         out += a[0]
         # After the loop, a is [x, x], which will be flattened to 2 elements
     return out


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

while 容器内新增的元素可能不是 Value，此时应该递归使用 `infer_type_with_next_var` 而不是 `create_loop_var_like`

PCard-66972