### PR TITLE
[CodeStyle][Typos][I-11] Fix typos(`indexs`,`Indexs`) (part 1)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -45,7 +45,6 @@ pash = 'pash'
 unpacket = "unpacket"
 
 # These words need to be fixed
-Indexs = 'Indexs'
 indexs = 'indexs'
 Infered = 'Infered'
 infered = 'infered'

--- a/paddle/cinn/adt/print_utils/print_equations.cc
+++ b/paddle/cinn/adt/print_utils/print_equations.cc
@@ -206,10 +206,10 @@ struct ToTxtStringStruct {
                          tOut<OpArgIndexes<std::optional<Index>>>,
                          tIn<OpArgIndexes<Index>>>& in_msg2out_msg) const {
     std::string ret;
-    const auto& [out_op, out_indexes, in_indexes] = in_msg2out_msg.tuple();
+    const auto& [out_op, out_indices, in_indices] = in_msg2out_msg.tuple();
     const FakeOpPlaceHolder& op = out_op.value();
-    const auto& out_index_tuple = out_indexes.value();
-    const auto& in_index_tuple = in_indexes.value();
+    const auto& out_index_tuple = out_indices.value();
+    const auto& in_index_tuple = in_indices.value();
     const auto& [out_msg_list_in, out_msg_list_out] = out_index_tuple.tuple();
     const auto& [in_msg_list_in, in_msg_list_out] = in_index_tuple.tuple();
     ret += ToTxtString(op) + ", ";

--- a/paddle/cinn/adt/print_utils/print_equations.cc
+++ b/paddle/cinn/adt/print_utils/print_equations.cc
@@ -206,10 +206,10 @@ struct ToTxtStringStruct {
                          tOut<OpArgIndexes<std::optional<Index>>>,
                          tIn<OpArgIndexes<Index>>>& in_msg2out_msg) const {
     std::string ret;
-    const auto& [out_op, out_indexs, in_indexs] = in_msg2out_msg.tuple();
+    const auto& [out_op, out_indexes, in_indexes] = in_msg2out_msg.tuple();
     const FakeOpPlaceHolder& op = out_op.value();
-    const auto& out_index_tuple = out_indexs.value();
-    const auto& in_index_tuple = in_indexs.value();
+    const auto& out_index_tuple = out_indexes.value();
+    const auto& in_index_tuple = in_indexes.value();
     const auto& [out_msg_list_in, out_msg_list_out] = out_index_tuple.tuple();
     const auto& [in_msg_list_in, in_msg_list_out] = in_index_tuple.tuple();
     ret += ToTxtString(op) + ", ";

--- a/paddle/cinn/adt/write_broadcast_disabled_bidirection_equation_generator.cc
+++ b/paddle/cinn/adt/write_broadcast_disabled_bidirection_equation_generator.cc
@@ -106,7 +106,7 @@ Equation EraseIndexes(
   return ret_equation;
 }
 
-std::vector<Index> GenerateWriteBroadcastTensorIndexes(
+std::vector<Index> GenerateWriteBroadcastTensorIndices(
     const std::shared_ptr<config::NaiveOpEquationContext>& ctx,
     const Equations& in_msg2out_msg_equations) {
   const auto& equation_graph_view =
@@ -138,7 +138,7 @@ WriteBroadcastDisabledBidirectionEquationGenerator::GetDirectionEquations()
         const auto& in_msg2out_msg_equations =
             naive_bidirection_equation_generator_.equations();
         const auto& truncated_output_tensor_index =
-            GenerateWriteBroadcastTensorIndexes(ctx, in_msg2out_msg_equations);
+            GenerateWriteBroadcastTensorIndices(ctx, in_msg2out_msg_equations);
         ret->emplace_back(EraseIndexes(in_msg2out_msg_equations->at(idx),
                                        truncated_output_tensor_index));
       });

--- a/paddle/cinn/adt/write_broadcast_disabled_bidirection_equation_generator.cc
+++ b/paddle/cinn/adt/write_broadcast_disabled_bidirection_equation_generator.cc
@@ -137,10 +137,10 @@ WriteBroadcastDisabledBidirectionEquationGenerator::GetDirectionEquations()
           const std::shared_ptr<config::NaiveOpEquationContext>& ctx) {
         const auto& in_msg2out_msg_equations =
             naive_bidirection_equation_generator_.equations();
-        const auto& truncated_output_tensor_index =
+        const auto& truncated_output_tensor_indices =
             GenerateWriteBroadcastTensorIndices(ctx, in_msg2out_msg_equations);
         ret->emplace_back(EraseIndexes(in_msg2out_msg_equations->at(idx),
-                                       truncated_output_tensor_index));
+                                       truncated_output_tensor_indices));
       });
   return ret;
 }

--- a/paddle/cinn/adt/write_broadcast_disabled_bidirection_equation_generator.cc
+++ b/paddle/cinn/adt/write_broadcast_disabled_bidirection_equation_generator.cc
@@ -106,7 +106,7 @@ Equation EraseIndexes(
   return ret_equation;
 }
 
-std::vector<Index> GenerateWriteBroadcastTensorIndexs(
+std::vector<Index> GenerateWriteBroadcastTensorIndexes(
     const std::shared_ptr<config::NaiveOpEquationContext>& ctx,
     const Equations& in_msg2out_msg_equations) {
   const auto& equation_graph_view =
@@ -137,10 +137,10 @@ WriteBroadcastDisabledBidirectionEquationGenerator::GetDirectionEquations()
           const std::shared_ptr<config::NaiveOpEquationContext>& ctx) {
         const auto& in_msg2out_msg_equations =
             naive_bidirection_equation_generator_.equations();
-        const auto& truncated_output_tensor_idxes =
-            GenerateWriteBroadcastTensorIndexs(ctx, in_msg2out_msg_equations);
+        const auto& truncated_output_tensor_index =
+            GenerateWriteBroadcastTensorIndexes(ctx, in_msg2out_msg_equations);
         ret->emplace_back(EraseIndexes(in_msg2out_msg_equations->at(idx),
-                                       truncated_output_tensor_idxes));
+                                       truncated_output_tensor_index));
       });
   return ret;
 }

--- a/paddle/cinn/hlir/framework/pir/op_mapper.h
+++ b/paddle/cinn/hlir/framework/pir/op_mapper.h
@@ -33,7 +33,7 @@ enum MapperType {
 };
 
 class OpMapper {
-  using OperandIndexesFunction = std::function<std::vector<size_t>()>;
+  using OperandIndicesFunction = std::function<std::vector<size_t>()>;
   using AppendAttrFunction =
       std::function<void(const ::pir::Operation& op,
                          utils::AttributeMap& attrs)>;  // NOLINT
@@ -59,7 +59,7 @@ class OpMapper {
         has(op, MapperType::OPERAND),
         true,
         ::common::errors::PreconditionNotMet(
-            "Not register OperandIndexesFunction for %s", op.name().c_str()));
+            "Not register OperandIndicesFunction for %s", op.name().c_str()));
     std::vector<::pir::Value> inputs;
     for (auto idx : operand_funcs_.at(op.name())()) {
       inputs.push_back(op.operand_source(idx));
@@ -81,7 +81,7 @@ class OpMapper {
   OpMapper() { RegisterMapRules(); }
   void RegisterMapRules();
 
-  std::unordered_map<std::string, OperandIndexesFunction> operand_funcs_;
+  std::unordered_map<std::string, OperandIndicesFunction> operand_funcs_;
   std::unordered_map<std::string, AppendAttrFunction> attr_funcs_;
 };
 

--- a/paddle/cinn/hlir/framework/pir/op_mapper.h
+++ b/paddle/cinn/hlir/framework/pir/op_mapper.h
@@ -33,7 +33,7 @@ enum MapperType {
 };
 
 class OpMapper {
-  using OperandIndexsFunction = std::function<std::vector<size_t>()>;
+  using OperandIndexesFunction = std::function<std::vector<size_t>()>;
   using AppendAttrFunction =
       std::function<void(const ::pir::Operation& op,
                          utils::AttributeMap& attrs)>;  // NOLINT
@@ -59,7 +59,7 @@ class OpMapper {
         has(op, MapperType::OPERAND),
         true,
         ::common::errors::PreconditionNotMet(
-            "Not register OperandIndexsFunction for %s", op.name().c_str()));
+            "Not register OperandIndexesFunction for %s", op.name().c_str()));
     std::vector<::pir::Value> inputs;
     for (auto idx : operand_funcs_.at(op.name())()) {
       inputs.push_back(op.operand_source(idx));
@@ -81,7 +81,7 @@ class OpMapper {
   OpMapper() { RegisterMapRules(); }
   void RegisterMapRules();
 
-  std::unordered_map<std::string, OperandIndexsFunction> operand_funcs_;
+  std::unordered_map<std::string, OperandIndexesFunction> operand_funcs_;
   std::unordered_map<std::string, AppendAttrFunction> attr_funcs_;
 };
 

--- a/paddle/cinn/hlir/pe/elementwise.cc
+++ b/paddle/cinn/hlir/pe/elementwise.cc
@@ -162,12 +162,12 @@ ir::Tensor Squeeze(const ir::Tensor& A,
 
   auto res = Compute(
       output_shape,
-      [=](const std::vector<Expr>& indices) {
-        std::vector<Expr> indexes(A->shape.size(), Expr(0));
-        for (int idx = 0; idx < indices.size(); ++idx) {
-          indexes[position[idx]] = indices[idx];
+      [=](const std::vector<Expr>& index) {
+        std::vector<Expr> indices(A->shape.size(), Expr(0));
+        for (int idx = 0; idx < index.size(); ++idx) {
+          indices[position[idx]] = index[idx];
         }
-        return A(indexes);
+        return A(indices);
       },
       output_name);
   return res;

--- a/paddle/cinn/hlir/pe/elementwise.cc
+++ b/paddle/cinn/hlir/pe/elementwise.cc
@@ -162,12 +162,12 @@ ir::Tensor Squeeze(const ir::Tensor& A,
 
   auto res = Compute(
       output_shape,
-      [=](const std::vector<Expr>& index) {
-        std::vector<Expr> indices(A->shape.size(), Expr(0));
-        for (int idx = 0; idx < index.size(); ++idx) {
-          indices[position[idx]] = index[idx];
+      [=](const std::vector<Expr>& indices) {
+        std::vector<Expr> out_indices(A->shape.size(), Expr(0));
+        for (int idx = 0; idx < indices.size(); ++idx) {
+          out_indices[position[idx]] = indices[idx];
         }
-        return A(indices);
+        return A(out_indices);
       },
       output_name);
   return res;

--- a/paddle/cinn/hlir/pe/elementwise.cc
+++ b/paddle/cinn/hlir/pe/elementwise.cc
@@ -163,11 +163,11 @@ ir::Tensor Squeeze(const ir::Tensor& A,
   auto res = Compute(
       output_shape,
       [=](const std::vector<Expr>& indices) {
-        std::vector<Expr> indexs(A->shape.size(), Expr(0));
+        std::vector<Expr> indexes(A->shape.size(), Expr(0));
         for (int idx = 0; idx < indices.size(); ++idx) {
-          indexs[position[idx]] = indices[idx];
+          indexes[position[idx]] = indices[idx];
         }
-        return A(indexs);
+        return A(indexes);
       },
       output_name);
   return res;

--- a/paddle/cinn/hlir/pe/reduction.cc
+++ b/paddle/cinn/hlir/pe/reduction.cc
@@ -330,17 +330,17 @@ std::vector<Tensor> WarpReduce(const ir::Tensor& A,
   tmp_shape.push_back(Expr(32));
   auto tmp_out = Compute(
       tmp_shape,
-      [=](const std::vector<Expr>& indexes) -> Expr {
-        std::vector<Expr> tmp_indexes(indexes.begin(),
-                                      indexes.begin() + indexes.size() - 1);
+      [=](const std::vector<Expr>& indices) -> Expr {
+        std::vector<Expr> tmp_indices(indices.begin(),
+                                      indices.begin() + indices.size() - 1);
         for (int idx = 0; idx < last_reduce_dim_num; ++idx) {
-          tmp_indexes.push_back(Expr(0));
+          tmp_indices.push_back(Expr(0));
         }
         PADDLE_ENFORCE_EQ(A->shape.size(),
-                          tmp_indexes.size(),
+                          tmp_indices.size(),
                           ::common::errors::InvalidArgument(
-                              "indexes size is not equal to Input shape!"));
-        Expr offset = cinn::common::IndiceToAbsOffset(A->shape, tmp_indexes);
+                              "indices size is not equal to Input shape!"));
+        Expr offset = cinn::common::IndiceToAbsOffset(A->shape, tmp_indices);
         return lang::CallExtern(reduce_type, {A, offset, reduce_width});
       },
       UniqName(output_name + "_" + reduce_type));
@@ -357,11 +357,11 @@ std::vector<Tensor> WarpReduce(const ir::Tensor& A,
   }
   auto out = Compute(
       out_shape,
-      [=](const std::vector<Expr>& indexes) -> Expr {
-        std::vector<Expr> tmp_indexes(
-            indexes.begin(), indexes.begin() + shape_size_without_reduce_dim);
-        tmp_indexes.push_back(Expr(0));
-        return tmp_out(tmp_indexes);
+      [=](const std::vector<Expr>& indices) -> Expr {
+        std::vector<Expr> tmp_indices(
+            indices.begin(), indices.begin() + shape_size_without_reduce_dim);
+        tmp_indices.push_back(Expr(0));
+        return tmp_out(tmp_indices);
       },
       output_name);
 
@@ -431,22 +431,22 @@ std::vector<ir::Tensor> BlockReduceInternal(const ir::Tensor& A,
 
   auto tmp_out = Compute(
       tmp_shape,
-      [=](const std::vector<Expr>& indexes) -> Expr {
+      [=](const std::vector<Expr>& indices) -> Expr {
         // compute index map from output to input.
-        auto last_index = indexes.back();
-        std::vector<Expr> input_indexes(indexes.begin(),
-                                        indexes.begin() + indexes.size() - 1);
+        auto last_index = indices.back();
+        std::vector<Expr> input_indices(indices.begin(),
+                                        indices.begin() + indices.size() - 1);
         for (int idx = 0; idx < A->shape.size() - axes.front(); ++idx) {
-          input_indexes.push_back(last_index / last_reduce_stride[idx]);
+          input_indices.push_back(last_index / last_reduce_stride[idx]);
           last_index = last_index % last_reduce_stride[idx];
         }
 
-        // checkout input_indexes size equals input shape
-        PADDLE_ENFORCE_EQ(input_indexes.size(),
+        // checkout input_indices size equals input shape
+        PADDLE_ENFORCE_EQ(input_indices.size(),
                           A->shape.size(),
                           ::common::errors::InvalidArgument(
-                              "indexes size is not equal to Input shape!"));
-        return lang::CallExtern(reduce_type, {A(input_indexes)});
+                              "indices size is not equal to Input shape!"));
+        return lang::CallExtern(reduce_type, {A(input_indices)});
       },
       UniqName(output_name + "_tmp"));
 
@@ -464,11 +464,11 @@ std::vector<ir::Tensor> BlockReduceInternal(const ir::Tensor& A,
   }
   auto out = Compute(
       out_shape,
-      [=](const std::vector<Expr>& indexes) -> Expr {
-        std::vector<Expr> tmp_indexes(indexes.begin(),
-                                      indexes.begin() + axes.front());
-        tmp_indexes.push_back(Expr(0));
-        return tmp_out(tmp_indexes);
+      [=](const std::vector<Expr>& indices) -> Expr {
+        std::vector<Expr> tmp_indices(indices.begin(),
+                                      indices.begin() + axes.front());
+        tmp_indices.push_back(Expr(0));
+        return tmp_out(tmp_indices);
       },
       output_name);
   return {out, tmp_out};
@@ -566,19 +566,19 @@ std::vector<ir::Tensor> BlockReduce(const ir::Tensor& A,
   tmp_shape.push_back(Expr(block_size));
   auto tmp_out = Compute(
       tmp_shape,
-      [=](const std::vector<Expr>& indexes) -> Expr {
-        std::vector<Expr> tmp_indexes(indexes.begin(),
-                                      indexes.begin() + axes.front());
+      [=](const std::vector<Expr>& indices) -> Expr {
+        std::vector<Expr> tmp_indices(indices.begin(),
+                                      indices.begin() + axes.front());
         for (int idx = 0; idx < A->shape.size() - axes.front(); ++idx) {
-          tmp_indexes.push_back(Expr(0));
+          tmp_indices.push_back(Expr(0));
         }
-        // checkout input shape size equals tmp indexes size.
+        // checkout input shape size equals tmp indices size.
         PADDLE_ENFORCE_EQ(A->shape.size(),
-                          tmp_indexes.size(),
+                          tmp_indices.size(),
                           ::common::errors::InvalidArgument(
-                              "indexes size is not equal to Input shape!"));
+                              "indices size is not equal to Input shape!"));
         // compute offset.
-        Expr offset = cinn::common::IndiceToAbsOffset(A->shape, tmp_indexes);
+        Expr offset = cinn::common::IndiceToAbsOffset(A->shape, tmp_indices);
         // call block reduce sum
         return lang::CallExtern(reduce_type, {A, offset, reduce_width});
       },
@@ -598,12 +598,12 @@ std::vector<ir::Tensor> BlockReduce(const ir::Tensor& A,
   }
   auto out = Compute(
       out_shape,
-      [=](const std::vector<Expr>& indexes) -> Expr {
+      [=](const std::vector<Expr>& indices) -> Expr {
         // compute input index
-        std::vector<Expr> tmp_indexes(indexes.begin(),
-                                      indexes.begin() + axes.front());
-        tmp_indexes.push_back(Expr(0));
-        return tmp_out(tmp_indexes);
+        std::vector<Expr> tmp_indices(indices.begin(),
+                                      indices.begin() + axes.front());
+        tmp_indices.push_back(Expr(0));
+        return tmp_out(tmp_indices);
       },
       output_name);
 
@@ -756,33 +756,33 @@ std::vector<ir::Tensor> ReduceInternal(const ir::Tensor& A,
                    [](int val) { return ir::Expr(val); });
     return Compute(
         reshape_output_shape,
-        [=](const std::vector<Expr>& indexes) -> Expr {
+        [=](const std::vector<Expr>& indices) -> Expr {
           // index is last axis in axes and index is last axis >= tail.
           auto selected = ir::And::Make(
-              ir::EQ::Make(indexes[axis], ir::Expr(reduce_shape[axis] - 1)),
-              ir::GE::Make(indexes[axis + 1], ir::Expr(tail)));
+              ir::EQ::Make(indices[axis], ir::Expr(reduce_shape[axis] - 1)),
+              ir::GE::Make(indices[axis + 1], ir::Expr(tail)));
           auto index =
-              indexes[axis] * ir::Expr(reshape_output_shape[axis + 1]) +
-              indexes[axis + 1];
+              indices[axis] * ir::Expr(reshape_output_shape[axis + 1]) +
+              indices[axis + 1];
 
           // first part index
-          std::vector<ir::Expr> tmp_indexes(indexes.begin(),
-                                            indexes.begin() + axes[axis_index]);
+          std::vector<ir::Expr> tmp_indices(indices.begin(),
+                                            indices.begin() + axes[axis_index]);
           // second part index
           for (int idx = 0; idx < strides.size(); ++idx) {
-            tmp_indexes.push_back(index / strides[idx]);
+            tmp_indices.push_back(index / strides[idx]);
             index = index % strides[idx];
           }
           // third part index
-          for (int idx = axis + 2; idx < indexes.size(); ++idx) {
-            tmp_indexes.push_back(indexes[idx]);
+          for (int idx = axis + 2; idx < indices.size(); ++idx) {
+            tmp_indices.push_back(indices[idx]);
           }
 
-          PADDLE_ENFORCE_EQ(tmp_indexes.size(),
+          PADDLE_ENFORCE_EQ(tmp_indices.size(),
                             A->shape.size(),
                             ::common::errors::InvalidArgument(
-                                "indexes size is not equal to Input shape!"));
-          return ir::Select::Make(selected, A(tmp_indexes), initial);
+                                "indices size is not equal to Input shape!"));
+          return ir::Select::Make(selected, A(tmp_indices), initial);
         },
         UniqName(output_name + "_reshape"));
   };
@@ -1002,27 +1002,27 @@ std::vector<ir::Tensor> TwoStepBlockReduceInternal(
     }
     auto out = Compute(
         out_shape,
-        [=](const std::vector<Expr>& indexes) -> Expr {
+        [=](const std::vector<Expr>& indices) -> Expr {
           Expr index =
-              indexes[size_without_tail - 1] +
-              indexes[size_without_tail - 2] * out_shape[size_without_tail - 1];
-          std::vector<Expr> tmp_indexes(
-              indexes.begin(), indexes.begin() + size_without_tail - 2);
+              indices[size_without_tail - 1] +
+              indices[size_without_tail - 2] * out_shape[size_without_tail - 1];
+          std::vector<Expr> tmp_indices(
+              indices.begin(), indices.begin() + size_without_tail - 2);
           // last and the second of last.
           auto selected = ir::LT::Make(index, Expr(lane));
           for (auto tail_stride : tail_strides) {
-            tmp_indexes.push_back(index / Expr(tail_stride));
+            tmp_indices.push_back(index / Expr(tail_stride));
             index = index % Expr(tail_stride);
           }
 
-          PADDLE_ENFORCE_EQ(tmp_indexes.size(),
+          PADDLE_ENFORCE_EQ(tmp_indices.size(),
                             A->shape.size(),
                             ::common::errors::InvalidArgument(
-                                "indexes size is not equal to Input shape!"));
+                                "indices size is not equal to Input shape!"));
           if (check_bound) {
-            return ir::Select::Make(selected, A(tmp_indexes), initial);
+            return ir::Select::Make(selected, A(tmp_indices), initial);
           } else {
-            return A(tmp_indexes);
+            return A(tmp_indices);
           }
         },
         UniqName(output_name + "_reshape"));

--- a/paddle/cinn/hlir/pe/reduction.cc
+++ b/paddle/cinn/hlir/pe/reduction.cc
@@ -330,17 +330,17 @@ std::vector<Tensor> WarpReduce(const ir::Tensor& A,
   tmp_shape.push_back(Expr(32));
   auto tmp_out = Compute(
       tmp_shape,
-      [=](const std::vector<Expr>& indexs) -> Expr {
-        std::vector<Expr> tmp_indexs(indexs.begin(),
-                                     indexs.begin() + indexs.size() - 1);
+      [=](const std::vector<Expr>& indexes) -> Expr {
+        std::vector<Expr> tmp_indexes(indexes.begin(),
+                                      indexes.begin() + indexes.size() - 1);
         for (int idx = 0; idx < last_reduce_dim_num; ++idx) {
-          tmp_indexs.push_back(Expr(0));
+          tmp_indexes.push_back(Expr(0));
         }
         PADDLE_ENFORCE_EQ(A->shape.size(),
-                          tmp_indexs.size(),
+                          tmp_indexes.size(),
                           ::common::errors::InvalidArgument(
-                              "Indexs size is not equal to Input shape!"));
-        Expr offset = cinn::common::IndiceToAbsOffset(A->shape, tmp_indexs);
+                              "indexes size is not equal to Input shape!"));
+        Expr offset = cinn::common::IndiceToAbsOffset(A->shape, tmp_indexes);
         return lang::CallExtern(reduce_type, {A, offset, reduce_width});
       },
       UniqName(output_name + "_" + reduce_type));
@@ -357,11 +357,11 @@ std::vector<Tensor> WarpReduce(const ir::Tensor& A,
   }
   auto out = Compute(
       out_shape,
-      [=](const std::vector<Expr>& indexs) -> Expr {
-        std::vector<Expr> tmp_indexs(
-            indexs.begin(), indexs.begin() + shape_size_without_reduce_dim);
-        tmp_indexs.push_back(Expr(0));
-        return tmp_out(tmp_indexs);
+      [=](const std::vector<Expr>& indexes) -> Expr {
+        std::vector<Expr> tmp_indexes(
+            indexes.begin(), indexes.begin() + shape_size_without_reduce_dim);
+        tmp_indexes.push_back(Expr(0));
+        return tmp_out(tmp_indexes);
       },
       output_name);
 
@@ -431,22 +431,22 @@ std::vector<ir::Tensor> BlockReduceInternal(const ir::Tensor& A,
 
   auto tmp_out = Compute(
       tmp_shape,
-      [=](const std::vector<Expr>& indexs) -> Expr {
+      [=](const std::vector<Expr>& indexes) -> Expr {
         // compute index map from output to input.
-        auto last_index = indexs.back();
-        std::vector<Expr> input_indexs(indexs.begin(),
-                                       indexs.begin() + indexs.size() - 1);
+        auto last_index = indexes.back();
+        std::vector<Expr> input_indexes(indexes.begin(),
+                                        indexes.begin() + indexes.size() - 1);
         for (int idx = 0; idx < A->shape.size() - axes.front(); ++idx) {
-          input_indexs.push_back(last_index / last_reduce_stride[idx]);
+          input_indexes.push_back(last_index / last_reduce_stride[idx]);
           last_index = last_index % last_reduce_stride[idx];
         }
 
-        // checkout input_indexs size equals input shape
-        PADDLE_ENFORCE_EQ(input_indexs.size(),
+        // checkout input_indexes size equals input shape
+        PADDLE_ENFORCE_EQ(input_indexes.size(),
                           A->shape.size(),
                           ::common::errors::InvalidArgument(
-                              "Indexs size is not equal to Input shape!"));
-        return lang::CallExtern(reduce_type, {A(input_indexs)});
+                              "indexes size is not equal to Input shape!"));
+        return lang::CallExtern(reduce_type, {A(input_indexes)});
       },
       UniqName(output_name + "_tmp"));
 
@@ -464,11 +464,11 @@ std::vector<ir::Tensor> BlockReduceInternal(const ir::Tensor& A,
   }
   auto out = Compute(
       out_shape,
-      [=](const std::vector<Expr>& indexs) -> Expr {
-        std::vector<Expr> tmp_indexs(indexs.begin(),
-                                     indexs.begin() + axes.front());
-        tmp_indexs.push_back(Expr(0));
-        return tmp_out(tmp_indexs);
+      [=](const std::vector<Expr>& indexes) -> Expr {
+        std::vector<Expr> tmp_indexes(indexes.begin(),
+                                      indexes.begin() + axes.front());
+        tmp_indexes.push_back(Expr(0));
+        return tmp_out(tmp_indexes);
       },
       output_name);
   return {out, tmp_out};
@@ -566,19 +566,19 @@ std::vector<ir::Tensor> BlockReduce(const ir::Tensor& A,
   tmp_shape.push_back(Expr(block_size));
   auto tmp_out = Compute(
       tmp_shape,
-      [=](const std::vector<Expr>& indexs) -> Expr {
-        std::vector<Expr> tmp_indexs(indexs.begin(),
-                                     indexs.begin() + axes.front());
+      [=](const std::vector<Expr>& indexes) -> Expr {
+        std::vector<Expr> tmp_indexes(indexes.begin(),
+                                      indexes.begin() + axes.front());
         for (int idx = 0; idx < A->shape.size() - axes.front(); ++idx) {
-          tmp_indexs.push_back(Expr(0));
+          tmp_indexes.push_back(Expr(0));
         }
-        // checkout input shape size equals tmp indexs size.
+        // checkout input shape size equals tmp indexes size.
         PADDLE_ENFORCE_EQ(A->shape.size(),
-                          tmp_indexs.size(),
+                          tmp_indexes.size(),
                           ::common::errors::InvalidArgument(
-                              "Indexs size is not equal to Input shape!"));
+                              "indexes size is not equal to Input shape!"));
         // compute offset.
-        Expr offset = cinn::common::IndiceToAbsOffset(A->shape, tmp_indexs);
+        Expr offset = cinn::common::IndiceToAbsOffset(A->shape, tmp_indexes);
         // call block reduce sum
         return lang::CallExtern(reduce_type, {A, offset, reduce_width});
       },
@@ -598,12 +598,12 @@ std::vector<ir::Tensor> BlockReduce(const ir::Tensor& A,
   }
   auto out = Compute(
       out_shape,
-      [=](const std::vector<Expr>& indexs) -> Expr {
+      [=](const std::vector<Expr>& indexes) -> Expr {
         // compute input index
-        std::vector<Expr> tmp_indexs(indexs.begin(),
-                                     indexs.begin() + axes.front());
-        tmp_indexs.push_back(Expr(0));
-        return tmp_out(tmp_indexs);
+        std::vector<Expr> tmp_indexes(indexes.begin(),
+                                      indexes.begin() + axes.front());
+        tmp_indexes.push_back(Expr(0));
+        return tmp_out(tmp_indexes);
       },
       output_name);
 
@@ -756,32 +756,33 @@ std::vector<ir::Tensor> ReduceInternal(const ir::Tensor& A,
                    [](int val) { return ir::Expr(val); });
     return Compute(
         reshape_output_shape,
-        [=](const std::vector<Expr>& indexs) -> Expr {
+        [=](const std::vector<Expr>& indexes) -> Expr {
           // index is last axis in axes and index is last axis >= tail.
           auto selected = ir::And::Make(
-              ir::EQ::Make(indexs[axis], ir::Expr(reduce_shape[axis] - 1)),
-              ir::GE::Make(indexs[axis + 1], ir::Expr(tail)));
-          auto index = indexs[axis] * ir::Expr(reshape_output_shape[axis + 1]) +
-                       indexs[axis + 1];
+              ir::EQ::Make(indexes[axis], ir::Expr(reduce_shape[axis] - 1)),
+              ir::GE::Make(indexes[axis + 1], ir::Expr(tail)));
+          auto index =
+              indexes[axis] * ir::Expr(reshape_output_shape[axis + 1]) +
+              indexes[axis + 1];
 
           // first part index
-          std::vector<ir::Expr> tmp_indexs(indexs.begin(),
-                                           indexs.begin() + axes[axis_index]);
+          std::vector<ir::Expr> tmp_indexes(indexes.begin(),
+                                            indexes.begin() + axes[axis_index]);
           // second part index
           for (int idx = 0; idx < strides.size(); ++idx) {
-            tmp_indexs.push_back(index / strides[idx]);
+            tmp_indexes.push_back(index / strides[idx]);
             index = index % strides[idx];
           }
           // third part index
-          for (int idx = axis + 2; idx < indexs.size(); ++idx) {
-            tmp_indexs.push_back(indexs[idx]);
+          for (int idx = axis + 2; idx < indexes.size(); ++idx) {
+            tmp_indexes.push_back(indexes[idx]);
           }
 
-          PADDLE_ENFORCE_EQ(tmp_indexs.size(),
+          PADDLE_ENFORCE_EQ(tmp_indexes.size(),
                             A->shape.size(),
                             ::common::errors::InvalidArgument(
-                                "Indexs size is not equal to Input shape!"));
-          return ir::Select::Make(selected, A(tmp_indexs), initial);
+                                "indexes size is not equal to Input shape!"));
+          return ir::Select::Make(selected, A(tmp_indexes), initial);
         },
         UniqName(output_name + "_reshape"));
   };
@@ -1001,27 +1002,27 @@ std::vector<ir::Tensor> TwoStepBlockReduceInternal(
     }
     auto out = Compute(
         out_shape,
-        [=](const std::vector<Expr>& indexs) -> Expr {
+        [=](const std::vector<Expr>& indexes) -> Expr {
           Expr index =
-              indexs[size_without_tail - 1] +
-              indexs[size_without_tail - 2] * out_shape[size_without_tail - 1];
-          std::vector<Expr> tmp_indexs(indexs.begin(),
-                                       indexs.begin() + size_without_tail - 2);
+              indexes[size_without_tail - 1] +
+              indexes[size_without_tail - 2] * out_shape[size_without_tail - 1];
+          std::vector<Expr> tmp_indexes(
+              indexes.begin(), indexes.begin() + size_without_tail - 2);
           // last and the second of last.
           auto selected = ir::LT::Make(index, Expr(lane));
           for (auto tail_stride : tail_strides) {
-            tmp_indexs.push_back(index / Expr(tail_stride));
+            tmp_indexes.push_back(index / Expr(tail_stride));
             index = index % Expr(tail_stride);
           }
 
-          PADDLE_ENFORCE_EQ(tmp_indexs.size(),
+          PADDLE_ENFORCE_EQ(tmp_indexes.size(),
                             A->shape.size(),
                             ::common::errors::InvalidArgument(
-                                "Indexs size is not equal to Input shape!"));
+                                "indexes size is not equal to Input shape!"));
           if (check_bound) {
-            return ir::Select::Make(selected, A(tmp_indexs), initial);
+            return ir::Select::Make(selected, A(tmp_indexes), initial);
           } else {
-            return A(tmp_indexs);
+            return A(tmp_indexes);
           }
         },
         UniqName(output_name + "_reshape"));

--- a/paddle/cinn/hlir/pe/transform.cc
+++ b/paddle/cinn/hlir/pe/transform.cc
@@ -1201,11 +1201,11 @@ ir::Tensor Reverse(const ir::Tensor& input,
   return lang::Compute(
       input->shape,
       [=](const std::vector<Expr>& indice) {
-        std::vector<Expr> indexs(indice.begin(), indice.end());
+        std::vector<Expr> indexes(indice.begin(), indice.end());
         for (auto idx : axis) {
-          indexs[idx] = shape[idx] - Expr(1) - indexs[idx];
+          indexes[idx] = shape[idx] - Expr(1) - indexes[idx];
         }
-        return input(indexs);
+        return input(indexes);
       },
       output_name);
 }
@@ -1257,11 +1257,11 @@ ir::Tensor Transpose(const ir::Tensor& input,
   return lang::Compute(
       output_shape,
       [=](const std::vector<Expr>& indice) {
-        std::vector<Expr> indexs;
+        std::vector<Expr> indexes;
         for (auto idx : new_axis) {
-          indexs.push_back(indice[idx]);
+          indexes.push_back(indice[idx]);
         }
-        return input(indexs);
+        return input(indexes);
       },
       output_name);
 }

--- a/paddle/cinn/hlir/pe/transform.cc
+++ b/paddle/cinn/hlir/pe/transform.cc
@@ -1200,12 +1200,12 @@ ir::Tensor Reverse(const ir::Tensor& input,
   std::vector<Expr> shape = input->shape;
   return lang::Compute(
       input->shape,
-      [=](const std::vector<Expr>& indice) {
-        std::vector<Expr> indices(indice.begin(), indice.end());
+      [=](const std::vector<Expr>& indices) {
+        std::vector<Expr> out_indices(indices.begin(), indices.end());
         for (auto idx : axis) {
-          indices[idx] = shape[idx] - Expr(1) - indices[idx];
+          out_indices[idx] = shape[idx] - Expr(1) - out_indices[idx];
         }
-        return input(indices);
+        return input(out_indices);
       },
       output_name);
 }
@@ -1256,12 +1256,12 @@ ir::Tensor Transpose(const ir::Tensor& input,
 
   return lang::Compute(
       output_shape,
-      [=](const std::vector<Expr>& indice) {
-        std::vector<Expr> indices;
+      [=](const std::vector<Expr>& indices) {
+        std::vector<Expr> out_indices;
         for (auto idx : new_axis) {
-          indices.push_back(indice[idx]);
+          out_indices.push_back(indices[idx]);
         }
-        return input(indices);
+        return input(out_indices);
       },
       output_name);
 }

--- a/paddle/cinn/hlir/pe/transform.cc
+++ b/paddle/cinn/hlir/pe/transform.cc
@@ -1201,11 +1201,11 @@ ir::Tensor Reverse(const ir::Tensor& input,
   return lang::Compute(
       input->shape,
       [=](const std::vector<Expr>& indice) {
-        std::vector<Expr> indexes(indice.begin(), indice.end());
+        std::vector<Expr> indices(indice.begin(), indice.end());
         for (auto idx : axis) {
-          indexes[idx] = shape[idx] - Expr(1) - indexes[idx];
+          indices[idx] = shape[idx] - Expr(1) - indices[idx];
         }
-        return input(indexes);
+        return input(indices);
       },
       output_name);
 }
@@ -1257,11 +1257,11 @@ ir::Tensor Transpose(const ir::Tensor& input,
   return lang::Compute(
       output_shape,
       [=](const std::vector<Expr>& indice) {
-        std::vector<Expr> indexes;
+        std::vector<Expr> indices;
         for (auto idx : new_axis) {
-          indexes.push_back(indice[idx]);
+          indices.push_back(indice[idx]);
         }
-        return input(indexes);
+        return input(indices);
       },
       output_name);
 }

--- a/paddle/cinn/hlir/pe/transform.h
+++ b/paddle/cinn/hlir/pe/transform.h
@@ -233,7 +233,7 @@ ir::Tensor Gather(const ir::Tensor& x,
  * @brief Perform meta op ScatterAssign
  * @param input The input tensor
  * @param assign The assign tensor
- * @param indices The indices tensor
+ * @param index The index tensor
  * @param output_name the name of the output tensor
  */
 ir::Tensor ScatterAssign(
@@ -248,7 +248,7 @@ ir::Tensor ScatterAssign(
  * @brief Perform meta op ScatterAdd
  * @param input The input tensor
  * @param updates The updates tensor
- * @param indices The indices tensor
+ * @param index The index tensor
  * @param output_name the name of the output tensor
  */
 ir::Tensor ScatterAdd(const ir::Tensor& input,

--- a/paddle/cinn/hlir/pe/transform.h
+++ b/paddle/cinn/hlir/pe/transform.h
@@ -233,7 +233,7 @@ ir::Tensor Gather(const ir::Tensor& x,
  * @brief Perform meta op ScatterAssign
  * @param input The input tensor
  * @param assign The assign tensor
- * @param indexes The indexes tensor
+ * @param indices The indices tensor
  * @param output_name the name of the output tensor
  */
 ir::Tensor ScatterAssign(
@@ -248,7 +248,7 @@ ir::Tensor ScatterAssign(
  * @brief Perform meta op ScatterAdd
  * @param input The input tensor
  * @param updates The updates tensor
- * @param indexes The indexes tensor
+ * @param indices The indices tensor
  * @param output_name the name of the output tensor
  */
 ir::Tensor ScatterAdd(const ir::Tensor& input,

--- a/paddle/cinn/hlir/pe/transform.h
+++ b/paddle/cinn/hlir/pe/transform.h
@@ -233,7 +233,7 @@ ir::Tensor Gather(const ir::Tensor& x,
  * @brief Perform meta op ScatterAssign
  * @param input The input tensor
  * @param assign The assign tensor
- * @param indexs The indexs tensor
+ * @param indexes The indexes tensor
  * @param output_name the name of the output tensor
  */
 ir::Tensor ScatterAssign(
@@ -248,7 +248,7 @@ ir::Tensor ScatterAssign(
  * @brief Perform meta op ScatterAdd
  * @param input The input tensor
  * @param updates The updates tensor
- * @param indexs The indexs tensor
+ * @param indexes The indexes tensor
  * @param output_name the name of the output tensor
  */
 ir::Tensor ScatterAdd(const ir::Tensor& input,

--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -354,12 +354,12 @@ static void ParseIndex(const paddle::Tensor& tensor,
   }
 
   // valid_index is the number of dimensions exclude None index
-  const int valid_indexs = size - none_axes->size() - ell_count;
-  PADDLE_ENFORCE_EQ(valid_indexs <= rank,
+  const int valid_indexes = size - none_axes->size() - ell_count;
+  PADDLE_ENFORCE_EQ(valid_indexes <= rank,
                     true,
                     common::errors::InvalidArgument(
                         "Too many indices (%d) for tensor of dimension %d.",
-                        valid_indexs,
+                        valid_indexes,
                         rank));
 }
 

--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -354,12 +354,12 @@ static void ParseIndex(const paddle::Tensor& tensor,
   }
 
   // valid_index is the number of dimensions exclude None index
-  const int valid_indexes = size - none_axes->size() - ell_count;
-  PADDLE_ENFORCE_EQ(valid_indexes <= rank,
+  const int valid_indices = size - none_axes->size() - ell_count;
+  PADDLE_ENFORCE_EQ(valid_indices <= rank,
                     true,
                     common::errors::InvalidArgument(
                         "Too many indices (%d) for tensor of dimension %d.",
-                        valid_indexes,
+                        valid_indices,
                         rank));
 }
 

--- a/paddle/phi/kernels/array_kernel.cc
+++ b/paddle/phi/kernels/array_kernel.cc
@@ -100,15 +100,15 @@ void ArrayToTensorKernel(const Context& dev_ctx,
   std::vector<DenseTensor> tmp_inputs(x.size());
   std::vector<const DenseTensor*> inputs;
 
-  std::vector<DenseTensor> tmp_indexes(x.size());
-  std::vector<const DenseTensor*> indexes;
+  std::vector<DenseTensor> tmp_indices(x.size());
+  std::vector<const DenseTensor*> indices;
 
   for (size_t i = 0; i < x.size(); i++) {
     tmp_inputs[i].ShareDataWith(x[i]);
     inputs.push_back(&tmp_inputs[i]);
     FullKernel<int, Context>(
-        dev_ctx, {1}, x[i].dims()[axis], DataType::INT32, &tmp_indexes[i]);
-    indexes.push_back(&tmp_indexes[i]);
+        dev_ctx, {1}, x[i].dims()[axis], DataType::INT32, &tmp_indices[i]);
+    indices.push_back(&tmp_indices[i]);
   }
 
   if (use_stack) {
@@ -132,7 +132,7 @@ void ArrayToTensorKernel(const Context& dev_ctx,
   }
 
   out_index->Resize(common::make_ddim({static_cast<int>(x.size())}));
-  StackKernel<int, Context>(dev_ctx, indexes, 0, out_index);
+  StackKernel<int, Context>(dev_ctx, indices, 0, out_index);
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/array_kernel.cc
+++ b/paddle/phi/kernels/array_kernel.cc
@@ -93,22 +93,22 @@ void ArrayToTensorKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_GT(
       n,
       0,
-      common::errors::InvalidArgument("Input tensorarray size should > 0,"
+      common::errors::InvalidArgument("Input tensor array size should > 0,"
                                       "but the received is %d",
                                       n));
 
   std::vector<DenseTensor> tmp_inputs(x.size());
   std::vector<const DenseTensor*> inputs;
 
-  std::vector<DenseTensor> tmp_indexs(x.size());
-  std::vector<const DenseTensor*> indexs;
+  std::vector<DenseTensor> tmp_indexes(x.size());
+  std::vector<const DenseTensor*> indexes;
 
   for (size_t i = 0; i < x.size(); i++) {
     tmp_inputs[i].ShareDataWith(x[i]);
     inputs.push_back(&tmp_inputs[i]);
     FullKernel<int, Context>(
-        dev_ctx, {1}, x[i].dims()[axis], DataType::INT32, &tmp_indexs[i]);
-    indexs.push_back(&tmp_indexs[i]);
+        dev_ctx, {1}, x[i].dims()[axis], DataType::INT32, &tmp_indexes[i]);
+    indexes.push_back(&tmp_indexes[i]);
   }
 
   if (use_stack) {
@@ -132,7 +132,7 @@ void ArrayToTensorKernel(const Context& dev_ctx,
   }
 
   out_index->Resize(common::make_ddim({static_cast<int>(x.size())}));
-  StackKernel<int, Context>(dev_ctx, indexs, 0, out_index);
+  StackKernel<int, Context>(dev_ctx, indexes, 0, out_index);
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/funcs/elementwise_grad_base.h
+++ b/paddle/phi/kernels/funcs/elementwise_grad_base.h
@@ -417,19 +417,19 @@ static inline bool CheckContiguousDims(const std::vector<int> &broadcast_pos) {
   return true;
 }
 
-inline void ComputeBroadcastTranspositionArray(const int *x_one_indexes,
-                                               int *x_trans_indexes,
+inline void ComputeBroadcastTranspositionArray(const int *x_one_indices,
+                                               int *x_trans_indices,
                                                const int max_dim,
                                                const int x_one_size) {
   int diff = max_dim - x_one_size;
-  std::copy_n(x_one_indexes, x_one_size, x_trans_indexes + diff);
+  std::copy_n(x_one_indices, x_one_size, x_trans_indices + diff);
   int p = 0;
   int q = diff;
   for (int i = 0; i < max_dim; ++i) {
-    if (q < max_dim && i == x_trans_indexes[q]) {
+    if (q < max_dim && i == x_trans_indices[q]) {
       ++q;
     } else {
-      x_trans_indexes[p++] = i;
+      x_trans_indices[p++] = i;
     }
   }
 }
@@ -1090,29 +1090,29 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
   T *dx_data = dx == nullptr ? nullptr : ctx.Alloc<T>(dx);
   T *dy_data = dy == nullptr ? nullptr : ctx.Alloc<T>(dy);
 
-  std::vector<int> x_one_indexes;
-  std::vector<int> y_one_indexes;
+  std::vector<int> x_one_indices;
+  std::vector<int> y_one_indices;
   for (int i = 0; i < max_dim; i++) {
     if (x_dims_array[i] != y_dims_array[i]) {
       if (x_dims_array[i] == 1) {
-        x_one_indexes.push_back(i);
+        x_one_indices.push_back(i);
       }
       if (y_dims_array[i] == 1) {
-        y_one_indexes.push_back(i);
+        y_one_indices.push_back(i);
       }
     }
   }
 
-  std::vector<int> x_trans_indexes(max_dim);
-  std::vector<int> y_trans_indexes(max_dim);
-  ComputeBroadcastTranspositionArray(x_one_indexes.data(),
-                                     x_trans_indexes.data(),
+  std::vector<int> x_trans_indices(max_dim);
+  std::vector<int> y_trans_indices(max_dim);
+  ComputeBroadcastTranspositionArray(x_one_indices.data(),
+                                     x_trans_indices.data(),
                                      max_dim,
-                                     x_one_indexes.size());
-  ComputeBroadcastTranspositionArray(y_one_indexes.data(),
-                                     y_trans_indexes.data(),
+                                     x_one_indices.size());
+  ComputeBroadcastTranspositionArray(y_one_indices.data(),
+                                     y_trans_indices.data(),
                                      max_dim,
-                                     y_one_indexes.size());
+                                     y_one_indices.size());
 
   // compute array stride for cuda kernel;
   // e.g. x.dims=[2,3,4], x_stride=[12,4,1]
@@ -1136,10 +1136,10 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
   std::vector<int> x_dims_order(max_dim);
   std::vector<int> y_dims_order(max_dim);
   for (int i = 0; i < max_dim; ++i) {
-    x_strides_order[i] = out_strides_array[x_trans_indexes[i]];
-    y_strides_order[i] = out_strides_array[y_trans_indexes[i]];
-    x_dims_order[i] = out_dims_array[x_trans_indexes[i]];
-    y_dims_order[i] = out_dims_array[y_trans_indexes[i]];
+    x_strides_order[i] = out_strides_array[x_trans_indices[i]];
+    y_strides_order[i] = out_strides_array[y_trans_indices[i]];
+    x_dims_order[i] = out_dims_array[x_trans_indices[i]];
+    y_dims_order[i] = out_dims_array[y_trans_indices[i]];
   }
   std::vector<int> x_broadcast_pos;
   std::vector<int> y_broadcast_pos;

--- a/paddle/phi/kernels/funcs/sparse/flatten_indices.cu.h
+++ b/paddle/phi/kernels/funcs/sparse/flatten_indices.cu.h
@@ -37,13 +37,13 @@ __global__ void FlattenIndicesKernel(const IntT* indices,
 }
 
 template <typename IntT>
-__global__ void IndexToCoordinateKernel(const IntT* indexs,
+__global__ void IndexToCoordinateKernel(const IntT* indexes,
                                         const Dim<DDim::kMaxRank> dims,
                                         const int64_t non_zero_num,
                                         const int64_t sparse_dim,
                                         IntT* indices) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
-  IndexToCoordinate(indexs,
+  IndexToCoordinate(indexes,
                     dims,
                     non_zero_num,
                     sparse_dim,

--- a/paddle/phi/kernels/funcs/sparse/flatten_indices.cu.h
+++ b/paddle/phi/kernels/funcs/sparse/flatten_indices.cu.h
@@ -37,13 +37,13 @@ __global__ void FlattenIndicesKernel(const IntT* indices,
 }
 
 template <typename IntT>
-__global__ void IndexToCoordinateKernel(const IntT* indexes,
+__global__ void IndexToCoordinateKernel(const IntT* indices,
                                         const Dim<DDim::kMaxRank> dims,
                                         const int64_t non_zero_num,
                                         const int64_t sparse_dim,
                                         IntT* indices) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
-  IndexToCoordinate(indexes,
+  IndexToCoordinate(indices,
                     dims,
                     non_zero_num,
                     sparse_dim,

--- a/paddle/phi/kernels/funcs/sparse/flatten_indices.cu.h
+++ b/paddle/phi/kernels/funcs/sparse/flatten_indices.cu.h
@@ -37,13 +37,13 @@ __global__ void FlattenIndicesKernel(const IntT* indices,
 }
 
 template <typename IntT>
-__global__ void IndexToCoordinateKernel(const IntT* indices,
+__global__ void IndexToCoordinateKernel(const IntT* index,
                                         const Dim<DDim::kMaxRank> dims,
                                         const int64_t non_zero_num,
                                         const int64_t sparse_dim,
                                         IntT* indices) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
-  IndexToCoordinate(indices,
+  IndexToCoordinate(index,
                     dims,
                     non_zero_num,
                     sparse_dim,

--- a/paddle/phi/kernels/funcs/sparse/flatten_indices.h
+++ b/paddle/phi/kernels/funcs/sparse/flatten_indices.h
@@ -76,7 +76,7 @@ inline void HOSTDEVICE IndexToCoordinate(const IntT index,
 }
 
 template <typename IntT>
-inline void HOSTDEVICE IndexToCoordinate(const IntT* t_indices,
+inline void HOSTDEVICE IndexToCoordinate(const IntT* index,
                                          const Dim<DDim::kMaxRank>& dims,
                                          const int64_t non_zero_num,
                                          const int64_t sparse_dim,
@@ -84,7 +84,7 @@ inline void HOSTDEVICE IndexToCoordinate(const IntT* t_indices,
                                          const int64_t stride,
                                          IntT* indices) {
   for (int64_t i = start; i < non_zero_num; i += stride) {
-    IntT tmp_index = t_indices[i];
+    IntT tmp_index = index[i];
     IndexToCoordinate(tmp_index, dims, non_zero_num, sparse_dim, i, indices);
   }
 }

--- a/paddle/phi/kernels/funcs/sparse/flatten_indices.h
+++ b/paddle/phi/kernels/funcs/sparse/flatten_indices.h
@@ -76,7 +76,7 @@ inline void HOSTDEVICE IndexToCoordinate(const IntT index,
 }
 
 template <typename IntT>
-inline void HOSTDEVICE IndexToCoordinate(const IntT* indexs,
+inline void HOSTDEVICE IndexToCoordinate(const IntT* indexes,
                                          const Dim<DDim::kMaxRank>& dims,
                                          const int64_t non_zero_num,
                                          const int64_t sparse_dim,
@@ -84,7 +84,7 @@ inline void HOSTDEVICE IndexToCoordinate(const IntT* indexs,
                                          const int64_t stride,
                                          IntT* indices) {
   for (int64_t i = start; i < non_zero_num; i += stride) {
-    IntT tmp_index = indexs[i];
+    IntT tmp_index = indexes[i];
     IndexToCoordinate(tmp_index, dims, non_zero_num, sparse_dim, i, indices);
   }
 }

--- a/paddle/phi/kernels/funcs/sparse/flatten_indices.h
+++ b/paddle/phi/kernels/funcs/sparse/flatten_indices.h
@@ -76,7 +76,7 @@ inline void HOSTDEVICE IndexToCoordinate(const IntT index,
 }
 
 template <typename IntT>
-inline void HOSTDEVICE IndexToCoordinate(const IntT* index,
+inline void HOSTDEVICE IndexToCoordinate(const IntT* t_indices,
                                          const Dim<DDim::kMaxRank>& dims,
                                          const int64_t non_zero_num,
                                          const int64_t sparse_dim,
@@ -84,7 +84,7 @@ inline void HOSTDEVICE IndexToCoordinate(const IntT* index,
                                          const int64_t stride,
                                          IntT* indices) {
   for (int64_t i = start; i < non_zero_num; i += stride) {
-    IntT tmp_index = index[i];
+    IntT tmp_index = t_indices[i];
     IndexToCoordinate(tmp_index, dims, non_zero_num, sparse_dim, i, indices);
   }
 }

--- a/paddle/phi/kernels/funcs/sparse/flatten_indices.h
+++ b/paddle/phi/kernels/funcs/sparse/flatten_indices.h
@@ -76,7 +76,7 @@ inline void HOSTDEVICE IndexToCoordinate(const IntT index,
 }
 
 template <typename IntT>
-inline void HOSTDEVICE IndexToCoordinate(const IntT* indices,
+inline void HOSTDEVICE IndexToCoordinate(const IntT* index,
                                          const Dim<DDim::kMaxRank>& dims,
                                          const int64_t non_zero_num,
                                          const int64_t sparse_dim,
@@ -84,7 +84,7 @@ inline void HOSTDEVICE IndexToCoordinate(const IntT* indices,
                                          const int64_t stride,
                                          IntT* indices) {
   for (int64_t i = start; i < non_zero_num; i += stride) {
-    IntT tmp_index = indices[i];
+    IntT tmp_index = index[i];
     IndexToCoordinate(tmp_index, dims, non_zero_num, sparse_dim, i, indices);
   }
 }

--- a/paddle/phi/kernels/funcs/sparse/flatten_indices.h
+++ b/paddle/phi/kernels/funcs/sparse/flatten_indices.h
@@ -76,7 +76,7 @@ inline void HOSTDEVICE IndexToCoordinate(const IntT index,
 }
 
 template <typename IntT>
-inline void HOSTDEVICE IndexToCoordinate(const IntT* indexes,
+inline void HOSTDEVICE IndexToCoordinate(const IntT* indices,
                                          const Dim<DDim::kMaxRank>& dims,
                                          const int64_t non_zero_num,
                                          const int64_t sparse_dim,
@@ -84,7 +84,7 @@ inline void HOSTDEVICE IndexToCoordinate(const IntT* indexes,
                                          const int64_t stride,
                                          IntT* indices) {
   for (int64_t i = start; i < non_zero_num; i += stride) {
-    IntT tmp_index = indexes[i];
+    IntT tmp_index = indices[i];
     IndexToCoordinate(tmp_index, dims, non_zero_num, sparse_dim, i, indices);
   }
 }

--- a/paddle/phi/kernels/sparse/cpu/coalesce_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/coalesce_kernel.cc
@@ -30,7 +30,7 @@ void CoalesceCooCPUKernel(const CPUContext& dev_ctx,
   DenseTensor out_values = phi::EmptyLike<T>(dev_ctx, x_values);
 
   const int64_t sparse_dim = x.indices().dims()[0];
-  std::vector<IntT> sparse_offsets(sparse_dim), x_indexes(x.nnz());
+  std::vector<IntT> sparse_offsets(sparse_dim), x_index(x.nnz());
   phi::funcs::sparse::CalcOffsetsPerDim<IntT>(
       x.dims(), sparse_dim, sparse_offsets.data());
 
@@ -40,19 +40,19 @@ void CoalesceCooCPUKernel(const CPUContext& dev_ctx,
                                      sparse_dim,
                                      0,
                                      1,
-                                     x_indexes.data());
+                                     x_index.data());
 
   const T* x_values_ptr = x_values.data<T>();
   const int64_t stride =
       x.dims().size() == sparse_dim ? 1 : x.values().dims()[1];
 
   std::map<IntT, std::vector<int64_t>> indices_to_index;
-  for (uint64_t i = 0; i < x_indexes.size(); i++) {
-    IntT index = x_indexes[i];
+  for (uint64_t i = 0; i < x_index.size(); i++) {
+    IntT index = x_index[i];
     if (indices_to_index.find(index) == indices_to_index.end()) {
-      std::vector<int64_t> indexes;
-      indexes.push_back(static_cast<int>(i));
-      indices_to_index[index] = indexes;
+      std::vector<int64_t> index;
+      index.push_back(static_cast<int>(i));
+      indices_to_index[index] = index;
     } else {
       indices_to_index[index].push_back(i);
     }

--- a/paddle/phi/kernels/sparse/cpu/coalesce_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/coalesce_kernel.cc
@@ -30,7 +30,7 @@ void CoalesceCooCPUKernel(const CPUContext& dev_ctx,
   DenseTensor out_values = phi::EmptyLike<T>(dev_ctx, x_values);
 
   const int64_t sparse_dim = x.indices().dims()[0];
-  std::vector<IntT> sparse_offsets(sparse_dim), tmp_indices(x.nnz());
+  std::vector<IntT> sparse_offsets(sparse_dim), x_nnz(x.nnz());
   phi::funcs::sparse::CalcOffsetsPerDim<IntT>(
       x.dims(), sparse_dim, sparse_offsets.data());
 
@@ -40,25 +40,25 @@ void CoalesceCooCPUKernel(const CPUContext& dev_ctx,
                                      sparse_dim,
                                      0,
                                      1,
-                                     tmp_indices.data());
+                                     x_nnz.data());
 
   const T* x_values_ptr = x_values.data<T>();
   const int64_t stride =
       x.dims().size() == sparse_dim ? 1 : x.values().dims()[1];
 
-  std::map<IntT, std::vector<int64_t>> indices_to_index;
-  for (uint64_t i = 0; i < tmp_indices.size(); i++) {
-    IntT index = tmp_indices[i];
-    if (indices_to_index.find(index) == indices_to_index.end()) {
+  std::map<IntT, std::vector<int64_t>> indices_to_nnz;
+  for (uint64_t i = 0; i < x_nnz.size(); i++) {
+    IntT index = x_nnz[i];
+    if (indices_to_nnz.find(index) == indices_to_nnz.end()) {
       std::vector<int64_t> lost_indices;
       lost_indices.push_back(static_cast<int>(i));
-      indices_to_index[index] = lost_indices;
+      indices_to_nnz[index] = lost_indices;
     } else {
-      indices_to_index[index].push_back(i);
+      indices_to_nnz[index].push_back(i);
     }
   }
 
-  const int64_t out_nnz = indices_to_index.size();
+  const int64_t out_nnz = indices_to_nnz.size();
 
   out_indices.Resize({x_indices.dims()[0], out_nnz});
   if (out_values.dims().size() == 1) {
@@ -69,14 +69,14 @@ void CoalesceCooCPUKernel(const CPUContext& dev_ctx,
 
   IntT* out_indices_ptr = out_indices.data<IntT>();
   T* out_values_ptr = out_values.data<T>();
-  auto iter = indices_to_index.begin();
+  auto iter = indices_to_nnz.begin();
 
   Dim<DDim::kMaxRank> const_dims;
   for (int i = 0; i < x.dims().size(); i++) {
     const_dims[i] = x.dims()[i];
   }
 
-  for (int i = 0; iter != indices_to_index.end(); iter++, i++) {
+  for (int i = 0; iter != indices_to_nnz.end(); iter++, i++) {
     phi::funcs::sparse::IndexToCoordinate(
         iter->first, const_dims, out_nnz, sparse_dim, i, out_indices_ptr);
     memcpy(out_values_ptr + i * stride,

--- a/paddle/phi/kernels/sparse/cpu/coalesce_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/coalesce_kernel.cc
@@ -30,7 +30,7 @@ void CoalesceCooCPUKernel(const CPUContext& dev_ctx,
   DenseTensor out_values = phi::EmptyLike<T>(dev_ctx, x_values);
 
   const int64_t sparse_dim = x.indices().dims()[0];
-  std::vector<IntT> sparse_offsets(sparse_dim), x_indexs(x.nnz());
+  std::vector<IntT> sparse_offsets(sparse_dim), x_indexes(x.nnz());
   phi::funcs::sparse::CalcOffsetsPerDim<IntT>(
       x.dims(), sparse_dim, sparse_offsets.data());
 
@@ -40,19 +40,19 @@ void CoalesceCooCPUKernel(const CPUContext& dev_ctx,
                                      sparse_dim,
                                      0,
                                      1,
-                                     x_indexs.data());
+                                     x_indexes.data());
 
   const T* x_values_ptr = x_values.data<T>();
   const int64_t stride =
       x.dims().size() == sparse_dim ? 1 : x.values().dims()[1];
 
   std::map<IntT, std::vector<int64_t>> indices_to_index;
-  for (uint64_t i = 0; i < x_indexs.size(); i++) {
-    IntT index = x_indexs[i];
+  for (uint64_t i = 0; i < x_indexes.size(); i++) {
+    IntT index = x_indexes[i];
     if (indices_to_index.find(index) == indices_to_index.end()) {
-      std::vector<int64_t> indexs;
-      indexs.push_back(static_cast<int>(i));
-      indices_to_index[index] = indexs;
+      std::vector<int64_t> indexes;
+      indexes.push_back(static_cast<int>(i));
+      indices_to_index[index] = indexes;
     } else {
       indices_to_index[index].push_back(i);
     }

--- a/paddle/phi/kernels/sparse/cpu/conv.h
+++ b/paddle/phi/kernels/sparse/cpu/conv.h
@@ -194,14 +194,14 @@ void UpdateRulebookAndOutIndex(const Context& dev_ctx,
                                SparseCooTensor* out) {
   const bool is2D = out_dims.size() == 4 ? true : false;
 
-  std::set<IntT> out_indices;
+  std::set<IntT> tmp_indices;
   int n = rulebook->dims()[1];
   IntT* rulebook_ptr = rulebook->data<IntT>();
   for (int i = 0; i < n; i++) {
-    out_indices.insert(rulebook_ptr[i + n * 2]);
+    tmp_indices.insert(rulebook_ptr[i + n * 2]);
   }
 
-  int out_non_zero_num = out_indices.size();
+  int out_non_zero_num = tmp_indices.size();
   const int64_t sparse_dim = is2D ? 3 : 4;
   DenseTensorMeta indices_meta(phi::CppTypeToDataType<IntT>::Type(),
                                {sparse_dim, out_non_zero_num},
@@ -220,7 +220,7 @@ void UpdateRulebookAndOutIndex(const Context& dev_ctx,
   odim3 = is2D ? 1 : out_dims[1];
   const Dims4D c_out_dims(odim0, odim1, odim2, odim3);
 
-  for (auto it = out_indices.begin(); it != out_indices.end(); it++, i++) {
+  for (auto it = tmp_indices.begin(); it != tmp_indices.end(); it++, i++) {
     const IntT index = *it;
     IntT batch, x, y, z;
     phi::funcs::sparse::IndexToPoint<Dims4D>(
@@ -238,7 +238,7 @@ void UpdateRulebookAndOutIndex(const Context& dev_ctx,
   for (i = 0; i < n; i++) {
     IntT out_index = rulebook_ptr[i + n * 2];
     rulebook_ptr[i + n * 2] =
-        std::distance(out_indices.begin(), out_indices.find(out_index));
+        std::distance(tmp_indices.begin(), tmp_indices.find(out_index));
   }
 
   out->SetMember(out_indices, out_values, out_dims, true);

--- a/paddle/phi/kernels/sparse/cpu/conv.h
+++ b/paddle/phi/kernels/sparse/cpu/conv.h
@@ -194,14 +194,14 @@ void UpdateRulebookAndOutIndex(const Context& dev_ctx,
                                SparseCooTensor* out) {
   const bool is2D = out_dims.size() == 4 ? true : false;
 
-  std::set<IntT> out_indexs;
+  std::set<IntT> out_indexes;
   int n = rulebook->dims()[1];
   IntT* rulebook_ptr = rulebook->data<IntT>();
   for (int i = 0; i < n; i++) {
-    out_indexs.insert(rulebook_ptr[i + n * 2]);
+    out_indexes.insert(rulebook_ptr[i + n * 2]);
   }
 
-  int out_non_zero_num = out_indexs.size();
+  int out_non_zero_num = out_indexes.size();
   const int64_t sparse_dim = is2D ? 3 : 4;
   DenseTensorMeta indices_meta(phi::CppTypeToDataType<IntT>::Type(),
                                {sparse_dim, out_non_zero_num},
@@ -220,7 +220,7 @@ void UpdateRulebookAndOutIndex(const Context& dev_ctx,
   odim3 = is2D ? 1 : out_dims[1];
   const Dims4D c_out_dims(odim0, odim1, odim2, odim3);
 
-  for (auto it = out_indexs.begin(); it != out_indexs.end(); it++, i++) {
+  for (auto it = out_indexes.begin(); it != out_indexes.end(); it++, i++) {
     const IntT index = *it;
     IntT batch, x, y, z;
     phi::funcs::sparse::IndexToPoint<Dims4D>(
@@ -238,7 +238,7 @@ void UpdateRulebookAndOutIndex(const Context& dev_ctx,
   for (i = 0; i < n; i++) {
     IntT out_index = rulebook_ptr[i + n * 2];
     rulebook_ptr[i + n * 2] =
-        std::distance(out_indexs.begin(), out_indexs.find(out_index));
+        std::distance(out_indexes.begin(), out_indexes.find(out_index));
   }
 
   out->SetMember(out_indices, out_values, out_dims, true);
@@ -246,18 +246,18 @@ void UpdateRulebookAndOutIndex(const Context& dev_ctx,
 
 template <typename T, typename IntT = int>
 void Gather(
-    const T* x, const IntT* indexs, const int n, const int channels, T* out) {
+    const T* x, const IntT* indexes, const int n, const int channels, T* out) {
   for (int i = 0; i < n; i++) {
-    IntT real_i = indexs[i];
+    IntT real_i = indexes[i];
     memcpy(out + i * channels, x + real_i * channels, channels * sizeof(T));
   }
 }
 
 template <typename T, typename IntT = int>
 void Scatter(
-    const T* x, const IntT* indexs, const int n, const int channels, T* out) {
+    const T* x, const IntT* indexes, const int n, const int channels, T* out) {
   for (int i = 0; i < n; i++) {
-    IntT real_i = indexs[i];
+    IntT real_i = indexes[i];
     for (int j = 0; j < channels; j++) {
       out[real_i * channels + j] += x[i * channels + j];
     }

--- a/paddle/phi/kernels/sparse/cpu/elementwise_grad_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/elementwise_grad_kernel.cc
@@ -62,8 +62,8 @@ void CopyCooValues(const Context& dev_ctx,
   Copy(dev_ctx, x.indices(), dev_ctx.GetPlace(), false, dx->mutable_indices());
 
   const int sparse_dim = x.sparse_dim();
-  std::vector<IntT> sparse_offsets(sparse_dim), dout_indexs(dout.nnz()),
-      x_indexs(x.nnz());
+  std::vector<IntT> sparse_offsets(sparse_dim), dout_indexes(dout.nnz()),
+      x_indexes(x.nnz());
 
   phi::funcs::sparse::CalcOffsetsPerDim<IntT>(
       dout.dims(), sparse_dim, sparse_offsets.data());
@@ -74,7 +74,7 @@ void CopyCooValues(const Context& dev_ctx,
                                      sparse_dim,
                                      0,
                                      1,
-                                     dout_indexs.data());
+                                     dout_indexes.data());
 
   phi::funcs::sparse::FlattenIndices(x.indices().data<IntT>(),
                                      sparse_offsets.data(),
@@ -82,7 +82,7 @@ void CopyCooValues(const Context& dev_ctx,
                                      sparse_dim,
                                      0,
                                      1,
-                                     x_indexs.data());
+                                     x_indexes.data());
 
   size_t i = 0, j = 0;
   T* dx_values_ptr = dx->mutable_values()->data<T>();
@@ -93,21 +93,21 @@ void CopyCooValues(const Context& dev_ctx,
     element_size *= x.values().dims()[j];
   }
 
-  while (i < dout_indexs.size() && j < x_indexs.size()) {
-    if (dout_indexs[i] == x_indexs[j]) {
+  while (i < dout_indexes.size() && j < x_indexes.size()) {
+    if (dout_indexes[i] == x_indexes[j]) {
       memcpy(dx_values_ptr + j * element_size,
              dout_values_ptr + i * element_size,
              element_size * sizeof(T));
       ++i;
       ++j;
-    } else if (dout_indexs[i] > x_indexs[j]) {
+    } else if (dout_indexes[i] > x_indexes[j]) {
       memset(dx_values_ptr + j * element_size, 0, element_size * sizeof(T));
       ++j;
     } else {
       ++i;
     }
   }
-  while (j < x_indexs.size()) {
+  while (j < x_indexes.size()) {
     memset(dx_values_ptr + j * element_size, 0, element_size * sizeof(T));
     ++j;
   }

--- a/paddle/phi/kernels/sparse/cpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/elementwise_kernel.cc
@@ -168,8 +168,8 @@ void ElementWiseCooKernelImpl(const Context& dev_ctx,
     max_len *= x.dims()[j];
   }
 
-  std::vector<IntT> sparse_offsets(sparse_dim), x_indexs(x.nnz()),
-      y_indexs(y.nnz());
+  std::vector<IntT> sparse_offsets(sparse_dim), x_indexes(x.nnz()),
+      y_indexes(y.nnz());
 
   phi::funcs::sparse::CalcOffsetsPerDim<IntT>(
       x.dims(), sparse_dim, sparse_offsets.data());
@@ -180,7 +180,7 @@ void ElementWiseCooKernelImpl(const Context& dev_ctx,
                                      sparse_dim,
                                      0,
                                      1,
-                                     x_indexs.data());
+                                     x_indexes.data());
 
   phi::funcs::sparse::FlattenIndices(y.indices().data<IntT>(),
                                      sparse_offsets.data(),
@@ -188,27 +188,27 @@ void ElementWiseCooKernelImpl(const Context& dev_ctx,
                                      sparse_dim,
                                      0,
                                      1,
-                                     y_indexs.data());
+                                     y_indexes.data());
 
-  std::vector<IntT> out_indexs;
+  std::vector<IntT> out_indexes;
   std::vector<T> out_values_vec;
   if (is_divide) {
-    out_indexs.reserve(max_len);
+    out_indexes.reserve(max_len);
   } else {
-    out_indexs.reserve(x.nnz() + y.nnz());
+    out_indexes.reserve(x.nnz() + y.nnz());
   }
   out_values_vec.reserve(max_len * element_size);
 
   //  merge x and y
   Merge<T, IntT, Functor>(element_size,
-                          x_indexs.data(),
+                          x_indexes.data(),
                           x_values,
-                          x_indexs.size(),
-                          y_indexs.data(),
+                          x_indexes.size(),
+                          y_indexes.data(),
                           y_values,
-                          y_indexs.size(),
+                          y_indexes.size(),
                           max_len,
-                          out_indexs.data(),
+                          out_indexes.data(),
                           out_values_vec.data(),
                           &nnz,
                           functor,
@@ -222,7 +222,7 @@ void ElementWiseCooKernelImpl(const Context& dev_ctx,
     const_dims[i] = x.dims()[i];
   }
 
-  funcs::sparse::IndexToCoordinate<IntT>(out_indexs.data(),
+  funcs::sparse::IndexToCoordinate<IntT>(out_indexes.data(),
                                          const_dims,
                                          nnz,
                                          sparse_dim,

--- a/paddle/phi/kernels/sparse/cpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/elementwise_kernel.cc
@@ -168,8 +168,8 @@ void ElementWiseCooKernelImpl(const Context& dev_ctx,
     max_len *= x.dims()[j];
   }
 
-  std::vector<IntT> sparse_offsets(sparse_dim), x_indexes(x.nnz()),
-      y_indexes(y.nnz());
+  std::vector<IntT> sparse_offsets(sparse_dim), x_indices(x.nnz()),
+      y_indices(y.nnz());
 
   phi::funcs::sparse::CalcOffsetsPerDim<IntT>(
       x.dims(), sparse_dim, sparse_offsets.data());
@@ -180,7 +180,7 @@ void ElementWiseCooKernelImpl(const Context& dev_ctx,
                                      sparse_dim,
                                      0,
                                      1,
-                                     x_indexes.data());
+                                     x_indices.data());
 
   phi::funcs::sparse::FlattenIndices(y.indices().data<IntT>(),
                                      sparse_offsets.data(),
@@ -188,27 +188,27 @@ void ElementWiseCooKernelImpl(const Context& dev_ctx,
                                      sparse_dim,
                                      0,
                                      1,
-                                     y_indexes.data());
+                                     y_indices.data());
 
-  std::vector<IntT> out_indexes;
+  std::vector<IntT> out_indices;
   std::vector<T> out_values_vec;
   if (is_divide) {
-    out_indexes.reserve(max_len);
+    out_indices.reserve(max_len);
   } else {
-    out_indexes.reserve(x.nnz() + y.nnz());
+    out_indices.reserve(x.nnz() + y.nnz());
   }
   out_values_vec.reserve(max_len * element_size);
 
   //  merge x and y
   Merge<T, IntT, Functor>(element_size,
-                          x_indexes.data(),
+                          x_indices.data(),
                           x_values,
-                          x_indexes.size(),
-                          y_indexes.data(),
+                          x_indices.size(),
+                          y_indices.data(),
                           y_values,
-                          y_indexes.size(),
+                          y_indices.size(),
                           max_len,
-                          out_indexes.data(),
+                          out_indices.data(),
                           out_values_vec.data(),
                           &nnz,
                           functor,
@@ -222,7 +222,7 @@ void ElementWiseCooKernelImpl(const Context& dev_ctx,
     const_dims[i] = x.dims()[i];
   }
 
-  funcs::sparse::IndexToCoordinate<IntT>(out_indexes.data(),
+  funcs::sparse::IndexToCoordinate<IntT>(out_indices.data(),
                                          const_dims,
                                          nnz,
                                          sparse_dim,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
fixed:
`indexs`

fixed part:
`Indexs` 

next PR will delete `indexs` in `typos.toml` file