### PR TITLE
Revert "[Auto Parallel] change lookup_table_v2 auto cast for align mode(#68231)"

### DIFF
--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -695,18 +695,6 @@ def amp_guard(
 
             # set amp op list
             original_white_list, original_black_list = tracer._get_amp_op_list()
-
-            # TODO(zhangyuqin1998): In auto parallel align mode, ensure lookup_table_v2 runs in FP32.
-            # By default, lookup_table_v2 is in the white_list, and runs in BF16/BF16.
-            # Users can add lookup_table_v2 to the amp_custom_black_list but cannot remove it from the default white_list.
-            # If lookup_table_v2 appears in both the white_list and black_list, AMP will select it in BF16/BF16.
-            # Therefore, in auto parallel align mode, add lookup_table_v2 to the black_list and ensure it is not in the white_list.
-            from paddle.distributed import in_auto_parallel_align_mode
-
-            if in_auto_parallel_align_mode():
-                _black_list.add("lookup_table_v2")
-                if "lookup_table_v2" in _white_list:
-                    _white_list.remove("lookup_table_v2")
             tracer._set_amp_op_list(_white_list, _black_list)
 
             # TODO(zhiqiu) set amp related flags automatically in this guard


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
Others


### Description
<!-- Describe what you’ve done -->
Revert PR https://github.com/PaddlePaddle/Paddle/pull/68231 ,去除自动并行对齐模式中对lookup_table_v2算子AMP逻辑的特殊hack（相关逻辑已在PaddleNLP中进行修复,不需要再hack，见 https://github.com/PaddlePaddle/PaddleNLP/pull/9340 ）。

Pcard-76459