### PR TITLE
[Distributed] [Cherry-Pick] increase synclog for tcpstore (#69988)

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1319,6 +1319,12 @@ PHI_DEFINE_EXPORTED_bool(eager_communication_connection,
                          false,
                          "enable eager to create nccl comm");
 
+PHI_DEFINE_EXPORTED_int64(
+    tcp_max_syn_backlog,
+    2048,
+    "The maximum length of the queue for completely established sockets "
+    "waiting to be accepted for tcp, default is 2048.");
+
 /**
  * Autotune related FLAG
  * Name: FLAGS_use_autotune

--- a/paddle/phi/core/distributed/store/tcp_utils.cc
+++ b/paddle/phi/core/distributed/store/tcp_utils.cc
@@ -20,6 +20,10 @@
 
 #include "glog/logging.h"
 
+#include "paddle/common/flags.h"
+
+COMMON_DECLARE_int64(tcp_max_syn_backlog);
+
 namespace phi {
 namespace distributed {
 namespace tcputils {
@@ -176,9 +180,10 @@ SocketType tcp_listen(const std::string host,
                     common::errors::InvalidArgument(
                         "Bind network on %s:%s failed.", node, port));
 
-  ::listen(sockfd, LISTENQ);
+  ::listen(sockfd, FLAGS_tcp_max_syn_backlog);
 
-  VLOG(0) << "The server starts to listen on " << node << ":" << port;
+  VLOG(0) << "The server starts to listen on " << node << ":" << port
+          << "; setting synclog to " << FLAGS_tcp_max_syn_backlog;
   return sockfd;
 }
 

--- a/paddle/phi/core/distributed/store/tcp_utils.h
+++ b/paddle/phi/core/distributed/store/tcp_utils.h
@@ -32,7 +32,6 @@
 #include <vector>
 
 #include "paddle/phi/core/enforce.h"
-
 // Utility functions for TCP socket.
 namespace phi {
 namespace distributed {
@@ -45,7 +44,6 @@ using SocketType = int;
 
 namespace tcputils {
 
-constexpr int LISTENQ = 2048;
 constexpr std::chrono::seconds kDelay = std::chrono::seconds(3);
 constexpr std::chrono::seconds kNoTimeout = std::chrono::seconds::zero();
 constexpr std::chrono::seconds kDefaultTimeout = std::chrono::seconds(360);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
setting
```
export FLAGS_tcp_max_syn_backlog=16384
```
for larger tcp_max_sync_backlog, which is necessary for training stability on large scale cluster.
[Pcard-88789]