### PR TITLE
Revert "[CINN][Backend Pass Update No.2] Update eliminate_common_global_memory_read pass"

### DIFF
--- a/paddle/cinn/optim/eliminate_common_global_memory_read.cc
+++ b/paddle/cinn/optim/eliminate_common_global_memory_read.cc
@@ -58,17 +58,9 @@ std::unordered_map<ir::Var, ir::Var> ConstructForVarReplaceMap(
   return ret;
 }
 
-struct GlobalTensorInfoCollector : public ir::IRMutator<Expr*>,
-                                   public ir::stmt::StmtMutator<> {
+struct GlobalTensorInfoCollector : public ir::IRMutator<Expr*> {
  public:
-  void operator()(const ir::Expr& expr) {
-    ir::Expr _expr = expr;
-    ir::IRMutator<>::Visit(&_expr, &_expr);
-  }
-
-  void operator()(ir::stmt::BlockRef block) {
-    ir::stmt::StmtMutator<>::VisitBlock(block);
-  }
+  void operator()(ir::Expr* expr) { ir::IRMutator<>::Visit(expr, expr); }
 
   std::unordered_set<std::string> GetEliminateBufferNames() const {
     auto IndiceToExprWithForVar =
@@ -122,7 +114,7 @@ struct GlobalTensorInfoCollector : public ir::IRMutator<Expr*>,
       for (const auto& index : indice_and_extent.indices) {
         std::set<Expr> load_tensors = ir::ir_utils::CollectLoadTensors(
             index, /*teller=*/[&](const Expr*) -> bool { return true; });
-        if (!load_tensors.empty()) {
+        if (load_tensors.size() > 0) {
           return true;
         }
       }
@@ -226,58 +218,41 @@ struct GlobalTensorInfoCollector : public ir::IRMutator<Expr*>,
   }
 
  private:
-  void VisitStmt(ir::stmt::Schedule stmt) override {
-    const auto& iter_vars = stmt->iter_vars();
-    const auto& iter_values = stmt->iter_values();
+  void Visit(const ir::ScheduleBlockRealize* op, ir::Expr* expr) override {
+    const auto* sbr_node = expr->As<ir::ScheduleBlockRealize>();
+    PADDLE_ENFORCE_NOT_NULL(
+        sbr_node,
+        ::common::errors::InvalidArgument(
+            "The input expr should be a ScheduleBlockRealize"));
+    const auto& iter_values = sbr_node->iter_values;
+    const auto* sb_node = sbr_node->schedule_block.As<ir::ScheduleBlock>();
+    const auto& iter_vars = sb_node->iter_vars;
     PADDLE_ENFORCE_EQ(
         iter_values.size(),
         iter_vars.size(),
-        ::common::errors::InvalidArgument("The size of iter_values should be "
-                                          "equal to the size of iter_vars."));
+        ::common::errors::InvalidArgument(
+            "The size of iter_values should equal to the size of iter_vars, as "
+            "they comes from the same ScheduleBlockRealize"));
 
     for (std::size_t i = 0; i < iter_values.size(); ++i) {
       var_to_sb_expr_[iter_vars[i]] = iter_values[i];
     }
-    operator()(stmt->body());
+    ir::IRMutator<>::Visit(op, expr);
   }
 
-  void VisitStmt(ir::stmt::For stmt) override {
+  void Visit(const ir::For* op, ir::Expr* expr) override {
+    auto* node = expr->As<ir::For>();
+    PADDLE_ENFORCE_NOT_NULL(
+        node,
+        ::common::errors::InvalidArgument("The input expr should be a For"));
     for_var_extents_.push_back(
-        {stmt->loop_var(), ir::ir_utils::IRCopy(stmt->extent())});
-    if (!stmt->is_binded()) {
-      iter_var_name_to_extent_[stmt->loop_var()->name] = stmt->extent();
+        {node->loop_var, ir::ir_utils::IRCopy(node->extent)});
+    if (!node->is_binded()) {
+      iter_var_name_to_extent_[node->loop_var->name] = node->extent;
     }
-    operator()(stmt->body());
+    ir::IRMutator<>::Visit(op, expr);
     for_var_extents_.pop_back();
   }
-
-  void VisitStmt(ir::stmt::Store stmt) override {
-    const auto& store_buffer = stmt->tensor().as_tensor_ref()->buffer;
-    if (store_buffer->memory_type == ir::MemoryType::Heap) {
-      global_store_buffer_names_.insert(store_buffer->name);
-    }
-    operator()(stmt->value());
-  }
-
-  void VisitStmt(ir::stmt::IfThenElse stmt) override {
-    operator()(stmt->condition());
-    operator()(stmt->true_case());
-    if (stmt->false_case().defined()) operator()(stmt->false_case());
-  }
-
-  void VisitStmt(ir::stmt::Alloc stmt) override {
-    for (const auto& extent : stmt->extents()) operator()(extent);
-    if (stmt->condition().defined()) operator()(stmt->condition());
-    if (stmt->body().defined()) operator()(stmt->body());
-  }
-
-  void VisitStmt(ir::stmt::Let stmt) override {
-    if (stmt->body().defined()) operator()(stmt->body());
-  }
-
-  void VisitStmt(ir::stmt::Evaluate stmt) override {}
-
-  void VisitStmt(ir::stmt::Free stmt) override {}
 
   void Visit(const ir::Load* op, ir::Expr* expr) override {
     auto* node = expr->As<ir::Load>();
@@ -300,6 +275,18 @@ struct GlobalTensorInfoCollector : public ir::IRMutator<Expr*>,
     }
   }
 
+  void Visit(const ir::Store* op, ir::Expr* expr) override {
+    auto* node = expr->As<ir::Store>();
+    PADDLE_ENFORCE_NOT_NULL(
+        node,
+        ::common::errors::InvalidArgument("The input expr should be a Store"));
+    const auto& store_buffer = node->tensor.as_tensor_ref()->buffer;
+    if (store_buffer->memory_type == ir::MemoryType::Heap) {
+      global_store_buffer_names_.insert(store_buffer->name);
+    }
+    ir::IRMutator<>::Visit(op, expr);
+  }
+
   void Visit(const ir::Select* op, ir::Expr* expr) override {
     contains_select_ = true;
     ir::IRMutator<>::Visit(op, expr);
@@ -314,72 +301,44 @@ struct GlobalTensorInfoCollector : public ir::IRMutator<Expr*>,
   bool contains_select_ = false;
 };
 
-struct CommonGlobalMemoryEliminator : public ir::IRMutator<Expr*>,
-                                      public ir::stmt::StmtMutator<> {
+struct CommonGlobalMemoryEliminator : public ir::IRMutator<Expr*> {
   CommonGlobalMemoryEliminator(
       const std::unordered_set<std::string>& eliminate_buffer_names)
       : eliminate_buffer_names_(eliminate_buffer_names) {}
 
-  void operator()(const ir::Expr& expr) {
-    ir::Expr _expr = expr;
-    ir::IRMutator<>::Visit(&_expr, &_expr);
-  }
-
-  void operator()(ir::stmt::BlockRef block) { VisitBlock(block); }
+  void operator()(ir::Expr* expr) { ir::IRMutator<>::Visit(expr, expr); }
 
  private:
-  void VisitBlock(ir::stmt::BlockRef block) override {
-    current_block_ = block;
-    ir::stmt::StmtMutator<>::VisitBlock(block);
+  void Visit(const ir::Block* op, Expr* expr) override {
+    auto* node = expr->As<ir::Block>();
+    PADDLE_ENFORCE_NOT_NULL(
+        node,
+        ::common::errors::InvalidArgument("The input expr should be a Block"));
+    current_block_ = node;
+    IRMutator<>::Visit(op, expr);
 
     // Insert buffer declare after visit current block.
-    auto iter_block = block_to_insert_stmts_.find(block);
-    if (iter_block != block_to_insert_stmts_.end()) {
-      const std::vector<ir::stmt::StmtRef>& insert_schedule_stmts =
-          iter_block->second;
-      std::vector<ir::stmt::StmtRef> new_stmts = block->stmts();
-      for (const auto& stmt : insert_schedule_stmts) {
-        new_stmts.insert(new_stmts.begin(), stmt);
+    if (block_to_insert_stmts_.find(node) != block_to_insert_stmts_.end()) {
+      const std::vector<ir::Expr>& insert_schedule_blocks =
+          block_to_insert_stmts_[node];
+      for (const ir::Expr& block : insert_schedule_blocks) {
+        node->stmts.insert(node->stmts.begin(), block);
       }
-      block->set_stmts(new_stmts);
     }
   }
 
-  void VisitStmt(ir::stmt::For stmt) override {
-    operator()(stmt->min());
-    operator()(stmt->extent());
-    operator()(stmt->body());
-  }
-
-  void VisitStmt(ir::stmt::Schedule stmt) override {
-    current_sch_ = stmt;
-    if (current_block_.defined()) insert_block_ = current_block_;
-    operator()(stmt->body());
-  }
-
-  void VisitStmt(ir::stmt::IfThenElse stmt) override {
-    operator()(stmt->condition());
-    operator()(stmt->true_case());
-    if (stmt->false_case().defined()) operator()(stmt->false_case());
-  }
-
-  void VisitStmt(ir::stmt::Alloc stmt) override {
-    for (const auto& extent : stmt->extents()) {
-      operator()(extent);
+  void Visit(const ir::ScheduleBlockRealize* op, Expr* expr) override {
+    auto* node = expr->As<ir::ScheduleBlockRealize>();
+    PADDLE_ENFORCE_NOT_NULL(
+        node,
+        ::common::errors::InvalidArgument(
+            "The input expr should be a ScheduleBlockRealize"));
+    current_sbr_ = node;
+    if (current_block_) {
+      insert_block_ = current_block_;
     }
-    if (stmt->condition().defined()) operator()(stmt->condition());
-    if (stmt->body().defined()) operator()(stmt->body());
+    IRMutator<>::Visit(op, expr);
   }
-
-  void VisitStmt(ir::stmt::Let stmt) override {
-    if (stmt->body().defined()) operator()(stmt->body());
-  }
-
-  void VisitStmt(ir::stmt::Store stmt) override { operator()(stmt->value()); }
-
-  void VisitStmt(ir::stmt::Evaluate stmt) override {}
-
-  void VisitStmt(ir::stmt::Free stmt) override {}
 
   void Visit(const ir::Load* op, Expr* expr) override {
     auto* node = expr->As<ir::Load>();
@@ -387,15 +346,24 @@ struct CommonGlobalMemoryEliminator : public ir::IRMutator<Expr*>,
         node,
         ::common::errors::InvalidArgument("The input expr should be a Load"));
     const auto& buffer_name = node->tensor.as_tensor_ref()->buffer->name;
-    if (eliminate_buffer_names_.count(buffer_name) == 0) return;
-    if (global_buffer_to_local_buffer_.count(buffer_name) == 0)
+    if (eliminate_buffer_names_.count(buffer_name) == 0) {
+      return;
+    }
+
+    if (global_buffer_to_local_buffer_.count(buffer_name) == 0) {
       InsertLocalTensorBlock(node, buffer_name);
+    }
     SubstituteGlobalTensor(node, buffer_name);
   }
 
   void InsertLocalTensorBlock(ir::Load* load_node,
                               const std::string& buffer_name) {
-    ir::stmt::Schedule sch_node = current_sch_;
+    ir::Expr sb = ir::ir_utils::IRCopy(current_sbr_->schedule_block);
+    ir::ScheduleBlock* sb_node = sb.As<ir::ScheduleBlock>();
+    PADDLE_ENFORCE_NOT_NULL(
+        sb_node,
+        ::common::errors::InvalidArgument(
+            "The input expr should be a ScheduleBlockRealize"));
     const auto& old_tensor = load_node->tensor.as_tensor_ref();
     ir::Expr new_tensor =
         ir::_Tensor_::Make(old_tensor->name + "_local",
@@ -405,18 +373,15 @@ struct CommonGlobalMemoryEliminator : public ir::IRMutator<Expr*>,
                            old_tensor->reduce_axis);
     new_tensor.as_tensor_ref()->WithBuffer(
         "local", new_tensor.as_tensor_ref()->name + "_buffer");
-    ir::stmt::Store new_store =
-        ir::stmt::Store(new_tensor,
+    ir::Expr new_body =
+        ir::Store::Make(new_tensor,
                         ir::ir_utils::IRCopy(ir::Expr(load_node)),
                         ir::ir_utils::IRCopy(load_node->indices));
-    std::vector<ir::stmt::StmtRef> new_stmts{new_store};
-    ir::stmt::BlockRef new_block = ir::stmt::BlockRef(new_stmts);
-    ir::stmt::Schedule new_sch = ir::stmt::Schedule(sch_node->iter_vars(),
-                                                    sch_node->iter_values(),
-                                                    {},
-                                                    {},
-                                                    sch_node->name() + "_local",
-                                                    new_block);
+    ir::Expr new_sb = ir::ScheduleBlock::Make(
+        sb_node->iter_vars, {}, {}, sb_node->name + "_local", new_body);
+
+    ir::Expr new_sbr = ir::ScheduleBlockRealize::Make(
+        ir::ir_utils::IRCopy(current_sbr_->iter_values), new_sb);
     PADDLE_ENFORCE_EQ(
         global_buffer_to_local_buffer_.count(buffer_name),
         0,
@@ -425,12 +390,10 @@ struct CommonGlobalMemoryEliminator : public ir::IRMutator<Expr*>,
             buffer_name));
     global_buffer_to_local_buffer_[buffer_name] = new_tensor;
 
-    if (!insert_block_.defined()) {
-      PADDLE_THROW(::common::errors::InvalidArgument(
-          "insert block CAN NOT be undefined"));
-    }
-
-    block_to_insert_stmts_[insert_block_].push_back(new_sch);
+    PADDLE_ENFORCE_NOT_NULL(
+        insert_block_,
+        ::common::errors::InvalidArgument("insert block CAN NOT be nullptr"));
+    block_to_insert_stmts_[insert_block_].push_back(new_sbr);
   }
 
   void SubstituteGlobalTensor(ir::Load* load_node,
@@ -446,27 +409,25 @@ struct CommonGlobalMemoryEliminator : public ir::IRMutator<Expr*>,
 
   std::unordered_set<std::string> eliminate_buffer_names_;
   std::unordered_map<std::string, ir::Expr> global_buffer_to_local_buffer_;
-  std::map<ir::stmt::BlockRef, std::vector<ir::stmt::StmtRef>>
-      block_to_insert_stmts_;
+  std::unordered_map<ir::Block*, std::vector<ir::Expr>> block_to_insert_stmts_;
 
-  ir::stmt::BlockRef current_block_{nullptr};
-  ir::stmt::BlockRef insert_block_{nullptr};
-  ir::stmt::Schedule current_sch_;
+  ir::Block* current_block_{nullptr};
+  ir::Block* insert_block_{nullptr};
+  ir::ScheduleBlockRealize* current_sbr_;
 };
 
 }  // namespace
 
-void EliminateCommonGlobalMemoryRead(ir::stmt::BlockRef block) {
-  VLOG(4) << "Before EliminateCommonGlobalMemoryRead: \n" << block;
+void EliminateCommonGlobalMemoryRead(Expr* e) {
+  VLOG(4) << "Before EliminateCommonGlobalMemoryRead: \n" << *e;
   GlobalTensorInfoCollector collector;
-  collector(block);
+  collector(e);
 
-  const std::unordered_set<std::string>& eliminate_buffer_names =
-      collector.GetEliminateBufferNames();
+  const auto& eliminate_buffer_names = collector.GetEliminateBufferNames();
 
   CommonGlobalMemoryEliminator eliminator(eliminate_buffer_names);
-  eliminator(block);
-  VLOG(4) << "After EliminateCommonGlobalMemoryRead: \n" << block;
+  eliminator(e);
+  VLOG(4) << "After EliminateCommonGlobalMemoryRead: \n" << *e;
 }
 
 }  // namespace optim

--- a/paddle/cinn/optim/eliminate_common_global_memory_read.h
+++ b/paddle/cinn/optim/eliminate_common_global_memory_read.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "paddle/cinn/ir/stmt.h"
+#include "paddle/cinn/ir/ir.h"
 
 namespace cinn {
 namespace optim {
@@ -46,7 +46,7 @@ namespace optim {
  * significant speedups in memory-intensive computations.
  *
  */
-void EliminateCommonGlobalMemoryRead(ir::stmt::BlockRef block);
+void EliminateCommonGlobalMemoryRead(Expr* e);
 
 }  // namespace optim
 }  // namespace cinn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Reverts PaddlePaddle/Paddle#70696