### PR TITLE
[CodeStyle] update ruff v0.8.3 and ignore some `PYI063`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.1
+    rev: v0.8.3
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix, --no-cache]

--- a/python/paddle/autograd/autograd.py
+++ b/python/paddle/autograd/autograd.py
@@ -107,7 +107,7 @@ class Jacobian:
     def __getitem__(self, indexes):
         return self._jacobian[indexes]
 
-    def __getattr__(self, __name: str):
+    def __getattr__(self, __name: str):  # noqa: PYI063
         if __name == "shape":
             return getattr(self._jacobian, __name)
         if __name == "_evaluate_all":

--- a/test/dygraph_to_static/test_program_translator.py
+++ b/test/dygraph_to_static/test_program_translator.py
@@ -75,7 +75,7 @@ class StaticCode1:
             nonlocal x_v
             return (x_v,)
 
-        def set_args_0(__args):
+        def set_args_0(__args):  # noqa: PYI063
             nonlocal x_v
             (x_v,) = __args
 
@@ -103,7 +103,7 @@ class StaticCode1:
             nonlocal __return_0, __return_1, __return_value_0, loss
             return __return_0, __return_1, __return_value_0, loss
 
-        def set_args_1(__args):
+        def set_args_1(__args):  # noqa: PYI063
             nonlocal __return_0, __return_1, __return_value_0, loss
             __return_0, __return_1, __return_value_0, loss = __args
 
@@ -146,7 +146,7 @@ class StaticCode2:
             nonlocal x_v
             return (x_v,)
 
-        def set_args_2(__args):
+        def set_args_2(__args):  # noqa: PYI063
             nonlocal x_v
             (x_v,) = __args
 
@@ -174,7 +174,7 @@ class StaticCode2:
             nonlocal __return_2, __return_3, __return_value_1, loss
             return __return_2, __return_3, __return_value_1, loss
 
-        def set_args_3(__args):
+        def set_args_3(__args):  # noqa: PYI063
             nonlocal __return_2, __return_3, __return_value_1, loss
             __return_2, __return_3, __return_value_1, loss = __args
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->

* 升级 ruff 到 v0.8.3
* `noqa PYI063`
