### PR TITLE
支持vpp去尾操作

### DIFF
--- a/test/auto_parallel/pir/vpp_pass_unittest_pir.py
+++ b/test/auto_parallel/pir/vpp_pass_unittest_pir.py
@@ -102,6 +102,7 @@ class MLPLayer(nn.Layer):
         dropout_ratio=0.1,
         initializer_range=0.02,
         manual=True,
+        hidden_layer=4,
     ):
         super().__init__()
 
@@ -112,7 +113,9 @@ class MLPLayer(nn.Layer):
         if manual:
             self.layer_to_mesh = [PP_MESH_0, PP_MESH_1, PP_MESH_0, PP_MESH_1]
         else:
-            self.layer_to_mesh = [PP_MESH_0, PP_MESH_0, PP_MESH_1, PP_MESH_1]
+            self.layer_to_mesh = [PP_MESH_0] * (
+                hidden_layer - hidden_layer // 2
+            ) + [PP_MESH_1] * (hidden_layer // 2)
 
         self.layers = nn.LayerList(
             [
@@ -123,7 +126,7 @@ class MLPLayer(nn.Layer):
                     weight_attr,
                     mesh=self.layer_to_mesh[i],
                 )
-                for i in range(4)
+                for i in range(hidden_layer)
             ]
         )
 
@@ -217,11 +220,12 @@ class TestVPPPass(unittest.TestCase):
         manual=True,
         enable_send_recv_overlap=False,
         batch_size=BATCH_SIZE,
+        hidden_layer=4,
     ):
         self.init()
 
         strategy = apply_pass(schedule_mode, acc_step, enable_send_recv_overlap)
-        model = MLPLayer(manual=manual)
+        model = MLPLayer(manual=manual, hidden_layer=hidden_layer)
         opt = paddle.optimizer.AdamW(
             learning_rate=0.00001, parameters=model.parameters()
         )
@@ -267,6 +271,11 @@ class TestVPPPass(unittest.TestCase):
         )
         self.check_result(Non_uniform_loss_vpp, Non_uniform_loss_vpp_manual)
         self.check_result(loss_fthenb, Non_uniform_loss_vpp)
+        # Tail-removed-vpp
+        Tail_removed_loss_vpp = self.run_pipeline(
+            schedule_mode="VPP", acc_step=4, manual=False, hidden_layer=7
+        )
+        self.check_result(Tail_removed_loss_vpp, loss_vpp)
 
     def check_result(self, loss1, loss2):
         return np.array_equal(loss1, loss2)


### PR DESCRIPTION
### PR Category
Auto Parallel


### PR Types
Others


### Description
- 当前的vpp编排仅仅支持模型hidden_layer层数整除vpp_degree的情况，然而在很多时候，模型hidden_layer的最后一层的计算量和计算时间往往都要大于前面的层，因此为了满足一定精度的同时拥有更快的训练速度，往往可以将hidden_layer的最后一层给去掉，不会给模型带来较大的精度影响，尤其是模型很大的时候，同时也能使训练速度有一个较高的提升，因此支持vpp去尾操作具有价值较大的现实意义。
- 这里我将展示一个在`llama`模型上测试的效果，此时我设定的`pp_degree=4`,`vpp_degree=2`,`acc_step=4`:
当hidden_layer=8时，vpp编排的结果如下：
![hidden_layer=8](https://github.com/user-attachments/assets/9f0d2b60-17e3-49c3-86c7-7f755c181757)
当hidden_layer=7时，vpp编排的结果如下:
![hidden_layer=7](https://github.com/user-attachments/assets/acdb697e-6764-4345-b0b8-8bdbc27b3f76)
因为vpp编排是根据*chunk*进行编排的，所以在两个参数下，编排的效果是一致的，这也证明了代码的准确性和通用性
- 同时我们观察一下训练10个step后的结果：
当hidden_layer=8时，训练后的结果如下：
![hidden_layer=8_time](https://github.com/user-attachments/assets/5878803b-c464-4ca1-8090-bbd2df356ea6)
当hidden_layer=8时，训练后的结果如下：
![hidden_layer=7_time](https://github.com/user-attachments/assets/2abb74e3-34a7-48df-99e5-38f6fc1ab3cd)
可以看到，此时loss相差0.007，但是时间上相差了0.005*10=0.05s。而这仅仅是训练的step为10，并且hidden_layer较小时的结果，可以预期，当模型较大，训练步数较大时，带来的时间收益是非常显著的。
