### PR TITLE
[fluid_ops] clean distributed_push_sparse config

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
@@ -158,8 +158,6 @@ NO_NEED_GEN_STATIC_ONLY_APIS = [
     'c_split',
     'comm_init_all',
     'decayed_adagrad',
-    'distributed_push_sparse',
-    'distributed_lookup_table',
     'dgc_momentum',
     'dgc',
     'dpsgd',

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -37,7 +37,6 @@ namespace paddle {
 namespace dialect {
 
 const std::unordered_set<std::string> LegacyOpList = {
-    DistributedPushSparseOp::name(),
     SendV2Op::name(),
     RecvV2Op::name(),
     CAllreduceSumOp::name(),

--- a/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
@@ -148,24 +148,6 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
   traits : paddle::dialect::ForwardOnlyTrait
 
-- op : distributed_lookup_table
-  args : (Tensor[] ids, Tensor w, int table_id = 0, bool is_distributed = false, str lookup_table_version = "lookup_table", int64_t padding_idx = -1, DataType dtype = DataType::FLOAT32, bool is_test = false)
-  output : Tensor[](outputs){ids.size()}
-  infer_meta :
-    func : DistributeLookupTableInferMeta
-  kernel :
-    func : distributed_lookup_table
-    data_type : dtype
-
-- op : distributed_push_sparse
-  args : (Tensor[] ids, Tensor[] shows, Tensor[] clicks, int table_id = 0, int size = 8, bool is_distributed = false, str push_sparse_version = "push_sparse", int64_t padding_idx = -1, DataType dtype=DataType::FLOAT32, bool is_test = false, bool use_cvm_op = false)
-  output : Tensor[](output){ids.size()}
-  infer_meta :
-    func : DistributedPushSparseInferMeta
-  kernel :
-    func: distributed_push_sparse
-    data_type : dtype
-
 - op : divide
   args : (Tensor x, Tensor y)
   output : Tensor(out)

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -972,14 +972,6 @@
   outputs :
     out : Out
 
-- op : distributed_push_sparse
-  inputs :
-    {ids : Ids, shows : Shows, clicks: Clicks}
-  outputs :
-    output : Outputs
-  extra :
-    attrs : ['int[] slots = {}']
-
 - op : divide (elementwise_div)
   backward : divide_grad (elementwise_div_grad)
   inputs :
@@ -4183,12 +4175,6 @@
     {param: Param, grad: Grad}
   outputs:
     {fp32_fused_param: FP32FusedParam, fp32_fused_grad: FP32FusedGrad, fp16_fused_param: FP16FusedParam, fp16_fused_grad: FP16FusedGrad, moment1: Moment1, moment2: Moment2, beta1_pow: Beta1Pow, beta2_pow: Beta2Pow, fused_param_offsets: FusedParamOffsets, fp32_shard_fused_param_offsets: FP32ShardFusedParamOffsets, fp16_shard_fused_param_offsets: FP16ShardFusedParamOffsets, param_info: ParamInfo, param_order: ParamOrder, param_out: ParamOut, master_param_out: MasterParamOut, grad_out: GradOut, global_scale: GlobalScale, step: Step}
-
-- op: distributed_lookup_table
-  inputs:
-    {ids: Ids, w: W}
-  outputs:
-    outputs: Outputs
 
 - op: dpsgd
   inputs:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
移除 distributed_push_sparse, distributed_lookup_table配置