### PR TITLE
[AutoParallel]:fix dataloader error in sft

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -344,15 +344,15 @@ class Engine:
 
         if isinstance(data, dict):
             data = tuple(data.values())
-            if len(data) != 2:
+            if len(data) > 3:
                 raise ValueError(
-                    f"Data should be a dict with two keys, but received {len(data)}."
+                    f"Data can contain up to three keys : inputs,labels,attention_mask and at least contain inputs and labels , but received {len(data)}."
                 )
             inputs, labels = data
         elif isinstance(data, (list, tuple)):
-            if len(data) != 2:
+            if len(data) > 3:
                 raise ValueError(
-                    f"Data should be a list or tuple with two elements, but received {len(data)}."
+                    f"Data can contain up to three keys : inputs,labels,attention_mask and at least contain inputs and labels, but received {len(data)}."
                 )
             inputs, labels = data
         else:

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -343,18 +343,24 @@ class Engine:
             batch_sampler.set_epoch(0)
 
         if isinstance(data, dict):
-            data = tuple(data.values())
-            if len(data) > 3:
+            data = list(data.values())
+            if len(data) == 2:
+                inputs, labels = data
+            elif len(data) == 3:
+                inputs, labels, _ = data
+            else:
                 raise ValueError(
                     f"Data can contain up to three keys : inputs,labels,attention_mask and at least contain inputs and labels , but received {len(data)}."
                 )
-            inputs, labels = data
         elif isinstance(data, (list, tuple)):
-            if len(data) > 3:
+            if len(data) == 2:
+                inputs, labels = data
+            elif len(data) == 3:
+                inputs, labels, _ = data
+            else:
                 raise ValueError(
-                    f"Data can contain up to three keys : inputs,labels,attention_mask and at least contain inputs and labels, but received {len(data)}."
+                    f"Data can contain up to three keys : inputs,labels,attention_mask and at least contain inputs and labels , but received {len(data)}."
                 )
-            inputs, labels = data
         else:
             raise TypeError(
                 f"Data should be a dict or list, but received {type(data)}."


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
sft中dataloader可能返回三元组：inputs，labels，attention_mask。
Pcard-67164