### PR TITLE
[SOT] Prune stack size analysis on walked branch and bind `has_custom_getattro` to python side

### DIFF
--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -137,6 +137,19 @@ void BindSot(pybind11::module *m) {
       },
       py::arg("callback"));
 
+  m->def("has_custom_getattro", [](py::object obj) {
+    PyObject *py_obj = obj.ptr();
+
+    if (!PyType_Check(py_obj)) {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "The input object should be a type object, but got %s.",
+          py::str(py_obj).cast<std::string>()));
+    }
+    PyTypeObject *type = reinterpret_cast<PyTypeObject *>(py_obj);
+
+    return type->tp_getattro != PyObject_GenericGetAttr;
+  });
+
   m->def(
       "sot_setup_codes_with_graph",
       [](const py::object &py_codes) {

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Callable
 
+import paddle
 from paddle.jit.utils import OrderedSet
 
 from ...profiler import EventGuard, event_register
@@ -886,7 +887,9 @@ class OpcodeExecutorBase:
             getattr, graph=self._graph, tracker=DanglingTracker()
         )(obj, method_name_var)
 
-        if isinstance(method, MethodVariable) and "__getattr__" not in dir(
+        if isinstance(
+            method, MethodVariable
+        ) and not paddle.base.libpaddle.has_custom_getattro(
             method.bound_instance.get_py_type()
         ):
             # bound method or the class override the __getattr__

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -361,6 +361,7 @@ def stacksize(instructions: list[Instruction]) -> float:
         int: The maximum stack size.
     """
     max_stack = [float("-inf")] * len(instructions)
+    histories = [[] for _ in range(len(instructions))]
 
     max_stack[0] = 0
 
@@ -379,12 +380,12 @@ def stacksize(instructions: list[Instruction]) -> float:
         Returns:
             None
         """
-        old_max = max_stack[nexti]
-        max_stack[nexti] = max(
-            max_stack[nexti], max_stack[lasti] + stack_effect
-        )
-        if old_max != max_stack[nexti]:
-            if nexti not in queue:  # may be slow, we can use a flag.
+        if (new_stack_size := max_stack[lasti] + stack_effect) > max_stack[
+            nexti
+        ]:
+            histories[nexti] = histories[lasti] + [lasti]
+            max_stack[nexti] = new_stack_size
+            if nexti not in queue and nexti not in histories[nexti]:
                 queue.append(nexti)
 
     while len(queue) > 0:

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import inspect
-import opcode
 import random
 import sys
 import types
@@ -49,6 +48,8 @@ from ..instruction_utils import (
     modify_vars,
 )
 from ..instruction_utils.opcode_info import (
+    ALL_JUMP,
+    RETURN,
     UNCONDITIONAL_JUMP,
     JumpDirection,
     PopJumpCond,
@@ -393,12 +394,12 @@ def stacksize(instructions: list[Instruction]) -> float:
         opname = instr.opname
         if (
             idx + 1 < len(instructions)
-            and instr.opname not in UNCONDITIONAL_JUMP
+            and opname not in UNCONDITIONAL_JUMP | RETURN
         ):
             stack_effect = calc_stack_effect(instr, jump=False)
             update_stacksize(idx, idx + 1, stack_effect)
 
-        if instr.opcode in opcode.hasjabs or instr.opcode in opcode.hasjrel:
+        if opname in ALL_JUMP:
             stack_effect = calc_stack_effect(instr, jump=True)
             target_idx = instructions.index(instr.jump_to)
             update_stacksize(idx, target_idx, stack_effect)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

- 遇到 `RETURN`-like 的 opcode 停止 stacksize 分析，因为我们有些字节码是 copy 后拼接到 `RETURN` 之后的（`MIN_GRAPH_SIZE` fallback 策略）
- stacksize 分析剪枝掉 visited 路径，避免无限循环不收敛
- bind `has_custom_getattro` 以确保和 Python 对齐，避免 #58956 中的问题（因为覆盖掉 `__getattribute__` 和 `__getattr__` 都会返回 True）

PCard-66972