### PR TITLE
[Cherry-Pick] Fix Overflow Error When Tensor’s Numel Exceeds int32_t Maximum Limit in Element-Wise Kernel (#70517)

### DIFF
--- a/paddle/phi/kernels/funcs/dims_simplifier.h
+++ b/paddle/phi/kernels/funcs/dims_simplifier.h
@@ -156,7 +156,7 @@ struct BroadcastDimsSimplifier {
     auto VectorReorganise = [](DimVector *vec, int l_idx, int m_idx) {
       (*vec)[m_idx - 1] = std::accumulate(vec->begin() + l_idx,
                                           vec->begin() + m_idx,
-                                          1,
+                                          int64_t{1},
                                           std::multiplies<int64_t>());
       vec->erase(vec->begin() + l_idx, vec->begin() + m_idx - 1);
     };


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Cherry-Pick #70517 
explicitly declare the init as int64_t, specialize std::accumulate to return int64_t