### PR TITLE
[Dy2st]Fix while to static bug

### DIFF
--- a/test/dygraph_to_static/test_loop.py
+++ b/test/dygraph_to_static/test_loop.py
@@ -485,5 +485,23 @@ class TestLoopWithInnerMutateList(Dy2StTestBase):
         np.testing.assert_allclose(dygraph_res.numpy(), static_res.numpy())
 
 
+def loop_change_value_to_int():
+    x = paddle.to_tensor(1, dtype='float32')
+    y = paddle.to_tensor(False, dtype='bool')
+    while y:
+        x = 2
+    return x
+
+
+class TestLoopChangeValueToInt(Dy2StTestBase):
+    def test_loop_change_value_to_int(self):
+        static_fn = paddle.jit.to_static(
+            loop_change_value_to_int, full_graph=True
+        )
+        static_res = static_fn()
+        dygraph_res = loop_change_value_to_int()
+        np.testing.assert_allclose(dygraph_res.numpy(), static_res.numpy())
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix to static bug of while op in this case：
```python
import paddle
from paddle.jit import to_static

@to_static(full_graph=True)
def test():
    x = paddle.to_tensor(1, dtype='float32')
    y = paddle.to_tensor(False, dtype='bool')
    while y:
        x = 2
test()
```
Origin error is：
```
File "./paddle/static/nn/control_flow.py", line 952, in while_loop
        cf_yield([next_cond, *(var.next_var for var in variable_loop_vars)])
RuntimeError: Unable to cast Python instance of type <class 'int'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details) 
```
Pcard-67164