### PR TITLE
[PIR-Auto-Parallel] Add assert when no segemnt in recompute pass

### DIFF
--- a/python/paddle/distributed/passes/auto_parallel_recompute_pir.py
+++ b/python/paddle/distributed/passes/auto_parallel_recompute_pir.py
@@ -182,9 +182,11 @@ class AutoParallelRecomputePIRPass(PassBase):
         self.program_ops = list(main_program.global_block().ops)
         # 1. Get the recompute segments information form program.
         segments = self.get_segments()
-        if len(segments) == 0:
-            logger.info("No segments found in PIR recompite pass, skip pass.")
-            return
+        assert (
+            len(segments) > 0
+        ), "No segment found in the PIR recompute pass.\n \
+            Please disable 'recompute.enable' or check 'recompute()' usage in model code."
+
         # 2. Get the forward and backward OPs from program.
         fwd_ops, bwd_ops = self.get_fwd_bwd_ops()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

在`recompute pass` 中添加对 `segment` 数目的 assert 断言检测
如果在开启`recompute` ( `strategy._recompute.enable=1`)，但是在模型代码没有使用到 `recompute(layer)`，则将在 `recompute pass` 中报错

PCard-88114