### PR TITLE
[CINN] Add data dependency graph

### DIFF
--- a/paddle/cinn/ir/ir_analyzer/CMakeLists.txt
+++ b/paddle/cinn/ir/ir_analyzer/CMakeLists.txt
@@ -1,3 +1,3 @@
 core_gather_headers()
 
-gather_srcs(cinnapi_src SRCS ir_analyzer.cc)
+gather_srcs(cinnapi_src SRCS ir_analyzer.cc data_dependency_graph.cc)

--- a/paddle/cinn/ir/ir_analyzer/data_dependency_graph.cc
+++ b/paddle/cinn/ir/ir_analyzer/data_dependency_graph.cc
@@ -1,0 +1,288 @@
+// Copyright (c) 2024 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "paddle/cinn/ir/ir.h"
+#include "paddle/cinn/ir/ir_analyzer/data_dependency_graph.h"
+#include "paddle/cinn/ir/ir_base.h"
+#include "paddle/cinn/ir/ir_printer.h"
+
+namespace cinn {
+namespace ir {
+namespace analyzer {
+
+std::ostream& operator<<(std::ostream& os, const DepKind& dep_kind) {
+  if (dep_kind == DepKind::DEP) {
+    os << " {DepKind : DEP} ";
+  } else if (dep_kind == DepKind::NO_DEP) {
+    os << " {DepKind : NO_DEP} ";
+  } else {
+    os << "Not support DepKind for output!";
+  }
+  return os;
+}
+
+// MemRefCollector walks stmts collects load and store.
+class MemRefCollector : public ir::stmt::StmtVisitor<>,
+                        public ir::IRMutator<const ir::Expr*> {
+ public:
+  void VisitStmt(const ir::stmt::StmtRef& stmt) {
+    ir::stmt::StmtVisitor<>::VisitStmt(stmt);
+  }
+
+  std::set<DepData, DepDataCompare> GetLoads() { return loads_; }
+  std::set<DepData, DepDataCompare> GetStores() { return stores_; }
+
+ private:
+#define __(stmt__) void VisitStmt(const ir::stmt::stmt__& stmt) override;
+  NODETY_FORALL_STMT(__)
+#undef __
+
+  void Visit(const ir::Load* op, const ir::Expr* expr) override {
+    auto tensor_node = op->tensor.As<ir::_Tensor_>();
+    loads_.insert({tensor_node->buffer->name, tensor_node->buffer});
+    ir::IRMutator<const ir::Expr*>::Visit(op, expr);
+  }
+
+  void Visit(const ir::_Var_* op, const ir::Expr* expr) override {
+    const std::unordered_set<std::string> gpu_axis = {"blockIdx.x",
+                                                      "blockIdx.y",
+                                                      "blockIdx.z",
+                                                      "threadIdx.x",
+                                                      "threadIdx.y",
+                                                      "threadIdx.z"};
+    if (op->is_symbolic_constant) return;
+    if (gpu_axis.count(op->name)) return;
+    loads_.insert({op->name, op->Copy()});
+    ir::IRMutator<const ir::Expr*>::Visit(op, expr);
+  }
+
+  void Visit(const ir::Call* op, const ir::Expr* expr) override {
+    for (auto write_arg : op->write_args) {
+      if (write_arg.As<ir::_Var_>()) {
+        stores_.insert({write_arg.As<ir::_Var_>()->name, write_arg});
+      } else if (write_arg.As<ir::Load>()) {
+        auto load_node = write_arg.As<ir::Load>();
+        auto tensor_node = load_node->tensor.As<ir::_Tensor_>();
+        stores_.insert({tensor_node->buffer->name, tensor_node->buffer});
+      } else {
+        VLOG(6) << "Not support type in write arguments: \n" << write_arg;
+      }
+    }
+    ir::IRMutator<const ir::Expr*>::Visit(op, expr);
+  }
+
+  std::set<DepData, DepDataCompare> loads_;
+  std::set<DepData, DepDataCompare> stores_;
+};
+
+void MemRefCollector::VisitStmt(const ir::stmt::Let& stmt) {
+  if (stmt->symbol().As<ir::_Var_>())
+    stores_.insert({stmt->symbol().As<ir::_Var_>()->name, stmt->symbol()});
+  ir::IRMutator<const ir::Expr*>::Visit(&stmt->body(), &stmt->body());
+}
+
+void MemRefCollector::VisitStmt(const ir::stmt::Store& stmt) {
+  auto tensor_node = stmt->tensor().As<ir::_Tensor_>();
+  if (tensor_node->buffer.get()) {
+    stores_.insert({tensor_node->buffer->name, tensor_node->buffer});
+  }
+  ir::IRMutator<const ir::Expr*>::Visit(&stmt->value(), &stmt->value());
+  for (std::size_t i = 0; i < stmt->indices().size(); i++) {
+    ir::IRMutator<const ir::Expr*>::Visit(&stmt->indices()[i],
+                                          &stmt->indices()[i]);
+  }
+}
+
+void MemRefCollector::VisitStmt(const ir::stmt::IfThenElse& stmt) {
+  ir::IRMutator<const ir::Expr*>::Visit(&stmt->condition(), &stmt->condition());
+  ir::stmt::StmtVisitor<>::VisitBlock(stmt->true_case());
+  if (stmt->false_case().defined())
+    ir::stmt::StmtVisitor<>::VisitBlock(stmt->false_case());
+}
+
+void MemRefCollector::VisitStmt(const ir::stmt::For& stmt) {
+  ir::IRMutator<const ir::Expr*>::Visit(&stmt->min(), &stmt->min());
+  ir::IRMutator<const ir::Expr*>::Visit(&stmt->extent(), &stmt->extent());
+  ir::stmt::StmtVisitor<>::VisitBlock(stmt->body());
+}
+
+void MemRefCollector::VisitStmt(const ir::stmt::Schedule& stmt) {
+  ir::stmt::StmtVisitor<>::VisitBlock(stmt->body());
+}
+
+void MemRefCollector::VisitStmt(const ir::stmt::Evaluate& stmt) {
+  ir::IRMutator<const ir::Expr*>::Visit(&stmt->value(), &stmt->value());
+}
+
+void MemRefCollector::VisitStmt(const ir::stmt::Alloc& stmt) {}
+void MemRefCollector::VisitStmt(const ir::stmt::Free& stmt) {}
+
+DepKind DataDependencyGraph::HasDependency(const ir::stmt::StmtRef& src,
+                                           const ir::stmt::StmtRef& dst) const {
+  // Run BFS traversal to check if src and dst are reachable.
+  auto HasDependencyPath = [&](const unsigned src_id,
+                               const unsigned dst_id) -> DepKind {
+    std::unordered_set<unsigned> visited;
+    std::deque<unsigned> queue;
+    queue.push_back(src_id);
+    while (!queue.empty()) {
+      auto id = queue.front();
+      if (id == dst_id) return DepKind::DEP;
+      // If node has no out edges, or have been visited already, record node and
+      // continue.
+      if (out_edges_.count(id) == 0 || visited.count(id) != 0) {
+        queue.pop_front();
+        visited.insert(id);
+        continue;
+      }
+      for (const auto& edge : out_edges_.at(id)) {
+        queue.push_back(edge.id);
+      }
+      queue.pop_front();
+      visited.insert(id);
+    }
+    return DepKind::NO_DEP;
+  };
+
+  PADDLE_ENFORCE_GT(stmt_to_node_ids_.count(src),
+                    0,
+                    ::common::errors::InvalidArgument(
+                        "stmt_to_node_ids_ should contain stmt src"));
+  PADDLE_ENFORCE_GT(stmt_to_node_ids_.count(dst),
+                    0,
+                    ::common::errors::InvalidArgument(
+                        "stmt_to_node_ids_ should contain stmt dst"));
+  auto src_id = stmt_to_node_ids_.at(src);
+  auto dst_id = stmt_to_node_ids_.at(dst);
+
+  return HasDependencyPath(src_id, dst_id);
+}
+
+void DataDependencyGraph::BuildGraphByStmts() {
+  auto BuildNodes = [&]() {
+    for (auto& stmt : stmts_) {
+      Node node(next_node_id_++, stmt);
+      MemRefCollector collector;
+      collector.VisitStmt(stmt);
+      node.loads = collector.GetLoads();
+      node.stores = collector.GetStores();
+      stmt_to_node_ids_.insert({stmt, node.id});
+      nodes_.insert({node.id, node});
+    }
+  };
+
+  auto GetDepInfo = [&](const unsigned src_id, const unsigned dst_id)
+      -> std::map<DepData, std::vector<DepKind>, DepDataCompare> {
+    auto src = nodes_[src_id];
+    auto dst = nodes_[dst_id];
+    std::map<DepData, std::vector<DepKind>, DepDataCompare> dep_info;
+    for (auto store : src.stores) {
+      // RAW
+      if (dst.loads.count(store)) {
+        dep_info[store].push_back(DepKind::DEP);
+      }
+      // WAW
+      if (dst.stores.count(store)) {
+        dep_info[store].push_back(DepKind::DEP);
+      }
+    }
+    for (auto load : src.loads) {
+      // WAR
+      if (dst.stores.count(load)) {
+        dep_info[load].push_back(DepKind::DEP);
+      }
+    }
+    return dep_info;
+  };
+
+  auto BuildEdges = [&]() {
+    for (unsigned i = 0; i < nodes_.size(); ++i) {
+      for (unsigned j = i + 1; j < nodes_.size(); ++j) {
+        auto dep_info = GetDepInfo(i, j);
+        if (!dep_info.empty()) {
+          AddEdge(i, j, dep_info);
+        }
+      }
+    }
+  };
+
+  BuildNodes();
+  BuildEdges();
+}
+
+void DataDependencyGraph::Print(int log_level) const {
+  VLOG(log_level) << "DataDependencyGraph";
+  VLOG(log_level) << "Nodes size: " << nodes_.size();
+  for (const auto& [id, node] : nodes_) {
+    auto stmt = node.stmt;
+    VLOG(log_level) << "Node" << id << " stmt: " << stmt;
+    for (auto load : node.loads) {
+      VLOG(log_level) << "Load: " << load.data;
+    }
+    for (auto store : node.stores) {
+      VLOG(log_level) << "Store: " << store.data;
+    }
+    auto it = in_edges_.find(id);
+    if (it != in_edges_.end()) {
+      for (const auto& e : it->second)
+        for (const auto& value : e.dep_info)
+          for (const auto& dep_kind : value.second)
+            VLOG(log_level) << "In Edge: \n"
+                            << nodes_.at(e.id).stmt << " dst: \n"
+                            << nodes_.at(id).stmt << " DepData:\n"
+                            << value.first.data << " DepKind: " << dep_kind;
+    }
+    it = out_edges_.find(id);
+    if (it != out_edges_.end()) {
+      for (const auto& e : it->second)
+        for (const auto& value : e.dep_info)
+          for (const auto& dep_kind : value.second)
+            VLOG(log_level) << "Out Edge: \n"
+                            << nodes_.at(id).stmt << " dst: \n"
+                            << nodes_.at(e.id).stmt << " DepData:\n"
+                            << value.first.data << " DepKind: " << dep_kind;
+    }
+  }
+}
+
+bool DataDependencyGraph::HasEdge(unsigned src_id, unsigned dst_id) {
+  auto CheckEdges = [&](const unsigned id, const std::vector<Edge>& edges) {
+    for (const auto edge : edges) {
+      if (edge.id == id) return true;
+    }
+    return false;
+  };
+
+  if (out_edges_.count(src_id == 0) || in_edges_.count(dst_id) == 0) {
+    return false;
+  }
+  return CheckEdges(dst_id, out_edges_[src_id]) &&
+         CheckEdges(src_id, in_edges_[dst_id]);
+}
+
+void DataDependencyGraph::AddEdge(
+    unsigned src_id,
+    unsigned dst_id,
+    const std::map<DepData, std::vector<DepKind>, DepDataCompare>& dep_info) {
+  if (!HasEdge(src_id, dst_id)) {
+    out_edges_[src_id].push_back({dst_id, dep_info});
+    in_edges_[dst_id].push_back({src_id, dep_info});
+  }
+}
+
+}  // namespace analyzer
+}  // namespace ir
+}  // namespace cinn

--- a/paddle/cinn/ir/ir_analyzer/data_dependency_graph.cc
+++ b/paddle/cinn/ir/ir_analyzer/data_dependency_graph.cc
@@ -154,7 +154,8 @@ DepKind DataDependencyGraph::HasDependency(const ir::stmt::StmtRef& src,
   DepKind res = DepKind::NO_DEP;
   ::common::BfsWalker<unsigned> bfs_walker(
       [&](unsigned id, const std::function<void(unsigned)> Visit) {
-        if (out_edges_.count(id) != 0) {
+        // Skip if node has no out edges, or have been found already.
+        if (out_edges_.count(id) != 0 && res == DepKind::NO_DEP) {
           for (const auto& edge : out_edges_.at(id)) {
             Visit(edge.id);
           }

--- a/paddle/cinn/ir/ir_analyzer/data_dependency_graph.h
+++ b/paddle/cinn/ir/ir_analyzer/data_dependency_graph.h
@@ -1,0 +1,143 @@
+// Copyright (c) 2024 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <deque>
+#include <string>
+#include <vector>
+
+#include "paddle/cinn/ir/ir.h"
+#include "paddle/cinn/ir/ir_base.h"
+#include "paddle/cinn/ir/ir_mutator.h"
+#include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/stmt.h"
+
+namespace cinn {
+namespace ir {
+namespace analyzer {
+
+// Dep detail: RAW | WAW | WAR
+enum class DepKind { DEP, NO_DEP };
+
+// Var or Tensor
+struct DepData {
+  std::string name;
+  ir::Expr data;
+};
+
+struct StmtCompare {
+  bool operator()(const ir::stmt::StmtRef& a,
+                  const ir::stmt::StmtRef& b) const {
+    return a.get() < b.get();
+  }
+};
+
+struct DepDataCompare {
+  bool operator()(const DepData& a, const DepData& b) const {
+    if (!a.data.defined() || !b.data.defined()) {
+      return a.name < b.name;
+    }
+    return !(a.data.get() == b.data.get() || a.name == b.name);
+  }
+};
+
+/**
+ * DataDependencyGraph is a graph data structure where graph nodes are
+ * stmts in a block, and edges are data dependences between the nodes.
+ *
+ * This graph can be used in scenarios where pass may change the order of
+ * stmts which containing store/load operation. Using this graph to analyze
+ * the dependences of stmts and keep the topological order.
+
+ * Examples:
+ * const auto &dep_graph = DataDependencyGraph(stmts);
+ * DepKind res = dep_graph.HasDependency(stmt1, stmt2);
+ */
+class DataDependencyGraph {
+ public:
+  explicit DataDependencyGraph(const std::vector<ir::stmt::StmtRef>& stmts)
+      : stmts_(stmts) {
+    BuildGraphByStmts();
+  }
+
+  // Returns DepKind::Dep if there is a path in the data dependency graph from
+  // node src to node dst. Returns DepKind::NO_DEP otherwise. src and dst, are
+  // expected to be from the same block.
+  DepKind HasDependency(const ir::stmt::StmtRef& src,
+                        const ir::stmt::StmtRef& dst) const;
+
+  // Node represents a node in the graph. A Node is a stmt which contains
+  // loads/stores,
+  struct Node {
+    // The unique identifier of this node in the graph.
+    unsigned id;
+    // The top-level statement which is (or contains) a load/store.
+    stmt::StmtRef stmt;
+    // Set of load data.
+    std::set<DepData, DepDataCompare> loads;
+    // Set of store data.
+    std::set<DepData, DepDataCompare> stores;
+
+    Node() = default;
+    Node(unsigned id, const ir::stmt::StmtRef& stmt) : id(id), stmt(stmt) {}
+  };
+
+  struct Edge {
+    // The id of the node at the other end of the edge.
+    // If this edge is stored in Edge = Node.in_edges_[i], then
+    // 'Node.in_edges_[i].id' is the identifier of the source node of the edge.
+    // If this edge is stored in Edge = Node.out_edges_[i], then
+    // 'Node.out_edges_[i].id' is the identifier of the dest node of the edge.
+    unsigned id;
+    // The DepInfo of this edge represents a dependence, each data represents a
+    // dependence between graph nodes.
+    std::map<DepData, std::vector<DepKind>, DepDataCompare> dep_info;
+  };
+
+  void Print(int log_level = 0) const;
+
+ private:
+  // Initializes the dependence graph based on stmts in block.
+  void BuildGraphByStmts();
+
+  // Returns true iff there is an edge from node src_id to node dst_id. Returns
+  // false otherwise.
+  bool HasEdge(unsigned src_id, unsigned dst_id);
+
+  // Adds an edge from node src_id to node dst_id for dep_info.
+  void AddEdge(
+      unsigned src_id,
+      unsigned dst_id,
+      const std::map<DepData, std::vector<DepKind>, DepDataCompare>& dep_info);
+
+  // Removes an edge from node src_id to node dst_id for dep_data.
+  void RemoveEdge(unsigned src_id, unsigned dst_id, const DepData& dep_data);
+
+  // The next unique identifier to use for newly created graph nodes.
+  unsigned next_node_id_ = 0;
+
+  std::vector<ir::stmt::StmtRef> stmts_;
+  std::map<ir::stmt::StmtRef, unsigned, StmtCompare> stmt_to_node_ids_;
+  std::unordered_map<unsigned, Node> nodes_;
+
+  // Map from node id to list of edges.
+  std::unordered_map<unsigned, std::vector<Edge>> in_edges_;
+  std::unordered_map<unsigned, std::vector<Edge>> out_edges_;
+};
+
+std::ostream& operator<<(std::ostream& os, const DepKind& dep_kind);
+
+}  // namespace analyzer
+}  // namespace ir
+}  // namespace cinn

--- a/paddle/cinn/ir/ir_analyzer/data_dependency_graph.h
+++ b/paddle/cinn/ir/ir_analyzer/data_dependency_graph.h
@@ -30,10 +30,9 @@ namespace analyzer {
 // Dep detail: RAW | WAW | WAR
 enum class DepKind { DEP, NO_DEP };
 
-// Var or Tensor
+// Var or Tensor name
 struct DepData {
   std::string name;
-  ir::Expr data;
 };
 
 struct StmtCompare {
@@ -45,10 +44,7 @@ struct StmtCompare {
 
 struct DepDataCompare {
   bool operator()(const DepData& a, const DepData& b) const {
-    if (!a.data.defined() || !b.data.defined()) {
-      return a.name < b.name;
-    }
-    return !(a.data.get() == b.data.get() || a.name == b.name);
+    return a.name < b.name;
   }
 };
 
@@ -71,14 +67,14 @@ class DataDependencyGraph {
     BuildGraphByStmts();
   }
 
-  // Returns DepKind::Dep if there is a path in the data dependency graph from
+  // Returns DepKind::DEP if there is a path in the data dependency graph from
   // node src to node dst. Returns DepKind::NO_DEP otherwise. src and dst, are
   // expected to be from the same block.
   DepKind HasDependency(const ir::stmt::StmtRef& src,
                         const ir::stmt::StmtRef& dst) const;
 
   // Node represents a node in the graph. A Node is a stmt which contains
-  // loads/stores,
+  // loads/stores.
   struct Node {
     // The unique identifier of this node in the graph.
     unsigned id;
@@ -90,7 +86,7 @@ class DataDependencyGraph {
     std::set<DepData, DepDataCompare> stores;
 
     Node() = default;
-    Node(unsigned id, const ir::stmt::StmtRef& stmt) : id(id), stmt(stmt) {}
+    Node(unsigned id, const ir::stmt::StmtRef& stmt);
   };
 
   struct Edge {

--- a/paddle/cinn/ir/ir_analyzer/data_dependency_graph.h
+++ b/paddle/cinn/ir/ir_analyzer/data_dependency_graph.h
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #pragma once
-#include <deque>
 #include <string>
 #include <vector>
 

--- a/test/cpp/pir/cinn/adt/CMakeLists.txt
+++ b/test/cpp/pir/cinn/adt/CMakeLists.txt
@@ -1,6 +1,7 @@
 if(WITH_TESTING AND WITH_CINN)
   paddle_test(map_expr_test SRCS map_expr_test.cc)
   set_tests_properties(map_expr_test PROPERTIES LABELS "RUN_TYPE=CINN")
+  paddle_test(test_data_dependency_graph SRCS data_dependency_graph_test.cc)
   paddle_test(test_index_expr SRCS index_expr_test.cc)
   paddle_test(test_iter_simplify SRCS iter_simplify_test.cc)
   paddle_test(merge_block_utils_test SRCS merge_block_utils_test.cc)

--- a/test/cpp/pir/cinn/adt/data_dependency_graph_test.cc
+++ b/test/cpp/pir/cinn/adt/data_dependency_graph_test.cc
@@ -1,0 +1,124 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <sstream>
+
+#include "paddle/cinn/ir/ir_analyzer/data_dependency_graph.h"
+#include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/stmt.h"
+
+namespace cinn {
+namespace ir {
+
+namespace {
+using ir::analyzer::DataDependencyGraph;
+using ir::analyzer::DepKind;
+
+class TestDataDependencyGraph : public ::testing::Test {
+ public:
+  void SetUp() override {
+    const std::vector<ir::Expr> shape = {};
+    tensor_a =
+        ir::_Tensor_::Make(common::UniqName("A"), common::Bool(), shape, shape);
+    tensor_b =
+        ir::_Tensor_::Make(common::UniqName("B"), common::Bool(), shape, shape);
+    tensor_c =
+        ir::_Tensor_::Make(common::UniqName("C"), common::Bool(), shape, shape);
+    tensor_d =
+        ir::_Tensor_::Make(common::UniqName("D"), common::Bool(), shape, shape);
+
+    tensor_a->WithBuffer("global", "_" + tensor_a->name + "_temp_buffer");
+    tensor_b->WithBuffer("global", "_" + tensor_b->name + "_temp_buffer");
+    tensor_c->WithBuffer("global", "_" + tensor_c->name + "_temp_buffer");
+    tensor_d->WithBuffer("global", "_" + tensor_d->name + "_temp_buffer");
+
+    var_x = ir::Var(ir::Expr(1), ir::Expr(INT32_MAX), "x");
+
+    load_a = ir::Load::Make(ir::Expr(tensor_a), {});
+    load_b = ir::Load::Make(ir::Expr(tensor_b), {});
+    load_c = ir::Load::Make(ir::Expr(tensor_c), {});
+  };
+
+  ir::Var var_x;
+  ir::Tensor tensor_a, tensor_b, tensor_c, tensor_d;
+  ir::Expr load_a, load_b, load_c;
+};
+
+TEST_F(TestDataDependencyGraph, TensorDep) {
+  // A[0] = B[0]
+  auto store_a_b = ir::stmt::Store(ir::Expr(tensor_a), load_b, {});
+  // B[0] = C[0]
+  auto store_b_c = ir::stmt::Store(ir::Expr(tensor_b), load_c, {});
+  // C[0] = A[0]
+  auto store_c_a = ir::stmt::Store(ir::Expr(tensor_c), load_a, {});
+  const std::vector<ir::stmt::StmtRef> stmts = {
+      store_a_b, store_b_c, store_c_a};
+  const auto &dep_graph = DataDependencyGraph(stmts);
+  dep_graph.Print();
+  EXPECT_EQ(dep_graph.HasDependency(stmts[0], stmts[1]), DepKind::DEP);
+  EXPECT_EQ(dep_graph.HasDependency(stmts[0], stmts[2]), DepKind::DEP);
+  EXPECT_EQ(dep_graph.HasDependency(stmts[1], stmts[2]), DepKind::DEP);
+}
+
+TEST_F(TestDataDependencyGraph, VarDep) {
+  // x = A[0]
+  auto let_x_a = ir::stmt::Let(ir::Expr(var_x), load_a);
+  // B[0] = x
+  auto store_b_x = ir::stmt::Store(ir::Expr(tensor_b), ir::Expr(var_x), {});
+  const std::vector<ir::stmt::StmtRef> stmts = {let_x_a, store_b_x};
+  const auto &dep_graph = DataDependencyGraph(stmts);
+  dep_graph.Print();
+  EXPECT_EQ(dep_graph.HasDependency(stmts[0], stmts[1]), DepKind::DEP);
+}
+
+TEST_F(TestDataDependencyGraph, TensorNoDep) {
+  // A[0] = B[0]
+  auto store_a_b = ir::stmt::Store(ir::Expr(tensor_a), load_b, {});
+  // C[0] = B[0]
+  auto store_c_b = ir::stmt::Store(ir::Expr(tensor_c), load_b, {});
+  // D[0] = B[0]
+  auto store_d_b = ir::stmt::Store(ir::Expr(tensor_d), load_b, {});
+  const std::vector<ir::stmt::StmtRef> stmts = {
+      store_a_b, store_c_b, store_d_b};
+  const auto &dep_graph = DataDependencyGraph(stmts);
+  dep_graph.Print();
+  EXPECT_EQ(dep_graph.HasDependency(stmts[0], stmts[1]), DepKind::NO_DEP);
+  EXPECT_EQ(dep_graph.HasDependency(stmts[0], stmts[2]), DepKind::NO_DEP);
+  EXPECT_EQ(dep_graph.HasDependency(stmts[1], stmts[2]), DepKind::NO_DEP);
+}
+
+TEST_F(TestDataDependencyGraph, VarNoDep) {
+  // x = A[0]
+  auto let_x_a = ir::stmt::Let(ir::Expr(var_x), load_a);
+  // B[0] = x
+  auto store_b_x = ir::stmt::Store(ir::Expr(tensor_b), ir::Expr(var_x), {});
+  // C[0] = x
+  auto store_c_x = ir::stmt::Store(ir::Expr(tensor_c), ir::Expr(var_x), {});
+  // D[0] = x
+  auto store_d_x = ir::stmt::Store(ir::Expr(tensor_d), ir::Expr(var_x), {});
+  const std::vector<ir::stmt::StmtRef> stmts = {
+      let_x_a, store_b_x, store_c_x, store_d_x};
+  const auto &dep_graph = DataDependencyGraph(stmts);
+  dep_graph.Print();
+  EXPECT_EQ(dep_graph.HasDependency(stmts[1], stmts[2]), DepKind::NO_DEP);
+  EXPECT_EQ(dep_graph.HasDependency(stmts[1], stmts[3]), DepKind::NO_DEP);
+  EXPECT_EQ(dep_graph.HasDependency(stmts[2], stmts[3]), DepKind::NO_DEP);
+}
+
+}  // namespace
+
+}  // namespace ir
+}  // namespace cinn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

[CINN] Add data dependency graph

DataDependencyGraph is a graph data structure where graph nodes are stmts in a block, and edges are data dependences between the nodes. 


Use function `HasDependency(src, dst)` to check dependency between stmts. `src` and `dst`, are expected to be from the same block.
- DEP means there is a path in the data dependency graph from node src to node dst
- NO_DEP otherwise

Didn't consider Alloc and Free IR

```
// stmts: std::vector<ir::stmt::StmtRef>
const auto &dep_graph = DataDependencyGraph(stmts);
DepKind res = dep_graph.HasDependency(stmt1, stmt2);
// enum DepKind {DEP, NO_DEP}
```

Pcard-67164
