### PR TITLE
[clean old comm][fluid_ops] margin_cross_entropy.cu.h

### DIFF
--- a/paddle/phi/kernels/impl/margin_cross_entropy.cu.h
+++ b/paddle/phi/kernels/impl/margin_cross_entropy.cu.h
@@ -90,12 +90,9 @@ void GetClassInterval(const gpuStream_t& stream,
     auto task = pg->AllReduce(in_tensor, out_tensor, opts);
     task->Wait();
   } else {
-    const auto& comm_context_manager =
-        phi::distributed::CommContextManager::GetInstance();
-    phi::distributed::NCCLCommContext* comm_ctx = nullptr;
-
-    comm_ctx = static_cast<phi::distributed::NCCLCommContext*>(
-        dev_ctx.GetCommContext());
+    phi::distributed::NCCLCommContext* comm_ctx =
+        static_cast<phi::distributed::NCCLCommContext*>(
+            dev_ctx.GetCommContext());
     PADDLE_ENFORCE_NE(comm_ctx,
                       nullptr,
                       common::errors::Unavailable(

--- a/paddle/phi/kernels/impl/margin_cross_entropy.cu.h
+++ b/paddle/phi/kernels/impl/margin_cross_entropy.cu.h
@@ -94,17 +94,8 @@ void GetClassInterval(const gpuStream_t& stream,
         phi::distributed::CommContextManager::GetInstance();
     phi::distributed::NCCLCommContext* comm_ctx = nullptr;
 
-    PADDLE_ENFORCE_EQ(comm_context_manager.Has(std::to_string(rid)),
-                      true,
-                      common::errors::InvalidArgument(
-                          "You choose to use new communication library by "
-                          "setting environment "
-                          "variable FLAGS_dynamic_static_unified_comm True. "
-                          "But ring_id(%d) is "
-                          "not found in comm_context_manager.",
-                          std::to_string(rid)));
     comm_ctx = static_cast<phi::distributed::NCCLCommContext*>(
-        comm_context_manager.Get(std::to_string(rid)));
+        dev_ctx.GetCommContext());
     PADDLE_ENFORCE_NE(comm_ctx,
                       nullptr,
                       common::errors::Unavailable(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
paddle/phi/kernels/impl/margin_cross_entropy.cu.h 移除 FLAGS_dynamic_static_unified_comm