### PR TITLE
[PIR][CINN] Update output place for memcpy op

### DIFF
--- a/paddle/phi/kernels/memcpy_kernel.cc
+++ b/paddle/phi/kernels/memcpy_kernel.cc
@@ -106,12 +106,12 @@ void MemcpyKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_GE(
       dst_place_type,
       0,
-      errors::OutOfRange("dst_place_type only support 0-2, but got: %d",
+      errors::OutOfRange("dst_place_type only support 0-4, but got: %d",
                          dst_place_type));
   PADDLE_ENFORCE_LE(
       dst_place_type,
-      2,
-      errors::OutOfRange("dst_place_type only support 0-2, but got: %d",
+      4,
+      errors::OutOfRange("dst_place_type only support 0-4, but got: %d",
                          dst_place_type));
   switch (dst_place_type) {
     case 0: /* CPUPlace */

--- a/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
+++ b/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
@@ -45,6 +45,12 @@ def tensor_copy_to_cuda_with_warning(x, device_id=None, blocking=True):
     return y
 
 
+def tensor_copy_to_cpu_with_compute(x):
+    x = paddle.to_tensor(x)
+    y = x.cpu()
+    return y + 1
+
+
 class TestTensorCopyToCpuOnDefaultGPU(Dy2StTestBase):
     def _run(self):
         x1 = paddle.ones([1, 2, 3])
@@ -122,6 +128,28 @@ class TestTensorCopyToCUDAWithWarningOnGPU(Dy2StTestBase):
                 x1, device_id=2, blocking=False
             )
         self.assertIn('math_op_patch.py', cm.filename)
+
+
+class TestTensorCopyToCPUWithComputeOnDefaultGPU(Dy2StTestBase):
+    def _run(self):
+        x1 = paddle.ones([1, 2, 3])
+        x2 = paddle.jit.to_static(tensor_copy_to_cpu_with_compute)(x1)
+        return x1.place, x2.place, x2.numpy()
+
+    def test_tensor_cpu_with_compute_on_default_gpu(self):
+        if not paddle.is_compiled_with_cuda():
+            return
+        place = paddle.CUDAPlace(int(os.environ.get('FLAGS_selected_gpus', 0)))
+        paddle.framework._set_expected_place(place)
+        with enable_to_static_guard(False):
+            dygraph_x1_place, dygraph_place, dygraph_res = self._run()
+
+        static_x1_place, static_place, static_res = self._run()
+        np.testing.assert_allclose(dygraph_res, static_res, rtol=1e-05)
+        self.assertTrue(dygraph_x1_place.is_gpu_place())
+        self.assertTrue(static_x1_place.is_gpu_place())
+        self.assertTrue(dygraph_place.is_cpu_place())
+        self.assertTrue(static_place.is_cpu_place())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

`MemcpyKernel` 比较特殊，单凭 Kernel 本身无法确定输出 Place，需要根据属性 `dst_place_type` 单独设置输出 Place

PCard-66972