### PR TITLE
[Windows CI] Record the exact size of dll and whl files and save them to disk D

### DIFF
--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -676,12 +676,12 @@ for /F "tokens=1-5" %%a in ('dir "%dll_file%"') do (
     echo %%e | findstr  "libpaddle.dll" >nul
     if !errorlevel! equ 0 (
         set dllsize=%%d
-        goto dll_break 
+        goto dll_break
     )
     echo %%d | findstr  "libpaddle.dll" >nul
     if !errorlevel! equ 0 (
         set dllsize=%%c
-        goto dll_break 
+        goto dll_break
     )
 )
 :dll_break
@@ -700,12 +700,12 @@ for /F "tokens=1-5" %%a in ('dir "%whl_folder%"') do (
     echo %%e | findstr  ".whl" >nul
     if !errorlevel! equ 0 (
         set whlsize=%%d
-        goto whl_break 
+        goto whl_break
     )
     echo %%d | findstr  ".whl" >nul
     if !errorlevel! equ 0 (
         set whlsize=%%c
-        goto whl_break 
+        goto whl_break
     )
 )
 :whl_break

--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -670,14 +670,55 @@ for /F %%# in ('wmic os get localdatetime^|findstr 20') do set end=%%#
 set end=%end:~4,10%
 call :timestamp "%start%" "%end%" "Build"
 
-%cache_dir%\tools\busybox64.exe du -h -d 0 %cd%\paddle\fluid\pybind\libpaddle.dll > paddle_dll_size.txt
-set /p paddledllsize=< paddle_dll_size.txt
-for /F %%i in ("%paddledllsize%") do echo "Windows libpaddle.dll Size: %%i"
+rem Record the exact size of dll and whl files and save them to disk D
+set dll_file=%cd%\paddle\fluid\pybind\libpaddle.dll
+for /F "tokens=1-5" %%a in ('dir "%dll_file%"') do (
+    echo %%e | findstr  "libpaddle.dll" >nul
+    if !errorlevel! equ 0 (
+        set dllsize=%%d
+        goto dll_break 
+    )
+    echo %%d | findstr  "libpaddle.dll" >nul
+    if !errorlevel! equ 0 (
+        set dllsize=%%c
+        goto dll_break 
+    )
+)
+:dll_break
+echo Windows libpaddle.dll Size: %dllsize% bytes
+set dllsize_folder=D:\record\dll_size
+if not exist "%dllsize_folder%" (
+    mkdir %dllsize_folder%
+)
+if exist "%dllsize_folder%\%AGILE_PULL_ID%.txt" (
+    del "%dllsize_folder%\%AGILE_PULL_ID%.txt"
+)
+echo %dllsize% > %dllsize_folder%\%AGILE_PULL_ID%.txt
 
-%cache_dir%\tools\busybox64.exe du -h -d 0 %cd%\python\dist > whl_size.txt
-set /p whlsize=< whl_size.txt
-for /F %%i in ("%whlsize%") do echo "Windows PR whl Size: %%i"
-for /F %%i in ("%whlsize%") do echo ipipe_log_param_Windows_PR_whl_Size: %%i
+set whl_folder=%cd%\python\dist
+for /F "tokens=1-5" %%a in ('dir "%whl_folder%"') do (
+    echo %%e | findstr  ".whl" >nul
+    if !errorlevel! equ 0 (
+        set whlsize=%%d
+        goto whl_break 
+    )
+    echo %%d | findstr  ".whl" >nul
+    if !errorlevel! equ 0 (
+        set whlsize=%%c
+        goto whl_break 
+    )
+)
+:whl_break
+echo Windows PR whl Size: %whlsize% bytes
+echo ipipe_log_param_Windows_PR_whl_Size: %whlsize% bytes
+set whlsize_folder=D:\record\whl_size
+if not exist "%whlsize_folder%" (
+    mkdir %whlsize_folder%
+)
+if exist "%whlsize_folder%\%AGILE_PULL_ID%.txt" (
+    del "%whlsize_folder%\%AGILE_PULL_ID%.txt"
+)
+echo %whlsize% > %whlsize_folder%\%AGILE_PULL_ID%.txt
 
 dir /s /b python\dist\*.whl > whl_file.txt
 set /p PADDLE_WHL_FILE_WIN=< whl_file.txt

--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -673,12 +673,12 @@ call :timestamp "%start%" "%end%" "Build"
 rem Record the exact size of dll and whl files and save them to disk D
 set dll_file=%cd%\paddle\fluid\pybind\libpaddle.dll
 for /F "tokens=1-5" %%a in ('dir "%dll_file%"') do (
-    echo %%e | findstr  "libpaddle.dll" >nul
+    echo "%%e" | findstr  "libpaddle.dll" >nul
     if !errorlevel! equ 0 (
         set dllsize=%%d
         goto dll_break
     )
-    echo %%d | findstr  "libpaddle.dll" >nul
+    echo "%%d" | findstr  "libpaddle.dll" >nul
     if !errorlevel! equ 0 (
         set dllsize=%%c
         goto dll_break
@@ -697,12 +697,12 @@ echo %dllsize% > %dllsize_folder%\%AGILE_PULL_ID%.txt
 
 set whl_folder=%cd%\python\dist
 for /F "tokens=1-5" %%a in ('dir "%whl_folder%"') do (
-    echo %%e | findstr  ".whl" >nul
+    echo "%%e" | findstr  ".whl" >nul
     if !errorlevel! equ 0 (
         set whlsize=%%d
         goto whl_break
     )
-    echo %%d | findstr  ".whl" >nul
+    echo "%%d" | findstr  ".whl" >nul
     if !errorlevel! equ 0 (
         set whlsize=%%c
         goto whl_break


### PR DESCRIPTION


<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->Environment Adaptation


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->Others


### Description
<!-- Describe what you’ve done -->When executing Windows CI, record the exact size of dll and whl files and save them to disk D.
