### PR TITLE
【SCU】【Paddle Tensor 第二期 API 支持 0-size TensorNo.25、47】paddle.tensordot 支持 0-size Tensor

### DIFF
--- a/paddle/cinn/optim/merge_block_utils.h
+++ b/paddle/cinn/optim/merge_block_utils.h
@@ -28,17 +28,24 @@ using ForEqualFunc =
     std::function<bool(const ForTreeNode&, const ForTreeNode&)>;
 
 /**
- * Determines if two blocks of code with nested for-loops have identical loop extents and can be merged.
+ * Determines if two blocks of code with nested for-loops have identical loop
+ extents and can be merged.
 
- * This pass is applicable in scenarios where there are multiple code blocks with nested for-loops,
- * and we need to determine if these blocks can be consolidated to simplify the code structure.
+ * This pass is applicable in scenarios where there are multiple code blocks
+ with nested for-loops,
+ * and we need to determine if these blocks can be consolidated to simplify the
+ code structure.
 
- * When applied, this pass will not directly modify the IR but serves as a prerequisite check
- * to ensure that loop extents match. If they do, a separate merging process can be safely conducted
+ * When applied, this pass will not directly modify the IR but serves as a
+ prerequisite check
+ * to ensure that loop extents match. If they do, a separate merging process can
+ be safely conducted
  * to combine the blocks into a single block with shared loop structures.
 
- * Performance impact: This pass itself does not directly impact performance but enables further
- * optimizations by identifying mergeable loop structures, which can reduce code size and potentially
+ * Performance impact: This pass itself does not directly impact performance but
+ enables further
+ * optimizations by identifying mergeable loop structures, which can reduce code
+ size and potentially
  * improve cache efficiency by consolidating similar data processing tasks.
 
  * Examples:

--- a/paddle/cinn/optim/merge_block_utils.h
+++ b/paddle/cinn/optim/merge_block_utils.h
@@ -28,39 +28,47 @@ using ForEqualFunc =
     std::function<bool(const ForTreeNode&, const ForTreeNode&)>;
 
 /**
- * Check if blocks can merge.
- * @param first for_loops vector
- * @param second Another for_loops vector.
- * @return Return if two block's for extents equal currently.
- */
-/**
- * Example 1: CanMergeBlocks(var_B, var_C)
- * block(var_B)
- *   for(i, 0, 10)
- *     for(j, 0, 10)
- *        B[i,j] = A[i,j]
+ * Determines if two blocks of code with nested for-loops have identical loop extents and can be merged.
+
+ * This pass is applicable in scenarios where there are multiple code blocks with nested for-loops,
+ * and we need to determine if these blocks can be consolidated to simplify the code structure.
+
+ * When applied, this pass will not directly modify the IR but serves as a prerequisite check
+ * to ensure that loop extents match. If they do, a separate merging process can be safely conducted
+ * to combine the blocks into a single block with shared loop structures.
+
+ * Performance impact: This pass itself does not directly impact performance but enables further
+ * optimizations by identifying mergeable loop structures, which can reduce code size and potentially
+ * improve cache efficiency by consolidating similar data processing tasks.
+
+ * Examples:
+ * 1. Simple identical loops:
+ *    Input IR:
+ *      block(var_B)
+ *        for(i, 0, 10)
+ *          for(j, 0, 10)
+ *            B[i,j] = A[i,j]
  *
- * block(var_C)
- *   for(i, 0, 10)
- *     for(j, 0, 10)
- *        C[i,j] = A[i,j]
- * =>
- * Return value:
- * true
+ *      block(var_C)
+ *        for(i, 0, 10)
+ *          for(j, 0, 10)
+ *            C[i,j] = A[i,j]
+ *    Output IR:
+ *      Can be merged since loop extents are identical.
  *
- * Example 2: CanMergeBlocks(var_B, var_C)
- * block(var_B)
- *   for(i, 0, 10)
- *     for(j, 0, 10)
- *        B[i,j] = A[i,j]
+ * 2. Different loop extents:
+ *    Input IR:
+ *      block(var_B)
+ *        for(i, 0, 10)
+ *          for(j, 0, 10)
+ *            B[i,j] = A[i,j]
  *
- * block(var_C)
- *   for(i, 0, 3)
- *     for(j, 0, 4)
- *        C[i,j] = A[i,j]
- * =>
- * Return value:
- * false
+ *      block(var_C)
+ *        for(i, 0, 3)
+ *          for(j, 0, 4)
+ *            C[i,j] = A[i,j]
+ *    Output IR:
+ *      Cannot be merged due to differing loop extents.
  */
 bool CanMergeBlocks(const ir::For* first,
                     const ir::For* second,

--- a/paddle/cinn/optim/merge_block_utils.h
+++ b/paddle/cinn/optim/merge_block_utils.h
@@ -28,54 +28,39 @@ using ForEqualFunc =
     std::function<bool(const ForTreeNode&, const ForTreeNode&)>;
 
 /**
- * Determines if two blocks of code with nested for-loops have identical loop
- extents and can be merged.
-
- * This pass is applicable in scenarios where there are multiple code blocks
- with nested for-loops,
- * and we need to determine if these blocks can be consolidated to simplify the
- code structure.
-
- * When applied, this pass will not directly modify the IR but serves as a
- prerequisite check
- * to ensure that loop extents match. If they do, a separate merging process can
- be safely conducted
- * to combine the blocks into a single block with shared loop structures.
-
- * Performance impact: This pass itself does not directly impact performance but
- enables further
- * optimizations by identifying mergeable loop structures, which can reduce code
- size and potentially
- * improve cache efficiency by consolidating similar data processing tasks.
-
- * Examples:
- * 1. Simple identical loops:
- *    Input IR:
- *      block(var_B)
- *        for(i, 0, 10)
- *          for(j, 0, 10)
- *            B[i,j] = A[i,j]
+ * Check if blocks can merge.
+ * @param first for_loops vector
+ * @param second Another for_loops vector.
+ * @return Return if two block's for extents equal currently.
+ */
+/**
+ * Example 1: CanMergeBlocks(var_B, var_C)
+ * block(var_B)
+ *   for(i, 0, 10)
+ *     for(j, 0, 10)
+ *        B[i,j] = A[i,j]
  *
- *      block(var_C)
- *        for(i, 0, 10)
- *          for(j, 0, 10)
- *            C[i,j] = A[i,j]
- *    Output IR:
- *      Can be merged since loop extents are identical.
+ * block(var_C)
+ *   for(i, 0, 10)
+ *     for(j, 0, 10)
+ *        C[i,j] = A[i,j]
+ * =>
+ * Return value:
+ * true
  *
- * 2. Different loop extents:
- *    Input IR:
- *      block(var_B)
- *        for(i, 0, 10)
- *          for(j, 0, 10)
- *            B[i,j] = A[i,j]
+ * Example 2: CanMergeBlocks(var_B, var_C)
+ * block(var_B)
+ *   for(i, 0, 10)
+ *     for(j, 0, 10)
+ *        B[i,j] = A[i,j]
  *
- *      block(var_C)
- *        for(i, 0, 3)
- *          for(j, 0, 4)
- *            C[i,j] = A[i,j]
- *    Output IR:
- *      Cannot be merged due to differing loop extents.
+ * block(var_C)
+ *   for(i, 0, 3)
+ *     for(j, 0, 4)
+ *        C[i,j] = A[i,j]
+ * =>
+ * Return value:
+ * false
  */
 bool CanMergeBlocks(const ir::For* first,
                     const ir::For* second,

--- a/paddle/phi/kernels/impl/matmul_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_kernel_impl.h
@@ -2007,16 +2007,34 @@ void MatmulKernel(const Context& ctx,
                   bool transpose_x,
                   bool transpose_y,
                   DenseTensor* out) {
-  PADDLE_ENFORCE_NE(common::product(x.dims()),
+  if (x.numel() == 0 || y.numel() == 0) {
+    auto x_dims = x.dims();
+    auto y_dims = y.dims();
+    if (transpose_x) {
+      std::swap(x_dims[x_dims.size() - 1], x_dims[x_dims.size() - 2]);
+    }
+    if (transpose_y) {
+      std::swap(y_dims[y_dims.size() - 1], y_dims[y_dims.size() - 2]);
+    }
+    std::vector<std::int64_t> out_dims(x_dims.size() - 1 + y_dims.size() - 1);
+    for (size_t i = 0; i < x_dims.size() - 1; ++i) {
+      out_dims[i] = x_dims[i];
+    }
+    for (size_t i = 1; i < y_dims.size(); ++i) {
+      out_dims[x_dims.size() - 1 + i - 1] = y_dims[i];
+    }
+    out->Resize(phi::make_ddim(out_dims));
+    ctx.template Alloc<T>(out);
+    return;
+  }
+  PADDLE_ENFORCE_GE(common::product(x.dims()),
                     0,
                     common::errors::InvalidArgument(
-                        "The Input(X) dims size must not be equal "
-                        "0, but received dims size is 0."));
-  PADDLE_ENFORCE_NE(common::product(y.dims()),
+                        "The dims of Input(X) should be greater than or equal to 0."));
+  PADDLE_ENFORCE_GE(common::product(y.dims()),
                     0,
                     common::errors::InvalidArgument(
-                        "The Input(Y) dims size must not be equal "
-                        "0, but received dims size is 0."));
+                        "The dims of Input(Y) should be greater than or equal to 0."));
   const std::vector<std::int64_t> x_dims = common::vectorize(x.dims());
   const std::vector<std::int64_t> y_dims = common::vectorize(y.dims());
   MatmulJudgeDtypeKernel<Context, T>(

--- a/paddle/phi/kernels/impl/matmul_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_kernel_impl.h
@@ -2017,24 +2017,26 @@ void MatmulKernel(const Context& ctx,
       std::swap(y_dims[y_dims.size() - 1], y_dims[y_dims.size() - 2]);
     }
     std::vector<std::int64_t> out_dims(x_dims.size() - 1 + y_dims.size() - 1);
-    for (size_t i = 0; i < x_dims.size() - 1; ++i) {
+    for (int64_t i = 0; i < x_dims.size() - 1; ++i) {
       out_dims[i] = x_dims[i];
     }
-    for (size_t i = 1; i < y_dims.size(); ++i) {
+    for (int64_t i = 1; i < y_dims.size(); ++i) {
       out_dims[x_dims.size() - 1 + i - 1] = y_dims[i];
     }
     out->Resize(phi::make_ddim(out_dims));
     ctx.template Alloc<T>(out);
     return;
   }
-  PADDLE_ENFORCE_GE(common::product(x.dims()),
-                    0,
-                    common::errors::InvalidArgument(
-                        "The dims of Input(X) should be greater than or equal to 0."));
-  PADDLE_ENFORCE_GE(common::product(y.dims()),
-                    0,
-                    common::errors::InvalidArgument(
-                        "The dims of Input(Y) should be greater than or equal to 0."));
+  PADDLE_ENFORCE_GE(
+      common::product(x.dims()),
+      0,
+      common::errors::InvalidArgument(
+          "The dims of Input(X) should be greater than or equal to 0."));
+  PADDLE_ENFORCE_GE(
+      common::product(y.dims()),
+      0,
+      common::errors::InvalidArgument(
+          "The dims of Input(Y) should be greater than or equal to 0."));
   const std::vector<std::int64_t> x_dims = common::vectorize(x.dims());
   const std::vector<std::int64_t> y_dims = common::vectorize(y.dims());
   MatmulJudgeDtypeKernel<Context, T>(

--- a/test/legacy_test/test_tensordot.py
+++ b/test/legacy_test/test_tensordot.py
@@ -371,5 +371,25 @@ class TestTensordotAPIAxesTypeFloat64(TestTensordotAPIAxesType):
         self.dtype = np.float64
 
 
+class TestTensordotAPIZeroSize(TestTensordotAPI):
+    def set_input_shape(self):
+        self.x_shape = [0, 5, 5, 5]
+        self.y_shape = [0, 5, 5, 5]
+
+    def set_input_data(self):
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+
+    def set_test_axes(self):
+        self.all_axes = [
+            [[], []],
+        ]
+
+
+class TestTensordotAPIFloat64ZeroSize(TestTensordotAPIZeroSize):
+    def set_dtype(self):
+        self.dtype = np.float64
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_tensordot.py
+++ b/test/legacy_test/test_tensordot.py
@@ -405,8 +405,6 @@ class TestTensordotAPIZeroSize(TestTensordotAPI):
             [[], []],
         ]
 
-
-class TestTensordotAPIFloat64ZeroSize(TestTensordotAPIZeroSize):
     def set_dtype(self):
         self.dtype = np.float64
 

--- a/test/legacy_test/test_tensordot.py
+++ b/test/legacy_test/test_tensordot.py
@@ -391,5 +391,80 @@ class TestTensordotAPIFloat64ZeroSize(TestTensordotAPIZeroSize):
         self.dtype = np.float64
 
 
+class TestTensordotAPIZeroSize(TestTensordotAPI):
+    def set_input_shape(self):
+        self.x_shape = [0, 5, 5, 5]
+        self.y_shape = [0, 5, 5, 5]
+
+    def set_input_data(self):
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.y = np.random.random(self.y_shape).astype(self.dtype)
+
+    def set_test_axes(self):
+        self.all_axes = [
+            [[], []],
+        ]
+
+
+class TestTensordotAPIFloat64ZeroSize(TestTensordotAPIZeroSize):
+    def set_dtype(self):
+        self.dtype = np.float64
+
+
+class TestTensordotAPIZeroSizeMultipleDims1(TestTensordotAPI):
+    def set_input_shape(self):
+        self.x_shape = [0, 0, 5, 5]
+        self.y_shape = [0, 0, 5, 5]
+
+    def set_test_axes(self):
+        self.all_axes = [
+            [[], []],
+        ]
+
+
+class TestTensordotAPIZeroSizeMultipleDims2(TestTensordotAPI):
+    def set_input_shape(self):
+        self.x_shape = [5, 0, 5, 0]
+        self.y_shape = [5, 0, 5, 0]
+
+    def set_test_axes(self):
+        self.all_axes = [
+            [[], []],
+        ]
+
+
+class TestTensordotAPIZeroSizeDifferentDims1(TestTensordotAPI):
+    def set_input_shape(self):
+        self.x_shape = [5, 5, 0, 5]
+        self.y_shape = [5, 5, 0, 5]
+
+    def set_test_axes(self):
+        self.all_axes = [
+            [[], []],
+        ]
+
+
+class TestTensordotAPIZeroSizeDifferentDims2(TestTensordotAPI):
+    def set_input_shape(self):
+        self.x_shape = [5, 5, 5, 0]
+        self.y_shape = [5, 5, 5, 0]
+
+    def set_test_axes(self):
+        self.all_axes = [
+            [[], []],
+        ]
+
+
+class TestTensordotAPISingleElementAndZeroSize(TestTensordotAPI):
+    def set_input_shape(self):
+        self.x_shape = [1, 5, 5, 5]
+        self.y_shape = [0, 5, 5, 5]
+
+    def set_test_axes(self):
+        self.all_axes = [
+            [[], []],
+        ]
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_tensordot.py
+++ b/test/legacy_test/test_tensordot.py
@@ -464,5 +464,23 @@ class TestTensordotAPISingleElementAndZeroSize(TestTensordotAPI):
         ]
 
 
+class TestBroadcastWithZeroSize1(unittest.TestCase):
+    def setUp(self):
+        self.x_shape = [5, 0, 3]
+        self.y_shape = [3, 4, 0]
+
+    def set_test_axes(self):
+        self.all_axes = [[], []]
+
+
+class TestBroadcastWithZeroSize2(unittest.TestCase):
+    def setUp(self):
+        self.x_shape = [5, 0, 3]
+        self.y_shape = [3, 0]
+
+    def set_test_axes(self):
+        self.all_axes = [[], []]
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Others

### Description
针对 `array_api_tests/test_linalg.py::test_linalg_tensordot` 单测，按照[api-array-compat标准](https://data-apis.org/array-api/latest/API_specification/generated/array_api.tensordot.html#array_api.tensordot)，为 tensordot(matmul) 函数添加 0-size tensor 支持，添加后可跑通array-api-tests的如下测试（忽略result_type报错；其次直接跑 _test_tensordot_stacks 计算会存在段错误，但是经过形状验证没问题，注释掉只保留形状验证就可以跑通了）
<img width="1047" alt="Screenshot 2024-12-16 at 11 28 49" src="https://github.com/user-attachments/assets/a91f83d5-0356-4f37-ac9a-50daf8b48fcc" />
<img width="1052" alt="Screenshot 2024-12-16 at 11 55 04" src="https://github.com/user-attachments/assets/f7b3bf3e-0479-4be0-9eca-7df2f430ca52" />
