### PR TITLE
【TJU】【Paddle Tensor 第二期 API支持 0-size Tensor】paddle.copysign 支持 0-size tensor

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -7998,7 +7998,7 @@ def copysign(x: Tensor, y: Tensor | float, name: str | None = None) -> Tensor:
     """
     if isinstance(y, (float, int)):
         y = paddle.to_tensor(y, dtype=x.dtype)
-    if x.numel() == 0 or y.numel() == 0:
+    if paddle.in_dynamic_mode() and (x.numel() == 0 or y.numel() == 0):
         out_shape = paddle.broadcast_shape(x.shape, y.shape)
         out_shape = [builtins.max(0, dim) for dim in out_shape]
         return paddle.empty(shape=out_shape, dtype=x.dtype)
@@ -8007,7 +8007,6 @@ def copysign(x: Tensor, y: Tensor | float, name: str | None = None) -> Tensor:
         warnings.warn(
             f"The shape of broadcast output {out_shape} is different from the input tensor x with shape: {x.shape}, please make sure you are using copysign api correctly."
         )
-
     if in_dynamic_or_pir_mode():
         return _C_ops.copysign(x, y)
     else:

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import builtins
 import math
 import warnings
 from typing import TYPE_CHECKING, Literal
@@ -7997,6 +7998,10 @@ def copysign(x: Tensor, y: Tensor | float, name: str | None = None) -> Tensor:
     """
     if isinstance(y, (float, int)):
         y = paddle.to_tensor(y, dtype=x.dtype)
+    if x.numel() == 0 or y.numel() == 0:
+        out_shape = paddle.broadcast_shape(x.shape, y.shape)
+        out_shape = [builtins.max(0, dim) for dim in out_shape]
+        return paddle.empty(shape=out_shape, dtype=x.dtype)
     out_shape = broadcast_shape(x.shape, y.shape)
     if out_shape != list(x.shape):
         warnings.warn(

--- a/test/legacy_test/test_copysign_op.py
+++ b/test/legacy_test/test_copysign_op.py
@@ -300,6 +300,35 @@ class TestCopySignBroadcastCase3(TestCopySignAPI):
         self.y = (np.random.randn(3, 4, 5) * 10).astype(dtype)
 
 
+class TestCopySignDygrapgZeroDimCase(unittest.TestCase):
+    def setUp(self):
+        self.input_init()
+        self.place_init()
+
+    def input_init(self):
+        dtype = np.float16
+        self.x = np.array(1.23, dtype=dtype)
+        self.y = np.empty([0], dtype=dtype)
+
+    def place_init(self):
+        self.place = (
+            paddle.CUDAPlace(0)
+            if paddle.is_compiled_with_cuda()
+            else paddle.CPUPlace()
+        )
+
+    def test_dygraph_api(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.x)
+        y = paddle.to_tensor(self.y)
+        out = paddle.copysign(x, y)
+        out_ref = ref_copysign(self.x, self.y)
+        np.testing.assert_allclose(out_ref, out.numpy())
+        out_ref_dtype = out_ref.dtype
+        np.testing.assert_equal((out_ref_dtype == out.numpy().dtype), True)
+        paddle.enable_static()
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
报错如下：
1.测试代码没有指定输入类型一致，需要修改api-test
![image](https://github.com/user-attachments/assets/def11416-ae7b-4e52-bc1c-a20db8ec3536)
2.需要在python API层判断0-size tensor
![image](https://github.com/user-attachments/assets/f7fe7a5f-09e4-4fc0-b4ac-3f2c21a716d8)
对于问题2，暂时没有找到在静态图模式下判断0-size tensor的办法，因此单测也只写了动态图模式的。

api-test如下：
![image](https://github.com/user-attachments/assets/6ace82a0-65ec-4e26-ae29-292443094d2a)

单测如下：
![image](https://github.com/user-attachments/assets/9b286d6e-e071-42c3-829c-3b0575404848)

