### PR TITLE
[CINN] Support compare for DimExpr

### DIFF
--- a/paddle/pir/include/dialect/shape/utils/dim_expr_util.h
+++ b/paddle/pir/include/dialect/shape/utils/dim_expr_util.h
@@ -37,6 +37,14 @@ enum class PriorityComparisonStatus {
 IR_API PriorityComparisonStatus CompareDimExprPriority(const DimExpr& lhs,
                                                        const DimExpr& rhs);
 
+enum class DimExprCompareResult {
+  GT,       // lhs is greater than rhs
+  EQ,       // lhs and rhs is equal
+  LT,       // lhs is less than rhs
+  UNKNOWN,  // lhs and rhs is not comparable
+};
+IR_API DimExprCompareResult Compare(const DimExpr& lhs, const DimExpr& rhs);
+
 IR_API std::unordered_set<std::string> CollectDimExprSymbols(
     const DimExpr& dim_expr);
 

--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -1280,6 +1280,30 @@ IR_API PriorityComparisonStatus CompareDimExprPriority(const DimExpr& lhs,
   return std::visit(CompareForEqualPriority, lhs.variant(), rhs.variant());
 }
 
+DimExprCompareResult Compare(const DimExpr& lhs, const DimExpr& rhs) {
+  auto CompareFunc = common::Overloaded{
+      [](const int& lhs, const int& rhs) {
+        return lhs == rhs ? DimExprCompareResult::EQ
+                          : (lhs < rhs ? DimExprCompareResult::LT
+                                       : DimExprCompareResult::GT);
+      },
+      [](const Add<DimExpr>& lhs, const Add<DimExpr>& rhs) {
+        DimExpr simplified_result =
+            SimplifyDimExpr(DimExpr{lhs} - DimExpr{rhs});
+        if (simplified_result.isa<int64_t>()) {
+          int64_t const_result = simplified_result.dyn_cast<int64_t>();
+          return const_result == 0  ? DimExprCompareResult::EQ
+                 : const_result < 0 ? DimExprCompareResult::LT
+                                    : DimExprCompareResult::GT;
+        }
+        return DimExprCompareResult::UNKNOWN;
+      },
+      [](const auto& lhs, const auto& rhs) {
+        return DimExprCompareResult::UNKNOWN;
+      }};
+  return std::visit(CompareFunc, lhs.variant(), rhs.variant());
+}
+
 }  // namespace symbol
 
 namespace symbol {

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -304,20 +304,35 @@ InferSymbolicShapeContext::SimplifyBroadcastForShapeOrData(
   auto SimplifyBroadcast =
       [&](const symbol::Broadcast<symbol::DimExpr>& bc) -> symbol::DimExpr {
     const symbol::List<symbol::DimExpr>& dim_exprs = bc.operands;
+    // 1. check if any dim_expr is greater than 1
     symbol::List<symbol::DimExpr> gtone_list;
     for (const auto& dim_expr : *dim_exprs) {
       if (IsGreatThanOne(dim_expr)) gtone_list->push_back(dim_expr);
     }
-    symbol::DimExpr simplified_dim_expr = bc;
-    if (gtone_list->size() == 1) {
-      simplified_dim_expr = gtone_list->at(0);
-    } else if (gtone_list->size() > 1) {
-      for (size_t i = 1; i < gtone_list->size(); i++) {
-        AddEqualCstr(gtone_list->at(0), gtone_list->at(i));
+    if (gtone_list->size() >= 1) {
+      if (gtone_list->size() > 1) {
+        for (size_t i = 1; i < gtone_list->size(); i++) {
+          AddEqualCstr(gtone_list->at(0), gtone_list->at(i));
+        }
       }
-      simplified_dim_expr = gtone_list->at(0);
+      return gtone_list->at(0);
     }
-    return simplified_dim_expr;
+
+    // compare each other dim_expr
+    for (size_t i = 0; i < dim_exprs->size() - 1; ++i) {
+      for (size_t j = i + 1; j < dim_exprs->size(); ++j) {
+        const auto compare_result =
+            symbol::Compare(dim_exprs->at(i), dim_exprs->at(j));
+        if (compare_result == symbol::DimExprCompareResult::GT) {
+          AddEqualCstr(dim_exprs->at(j), symbol::DimExpr(1));
+          return dim_exprs->at(i);
+        } else if (compare_result == symbol::DimExprCompareResult::LT) {
+          AddEqualCstr(dim_exprs->at(i), symbol::DimExpr(1));
+          return dim_exprs->at(j);
+        }
+      }
+    }
+    return bc;
   };
 
   auto DimExprsVisitor =


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

DimExpr支持简单的比较功能，目前主要用于支持Broadcast表达式的化简。