### PR TITLE
int8 cuda core gemm must transpose weight

### DIFF
--- a/paddle/phi/kernels/impl/matmul_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_kernel_impl.h
@@ -1856,16 +1856,9 @@ MatmulJudgeDtypeKernel(const Context& ctx,
                 std::is_same<T, int8_t>::value) {
     if (x.dtype() == phi::DataType::INT8 && x_dims[0] <= 4 &&
         y_dims.size() == 2 && y_dims[0] % 16 == 0 && y_dims[1] % 16 == 0 &&
-        FLAGS_cuda_core_int8_gemm && ctx.GetComputeCapability() >= 70) {
-      if (!transpose_y) {
-        DenseTensor delta;
-        phi::EmptyKernel<float, Context>(
-            ctx, {y.dims()[1], y.dims()[0]}, DataType::INT8, &delta);
-        phi::TransposeKernel<int8_t, Context>(ctx, y, {1, 0}, &delta);
-        phi::CudaGemm<T, Context>(ctx, x, delta, out);
-      } else {
-        phi::CudaGemm<T, Context>(ctx, x, y, out);
-      }
+        FLAGS_cuda_core_int8_gemm && ctx.GetComputeCapability() >= 70 &&
+        transpose_y) {
+      phi::CudaGemm<T, Context>(ctx, x, y, out);
       return;
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
pcard-71500
int8 cuda core gemm must transpose weight