### PR TITLE
Fix random failure on `test_trt_convert_yolo_box`

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/generic_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/generic_plugin.cu
@@ -382,7 +382,7 @@ bool GenericPlugin::supportsFormatCombination(
       return (in_out[pos].type == nvinfer1::DataType::kINT32) &&
              (in_out[pos].format == nvinfer1::TensorFormat::kLINEAR);
     // output
-    if (pos == 2)
+    if (pos == 2 || pos == 3)
       return in_out[0].type == in_out[pos].type &&
              in_out[0].format == in_out[pos].format;
   } else if (op_desc_.Type() == "scatter_nd_add") {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
The 2nd output, `pos==3`(`score`), which is unhandled in current codes, resulting in undefined behavior.
When we integrate Paddle with newer toolchain we found the unittest with FP16, `test_trt_convert_yolo_box`, might randomly failure.

The root-cause is the generic_plugin for yolo_box doesn't force output be the same datatype as input (recap: the format of `pos==3` is unhandled).
Thus, auto-tune of TRT may sometime select different tatics and reformat the output data-type, which yolo_box doesn't support (because it don't explicitly reject in `supportsFormatCombination`). When it happened, the unittest generate all zero output tensor.