### PR TITLE
Revert "[CINN] Align initial subgraph order with block.ops (#70719)"

### DIFF
--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -461,14 +461,13 @@ void SubgraphDetector::MergeSource2Target(const SubGraphPtr& source,
 
 SubgraphDetector::SubgraphDetector(pir::Block* block,
                                    const OpClassifier& classifier) {
-  // init sort_ops_ in reverse topo order and op2index_ in topo order
+  // init sort_ops_ in reverse topo order
+  sort_ops_ = InverselyTopologicalSort(block);
+  // init op2index_ in topo order
   int index = 0;
   for (auto& op : *block) {
-    sort_ops_.push_back(&op);
     op2index_[&op] = index++;
   }
-  std::reverse(sort_ops_.begin(), sort_ops_.end());
-
   // construct subgraphs and upstream/downstream relation
   std::vector<SubGraphPtr> subgraph_list;
   for (const auto& op : sort_ops_) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- Revert #70719