### PR TITLE
【 Paddle Tensor 规范化第二期 】解决隐式广播不能够处理0-size的问题

### DIFF
--- a/paddle/phi/kernels/funcs/broadcast_function.h
+++ b/paddle/phi/kernels/funcs/broadcast_function.h
@@ -806,7 +806,7 @@ void BroadcastKernel(const KPDevice &ctx,
     }
     ctx.template Alloc<OutT>((*outs)[i]);
   }
-  if ((*outs).size() == 1 && (*outs)[0]->numel() == 0) {
+  if ((*outs)[0]->numel() == 0) {
     return;
   }
   int max_rank = 0;

--- a/paddle/phi/kernels/funcs/broadcast_function.h
+++ b/paddle/phi/kernels/funcs/broadcast_function.h
@@ -806,7 +806,9 @@ void BroadcastKernel(const KPDevice &ctx,
     }
     ctx.template Alloc<OutT>((*outs)[i]);
   }
-
+  if ((*outs).size() == 1 && (*out)[0]->numel() == 0) {
+    return;
+  }
   int max_rank = 0;
   int min_rank = phi::DDim::kMaxRank;
   for (auto *in : ins) {

--- a/paddle/phi/kernels/funcs/broadcast_function.h
+++ b/paddle/phi/kernels/funcs/broadcast_function.h
@@ -806,7 +806,7 @@ void BroadcastKernel(const KPDevice &ctx,
     }
     ctx.template Alloc<OutT>((*outs)[i]);
   }
-  if ((*outs).size() == 1 && (*out)[0]->numel() == 0) {
+  if ((*outs).size() == 1 && (*outs)[0]->numel() == 0) {
     return;
   }
   int max_rank = 0;

--- a/paddle/phi/kernels/funcs/common_shape.h
+++ b/paddle/phi/kernels/funcs/common_shape.h
@@ -69,8 +69,9 @@ inline void GetBroadcastDimsArrays(const DDim &x_dims,
   }
   for (int i = 0; i < max_dim; ++i) {
     PADDLE_ENFORCE_EQ(
-        x_dims_array[i] == y_dims_array[i] || x_dims_array[i] <= 1 ||
-            y_dims_array[i] <= 1,
+        x_dims_array[i] == y_dims_array[i] ||
+            x_dims_array[i] <= 1 && x_dims_array[i] != 0 ||
+            y_dims_array[i] <= 1 && y_dims_array[i] != 0,
         true,
         common::errors::InvalidArgument(
             "Broadcast dimension mismatch. Operands could "

--- a/paddle/phi/kernels/funcs/common_shape.h
+++ b/paddle/phi/kernels/funcs/common_shape.h
@@ -87,6 +87,9 @@ inline void GetBroadcastDimsArrays(const DDim &x_dims,
       out_dims_array[i] = (std::max)(x_dims_array[i], y_dims_array[i]);
     } else {
       out_dims_array[i] = -1;
+      if (y_dims_array[i] == 0 || x_dims_array[i] == 0) {
+        out_dims_array[i] = 0;
+      }
     }
   }
 }

--- a/paddle/phi/kernels/funcs/common_shape.h
+++ b/paddle/phi/kernels/funcs/common_shape.h
@@ -70,8 +70,8 @@ inline void GetBroadcastDimsArrays(const DDim &x_dims,
   for (int i = 0; i < max_dim; ++i) {
     PADDLE_ENFORCE_EQ(
         x_dims_array[i] == y_dims_array[i] ||
-            x_dims_array[i] <= 1 && x_dims_array[i] != 0 ||
-            y_dims_array[i] <= 1 && y_dims_array[i] != 0,
+            (x_dims_array[i] <= 1 && x_dims_array[i] != 0) ||
+            (y_dims_array[i] <= 1 && y_dims_array[i] != 0),
         true,
         common::errors::InvalidArgument(
             "Broadcast dimension mismatch. Operands could "

--- a/test/legacy_test/test_broadcast_shape.py
+++ b/test/legacy_test/test_broadcast_shape.py
@@ -32,6 +32,23 @@ class TestBroadcastShape(unittest.TestCase):
             ValueError, paddle.broadcast_shape, [2, 1, 3], [3, 3, 1]
         )
 
+    def test_zero_size_dim(self):
+        test_cases = [
+            ([0], [], [0]),
+            ([1], [0], [0]),
+            ([2, -1], [0], [2, 0]),
+            ([0, 3], [3], [0, 3]),
+            ([0, 1, 3], [0, 1, 0, 3], [0, 0, 0, 3]),
+            ([0, 1, 3], [0, 1, 1, 5, 3], [0, 1, 0, 5, 3]),
+        ]
+
+        for shape1, shape2, expected in test_cases:
+            result = paddle.broadcast_shape(shape1, shape2)
+            self.assertEqual(result, expected)
+
+    def test_zero_size_error(self):
+        self.assertRaises(ValueError, paddle.broadcast_shape, [0], [0, 2])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->Bug fixes


### Description
<!-- Describe what you’ve done -->
先前的隐式广播是不能够处理输入存在维度为0的情况：
![A2E36F6B14F4C02FC3948DE3B8A10990](https://github.com/user-attachments/assets/2af68e8b-b856-4008-8c85-4a0f2e2523c1)
修改后:
![46F287101CB620FC3B8BDE74C7B2CE55](https://github.com/user-attachments/assets/af97156b-cdaa-4caa-b9f0-e173a91456a7)
测试代码
```
import paddle
import pdb
def test_paddle_add_broadcast(shape1, shape2):
    x = paddle.randn(shape1, dtype='float32') if shape1 != [0] and 0 not in shape1 else paddle.to_tensor([], dtype='float32').reshape(shape1)
    y = paddle.randn(shape2, dtype='float32') if shape2 != [0] and 0 not in shape2 else paddle.to_tensor([], dtype='float32').reshape(shape2)

    try:
        # pdb.set_trace()
        result = x + y
        print(f"Paddle Add: Shapes: {shape1} + {shape2}, Result shape: {result.shape}")

    except Exception as e:
        print(f"Paddle Add/Pow Add Error: Shapes: {shape1} + {shape2}, Error: {e}")

shapes = [
    ([0], [0]),
    ([0, 0], [0]),
    ([0], [0, 0]),
    ([0, 3], [3]),
    ([3], [0, 3]),
    ([0, 3], [0, 3]),
    ([2, 0], [0]),
    ([0], [2, 0]),
]


for shape1, shape2 in shapes:
    test_paddle_add_broadcast(shape1, shape2)
```