### PR TITLE
[Warning] Refine `to_tensor` warning

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -64,6 +64,8 @@ if TYPE_CHECKING:
 
 __all__ = []
 
+_has_warned = False
+
 
 def _complex_to_real_dtype(dtype: DTypeLike) -> DTypeLike:
     if dtype == core.VarDesc.VarType.COMPLEX64:
@@ -941,10 +943,14 @@ def to_tensor(
                 )
             return core.tensor_from_cuda_array_interface(data)
         if is_tensor:
-            warnings.warn(
-                "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach(), "
-                "rather than paddle.to_tensor(sourceTensor)."
-            )
+            global _has_warned
+            if not _has_warned:
+                warnings.warn(
+                    "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach(), "
+                    "rather than paddle.to_tensor(sourceTensor).",
+                    stacklevel=2,
+                )
+                _has_warned = True
         return _to_tensor_non_static(data, dtype, place, stop_gradient)
 
     # call assign for static graph

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
 
 __all__ = []
 
-_has_warned = False
+_warned_in_to_tensor = False
 
 
 def _complex_to_real_dtype(dtype: DTypeLike) -> DTypeLike:
@@ -943,14 +943,14 @@ def to_tensor(
                 )
             return core.tensor_from_cuda_array_interface(data)
         if is_tensor:
-            global _has_warned
-            if not _has_warned:
+            global _warned_in_to_tensor
+            if not _warned_in_to_tensor:
                 warnings.warn(
                     "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach(), "
                     "rather than paddle.to_tensor(sourceTensor).",
                     stacklevel=2,
                 )
-                _has_warned = True
+                _warned_in_to_tensor = True
         return _to_tensor_non_static(data, dtype, place, stop_gradient)
 
     # call assign for static graph

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -1300,15 +1300,7 @@ class TestEagerTensor(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 x = paddle.to_tensor([1, 2, 3])
                 paddle.to_tensor(x)
-                flag = False
-                for warn in w:
-                    if (
-                        issubclass(warn.category, UserWarning)
-                    ) and "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach(), rather than paddle.to_tensor(sourceTensor)." in str(
-                        warn.message
-                    ):
-                        flag = True
-                        break
+                flag = paddle.tensor.creation._has_warned
                 self.assertTrue(flag)
 
     def test_dlpack_device(self):

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -1300,7 +1300,7 @@ class TestEagerTensor(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 x = paddle.to_tensor([1, 2, 3])
                 paddle.to_tensor(x)
-                flag = paddle.tensor.creation._has_warned
+                flag = paddle.tensor.creation._warned_in_to_tensor
                 self.assertTrue(flag)
 
     def test_dlpack_device(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
Pcard-75624

优化`paddle.to_tensor(tensor)`行为给出的警告，仅提示一次，并且给出第一处触发该警告的代码，避免满屏警告。

对于如下代码：
``` py
import paddle

x = paddle.zeros([2, 2])

y = paddle.to_tensor(x)
y = paddle.to_tensor(y)
```

给出警告：
``` sh
W1223 11:21:01.809945 30572 gpu_resources.cc:119] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 12.0, Runtime API Version: 11.6
W1223 11:21:01.852218 30572 gpu_resources.cc:164] device: 0, cuDNN Version: 8.4.
/workspace/test_warning.py:6: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach(), rather than paddle.to_tensor(sourceTensor).
  y = paddle.to_tensor(x)
```