### PR TITLE
[CodeStyle][Typos][I-11] Fix typos(`indexs`,`Indexs`) (part 2)

### DIFF
--- a/paddle/phi/kernels/sparse/cpu/mask_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/mask_kernel.cc
@@ -55,7 +55,7 @@ void MaskCooCPUKernel(const CPUContext& dev_ctx,
   const int cols = static_cast<int>(dims_2d[1]);
   const IntT* indices_ptr = indices.data<IntT>();
 
-  std::vector<IntT> out_indexs(non_zero_num), sparse_offsets(sparse_dim);
+  std::vector<IntT> out_indices(non_zero_num), sparse_offsets(sparse_dim);
 
   phi::funcs::sparse::CalcOffsetsPerDim<IntT>(
       dims, sparse_dim, sparse_offsets.data());
@@ -197,8 +197,8 @@ void MaskHelperCooCPUKernel(const CPUContext& dev_ctx,
 
   const int32_t sparse_dim = x.sparse_dim();
 
-  std::vector<IntT> sparse_offsets(sparse_dim), x_indexs(x.nnz()),
-      mask_indexs(mask_indices.dims()[1]);
+  std::vector<IntT> sparse_offsets(sparse_dim), x_indices(x.nnz()),
+      mask_out_indices(mask_indices.dims()[1]);
   phi::funcs::sparse::CalcOffsetsPerDim<IntT>(
       x.dims(), sparse_dim, sparse_offsets.data());
 
@@ -208,18 +208,18 @@ void MaskHelperCooCPUKernel(const CPUContext& dev_ctx,
                                      sparse_dim,
                                      0,
                                      1,
-                                     x_indexs.data());
+                                     x_indices.data());
   phi::funcs::sparse::FlattenIndices(mask_indices.data<IntT>(),
                                      sparse_offsets.data(),
                                      x.nnz(),
                                      sparse_dim,
                                      0,
                                      1,
-                                     mask_indexs.data());
+                                     mask_out_indices.data());
 
-  std::unordered_map<IntT, uint64_t> x_indexs_map;
-  for (uint64_t i = 0; i < x_indexs.size(); i++) {
-    x_indexs_map[x_indexs[i]] = i;
+  std::unordered_map<IntT, uint64_t> x_indices_map;
+  for (uint64_t i = 0; i < x_indices.size(); i++) {
+    x_indices_map[x_indices[i]] = i;
   }
 
   *out = phi::EmptyLike<T>(dev_ctx, x.values());
@@ -230,9 +230,9 @@ void MaskHelperCooCPUKernel(const CPUContext& dev_ctx,
       x.dims().size() == sparse_dim ? 1 : x.values().dims()[1];
   const T* in_ptr = x.values().data<T>();
   // TODO(zhangkaihuo): multithreading can be used for acceleration
-  for (uint64_t i = 0; i < mask_indexs.size(); i++) {
-    auto iter = x_indexs_map.find(mask_indexs[i]);
-    if (iter != x_indexs_map.end()) {
+  for (uint64_t i = 0; i < mask_out_indices.size(); i++) {
+    auto iter = x_indices_map.find(mask_out_indices[i]);
+    if (iter != x_indices_map.end()) {
       memcpy(out_ptr + i * stride,
              in_ptr + iter->second * stride,
              stride * sizeof(T));

--- a/paddle/phi/kernels/sparse/cpu/mask_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/mask_kernel.cc
@@ -55,7 +55,7 @@ void MaskCooCPUKernel(const CPUContext& dev_ctx,
   const int cols = static_cast<int>(dims_2d[1]);
   const IntT* indices_ptr = indices.data<IntT>();
 
-  std::vector<IntT> out_indices(non_zero_num), sparse_offsets(sparse_dim);
+  std::vector<IntT> sparse_offsets(sparse_dim);
 
   phi::funcs::sparse::CalcOffsetsPerDim<IntT>(
       dims, sparse_dim, sparse_offsets.data());

--- a/paddle/phi/kernels/sparse/gpu/conv_grad_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/conv_grad_kernel.cu
@@ -156,16 +156,16 @@ void Conv3dCooGradGPUKernel(const GPUContext& dev_ctx,
   if (!cutlass) {
 #endif
 
-    GroupIndexsV2<<<config.block_per_grid,
-                    config.thread_per_block,
-                    0,
-                    dev_ctx.stream()>>>(rulebook_len,
-                                        x.nnz(),
-                                        kernel_size,
-                                        offsets[kernel_size / 2],
-                                        rulebook_ptr,
-                                        out_index_ptr,
-                                        unique_value_ptr);
+    GroupIndicesV2<<<config.block_per_grid,
+                     config.thread_per_block,
+                     0,
+                     dev_ctx.stream()>>>(rulebook_len,
+                                         x.nnz(),
+                                         kernel_size,
+                                         offsets[kernel_size / 2],
+                                         rulebook_ptr,
+                                         out_index_ptr,
+                                         unique_value_ptr);
 
     GatherV2<T, IntT>(dev_ctx,
                       x.values().data<T>(),

--- a/paddle/phi/kernels/sparse/gpu/conv_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/conv_kernel.cu
@@ -223,14 +223,14 @@ void Conv3dCooGPUKernel(const GPUContext& dev_ctx,
       int* unique_value_ptr = unique_value.data<int>();
       phi::backends::gpu::GpuMemsetAsync(
           out_index_ptr, 0, sizeof(int) * rulebook_len, dev_ctx.stream());
-      GroupIndexs<<<config.block_per_grid,
-                    config.thread_per_block,
-                    0,
-                    dev_ctx.stream()>>>(rulebook_len,
-                                        kernel_size,
-                                        rulebook_ptr + rulebook_len,
-                                        out_index_ptr,
-                                        unique_value_ptr);
+      GroupIndices<<<config.block_per_grid,
+                     config.thread_per_block,
+                     0,
+                     dev_ctx.stream()>>>(rulebook_len,
+                                         kernel_size,
+                                         rulebook_ptr + rulebook_len,
+                                         out_index_ptr,
+                                         unique_value_ptr);
     }
     // 2. gather
     phi::DenseTensor in_features =

--- a/paddle/phi/kernels/sparse/gpu/convolution.cu.h
+++ b/paddle/phi/kernels/sparse/gpu/convolution.cu.h
@@ -110,21 +110,21 @@ inline IntT* SortedAndUniqueIndex(const Context& dev_ctx,
  * @brief: update the out index and indices
  * unique_keys: save the index of the output feature list
  * unique_values: indicates the index of key before deduplication
- * out_indexs: indicates the position of the output index in the rulebook
+ * output_indices: indicates the position of the output index in the rulebook
  * rulebook_len: indicates the length of rulebook
  * out_dims: indicates the output dims
  * out_indices: the indices of output, out_indices = IndexToPoint(unique_keys)
- * rulebook_out_indexs: the output index in rulebook
+ * rulebook_out_indices: the output index in rulebook
  **/
 template <typename T>
 __global__ void UpdateIndexKernel(const T* unique_keys,
                                   const int* unique_values,
-                                  const int* out_indexs,
+                                  const int* output_indices,
                                   const int64_t non_zero_num,
                                   const int rulebook_len,
                                   const Dims4D out_dims,
                                   T* out_indices,
-                                  T* rulebook_out_indexs) {
+                                  T* rulebook_out_indices) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   for (int i = tid; i < non_zero_num; i += gridDim.x * blockDim.x) {
     const T index = unique_keys[i];
@@ -142,20 +142,20 @@ __global__ void UpdateIndexKernel(const T* unique_keys,
     int end = i == non_zero_num - 1 ? rulebook_len : unique_values[i + 1];
     // max(end-start) = kernel_size
     for (T j = start; j < end; j++) {
-      rulebook_out_indexs[out_indexs[j]] = i;
+      rulebook_out_indices[output_indices[j]] = i;
     }
   }
 }
 
 template <typename IntT>
 __global__ void UpdateOutIndexAndCounterAfterLowerBound(
-    const IntT* x_indexs,
+    const IntT* x_indices,
     const IntT* bound_out,
     const int rulebook_len,
     const int kernel_size,
     const int64_t non_zero_num,
     IntT* rulebook_ptr,
-    IntT* out_indexs,
+    IntT* out_indices,
     int* counter_ptr) {
   extern __shared__ int cache_count[];
   for (int i = threadIdx.x; i < kernel_size; i += blockDim.x) {
@@ -165,8 +165,8 @@ __global__ void UpdateOutIndexAndCounterAfterLowerBound(
 
   CUDA_KERNEL_LOOP_TYPE(i, rulebook_len, int64_t) {
     int j = bound_out[i];
-    if (j >= 0 && j < non_zero_num && out_indexs[i] == x_indexs[j]) {
-      out_indexs[i] = j;
+    if (j >= 0 && j < non_zero_num && out_indices[i] == x_indices[j]) {
+      out_indices[i] = j;
     } else {
       // mask this position will be remove
       int kernel_index = rulebook_ptr[i];
@@ -211,7 +211,7 @@ __global__ void ProductRuleBookKernel(const T* x_indices,
                                       const bool subm,
                                       T* rulebook,
                                       int* counter,
-                                      T* in_indexs) {
+                                      T* in_indices) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   extern __shared__ int counter_buf[];  // kernel_size
   const int kernel_size = kernel_dims[3] * kernel_dims[2] * kernel_dims[1];
@@ -228,7 +228,7 @@ __global__ void ProductRuleBookKernel(const T* x_indices,
     T in_y = x_indices[i + 2 * non_zero_num];
     T in_x = x_indices[i + 3 * non_zero_num];
     if (subm) {
-      in_indexs[i] = PointToIndex(batch, in_x, in_y, in_z, x_dims);
+      in_indices[i] = PointToIndex(batch, in_x, in_y, in_z, x_dims);
     }
     for (int kz = 0; kz < kernel_dims[1]; kz++) {
       for (int ky = 0; ky < kernel_dims[2]; ky++) {
@@ -304,7 +304,7 @@ int ProductRuleBook(const Context& dev_ctx,
   const int64_t non_zero_num = x.nnz();
   const auto& indices = x.indices();
   const IntT* indices_ptr = indices.data<IntT>();
-  DenseTensor in_indexs = phi::Empty<Context>(
+  DenseTensor in_indices = phi::Empty<Context>(
       dev_ctx, DenseTensorMeta(indices_dtype, {x.nnz()}, DataLayout::NCHW));
   int* counter_ptr = counter_per_kernel->data<int>();
   int* offsets_ptr = offsets_per_kernel->data<int>();
@@ -343,7 +343,7 @@ int ProductRuleBook(const Context& dev_ctx,
                                                     subm,
                                                     rulebook_ptr,
                                                     counter_ptr,
-                                                    in_indexs.data<IntT>());
+                                                    in_indices.data<IntT>());
 
 // 2. remove -1
 #ifdef PADDLE_WITH_HIP
@@ -379,8 +379,8 @@ int ProductRuleBook(const Context& dev_ctx,
     // to obain the rulebook.
 
     // call lower_bound to get the real index of out_index
-    const IntT* in_indexs_ptr = in_indexs.data<IntT>();
-    IntT* out_indexs_ptr = rulebook_ptr + 2 * rulebook_len;
+    const IntT* in_indices_ptr = in_indices.data<IntT>();
+    IntT* out_indices_ptr = rulebook_ptr + 2 * rulebook_len;
     DenseTensor bound = phi::Empty(
         dev_ctx,
         DenseTensorMeta(
@@ -391,10 +391,10 @@ int ProductRuleBook(const Context& dev_ctx,
 #else
     thrust::lower_bound(thrust::cuda::par.on(dev_ctx.stream()),
 #endif
-                        in_indexs_ptr,
-                        in_indexs_ptr + in_indexs.numel(),
-                        out_indexs_ptr,
-                        out_indexs_ptr + rulebook_len,
+                        in_indices_ptr,
+                        in_indices_ptr + in_indices.numel(),
+                        out_indices_ptr,
+                        out_indices_ptr + rulebook_len,
                         bound_ptr);
 
     config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, rulebook_len, 1);
@@ -403,13 +403,13 @@ int ProductRuleBook(const Context& dev_ctx,
                                               config.thread_per_block,
                                               kernel_size * sizeof(int),
                                               dev_ctx.stream()>>>(
-        in_indexs_ptr,
+        in_indices_ptr,
         bound.data<IntT>(),
         rulebook_len,
         kernel_size,
         x.nnz(),
         rulebook_ptr,
-        out_indexs_ptr,
+        out_indices_ptr,
         counter_ptr);
 
 // remove -1

--- a/paddle/phi/kernels/sparse/gpu/convolution.cu.h
+++ b/paddle/phi/kernels/sparse/gpu/convolution.cu.h
@@ -110,7 +110,7 @@ inline IntT* SortedAndUniqueIndex(const Context& dev_ctx,
  * @brief: update the out index and indices
  * unique_keys: save the index of the output feature list
  * unique_values: indicates the index of key before deduplication
- * output_indices: indicates the position of the output index in the rulebook
+ * out_indexes: indicates the position of the output index in the rulebook
  * rulebook_len: indicates the length of rulebook
  * out_dims: indicates the output dims
  * out_indices: the indices of output, out_indices = IndexToPoint(unique_keys)
@@ -119,7 +119,7 @@ inline IntT* SortedAndUniqueIndex(const Context& dev_ctx,
 template <typename T>
 __global__ void UpdateIndexKernel(const T* unique_keys,
                                   const int* unique_values,
-                                  const int* output_indices,
+                                  const int* out_indexes,
                                   const int64_t non_zero_num,
                                   const int rulebook_len,
                                   const Dims4D out_dims,
@@ -142,7 +142,7 @@ __global__ void UpdateIndexKernel(const T* unique_keys,
     int end = i == non_zero_num - 1 ? rulebook_len : unique_values[i + 1];
     // max(end-start) = kernel_size
     for (T j = start; j < end; j++) {
-      rulebook_out_indices[output_indices[j]] = i;
+      rulebook_out_indices[out_indexes[j]] = i;
     }
   }
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
fixed part:
indexs -> indices