### PR TITLE
fix cinn jit instruction check bug (#70418)

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -180,6 +180,9 @@ class CinnJitInstruction::FnPtrImpl {
     for (int i = 0; i < output_tensor_size; ++i) {
       DDim dim(output_tensor_shapes[i],
                kernel_tensor_args[input_tensor_size + i]->dims().size());
+      if (static_cast<size_t>(i) < ir_dim.size()) {
+        CheckDims(ir_dim[i], dim);
+      }
       kernel_tensor_args[input_tensor_size + i]->Resize(dim);
       free(output_tensor_shapes[i]);
     }


### PR DESCRIPTION
### PR Category
CINN

### PR Types
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-76996

cherry-pick #70418
修复cinn jit instruction 中shape的检查，对于temp_space_sizes，由于未初始化，跳过检查
