### PR TITLE
【Cherrypick】fix flash_attn seed (#70298)

### DIFF
--- a/paddle/phi/kernels/gpu/flash_attn_utils.h
+++ b/paddle/phi/kernels/gpu/flash_attn_utils.h
@@ -285,10 +285,15 @@ struct FlashAttnFwdParamsV2 : public FlashAttnParamsBase {
     // with the same size.
     rng_state = Empty<int64_t>(ctx, {2});
 
-    auto seed_offset_pair = GenerateRNGState(
-        ctx, fixed_seed_offset, rng_name, batch_size, num_heads);
-    seed = seed_offset_pair.first;
-    offset = seed_offset_pair.second;
+    if (_dropout > 0.0f) {
+      auto seed_offset_pair = GenerateRNGState(
+          ctx, fixed_seed_offset, rng_name, batch_size, num_heads);
+      seed = seed_offset_pair.first;
+      offset = seed_offset_pair.second;
+    } else {
+      seed = 0;
+      offset = 0;
+    }
 
     seed_offset->Resize({2});
     int64_t* seed_offset_data = ctx.template HostAlloc<int64_t>(seed_offset);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
card-71500
Fixed the problem of flash_attn modifying seed internally when dropout=0.0