### PR TITLE
[SOT][3.13] Re-enable SOT in Python 3.13 and run all unittest in CI

### DIFF
--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -292,9 +292,9 @@ def to_static(
             flag = ENV_ENABLE_SOT.get()
             full_graph = not flag
 
-        if sys.version_info >= (3, 13) and not full_graph:
+        if sys.version_info >= (3, 14) and not full_graph:
             warnings.warn(
-                "full_graph=False is not supported in Python 3.13+. Set full_graph=True automatically"
+                "full_graph=False is not supported in Python 3.14+. Set full_graph=True automatically"
             )
             full_graph = True
 

--- a/test/sot/skip_files_py313
+++ b/test/sot/skip_files_py313
@@ -1,4 +1,0 @@
-./test_model_switch_training.py
-./test_sot_cost_model.py
-./test_sot_dynamic_shape.py
-./test_sot_export.py


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

3.0-rc 分支已拉，revert #69887，develop 启用 SOT python 3.13 支持

删除 3.13 单测 skip file，CI 监控全部单测

PCard-66972