### PR TITLE
Directly use `paddle.full` to create complex tensor in `paddle.equal`.

### DIFF
--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -586,12 +586,8 @@ def equal(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         raise TypeError(
             f"Type of input args must be float, bool, complex, int or Tensor, but received type {type(y)}"
         )
-    if not isinstance(y, (Variable, paddle.pir.Value, complex)):
+    if not isinstance(y, (Variable, paddle.pir.Value)):
         y = full(shape=[], dtype=x.dtype, fill_value=y)
-
-    if isinstance(y, complex):
-        # full not support for complex yet
-        y = paddle.to_tensor(y)
 
     if in_dynamic_or_pir_mode():
         return _C_ops.equal(x, y)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience 

### PR Types
Performance

### Description
上一次因为发现 full 对 complex 创建有各种小 bug, 于是特地绕了一下用 to_tensor 单独创建. 目前已经修复.

- #70277

现在和 float, int, bool 等保持一致直接用`paddle.full`来创建 tensor.