### PR TITLE
[Paddle TensorRT] Add converter output layer naming function `replenish_layer_and_output` test

### DIFF
--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -229,7 +229,9 @@ def trt_expand(network, paddle_op, input, rank, shape_tensor, shape_rank):
     slice_layer.set_input(2, sizes_tensor)
     slice_layer.set_input(3, strides_tensor)
 
-    replenish_layer_and_output(slice_layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        slice_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return slice_layer.get_output(0)
 
 

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -253,7 +253,7 @@ def trt_cast(network, input, dtype):
     return identity_layer.get_output(0)
 
 
-def trt_shape(network: INetworkDefinition, paddle_op, input: ITensor) -> ITensor:
+def trt_shape(network: INetworkDefinition, input: ITensor) -> ITensor:
     """
     Add a IShapeLayer to get the shape of `input` ITensor.
     This includes a workaround that casting the shape result(int64) from TRT10 back to int32.
@@ -265,9 +265,6 @@ def trt_shape(network: INetworkDefinition, paddle_op, input: ITensor) -> ITensor
     if version_list[0] >= 10:  # trt_version >=10
         # workaround
         return trt_cast(network, shape_layer.get_output(0), trt.int32)
-    replenish_layer_and_output(
-        shape_layer, paddle_op.name(), paddle_op.get_output_names()
-    )
     return shape_layer.get_output(0)
 
 
@@ -313,11 +310,8 @@ def trt_less(network, a, b):
     return layer.get_output(0)
 
 
-def trt_sum(network, paddle_op, a, b):
+def trt_sum(network, a, b):
     layer = network.add_elementwise(a, b, trt.ElementWiseOperation.SUM)
-    replenish_layer_and_output(
-        layer, paddle_op.name(), paddle_op.get_output_names()
-    )
     return layer.get_output(0)
 
 
@@ -357,11 +351,8 @@ def trt_gather(network, input, indices, axis=0):
     return result
 
 
-def trt_prod(network, paddle_op, a, b):
+def trt_prod(network, a, b):
     layer = network.add_elementwise(a, b, trt.ElementWiseOperation.PROD)
-    replenish_layer_and_output(
-        layer, paddle_op.name(), paddle_op.get_output_names()
-    )
     return layer.get_output(0)
 
 

--- a/python/paddle/tensorrt/impls/activation.py
+++ b/python/paddle/tensorrt/impls/activation.py
@@ -216,7 +216,11 @@ def swish_silu_converter(network, paddle_op, inputs):
     layer_output = network.add_activation(
         inputs[0], activation_type_map[paddle_op.name()]
     ).get_output(0)
-    return trt_prod(network, paddle_op, inputs[0], layer_output)
+    prod_layer = network.add_elementwise(inputs[0], layer_output, trt.ElementWiseOperation.PROD)
+    replenish_layer_and_output(
+        prod_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
+    return prod_layer.get_output(0)
 
 
 @converter_registry.register("pd_op.tanh_shrink", trt_version="8.x")

--- a/python/paddle/tensorrt/impls/activation.py
+++ b/python/paddle/tensorrt/impls/activation.py
@@ -27,7 +27,6 @@ from paddle.tensorrt.converter_utils import (
 )
 from paddle.tensorrt.register import converter_registry
 
-from test.rpc.test_rpc import paddle_add
 
 activation_type_map = {
     "pd_op.tanh": trt.ActivationType.TANH,

--- a/python/paddle/tensorrt/impls/activation.py
+++ b/python/paddle/tensorrt/impls/activation.py
@@ -27,7 +27,6 @@ from paddle.tensorrt.converter_utils import (
 )
 from paddle.tensorrt.register import converter_registry
 
-
 activation_type_map = {
     "pd_op.tanh": trt.ActivationType.TANH,
     "pd_op.relu": trt.ActivationType.RELU,
@@ -108,7 +107,9 @@ def gelu_converter(network, paddle_op, inputs):
         ).get_output(0)
         layer_one = trt_sum(network, layer_tanh, constant_layer_one)
         layer_cdf = trt_prod(network, layer_one, constant_layer_half)
-        prod_layer = network.add_elementwise(layer_cdf, input_val, trt.ElementWiseOperation.PROD)
+        prod_layer = network.add_elementwise(
+            layer_cdf, input_val, trt.ElementWiseOperation.PROD
+        )
         y = prod_layer.get_output(0)
         replenish_layer_and_output(
             prod_layer, paddle_op.name(), paddle_op.get_output_names()
@@ -128,7 +129,9 @@ def gelu_converter(network, paddle_op, inputs):
         ).get_output(0)
         layer_add = trt_sum(network, layer_erf, constant_layer_one)
         layer_cdf = trt_prod(network, layer_add, constant_layer_half)
-        prod_layer = network.add_elementwise(layer_cdf, input_val, trt.ElementWiseOperation.PROD)
+        prod_layer = network.add_elementwise(
+            layer_cdf, input_val, trt.ElementWiseOperation.PROD
+        )
         y = prod_layer.get_output(0)
         replenish_layer_and_output(
             prod_layer, paddle_op.name(), paddle_op.get_output_names()
@@ -216,7 +219,9 @@ def swish_silu_converter(network, paddle_op, inputs):
     layer_output = network.add_activation(
         inputs[0], activation_type_map[paddle_op.name()]
     ).get_output(0)
-    prod_layer = network.add_elementwise(inputs[0], layer_output, trt.ElementWiseOperation.PROD)
+    prod_layer = network.add_elementwise(
+        inputs[0], layer_output, trt.ElementWiseOperation.PROD
+    )
     replenish_layer_and_output(
         prod_layer, paddle_op.name(), paddle_op.get_output_names()
     )
@@ -260,7 +265,9 @@ def mish_converter(network, paddle_op, inputs):
         softplus_output, trt.ActivationType.TANH
     )
     tanh_output = tanh_layer.get_output(0)
-    prod_layer = network.add_elementwise(x, tanh_output, trt.ElementWiseOperation.PROD)
+    prod_layer = network.add_elementwise(
+        x, tanh_output, trt.ElementWiseOperation.PROD
+    )
     y = prod_layer.get_output(0)
     replenish_layer_and_output(
         prod_layer, paddle_op.name(), paddle_op.get_output_names()
@@ -293,7 +300,9 @@ def celu_converter(network, paddle_op, inputs):
     input_prod_with_alpha = trt_prod(network, input_sub_with_one, alpha_data)
     min_input = trt_min(network, input_prod_with_alpha, constant_zero_data)
     relu_layer = network.add_activation(input_tensor, trt.ActivationType.RELU)
-    output = network.add_elementwise(relu_layer.get_output(0), min_input, trt.ElementWiseOperation.SUM)
+    output = network.add_elementwise(
+        relu_layer.get_output(0), min_input, trt.ElementWiseOperation.SUM
+    )
     output_tensor = output.get_output(0)
     replenish_layer_and_output(
         output, paddle_op.name(), paddle_op.get_output_names()

--- a/python/paddle/tensorrt/impls/attribute.py
+++ b/python/paddle/tensorrt/impls/attribute.py
@@ -17,6 +17,7 @@ import tensorrt as trt
 from paddle.tensorrt.converter_utils import replenish_layer_and_output
 from paddle.tensorrt.register import converter_registry
 
+
 @converter_registry.register("pd_op.shape", trt_version="trt_version_ge=8.0")
 def shape_converter(network, paddle_op, inputs):
     version = trt.__version__

--- a/python/paddle/tensorrt/impls/attribute.py
+++ b/python/paddle/tensorrt/impls/attribute.py
@@ -12,17 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from paddle.tensorrt.converter_utils import trt_shape
+from paddle.tensorrt.converter_utils import (
+    replenish_layer_and_output,
+    trt_shape,
+)
 from paddle.tensorrt.register import converter_registry
 
 
 @converter_registry.register("pd_op.shape", trt_version="trt_version_ge=8.0")
 def shape_converter(network, paddle_op, inputs):
-    return trt_shape(network, inputs[0])
+    return trt_shape(network, paddle_op, inputs[0])
 
 
 @converter_registry.register("pd_op.shape64", trt_version="trt_version_ge=8.0")
 def shape64_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]
     shape_layer = network.add_shape(input_tensor)
+    replenish_layer_and_output(
+        shape_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return shape_layer.get_output(0)

--- a/python/paddle/tensorrt/impls/attribute.py
+++ b/python/paddle/tensorrt/impls/attribute.py
@@ -12,14 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from paddle.tensorrt.converter_utils import (
-    replenish_layer_and_output,
-    trt_cast,
-    trt_shape,
-)
-from paddle.tensorrt.register import converter_registry
 import tensorrt as trt
 
+from paddle.tensorrt.converter_utils import replenish_layer_and_output
+from paddle.tensorrt.register import converter_registry
 
 @converter_registry.register("pd_op.shape", trt_version="trt_version_ge=8.0")
 def shape_converter(network, paddle_op, inputs):

--- a/python/paddle/tensorrt/impls/common.py
+++ b/python/paddle/tensorrt/impls/common.py
@@ -20,6 +20,7 @@ from paddle import pir
 from paddle.tensorrt.converter_utils import (
     get_input_constant_value,
     get_shape_tensor_element,
+    replenish_layer_and_output,
 )
 from paddle.tensorrt.register import converter_registry
 from paddle.tensorrt.util import get_trt_version_list
@@ -48,6 +49,9 @@ def dropout_converter(network, paddle_op, inputs):
         power=power_weights,
     )
 
+    replenish_layer_and_output(
+        scale_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return scale_layer.get_output(0)
 
 
@@ -196,6 +200,9 @@ def bilinear_interp_converter(network, paddle_op, inputs):
             ).get_output(0)
             resize_layer.set_input(1, output_size_tensor)
 
+    replenish_layer_and_output(
+        resize_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return resize_layer.get_output(0)
 
 
@@ -292,4 +299,7 @@ def nearest_interp_converter(network, paddle_op, inputs):
     else:
         resize_layer.scales = scales
 
+    replenish_layer_and_output(
+        resize_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return resize_layer.get_output(0)

--- a/python/paddle/tensorrt/impls/input.py
+++ b/python/paddle/tensorrt/impls/input.py
@@ -16,7 +16,11 @@
 import numpy as np
 import tensorrt as trt
 
-from paddle.tensorrt.converter_utils import add_1D_constant_layer, cast_tensor
+from paddle.tensorrt.converter_utils import (
+    add_1D_constant_layer,
+    cast_tensor,
+    replenish_layer_and_output,
+)
 from paddle.tensorrt.register import converter_registry
 
 
@@ -64,4 +68,7 @@ def one_hot_converter(network, paddle_op, inputs):
     one_hot_layer.set_output_type(0, trt_dtype)
     output_tensor = one_hot_layer.get_output(0)
 
+    replenish_layer_and_output(
+        one_hot_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return [output_tensor]

--- a/python/paddle/tensorrt/impls/linalg.py
+++ b/python/paddle/tensorrt/impls/linalg.py
@@ -19,6 +19,7 @@ from paddle.tensorrt.converter_utils import (
     add_1D_constant_layer,
     broadcast,
     get_shape_tensor_element,
+    replenish_layer_and_output,
     trt_shape,
     trt_sum,
 )
@@ -58,6 +59,9 @@ def matmul_converter(network, paddle_op, inputs):
     out = network.add_matrix_multiply(
         lhs_val, self_matrix_op, rhs_val, other_matrix_op
     )
+    replenish_layer_and_output(
+        out, paddle_op.name(), paddle_op.get_output_names()
+    )
     return out.get_output(0)
 
 
@@ -68,6 +72,9 @@ def transpose_converter(network, paddle_op, inputs):
     perm = paddle_op.attrs()["perm"]
     transposed_tensor = network.add_shuffle(inputs[0])
     transposed_tensor.second_transpose = perm
+    replenish_layer_and_output(
+        transposed_tensor, paddle_op.name(), paddle_op.get_output_names()
+    )
     return transposed_tensor.get_output(0)
 
 
@@ -75,6 +82,9 @@ def transpose_converter(network, paddle_op, inputs):
 def bmm_converter(network, paddle_op, inputs):
     out = network.add_matrix_multiply(
         inputs[0], trt.MatrixOperation.NONE, inputs[1], trt.MatrixOperation.NONE
+    )
+    replenish_layer_and_output(
+        out, paddle_op.name(), paddle_op.get_output_names()
     )
     return out.get_output(0)
 
@@ -115,4 +125,7 @@ def flip_converter(network, paddle_op, inputs):
         input_tensor = loop_out_layer.get_output(0)
 
     identity_layer = network.add_identity(input_tensor)
+    replenish_layer_and_output(
+        identity_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return identity_layer.get_output(0)

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -74,7 +74,9 @@ def reshape_converter(network, paddle_op, inputs):
         'you should modify trt_config(a TensorRTConfig object) and set trt_config.disable_ops = ["pd_op.reshape"] to forbid this op.'
     )
 
-    replenish_layer_and_output(layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return layer.get_output(0)
 
 
@@ -85,7 +87,9 @@ def gather_nd_converter(network, paddle_op, inputs):
         input_tensor, indices_tensor, trt.GatherMode.ND
     )
     non_zero_layer.num_elementwise_dims = 0
-    replenish_layer_and_output(non_zero_layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        non_zero_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return non_zero_layer.get_output(0)
 
 
@@ -170,7 +174,9 @@ def flatten_converter(network, paddle_op, inputs):
         final_shape_layer.name = f"{input_val.name}_final_shape"
         flatten_layer.set_input(1, final_shape_layer.get_output(0))
 
-    replenish_layer_and_output(flatten_layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        flatten_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return flatten_layer.get_output(0)
 
 
@@ -187,7 +193,9 @@ def concat_converter(network, paddle_op, inputs):
         axis = len(input_tensors[0].shape) + axis
     concat_layer.axis = axis
 
-    replenish_layer_and_output(concat_layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        concat_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return concat_layer.get_output(0)
 
 
@@ -240,7 +248,9 @@ def unsqueeze_converter(network, paddle_op, inputs):
         network, trt_concat(network, concat_inputs), gather_indices
     )
     layer.set_input(1, real_shape_tensor)
-    replenish_layer_and_output(layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return layer.get_output(0)
 
 
@@ -296,7 +306,9 @@ def squeeze_converter(network, paddle_op, inputs):
     real_shape_tensor = trt_gather(network, shape_tensor, gather_indices)
     layer.set_input(1, real_shape_tensor)
 
-    replenish_layer_and_output(layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return layer.get_output(0)
 
 
@@ -366,7 +378,9 @@ def cast_converter(network, paddle_op, inputs):
     cast_layer = network.add_identity(input_tensor)
     cast_layer.set_output_type(0, out_dtype)
     cast_layer.get_output(0).dtype = out_dtype
-    replenish_layer_and_output(cast_layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        cast_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return cast_layer.get_output(0)
 
 
@@ -469,7 +483,9 @@ def slice_converter(network, paddle_op, inputs):
     slice_layer.set_input(2, size_tensor)
 
     output_tensor = slice_layer.get_output(0)
-    replenish_layer_and_output(slice_layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        slice_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
 
     # Handle decrease_axis
     if len(decrease_axis) > 0:
@@ -489,7 +505,9 @@ def slice_converter(network, paddle_op, inputs):
             shuffle_layer.set_input(1, real_size_tensor)
 
         output_tensor = shuffle_layer.get_output(0)
-        replenish_layer_and_output(shuffle_layer, paddle_op.name(), paddle_op.get_output_names())
+        replenish_layer_and_output(
+            shuffle_layer, paddle_op.name(), paddle_op.get_output_names()
+        )
 
     return output_tensor
 
@@ -560,7 +578,9 @@ def split_with_num_converter(network, paddle_op, inputs):
         )
         slice_layer.set_input(1, start_tensor)
         slice_layer.set_input(2, size_tensor)
-        replenish_layer_and_output(slice_layer, paddle_op.name(), paddle_op.get_output_names())
+        replenish_layer_and_output(
+            slice_layer, paddle_op.name(), paddle_op.get_output_names()
+        )
 
         outputs.append(slice_layer.get_output(0))
 
@@ -637,7 +657,9 @@ def split_converter(network, paddle_op, inputs):
             )
             slice_layer.set_input(1, start_tensor)
             slice_layer.set_input(2, size_tensor)
-            replenish_layer_and_output(slice_layer, paddle_op.name(), paddle_op.get_output_names())
+            replenish_layer_and_output(
+                slice_layer, paddle_op.name(), paddle_op.get_output_names()
+            )
 
             outputs.append(slice_layer.get_output(0))
 
@@ -683,7 +705,9 @@ def split_converter(network, paddle_op, inputs):
             )
             slice_layer.set_input(1, start_tensor)
             slice_layer.set_input(2, size_tensor)
-            replenish_layer_and_output(slice_layer, paddle_op.name(), paddle_op.get_output_names())
+            replenish_layer_and_output(
+                slice_layer, paddle_op.name(), paddle_op.get_output_names()
+            )
 
             outputs.append(slice_layer.get_output(0))
 
@@ -747,7 +771,9 @@ def stack_converter(network, paddle_op, inputs):
     ):
         output_tensor = resize_to_1d(network, output_tensor)
 
-    replenish_layer_and_output(concat_layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        concat_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return output_tensor
 
 
@@ -803,7 +829,9 @@ def tile_converter(network, paddle_op, inputs):
     else:
         slice_layer.mode = trt.SliceMode.WRAP
 
-    replenish_layer_and_output(slice_layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        slice_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return slice_layer.get_output(0)
 
 
@@ -870,7 +898,9 @@ def strided_slice_converter(network, paddle_op, inputs):
     layer.set_input(1, start_tensor)
     layer.set_input(2, size_tensor)
     layer.set_input(3, step_tensor)
-    replenish_layer_and_output(layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return layer.get_output(0)
 
 
@@ -937,7 +967,9 @@ def roll_converter(network, paddle_op, inputs):
                 input=layer.get_output(0), indices=concat_input_tensor, axis=axi
             )
 
-    replenish_layer_and_output(layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return layer.get_output(0)
 
 
@@ -948,5 +980,7 @@ def numel_converter(network, paddle_op, inputs):
     layer = network.add_reduce(
         shape_tensor, trt.ReduceOperation.PROD, axes=1, keep_dims=False
     )
-    replenish_layer_and_output(layer, paddle_op.name(), paddle_op.get_output_names())
+    replenish_layer_and_output(
+        layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return layer.get_output(0)

--- a/python/paddle/tensorrt/impls/math.py
+++ b/python/paddle/tensorrt/impls/math.py
@@ -188,7 +188,7 @@ def clip_converter(network, paddle_op, inputs):
             )
         else:
             expanded_tensor = trt_expand(
-                network, constant_inputs, 1, input_shape_tensor, rank
+                network, paddle_op, constant_inputs, 1, input_shape_tensor, rank
             )
             if expanded_tensor.dtype != input_tensor.dtype:
                 expanded_tensor = cast_tensor(

--- a/python/paddle/tensorrt/impls/math.py
+++ b/python/paddle/tensorrt/impls/math.py
@@ -27,6 +27,7 @@ from paddle.tensorrt.converter_utils import (
     get_axis_length,
     get_input_constant_value,
     get_shape_tensor_element,
+    replenish_layer_and_output,
     trt_cast,
     trt_concat,
     trt_expand,
@@ -120,6 +121,9 @@ def scale_converter(network, paddle_op, inputs):
                     trt.ElementWiseOperation.PROD,
                 )
 
+    replenish_layer_and_output(
+        layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return layer.get_output(0)
 
 
@@ -144,6 +148,9 @@ def max_converter(network, paddle_op, inputs):
         trt.ReduceOperation.MAX,
         axes=get_axes_for_reduce_op(axis),
         keep_dims=keepdim,
+    )
+    replenish_layer_and_output(
+        layer, paddle_op.name(), paddle_op.get_output_names()
     )
     return layer.get_output(0)
 
@@ -211,6 +218,9 @@ def clip_converter(network, paddle_op, inputs):
     layer = network.add_elementwise(
         lower_clip, beta_t, trt.ElementWiseOperation.MIN
     )
+    replenish_layer_and_output(
+        layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return layer.get_output(0)
 
 
@@ -264,6 +274,9 @@ def remainder_converter(network, paddle_op, inputs):
     remainder = remainder_layer.get_output(0)
     support_fp32_mix_precision(paddle_op.name(), remainder_layer)
 
+    replenish_layer_and_output(
+        remainder_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return remainder
 
 
@@ -376,6 +389,9 @@ def cumsum_converter(network, paddle_op, inputs):
     loop_out = loop.add_loop_output(cur_sum, reverse_flag, axis)
     loop_out.set_input(1, trip_limit)
 
+    replenish_layer_and_output(
+        loop_out, paddle_op.name(), paddle_op.get_output_names()
+    )
     return loop_out.get_output(0)
 
 
@@ -390,6 +406,9 @@ def floor_divide_converter(network, paddle_op, inputs):
 def sqrt_converter(network, paddle_op, inputs):
     input_tensor = trt_cast(network, inputs[0], trt.float32)
     layer = network.add_unary(input_tensor, trt.UnaryOperation.LOG)
+    replenish_layer_and_output(
+        layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return layer.get_output(0)
 
 

--- a/python/paddle/tensorrt/impls/norm.py
+++ b/python/paddle/tensorrt/impls/norm.py
@@ -21,6 +21,7 @@ from paddle.tensorrt.converter_utils import (
     get_dynamic_dims,
     get_trt_plugin,
     has_dynamic_shape,
+    replenish_layer_and_output,
 )
 from paddle.tensorrt.register import converter_registry
 
@@ -64,6 +65,9 @@ def layernorm_converter(network, paddle_op, inputs):
     layer_norm.epsilon = epsilon
     layer_norm.compute_precision = trt.float32
 
+    replenish_layer_and_output(
+        layer_norm, paddle_op.name(), paddle_op.get_output_names()
+    )
     return layer_norm.get_output(0)
 
 
@@ -128,6 +132,9 @@ def batch_norm_converter(network, paddle_op, inputs):
         reshape_output_layer.reshape_dims = tuple(output_shape)
         batch_norm_layer = reshape_output_layer
 
+    replenish_layer_and_output(
+        batch_norm_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return batch_norm_layer.get_output(0)
 
 
@@ -151,4 +158,7 @@ def instance_norm_converter(network, paddle_op, inputs):
         plugin_name, plugin_field_collection, plugin_version
     )
     instance_norm_layer = network.add_plugin_v2(instance_norm_inputs, plugin)
+    replenish_layer_and_output(
+        instance_norm_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return instance_norm_layer.get_output(0)

--- a/python/paddle/tensorrt/impls/pooling.py
+++ b/python/paddle/tensorrt/impls/pooling.py
@@ -16,7 +16,10 @@
 import numpy as np
 import tensorrt as trt
 
-from paddle.tensorrt.converter_utils import get_input_constant_value
+from paddle.tensorrt.converter_utils import (
+    get_input_constant_value,
+    replenish_layer_and_output,
+)
 from paddle.tensorrt.register import converter_registry
 
 
@@ -307,4 +310,7 @@ def pool2d_converter(network, paddle_op, inputs):
     if layer is None:
         raise RuntimeError("Failed to create pooling layer in TensorRT.")
 
+    replenish_layer_and_output(
+        layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return layer.get_output(0)

--- a/python/paddle/tensorrt/impls/search.py
+++ b/python/paddle/tensorrt/impls/search.py
@@ -101,7 +101,7 @@ def argmin_converter(network, paddle_op, inputs):
 
     if keepdims:
         replenish_layer_and_output(
-            topk_layer, paddle_op.name(), paddle_op.get_output_names()[1]
+            topk_layer, paddle_op.name(), paddle_op.get_output_names()
         )
         return topk_layer.get_output(1)
     else:
@@ -112,6 +112,9 @@ def argmin_converter(network, paddle_op, inputs):
                 continue
             output_dims.append(input_dims[i])
         squeeze_layer.reshape_dims = tuple(output_dims)
+        replenish_layer_and_output(
+            squeeze_layer, paddle_op.name(), paddle_op.get_output_names()
+        )
         return squeeze_layer.get_output(0)
 
 

--- a/python/paddle/tensorrt/impls/stat.py
+++ b/python/paddle/tensorrt/impls/stat.py
@@ -14,7 +14,10 @@
 
 import tensorrt as trt
 
-from paddle.tensorrt.converter_utils import get_axes_for_reduce_op
+from paddle.tensorrt.converter_utils import (
+    get_axes_for_reduce_op,
+    replenish_layer_and_output,
+)
 from paddle.tensorrt.register import converter_registry
 
 
@@ -29,5 +32,8 @@ def mean_converter(network, paddle_op, inputs):
         trt.ReduceOperation.AVG,
         axes=get_axes_for_reduce_op(dim, network.has_implicit_batch_dimension),
         keep_dims=keep_dim,
+    )
+    replenish_layer_and_output(
+        mean_layer, paddle_op.name(), paddle_op.get_output_names()
     )
     return mean_layer.get_output(0)

--- a/python/paddle/tensorrt/impls/vision.py
+++ b/python/paddle/tensorrt/impls/vision.py
@@ -14,6 +14,7 @@
 
 import tensorrt as trt
 
+from paddle.tensorrt.converter_utils import replenish_layer_and_output
 from paddle.tensorrt.register import converter_registry
 
 
@@ -43,4 +44,7 @@ def grid_sample_converter(network, paddle_op, inputs):
     grid_sample_layer.interpolation_mode = interpolation_mode
     grid_sample_layer.align_corners = align_corners
     grid_sample_layer.sample_mode = sample_mode
+    replenish_layer_and_output(
+        grid_sample_layer, paddle_op.name(), paddle_op.get_output_names()
+    )
     return grid_sample_layer.get_output(0)


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
card-71500
- 新增给converter输出层命名函数`replenish_layer_and_output`（格式：pd_op.xxx(Output: Out1.name, Out2.name, ...)）
- 当最后一层为layer时候，直接用`replenish_layer_and_output(layer, paddle_op.name(), paddle_op.get_output_names())`
- 当最后一层为trt_xxx时（返回的是最后一层的get_output）：对于trt_expand考虑增加paddle_op参数；对于有paddle_op参数的直接在里面命名；对于其他trt_sum之类常用但没有paddle_op参数的，这里手动修改了相应的converter。（reviewer可以看看有没有更好的替代方法～）