### PR TITLE
add acos_double_grad in dygraph composite

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -85,6 +85,7 @@ prim_white_list = [
     "reshape_double_grad",
     "take_along_axis_double_grad",
     "index_add_double_grad",
+    "acos_double_grad",
 ]
 
 # white ops list whose kernel can automatically do type promotion.

--- a/paddle/fluid/pir/dialect/op_generator/vjp_interface_black_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/vjp_interface_black_list.py
@@ -37,4 +37,5 @@ vjp_interface_black_list = [
     'gather_nd_grad',
     'take_along_axis_grad',
     'index_add_grad',
+    'acos_grad',
 ]

--- a/paddle/fluid/prim/api/api.yaml
+++ b/paddle/fluid/prim/api/api.yaml
@@ -44,7 +44,6 @@
 - put_along_axis
 - sin
 - cos
-- acos
 - where
 - split
 - reshape

--- a/paddle/fluid/prim/api/api.yaml
+++ b/paddle/fluid/prim/api/api.yaml
@@ -44,6 +44,7 @@
 - put_along_axis
 - sin
 - cos
+- acos
 - where
 - split
 - reshape

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -95,15 +95,16 @@ void acos_double_grad(const Tensor& x,
                       const Tensor& grad_x_grad,
                       Tensor* x_grad,
                       Tensor* grad_out_grad) {
-  // acos grad grad : ddout = -((1-x*x)^(-0.5)) * ddx, dx = dy *
-  // (-x)*((1-x*x)^(-1.5)) * ddx
+  // acos grad grad : ddout = -((1-x*x)^(-0.5)) * ddx
+  // dx = dy * (-x)*((1-x*x)^(-1.5)) * ddx
+  auto x_tmp = 1 - x * x;
   if (x_grad) {
-    auto x_grad_tmp = (grad_out * (-x) * pow<T>(1 - x * x, -1.5) * grad_x_grad);
+    auto x_grad_tmp = (grad_out * (-x) * pow<T>(x_tmp, -1.5) * grad_x_grad);
     set_output<T>(x_grad_tmp, x_grad);
   }
 
   if (grad_out_grad) {
-    auto grad_out_grad_tmp = -pow<T>(1 - x * x, -0.5) * grad_x_grad;
+    auto grad_out_grad_tmp = -pow<T>(x_tmp, -0.5) * grad_x_grad;
     set_output<T>(grad_out_grad_tmp, grad_out_grad);
   }
 }

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -90,6 +90,25 @@ void cos_double_grad(const Tensor& x,
 }
 
 template <typename T>
+void acos_double_grad(const Tensor& x,
+                      const Tensor& grad_out,
+                      const Tensor& grad_x_grad,
+                      Tensor* x_grad,
+                      Tensor* grad_out_grad) {
+  // acos grad grad : ddout = -((1-x*x)^(-0.5)) * ddx, dx = dy *
+  // (-x)*((1-x*x)^(-1.5)) * ddx
+  if (x_grad) {
+    auto x_grad_tmp = (grad_out * (-x) * pow<T>(1 - x * x, -1.5) * grad_x_grad);
+    set_output<T>(x_grad_tmp, x_grad);
+  }
+
+  if (grad_out_grad) {
+    auto grad_out_grad_tmp = -pow<T>(1 - x * x, -0.5) * grad_x_grad;
+    set_output<T>(grad_out_grad_tmp, grad_out_grad);
+  }
+}
+
+template <typename T>
 void minimum_double_grad(const Tensor& x,
                          const Tensor& y,
                          const paddle::optional<Tensor>& grad_x_grad,

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -45,7 +45,7 @@
   output : Tensor(x_grad), Tensor(grad_out_grad)
   infer_meta :
     func : GeneralBinaryGradInferMeta
-    param : [x, x]
+    param : [x, grad_out]
   kernel :
     func : acos_double_grad
   inplace : (grad_x_grad -> grad_out_grad)

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -39,6 +39,18 @@
     support_trans_dtype : x
   composite : abs_triple_grad(x, grad_out_grad_grad, grad_x_grad_grad)
 
+- backward_op : acos_double_grad
+  forward : acos_grad (Tensor x, Tensor grad_out) -> Tensor(grad_x)
+  args : (Tensor x, Tensor grad_out, Tensor grad_x_grad)
+  output : Tensor(x_grad), Tensor(grad_out_grad)
+  infer_meta :
+    func : GeneralBinaryGradInferMeta
+    param : [x, x]
+  kernel :
+    func : acos_double_grad
+  inplace : (grad_x_grad -> grad_out_grad)
+  composite : acos_double_grad(x, grad_out, grad_x_grad, x_grad, grad_out_grad)
+
 - backward_op : acos_grad
   forward : acos (Tensor x) -> Tensor(out)
   args : (Tensor x, Tensor out_grad)
@@ -49,6 +61,7 @@
   kernel :
     func : acos_grad
   inplace : (out_grad -> x_grad)
+  backward : acos_double_grad
 
 - backward_op : acosh_grad
   forward : acosh (Tensor x) -> Tensor(out)

--- a/test/prim/prim/vjp/eager/test_comp_eager_acos_double_grad.py
+++ b/test/prim/prim/vjp/eager/test_comp_eager_acos_double_grad.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import parameterized as param
+
+import paddle
+from paddle.base import core
+
+
+@param.parameterized_class(
+    ('primal', 'cotangent', 'dtype'),
+    [
+        (np.random.rand(10, 10), np.random.rand(10, 10), np.float32),
+    ],
+)
+class TestAcosDoubleGradComp(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.primal = cls.primal.astype(cls.dtype)
+        if cls.cotangent is not None:
+            cls.cotangent = cls.cotangent.astype(cls.dtype)
+
+    def test_acos_double_grad_comp_dygraph(self):
+        paddle.disable_static()
+        core.set_prim_eager_enabled(True)
+
+        x = paddle.to_tensor(self.primal, dtype='float32', stop_gradient=False)
+        x.stop_gradient = False
+        y = paddle.acos(x)
+        dx = paddle.grad(y, x, create_graph=True, retain_graph=True)[0]
+        ddx = paddle.grad(dx, x, create_graph=True, retain_graph=True)[0]
+        core.set_prim_eager_enabled(False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/prim/prim/vjp/eager/test_comp_eager_acos_double_grad.py
+++ b/test/prim/prim/vjp/eager/test_comp_eager_acos_double_grad.py
@@ -24,7 +24,11 @@ from paddle.base import core
 @param.parameterized_class(
     ('primal', 'cotangent', 'dtype'),
     [
-        (np.random.rand(10, 10), np.random.rand(10, 10), np.float32),
+        (
+            np.random.rand(-0.95, 0.95, size=(10, 10)),
+            np.random.rand(10, 10),
+            np.float32,
+        ),
     ],
 )
 class TestAcosDoubleGradComp(unittest.TestCase):

--- a/test/prim/prim/vjp/eager/test_comp_eager_acos_double_grad.py
+++ b/test/prim/prim/vjp/eager/test_comp_eager_acos_double_grad.py
@@ -25,7 +25,7 @@ from paddle.base import core
     ('primal', 'cotangent', 'dtype'),
     [
         (
-            np.random.rand(-0.95, 0.95, size=(10, 10)),
+            np.random.uniform(-0.95, 0.95, size=(10, 10)),
             np.random.rand(10, 10),
             np.float32,
         ),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

Pcard-75624
添加acos的动态图二阶反向组合

精度对齐时，参考[acos测试代码](https://github.com/PaddlePaddle/Paddle/blob/9576811524a47d09a28a051771476b66eef1c955/python/paddle/fluid/tests/unittests/test_activation_op.py#L1222)，使用[-0.95, 0.95]范围内数据作为输入。

与torch对齐验证代码：
```
import paddle
import numpy as np
import torch

np.random.seed(42)

x_np = np.random.uniform(-0.95, 0.95, size=(100, 10000)).astype("float32")
dout_np = np.random.rand(*x_np.shape).astype("float32")
dout_np2 = np.random.rand(*x_np.shape).astype("float32")


# paddle
x = paddle.to_tensor(x_np)
x.stop_gradient = False

dout_pd = paddle.to_tensor(dout_np)
dout_pd.stop_gradient = False

dout_pd2 = paddle.to_tensor(dout_np2)
dout_pd2.stop_gradient = False

y_pd = paddle.acos(x)

y_grad_pd = paddle.grad(y_pd, x, dout_pd, create_graph=True, retain_graph=True)[0]
y_grad_grad_pd = paddle.grad(y_grad_pd, x, dout_pd2, create_graph=True, retain_graph=True)[0]


# torch
x = torch.tensor(x_np, requires_grad=True)
y_pt = torch.acos(x)

dout_pt = torch.as_tensor(dout_np)
dout_pt.requires_grad = True

dout_pt2 = torch.as_tensor(dout_np2)
dout_pt2.requires_grad = True

y_grad_pt = torch.autograd.grad(y_pt, x, dout_pt, create_graph=True, retain_graph=True)[0]
y_grad_grad_pt = torch.autograd.grad(y_grad_pt, x, dout_pt2, create_graph=True, retain_graph=True)[0]


np.testing.assert_allclose(y_grad_pd.numpy(), y_grad_pt.detach().numpy(), rtol=1e-6)
print('1st order grad check passed')
np.testing.assert_allclose(y_grad_grad_pd.numpy(), y_grad_grad_pt.detach().numpy(), rtol=1e-6)
print('2nd order grad check passed')

```
