### PR TITLE
【SCU】【Paddle Tensor 第二期 API支持 0-size Tensor】（paddle.sum、paddle.mean、paddle.prod、 paddle.var、 paddle.std）支持 0-size tensor

### DIFF
--- a/paddle/phi/kernels/cpu/elementwise_subtract_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_subtract_kernel.cc
@@ -37,16 +37,13 @@ void SubtractKernel(const Context& dev_ctx,
         dev_ctx, y, out, phi::funcs::NegativeFunctor<T>());
     return;
   }
-
   if (y.numel() == 0 && x.numel() != 0) {
     out->Resize(x.dims());
     dev_ctx.template Alloc<T>(out);
     phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
     return;
   }
-
   dev_ctx.template Alloc<T>(out);
-
   if (x.dims() == y.dims()) {
     SameDimsElementwiseCompute<SameDimsSubtractFunctor<CPUContext, T>>()(
         dev_ctx, x, y, out);

--- a/paddle/phi/kernels/cpu/prod_kernel.cc
+++ b/paddle/phi/kernels/cpu/prod_kernel.cc
@@ -16,7 +16,9 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/kernel_utils.h"
 #include "paddle/phi/kernels/cpu/reduce.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/reduce_functor.h"
 
 namespace phi {
@@ -28,6 +30,13 @@ void ProdKernel(const Context& dev_ctx,
                 bool keep_dim,
                 bool reduce_all,
                 DenseTensor* out) {
+  if (x.numel() == 0) {
+    DataType dtype = phi::CppTypeToDataType<T>::Type();
+    int value = 1;
+    FullKernel<T, Context>(
+        dev_ctx, std::vector<int64_t>({}), value, dtype, out);
+    return;
+  }
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   auto out_dtype = x.dtype();
   phi::Reduce<CPUContext, T, phi::funcs::ProdFunctor>(

--- a/paddle/phi/kernels/cpu/reduce_mean_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_mean_kernel.cc
@@ -16,7 +16,9 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/kernel_utils.h"
 #include "paddle/phi/kernels/cpu/reduce.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/reduce_functor.h"
 
 namespace phi {
@@ -28,6 +30,13 @@ void MeanRawKernel(const Context& dev_ctx,
                    bool keep_dim,
                    bool reduce_all,
                    DenseTensor* out) {
+  if (x.numel() == 0) {
+    DataType dtype = phi::CppTypeToDataType<T>::Type();
+    double nanValue = std::numeric_limits<double>::quiet_NaN();
+    FullKernel<T, Context>(
+        dev_ctx, std::vector<int64_t>({}), nanValue, dtype, out);
+    return;
+  }
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   auto out_dtype = x.dtype();
   phi::Reduce<CPUContext, T, phi::funcs::MeanFunctor>(

--- a/paddle/phi/kernels/cpu/reduce_sum_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_sum_kernel.cc
@@ -16,7 +16,9 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/kernel_utils.h"
 #include "paddle/phi/kernels/cpu/reduce.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/reduce_functor.h"
 
 namespace phi {
@@ -29,6 +31,13 @@ void SumRawKernel(const Context& dev_ctx,
                   bool reduce_all,
                   DataType out_dtype,
                   DenseTensor* out) {
+  if (x.numel() == 0) {
+    DataType dtype = phi::CppTypeToDataType<T>::Type();
+    int value = 0;
+    FullKernel<T, Context>(
+        dev_ctx, std::vector<int64_t>({}), value, dtype, out);
+    return;
+  }
   if (out_dtype == DataType::UNDEFINED && out->dtype() != x.dtype()) {
     out_dtype = out->dtype();
   }

--- a/paddle/phi/kernels/funcs/reduce_function.h
+++ b/paddle/phi/kernels/funcs/reduce_function.h
@@ -1051,19 +1051,11 @@ void ReduceKernel(const KPDevice& dev_ctx,
                   phi::DenseTensor* y,
                   const TransformOp& transform,
                   const std::vector<int>& origin_reduce_dims) {
-  PADDLE_ENFORCE_GE(x.numel(),
+  PADDLE_ENFORCE_GT(x.numel(),
                     0,
                     common::errors::InvalidArgument(
                         "Tensor need be reduced must not empty."));
-  if (x.numel() == 0) {
-    if (IsMean) {
-      DataType dtype = phi::CppTypeToDataType<Ty>::Type();
-      double nanValue = std::numeric_limits<double>::quiet_NaN();
-      FullKernel<Ty, KPDevice>(
-          dev_ctx, std::vector<int64_t>({}), nanValue, dtype, y);
-      return;
-    }
-  }
+
 #ifdef PADDLE_WITH_XPU_KP
   auto stream = dev_ctx.x_context()->xpu_stream;
 #else
@@ -1359,51 +1351,6 @@ void HandleLargeDim(const Context& dev_ctx,
   output->ResizeAndAllocate(output_dim);
 }
 
-////////////// Handle Special Case
-
-template <typename Functor, typename Context, typename T, typename OutT>
-struct SpecialCaseReduceOp {
-  static void HandleEmptyTensor(const Context& dev_ctx,
-                                const phi::DenseTensor& input,
-                                phi::DenseTensor* output) {
-    PADDLE_THROW(common::errors::InvalidArgument(
-        "Unsupported reduction operation for empty tensor."));
-  }
-};
-
-// Sum操作的特化
-template <typename Context, typename T, typename OutT>
-struct SpecialCaseReduceOp<phi::funcs::SumFunctor, Context, T, OutT> {
-  static void HandleEmptyTensor(const Context& dev_ctx,
-                                const phi::DenseTensor& input,
-                                phi::DenseTensor* output) {
-    auto out = dev_ctx.template Alloc<OutT>(output);
-    *out = static_cast<OutT>(0);
-  }
-};
-
-// Mean操作的特化
-template <typename Context, typename T, typename OutT>
-struct SpecialCaseReduceOp<phi::funcs::MeanFunctor, Context, T, OutT> {
-  static void HandleEmptyTensor(const Context& dev_ctx,
-                                const phi::DenseTensor& input,
-                                phi::DenseTensor* output) {
-    auto out = dev_ctx.template Alloc<OutT>(output);
-    *out = static_cast<OutT>(std::numeric_limits<float>::quiet_NaN());
-  }
-};
-
-// Prod操作的特化
-template <typename Context, typename T, typename OutT>
-struct SpecialCaseReduceOp<phi::funcs::ProdFunctor, Context, T, OutT> {
-  static void HandleEmptyTensor(const Context& dev_ctx,
-                                const phi::DenseTensor& input,
-                                phi::DenseTensor* output) {
-    auto out = dev_ctx.template Alloc<OutT>(output);
-    *out = static_cast<OutT>(1);
-  }
-};
-
 ////////////// ReduceKernel
 
 template <typename Context, typename T, typename OutT, typename Functor>
@@ -1413,18 +1360,12 @@ void ReduceKernelImpl(const Context& dev_ctx,
                       const std::vector<int64_t>& dims,
                       bool keep_dim,
                       bool reduce_all) {
-  PADDLE_ENFORCE_GE(input.numel(),
+  PADDLE_ENFORCE_GT(input.numel(),
                     0,
                     common::errors::InvalidArgument(
                         "The input size (numel) of reduce op should be larger "
                         "than or equal to 0, but received size is %d",
                         input.numel()));
-
-  if (input.numel() == 0) {
-    SpecialCaseReduceOp<Functor, Context, T, OutT>::HandleEmptyTensor(
-        dev_ctx, input, output);
-    return;
-  }
 
   dev_ctx.template Alloc<OutT>(output);
 

--- a/paddle/phi/kernels/kps/elementwise_kernel.cu
+++ b/paddle/phi/kernels/kps/elementwise_kernel.cu
@@ -42,7 +42,6 @@ void SubtractKernel(const Context& dev_ctx,
         dev_ctx, y, out, phi::funcs::NegativeFunctor<T>());
     return;
   }
-
   if (y.numel() == 0 && x.numel() != 0) {
     out->Resize(x.dims());
     dev_ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/kps/reduce_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_kernel.cu
@@ -16,6 +16,8 @@
 #include "paddle/phi/common/complex.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/kernel_utils.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/gpu/reduce.h"
 #include "paddle/phi/kernels/legacy/reduce_max_kernel.h"
 #include "paddle/phi/kernels/prod_kernel.h"
@@ -42,6 +44,13 @@ void ProdKernel(const Context& dev_ctx,
                 bool keep_dim,
                 bool reduce_all,
                 DenseTensor* out) {
+  if (x.numel() == 0) {
+    DataType dtype = phi::CppTypeToDataType<T>::Type();
+    int value = 1;
+    FullKernel<T, Context>(
+        dev_ctx, std::vector<int64_t>({}), value, dtype, out);
+    return;
+  }
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::MulFunctor, kps::IdentityFunctor>(
@@ -117,6 +126,13 @@ void MeanRawKernel(const Context& dev_ctx,
                    bool keep_dim,
                    bool reduce_all,
                    DenseTensor* out) {
+  if (x.numel() == 0) {
+    DataType dtype = phi::CppTypeToDataType<T>::Type();
+    double nanValue = std::numeric_limits<double>::quiet_NaN();
+    FullKernel<T, Context>(
+        dev_ctx, std::vector<int64_t>({}), nanValue, dtype, out);
+    return;
+  }
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::AddFunctor, kps::IdentityFunctor, true>(
@@ -193,6 +209,13 @@ void SumRawKernel(const Context& dev_ctx,
                   bool reduce_all,
                   DataType out_dtype,
                   DenseTensor* out) {
+  if (x.numel() == 0) {
+    DataType dtype = phi::CppTypeToDataType<T>::Type();
+    int value = 0;
+    FullKernel<T, Context>(
+        dev_ctx, std::vector<int64_t>({}), value, dtype, out);
+    return;
+  }
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   if (out_dtype == DataType::UNDEFINED && out->dtype() != x.dtype()) {
     out_dtype = out->dtype();

--- a/paddle/phi/kernels/xpu/elementwise_subtract_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_subtract_kernel.cc
@@ -24,6 +24,19 @@ void SubtractKernel(const Context& dev_ctx,
                     const DenseTensor& x,
                     const DenseTensor& y,
                     DenseTensor* out) {
+  if (x.numel() == 0 && y.numel() != 0) {
+    out->Resize(y.dims());
+    dev_ctx.template Alloc<T>(out);
+    ActivationImpl<T, T, Context, phi::funcs::NegativeFunctor<T>>(
+        dev_ctx, y, out, phi::funcs::NegativeFunctor<T>());
+    return;
+  }
+  if (y.numel() == 0 && x.numel() != 0) {
+    out->Resize(x.dims());
+    dev_ctx.template Alloc<T>(out);
+    phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    return;
+  }
   using XPUType = typename XPUTypeTrait<T>::Type;
   auto f = [](xpu::Context* ctx,
               const XPUType* x,

--- a/paddle/phi/kernels/xpu/elementwise_subtract_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_subtract_kernel.cc
@@ -16,7 +16,10 @@ limitations under the License. */
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/backends/xpu/xpu_header.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/xpu/elementwise.h"
+#include "paddle/phi/kernels/funcs/activation_functor.h"
+#include "paddle/phi/kernels/impl/activation_impl.h"
 namespace phi {
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/xpu/elementwise_subtract_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_subtract_kernel.cc
@@ -17,9 +17,9 @@ limitations under the License. */
 #include "paddle/phi/backends/xpu/xpu_header.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
-#include "paddle/phi/kernels/xpu/elementwise.h"
 #include "paddle/phi/kernels/funcs/activation_functor.h"
 #include "paddle/phi/kernels/impl/activation_impl.h"
+#include "paddle/phi/kernels/xpu/elementwise.h"
 namespace phi {
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/xpu/prod_kernel.cc
+++ b/paddle/phi/kernels/xpu/prod_kernel.cc
@@ -18,8 +18,8 @@
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/kernel_utils.h"
-#include "paddle/phi/kernels/xpu/reduce.h"
 #include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/xpu/reduce.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/xpu/prod_kernel.cc
+++ b/paddle/phi/kernels/xpu/prod_kernel.cc
@@ -28,6 +28,13 @@ void ProdKernel(const Context& dev_ctx,
                 bool keep_dim,
                 bool reduce_all,
                 DenseTensor* out) {
+  if (x.numel() == 0) {
+    DataType dtype = phi::CppTypeToDataType<T>::Type();
+    int value = 1;
+    FullKernel<T, Context>(
+        dev_ctx, std::vector<int64_t>({}), value, dtype, out);
+    return;
+  }
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   using XPUType = typename XPUTypeTrait<T>::Type;
 

--- a/paddle/phi/kernels/xpu/prod_kernel.cc
+++ b/paddle/phi/kernels/xpu/prod_kernel.cc
@@ -17,7 +17,9 @@
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/kernel_utils.h"
 #include "paddle/phi/kernels/xpu/reduce.h"
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/xpu/reduce_mean_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_mean_kernel.cc
@@ -18,8 +18,8 @@
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/kernel_utils.h"
-#include "paddle/phi/kernels/xpu/reduce.h"
 #include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/xpu/reduce.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/xpu/reduce_mean_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_mean_kernel.cc
@@ -28,6 +28,13 @@ void MeanRawKernel(const Context& dev_ctx,
                    bool keep_dim,
                    bool reduce_all,
                    DenseTensor* out) {
+  if (x.numel() == 0) {
+    DataType dtype = phi::CppTypeToDataType<T>::Type();
+    double nanValue = std::numeric_limits<double>::quiet_NaN();
+    FullKernel<T, Context>(
+        dev_ctx, std::vector<int64_t>({}), nanValue, dtype, out);
+    return;
+  }
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   using XPUType = typename XPUTypeTrait<T>::Type;
   auto f = [](xpu::Context* ctx,

--- a/paddle/phi/kernels/xpu/reduce_mean_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_mean_kernel.cc
@@ -17,7 +17,9 @@
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/kernel_utils.h"
 #include "paddle/phi/kernels/xpu/reduce.h"
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/xpu/reduce_sum_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_sum_kernel.cc
@@ -17,8 +17,8 @@
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/kernel_utils.h"
-#include "paddle/phi/kernels/xpu/reduce.h"
 #include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/xpu/reduce.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/xpu/reduce_sum_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_sum_kernel.cc
@@ -28,6 +28,13 @@ void SumRawKernel(const Context& dev_ctx,
                   bool reduce_all,
                   DataType out_dtype,
                   DenseTensor* out) {
+  if (x.numel() == 0) {
+    DataType dtype = phi::CppTypeToDataType<T>::Type();
+    int value = 0;
+    FullKernel<T, Context>(
+        dev_ctx, std::vector<int64_t>({}), value, dtype, out);
+    return;
+  }
   if (out_dtype == DataType::UNDEFINED && out->dtype() != x.dtype()) {
     out_dtype = out->dtype();
   }

--- a/paddle/phi/kernels/xpu/reduce_sum_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_sum_kernel.cc
@@ -16,7 +16,9 @@
 
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/kernel_utils.h"
 #include "paddle/phi/kernels/xpu/reduce.h"
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -201,7 +201,7 @@ def var(
     )
     n = n.astype(dtype)
     if unbiased:
-        one_const = paddle.ones([], x.dtype).to(x.place)
+        one_const = paddle.ones([], x.dtype)
         n = where(n > one_const, n - 1.0, one_const)
     n.stop_gradient = True
     out /= n

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -201,7 +201,7 @@ def var(
     )
     n = n.astype(dtype)
     if unbiased:
-        one_const = paddle.ones([], x.dtype)
+        one_const = paddle.ones([], x.dtype).to(x.place)
         n = where(n > one_const, n - 1.0, one_const)
     n.stop_gradient = True
     out /= n


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
解决 sum, mean, prod, var, std 五个 reduce_op 输入 Tensor 为 0-size Tensor 时出现的报错。
![image](https://github.com/user-attachments/assets/370315bc-f22f-461e-be0f-d90d51326661)

