### PR TITLE
fix bug of fused_bias_act fp8

### DIFF
--- a/paddle/phi/kernels/funcs/load_store_util.h
+++ b/paddle/phi/kernels/funcs/load_store_util.h
@@ -44,6 +44,18 @@ __forceinline__ __device__ OutType QuantHelperFunc(const InType input,
       ClipFunc<float>(quant_value, min_bound, max_bound));
 }
 
+template <typename InType>
+__forceinline__ __device__ phi::dtype::float8_e4m3fn QuantHelperFunc(
+    const InType input,
+    const float scale,
+    const int round_type,
+    const float max_bound,
+    const float min_bound) {
+  float quant_value = max_bound * scale * input;
+  return static_cast<phi::dtype::float8_e4m3fn>(
+      ClipFunc<float>(quant_value, min_bound, max_bound));
+}
+
 template <typename T>
 struct Load {
   explicit Load(const T *src) : src_(src) {}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
Pcard-71500

修复fp8计算时候做了round的bug
