### PR TITLE
[CINN] Improve subgraph topo index update algorithm

### DIFF
--- a/paddle/fluid/pir/transforms/build_cinn_pass.cc
+++ b/paddle/fluid/pir/transforms/build_cinn_pass.cc
@@ -51,6 +51,7 @@ class BuildCinnPass : public pir::Pass {
  private:
   void ProcessBlock(pir::Block* block) {
     auto start_t = std::chrono::high_resolution_clock::now();
+    auto num_ops = block->size();
     std::vector<GroupOpsVec> groups =
         ::pir::DetectSubGraphs(block, CompatibleInfo::IsSupportForCinn);
     AddStatistics(groups.size());
@@ -64,8 +65,8 @@ class BuildCinnPass : public pir::Pass {
     auto end_t = std::chrono::high_resolution_clock::now();
     auto duration =
         std::chrono::duration_cast<std::chrono::milliseconds>(end_t - start_t);
-    VLOG(1) << "Time of building group ops (size=" << block->size()
-            << "): " << FormatDuration(duration);
+    LOG(INFO) << "Time of building group ops (size=" << num_ops
+              << "): " << FormatDuration(duration);
   }
 };
 

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -105,7 +105,7 @@ std::vector<pir::Operation*> InverselyTopologicalSort(pir::Block* block) {
 
 std::vector<pir::Operation*> GetProducerOpsReverseSort(
     pir::Operation* op,
-    const std::unordered_map<pir::Operation*, size_t>& op2index) {
+    const std::unordered_map<pir::Operation*, int>& op2index) {
   std::unordered_set<pir::Operation*> producers;
 
   std::vector<pir::Operation*> vec_res;
@@ -150,7 +150,7 @@ std::vector<pir::Operation*> GetProducerOps(pir::Operation* op) {
 
 std::vector<pir::Operation*> GetConsumerOps(
     pir::Operation* op,
-    const std::unordered_map<pir::Operation*, size_t>& op2index) {
+    const std::unordered_map<pir::Operation*, int>& op2index) {
   std::vector<pir::Operation*> consumers;
 
   for (auto& result : op->results()) {
@@ -181,8 +181,8 @@ static std::string OpsDebugStr(std::vector<pir::Operation*> ops) {
 struct SubGraph : public std::enable_shared_from_this<SubGraph> {
   using SubGraphPtr = std::shared_ptr<SubGraph>;
   SubGraph() = delete;
-  SubGraph(pir::Operation* op, int id, bool subst)
-      : substitute(subst), min_op_index(id), max_op_index(id), id(UniqueId()) {
+  SubGraph(pir::Operation* op, int index, bool subst)
+      : substitute(subst), topo_index(index), id(UniqueId()) {
     ops.push_back(op);
   }
 
@@ -207,8 +207,7 @@ struct SubGraph : public std::enable_shared_from_this<SubGraph> {
     std::stringstream ss;
     ss << "=========================================\n";
     ss << name() << " (substitute=" << substitute << ", "
-       << "min=" << min_op_index << ", "
-       << "max=" << max_op_index << ", "
+       << "index=" << topo_index << ", "
        << "size=" << ops.size() << ")\n";
     if (print_ops) ss << OpsDebugStr(ops);
     ss << "upstream: " << JointName(upstreams);
@@ -231,18 +230,15 @@ struct SubGraph : public std::enable_shared_from_this<SubGraph> {
   std::set<SubGraphPtr, compare> upstreams;
   std::set<SubGraphPtr, compare> downstreams;
 
-  bool substitute;      // whether this subgraph can be merged
-  size_t min_op_index;  // min topo index of ops in this subgraph
-  size_t max_op_index;  // max topo index of ops in this subgraph
+  bool substitute;  // whether this subgraph can be merged
+  int topo_index;
   size_t id;
 };
 using SubGraphPtr = std::shared_ptr<SubGraph>;
 
 void SubGraph::Merge(const SubGraphPtr& other) {
   // Merge other subgraph into this subgraph:
-  // 1. Inherit its upstreams and downstreams
-  VLOG(6) << "Merging : " << other->DebugStr();
-  VLOG(6) << "Into : " << DebugStr();
+  // Inherit its upstreams/downstreams and ops
   SubGraphPtr self = shared_from_this();
   for (const auto& upstream : other->upstreams) {
     if (upstream == self) continue;
@@ -258,11 +254,7 @@ void SubGraph::Merge(const SubGraphPtr& other) {
   }
   upstreams.erase(other);
   downstreams.erase(other);
-  // 2. Merge ops and update min_op_index and max_op_index
   ops.insert(ops.begin(), other->ops.begin(), other->ops.end());
-  min_op_index = std::min(self->min_op_index, other->min_op_index);
-  max_op_index = std::max(self->max_op_index, other->max_op_index);
-  VLOG(6) << "Merged : " << DebugStr();
 }
 
 bool HasSinkRoute(const SubGraphPtr& source, const SubGraphPtr& target) {
@@ -275,7 +267,7 @@ bool HasSinkRoute(const SubGraphPtr& source, const SubGraphPtr& target) {
     queue.pop();
     visited.insert(cur);
     if (cur == target) return true;
-    if (cur->min_op_index > target->max_op_index) continue;
+    if (cur->topo_index > target->topo_index) continue;
     for (const auto& subgraph : cur->downstreams) {
       if (visited.count(subgraph)) continue;
       queue.push(subgraph);
@@ -294,7 +286,7 @@ bool HasLiftRoute(const SubGraphPtr& source, const SubGraphPtr& target) {
     queue.pop();
     visited.insert(cur);
     if (cur == target) return true;
-    if (source->max_op_index < target->min_op_index) continue;
+    if (source->topo_index < target->topo_index) continue;
     for (const auto& subgraph : cur->upstreams) {
       if (visited.count(subgraph)) continue;
       queue.push(subgraph);
@@ -383,6 +375,8 @@ class SubgraphDetector {
  private:
   void ReorderIndexOfSubgraphs();
 
+  void MergeSource2Target(const SubGraphPtr& source, const SubGraphPtr& target);
+
   SubGraphPtr GetOpSubgraph(pir::Operation* op) {
     PADDLE_ENFORCE(
         op2subgraph_.count(op),
@@ -391,9 +385,10 @@ class SubgraphDetector {
     return op2subgraph_.at(op);
   }
 
-  std::unordered_map<pir::Operation*, size_t> op2index_;
+  std::unordered_map<pir::Operation*, int> op2index_;
   std::vector<pir::Operation*> sort_ops_;
   std::unordered_map<pir::Operation*, SubGraphPtr> op2subgraph_;
+  std::unordered_set<int> subgraph_index_set_;
 };
 
 void SubgraphDetector::ReorderIndexOfSubgraphs() {
@@ -412,8 +407,7 @@ void SubgraphDetector::ReorderIndexOfSubgraphs() {
   while (!queue.empty()) {
     auto subgraph = queue.front();
     queue.pop();
-    subgraph->min_op_index = index;
-    subgraph->max_op_index = index++;
+    subgraph->topo_index = index++;
     for (const auto& downstream : subgraph->downstreams) {
       in_degree[downstream]--;
       if (in_degree[downstream] == 0) queue.push(downstream);
@@ -421,12 +415,54 @@ void SubgraphDetector::ReorderIndexOfSubgraphs() {
   }
 }
 
+void SubgraphDetector::MergeSource2Target(const SubGraphPtr& source,
+                                          const SubGraphPtr& target) {
+  VLOG(6) << "Merge source: " << source->DebugStr();
+  VLOG(6) << "Merge target: " << target->DebugStr();
+  target->Merge(source);
+  int max_index = std::max(source->topo_index, target->topo_index);
+  int min_index = std::min(source->topo_index, target->topo_index);
+  auto merged = target;
+  // Check if merged subgraph and its related subgraphs
+  // satisfy the topological order condition.
+  int upstream_max_index = -1, downstream_min_index = INT_MAX;
+  for (const auto& upstream : merged->upstreams) {
+    upstream_max_index = std::max(upstream->topo_index, upstream_max_index);
+  }
+  for (const auto& downstream : merged->downstreams) {
+    downstream_min_index =
+        std::min(downstream->topo_index, downstream_min_index);
+  }
+  // 1. If satisfy the topological order after merging, just set max_index
+  VLOG(6) << "Check if satisfy the topological order after merging";
+  if (min_index > upstream_max_index && max_index < downstream_min_index) {
+    merged->topo_index = max_index;
+    subgraph_index_set_.erase(min_index);
+    return;
+  }
+  // 2. If not satisfy the order, find a index between upstream_max_index
+  // and downstream_min_index while not in subgraph_index_set_.
+  VLOG(6) << "Try to find a valid index in subgraph_index_set_";
+  for (size_t i = upstream_max_index + 1; i < downstream_min_index; ++i) {
+    if (!subgraph_index_set_.count(i)) {
+      merged->topo_index = i;
+      subgraph_index_set_.erase(min_index);
+      subgraph_index_set_.erase(max_index);
+      subgraph_index_set_.insert(i);
+      return;
+    }
+  }
+  // 3. If can not find a valid index, reorder topo index of all subgraphs.
+  VLOG(6) << "Reorder topo index of all subgraphs";
+  ReorderIndexOfSubgraphs();
+}
+
 SubgraphDetector::SubgraphDetector(pir::Block* block,
                                    const OpClassifier& classifier) {
   // init sort_ops_ in reverse topo order
   sort_ops_ = InverselyTopologicalSort(block);
   // init op2index_ in topo order
-  size_t index = 0;
+  int index = 0;
   for (auto& op : *block) {
     op2index_[&op] = index++;
   }
@@ -436,6 +472,7 @@ SubgraphDetector::SubgraphDetector(pir::Block* block,
     bool substitute = classifier(*op);
     auto subgraph = std::make_shared<SubGraph>(op, op2index_[op], substitute);
     op2subgraph_[op] = subgraph;
+    subgraph_index_set_.insert(op2index_[op]);
     subgraph_list.push_back(subgraph);
   }
   for (const auto& op : sort_ops_) {
@@ -474,14 +511,15 @@ void SubgraphDetector::SubgraphFusion() {
       auto upstream = GetOpSubgraph(producer);
       if (upstream == downstream || !upstream->substitute) continue;
       if (CanFuseUpstream2Downstream(upstream, downstream)) {
-        downstream->Merge(upstream);
+        MergeSource2Target(upstream, downstream);
         for (auto upstream_op : upstream->ops) {
           op2subgraph_[upstream_op] = downstream;
         }
-        ReorderIndexOfSubgraphs();
+        VLOG(6) << "Merged subgraph: " << downstream->DebugStr();
       }
     }
   }
+
   VLOG(4) << "Merge brother subgraphs with same upstream";
   for (const auto& op : sort_ops_) {
     auto subgraph = GetOpSubgraph(op);
@@ -492,11 +530,11 @@ void SubgraphDetector::SubgraphFusion() {
         auto brother = GetOpSubgraph(consumer);
         if (brother == subgraph || !brother->substitute) continue;
         if (!HasRoute(subgraph, brother) && !HasRoute(brother, subgraph)) {
-          subgraph->Merge(brother);
+          MergeSource2Target(brother, subgraph);
           for (auto brother_op : brother->ops) {
             op2subgraph_[brother_op] = subgraph;
           }
-          ReorderIndexOfSubgraphs();
+          VLOG(6) << "Merged subgraph: " << subgraph->DebugStr();
         }
       }
     }

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -442,7 +442,7 @@ void SubgraphDetector::MergeSource2Target(const SubGraphPtr& source,
   }
   // 2. If not satisfy the order, find a index between upstream_max_index
   // and downstream_min_index while not in subgraph_index_set_.
-  VLOG(6) << "Try to find a valid index in subgraph_index_set_";
+  VLOG(6) << "Try to find a valid index not in subgraph_index_set_";
   for (size_t i = upstream_max_index + 1; i < downstream_min_index; ++i) {
     if (!subgraph_index_set_.count(i)) {
       merged->topo_index = i;

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -443,7 +443,7 @@ void SubgraphDetector::MergeSource2Target(const SubGraphPtr& source,
   // 2. If not satisfy the order, find a index between upstream_max_index
   // and downstream_min_index while not in subgraph_index_set_.
   VLOG(6) << "Try to find a valid index not in subgraph_index_set_";
-  for (size_t i = upstream_max_index + 1; i < downstream_min_index; ++i) {
+  for (int i = upstream_max_index + 1; i < downstream_min_index; ++i) {
     if (!subgraph_index_set_.count(i)) {
       merged->topo_index = i;
       subgraph_index_set_.erase(min_index);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-76996
#### 问题描述
- 之前 #70074 实现 Subgraph 融合环检测方案利用原始 Op 的拓扑序进行剪枝，但可能会出现下面的 case（图中红色表示可融合结点，灰色表示不可融合结点）：序号 1 Subgraph 和序号 5 Subgraph 尝试进行融合，按照算法需要搜索 1 到 5 是否存在其他路径来检查融合后是否有环，当沿着路径 1 - 3 - 6 进行搜索时，由于 6 的拓扑序号大于 5，被认为 5 不可能是 6 的下游，从而被剪枝不继续搜索，导致 1 和 5 进行融合形成环
  <img width="414" alt="image" src="https://github.com/user-attachments/assets/10aab52f-1b9e-4801-b610-2294e577b808" />
#### 问题分析与解决
- 上述问题是因为在原始 Op 的拓扑序中，6 确实不是 5 的下游，但由于 2 和 7 进行了融合，原始 Op 的拓扑序无法正确表示融合后子图的拓扑序，导致按照原始 Op 拓扑序进行剪枝是有问题的，因此需要在每一次结点融合后更新拓扑序，保证整个图的拓扑序是正确的，#70249 中在每一次结点融合后都会对整个图的拓扑序进行重排，这虽然解决的上述问题。
- 每一次融合都重排整个图的代价是很高的，针对这个问题，本次 PR 优化了拓扑序更新算法，主要思想为非必要不重排，具体分为 3 个分支：1）如果融合后拓扑序是正确的，则不变；2）如果融合后结点所有上游的拓扑序都小于所有下游的拓扑序，那么搜索是否存在它们之间的未被使用的拓扑序（某些拓扑序被融合后就没被使用了），若存在则融合后结点则直接用该拓扑序；3）对整图进行重排（这里应该也能进行优化，比如说进行局部递归重排，但目前无法确定是否完备）
