### PR TITLE
[CINN] Adjust order of infer_symbol_shape pass in inference (#70042)

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -260,15 +260,20 @@ int64_t GetOpCount(const ::pir::Operation* op) {
   return count;
 }
 
-void ApplyCinnPass(::pir::Program* program,
-                   const std::function<std::shared_ptr<pir::PassManager>()>&
-                       CreatePassManager) {
+void ApplyCinnPass(
+    ::pir::Program* program,
+    const std::function<std::shared_ptr<pir::PassManager>()>& CreatePassManager,
+    bool is_train_mode) {
   const uint32_t origin_num_ops = program->num_ops();
   PirToPyCodeConverter(program)
       .file_name("original_programs.py")
       .dump_symbolic_shape(FLAGS_logging_pir_py_code_dump_symbolic_dims)
       .SaveIfFlagEnabled();
-  ApplyShapeOptimizationPass(program, CreatePassManager);
+  if (is_train_mode) {
+    // Skip infer symbol shape in inference, because we have run this pass in
+    // the previous process
+    ApplyShapeOptimizationPass(program, CreatePassManager);
+  }
   ApplyPdToCinnPass(program, CreatePassManager);
   ApplyCinnPreprocessPass(program, CreatePassManager);
   ApplyBuildGroupOpPass(program, CreatePassManager);

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.h
@@ -26,8 +26,9 @@ class Program;
 
 namespace cinn::dialect::ir {
 
-void ApplyCinnPass(::pir::Program* program,
-                   const std::function<std::shared_ptr<pir::PassManager>()>&
-                       CreatePassManager);
+void ApplyCinnPass(
+    ::pir::Program* program,
+    const std::function<std::shared_ptr<pir::PassManager>()>& CreatePassManager,
+    bool is_train_mode = true);
 
 }  // namespace cinn::dialect::ir

--- a/paddle/cinn/hlir/framework/pir/utils.cc
+++ b/paddle/cinn/hlir/framework/pir/utils.cc
@@ -409,7 +409,6 @@ bool CauseNewSymbolicShape(const ::pir::Operation& op) {
     }
     return false;
   }();
-
   return outputs_have_new_symbol;
 }
 
@@ -445,14 +444,24 @@ bool HasHandledInPass(const ::pir::Operation& op) {
 // 3. it should be handled in pd_to_cinn_pass;
 bool IsSupportInCinn(const ::pir::Operation& op) {
   const bool is_denied = IsDeniedInCinn(op);
-  const bool is_registered = IsRegisteredInCINN(op);
-  const bool is_handled = HasHandledInPass(op);
-  const bool cause_new_symbolic_shape = CauseNewSymbolicShape(op);
-  VLOG(5) << op.name() << ": IsDeniedInCinn = " << is_denied
-          << ", IsRegisteredInCINN = " << is_registered
-          << ", HasHandledInPass = " << is_handled
-          << ", CauseNewSymbolicShape = " << cause_new_symbolic_shape;
-  return !is_denied && is_registered && is_handled && !cause_new_symbolic_shape;
+  if (IsDeniedInCinn(op)) {
+    VLOG(5) << op.name() << "[id:" << op.id() << "] is denied in CINN";
+    return false;
+  }
+  if (!IsRegisteredInCINN(op)) {
+    VLOG(5) << op.name() << "[id:" << op.id() << "] isn't registered in CINN";
+    return false;
+  }
+  if (!HasHandledInPass(op)) {
+    VLOG(5) << op.name() << "[id:" << op.id() << "] isn't handled in CINN";
+    return false;
+  }
+  if (CauseNewSymbolicShape(op)) {
+    VLOG(5) << op.name() << "[id:" << op.id()
+            << "] caused new symbolic shape in CINN";
+    return false;
+  }
+  return true;
 }
 }  // namespace
 

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -102,6 +102,7 @@
 #include "paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_util.h"
 #include "paddle/pir/include/dialect/shape/ir/shape_dialect.h"
+#include "paddle/pir/include/dialect/shape/transforms/shape_optimization_pass.h"
 #include "paddle/pir/include/dialect/shape/utils/shape_analysis.h"
 #endif
 
@@ -126,7 +127,6 @@
 #include "paddle/pir/include/core/block_argument.h"
 #include "paddle/pir/include/core/builtin_attribute.h"
 #include "paddle/pir/include/core/program.h"
-#include "paddle/pir/include/dialect/shape/transforms/shape_optimization_pass.h"
 #include "paddle/pir/include/pass/pass_manager.h"
 #include "paddle/pir/include/pass/pass_registry.h"
 
@@ -869,6 +869,13 @@ void AnalysisPredictor::OptimizeInferencePirProgram() {
       if (!config_.custom_pass_only_) {
         ::pir::PassManager fused_op_pm(::pir::IrContext::Instance(),
                                        config_.pm_opt_level_);
+        auto &shape_analysis =
+            pir::ShapeAnalysisManager::Instance().Get(pir_program_.get());
+        fused_op_pm.SetValueReplacedHook([&](pir::Value from, pir::Value to) {
+          shape_analysis.ShareShapeOrData(from, to);
+        });
+        // Infer symbol shape for all ops before fused pass
+        fused_op_pm.AddPass(pir::CreateShapeOptimizationPass());
         const std::vector<std::string> FusedOpPasses{// Operator fusion pass
                                                      "conv2d_bn_fuse_pass",
                                                      "conv2d_add_act_fuse_pass",
@@ -902,7 +909,8 @@ void AnalysisPredictor::OptimizeInferencePirProgram() {
 
     if (config_.cinn_enabled()) {
       VLOG(4) << "[CINN] Begin ApplyCinnPass";
-      cinn::dialect::ir::ApplyCinnPass(pir_program_.get(), CreatePassMgr);
+      cinn::dialect::ir::ApplyCinnPass(
+          pir_program_.get(), CreatePassMgr, false);
     }
 #endif
 

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -605,7 +605,8 @@ ShapeConstraintIRAnalysis::GetShapeOrDataForValue(Value val) {
       SetSymbolForValueByStaticShape(val);
     } else {
       VLOG(3) << "InferShapeOrDataForValue,  defining_op: "
-              << val.defining_op()->name() << " id:" << val.defining_op()->id();
+              << val.defining_op()->name() << " id:" << val.defining_op()->id()
+              << " value id: " << val.impl()->id();
       InferShapeOrDataForValue(val);
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Pcard-67164

重新提交[PR70042](https://github.com/PaddlePaddle/Paddle/pull/70042)

将 Inference Pass中符号推导的执行顺序调整到算子融合Pass前，避免因融合算子无符号推导接口引发的一系列如下问题：

![b625a28c714b8580ee30341d6f20eb18](https://github.com/user-attachments/assets/f673358c-808b-44b0-8694-b37398a59e95)
