### PR TITLE
[SOT] Compare float in guard with a threshold

### DIFF
--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -82,6 +82,11 @@ void BindGuard(pybind11::module *m) {
   py::class_<LengthMatchGuard, GuardBase, std::shared_ptr<LengthMatchGuard>>(
       *m, "LengthMatchGuard", R"DOC(LengthMatchGuard Class.)DOC")
       .def(py::init<const Py_ssize_t &>(), py::arg("length"));
+  py::class_<FloatCloseGuard, GuardBase, std::shared_ptr<FloatCloseGuard>>(
+      *m, "FloatCloseGuard", R"DOC(FloatCloseGuard Class.)DOC")
+      .def(py::init<const double, const double>(),
+           py::arg("value"),
+           py::arg("epsilon"));
   py::class_<ValueMatchGuard, GuardBase, std::shared_ptr<ValueMatchGuard>>(
       *m, "ValueMatchGuard", R"DOC(ValueMatchGuard Class.)DOC")
       .def(py::init<const py::object &>(), py::arg("py_value"));

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -76,6 +76,14 @@ bool TypeMatchGuard::check(PyObject* value) {
 
 bool IdMatchGuard::check(PyObject* value) { return value == expected_; }
 
+bool FloatCloseGuard::check(PyObject* value) {
+  if (Py_TYPE(value) != &PyFloat_Type) {
+    return false;
+  }
+  double v = reinterpret_cast<PyFloatObject*>(value)->ob_fval;
+  return std::abs(v - expected_) < 1e-13;
+}
+
 bool ValueMatchGuard::check(PyObject* value) {
   return PyObject_Equal(value, expected_value_);
 }

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -117,6 +117,18 @@ class ValueMatchGuard : public GuardBase {
   PyTypeObject* expected_type_;
 };
 
+class FloatCloseGuard : public GuardBase {
+ public:
+  explicit FloatCloseGuard(double value, double epsilon)
+      : expected_(value), epsilon_(epsilon) {}
+
+  bool check(PyObject* value);
+
+ private:
+  double expected_;
+  double epsilon_;
+};
+
 class LengthMatchGuard : public GuardBase {
  public:
   explicit LengthMatchGuard(const Py_ssize_t& length) : expected_(length) {}

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -196,6 +196,24 @@ class ConstantVariable(VariableBase):
             DummyTracker([self]),
         )
 
+    @check_guard
+    def make_stringified_guard(self) -> list[StringifiedExpression]:
+        if self.get_py_type() is not float:
+            return super().make_stringified_guard()
+
+        frame_value_tracer = self.tracker.trace_value_from_frame()
+        epsilon = 1e-13
+        return [
+            FasterStringifiedExpression(
+                f"type({{0}}) is float and abs({self.get_py_value()!r} - {{0}}) < {epsilon}",
+                paddle.framework.core.FloatCloseGuard(
+                    self.get_py_value(), epsilon
+                ),
+                [frame_value_tracer],
+                union_free_vars(frame_value_tracer.free_vars),
+            )
+        ]
+
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
         if type(value) in ConstTypes:

--- a/python/paddle/jit/sot/symbolic/compile_cache.py
+++ b/python/paddle/jit/sot/symbolic/compile_cache.py
@@ -214,6 +214,7 @@ class FallbackWrapper:
             input_shape_infos,
             output_shape_infos,
             self.is_first_call,
+            self.graph_size(),
         )
 
     def __call__(self, *args, **kwargs):

--- a/python/paddle/jit/sot/utils/info_collector.py
+++ b/python/paddle/jit/sot/utils/info_collector.py
@@ -125,12 +125,14 @@ class SubGraphRelationInfo(StepInfoBase):
         input_shape_infos: list[SubGraphRelationInfo.ConcreteShapeInfo],
         output_shape_infos: list[SubGraphRelationInfo.ConcreteShapeInfo],
         is_first_call: bool,
+        graph_size: int,
     ):
         super().__init__()
         self.subgraph_name = subgraph_name
         self.input_shape_infos = input_shape_infos
         self.output_shape_infos = output_shape_infos
         self.is_first_call = is_first_call
+        self.graph_size = graph_size
 
     @classmethod
     def summary(cls, history: list[Self]) -> str:
@@ -169,7 +171,7 @@ class SubGraphRelationInfo(StepInfoBase):
             subgraph_id = f"subgraph_{i}"
             dot.node(
                 subgraph_id,
-                f"Subgraph {i} ({info.subgraph_name})",
+                f"Subgraph {i} ({info.subgraph_name}, size={info.graph_size})",
                 shape='oval',
                 fillcolor='cyan' if info.is_first_call else None,
                 style='filled' if info.is_first_call else None,

--- a/test/sot/test_faster_guard.py
+++ b/test/sot/test_faster_guard.py
@@ -147,6 +147,7 @@ class TestFasterGuardGroup(unittest.TestCase):
         epsilon = 1e-13
         guard_float = paddle.framework.core.FloatCloseGuard(expected, epsilon)
         self.assertTrue(guard_float.check(0.018181818181818184))
+        self.assertTrue(guard_float.check(0.018181818181818177))
         self.assertFalse(guard_float.check(0.018181818191818184))
 
 

--- a/test/sot/test_faster_guard.py
+++ b/test/sot/test_faster_guard.py
@@ -142,6 +142,13 @@ class TestFasterGuardGroup(unittest.TestCase):
         self.assertTrue(guard_range.check(range(1, 10, 2)))
         self.assertFalse(guard_range.check(range(11)))
 
+    def test_float_close_guard(self):
+        expected = 0.018181818181818184
+        epsilon = 1e-13
+        guard_float = paddle.framework.core.FloatCloseGuard(expected, epsilon)
+        self.assertTrue(guard_float.check(0.018181818181818184))
+        self.assertFalse(guard_float.check(0.018181818191818184))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

float 对比时不使用完全匹配，而是改为允许 1e-13 内的误差

一般情况不会出现这个问题，目前在 SwinTransformer 上一个 guard 内的数值 `0.018181818181818184` 总是匹配不上，导致重复组网，而且目前该问题只能在编译器场景下复现，且有一定随机性

在出现问题的情况下，无论是 python float 直接运算还是 numpy 运算都会出现一定的精度损失，`0.2 / 11` 的结果会变成 `0.018181818181818177`，导致 guard 无法命中，由于复现困难且**目前难以理解**（属实超过我认知了），因此暂时在 guard 中允许一定误差，避免重复组网

PCard-66972