### PR TITLE
【BUPT】[CodeStyle][Typos][C-[1-3],C-16,C-[67-70],C-[72-74]] Fix typos (`cahe`, `Caculate`, `caculate`, `calcualtion`, `checkings`, `Cound`, `coule`, `craete`, `craeted`, `Currenly`, `curent`, `currnt`, `Costum`)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -32,22 +32,9 @@ UE = "UE"
 unpacket = "unpacket"
 
 # These words need to be fixed
-cahe = 'cahe'
-Caculate = 'Caculate'
-caculate = 'caculate'
-calcualtion = 'calcualtion'
-checkings = 'checkings'
 childs = 'childs'
-Cound = 'Cound'
-coule = 'coule'
-craete = 'craete'
-craeted = 'craeted'
 Creater = 'Creater'
 creater = 'creater'
-Currenly = 'Currenly'
-curent = 'curent'
-currnt = 'currnt'
-Costum = 'Costum'
 dateset = 'dateset'
 dota = 'dota'
 Datas = 'Datas'

--- a/paddle/cinn/operator_fusion/policy/iters_fusion_policy.cc
+++ b/paddle/cinn/operator_fusion/policy/iters_fusion_policy.cc
@@ -160,7 +160,7 @@ ItersFusionPolicy::SearchTransformRouteFromReduce2Reduce(
   VLOG(4) << "Start search transform Route from reduce to reduce.";
   if (source.loop_iters.size() == target.loop_iters.size() &&
       source.reduce_iter_nums == target.reduce_iter_nums) {
-    // Currenly only support fusion with same iter_nums and same reduce axis
+    // Currently only support fusion with same iter_nums and same reduce axis
     // TODO(huangjiyi): Analysis fusion with different non reduce axis
     auto [source_flatten_iters, source_reduce_iters] = SplitReduceIters(source);
     auto [target_flatten_iters, target_reduce_iters] = SplitReduceIters(target);

--- a/paddle/fluid/framework/data_device_transform.cc
+++ b/paddle/fluid/framework/data_device_transform.cc
@@ -41,7 +41,7 @@ void TransDataDevice(const phi::DenseTensor &in,
   }
 
   // FIXME(zcd): TransDataDevice is used to transform data from GPU to CPU and
-  // the enforced checkings have been done in GetDeviceContext, so the
+  // the enforced checks have been done in GetDeviceContext, so the
   // `dev_ctx->Wait()` is necessary. But `dev_ctx->Wait()` will make the program
   // slow, especially when the number of elements is little, for example,
   // the elements of learning rate are one and it's CPU side.

--- a/paddle/fluid/imperative/gradient_accumulator.cc
+++ b/paddle/fluid/imperative/gradient_accumulator.cc
@@ -690,7 +690,7 @@ void EagerGradientAccumulator::SumGrad(std::shared_ptr<VariableWrapper> var,
     dst_var->SetType(framework::proto::VarType::SELECTED_ROWS);
   }
 
-  // Increase curent count
+  // Increase current count
   IncreaseCurCnt();
 }
 

--- a/paddle/fluid/operators/reduce_ops/reduce_mean_op.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_mean_op.cc
@@ -222,7 +222,7 @@ class ReduceGradOp : public framework::OperatorWithKernel {
 };
 
 // NOTE(dengkaipeng): Input(Out) is unnecessary in reduce_mean_grad
-// calcualtion, but will incur a reduce_mean_grad op after
+// calculation, but will incur a reduce_mean_grad op after
 // reduce_mean_grad_grad, delete Input(Out) here.
 // This change has no effect on reduce_mean_grad calculations.
 template <typename T>

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -3487,7 +3487,7 @@ bool SplitWithNumOpInferSymbolicShape(
       }
     }
     if (count == 1) {
-      // caculate the axis of split_with_num_op
+      // calculate the axis of split_with_num_op
       symbol::TensorListShapeOrDataDimExprs res_list_s_d(
           num, out_s_d(candidate_axis, num));
       infer_context->SetShapeOrDataForValue(

--- a/paddle/phi/api/lib/data_transform.cc
+++ b/paddle/phi/api/lib/data_transform.cc
@@ -235,7 +235,7 @@ inline phi::DenseTensor TransDataPlace(const phi::DenseTensor& tensor,
 #endif
 
   // FIXME(zcd): TransDataPlace is used to transform data from GPU to CPU and
-  // the enforced checkings have been done in GetDeviceContext, so the
+  // the enforced checks have been done in GetDeviceContext, so the
   // `dev_ctx->Wait()` is necessary. But `dev_ctx->Wait()` will make the program
   // slow, especially when the number of elements is little, for example,
   // the elements of learning rate are one and it's CPU side.

--- a/paddle/phi/kernels/fusion/gpu/block_attn.h
+++ b/paddle/phi/kernels/fusion/gpu/block_attn.h
@@ -3977,7 +3977,7 @@ void qkv_transpose_split(const phi::GPUContext &dev_ctx,
 }
 
 template <typename T, int VecSize>
-__global__ void write_pre_cahe_to_kv_buffer(
+__global__ void write_pre_cache_to_kv_buffer(
     T *k_buf,  // [bsz, num_head, seq_len + pre_cache_length, head_dim]
     T *v_buf,
     const T *pre_key_cache,  // [bsz, num_head, pre_cache_length, head_dim]
@@ -4150,7 +4150,7 @@ void qkv_transpose_split(
     elem_cnt = batch_size * q_head_num * pre_cache_length * size_per_head * 2;
     pack_num = elem_cnt / PackSize;
     GetNumBlocks(pack_num, &grid_size);
-    write_pre_cahe_to_kv_buffer<T, PackSize>
+    write_pre_cache_to_kv_buffer<T, PackSize>
         <<<grid_size, blocksize, 0, dev_ctx.stream()>>>(k_buf,
                                                         v_buf,
                                                         pre_key_cache,

--- a/paddle/phi/kernels/gpu/c_softmax_with_cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/c_softmax_with_cross_entropy_grad_kernel.cu
@@ -35,15 +35,15 @@ static inline int64_t NumBlocks(const int64_t N) {
 }
 
 template <typename T, typename IndexT>
-__global__ void CaculateSoftLogitsGrad(T* logits_grad,
-                                       IndexT* is_ignore,
-                                       const IndexT* labels,
-                                       const IndexT ignore_index,
-                                       const int64_t start_index,
-                                       const int64_t end_index,
-                                       const int64_t N,
-                                       const int64_t D,
-                                       const int64_t C) {
+__global__ void CalculateSoftLogitsGrad(T* logits_grad,
+                                        IndexT* is_ignore,
+                                        const IndexT* labels,
+                                        const IndexT ignore_index,
+                                        const int64_t start_index,
+                                        const int64_t end_index,
+                                        const int64_t N,
+                                        const int64_t D,
+                                        const int64_t C) {
   const T prob = static_cast<T>(1.0 / C);
   CUDA_KERNEL_LOOP_TYPE(i, N, int64_t) {
     is_ignore[i] = labels[i * C];
@@ -145,7 +145,7 @@ void CSoftmaxWithCrossEntropyGradKernel(const Context& dev_ctx,
       is_ignore.Resize({N, 1});
       dev_ctx.template Alloc<int32_t>(&is_ignore);
 
-      CaculateSoftLogitsGrad<T, int32_t>
+      CalculateSoftLogitsGrad<T, int32_t>
           <<<blocks_cal, threads, 0, dev_ctx.stream()>>>(
               logit_grad_2d.data<T>(),
               is_ignore.data<int32_t>(),
@@ -183,7 +183,7 @@ void CSoftmaxWithCrossEntropyGradKernel(const Context& dev_ctx,
       is_ignore.Resize({N, 1});
       dev_ctx.template Alloc<int32_t>(&is_ignore);
 
-      CaculateSoftLogitsGrad<T, int64_t>
+      CalculateSoftLogitsGrad<T, int64_t>
           <<<blocks_cal, threads, 0, dev_ctx.stream()>>>(
               logit_grad_2d.data<T>(),
               is_ignore.data<int64_t>(),

--- a/paddle/phi/kernels/gpu/c_softmax_with_cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/c_softmax_with_cross_entropy_kernel.cu
@@ -111,12 +111,12 @@ __global__ void SoftMaskLabelByIndex(T* predicted_logits,
 }
 
 template <typename T, typename IndexT>
-__global__ void CaculateLoss(T* loss,
-                             const T* predict_logits,
-                             const T* sum_exp_logits,
-                             const IndexT* label,
-                             const int64_t ignore_index,
-                             const int64_t N) {
+__global__ void CalculateLoss(T* loss,
+                              const T* predict_logits,
+                              const T* sum_exp_logits,
+                              const IndexT* label,
+                              const int64_t ignore_index,
+                              const int64_t N) {
   CUDA_KERNEL_LOOP_TYPE(i, N, int64_t) {
     auto real_label = static_cast<int64_t>(label[i]);
     loss[i] = ignore_index == real_label
@@ -129,13 +129,13 @@ __global__ void CaculateLoss(T* loss,
 }
 
 template <typename T, typename IndexT>
-__global__ void CaculateSoftLoss(T* loss,
-                                 const T* predict_logits,
-                                 const T* sum_exp_logits,
-                                 const IndexT* label,
-                                 const int64_t ignore_index,
-                                 const int64_t N,
-                                 const int64_t C) {
+__global__ void CalculateSoftLoss(T* loss,
+                                  const T* predict_logits,
+                                  const T* sum_exp_logits,
+                                  const IndexT* label,
+                                  const int64_t ignore_index,
+                                  const int64_t N,
+                                  const int64_t C) {
   const T prob = static_cast<T>(1.0 / C);
 
   CUDA_KERNEL_LOOP_TYPE(i, N, int64_t) {
@@ -323,7 +323,7 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::GPUContext, T> {
 
     if (label_type == phi::DataType::INT32) {
       if (C > 1) {
-        CaculateSoftLoss<T, int32_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+        CalculateSoftLoss<T, int32_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
             loss_2d.data<T>(),
             predicted_logits.data<T>(),
             sum_exp_logits.data<T>(),
@@ -332,7 +332,7 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::GPUContext, T> {
             N,
             C);
       } else {
-        CaculateLoss<T, int32_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+        CalculateLoss<T, int32_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
             loss_2d.data<T>(),
             predicted_logits.data<T>(),
             sum_exp_logits.data<T>(),
@@ -343,7 +343,7 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::GPUContext, T> {
 
     } else {
       if (C > 1) {
-        CaculateSoftLoss<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+        CalculateSoftLoss<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
             loss_2d.data<T>(),
             predicted_logits.data<T>(),
             sum_exp_logits.data<T>(),
@@ -352,7 +352,7 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::GPUContext, T> {
             N,
             C);
       } else {
-        CaculateLoss<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+        CalculateLoss<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
             loss_2d.data<T>(),
             predicted_logits.data<T>(),
             sum_exp_logits.data<T>(),

--- a/paddle/phi/kernels/kps/reduce_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_kernel.cu
@@ -178,7 +178,7 @@ void ReduceSumEigen(const KPDevice& dev_ctx,
   }
   auto eigen_reduce_dim =
       EigenDim<ReducedDimSize>::From(common::make_ddim(*reduce_dims));
-  // Caculate
+  // Calculate
   eigen_out_tensor.device(*dev_ctx.eigen_device()) =
       eigen_x_tensor.sum(eigen_reduce_dim);
   out->Resize(origin_out_dims);

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -2324,7 +2324,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         for_iter_idx = self.indexof(for_iter)
         loop_body_start_idx = for_iter_idx + 1
         loop_body_end_idx = self.indexof(for_iter.jump_to)
-        curent_stack = 1
+        current_stack = 1
 
         while True:
             if loop_body_start_idx >= len(self._instructions):
@@ -2332,9 +2332,9 @@ class OpcodeExecutor(OpcodeExecutorBase):
             cur_instr = self._instructions[loop_body_start_idx]
             # do not consider jump instr
             stack_effect = calc_stack_effect(cur_instr, jump=False)
-            curent_stack += stack_effect
+            current_stack += stack_effect
             loop_body_start_idx += 1
-            if curent_stack == 0:
+            if current_stack == 0:
                 break
 
         # 2. create loop body function

--- a/python/paddle/jit/sot/symbolic/export.py
+++ b/python/paddle/jit/sot/symbolic/export.py
@@ -211,7 +211,7 @@ class PyFileGen:
     def create_inputs(self):
         create_paddle_inputs = self.new_root("def create_paddle_inputs():")
         self.new_root("\n")
-        craete_numpy_inputs = self.new_root("def create_numpy_inputs():")
+        create_numpy_inputs = self.new_root("def create_numpy_inputs():")
 
         paddle_inputs = ["inputs = ("]
         numpy_inputs = ["inputs = ("]
@@ -257,7 +257,7 @@ class PyFileGen:
         numpy_inputs.append("return inputs")
 
         create_paddle_inputs.add_sub(*paddle_inputs)
-        craete_numpy_inputs.add_sub(*numpy_inputs)
+        create_numpy_inputs.add_sub(*numpy_inputs)
 
     def create_test(self):
         test_class = self.new_root("class TestLayer(unittest.TestCase):")

--- a/python/paddle/jit/sot/translate.py
+++ b/python/paddle/jit/sot/translate.py
@@ -49,7 +49,7 @@ def symbolic_translate(fn: Callable[P, R], **kwargs) -> Callable[P, R]:
         Callable, The wrapped function.
 
     Examples:
-        >>> # doctest: +SKIP("Cound not get source code of function foo."")
+        >>> # doctest: +SKIP("Could not get source code of function foo."")
         >>> import paddle
         >>> import numpy as np
         >>> from sot.translate import symbolic_translate

--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -630,7 +630,7 @@ class Conv2D(_ConvNd):
         stride(int|list|tuple, optional): The stride size. If stride is a list/tuple, it must
             contain two integers, (stride_H, stride_W). Otherwise, the
             stride_H = stride_W = stride. The default value is 1.
-        padding(int|str|tuple|list, optional): The padding size. Padding coule be in one of the following forms.
+        padding(int|str|tuple|list, optional): The padding size. Padding could be in one of the following forms.
             1. a string in ['valid', 'same'].
             2. an int, which means each spartial dimension(depth, height, width) is zero paded by size of `padding`
             3. a list[int] or tuple[int] whose length is the number of spartial dimensions, which contains the amount of padding on each side for each spartial dimension. It has the form [pad_d1, pad_d2, ...].
@@ -800,7 +800,7 @@ class Conv2DTranspose(_ConvNd):
         stride(int|list|tuple, optional): The stride size. If stride is a list/tuple, it must
             contain two integers, (stride_H, stride_W). Otherwise, the
             stride_H = stride_W = stride. Default: 1.
-        padding(int|str|tuple|list, optional): The padding size. Padding coule be in one of the following forms.
+        padding(int|str|tuple|list, optional): The padding size. Padding could be in one of the following forms.
             1. a string in ['valid', 'same'].
             2. an int, which means each spartial dimension(depth, height, width) is zero paded by size of `padding` on both sides
             3. a list[int] or tuple[int] whose length is the number of spartial dimensions, which contains the amount of padding on each side for each spartial dimension. It has the form [pad_d1, pad_d2, ...].
@@ -960,7 +960,7 @@ class Conv3D(_ConvNd):
         stride(int|list|tuple, optional): The stride size. If stride is a list/tuple, it must
             contain three integers, (stride_D, stride_H, stride_W). Otherwise, the
             stride_D = stride_H = stride_W = stride. The default value is 1.
-        padding(int|str|tuple|list, optional): The padding size. Padding coule be in one of the following forms.
+        padding(int|str|tuple|list, optional): The padding size. Padding could be in one of the following forms.
             1. a string in ['valid', 'same'].
             2. an int, which means each spartial dimension(depth, height, width) is zero paded by size of `padding`
             3. a list[int] or tuple[int] whose length is the number of spartial dimensions, which contains the amount of padding on each side for each spartial dimension. It has the form [pad_d1, pad_d2, ...].
@@ -1138,7 +1138,7 @@ class Conv3DTranspose(_ConvNd):
             If stride is a list/tuple, it must contain three integers, (stride_depth, stride_height,
             stride_width). Otherwise, stride_depth = stride_height = stride_width = stride.
             Default: 1.
-        padding(int|str|tuple|list, optional): The padding size. Padding coule be in one of the following forms.
+        padding(int|str|tuple|list, optional): The padding size. Padding could be in one of the following forms.
             1. a string in ['valid', 'same'].
             2. an int, which means each spartial dimension(depth, height, width) is zero paded by size of `padding`
             3. a list[int] or tuple[int] whose length is the number of spartial dimensions, which contains the amount of padding on each side for each spartial dimension. It has the form [pad_d1, pad_d2, ...].

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -1649,7 +1649,7 @@ class OpTest(unittest.TestCase):
             pass
 
     def _infer_and_compare_symbol(self, place):
-        """Don't caculate the program, only infer the shape of var"""
+        """Don't calculate the program, only infer the shape of var"""
 
         kernel_sig = self.get_kernel_signature(place)
         program = paddle.static.Program()

--- a/test/legacy_test/test_hsigmoid_op.py
+++ b/test/legacy_test/test_hsigmoid_op.py
@@ -284,7 +284,7 @@ class TestHSigmoidOpSparse(OpTest):
 @skip_check_grad_ci(
     reason="[skip shape check] The huffman tree is structed separately. It will be complicated if use large shape."
 )
-class TestHSigmoidOpWithCostumTree(OpTest):
+class TestHSigmoidOpWithCustomTree(OpTest):
     def setUp(self):
         self.op_type = "hierarchical_sigmoid"
         self.python_api = python_api
@@ -345,7 +345,7 @@ class TestHSigmoidOpWithCostumTree(OpTest):
 @skip_check_grad_ci(
     reason="[skip shape check] The huffman tree is structed separately. It will be complicated if use large shape."
 )
-class TestHSigmoidOpWithCostumTreeWithoutBias(OpTest):
+class TestHSigmoidOpWithCustomTreeWithoutBias(OpTest):
     def setUp(self):
         self.op_type = "hierarchical_sigmoid"
         self.python_api = python_api

--- a/tools/gen_ut_cmakelists.py
+++ b/tools/gen_ut_cmakelists.py
@@ -218,7 +218,7 @@ class DistUTPortManager:
     def reset_current_port(self, port=None):
         self.dist_ut_port = 21200 if port is None else port
 
-    def get_currnt_port(self):
+    def get_current_port(self):
         return self.dist_ut_port
 
     def gset_port(self, test_name, port):
@@ -387,7 +387,7 @@ class CMakeGenerator:
 
     def parse_csvs(self):
         '''
-        parse csv files, return the lists of craeted or modified files
+        parse csv files, return the lists of created or modified files
         '''
         self.modified_or_created_files = []
         for c in self.current_dirs:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

Fix:

- cahe
- Caculate
- caculate
- calcualtion
- checkings (-> checks)
- Cound (-> Could)
- coule
- craete (-> create)
- craeted (-> created)
- Currenly
- currnt
- curent
- Costum (-> Custom)