### PR TITLE
fix issue of to_distributed in 2 devices and config sequence_parallel

### DIFF
--- a/python/paddle/distributed/auto_parallel/high_level_api.py
+++ b/python/paddle/distributed/auto_parallel/high_level_api.py
@@ -708,7 +708,7 @@ def to_distributed(
     custom_input_spec = (
         config.input_spec
         if config.input_spec
-        else [paddle.static.InputSpec([4, 1024], 'float32', 'input_seq', True)]
+        else [paddle.static.InputSpec([8, 512], 'float32', 'input_seq', True)]
     )
     static_func = paddle.jit.to_static(
         model.forward, input_spec=custom_input_spec, full_graph=True
@@ -779,7 +779,9 @@ def to_distributed(
     with_pp = True if "pp" in mesh.dim_names else False
     with_mp = True if "mp" in mesh.dim_names else False
     with_dp = True if "dp" in mesh.dim_names else False
-    with_sp = True if config.sequence_parallel else False
+    with_sp = (
+        True if "mp" in mesh.dim_names and config.sequence_parallel else False
+    )
 
     # step 3: processing tensor parallel if necessary, according to the optimal parallel strategies shard weight tensors in decoder blocks
     if with_mp:

--- a/python/paddle/distributed/auto_parallel/high_level_api.py
+++ b/python/paddle/distributed/auto_parallel/high_level_api.py
@@ -708,7 +708,7 @@ def to_distributed(
     custom_input_spec = (
         config.input_spec
         if config.input_spec
-        else [paddle.static.InputSpec([8, 512], 'float32', 'input_seq', True)]
+        else [paddle.static.InputSpec([4, 1024], 'float32', 'input_seq', True)]
     )
     static_func = paddle.jit.to_static(
         model.forward, input_spec=custom_input_spec, full_graph=True

--- a/test/auto_parallel/hybrid_strategy/to_distributed_api_for_llama.py
+++ b/test/auto_parallel/hybrid_strategy/to_distributed_api_for_llama.py
@@ -613,12 +613,8 @@ class TestLlamaDecoderForSemiAutoParallel:
         paddle.set_device(self._backend)
 
     def test_to_distributed_api(self):
-        # # config: input_spec
-        input_seq_spec = paddle.static.InputSpec(
-            [BATCH_SIZE, SEQ_LENGTH], 'float32', 'input_seq', True
-        )
+        # # config: sequence_parallel
         dist_config = ToDistributedConfig()
-        dist_config.input_spec = [input_seq_spec]
         dist_config.sequence_parallel = True
 
         # # wrap model by using **to_distributed**


### PR DESCRIPTION
### PR Category
Auto Parallel

### PR Types
Bug fixes

### Description
pcard-88516
when use `paddle.distributed.to_distributed` in code below, error will be reported, this PR fix this issue.
```python
import math
import numpy as np
import paddle
import paddle.nn.functional as F
from paddle import nn
from paddle.io import Dataset
from paddle.distributed import to_distributed
from paddle.distributed.auto_parallel.high_level_api import ToDistributedConfig

# Instantiate model, optimizer and dataloader, omit relevant code

dist_config = ToDistributedConfig()
dist_config.sequence_parallel = True

# wrap model, opt, dataloader by using **to_distributed**, use 2 devices in 1 node 
dist_model, dist_opt, dist_loader = to_distributed(
    model,
    opt,
    loader,
    device_num=2,
    node_num=1,
    config=dist_config,
)

# train as usual, dynamic graph
for epoch in range(EPOCHES):
    dist_model.train()
    for i, data in enumerate(dist_loader()):
        inputs, labels = data
        loss, _ = dist_model(inputs, labels=labels)
        print(f"epoch {epoch}, step {i}: loss {loss}")
        loss.backward()
        dist_opt.step()
        dist_opt.clear_grad()
```
![image](https://github.com/user-attachments/assets/04d9b0cd-4a30-4a27-8468-ab285163e0cc)

