### PR TITLE
[PIR-Auto-Parallel] set `op_role` and `chunk_id` for fuse linear pass

### DIFF
--- a/paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.cc
@@ -37,7 +37,7 @@ class FusedLinearPattern
                        pir::PatternRewriter &rewriter) const override {
     auto tmp = matmul->result(0);
 
-    if (pir::GetShapeFromValue(matmul->operand_source(0)).size() != 2) {
+    if (pir::GetShapeFromValue(matmul->operand_source(1)).size() != 2) {
       return false;
     }
 

--- a/paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.cc
@@ -76,6 +76,8 @@ class FusedLinearPattern
         "activation",
         pir::StrAttribute::get(pir::IrContext::Instance(), "none"));
 
+    rewriter.SetInsertionPointAfter(matmul);
+
     auto fuse_gemm = rewriter.Build<paddle::dialect::FusedGemmEpilogueOp>(
         matmul->operand_source(0),
         matmul->operand_source(1),
@@ -142,6 +144,7 @@ class FusedLinearGradPattern
         "activation_grad",
         pir::StrAttribute::get(pir::IrContext::Instance(), "none"));
 
+    rewriter.SetInsertionPointAfter(add_grad);
     auto fuse_gemm_grad =
         rewriter.Build<paddle::dialect::FusedGemmEpilogueGradOp>(
             matmul_grad->operand_source(0),

--- a/paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.cc
@@ -24,92 +24,130 @@
 
 namespace {
 
-class FusedLinearPattern : public paddle::drr::DrrPatternBase {
+//  %2 = pd_op.matmul( %0, %1 )
+//  %4 = pd_op.add( %2, %3 )
+//  fused to
+//  %4, %5 = pd_op.fused_gemm_epilogue( %0, %1, %3 )
+class FusedLinearPattern
+    : public pir::OpRewritePattern<paddle::dialect::MatmulOp> {
  public:
-  std::string name() const override { return "FusedLinearPattern"; }
+  using pir::OpRewritePattern<paddle::dialect::MatmulOp>::OpRewritePattern;
 
-  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
-    paddle::drr::SourcePattern pat = ctx->SourcePattern();
-    const auto &matmul = pat.Op(paddle::dialect::MatmulOp::name(),
-                                {{"transpose_x", pat.Attr("trans_x")},
-                                 {"transpose_y", pat.Attr("trans_y")}});
-    const auto &add = pat.Op(paddle::dialect::AddOp::name());
+  bool MatchAndRewrite(paddle::dialect::MatmulOp matmul,
+                       pir::PatternRewriter &rewriter) const override {
+    auto tmp = matmul->result(0);
 
-    pat.Tensor("tmp") = matmul(pat.Tensor("x"), pat.Tensor("w"));
-    pat.Tensor("out") = add(pat.Tensor("tmp"), pat.Tensor("bias"));
+    if (pir::GetShapeFromValue(matmul->operand_source(0)).size() != 2) {
+      return false;
+    }
 
-    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
-      auto w_dims = pir::GetShapeFromValue(match_ctx.Tensor("w"));
-      auto x_dims = pir::GetShapeFromValue(match_ctx.Tensor("x"));
-      auto bias_dims = pir::GetShapeFromValue(match_ctx.Tensor("bias"));
-      return (w_dims.size() == 2 && x_dims.size() >= 2 &&
-              bias_dims.size() == 1);
-    });
+    paddle::dialect::AddOp add;
+    bool can_fuse = false;
+    for (auto user_it = tmp.use_begin(); user_it != tmp.use_end(); ++user_it) {
+      if (!user_it->owner()) {
+        continue;
+      }
+      if (add = user_it->owner()->dyn_cast<paddle::dialect::AddOp>()) {
+        if (add->operand_source(0) != tmp) {
+          continue;
+        }
+        can_fuse = true;
+        break;
+      }
+    }
+    if (!can_fuse) {
+      return false;
+    }
 
-    paddle::drr::ResultPattern res = pat.ResultPattern();
-    const auto &fused_gemm_epilogue =
-        res.Op(paddle::dialect::FusedGemmEpilogueOp::name(),
-               {{{"trans_x", pat.Attr("trans_x")},
-                 {"trans_y", pat.Attr("trans_y")},
-                 {"activation", res.StrAttr("none")}}});
-    fused_gemm_epilogue(
-        {&res.Tensor("x"), &res.Tensor("w"), &res.Tensor("bias")},
-        {&res.Tensor("out")});
+    pir::AttributeMap attr_map;
+    attr_map.emplace("trans_x", matmul->attribute("transpose_x"));
+    attr_map.emplace("trans_y", matmul->attribute("transpose_y"));
+    attr_map.emplace(
+        "activation",
+        pir::StrAttribute::get(pir::IrContext::Instance(), "none"));
+
+    auto fuse_gemm = rewriter.Build<paddle::dialect::FusedGemmEpilogueOp>(
+        matmul->operand_source(0),
+        matmul->operand_source(1),
+        add->operand_source(1),
+        attr_map);
+
+    if (matmul->HasAttribute("op_role")) {
+      fuse_gemm->set_attribute("op_role", matmul->attribute("op_role"));
+    }
+    if (matmul->HasAttribute("chunk_id")) {
+      fuse_gemm->set_attribute("chunk_id", matmul->attribute("chunk_id"));
+    }
+
+    rewriter.ReplaceAllUsesWith(add->result(0), fuse_gemm.result(0));
+    rewriter.ReplaceAllUsesWith(tmp, fuse_gemm.result(0));
+
+    rewriter.EraseOp(add);
+    rewriter.EraseOp(matmul);
+    return true;
   }
 };
 
-class FusedLinearGradPattern : public paddle::drr::DrrPatternBase {
+//  %2, %3 = pd_op.add_grad( %0, %1 )
+//  %6, %7 = pd_op.matmul_grad( %4, %5, %2)
+//  fused to
+//  %6, %7, %3 = pd_op.fused_gemm_epilogue_grad( %4, %5, none, %1)
+class FusedLinearGradPattern
+    : public pir::OpRewritePattern<paddle::dialect::MatmulGradOp> {
  public:
-  std::string name() const override { return "FusedLinearGradPattern"; }
+  using pir::OpRewritePattern<paddle::dialect::MatmulGradOp>::OpRewritePattern;
 
-  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
-    paddle::drr::SourcePattern pat = ctx->SourcePattern();
-    const auto &matmul = pat.Op(paddle::dialect::MatmulOp::name(),
-                                {{"transpose_x", pat.Attr("trans_x")},
-                                 {"transpose_y", pat.Attr("trans_y")}});
-    const auto &matmul_grad = pat.Op(paddle::dialect::MatmulGradOp::name(),
-                                     {{"transpose_x", pat.Attr("trans_x")},
-                                      {"transpose_y", pat.Attr("trans_y")}});
-    const auto &add = pat.Op(paddle::dialect::AddOp::name());
-    const auto &add_grad = pat.Op(paddle::dialect::AddGradOp::name());
+  bool MatchAndRewrite(paddle::dialect::MatmulGradOp matmul_grad,
+                       pir::PatternRewriter &rewriter) const override {
+    auto dout = matmul_grad->operand_source(2);
 
-    pat.Tensor("tmp") = matmul(pat.Tensor("x"), pat.Tensor("w"));
-    pat.Tensor("out") = add(pat.Tensor("tmp"), pat.Tensor("bias"));
-    add_grad({&pat.Tensor("tmp"), &pat.Tensor("bias"), &pat.Tensor("out_grad")},
-             {&pat.Tensor("tmp_grad"), &pat.Tensor("bias_grad")});
-    matmul_grad({&pat.Tensor("x"), &pat.Tensor("w"), &pat.Tensor("tmp_grad")},
-                {&pat.Tensor("x_grad"), &pat.Tensor("w_grad")});
+    if (pir::GetShapeFromValue(matmul_grad->operand_source(1)).size() != 2) {
+      return false;
+    }
 
-    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
-      auto w_dims = pir::GetShapeFromValue(match_ctx.Tensor("w"));
-      auto x_dims = pir::GetShapeFromValue(match_ctx.Tensor("x"));
-      auto bias_dims = pir::GetShapeFromValue(match_ctx.Tensor("bias"));
-      return (w_dims.size() == 2 && x_dims.size() >= 2 &&
-              bias_dims.size() == 1);
-    });
+    paddle::dialect::AddGradOp add_grad;
+    if (add_grad = dout.defining_op()->dyn_cast<paddle::dialect::AddGradOp>()) {
+      if (dout != add_grad->result(0)) {
+        return false;
+      }
+    } else {
+      return false;
+    }
 
-    paddle::drr::ResultPattern res = pat.ResultPattern();
+    pir::AttributeMap attr_map;
+    attr_map.emplace("trans_x", matmul_grad.attribute("transpose_x"));
+    attr_map.emplace("trans_y", matmul_grad.attribute("transpose_y"));
+    attr_map.emplace(
+        "activation_grad",
+        pir::StrAttribute::get(pir::IrContext::Instance(), "none"));
 
-    const auto &fused_gemm_epilogue =
-        res.Op(paddle::dialect::FusedGemmEpilogueOp::name(),
-               {{{"trans_x", pat.Attr("trans_x")},
-                 {"trans_y", pat.Attr("trans_y")},
-                 {"activation", res.StrAttr("none")}}});
-    const auto &fused_gemm_epilogue_grad =
-        res.Op(paddle::dialect::FusedGemmEpilogueGradOp::name(),
-               {{{"trans_x", pat.Attr("trans_x")},
-                 {"trans_y", pat.Attr("trans_y")},
-                 {"activation_grad", res.StrAttr("none")}}});
-    fused_gemm_epilogue(
-        {&res.Tensor("x"), &res.Tensor("w"), &res.Tensor("bias")},
-        {&res.Tensor("out")});
-    fused_gemm_epilogue_grad({&res.Tensor("x"),
-                              &res.Tensor("w"),
-                              &res.InputNoneTensor(),
-                              &res.Tensor("out_grad")},
-                             {&res.Tensor("x_grad"),
-                              &res.Tensor("w_grad"),
-                              &res.Tensor("bias_grad")});
+    auto fuse_gemm_grad =
+        rewriter.Build<paddle::dialect::FusedGemmEpilogueGradOp>(
+            matmul_grad->operand_source(0),
+            matmul_grad->operand_source(1),
+            pir::Value(),
+            add_grad->operand_source(2),
+            attr_map);
+
+    if (matmul_grad->HasAttribute("op_role")) {
+      fuse_gemm_grad->set_attribute("op_role",
+                                    matmul_grad->attribute("op_role"));
+    }
+    if (matmul_grad->HasAttribute("chunk_id")) {
+      fuse_gemm_grad->set_attribute("chunk_id",
+                                    matmul_grad->attribute("chunk_id"));
+    }
+
+    rewriter.ReplaceAllUsesWith(matmul_grad.result(0),
+                                fuse_gemm_grad.result(0));
+    rewriter.ReplaceAllUsesWith(matmul_grad.result(1),
+                                fuse_gemm_grad.result(1));
+    rewriter.ReplaceAllUsesWith(add_grad.result(1), fuse_gemm_grad.result(2));
+
+    rewriter.EraseOp(matmul_grad);
+    rewriter.EraseOp(add_grad);
+
+    return true;
   }
 };
 
@@ -420,8 +458,8 @@ class FusedGemmEpiloguePass : public pir::PatternRewritePass {
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
-    ps.Add(paddle::drr::Create<FusedLinearPattern>(context));
-    ps.Add(paddle::drr::Create<FusedLinearGradPattern>(context));
+    ps.Add<FusedLinearPattern>(context);
+    ps.Add<FusedLinearGradPattern>(context);
     ps.Add(paddle::drr::Create<FusedLinearGeluPattern>(context));
     ps.Add(paddle::drr::Create<FusedLinearReluPattern>(context));
     ps.Add(paddle::drr::Create<FusedLinearGeluGradPattern>(context));

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -930,6 +930,15 @@ class Engine:
                 lambda op: bool(op.has_attr('op_role') and op.op_role == 0),
             )
 
+        if (
+            self._strategy.fused_passes.fused_passes_list is not None
+            and "fused_gemm_epilogue_pass"
+            in self._strategy.fused_passes.fused_passes_list
+        ):
+            pm = pir.PassManager()
+            pm.add_pass("fused_gemm_epilogue_pass", {})
+            pm.run(dense_program)
+
         if self._strategy.pipeline.enable:
             self._job_plan = pipeline_pass(
                 [dense_program], [dense_program], self._strategy.pipeline

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -938,6 +938,9 @@ class Engine:
             pm = pir.PassManager()
             pm.add_pass("fused_gemm_epilogue_pass", {})
             pm.run(dense_program)
+            self._strategy.fused_passes.fused_passes_list.remove(
+                "fused_gemm_epilogue_pass"
+            )
 
         if self._strategy.pipeline.enable:
             self._job_plan = pipeline_pass(

--- a/test/ir/pir/fused_pass/test_fused_gemm_epilogue_pass.py
+++ b/test/ir/pir/fused_pass/test_fused_gemm_epilogue_pass.py
@@ -19,6 +19,10 @@ import numpy as np
 import paddle
 from paddle.autograd.ir_backward import grad as ir_grad
 from paddle.base import core
+from paddle.base.framework import (
+    pir_chunk_id_guard,
+    pir_op_role_guard,
+)
 
 np.random.seed(2013)
 
@@ -44,89 +48,112 @@ def get_cuda_version():
 )
 class TestFusedGemm_epilogueAdd(unittest.TestCase):
     def test_fused_gemm_epilogue_add(self):
+        paddle.enable_static()
+        main_program = paddle.base.Program()
         with paddle.pir_utils.IrGuard():
             x_np = np.random.normal(3, 2.5, size=(1024, 1024)).astype(
                 np.float32
             )
             y_np = x_np
             z_np = np.random.normal(3, 2.5, size=(1024)).astype(np.float32)
-            main_program = paddle.static.Program()
-            with paddle.static.program_guard(main_program):
-                x_ = paddle.static.data(
-                    name="x", shape=[1024, 1024], dtype="float32"
-                )
-                y_ = paddle.static.data(
-                    name="y", shape=[1024, 1024], dtype="float32"
-                )
-                z_ = paddle.static.data(name="z", shape=[1024], dtype="float32")
-                x_.stop_gradient = False
-                y_.stop_gradient = False
-                z_.stop_gradient = False
-                x = paddle.assign(x_)
-                y = paddle.assign(y_)
-                z = paddle.assign(z_)
-                res1 = paddle.matmul(x=x, y=y)
-                res2 = paddle.add(res1, z)
-                res3 = paddle.assign(res2)
+            with paddle.base.program_guard(main_program):
+                with pir_op_role_guard(0), pir_chunk_id_guard(0):
+                    x_ = paddle.static.data(
+                        name="x", shape=[1024, 1024], dtype="float32"
+                    )
+                    y_ = paddle.static.data(
+                        name="y", shape=[1024, 1024], dtype="float32"
+                    )
+                    z_ = paddle.static.data(
+                        name="z", shape=[1024], dtype="float32"
+                    )
+                    x_.stop_gradient = False
+                    y_.stop_gradient = False
+                    z_.stop_gradient = False
+                    x = paddle.assign(x_)
+                    y = paddle.assign(y_)
+                    z = paddle.assign(z_)
+                    res1 = paddle.matmul(x=x, y=y)
+                    res2 = paddle.add(res1, z)
+                    res3 = paddle.assign(res2)
 
-                res4, res5, res6 = ir_grad(res3, [x, y, z])
-                res4_ = paddle.assign(res4)
-                res5_ = paddle.assign(res5)
-                res6_ = paddle.assign(res6)
+                with pir_op_role_guard(1), pir_chunk_id_guard(0):
+                    res4, res5, res6 = ir_grad(res3, [x, y, z])
+                with pir_op_role_guard(2), pir_chunk_id_guard(0):
+                    res4_ = paddle.assign(res4)
+                    res5_ = paddle.assign(res5)
+                    res6_ = paddle.assign(res6)
 
-                for op in main_program.global_block().ops:
-                    op.set_int_attr("op_role", 1)
-                    op.set_int_attr("chunk_id", -1)
-
-                op_names = [op.name() for op in main_program.global_block().ops]
+        op_names = [op.name() for op in main_program.global_block().ops]
+        self.assertTrue('pd_op.matmul' in op_names and 'pd_op.add' in op_names)
+        self.assertTrue(
+            'pd_op.add_grad' in op_names and 'pd_op.matmul_grad' in op_names
+        )
+        for op in main_program.global_block().ops:
+            if op.name() == 'pd_op.matmul' or op.name() == 'pd_op.add':
                 self.assertTrue(
-                    'pd_op.matmul' in op_names and 'pd_op.add' in op_names
+                    op.has_attr("op_role")
+                    and op.attrs()["op_role"] == 0
+                    and op.has_attr("chunk_id")
+                    and op.attrs()["chunk_id"] == 0
                 )
+            if (
+                op.name() == 'pd_op.matmul_grad'
+                or op.name() == 'pd_op.add_grad'
+            ):
                 self.assertTrue(
-                    'pd_op.add_grad' in op_names
-                    and 'pd_op.matmul_grad' in op_names
+                    op.has_attr("op_role")
+                    and op.attrs()["op_role"] == 1
+                    and op.has_attr("chunk_id")
+                    and op.attrs()["chunk_id"] == 0
                 )
 
-                with paddle.static.scope_guard(paddle.static.Scope()):
-                    exe = paddle.base.Executor(paddle.base.CUDAPlace(0))
-                    fetches0 = exe.run(
-                        main_program,
-                        feed={"x": x_np, "y": y_np, "z": z_np},
-                        fetch_list=[res3, res4_, res5_, res6_],
-                    )
-                # main_program = main_program.clone()
+        with paddle.static.scope_guard(paddle.static.Scope()):
+            exe = paddle.base.Executor(paddle.base.CUDAPlace(0))
+            fetches0 = exe.run(
+                main_program,
+                feed={"x": x_np, "y": y_np, "z": z_np},
+                fetch_list=[res3, res4_, res5_, res6_],
+            )
+        # main_program = main_program.clone()
 
-                pm = paddle.pir.PassManager()
-                pm.add_pass(
-                    'fused_gemm_epilogue_pass', {}
-                )  # apply pass to eliminate dead code
-                pm.run(main_program)
-                op_names = [op.name() for op in main_program.global_block().ops]
+        pm = paddle.pir.PassManager()
+        pm.add_pass(
+            'fused_gemm_epilogue_pass', {}
+        )  # apply pass to eliminate dead code
+        pm.run(main_program)
+        op_names = [op.name() for op in main_program.global_block().ops]
+        self.assertTrue(
+            'pd_op.fused_gemm_epilogue' in op_names
+            and 'pd_op.fused_gemm_epilogue_grad' in op_names
+        )
+        for op in main_program.global_block().ops:
+            if op.name() == 'pd_op.fused_gemm_epilogue':
                 self.assertTrue(
-                    'pd_op.fused_gemm_epilogue' in op_names
-                    and 'pd_op.fused_gemm_epilogue_grad' in op_names
+                    op.has_attr("op_role")
+                    and op.attrs()["op_role"] == 0
+                    and op.has_attr("chunk_id")
+                    and op.attrs()["chunk_id"] == 0
+                )
+            if op.name() == 'pd_op.fused_gemm_epilogue_grad':
+                self.assertTrue(
+                    op.has_attr("op_role")
+                    and op.attrs()["op_role"] == 1
+                    and op.has_attr("chunk_id")
+                    and op.attrs()["chunk_id"] == 0
                 )
 
-                for op in main_program.global_block().ops:
-                    self.assertTrue(
-                        op.has_attr("op_role") and op.attrs()["op_role"] == 1
-                    )
-                    self.assertTrue(
-                        op.has_attr("chunk_id") and op.attrs()["chunk_id"] == -1
-                    )
-
-                with paddle.static.scope_guard(paddle.static.Scope()):
-                    exe = paddle.base.Executor(paddle.base.CUDAPlace(0))
-                    fetches1 = exe.run(
-                        main_program,
-                        feed={"x": x_np, "y": y_np, "z": z_np},
-                        fetch_list=[res3, res4_, res5_, res6_],
-                    )
-
-                np.array_equal(fetches0[0], fetches1[0])
-                np.array_equal(fetches0[1], fetches1[1])
-                np.array_equal(fetches0[2], fetches1[2])
-                np.array_equal(fetches0[3], fetches1[3])
+        with paddle.static.scope_guard(paddle.static.Scope()):
+            exe = paddle.base.Executor(paddle.base.CUDAPlace(0))
+            fetches1 = exe.run(
+                main_program,
+                feed={"x": x_np, "y": y_np, "z": z_np},
+                fetch_list=[res3, res4_, res5_, res6_],
+            )
+        np.array_equal(fetches0[0], fetches1[0])
+        np.array_equal(fetches0[1], fetches1[1])
+        np.array_equal(fetches0[2], fetches1[2])
+        np.array_equal(fetches0[3], fetches1[3])
 
 
 if __name__ == "__main__":

--- a/test/ir/pir/fused_pass/test_fused_gemm_epilogue_pass.py
+++ b/test/ir/pir/fused_pass/test_fused_gemm_epilogue_pass.py
@@ -73,6 +73,11 @@ class TestFusedGemm_epilogueAdd(unittest.TestCase):
                 res4_ = paddle.assign(res4)
                 res5_ = paddle.assign(res5)
                 res6_ = paddle.assign(res6)
+
+                for op in main_program.global_block().ops:
+                    op.set_int_attr("op_role", 1)
+                    op.set_int_attr("chunk_id", -1)
+
                 op_names = [op.name() for op in main_program.global_block().ops]
                 self.assertTrue(
                     'pd_op.matmul' in op_names and 'pd_op.add' in op_names
@@ -101,6 +106,14 @@ class TestFusedGemm_epilogueAdd(unittest.TestCase):
                     'pd_op.fused_gemm_epilogue' in op_names
                     and 'pd_op.fused_gemm_epilogue_grad' in op_names
                 )
+
+                for op in main_program.global_block().ops:
+                    self.assertTrue(
+                        op.has_attr("op_role") and op.attrs()["op_role"] == 1
+                    )
+                    self.assertTrue(
+                        op.has_attr("chunk_id") and op.attrs()["chunk_id"] == -1
+                    )
 
                 with paddle.static.scope_guard(paddle.static.Scope()):
                     exe = paddle.base.Executor(paddle.base.CUDAPlace(0))


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
**背景：**
在 `PP` 并行 或者 `gradient merge` 策略下，PIR program 会被切分成 `forward`、`backward` 和 `optimizer` 子图，同时插入 `shawdow_output` 算子进行子图间数据传输，这可能会插在 fuse linear pattern 中，造成子图中 pattern 识别失败，使得 fuse linear pass 不能生效
**解决：**
该 PR 将 fuse linear pass 转移到 `PP` 并行 和 `gradient merge` 策略之前进行调用，但融合的`fused_gemm_epilogue`算子会丢失 `op_role` 和 `chunk_id` 的属性，在 pass 中增加 `op_role` 和 `chunk_id` 的属性设置，保证 `pp` 和 `gradient merge` 正常执行
PCard-89139
