### PR TITLE
[CINN] Restore "Enhance BuildCinnPass efficiency"

### DIFF
--- a/paddle/fluid/pir/transforms/build_cinn_pass.cc
+++ b/paddle/fluid/pir/transforms/build_cinn_pass.cc
@@ -28,6 +28,8 @@ using CompatibleInfo = cinn::hlir::framework::pir::CompatibleInfo;
 
 void VerifyOperationOrder(const pir::Block& block);
 
+std::string FormatDuration(std::chrono::milliseconds ms);
+
 class BuildCinnPass : public pir::Pass {
  public:
   BuildCinnPass() : pir::Pass("build_cinn_pass", /*opt_level=*/1) {}
@@ -48,6 +50,7 @@ class BuildCinnPass : public pir::Pass {
 
  private:
   void ProcessBlock(pir::Block* block) {
+    auto start_t = std::chrono::high_resolution_clock::now();
     std::vector<GroupOpsVec> groups =
         ::pir::DetectSubGraphs(block, CompatibleInfo::IsSupportForCinn);
     AddStatistics(groups.size());
@@ -58,6 +61,11 @@ class BuildCinnPass : public pir::Pass {
       VLOG(4) << "current group_ops.size(): " << group_ops.size();
       ::pir::ReplaceWithGroupOp(block, group_ops);
     }
+    auto end_t = std::chrono::high_resolution_clock::now();
+    auto duration =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end_t - start_t);
+    VLOG(1) << "Time of building group ops (size=" << block->size()
+            << "): " << FormatDuration(duration);
   }
 };
 
@@ -130,6 +138,17 @@ void VerifyOperationOrder(const pir::Block& block) {
       CheckOpOrder(&op);
     }
   }
+}
+
+std::string FormatDuration(std::chrono::milliseconds ms) {
+  auto minutes = std::chrono::duration_cast<std::chrono::minutes>(ms);
+  ms -= std::chrono::duration_cast<std::chrono::milliseconds>(minutes);
+  auto seconds = std::chrono::duration_cast<std::chrono::seconds>(ms);
+  ms -= std::chrono::duration_cast<std::chrono::milliseconds>(seconds);
+  std::stringstream ss;
+  ss << minutes.count() << " min " << seconds.count() << " s " << ms.count()
+     << " ms";
+  return ss.str();
 }
 
 }  // namespace

--- a/paddle/fluid/pir/transforms/build_cinn_pass.cc
+++ b/paddle/fluid/pir/transforms/build_cinn_pass.cc
@@ -49,7 +49,7 @@ class BuildCinnPass : public pir::Pass {
  private:
   void ProcessBlock(pir::Block* block) {
     std::vector<GroupOpsVec> groups =
-        ::pir::SubgraphDetector(block, CompatibleInfo::IsSupportForCinn)();
+        ::pir::DetectSubGraphs(block, CompatibleInfo::IsSupportForCinn);
     AddStatistics(groups.size());
     for (auto& group_ops : groups) {
       if (group_ops.size() == 1 && group_ops[0]->name() == "pd_op.full") {

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -482,7 +482,6 @@ void SubgraphDetector::SubgraphFusion() {
       }
     }
   }
-  ReorderIndexOfSubgraphs();
   VLOG(4) << "Merge brother subgraphs with same upstream";
   for (const auto& op : sort_ops_) {
     auto subgraph = GetOpSubgraph(op);

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -478,6 +478,7 @@ void SubgraphDetector::SubgraphFusion() {
         for (auto upstream_op : upstream->ops) {
           op2subgraph_[upstream_op] = downstream;
         }
+        ReorderIndexOfSubgraphs();
       }
     }
   }

--- a/paddle/fluid/pir/transforms/sub_graph_detector.h
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.h
@@ -29,37 +29,11 @@
 #include "paddle/pir/include/core/builder.h"
 
 namespace pir {
-
-struct SubGraph;
-using SubGraphPtr = std::shared_ptr<SubGraph>;
+using OpClassifier = std::function<bool(const pir::Operation&)>;
 using GroupOpsVec = std::vector<pir::Operation*>;
 
-class SubgraphDetector {
- public:
-  // Tell whether a node is inside a sub-graph.
-  using OpClassifier = std::function<bool(const pir::Operation&)>;
-
-  SubgraphDetector(pir::Block* block, const OpClassifier& classifier);
-
-  std::vector<GroupOpsVec> operator()();
-
- protected:
-  // Do Op Fusion
-  void DoOpFusion();
-
-  void BuildSubGraph();
-
- private:
-  pir::Block* block_;
-  OpClassifier op_classifier_;
-
-  std::vector<pir::Operation*> sort_ops_;
-  std::unordered_map<pir::Operation*, size_t> op2id_;
-  std::vector<SubGraphPtr> subgraph_list_;
-  std::unordered_map<pir::Operation*, SubGraphPtr> subgraph_map_;
-  std::unordered_map<pir::Operation*, std::unordered_map<pir::Operation*, bool>>
-      can_apply_fusion_map_;
-};
+std::vector<GroupOpsVec> DetectSubGraphs(pir::Block* block,
+                                         const OpClassifier& classifier);
 
 std::vector<pir::Value> AnalysisOutputs(const GroupOpsVec& group_ops);
 void ReplaceWithGroupOp(pir::Block* block, const GroupOpsVec& group_ops);

--- a/paddle/fluid/pir/transforms/sub_graph_extract_pass.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_extract_pass.cc
@@ -53,7 +53,7 @@ class SubGraphExtractPass : public pir::Pass {
     auto& block = module_op.block();
 
     std::vector<GroupOpsVec> groups =
-        ::pir::SubgraphDetector(&block, IsMatmulOp)();
+        ::pir::DetectSubGraphs(&block, IsMatmulOp);
     AddStatistics(groups.size());
     for (auto& group_ops : groups) {
       VLOG(4) << "current group_ops.size(): " << group_ops.size();

--- a/paddle/fluid/pir/transforms/tensorrt/trt_sub_graph_extract_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_sub_graph_extract_pass.cc
@@ -57,7 +57,7 @@ class TrtSubGraphExtractPass : public pir::Pass {
     auto& block = module_op.block();
 
     std::vector<GroupOpsVec> groups =
-        ::pir::SubgraphDetector(&block, IsSupportedByTRT)();
+        ::pir::DetectSubGraphs(&block, IsSupportedByTRT);
     AddStatistics(groups.size());
     for (auto& group_ops : groups) {
       if (group_ops.size() < static_cast<size_t>(FLAGS_trt_min_group_size)) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- 重新提交 #70074：
- 相比于之前 revert 版本的更新：
  1. 完善注释和部分代码，更新一些指针的 set 用法，将需要遍历的 set 改为 vector 或者添加自定义的指针 compare 函数，避免出现随机性
  2. 将递归遍历改为循环遍历，避免出现环进入无限递归 hang 住
  3. 子图融合利用原始 Op 的拓扑信息进行剪枝可能会出现环，因此在每一次融合之后进行一次拓扑重排序
  4. 添加环检测方法，分别在执行 BuildCinnPass 之前和之后进行检测，方便定位问题
- Todo：优化重排序算法，根据融合结点的情况进行局部重排序