### PR TITLE
Revert "[CINN]Add EqCstr for broadcast substitute"

### DIFF
--- a/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
+++ b/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
@@ -103,24 +103,6 @@ void ConstraintsManager::AddEqCstr(const DimExpr& lhs, const DimExpr& rhs) {
     return;
   }
 
-  const auto& AddEqCstrForBroadcastSubstitute = [&](const DimExpr& bc_dimexpr,
-                                                    const DimExpr&
-                                                        string_dimexpr) {
-    if (!bc_dimexpr.isa<Broadcast<DimExpr>>()) return;
-    if (!string_dimexpr.isa<std::string>()) return;
-    const auto& [operands] = bc_dimexpr.Get<Broadcast<DimExpr>>();
-    for (const auto& operand : *operands) {
-      if (operand == string_dimexpr) return;
-    }
-    for (const auto& operand : *operands) {
-      AddEqCstr(Broadcast<DimExpr>{{operand, string_dimexpr}}, string_dimexpr);
-    }
-  };
-  if (lhs.isa<Broadcast<DimExpr>>() && rhs.isa<std::string>())
-    AddEqCstrForBroadcastSubstitute(lhs, rhs);
-  if (rhs.isa<Broadcast<DimExpr>>() && lhs.isa<std::string>())
-    AddEqCstrForBroadcastSubstitute(rhs, lhs);
-
   auto simplify_result = SimplifyEqCstr(lhs, rhs);
   if (simplify_result.first != lhs && simplify_result.second != rhs) {
     AddEqCstr(simplify_result.first, simplify_result.second);

--- a/test/cpp/pir/shape_dialect/constraints_manager_test.cc
+++ b/test/cpp/pir/shape_dialect/constraints_manager_test.cc
@@ -61,18 +61,4 @@ TEST(ConstraintsManager, BroadcastableCstr) {
   ASSERT_TRUE(cstr_mgr.IsBroadcastable(sym_expr_0, int_expr));
 }
 
-TEST(ConstraintsManager, Case1) {
-  // BC(S0, S1) == S2 => BC(S0, S2) == S2
-  ConstraintsManager cstr_mgr;
-  DimExpr s0 = DimExpr("S0");
-  DimExpr s1 = DimExpr("S1");
-  DimExpr s2 = DimExpr("S2");
-  DimExpr bc_s0_s1 = Broadcast<DimExpr>{{s0, s1}};
-  cstr_mgr.AddEqCstr(bc_s0_s1, s2);
-  cstr_mgr.AddBroadcastableCstr(s0, s1);
-  DimExpr bc_s0_s2 = Broadcast<DimExpr>{{s0, s2}};
-  cstr_mgr.AddBroadcastableCstr(s0, s2);
-  ASSERT_TRUE(cstr_mgr.IsEqual(bc_s0_s2, s2));
-}
-
 }  // namespace symbol::test


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

Reverts PaddlePaddle/Paddle#70093