### PR TITLE
[Serde] Use `in` to check special var (dropout state) is persistable

### DIFF
--- a/python/paddle/base/dygraph/base.py
+++ b/python/paddle/base/dygraph/base.py
@@ -177,7 +177,10 @@ def _convert_into_variable(tensor):
             # But if its shape is empty while created from `create_variable()`, we consider this buffer
             # non-persistable. See case of `dropout_state` in lstm api.
             is_persistable = True
-            if tensor.name.endswith(NON_PERSISTABLE_VAR_NAME_SUFFIX):
+            # NOTE(SigureMo): Why do not use `tensor.name.endswith(NON_PERSISTABLE_VAR_NAME_SUFFIX)`?
+            # Because the tensor maybe copied, the name of the tensor will be appended with a new suffix.
+            # Such as `lstm_0.dropout_state__non_persistable_deepcopy_204`
+            if NON_PERSISTABLE_VAR_NAME_SUFFIX in tensor.name:
                 is_persistable = False
 
             new_var = tensor._to_static_var(

--- a/python/paddle/pir/core.py
+++ b/python/paddle/pir/core.py
@@ -494,7 +494,10 @@ def _convert_into_value(tensor):
             paddle.pir.core.default_main_program(), tensor
         )
         NON_PERSISTABLE_VAR_NAME_SUFFIX = "__non_persistable"
-        if tensor.name.endswith(NON_PERSISTABLE_VAR_NAME_SUFFIX):
+        # NOTE(SigureMo): Why do not use `tensor.name.endswith(NON_PERSISTABLE_VAR_NAME_SUFFIX)`?
+        # Because the tensor maybe copied, the name of the tensor will be appended with a new suffix.
+        # Such as `lstm_0.dropout_state__non_persistable_deepcopy_204`
+        if NON_PERSISTABLE_VAR_NAME_SUFFIX in tensor.name:
             value.persistable = False
         return value
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

由于历史原因，我们对 dropout state 有一个 trick，通过其命名来判断是否是 `persistable`，之前是通过后缀匹配（`endswith`）判断的，但实际上 tensor 是可能进行 copy 的，比如 deepcopy 之后命名可能就变成了 `lstm_0.dropout_state__non_persistable_deepcopy_204`，此时就会出问题了

因此修改为使用 `in` 来判断，只要名字中出现 `__non_persistable` 即认为其为 non persistable 的

PCard-66972