### PR TITLE
[CINN] Use `trunc` instead of `fesetround` to avoid affect other calculation precision in same process

### DIFF
--- a/paddle/cinn/ir/ir_printer.cc
+++ b/paddle/cinn/ir/ir_printer.cc
@@ -14,7 +14,7 @@
 
 #include "paddle/cinn/ir/ir_printer.h"
 #include <algorithm>
-#include <cfenv>
+#include <cmath>
 #include <iomanip>
 #include <limits>
 #include <vector>
@@ -175,7 +175,7 @@ void IrPrinter::Visit(const FloatImm *x) {
       }
     } else {
       float v = TruncateInfinity<float>(x->value);
-      if (IsCloseEqualBoundValue<float>(v)) std::fesetround(FE_TOWARDZERO);
+      if (IsCloseEqualBoundValue<float>(v)) v = std::trunc(v);
       ss << std::setprecision(std::numeric_limits<float>::max_digits10);
       ss << std::showpoint;
       ss << v;

--- a/test/cpp/pir/cinn/replace_cross_block_reduction_test.cc
+++ b/test/cpp/pir/cinn/replace_cross_block_reduction_test.cc
@@ -155,7 +155,7 @@ TEST(CrossBlockReductionReplacer, RSLayout) {
           ScheduleBlock(B__reduce_init)
           {
             i0, i1 = axis.bind(i, j)
-            B__reduce_init[i0, i1] = -3.40282346e+38f
+            B__reduce_init[i0, i1] = -3.40282347e+38f
           }
           thread_bind[blockIdx.y] for (reduce_k, 0, 8)
           {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

`std::fesetround`[^1] 会影响当前进程浮点舍入规则，后续计算精度都会受到影响（后续 Python、NumPy 浮点数表示都会有问题），包括 #70510 中的 guard 精度问题，因此尝试使用 trunc 解决 #64529 的上界溢出问题

#70510 后续找时间 revert 下

PCard-66972

[^1]: https://en.cppreference.com/w/cpp/numeric/fenv/feround