### PR TITLE
[CINN] Eliminate loops for inplace operation

### DIFF
--- a/paddle/cinn/optim/eliminate_invariant_loop.h
+++ b/paddle/cinn/optim/eliminate_invariant_loop.h
@@ -26,8 +26,8 @@ namespace optim {
  * (1) The loop variable is not used in any load/store indices or computation
  *     within child schedule blocks. This ensures that the loop writes the same
  *     value to the same index in each iteration.
- * (2) It doesn't contain any inplace operations, e.g. a[0] = a[0] + b[0]. In
- *     the presence of inplace operations, the loop count matters.
+ * (2) It is not a Reduce (e.g. a[0] = a[0] + b[k]), because for a Reduce, even
+ *     though its indices don't change in each iteration, its value changes.
  *
  * We can eliminate a bound loop if it also satisfies rule (3) and (4):
  * (3) It doesn't write to the local buffer (for thread-bound loop) or shared


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Performance


### Description
解除`EliminateInvariantLoop`对inplace操作的限制，仅保留对reduce的限制，可以提升动态shape下含有此类inplace操作的算子性能10%

<b>解释：</b>inplace操作可以分为两种：
* reduce，比如`a[0] = a[0] + b[k]`
* 单次inplace assign，比如`a[0] = rsqrt(a[0])`

之前担心正确性问题，所以两种inplace都不允许，现在发现第二种没必要限制，因为它总是只执行一次，所以for循环是没必要的

<br>
Pcard-85711