### PR TITLE
[CINN] Add support for mod and pow in x86 kernel

### DIFF
--- a/paddle/cinn/optim/lower_intrin.h
+++ b/paddle/cinn/optim/lower_intrin.h
@@ -28,7 +28,7 @@ static const std::set<std::string> kIntrinsicCalls{
      "cos",         "cosh",        "tan",        "tanh",        "sin",
      "sinh",        "fabs",        "isnan",      "isfinite",    "isinf",
      "left_shift",  "right_shift", "bitwise_or", "bitwise_and", "bitwise_xor",
-     "bitwise_not", "fma",         "rsqrt"}};
+     "bitwise_not", "fma",         "rsqrt",      "mod",         "pow"}};
 
 /**
  * Map the Call nodes to llvm intrinsic.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
在X86 kernel里增加`mod`和`pow`的支持，其中`mod`支持整点和浮点，`pow`只支持浮点，整点会报错

Pcard-85711