### PR TITLE
[XPU] update xhpc date to 0121

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -30,7 +30,7 @@ set(XPU_XFA_LIB_NAME "libxpu_flash_attention.so")
 set(XPU_XPUDNN_LIB_NAME "libxpu_dnn.so")
 
 if(NOT DEFINED XPU_XHPC_BASE_DATE)
-  set(XPU_XHPC_BASE_DATE "dev/20250114")
+  set(XPU_XHPC_BASE_DATE "dev/20250121")
 endif()
 set(XPU_XCCL_BASE_VERSION "3.0.1.6") # For XRE5
 if(NOT DEFINED XPU_XFT_BASE_VERSION)

--- a/paddle/phi/kernels/xpu/flash_attn_kernel.cc
+++ b/paddle/phi/kernels/xpu/flash_attn_kernel.cc
@@ -150,8 +150,14 @@ void FlashAttnKernelBase(const Context& ctx,
                              {},         // alibi_slopes_shape
                              -1,         // window_size_left
                              -1,         // window_size_right
-                             -1          // v_head_dim
-      );
+                             -1,         // v_head_dim
+                             nullptr,    // downstart_row_indices_data
+                             nullptr,    // downend_row_indices_data
+                             nullptr,    // upstart_row_indices_data
+                             nullptr,    // upend_row_indices_data
+                             0,          // flash_mask_head_num
+                             nullptr,    // flashmask_maxmin
+                             nullptr);   // side_stream
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "mha_varlen_fwd");
 }
 #else

--- a/test/xpu/test_conv2d_op_xpu.py
+++ b/test/xpu/test_conv2d_op_xpu.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 
 import numpy as np
@@ -204,6 +205,8 @@ class XPUTestConv2DOp(XPUOpTestWrapper):
             self.init_dilation()
             self.init_test_case()
 
+            os.environ["XPU_PADDLE_CONV_FLOAT"] = "1"
+
             conv2d_param = {
                 'stride': self.stride,
                 'pad': self.pad,
@@ -359,6 +362,8 @@ class XPUTestConv2DOp_v2(XPUOpTestWrapper):
             self.init_test_case()
             self.init_paddings()
             self.init_test_case_2()
+
+            os.environ["XPU_PADDLE_CONV_FLOAT"] = "1"
 
             conv2d_param = {
                 'stride': self.stride,

--- a/test/xpu/test_depthwise_conv2d_op_xpu.py
+++ b/test/xpu/test_depthwise_conv2d_op_xpu.py
@@ -26,8 +26,6 @@ from get_test_cover_info import (
 )
 from test_conv2d_op_xpu import XPUTestConv2DOp, XPUTestConv2DOp_v2
 
-from paddle.base import core
-
 
 class XPUTestDepthwiseConv2DOp(XPUOpTestWrapper):
     def __init__(self):
@@ -46,10 +44,6 @@ class XPUTestDepthwiseConv2DOp(XPUOpTestWrapper):
             self.filter_size = [12, f_c, 3, 3]
             self.op_type = "depthwise_conv2d"
 
-    @unittest.skipIf(
-        core.get_xpu_device_version(0) == core.XPUVersion.XPU3,
-        "bugs on kl3, disable it temporarily",
-    )
     class TestDepthwiseConv2(XPUTestConv2DOp.TestConv2DOp):
         def init_test_case(self):
             self.use_cuda = False
@@ -62,10 +56,6 @@ class XPUTestDepthwiseConv2DOp(XPUOpTestWrapper):
             self.filter_size = [12, f_c, 3, 3]
             self.op_type = "depthwise_conv2d"
 
-    @unittest.skipIf(
-        core.get_xpu_device_version(0) == core.XPUVersion.XPU3,
-        "bugs on kl3, disable it temporarily",
-    )
     class TestDepthwiseConv3(XPUTestConv2DOp.TestConv2DOp):
         def init_test_case(self):
             self.use_cuda = False
@@ -78,10 +68,6 @@ class XPUTestDepthwiseConv2DOp(XPUOpTestWrapper):
             self.filter_size = [24, f_c, 3, 3]
             self.op_type = "depthwise_conv2d"
 
-    @unittest.skipIf(
-        core.get_xpu_device_version(0) == core.XPUVersion.XPU3,
-        "bugs on kl3, disable it temporarily",
-    )
     class TestDepthwiseConvWithDilation(XPUTestConv2DOp.TestConv2DOp):
         def init_test_case(self):
             self.use_cuda = False
@@ -95,10 +81,6 @@ class XPUTestDepthwiseConv2DOp(XPUOpTestWrapper):
             self.filter_size = [24, f_c, 3, 3]
             self.op_type = "depthwise_conv2d"
 
-    @unittest.skipIf(
-        core.get_xpu_device_version(0) == core.XPUVersion.XPU3,
-        "bugs on kl3, disable it temporarily",
-    )
     class TestDepthwiseConvWithDilation2(XPUTestConv2DOp.TestConv2DOp):
         def init_test_case(self):
             self.use_cuda = False
@@ -163,10 +145,6 @@ class XPUTestDepthwiseConv2DOp_v2(XPUOpTestWrapper):
             self.pad = [1, 1, 0, 0]
             self.padding_algorithm = "EXPLICIT"
 
-    @unittest.skipIf(
-        core.get_xpu_device_version(0) == core.XPUVersion.XPU3,
-        "bugs on kl3, disable it temporarily",
-    )
     class TestDepthwiseConvWithDilation_AsyPadding(
         XPUTestConv2DOp_v2.TestConv2DOp_v2
     ):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
1. update xhpc date to 250121
2. release skipped tests of depthwise_conv2d