### PR TITLE
fix eigvalsh input arg index out of bound

### DIFF
--- a/paddle/phi/kernels/gpu/eigvalsh_kernel.cu
+++ b/paddle/phi/kernels/gpu/eigvalsh_kernel.cu
@@ -29,7 +29,7 @@ PD_REGISTER_KERNEL(eigvalsh,  // cuda_only
                    double,
                    phi::dtype::complex<float>,
                    phi::dtype::complex<double>) {
-  kernel->InputAt(1).SetDataType(phi::dtype::ToReal(kernel_key.dtype()));
+  kernel->InputAt(0).SetDataType(phi::dtype::ToReal(kernel_key.dtype()));
 }
 
 #endif  // not PADDLE_WITH_HIP


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
eigvalsh kernel的args里只有一个Dense Tensor。 在注册过程中根据SetKernelArgsDef的定义，input_defs_的size是1。 但在取input时，却将index写成了1。在debug编译下，该算子注册会触发small_vector的运行时检查，导致程序core_dump。
![image](https://github.com/user-attachments/assets/e4ca5233-3ba2-4df7-ae0f-e39fd69a4032)
