### PR TITLE
Remove `return`  seems to be unreachable

### DIFF
--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -383,8 +383,6 @@ double CastPyArg2Double(PyObject* obj,
         arg_pos + 1,
         ((PyTypeObject*)obj->ob_type)->tp_name));  // NOLINT
   }
-
-  return 0.0;
 }
 
 phi::dtype::complex<float> CastPyArg2Complex(PyObject* obj,
@@ -407,8 +405,6 @@ phi::dtype::complex<float> CastPyArg2Complex(PyObject* obj,
         arg_pos + 1,
         ((PyTypeObject*)obj->ob_type)->tp_name));  // NOLINT
   }
-
-  return phi::dtype::complex<float>(0, 0);
 }
 
 phi::dtype::complex<double> CastPyArg2Complex128(PyObject* obj,
@@ -426,8 +422,6 @@ phi::dtype::complex<double> CastPyArg2Complex128(PyObject* obj,
         arg_pos + 1,
         ((PyTypeObject*)obj->ob_type)->tp_name));  // NOLINT
   }
-
-  return phi::dtype::complex<double>(0, 0);
 }
 
 void CastPyArg2AttrDouble(PyObject* obj,
@@ -454,8 +448,6 @@ std::string CastPyArg2String(PyObject* obj,
         arg_pos + 1,
         ((PyTypeObject*)obj->ob_type)->tp_name));  // NOLINT
   }
-
-  return "";
 }
 
 void CastPyArg2AttrString(PyObject* obj,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
Bug fixes


### Description
像这样子的return是不是走不到？
```C++
double CastPyArg2Double(PyObject* obj,
                        const std::string& op_type,
                        ssize_t arg_pos) {
  if (PyObject_CheckFloat(obj)) {
    return PyObject_ToDouble(obj);  // NOLINT
  } else {
    PADDLE_THROW(common::errors::InvalidType(
        "%s(): argument (position %d) must be "
        "double, but got %s",
        op_type,
        arg_pos + 1,
        ((PyTypeObject*)obj->ob_type)->tp_name));  // NOLINT
  }

  return 0.0;
}
```

比如这个`return 0.0`
