### PR TITLE
[UT] fix c_concat c_split unittest

### DIFF
--- a/test/collective/CMakeLists.txt
+++ b/test/collective/CMakeLists.txt
@@ -13,6 +13,13 @@ if((WITH_GPU OR WITH_ROCM) AND (LINUX))
 endif()
 if((WITH_GPU OR WITH_ROCM) AND (LINUX))
   py_test_modules(
+    test_c_split MODULES test_c_split ENVS
+    "http_proxy=;https_proxy=;PYTHONPATH=..:${PADDLE_BINARY_DIR}/python")
+  set_tests_properties(test_c_split PROPERTIES TIMEOUT "120" LABELS
+                                               "RUN_TYPE=DIST")
+endif()
+if((WITH_GPU OR WITH_ROCM) AND (LINUX))
+  py_test_modules(
     test_collective_allgather_api MODULES test_collective_allgather_api ENVS
     "http_proxy=;https_proxy=;PYTHONPATH=..:${PADDLE_BINARY_DIR}/python")
   set_tests_properties(test_collective_allgather_api

--- a/test/collective/CMakeLists.txt
+++ b/test/collective/CMakeLists.txt
@@ -6,6 +6,13 @@ set(LOCAL_ALL_ARCH ON)
 set(LOCAL_ALL_PLAT ON)
 if((WITH_GPU OR WITH_ROCM) AND (LINUX))
   py_test_modules(
+    test_c_concat MODULES test_c_concat ENVS
+    "http_proxy=;https_proxy=;PYTHONPATH=..:${PADDLE_BINARY_DIR}/python")
+  set_tests_properties(test_c_concat PROPERTIES TIMEOUT "120" LABELS
+                                                "RUN_TYPE=DIST")
+endif()
+if((WITH_GPU OR WITH_ROCM) AND (LINUX))
+  py_test_modules(
     test_collective_allgather_api MODULES test_collective_allgather_api ENVS
     "http_proxy=;https_proxy=;PYTHONPATH=..:${PADDLE_BINARY_DIR}/python")
   set_tests_properties(test_collective_allgather_api

--- a/test/collective/collective_concat_op.py
+++ b/test/collective/collective_concat_op.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+os.environ['FLAGS_enable_pir_api'] = '0'
+
 from legacy_test.test_collective_base import (
     TestCollectiveRunnerBase,
     runtime_main,

--- a/test/collective/collective_split_op.py
+++ b/test/collective/collective_split_op.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+os.environ['FLAGS_enable_pir_api'] = '0'
+
 from legacy_test.test_collective_base import (
     TestCollectiveRunnerBase,
     runtime_main,


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description
在运行并修复XPU单测的过程中，发现有些单测在GPU下也跑不过或者不存在，比如`test_c_concat`以及`test_c_split`。排查发现：
* 在这个PR https://github.com/PaddlePaddle/Paddle/pull/68278 中，修改了`test/collective/CMakeLists.txt`，将`test_c_concat`以及`test_c_split`去掉了。
* 把它添加回来之后发现跑不过，原因是PIR中不再支持`current_block`（参考： https://github.com/PaddlePaddle/Paddle/issues/58788 ）。
* 根据这个issue https://github.com/PaddlePaddle/Paddle/issues/70782 的讨论，挡一个环境变量可以关掉PIR。

因此本PR做了以下事情，使得这个单测可以正常运行并且通过。
* 修改`CMakeLists.txt`，把这个单测加回来。
* 挡了一个环境变量，不走PIR。

后续再改XPU的相关单测代码。