### PR TITLE
[PIR-Auto-Parallel] Modify the meaning of the `num` parameter in refined recompute.

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -806,6 +806,9 @@ class Engine:
         apply_mix2dist_pass(dist_program)
         if mode == "train" and self._strategy.recompute.enable:
             config = copy.deepcopy(self._strategy.recompute.to_dict())
+            pipeline_config = copy.deepcopy(self._strategy.pipeline.to_dict())
+            pipeline_config['pipeline_enable'] = pipeline_config.pop('enable')
+            config.update(pipeline_config)
             auto_parallel_recompute_pir_pass = new_pass(
                 "auto_parallel_recompute_pir", config
             )

--- a/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
+++ b/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
@@ -79,8 +79,8 @@ class TestRefinedRecomputeLlamaAuto(TestRecomputeLlamaAuto):
         # check recompute op number
         assert bwd_rc_op_num_base == 0
         assert bwd_rc_op_num_0 == 288
-        assert bwd_rc_op_num_1 == 284
-        assert bwd_rc_op_num_2 == 280
+        assert bwd_rc_op_num_1 == 282
+        assert bwd_rc_op_num_2 == 276
 
         # memory check
         assert max_mem_reserved_0 < max_mem_reserved_1
@@ -90,6 +90,11 @@ class TestRefinedRecomputeLlamaAuto(TestRecomputeLlamaAuto):
         assert max_mem_allocated_0 < max_mem_allocated_1
         assert max_mem_allocated_1 < max_mem_allocated_2
         assert max_mem_allocated_2 < max_mem_allocated_base
+
+        assert (
+            max_mem_reserved_2 - max_mem_reserved_1
+            == max_mem_allocated_2 - max_mem_allocated_1
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
complete later
PCard-88114
