### PR TITLE
[CINN] Fix subgraph topo error in buildcinnpass

### DIFF
--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -422,6 +422,9 @@ void SubgraphDetector::MergeSource2Target(const SubGraphPtr& source,
   VLOG(6) << "Merge source: " << source->DebugStr();
   VLOG(6) << "Merge target: " << target->DebugStr();
   target->Merge(source);
+  for (const auto& op : source->ops) {
+    op2subgraph_[op] = target;
+  }
   int max_index = std::max(source->topo_index, target->topo_index);
   int min_index = std::min(source->topo_index, target->topo_index);
   auto merged = target;
@@ -514,9 +517,6 @@ void SubgraphDetector::SubgraphFusion() {
       if (upstream == downstream || !upstream->substitute) continue;
       if (CanFuseUpstream2Downstream(upstream, downstream)) {
         MergeSource2Target(upstream, downstream);
-        for (auto upstream_op : upstream->ops) {
-          op2subgraph_[upstream_op] = downstream;
-        }
         VLOG(6) << "Merged subgraph: " << downstream->DebugStr();
       }
     }
@@ -533,9 +533,6 @@ void SubgraphDetector::SubgraphFusion() {
         if (brother == subgraph || !brother->substitute) continue;
         if (!HasRoute(subgraph, brother) && !HasRoute(brother, subgraph)) {
           MergeSource2Target(brother, subgraph);
-          for (auto brother_op : brother->ops) {
-            op2subgraph_[brother_op] = subgraph;
-          }
           VLOG(6) << "Merged subgraph: " << subgraph->DebugStr();
         }
       }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- 修复一个 BuildCinnPass 出现环的问题：Subgraph 拓扑序重排应该在融合更新 op2subgraph_ 之后，不然可能会导致拓扑序错误