### PR TITLE
[SOT] Fix SOT need skip prefix check logic

### DIFF
--- a/paddle/fluid/pybind/sot/eval_frame_tools.cc
+++ b/paddle/fluid/pybind/sot/eval_frame_tools.cc
@@ -23,6 +23,7 @@
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
 
 #if SOT_IS_SUPPORTED
+#define END_OF_STRING '\0'
 
 /*============================ Dict Tree ================================*/
 
@@ -32,10 +33,10 @@ class TreeNode {
   ~TreeNode() { clear(); }
   void clear();
   void add_prefix(const char* filename);
-  int check_filename(const char* filename);
+  bool check_filename(const char* filename);
 
  private:
-  int is_prefix;
+  bool is_end;
   TreeNode* children[256];  // NOLINT
 };
 
@@ -46,9 +47,9 @@ void TreeNode::clear() {
 }
 
 void TreeNode::add_prefix(const char* filepath) {
-  if (is_prefix) return;
-  if (filepath[0] == '\0') {
-    is_prefix = 1;
+  if (is_end) return;
+  if (filepath[0] == END_OF_STRING) {
+    is_end = true;
     return;
   }
 
@@ -63,18 +64,18 @@ void TreeNode::add_prefix(const char* filepath) {
   return;
 }
 
-int TreeNode::check_filename(const char* filename) {
-  int cur_idx = 0;
+bool TreeNode::check_filename(const char* filename) {
+  size_t cur_idx = 0;
   TreeNode* cur_node = this;
 
-  while (filename[cur_idx] != '\0') {
+  while (filename[cur_idx] != END_OF_STRING) {
     cur_node = cur_node->children[(int)filename[cur_idx]];  // NOLINT
-    if (cur_node == nullptr) return 0;
-    if (cur_node->is_prefix) return 1;
+    if (cur_node == nullptr) return false;
+    if (cur_node->is_end) return true;
     cur_idx += 1;
   }
 
-  return 0;
+  return false;
 }
 
 /*========================== utils  ==========================*/

--- a/paddle/fluid/pybind/sot/eval_frame_tools.cc
+++ b/paddle/fluid/pybind/sot/eval_frame_tools.cc
@@ -31,7 +31,7 @@ class TreeNode {
   TreeNode() = default;
   ~TreeNode() { clear(); }
   void clear();
-  int add_prefix(const char* filename);
+  void add_prefix(const char* filename);
   int check_filename(const char* filename);
 
  private:
@@ -45,9 +45,12 @@ void TreeNode::clear() {
   }
 }
 
-int TreeNode::add_prefix(const char* filepath) {
-  if (is_prefix) return 0;
-  if (filepath[0] == '\0') return 1;
+void TreeNode::add_prefix(const char* filepath) {
+  if (is_prefix) return;
+  if (filepath[0] == '\0') {
+    is_prefix = 1;
+    return;
+  }
 
   int ch = (int)filepath[0];  // NOLINT
   if (children[ch] == nullptr) {
@@ -55,9 +58,9 @@ int TreeNode::add_prefix(const char* filepath) {
     children[ch] = node;
   }
 
-  if (children[ch]->add_prefix(filepath + 1)) is_prefix = 1;
+  children[ch]->add_prefix(filepath + 1);
 
-  return 0;
+  return;
 }
 
 int TreeNode::check_filename(const char* filename) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 SOT 是否需要跳过的路径判定逻辑，当前 node 的判定逻辑不应该反馈到上层，而是当前层，之前逻辑会导致 `.../paddle/` 的 `e` 被设置为 `is_prefix`，进而导致判定时 `.../paddleseg` 也会被匹配上，导致 `paddleseg`（`paddlenlp` 同，`ppdet`、`ppcls` 等套件则不会） 入口及内部大量函数被跳过跑动态图

值得注意的是，开发时大多 paddle 路径指定的是 `PYTHONPATH` 即 build 里的开发路径，paddleseg 则在 `site-package` 里，不会有这个问题，只有使用 wheel 包安装时才会有因为有相同前缀导致这个问题，潜在的隐患就是，PaddleSeg、PaddleNLP 等套件在 CE 监控一定使用的是通过 wheel 包安装的，这可能会导致现有监控下部分代码是没测到的

PCard-66972