### PR TITLE
[SOT][Faster Guard] implement basic guard tree mechanism

### DIFF
--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -127,17 +127,15 @@ void BindGuard(pybind11::module *m) {
 
 void BindGuardTree(pybind11::module *m) {
 #if SOT_IS_SUPPORTED
-#if PY_3_11_PLUS
   py::class_<GuardTree, std::shared_ptr<GuardTree>>(
       *m, "GuardTree", R"DOC(GuardTree Class.)DOC")
       .def(py::init<
                const std::vector<std::vector<std::shared_ptr<GuardNode>>> &>(),
            py::arg("guard_nodes_list"))
       .def(
-          "check",
+          "lookup",
           [](GuardTree &self, py::object frame) {
-            return self.check(
-                reinterpret_cast<PyInterpreterFrameProxy *>(frame.ptr()));
+            return self.lookup(reinterpret_cast<FrameProxy *>(frame.ptr()));
           },
           py::arg("frame"));
 
@@ -156,10 +154,9 @@ void BindGuardTree(pybind11::module *m) {
           [](GuardNode &self) { return self.return_cache_index; },
           [](GuardNode &self, int index) { self.return_cache_index = index; })
       .def(
-          "check",
+          "lookup",
           [](GuardNode &self, py::object frame) {
-            return self.check(
-                reinterpret_cast<PyInterpreterFrameProxy *>(frame.ptr()));
+            return self.lookup(reinterpret_cast<FrameProxy *>(frame.ptr()));
           },
           py::arg("frame"));
 
@@ -168,8 +165,7 @@ void BindGuardTree(pybind11::module *m) {
       .def(
           "eval",
           [](ExprNode &self, py::object frame) {
-            return self.eval(
-                reinterpret_cast<PyInterpreterFrameProxy *>(frame.ptr()));
+            return self.eval(reinterpret_cast<FrameProxy *>(frame.ptr()));
           },
           py::arg("frame"));
 
@@ -196,7 +192,6 @@ void BindGuardTree(pybind11::module *m) {
       .def(py::init<std::shared_ptr<ExprNode>, std::shared_ptr<ExprNode>>(),
            py::arg("var_expr"),
            py::arg("key_expr"));
-#endif
 #endif
 }
 
@@ -265,9 +260,7 @@ void BindSot(pybind11::module *m) {
       },
       py::arg("py_codes"));
   BindGuard(m);
-#if PY_3_11_PLUS
   BindGuardTree(m);
-#endif
 #endif
 }
 

--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -127,6 +127,7 @@ void BindGuard(pybind11::module *m) {
 
 void BindGuardTree(pybind11::module *m) {
 #if SOT_IS_SUPPORTED
+#if PY_3_11_PLUS
   py::class_<GuardTree, std::shared_ptr<GuardTree>>(
       *m, "GuardTree", R"DOC(GuardTree Class.)DOC")
       .def(py::init<
@@ -196,6 +197,7 @@ void BindGuardTree(pybind11::module *m) {
            py::arg("var_expr"),
            py::arg("key_expr"));
 #endif
+#endif
 }
 
 void BindSot(pybind11::module *m) {
@@ -263,7 +265,9 @@ void BindSot(pybind11::module *m) {
       },
       py::arg("py_codes"));
   BindGuard(m);
+#if PY_3_11_PLUS
   BindGuardTree(m);
+#endif
 #endif
 }
 

--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -28,6 +28,8 @@ limitations under the License. */
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/utils/pybind.h"
+#include "pybind11/pybind11.h"
+#include "pybind11/pytypes.h"
 
 namespace py = pybind11;
 
@@ -123,6 +125,79 @@ void BindGuard(pybind11::module *m) {
 #endif
 }
 
+void BindGuardTree(pybind11::module *m) {
+#if SOT_IS_SUPPORTED
+  py::class_<GuardTree, std::shared_ptr<GuardTree>>(
+      *m, "GuardTree", R"DOC(GuardTree Class.)DOC")
+      .def(py::init<
+               const std::vector<std::vector<std::shared_ptr<GuardNode>>> &>(),
+           py::arg("guard_nodes_list"))
+      .def(
+          "check",
+          [](GuardTree &self, py::object frame) {
+            return self.check(
+                reinterpret_cast<PyInterpreterFrameProxy *>(frame.ptr()));
+          },
+          py::arg("frame"));
+
+  py::class_<GuardNode, std::shared_ptr<GuardNode>>(
+      *m, "GuardNode", R"DOC(GuardNode Class.)DOC")
+      .def(py::init<const std::shared_ptr<GuardBase> &,
+                    const std::shared_ptr<ExprNode> &,
+                    const std::vector<std::shared_ptr<GuardNode>> &,
+                    const std::optional<int> &>(),
+           py::arg("guard"),
+           py::arg("expr"),
+           py::arg("next_guard_nodes") = py::list(),
+           py::arg("return_cache_index") = py::none())
+      .def_property(
+          "return_cache_index",
+          [](GuardNode &self) { return self.return_cache_index; },
+          [](GuardNode &self, int index) { self.return_cache_index = index; })
+      .def(
+          "check",
+          [](GuardNode &self, py::object frame) {
+            return self.check(
+                reinterpret_cast<PyInterpreterFrameProxy *>(frame.ptr()));
+          },
+          py::arg("frame"));
+
+  py::class_<ExprNode, std::shared_ptr<ExprNode>>(
+      *m, "ExprNode", R"DOC(ExprNode Class.)DOC")
+      .def(
+          "eval",
+          [](ExprNode &self, py::object frame) {
+            return self.eval(
+                reinterpret_cast<PyInterpreterFrameProxy *>(frame.ptr()));
+          },
+          py::arg("frame"));
+
+  py::class_<ConstantExprNode, ExprNode, std::shared_ptr<ConstantExprNode>>(
+      *m, "ConstantExprNode", R"DOC(ConstantExprNode Class.)DOC")
+      .def(py::init<const py::object &>(), py::arg("value_ptr"));
+
+  py::class_<LocalVarExprNode, ExprNode, std::shared_ptr<LocalVarExprNode>>(
+      *m, "LocalVarExprNode", R"DOC(LocalVarExprNode Class.)DOC")
+      .def(py::init<const std::string &>(), py::arg("var_name"));
+
+  py::class_<GlobalVarExprNode, ExprNode, std::shared_ptr<GlobalVarExprNode>>(
+      *m, "GlobalVarExprNode", R"DOC(GlobalVarExprNode Class.)DOC")
+      .def(py::init<const std::string &>(), py::arg("var_name"));
+
+  py::class_<AttributeExprNode, ExprNode, std::shared_ptr<AttributeExprNode>>(
+      *m, "AttributeExprNode", R"DOC(AttributeExprNode Class.)DOC")
+      .def(py::init<std::shared_ptr<ExprNode>, const std::string &>(),
+           py::arg("var_expr"),
+           py::arg("attr_name"));
+
+  py::class_<ItemExprNode, ExprNode, std::shared_ptr<ItemExprNode>>(
+      *m, "ItemExprNode", R"DOC(ItemExprNode Class.)DOC")
+      .def(py::init<std::shared_ptr<ExprNode>, std::shared_ptr<ExprNode>>(),
+           py::arg("var_expr"),
+           py::arg("key_expr"));
+#endif
+}
+
 void BindSot(pybind11::module *m) {
 #if SOT_IS_SUPPORTED
   PyInit__eval_frame();
@@ -188,6 +263,7 @@ void BindSot(pybind11::module *m) {
       },
       py::arg("py_codes"));
   BindGuard(m);
+  BindGuardTree(m);
 #endif
 }
 

--- a/paddle/fluid/pybind/sot/frame_proxy.h
+++ b/paddle/fluid/pybind/sot/frame_proxy.h
@@ -51,13 +51,13 @@ typedef struct PyInterpreterFrameProxy {
 PyInterpreterFrameProxy *PyInterpreterFrameProxy_New(
     _PyInterpreterFrame *frame);
 PyMODINIT_FUNC PyInit__frame_proxy();
-
+typedef PyInterpreterFrameProxy FrameProxy;
 #else
 typedef PyFrameObject FrameObject;
+typedef PyFrameObject FrameProxy;
 #endif
 
 #endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -158,7 +158,11 @@ PyObject* ConstantExprNode::eval(PyInterpreterFrameProxy* frame) {
 }
 
 PyObject* LocalVarExprNode::eval(PyInterpreterFrameProxy* frame) {
+#if PY_3_13_PLUS
+  return PyDict_GetItemString(frame->locals, var_name_.c_str());
+#else
   return PyDict_GetItemString(frame->frame->f_locals, var_name_.c_str());
+#endif
 }
 PyObject* GlobalVarExprNode::eval(PyInterpreterFrameProxy* frame) {
   return PyDict_GetItemString(frame->frame->f_globals, var_name_.c_str());
@@ -200,5 +204,4 @@ std::optional<int> GuardTree::check(PyInterpreterFrameProxy* frame) {
 }
 
 #endif
-
 #endif

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -20,8 +20,8 @@ limitations under the License. */
 
 #include <Python.h>
 #include <frameobject.h>
-#include "pybind11/numpy.h"
 #include <object.h>
+#include "pybind11/numpy.h"
 
 #if !defined(PyObject_CallOneArg) && !PY_3_9_PLUS
 static inline PyObject* PyObject_CallOneArg(PyObject* func, PyObject* arg) {

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -328,8 +328,8 @@ class GuardTree {
  private:
   std::vector<std::shared_ptr<GuardNode>> guard_nodes_;
 };
-#endif
 
 std::string guard_tree_to_str(const GuardTree& guard_tree);
+#endif
 
 #endif

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -220,8 +220,6 @@ class NumpyDtypeMatchGuard : public GuardBase {
   PyObject* expected_;
 };
 
-#if PY_3_11_PLUS
-
 class GuardTreeNode {};
 
 class AttributeExprNode;
@@ -229,7 +227,7 @@ class ItemExprNode;
 class ExprNode : public GuardTreeNode,
                  public std::enable_shared_from_this<ExprNode> {
  public:
-  virtual PyObject* eval(PyInterpreterFrameProxy* frame) = 0;
+  virtual PyObject* eval(FrameProxy* frame) = 0;
 };
 class ConstantExprNode : public ExprNode {
  public:
@@ -239,7 +237,7 @@ class ConstantExprNode : public ExprNode {
     Py_INCREF(value_ptr_);
   }
   ~ConstantExprNode() { Py_DECREF(value_ptr_); }
-  PyObject* eval(PyInterpreterFrameProxy* frame);
+  PyObject* eval(FrameProxy* frame);
 
  private:
   PyObject* value_ptr_;
@@ -250,7 +248,7 @@ class LocalVarExprNode : public ExprNode {
   explicit LocalVarExprNode(const std::string& var_name)
       : var_name_(var_name) {}
 
-  PyObject* eval(PyInterpreterFrameProxy* frame);
+  PyObject* eval(FrameProxy* frame);
 
  private:
   std::string var_name_;
@@ -260,7 +258,7 @@ class GlobalVarExprNode : public ExprNode {
   explicit GlobalVarExprNode(const std::string& var_name)
       : var_name_(var_name) {}
 
-  PyObject* eval(PyInterpreterFrameProxy* frame);
+  PyObject* eval(FrameProxy* frame);
 
  private:
   std::string var_name_;
@@ -271,7 +269,7 @@ class AttributeExprNode : public ExprNode {
                              const std::string& attr_name)
       : var_expr_(var_expr), attr_name_(attr_name) {}
 
-  PyObject* eval(PyInterpreterFrameProxy* frame);
+  PyObject* eval(FrameProxy* frame);
 
  private:
   std::shared_ptr<ExprNode> var_expr_;
@@ -283,7 +281,7 @@ class ItemExprNode : public ExprNode {
                         std::shared_ptr<ExprNode> key_expr)
       : var_expr_(var_expr), key_expr_(key_expr) {}
 
-  PyObject* eval(PyInterpreterFrameProxy* frame);
+  PyObject* eval(FrameProxy* frame);
 
  private:
   std::shared_ptr<ExprNode> var_expr_;
@@ -306,7 +304,7 @@ class GuardNode : public GuardTreeNode {
         next_guard_nodes(next_guard_nodes),
         return_cache_index(return_cache_index) {}
 
-  std::optional<int> check(PyInterpreterFrameProxy* frame);
+  std::optional<int> lookup(FrameProxy* frame);
 };
 
 class GuardTree {
@@ -323,13 +321,11 @@ class GuardTree {
     }
   }
 
-  std::optional<int> check(PyInterpreterFrameProxy* frame);
+  std::optional<int> lookup(FrameProxy* frame);
 
  private:
   std::vector<std::shared_ptr<GuardNode>> guard_nodes_;
 };
 
 std::string guard_tree_to_str(const GuardTree& guard_tree);
-#endif
-
 #endif

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -295,6 +295,7 @@ class GuardNode : public GuardTreeNode {
   std::shared_ptr<GuardBase> guard;
   std::shared_ptr<ExprNode> expr;
   std::vector<std::shared_ptr<GuardNode>> next_guard_nodes;
+  // return_cache_index is used to record the index of the guard list
   std::optional<int> return_cache_index;
   GuardNode(std::shared_ptr<GuardBase> guard,
             std::shared_ptr<ExprNode> expr,

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -14,7 +14,10 @@ limitations under the License. */
 #pragma once
 
 #include <Python.h>
+#include <memory>
 #include "paddle/fluid/framework/data_type.h"
+#include "paddle/fluid/pybind/sot/eval_frame_tools.h"
+#include "paddle/fluid/pybind/sot/frame_proxy.h"
 #include "paddle/fluid/pybind/sot/macros.h"
 #include "paddle/phi/core/utils/data_type.h"
 #include "paddle/utils/pybind.h"
@@ -216,5 +219,116 @@ class NumpyDtypeMatchGuard : public GuardBase {
  private:
   PyObject* expected_;
 };
+
+#if PY_3_11_PLUS
+
+class GuardTreeNode {};
+
+class AttributeExprNode;
+class ItemExprNode;
+class ExprNode : public GuardTreeNode,
+                 public std::enable_shared_from_this<ExprNode> {
+ public:
+  virtual PyObject* eval(PyInterpreterFrameProxy* frame) = 0;
+};
+class ConstantExprNode : public ExprNode {
+ public:
+  explicit ConstantExprNode(PyObject* value_ptr) : value_ptr_(value_ptr) {}
+  explicit ConstantExprNode(const py::object& value_obj)
+      : value_ptr_(value_obj.ptr()) {
+    Py_INCREF(value_ptr_);
+  }
+  ~ConstantExprNode() { Py_DECREF(value_ptr_); }
+  PyObject* eval(PyInterpreterFrameProxy* frame);
+
+ private:
+  PyObject* value_ptr_;
+};
+
+class LocalVarExprNode : public ExprNode {
+ public:
+  explicit LocalVarExprNode(const std::string& var_name)
+      : var_name_(var_name) {}
+
+  PyObject* eval(PyInterpreterFrameProxy* frame);
+
+ private:
+  std::string var_name_;
+};
+class GlobalVarExprNode : public ExprNode {
+ public:
+  explicit GlobalVarExprNode(const std::string& var_name)
+      : var_name_(var_name) {}
+
+  PyObject* eval(PyInterpreterFrameProxy* frame);
+
+ private:
+  std::string var_name_;
+};
+class AttributeExprNode : public ExprNode {
+ public:
+  explicit AttributeExprNode(std::shared_ptr<ExprNode> var_expr,
+                             const std::string& attr_name)
+      : var_expr_(var_expr), attr_name_(attr_name) {}
+
+  PyObject* eval(PyInterpreterFrameProxy* frame);
+
+ private:
+  std::shared_ptr<ExprNode> var_expr_;
+  std::string attr_name_;
+};
+class ItemExprNode : public ExprNode {
+ public:
+  explicit ItemExprNode(std::shared_ptr<ExprNode> var_expr,
+                        std::shared_ptr<ExprNode> key_expr)
+      : var_expr_(var_expr), key_expr_(key_expr) {}
+
+  PyObject* eval(PyInterpreterFrameProxy* frame);
+
+ private:
+  std::shared_ptr<ExprNode> var_expr_;
+  std::shared_ptr<ExprNode> key_expr_;
+};
+
+class GuardNode : public GuardTreeNode {
+ public:
+  std::shared_ptr<GuardBase> guard;
+  std::shared_ptr<ExprNode> expr;
+  std::vector<std::shared_ptr<GuardNode>> next_guard_nodes;
+  std::optional<int> return_cache_index;
+  GuardNode(std::shared_ptr<GuardBase> guard,
+            std::shared_ptr<ExprNode> expr,
+            std::vector<std::shared_ptr<GuardNode>> next_guard_nodes,
+            std::optional<int> return_cache_index)
+      : guard(guard),
+        expr(expr),
+        next_guard_nodes(next_guard_nodes),
+        return_cache_index(return_cache_index) {}
+
+  std::optional<int> check(PyInterpreterFrameProxy* frame);
+};
+
+class GuardTree {
+ public:
+  GuardTree(const std::vector<std::vector<std::shared_ptr<GuardNode>>>&
+                guard_nodes_list) {
+    for (size_t index = 0; index < guard_nodes_list.size(); ++index) {
+      const auto& guard_nodes = guard_nodes_list[index];
+      for (size_t i = 1; i < guard_nodes.size(); ++i) {
+        guard_nodes[i - 1]->next_guard_nodes.push_back(guard_nodes[i]);
+      }
+      guard_nodes.back()->return_cache_index = index;
+      guard_nodes_.push_back(guard_nodes.front());
+    }
+  }
+
+  std::optional<int> check(PyInterpreterFrameProxy* frame);
+
+ private:
+  std::vector<std::shared_ptr<GuardNode>> guard_nodes_;
+};
+#endif
+
+std::string guard_tree_to_str(const GuardTree& guard_tree);
 
 #endif

--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -24,6 +24,7 @@ from ...profiler import EventGuard, event_register
 from ...psdb import NO_FALLBACK_CODES
 from ...utils import (
     ENV_SOT_ALLOW_DYNAMIC_SHAPE,
+    ENV_SOT_ENABLE_GUARD_TREE,
     ENV_SOT_ENABLE_STRICT_GUARD_CHECK,
     BreakGraphError,
     CompileCountInfo,
@@ -157,7 +158,8 @@ class OpcodeExecutorCache(metaclass=Singleton):
                         f"[Cache] Cache hit, Guard is \n{getattr(guard_fn, 'expr', 'None')}\n",
                     )
                     return custom_code
-                else:
+                elif not ENV_SOT_ENABLE_GUARD_TREE.get():
+                    # TODO(zrr1999): remove condition after faster guard tree support error analysis
                     log_do(
                         4,
                         self.analyse_guard_global_object(guard_fn),

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -41,7 +41,6 @@ from ...symbolic.statement_ir import Reference, StatementIR, Symbol
 from ...symbolic.symbolic_context import SymbolicTraceContext
 from ...utils import (
     ENV_SOT_ALLOW_DYNAMIC_SHAPE,
-    ENV_SOT_ENABLE_FASTER_GUARD,
     ENV_SOT_ENABLE_GUARD_TREE,
     NameGenerator,
     SotUndefinedVar,
@@ -318,17 +317,13 @@ class FunctionGraph:
     @property
     @event_register("guard_fn")
     def guard_fn(self) -> Guard:
-        if (
-            ENV_SOT_ENABLE_FASTER_GUARD.get()
-            and ENV_SOT_ENABLE_GUARD_TREE.get()
-        ):
+        if ENV_SOT_ENABLE_GUARD_TREE.get():
             guard_nodes: list[paddle.framework.core.GuardNode] = []
             with EventGuard("guard_fn: find vars and make faster guard"):
                 for variable in find_traceable_vars(
                     self.input_variables + list(self._global_guarded_variables)
                 ):
                     guard_nodes.extend(variable.make_faster_guard())
-
             return make_faster_guard(guard_nodes)
 
         with switch_symbol_registry():

--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -232,6 +232,7 @@ def support_weak_ref(obj):
     return False
 
 
+# TODO(zrr1999): unify check_guard and check_faster_guard
 def check_guard(
     fn: Callable[[CheckGuardInputT], list[StringifiedExpression]],
 ) -> Callable[[CheckGuardInputT], list[StringifiedExpression]]:
@@ -265,7 +266,7 @@ def check_faster_guard(
         def guard_log():
             frame_value_tracer = self.tracker.trace_value_from_frame()
             print(
-                f"[Guard]: guard_fn for {self}, tracker={self.tracker.__class__.__name__}, value={frame_value_tracer.registered_expr}"
+                f"[Guard Tree]: guard_fn for {self}, tracker={self.tracker.__class__.__name__}, value={frame_value_tracer.registered_expr}"
             )
 
         log_do(4, guard_log)

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import inspect
 import sys
 from typing import TYPE_CHECKING
+
 import paddle
 
 from ...utils import (
@@ -75,6 +76,16 @@ class FunctionGlobalTracker(Tracker):
         codegen.gen_load_const(self.name)
         codegen.gen_subscribe()
 
+    def guard_tree_expr_node(self) -> paddle.framework.core.ExprNode:
+        fn_tracer = self.fn.tracker.guard_tree_expr_node()
+        return paddle.framework.core.ItemExprNode(
+            paddle.framework.core.AttributeExprNode(
+                fn_tracer,
+                "__globals__",
+            ),
+            paddle.framework.core.ConstantExprNode(self.name),
+        )
+
     def trace_value_from_frame(self) -> StringifiedExpression:
         """
         Trace the value of the function global variable from the frame.
@@ -88,16 +99,6 @@ class FunctionGlobalTracker(Tracker):
             f"{{}}.__globals__['{self.name}']",
             [fn_tracer],
             union_free_vars(fn_tracer.free_vars),
-        )
-
-    def guard_tree_expr_node(self) -> paddle.framework.core.ExprNode:
-        fn_tracer = self.fn.tracker.guard_tree_expr_node()
-        return paddle.framework.core.ItemExprNode(
-            paddle.framework.core.AttributeExprNode(
-                fn_tracer,
-                "__globals__",
-            ),
-            paddle.framework.core.ConstantExprNode(self.name),
         )
 
     def __repr__(self) -> str:
@@ -132,6 +133,10 @@ class FunctionClosureTracker(Tracker):
         codegen.gen_load_const(self.idx)
         codegen.gen_subscribe()
         codegen.gen_load_attr("cell_contents")
+
+    def guard_tree_expr_node(self) -> paddle.framework.core.ExprNode:
+        # TODO(zrr1999): implement FunctionClosureExprNode
+        raise NotImplementedError("FunctionClosureExprNode is not implemented")
 
     def trace_value_from_frame(self):
         """

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import inspect
 import sys
 from typing import TYPE_CHECKING
+import paddle
 
 from ...utils import (
     BreakGraphError,
@@ -87,6 +88,16 @@ class FunctionGlobalTracker(Tracker):
             f"{{}}.__globals__['{self.name}']",
             [fn_tracer],
             union_free_vars(fn_tracer.free_vars),
+        )
+
+    def guard_tree_expr_node(self) -> paddle.framework.core.ExprNode:
+        fn_tracer = self.fn.tracker.guard_tree_expr_node()
+        return paddle.framework.core.ItemExprNode(
+            paddle.framework.core.AttributeExprNode(
+                fn_tracer,
+                "__globals__",
+            ),
+            paddle.framework.core.ConstantExprNode(self.name),
         )
 
     def __repr__(self) -> str:

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
@@ -33,6 +33,7 @@ from ..dispatcher import Dispatcher
 from ..guard import (
     FasterStringifiedExpression,
     StringifiedExpression,
+    check_faster_guard,
     check_guard,
     union_free_vars,
 )
@@ -343,6 +344,16 @@ class VariableBase:
 
     def __hash__(self):
         return hash(self.id)
+
+    @check_faster_guard
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+        frame_value_tracer = self.tracker.guard_tree_expr_node()
+        return [
+            paddle.framework.core.GuardNode(
+                paddle.framework.core.ValueMatchGuard(self.get_py_value()),
+                frame_value_tracer,
+            )
+        ]
 
     @check_guard
     def make_stringified_guard(self) -> list[StringifiedExpression]:

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -483,6 +483,7 @@ class TensorVariable(VariableBase):
                     expr_node, "stop_gradient"
                 ),
             ),
+            # TODO(zrr1999): add dist_info check
         ]
 
     @check_guard

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -57,6 +57,7 @@ from ..dispatch_functions import tensor_dim
 from ..guard import (
     FasterStringifiedExpression,
     StringifiedExpression,
+    check_faster_guard,
     check_guard,
     object_equal_stringified_guard,
     stringify_pyobject,
@@ -458,6 +459,31 @@ class TensorVariable(VariableBase):
 
     def _reconstruct(self, codegen: PyCodeGen):
         codegen.gen_load_fast(self.out_var_name)
+
+    @check_faster_guard
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+        assert paddle.framework.use_pir_api(), "Only support PIR"
+        expr_node = self.tracker.guard_tree_expr_node()
+        meta = self.origin_meta
+        return [
+            # Check shape
+            paddle.framework.core.GuardNode(
+                paddle.framework.core.ShapeMatchGuard(meta.shape),
+                expr_node,
+            ),
+            # Check dtype
+            paddle.framework.core.GuardNode(
+                paddle.framework.core.DtypeMatchGuard(meta.dtype),
+                expr_node,
+            ),
+            # Check stop_gradient
+            paddle.framework.core.GuardNode(
+                paddle.framework.core.ValueMatchGuard(meta.stop_gradient),
+                paddle.framework.core.AttributeExprNode(
+                    expr_node, "stop_gradient"
+                ),
+            ),
+        ]
 
     @check_guard
     def make_stringified_guard(self) -> list[StringifiedExpression]:

--- a/test/sot/test_guard_tree.py
+++ b/test/sot/test_guard_tree.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import sys
 import unittest
 from typing import TYPE_CHECKING, Callable
 
@@ -43,10 +42,6 @@ def guard_tree(
     return inner
 
 
-@unittest.skipIf(
-    sys.version_info < (3, 11),
-    reason="Guard tree is only supported in python 3.11+.",
-)
 class TestGuardTree(unittest.TestCase):
     def test_guard_tree(self):
         def callback(frame, **kwargs):

--- a/test/sot/test_guard_tree.py
+++ b/test/sot/test_guard_tree.py
@@ -97,7 +97,7 @@ class TestGuardTree(unittest.TestCase):
                     [node_guard_1_eq_1],
                 ]
             )
-            self.assertEqual(guard_tree.check(frame), target)
+            self.assertEqual(guard_tree.lookup(frame), target)
             return CustomCode(frame.f_code, False)
 
         global z

--- a/test/sot/test_guard_tree.py
+++ b/test/sot/test_guard_tree.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import sys
+import unittest
+from typing import TYPE_CHECKING, Callable
+
+import paddle
+from paddle.jit.sot.opcode_translator.custom_code import CustomCode
+
+if TYPE_CHECKING:
+    import types
+
+z = paddle.to_tensor(1)
+
+
+def guard_tree(
+    callback: Callable[[types.FrameType], CustomCode],
+):
+    def foo(x, y):
+        return x, y, z
+
+    def inner(x, y):
+        paddle.framework.core.set_eval_frame(callback)
+        try:
+            return foo(x, y)
+        finally:
+            paddle.framework.core.set_eval_frame(None)
+
+    return inner
+
+
+@unittest.skipIf(
+    sys.version_info < (3, 11),
+    reason="Guard tree is only supported in python 3.11+.",
+)
+class TestGuardTree(unittest.TestCase):
+    def test_guard_tree(self):
+        def callback(frame, **kwargs):
+            guard_int = paddle.framework.core.TypeMatchGuard(int)
+            guard_tensor = paddle.framework.core.TypeMatchGuard(
+                type(paddle.to_tensor(1))
+            )
+            guard_tensor_shape_eq = paddle.framework.core.ValueMatchGuard(
+                paddle.to_tensor([1]).shape
+            )
+            guard_eq = paddle.framework.core.ValueMatchGuard(1)
+
+            node_expr_x = paddle.framework.core.LocalVarExprNode("x")
+            node_expr_y = paddle.framework.core.LocalVarExprNode("y")
+            node_expr_z = paddle.framework.core.GlobalVarExprNode("z")
+            node_expr_y_shape = paddle.framework.core.AttributeExprNode(
+                node_expr_y, "shape"
+            )
+            node_expr_const_1 = paddle.framework.core.ConstantExprNode(1)
+
+            node_guard_x_type_match_int = paddle.framework.core.GuardNode(
+                guard_int, node_expr_x
+            )
+            node_guard_x_eq_1 = paddle.framework.core.GuardNode(
+                guard_eq, node_expr_x
+            )
+            node_guard_y_type_match_int = paddle.framework.core.GuardNode(
+                guard_int, node_expr_y
+            )
+            node_guard_y_type_match_tensor = paddle.framework.core.GuardNode(
+                guard_tensor, node_expr_y
+            )
+            node_guard_y_tensor_shape = paddle.framework.core.GuardNode(
+                guard_tensor_shape_eq, node_expr_y_shape
+            )
+            node_guard_z_type_match_tensor = paddle.framework.core.GuardNode(
+                guard_tensor, node_expr_z
+            )
+            node_guard_1_eq_1 = paddle.framework.core.GuardNode(
+                guard_eq, node_expr_const_1
+            )
+
+            guard_tree = paddle.framework.core.GuardTree(
+                [
+                    [node_guard_x_eq_1],
+                    [node_guard_x_type_match_int, node_guard_y_type_match_int],
+                    [
+                        node_guard_x_type_match_int,
+                        node_guard_y_type_match_tensor,
+                        node_guard_y_tensor_shape,
+                    ],
+                    [node_guard_z_type_match_tensor],
+                    [node_guard_1_eq_1],
+                ]
+            )
+            self.assertEqual(guard_tree.check(frame), target)
+            return CustomCode(frame.f_code, False)
+
+        global z
+        foo = guard_tree(callback)
+        target = 0
+        foo(1, 1)
+        target = 1
+        foo(2, 2)
+        target = 2
+        foo(2, paddle.to_tensor([2]))
+        target = 3
+        foo(2, 1.0)
+        z = 1
+        target = 4
+        foo(2, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->
实现了基本的 guard tree 机制，GuardTree 目前是list[list[node]]，没有实现树结构

目前实现的节点：
- ConstantExprNode：常量表达式节点
- LocalVarExprNode：局部变量表达式节点
- GlobalVarExprNode：全局变量表达式节点
- AttributeExprNode：属性访问表达式节点
- ItemExprNode：索引访问表达式节点

下面的行为是后续的计划，目前还没有实现
ENV_SOT_ENABLE_STRICT_GUARD_CHECK 记做 S, ENV_SOT_ENABLE_GUARD_TREE 记做C1，ENV_SOT_ENABLE_FASTER_GUARD 记做C2
| S | C1 | C2 | 执行结果 |
|----------------------------------|---------------------------|---------------------------|----------|
| True | 任意值 | True | 默认 FasterGuard，同时跑其他 Guard |
| True | 任意值 | False | 默认 PyGuard，同时跑其他 Guard |
| False | True | 任意值 | 仅 GuardTree |
| False | False | False | 仅 FasterGuard |
| False | False | False | 仅 PyGuard |

