### PR TITLE
[SOT] Refactor `RangeVariable` and setitem and add compilation count stats

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -235,7 +235,6 @@ def start_translate(
     try:
         simulator.check_code_simulatable()
         InfoCollector().attach(CompileCountInfo, frame.f_code)
-        print(f"Attach info for {frame.f_code.co_filename}")
         with sot_simulation_mode_guard(True):
             new_custom_code, guard_fn = simulator.transform()
         if not simulator._graph.need_cache:

--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -25,7 +25,9 @@ from ...psdb import NO_FALLBACK_CODES
 from ...utils import (
     ENV_SOT_ALLOW_DYNAMIC_SHAPE,
     BreakGraphError,
+    CompileCountInfo,
     FallbackError,
+    InfoCollector,
     InnerError,
     Singleton,
     is_strict_mode,
@@ -148,9 +150,9 @@ class OpcodeExecutorCache(metaclass=Singleton):
                     )
             except Exception as e:
                 log(2, f"[Cache]: Guard function error: {e}\n")
-                log(
+                log_do(
                     2,
-                    f"[Cache]: Guard string is: {getattr(guard_fn, 'expr', 'None')}\n",
+                    self.analyse_guard_error(guard_fn, frame),
                 )
 
                 continue
@@ -205,8 +207,9 @@ class OpcodeExecutorCache(metaclass=Singleton):
                     result = guard(frame)
                 except Exception as e:
                     print(
-                        f"[Cache]: skip checking {guard_str}\n         because error occurred {e}"
+                        f"[Cache]: Error occurred when checking guard {guard_str}: {e}"
                     )
+                    return
                 if result is False:
                     print(f"[Cache]: missed at {guard_str}")
                     return
@@ -231,6 +234,8 @@ def start_translate(
     simulator = OpcodeExecutor(frame, **kwargs)
     try:
         simulator.check_code_simulatable()
+        InfoCollector().attach(CompileCountInfo, frame.f_code)
+        print(f"Attach info for {frame.f_code.co_filename}")
         with sot_simulation_mode_guard(True):
             new_custom_code, guard_fn = simulator.transform()
         if not simulator._graph.need_cache:

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -369,8 +369,9 @@ class FunctionGraph:
         # here is not update changed values, it just give names to stack vars
         # and want keep same interface as _build_compile_fn_with_name_store
         for var in stack_vars[::-1]:
-            if not store_var_info[var.id]:
+            if not store_var_info.get(var.id, []):
                 name = name_gen.next()
+                store_var_info.setdefault(var.id, [])
                 store_var_info[var.id].append(name)
                 self.pycode_gen.gen_store_fast(name)
             else:
@@ -398,8 +399,9 @@ class FunctionGraph:
         name_gen = NameGenerator("___graph_fn_saved_")
 
         for var in to_store_vars[::-1]:
-            if not store_var_info[var.id]:
+            if not store_var_info.get(var.id, []):
                 name = name_gen.next()
+                store_var_info.setdefault(var.id, [])
                 store_var_info[var.id].append(name)
                 self.pycode_gen.gen_store_fast(name)
             else:

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -973,13 +973,6 @@ class OpcodeExecutorBase:
 
     def store_subscr_operation(self, key, container, value, opname):
         assert isinstance(key, VariableBase)
-        # self._graph.add_global_guarded_variable(key)
-        # if isinstance(key, TensorVariable):
-        #     raise BreakGraphError(
-        #         f"Key is a TensorVariable in {opname}, {container}[{key}] = {value}"
-        #     )
-        # # TODO(xiongkun): support tensor[tensor] = tensor, dy2static is not the same with dygraph.
-        # container[key.get_py_value()] = value
         BuiltinVariable(operator.setitem, self._graph, DanglingTracker())(
             container, key, value
         )
@@ -989,7 +982,6 @@ class OpcodeExecutorBase:
         key = self.stack.pop()
         container = self.stack.pop()
         assert isinstance(key, VariableBase)
-        # self._graph.add_global_guarded_variable(key)
         BuiltinVariable(operator.delitem, self._graph, DanglingTracker())(
             container, key
         )
@@ -2070,10 +2062,6 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 store_vars.append(_var)
             store_var_info.setdefault(_var.id, [])
             store_var_info[_var.id].append(name)
-        # for store_var in store_vars:
-        #     if store_var.id not in store_var_info:
-        #         store_var_info.setdefault(store_var.id, [])
-        #         store_var_info[store_var.id].append(store_var.id)
 
         compile_graph_result = self._graph.compile_graph(*store_vars)
 

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -770,22 +770,6 @@ class OpcodeExecutorBase:
 
     def binary_subscr_operation(self, key, container, opname):
         assert isinstance(key, VariableBase)
-        # TODO(xiongkun): getitem / getattr support key and attr as variable.
-        if isinstance(key, TensorVariable) and isinstance(
-            container, TensorVariable
-        ):
-            # NOTE(xiongkun): tensor[tensor] should support.
-            output = self._graph.call_tensor_method(
-                "__getitem__", container, key
-            )
-            self.stack.push(output)
-            return
-
-        if isinstance(key, TensorVariable):
-            raise BreakGraphError(
-                f"Key is a TensorVariable in {opname}, {container}[{key}]"
-            )
-
         result = BuiltinVariable(
             operator.getitem, self._graph, DanglingTracker()
         )(container, key)
@@ -989,20 +973,23 @@ class OpcodeExecutorBase:
 
     def store_subscr_operation(self, key, container, value, opname):
         assert isinstance(key, VariableBase)
-        self._graph.add_global_guarded_variable(key)
-        if isinstance(key, TensorVariable):
-            raise BreakGraphError(
-                f"Key is a TensorVariable in {opname}, {container}[{key}] = {value}"
-            )
-        # TODO(xiongkun): support tensor[tensor] = tensor, dy2static is not the same with dygraph.
-        container[key.get_py_value()] = value
+        # self._graph.add_global_guarded_variable(key)
+        # if isinstance(key, TensorVariable):
+        #     raise BreakGraphError(
+        #         f"Key is a TensorVariable in {opname}, {container}[{key}] = {value}"
+        #     )
+        # # TODO(xiongkun): support tensor[tensor] = tensor, dy2static is not the same with dygraph.
+        # container[key.get_py_value()] = value
+        BuiltinVariable(operator.setitem, self._graph, DanglingTracker())(
+            container, key, value
+        )
         value.debug_name = f"{container.debug_name}[{key.debug_name}]"
 
     def DELETE_SUBSCR(self, instr: Instruction):
         key = self.stack.pop()
         container = self.stack.pop()
         assert isinstance(key, VariableBase)
-        self._graph.add_global_guarded_variable(key)
+        # self._graph.add_global_guarded_variable(key)
         BuiltinVariable(operator.delitem, self._graph, DanglingTracker())(
             container, key
         )
@@ -2079,10 +2066,14 @@ class OpcodeExecutor(OpcodeExecutorBase):
             _var = self.get_var(name, allow_undefined=True)
             if _var is SotUndefinedVar():
                 continue
-            if _var not in stack:
+            if _var not in store_vars:
                 store_vars.append(_var)
             store_var_info.setdefault(_var.id, [])
             store_var_info[_var.id].append(name)
+        # for store_var in store_vars:
+        #     if store_var.id not in store_var_info:
+        #         store_var_info.setdefault(store_var.id, [])
+        #         store_var_info[store_var.id].append(store_var.id)
 
         compile_graph_result = self._graph.compile_graph(*store_vars)
 
@@ -2499,9 +2490,12 @@ class OpcodeExecutor(OpcodeExecutorBase):
             OrderedSet(loop_body_inputs[:-1]) | after_loop_read_names
         )
         extra_store_vars = (
-            [iterator]
+            [
+                item
+                for item in iterator.flatten_items()
+                if isinstance(item, (TensorVariable, SymbolicVariable))
+            ]
             if isinstance(iterator, IterVariable)
-            and isinstance(iterator.hold, TensorVariable)
             else []
         )
         var_loader = self.get_compute_fn_and_update_changed_vars(

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -572,9 +572,11 @@ Dispatcher.register(
 # stop
 Dispatcher.register(
     range,
-    ("ConstantVariable",),
+    ("ConstantVariable | TensorVariable",),
     lambda stop: RangeVariable(
-        range(stop.get_py_value()),
+        ConstantVariable.wrap_literal(0, stop.graph),
+        stop,
+        ConstantVariable.wrap_literal(1, stop.graph),
         graph=stop.graph,
         tracker=DummyTracker([stop]),
     ),
@@ -583,9 +585,11 @@ Dispatcher.register(
 # start, stop
 Dispatcher.register(
     range,
-    ("ConstantVariable", "ConstantVariable"),
+    ("ConstantVariable | TensorVariable", "ConstantVariable | TensorVariable"),
     lambda start, stop: RangeVariable(
-        range(start.get_py_value(), stop.get_py_value()),
+        start,
+        stop,
+        ConstantVariable.wrap_literal(1, stop.graph),
         graph=stop.graph,
         tracker=DummyTracker([start, stop]),
     ),
@@ -593,9 +597,15 @@ Dispatcher.register(
 # start, stop, step
 Dispatcher.register(
     range,
-    ("ConstantVariable", "ConstantVariable", "ConstantVariable"),
+    (
+        "ConstantVariable | TensorVariable",
+        "ConstantVariable | TensorVariable",
+        "ConstantVariable | TensorVariable",
+    ),
     lambda start, stop, step: RangeVariable(
-        range(start.get_py_value(), stop.get_py_value(), step.get_py_value()),
+        start,
+        stop,
+        step,
         graph=stop.graph,
         tracker=DummyTracker([start, stop, step]),
     ),
@@ -795,11 +805,26 @@ Dispatcher.register(
 Dispatcher.register(
     operator.setitem,
     (
+        "TensorVariable",
+        "Any",
+        "VariableBase",
+    ),
+    lambda var, key, value: var.setitem(
+        VariableFactory.from_value(
+            key, graph=var.graph, tracker=ConstTracker(key)
+        ),
+        value,
+    ),
+)
+
+Dispatcher.register(
+    operator.setitem,
+    (
         "VariableBase",
         "int | str | ConstantVariable | TensorVariable",
         "int | str | ConstantVariable | TensorVariable",
     ),
-    lambda var, key, value: var.setitem(key.get_py_value(), value),
+    lambda var, key, value: var.setitem(add_guard(key).get_py_value(), value),
 )
 
 # delitem
@@ -817,7 +842,7 @@ Dispatcher.register(
         "VariableBase",
         "ConstantVariable",
     ),
-    lambda var, key: var.delitem(key.get_py_value()),
+    lambda var, key: var.delitem(add_guard(key).get_py_value()),
 )
 
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
@@ -430,8 +430,9 @@ class VariableBase:
             list[VariableBase]: Flattened items of a container variable.
         """
         from .container import ContainerVariable
+        from .iter import IterVariable
 
-        if not isinstance(self, ContainerVariable):
+        if not isinstance(self, (ContainerVariable, IterVariable)):
             return [self]
         flattened_items = []
         for item in self.get_items():

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -545,15 +545,10 @@ class TensorVariable(VariableBase):
         return self.graph.call_tensor_method("__getitem__", self, key)
 
     def setitem(self, key, value):
-        self.graph.add_global_guarded_variable(value)
-
-        key_var = VariableFactory.from_value(
-            key, self.graph, tracker=ConstTracker(key)
-        )
         new_tensor = self.graph.call_paddle_api(
             paddle.static.setitem,
             self,
-            key_var,
+            key,
             value,
         )
 
@@ -825,6 +820,7 @@ class SymbolicVariable(VariableBase):
 
         disable_symbolic(self)
         self.graph.need_cache = False
+        print(f"Fallback {self} to ConstantVariable")
         return ConstantVariable(
             self.get_py_value(), self.graph, DummyTracker([self])
         )
@@ -833,6 +829,8 @@ class SymbolicVariable(VariableBase):
         if ENV_SOT_BREAK_GRAPH_ON_GET_SYMBOLIC_VALUE.get():
             raise BreakGraphError("get_py_value from SymbolicVariable")
         self.need_guard_value = True
+        # if self.id == "object_13653":
+        #     breakpoint()
         if isinstance(self.value, SymbolicValue):
             assert isinstance(
                 self.tracker, SymbolicOperationTracker

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -820,7 +820,7 @@ class SymbolicVariable(VariableBase):
 
         disable_symbolic(self)
         self.graph.need_cache = False
-        print(f"Fallback {self} to ConstantVariable")
+        log(3, f"Fallback {self} to ConstantVariable")
         return ConstantVariable(
             self.get_py_value(), self.graph, DummyTracker([self])
         )
@@ -829,8 +829,10 @@ class SymbolicVariable(VariableBase):
         if ENV_SOT_BREAK_GRAPH_ON_GET_SYMBOLIC_VALUE.get():
             raise BreakGraphError("get_py_value from SymbolicVariable")
         self.need_guard_value = True
-        # if self.id == "object_13653":
-        #     breakpoint()
+        log(
+            3,
+            f"get_py_value from SymbolicVariable {self} caused value need guard",
+        )
         if isinstance(self.value, SymbolicValue):
             assert isinstance(
                 self.tracker, SymbolicOperationTracker

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
@@ -50,6 +50,11 @@ class IterVariable(VariableBase):
     def get_iter(self):
         return self
 
+    def get_items(self):
+        if isinstance(self.hold, (ContainerVariable, IterVariable)):
+            return self.hold.get_items()
+        return [self.hold]
+
 
 class SequenceIterVariable(IterVariable):
     """
@@ -156,6 +161,15 @@ class ZipVariable(SequenceIterVariable):
 
     def __init__(self, iters, graph, tracker):
         super().__init__(iters, graph, tracker)
+
+    def get_items(self):
+        items = []
+        for hold in self.hold:
+            if isinstance(hold, (ContainerVariable, IterVariable)):
+                items.extend(hold.get_items())
+            else:
+                items.append(hold)
+        return items
 
     def next(self):
         # can not use <listcomp> here, because it will raise a RuntimeError("StopIteration")

--- a/python/paddle/jit/sot/translate.py
+++ b/python/paddle/jit/sot/translate.py
@@ -102,7 +102,7 @@ def symbolic_translate(fn: Callable[P, R], **kwargs) -> Callable[P, R]:
         ), "Target function doesn't have code for simulating."
         StepInfoManager().sot_step()
         GraphLogger().clear()
-        InfoCollector().clear()
+        InfoCollector().clear_step_info()
         paddle.framework.core.set_eval_frame(callback)
         try:
             outs = fn(*args, **kwargs)
@@ -112,7 +112,7 @@ def symbolic_translate(fn: Callable[P, R], **kwargs) -> Callable[P, R]:
             paddle.framework.core.set_eval_frame(None)
 
         log_do(1, lambda: GraphLogger().print_info())
-        InfoCollector().print_report()
+        InfoCollector().print_step_report()
         return outs
 
     def impl_dynamic(*args: P.args, **kwargs: P.kwargs) -> R:

--- a/python/paddle/jit/sot/utils/__init__.py
+++ b/python/paddle/jit/sot/utils/__init__.py
@@ -43,6 +43,7 @@ from .exceptions import (  # noqa: F401
     inner_error_default_handler,
 )
 from .info_collector import (  # noqa: F401
+    CompileCountInfo,
     InfoCollector,
     NewSymbolHitRateInfo,
     SubGraphRelationInfo,

--- a/python/paddle/jit/sot/utils/info_collector.py
+++ b/python/paddle/jit/sot/utils/info_collector.py
@@ -14,14 +14,20 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractclassmethod
+import atexit
+import sys
+from abc import ABC, abstractmethod
+from enum import Enum
 from pathlib import Path
-from typing import ClassVar, NamedTuple
+from typing import TYPE_CHECKING, ClassVar, NamedTuple
 
 from typing_extensions import Self
 
 from .envs import ENV_SOT_COLLECT_INFO
 from .utils import Singleton
+
+if TYPE_CHECKING:
+    import types
 
 
 def try_import_graphviz():
@@ -33,33 +39,65 @@ def try_import_graphviz():
         return None
 
 
+class InfoType(Enum):
+    STEP_INFO = 0
+    E2E_INFO = 1
+
+
 class InfoCollector(metaclass=Singleton):
     def __init__(self):
-        self._info: dict[str, list[StepInfoBase]] = {}
+        self._step_info: dict[str, list[InfoBase]] = {}
+        self._e2e_info: dict[str, list[InfoBase]] = {}
 
-    def attach(self, cls: type[StepInfoBase], *args, **kwargs) -> None:
+    def get_info_dict(self, info_type: InfoType) -> dict[str, list[InfoBase]]:
+        if info_type == InfoType.STEP_INFO:
+            return self._step_info
+        else:
+            return self._e2e_info
+
+    def attach(self, cls: type[InfoBase], *args, **kwargs) -> None:
         if self.need_collect(cls):
             info = cls(*args, **kwargs)
             self.register(info)
 
-    def register(self, info: StepInfoBase) -> None:
+    def register(self, info: InfoBase) -> None:
         info_class_name = info.__class__.__name__
-        self._info.setdefault(info_class_name, [])
-        self._info[info_class_name].append(info)
+        info_type = info.TYPE
+        info_dict = self.get_info_dict(info_type)
+        info_dict.setdefault(info_class_name, [])
+        info_dict[info_class_name].append(info)
 
-    def need_collect(self, cls: type[StepInfoBase]) -> bool:
+    def need_collect(self, cls: type[InfoBase]) -> bool:
         return cls.SHORT_NAME in ENV_SOT_COLLECT_INFO.get()
 
+    def clear_step_info(self):
+        self._step_info.clear()
+
+    def clear_e2e_info(self):
+        self._e2e_info.clear()
+
     def clear(self):
-        self._info.clear()
+        self.clear_step_info()
+        self.clear_e2e_info()
 
-    def print_report(self):
-        if self._info:
-            print(self.generate_report())
+    def print_step_report(self):
+        self.print_report(InfoType.STEP_INFO)
 
-    def generate_report(self) -> str:
+    def print_e2e_info_atexit(self) -> None:
+        def atexit_hook():
+            self.print_report(InfoType.E2E_INFO)
+            sys.stdout.flush()
+            self.clear()
+
+        atexit.register(atexit_hook)
+
+    def print_report(self, info_type: InfoType) -> None:
+        if info_dict := self.get_info_dict(info_type):
+            print(self.generate_report(info_dict))
+
+    def generate_report(self, info_dict: dict[str, list[InfoBase]]) -> str:
         report = ""
-        for info_class_name, info_list in self._info.items():
+        for info_class_name, info_list in info_dict.items():
             cls = info_list[0].__class__
             report += f"{info_class_name} ({cls.SHORT_NAME}):\n"
             report += cls.summary(info_list)
@@ -67,18 +105,23 @@ class InfoCollector(metaclass=Singleton):
         return report
 
 
-class StepInfoBase(ABC):
+InfoCollector().print_e2e_info_atexit()
+
+
+class InfoBase(ABC):
     SHORT_NAME: ClassVar[str]
+    TYPE: ClassVar[InfoType]
 
     def __init__(self): ...
 
     @classmethod
-    @abstractclassmethod
+    @abstractmethod
     def summary(cls, history: list[Self]) -> str: ...
 
 
-class NewSymbolHitRateInfo(StepInfoBase):
+class NewSymbolHitRateInfo(InfoBase):
     SHORT_NAME = "new_symbol_hit_rate"
+    TYPE = InfoType.STEP_INFO
 
     def __init__(
         self, input_tensor_ids: list[int], output_tensor_ids: list[int]
@@ -110,8 +153,9 @@ class NewSymbolHitRateInfo(StepInfoBase):
         return summary
 
 
-class SubGraphRelationInfo(StepInfoBase):
+class SubGraphRelationInfo(InfoBase):
     SHORT_NAME = "subgraph_relation"
+    TYPE = InfoType.STEP_INFO
     STEP_UNIQUE_ID = 0
 
     class ConcreteShapeInfo(NamedTuple):
@@ -192,5 +236,32 @@ class SubGraphRelationInfo(StepInfoBase):
         directory = Path(".") / "subgraph_relation"
         directory.mkdir(exist_ok=True, parents=True)
         filename = f"subgraph_relation_{cls.STEP_UNIQUE_ID}"
-        dot.render(directory / filename, format="png", cleanup=True)
-        return f"Please check {directory / filename}.png for subgraph relation"
+        dot.render(directory / filename, format="svg", cleanup=True)
+        return f"Please check {directory / filename}.svg for subgraph relation"
+
+
+class CompileCountInfo(InfoBase):
+    SHORT_NAME = "compile_count"
+    TYPE = InfoType.E2E_INFO
+
+    def __init__(self, code: types.CodeType):
+        super().__init__()
+        self.code = code
+
+    @classmethod
+    def summary(cls, history: list[Self]) -> str:
+        if len(history) == 0:
+            return f"No {cls.SHORT_NAME} info"
+        code_count = {}
+        for info in history:
+            code_count[info.code] = code_count.get(info.code, 0) + 1
+        summary_lines = []
+        for code, count in sorted(
+            code_count.items(), key=lambda x: x[1], reverse=True
+        ):
+            filename, lineno = code.co_filename, code.co_firstlineno
+            summary_lines.append(
+                f"    {code.co_name} ({filename}:{lineno}): {count}"
+            )
+        summary = "\n".join(summary_lines)
+        return summary


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

1. 优化 RangeVariable，使其可以延迟 `get_py_value`，比如：

    ```python
    for i in range(tensor):
        foo(i)
    ```

    之前 `range(tensor)` 会提前打断，之后的 `range` 对象里就真的是一个数了，导致 for 循环这里感知不到可能和 tensor 相关，如果 tensor 本身很大（比如 400），而且每次都很大，那么结果就是会组一个 unroll 400*foo 的网，而且这里 tensor 本身是组网输出，是会变的，那么必然每次都重新组网，导致编译时间非常长，无论是动转静还是编译器都跑不完

    因此延迟 `get_py_value`，使 `range(tensor)` 的打断延迟到 for 循环，使 for 循环感知打断，会按照 for 打断处理，避免重复构图

2. 优化统一 `setitem`、`getitem`、`delitem` 相关代码，统一使用 dispatch，使 Tensor setitem 可以组网
3. 添加端到端编译数量统计

PCard-66972