### PR TITLE
[CINN] Grid reduce supports static-S-dynamic-R

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -418,16 +418,9 @@ std::vector<ir::LoweredFunc> OpLowererImpl::PostProcess(
     lowered_funcs.push_back(std::move(func));
   }
 
-  // collect temp space sizes
-  if (lowered_funcs.size() > 1) {
-    for (auto& temp_space : lowered_funcs[0]->temp_spaces) {
-      int64_t size = -1;
-      if (temp_space.size().is_constant()) {
-        size = temp_space.size().as_int64();
-      }
-      group->mut_temp_space_sizes().push_back(size);
-    }
-  }
+  // 5. Unify temp_space args and set temp_space sizes
+  UnifyTempSpaceArgs(&lowered_funcs);
+  group->mut_temp_space_sizes() = CollectTempSpaceSizes(lowered_funcs);
 
   return lowered_funcs;
 }

--- a/paddle/cinn/hlir/framework/pir/op_lowering_util.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_util.h
@@ -68,6 +68,30 @@ void LoopAssignReduce(
     const std::unordered_map<::pir::Value, ir::Tensor>& tensor_map,
     const std::unordered_map<std::string, ir::Tensor>& tmp_tensor_info);
 
+/**
+ * Unify the temp_space args (inserted by grid reduce) so that all functions in
+ * this group have the same number of arguments.
+ *
+ * For example, if there are 3 functions in this group, whose args are:
+ *   fn_kernel_1(var_0, var_1, S0, S1)
+ *   fn_kernel_2(var_0, var_1, var_1_tmp, semaphore, S0, S1)
+ *   fn_kernel_3(var_0, var_1, var_0_tmp, var_1_tmp, semaphore, S0, S1)
+ *
+ * This method will insert placeholders after the last tensor argument to align
+ * all functions with the longest argument list:
+ *   fn_kernel_1(var_0, var_1, _plchdr_0, _plchdr_1, _plchdr_2, S0, S1)
+ *   fn_kernel_2(var_0, var_1, var_1_tmp, semaphore, _plchdr_0, S0, S1)
+ *   fn_kernel_3(var_0, var_1, var_0_tmp, var_1_tmp, semaphore, S0, S1)
+ */
+void UnifyTempSpaceArgs(std::vector<ir::LoweredFunc>* funcs);
+
+/**
+ * Get a composed list of the temp_space sizes of all functions in this group.
+ * The position with dynamic shape or with multiple shapes is set to -1.
+ */
+std::vector<int64_t> CollectTempSpaceSizes(
+    const std::vector<ir::LoweredFunc>& funcs);
+
 }  // namespace pir
 }  // namespace framework
 }  // namespace hlir


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Performance


### Description
新增Grid Reduce对动态shape的支持，这个PR先支持“静态S动态R”的配置，验证Grid Reduce在动态shape上的正确性，之后再扩展到其他动态维度，目前支持其他动态维度的需求不是很强烈

#### 性能测试
| 模型 | 旧 | 新 | 提升 |
| --- | --- | --- | --- |
| PaddleDetection_yolov3_darknet53_270e_coco_bs8_fp16 | 58.1 | 70.8 | 21.9%
| PaddleClas_PPLCNetV2_base_bs500_fp16 | 802 | 972 | 21.2%
| PaddleSeg_segformer_b0_bs4_fp16 | 17.6 | 20.3 | 15.3%

<br>
Pcard-85711