### PR TITLE
[Paddle TensorRT] pd_op.logical_not

### DIFF
--- a/python/paddle/distributed/checkpoint/save_state_dict.py
+++ b/python/paddle/distributed/checkpoint/save_state_dict.py
@@ -148,10 +148,9 @@ def save_state_dict(
         path(str): The directory to save state_dict.
         process_group(paddle.distributed.collective.Group): ProcessGroup to be used for cross-rank synchronization. Use the default process group which contains all cards.
         coordinator_rank(int): The rank used to save non distributed values. Rank 0 is used by default.
-        unique_id(int): The unique id of ckeckpoint, used to distinguish between different checkpoint versions. Default is None, in which case the id 0 when save for the first time and increased by 1 each time when calling save_state_dict in the same path.
+        unique_id(int): The unique id of ckeckpoint, used to distinguish between different checkpoint versions. Default is None, in which case the id 0 when save for the first time and increased by 1 each time when calling save_state_dict in the same path. If unique_id is given and there is already checkpoint with the same unique_id, it will be overwritten.
         async_save(bool): Async save the state_dict, default is False.
 
-        Note: If there is already checkpoint in
     Examples:
         .. code-block:: python
 

--- a/test/tensorrt/test_converter_model_dummy.py
+++ b/test/tensorrt/test_converter_model_dummy.py
@@ -45,7 +45,8 @@ class TestConverterDummy(unittest.TestCase):
         # Create a TensorRTConfig with inputs as a required field.
         trt_config = TensorRTConfig(inputs=[input_config])
         trt_config.precision_mode = PrecisionMode.FP16
-        trt_config.tensorrt_ops_run_float = "pd_op.add"
+        trt_config.ops_run_float = "pd_op.add"
+        trt_config.optimization_level = 5
 
         output_var = program.list_vars()[-1]
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
card-71500
支持pd_op.logical_not converter
从TensorRT8.6开始，构建引擎的优化级别可以由用户使用新的API来确定[setBuilderOptimizationLevel](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder_config.html#af51d2c96a3dcc98c345141ff93562e42)。
新增优化级别 optimization_level，默认优化级别为3，此接口接受[0,5]范围内的优化级别，高优化级别允许优化器寻更多时间找寻优化机会，但是可能会产生bug