### PR TITLE
[XPU] replace xpu::where with xpu::nonzero_compute for nonzero kernel

### DIFF
--- a/paddle/phi/kernels/xpu/nonzero_kernel.cc
+++ b/paddle/phi/kernels/xpu/nonzero_kernel.cc
@@ -26,22 +26,27 @@ template <typename T, typename Context>
 void NonZeroKernel(const Context& dev_ctx,
                    const DenseTensor& condition,
                    DenseTensor* out) {
-  const T* cond_data = condition.data<T>();
   auto numel = condition.numel();
   auto dims = condition.dims();
   const int rank = dims.size();
 
+  using XPUType = typename XPUTypeTrait<T>::Type;
+
   xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
-  int* true_num = RAII_GUARD.alloc_l3_or_gm<int32_t>(1);
-  int true_num_cpu;
-  int ret = xpu::nonzero_count(dev_ctx.x_context(), cond_data, true_num, numel);
+  int* true_num = RAII_GUARD.alloc_l3_or_gm<int>(1);
+  int* workspace =
+      RAII_GUARD.alloc_l3_or_gm<int>(dev_ctx.x_context()->ncluster() * 64);
+  auto cond_data = reinterpret_cast<const XPUType*>(condition.data<T>());
+  int ret = xpu::nonzero_count<XPUType, int>(
+      dev_ctx.x_context(), cond_data, true_num, numel, workspace);
   PADDLE_ENFORCE_XDNN_SUCCESS(ret, "nonzero_count");
 
+  int true_num_cpu;
   memory_utils::Copy(phi::CPUPlace(),
                      static_cast<void*>(&true_num_cpu),
                      dev_ctx.GetPlace(),
                      static_cast<void*>(true_num),
-                     sizeof(int32_t));
+                     sizeof(int));
   if (std::getenv("XPUSIM_SKIP_RUN") &&
       std::strcmp(std::getenv("XPUSIM_SKIP_RUN"), "1") == 0) {
     VLOG(3) << "WARNING: In the simulator mode, the variable true_num_cpu "
@@ -57,10 +62,14 @@ void NonZeroKernel(const Context& dev_ctx,
     return;
   }
 
-  auto condition_shape = common::vectorize<int>(dims);
-  ret = xpu::where(
-      dev_ctx.x_context(), cond_data, out_data, condition_shape, true_num_cpu);
-  PADDLE_ENFORCE_XDNN_SUCCESS(ret, "where");
+  auto condition_shape = common::vectorize<int64_t>(dims);
+  ret = xpu::nonzero_compute<XPUType, int64_t, int>(dev_ctx.x_context(),
+                                                    cond_data,
+                                                    out_data,
+                                                    condition_shape,
+                                                    true_num_cpu,
+                                                    workspace);
+  PADDLE_ENFORCE_XDNN_SUCCESS(ret, "nonzero_compute");
 }
 
 }  // namespace phi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
XDNN change the interface and semantics of `xpu::where`, so we use `xpu::nonzero_compute` to replace it in nonzero kernel