### PR TITLE
[SOT] Mark some APIs can be directly run in simulation mode

### DIFF
--- a/python/paddle/jit/sot/utils/__init__.py
+++ b/python/paddle/jit/sot/utils/__init__.py
@@ -49,6 +49,7 @@ from .magic_methods import magic_method_builtin_dispatch  # noqa: F401
 from .paddle_api_config import (  # noqa: F401
     get_tensor_methods,
     is_break_graph_tensor_methods,
+    is_directly_run_api,
     is_inplace_api,
     is_not_supported_paddle_layer,
 )

--- a/python/paddle/jit/sot/utils/paddle_api_config.py
+++ b/python/paddle/jit/sot/utils/paddle_api_config.py
@@ -129,3 +129,24 @@ def is_break_graph_tensor_methods(method_name):
 
 def add_break_graph_apis(apis: list):
     break_graph_set.update(apis)
+
+
+def is_directly_run_api(api):
+    NATIVE_CODE_PURE_FUNCTIONS = {
+        paddle.base.libpaddle.is_compiled_with_avx,
+        paddle.base.libpaddle.is_compiled_with_cuda,
+        paddle.base.libpaddle.is_compiled_with_cudnn_frontend,
+        paddle.base.libpaddle.is_compiled_with_rocm,
+        paddle.base.libpaddle.is_compiled_with_custom_device,
+        paddle.base.libpaddle.is_compiled_with_ipu,
+        paddle.base.libpaddle.is_compiled_with_xpu,
+        paddle.base.libpaddle.is_compiled_with_mkldnn,
+        paddle.base.libpaddle.is_compiled_with_nccl,
+        paddle.base.libpaddle.is_compiled_with_mpi,
+        paddle.base.libpaddle.is_compiled_with_mpi_aware,
+        paddle.base.libpaddle.is_compiled_with_cinn,
+        paddle.base.libpaddle.is_compiled_with_distribute,
+        paddle.base.libpaddle.is_compiled_with_brpc,
+        paddle.base.libpaddle.is_compiled_with_dist,
+    }
+    return api in NATIVE_CODE_PURE_FUNCTIONS

--- a/python/paddle/jit/sot/utils/paddle_api_config.py
+++ b/python/paddle/jit/sot/utils/paddle_api_config.py
@@ -132,6 +132,10 @@ def add_break_graph_apis(apis: list):
 
 
 def is_directly_run_api(api):
+    from .utils import hashable
+
+    if not hashable(api):
+        return False
     NATIVE_CODE_PURE_FUNCTIONS = {
         paddle.base.libpaddle.is_compiled_with_avx,
         paddle.base.libpaddle.is_compiled_with_cuda,

--- a/test/dygraph_to_static/test_tensor_attr_consistency.py
+++ b/test/dygraph_to_static/test_tensor_attr_consistency.py
@@ -26,6 +26,7 @@ DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(
         '__len__',
         '__long__',
         '__nonzero__',
+        '__dict__',
         'apply_',
         'backward',
         'clear_grad',

--- a/test/dygraph_to_static/test_tensor_attr_consistency.py
+++ b/test/dygraph_to_static/test_tensor_attr_consistency.py
@@ -26,7 +26,6 @@ DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(
         '__len__',
         '__long__',
         '__nonzero__',
-        '__dict__',
         'apply_',
         'backward',
         'clear_grad',

--- a/test/sot/test_builtin_dispatch.py
+++ b/test/sot/test_builtin_dispatch.py
@@ -388,5 +388,46 @@ class TestBuiltinTypeConversion(TestCaseBase):
         )
 
 
+@check_no_breakgraph
+def test_native_code_function():
+    res1 = paddle.base.libpaddle.is_compiled_with_avx()
+    res2 = paddle.base.libpaddle.is_compiled_with_cuda()
+    res3 = paddle.base.libpaddle.is_compiled_with_cudnn_frontend()
+    res4 = paddle.base.libpaddle.is_compiled_with_rocm()
+    res5 = paddle.base.libpaddle.is_compiled_with_custom_device("npu")
+    res6 = paddle.base.libpaddle.is_compiled_with_ipu()
+    res7 = paddle.base.libpaddle.is_compiled_with_xpu()
+    res8 = paddle.base.libpaddle.is_compiled_with_mkldnn()
+    res9 = paddle.base.libpaddle.is_compiled_with_nccl()
+    res10 = paddle.base.libpaddle.is_compiled_with_mpi()
+    res11 = paddle.base.libpaddle.is_compiled_with_mpi_aware()
+    res12 = paddle.base.libpaddle.is_compiled_with_cinn()
+    res13 = paddle.base.libpaddle.is_compiled_with_distribute()
+    res14 = paddle.base.libpaddle.is_compiled_with_brpc()
+    res15 = paddle.base.libpaddle.is_compiled_with_dist()
+    return (
+        res1,
+        res2,
+        res3,
+        res4,
+        res5,
+        res6,
+        res7,
+        res8,
+        res9,
+        res10,
+        res11,
+        res12,
+        res13,
+        res14,
+        res15,
+    )
+
+
+class TestNativeCodeFunction(TestCaseBase):
+    def test_native_code_function(self):
+        self.assert_results(test_native_code_function)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

支持一些本机代码在 SOT 模拟过程中直接取 value 运行，并将结果重新包装为 Variable，避免相关代码发生打断

PCard-66972