### PR TITLE
Remove storage when recompute using saved_tensor_hooks

### DIFF
--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -448,9 +448,7 @@ def _recompute_without_reentrant(
                 "Not supported to retrieve a tensor saved by autograd multiple times that is no need to recompute."
             )
 
-        ret = storage[x]
-        del storage[x]
-        return ret
+        return storage.pop(x)
 
     with paddle.autograd.saved_tensors_hooks(pack, unpack):
         outputs = function(*args, **kwargs)

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -430,7 +430,7 @@ def _recompute_without_reentrant(
                             with paddle.autograd.saved_tensors_hooks(
                                 inner_pack, inner_unpack
                             ):
-                                unused_outputs = function(*args, **kwargs)
+                                function(*args, **kwargs)
             else:
                 with paddle.set_grad_enabled(True), paddle.amp.auto_cast(
                     enable=is_fw_autocast,
@@ -441,14 +441,16 @@ def _recompute_without_reentrant(
                 ), paddle.autograd.saved_tensors_hooks(
                     inner_pack, inner_unpack
                 ):
-                    unused_outputs = function(*args, **kwargs)
+                    function(*args, **kwargs)
 
         if x not in storage:
             raise Exception(
                 "Not supported to retrieve a tensor saved by autograd multiple times that is no need to recompute."
             )
 
-        return storage[x]
+        ret = storage[x]
+        del storage[x]
+        return ret
 
     with paddle.autograd.saved_tensors_hooks(pack, unpack):
         outputs = function(*args, **kwargs)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Performance Optimization

### PR Types
Performance

### Description
After https://github.com/PaddlePaddle/Paddle/pull/69585 fixed https://github.com/PaddlePaddle/Paddle/issues/69392, the `storage[x]` in recompute using `saved_tensor_hooks` would not be released, which causes OOM errors in many models. This PR fixes this bug.

Pcard-67164