### PR TITLE
[CINN] ComputeAt supports loop fusion for Elementwise

### DIFF
--- a/paddle/cinn/ir/group_schedule/tactic/compute_at_reduction_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/compute_at_reduction_tactic.cc
@@ -13,36 +13,107 @@
 // limitations under the License.
 
 #include "paddle/cinn/ir/group_schedule/tactic/compute_at_reduction_tactic.h"
-#include "paddle/cinn/ir/ir.h"
 #include "paddle/cinn/ir/ir_analyzer/ir_analyzer.h"
-#include "paddle/cinn/ir/schedule/ir_schedule_util.h"
 #include "paddle/cinn/ir/utils/ir_compare.h"
 #include "paddle/cinn/optim/replace_var_with_expr.h"
-#include "paddle/common/enforce.h"
 
 namespace cinn {
 namespace ir {
+namespace {
 
+/**
+ * Do loop fusion using the SimpleComputeAt primitive.
+ *
+ * This tactic fuses loops that can be executed parallelly and have common
+ * loads, in order to eliminate duplicate memory reads. For each schedule block
+ * in the graph, it uses a four-step procedure (see FindCandidateBlocks for
+ * details) to find candidate blocks that are both VALID and BENEFICIAL to do
+ * ComputeAt. If found, it picks the best candidate and fuses the current block
+ * to the candidate block.
+ *
+ * This tactic currently supports 3 fusion patterns:
+ *    Reduce -> Reduce
+ *    Trivial -> Reduce
+ *    Trivial -> Trivial
+ * We don't support `Reduce -> Trivial` because we treat Reduce as the anchor,
+ * so we should move Trivial instead of moving Reduce.
+ */
 class ComputeAtReductionTactic final : public ScheduleTactic {
  public:
-  void Init(ScheduleContext* context) override;
+  void Init(ScheduleContext* context, ir::IRSchedule* sch) override;
 
   void Apply(ir::IRSchedule* sch, const std::string& block_id) override;
 
   std::string TacticName() const override { return "ComputeAtReductionTactic"; }
 
  private:
-  void ComputeAtReduceInit(ir::IRSchedule* sch, const std::string& block_id);
-  void ComputeAtReduceLoad(ir::IRSchedule* sch, const std::string& block_id);
+  /**
+   * Find the candidate blocks that are both valid and beneficial for this block
+   * to do ComputeAt with.
+   *
+   * Note:
+   * 1) We only do ComputeAt in the direction `this_block -> candidate_block`.
+   *    If this direction is not applicable but the opposite direction does,
+   *    ComputeAt will be performed when the outer Scheduler applies on that
+   *    candidate block.
+   * 2) This interface currently only returns at most one block, so if there are
+   *    multiple candidates, it choose one of them using some heuristics.
+   */
+  std::vector<std::string> FindCandidateBlocks(ir::IRSchedule* sch,
+                                               const std::string& block_id);
+
+  /**
+   * Get blocks in this graph to which we can fuse the current block without
+   * dependency harzards.
+   *
+   * A block will not cause dependency harzard with the current block if:
+   * 1) It has no data dependency with the current block, and
+   * 2) There is no block that would cause dependency harzard when we move the
+   *    current block to the target block.
+   */
+  std::vector<std::string> GetDependencyHarzardFreeBlocks(
+      ir::IRSchedule* sch, const std::string& block_id);
+
+  /**
+   * Get the control flow (including For and IfThenElse) of this block.
+   * The loop_vars in the returned nodes are unifiedly rewritten to the form
+   * `$<loop_index>` to facilitate comparison.
+   */
+  std::vector<ir::Expr> GetUnifiedControlFlow(
+      const ir::Expr& block, const std::vector<ir::Expr>& loops);
+
+  /**
+   * Get loads in this schedule block whose indices correlate with the serial
+   * loop's index. Only with these loads can we save memory accesses by doing
+   * loop fusion.
+   * The loop_vars in the returned loads' indices are unifiedly rewritten to the
+   * form `$<loop_index>` to facilitate comparison.
+   */
+  std::vector<ir::Expr> GetLoopVariantLoads(const ir::Expr& block,
+                                            const std::vector<ir::Expr>& loops);
+
+  /**
+   * Get the total extent of serial loops (loops not bound on GPU block/thread).
+   * Returns -1 if the extent is dynamic.
+   */
+  int64_t GetSerialLoopExtent(const std::vector<ir::Expr>& loops);
 
  private:
   ScheduleContext* context_;
-  bool compute_at_reduce_init_done_{false};
-};
 
-void ComputeAtReductionTactic::Init(ScheduleContext* context) {
-  context_ = context;
-}
+  // A copy of the IRSchedule and ScheduleBlockGraph, with all loop vars
+  // unifiedly rewritten to the form `$<loop_index>` (e.g. $0, $1).
+  std::unique_ptr<ir::IRSchedule> sch_;
+  std::unique_ptr<ir::ScheduleBlockGraph> graph_;
+
+  // Cache of the results of GetUnifiedControlFlow, GetLoopVariantLoads,
+  // GetSerialLoopExtent and IsReductionSBlock because these functions are too
+  // slow while their results don't change after scheduling.
+  std::unordered_map<std::string, std::vector<ir::Expr>> unified_control_flow_;
+  std::unordered_map<std::string, std::vector<ir::Expr>> loop_variant_loads_;
+  std::unordered_map<std::string, int64_t> serial_loop_extent_;
+  std::unordered_map<std::string, bool> is_reduction_sblock_;
+};
 
 bool ControlFlowAllEqual(const std::vector<ir::Expr>& first,
                          const std::vector<ir::Expr>& second) {
@@ -69,16 +140,14 @@ bool ControlFlowAllEqual(const std::vector<ir::Expr>& first,
       auto first_for = first.As<ir::For>();
       auto second_for = second.As<ir::For>();
       if (first_for->for_type() != second_for->for_type()) return false;
-      return ir::ir_utils::IRCompare(first_for->extent, second_for->extent);
+      return first_for->extent == second_for->extent;
     } else if (first.As<ir::IfThenElse>() && second.As<ir::IfThenElse>()) {
       auto first_if = first.As<ir::IfThenElse>();
       auto second_if = second.As<ir::IfThenElse>();
       if (!IsIndexCondWithoutFalseCase(first_if)) return false;
       if (!IsIndexCondWithoutFalseCase(second_if)) return false;
-      return ir::ir_utils::IRCompare(first_if->condition, second_if->condition);
+      return first_if->condition == second_if->condition;
     } else {
-      VLOG(8) << "Is not for or if_then_else node, first: " << first
-              << " second: " << second;
       return false;
     }
     return false;
@@ -91,21 +160,6 @@ bool ControlFlowAllEqual(const std::vector<ir::Expr>& first,
   return true;
 }
 
-bool IsForEqual(const std::vector<ir::Expr>& first,
-                const std::vector<ir::Expr>& second) {
-  return ControlFlowAllEqual(first, second);
-}
-
-void CheckAndComputeAt(ir::IRSchedule* sch,
-                       const std::string& src_id,
-                       const std::string& dst_id) {
-  auto block = sch->GetBlock(src_id);
-  auto loop = sch->GetLoops(dst_id).back();
-  auto root = sch->GetRootBlock(block);
-  CheckComputeAtValidation(block, loop, root);
-  sch->SimpleComputeAt(block, loop);
-}
-
 bool BlockWithSameLoop(const std::vector<ir::Expr>& first,
                        const std::vector<ir::Expr>& second) {
   VLOG(8) << "First inner loop: " << first.back();
@@ -114,14 +168,23 @@ bool BlockWithSameLoop(const std::vector<ir::Expr>& first,
   return first.back() == second.back();
 }
 
-std::string BlockToName(const ir::Expr& block) {
-  PADDLE_ENFORCE_NOT_NULL(
-      block.As<ir::ScheduleBlockRealize>(),
-      ::common::errors::InvalidArgument(
-          "The input block should be a ScheduleBlockRealize!"));
-  return block.As<ir::ScheduleBlockRealize>()
-      ->schedule_block.As<ir::ScheduleBlock>()
-      ->name;
+bool HasCommonLoad(const std::vector<ir::Expr>& first_loads,
+                   const std::vector<ir::Expr>& other_loads) {
+  for (auto& first_load : first_loads) {
+    for (auto& other_load : other_loads) {
+      if (ir::ir_utils::IRCompare(first_load, other_load)) return true;
+    }
+  }
+  return false;
+}
+
+bool LoadsAllEqual(const std::vector<ir::Expr>& first_loads,
+                   const std::vector<ir::Expr>& other_loads) {
+  if (first_loads.size() != other_loads.size()) return false;
+  for (auto& load : first_loads) {
+    if (!HasCommonLoad({load}, other_loads)) return false;
+  }
+  return true;
 }
 
 struct GetControlFlowFunctor {
@@ -144,7 +207,7 @@ struct GetControlFlowFunctor {
       GetControlFlow(expr.As<ir::For>()->body);
       control_flow_.pop_back();
     } else if (expr.As<ir::ScheduleBlockRealize>()) {
-      if (BlockToName(expr) == BlockToName(block_)) {
+      if (analyzer::GetBlockName(expr) == analyzer::GetBlockName(block_)) {
         result_ = control_flow_;
         end_ = true;
         return;
@@ -170,355 +233,267 @@ struct GetControlFlowFunctor {
   const Expr& block_;
 };
 
+void ComputeAtReductionTactic::Init(ScheduleContext* context,
+                                    ir::IRSchedule* sch) {
+  context_ = context;
+  unified_control_flow_.clear();
+  loop_variant_loads_.clear();
+  serial_loop_extent_.clear();
+
+  sch_ = std::make_unique<ir::IRSchedule>(*sch);
+  graph_ = std::make_unique<ir::ScheduleBlockGraph>(*sch_);
+
+  for (auto& block : sch_->GetAllBlocks()) {
+    // Replace loop_vars to the unified form `$<loop_index>`
+    std::vector<ir::Expr> loops = sch_->GetLoops(block);
+    for (int i = 0; i < loops.size(); ++i) {
+      auto& loop_var = loops[i].As<ir::For>()->loop_var;
+      ir::Expr unified_var(ir::Var("$" + std::to_string(i)));
+      optim::ReplaceVarWithExpr(&loops[i], loop_var, unified_var);
+    }
+
+    // Replace iter_vars to iter_values in schedule block
+    auto* block_realize = block.As<ir::ScheduleBlockRealize>();
+    auto* block_node = block_realize->schedule_block.As<ir::ScheduleBlock>();
+    block_node->body = analyzer::ReplaceVarWithExpr(
+        block_node->body, block_node->iter_vars, block_realize->iter_values);
+
+    // Cache the results of some slow functions to accelerate Apply execution
+    unified_control_flow_[block_node->name] =
+        GetUnifiedControlFlow(block, loops);
+    loop_variant_loads_[block_node->name] = GetLoopVariantLoads(block, loops);
+    serial_loop_extent_[block_node->name] = GetSerialLoopExtent(loops);
+    is_reduction_sblock_[block_node->name] = analyzer::IsReductionSBlock(block);
+  }
+}
+
 void ComputeAtReductionTactic::Apply(ir::IRSchedule* sch,
                                      const std::string& block_id) {
-  const auto ContainsLet = [&](const ir::Expr& expr) -> bool {
-    const auto let_set = ir::ir_utils::CollectIRNodesWithoutTensor(
-        expr, [&](const Expr* x) -> bool { return x->As<ir::Let>(); });
-    return !let_set.empty();
-  };
+  if (IsReduceInitTensorName(block_id)) return;
+  if (serial_loop_extent_[block_id] == 1) return;  // no loop, nothing to fuse
 
-  // Should analyze let when dependency tools are done.
-  if (ContainsLet(sch->GetModule().GetExprs().front())) return;
+  std::vector<std::string> candidates = FindCandidateBlocks(sch, block_id);
+  if (candidates.empty()) return;
 
-  if (!compute_at_reduce_init_done_) {
-    for (const auto& block : sch->GetAllBlocks()) {
-      ComputeAtReduceInit(sch, BlockToName(block));
+  auto& target_id = candidates.front();
+  VLOG(4) << "ComputeAt Apply: " << block_id << " -> " << target_id;
+
+  ir::Expr block = sch->GetBlock(block_id);
+  sch->SimpleComputeAt(block, sch->GetLoops(target_id).back());
+
+  // If the current block is a Reduce, don't forget to also do ComputeAt for its
+  // `reduce_init` block.
+  // TODO(liangshuhao): the IsReductionSBlock interface returns false for a unit
+  // Reduce (Reduce whose loop extent is 1), so we have to use HasBlock to check
+  // the existence of the `reduce_init` block.
+  std::string reduce_init_block_id = GenReduceInitTensorNameOf(block_id);
+  if (sch->HasBlock(reduce_init_block_id)) {
+    std::vector<ir::Expr> loops = sch->GetLoops(reduce_init_block_id);
+    PADDLE_ENFORCE_GT(
+        loops.size(),
+        0UL,
+        ::common::errors::PreconditionNotMet(
+            "The reduce_init schedule block must be inside loops, but found "
+            "one that has no parent loop: %s",
+            reduce_init_block_id));
+    int loop_index = loops.size() - 1;
+    ir::Expr reduce_init_block = sch->GetBlock(reduce_init_block_id);
+    sch->SimpleComputeAt(reduce_init_block,
+                         sch->GetLoops(target_id)[loop_index]);
+  }
+}
+
+std::vector<std::string> ComputeAtReductionTactic::FindCandidateBlocks(
+    ir::IRSchedule* sch, const std::string& block_id) {
+  ir::Expr this_block = sch->GetBlock(block_id);
+  std::vector<ir::Expr> this_loops = sch->GetLoops(block_id);
+  std::vector<ir::Expr> this_cf = unified_control_flow_[block_id];
+  std::vector<ir::Expr> this_loads = loop_variant_loads_[block_id];
+
+  // Step 1. Get the blocks to which we can do ComputeAt without dependency
+  //   hazards. This ensures the fundamental correctness of ComputeAt.
+  std::vector<std::string> dep_free_blocks =
+      GetDependencyHarzardFreeBlocks(sch, block_id);
+  if (dep_free_blocks.empty()) return {};
+
+  // Step 2. Get the blocks that have equal control flow with the current block.
+  //    This makes the problem easier by preventing handling unaligned loops.
+  //    Usually, fusing unaligned loops will not improve the performance, so it
+  //    is OK to skip them.
+  std::vector<std::string> cf_equal_blocks;
+  for (auto& other_id : dep_free_blocks) {
+    std::vector<ir::Expr> other_cf = unified_control_flow_[other_id];
+    if (ControlFlowAllEqual(this_cf, other_cf)) {
+      cf_equal_blocks.push_back(other_id);
     }
-    VLOG(6) << "After ComputeAtReductionInit on expr: [" << block_id
-            << "], expr:\n"
-            << sch->GetModule().GetExprs().front();
-    compute_at_reduce_init_done_ = true;
+  }
+  if (cf_equal_blocks.empty()) return {};
+
+  // Step 3. Get the blocks that are beneficial to do ComputeAt.
+  // Rules:
+  // 1) The block should have common loop-variant loads with the current block,
+  //    so that we can save memory accesses by loop fusion.
+  // 2) Both blocks should not be inside the same loop, otherwise they have
+  //    already been fused and we have nothing to do.
+  // 3) If the current block is Reduce, the candidate block must also be Reduce,
+  //    because we don't allow fusing Reduce into Trivial.
+  // 4) If the current block is Trivial and its serial loop's extent is <= 8, we
+  //    only choose blocks that share all the same loads, because fusing blocks
+  //    that have different loads will introduce non-continuous reads, which can
+  //    only be compensated when the loop is large enough.
+  std::vector<std::string> beneficial_blocks;
+  for (auto& other_id : cf_equal_blocks) {
+    std::vector<ir::Expr> other_loads = loop_variant_loads_[other_id];
+    if (!HasCommonLoad(this_loads, other_loads)) continue;
+    std::vector<ir::Expr> other_loops = sch->GetLoops(other_id);
+    if (BlockWithSameLoop(this_loops, other_loops)) continue;
+    if (is_reduction_sblock_[block_id]) {
+      if (!is_reduction_sblock_[other_id]) continue;
+    } else {
+      int64_t extent = serial_loop_extent_[block_id];
+      if (extent <= 8 && extent != -1) {
+        if (!LoadsAllEqual(this_loads, other_loads)) continue;
+      }
+    }
+    beneficial_blocks.push_back(other_id);
+  }
+  if (beneficial_blocks.empty()) return {};
+
+  // Step 4. Choose the best candidate using some heuristic rules.
+  // Rules:
+  // 1) If there exists Reduce, choose the first Reduce.
+  // 2) Otherwise, just choose the first candidate.
+  for (auto& other_id : beneficial_blocks) {
+    if (is_reduction_sblock_[other_id]) return {other_id};
+  }
+  return beneficial_blocks;
+}
+
+std::vector<std::string>
+ComputeAtReductionTactic::GetDependencyHarzardFreeBlocks(
+    ir::IRSchedule* sch, const std::string& block_id) {
+  std::vector<std::string> results;
+  std::vector<ir::Expr> blocks = sch->GetAllBlocks();
+  auto* graph_node = graph_->RetrieveNode(block_id);
+  std::unordered_set<std::string> upstreams = graph_node->UpstreamNodes();
+  std::unordered_set<std::string> downstreams = graph_node->DownstreamNodes();
+
+  // Find the position of the current block in the graph, then search upwards
+  // and downwards until a denepency harzard is met.
+  //
+  // For example, in the following graph (A-E are schedule blocks, `|` denotes
+  // data dependency):
+  //
+  //     A      Search upwards
+  //                  ^
+  //     B            |
+  //     |
+  //     C   <- current block
+  //
+  //     D            |
+  //     |            v
+  //     E     Search downwards
+  //
+  // C has denepency harzard with B because it directly depends on B. C also has
+  // dependency harzard with A, because if we move C to the position of A, we
+  // will violate the dependency of B->C. C is only harzard-free with D and E.
+  auto this_it =
+      std::find_if(blocks.begin(), blocks.end(), [&](const ir::Expr& block) {
+        return analyzer::GetBlockName(block) == block_id;
+      });
+
+  // Search upwards
+  auto this_it_rev = std::make_reverse_iterator(this_it);
+  for (auto it = this_it_rev; it != blocks.rend(); ++it) {
+    std::string other_id = analyzer::GetBlockName(*it);
+    // As a special case, we can ignore the `reduce_init` in front of Reduce.
+    if (IsReduceInitTensorName(other_id)) continue;
+    if (upstreams.count(other_id) > 0) break;
+    results.push_back(other_id);
   }
 
-  ComputeAtReduceLoad(sch, block_id);
-  VLOG(6) << "After ComputeAtReductionLoad on expr: [" << block_id
-          << "], expr:\n"
-          << sch->GetModule().GetExprs().front();
+  // Search downwards
+  for (auto it = this_it + 1; it != blocks.end(); ++it) {
+    std::string other_id = analyzer::GetBlockName(*it);
+    if (downstreams.count(other_id) > 0) break;
+    results.push_back(other_id);
+  }
+
+  return results;
 }
 
-void ComputeAtReductionTactic::ComputeAtReduceInit(
-    ir::IRSchedule* sch, const std::string& block_id) {
-  if (!ir::IsReduceInitTensorName(block_id)) return;
-
-  const auto GetRootInitBlockId =
-      [&](const std::vector<ir::Expr>& blocks) -> std::optional<std::string> {
-    const std::vector<ir::Expr> cur_loops = sch->GetLoops(block_id);
-    for (const auto& block : blocks) {
-      const std::string root_block_name = BlockToName(block);
-      if (ir::IsReduceInitTensorName(root_block_name)) {
-        const std::vector<ir::Expr> root_loops = sch->GetLoops(root_block_name);
-        if (IsForEqual(root_loops, cur_loops)) {
-          return std::optional<std::string>{root_block_name};
-        }
-      }
-    }
-    return std::nullopt;
-  };
-
-  const std::vector<ir::Expr> blocks = sch->GetAllBlocks();
-  std::optional<std::string> root_init_block_id_value =
-      GetRootInitBlockId(blocks);
-  if (!root_init_block_id_value.has_value()) return;
-  const std::string root_init_block_id = root_init_block_id_value.value();
-  if (BlockWithSameLoop(sch->GetLoops(root_init_block_id),
-                        sch->GetLoops(block_id)))
-    return;
-
-  CheckAndComputeAt(sch, block_id, root_init_block_id);
+std::vector<ir::Expr> ComputeAtReductionTactic::GetUnifiedControlFlow(
+    const ir::Expr& block, const std::vector<ir::Expr>& loops) {
+  if (loops.empty()) {
+    return {};
+  }
+  GetControlFlowFunctor functor(block);
+  return functor(loops[0]);
 }
 
-std::optional<std::string> FindCandidateBlockId(
-    ir::IRSchedule* sch,
-    const std::vector<ir::Expr>& blocks,
-    const ir::Expr& cur_block) {
-  const auto ConstructForVarMap = [&](const std::vector<ir::Expr>& lhs_loops,
-                                      const std::vector<ir::Expr>& rhs_loops)
-      -> std::unordered_map<ir::Var, ir::Var> {
-    PADDLE_ENFORCE_EQ(lhs_loops.size(),
-                      rhs_loops.size(),
-                      ::common::errors::InvalidArgument(
-                          "The for loops size should be equal."));
-    std::unordered_map<ir::Var, ir::Var> ret;
-    for (std::size_t i = 0; i < lhs_loops.size(); ++i) {
-      const auto& rhs_var = rhs_loops[i].As<ir::For>()->loop_var;
-      ret[lhs_loops[i].As<ir::For>()->loop_var] = rhs_var;
+std::vector<ir::Expr> ComputeAtReductionTactic::GetLoopVariantLoads(
+    const ir::Expr& block, const std::vector<ir::Expr>& loops) {
+  std::unordered_set<ir::Var> serial_loop_vars;
+  for (auto& loop : loops) {
+    auto* node = loop.As<ir::For>();
+    if (!node->is_binded()) {
+      serial_loop_vars.insert(node->loop_var);
     }
-    return ret;
-  };
+  }
 
-  const auto ReplaceIterWithMap =
-      [&](const ir::Expr& expr,
-          const std::unordered_map<ir::Var, ir::Var>& for_var_map) -> ir::Expr {
-    ir::Expr map_expr = ir::ir_utils::IRCopy(expr);
-    for (const auto& [lhs_var, rhs_var] : for_var_map) {
-      auto tmp_var =
-          ir::_Var_::Make(rhs_var->lower_bound,
-                          rhs_var->upper_bound,
-                          lhs_var->name + "_compare_var_" + rhs_var->name,
-                          rhs_var->is_reduce_axis,
-                          rhs_var->is_symbolic_constant,
-                          rhs_var->is_keepdim);
-      map_expr =
-          ir::analyzer::ReplaceVarWithExpr(map_expr, {lhs_var}, {tmp_var});
-      map_expr =
-          ir::analyzer::ReplaceVarWithExpr(map_expr, {rhs_var}, {tmp_var});
-    }
-    return map_expr;
-  };
-
-  const auto ConditionWithIter =
-      [&](const ir::Expr& block,
-          const std::unordered_map<ir::Var, ir::Var>& for_var_map)
-      -> std::vector<ir::Expr> {
-    std::vector<ir::Expr> control_flows;
-    for (auto& cf : GetControlFlowFunctor(block)(sch->GetRootBlock(block))) {
-      auto tmp_cf = ir::ir_utils::IRCopy(cf);
-      if (tmp_cf.As<ir::IfThenElse>()) {
-        auto if_then_else = tmp_cf.As<ir::IfThenElse>();
-        if_then_else->condition =
-            ReplaceIterWithMap(if_then_else->condition, for_var_map);
-      }
-      control_flows.push_back(tmp_cf);
-    }
-    return control_flows;
-  };
-
-  const auto ControlFlowWithIterEqual =
-      [&](const ir::Expr& first_block,
-          const ir::Expr& second_block,
-          const std::unordered_map<ir::Var, ir::Var>& for_var_map) -> bool {
-    // Handle index expression.
-    if (ir::ir_utils::CollectIRNodesWithoutTensor(
-            sch->GetLoops(second_block).back(),
-            [](const Expr* x) { return x->As<ir::IfThenElse>(); })
-            .size() > 1) {
-      return false;
-    }
-    return ControlFlowAllEqual(ConditionWithIter(first_block, for_var_map),
-                               ConditionWithIter(second_block, for_var_map));
-  };
-
-  const auto IndicesWithIterValues =
-      [&](const std::vector<ir::Expr>& indices,
-          const ir::ScheduleBlockRealize* sbr,
-          const std::unordered_map<ir::Var, ir::Var>& for_var_map)
-      -> std::vector<ir::Expr> {
-    std::vector<ir::Expr> tensor_indices;
-    std::vector<ir::Expr> map_iter_values;
-    for (const auto& iter_value : sbr->iter_values) {
-      map_iter_values.push_back(ReplaceIterWithMap(iter_value, for_var_map));
-    }
-    for (ir::Expr index : indices) {
-      ir::Expr index_value = ir::analyzer::ReplaceVarWithExpr(
-          index,
-          sbr->schedule_block.As<ir::ScheduleBlock>()->iter_vars,
-          map_iter_values);
-      tensor_indices.push_back(index_value);
-    }
-    return tensor_indices;
-  };
-
-  const auto LoadIndicesEqual =
-      [&](const std::vector<ir::Expr>& first,
-          const std::vector<ir::Expr>& second) -> bool {
-    if (first.size() != second.size()) return false;
-    for (size_t i = 0; i < first.size(); ++i) {
-      if (!ir::ir_utils::IRCompare(first[i], second[i])) {
-        VLOG(8) << "Indices not equal, first: " << first[i]
-                << " second: " << second[i];
-        return false;
-      }
-    }
-    VLOG(8) << "Indices equal";
-    return true;
-  };
-
-  const auto LoadBufferEqual = [&](const ir::Load* first,
-                                   const ir::Load* second) -> bool {
-    return (first->tensor.as_tensor_ref()->buffer->name ==
-            second->tensor.as_tensor_ref()->buffer->name);
-  };
-
-  const auto IndicesContainLoad = [&](const ir::Load* load) -> bool {
-    for (const auto& index : load->indices) {
-      std::set<Expr> load_tensors = ir::ir_utils::CollectLoadTensors(
-          index, /*teller=*/[&](const Expr*) -> bool { return true; });
-      if (load_tensors.size() > 0) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  const auto HasCommonLoad = [&](const ir::Load* target_load,
-                                 const std::set<ir::Expr>& load_nodes,
-                                 const ir::Expr& first_block,
-                                 const ir::Expr& second_block) -> bool {
-    if (IndicesContainLoad(target_load)) return false;
-    const std::vector<ir::Expr> first_loops = sch->GetLoops(first_block);
-    const std::vector<ir::Expr> second_loops = sch->GetLoops(second_block);
-    if (first_loops.size() != second_loops.size()) return false;
-    std::unordered_map<ir::Var, ir::Var> for_var_map =
-        ConstructForVarMap(first_loops, second_loops);
-    if (!ControlFlowWithIterEqual(first_block, second_block, for_var_map))
-      return false;
-
-    for (const auto& load_node : load_nodes) {
-      const auto node = load_node.As<ir::Load>();
-      PADDLE_ENFORCE_NOT_NULL(node,
-                              ::common::errors::InvalidArgument(
-                                  "The input node should be a Load!"));
-      const auto first_indices =
-          IndicesWithIterValues(target_load->indices,
-                                first_block.As<ir::ScheduleBlockRealize>(),
-                                for_var_map);
-      const auto second_indices =
-          IndicesWithIterValues(node->indices,
-                                second_block.As<ir::ScheduleBlockRealize>(),
-                                for_var_map);
-      if (LoadBufferEqual(target_load, node) &&
-          LoadIndicesEqual(first_indices, second_indices))
-        return true;
-    }
-    return false;
-  };
-
-  const auto GetCandidateBlockId =
-      [&](const std::vector<ir::Expr>& blocks,
-          const ir::Expr& cur_block) -> std::optional<std::string> {
-    const auto load_nodes = ir::ir_utils::CollectIRNodesWithoutTensor(
-        cur_block, [&](const Expr* x) -> bool {
-          return x->As<ir::Load>() &&
-                 x->As<ir::Load>()
-                         ->tensor.as_tensor_ref()
-                         ->buffer->memory_type == ir::MemoryType::Heap;
+  auto ContainsSerialLoopVar = [&](const ir::Expr& expr) {
+    std::set<ir::Expr> vars_in_expr =
+        ir::ir_utils::CollectIRNodes(expr, [](const ir::Expr* x) {
+          return x->as_var() && !x->as_var()->is_symbolic_constant;
         });
-
-    for (const auto& block : blocks) {
-      const auto common_loads = ir::ir_utils::CollectIRNodesWithoutTensor(
-          block, [&](const Expr* x) -> bool {
-            return x->As<ir::Load>() &&
-                   HasCommonLoad(
-                       x->As<ir::Load>(), load_nodes, block, cur_block);
-          });
-      if (!common_loads.empty()) {
-        return std::optional<std::string>{BlockToName(block)};
-      }
-    }
-    return std::nullopt;
-  };
-
-  return GetCandidateBlockId(blocks, cur_block);
-}
-
-bool IsSafeComputeAt(ir::IRSchedule* sch,
-                     const std::string& candidate_block_id,
-                     const std::string& block_id) {
-  const auto GetLoopsAllSbrs =
-      [&](const std::vector<ir::Expr>& loops) -> std::vector<ir::Expr> {
-    std::vector<ir::Expr> loop_sbrs;
-    if (!loops.empty()) {
-      ir::ir_utils::CollectIRNodesWithoutTensor(
-          loops[0], [&](const Expr* x) -> bool {
-            if (x->As<ir::ScheduleBlockRealize>() &&
-                !(ir::IsReduceInitTensorName(BlockToName(*x)))) {
-              loop_sbrs.push_back(*x);
-            }
-            return false;
-          });
-    }
-    return loop_sbrs;
-  };
-
-  const auto GetBlockIndex = [&](const std::vector<ir::Expr>& blocks,
-                                 const std::string& block_name) -> size_t {
-    for (size_t i = 0; i < blocks.size(); ++i) {
-      if (BlockToName(blocks[i]) == block_name) {
-        return i;
-      }
-    }
-    VLOG(8) << "Can't find block index!";
-    return blocks.size();
-  };
-
-  const auto GetAffectedSbrs =
-      [&](const std::vector<ir::Expr>& blocks,
-          const std::string& dst_id,
-          const std::string& src_id) -> std::vector<ir::Expr> {
-    std::vector<ir::Expr> affected_sbrs;
-    size_t dst_index = GetBlockIndex(blocks, dst_id);
-    size_t src_index = GetBlockIndex(blocks, src_id);
-    PADDLE_ENFORCE_LT(dst_index,
-                      src_index,
-                      ::common::errors::InvalidArgument(
-                          "We should guarantee dst_index < src_index!"));
-    PADDLE_ENFORCE_LT(src_index,
-                      blocks.size(),
-                      ::common::errors::InvalidArgument(
-                          "We should guarantee src_index < blocks.size()!"));
-    for (size_t i = dst_index; i < src_index; ++i) {
-      affected_sbrs.push_back(blocks[i]);
-    }
-    return affected_sbrs;
-  };
-
-  const auto BlockDependency = [&](const ir::Expr& first,
-                                   const ir::Expr& second) -> bool {
-    if (GetTensor(first)->name == GetTensor(second)->name) return true;
-    const auto consumers = GetConsumers(second, sch->GetRootBlock(second));
-    const auto producers = GetProducers(second, sch->GetRootBlock(second));
-    const auto first_name = BlockToName(first);
-    for (const auto& consumer : consumers) {
-      if (BlockToName(consumer) == first_name) return true;
-    }
-    for (const auto& producer : producers) {
-      if (BlockToName(producer) == first_name) return true;
+    for (auto& var : vars_in_expr) {
+      if (serial_loop_vars.count(var.as_var_ref()) > 0) return true;
     }
     return false;
   };
 
-  const auto AllBlockSafeComputeAt = [&](const std::vector<ir::Expr>& blocks,
-                                         const std::string& dst_id,
-                                         const std::string& src_id) -> bool {
-    std::vector<ir::Expr> check_blocks = GetLoopsAllSbrs(sch->GetLoops(dst_id));
-    const auto src_loop_sbrs = GetLoopsAllSbrs(sch->GetLoops(src_id));
-    const auto affected_sbrs = GetAffectedSbrs(blocks, dst_id, src_id);
-    check_blocks.insert(
-        check_blocks.end(), src_loop_sbrs.begin(), src_loop_sbrs.end());
-    check_blocks.insert(
-        check_blocks.end(), affected_sbrs.begin(), affected_sbrs.end());
-    for (const auto& block : check_blocks) {
-      VLOG(8) << "Check dependency: " << block;
-      if (src_id == BlockToName(block)) continue;
-      if (BlockDependency(block, sch->GetBlock(src_id))) return false;
+  auto IsLoopVariantLoad = [&](const ir::Expr* x) {
+    auto* node = x->As<ir::Load>();
+    if (!node) return false;
+    auto& buffer = node->tensor.as_tensor()->buffer;
+    if (buffer->memory_type != ir::MemoryType::Heap) return false;
+    for (auto& index : node->indices) {
+      if (ContainsSerialLoopVar(index)) return true;
     }
-    return true;
+    return false;
   };
-  return AllBlockSafeComputeAt(
-      sch->GetAllBlocks(), candidate_block_id, block_id);
+
+  ir::Expr store = analyzer::GetStoreOfSBlock(block);
+  std::set<ir::Expr> loads = ir::ir_utils::CollectIRNodes(
+      store.As<ir::Store>()->value, IsLoopVariantLoad);
+
+  // remove duplicate loads
+  std::vector<ir::Expr> dedup_loads;
+  for (auto& load : loads) {
+    auto it = std::find_if(
+        dedup_loads.begin(), dedup_loads.end(), [&](const ir::Expr& other) {
+          return ir::ir_utils::IRCompare(load, other);
+        });
+    if (it == dedup_loads.end()) {
+      dedup_loads.push_back(load);
+    }
+  }
+  return dedup_loads;
 }
 
-void ComputeAtReductionTactic::ComputeAtReduceLoad(
-    ir::IRSchedule* sch, const std::string& block_id) {
-  if (!ir::analyzer::IsReductionSBlock(sch->GetBlock(block_id))) return;
-  // 1. Find candidate block, load buffer with same indices.
-  std::optional<std::string> candidate_block_id_value =
-      FindCandidateBlockId(sch, sch->GetAllBlocks(), sch->GetBlock(block_id));
-  if (!candidate_block_id_value.has_value()) return;
-  const std::string candidate_block_id = candidate_block_id_value.value();
-  if (BlockWithSameLoop(sch->GetLoops(candidate_block_id),
-                        sch->GetLoops(block_id)))
-    return;
-  VLOG(8) << "Candidate block: " << candidate_block_id;
-
-  // 2. Check block-level dependency.
-  if (!IsSafeComputeAt(sch, candidate_block_id, block_id)) return;
-  VLOG(8) << "Compate at is safe: " << block_id;
-
-  // 3. Check and compute at schedule.
-  CheckAndComputeAt(sch, block_id, candidate_block_id);
+int64_t ComputeAtReductionTactic::GetSerialLoopExtent(
+    const std::vector<ir::Expr>& loops) {
+  int64_t extent = 1;
+  for (auto& loop : loops) {
+    auto* node = loop.As<ir::For>();
+    if (node->is_binded()) continue;
+    if (!node->extent.is_constant()) return -1;
+    extent *= node->extent.as_int64();
+  }
+  return extent;
 }
+
+}  // namespace
 
 std::unique_ptr<ScheduleTactic> CreateComputeAtReductionTactic() {
   return std::make_unique<ComputeAtReductionTactic>();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Performance


### Description
重构了`ComputeAtReductionTactic`的流程，新增对Elementwise的支持

该流程的核心函数为`FindCandidateBlocks(block)`，该函数用于在计算图中寻找对于当前block而言可以合法进行ComputeAt、且有性能提升的候选block，分为4个步骤：
1. 使用`GetDependencyHarzardFreeBlocks`找到所有与当前block没有依赖冲突的block
2. 使用`ControlFlowAllEqual`筛选出其中控制流也与当前block相等的block
3. 使用`HasCommonLoad`进一步筛选出其中与当前block有共同输入的block
4. 根据优先级选出最合适的一个候选block

#### 性能测试
| 子图 / 模型 | 旧 | 新 | 提升 |
| --- | --- | --- | --- |
| BatchNorm NCHW [128, 256, <i>-112</i>, <i>-112</i>] | 57,978 us | 47,506 us | 22.0%
| yolov3_darknet53_270e_coco_bs8_fp16 | 43.01 ips | 53.52 ips | 24.4%

<br>
Pcard-85711