### PR TITLE
【CINN】Change int64 to int32 in IndexExpr simplify

### DIFF
--- a/paddle/cinn/ir/ir_base.h
+++ b/paddle/cinn/ir/ir_base.h
@@ -497,7 +497,8 @@ struct IndexExpr : public IrNodeRef {
   explicit IndexExpr(int32_t x) : IrNodeRef(new IntImm(Int(32), x)) {}
   explicit IndexExpr(int64_t x) : IrNodeRef(new IntImm(Int(64), x)) {}
 
-  explicit IndexExpr(Type t, int64_t x) : IrNodeRef(new IntImm(t, x)) {}
+  explicit IndexExpr(Type t, int64_t x)
+      : IrNodeRef(new IntImm(x > INT32_MAX ? Int(64) : t, x)) {}
 
   bool is_var() const;
   _Var_* as_var();

--- a/paddle/cinn/ir/ir_base.h
+++ b/paddle/cinn/ir/ir_base.h
@@ -497,6 +497,8 @@ struct IndexExpr : public IrNodeRef {
   explicit IndexExpr(int32_t x) : IrNodeRef(new IntImm(Int(32), x)) {}
   explicit IndexExpr(int64_t x) : IrNodeRef(new IntImm(Int(64), x)) {}
 
+  explicit IndexExpr(Type t, int64_t x) : IrNodeRef(new IntImm(t, x)) {}
+
   bool is_var() const;
   _Var_* as_var();
   const _Var_* as_var() const;

--- a/paddle/cinn/ir/op/ir_operators.cc
+++ b/paddle/cinn/ir/op/ir_operators.cc
@@ -377,14 +377,16 @@ static IndexExpr SimplifyAdd(const IndexExpr &lhs, const IndexExpr &rhs) {
   auto lhsAdd = lhs.As<Add>();
   if (lhsAdd && rhsConst) {
     if (auto lrhs = lhsAdd->b().as_index().As<IntImm>()) {
-      return lhsAdd->a().as_index() + (lrhs->value + rhsConst->value);
+      return lhsAdd->a().as_index() +
+             IndexExpr(lrhs->type(), lrhs->value + rhsConst->value);
     }
   }
 
   // (d0 + 2) + d1 ===> d0 + d1 + 2.
   if (lhsAdd) {
     if (auto lrhs = lhsAdd->b().as_index().As<IntImm>()) {
-      return lhsAdd->a().as_index() + rhs + lrhs->value;
+      return lhsAdd->a().as_index() + rhs +
+             IndexExpr(lrhs->type(), lrhs->value);
     }
   }
   // expr * c1 + expr * c2 ===> expr * (c1 + c2)
@@ -409,12 +411,14 @@ static IndexExpr SimplifyAdd(const IndexExpr &lhs, const IndexExpr &rhs) {
   }
 
   if (first == second) {
-    return first * (lconst + rconst);
+    return first * IndexExpr(lhs->type(), lconst + rconst);
   }
 
   if (lconst != 1 && rconst != 1) {
-    if (lconst == rconst) return (first + second) * lconst;
-    if (lconst == -rconst) return (first - second) * lconst;
+    if (lconst == rconst)
+      return (first + second) * IndexExpr(lhs->type(), lconst);
+    if (lconst == -rconst)
+      return (first - second) * IndexExpr(lhs->type(), lconst);
   }
 
   // deal corner case!
@@ -460,7 +464,8 @@ static IndexExpr SimplifyMul(const IndexExpr &lhs, const IndexExpr &rhs) {
   auto lhsMul = lhs.As<Mul>();
   if (lhsMul && rhsConst) {
     if (auto lrhs = lhsMul->b().as_index().As<IntImm>()) {
-      return lhsMul->a().as_index() * (lrhs->value * rhsConst->value);
+      return lhsMul->a().as_index() *
+             IndexExpr(lrhs->type(), lrhs->value * rhsConst->value);
     }
   }
 
@@ -468,14 +473,16 @@ static IndexExpr SimplifyMul(const IndexExpr &lhs, const IndexExpr &rhs) {
   auto lhsAdd = lhs.As<Add>();
   if (lhsAdd && rhsConst) {
     if (auto lrhs = lhsAdd->b().as_index().As<IntImm>()) {
-      return lhsAdd->a().as_index() * rhs + (lrhs->value * rhsConst->value);
+      return lhsAdd->a().as_index() * rhs +
+             IndexExpr(lrhs->type(), lrhs->value * rhsConst->value);
     }
   }
 
   // (d0 * 2) * d1 ===> d0 * d1 * 2.
   if (lhsMul) {
     if (auto lrhs = lhsMul->b().as_index().As<IntImm>()) {
-      return lhsMul->a().as_index() * rhs * lrhs->value;
+      return lhsMul->a().as_index() * rhs *
+             IndexExpr(lrhs->type(), lrhs->value);
     }
   }
 
@@ -513,8 +520,7 @@ static IndexExpr SimplifyDiv(const IndexExpr &lhs, const IndexExpr &rhs) {
       int64_t lrhsFactor = lhsAdd->b().as_index().GetLargestMultiplyPart();
       if (llhsFactor % rhsConst->value == 0 &&
           lrhsFactor % rhsConst->value == 0) {
-        return lhsAdd->a().as_index() / rhsConst->value +
-               lhsAdd->b().as_index() / rhsConst->value;
+        return lhsAdd->a().as_index() / rhs + lhsAdd->b().as_index() / rhs;
       }
     }
 
@@ -522,7 +528,8 @@ static IndexExpr SimplifyDiv(const IndexExpr &lhs, const IndexExpr &rhs) {
     if (lhsMul) {
       if (auto lrhs = lhsMul->b().as_index().As<IntImm>()) {
         if (lrhs->value % rhsConst->value == 0) {
-          return lhsMul->a().as_index() * (lrhs->value / rhsConst->value);
+          return lhsMul->a().as_index() *
+                 IndexExpr(lrhs->type(), lrhs->value / rhsConst->value);
         }
       }
     }
@@ -530,7 +537,8 @@ static IndexExpr SimplifyDiv(const IndexExpr &lhs, const IndexExpr &rhs) {
     // S0 / 2 / 5 ===> S0 / 10.
     if (lhsDiv) {
       if (auto lrhs = lhsDiv->b().as_index().As<IntImm>()) {
-        return lhsDiv->a().as_index() / (lrhs->value * rhsConst->value);
+        return lhsDiv->a().as_index() /
+               IndexExpr(lrhs->type(), lrhs->value * rhsConst->value);
       }
     }
   } else {
@@ -568,9 +576,9 @@ static IndexExpr SimplifyMod(const IndexExpr &lhs, const IndexExpr &rhs) {
       int64_t llhsFactor = lhsAdd->a().as_index().GetLargestMultiplyPart();
       int64_t lrhsFactor = lhsAdd->b().as_index().GetLargestMultiplyPart();
       if (llhsFactor % rhsConst->value == 0)
-        return lhsAdd->b().as_index() % rhsConst->value;
+        return lhsAdd->b().as_index() % rhs;
       if (lrhsFactor % rhsConst->value == 0)
-        return lhsAdd->a().as_index() % rhsConst->value;
+        return lhsAdd->a().as_index() % rhs;
     }
 
     // expr1 * (c1 * c2) % c1 ===> 0.
@@ -581,7 +589,7 @@ static IndexExpr SimplifyMod(const IndexExpr &lhs, const IndexExpr &rhs) {
     if (lhsMod) {
       int64_t llhsFactor = lhsMod->b().as_index().GetLargestMultiplyPart();
       if (llhsFactor % rhsConst->value == 0)
-        return lhsMod->a().as_index() % rhsConst->value;
+        return lhsMod->a().as_index() % rhs;
     }
   } else {
     // dynamic branch!


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Because `intimm->value` is always of type int64 rather than intimm's type, avoid using `intimm->value` and `Expr` directly.
Pcard-67164