### PR TITLE
dcu warpctc support gfx926 gfx928

### DIFF
--- a/cmake/external/warpctc.cmake
+++ b/cmake/external/warpctc.cmake
@@ -53,7 +53,8 @@ if(WITH_ROCM)
   set(WARPCTC_PATHCH_ROCM_COMMAND
       patch -p1 <
       ${PADDLE_SOURCE_DIR}/patches/warpctc/CMakeLists.txt.rocm.patch && patch
-      -p1 < ${PADDLE_SOURCE_DIR}/patches/warpctc/devicetypes.cuh.patch)
+      -p1 < ${PADDLE_SOURCE_DIR}/patches/warpctc/devicetypes.cuh.patch && patch
+      -p1 < ${PADDLE_SOURCE_DIR}/patches/warpctc/hip.cmake.patch)
 endif()
 
 set(WARPCTC_INCLUDE_DIR

--- a/patches/warpctc/hip.cmake.patch
+++ b/patches/warpctc/hip.cmake.patch
@@ -1,0 +1,15 @@
+--- a/cmake/hip.cmake
++++ b/cmake/hip.cmake
+@@ -64,8 +64,12 @@ set(HIP_CLANG_FLAGS ${HIP_CXX_FLAGS})
+ # host linker to link.
+ list(APPEND HIP_HCC_FLAGS -fno-gpu-rdc)
+ list(APPEND HIP_HCC_FLAGS --amdgpu-target=gfx906)
++list(APPEND HIP_HCC_FLAGS --amdgpu-target=gfx926)
++list(APPEND HIP_HCC_FLAGS --amdgpu-target=gfx928)
+ list(APPEND HIP_CLANG_FLAGS -fno-gpu-rdc)
+ list(APPEND HIP_CLANG_FLAGS --amdgpu-target=gfx906)
++list(APPEND HIP_CLANG_FLAGS --amdgpu-target=gfx926)
++list(APPEND HIP_CLANG_FLAGS --amdgpu-target=gfx928)
+
+
+ if(HIP_COMPILER STREQUAL clang)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
dcu warpctc support gfx926 gfx928
