### PR TITLE
【CINN】Use ArithSimplify instead of Autosimplify--Part3

### DIFF
--- a/paddle/cinn/optim/vectorize_loops.cc
+++ b/paddle/cinn/optim/vectorize_loops.cc
@@ -170,7 +170,7 @@ class TensorVectorizeTeller : public ir::IRMutator<const Expr *> {
       Expr next_idx = ir::ir_utils::IRCopy(indices.back());
       cinn::ir::ir_utils::IrReplaceVarBroadcast(
           &next_idx, Expr(iter_var_), Expr(i));
-      auto gap = cinn::common::AutoSimplify(Expr(next_idx - first_idx));
+      auto gap = cinn::optim::ArithSimplify(Expr(next_idx - first_idx));
       if (!gap.As<IntImm>() || gap.as_int32() != i) {
         VLOG(5) << "Tensor:" << tensor->name
                 << " is not accessed sequentially, next:" << next_idx
@@ -781,7 +781,7 @@ struct VectorizeLoops_ : public IRMutator<Expr *> {
           true,
           ::common::errors::InvalidArgument(
               "The minimum of forloop should be zero, please check."));
-      Expr for_extent = cinn::common::AutoSimplify(forloop->extent);
+      Expr for_extent = cinn::optim::ArithSimplify(forloop->extent);
       Simplify(&for_extent);
       node->extent = for_extent;
       auto *extent_min = for_extent.As<Min>();
@@ -918,7 +918,7 @@ struct VectorizeLoops_ : public IRMutator<Expr *> {
         inner_for,
         ::common::errors::InvalidArgument(
             "Inner_for is nullptr in UnrollCmpFor function."));
-    Expr inner_for_extent = cinn::common::AutoSimplify(inner_for->extent);
+    Expr inner_for_extent = cinn::optim::ArithSimplify(inner_for->extent);
     Simplify(&inner_for_extent);
     auto *extent_min = inner_for_extent.As<Min>();
     if (extent_min) {
@@ -951,7 +951,7 @@ struct VectorizeLoops_ : public IRMutator<Expr *> {
                                      DeviceAPI::UNK,
                                      inner_for->body,
                                      inner_for->vectorize_info())});
-          Expr new_extent_a = cinn::common::AutoSimplify(le_n->b() + 1);
+          Expr new_extent_a = cinn::optim::ArithSimplify(le_n->b() + 1);
           Expr out_for_a = For::Make(outer_for->loop_var,
                                      outer_for->min,
                                      new_extent_a,
@@ -1021,7 +1021,7 @@ struct VectorizeLoops_ : public IRMutator<Expr *> {
           extent_int % factor == 0 ? extent_trunc : extent_trunc + 1;
       times = cinn::common::make_const(forloop->extent->type(), extent_times);
     } else {
-      times = cinn::common::AutoSimplify(
+      times = cinn::optim::ArithSimplify(
           Div::Make(forloop->extent, make_const(factor)));
       Simplify(&times);
     }

--- a/paddle/cinn/runtime/cpu/cblas.cc
+++ b/paddle/cinn/runtime/cpu/cblas.cc
@@ -151,8 +151,8 @@ CINN_REGISTER_HELPER(cinn_cpu_mkl) {
                           12UL,
                           ::common::errors::InvalidArgument(
                               "Wrong number of arguments passed in."));
-        auto M = cinn::common::AutoSimplify(args[1]);
-        auto N = cinn::common::AutoSimplify(args[2]);
+        auto M = cinn::optim::ArithSimplify(args[1]);
+        auto N = cinn::optim::ArithSimplify(args[2]);
         std::vector<Expr> shape;
         shape.push_back(M);
         shape.push_back(N);
@@ -173,16 +173,16 @@ CINN_REGISTER_HELPER(cinn_cpu_mkl) {
             A_tensor,
             ::common::errors::InvalidArgument("expected type is tensor."));
 
-        auto batch_size = cinn::common::AutoSimplify(args[1]);
+        auto batch_size = cinn::optim::ArithSimplify(args[1]);
         int32_t batch_size_val = batch_size.as_int32();
 
-        auto M = cinn::common::AutoSimplify(args[2]);
-        auto N = cinn::common::AutoSimplify(args[3]);
+        auto M = cinn::optim::ArithSimplify(args[2]);
+        auto N = cinn::optim::ArithSimplify(args[3]);
 
         std::vector<Expr> shape;
         int total = 1;
         for (auto& v : A_tensor->shape) {
-          auto val = cinn::common::AutoSimplify(v);
+          auto val = cinn::optim::ArithSimplify(v);
           PADDLE_ENFORCE_EQ(
               val.is_constant(),
               true,

--- a/paddle/cinn/runtime/cpu/onednn_math.cc
+++ b/paddle/cinn/runtime/cpu/onednn_math.cc
@@ -168,18 +168,18 @@ CINN_REGISTER_HELPER(cinn_cpu_onednn) {
                           16UL,
                           ::common::errors::InvalidArgument(
                               "Wrong number of arguments passed in."));
-        auto N = cinn::common::AutoSimplify(args[0]);
-        int input_h = cinn::common::AutoSimplify(args[2]).as_int32();
-        int input_w = cinn::common::AutoSimplify(args[3]).as_int32();
-        auto c_out = cinn::common::AutoSimplify(args[4]);
-        int filter_h = cinn::common::AutoSimplify(args[6]).as_int32();
-        int filter_w = cinn::common::AutoSimplify(args[7]).as_int32();
-        int pad_h = cinn::common::AutoSimplify(args[8]).as_int32();
-        int pad_w = cinn::common::AutoSimplify(args[9]).as_int32();
-        int stride_h = cinn::common::AutoSimplify(args[10]).as_int32();
-        int stride_w = cinn::common::AutoSimplify(args[11]).as_int32();
-        int dilation_h = cinn::common::AutoSimplify(args[12]).as_int32();
-        int dilation_w = cinn::common::AutoSimplify(args[13]).as_int32();
+        auto N = cinn::optim::ArithSimplify(args[0]);
+        int input_h = cinn::optim::ArithSimplify(args[2]).as_int32();
+        int input_w = cinn::optim::ArithSimplify(args[3]).as_int32();
+        auto c_out = cinn::optim::ArithSimplify(args[4]);
+        int filter_h = cinn::optim::ArithSimplify(args[6]).as_int32();
+        int filter_w = cinn::optim::ArithSimplify(args[7]).as_int32();
+        int pad_h = cinn::optim::ArithSimplify(args[8]).as_int32();
+        int pad_w = cinn::optim::ArithSimplify(args[9]).as_int32();
+        int stride_h = cinn::optim::ArithSimplify(args[10]).as_int32();
+        int stride_w = cinn::optim::ArithSimplify(args[11]).as_int32();
+        int dilation_h = cinn::optim::ArithSimplify(args[12]).as_int32();
+        int dilation_w = cinn::optim::ArithSimplify(args[13]).as_int32();
         int out_h = (input_h - ((filter_h - 1) * dilation_h + 1) + 2 * pad_h) /
                         stride_h +
                     1;

--- a/test/cpp/pir/cinn/adt/merge_block_utils_test.cc
+++ b/test/cpp/pir/cinn/adt/merge_block_utils_test.cc
@@ -29,7 +29,7 @@ bool IsBlockForAllEqual(const ForTreeNode& first, const ForTreeNode& second) {
                                const ForTreeNode& second) -> bool {
     const ir::Expr lhs = first.val->extent();
     const ir::Expr rhs = second.val->extent();
-    if (cinn::common::AutoSimplify(ir::Sub::Make(lhs, rhs)) != ir::Expr(0)) {
+    if (lhs != rhs) {
       return false;
     }
     return true;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Use ArithSimplify instead of AutoSimplify.
Pcard-67164