### PR TITLE
【BUPT】[Paddle Tensor 第二期 API 鲁棒性增强] 修改 paddle.atan2 以减少对 CINN 的影响

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -195,29 +195,24 @@ void Atan2InferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out) {
   const auto& x_dims = x.dims();
   const auto& y_dims = y.dims();
 
-  if (x_dims == y_dims) {
-    out->share_meta(x);
-    return;
-  }
+  PADDLE_ENFORCE_EQ(
+      x_dims.size(),
+      y_dims.size(),
+      common::errors::InvalidArgument("The rank (%d) of X shall be same as "
+                                      "rank (%d) of Y.",
+                                      x_dims.size(),
+                                      y_dims.size()));
 
-  const int max_ndim = std::max(x_dims.size(), y_dims.size());
-  const int axis = std::abs(static_cast<int>(x_dims.size()) -
-                            static_cast<int>(y_dims.size()));
+  if (x_dims.size() > 0)
+    PADDLE_ENFORCE_LE(x_dims[0],
+                      y_dims[0],
+                      common::errors::InvalidArgument(
+                          "The count (%d) of elements of X shall not "
+                          "greater than count (%d) of elements of Y.",
+                          x_dims[0],
+                          y_dims[0]));
 
-  std::vector<int> x_dims_array(max_ndim, 1);
-  std::vector<int> y_dims_array(max_ndim, 1);
-  std::vector<int> out_dims_array(max_ndim, 1);
-
-  funcs::GetBroadcastDimsArrays(x_dims,
-                                y_dims,
-                                x_dims_array.data(),
-                                y_dims_array.data(),
-                                out_dims_array.data(),
-                                max_ndim,
-                                axis);
-
-  out->set_dims(common::make_ddim(out_dims_array));
-  out->share_lod(x);
+  out->share_meta(x);
   if (x.dtype() == DataType::INT32 || x.dtype() == DataType::INT64 ||
       y.dtype() == DataType::INT32 || y.dtype() == DataType::INT64) {
     out->set_dtype(DataType::FLOAT64);

--- a/paddle/phi/kernels/funcs/common_shape.h
+++ b/paddle/phi/kernels/funcs/common_shape.h
@@ -69,8 +69,6 @@ inline void GetBroadcastDimsArrays(const DDim &x_dims,
   }
   for (int i = 0; i < max_dim; ++i) {
     PADDLE_ENFORCE_EQ(
-        x_dims_array[i] == y_dims_array[i] || x_dims_array[i] <= 1 ||
-            y_dims_array[i] <= 1,
         x_dims_array[i] == y_dims_array[i] ||
             (x_dims_array[i] <= 1 && x_dims_array[i] != 0) ||
             (y_dims_array[i] <= 1 && y_dims_array[i] != 0),

--- a/paddle/phi/kernels/funcs/common_shape.h
+++ b/paddle/phi/kernels/funcs/common_shape.h
@@ -71,6 +71,9 @@ inline void GetBroadcastDimsArrays(const DDim &x_dims,
     PADDLE_ENFORCE_EQ(
         x_dims_array[i] == y_dims_array[i] || x_dims_array[i] <= 1 ||
             y_dims_array[i] <= 1,
+        x_dims_array[i] == y_dims_array[i] ||
+            (x_dims_array[i] <= 1 && x_dims_array[i] != 0) ||
+            (y_dims_array[i] <= 1 && y_dims_array[i] != 0),
         true,
         common::errors::InvalidArgument(
             "Broadcast dimension mismatch. Operands could "
@@ -87,6 +90,9 @@ inline void GetBroadcastDimsArrays(const DDim &x_dims,
       out_dims_array[i] = (std::max)(x_dims_array[i], y_dims_array[i]);
     } else {
       out_dims_array[i] = -1;
+      if (y_dims_array[i] == 0 || x_dims_array[i] == 0) {
+        out_dims_array[i] = 0;
+      }
     }
   }
 }

--- a/paddle/phi/kernels/gpu/expand_kernel.cu
+++ b/paddle/phi/kernels/gpu/expand_kernel.cu
@@ -43,6 +43,7 @@ void ExpandKernel(const Context& ctx,
               "The expanded size (%d) for non-existing dimensions must be "
               "positive for expand_v2 op.",
               expand_shape[i]));
+      if (expand_shape[i] == 0) has_zero_dim = true;
       out_shape[i] = expand_shape[i];
     } else if (expand_shape[i] == -1) {
       out_shape[i] = vec_in_dims[i];

--- a/paddle/phi/kernels/xpu/expand_kernel.cc
+++ b/paddle/phi/kernels/xpu/expand_kernel.cc
@@ -41,6 +41,7 @@ void ExpandKernel(const Context& ctx,
               "The expanded size (%d) for non-existing dimensions must be "
               "positive for expand_v2 op.",
               expand_shape[i]));
+      if (expand_shape[i] == 0) has_zero_dim = true;
       final_expand_shape[i] = expand_shape[i];
     } else if (expand_shape[i] == -1) {
       final_expand_shape[i] = vec_in_dims[i];

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5734,8 +5734,17 @@ def atan2(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
 
     """
 
+    x_shape = list(x.shape)
+    y_shape = list(y.shape)
     if in_dynamic_or_pir_mode():
-        return _C_ops.atan2(x, y)
+        broadcast_x = x
+        broadcast_y = y
+        if x_shape != y_shape:
+            broadcast_shape = paddle.broadcast_shape(x_shape, y_shape)
+            broadcast_x = paddle.broadcast_to(broadcast_x, broadcast_shape)
+            broadcast_y = paddle.broadcast_to(broadcast_y, broadcast_shape)
+
+        return _C_ops.atan2(broadcast_x, broadcast_y)
     else:
         check_variable_and_dtype(
             x,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

1. 将 Atan2Kernel 和 Atan2Kernel 回滚到 https://github.com/PaddlePaddle/Paddle/pull/70253 前，仅做少量修改。广播机制在 Python 端使用 paddle.broadcast_to 和 paddle.broadcast_shape 实现，减少对 CINN 的影响
2. 修复了一个 `ExpandKernel` 的问题，现在可以正确的处理 GPU 下标量到 0-size 的广播（与 @fxy1699 一同修改），这和 `paddle.broadcast_to` 接口相关
3. 参考 https://github.com/PaddlePaddle/Paddle/pull/70369 的改动使 paddle.broadcast_shape 兼容 0-size tensor