### PR TITLE
【Bug Fix】Fix ReduceSum inferMeta bug

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
+++ b/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
@@ -73,7 +73,7 @@
   output : Tensor(out)
   infer_meta :
     func : ReduceSumInferMeta
-    param : [x, axis, keepdim]
+    param : [x, axis, keepdim, dtype]
   kernel :
     func : frobenius_norm
     param : [x, axis, keepdim]

--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -117,11 +117,15 @@ class SumOpPattern : public pir::OpRewritePattern<paddle::dialect::SumOp> {
 
     auto in = op->operand_source(0);
     auto in_data_type = in.type().dyn_cast<pir::DenseTensorType>().dtype();
-    if (in_data_type.isa<pir::Int32Type>() ||
-        in_data_type.isa<pir::BoolType>()) {
+
+    if (dtype != paddle::dialect::TransToPhiDataType(in_data_type)) {
+      in = rewriter.Build<paddle::dialect::CastOp>(in, dtype).result(0);
+    } else if (in_data_type.isa<pir::Int32Type>() ||
+               in_data_type.isa<pir::BoolType>()) {
       in = rewriter.Build<paddle::dialect::CastOp>(in, phi::DataType::INT64)
                .result(0);
     }
+
     auto cinn_reduce =
         rewriter.Build<cinn::dialect::ReduceSumOp>(in, axis, keepdim, dtype);
 

--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -118,7 +118,8 @@ class SumOpPattern : public pir::OpRewritePattern<paddle::dialect::SumOp> {
     auto in = op->operand_source(0);
     auto in_data_type = in.type().dyn_cast<pir::DenseTensorType>().dtype();
 
-    if (dtype != paddle::dialect::TransToPhiDataType(in_data_type)) {
+    if (dtype != phi::DataType::UNDEFINED &&
+        dtype != paddle::dialect::TransToPhiDataType(in_data_type)) {
       in = rewriter.Build<paddle::dialect::CastOp>(in, dtype).result(0);
     } else if (in_data_type.isa<pir::Int32Type>() ||
                in_data_type.isa<pir::BoolType>()) {

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -3707,12 +3707,13 @@ void ReduceInferMetaBase(const MetaTensor& x,
 void ReduceSumInferMeta(const MetaTensor& x,
                         const std::vector<int64_t>& axis,
                         bool keep_dim,
+                        DataType dtype,
                         MetaTensor* out) {
   bool reduce_all = false;
   if (axis.empty()) {
     reduce_all = true;
   }
-  SumRawInferMeta(x, axis, keep_dim, reduce_all, DataType::UNDEFINED, out);
+  SumRawInferMeta(x, axis, keep_dim, reduce_all, dtype, out);
 }
 
 void ReduceInferMeta(const MetaTensor& x,

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -589,6 +589,7 @@ void RealAndImagInferMeta(const MetaTensor& x, MetaTensor* out);
 void ReduceSumInferMeta(const MetaTensor& x,
                         const std::vector<int64_t>& axis,
                         bool keep_dim,
+                        DataType dtype,
                         MetaTensor* out);
 
 void ReduceInferMeta(const MetaTensor& x,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复由于 reduce_sum 输出类型与 dtype 类型不一致导致的后端 binary_op 类型不统一的问题。
Pcard-67164