### PR TITLE
【CINN】Simplify dynamic shape

### DIFF
--- a/paddle/cinn/common/ir_util.cc
+++ b/paddle/cinn/common/ir_util.cc
@@ -25,6 +25,7 @@
 #include "paddle/cinn/ir/ir_printer.h"
 #include "paddle/cinn/ir/op/ir_operators.h"
 #include "paddle/cinn/ir/utils/ir_compare.h"
+#include "paddle/cinn/ir/utils/ir_copy.h"
 #include "paddle/common/enforce.h"
 namespace cinn {
 namespace common {
@@ -739,6 +740,9 @@ ir::IndexExpr ChangeSeqOfDivMod(const ir::IndexExpr &expr) {
       } else {
         auto lhs = ChangeSeqOfDivMod(expr.operand(0));
         auto rhs = ChangeSeqOfDivMod(expr.operand(1));
+        if (lhs.node_type() == ir::IrNodeTy::Div) {
+          return (lhs.operand(0) % (lhs.operand(1) * rhs)) / lhs.operand(1);
+        }
         return ConstructIndexExprByNodeType(expr.node_type(), lhs, rhs, false);
       }
     }
@@ -746,6 +750,61 @@ ir::IndexExpr ChangeSeqOfDivMod(const ir::IndexExpr &expr) {
       PADDLE_THROW(::common::errors::InvalidArgument(
           "Unsupported type of expr in ChangeSeqOfDivMod which is: %s", expr));
   }
+}
+std::optional<ir::IndexExpr> DivByPartMul(const ir::IndexExpr &lhs,
+                                          const ir::IndexExpr &rhs,
+                                          ir::IrNodeTy ty) {
+  std::vector<ir::IndexExpr> elems = common::GetFlattenExprs<ir::Mul>(rhs);
+
+  ir::IndexExpr result = ir::ir_utils::IRCopy(lhs);
+
+  for (const auto &elem : elems) {
+    if (common::IsDivisiblieBySymbol(result, elem, ty)) {
+      result = common::SimplifySymbolicDivide(result, elem, ty);
+    } else {
+      return std::nullopt;
+    }
+  }
+  return result;
+}
+
+std::optional<ir::IndexExpr> SimplifyComplexMod(const ir::IndexExpr &lhs,
+                                                const ir::IndexExpr &rhs) {
+  if (lhs == rhs) return ir::IndexExpr(lhs.type(), 0);
+  switch (lhs.node_type()) {
+    case ir::IrNodeTy::Add: {
+      auto simplify_lhs = SimplifyComplexMod(lhs.operand(0), rhs);
+      auto simplify_rhs = SimplifyComplexMod(lhs.operand(1), rhs);
+      if (simplify_lhs.has_value() && simplify_rhs.has_value())
+        return (simplify_lhs.value() + simplify_rhs.value());
+      return std::nullopt;
+    }
+    case ir::IrNodeTy::Mul: {
+      // (S0 % 4 * S1 % 8) % 4 != S0 % 4 * S1 % 4;
+      if (DivByPartMul(lhs, rhs, ir::IrNodeTy::Mod))
+        return ir::IndexExpr(lhs.type(), 0);
+      return std::nullopt;
+    }
+    case ir::IrNodeTy::Div:
+    case ir::IrNodeTy::IntImm:
+    case ir::IrNodeTy::_Var_:
+    case ir::IrNodeTy::Min:
+    case ir::IrNodeTy::Max:
+    case ir::IrNodeTy::Load:
+    case ir::IrNodeTy::Cast: {
+      return std::nullopt;
+    }
+    case ir::IrNodeTy::Mod: {
+      if (DivByPartMul(lhs.operand(1), rhs, ir::IrNodeTy::Mod)) {
+        return lhs.operand(0) % rhs;
+      }
+      return std::nullopt;
+    }
+    default:
+      PADDLE_THROW(::common::errors::InvalidArgument(
+          "Unsupported type of expr in SimplifyComplexMod which is: %s", lhs));
+  }
+  return std::nullopt;
 }
 }  // namespace common
 }  // namespace cinn

--- a/paddle/cinn/common/ir_util.cc
+++ b/paddle/cinn/common/ir_util.cc
@@ -720,12 +720,16 @@ ir::IndexExpr ConstructIndexExprByNodeType(const ir::IrNodeTy &ty,
 ir::IndexExpr ChangeSeqOfDivMod(const ir::IndexExpr &expr) {
   switch (expr.node_type()) {
     case ir::IrNodeTy::IntImm:
-    case ir::IrNodeTy::_Var_: {
+    case ir::IrNodeTy::_Var_:
+    case ir::IrNodeTy::Cast:
+    case ir::IrNodeTy::Load: {
       return expr;
     }
     case ir::IrNodeTy::Add:
     case ir::IrNodeTy::Sub:
     case ir::IrNodeTy::Mul:
+    case ir::IrNodeTy::Min:
+    case ir::IrNodeTy::Max:
     case ir::IrNodeTy::Div: {
       auto lhs = ChangeSeqOfDivMod(expr.operand(0));
       auto rhs = ChangeSeqOfDivMod(expr.operand(1));

--- a/paddle/cinn/common/ir_util.h
+++ b/paddle/cinn/common/ir_util.h
@@ -381,5 +381,38 @@ enum IndexType {
  * information in some scenarios.
  */
 IndexType VerifyIndex(const ir::Expr &expr);
+
+/*!
+ * \brief The multiplication in rhs is broken down and each sub-part is
+ * independently determined to be divisible.
+ * \param lhs The dividend.
+ * \param rhs The divisor.
+ * \param ty  ty is `Mod` or `Div`.
+ * \return A optional index expression indicating whether the `lhs`
+ * is divisible, nullopt indicating not divisible.
+ *
+ * For example:
+ * 1. i * S0 * S1 * S2 / (S0 * S1) ==> i / S2
+ * 2. i * S0 * S1 / S0 ==> i * S1
+ * 3. i * S0 / (S0 + 1) ==> nullopt
+ */
+std::optional<ir::IndexExpr> DivByPartMul(const ir::IndexExpr &lhs,
+                                          const ir::IndexExpr &rhs,
+                                          ir::IrNodeTy ty);
+
+/*!
+ * \brief Simplify complex modulo expressions.
+ * \param lhs The dividend.
+ * \param rhs The divisor.
+ * \return A optional index expression indicating whether simplified
+ *
+ * For example:
+ * 1. (i / S0 * S0 + i % (S0 * S1)) % S0 ==> i % S0
+ * 2. (i / S0 * S0 * S1 + i % (S0 * S1 * S2)) % (S0 * S1) ==> i % (S0 * S1)
+ * 3. i % (S0 * S1) % S0 ==> i % S0
+ * 4. i * S0 * S1 % (S0 * S1) ==> 0
+ */
+std::optional<ir::IndexExpr> SimplifyComplexMod(const ir::IndexExpr &lhs,
+                                                const ir::IndexExpr &rhs);
 }  // namespace common
 }  // namespace cinn

--- a/paddle/cinn/ir/ir_base.cc
+++ b/paddle/cinn/ir/ir_base.cc
@@ -536,7 +536,9 @@ IndexExpr Simplify(const IndexExpr &expr, IndexExpr::OptLevel level) {
 }
 
 IndexExpr IndexExpr::Normalize(OptLevel level) const {
-  return Simplify(*this, level);
+  auto res = Simplify(*this, level);
+  res = ChangeSeqOfDivMod(res);
+  return Simplify(res, level);
 }
 
 int32_t IndexExpr::as_int32() const {

--- a/test/cpp/pir/cinn/adt/index_expr_test.cc
+++ b/test/cpp/pir/cinn/adt/index_expr_test.cc
@@ -34,9 +34,15 @@ class TestIndexExpr : public ::testing::Test {
              .set_index(true);
     S7 = ir::Var(ir::Expr(static_cast<int64_t>(1)), ir::Expr(INT32_MAX), "S7")
              .set_index(true);
+    S8 = ir::Var(ir::Expr(static_cast<int64_t>(1)), ir::Expr(INT32_MAX), "S8")
+             .set_index(true);
+    S9 = ir::Var(ir::Expr(static_cast<int64_t>(1)), ir::Expr(INT32_MAX), "S9")
+             .set_index(true);
+
+    f = ir::Var(ir::Expr(static_cast<int64_t>(1)), ir::Expr(INT32_MAX), "f");
   };
 
-  ir::Var S4, S5, S6, S7;
+  ir::Var S4, S5, S6, S7, S8, S9, f;
 };
 TEST_F(TestIndexExpr, IndexExpr_0) {
   ir::IndexExpr a(14);
@@ -166,7 +172,8 @@ TEST_F(TestIndexExpr, IndexExpr_3) {
   EXPECT_EQ(q14.as_index().Normalize(), ir::IndexExpr(S4 + S5));
   EXPECT_EQ(q15.as_index().Normalize(),
             ir::IndexExpr((S4 * 256 + S5 + S6 * 1024)) % 25088);
-  EXPECT_EQ(q16.as_index().Normalize(), ir::IndexExpr(S4 * 256 + S5));
+  EXPECT_EQ(q16.as_index().Normalize(ir::IndexExpr::OptLevel::Level2),
+            ir::IndexExpr(S4 * 256 + S5));
 }
 
 TEST_F(TestIndexExpr, Change_Seq_Of_Div_Mod) {
@@ -203,6 +210,76 @@ TEST_F(TestIndexExpr, Test_ConstructIndexExprByNodeType) {
   EXPECT_EQ(result_mod, S4 % S5);
   EXPECT_EQ(result_min, ir::Min::Make(S4, S5));
   EXPECT_EQ(result_max, ir::Max::Make(S4, S5));
+}
+
+TEST_F(TestIndexExpr, Test_dynamic) {
+  ir::Expr q =
+      ((((((((((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) % S5) * S6) +
+                ((((S7 * 1024) + S8) + (S9 * 4096)) % S6)) +
+               (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) % 640) %
+                  S4) *
+                 S6) *
+                S5)) +
+              (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) / 640) *
+                 S5) *
+                S6) *
+               S4)) /
+             ((S5 * S6) * S4)) *
+            S4) +
+           (((((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) % S5) * S6) +
+                ((((S7 * 1024) + S8) + (S9 * 4096)) % S6)) +
+               (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) % 640) %
+                  S4) *
+                 S6) *
+                S5)) +
+              (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) / 640) *
+                 S5) *
+                S6) *
+               S4)) /
+             (S5 * S6)) %
+            S4)) *
+          S5) +
+         (((((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) % S5) * S6) +
+              ((((S7 * 1024) + S8) + (S9 * 4096)) % S6)) +
+             (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) % 640) % S4) *
+               S6) *
+              S5)) +
+            (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) / 640) * S5) *
+              S6) *
+             S4)) /
+           S6) %
+          S5)) *
+        S6) +
+       ((((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) % S5) * S6) +
+           ((((S7 * 1024) + S8) + (S9 * 4096)) % S6)) +
+          (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) % 640) % S4) *
+            S6) *
+           S5)) +
+         (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) / 640) * S5) *
+           S6) *
+          S4)) %
+        S6));
+
+  ir::Expr q1 =
+      ((((((f % ((S5 * S6) * 640)) % ((S5 * S6) * S4)) / (S5 * S6)) * S6) *
+        S5) +
+       (f % (S5 * S6)));
+  ir::Expr q2 = ((f % ((S5 * S6) * 640)) % ((S5 * S6) * S4)) % (S5 * S6);
+  ir::Expr q3 = (S5 * S6) * S4 / (S5 * S6);
+  ir::Expr q4 = (S5 * S6) * S4 % (S5 * S6);
+
+  EXPECT_EQ(
+      q.as_index().Normalize(ir::IndexExpr::OptLevel::Level2),
+      ((((((((S7 * 1024) + S8) + (S9 * 4096)) / ((S5 * S6) * 640)) * S5) * S6) *
+        S4) +
+       (((((S7 * 1024) + S8) + (S9 * 4096)) % ((S5 * S6) * 640)) %
+        ((S5 * S6) * S4))));
+  EXPECT_EQ(q1.as_index().Normalize(ir::IndexExpr::OptLevel::Level2),
+            ((f % ((S5 * S6) * 640)) % ((S5 * S6) * S4)));
+  EXPECT_EQ(q2.as_index().Normalize(ir::IndexExpr::OptLevel::Level2),
+            f % (S5 * S6));
+  EXPECT_EQ(q3.as_index().Normalize(ir::IndexExpr::OptLevel::Level2), Expr(S4));
+  EXPECT_EQ(q4.as_index().Normalize(ir::IndexExpr::OptLevel::Level2), Expr(0));
 }
 }  // namespace common
 }  // namespace cinn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Enrich IndexExpr ability of Simplify dynamic shape.
```
case1.
(S5 * S6) * S4 / (S5 * S6)
=======>
S4

case2.
(S5 * S6) * S4 % (S5 * S6)
=======>
0

case 3. 
((((((f % ((S5 * S6) * 640)) % ((S5 * S6) * S4)) / (S5 * S6)) * S6) *
        S5) +
       (f % (S5 * S6))
=======>
((f % ((S5 * S6) * 640)) % ((S5 * S6) * S4))

case 4.
((f % ((S5 * S6) * 640)) % ((S5 * S6) * S4)) % (S5 * S6)
=======>
f % (S5 * S6)

case5.
      ((((((((((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) % S5) * S6) +
                ((((S7 * 1024) + S8) + (S9 * 4096)) % S6)) +
               (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) % 640) %
                  S4) *
                 S6) *
                S5)) +
              (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) / 640) *
                 S5) *
                S6) *
               S4)) /
             ((S5 * S6) * S4)) *
            S4) +
           (((((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) % S5) * S6) +
                ((((S7 * 1024) + S8) + (S9 * 4096)) % S6)) +
               (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) % 640) %
                  S4) *
                 S6) *
                S5)) +
              (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) / 640) *
                 S5) *
                S6) *
               S4)) /
             (S5 * S6)) %
            S4)) *
          S5) +
         (((((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) % S5) * S6) +
              ((((S7 * 1024) + S8) + (S9 * 4096)) % S6)) +
             (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) % 640) % S4) *
               S6) *
              S5)) +
            (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) / 640) * S5) *
              S6) *
             S4)) /
           S6) %
          S5)) *
        S6) +
       ((((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) % S5) * S6) +
           ((((S7 * 1024) + S8) + (S9 * 4096)) % S6)) +
          (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) % 640) % S4) *
            S6) *
           S5)) +
         (((((((((S7 * 1024) + S8) + (S9 * 4096)) / S6) / S5) / 640) * S5) *
           S6) *
          S4)) %
        S6));
========>
((((((((S7 * 1024) + S8) + (S9 * 4096)) / ((S5 * S6) * 640)) * S5) * S6) *
        S4) +
       (((((S7 * 1024) + S8) + (S9 * 4096)) % ((S5 * S6) * 640)) %
        ((S5 * S6) * S4)))
```
Pcard-67164