### PR TITLE
[CINN] Temporarily disable the EliminateCommonGlobalMemoryRead pass

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -382,12 +382,12 @@ std::vector<ir::LoweredFunc> OpLowererImpl::PostProcess(
                            common::ARMArch>) {},
           [&](common::NVGPUArch) {
 #ifdef CINN_WITH_CUDA
-            optim::EliminateCommonGlobalMemoryRead(&(func_body));
+            // optim::EliminateCommonGlobalMemoryRead(&(func_body));
             optim::OptimizeExprGPU(&(func_body));
 #endif
           },
           [&](std::variant<common::HygonDCUArchHIP, common::HygonDCUArchSYCL>) {
-            optim::EliminateCommonGlobalMemoryRead(&(func_body));
+            // optim::EliminateCommonGlobalMemoryRead(&(func_body));
             optim::OptimizeExprGPU(&(func_body));
           });
     }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
EliminateCommonGlobalMemoryRead出现变量未初始化的bug，由于该Pass正在重构中，且当前该Pass本来也没有什么性能收益，因此暂时将其禁用

<b>说明：</b>该Pass当前作用范围非常有限，它无法处理动态Shape，对于静态Shape也只能处理loop<=8的情况，但loop<=8时nvcc也可以优化，因此该Pass几乎未带来实质性的优化；经测试，禁用该Pass对重点子图（BatchNorm、Softmax）和重点Benchmark模型均无任何影响（nsys统计的Kernel时间无任何差别）

Pcard-85711