### PR TITLE
【CINN】Use ArithSimplify instead of Autosimplify--Part2

### DIFF
--- a/paddle/cinn/optim/trans_buffer_with_dynamic_shape.cc
+++ b/paddle/cinn/optim/trans_buffer_with_dynamic_shape.cc
@@ -59,8 +59,8 @@ struct Mutator : public ir::IRMutator<>, public ir::stmt::StmtMutator<> {
         Expr e = expr->as_tensor()->shape[i];
         Expr buf_e = buf->shape[i];
         if (buf->memory_type == ir::MemoryType::GPULocal) {
-          e = cinn::common::AutoSimplify(e);
-          buf_e = cinn::common::AutoSimplify(buf_e);
+          e = cinn::optim::ArithSimplify(e);
+          buf_e = cinn::optim::ArithSimplify(buf_e);
           if (!e.is_constant()) {
             auto new_shape = ir::ir_utils::IRCopy(e);
             new_shape = analyzer.UpperBound(new_shape);
@@ -86,7 +86,7 @@ struct Mutator : public ir::IRMutator<>, public ir::stmt::StmtMutator<> {
         auto e = buf->shape.size() > tensor->shape.size() ? buf->shape[i]
                                                           : tensor->shape[i];
         if (buf->memory_type == ir::MemoryType::GPULocal) {
-          e = cinn::common::AutoSimplify(e);
+          e = cinn::optim::ArithSimplify(e);
           if (!e.is_constant()) {
             auto new_shape = ir::ir_utils::IRCopy(e);
             new_shape = analyzer.UpperBound(new_shape);

--- a/paddle/cinn/optim/transform_gpu_forloop.cc
+++ b/paddle/cinn/optim/transform_gpu_forloop.cc
@@ -317,7 +317,7 @@ class SharedAxisVisitor : public ir::IRMutator<> {
         for (auto axis : gpu_axis) {
           optim::ReplaceVarWithExpr(&indice, ir::Var(axis), ir::Expr(0));
         }
-        indice = cinn::common::AutoSimplify(indice);
+        indice = cinn::optim::ArithSimplify(indice);
       }
     }
     ir::IRMutator<>::Visit(op, expr);
@@ -338,7 +338,7 @@ class SharedAxisVisitor : public ir::IRMutator<> {
         for (auto axis : gpu_axis) {
           optim::ReplaceVarWithExpr(&indice, ir::Var(axis), ir::Expr(0));
         }
-        indice = cinn::common::AutoSimplify(indice);
+        indice = cinn::optim::ArithSimplify(indice);
       }
     }
     ir::IRMutator<>::Visit(op, expr);
@@ -367,7 +367,7 @@ class LocalAxisVisitor : public ir::IRMutator<> {
         for (auto axis : gpu_axis) {
           optim::ReplaceVarWithExpr(&indice, ir::Var(axis), ir::Expr(0));
         }
-        indice = cinn::common::AutoSimplify(indice);
+        indice = cinn::optim::ArithSimplify(indice);
       }
     }
   }
@@ -388,7 +388,7 @@ class LocalAxisVisitor : public ir::IRMutator<> {
         for (auto axis : gpu_axis) {
           optim::ReplaceVarWithExpr(&indice, ir::Var(axis), ir::Expr(0));
         }
-        indice = cinn::common::AutoSimplify(indice);
+        indice = cinn::optim::ArithSimplify(indice);
       }
     }
     ir::IRMutator<>::Visit(op, expr);
@@ -418,7 +418,7 @@ class ReplaceUnitVarToZero : public ir::IRMutator<> {
       for (auto var_ : loop_var_) {
         optim::ReplaceVarWithExpr(&indice, ir::Var(var_), ir::Expr(0));
       }
-      indice = cinn::common::AutoSimplify(indice);
+      indice = cinn::optim::ArithSimplify(indice);
     }
     ir::IRMutator<>::Visit(op, expr);
   }
@@ -434,7 +434,7 @@ class ReplaceUnitVarToZero : public ir::IRMutator<> {
       for (auto var_ : loop_var_) {
         optim::ReplaceVarWithExpr(&indice, ir::Var(var_), ir::Expr(0));
       }
-      indice = cinn::common::AutoSimplify(indice);
+      indice = cinn::optim::ArithSimplify(indice);
     }
 
     ir::IRMutator<>::Visit(op, expr);

--- a/paddle/cinn/optim/transform_polyfor_to_for.cc
+++ b/paddle/cinn/optim/transform_polyfor_to_for.cc
@@ -136,7 +136,7 @@ struct PolyForWithSimpleConditionToForMutator : public ir::IRMutator<Expr*> {
 
     Expr lhs = lt_n ? lt_n->a() : le_n->a();
     Expr rhs = lt_n ? lt_n->b() : PlusOneWithMinMax(le_n->b());
-    rhs = cinn::common::AutoSimplify(rhs);
+    rhs = cinn::optim::ArithSimplify(rhs);
 
     if (op->is_vectorized())
       PADDLE_ENFORCE_EQ(

--- a/paddle/cinn/optim/update_buffer_axis_pass.cc
+++ b/paddle/cinn/optim/update_buffer_axis_pass.cc
@@ -28,24 +28,6 @@
 namespace cinn {
 namespace optim {
 
-bool ExprMathEqual(const Expr& expr1, const Expr& expr2) {
-  ir::Expr cmp_expr = common::AutoSimplify(ir::Sub::Make(expr1, expr2));
-  // This is ugly code since AutoSimplify is not powerful enough. Modify it
-  // after we make auto simplify better
-  ir::Expr simplified = common::AutoSimplify(cmp_expr);
-  int count = 0;
-  while (simplified != cmp_expr) {
-    cmp_expr = simplified;
-    simplified = common::AutoSimplify(cmp_expr);
-    ++count;
-    // Control dead loop
-    if (count >= 5) {
-      break;
-    }
-  }
-  return simplified.is_constant() && simplified.get_constant() == 0;
-}
-
 void FormalizeSingleIndex(const ir::Tensor& tensor,
                           std::vector<ir::Expr>* indices) {
   if (tensor->shape.size() > 1 && indices->size() == 1) {
@@ -56,7 +38,7 @@ void FormalizeSingleIndex(const ir::Tensor& tensor,
       mul = ir::Mul::Make(tensor->shape[i + 1], mul);
       ir::Expr div_expr = ir::Div::Make(origin_index_expr, mul);
       ir::Expr index_expr = ir::Mod::Make(div_expr, tensor->shape[i]);
-      indices->insert(indices->begin(), common::AutoSimplify(index_expr));
+      indices->insert(indices->begin(), optim::ArithSimplify(index_expr));
     }
   }
 }
@@ -150,7 +132,7 @@ class AnalyzeBufferAxis : public ir::IRMutator<> {
         buffer_name_access_same_index_expr[buffer_name];
     for (int i = 0; i < indices.size(); ++i) {
       if (index_expr.count(i)) {
-        if (!ExprMathEqual(index_expr[i], GetIndexBindExpr(indices[i]))) {
+        if (index_expr[i] != GetIndexBindExpr(indices[i])) {
           index_expr.erase(i);
         }
       }

--- a/paddle/cinn/optim/var_mod_simplify.cc
+++ b/paddle/cinn/optim/var_mod_simplify.cc
@@ -86,11 +86,11 @@ struct ReplaceVarWithDivMutator : public ir::IRMutator<> {
 }  // namespace
 
 void VarModSimplify(Expr* e) {
-  *e = cinn::common::AutoSimplify(*e);
+  *e = cinn::optim::ArithSimplify(*e);
   ReplaceModWithDivMutator()(e);
   ReplaceDivWithVarMutator mutator;
   mutator(e);
-  *e = cinn::common::AutoSimplify(*e);
+  *e = cinn::optim::ArithSimplify(*e);
   auto div_var_map = mutator.div_var_map_;
   ReplaceVarWithDivMutator()(e, mutator.div_var_map_);
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Use ArithSimplify instead of AutoSimplify.
Pcard-67164
