### PR TITLE
【HEU】【Paddle Tensor 第二期 API支持 0-size Tensor】paddle.eigh paddle.eigvalsh支持 0-size tensor

### DIFF
--- a/paddle/phi/kernels/cpu/eigh_kernel.cc
+++ b/paddle/phi/kernels/cpu/eigh_kernel.cc
@@ -27,6 +27,16 @@ void EighKernel(const Context& dev_ctx,
                 const std::string& uplo,
                 DenseTensor* out_w,
                 DenseTensor* out_v) {
+  if (x.numel() == 0) {
+    auto x_dim = x.dims();
+    auto w_dim = slice_ddim(x_dim, 0, x_dim.size() - 1);
+    out_w->Resize(w_dim);
+    out_v->Resize(x_dim);
+    dev_ctx.template Alloc<T>(out_w);
+    dev_ctx.template Alloc<T>(out_v);
+    DDim();
+    return;
+  }
   bool is_lower = (uplo == "L");
   phi::funcs::MatrixEighFunctor<Context, T> functor;
   functor(dev_ctx, x, out_w, out_v, is_lower, true);

--- a/paddle/phi/kernels/cpu/eigh_kernel.cc
+++ b/paddle/phi/kernels/cpu/eigh_kernel.cc
@@ -34,7 +34,6 @@ void EighKernel(const Context& dev_ctx,
     out_v->Resize(x_dim);
     dev_ctx.template Alloc<T>(out_w);
     dev_ctx.template Alloc<T>(out_v);
-    DDim();
     return;
   }
   bool is_lower = (uplo == "L");

--- a/paddle/phi/kernels/gpu/eigh_kernel.cu
+++ b/paddle/phi/kernels/gpu/eigh_kernel.cu
@@ -30,6 +30,15 @@ void EighKernel(const Context& dev_ctx,
                 const std::string& uplo,
                 DenseTensor* out_w,
                 DenseTensor* out_v) {
+  if (x.numel() == 0) {
+    auto x_dim = x.dims();
+    auto w_dim = slice_ddim(x_dim, 0, x_dim.size() - 1);
+    out_w->Resize(w_dim);
+    out_v->Resize(x_dim);
+    dev_ctx.template Alloc<T>(out_w);
+    dev_ctx.template Alloc<T>(out_v);
+    return;
+  }
   bool is_lower = (uplo == "L");
   phi::funcs::MatrixEighFunctor<Context, T> functor;
   functor(dev_ctx, x, out_w, out_v, is_lower, true);

--- a/paddle/phi/kernels/impl/eigvalsh_kernel_impl.h
+++ b/paddle/phi/kernels/impl/eigvalsh_kernel_impl.h
@@ -24,6 +24,15 @@ void EigvalshKernel(const Context& dev_ctx,
                     bool is_test,
                     DenseTensor* out_w,
                     DenseTensor* out_v) {
+  if (x.numel() == 0) {
+    auto x_dim = x.dims();
+    auto w_dim = slice_ddim(x_dim, 0, x_dim.size() - 1);
+    out_w->Resize(w_dim);
+    out_v->Resize(x_dim);
+    dev_ctx.template Alloc<T>(out_w);
+    dev_ctx.template Alloc<T>(out_v);
+    return;
+  }
   bool is_lower = (uplo == "L");
   phi::funcs::MatrixEighFunctor<Context, T> functor;
   if (is_test) {

--- a/test/legacy_test/test_eigh_op.py
+++ b/test/legacy_test/test_eigh_op.py
@@ -16,6 +16,7 @@ import unittest
 
 import numpy as np
 from op_test import OpTest
+from utils import static_guard
 
 import paddle
 
@@ -65,6 +66,30 @@ def valid_single_eigh_result(A, eigh_value, eigh_vector, uplo):
     # ||I - Q*Q'|| / M < rtol
     residual = np.eye(M) - eigh_vector @ np.linalg.inv(eigh_vector)
     np.testing.assert_array_less(np.linalg.norm(residual, np.inf) / M, rtol)
+
+
+def valid_eigh_shape_result(A, eigh_value, eigh_vector):
+    assert A.ndim == 2 or A.ndim == 3
+
+    if A.ndim == 2:
+        valid_single_eigh_shape_result(A, eigh_value, eigh_vector)
+        return
+
+    for batch_A, batch_w, batch_v in zip(A, eigh_value, eigh_vector):
+        valid_single_eigh_shape_result(batch_A, batch_w, batch_v)
+
+
+def valid_single_eigh_shape_result(A, eigh_value, eigh_vector):
+    N = A.shape[0]
+    if eigh_value.shape != (N,):
+        raise ValueError(
+            f"Eigenvalues array must have shape ({N},), but got {eigh_value.shape}."
+        )
+
+    if eigh_vector.shape != (N, N):
+        raise ValueError(
+            f"Eigenvectors matrix must have shape ({N}, {N}), but got {eigh_vector.shape}."
+        )
 
 
 class TestEighOp(OpTest):
@@ -260,6 +285,55 @@ class TestEighAPIError(unittest.TestCase):
                 name='x_4', shape=[4, 4], dtype="int32"
             )
             self.assertRaises(TypeError, paddle.linalg.eigh, input_x)
+
+
+class TestEighAPIZeroSize(unittest.TestCase):
+    def setUp(self):
+        self.init_input_data()
+        self.place = (
+            paddle.CUDAPlace(0)
+            if paddle.is_compiled_with_cuda()
+            else paddle.CPUPlace()
+        )
+        np.random.seed(123)
+
+    def init_input_shape(self):
+        self.x_shape = [0, 0]
+
+    def init_input_data(self):
+        self.init_input_shape()
+        self.dtype = "float32"
+        self.real_data = np.random.random(self.x_shape).astype(self.dtype)
+
+    def test_in_static_mode(self):
+        with static_guard():
+            main_prog = paddle.static.Program()
+            startup_prog = paddle.static.Program()
+            with paddle.static.program_guard(main_prog, startup_prog):
+                input_x = paddle.static.data(
+                    'input_x', shape=self.x_shape, dtype=self.dtype
+                )
+                output_w, output_v = paddle.linalg.eigh(input_x)
+                exe = paddle.static.Executor(self.place)
+                actual_w, actual_v = exe.run(
+                    main_prog,
+                    feed={"input_x": self.real_data},
+                    fetch_list=[output_w, output_v],
+                )
+                valid_eigh_shape_result(self.real_data, actual_w, actual_v)
+
+    def test_in_dynamic_mode(self):
+        paddle.disable_static()
+        input_real_data = paddle.to_tensor(self.real_data)
+        actual_w, actual_v = paddle.linalg.eigh(input_real_data)
+        valid_eigh_shape_result(
+            self.real_data, actual_w.numpy(), actual_v.numpy()
+        )
+
+
+class TestEighBatchAPIZeroSize(TestEighAPIZeroSize):
+    def init_input_shape(self):
+        self.x_shape = [0, 5, 5]
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_eigvalsh_op.py
+++ b/test/legacy_test/test_eigvalsh_op.py
@@ -16,6 +16,7 @@ import unittest
 
 import numpy as np
 from op_test import OpTest
+from utils import static_guard
 
 import paddle
 
@@ -46,6 +47,24 @@ def valid_eigenvalues(actual, expected):
     max_ref = np.max(np.abs(expected))
     relative_error = max_diff / max_ref
     np.testing.assert_array_less(relative_error, rtol)
+
+
+def compare_shape_result(actual, expected):
+    assert actual.ndim == 1 or actual.ndim == 2
+
+    if actual.ndim == 1:
+        valid_shape_eigenvalues(actual, expected)
+        return
+
+    for batch_actual, batch_expected in zip(actual, expected):
+        valid_shape_eigenvalues(batch_actual, batch_expected)
+
+
+def valid_shape_eigenvalues(actual, expected):
+    if actual.shape != expected.shape:
+        raise ValueError(
+            f"Shape mismatch: actual shape {actual.shape} does not match expected shape {expected.shape}."
+        )
 
 
 class TestEigvalshOp(OpTest):
@@ -236,6 +255,56 @@ class TestEigvalshAPIError(unittest.TestCase):
                 name='x_4', shape=[4, 4], dtype="int32"
             )
             self.assertRaises(TypeError, paddle.linalg.eigvalsh, input_x)
+
+
+class TestEigvalshAPIZeroSize(unittest.TestCase):
+    def setUp(self):
+        self.dtype = "float32"
+        self.place = (
+            paddle.CUDAPlace(0)
+            if paddle.is_compiled_with_cuda()
+            else paddle.CPUPlace()
+        )
+        np.random.seed(123)
+        self.init_input_shape()
+        self.init_input_data()
+
+    def init_input_shape(self):
+        self.x_shape = [0, 0]
+
+    def init_input_data(self):
+        self.real_data = np.random.random(self.x_shape).astype(self.dtype)
+
+    def check_static_float_result(self):
+        with static_guard():
+            main_prog = paddle.static.Program()
+            startup_prog = paddle.static.Program()
+            with paddle.static.program_guard(main_prog, startup_prog):
+                input_x = paddle.static.data(
+                    'input_x', shape=self.x_shape, dtype=self.dtype
+                )
+                output_w = paddle.linalg.eigvalsh(input_x)
+                exe = paddle.static.Executor(self.place)
+                actual_w = exe.run(
+                    main_prog,
+                    feed={"input_x": self.real_data},
+                    fetch_list=[output_w],
+                )
+
+                expected_w = np.linalg.eigvalsh(self.real_data)
+                compare_shape_result(actual_w[0], expected_w)
+
+    def test_in_dynamic_mode(self):
+        paddle.disable_static(self.place)
+        input_real_data = paddle.to_tensor(self.real_data)
+        expected_w = np.linalg.eigvalsh(self.real_data)
+        actual_w = paddle.linalg.eigvalsh(input_real_data)
+        compare_shape_result(actual_w.numpy(), expected_w)
+
+
+class TestEigvalshBatchAPIZeroSize(TestEigvalshAPIZeroSize):
+    def init_input_shape(self):
+        self.x_shape = [0, 5, 5]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Bug fixes

### Description
解决了egih,eigvalsh的输入为0size时的情况
![b1949d4a5ed93131ad1d407cd3bc4cf0](https://github.com/user-attachments/assets/b94e03ac-3071-44be-8f10-2a7d6ef0c1f6)
![b94c95b9d47d9a98afea08067da11d23](https://github.com/user-attachments/assets/1c651ac4-3025-41ea-9bdb-ec9f0518b17d)
array-test测试时，需要paddle.any和paddle.all均支持0size输入，其他人在做这两个了