### PR TITLE
[SOT] Attach need breakgraph info to some exceptions

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -52,7 +52,7 @@ from ...utils import (
     map_if,
     switch_symbol_registry,
 )
-from ...utils.exceptions import BreakGraphError
+from ...utils.exceptions import BreakGraphError, SotExtraInfo
 from ..instruction_utils import get_instructions
 from .guard import Guard, StringifiedExpression, make_guard
 from .mutable_data import MutationDel, MutationNew, MutationSet
@@ -702,6 +702,13 @@ class FunctionGraph:
                 metas = convert_to_meta(args)
                 kwmetas = convert_to_meta(kwargs)
                 return args, kwargs, infer_meta_fn(func, *metas, **kwmetas)
+
+            except Exception as e:
+                if SotExtraInfo.from_exception(e).need_breakgraph:
+                    raise BreakGraphError(
+                        f"API {func} encountered a need break graph error {e}"
+                    )
+                raise e
 
         if ENV_SOT_ALLOW_DYNAMIC_SHAPE.get():
             args, kwargs, out_metas = try_infer_meta_fn(args, kwargs)

--- a/python/paddle/jit/sot/utils/exceptions.py
+++ b/python/paddle/jit/sot/utils/exceptions.py
@@ -69,3 +69,28 @@ def inner_error_default_handler(func, message_fn):
 
 class ExportError(SotErrorBase):
     pass
+
+
+class SotExtraInfo:
+    SOT_EXTRA_INFO_ATTR_NAME = "__SOT_EXTRA_INFO__"
+
+    def __init__(self, *, need_breakgraph: bool = False):
+        self.need_breakgraph = need_breakgraph
+
+    def set_need_breakgraph(self, need_breakgraph: bool):
+        self.need_breakgraph = need_breakgraph
+
+    def attach(self, err: BaseException):
+        setattr(err, SotExtraInfo.SOT_EXTRA_INFO_ATTR_NAME, self)
+
+    @staticmethod
+    def default() -> SotExtraInfo:
+        return SotExtraInfo()
+
+    @staticmethod
+    def from_exception(err: BaseException) -> SotExtraInfo:
+        info = getattr(
+            err, SotExtraInfo.SOT_EXTRA_INFO_ATTR_NAME, SotExtraInfo.default()
+        )
+        setattr(err, SotExtraInfo.SOT_EXTRA_INFO_ATTR_NAME, info)
+        return info

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2780,10 +2780,15 @@ def assign(x: TensorLike, output: paddle.Tensor | None = None) -> paddle.Tensor:
         value_name = "values"
         values = input.ravel().tolist()
         if input.size > 1024 * 1024:
-            raise ValueError(
+            from paddle.jit.sot.utils.exceptions import SotExtraInfo
+
+            sot_extra_info = SotExtraInfo(need_breakgraph=True)
+            err = ValueError(
                 "The size of input is too big. Please consider "
                 "saving it to file and 'load_op' to load it"
             )
+            sot_extra_info.attach(err)
+            raise err
         if in_dynamic_or_pir_mode():
             if output is None:
                 output = zeros(list(input.shape), dtype)

--- a/test/sot/test_numpy.py
+++ b/test/sot/test_numpy.py
@@ -31,6 +31,10 @@ def tensor_add_numpy(x, y):
     return ret
 
 
+def large_numpy_array_to_tensor(x):
+    return paddle.to_tensor(x)
+
+
 class TestNumpy(TestCaseBase):
     @strict_mode_guard(False)
     def test_numpy_add(self):
@@ -50,6 +54,12 @@ class TestNumpy(TestCaseBase):
         y = np.array(2.0)
         self.assert_results(tensor_add_numpy, x, y)
         self.assert_results(tensor_add_numpy, y, x)
+
+    def test_large_numpy_array_to_tensor(self):
+        # size should be larger than 1024*1024, because we throw an exception
+        # when the size is larger than 1024*1024 in assign API (to_tensor static branch)
+        x = np.random.rand(1024, 1024, 2).astype(np.float32)
+        self.assert_results(large_numpy_array_to_tensor, x)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

`paddle.to_tensor` 所使用的静态图 assign API 中对 NumPy Array 元素数量有限制，最多为 1024*1024，高于上限时会报错，SOT 在 infermeta 阶段可以捕获这个报错，并进行打断

PCard-66972