### PR TITLE
[SOT] Add dispatch for check eq between builtin types (list, tuple, dict, const)

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -504,6 +504,35 @@ def dispatch_list_ne(lhs: ListVariable, rhs: ListVariable):
     return Dispatcher.call(operator.eq, lhs, rhs).bool_not()
 
 
+BUILTIN_EQ_DISPATCH_TYPES = [
+    "ListVariable",
+    "TupleVariable",
+    "DictVariable",
+    "ConstantVariable",
+]
+
+for i in range(len(BUILTIN_EQ_DISPATCH_TYPES)):
+    current_type = BUILTIN_EQ_DISPATCH_TYPES[i]
+    other_types = (
+        BUILTIN_EQ_DISPATCH_TYPES[:i] + BUILTIN_EQ_DISPATCH_TYPES[i + 1 :]
+    )
+    Dispatcher.register(
+        operator.eq,
+        (current_type, " | ".join(other_types)),
+        lambda var, other: ConstantVariable(
+            False, var.graph, DummyTracker([var, other])
+        ),
+    )
+
+    Dispatcher.register(
+        operator.ne,
+        (current_type, " | ".join(other_types)),
+        lambda var, other: ConstantVariable(
+            True, var.graph, DummyTracker([var, other])
+        ),
+    )
+
+
 # getattr
 Dispatcher.register(
     getattr,

--- a/test/sot/test_builtin_dispatch.py
+++ b/test/sot/test_builtin_dispatch.py
@@ -134,6 +134,25 @@ def test_log(x: int):
     return math.log(x)
 
 
+@check_no_breakgraph
+def test_builtin_type_check_eq():
+    a = 1
+    b = []
+    c = ()
+    d = {}
+    eq_results = (
+        a == b, a == c, a == d,
+        b == a, b == c, b == d,
+        c == a, c == b, c == d,
+    )  # fmt: skip
+    ne_results = (
+        a != b, a != c, a != d,
+        b != a, b != c, b != d,
+        c != a, c != b, c != d,
+    )  # fmt: skip
+    return eq_results, ne_results
+
+
 class TestBuiltinDispatch(TestCaseBase):
     def test_dispatch_len(self):
         self.assert_results(dispatch_len, paddle.to_tensor([1, 2, 3]))
@@ -274,6 +293,9 @@ class TestBuiltinDispatch(TestCaseBase):
 
     def test_dispatch_max(self):
         self.assert_results(test_max)
+
+    def test_dispatch_builtin_type_check_eq(self):
+        self.assert_results(test_builtin_type_check_eq)
 
 
 def run_getattr(x: paddle.Tensor):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

支持 list、tuple、dict、const 不同 type 之间的 eq、ne 比较，以免打断

PCard-66972