### PR TITLE
丢弃:添加 full 函数复数类型支持

### DIFF
--- a/paddle/fluid/pybind/manual_static_op_function.h
+++ b/paddle/fluid/pybind/manual_static_op_function.h
@@ -156,12 +156,25 @@ PyObject *static_api_full(PyObject *self, PyObject *args, PyObject *kwargs) {
         !PyObject_CheckIRVectorOfValue(shape_obj) &&
         !PyObject_CheckIRValue(value_obj)) {
       std::vector<int64_t> shape = CastPyArg2Longs(shape_obj, "full", 0);
-      double value = CastPyArg2Double(value_obj, "full", 1);
-      CallStackRecorder callstack_recoder("full");
-      callstack_recoder.Record();
-      auto static_api_out = paddle::dialect::full(shape, value, dtype, place);
-      callstack_recoder.AttachToOps();
-      return ToPyObject(static_api_out);
+      if (PyComplex_Check(value_obj)) {
+        phi::dtype::complex<float> complex_value =
+            CastPyArg2Complex(value_obj, "full", 1);
+        double value_real = complex_value.real;
+        double value_imag = complex_value.imag;
+        CallStackRecorder callstack_recoder("full_complex");
+        callstack_recoder.Record();
+        auto static_api_out = paddle::dialect::full_complex(
+            shape, value_real, value_imag, dtype, place);
+        callstack_recoder.AttachToOps();
+        return ToPyObject(static_api_out);
+      } else {
+        double value = CastPyArg2Double(value_obj, "full", 1);
+        CallStackRecorder callstack_recoder("full");
+        callstack_recoder.Record();
+        auto static_api_out = paddle::dialect::full(shape, value, dtype, place);
+        callstack_recoder.AttachToOps();
+        return ToPyObject(static_api_out);
+      }
     } else {
       pir::Value shape, value;
 
@@ -180,13 +193,21 @@ PyObject *static_api_full(PyObject *self, PyObject *args, PyObject *kwargs) {
       if (PyObject_CheckIRValue(value_obj)) {
         value = CastPyArg2Value(value_obj, "full", 1, false);
       } else {
-        double value_tmp = CastPyArg2Double(value_obj, "full", 1);
-        value = paddle::dialect::full(std::vector<int64_t>{1},
-                                      value_tmp,
-                                      phi::DataType::FLOAT32,
-                                      phi::CPUPlace());
+        if (PyComplex_Check(value_obj)) {
+          phi::dtype::complex<float> complex_value =
+              CastPyArg2Complex(value_obj, "full", 1);
+          double value_real = complex_value.real;
+          double value_imag = complex_value.imag;
+          value = paddle::dialect::full_complex(
+              std::vector<int64_t>{1}, value_real, value_imag, dtype, place);
+        } else {
+          double value_tmp = CastPyArg2Double(value_obj, "full", 1);
+          value = paddle::dialect::full(std::vector<int64_t>{1},
+                                        value_tmp,
+                                        phi::DataType::FLOAT32,
+                                        phi::CPUPlace());
+        }
       }
-
       CallStackRecorder callstack_recoder("full_with_tensor");
       callstack_recoder.Record();
       auto static_api_out =

--- a/paddle/fluid/pybind/manual_static_op_function.h
+++ b/paddle/fluid/pybind/manual_static_op_function.h
@@ -159,12 +159,10 @@ PyObject *static_api_full(PyObject *self, PyObject *args, PyObject *kwargs) {
       if (PyComplex_Check(value_obj)) {
         phi::dtype::complex<float> complex_value =
             CastPyArg2Complex(value_obj, "full", 1);
-        double value_real = complex_value.real;
-        double value_imag = complex_value.imag;
         CallStackRecorder callstack_recoder("full_complex");
         callstack_recoder.Record();
         auto static_api_out = paddle::dialect::full_complex(
-            shape, value_real, value_imag, dtype, place);
+            shape, complex_value.real, complex_value.imag, dtype, place);
         callstack_recoder.AttachToOps();
         return ToPyObject(static_api_out);
       } else {
@@ -196,10 +194,11 @@ PyObject *static_api_full(PyObject *self, PyObject *args, PyObject *kwargs) {
         if (PyComplex_Check(value_obj)) {
           phi::dtype::complex<float> complex_value =
               CastPyArg2Complex(value_obj, "full", 1);
-          double value_real = complex_value.real;
-          double value_imag = complex_value.imag;
-          value = paddle::dialect::full_complex(
-              std::vector<int64_t>{1}, value_real, value_imag, dtype, place);
+          value = paddle::dialect::full_complex(std::vector<int64_t>{1},
+                                                complex_value.real,
+                                                complex_value.imag,
+                                                dtype,
+                                                place);
         } else {
           double value_tmp = CastPyArg2Double(value_obj, "full", 1);
           value = paddle::dialect::full(std::vector<int64_t>{1},

--- a/paddle/phi/kernels/cpu/full_kernel.cc
+++ b/paddle/phi/kernels/cpu/full_kernel.cc
@@ -46,7 +46,6 @@ void FullComplexKernel(const Context& dev_ctx,
                        const Scalar& imag,
                        DataType dtype UNUSED,
                        DenseTensor* out) {
-  out->Resize(common::make_ddim(shape.GetData()));
   Scalar fill_value = Scalar(complex128(real.to<double>(), imag.to<double>()));
   FullKernel<T>(dev_ctx, shape, fill_value, dtype, out);
 }

--- a/paddle/phi/kernels/cpu/full_kernel.cc
+++ b/paddle/phi/kernels/cpu/full_kernel.cc
@@ -40,6 +40,18 @@ void FullKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
+void FullComplexKernel(const Context& dev_ctx,
+                       const IntArray& shape,
+                       const Scalar& real,
+                       const Scalar& imag,
+                       DataType dtype UNUSED,
+                       DenseTensor* out) {
+  out->Resize(common::make_ddim(shape.GetData()));
+  Scalar fill_value = Scalar(complex128(real.to<double>(), imag.to<double>()));
+  FullKernel<T>(dev_ctx, shape, fill_value, dtype, out);
+}
+
+template <typename T, typename Context>
 void FullLikeKernel(const Context& dev_ctx,
                     const DenseTensor& x UNUSED,
                     const Scalar& val,
@@ -117,6 +129,13 @@ PD_REGISTER_KERNEL(full,
                    phi::dtype::float8_e5m2,
                    phi::dtype::float16,
                    phi::dtype::bfloat16,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}
+
+PD_REGISTER_KERNEL(full_complex,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::FullComplexKernel,
                    phi::dtype::complex<float>,
                    phi::dtype::complex<double>) {}
 

--- a/paddle/phi/kernels/cpu/full_kernel.cc
+++ b/paddle/phi/kernels/cpu/full_kernel.cc
@@ -46,8 +46,11 @@ void FullComplexKernel(const Context& dev_ctx,
                        const Scalar& imag,
                        DataType dtype UNUSED,
                        DenseTensor* out) {
-  Scalar fill_value = Scalar(complex128(real.to<double>(), imag.to<double>()));
-  FullKernel<T>(dev_ctx, shape, fill_value, dtype, out);
+  FullKernel<T>(dev_ctx,
+                shape,
+                Scalar(complex128(real.to<double>(), imag.to<double>())),
+                dtype,
+                out);
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/full_kernel.h
+++ b/paddle/phi/kernels/full_kernel.h
@@ -32,6 +32,14 @@ void FullKernel(const Context& dev_ctx,
                 DenseTensor* out);
 
 template <typename T, typename Context>
+void FullComplexKernel(const Context& dev_ctx,
+                       const IntArray& shape,
+                       const Scalar& real,
+                       const Scalar& imag,
+                       DataType dtype,
+                       DenseTensor* out);
+
+template <typename T, typename Context>
 void FullWithTensorKernel(const Context& dev_ctx,
                           const DenseTensor& value,
                           const IntArray& shape,

--- a/paddle/phi/kernels/gpu/full_kernel.cu
+++ b/paddle/phi/kernels/gpu/full_kernel.cu
@@ -58,6 +58,17 @@ void FullKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
+void FullComplexKernel(const Context& dev_ctx,
+                       const IntArray& shape,
+                       const Scalar& real,
+                       const Scalar& imag,
+                       DataType dtype UNUSED,
+                       DenseTensor* out) {
+  Scalar fill_value = Scalar(complex128(real.to<double>(), imag.to<double>()));
+  FullKernel<T>(dev_ctx, shape, fill_value, dtype, out);
+}
+
+template <typename T, typename Context>
 void FullLikeKernel(const Context& dev_ctx,
                     const DenseTensor& x,
                     const Scalar& val,
@@ -138,6 +149,13 @@ PD_REGISTER_KERNEL(full,
                    phi::dtype::float8_e5m2,
                    phi::dtype::float16,
                    phi::dtype::bfloat16,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}
+
+PD_REGISTER_KERNEL(full_complex,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::FullComplexKernel,
                    phi::dtype::complex<float>,
                    phi::dtype::complex<double>) {}
 

--- a/paddle/phi/kernels/gpu/full_kernel.cu
+++ b/paddle/phi/kernels/gpu/full_kernel.cu
@@ -64,8 +64,11 @@ void FullComplexKernel(const Context& dev_ctx,
                        const Scalar& imag,
                        DataType dtype UNUSED,
                        DenseTensor* out) {
-  Scalar fill_value = Scalar(complex128(real.to<double>(), imag.to<double>()));
-  FullKernel<T>(dev_ctx, shape, fill_value, dtype, out);
+  FullKernel<T>(dev_ctx,
+                shape,
+                Scalar(complex128(real.to<double>(), imag.to<double>())),
+                dtype,
+                out);
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -2149,6 +2149,19 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
   traits : paddle::dialect::ForwardOnlyTrait
 
+- op : full_complex
+  args : (IntArray shape, Scalar(double) real, Scalar(double) imag, DataType dtype=DataType::COMPLEX64, Place place=CPUPlace())
+  output: Tensor(out)
+  infer_meta :
+    func : CreateInferMeta
+    param : [shape, dtype]
+  kernel :
+    func: full_complex
+    param : [shape, real, imag, dtype]
+    data_type : dtype
+    backend : place
+  traits : paddle::dialect::ForwardOnlyTrait
+
 - op : full_int_array
   args : (int64_t[] value, DataType dtype=DataType::FLOAT32, Place place=CPUPlace())
   output: Tensor(out)

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1050,7 +1050,8 @@ def fill_constant(
             dtype = paddle.pir.core.vartype_to_datatype[dtype]
 
         if in_dynamic_mode():
-            value = float(value)
+            if not isinstance(value, type(1j)):  # noqa: UP003
+                value = float(value)
             if isinstance(shape, (list, tuple)):
                 shape = paddle.utils.convert_shape_to_list(shape)
         else:
@@ -1475,10 +1476,10 @@ def full(
              [2. 2.]
              [2. 2.]]
     """
-
     if dtype is None:
         dtype = paddle.get_default_dtype()
-
+    if isinstance(fill_value, type(1j)):  # noqa: UP003
+        dtype = "complex64"
     return fill_constant(shape=shape, dtype=dtype, value=fill_value, name=name)
 
 

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1478,9 +1478,17 @@ def full(
              [2. 2.]]
     """
     if dtype is None:
-        dtype = paddle.get_default_dtype()
-    if isinstance(fill_value, builtins.complex):
-        dtype = "complex64"
+        if isinstance(fill_value, bool):  # it need to be check before int.
+            dtype = 'bool'
+        elif isinstance(fill_value, (int)):
+            dtype = 'int64'
+        elif isinstance(fill_value, (float)):
+            dtype = "float64"
+        elif isinstance(fill_value, (builtins.complex)):
+            dtype = "complex128"
+        else:
+            dtype = paddle.get_default_dtype()
+
     return fill_constant(shape=shape, dtype=dtype, value=fill_value, name=name)
 
 

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1056,10 +1056,6 @@ def fill_constant(
             if isinstance(shape, (list, tuple)):
                 shape = paddle.utils.convert_shape_to_list(shape)
         else:
-            if isinstance(value, builtins.complex):
-                raise ValueError(
-                    "In static mode, the value of fill_constant can not be complex number."
-                )
             paddle.utils.check_shape(shape)
             if isinstance(shape, (list, tuple)):
                 if paddle.utils._contain_var(shape):

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import builtins
 import math
 import re
 from typing import TYPE_CHECKING, Any, overload
@@ -1050,11 +1051,15 @@ def fill_constant(
             dtype = paddle.pir.core.vartype_to_datatype[dtype]
 
         if in_dynamic_mode():
-            if not isinstance(value, type(1j)):  # noqa: UP003
+            if not isinstance(value, builtins.complex):
                 value = float(value)
             if isinstance(shape, (list, tuple)):
                 shape = paddle.utils.convert_shape_to_list(shape)
         else:
+            if isinstance(value, builtins.complex):
+                raise ValueError(
+                    "In static mode, the value of fill_constant can not be complex number."
+                )
             paddle.utils.check_shape(shape)
             if isinstance(shape, (list, tuple)):
                 if paddle.utils._contain_var(shape):
@@ -1478,7 +1483,7 @@ def full(
     """
     if dtype is None:
         dtype = paddle.get_default_dtype()
-    if isinstance(fill_value, type(1j)):  # noqa: UP003
+    if isinstance(fill_value, builtins.complex):
         dtype = "complex64"
     return fill_constant(shape=shape, dtype=dtype, value=fill_value, name=name)
 

--- a/test/legacy_test/test_full_op.py
+++ b/test/legacy_test/test_full_op.py
@@ -166,6 +166,43 @@ class TestFullAPI(unittest.TestCase):
 
             out_11 = paddle.full(shape=10, dtype="float32", fill_value=1.1)
 
+            out_12 = paddle.full(
+                shape=[1, 2, 3], dtype="complex64", fill_value=1.1 + 1.1j
+            )
+
+            out_13 = paddle.full(
+                shape=[1, 2, 3], dtype="complex128", fill_value=1.1 + 1.1j
+            )
+
+            out_14 = paddle.full(
+                shape=[1, 2, 3], dtype="complex64", fill_value=1.1 + np.inf * 1j
+            )
+
+            out_15 = paddle.full(
+                shape=[1, 2, 3],
+                dtype="complex128",
+                fill_value=1.1 + np.inf * 1j,
+            )
+
+            out_16 = paddle.full(
+                shape=[1, 2, 3], dtype="complex64", fill_value=1.1 - np.inf * 1j
+            )
+
+            out_17 = paddle.full(
+                shape=[1, 2, 3],
+                dtype="complex128",
+                fill_value=1.1 - np.inf * 1j,
+            )
+
+            out_18 = paddle.full(
+                shape=[1, 2, 3], dtype="complex64", fill_value=1.1 + np.nan * 1j
+            )
+
+            out_19 = paddle.full(
+                shape=[1, 2, 3],
+                dtype="complex128",
+                fill_value=1.1 + np.nan * 1j,
+            )
             np.testing.assert_array_equal(
                 out_1, np.full([1, 2], 1.1, dtype="float32")
             )
@@ -199,6 +236,33 @@ class TestFullAPI(unittest.TestCase):
             np.testing.assert_array_equal(
                 out_11, np.full([10], 1.1, dtype="float32")
             )
+            np.testing.assert_allclose(
+                out_12, np.full([1, 2, 3], 1.1 + 1.1j, dtype="complex64")
+            )
+            np.testing.assert_allclose(
+                out_13, np.full([1, 2, 3], 1.1 + 1.1j, dtype="complex128")
+            )
+            np.testing.assert_allclose(
+                out_14, np.full([1, 2, 3], 1.1 + np.inf * 1j, dtype="complex64")
+            )
+            np.testing.assert_allclose(
+                out_15,
+                np.full([1, 2, 3], 1.1 + np.inf * 1j, dtype="complex128"),
+            )
+            np.testing.assert_allclose(
+                out_16, np.full([1, 2, 3], 1.1 - np.inf * 1j, dtype="complex64")
+            )
+            np.testing.assert_allclose(
+                out_17,
+                np.full([1, 2, 3], 1.1 - np.inf * 1j, dtype="complex128"),
+            )
+            np.testing.assert_allclose(
+                out_18, np.full([1, 2, 3], 1.1 + np.nan * 1j, dtype="complex64")
+            )
+            np.testing.assert_allclose(
+                out_19,
+                np.full([1, 2, 3], 1.1 + np.nan * 1j, dtype="complex128"),
+            )
 
 
 class TestFullOpError(unittest.TestCase):
@@ -213,6 +277,14 @@ class TestFullOpError(unittest.TestCase):
             # float32, float64, uint8, int16, int32 or int64
             self.assertRaises(
                 TypeError, paddle.full, shape=[1], fill_value=5, dtype='uint4'
+            )
+
+            self.assertRaises(
+                ValueError,
+                paddle.full,
+                shape=[1],
+                fill_value=1 + 1j,
+                dtype='complex64',
             )
 
             # The shape dtype of full op must be int32 or int64.
@@ -231,6 +303,7 @@ class TestFullOpError(unittest.TestCase):
                 paddle.full(shape=[shape, 2], dtype="float32", fill_value=1)
 
             self.assertRaises(TypeError, test_shape_tensor_list_dtype)
+
         paddle.disable_static()
 
 

--- a/test/legacy_test/test_full_op.py
+++ b/test/legacy_test/test_full_op.py
@@ -67,8 +67,57 @@ class TestFullAPI(unittest.TestCase):
             )
             out_8 = paddle.full(shape=10, dtype=np.float32, fill_value=val)
 
+            out_9 = paddle.full(
+                shape=10, dtype="complex64", fill_value=1.1 + 1.1j
+            )
+
+            out_10 = paddle.full(
+                shape=10, dtype="complex128", fill_value=1.1 + 1.1j
+            )
+
+            out_11 = paddle.full(
+                shape=10, dtype="complex64", fill_value=1.1 + np.inf * 1j
+            )
+
+            out_12 = paddle.full(
+                shape=10, dtype="complex128", fill_value=1.1 + np.inf * 1j
+            )
+
+            out_13 = paddle.full(
+                shape=10, dtype="complex64", fill_value=1.1 - np.inf * 1j
+            )
+
+            out_14 = paddle.full(
+                shape=10, dtype="complex128", fill_value=1.1 - np.inf * 1j
+            )
+
+            out_15 = paddle.full(
+                shape=10, dtype="complex64", fill_value=1.1 + np.nan * 1j
+            )
+
+            out_16 = paddle.full(
+                shape=10, dtype="complex128", fill_value=1.1 + np.nan * 1j
+            )
+
             exe = base.Executor(place=base.CPUPlace())
-            res_1, res_2, res_3, res_4, res_5, res_6, res_7, res_8 = exe.run(
+            (
+                res_1,
+                res_2,
+                res_3,
+                res_4,
+                res_5,
+                res_6,
+                res_7,
+                res_8,
+                res_9,
+                res_10,
+                res_11,
+                res_12,
+                res_13,
+                res_14,
+                res_15,
+                res_16,
+            ) = exe.run(
                 paddle.static.default_main_program(),
                 feed={
                     "shape_tensor_int32": np.array([1, 2]).astype("int32"),
@@ -83,6 +132,14 @@ class TestFullAPI(unittest.TestCase):
                     out_6,
                     out_7,
                     out_8,
+                    out_9,
+                    out_10,
+                    out_11,
+                    out_12,
+                    out_13,
+                    out_14,
+                    out_15,
+                    out_16,
                 ],
             )
 
@@ -109,6 +166,30 @@ class TestFullAPI(unittest.TestCase):
         )
         np.testing.assert_array_equal(
             res_8, np.full([10], 1.1, dtype="float32")
+        )
+        np.testing.assert_allclose(
+            res_9, np.full([10], 1.1 + 1.1j, dtype="complex64")
+        )
+        np.testing.assert_allclose(
+            res_10, np.full([10], 1.1 + 1.1j, dtype="complex128")
+        )
+        np.testing.assert_allclose(
+            res_11, np.full([10], 1.1 + np.inf * 1j, dtype="complex64")
+        )
+        np.testing.assert_allclose(
+            res_12, np.full([10], 1.1 + np.inf * 1j, dtype="complex128")
+        )
+        np.testing.assert_allclose(
+            res_13, np.full([10], 1.1 - np.inf * 1j, dtype="complex64")
+        )
+        np.testing.assert_allclose(
+            res_14, np.full([10], 1.1 - np.inf * 1j, dtype="complex128")
+        )
+        np.testing.assert_allclose(
+            res_15, np.full([10], 1.1 + np.nan * 1j, dtype="complex64")
+        )
+        np.testing.assert_allclose(
+            res_16, np.full([10], 1.1 + np.nan * 1j, dtype="complex128")
         )
         paddle.disable_static()
 
@@ -277,14 +358,6 @@ class TestFullOpError(unittest.TestCase):
             # float32, float64, uint8, int16, int32 or int64
             self.assertRaises(
                 TypeError, paddle.full, shape=[1], fill_value=5, dtype='uint4'
-            )
-
-            self.assertRaises(
-                ValueError,
-                paddle.full,
-                shape=[1],
-                fill_value=1 + 1j,
-                dtype='complex64',
             )
 
             # The shape dtype of full op must be int32 or int64.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features 

### Description
<!-- Describe what you’ve done -->

### 为什么创建新的op:

我需要用它来支持静态图的计算。

`paddle/fluid/pybind/manual_static_op_function.h` 里自定义了 `full` 的静态图 api  。

里面调用的 `paddle::dialect::full`这个是根据ops.yaml自动生成的文件。`ops.yaml`的Scalar不支持complex输入。
https://github.com/PaddlePaddle/Paddle/blob/64e8d1b2503e7c6672c6a62c5557ae5821a393c2/paddle/fluid/operators/generator/type_mapping.py#L62
不存在complex的mapping,也许可以自己创建？我明天开一个分支试一下，如果修改mapping实现起来会简单很多。

遗留的test问题:

```
        if in_dynamic_or_pir_mode():
>           return _C_ops.equal(x, y)
E           RuntimeError: (PreconditionNotMet) The meta data must be valid when call the mutable data function.
E             [Hint: Expected valid() == true, but received valid():0 != true:1.] (at /paddle/paddle/phi/core/dense_tensor.cc:113)                                                                                                                
E           
E           Falsifying example: test_full(
E               shape=(0,),
E               fill_value=False,
E               kw={},
E           )

../../miniconda3/envs/tests/lib/python3.9/site-packages/paddle/tensor/logic.py:591: RuntimeError

FAILED array_api_tests/test_creation_functions.py::test_full - RuntimeError: (PreconditionNotMet) The meta data must be valid when call the mutable data function.
  [Hint: Expected valid() == true, but received valid():0 != true:1.] (at /paddle/paddle/phi/core/dense_tensor.cc:113)

Falsifying example: test_full(
    shape=(0,),
    fill_value=False,
    kw={},
)
```
这个似乎同时也和我的另一个equal的任务相关，它对空张量的检查逻辑和预期不一致。我记得equal里面似乎没有特别对空张量的检查。isnan不知道算不算。

CPU单测过了，但GPU编译暂时还存在一个问题，所以暂时不merging了。

老师可以的话救一下!没头绪。

![image](https://github.com/user-attachments/assets/92c73557-c8f5-4c69-8d3b-e45c4dd8cb8c)



