### PR TITLE
[CINN] Fix remove reduce one axis in anchor fusion

### DIFF
--- a/paddle/cinn/operator_fusion/policy/iters_fusion_policy.cc
+++ b/paddle/cinn/operator_fusion/policy/iters_fusion_policy.cc
@@ -225,12 +225,13 @@ std::optional<ItersTransformRoute> ItersFusionPolicy::SearchItersTransformRoute(
   auto squeezed_source = source;
   if (squeeze_source) {
     // Remove iters equal to one in source
-    auto source_ones = MapVectorIfTrue<std::pair<std::string, int>, int>(
-        Enumerate(source.loop_iters),
-        [this](std::pair<std::string, int> p) { return p.second; },
-        [this](std::pair<std::string, int> p) {
-          return this->iters_manager_->IterSymbolEqualOne(p.first);
-        });
+    std::vector<int> source_ones;
+    for (int i = 0; i < source.loop_iters.size() - source.reduce_iter_nums;
+         ++i) {
+      if (iters_manager_->IterSymbolEqualOne(source.loop_iters[i])) {
+        source_ones.push_back(i);
+      }
+    }
     if (!source_ones.empty() &&
         source_ones.size() != source.loop_iters.size()) {
       iters_transforms.emplace_back(RemoveOnesTransform(source_ones));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- Fix remove reduce one axis in anchor fusion