### PR TITLE
[XPU] fix logits_max allreduce_type of XPU c_softmax_with_cross_entropy

### DIFF
--- a/paddle/phi/kernels/xpu/c_softmax_with_cross_entropy_kernel.cc
+++ b/paddle/phi/kernels/xpu/c_softmax_with_cross_entropy_kernel.cc
@@ -202,7 +202,7 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::XPUContext, T> {
           f);
       PADDLE_ENFORCE_XDNN_SUCCESS(ret, "reduce_max");
     }
-    comm_ctx->AllReduce(&logits_max, logits_max, BKCL_ADD, stream);
+    comm_ctx->AllReduce(&logits_max, logits_max, BKCL_MAX, stream);
 
     // step 2, obtain logit - logit_max
     {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
1. fix logits_max allreduce_type of XPU c_softmax_with_cross_entropy
2. 此PR引入的问题：https://github.com/PaddlePaddle/Paddle/pull/70165
3. 在原始的Fluid算子中，实际执行的是CSoftmaxWithCrossEntropyProcessGroupFunctor，里面使用的BKCL_OP为MAX而不是SUM，因此之前没有问题：
https://github.com/PaddlePaddle/Paddle/blob/f8a219feae24cbe3ae31d80a1b813d7b67079df7/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op_xpu.cc#L148