### PR TITLE
[CINN] Remove split_transform for Reduce

### DIFF
--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
@@ -129,8 +129,6 @@ DownStreamOp TrivalxOther_Fusion(TrivialOp upstream, DownStreamOp downstream) {
   return DownStreamOp(modified_body);
 }
 
-std::pair<TrivialOp, ReduceOp> SplitReduceOp(const ReduceOp& reduce_op);
-
 std::vector<FusibleOp> TransformReduceLoopRange(
     const ReduceOp& upstream,
     FusibleOp* downstream,

--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
@@ -317,15 +317,6 @@ ExprSetFinder ScheduleBlockRealizeIsInit = FilterMaker(
     },
     "ScheduleBlockRealizeIsInit");
 
-ExprSetFinder ScheduleBlockRealizeIsSplitTransform = FilterMaker(
-    [](const ir::Expr& e) -> bool {
-      return (e.As<ir::ScheduleBlockRealize>() &&
-              e.As<ir::ScheduleBlockRealize>()
-                      ->schedule_block.As<ir::ScheduleBlock>()
-                      ->name.find("_split_transform") != std::string::npos);
-    },
-    "ScheduleBlockRealizeIsSplitTransform");
-
 ExprSetFinder IsFor = FilterMaker(
     [](const ir::Expr& e) -> bool { return e.As<ir::For>(); }, "IsFor");
 

--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.h
@@ -169,8 +169,6 @@ extern ExprSetFinder ScheduleBlockRealizeIsNotInit;
 
 extern ExprSetFinder ScheduleBlockRealizeIsInit;
 
-extern ExprSetFinder ScheduleBlockRealizeIsSplitTransform;
-
 extern ExprSetFinder IsFor;
 
 extern ExprSetFinder ChildScheduleBlocks;

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -24,7 +24,7 @@ using TileConfigMap =
 
 namespace {
 
-const int kMaxNumel = INT32_MAX;
+const int kMaxNumel = BucketInfo::kMaxNumel;
 
 int64_t CeilPow2(int64_t n) {
   int64_t pow = 1;

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.h
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.h
@@ -56,6 +56,8 @@ struct ScheduleConfig {
 };
 
 struct BucketInfo {
+  static constexpr int kMaxNumel = INT32_MAX;
+
   struct Dimension {
     int lower_bound;
     int upper_bound;

--- a/paddle/cinn/ir/group_schedule/dy_shape_group_scheduler.h
+++ b/paddle/cinn/ir/group_schedule/dy_shape_group_scheduler.h
@@ -58,7 +58,8 @@ class DynamicShapeGroupScheduler : public GroupScheduler {
   ir::ScheduleBlockNode* FindGlobalMasterNode(
       const std::unique_ptr<ir::ScheduleBlockGraph>& schedule_block_graph);
 
-  IterativeSpaceInfo ConstructIterSpaceInfo(ScheduleBlockNode* node);
+  SymbolicPredicate MakeBucketPredicate(const BucketInfo& bucket_info,
+                                        ScheduleBlockNode* node);
 
  private:
   std::vector<BucketContext> bucket_contexts_;

--- a/paddle/cinn/ir/group_schedule/tactic/schedule_tactic.h
+++ b/paddle/cinn/ir/group_schedule/tactic/schedule_tactic.h
@@ -81,9 +81,9 @@ struct IterativeSpaceInfo {
 };
 
 struct ScheduleContext {
-  // TODO(BiynXu): Unify fields with similar meanings
   std::unordered_set<std::string> output_names;
   Target target;
+  // TODO(liangshuhao): this struct is deprecated and will be removed later.
   IterativeSpaceInfo iter_space_info;
   BucketInfo bucket_info;
   ScheduleConfig config;

--- a/paddle/cinn/operator_fusion/fusion_tracker/expr_utils.h
+++ b/paddle/cinn/operator_fusion/fusion_tracker/expr_utils.h
@@ -30,16 +30,6 @@ struct FusibleOp2Expr {
   }
 };
 
-struct GetSplitedExprFromFusionOp {
-  std::vector<ir::Expr> operator()(const TrivialOp& op) {
-    return {op.GetFuncBody()};
-  }
-  std::vector<ir::Expr> operator()(const ReduceOp& op) {
-    const auto& t_r = SplitReduceOp(op);
-    return {t_r.first.GetFuncBody(), t_r.second.GetFuncBody()};
-  }
-};
-
 struct ApplyItersTransform {
   explicit ApplyItersTransform(const ir::Expr& expr,
                                const ir::Expr& aligned_expr)

--- a/paddle/cinn/operator_fusion/fusion_tracker/interpreter.cc
+++ b/paddle/cinn/operator_fusion/fusion_tracker/interpreter.cc
@@ -186,7 +186,7 @@ void RunReturnInstr(const std::shared_ptr<ReturnInstr>& instr,
                     FusionInterpreter* interpreter) {
   using namespace cinn::hlir::framework::pir::trivial_fusion_detail;  // NOLINT
   for (auto fusion_op : interpreter->scope[instr->target_]->fusion_ops) {
-    auto exprs = std::visit(GetSplitedExprFromFusionOp(), fusion_op);
+    auto exprs = std::visit(FusibleOp2Expr(), fusion_op);
     // Insert if for append loops
     for (const auto& expr : exprs) {
       // interpreter->ret_expr.push_back(expr);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Deprecations


### Description
本PR移除了Reduce的`split_transform`，包括融合时不再切出split_transform，和修改了2处依赖于split_transform的代码

#### 安全性说明
split_transform原本只在ComputeInlineTactic之前存在，不会影响到后处理阶段；经过梳理发现ComputeInlineTactic之前的阶段仅有2处依赖split_transform：
1. `GetLoopStrides`原本以split_transform为输入，这不是必须的，我将其改为以Reduce本身为输入，顺便把整个函数挪到了另一个更恰当的文件里
2. `DynamicShapeGroupScheduler`原本从split_transform中提取维度大小来计算bucket的predicate，这样做是把问题复杂化了，因为实际上FusionGroupInfo中已经有现成的信息了，因此我将其简化为使用FusionGroupInfo来计算

综上，经过修改后，移除split_transform是安全的

#### 关于存量AutoSimplify
迁移的代码里面有4处存量的AutoSimplify，都是跟shape有关，我试着改成as_index().Normalize()，发现无法处理动态shape的一些op，因此保留了AutoSimplify

<br>
Pcard-85711