### PR TITLE
[Paddle TensorRT] Modify the base class for enabling FP16 unit tests

### DIFF
--- a/test/tensorrt/tensorrt_test_base.py
+++ b/test/tensorrt/tensorrt_test_base.py
@@ -42,7 +42,6 @@ class TensorRTBaseTest(unittest.TestCase):
         self.max_shape = None
         self.target_marker_op = ""
         self.dynamic_shape_data = {}
-        self.enable_fp16 = None
 
     def create_fake_program(self):
         if self.python_api is None:
@@ -155,7 +154,7 @@ class TensorRTBaseTest(unittest.TestCase):
                     new_list_args[sub_arg_name] = self.api_args[arg_name][i]
                 self.api_args[arg_name] = new_list_args
 
-    def check_trt_result(self, rtol=1e-5, atol=1e-5):
+    def check_trt_result(self, rtol=1e-5, atol=1e-5,enable_fp16=False):
         paddle.framework.set_flags({"FLAGS_trt_min_group_size": 1})
         with paddle.pir_utils.IrGuard():
             self.prepare_feed()
@@ -255,7 +254,7 @@ class TensorRTBaseTest(unittest.TestCase):
 
             # run TRTConverter(would lower group_op into tensorrt_engine_op)
             trt_config = None
-            if self.enable_fp16:
+            if enable_fp16:
                 input = Input(
                     min_input_shape=self.min_shape,
                     optim_input_shape=self.min_shape,

--- a/test/tensorrt/tensorrt_test_base.py
+++ b/test/tensorrt/tensorrt_test_base.py
@@ -154,7 +154,7 @@ class TensorRTBaseTest(unittest.TestCase):
                     new_list_args[sub_arg_name] = self.api_args[arg_name][i]
                 self.api_args[arg_name] = new_list_args
 
-    def check_trt_result(self, rtol=1e-5, atol=1e-5,enable_fp16=False):
+    def check_trt_result(self, rtol=1e-5, atol=1e-5, precision_mode="fp32"):
         paddle.framework.set_flags({"FLAGS_trt_min_group_size": 1})
         with paddle.pir_utils.IrGuard():
             self.prepare_feed()
@@ -254,7 +254,7 @@ class TensorRTBaseTest(unittest.TestCase):
 
             # run TRTConverter(would lower group_op into tensorrt_engine_op)
             trt_config = None
-            if enable_fp16:
+            if precision_mode == "fp16":
                 input = Input(
                     min_input_shape=self.min_shape,
                     optim_input_shape=self.min_shape,

--- a/test/tensorrt/test_converter_conv.py
+++ b/test/tensorrt/test_converter_conv.py
@@ -42,7 +42,7 @@ class TestConv2dTRTPattern(TensorRTBaseTest):
         self.max_shape = {"x": [10, 3, 8, 8]}
 
     def test_trt_result_fp16(self):
-        self.check_trt_result(enable_fp16=True)
+        self.check_trt_result(precision_mode="fp16")
 
     def test_trt_result_fp32(self):
         self.check_trt_result()

--- a/test/tensorrt/test_converter_conv.py
+++ b/test/tensorrt/test_converter_conv.py
@@ -41,10 +41,10 @@ class TestConv2dTRTPattern(TensorRTBaseTest):
         self.min_shape = {"x": [1, 3, 8, 8]}
         self.max_shape = {"x": [10, 3, 8, 8]}
 
-    def test_trt_result_fp32(self):
+    def test_trt_result_fp16(self):
         self.check_trt_result(enable_fp16=True)
 
-    def test_trt_result_fp16(self):
+    def test_trt_result_fp32(self):
         self.check_trt_result()
 
 

--- a/test/tensorrt/test_converter_conv.py
+++ b/test/tensorrt/test_converter_conv.py
@@ -40,9 +40,11 @@ class TestConv2dTRTPattern(TensorRTBaseTest):
         self.program_config = {"feed_list": ["x"]}
         self.min_shape = {"x": [1, 3, 8, 8]}
         self.max_shape = {"x": [10, 3, 8, 8]}
-        self.enable_fp16 = True
 
-    def test_trt_result(self):
+    def test_trt_result_fp32(self):
+        self.check_trt_result(enable_fp16=True)
+
+    def test_trt_result_fp16(self):
         self.check_trt_result()
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
card-71500
修改单测基类，测试fp16，只需要在check_trt_result中传入enable_fp16=True，默认是False