### PR TITLE
[Infer] Add head_dim=96 dispatch for block attention

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/block_attn.h
+++ b/paddle/phi/kernels/fusion/gpu/block_attn.h
@@ -1600,6 +1600,10 @@ void dispatch_blha_impl_headsize(const phi::GPUContext &dev_ctx,
       dispatch_blha_impl_blocksize<T, 64, 64>(
           params, dev_ctx.stream(), load_func, store_func, use_cachekv_int8);
       break;
+    case 96:
+      dispatch_blha_impl_blocksize<T, 96, 128>(
+          params, dev_ctx.stream(), load_func, store_func, use_cachekv_int8);
+      break;
     case 128:
       dispatch_blha_impl_blocksize<T, 128, 128>(
           params, dev_ctx.stream(), load_func, store_func, use_cachekv_int8);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

 Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

为block attention添加head_dim=96的dispatch

复现方式：PaddleNLP中使用下面的指令

```shell
cd llm
# block attention
python ./predict/predictor.py --model_name_or_path bigscience/bloom-1b1 --dtype float16 --mode dynamic --decode_strategy greedy_search --inference_model 1 --block_attn 1

# normal attention
python ./predict/predictor.py --model_name_or_path bigscience/bloom-1b1 --dtype float16 --mode dynamic --decode_strategy greedy_search --inference_model 1 --block_attn 0

# block 的指令与normal指令的计算结果相同
```


