### PR TITLE
[XPU] Fix Adam optimizer bug

### DIFF
--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -1067,8 +1067,10 @@ class Optimizer:
                 belong_to_optimizer=True,
             )
 
-            if in_dygraph_mode() and (
-                device == 'cpu' or isinstance(device, core.CPUPlace)
+            if (
+                in_dygraph_mode()
+                and (device == 'cpu' or isinstance(device, core.CPUPlace))
+                and (not core.is_compiled_with_xpu())
             ):
                 _C_ops.full_(
                     var,


### PR DESCRIPTION
### PR Category

Custom Device

### PR Types

Bug fixes

### Description
Pcard-75624
这个PR是回滚了PR #63108 的部分内容，修复了adam优化器在xpu上更新参数不正确的问题。输出与CPU，GPU对齐。

- GPU下部分参数的输出为

![cef3238e208813ecbea494faea074879](https://github.com/user-attachments/assets/fb0834ea-d8f4-4a82-b6fc-77f278ab6add)
- xpu下部分参数的输出为

![72643961d2f80dd1eb1a6ed387949165](https://github.com/user-attachments/assets/0eac20fc-3239-4d3e-a411-f930b4bfc4ae)

测试代码如下
```python
import paddle
import paddle.nn as nn
import paddle.optimizer as optim
import numpy as np
import random

def set_seed(seed=42):
    paddle.seed(seed)
    np.random.seed(seed)
    random.seed(seed)

set_seed(42)

class SimpleMLP(nn.Layer):
    def __init__(self, input_size=1, num_classes=1):
        super(SimpleMLP, self).__init__()
        self.fc1 = nn.Linear(input_size, 128)
        self.relu = nn.ReLU()
        self.fc2 = nn.Linear(128, num_classes)
    
    def forward(self, x):
        x = self.fc1(x)
        x = self.relu(x)
        x = self.fc2(x)
        return x

X=[[0.37454012],
 [0.9507143 ],
 [0.7319939 ]]
y=[[0.63789225],
 [1.9333189 ],
 [1.491892  ]]
X_tensor = paddle.to_tensor(X)
y_tensor = paddle.to_tensor(y)
train_dataset = paddle.io.TensorDataset([X_tensor, y_tensor])
train_loader = paddle.io.DataLoader(train_dataset, batch_size=1, shuffle=False)

model = SimpleMLP(input_size=1, num_classes=1)
model_state_dict = paddle.load("/work/hesensen/hss_test/mlp.pdparams")
model.set_dict(model_state_dict)
criterion = nn.MSELoss()
optimizer = optim.Adam(parameters=model.parameters(), learning_rate=0.01)

model.train()
batch_id, (features, targets) = next(enumerate(train_loader))
predictions = model(features)
loss = criterion(predictions, targets)
loss.backward()
optimizer.step()
total_sum = paddle.sum(model.parameters()[0]).item()
# 输出的total_sum为模型第一层参数的和
# paddle2.6.1下输出为-0.8222507834434509，paddle3.0b0下输出为-27.552602767944336。
print(total_sum)
```
