### PR TITLE
【CINN】Improve ablitiy of IR_Compare

### DIFF
--- a/paddle/cinn/ir/utils/ir_compare.cc
+++ b/paddle/cinn/ir/utils/ir_compare.cc
@@ -38,8 +38,11 @@ bool IrEqualVisitor::Compare(const Expr& lhs, const Expr& rhs) {
     VLOG(7) << "Not equal on Expr, someone not defined";
   }
   bool equal = lhs->node_type() == rhs->node_type();
-  equal = equal && IRVisitorRequireReImpl<bool, const Expr*>::Visit(&lhs, &rhs);
-
+  if (lhs.is_index() && rhs.is_index())
+    equal = equal && lhs.as_index() == rhs.as_index();
+  else
+    equal =
+        equal && IRVisitorRequireReImpl<bool, const Expr*>::Visit(&lhs, &rhs);
   if (!equal) {
     VLOG(7) << "Not equal on Expr, lhs:[type:"
             << kIrNodeTyReprs[static_cast<int>(lhs->node_type())] << "]\n"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Enrich ablity of IRcompare, use IndexExpr equal func instead of Expr equal func when compare two indexexpr in IRcompare.

Pcard-67164