### PR TITLE
[CINN] Fallback FuionOp with single reshape to PHI kernel

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/single_op_fallback_to_phi.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/single_op_fallback_to_phi.cc
@@ -58,9 +58,6 @@ class FusionOpPattern : public pir::OpRewritePattern<cinn::dialect::FusionOp> {
             "The last operator of fusion_op must be YieldOp, but got %s",
             fusion_op.GetOperators()[2]->name()));
 
-    auto* program = fusion_op->GetParentProgram();
-    auto& shape_analysis = pir::ShapeAnalysisManager::Instance().Get(
-        fusion_op->GetParentProgram());
     std::optional<pir::Operation*> paddle_op =
         FallBackOp(fusion_op.GetOperators()[0], rewriter);
     if (!paddle_op.has_value()) {
@@ -171,6 +168,85 @@ class FusionOpPattern : public pir::OpRewritePattern<cinn::dialect::FusionOp> {
   }
 };
 
+// Fallback reshape pattern like this:
+// (%1) = cinn_op.generate_shape (%0)
+// (%2) = pd_op.reshape (%0, %1)
+// (%3) = cinn_op.yield_store (%2)
+// () = cf.yield (%3)
+class FusionOpSingleReshapePattern
+    : public pir::OpRewritePattern<cinn::dialect::FusionOp> {
+ public:
+  explicit FusionOpSingleReshapePattern(::pir::IrContext* context)
+      : pir::OpRewritePattern<cinn::dialect::FusionOp>(context) {}
+
+  bool MatchAndRewrite(cinn::dialect::FusionOp fusion_op,
+                       pir::PatternRewriter& rewriter) const override {
+    const auto& ops = fusion_op.GetOperators();
+    if (ops.size() != 4) return false;
+    if (!ops[0]->isa<cinn::dialect::GenerateShapeOp>() ||
+        !ops[1]->isa<paddle::dialect::ReshapeOp>() ||
+        !ops[2]->isa<cinn::dialect::YieldStoreOp>()) {
+      return false;
+    }
+
+    // Input of generate_shape op and reshape op should be same, so
+    // generate_shape has no new symbol dim
+    if (ops[0]->num_operands() == 1 &&
+        ops[0]->operand_source(0) != ops[1]->operand_source(0)) {
+      return false;
+    }
+
+    // generate_shape op should only be used by reshape op
+    // reshape op should only be used by yield_store op
+    if (ops[0]->result(0).use_count() != 1 ||
+        ops[1]->result(0).use_count() != 1) {
+      return false;
+    }
+    if (ops[0]->result(0).first_use().owner() != ops[1] ||
+        ops[1]->result(0).first_use().owner() != ops[2]) {
+      return false;
+    }
+
+    const std::vector<int64_t> shape = [&] {
+      auto& shape_analysis = pir::ShapeAnalysisManager::Instance().Get(
+          fusion_op->GetParentProgram());
+      const auto& reshape_x_shape =
+          shape_analysis.GetShapeOrDataForValue(ops[1]->operand_source(0))
+              .shape();
+      const auto& reshape_out_shape =
+          shape_analysis.GetShapeOrDataForValue(ops[1]->result(0)).shape();
+      std::vector<int64_t> shape(reshape_out_shape.size(), -1);
+      for (size_t i = 0; i < reshape_out_shape.size(); ++i) {
+        if (reshape_out_shape[i].isa<int64_t>()) {
+          shape[i] = reshape_out_shape[i].dyn_cast<int64_t>();
+          continue;
+        }
+        if (reshape_out_shape[i].isa<std::string>()) {
+          if (reshape_x_shape[i] == reshape_out_shape[i]) {
+            shape[i] = 0;
+            continue;
+          }
+        }
+        shape[i] = -1;
+      }
+      return shape;
+    }();
+
+    const int dynamic_dim_cnt = std::count(shape.begin(), shape.end(), -1);
+    if (dynamic_dim_cnt > 1) {
+      return false;
+    }
+
+    // create new reshape out of fusion op
+    auto new_reshape = rewriter.Build<paddle::dialect::ReshapeOp>(
+        ops[1]->operand_source(0), shape);
+
+    rewriter.ReplaceAllUsesWith(fusion_op.result(0), new_reshape.result(0));
+    rewriter.EraseOp(fusion_op);
+    return true;
+  }
+};
+
 class SingleOpFallbackToPhiPass : public pir::PatternRewritePass {
  public:
   SingleOpFallbackToPhiPass()
@@ -183,6 +259,7 @@ class SingleOpFallbackToPhiPass : public pir::PatternRewritePass {
 
     pir::RewritePatternSet ps(context);
     ps.Add<FusionOpPattern>(context);
+    ps.Add<FusionOpSingleReshapePattern>(context);
 
     return ps;
   }

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/single_op_fallback_to_phi.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/single_op_fallback_to_phi.cc
@@ -222,7 +222,8 @@ class FusionOpSingleReshapePattern
           continue;
         }
         if (reshape_out_shape[i].isa<std::string>()) {
-          if (reshape_x_shape[i] == reshape_out_shape[i]) {
+          if (i < reshape_x_shape.size() &&
+              reshape_x_shape[i] == reshape_out_shape[i]) {
             shape[i] = 0;
             continue;
           }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Pcard-67164

对于FusionOp中只有单个reshape算子的情况，通过编译器无法达到到使用了View机制的PHI Kernel性能，因此将此类FusionOp回退到PHI Kernel下执行。