### PR TITLE
[CINN] Fix duplicate traversal in build group ops

### DIFF
--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -262,15 +262,16 @@ bool HasSinkRoute(const SubGraphPtr& source, const SubGraphPtr& target) {
   std::unordered_set<SubGraphPtr> visited;
   std::queue<SubGraphPtr> queue;
   queue.push(source);
+  visited.insert(source);
   while (!queue.empty()) {
     SubGraphPtr cur = queue.front();
     queue.pop();
-    visited.insert(cur);
     if (cur == target) return true;
     if (cur->topo_index > target->topo_index) continue;
     for (const auto& subgraph : cur->downstreams) {
       if (visited.count(subgraph)) continue;
       queue.push(subgraph);
+      visited.insert(subgraph);
     }
   }
   return false;
@@ -281,15 +282,16 @@ bool HasLiftRoute(const SubGraphPtr& source, const SubGraphPtr& target) {
   std::unordered_set<SubGraphPtr> visited;
   std::queue<SubGraphPtr> queue;
   queue.push(source);
+  visited.insert(source);
   while (!queue.empty()) {
     SubGraphPtr cur = queue.front();
     queue.pop();
-    visited.insert(cur);
     if (cur == target) return true;
     if (source->topo_index < target->topo_index) continue;
     for (const auto& subgraph : cur->upstreams) {
       if (visited.count(subgraph)) continue;
       queue.push(subgraph);
+      visited.insert(subgraph);
     }
   }
   return false;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- Fix duplicate traversal in build group ops