### PR TITLE
[CINN]fix relu6 hardsigmoid cpu kernel bug

### DIFF
--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -1305,7 +1305,7 @@ void relu6_grad(const Tensor& out, const Tensor& out_grad, Tensor* x_grad) {
     Tensor six = full_scalar<T>(6.0, out.dtype());
     auto mask_gt = greater_than<T>(out, zeros);
     auto mask_lt = less_than<T>(out, six);
-    auto mask = bitwise_and<T>(mask_gt, mask_lt);
+    auto mask = backend::logical_and<T>(mask_gt, mask_lt);
     auto res = cast<T>(mask, out.dtype()) * out_grad;
     set_output<T>(res, x_grad);
   }
@@ -1834,7 +1834,7 @@ void hardsigmoid_grad(const Tensor& out,
     Tensor one = full_scalar<T>(1.0, out.dtype());
     auto mask_gt = greater_than<T>(out, zeros);
     auto mask_lt = less_than<T>(out, one);
-    auto mask = bitwise_and<T>(mask_gt, mask_lt);
+    auto mask = backend::logical_and<T>(mask_gt, mask_lt);
     Tensor slope_t = full_scalar<T>(slope, out.dtype());
     auto res = cast<T>(mask, out.dtype()) * slope_t * out_grad;
     set_output<T>(res, x_grad);


### PR DESCRIPTION
### PR Category
CINN

### PR Types
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-76996

修复relu6 hardsigmoid 使用bitwise_and时候在，cpu场景codegen的错误
