### PR TITLE
[AutoParallel] add tensor fusion convert func

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -2647,7 +2647,6 @@ class DistModel:
         self,
         mode: Literal['opt', 'param', 'all'] = "all",
         split_fusion: bool = True,
-        load_sharded_model: bool = True,
     ) -> dict[str, Tensor]:
         """
         Get the state dict of model and optimizer.
@@ -2725,39 +2724,6 @@ class DistModel:
                                     ] = dist_tensor
                                 dist_state_dict.pop(param)
 
-        # When tensor fusion is enabled, optimizer parameters can become unbalanced in
-        # sharding. We need to either balance them or rename unbalanced parameters for each
-        # rank and directly load them.
-        enable_tensor_fusion = (
-            self._inner_strategy.sharding.enable_tensor_fusion
-            if self._inner_strategy
-            else False
-        )
-        if (
-            self._engine._optimizer is not None
-            and load_sharded_model
-            and enable_tensor_fusion
-        ):
-            optimizer = self._engine._optimizer
-            if isinstance(
-                optimizer,
-                paddle.static.amp.decorator.OptimizerWithMixedPrecision,
-            ):
-                optimizer = optimizer._optimizer
-
-            assert isinstance(
-                optimizer, ShardingOptimizerStage1
-            ), "The optimizer should be ShardingOptimizerStage1 when stage1 tensor fusion is enabled."
-
-            if self._inner_strategy.sharding.save_unbalanced_param:
-                optimizer.convert_state_dict_with_rank_unique_name(
-                    dist_state_dict
-                )
-            else:
-                optimizer.convert_state_dict_without_tensor_fusion_param(
-                    dist_state_dict
-                )
-
         mapping_names = [
             (
                 self._parameter_to_structured_name[k]
@@ -2826,43 +2792,19 @@ class DistModel:
     def set_state_dict(self, state_dict: dict[str, Tensor]) -> None:
         local_state_dict = {}
         dist_main_program = self.dist_main_program(mode=self._engine._mode)
-        cur_state_dict = self.state_dict(
-            split_fusion=False, load_sharded_model=False
-        )
+        cur_state_dict = self.state_dict(split_fusion=False)
         copy_tensor = False
 
-        # For sharding with tensor-fusion, we need to convert the state_dict
-        # to include tensor-fusion parameters before calling set_state_dict,
-        # as stored parameters are processed as if tensor-fusion is not applied
-        # or we can choose to load the unblanced parameters directly.
+        # When using the tensor-fusion strategy, model parameters are shared with
+        # slice@ parameters. When setting the state_dict, we must copy the tensor
+        # instead of changing the handle directly, as this could cause errors in
+        # the slice@ parameters and increase memory usage.
         enable_tensor_fusion = (
             self._inner_strategy.sharding.enable_tensor_fusion
             if self._inner_strategy
             else False
         )
         if self._engine._optimizer is not None and enable_tensor_fusion:
-            optimizer = self._engine._optimizer
-            if isinstance(
-                optimizer,
-                paddle.static.amp.decorator.OptimizerWithMixedPrecision,
-            ):
-                optimizer = optimizer._optimizer
-
-            assert isinstance(
-                optimizer, ShardingOptimizerStage1
-            ), "The optimizer should be ShardingOptimizerStage1 when stage1 tensor fusion is enabled."
-
-            if self._inner_strategy.sharding.save_unbalanced_param:
-                optimizer.convert_state_dict_with_origin_name(state_dict)
-            else:
-                optimizer.convert_state_dict_with_tensor_fusion_param(
-                    state_dict
-                )
-
-            # When using the tensor-fusion strategy, model parameters are shared with
-            # slice@ parameters. When setting the state_dict, we must copy the tensor
-            # instead of changing the handle directly, as this could cause errors in
-            # the slice@ parameters and increase memory usage.
             copy_tensor = True
 
         for k, v in state_dict.items():
@@ -2947,6 +2889,92 @@ class DistModel:
             dist_main_program.set_state_dict(
                 local_state_dict, paddle.static.global_scope()
             )
+
+    def _get_shard_stage1_optimizer(self):
+        optimizer = self._engine._optimizer
+        if optimizer is None:
+            return optimizer
+
+        if isinstance(
+            optimizer,
+            paddle.static.amp.decorator.OptimizerWithMixedPrecision,
+        ):
+            optimizer = optimizer._optimizer
+
+        assert isinstance(
+            optimizer, ShardingOptimizerStage1
+        ), "The optimizer should be ShardingOptimizerStage1 when stage1 tensor fusion is enabled."
+
+        return optimizer
+
+    def _convert_state_dict_tensor_fusion(self, state_dict, optimizer_function):
+        enable_tensor_fusion = (
+            self._inner_strategy.sharding.enable_tensor_fusion
+            if self._inner_strategy
+            else False
+        )
+
+        assert (
+            enable_tensor_fusion
+        ), "Can only convert state_dict when tensor fusion is enabled."
+        optimizer = self._get_shard_stage1_optimizer()
+        assert optimizer is not None, "The optimizer should not be None."
+
+        parameter_names = [
+            (
+                self._structured_to_parameter_name[k]
+                if k in self._structured_to_parameter_name
+                else k
+            )
+            for k in state_dict.keys()
+        ]
+        state_dict = dict(zip(parameter_names, list(state_dict.values())))
+
+        optimizer_function(optimizer, state_dict)
+
+        structured_names = [
+            (
+                self._parameter_to_structured_name[k]
+                if k in self._parameter_to_structured_name
+                else k
+            )
+            for k in state_dict.keys()
+        ]
+        state_dict = dict(zip(structured_names, list(state_dict.values())))
+
+        return state_dict
+
+    def _convert_state_dict_with_rank_unique_name(self, state_dict):
+        def optimizer_function(optimizer, state_dict):
+            optimizer.convert_state_dict_with_rank_unique_name(state_dict)
+
+        return self._convert_state_dict_tensor_fusion(
+            state_dict, optimizer_function
+        )
+
+    def _convert_state_dict_without_tensor_fusion_param(self, state_dict):
+        def optimizer_function(optimizer, state_dict):
+            optimizer.convert_state_dict_without_tensor_fusion_param(state_dict)
+
+        return self._convert_state_dict_tensor_fusion(
+            state_dict, optimizer_function
+        )
+
+    def _convert_state_dict_with_tensor_fusion_param(self, state_dict):
+        def optimizer_function(optimizer, state_dict):
+            optimizer.convert_state_dict_with_tensor_fusion_param(state_dict)
+
+        return self._convert_state_dict_tensor_fusion(
+            state_dict, optimizer_function
+        )
+
+    def _convert_state_dict_with_origin_name(self, state_dict):
+        def optimizer_function(optimizer, state_dict):
+            optimizer.convert_state_dict_with_origin_name(state_dict)
+
+        return self._convert_state_dict_tensor_fusion(
+            state_dict, optimizer_function
+        )
 
 
 def to_static(

--- a/test/auto_parallel/pir/sharding_tensor_fusion_save_load.py
+++ b/test/auto_parallel/pir/sharding_tensor_fusion_save_load.py
@@ -227,6 +227,17 @@ class TestSimpleNetShardingTensorFusionSaveLoad:
                 state_dict = dist_model.state_dict()
                 if self.save_unbalanced_param:
                     state_dict = (
+                        dist_model._convert_state_dict_with_rank_unique_name(
+                            state_dict
+                        )
+                    )
+                else:
+                    state_dict = dist_model._convert_state_dict_without_tensor_fusion_param(
+                        state_dict
+                    )
+                dist.load_state_dict(state_dict, self._ckpt_path)
+                if self.save_unbalanced_param:
+                    state_dict = (
                         dist_model._convert_state_dict_with_origin_name(
                             state_dict
                         )
@@ -237,7 +248,6 @@ class TestSimpleNetShardingTensorFusionSaveLoad:
                             state_dict
                         )
                     )
-                dist.load_state_dict(state_dict, self._ckpt_path)
                 dist_model.set_state_dict(state_dict)
             if step > 2:
                 numpy_array = np.array(loss)

--- a/test/auto_parallel/pir/sharding_tensor_fusion_save_load.py
+++ b/test/auto_parallel/pir/sharding_tensor_fusion_save_load.py
@@ -192,6 +192,16 @@ class TestSimpleNetShardingTensorFusionSaveLoad:
             lr_scheduler.step()
             if step == 2:
                 state_dict = dist_model.state_dict()
+                if self.save_unbalanced_param:
+                    state_dict = (
+                        dist_model._convert_state_dict_with_rank_unique_name(
+                            state_dict
+                        )
+                    )
+                else:
+                    state_dict = dist_model._convert_state_dict_without_tensor_fusion_param(
+                        state_dict
+                    )
                 dist.save_state_dict(
                     state_dict, self._ckpt_path, async_save=True
                 )
@@ -215,6 +225,18 @@ class TestSimpleNetShardingTensorFusionSaveLoad:
             lr_scheduler.step()
             if step == 2:
                 state_dict = dist_model.state_dict()
+                if self.save_unbalanced_param:
+                    state_dict = (
+                        dist_model._convert_state_dict_with_origin_name(
+                            state_dict
+                        )
+                    )
+                else:
+                    state_dict = (
+                        dist_model._convert_state_dict_with_tensor_fusion_param(
+                            state_dict
+                        )
+                    )
                 dist.load_state_dict(state_dict, self._ckpt_path)
                 dist_model.set_state_dict(state_dict)
             if step > 2:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

我们需要支持：开 tensor_fusion 的情况下既可以从均匀的参数 load、也可以从非均匀的参数 load，存的时候既可以存均匀的参数，也可以存非均匀的参数

为了满足上述需求，需要把开关从 state_dict 和 set_state_dict 里面剥离出来，放在 PaddleNLP 端
paddlenlp 端新加参数，save_model_with_sharding_tensor_fusion 和 load_model_with_sharding_tensor_fusion

当使用 tensor_fusion 的时候：

1. save_model_with_sharding_tensor_fusion 为 True 表示 Save 非均衡模型，为 False 表示 Save 均衡模型
2. load_model_with_sharding_tensor_fusion 为 True 表示 Load 非均衡模型，为 False 表示 Load 均衡模型

由于转化依赖 sharding_optimize 中的内部变量信息，所以 convert 函数放在 DistModel 中作为不对用户公开的接口，一共有 4 个：

1. _convert_state_dict_with_rank_unique_name:  修改参数的名字后缀 _rankn 每张卡 slice 参数的名字不一样，这样可以保留每个参数的 metadata 信息，同时避免同名参数的通信，用于 save 非均衡参数
2. _convert_state_dict_with_origin_name：将模型参数去除 _rankn 后缀，用于 load 非均衡 参数
3. _convert_state_dict_without_tensor_fusion_param将模型参数转化为均衡模式，用于 save 均衡参数
4. _convert_state_dict_with_tensor_fusion_param将均衡的参数转化为非均衡模式，用于 load 参数

Pcard-76459
