### PR TITLE
[PIR]Fix kAnyLayout bug

### DIFF
--- a/paddle/common/layout.h
+++ b/paddle/common/layout.h
@@ -81,6 +81,8 @@ inline DataLayout StringToDataLayout(const std::string& str) {
     return DataLayout::kNCHW;
   } else if (s == "ANYLAYOUT") {
     return DataLayout::kAnyLayout;
+  } else if (s == "UNDEFINED(ANYLAYOUT)") {
+    return DataLayout::kAnyLayout;
   } else if (s == "MKLDNNLAYOUT") {
     return DataLayout::kMKLDNN;
   } else if (s == "SPARSE_COO") {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
Fix kAnyLayout bug:
- 问题：layout.h 中 `DataLayoutToString` 对 kAnyLayout 转换为 `"Undefined(AnyLayout)"` ，但是 `StringToDataLayout` 中只有对 `s == "ANYLAYOUT"` 的判断情况，因此在save/load时遇到kAnyLayout类型的DenseTensor会无法加载。
- 修复：在 `StringToDataLayout` 中新增对 `s == "UNDEFINED(ANYLAYOUT)"` 的分支判断。