### PR TITLE
[CINN]fix IfFusionPass condition

### DIFF
--- a/paddle/cinn/optim/if_fusion_pass.cc
+++ b/paddle/cinn/optim/if_fusion_pass.cc
@@ -25,7 +25,7 @@ using ir::stmt::StmtRef;
 
 void FuseIfStmtWithSameCondInBlock(BlockRef block) {
   const std::vector<StmtRef>& stmts = block->stmts();
-  if (stmts.size() <= 2) return;
+  if (stmts.size() < 2) return;
 
   const auto& IsIfStmtWithSpecCond = [](const StmtRef& stmt, const Expr& cond) {
     if (!stmt.isa<IfThenElse>()) return false;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR fixes the condition of when can apply IfFusionPass.