### PR TITLE
[CINN] Support inferSymbolicShape for cf.tuple_pop and cf.tuple_push

### DIFF
--- a/paddle/pir/include/dialect/control_flow/ir/cf_op.h
+++ b/paddle/pir/include/dialect/control_flow/ir/cf_op.h
@@ -16,10 +16,12 @@
 
 #include <functional>
 
+#include "paddle/fluid/pir/dialect/operator/utils/shape_analysis_utils.h"
 #include "paddle/pir/include/core/builder.h"
 #include "paddle/pir/include/core/op_base.h"
 #include "paddle/pir/include/core/op_trait.h"
 #include "paddle/pir/include/dialect/control_flow/ir/cf_interface.h"
+#include "paddle/pir/include/dialect/shape/interface/infer_symbolic_shape/cache_grad_op_symbolic_shape.h"
 #include "paddle/pir/include/dialect/shape/interface/infer_symbolic_shape/infer_symbolic_shape.h"
 
 namespace pir {
@@ -73,7 +75,7 @@ class IR_API TuplePushOp : public Op<TuplePushOp,
   }
   TuplePopOp tuple_pop_op();
 
-  CacheGradOpSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
+  void CacheGradOpSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
 };
 
 class IR_API TuplePopOp : public Op<TuplePopOp, SideEffectTrait> {

--- a/paddle/pir/include/dialect/control_flow/ir/cf_op.h
+++ b/paddle/pir/include/dialect/control_flow/ir/cf_op.h
@@ -39,7 +39,9 @@ class IR_API YieldOp : public Op<YieldOp, SideEffectTrait> {
 ///
 /// \brief Push a value tuple to a container.
 ///
-class IR_API TuplePushOp : public Op<TuplePushOp, SideEffectTrait> {
+class IR_API TuplePushOp : public Op<TuplePushOp,
+                                     SideEffectTrait,
+                                     CacheGradOpSymbolicShapeInterface> {
  public:
   using Op::Op;
   static const char *name() { return "cf.tuple_push"; }
@@ -70,6 +72,8 @@ class IR_API TuplePushOp : public Op<TuplePushOp, SideEffectTrait> {
     return inlet().defining_op<ContainerOpInterface>();
   }
   TuplePopOp tuple_pop_op();
+
+  CacheGradOpSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
 };
 
 class IR_API TuplePopOp : public Op<TuplePopOp, SideEffectTrait> {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Before solution: ~~https://github.com/PaddlePaddle/Paddle/pull/70565~~
Support cf.tuple_pop, cf.tuple_push, cf.stack_create:
1. In stack_create op, set in_let and out_let to the same and meaningless shape as the match key
2. Infer the shape of cf.tuple_pop by adding a grad cache interface for cf.tuple_push
3. Mark cf.tuple_pop as a special cached op to avoid using static shape
4. Execute delete_assert_op_pass and infer_symbolic_shape_pass before reduce_as_sum_pass
5. In infer mode, the infer_symbolic_shape_pass should not be executed

Depend on https://github.com/PaddlePaddle/Paddle/pull/70947