### PR TITLE
[Dy2St][PIR] Add PIR mode into AST dy2st cache key

### DIFF
--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -361,6 +361,7 @@ class CacheKey:
                 with_hook,
                 is_train,
                 self._pir_flags,
+                use_pir_api(),
             )
         )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
pcard-67164
同一个模型先后使用新旧IR进行jit.save，第一次to_static会导致模型的forward被绑定，出现save与模型本身模式不匹配的问题。之前需要在切换模式之前使用rollback将模型恢复成动态图模式。
在hash中加入use_pir_api后不再需要rollback，直接切换即可。