### PR TITLE
[CINN / Fusion] Fix too long log string truncated when used once VLOG

### DIFF
--- a/paddle/cinn/operator_fusion/pattern_graph.cc
+++ b/paddle/cinn/operator_fusion/pattern_graph.cc
@@ -23,52 +23,61 @@
 namespace cinn::fusion {
 
 std::vector<PatternNodePtr> PatternGraph::ClusterOps() {
-  VLOG(4) << "[Group Cluster] Initial Condition: " << GraphInfo();
+  VLOG(4) << "[Group Cluster] Initial Condition: ";
+  PrintGraphInfo();
 
   VLOG(4) << "[Group Cluster] Start SinkTrivialPattern";
   SinkTrivialPattern();
-  VLOG(4) << "[Group Cluster] After SinkTrivialPattern: " << GraphInfo();
+  VLOG(4) << "[Group Cluster] After SinkTrivialPattern: ";
+  PrintGraphInfo();
 
   // ReducePattern -> ReduceTreePattern
   VLOG(4) << "[Group Cluster] Start ReduceLiftReduceTree";
   ReduceLiftReduceTree();
-  VLOG(4) << "[Group Cluster] After ReduceLiftReduceTree: " << GraphInfo();
+  VLOG(4) << "[Group Cluster] After ReduceLiftReduceTree: ";
+  PrintGraphInfo();
 
   // ReduceTreePattern + ReduceTreePattern fusion
   VLOG(4) << "[Group Cluster] Start ReduceTreeGrown";
   ReduceTreeGrown();
-  VLOG(4) << "[Group Cluster] After ReduceTreeGrown: " << GraphInfo();
+  VLOG(4) << "[Group Cluster] After ReduceTreeGrown: ";
+  PrintGraphInfo();
 
   // ReduceTreePattern + TrivialPattern fusion.
   VLOG(4) << "[Group Cluster] Start ReduceTree_Trivial_Fusion";
   ReduceTree_Trivial_Fusion();
-  VLOG(4) << "[Group Cluster] After ReduceTree_Trivial_Fusion: " << GraphInfo();
+  VLOG(4) << "[Group Cluster] After ReduceTree_Trivial_Fusion: ";
+  PrintGraphInfo();
 
   // All -> ItersPermutationPattern
   VLOG(4) << "[Group Cluster] Start LiftToItersPermutationPattern";
   LiftToItersPermutationPattern();
-  VLOG(4) << "[Group Cluster] After LiftToItersPermutationPattern: "
-          << GraphInfo();
+  VLOG(4) << "[Group Cluster] After LiftToItersPermutationPattern: ";
+  PrintGraphInfo();
 
   // ItersPermutationPattern x ItersPermutationPattern Fusion
   VLOG(4) << "[Group Cluster] Start IdentityAnchorFusion";
   LimitedAnchorFusion();
-  VLOG(4) << "[Group Cluster] After IdentityAnchorFusion: " << GraphInfo();
+  VLOG(4) << "[Group Cluster] After IdentityAnchorFusion: ";
+  PrintGraphInfo();
 
   // Sink single trivial op pattern
   VLOG(4) << "[Group Cluster] Start SplitRecomputePattern";
   SplitRecomputePattern();
-  VLOG(4) << "[Group Cluster] After SplitRecomputePattern: " << GraphInfo();
+  VLOG(4) << "[Group Cluster] After SplitRecomputePattern: ";
+  PrintGraphInfo();
 
   // ItersPermutationPattern x ItersPermutationPattern Fusion
   VLOG(4) << "[Group Cluster] Start ItersPermutationFusion";
   ItersPermutationFusion();
-  VLOG(4) << "[Group Cluster] After ItersPermutationFusion: " << GraphInfo();
+  VLOG(4) << "[Group Cluster] After ItersPermutationFusion: ";
+  PrintGraphInfo();
 
   // Horizontal fusion.
   VLOG(4) << "[Group Cluster] Start HorizontalFusion";
   HorizontalFusion();
-  VLOG(4) << "[Group Cluster] After HorizontalFusion: " << GraphInfo();
+  VLOG(4) << "[Group Cluster] After HorizontalFusion: ";
+  PrintGraphInfo();
 
   return ReturnFusionResults();
 }
@@ -324,19 +333,16 @@ void PatternGraph::AppendNode(const PatternNodePtr& node) {
   all_pattern_nodes_.emplace(node);
 }
 
-std::string PatternGraph::GraphInfo() const {
-  std::stringstream ss;
-  ss << "\n========= GraphInfo ===========";
+void PatternGraph::PrintGraphInfo() const {
+  VLOG(4) << "========= GraphInfo ===========";
   for (const auto& v : all_pattern_nodes_) {
+    std::stringstream ss;
     ss << "\n##############################";
     ss << "\n" << v->DebugStr();
-    ss << "    IsOutput: " << IsOutputNodeMatcher()(*this, v);
-    ss << "\n    Loop Framework is: "
-       << GetLoopFramework(v->stmt_pattern()).loop;
-    ss << std::endl;
+    ss << "\n    IsOutput: " << IsOutputNodeMatcher()(*this, v);
+    VLOG(4) << ss.str();
   }
-  ss << "\n===============================";
-  return ss.str();
+  VLOG(4) << "===============================";
 }
 
 PatternNodePtr PatternGraph::MergeNode(const PatternNodePtr& upstream,

--- a/paddle/cinn/operator_fusion/pattern_graph.h
+++ b/paddle/cinn/operator_fusion/pattern_graph.h
@@ -43,7 +43,7 @@ class PatternGraph {
 
   void RemoveNode(const PatternNodePtr& node);
   void AppendNode(const PatternNodePtr& node);
-  std::string GraphInfo() const;
+  void PrintGraphInfo() const;
   PatternNodePtr MergeNode(const PatternNodePtr& upstream,
                            const PatternNodePtr& downstream,
                            MergePatternFn merge_pattern_fn);

--- a/paddle/cinn/operator_fusion/pattern_node.h
+++ b/paddle/cinn/operator_fusion/pattern_node.h
@@ -62,6 +62,7 @@ struct PatternNode {
     ss << "\n" << fusion_iters_.DebugStr();
     ss << "\nOps in pattern:" << std::endl;
     ss << OpsDebugStr(GetOpsInPattern(this->stmt_pattern()));
+    ss << "Loop Framework is: " << GetLoopFramework(this->stmt_pattern()).loop;
     return ss.str();
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- 修复 Fusion 代码中一次 VLOG 调用打印的 string 太长导致 log 被截断的问题，这个问题可能是因为 VLOG 有一次 log 内容大小的限制，本次 PR 通过多次调用 VLOG 解决