### PR TITLE
[inference]update pir argmax and bilinear trt op convert

### DIFF
--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -1420,13 +1420,6 @@ class BilinearInterpV2Pattern
         return false;
       }
     }
-    pir::Value size_tensor = op.operand_source(2);
-    if (size_tensor != nullptr) {
-      VLOG(3) << "The Paddle-TRT doesn't support the SizeTensor for "
-                 "BilinearInterpV2";
-      return false;
-    }
-
     auto data_format =
         op->attribute<pir::StrAttribute>("data_format").AsString();
     if (data_format != "NCHW" && data_format != "NHWC") {
@@ -1439,7 +1432,26 @@ class BilinearInterpV2Pattern
       VLOG(3) << "The interp_method of BilinearInterpV2 is not bilinear";
       return false;
     }
-
+#if IS_TRT_VERSION_GE(8200)
+    pir::Value size_tensor = op.operand_source(2);
+    if (size_tensor) {
+      auto size_tensor_type = size_tensor.type();
+      if (size_tensor_type.isa<pir::VectorType>()) {
+        auto vector_type = size_tensor.type().dyn_cast<pir::VectorType>();
+        if (vector_type.size() == 2) {
+          op->set_attribute(kCanRunTrtAttr, rewriter.bool_attr(true));
+          return true;
+        }
+      }
+    }
+#elif
+    pir::Value size_tensor = op.operand_source(2);
+    if (size_tensor != nullptr) {
+      VLOG(3) << "The Paddle-TRT doesn't support the SizeTensor for "
+                 "BilinearInterpV2";
+      return false;
+    }
+#endif
     pir::Value scale_tensor = op.operand_source(3);
 
     bool has_scale_input = false;

--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -1433,8 +1433,8 @@ class BilinearInterpV2Pattern
       return false;
     }
 #if IS_TRT_VERSION_GE(8200)
-    pir::Value size_tensor = op.operand_source(2);
-    if (size_tensor) {
+    auto size_tensor = op.operand_source(2);
+    if (size_tensor.impl()) {
       auto size_tensor_type = size_tensor.type();
       if (size_tensor_type.isa<pir::VectorType>()) {
         auto vector_type = size_tensor.type().dyn_cast<pir::VectorType>();
@@ -1444,9 +1444,9 @@ class BilinearInterpV2Pattern
         }
       }
     }
-#elif
-    pir::Value size_tensor = op.operand_source(2);
-    if (size_tensor != nullptr) {
+#else
+    auto size_tensor = op.operand_source(2);
+    if (size_tensor.impl() != nullptr) {
       VLOG(3) << "The Paddle-TRT doesn't support the SizeTensor for "
                  "BilinearInterpV2";
       return false;

--- a/test/tensorrt/tensorrt_test_base.py
+++ b/test/tensorrt/tensorrt_test_base.py
@@ -53,6 +53,8 @@ class TensorRTBaseTest(unittest.TestCase):
         with paddle.static.program_guard(main_program, startup_program):
             api_args = copy.deepcopy(self.api_args)
             for feed_name in self.program_config["feed_list"]:
+                if self.api_args[feed_name] is None:
+                    continue
                 if isinstance(self.api_args[feed_name], dict):
                     new_list_args = []
                     for sub_arg_name, sub_arg_value in self.api_args[
@@ -131,6 +133,8 @@ class TensorRTBaseTest(unittest.TestCase):
         exe = paddle.static.Executor(place)
         feed_data = dict()  # noqa: C408
         for feed_name in self.program_config["feed_list"]:
+            if self.api_args[feed_name] is None:
+                continue
             if isinstance(self.api_args[feed_name], dict):
                 for sub_arg_name, sub_arg_value in self.api_args[
                     feed_name
@@ -154,7 +158,7 @@ class TensorRTBaseTest(unittest.TestCase):
                     new_list_args[sub_arg_name] = self.api_args[arg_name][i]
                 self.api_args[arg_name] = new_list_args
 
-    def check_trt_result(self, rtol=1e-5, atol=1e-5, precision_mode=None):
+    def check_trt_result(self, rtol=1e-5, atol=1e-5, precision_mode="fp32"):
         paddle.framework.set_flags({"FLAGS_trt_min_group_size": 1})
         with paddle.pir_utils.IrGuard():
             self.prepare_feed()
@@ -179,6 +183,8 @@ class TensorRTBaseTest(unittest.TestCase):
             min_shape_data = dict()  # noqa: C408
             max_shape_data = dict()  # noqa: C408
             for feed_name in self.program_config["feed_list"]:
+                if self.api_args[feed_name] is None:
+                    continue
                 if isinstance(self.api_args[feed_name], dict):
                     # shape_tensor
                     if (
@@ -229,7 +235,6 @@ class TensorRTBaseTest(unittest.TestCase):
                             max_shape_data[feed_name] = np.random.randn(
                                 *self.max_shape[feed_name]
                             ).astype(self.api_args[feed_name].dtype)
-
             scope = paddle.static.global_scope()
             main_program = warmup_shape_infer(
                 main_program,
@@ -285,7 +290,6 @@ class TensorRTBaseTest(unittest.TestCase):
                 raise ValueError(
                     "The last op of convert pir Program in test must be split op that is the next op of pd_op.engine."
                 )
-
             output_trt = self.run_program(program_with_trt, trt_fetch_list)
 
         # Check that the results are close to each other within a tolerance of 1e-3

--- a/test/tensorrt/test_converter_common.py
+++ b/test/tensorrt/test_converter_common.py
@@ -188,6 +188,38 @@ class TestBilinearOutSizeTRTPattern(TensorRTBaseTest):
         self.check_trt_result()
 
 
+class TestBilinearSizeTensorTRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = bilinear_python_api
+        self.api_args = {
+            "x": np.random.random([2, 3, 6, 10]).astype("float32"),
+            "OutSize": None,
+            "SizeTensor": [
+                np.array([2], dtype="int64"),
+                np.array([2], dtype="int64"),
+            ],
+            "Scale": None,
+            "attrs": {
+                "data_layout": "NCHW",
+                "scale": [],
+                "out_h": -1,
+                "out_w": -1,
+                "out_d": -1,
+                "interp_method": "bilinear",
+                "align_corners": False,
+                "align_mode": 0,
+            },
+        }
+        self.program_config = {
+            "feed_list": ["x", "OutSize", "SizeTensor", "Scale"]
+        }
+        self.min_shape = {"x": [2, 3, 6, 10]}
+        self.max_shape = {"x": [12, 3, 6, 10]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+
 class TestNearestNHWCTRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = nearest_python_api


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Inference
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
Pcard-71500
1.更新 pir op convert bilinear_interp_v2 
2.修复 argmax
3.单测基类调整