### PR TITLE
[CINN]support backend PassManager run on block

### DIFF
--- a/paddle/cinn/pass/pass_manager.h
+++ b/paddle/cinn/pass/pass_manager.h
@@ -28,6 +28,9 @@ class PassManager {
   virtual LogicalResult Run(ir::LoweredFunc func) {
     return adaptor_.RunPipeline(func, passes_);
   }
+  virtual LogicalResult Run(ir::stmt::BlockRef block) {
+    return adaptor_.RunPipeline(block, passes_);
+  }
   void AddPass(std::unique_ptr<PassT> pass) {
     passes_.emplace_back(std::move(pass));
   }
@@ -38,9 +41,9 @@ class PassManager {
 };
 
 using FuncPassManager = PassManager<FuncPass, detail::FuncPassAdaptor>;
-using BlockPassManager = PassManager<BlockPass, detail::FuncToBlockPassAdaptor>;
-using StmtPassManager = PassManager<StmtPass, detail::FuncToStmtPassAdaptor>;
-using ExprPassManager = PassManager<ExprPass, detail::FuncToExprPassAdaptor>;
+using BlockPassManager = PassManager<BlockPass, detail::BlockPassAdaptor>;
+using StmtPassManager = PassManager<StmtPass, detail::StmtPassAdaptor>;
+using ExprPassManager = PassManager<ExprPass, detail::ExprPassAdaptor>;
 
 }  // namespace optim
 }  // namespace cinn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR supports backend PassManager run on block. Every PassManager except FuncPassManager provides this method:
```c++
LogicalResult Run(ir::stmt::BlockRef block);
```
