### PR TITLE
【CINN】Add longlong2int method for if and select.

### DIFF
--- a/paddle/cinn/ir/lowered_func.cc
+++ b/paddle/cinn/ir/lowered_func.cc
@@ -161,6 +161,7 @@ std::vector<Expr> _LoweredFunc_::PrepareAxisRangeAssumptions() const {
     if (dim_size == common::make_const(1)) {
       return;
     }
+    dim_size->convert_int64_to_int32();
     Expr expr_lt = LT::Make(Var(axis), dim_size);
     Expr call_lt = Call::Make(Void(),
                               runtime::intrinsic::cuda_builtin_assume,

--- a/paddle/cinn/ir/lowered_func.cc
+++ b/paddle/cinn/ir/lowered_func.cc
@@ -161,7 +161,6 @@ std::vector<Expr> _LoweredFunc_::PrepareAxisRangeAssumptions() const {
     if (dim_size == common::make_const(1)) {
       return;
     }
-    dim_size->convert_int64_to_int32();
     Expr expr_lt = LT::Make(Var(axis), dim_size);
     Expr call_lt = Call::Make(Void(),
                               runtime::intrinsic::cuda_builtin_assume,

--- a/paddle/cinn/optim/longlong2int.cc
+++ b/paddle/cinn/optim/longlong2int.cc
@@ -102,7 +102,7 @@ class CastLonglong2Int : public ir::IRMutator<> {
     }
   }
   void Visit(const ir::Select* op, Expr* expr) override {
-    auto node = expr->As<ir::IfThenElse>();
+    auto node = expr->As<ir::Select>();
     auto cond = node->condition;
     if (cond.is_cmp()) {
       if (cond->operand(0).is_index())
@@ -110,8 +110,8 @@ class CastLonglong2Int : public ir::IRMutator<> {
       if (cond->operand(1).is_index())
         cond->operand(1)->convert_int64_to_int32();
     }
-    ir::IRMutator<>::Visit(&node->true_case, &node->true_case);
-    ir::IRMutator<>::Visit(&node->false_case, &node->false_case);
+    ir::IRMutator<>::Visit(&node->true_value, &node->true_value);
+    ir::IRMutator<>::Visit(&node->false_value, &node->false_value);
   }
   void Visit(const ir::For* op, Expr* expr) override {
     auto node = expr->As<ir::For>();

--- a/paddle/cinn/optim/longlong2int.cc
+++ b/paddle/cinn/optim/longlong2int.cc
@@ -87,6 +87,32 @@ class CastLonglong2Int : public ir::IRMutator<> {
     ir::IRMutator<>::Visit(&node->value, &node->value);
     ir::IRMutator<>::Visit(&node->tensor, &node->tensor);
   }
+  void Visit(const ir::IfThenElse* op, Expr* expr) override {
+    auto node = expr->As<ir::IfThenElse>();
+    auto cond = node->condition;
+    if (cond.is_cmp()) {
+      if (cond->operand(0).is_index())
+        cond->operand(0)->convert_int64_to_int32();
+      if (cond->operand(1).is_index())
+        cond->operand(1)->convert_int64_to_int32();
+    }
+    ir::IRMutator<>::Visit(&node->true_case, &node->true_case);
+    if (node->false_case.defined()) {
+      ir::IRMutator<>::Visit(&node->false_case, &node->false_case);
+    }
+  }
+  void Visit(const ir::Select* op, Expr* expr) override {
+    auto node = expr->As<ir::IfThenElse>();
+    auto cond = node->condition;
+    if (cond.is_cmp()) {
+      if (cond->operand(0).is_index())
+        cond->operand(0)->convert_int64_to_int32();
+      if (cond->operand(1).is_index())
+        cond->operand(1)->convert_int64_to_int32();
+    }
+    ir::IRMutator<>::Visit(&node->true_case, &node->true_case);
+    ir::IRMutator<>::Visit(&node->false_case, &node->false_case);
+  }
   void Visit(const ir::For* op, Expr* expr) override {
     auto node = expr->As<ir::For>();
     CastVarWithBound(node->loop_var);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
when condition of `IfThenElse` and `Select` is `IndexExpr`, it can change dtype form longlong to int.
Pcard-67164
