### PR TITLE
[CINN] Support inferSymbolicShape in cf.tuple_pop

### DIFF
--- a/paddle/pir/include/dialect/control_flow/ir/cf_op.h
+++ b/paddle/pir/include/dialect/control_flow/ir/cf_op.h
@@ -39,7 +39,9 @@ class IR_API YieldOp : public Op<YieldOp, SideEffectTrait> {
 ///
 /// \brief Push a value tuple to a container.
 ///
-class IR_API TuplePushOp : public Op<TuplePushOp, SideEffectTrait> {
+class IR_API TuplePushOp : public Op<TuplePushOp,
+                                     SideEffectTrait,
+                                     pir::InferSymbolicShapeInterface> {
  public:
   using Op::Op;
   static const char *name() { return "cf.tuple_push"; }
@@ -70,6 +72,8 @@ class IR_API TuplePushOp : public Op<TuplePushOp, SideEffectTrait> {
     return inlet().defining_op<ContainerOpInterface>();
   }
   TuplePopOp tuple_pop_op();
+
+  bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
 };
 
 class IR_API TuplePopOp

--- a/paddle/pir/include/dialect/control_flow/ir/cf_op.h
+++ b/paddle/pir/include/dialect/control_flow/ir/cf_op.h
@@ -72,7 +72,8 @@ class IR_API TuplePushOp : public Op<TuplePushOp, SideEffectTrait> {
   TuplePopOp tuple_pop_op();
 };
 
-class IR_API TuplePopOp : public Op<TuplePopOp, SideEffectTrait> {
+class IR_API TuplePopOp
+    : public Op<TuplePopOp, SideEffectTrait, pir::InferSymbolicShapeInterface> {
  public:
   using Op::Op;
   static const char *name() { return "cf.tuple_pop"; }
@@ -99,6 +100,8 @@ class IR_API TuplePopOp : public Op<TuplePopOp, SideEffectTrait> {
     return outlet().defining_op<ContainerOpInterface>();
   }
   TuplePushOp tuple_push_op() { return container_interface().tuple_push_op(); }
+
+  bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
 };
 
 class IR_API StackCreateOp : public Op<StackCreateOp,

--- a/paddle/pir/src/dialect/control_flow/ir/cf_op.cc
+++ b/paddle/pir/src/dialect/control_flow/ir/cf_op.cc
@@ -166,7 +166,7 @@ bool TuplePopOp::InferSymbolicShape(
   for (size_t index = 1; index < tuple_push_op->num_operands(); ++index) {
     const Value &pushed_value = tuple_push_op->operand_source(index);
     infer_context->SetShapeOrDataForValue(
-        result(index), infer_context->GetShapeOrDataForValue(pushed_value));
+        result(index - 1), infer_context->GetShapeOrDataForValue(pushed_value));
   }
   return true;
 }

--- a/paddle/pir/src/dialect/control_flow/ir/cf_op.cc
+++ b/paddle/pir/src/dialect/control_flow/ir/cf_op.cc
@@ -158,15 +158,48 @@ void TuplePopOp::VerifyRegion() {
   VLOG(4) << "End Verifying for TuplePopOp.";
 }
 
-bool TuplePopOp::InferSymbolicShape(
+bool TuplePushOp::InferSymbolicShape(
     pir::InferSymbolicShapeContext *infer_context) {
   const auto &stack_create_op = operand_source(0).defining_op<StackCreateOp>();
-  const Value &inlet_of_stack_create = stack_create_op.result(1);
-  Operation *tuple_push_op = inlet_of_stack_create.first_use().owner();
-  for (size_t index = 1; index < tuple_push_op->num_operands(); ++index) {
-    const Value &pushed_value = tuple_push_op->operand_source(index);
-    infer_context->SetShapeOrDataForValue(
-        result(index - 1), infer_context->GetShapeOrDataForValue(pushed_value));
+  PADDLE_ENFORCE_EQ((stack_create_op != nullptr),
+                    true,
+                    common::errors::InvalidArgument(
+                        "In cf.tuple_push, can not get the stack_create_op to "
+                        "set shape of cf.tuple_pop result, please check if the "
+                        "program has been segment."));
+  // Using an outlet to temporarily store the ShapeOrData of the output of
+  // tuple_pop op
+  const Value &outlet = stack_create_op.result(2);
+  symbol::TensorListShapeOrDataDimExprs outlet_list;
+  for (size_t index = 1; index < num_operands(); ++index) {
+    symbol::ShapeOrDataDimExprs pushed_shape_data =
+        infer_context->GetShapeOrDataForValue(operand_source(index));
+    std::vector<symbol::DimExpr> shape = pushed_shape_data.shape();
+    symbol::TensorShapeOrDataDimExprs out_shape_data;
+    if (!pushed_shape_data.data().has_value()) {
+      out_shape_data = symbol::TensorShapeOrDataDimExprs(shape);
+    } else {
+      std::vector<symbol::DimExpr> data = pushed_shape_data.data().value();
+      out_shape_data = symbol::TensorShapeOrDataDimExprs(shape, data);
+    }
+    outlet_list.push_back(out_shape_data);
+  }
+  infer_context->SetShapeOrDataForValue(outlet, outlet_list);
+  return true;
+}
+
+bool TuplePopOp::InferSymbolicShape(
+    pir::InferSymbolicShapeContext *infer_context) {
+  const auto &outlet_list =
+      infer_context->GetShapeOrDataForValue(this->outlet())
+          .dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
+  PADDLE_ENFORCE_EQ(
+      outlet_list.size(),
+      this->num_results(),
+      common::errors::InvalidArgument("The quantity temporarily stored must be "
+                                      "equal to the actual output quantity."));
+  for (size_t index = 0; index < outlet_list.size(); ++index) {
+    infer_context->SetShapeOrDataForValue(result(index), outlet_list.at(index));
   }
   return true;
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-67164
By obtaining the input of cf.tuple_push, support inferSymbolicShape in cf.tuple_pop