### PR TITLE
Revert "[clean old comm][fluid_ops] c_allreduce_op_plugin.cu"

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/c_allreduce_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/c_allreduce_op_plugin.cu
@@ -20,7 +20,9 @@
 #include "paddle/phi/core/distributed/utils.h"
 #include "paddle/phi/core/platform/collective_helper.h"
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
+#include "paddle/common/flags.h"
 #include "paddle/phi/core/distributed/nccl_comm_context.h"
+COMMON_DECLARE_bool(dynamic_static_unified_comm);
 #endif
 
 namespace paddle {
@@ -182,31 +184,46 @@ int CAllReducePluginDynamic::enqueue(
   }
   const auto& comm_context_manager =
       phi::distributed::CommContextManager::GetInstance();
-  PADDLE_ENFORCE_EQ(comm_context_manager.Has(std::to_string(ring_id_)),
-                    true,
-                    common::errors::InvalidArgument(
-                        "You choose to use new communication library. "
-                        "But ring_id(%d) is "
-                        "not found in comm_context_manager.",
-                        std::to_string(ring_id_)));
-  auto comm_ctx = static_cast<phi::distributed::NCCLCommContext*>(
-      comm_context_manager.Get(std::to_string(ring_id_)));
-  PADDLE_ENFORCE_NE(comm_ctx,
-                    nullptr,
-                    common::errors::Unavailable(
-                        "NCCLCommContext is nullptr, collective op should "
-                        "has ring_id attr."));
-  auto stream2 = comm_ctx->GetStream();
-  // ncclRedOp_t nccl_red_type = ncclSum;
-  // comm_ctx->AllReduce(&inputs[0], inputs[0], nccl_red_type, stream);
-  phi::dynload::ncclAllReduce(sendbuff,
-                              recvbuff,
-                              numel,
-                              dtype,
-                              nccl_red_type,
-                              comm_ctx->GetNcclComm(),
-                              stream2);
-  VLOG(3) << "new NCCLCommContext has ring_id_ " << ring_id_;
+  if (FLAGS_dynamic_static_unified_comm) {
+    PADDLE_ENFORCE_EQ(comm_context_manager.Has(std::to_string(ring_id_)),
+                      true,
+                      common::errors::InvalidArgument(
+                          "You choose to use new communication library by "
+                          "setting environment "
+                          "variable FLAGS_dynamic_static_unified_comm True. "
+                          "But ring_id(%d) is "
+                          "not found in comm_context_manager.",
+                          std::to_string(ring_id_)));
+    auto comm_ctx = static_cast<phi::distributed::NCCLCommContext*>(
+        comm_context_manager.Get(std::to_string(ring_id_)));
+    PADDLE_ENFORCE_NE(comm_ctx,
+                      nullptr,
+                      common::errors::Unavailable(
+                          "NCCLCommContext is nullptr, collective op should "
+                          "has ring_id attr."));
+    auto stream = comm_ctx->GetStream();
+    ncclRedOp_t nccl_red_type = ncclSum;
+    // comm_ctx->AllReduce(&inputs[0], inputs[0], nccl_red_type, stream);
+    phi::dynload::ncclAllReduce(sendbuff,
+                                recvbuff,
+                                numel,
+                                dtype,
+                                nccl_red_type,
+                                comm_ctx->GetNcclComm(),
+                                stream);
+    VLOG(3) << "new NCCLCommContext has ring_id_ " << ring_id_;
+  } else {
+    auto comm = platform::NCCLCommContext::Instance().Get(ring_id_);
+    cudaStream_t custream = use_calc_stream_ ? stream : comm->stream();
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclAllReduce(sendbuff,
+                                                           recvbuff,
+                                                           numel,
+                                                           dtype,
+                                                           nccl_red_type,
+                                                           comm->comm(),
+                                                           custream));
+    VLOG(3) << "old NCCLCommContext has ring_id_ " << ring_id_;
+  }
 #endif
   return (cudaGetLastError() != cudaSuccess);
 }

--- a/paddle/fluid/operators/data_norm_op.cu
+++ b/paddle/fluid/operators/data_norm_op.cu
@@ -24,6 +24,7 @@ limitations under the License. */
 #include "paddle/phi/core/distributed/comm_context_manager.h"
 #include "paddle/phi/core/distributed/nccl_comm_context.h"
 #include "paddle/phi/core/platform/collective_helper.h"
+COMMON_DECLARE_bool(dynamic_static_unified_comm);
 #endif
 
 namespace paddle {
@@ -217,48 +218,85 @@ class DataNormGradKernel<T, phi::GPUContext> : public framework::OpKernel<T> {
     if (need_sync_stats) {
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
       int rid = 0;
+      platform::NCCLComm *comm = nullptr;
       const auto &comm_context_manager =
           phi::distributed::CommContextManager::GetInstance();
       phi::distributed::NCCLCommContext *comm_ctx = nullptr;
-      PADDLE_ENFORCE_EQ(comm_context_manager.Has(std::to_string(rid)),
-                        true,
-                        common::errors::InvalidArgument(
-                            "You choose to use new communication library. "
-                            "But ring_id(%d) is "
-                            "not found in comm_context_manager.",
-                            std::to_string(rid)));
-      comm_ctx = static_cast<phi::distributed::NCCLCommContext *>(
-          comm_context_manager.Get(std::to_string(rid)));
-      PADDLE_ENFORCE_NE(comm_ctx,
-                        nullptr,
-                        common::errors::Unavailable(
-                            "NCCLCommContext is nullptr, collective op should "
-                            "has ring_id attr."));
+      if (FLAGS_dynamic_static_unified_comm) {
+        PADDLE_ENFORCE_EQ(
+            comm_context_manager.Has(std::to_string(rid)),
+            true,
+            common::errors::InvalidArgument(
+                "You choose to use new communication library by "
+                "setting environment "
+                "variable FLAGS_dynamic_static_unified_comm True. "
+                "But ring_id(%d) is "
+                "not found in comm_context_manager.",
+                std::to_string(rid)));
+        comm_ctx = static_cast<phi::distributed::NCCLCommContext *>(
+            comm_context_manager.Get(std::to_string(rid)));
+        PADDLE_ENFORCE_NE(
+            comm_ctx,
+            nullptr,
+            common::errors::Unavailable(
+                "NCCLCommContext is nullptr, collective op should "
+                "has ring_id attr."));
+      } else {
+        comm = paddle::platform::NCCLCommContext::Instance().Get(
+            rid, ctx.GetPlace());
+      }
 
-      PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclAllReduce(
-          reinterpret_cast<const void *>(d_batch_size),
-          reinterpret_cast<void *>(d_batch_size),
-          C,
-          phi::ToNCCLDataType(x->dtype()),
-          ncclSum,
-          comm_ctx->GetNcclComm(),
-          stream));
-      PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclAllReduce(
-          reinterpret_cast<const void *>(d_batch_sum),
-          reinterpret_cast<void *>(d_batch_sum),
-          C,
-          phi::ToNCCLDataType(x->dtype()),
-          ncclSum,
-          comm_ctx->GetNcclComm(),
-          stream));
-      PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclAllReduce(
-          reinterpret_cast<const void *>(d_batch_square_sum),
-          reinterpret_cast<void *>(d_batch_square_sum),
-          C,
-          phi::ToNCCLDataType(x->dtype()),
-          ncclSum,
-          comm_ctx->GetNcclComm(),
-          stream));
+      if (comm_ctx) {
+        PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclAllReduce(
+            reinterpret_cast<const void *>(d_batch_size),
+            reinterpret_cast<void *>(d_batch_size),
+            C,
+            phi::ToNCCLDataType(x->dtype()),
+            ncclSum,
+            comm_ctx->GetNcclComm(),
+            stream));
+        PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclAllReduce(
+            reinterpret_cast<const void *>(d_batch_sum),
+            reinterpret_cast<void *>(d_batch_sum),
+            C,
+            phi::ToNCCLDataType(x->dtype()),
+            ncclSum,
+            comm_ctx->GetNcclComm(),
+            stream));
+        PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclAllReduce(
+            reinterpret_cast<const void *>(d_batch_square_sum),
+            reinterpret_cast<void *>(d_batch_square_sum),
+            C,
+            phi::ToNCCLDataType(x->dtype()),
+            ncclSum,
+            comm_ctx->GetNcclComm(),
+            stream));
+      } else {
+        PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclAllReduce(
+            reinterpret_cast<const void *>(d_batch_size),
+            reinterpret_cast<void *>(d_batch_size),
+            C,
+            phi::ToNCCLDataType(x->dtype()),
+            ncclSum,
+            comm->comm(),
+            stream));
+        PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclAllReduce(
+            reinterpret_cast<const void *>(d_batch_sum),
+            reinterpret_cast<void *>(d_batch_sum),
+            C,
+            phi::ToNCCLDataType(x->dtype()),
+            ncclSum,
+            comm->comm(),
+            stream));
+        PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclAllReduce(
+            reinterpret_cast<const void *>(d_batch_square_sum),
+            reinterpret_cast<void *>(d_batch_square_sum),
+            C,
+            phi::ToNCCLDataType(x->dtype()),
+            ncclSum,
+            comm->comm(),
+            stream));
+      }
       phi::backends::gpu::GpuStreamSync(stream);
 #else
       PADDLE_THROW(common::errors::PreconditionNotMet(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Reverts PaddlePaddle/Paddle#70743
PS 依赖旧通信库 data_norm，先回退

Pcard-70448