### PR TITLE
Fix the normalization of logits in  Categorical

### DIFF
--- a/python/paddle/distribution/categorical.py
+++ b/python/paddle/distribution/categorical.py
@@ -145,8 +145,7 @@ class Categorical(distribution.Distribution):
             self.logits = self._to_tensor(logits)[0]
             if self.dtype != convert_dtype(self.logits.dtype):
                 self.logits = paddle.cast(self.logits, dtype=self.dtype)
-        dist_sum = paddle.sum(self.logits, axis=-1, keepdim=True)
-        self._prob = self.logits / dist_sum
+        self._prob = paddle.nn.functional.softmax(self.logits, axis=-1)
 
     def sample(self, shape: Sequence[int] = []) -> Tensor:
         """Generate samples of the specified shape.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->


### Description
<!-- Describe what you’ve done -->
paddle.distribution.categorical对接受的logits参数并未采用softmax函数进行归一后传递给self._prob，导致其创建的概率分布时的逻辑与torch.distributions.Categorical接受probs参数一致，而与torch接受logits参数的逻辑不同。因此将归一方法更正为softmax函数，更改后categorical的行为与torch一致。
测试效果参考文档：https://ku.baidu-int.com/knowledge/HFVrC7hq1Q/pKzJfZczuc/qv-vZnw7HE/HnwAXB-xDS0-4B