### PR TITLE
[clean old comm][fluid_ops] c_allreduce_op.h

### DIFF
--- a/paddle/fluid/operators/collective/c_allreduce_op.h
+++ b/paddle/fluid/operators/collective/c_allreduce_op.h
@@ -135,11 +135,7 @@ class CAllReduceOpXPUKernel : public framework::OpKernel<T> {
     int rid = ctx.Attr<int>("ring_id");
 
     auto place = ctx.GetPlace();
-    BKCLDataType dtype = phi::ToBKCLDataType(in->dtype());
-    int64_t numel = in->numel();
-    const void* sendbuff = in->data<T>();
     out->Resize(in->dims());
-    void* recvbuff = out->mutable_data<T>(place);
 
     auto map = phi::distributed::ProcessGroupMapFromGid::getInstance();
     if (map->has(rid)) {
@@ -225,17 +221,7 @@ class CAllReduceOpXPUKernel : public framework::OpKernel<T> {
                                                      red_type));
     }
 
-    if (comm_ctx) {
-      comm_ctx->AllReduce(out, *in, bkcl_red_type, stream);
-    } else {
-      PADDLE_ENFORCE_XPU_SUCCESS(bkcl_all_reduce(comm->comm(),
-                                                 sendbuff,
-                                                 recvbuff,
-                                                 numel,
-                                                 dtype,
-                                                 bkcl_red_type,
-                                                 stream));
-    }
+    comm_ctx->AllReduce(out, *in, bkcl_red_type, stream);
 #else
     PADDLE_THROW(common::errors::PreconditionNotMet(
         "PaddlePaddle should be compiled with XPU."));
@@ -273,12 +259,10 @@ class CAllReduceOpCUDAKernel : public framework::OpKernel<T> {
     auto out = ctx.Output<phi::DenseTensor>("Out");
     int rid = ctx.Attr<int>("ring_id");
 
-    auto place = ctx.GetPlace();
     ncclDataType_t dtype = phi::ToNCCLDataType(in->dtype());
     int64_t numel = in->numel();
     const void* sendbuff = in->data<T>();
     out->Resize(in->dims());
-    void* recvbuff = out->mutable_data<T>(place);
 
     auto map = phi::distributed::ProcessGroupMapFromGid::getInstance();
     if (map->has(rid)) {
@@ -377,17 +361,7 @@ class CAllReduceOpCUDAKernel : public framework::OpKernel<T> {
                                                      red_type));
     }
 
-    if (comm_ctx) {
-      comm_ctx->AllReduce(out, *in, nccl_red_type, stream);
-    } else {
-      PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclAllReduce(sendbuff,
-                                                             recvbuff,
-                                                             numel,
-                                                             dtype,
-                                                             nccl_red_type,
-                                                             comm->comm(),
-                                                             stream));
-    }
+    comm_ctx->AllReduce(out, *in, nccl_red_type, stream);
 #else
     PADDLE_THROW(common::errors::PreconditionNotMet(
         "PaddlePaddle should compile with GPU."));

--- a/paddle/fluid/operators/collective/recv_v2_op.cu.cc
+++ b/paddle/fluid/operators/collective/recv_v2_op.cu.cc
@@ -46,21 +46,14 @@ phi::DDim recv_shape_info(const phi::Place &place,
   }
 
   phi::DataType shape_dtype = phi::DataType::INT32;
-  ncclDataType_t nccl_dtype = phi::ToNCCLDataType(shape_dtype);
 
   // step1: recv the shape size
   phi::DenseTensor gpu_shape_size_tensor(shape_dtype);
   if (!group) {
     gpu_shape_size_tensor.Resize({1});
     gpu_shape_size_tensor.mutable_data(place, shape_dtype);
-    auto *gpu_data = gpu_shape_size_tensor.data<int>();
 
-    if (comm_ctx) {
-      comm_ctx->Recv(&gpu_shape_size_tensor, 1, peer, stream);
-    } else {
-      PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclRecv(
-          gpu_data, 1, nccl_dtype, peer, comm->comm(), stream));
-    }
+    comm_ctx->Recv(&gpu_shape_size_tensor, 1, peer, stream);
   }
 
   // copy the shape size tensor to cpu
@@ -84,13 +77,7 @@ phi::DDim recv_shape_info(const phi::Place &place,
   if (!group) {
     gpu_shape_tensor.Resize({shape_size});
     gpu_shape_tensor.mutable_data(place, shape_dtype);
-    auto *gpu_shape_data = gpu_shape_tensor.data<int>();
-    if (comm_ctx) {
-      comm_ctx->Recv(&gpu_shape_tensor, shape_size, peer, stream);
-    } else {
-      PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclRecv(
-          gpu_shape_data, shape_size, nccl_dtype, peer, comm->comm(), stream));
-    }
+    comm_ctx->Recv(&gpu_shape_tensor, shape_size, peer, stream);
   }
 
   // copy the shape tensor to cpu
@@ -196,11 +183,6 @@ class RecvOpV2CUDAKernel : public framework::OpKernel<T> {
       // should ExecutionContext for calc stream.
       stream = ctx.cuda_device_context().stream();
     }
-    int data_type = ctx.Attr<int>("dtype");
-    framework::proto::VarType::Type type =
-        framework::proto::VarType::Type(data_type);
-    ncclDataType_t dtype = platform::ToNCCLDataType(type);
-
     auto *out_var = ctx.OutputVar("Out");
     if (out_var->IsType<phi::TensorArray>()) {
       PADDLE_ENFORCE_EQ(
@@ -212,17 +194,9 @@ class RecvOpV2CUDAKernel : public framework::OpKernel<T> {
       for (size_t idx = 0; idx < out_array->size(); ++idx) {
         VLOG(3) << "DenseTensorArray: idx(" << idx << ")";
         auto out = &out_array->at(idx);
-        auto out_dims = out->dims();
         ctx.cuda_device_context().Alloc<T>(out);
         auto numel = out->numel();
-        if (comm_ctx) {
-          comm_ctx->Recv(out, numel, peer, stream);
-        } else {
-          PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclRecv(
-              out->data<T>(), numel, dtype, peer, comm->comm(), stream));
-          VLOG(3) << "rank " << comm->rank() << " recv "
-                  << common::product(out_dims) << " from " << peer;
-        }
+        comm_ctx->Recv(out, numel, peer, stream);
       }
       return;
     }
@@ -246,22 +220,7 @@ class RecvOpV2CUDAKernel : public framework::OpKernel<T> {
     } else {
       ctx.cuda_device_context().Alloc<T>(out);
     }
-    if (comm_ctx) {
-      comm_ctx->Recv(out, numel, peer, stream);
-    } else {
-      comm = platform::NCCLCommContext::Instance().Get(rid, place);
-      PADDLE_ENFORCE_LT(
-          peer,
-          comm->nranks(),
-          common::errors::InvalidArgument("The value of peer (%d) you set must "
-                                          "be less than comm->nranks (%d).",
-                                          peer,
-                                          comm->nranks()));
-      PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclRecv(
-          out->data<T>(), numel, dtype, peer, comm->comm(), stream));
-      VLOG(3) << "rank " << comm->rank() << " recv "
-              << common::product(out->dims()) << " from " << peer;
-    }
+    comm_ctx->Recv(out, numel, peer, stream);
 #else
     PADDLE_THROW(common::errors::Unavailable(
         "PaddlePaddle should be compiled with NCCL and "


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
paddle/fluid/operators/collective/c_allreduce_op.h 清理切换通信库不会执行部分代码，gcc高版本编译会有错误