### PR TITLE
[CINN] Fix bug of convert squeeze to reshape in cinn

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -1005,18 +1005,23 @@ class SqueezeOpPattern
     if (IsDefinedBy<FullIntArrayOp>(op, 1) && !is_dyshape) {
       const FullIntArrayOp axis_full_op = CastDefinedTo<FullIntArrayOp>(op, 1);
       auto axis_vec = cinn::dialect::ir::GetVectorAttr(axis_full_op, "value");
-      std::set<int64_t> axis_set(axis_vec.begin(), axis_vec.end());
-
       auto in_shape =
           phi::vectorize(op.operand_source(0)
                              .type()
                              .dyn_cast<paddle::dialect::DenseTensorType>()
                              .dims());
+      const std::set<int64_t> axis_set = [&] {
+        std::set<int64_t> axis_set;
+        for (int64_t axis : axis_vec) {
+          axis_set.insert(axis < 0 ? axis + in_shape.size() : axis);
+        }
+        return axis_set;
+      }();
 
       std::vector<int> output_shape;
 
       for (size_t i = 0; i < in_shape.size(); ++i) {
-        if (!axis_set.count(i)) {
+        if (!axis_set.count(i) || in_shape[i] != 1) {
           output_shape.push_back(in_shape[i]);
         } else {
           PADDLE_ENFORCE_EQ(

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/shardable_axes_base.cc
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/shardable_axes_base.cc
@@ -160,7 +160,9 @@ ShardableAxesSignature CreateSignatureForElementWise(pir::Operation* op) {
                       GetCompatibleRank(op->operand_source(i)),
                       ::common::errors::PreconditionNotMet(
                           "Required all inputs rank shall be equal output in "
-                          "elementwise op."));
+                          "elementwise op : %s [id:%d]",
+                          op->name(),
+                          op->id()));
     result.inputs.emplace_back(same_axes);
   }
   for (int i = 0; i < op->num_results(); ++i) {
@@ -168,7 +170,9 @@ ShardableAxesSignature CreateSignatureForElementWise(pir::Operation* op) {
                       GetCompatibleRank(op->result(i)),
                       ::common::errors::PreconditionNotMet(
                           "Required all outputs rank shall be equal each other "
-                          "in elementwise op."));
+                          "in elementwise op : %s [id:%d]",
+                          op->name(),
+                          op->id()));
     result.outputs.emplace_back(same_axes);
   }
   result.loop = result.outputs.back();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复 squeeze 转换为 reshape 的处理bug。