### PR TITLE
【Inference】add_fused_group_moe

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -5911,6 +5911,7 @@ void FusedMoeInferMeta(const MetaTensor& X,
                        const std::string& quant_method,
                        const int moe_topk,
                        const bool norm_topk_prob,
+                       const bool group_moe,
                        MetaTensor* out) {
   out->set_dims(X.dims());
   out->share_lod(X);

--- a/paddle/phi/infermeta/multiary.h
+++ b/paddle/phi/infermeta/multiary.h
@@ -1164,6 +1164,7 @@ void FusedMoeInferMeta(const MetaTensor& X,
                        const std::string& quant_method,
                        const int moe_topk,
                        const bool norm_topk_prob,
+                       const bool group_moe,
                        MetaTensor* out);
 
 void FusedMultiHeadAttentionInferMeta(const MetaTensor& query,

--- a/paddle/phi/kernels/fusion/cutlass/fused_moe_kernel.cu
+++ b/paddle/phi/kernels/fusion/cutlass/fused_moe_kernel.cu
@@ -55,6 +55,7 @@ void FusedMoeKernel(const Context& ctx,
                     const std::string& quant_method,
                     const int moe_topk,
                     const bool norm_topk_prob,
+                    const bool group_moe,
                     DenseTensor* out) {
   out->Resize(X.dims());
   auto* output_data = ctx.template Alloc<T>(out);
@@ -85,6 +86,7 @@ void FusedMoeKernel(const Context& ctx,
                          nullptr,
                          moe_topk,
                          norm_topk_prob,
+                         group_moe,
                          "ffn",
                          out);
 }

--- a/paddle/phi/kernels/fusion/cutlass/moe/fused_moe_op.h
+++ b/paddle/phi/kernels/fusion/cutlass/moe/fused_moe_op.h
@@ -57,6 +57,137 @@ namespace phi {
 // the output in the softmax kernel when we extend this module to support
 // expert-choice routing.
 template <typename T, int TPB>
+__launch_bounds__(TPB) __global__ void group_moe_softmax(const T* input,
+                                                         const bool* finished,
+                                                         T* output,
+                                                         T* softmax_max_prob,
+                                                         const int num_cols) {
+  using BlockReduce = cub::BlockReduce<float, TPB>;
+  __shared__ typename BlockReduce::TempStorage tmpStorage;
+
+  __shared__ float normalizing_factor;
+  __shared__ float float_max;
+  __shared__ float max_out;
+
+  const int thread_row_offset = blockIdx.x * num_cols;
+
+  cub::Sum sum;
+  float threadData(-FLT_MAX);
+
+  // Don't touch finished rows.
+  // if ((finished != nullptr) && finished[blockIdx.x]) {
+  //     return;
+  // }
+
+  for (int ii = threadIdx.x; ii < num_cols; ii += TPB) {
+    const int idx = thread_row_offset + ii;
+    threadData = max(static_cast<float>(input[idx]), threadData);
+  }
+
+  const float maxElem = BlockReduce(tmpStorage).Reduce(threadData, cub::Max());
+  if (threadIdx.x == 0) {
+    float_max = maxElem;
+  }
+  __syncthreads();
+
+  threadData = 0;
+
+  for (int ii = threadIdx.x; ii < num_cols; ii += TPB) {
+    const int idx = thread_row_offset + ii;
+    threadData += exp((static_cast<float>(input[idx]) - float_max));
+  }
+
+  const auto Z = BlockReduce(tmpStorage).Reduce(threadData, sum);
+
+  if (threadIdx.x == 0) {
+    normalizing_factor = 1.f / Z;
+  }
+  __syncthreads();
+
+  threadData = 0;
+
+  for (int ii = threadIdx.x; ii < num_cols; ii += TPB) {
+    const int idx = thread_row_offset + ii;
+    const float val =
+        exp((static_cast<float>(input[idx]) - float_max)) * normalizing_factor;
+    output[idx] = T(val);
+    threadData = max(static_cast<float>(T(val)), threadData);
+  }
+
+  const float maxOut = BlockReduce(tmpStorage).Reduce(threadData, cub::Max());
+  if (threadIdx.x == 0) {
+    // group max probs
+    // printf("maxOut.  %f \n ", maxOut);
+    // printf("blockIdx.x.  %d \n ", blockIdx.x);
+    max_out = 1.f / maxOut;
+    softmax_max_prob[blockIdx.x] = T(max_out);
+  }
+  __syncthreads();
+
+  for (int ii = threadIdx.x; ii < num_cols; ii += TPB) {
+    const int idx = thread_row_offset + ii;
+    // group softmax normalization
+    output[idx] = output[idx] * static_cast<T>(max_out);
+  }
+}
+
+template <typename T, int TPB>
+__launch_bounds__(TPB) __global__ void moe_top_k(const T* inputs_after_softmax,
+                                                 const bool* finished,
+                                                 T* output,
+                                                 int* indices,
+                                                 int* source_rows,
+                                                 T* softmax_max_prob,
+                                                 const int num_experts,
+                                                 const int k) {
+  using cub_kvp = cub::KeyValuePair<int, T>;
+  using BlockReduce = cub::BlockReduce<cub_kvp, TPB>;
+  __shared__ typename BlockReduce::TempStorage tmpStorage;
+
+  cub_kvp thread_kvp;
+  cub::ArgMax arg_max;
+
+  const int num_rows = gridDim.x;
+  const int block_row = blockIdx.x;
+
+  const bool should_process_row = finished ? !finished[block_row] : true;
+  const int thread_read_offset = blockIdx.x * num_experts;
+
+  for (int k_idx = 0; k_idx < k; ++k_idx) {
+    thread_kvp.key = 0;
+    thread_kvp.value = T(-1.f);  // This is OK because inputs are probabilities
+
+    cub_kvp inp_kvp;
+    for (int expert = threadIdx.x; expert < num_experts; expert += TPB) {
+      const int idx = thread_read_offset + expert;
+      inp_kvp.key = expert;
+      inp_kvp.value = inputs_after_softmax[idx];
+
+      for (int prior_k = 0; prior_k < k_idx; ++prior_k) {
+        const int prior_winning_expert = indices[k * block_row + prior_k];
+
+        if (prior_winning_expert == expert) {
+          inp_kvp = thread_kvp;
+        }
+      }
+
+      thread_kvp = arg_max(inp_kvp, thread_kvp);
+    }
+
+    const cub_kvp result_kvp =
+        BlockReduce(tmpStorage).Reduce(thread_kvp, arg_max);
+    if (threadIdx.x == 0) {
+      const int idx = k * block_row + k_idx;
+      // restore normalized probes
+      output[idx] = result_kvp.value / T(softmax_max_prob[idx]);
+      indices[idx] = should_process_row ? result_kvp.key : num_experts;
+      source_rows[idx] = k_idx * num_rows + block_row;
+    }
+    __syncthreads();
+  }
+}
+
+template <typename T, int TPB>
 __launch_bounds__(TPB) __global__ void moe_softmax(const T* input,
                                                    const bool* finished,
                                                    T* output,
@@ -454,9 +585,11 @@ void topk_gating_softmax_kernelLauncher(const T* input,
                                         T* softmax,
                                         int* indices,
                                         int* source_row,
+                                        T* softmax_max_prob,
                                         const int num_rows,
                                         const int num_experts,
                                         const int k,
+                                        const bool group_moe,
                                         cudaStream_t stream) {
   static constexpr int WARPS_PER_TB = 4;
 
@@ -559,10 +692,25 @@ void topk_gating_softmax_kernelLauncher(const T* input,
     }
     default: {
       static constexpr int TPB = 256;
-      moe_softmax<T, TPB>
-          <<<num_rows, TPB, 0, stream>>>(input, finished, softmax, num_experts);
-      moe_top_k<T, TPB><<<num_rows, TPB, 0, stream>>>(
-          softmax, finished, output, indices, source_row, num_experts, k);
+      if (group_moe) {
+        const int group_experts = num_experts / k;
+        const int softmax_num_rows = num_rows * k;
+        group_moe_softmax<T, TPB><<<softmax_num_rows, TPB, 0, stream>>>(
+            input, finished, softmax, softmax_max_prob, group_experts);
+        moe_top_k<T, TPB><<<num_rows, TPB, 0, stream>>>(softmax,
+                                                        finished,
+                                                        output,
+                                                        indices,
+                                                        source_row,
+                                                        softmax_max_prob,
+                                                        num_experts,
+                                                        k);
+      } else {
+        moe_softmax<T, TPB><<<num_rows, TPB, 0, stream>>>(
+            input, finished, softmax, num_experts);
+        moe_top_k<T, TPB><<<num_rows, TPB, 0, stream>>>(
+            softmax, finished, output, indices, source_row, num_experts, k);
+      }
     }
   }
 }
@@ -799,9 +947,11 @@ template void topk_gating_softmax_kernelLauncher(const float*,
                                                  float*,
                                                  int*,
                                                  int*,
+                                                 float*,
                                                  const int,
                                                  const int,
                                                  const int,
+                                                 const bool,
                                                  cudaStream_t);
 template void topk_gating_softmax_kernelLauncher(const half*,
                                                  const bool*,
@@ -809,9 +959,11 @@ template void topk_gating_softmax_kernelLauncher(const half*,
                                                  half*,
                                                  int*,
                                                  int*,
+                                                 half*,
                                                  const int,
                                                  const int,
                                                  const int,
+                                                 const bool,
                                                  cudaStream_t);
 #ifdef PADDLE_CUDA_BF16
 template void topk_gating_softmax_kernelLauncher(const __nv_bfloat16*,
@@ -820,9 +972,11 @@ template void topk_gating_softmax_kernelLauncher(const __nv_bfloat16*,
                                                  __nv_bfloat16*,
                                                  int*,
                                                  int*,
+                                                 __nv_bfloat16*,
                                                  const int,
                                                  const int,
                                                  const int,
+                                                 const bool,
                                                  cudaStream_t);
 #endif
 // ===================== Specializations for init routing

--- a/paddle/phi/ops/yaml/fused_ops.yaml
+++ b/paddle/phi/ops/yaml/fused_ops.yaml
@@ -868,7 +868,7 @@
 
 - op: fused_moe
   args: (Tensor x, Tensor gate_weight, Tensor ffn1_weight, Tensor ffn1_scale, Tensor ffn1_bias, Tensor ffn2_weight, Tensor ffn2_scale, Tensor ffn2_bias,
-    str quant_method = "None", int moe_topk = 2, bool norm_topk_prob = true)
+    str quant_method = "None", int moe_topk = 2, bool norm_topk_prob = true, bool group_moe = false)
   output: Tensor (out)
   infer_meta:
     func: FusedMoeInferMeta

--- a/python/paddle/incubate/nn/functional/fused_moe.py
+++ b/python/paddle/incubate/nn/functional/fused_moe.py
@@ -12,23 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from paddle import _C_ops
 from paddle.base.layer_helper import LayerHelper
 from paddle.framework import in_dynamic_or_pir_mode
 
+if TYPE_CHECKING:
+    from paddle import Tensor
+
 
 def fused_moe(
-    x,
-    gate_weight,
-    ffn1_weight,
-    ffn2_weight,
-    ffn1_bias=None,
-    ffn1_scale=None,
-    ffn2_bias=None,
-    ffn2_scale=None,
-    quant_method="None",
-    moe_topk=2,
-    norm_topk_prob=True,
+    x: Tensor,
+    gate_weight: Tensor,
+    ffn1_weight: Tensor,
+    ffn2_weight: Tensor,
+    ffn1_bias: Tensor | None = None,
+    ffn1_scale: Tensor | None = None,
+    ffn2_bias: Tensor | None = None,
+    ffn2_scale: Tensor | None = None,
+    quant_method: str = "None",
+    moe_topk: int = 2,
+    norm_topk_prob: bool = True,
+    group_moe: bool = False,
 ):
     """
     Applies fused moe kernel.
@@ -46,6 +54,7 @@ def fused_moe(
         quant_method (string): Currently not supported.
         moe_topk (int): Select the top k experts for each token.
         norm_topk_prob (bool): Whether to normalize the topk probabilities.
+        group_moe (bool): Whether to use group moe.
 
     Returns:
         Tensor: the output Tensor.
@@ -84,6 +93,7 @@ def fused_moe(
             quant_method,
             moe_topk,
             norm_topk_prob,
+            group_moe,
         )
         return final_out
     else:
@@ -113,6 +123,7 @@ def fused_moe(
                 'quant_method': quant_method,
                 'moe_topk': moe_topk,
                 'norm_topk_prob': norm_topk_prob,
+                'group_moe': group_moe,
             },
         )
         return final_out


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
card-71500
支持group_moe
1.softmax中会进行分组softmax及归一化，并获得每组的max_probs;
2.topk中会从n中专家中取top_k个，并对选到的浮点数乘上max_probs进行复原；

融合算子的单独修改