### PR TITLE
[PIR-Auto-Parallel] [cherry-pick] refactor refined recompute pass in PIR mode

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -957,6 +957,10 @@ void BindOperation(py::module *m) {
                  attr_name,
                  pir::Int32Attribute::get(pir::IrContext::Instance(), val));
            })
+      .def("erase_attr",
+           [](Operation &self, std::string &attr_name) {
+             self.erase_attribute(attr_name);
+           })
       .def("attrs",
            [](Operation &self) -> py::dict {
              py::dict attrs_dict;

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -806,8 +806,9 @@ class Engine:
         apply_mix2dist_pass(dist_program)
 
         if mode == "train" and self._strategy.recompute.enable:
+            config = copy.deepcopy(self._strategy.recompute.to_dict())
             auto_parallel_recompute_pir_pass = new_pass(
-                "auto_parallel_recompute_pir", {}
+                "auto_parallel_recompute_pir", config
             )
             auto_parallel_recompute_pir_pass.apply(
                 [dist_program], [startup_program]

--- a/python/paddle/distributed/passes/auto_parallel_recompute_pir.py
+++ b/python/paddle/distributed/passes/auto_parallel_recompute_pir.py
@@ -182,9 +182,11 @@ class AutoParallelRecomputePIRPass(PassBase):
         self.program_ops = list(main_program.global_block().ops)
         # 1. Get the recompute segments information form program.
         segments = self.get_segments()
-        if len(segments) == 0:
-            logger.info("No segments found in PIR recompite pass, skip pass.")
-            return
+        assert (
+            len(segments) > 0
+        ), "No segment found in the PIR recompute pass.\n \
+            Please disable 'recompute.enable' or check 'recompute()' usage in model code."
+
         # 2. Get the forward and backward OPs from program.
         fwd_ops, bwd_ops = self.get_fwd_bwd_ops()
 

--- a/python/paddle/distributed/passes/auto_parallel_recompute_pir.py
+++ b/python/paddle/distributed/passes/auto_parallel_recompute_pir.py
@@ -33,6 +33,7 @@ logger = get_logger(logging.INFO)
 class AutoParallelRecomputePIRPass(PassBase):
     def __init__(self):
         super().__init__()
+        self.program_ops = []
 
     def _check_self(self):
         return True
@@ -40,10 +41,10 @@ class AutoParallelRecomputePIRPass(PassBase):
     def _check_conflict(self, other_pass):
         return True
 
-    def get_fwd_bwd_ops(self, program):
+    def get_fwd_bwd_ops(self):
         fwd_ops = []
         bwd_ops = []
-        for op in program.global_block().ops:
+        for op in self.program_ops:
             if op.op_role == int(OpRole.Forward):
                 fwd_ops.append(op)
             elif op.op_role == int(OpRole.Backward):
@@ -72,7 +73,27 @@ class AutoParallelRecomputePIRPass(PassBase):
             if used_op.name() in dropout_ops
         )
 
-    def get_segments(self, program):
+    def remove_outgoing_op(self, segment):
+        # An OP is considered an outgoing OP if all of results' user OPs are not in segment.
+        # These OPs do not participate in the backward gradient computation and therefore
+        # do not need to have a recomputation during backward.
+        segment_ops = [self.program_ops[idx] for idx in segment]
+        segment_len = len(segment)
+        for idx in range(segment_len - 1, 0, -1):
+            op = segment_ops[idx]
+            user_ops = set()
+            for res in op.results():
+                user_ops = user_ops | set(res.all_used_ops())
+
+            if user_ops & set(segment_ops):
+                continue
+            segment.pop(idx)
+            logger.info(
+                f"Remove outgoing OP '{op.name()}' from the segment for recomputation, as it does not participate in the backward."
+            )
+        return segment
+
+    def get_segments(self):
         # `fwd_recompute_id` indicates the ID assigned to the segment for
         # which the OP requires recompute.
         # A segment comprises all OPs within a program, ranging from the OP
@@ -80,10 +101,13 @@ class AutoParallelRecomputePIRPass(PassBase):
         # these operations share the same `fwd_recompute_id`.
         segment_beg = {}
         segment_end = {}
-        max_op_id = len(program.global_block().ops)
-        for idx, op in enumerate(program.global_block().ops):
+        max_op_id = len(self.program_ops)
+        for idx, op in enumerate(self.program_ops):
+            # 1. Find the OPs marked with `fwd_recompute_id`.
             if not op.has_attr("fwd_recompute_id"):
                 continue
+            # 2. Delineate the segment range marked by `fwd_recompute_id`.
+            # Note: there may be some unmarked OPs in between.
             rc_id = op.attrs()["fwd_recompute_id"]
             if rc_id not in segment_beg:
                 segment_beg[rc_id] = max_op_id
@@ -91,37 +115,139 @@ class AutoParallelRecomputePIRPass(PassBase):
             segment_beg[rc_id] = min(segment_beg[rc_id], idx)
             segment_end[rc_id] = max(segment_end[rc_id], idx)
 
+        # 3. Aggregate all segment information into a dictionary.
+        # The key is the id of the segment, which is used to uniquely identify each segment.
+        # The value is a list of indices of the segment OPs in `self.program_ops`.
         segments = {}
-        idx = 0
         assert len(segment_beg.keys()) == len(segment_end.keys())
         for segment_id, beg_id in segment_beg.items():
             assert segment_id in segment_end.keys()
             end_id = segment_end[segment_id]
             assert beg_id <= end_id
-            segment = []
-            for p_id in range(beg_id, end_id - 1):
-                segment.append(p_id)
-            segments[idx] = segment
-            idx += 1
+            segment = list(range(beg_id, end_id + 1))
+            # 4. Remove the outgoing OPs from the segment, as these OPs
+            # do not participate in the backward gradient computation.
+            segments[segment_id] = self.remove_outgoing_op(segment)
+            logger.info(
+                f"Segment ID {segment_id} contains {len(segment)} OPs, all of which will be recomputed."
+            )
         return segments
 
+    def get_op_name(self, op):
+        return op.name().split('.')[1]
+
+    def match_pattern(
+        self,
+        op,
+        visit,
+        fetch_id,
+        fetch_pattern,
+        target_pattern,
+        pre_len,
+        main_len,
+        count,
+        max_count,
+    ):
+        if count >= max_count:
+            return max_count
+        if len(fetch_pattern) > len(target_pattern):
+            return count
+        if self.get_op_name(op) != target_pattern[fetch_id]:
+            return count
+        if fetch_id == len(target_pattern) - 1:
+            for idx in range(pre_len, pre_len + main_len):
+                fetch_op = fetch_pattern[idx]
+                visit[fetch_op] = -1
+            refined_segment = list(set(visit.values()))
+            refined_segment.sort()
+            refined_segment = [idx for idx in refined_segment if idx != -1]
+            return count + 1
+        for res_val in op.results():
+            for user_op in res_val.all_used_ops():
+                fetch_pattern[fetch_id + 1] = user_op
+                count = self.match_pattern(
+                    op=user_op,
+                    visit=visit,
+                    fetch_id=fetch_id + 1,
+                    fetch_pattern=fetch_pattern,
+                    target_pattern=target_pattern,
+                    pre_len=pre_len,
+                    main_len=main_len,
+                    count=count,
+                    max_count=max_count,
+                )
+        return count
+
     def _apply_single_impl(self, main_program, startup_program, context=None):
-        segments = self.get_segments(main_program)
+        self.program_ops = list(main_program.global_block().ops)
+        # 1. Get the recompute segments information form program.
+        segments = self.get_segments()
         if len(segments) == 0:
-            logger.info("No segments found in PIR recompite pass.")
+            logger.info("No segments found in PIR recompite pass, skip pass.")
             return
+        # 2. Get the forward and backward OPs from program.
+        fwd_ops, bwd_ops = self.get_fwd_bwd_ops()
 
-        fwd_ops, bwd_ops = self.get_fwd_bwd_ops(main_program)
+        # 3. Refine the segments based on the patterns.
+        refined_ops_patterns = self.get_attr("refined_ops_patterns")
+        for refined_ops_pattern in refined_ops_patterns:
+            # 3.1 get the refined pattern information.
+            # refined_ops_patterns = pre_ops + main_ops + suf_ops
+            # `main_ops` pattern: it does not participate in backward recomputation
+            #                     and needs to be removed from the segment.
+            # `pre_ops` pattern: it serve only as markers and do require recomputation.
+            # `suf_ops` pattern: it serve only as markers and do require recomputation.
+            # `num` : it limits the maximum number of `main_ops` patterns identified
+            #         within each segment. A value of -1 represents all patterns.
+            num = int(refined_ops_pattern['num'])
+            num = num if num >= 0 else len(fwd_ops)
+            main_ops = refined_ops_pattern['main_ops']
+            pre_ops = refined_ops_pattern['pre_ops']
+            suf_ops = refined_ops_pattern['suf_ops']
+            pattern_ops = pre_ops + main_ops + suf_ops
 
+            for rc_id in segments.keys():
+                # 3.2 Identify and mark the first 'num' patterns in each segment.
+                # The dictionary 'op_idx_map' has keys as OP information.
+                # If an OP belongs to a pattern, its value in the dictionary is marked as -1.
+                op_idx_map = {
+                    self.program_ops[idx]: idx for idx in segments[rc_id]
+                }
+                pattern_count = 0
+                fetch_pattern = [None] * len(pattern_ops)
+                for idx in segments[rc_id]:
+                    op = self.program_ops[idx]
+                    fetch_pattern[0] = op
+                    pattern_count = self.match_pattern(
+                        op=self.program_ops[idx],
+                        visit=op_idx_map,
+                        fetch_id=0,
+                        fetch_pattern=fetch_pattern,
+                        target_pattern=pattern_ops,
+                        pre_len=len(pre_ops),
+                        main_len=len(main_ops),
+                        count=pattern_count,
+                        max_count=num,
+                    )
+                # 3.3 Refined segment to exclude the specified pattern.
+                refined_segment = list(set(op_idx_map.values()))
+                refined_segment.sort()
+                refined_segment = [idx for idx in refined_segment if idx != -1]
+                segments[rc_id] = refined_segment
+
+        # 4. Construct the segment for backward recomputation.
+        # 4.1 Build IrMapping to eplace forward value with backward recompute value.
         input_value = main_program.list_vars()
         value_map = paddle.pir.IrMapping()
         for val in input_value:
             value_map.add(val, val)
 
         for rc_id, segment in segments.items():
+            # 4.2 Find the insertion position for the backward segment,
+            # which should be before backward gradient computation.
             first_bwd_used_op = bwd_ops[-1]
             for idx in segment:
-                op = main_program.global_block().ops[idx]
+                op = self.program_ops[idx]
                 bwd_used_op = self.get_first_bwd_used_op(op, bwd_ops)
                 if first_bwd_used_op.id() > bwd_used_op.id():
                     first_bwd_used_op = bwd_used_op
@@ -129,24 +255,33 @@ class AutoParallelRecomputePIRPass(PassBase):
             ori_segment_outputs = backward_utils.ValueSet()
             paddle.pir.set_insertion_point(first_bwd_used_op)
 
+            # 4.3 Clone the segment OPs and replace the forward
+            # value with backward recompute value.
             for idx in segment:
-                op = main_program.global_block().ops[idx]
+                op = self.program_ops[idx]
                 ori_segment_outputs.update(op.results())
 
+                # Random OPs should produce the same output before and after recomputation.
                 if self.is_seed_used_by_dropout(op):
                     continue
 
                 rc_op = op.clone(
                     value_map, paddle.pir.CloneOptions(False, True, True)
                 )
+                # The forward segment and the backward segment have the same segment ID.
+                if rc_op.has_attr("fwd_recompute_id"):
+                    rc_op.erase_attr("fwd_recompute_id")
+
                 rc_op.set_int_attr("bwd_recompute_id", rc_id)
 
+                # Updtate attributes.
                 if first_bwd_used_op.has_attr('op_role'):
                     rc_op.set_int_attr("op_role", first_bwd_used_op.op_role)
 
                 if first_bwd_used_op.has_attr('chunk_id'):
                     rc_op.set_int_attr("chunk_id", first_bwd_used_op.chunk_id)
 
+            # 4.4 Replace the forward value with backward recompute value.
             for ori_value in ori_segment_outputs:
                 rc_value = value_map.look_up(ori_value)
                 ori_value.replace_grad_users_with(rc_value, set(bwd_ops))

--- a/test/auto_parallel/pir/CMakeLists.txt
+++ b/test/auto_parallel/pir/CMakeLists.txt
@@ -51,7 +51,7 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
     test_auto_parallel_replace_with_parallel_cross_entropy_pass
     PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 60)
   set_tests_properties(test_auto_parallel_recompute_pir_pass
-                       PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 60)
+                       PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 200)
   py_test_modules(
     test_eliminate_transpose_pass MODULES test_eliminate_transpose_pass ENVS
     FLAGS_enable_pir_in_executor=1)

--- a/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
+++ b/test/auto_parallel/pir/auto_parallel_refined_recompute_pir_pass_unittest.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from auto_parallel_recompute_pir_pass_unittest import TestRecomputeLlamaAuto
+
+import paddle
+
+
+class TestRefinedRecomputeLlamaAuto(TestRecomputeLlamaAuto):
+
+    def run_test_cases(self):
+        self.config.recompute = True
+        self.config.recompute_granularity = "full"
+
+        self.strategy._recompute.enable = True
+        losses_0, model_0 = self.run_llama(self.config)
+
+        self.strategy._recompute.refined_ops_patterns = [
+            {
+                "main_ops": ["matmul"],
+                "num": -1,
+                "pre_ops": ["multiply"],
+                "suf_ops": [],
+            }
+        ]
+        refined_ops_pattern = self.strategy._recompute.refined_ops_patterns[0]
+        refined_ops_pattern["num"] = 0
+        losses_0, model_0 = self.run_llama(self.config)
+        max_mem_allocated_0, max_mem_reserved_0 = self.get_mem_message()
+
+        refined_ops_pattern["num"] = 1
+        losses_1, model_1 = self.run_llama(self.config)
+        max_mem_allocated_1, max_mem_reserved_1 = self.get_mem_message()
+
+        refined_ops_pattern["num"] = 2
+        losses_2, model_2 = self.run_llama(self.config)
+        max_mem_allocated_2, max_mem_reserved_2 = self.get_mem_message()
+
+        self.config.recompute = False
+        self.strategy._recompute.enable = False
+        base_losses, base_model = self.run_llama(self.config)
+        max_mem_allocated_base = paddle.device.cuda.max_memory_allocated()
+        max_mem_reserved_base = paddle.device.cuda.max_memory_reserved()
+
+        # check loss
+        self.check_loss(base_losses, losses_0)
+        self.check_loss(base_losses, losses_1)
+        self.check_loss(base_losses, losses_2)
+
+        # check program
+        base_prog = base_model.dist_main_program()
+        prog_0 = model_0.dist_main_program()
+        prog_1 = model_1.dist_main_program()
+        prog_2 = model_2.dist_main_program()
+        segment_num_base, bwd_rc_op_num_base = self.get_recompute_message(
+            base_prog
+        )
+        segment_num_0, bwd_rc_op_num_0 = self.get_recompute_message(prog_0)
+        segment_num_1, bwd_rc_op_num_1 = self.get_recompute_message(prog_1)
+        segment_num_2, bwd_rc_op_num_2 = self.get_recompute_message(prog_2)
+
+        # check segment number
+        assert segment_num_base == 0
+        assert segment_num_0 == 4
+        assert segment_num_1 == 4
+        assert segment_num_2 == 4
+
+        # check recompute op number
+        assert bwd_rc_op_num_base == 0
+        assert bwd_rc_op_num_0 == 288
+        assert bwd_rc_op_num_1 == 284
+        assert bwd_rc_op_num_2 == 280
+
+        # memory check
+        assert max_mem_reserved_0 < max_mem_reserved_1
+        assert max_mem_reserved_1 < max_mem_reserved_2
+        assert max_mem_reserved_2 < max_mem_reserved_base
+
+        assert max_mem_allocated_0 < max_mem_allocated_1
+        assert max_mem_allocated_1 < max_mem_allocated_2
+        assert max_mem_allocated_2 < max_mem_allocated_base
+
+
+if __name__ == '__main__':
+    TestRefinedRecomputeLlamaAuto().run_test_cases()

--- a/test/auto_parallel/pir/test_auto_parallel_recompute_pir_pass.py
+++ b/test/auto_parallel/pir/test_auto_parallel_recompute_pir_pass.py
@@ -19,13 +19,13 @@ import collective.test_communication_api_base as test_base
 
 class TestSemiAutoParallelLlamaACCTest(test_base.CommunicationTestDistBase):
     def setUp(self):
-        super().setUp(num_of_devices=8, timeout=200, nnode=1)
+        super().setUp(num_of_devices=2, timeout=200, nnode=1)
 
-    def test_simple_net_hybrid_strategy_acc(self):
+    def test_simple_net_dp_strategy_recompute(self):
         _default_envs = {
             "dp": "2",
-            "mp": "2",
-            "pp": "2",
+            "mp": "1",
+            "pp": "1",
             "FLAGS_embedding_deterministic": "1",
             "FLAGS_cudnn_deterministic": "1",
         }
@@ -38,6 +38,26 @@ class TestSemiAutoParallelLlamaACCTest(test_base.CommunicationTestDistBase):
         for envs in envs_list:
             self.run_test_case(
                 "auto_parallel_recompute_pir_pass_unittest.py",
+                user_defined_envs=envs,
+            )
+
+    def test_simple_net_dp_strategy_refined_recompute(self):
+        _default_envs = {
+            "dp": "2",
+            "mp": "1",
+            "pp": "1",
+            "FLAGS_embedding_deterministic": "1",
+            "FLAGS_cudnn_deterministic": "1",
+        }
+        _changeable_envs = {
+            "backend": ["gpu"],
+        }
+        envs_list = test_base.gen_product_envs_list(
+            _default_envs, _changeable_envs
+        )
+        for envs in envs_list:
+            self.run_test_case(
+                "auto_parallel_refined_recompute_pir_pass_unittest.py",
                 user_defined_envs=envs,
             )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Cherry-Pick from：https://github.com/PaddlePaddle/Paddle/pull/70064 、 https://github.com/PaddlePaddle/Paddle/pull/70521

该 PR 是在 recompute pass( https://github.com/PaddlePaddle/Paddle/pull/69681 ) 的基础上，实现的 refined recompute，是在recompute layer 中选择一些算子不参与重计算，其开关在代码中的调用如下所示：
```c++
strategy = dist.Strategy()
strategy._recompute.enable = True
strategy._recompute.refined_ops_patterns = [
            {
                "main_ops": ["matmul"],
                "num": -1,
                "pre_ops": ["multiply"],
                "suf_ops": [],
            }
        ]
...
model = dist.to_static(model, dist_loader, criterion, optimizer, strategy=strategy)

``` 


在每个layer segment 中，按照计算图拓扑结构匹配 `pattern = pre_ops + main_ops + suf_ops`，其中，pre_ops 和 suf_ops 是用于辅助匹配 main_ops 的，对于匹配到的前 num 个 main_ops，在反向时不进行重计算，当 num = -1 时，默认匹配到的 main_ops 全部不进行重计算。

同时 pass 也对 segment 的数目进行 assert 断言检测，如果在开启`recompute ( strategy._recompute.enable=1)`，但是在模型代码没有使用到 recompute(layer)，则将在 recompute pass 中报错

其他：
PaddleNLP 中增加 refined recompute 的测试：https://github.com/PaddlePaddle/PaddleNLP/pull/9679
该实现部分参考了旧 IR 下 refined recompute实现：https://github.com/PaddlePaddle/Paddle/pull/58533

PCard-88114
