### PR TITLE
[Recompute] Fix recompute full_int_array bug

### DIFF
--- a/python/paddle/decomposition/recompute.py
+++ b/python/paddle/decomposition/recompute.py
@@ -467,7 +467,6 @@ def auto_recompute(
         ):
             return 0.1
 
-
         # Heuristic to bias towards nodes closer to the backwards pass
         mem_sz = int(
             mem_sz * (1.1 ** max(min(dist_from_bw[value_node], 100), 1))

--- a/python/paddle/decomposition/recompute.py
+++ b/python/paddle/decomposition/recompute.py
@@ -459,10 +459,13 @@ def auto_recompute(
         return not all(_is_fusible(value_node, user) for user in users)
 
     def _get_node_weight(value_node, placeholder_value_nodes):
-        if value_node.get_defining_op().name() in tending_to_recompute_ops:
-            return math.inf
-
         mem_sz = cal_value_node_size(value_node)
+
+        if (
+            value_node.get_defining_op().name() in tending_to_recompute_ops
+            and mem_sz == 0
+        ):
+            return 0.1
 
         # Heuristic to bias towards nodes closer to the backwards pass
         mem_sz = int(

--- a/python/paddle/decomposition/recompute.py
+++ b/python/paddle/decomposition/recompute.py
@@ -459,6 +459,9 @@ def auto_recompute(
         return not all(_is_fusible(value_node, user) for user in users)
 
     def _get_node_weight(value_node, placeholder_value_nodes):
+        if value_node.get_defining_op().name() in tending_to_recompute_ops:
+            return math.inf
+
         mem_sz = cal_value_node_size(value_node)
 
         # Heuristic to bias towards nodes closer to the backwards pass

--- a/python/paddle/decomposition/recompute.py
+++ b/python/paddle/decomposition/recompute.py
@@ -467,6 +467,7 @@ def auto_recompute(
         ):
             return 0.1
 
+
         # Heuristic to bias towards nodes closer to the backwards pass
         mem_sz = int(
             mem_sz * (1.1 ** max(min(dist_from_bw[value_node], 100), 1))


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164

Previous PR: https://github.com/PaddlePaddle/Paddle/pull/69897
We want to regard [full] or [full_int_array] and it's child op as a whole part and don't want them to be apart( e.g, recompute pd_op.sum but not recompute it's parent pd_op.full op). Now we do this strategy by enforcing edge weight to be **inf** .