### PR TITLE
【Bug Fix】Remove type promote of cinn reduce

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -121,8 +121,9 @@ class SumOpPattern : public pir::OpRewritePattern<paddle::dialect::SumOp> {
     if (dtype != phi::DataType::UNDEFINED &&
         dtype != paddle::dialect::TransToPhiDataType(in_data_type)) {
       in = rewriter.Build<paddle::dialect::CastOp>(in, dtype).result(0);
-    } else if (in_data_type.isa<pir::Int32Type>() ||
-               in_data_type.isa<pir::BoolType>()) {
+    } else if (dtype == phi::DataType::UNDEFINED &&
+               (in_data_type.isa<pir::Int32Type>() ||
+                in_data_type.isa<pir::BoolType>())) {
       in = rewriter.Build<paddle::dialect::CastOp>(in, phi::DataType::INT64)
                .result(0);
     }

--- a/paddle/cinn/ir/ir.cc
+++ b/paddle/cinn/ir/ir.cc
@@ -1323,13 +1323,6 @@ Expr Reduce::Make(Reduce::ReduceType reduce_type,
 
   n->set_type(body.type());
 
-  if (reduce_type == ir::Reduce::kSum &&
-      (body.type().is_int(32) || body.type().is_bool())) {
-    n->body->set_type(Int(64));
-    n->set_type(Int(64));
-    n->init->set_type(Int(64));
-  }
-
   return Expr(n);
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
删除了 ir.cc 中 reuduce::make 中的 int32 & bool --> int64 的类型提升，原因如下：
1. 在 pd_to_cinn_pass 中严格限制了输入，会对 Reduce 的 dtype 和 x.type 不一致时，提前插入 cast 改变 x 的 type，在未指定 dtype 时，对 x.type == int32 & bool 时插入 cast 对 x 类型提升至 int64，因此 Kernel 中只需要向 x.type 对齐即可
2. reuduce::make 中的类型提升具有「副作用」，会改变 var_initial 的类型，而 compute 为 lambda 函数捕获了 var_initial，第二次执行 var_initial 类型转换为 int64 导致报错

ref: https://github.com/PaddlePaddle/Paddle/pull/70660
Pcard-67164