### PR TITLE
[XPU] fix dense tensor usage in adam

### DIFF
--- a/paddle/phi/kernels/xpu/adam_kernel.cc
+++ b/paddle/phi/kernels/xpu/adam_kernel.cc
@@ -77,8 +77,8 @@ void AdamDenseKernel(
 
   float* beta1_pow_ptr = nullptr;
   const float* beta1_const_pow_ptr = nullptr;
+  DenseTensor xpu_beta1_pow;
   if (beta1_pow.place() == CPUPlace()) {
-    DenseTensor xpu_beta1_pow;
     phi::Copy(dev_ctx, beta1_pow, dev_ctx.GetPlace(), false, &xpu_beta1_pow);
     if (xpu_beta1_pow.dtype() == DataType::FLOAT16)
       funcs::GetDataPointer<Context, float>(
@@ -95,8 +95,8 @@ void AdamDenseKernel(
 
   float* beta2_pow_ptr = nullptr;
   const float* beta2_const_pow_ptr = nullptr;
+  DenseTensor xpu_beta2_pow;
   if (beta2_pow.place() == CPUPlace()) {
-    DenseTensor xpu_beta2_pow;
     phi::Copy(dev_ctx, beta2_pow, dev_ctx.GetPlace(), false, &xpu_beta2_pow);
     if (xpu_beta2_pow.dtype() == DataType::FLOAT16)
       funcs::GetDataPointer<Context, float>(


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
接到用户反馈说`adam`算子在某些情况下计算结果不正确，排查的时候受到了这个PR https://github.com/PaddlePaddle/Paddle/pull/70847 的启发，发现`beta1_pow`和`beta2_pow`放在CPU上的时候会出错，而在XPU上的时候就没事。

排查发现是有一个临时变量的使用不当，原版生成了临时的`DenseTensor`之后给它赋值然后取了指针，随后这个临时变量被销毁，进而设备上的指针失效，但是在原版的后续代码中仍然使用了它。

本PR修复了此问题，调整了两个临时变量的位置，改变了它们的生命周期。

这个优化器的代码实现较久，不确定是否还有别的问题，本PR先把这处明显有问题的给修掉。