### PR TITLE
[Cherr-pick] Fix `take_along_axis_grad` and `p_norm_decomp`

### DIFF
--- a/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
@@ -112,37 +112,44 @@ Tensor p_norm_decomp(const Tensor& x,
                      const float epsilon = 1.0e-12f,
                      const bool& keepdim = false,
                      const bool& asvector = false) {
+  // NOTE: if asvector is True, then axis will be ignored
+  // and will reduce all elements in x
+
   auto x_tmp = ConvertToMT<T>(x);
 
   Tensor res;
+  std::vector<int> reduce_axis = {};
+  if (!asvector) {
+    reduce_axis.push_back(axis);
+  }
   if (porder == 0.0) {
     // 0-norm
     auto zero = full_scalar<T>(0, x_tmp.dtype(), x_tmp.place());
     auto none_zero = not_equal<T>(x_tmp, zero);
     res = cast<T>(none_zero, x_tmp.dtype());
-    res = sum<T>(res, {axis}, x_tmp.dtype(), keepdim);
+    res = sum<T>(res, reduce_axis, x_tmp.dtype(), keepdim);
   } else if (porder == 1.0) {
     // 1-norm
     res = abs<T>(x_tmp);
-    res = sum<T>(res, {axis}, x_tmp.dtype(), keepdim);
+    res = sum<T>(res, reduce_axis, x_tmp.dtype(), keepdim);
   } else if (porder == 2.0) {
     // 2-norm
-    res = sqrt<T>(sum<T>(x_tmp * x_tmp, {axis}, x_tmp.dtype(), keepdim));
+    res = sqrt<T>(sum<T>(x_tmp * x_tmp, reduce_axis, x_tmp.dtype(), keepdim));
   } else if (porder == INFINITY) {
     // +INF-norm
     res = abs<T>(x_tmp);
-    res = max<T>(x_tmp, {axis}, keepdim);
+    res = max<T>(x_tmp, reduce_axis, keepdim);
   } else if (porder == -INFINITY) {
     // -INF-norm
     res = abs<T>(x_tmp);
-    res = min<T>(x_tmp, {axis}, keepdim);
+    res = min<T>(x_tmp, reduce_axis, keepdim);
   } else {
     // vanilla p-norm
     auto porder_tensor = full_scalar<T>(porder, x_tmp.dtype(), x_tmp.place());
     auto inv_porder_tensor =
         full_scalar<T>(1 / porder, x_tmp.dtype(), x_tmp.place());
     res = elementwise_pow<T>(x_tmp, porder_tensor);
-    res = sum<T>(res, {axis}, x_tmp.dtype(), keepdim);
+    res = sum<T>(res, reduce_axis, x_tmp.dtype(), keepdim);
     res = elementwise_pow<T>(res, inv_porder_tensor);
   }
 

--- a/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
@@ -148,7 +148,8 @@ Tensor p_norm_decomp(const Tensor& x,
     auto porder_tensor = full_scalar<T>(porder, x_tmp.dtype(), x_tmp.place());
     auto inv_porder_tensor =
         full_scalar<T>(1 / porder, x_tmp.dtype(), x_tmp.place());
-    res = elementwise_pow<T>(x_tmp, porder_tensor);
+    res = abs<T>(x_tmp);
+    res = elementwise_pow<T>(res, porder_tensor);
     res = sum<T>(res, reduce_axis, x_tmp.dtype(), keepdim);
     res = elementwise_pow<T>(res, inv_porder_tensor);
   }

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -3346,7 +3346,7 @@ void take_along_axis_grad(const Tensor& arr,
                                           out_grad_cast,
                                           axis,
                                           /*reduce*/ "add",
-                                          /*include_self*/ false);
+                                          /*include_self*/ true);
     set_output<T>(ConvertToOrig<T>(arr_grad_tmp, arr.dtype()), arr_grad);
   }
 }

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -3341,8 +3341,12 @@ void take_along_axis_grad(const Tensor& arr,
                             arr_cast.dtype(),
                             arr_cast.place());
     }
-    auto arr_grad_tmp =
-        put_along_axis<T>(zero_tensor, indices, out_grad_cast, axis);
+    auto arr_grad_tmp = put_along_axis<T>(zero_tensor,
+                                          indices,
+                                          out_grad_cast,
+                                          axis,
+                                          /*reduce*/ "add",
+                                          /*include_self*/ false);
     set_output<T>(ConvertToOrig<T>(arr_grad_tmp, arr.dtype()), arr_grad);
   }
 }

--- a/test/legacy_test/test_take_along_axis_op.py
+++ b/test/legacy_test/test_take_along_axis_op.py
@@ -70,6 +70,36 @@ class TestTakeAlongAxisOp(OpTest):
         self.axis_type = "int64"
 
 
+class TestTakeAlongAxisDuplicatedIndices(TestTakeAlongAxisOp):
+    def init_data(self):
+        self.dtype = np.float32
+        self.x_type = "float32"
+        self.x_shape = (5, 6, 7)
+        self.index_type = "int64"
+        self.axis = 2
+        dim_size = self.x_shape[self.axis]
+        self.index = (
+            np.asarray([-dim_size, -dim_size, dim_size - 1, dim_size - 1, 0])
+            .astype(self.index_type)
+            .reshape([5, 1, 1])
+        )
+        self.axis_type = "int64"
+
+    def test_check_output(self):
+        self.check_output(
+            check_cinn=self.check_cinn, check_pir=True, check_prim_pir=True
+        )
+
+    def test_check_grad(self):
+        self.check_grad(
+            ['Input'],
+            'Result',
+            check_cinn=self.check_cinn,
+            check_pir=True,
+            check_prim_pir=True,
+        )
+
+
 class TestTakeAlongAxisFP16Op(TestTakeAlongAxisOp):
     def init_data(self):
         self.dtype = np.float16


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
 Bug fixes 

### Description
<!-- Describe what you’ve done -->
Pcard-75624

1. 修复`p_norm_decomp`的`asvector=True`时，规约axis和结果形状不正确的问题
2. 修复静态图拆解`take_along_axis_grad`中，当indices内含有重复的下标时，结果错误的问题，从assign模式改为add模式解决（`include_self`暂时需要指定为True，不能为False，否则计算结果错误）。

Related PR: #70250 , #69675