### PR TITLE
[SOT] Remove float close guard (i.e. reverts #70510)

### DIFF
--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -82,11 +82,6 @@ void BindGuard(pybind11::module *m) {
   py::class_<LengthMatchGuard, GuardBase, std::shared_ptr<LengthMatchGuard>>(
       *m, "LengthMatchGuard", R"DOC(LengthMatchGuard Class.)DOC")
       .def(py::init<const Py_ssize_t &>(), py::arg("length"));
-  py::class_<FloatCloseGuard, GuardBase, std::shared_ptr<FloatCloseGuard>>(
-      *m, "FloatCloseGuard", R"DOC(FloatCloseGuard Class.)DOC")
-      .def(py::init<const double, const double>(),
-           py::arg("value"),
-           py::arg("epsilon"));
   py::class_<ValueMatchGuard, GuardBase, std::shared_ptr<ValueMatchGuard>>(
       *m, "ValueMatchGuard", R"DOC(ValueMatchGuard Class.)DOC")
       .def(py::init<const py::object &>(), py::arg("py_value"));

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -76,14 +76,6 @@ bool TypeMatchGuard::check(PyObject* value) {
 
 bool IdMatchGuard::check(PyObject* value) { return value == expected_; }
 
-bool FloatCloseGuard::check(PyObject* value) {
-  if (Py_TYPE(value) != &PyFloat_Type) {
-    return false;
-  }
-  double v = reinterpret_cast<PyFloatObject*>(value)->ob_fval;
-  return std::abs(v - expected_) < 1e-13;
-}
-
 bool ValueMatchGuard::check(PyObject* value) {
   return PyObject_Equal(value, expected_value_);
 }

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -117,18 +117,6 @@ class ValueMatchGuard : public GuardBase {
   PyTypeObject* expected_type_;
 };
 
-class FloatCloseGuard : public GuardBase {
- public:
-  explicit FloatCloseGuard(double value, double epsilon)
-      : expected_(value), epsilon_(epsilon) {}
-
-  bool check(PyObject* value);
-
- private:
-  double expected_;
-  double epsilon_;
-};
-
 class LengthMatchGuard : public GuardBase {
  public:
   explicit LengthMatchGuard(const Py_ssize_t& length) : expected_(length) {}

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -208,24 +208,6 @@ class ConstantVariable(VariableBase):
             DummyTracker([self]),
         )
 
-    @check_guard
-    def make_stringified_guard(self) -> list[StringifiedExpression]:
-        if self.get_py_type() is not float:
-            return super().make_stringified_guard()
-
-        frame_value_tracer = self.tracker.trace_value_from_frame()
-        epsilon = 1e-13
-        return [
-            FasterStringifiedExpression(
-                f"type({{0}}) is float and abs({self.get_py_value()!r} - {{0}}) < {epsilon}",
-                paddle.framework.core.FloatCloseGuard(
-                    self.get_py_value(), epsilon
-                ),
-                [frame_value_tracer],
-                union_free_vars(frame_value_tracer.free_vars),
-            )
-        ]
-
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
         if type(value) in ConstTypes:

--- a/test/sot/test_faster_guard.py
+++ b/test/sot/test_faster_guard.py
@@ -142,14 +142,6 @@ class TestFasterGuardGroup(unittest.TestCase):
         self.assertTrue(guard_range.check(range(1, 10, 2)))
         self.assertFalse(guard_range.check(range(11)))
 
-    def test_float_close_guard(self):
-        expected = 0.018181818181818184
-        epsilon = 1e-13
-        guard_float = paddle.framework.core.FloatCloseGuard(expected, epsilon)
-        self.assertTrue(guard_float.check(0.018181818181818184))
-        self.assertTrue(guard_float.check(0.018181818181818177))
-        self.assertFalse(guard_float.check(0.018181818191818184))
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

Revert #70510 添加的 `FloatCloseGuard`，因为 #70766 已经找到原因了

合入后需要观察下 CINN CE 编译时间，因为 #70510 合入后，编译时间大幅缩减（因为编译器有不少模型有这个问题，guard 一直不命中一直重复编译），#70766 修复该问题后，预期即便 revert 后也不会增加编译时间

PCard-66972