### PR TITLE
[AutoParallel] opt memory usage for tensor-fusion save&load

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -30,6 +30,7 @@
 #include "paddle/fluid/framework/executor.h"
 #include "paddle/fluid/framework/ir/pass.h"
 #include "paddle/fluid/framework/program_desc.h"
+#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/fluid/ir_adaptor/translator/program_translator.h"
 #include "paddle/fluid/ir_adaptor/translator/translate.h"
 #include "paddle/fluid/ir_adaptor/translator/utils.h"
@@ -639,14 +640,21 @@ void BindProgram(py::module *m) {
            [](std::shared_ptr<Program> self,
               const std::unordered_map<std::string, phi::DenseTensor>
                   &state_dict,
-              const framework::Scope &scope = framework::Scope()) {
+              const framework::Scope &scope = framework::Scope(),
+              bool copy_tensor = false) {
              for (auto item : state_dict) {
                auto var = scope.FindVar(item.first);
                if (var == nullptr) {
                  PADDLE_THROW(common::errors::NotFound(
                      "The variable %s is not found.", item.first));
                } else {
-                 *var->GetMutable<phi::DenseTensor>() = item.second;
+                 if (copy_tensor) {
+                   auto *mutable_tensor = var->GetMutable<phi::DenseTensor>();
+                   paddle::framework::TensorCopy(
+                       item.second, item.second.place(), mutable_tensor);
+                 } else {
+                   *var->GetMutable<phi::DenseTensor>() = item.second;
+                 }
                }
              }
            })

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -636,28 +636,32 @@ void BindProgram(py::module *m) {
                   "The mode is not supported."));
             }
           })
-      .def("set_state_dict",
-           [](std::shared_ptr<Program> self,
-              const std::unordered_map<std::string, phi::DenseTensor>
-                  &state_dict,
-              const framework::Scope &scope = framework::Scope(),
-              bool copy_tensor = false) {
-             for (auto item : state_dict) {
-               auto var = scope.FindVar(item.first);
-               if (var == nullptr) {
-                 PADDLE_THROW(common::errors::NotFound(
-                     "The variable %s is not found.", item.first));
-               } else {
-                 if (copy_tensor) {
-                   auto *mutable_tensor = var->GetMutable<phi::DenseTensor>();
-                   paddle::framework::TensorCopy(
-                       item.second, item.second.place(), mutable_tensor);
-                 } else {
-                   *var->GetMutable<phi::DenseTensor>() = item.second;
-                 }
-               }
-             }
-           })
+      .def(
+          "set_state_dict",
+          [](std::shared_ptr<Program> self,
+             const std::unordered_map<std::string, phi::DenseTensor>
+                 &state_dict,
+             const framework::Scope &scope = framework::Scope(),
+             bool copy_tensor = false) {
+            for (auto item : state_dict) {
+              auto var = scope.FindVar(item.first);
+              if (var == nullptr) {
+                PADDLE_THROW(common::errors::NotFound(
+                    "The variable %s is not found.", item.first));
+              } else {
+                if (copy_tensor) {
+                  auto *mutable_tensor = var->GetMutable<phi::DenseTensor>();
+                  paddle::framework::TensorCopy(
+                      item.second, item.second.place(), mutable_tensor);
+                } else {
+                  *var->GetMutable<phi::DenseTensor>() = item.second;
+                }
+              }
+            }
+          },
+          py::arg("state_dict"),
+          py::arg("scope"),
+          py::arg("copy_tensor") = false)
       .def(
           "_prune",
           [](Program &self, std::vector<pir::Value> output_vars) {

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -2208,14 +2208,13 @@ class DistModel:
             )
             dist.fleet.init(is_collective=True)
 
-        if int(os.environ.get('FLAGS_enable_sharding_stage1_tensor_fusion', 0)):
-            if isinstance(optimizer, _ShardOptimizer) and use_pir_api():
-                shard_fn = optimizer._shard_fn
-                optimizer = optimizer._inner_opt
-                if isinstance(optimizer._shard_fn, ShardingStage1):
-                    optimizer = ShardingOptimizerStage1(
-                        optimizer, shard_fn, self._inner_strategy
-                    )
+        if isinstance(optimizer, _ShardOptimizer) and use_pir_api():
+            shard_fn = optimizer._shard_fn
+            optimizer = optimizer._inner_opt
+            if isinstance(optimizer._shard_fn, ShardingStage1):
+                optimizer = ShardingOptimizerStage1(
+                    optimizer, shard_fn, self._inner_strategy
+                )
 
         self._engine = Engine(
             layer, loss, optimizer, metrics, strategy=self._inner_strategy
@@ -2688,6 +2687,7 @@ class DistModel:
         cur_state_dict = self.state_dict(
             split_fusion=False, load_sharded_model=False
         )
+        copy_tensor = False
 
         # For sharding with tensor-fusion, we need to convert the state_dict
         # to include tensor-fusion parameters before calling set_state_dict,
@@ -2703,6 +2703,11 @@ class DistModel:
                 optimizer.convert_state_dict_with_tensor_fusion_param(
                     state_dict
                 )
+                # When using the tensor-fusion strategy, model parameters are shared with
+                # slice@ parameters. When setting the state_dict, we must copy the tensor
+                # instead of changing the handle directly, as this could cause errors in
+                # the slice@ parameters and increase memory usage.
+                copy_tensor = True
 
         for k, v in state_dict.items():
             assert v.is_dist(), f"key {k} value:{v} is not a dist tensor."
@@ -2779,7 +2784,7 @@ class DistModel:
                                     local_state_dict.pop(ori_p + suffix)
 
         dist_main_program.set_state_dict(
-            local_state_dict, paddle.static.global_scope()
+            local_state_dict, paddle.static.global_scope(), copy_tensor
         )
 
 

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -2784,7 +2784,7 @@ class DistModel:
                                     local_state_dict.pop(ori_p + suffix)
 
         dist_main_program.set_state_dict(
-            local_state_dict, paddle.static.global_scope(), copy_tensor
+            local_state_dict, paddle.static.global_scope()
         )
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

When using the tensor-fusion strategy, model parameters are shared with slice@ parameters. When setting the state_dict, we must copy the tensor instead of changing the handle directly, as this could cause errors in the slice@ parameters and increase memory usage.

1. optimize memory usage for tensor-fusion save&load
2. open sharding stage1 tensor-fusion as default

Pcard-76459