### PR TITLE
【Inference】Fix Bug for OpenVINO Config.h

### DIFF
--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -1179,11 +1179,10 @@ struct PD_INFER_DECL AnalysisConfig {
 
   // Padding related
   bool use_fc_padding_{true};
-#ifdef PADDLE_WITH_OPENVINO
+
   // OpenVINO related.
   bool use_openvino_{false};
   Precision openvino_inference_precision_{Precision::kFloat32};
-#endif
 
   // TensorRT related.
   bool use_tensorrt_{false};


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-71500
删去config.h中对OpenVINO变量的限制，否则在使用c++ sdk时会产生core dump