### PR TITLE
[XPU] enable test for minimum int64 type

### DIFF
--- a/test/legacy_test/test_minimum_op.py
+++ b/test/legacy_test/test_minimum_op.py
@@ -93,9 +93,6 @@ class ApiMinimumTest(unittest.TestCase):
             )
         np.testing.assert_allclose(res, self.np_expected4, rtol=1e-05)
 
-    @unittest.skipIf(
-        core.is_compiled_with_xpu(), "XPU int64_t minimum has bug now"
-    )
     def test_dynamic_api(self):
         paddle.disable_static()
         x = paddle.to_tensor(self.input_x)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
[XPU] enable test for minimum int64 type (fix https://github.com/PaddlePaddle/Paddle/pull/70428)