### PR TITLE
【Comm】Fix broadcast comm_ctx in old_program

### DIFF
--- a/paddle/fluid/framework/new_executor/program_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/program_interpreter.cc
@@ -1032,15 +1032,17 @@ void ProgramInterpreter::RunOperator(const Instruction& instr_node) {
                   static_cast<paddle::distributed::ProcessGroupNCCL*>(pg)
                       ->GetOrCreateCommContext(place);
             }
-            if (comm_context) {
-              dev_ctx =
-                  static_cast<phi::distributed::NCCLCommContext*>(comm_context)
-                      ->GetDevContext();
-              dev_ctx->SetCommContext(comm_context);
-            } else {
-              VLOG(3) << "ring_id " << ring_id
-                      << " not found in ProcessGroupMapFromGid ";
-            }
+            PADDLE_ENFORCE_NE(
+                comm_context,
+                nullptr,
+                errors::Unavailable(
+                    "NCCLCommContext is nullptr. For op with ring_id attr, "
+                    "comm_context should be set in dev_ctx, but it cannot be "
+                    "get from CommContextManager or ProcessGroup."));
+            dev_ctx =
+                static_cast<phi::distributed::NCCLCommContext*>(comm_context)
+                    ->GetDevContext();
+            dev_ctx->SetCommContext(comm_context);
           }
 #endif
           phi::KernelContext phi_kernel_context;

--- a/paddle/fluid/framework/new_executor/program_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/program_interpreter.cc
@@ -1016,15 +1016,23 @@ void ProgramInterpreter::RunOperator(const Instruction& instr_node) {
               const_cast<phi::DeviceContext*>(&instr_node.DeviceContext());
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
           auto attrs = op->Attrs();
-          if (attrs.find("ring_id") != attrs.end()) {
+          if (!dev_ctx->GetCommContext() &&
+              attrs.find("ring_id") != attrs.end()) {
             auto ring_id_attr = attrs.at("ring_id");
             int ring_id = PADDLE_GET(int, ring_id_attr);
             auto map = distributed::ProcessGroupMapFromGid::getInstance();
-            if (map->has(ring_id)) {
+            const auto& comm_context_manager =
+                phi::distributed::CommContextManager::GetInstance();
+            phi::distributed::CommContext* comm_context = nullptr;
+            if (comm_context_manager.Has(std::to_string(ring_id))) {
+              comm_context = comm_context_manager.Get(std::to_string(ring_id));
+            } else if (map->has(ring_id)) {
               distributed::ProcessGroup* pg = map->get(ring_id);
-              auto comm_context =
+              comm_context =
                   static_cast<paddle::distributed::ProcessGroupNCCL*>(pg)
                       ->GetOrCreateCommContext(place);
+            }
+            if (comm_context) {
               dev_ctx =
                   static_cast<phi::distributed::NCCLCommContext*>(comm_context)
                       ->GetDevContext();

--- a/paddle/fluid/framework/new_executor/program_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/program_interpreter.cc
@@ -1035,7 +1035,7 @@ void ProgramInterpreter::RunOperator(const Instruction& instr_node) {
             PADDLE_ENFORCE_NE(
                 comm_context,
                 nullptr,
-                errors::Unavailable(
+                common::errors::Unavailable(
                     "NCCLCommContext is nullptr. For op with ring_id attr, "
                     "comm_context should be set in dev_ctx, but it cannot be "
                     "get from CommContextManager or ProcessGroup."));

--- a/python/paddle/distributed/fleet/meta_optimizers/tensor_parallel_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/tensor_parallel_optimizer.py
@@ -78,9 +78,9 @@ class TensorParallelOptimizer(MetaOptimizerBase):
                 continue
 
             block.append_op(
-                type='c_broadcast',
-                inputs={'X': param},
-                outputs={'Out': param},
+                type='broadcast',
+                inputs={'x': param},
+                outputs={'out': param},
                 attrs={
                     'ring_id': ring_id,
                     'root': 0,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

1. In old program, when setting `comm_ctx` for `dev_ctx`, it needs to get `comm_ctx` from `ProcessGroupMapFromGid` or `CommContextManager`.
2. Add a check, if `comm_ctx` is set in `BuildOpFuncList`, then it will not be set again in `RunOperator`.

Pcard-70448