### PR TITLE
[CodeStyle][UP031] Use f-string instead of percent format in uts (part32)

### DIFF
--- a/test/deprecated/legacy_test/auto_parallel_op_test.py
+++ b/test/deprecated/legacy_test/auto_parallel_op_test.py
@@ -726,14 +726,8 @@ class AutoParallelGradChecker(AutoParallelForwardChecker):
                     atol=self.rtol,
                     err_msg=(
                         'Check eager auto parallel failed. Mismatch between eager auto parallel outputs '
-                        'and eager outputs on %s, the eager forward output tensor\'s index is : %d \n'
-                        'eager auto parallel output tensor:\n%s\n eager output tensor:\n%s\n'
-                        % (
-                            str(self.place),
-                            i,
-                            actual_forward_res[i],
-                            self.eager_forward_desire[i],
-                        )
+                        f'and eager outputs on {self.place}, the eager forward output tensor\'s index is : {i} \n'
+                        f'eager auto parallel output tensor:\n{actual_forward_res[i]}\n eager output tensor:\n{self.eager_forward_desire[i]}\n'
                     ),
                 )
 
@@ -752,14 +746,8 @@ class AutoParallelGradChecker(AutoParallelForwardChecker):
                     atol=self.rtol,
                     err_msg=(
                         'Check eager auto parallel backward failed. Mismatch between eager auto parallel grad outputs '
-                        'and eager grad outputs on %s, the eager grad output tensor\'s index is : %d \n'
-                        'eager auto parallel grad output tensor:\n%s\n eager grad output tensor:\n%s\n'
-                        % (
-                            str(self.place),
-                            i,
-                            actual_grad_res[i],
-                            self.eager_grad_desire[i],
-                        )
+                        f'and eager grad outputs on {self.place}, the eager grad output tensor\'s index is : {i} \n'
+                        f'eager auto parallel grad output tensor:\n{actual_grad_res[i]}\n eager grad output tensor:\n{self.eager_grad_desire[i]}\n'
                     ),
                 )
 

--- a/test/deprecated/legacy_test/dist_fleet_ctr.py
+++ b/test/deprecated/legacy_test/dist_fleet_ctr.py
@@ -122,7 +122,7 @@ class TestDistCTR2x2(FleetDistRunnerBase):
                 weight_attr=base.ParamAttr(
                     initializer=paddle.nn.initializer.Constant(value=0.01)
                 ),
-                name='dnn-fc-%d' % i,
+                name=f'dnn-fc-{i}',
             )
             dnn_out = fc
 

--- a/test/deprecated/legacy_test/test_argsort_op_deprecated.py
+++ b/test/deprecated/legacy_test/test_argsort_op_deprecated.py
@@ -202,17 +202,8 @@ class TestArgsortOpCPU(unittest.TestCase):
             def err_msg():
                 offset = np.argmax(diff_mat > max_relative_error)
                 return (
-                    "%s error, %s variable %s max gradient diff %f over limit %f, "
-                    "the first error element is %d, expected %f, but got %f."
-                ) % (
-                    'argsort',
-                    msg_prefix,
-                    name,
-                    max_diff,
-                    max_relative_error,
-                    offset,
-                    a.flatten()[offset],
-                    b.flatten()[offset],
+                    f"argsort error, {msg_prefix} variable {name} max gradient diff {max_diff:f} over limit {max_relative_error:f}, "
+                    f"the first error element is {a.flatten()[offset]}, expected {b.flatten()[offset]:f}, but got {a.flatten()[offset]:f}."
                 )
 
             self.assertLessEqual(max_diff, max_relative_error, err_msg())

--- a/test/deprecated/legacy_test/test_save_load_deprecated.py
+++ b/test/deprecated/legacy_test/test_save_load_deprecated.py
@@ -332,7 +332,7 @@ class SimpleLSTMRNN(paddle.nn.Layer):
                     low=-self._init_scale, high=self._init_scale
                 ),
             )
-            self.weight_1_arr.append(self.add_parameter('w_%d' % i, weight_1))
+            self.weight_1_arr.append(self.add_parameter(f'w_{i}', weight_1))
             bias_1 = self.create_parameter(
                 attr=base.ParamAttr(
                     initializer=paddle.nn.initializer.Uniform(
@@ -343,7 +343,7 @@ class SimpleLSTMRNN(paddle.nn.Layer):
                 dtype="float32",
                 default_initializer=paddle.nn.initializer.Constant(0.0),
             )
-            self.bias_arr.append(self.add_parameter('b_%d' % i, bias_1))
+            self.bias_arr.append(self.add_parameter(f'b_{i}', bias_1))
 
     def forward(self, input_embedding, init_hidden=None, init_cell=None):
         self.cell_array = []

--- a/test/deprecated/mkldnn/test_split_mkldnn_op_deprecated.py
+++ b/test/deprecated/mkldnn/test_split_mkldnn_op_deprecated.py
@@ -64,7 +64,7 @@ class TestSplitSectionsOneDNNOp(OpTest):
             self.inputs['SectionsTensorList'] = self.sections_tensor_list
 
         self.outputs = {
-            'Out': [('out%d' % i, self.out[i]) for i in range(len(self.out))]
+            'Out': [(f'out{i}', self.out[i]) for i in range(len(self.out))]
         }
 
     def test_check_output(self):

--- a/test/dygraph_to_static/test_decorator_transform.py
+++ b/test/dygraph_to_static/test_decorator_transform.py
@@ -96,7 +96,7 @@ def deco6(x=0):
 @deco2
 def fun1(x, y=0):
     a = paddle.to_tensor(y)
-    print('in fun1, x=%d' % (x))
+    print(f'in fun1, x={x}')
     return a
 
 
@@ -104,21 +104,21 @@ def fun1(x, y=0):
 @deco2
 def fun2(x, y=0):
     a = paddle.to_tensor(y)
-    print('in fun2, x=%d' % (x))
+    print(f'in fun2, x={x}')
     return a
 
 
 @deco3(3)
 def fun3(x, y=0):
     a = paddle.to_tensor(y)
-    print('in fun3, x=%d' % (x))
+    print(f'in fun3, x={x}')
     return a
 
 
 @deco4(x=4)
 def fun4(x, y=0):
     a = paddle.to_tensor(y)
-    print('in fun4, x=%d' % (x))
+    print(f'in fun4, x={x}')
     return a
 
 
@@ -126,7 +126,7 @@ def fun4(x, y=0):
 @deco4()
 def fun5(x, y=0):
     a = paddle.to_tensor(y)
-    print('in fun5, x=%d' % (x))
+    print(f'in fun5, x={x}')
     return a
 
 
@@ -134,21 +134,21 @@ def fun5(x, y=0):
 @decos.deco2(2)
 def fun6(x, y=0):
     a = paddle.to_tensor(y)
-    print('in fun6, x=%d' % (x))
+    print(f'in fun6, x={x}')
     return a
 
 
 @deco5()
 def fun7(x, y=0):
     a = paddle.to_tensor(y)
-    print('in fun7, x=%d' % (x))
+    print(f'in fun7, x={x}')
     return a
 
 
 @deco6(2)
 def fun8(x, y=0):
     a = paddle.to_tensor(y)
-    print('in fun8, x=%d' % (x))
+    print(f'in fun8, x={x}')
     return a
 
 

--- a/test/dygraph_to_static/test_word2vec.py
+++ b/test/dygraph_to_static/test_word2vec.py
@@ -86,7 +86,7 @@ def build_dict(corpus, min_freq=3):
 
 word2id_freq, word2id_dict, id2word_dict = build_dict(corpus)
 vocab_size = len(word2id_freq)
-print("there are totoally %d different words in the corpus" % vocab_size)
+print(f"there are totoally {vocab_size} different words in the corpus")
 for _, (word, word_id) in zip(range(50), word2id_dict.items()):
     print(
         f"word {word}, its id {word_id}, its word freq {word2id_freq[word_id]}"
@@ -311,7 +311,7 @@ def train():
 
             step += 1
             mean_loss = np.mean(loss.numpy())
-            print("step %d / %d, loss %f" % (step, total_steps, mean_loss))
+            print(f"step {step} / {total_steps}, loss {mean_loss:f}")
             ret.append(mean_loss)
         return np.array(ret)
 

--- a/test/legacy_test/test_dist_base.py
+++ b/test/legacy_test/test_dist_base.py
@@ -225,7 +225,7 @@ class TestDistRunnerBase:
         )
 
         device_id = int(os.getenv("FLAGS_selected_gpus", "0"))
-        eprint(type(self).__name__, "device_id: %d." % device_id)
+        eprint(type(self).__name__, f"device_id: {device_id}.")
         place = base.CUDAPlace(device_id)
 
         exe = base.Executor(place)
@@ -243,7 +243,7 @@ class TestDistRunnerBase:
             loss = exe.run(main_program, fetch_list=[avg_cost])
             loss = loss[0] if loss else None
             out_losses.append(loss)
-            print_to_err(type(self).__name__, "run step %d finished" % i)
+            print_to_err(type(self).__name__, f"run step {i} finished")
             if lr_scheduler is not None:
                 lr_scheduler.step()
 
@@ -327,7 +327,7 @@ class TestDistRunnerBase:
                 feed=feeder.feed(get_data()),
             )
             out_losses.append(float(loss))
-            print_to_err(type(self).__name__, "run step %d finished" % i)
+            print_to_err(type(self).__name__, f"run step {i} finished")
         print_to_err(type(self).__name__, "trainer run finished")
         print_to_err(type(self).__name__, f"dist losses: {out_losses}")
 
@@ -421,7 +421,7 @@ class TestDistRunnerBase:
                 feed=feeder.feed(get_data()),
             )
             out_losses.append(float(loss))
-            print_to_err(type(self).__name__, "run step %d finished" % i)
+            print_to_err(type(self).__name__, f"run step {i} finished")
         print_to_err(type(self).__name__, "trainer run finished")
 
         dump_output(out_losses)
@@ -654,7 +654,7 @@ class TestDistRunnerBase:
                 binary, fetch_list=[avg_cost.name], feed=feeder.feed(get_data())
             )
             out_losses.append(float(loss))
-            print_to_err(type(self).__name__, "run step %d finished" % i)
+            print_to_err(type(self).__name__, f"run step {i} finished")
             if lr_scheduler is not None:
                 lr_scheduler.step()
 

--- a/tools/prune_for_jetson.py
+++ b/tools/prune_for_jetson.py
@@ -93,8 +93,8 @@ def prune_phi_kernels():
             f.write(content)
 
     print('We erase all grad op and kernel for Paddle-Inference lib.')
-    print('%50s%10s' % ('type', 'count'))
-    print('%50s%10s' % ('REGISTER_OPERATOR', register_op_count))
+    print(f'{"type":>50}{"count":>10}')
+    print(f'{"REGISTER_OPERATOR":>50}{register_op_count:>10}')
     return True
 
 

--- a/tools/remove_grad_op_and_kernel.py
+++ b/tools/remove_grad_op_and_kernel.py
@@ -207,19 +207,13 @@ if __name__ == '__main__':
     )
 
     print('We erase all grad op and kernel for Paddle-Inference lib.')
-    print('%50s%10s' % ('type', 'count'))
-    print('%50s%10s' % ('REGISTER_OPERATOR', register_op_count))
-    print('%50s%10s' % ('REGISTER_OP_CPU_KERNEL', register_op_cpu_kernel_count))
+    print(f'{"type":>50}{"count":>10}')
+    print(f'{"REGISTER_OPERATOR":>50}{register_op_count:>10}')
+    print(f'{"REGISTER_OP_CPU_KERNEL":>50}{register_op_cpu_kernel_count:>10}')
+    print(f'{"REGISTER_OP_CUDA_KERNEL":>50}{register_op_cuda_kernel_count:>10}')
+    print(f'{"REGISTER_OP_XPU_KERNEL":>50}{register_op_xpu_kernel_count:>10}')
+    print(f'{"REGISTER_OP_KERNEL":>50}{register_op_kernel_count:>10}')
     print(
-        '%50s%10s' % ('REGISTER_OP_CUDA_KERNEL', register_op_cuda_kernel_count)
+        f'{"REGISTER_OP_KERNEL_WITH_CUSTOM_TYPE":>50}{register_op_kernel_with_custom_type_count:>10}'
     )
-    print('%50s%10s' % ('REGISTER_OP_XPU_KERNEL', register_op_xpu_kernel_count))
-    print('%50s%10s' % ('REGISTER_OP_KERNEL', register_op_kernel_count))
-    print(
-        '%50s%10s'
-        % (
-            'REGISTER_OP_KERNEL_WITH_CUSTOM_TYPE',
-            register_op_kernel_with_custom_type_count,
-        )
-    )
-    print('%50s%10s' % ('REGISTER_OP_PD_KERNEL', register_pd_kernel_count))
+    print(f'{"REGISTER_OP_PD_KERNEL":>50}{register_pd_kernel_count:>10}')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

继 #65585 part19 后再次对 %x 形式 format 替换，因为 Ruff 0.8[^1] UP031 检查又有修改，现在只要是 %x 的形式都会抛出 UP031，即便没有自动修复，而有自动修复的之前已经全部修复过了，剩下的都是没有自动修复的，需要手动修复

> [!CAUTION]
>
> 相关地方均为手动逐个修复，需要仔细 review！

还有一些 `PYI063` 下个 pr 收尾

### Related links

- #70031
- #70033
- #70034
- #70035
- #70036
- #70037
- #70043
- #70044
- #70045
- #70046
- #70084
- #70085

[^1]: [Ruff 0.8 release notes](https://github.com/astral-sh/ruff/releases/tag/0.8.0)