### PR TITLE
[Inference]Reorder the passes

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -848,7 +848,7 @@ void AnalysisPredictor::OptimizeInferencePirProgram() {
 
   if (!config_.use_optimized_model_) {
 #ifdef PADDLE_WITH_CINN
-    auto = [&](pir::PassManager &pass_manager) {
+    auto AddAutoLayoutPasses = [&](pir::PassManager &pass_manager) {
       auto &pass_registry = pir::PassRegistry::Instance();
       std::vector<std::string> passes = {"auto_layout_pass"};
 
@@ -976,7 +976,7 @@ void AnalysisPredictor::OptimizeInferencePirProgram() {
     if (config_.use_gpu()) {
       // gpu
       if (!config_.custom_pass_only_) {
-        for (auto &gpu_pass : kPirGpuPasses) {
+        for (auto gpu_pass : kPirGpuPasses) {
           if (FLAGS_enable_auto_layout_pass &&
               gpu_pass == "transfer_layout_pass") {
             gpu_pass = "auto_layout_pass";

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -608,6 +608,9 @@ const std::vector<std::string> kPirGpuPasses{
     "transpose_flatten_concat_fuse_pass",
     "remove_redundant_transpose_pass",
     "horizontal_fuse_pass",
+    "auto_mixed_precision_pass",
+    "transfer_layout_pass",
+    "identity_op_clean_pass",
 };
 
 const std::vector<std::string> kPirXpuPasses{


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
pcard-71500
1.调整pass调用顺序，修复sd-15 失败
2.修复config.enable_custom_passes( [pass_name list], custom_pass_only=True)
