### PR TITLE
[Fix] Reduce unnecessary GpuMemGetInfo in `Tensor.to`

### DIFF
--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -583,6 +583,36 @@ def monkey_patch_tensor():
         if device is None and dtype is None and blocking is None:
             return self
 
+        def is_cuda_place(place: PlaceLike):
+            return isinstance(place, core.CUDAPlace) or (
+                isinstance(place, Place) and place.is_gpu_place()
+            )
+
+        def get_device_id(place: PlaceLike):
+            if isinstance(
+                place,
+                (
+                    core.CUDAPlace,
+                    core.XPUPlace,
+                    core.IPUPlace,
+                    core.CustomPlace,
+                ),
+            ):
+                return place.get_device_id()
+            elif isinstance(place, Place):
+                if place.is_gpu_place():
+                    return place.gpu_device_id()
+                elif place.is_xpu_place():
+                    return place.xpu_device_id()
+                elif place.is_ipu_place():
+                    return place.ipu_device_id()
+                elif place.is_custom_place():
+                    return place.custom_device_id()
+            else:
+                raise ValueError(
+                    f"Invalid place: {place}, only support getting device id from CUDAPlace/XPUPlace/IPUPlace/CustomPlace"
+                )
+
         if device is not None:
             if isinstance(device, str):
                 device = paddle.device._convert_to_place(device)
@@ -617,7 +647,13 @@ def monkey_patch_tensor():
             if dtype is None:
                 dtype = t.dtype
             # 1. gpu place need to determine whether the memory is sufficient for allocation.
-            if t.place.is_gpu_place():
+            if t.place.is_gpu_place() and (
+                # NOTE: Only copy memory when place or device id is different,
+                # otherwise, it may frequently call GpuMemGetInfo in
+                # core.gpu_memory_available, leading to abnormal overhead.
+                not is_cuda_place(device)
+                or t.place.gpu_device_id() != get_device_id(device)
+            ):
                 proto_dtype = framework.convert_to_proto_type(dtype)
                 size_dtype = core.size_of_dtype(proto_dtype)
                 # Note(weilong wu): Paddle GPU minimum memory allocation unit is 256 bytes,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance 

### Description
<!-- Describe what you’ve done -->
Pcard-75624

## 问题
`Tensor.to`方法中，对于device的处理是当src.place在GPU上时会通过`core.gpu_memory_available()`计算当前设备上的剩余可用显存，接着后续一系列操作。这个过程中`core.gpu_memory_available()`会调用`cudaMemGetInfo`，而当`.to`操作一多时，会非常频繁地调用`cudaMemGetInfo`，导致拖慢整体动态图的运行速度（cudaMemGetInfo看起来会产生一个CPU阻塞效果，[API文档](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html#group__CUDART__MEMORY_1g376b97f5ab20321ca46f7cfa9511b978)也没有相关说明）。
<https://github.com/PaddlePaddle/Paddle/blob/5859a053bbc0694f41ccb425da76de2e2247e415/paddle/phi/core/platform/device/gpu/gpu_info.cc#L71-L78>
![image](https://github.com/user-attachments/assets/767eb6a1-d299-4d86-a623-cf1a32425832)

## 解决方案
修改进入`core.gpu_memory_available`分支的判断条件，**仅当`t.place(source place)`与`device(dst place)`设备类型不同，或者同设备类型但卡号不同时**，才进入该copy分支，而不是`t.place`只要在GPU上就直接进入分支。从VLOG来看，这一修改可以避免所有step中的cudaMemGetInfo操作，耗时恢复正常。

![image](https://github.com/user-attachments/assets/9d4c188b-5186-4783-b592-0ba8abd8fce6)

nsys可以看到每个step内已经没有cudaMemGetInfo
![image](https://github.com/user-attachments/assets/f358db4e-722c-43c8-90ad-dbf46080224f)
