### PR TITLE
[XPU] fix link issue of xpti

### DIFF
--- a/paddle/phi/backends/CMakeLists.txt
+++ b/paddle/phi/backends/CMakeLists.txt
@@ -28,7 +28,6 @@ if(WITH_XPU)
     xpu/xpu2_op_list.cc
     xpu/xpu3_op_list.cc
     xpu/xpu_l3_strategy.cc)
-  list(APPEND BACKENDS_DEPS phi_dynload_xpti)
 endif()
 
 if(WITH_ONEDNN)

--- a/paddle/phi/backends/dynload/CMakeLists.txt
+++ b/paddle/phi/backends/dynload/CMakeLists.txt
@@ -76,10 +76,7 @@ if(WITH_MKLML)
 endif()
 
 if(WITH_XPU)
-  cc_library(
-    phi_dynload_xpti
-    SRCS xpti.cc
-    DEPS phi common)
+  collect_srcs(backends_srcs SRCS xpti.cc)
 endif()
 
 if(WITH_FLASHATTN)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
the phi/backend/dynload previsously  use `cc_library` to manage deps, but  change to use `collect_srcs` to add source files that need to compile. The pr adapt the change to xpti
