### PR TITLE
[infrence] Make transfer_layout_pass run in FP32 precision.

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1054,18 +1054,17 @@ void AnalysisPredictor::OptimizeInferencePirProgram() {
   if (config_.enable_gpu_mixed_) {
     if (!config_.cinn_enabled()) {
       AddAutoMixedPrecisionPass(basic_pass_pm);
-
-      if (FLAGS_enable_auto_layout_pass) {
-        AddAutoLayoutPasses(basic_pass_pm);
-      } else {
-        auto transfer_layout_pass = ::pir::CreateTransferLayoutPass();
-        if (std::find(config_.deleted_passes_.begin(),
-                      config_.deleted_passes_.end(),
-                      transfer_layout_pass->name()) ==
-            config_.deleted_passes_.end()) {
-          basic_pass_pm.AddPass(std::move(transfer_layout_pass));
-        }
-      }
+    }
+  }
+  if (FLAGS_enable_auto_layout_pass) {
+    AddAutoLayoutPasses(basic_pass_pm);
+  } else {
+    auto transfer_layout_pass = ::pir::CreateTransferLayoutPass();
+    if (std::find(config_.deleted_passes_.begin(),
+                  config_.deleted_passes_.end(),
+                  transfer_layout_pass->name()) ==
+        config_.deleted_passes_.end()) {
+      basic_pass_pm.AddPass(std::move(transfer_layout_pass));
     }
   }
   auto common_subexpression_elimination_pass =


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-71500
1.修复sd-15 挂掉
