### PR TITLE
refine forece_sequential

### DIFF
--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/nodes.h
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/nodes.h
@@ -548,7 +548,9 @@ class SyncBatchNormGradNode : public egr::GradNodeBase {
   SyncBatchNormGradNode() : egr::GradNodeBase() {}
   SyncBatchNormGradNode(size_t bwd_in_slot_num, size_t bwd_out_slot_num)
       : egr::GradNodeBase(bwd_in_slot_num, bwd_out_slot_num) {}
-  ~SyncBatchNormGradNode() override = default;
+  ~SyncBatchNormGradNode() {
+    egr::Controller::Instance().EraseForceSequentialNodes(this);
+  }
 
   virtual paddle::small_vector<std::vector<paddle::Tensor>,
                                egr::kSlotSmallVectorSize>

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/nodes.h
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/nodes.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/fluid/eager/grad_node_info.h"
 #include "paddle/fluid/eager/tensor_wrapper.h"
 #include "paddle/fluid/imperative/tracer.h"
@@ -317,7 +318,9 @@ class SyncBatchNormGradNode : public egr::GradNodeBase {
   SyncBatchNormGradNode() : egr::GradNodeBase() {}
   SyncBatchNormGradNode(size_t bwd_in_slot_num, size_t bwd_out_slot_num)
       : egr::GradNodeBase(bwd_in_slot_num, bwd_out_slot_num) {}
-  ~SyncBatchNormGradNode() override = default;
+  ~SyncBatchNormGradNode() {
+    egr::Controller::Instance().EraseForceSequentialNodes(this);
+  }
 
   virtual paddle::small_vector<std::vector<paddle::Tensor>,
                                egr::kSlotSmallVectorSize>

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -126,15 +126,23 @@ class Controller {
 
   void ClearFinalBackwardHooks() { final_backward_hooks_.clear(); }
 
-  void ClearForceSequentialNodes() {
-    while (!force_sequential_nodes_.empty()) {
-      force_sequential_nodes_.pop();
+  void ClearForceSequentialNodes() { force_sequential_nodes_.clear(); }
+  void PushBackForceSequentialNodes(GradNodeBase* node) {
+    force_sequential_nodes_.push_back(node);
+  }
+
+  void EraseForceSequentialNodes(GradNodeBase* node) {
+    for (auto iter = force_sequential_nodes_.begin();
+         iter != force_sequential_nodes_.end();
+         ++iter) {
+      if (*iter == node) {
+        force_sequential_nodes_.erase(iter);
+        return;
+      }
     }
   }
-  void PushBackForceSequentialNodes(GradNodeBase* node) {
-    force_sequential_nodes_.push(node);
-  }
-  std::queue<GradNodeBase*> GetForceSequentialNodes() {
+
+  std::list<GradNodeBase*> GetForceSequentialNodes() {
     return force_sequential_nodes_;
   }
 
@@ -153,7 +161,7 @@ class Controller {
                      std::vector<std::vector<std::unordered_map<int, int>>>>
       custom_edges_slot_map_;
   std::vector<std::shared_ptr<VoidHook>> final_backward_hooks_;
-  std::queue<GradNodeBase*> force_sequential_nodes_;
+  std::list<GradNodeBase*> force_sequential_nodes_;
   bool is_in_backward_{false};
   DISABLE_COPY_AND_ASSIGN(Controller);
 };

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -225,7 +225,7 @@ std::vector<paddle::Tensor> RunBackward(
   std::unordered_map<GradNodeBase*, int> node_in_degree_map =
       getInDegreeMap(queue);
 
-  std::queue<GradNodeBase*> force_sequential_nodes_forward_queue =
+  std::list<GradNodeBase*> force_sequential_nodes_forward_queue =
       egr::Controller::Instance().GetForceSequentialNodes();
   std::deque<GradNodeBase*> force_sequential_nodes_queue;
   std::set<GradNodeBase*> force_sequential_nodes_set;
@@ -240,7 +240,7 @@ std::vector<paddle::Tensor> RunBackward(
       force_sequential_nodes_queue.push_front(
           force_sequential_nodes_forward_queue.front());
     }
-    force_sequential_nodes_forward_queue.pop();
+    force_sequential_nodes_forward_queue.pop_front();
   }
 
   VLOG(5) << "Startup_ops's size is " << queue.size();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
forece_sequential 需考虑 Op output不被使用销毁，进而销毁node的场景。

Pcard-67164