### PR TITLE
[AutoParallel]:shard dataloader support multi inputs

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -3234,8 +3234,6 @@ class ShardDataloader:
             raise ValueError(
                 f"process_id {process_id} is in more than one mesh, the meshes are {self._meshes}"
             )
-        if input_keys is not None:
-            assert len(input_keys) == 2, "input_keys lengths must be 2"
 
         self._all_inputs_in_one_mesh = len(self._meshes) == 1
         self._input_keys = input_keys
@@ -3424,14 +3422,14 @@ class ShardDataloader:
                     )
             return dist_batch_data
         elif isinstance(batch_data, dict):
-            if self._all_inputs_in_one_mesh is False:
-                assert len(self._input_keys) == len(self._meshes)
-            dist_batch_data = {}
             input_keys = (
                 batch_data.keys()
                 if self._input_keys is None
                 else self._input_keys
             )
+            if self._all_inputs_in_one_mesh is False:
+                assert len(input_keys) == len(self._meshes)
+            dist_batch_data = {}
             for i, key in enumerate(input_keys):
                 input_data = batch_data[key]
                 if isinstance(input_data, (list, tuple)):

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -335,48 +335,34 @@ class Engine:
             batch_sampler = dataloader.batch_sampler
         else:
             batch_sampler = dataloader._dataloader.batch_sampler
-
         if hasattr(batch_sampler, "set_epoch"):
             # Get data from DataLoader iterator directly may affect data generation randomness
             # of BatchSampler when `Shuffle=True`. It may cause difference of data feeding
             # between dynamic and to_static mode.
             batch_sampler.set_epoch(0)
-        atttention_mask = None
         if isinstance(data, dict):
             data = list(data.values())
-            if len(data) == 2:
-                (
-                    inputs,
-                    labels,
-                ) = data
-            elif len(data) == 3:
-                inputs, labels, attention_mask = data
+            if len(data) >= 2:
+                labels = data.pop()
+                inputs = data
             else:
                 raise ValueError(
-                    f"Data should be a dict with two keys, but received {len(data)}."
+                    f"Data should be a dict at least two keys, but received {len(data)}."
                 )
         elif isinstance(data, (list, tuple)):
-            if len(data) == 2:
-                (
-                    inputs,
-                    labels,
-                ) = data
-            elif len(data) == 3:
-                inputs, labels, attention_mask = data
+            if len(data) >= 2:
+                labels = data.pop()
+                inputs = data
             else:
                 raise ValueError(
-                    f"Data should be a dict with two keys, but received {len(data)}."
+                    f"Data should be a dict or list at list two element, but received {len(data)}."
                 )
         else:
             raise TypeError(
                 f"Data should be a dict or list, but received {type(data)}."
             )
-
         inputs = auto_utils.to_list(inputs)
-        if atttention_mask is not None:
-            inputs.append(atttention_mask)
         labels = auto_utils.to_list(labels)
-
         if inputs is not None:
             for i, item in enumerate(inputs):
                 assert item is not None, "Receive None input."

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -361,8 +361,21 @@ class Engine:
             raise TypeError(
                 f"Data should be a dict or list, but received {type(data)}."
             )
-        inputs = auto_utils.to_list(inputs)
+        if not isinstance(inputs, (list, tuple)):
+            inputs = auto_utils.to_list(inputs)
         labels = auto_utils.to_list(labels)
+
+        def flatten_list(nested_list):
+            flat_list = []
+            for item in nested_list:
+                if isinstance(item, (list, tuple)):
+                    flat_list.extend(flatten_list(item))
+                else:
+                    flat_list.append(item)
+            return flat_list
+
+        # flatten [[1,2],3] - > [1,2,3]
+        inputs = flatten_list(inputs)
         if inputs is not None:
             for i, item in enumerate(inputs):
                 assert item is not None, "Receive None input."

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -341,26 +341,40 @@ class Engine:
             # of BatchSampler when `Shuffle=True`. It may cause difference of data feeding
             # between dynamic and to_static mode.
             batch_sampler.set_epoch(0)
-
+        atttention_mask = None
         if isinstance(data, dict):
-            data = tuple(data.values())
-            if len(data) != 2:
+            data = list(data.values())
+            if len(data) == 2:
+                (
+                    inputs,
+                    labels,
+                ) = data
+            elif len(data) == 3:
+                inputs, labels, attention_mask = data
+            else:
                 raise ValueError(
                     f"Data should be a dict with two keys, but received {len(data)}."
                 )
-            inputs, labels = data
         elif isinstance(data, (list, tuple)):
-            if len(data) != 2:
+            if len(data) == 2:
+                (
+                    inputs,
+                    labels,
+                ) = data
+            elif len(data) == 3:
+                inputs, labels, attention_mask = data
+            else:
                 raise ValueError(
-                    f"Data should be a list or tuple with two elements, but received {len(data)}."
+                    f"Data should be a dict with two keys, but received {len(data)}."
                 )
-            inputs, labels = data
         else:
             raise TypeError(
                 f"Data should be a dict or list, but received {type(data)}."
             )
 
         inputs = auto_utils.to_list(inputs)
+        if atttention_mask is not None:
+            inputs.append(atttention_mask)
         labels = auto_utils.to_list(labels)
 
         if inputs is not None:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
自动并行支持模型多输入
Pcard-67164