### PR TITLE
[CI] Use `GITHUB_TOKEN` in CheckPRTemplate workflow

### DIFF
--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
     - name: Clone paddle
       uses: actions/checkout@v4
-      with:
-        ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
     - name: Cache python dependencies
       uses: actions/cache@v4

--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r httpx
+        pip install httpx
 
     - name: Check PR Template
       env:

--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -14,7 +14,8 @@ jobs:
     - name: Clone paddle
       uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v5
+    - name: Setup Python
+      uses: actions/setup-python@v5
       with:
         python-version: '3.13'
         cache: 'pip'

--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -14,20 +14,21 @@ jobs:
     - name: Clone paddle
       uses: actions/checkout@v4
 
-    - name: Cache python dependencies
-      uses: actions/cache@v4
+    - uses: actions/setup-python@v5
       with:
-        path: ~/.cache/pip
-        key: checkpr_pip
+        python-version: '3.13'
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        pip install -r httpx
 
     - name: Check PR Template
       env:
         AGILE_PULL_ID: ${{ github.event.pull_request.number }}
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        git checkout -b test
-        pip install httpx pymysql PyGithub
-        python tools/CheckPRTemplate.py;EXCODE=$?
+        python tools/CheckPRTemplate.py; EXCODE=$?
         echo "EXCODE: $EXCODE"
         echo "ipipe_log_param_EXCODE: $EXCODE"
         set +x

--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Clone paddle
       uses: actions/checkout@v4
@@ -17,14 +19,6 @@ jobs:
       with:
         path: ~/.cache/pip
         key: checkpr_pip
-
-    - name: Get commit message
-      id: get_commit_message
-      run: |
-        PR_BRANCH_SHA="${{ github.event.pull_request.head.sha }}"
-        git fetch origin $PR_BRANCH_SHA --depth=1
-        COMMIT_MESSAGE=$(git log -1 --format=%B $PR_BRANCH_SHA)
-        echo "commit_message=$COMMIT_MESSAGE" >> $GITHUB_ENV
 
     - name: Check PR Template
       env:
@@ -38,10 +32,10 @@ jobs:
         echo "ipipe_log_param_EXCODE: $EXCODE"
         set +x
         if [[ "$EXCODE" != "0" ]];then
-        echo -e "######################################################"
-        echo -e "If you encounter a situation where the PR template does not match the error message, please use the following link to update your PR: [  https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/.github/PULL_REQUEST_TEMPLATE.md ]"
-        echo -e "##ReferenceDocumentation: ##"
-        echo -e "[ https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE ]"
-        echo -e "[ https://github.com/PaddlePaddle/Paddle/wiki/paddle_ci_manual ]"
-        echo -e "######################################################"
+          echo -e "######################################################"
+          echo -e "If you encounter a situation where the PR template does not match the error message, please use the following link to update your PR: [  https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/.github/PULL_REQUEST_TEMPLATE.md ]"
+          echo -e "##ReferenceDocumentation: ##"
+          echo -e "[ https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE ]"
+          echo -e "[ https://github.com/PaddlePaddle/Paddle/wiki/paddle_ci_manual ]"
+          echo -e "######################################################"
         fi

--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -1,7 +1,7 @@
 name: Check PR Template
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [develop]
     types: [opened, synchronize, reopened, edited]
 
@@ -31,7 +31,7 @@ jobs:
     - name: Check PR Template
       env:
         AGILE_PULL_ID: ${{ github.event.pull_request.number }}
-        GITHUB_API_TOKEN: ${{ secrets.PADDLE_GITHUB_API_TOKEN }}
+        GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git checkout -b test
         pip install httpx pymysql PyGithub


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

直接使用 `GITHUB_TOKEN` 而不是单独配置的 `PADDLE_GITHUB_API_TOKEN`，清理无用操作

PCard-66972