### PR TITLE
【CINN】Add min max load cast hash func

### DIFF
--- a/paddle/cinn/ir/ir.h
+++ b/paddle/cinn/ir/ir.h
@@ -1221,13 +1221,20 @@ struct hash<cinn::ir::IndexExpr> {
       case cinn::ir::IrNodeTy::Sub:
       case cinn::ir::IrNodeTy::Mul:
       case cinn::ir::IrNodeTy::Div:
-      case cinn::ir::IrNodeTy::Mod: {
+      case cinn::ir::IrNodeTy::Mod:
+      case cinn::ir::IrNodeTy::Min:
+      case cinn::ir::IrNodeTy::Max: {
         auto hash_lhs = std::hash<cinn::ir::IndexExpr>()(x.operand(0));
         auto hash_rhs = std::hash<cinn::ir::IndexExpr>()(x.operand(1));
         return cinn::adt::hash_combine(hash_lhs, hash_rhs);
       }
+      case cinn::ir::IrNodeTy::Load:
+      case cinn::ir::IrNodeTy::Cast: {
+        return reinterpret_cast<size_t>(x.get());
+      }
     }
-    ::common::errors::InvalidArgument("Unsupported index expr type.");
+    PADDLE_THROW(
+        ::common::errors::InvalidArgument("Unsupported index expr type."));
   }
 };
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Add hash func of min/max/load/cast in IndexExpr
Pcard-67164