### PR TITLE
[CodeStyle][Typos][I-15] Fix typo `infered` (part1)

### DIFF
--- a/paddle/phi/kernels/onednn/reshape_kernel.cc
+++ b/paddle/phi/kernels/onednn/reshape_kernel.cc
@@ -22,7 +22,7 @@ static DDim ValidateShape(const std::vector<int64_t>& shape,
                                   in_dims_vec.cend(),
                                   [](int64_t i) { return i > 0; });
   // only one dimension can be set to -1, whose size will be automatically
-  // infered
+  // inferred
   const int64_t unk_dim_val = -1;
   const int64_t copy_dim_val = 0;
 

--- a/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
+++ b/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
@@ -32,8 +32,8 @@ COMMON_DECLARE_bool(pir_apply_shape_optimization_pass);
 
 constexpr int vlog_level = 3;
 
-// TODO(zhangbopd): Some op results infered by InferSymbolicShape is NOT consist
-// with the result infered by InferMeta and should be fixed.
+// TODO(zhangbopd): Some op results inferred by InferSymbolicShape is NOT
+// consist with the result inferred by InferMeta and should be fixed.
 namespace {
 bool NeedCheckInferSymbolicWithInferMeta(const std::string& op_name,
                                          size_t result_idx) {

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -513,7 +513,7 @@ void ShapeConstraintIRAnalysis::InferShapeOrDataForValue(Value val) {
     }
   };
 
-  const auto& VisitNotInferedInputOp =
+  const auto& VisitNotInferredInputOp =
       [&](Operation* op, const std::function<void(Operation*)>& Visit) {
         for (auto& operand : GetRealOperandSource(op)) {
           if (operand.impl() && !context_.HasShapeOrDataForValue(operand)) {
@@ -526,7 +526,8 @@ void ShapeConstraintIRAnalysis::InferShapeOrDataForValue(Value val) {
         }
       };
 
-  ::common::BfsWalker<Operation*> build_subgraph_walker(VisitNotInferedInputOp);
+  ::common::BfsWalker<Operation*> build_subgraph_walker(
+      VisitNotInferredInputOp);
   build_subgraph_walker(val.defining_op(), [&](Operation* op) {
     subgraph_ops.insert(op);
     bool has_prev_op = false;

--- a/python/paddle/base/variable_index.py
+++ b/python/paddle/base/variable_index.py
@@ -910,7 +910,7 @@ def _getitem_static(x, indices):
 
 def parse_bool_and_broadcast_indices(indices):
     # deal with multiple Tensors and translating bool tensor to int tensor.
-    # In static mode, bool-tensor cannot be broadcasted since its corresponding int tensor's shape cannot be infered.
+    # In static mode, bool-tensor cannot be broadcasted since its corresponding int tensor's shape cannot be inferred.
     for i, indice in enumerate(indices):
         if (
             indice.dtype == paddle.bool

--- a/test/cpp/auto_parallel/custom_op_spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/custom_op_spmd_rule_test.cc
@@ -55,25 +55,25 @@ TEST(CustomOp, Ctor) {
   std::vector<CustomSpmdInferTensorArg> infer_inputs = {inputs};
   std::vector<CustomSpmdInferAttrArg> attrs = {axis};
 
-  auto infered_dist_attrs = forward_spmd_func(infer_inputs, attrs);
+  auto inferred_dist_attrs = forward_spmd_func(infer_inputs, attrs);
   // list of tensor => single tensor
-  EXPECT_EQ(infered_dist_attrs.first.size(), static_cast<size_t>(1));
-  EXPECT_EQ(infered_dist_attrs.second.size(), static_cast<size_t>(1));
+  EXPECT_EQ(inferred_dist_attrs.first.size(), static_cast<size_t>(1));
+  EXPECT_EQ(inferred_dist_attrs.second.size(), static_cast<size_t>(1));
   EXPECT_TRUE(
       paddle::holds_alternative<std::vector<phi::distributed::TensorDistAttr>>(
-          infered_dist_attrs.first[0]));
+          inferred_dist_attrs.first[0]));
   EXPECT_TRUE(paddle::holds_alternative<phi::distributed::TensorDistAttr>(
-      infered_dist_attrs.second[0]));
+      inferred_dist_attrs.second[0]));
   auto& inputs_infer1 =
       PADDLE_GET_CONST(std::vector<phi::distributed::TensorDistAttr>,
-                       infered_dist_attrs.first[0]);
+                       inferred_dist_attrs.first[0]);
 
   for (auto e : inputs_infer1) {
     check_dim_mapping(e, {-1, 1, 0});
     check_partial_dims(e, {});
   }
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, 1, 0});
-  check_partial_dims(infered_dist_attrs.second[0], {});
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, 1, 0});
+  check_partial_dims(inferred_dist_attrs.second[0], {});
 }
 
 TEST(CustomOp, Register) {

--- a/test/cpp/auto_parallel/fused_rms_norm_spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/fused_rms_norm_spmd_rule_test.cc
@@ -44,16 +44,16 @@ TEST(FusedRmsNormSPMDRule, test_fused_rms_norm) {
   phi::distributed::DistMetaTensor x(common::make_ddim(x_shape), x_dist_attr);
   phi::distributed::DistMetaTensor scale(common::make_ddim(scale_shape),
                                          scale_dist_attr);
-  auto infered_dist_attrs = phi::distributed::RmsNormInferSpmd(x, scale, 0.5);
+  auto inferred_dist_attrs = phi::distributed::RmsNormInferSpmd(x, scale, 0.5);
 
   size_t input_size = 2;
   size_t output_size = 2;
-  EXPECT_EQ(infered_dist_attrs.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs.second.size(), output_size);
-  check_dim_mapping(infered_dist_attrs.first[0], {1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1});
-  check_dim_mapping(infered_dist_attrs.second[0], {1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[1], {1, -1});
+  EXPECT_EQ(inferred_dist_attrs.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs.second.size(), output_size);
+  check_dim_mapping(inferred_dist_attrs.first[0], {1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[1], {1, -1});
 
   VLOG(4) << "test1 done.";
 
@@ -63,11 +63,11 @@ TEST(FusedRmsNormSPMDRule, test_fused_rms_norm) {
   scale = phi::distributed::DistMetaTensor(common::make_ddim(scale_shape),
                                            scale_dist_attr);
 
-  infered_dist_attrs = phi::distributed::RmsNormInferSpmd(x, scale, 0.5);
-  check_dim_mapping(infered_dist_attrs.first[0], {1, 0, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1});
-  check_dim_mapping(infered_dist_attrs.second[0], {1, 0, -1});
-  check_dim_mapping(infered_dist_attrs.second[1], {1, 0});
+  inferred_dist_attrs = phi::distributed::RmsNormInferSpmd(x, scale, 0.5);
+  check_dim_mapping(inferred_dist_attrs.first[0], {1, 0, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {1, 0, -1});
+  check_dim_mapping(inferred_dist_attrs.second[1], {1, 0});
   VLOG(4) << "test2 done.";
 
   TensorDistAttr out_dist_attr = TensorDistAttr();
@@ -84,26 +84,26 @@ TEST(FusedRmsNormSPMDRule, test_fused_rms_norm) {
   phi::distributed::DistMetaTensor invvar(common::make_ddim(variance_shape),
                                           invvar_dist_attr);
 
-  infered_dist_attrs =
+  inferred_dist_attrs =
       phi::distributed::RmsNormInferSpmdReverse(x, scale, out, invvar, 0.5);
-  check_dim_mapping(infered_dist_attrs.first[0], {0, 1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1});
-  check_dim_mapping(infered_dist_attrs.second[0], {0, 1, -1});
-  check_dim_mapping(infered_dist_attrs.second[1], {0, 1});
+  check_dim_mapping(inferred_dist_attrs.first[0], {0, 1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {0, 1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[1], {0, 1});
   VLOG(4) << "test3 done.";
 
   x_dist_attr.set_dims_mapping({0, 1, -1});
   x = phi::distributed::DistMetaTensor(common::make_ddim(x_shape), x_dist_attr);
-  infered_dist_attrs =
+  inferred_dist_attrs =
       phi::distributed::RmsNormGradInferSpmd(x, scale, invvar, out, 0.5);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {0, 1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1});
-  check_dim_mapping(infered_dist_attrs.first[2], {0, 1});
-  check_dim_mapping(infered_dist_attrs.first[3], {0, 1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {0, 1, -1});
-  check_dim_mapping(infered_dist_attrs.second[1], {-1});
-  check_partial_dims(infered_dist_attrs.second[1], {0, 1});
+  check_dim_mapping(inferred_dist_attrs.first[0], {0, 1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1});
+  check_dim_mapping(inferred_dist_attrs.first[2], {0, 1});
+  check_dim_mapping(inferred_dist_attrs.first[3], {0, 1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {0, 1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[1], {-1});
+  check_partial_dims(inferred_dist_attrs.second[1], {0, 1});
 }
 }  // namespace auto_parallel
 }  // namespace distributed

--- a/test/cpp/auto_parallel/moe_combine_spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/moe_combine_spmd_rule_test.cc
@@ -91,9 +91,9 @@ void test_moe_combine_spmd(
         << dist_attrs.size() << " != " << dims_mappings.size();
 
     for (size_t j = 0; j < dist_attrs.size(); ++j) {
-      const ArgDistAttr& infered_attr = dist_attrs[j];
+      const ArgDistAttr& inferred_attr = dist_attrs[j];
       const std::vector<int64_t>& expected_dims_mapping = dims_mappings[j];
-      check_dim_mapping(infered_attr, expected_dims_mapping);
+      check_dim_mapping(inferred_attr, expected_dims_mapping);
     }
   }
 }

--- a/test/cpp/auto_parallel/moe_gate_dispatch_spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/moe_gate_dispatch_spmd_rule_test.cc
@@ -96,9 +96,9 @@ void test_moe_gate_dispatch_spmd(
         << dist_attrs.size() << " != " << dims_mappings.size();
 
     for (size_t j = 0; j < dist_attrs.size(); ++j) {
-      const ArgDistAttr& infered_attr = dist_attrs[j];
+      const ArgDistAttr& inferred_attr = dist_attrs[j];
       const std::vector<int64_t>& expected_dims_mapping = dims_mappings[j];
-      check_dim_mapping(infered_attr, expected_dims_mapping);
+      check_dim_mapping(inferred_attr, expected_dims_mapping);
     }
   }
 }

--- a/test/cpp/auto_parallel/spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/spmd_rule_test.cc
@@ -686,7 +686,8 @@ TEST(ConcatRule, Ctor) {
           inferred_dist_attrs.first[0]));
   EXPECT_TRUE(paddle::holds_alternative<phi::distributed::TensorDistAttr>(
       inferred_dist_attrs.second[0]));
-  auto& inputs_infer1 = paddle::get<1>(inferred_dist_attrs.first[0]);
+  auto& inputs_infer1 =
+      PADDLE_GET(std::vector<TensorDistAttr>, inferred_dist_attrs.first[0]);
   for (auto e : inputs_infer1) {
     check_dim_mapping(e, {-1, 1, 0});
     check_partial_dims(e, {});
@@ -743,7 +744,8 @@ TEST(ConcatRule, Ctor) {
           inferred_dist_attrs.first[0]));
   EXPECT_TRUE(paddle::holds_alternative<phi::distributed::TensorDistAttr>(
       inferred_dist_attrs.second[0]));
-  auto& inputs_infer2 = paddle::get<1>(inferred_dist_attrs.first[0]);
+  auto& inputs_infer2 =
+      PADDLE_GET(std::vector<TensorDistAttr>, inferred_dist_attrs.first[0]);
   for (auto e : inputs_infer2) {
     check_dim_mapping(e, {1, -1, 0});
     check_partial_dims(e, {});

--- a/test/cpp/auto_parallel/spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/spmd_rule_test.cc
@@ -51,14 +51,14 @@ TEST(MatmulSPMDRule, Ctor) {
   // mk[1, -1],kn[-1, -1] --> mk[1, -1],kn[-1, -1] = nm[1, -1] partial[]
   phi::distributed::InferSpmdContext ctx(
       {x, y}, {/*trans_x=*/false, /*trans_x=*/false});
-  auto infered_dist_attrs = matmul_spmd_rule.InferForward(ctx);
+  auto inferred_dist_attrs = matmul_spmd_rule.InferForward(ctx);
 
-  EXPECT_EQ(infered_dist_attrs.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs.second.size(), output_size);
-  check_dim_mapping(infered_dist_attrs.first[0], {1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), false);
+  EXPECT_EQ(inferred_dist_attrs.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs.second.size(), output_size);
+  check_dim_mapping(inferred_dist_attrs.first[0], {1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), false);
   VLOG(4) << "test1 done." << std::endl << std::endl << std::endl;
 
   // mk[-1,-1],kn[-1,0] --> mk[-1,-1],kn[-1,0] = nm[-1,0] partial[]
@@ -68,11 +68,11 @@ TEST(MatmulSPMDRule, Ctor) {
   y = phi::distributed::DistMetaTensor(common::make_ddim(y_shape), y_dist_attr);
   ctx = phi::distributed::InferSpmdContext(
       {x, y}, {/*trans_x=*/false, /*trans_x=*/false});
-  infered_dist_attrs = matmul_spmd_rule.InferForward(ctx);
-  check_dim_mapping(infered_dist_attrs.first[0], {-1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1, 0});
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, 0});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), false);
+  inferred_dist_attrs = matmul_spmd_rule.InferForward(ctx);
+  check_dim_mapping(inferred_dist_attrs.first[0], {-1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1, 0});
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, 0});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), false);
   VLOG(4) << "test2 done." << std::endl << std::endl << std::endl;
   // mk[1, 0],kn[-1,-1] --> mk[1, 0],kn[0, -1] = nm[1, -1] partial[0]: done
   x_dist_attr.set_dims_mapping({1, 0});
@@ -81,12 +81,12 @@ TEST(MatmulSPMDRule, Ctor) {
   y = phi::distributed::DistMetaTensor(common::make_ddim(y_shape), y_dist_attr);
   ctx = phi::distributed::InferSpmdContext(
       {x, y}, {/*trans_x=*/false, /*trans_x=*/false});
-  infered_dist_attrs = matmul_spmd_rule.InferForward(ctx);
-  check_dim_mapping(infered_dist_attrs.first[0], {1, 0});
-  check_dim_mapping(infered_dist_attrs.first[1], {0, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), true);
-  check_partial_dims(infered_dist_attrs.second[0], {0});
+  inferred_dist_attrs = matmul_spmd_rule.InferForward(ctx);
+  check_dim_mapping(inferred_dist_attrs.first[0], {1, 0});
+  check_dim_mapping(inferred_dist_attrs.first[1], {0, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), true);
+  check_partial_dims(inferred_dist_attrs.second[0], {0});
   VLOG(4) << "test3 done." << std::endl << std::endl << std::endl;
 
   // mk[-1,-1],kn[1,0] --> mk[-1, 1],kn[1, 0] = nm[-1, 0] partial[1]: done
@@ -96,12 +96,12 @@ TEST(MatmulSPMDRule, Ctor) {
   y = phi::distributed::DistMetaTensor(common::make_ddim(y_shape), y_dist_attr);
   ctx = phi::distributed::InferSpmdContext(
       {x, y}, {/*trans_x=*/false, /*trans_x=*/false});
-  infered_dist_attrs = matmul_spmd_rule.InferForward(ctx);
-  check_dim_mapping(infered_dist_attrs.first[0], {-1, 1});
-  check_dim_mapping(infered_dist_attrs.first[1], {1, 0});
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, 0});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), true);
-  check_partial_dims(infered_dist_attrs.second[0], {1});
+  inferred_dist_attrs = matmul_spmd_rule.InferForward(ctx);
+  check_dim_mapping(inferred_dist_attrs.first[0], {-1, 1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {1, 0});
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, 0});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), true);
+  check_partial_dims(inferred_dist_attrs.second[0], {1});
   VLOG(4) << "test4 done." << std::endl << std::endl << std::endl;
 
   // abcmk[1, 0, -1, -1],kn[-1, -1] --> abcmk[1, 0, -1, -1],kn[-1, -1] =
@@ -113,11 +113,11 @@ TEST(MatmulSPMDRule, Ctor) {
   y = phi::distributed::DistMetaTensor(common::make_ddim(y_shape), y_dist_attr);
   ctx = phi::distributed::InferSpmdContext(
       {x, y}, {/*trans_x=*/false, /*trans_x=*/false});
-  infered_dist_attrs = matmul_spmd_rule.InferForward(ctx);
-  check_dim_mapping(infered_dist_attrs.first[0], {0, 1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {0, 1, -1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), false);
+  inferred_dist_attrs = matmul_spmd_rule.InferForward(ctx);
+  check_dim_mapping(inferred_dist_attrs.first[0], {0, 1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {0, 1, -1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), false);
   VLOG(4) << "test5 done." << std::endl << std::endl << std::endl;
 
   // abcmk[1, -1, -1, 0],kn[-1, -1] --> abcmk[1, -1, -1, 0],kn[0, -1] = abcmn[1,
@@ -128,12 +128,12 @@ TEST(MatmulSPMDRule, Ctor) {
   y = phi::distributed::DistMetaTensor(common::make_ddim(y_shape), y_dist_attr);
   ctx = phi::distributed::InferSpmdContext(
       {x, y}, {/*trans_x=*/false, /*trans_x=*/false});
-  infered_dist_attrs = matmul_spmd_rule.InferForward(ctx);
-  check_dim_mapping(infered_dist_attrs.first[0], {1, -1, -1, 0});
-  check_dim_mapping(infered_dist_attrs.first[1], {0, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {1, -1, -1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), true);
-  check_partial_dims(infered_dist_attrs.second[0], {0});
+  inferred_dist_attrs = matmul_spmd_rule.InferForward(ctx);
+  check_dim_mapping(inferred_dist_attrs.first[0], {1, -1, -1, 0});
+  check_dim_mapping(inferred_dist_attrs.first[1], {0, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {1, -1, -1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), true);
+  check_partial_dims(inferred_dist_attrs.second[0], {0});
   VLOG(4) << "test6 done." << std::endl << std::endl << std::endl;
 
   // abcmk[1, -1, -1, 0], kn[-1, -1] --> abcmk[1, -1, -1, 0],kn[-1, -1] =
@@ -144,12 +144,12 @@ TEST(MatmulSPMDRule, Ctor) {
   y = phi::distributed::DistMetaTensor(common::make_ddim(y_shape), y_dist_attr);
   ctx = phi::distributed::InferSpmdContext(
       {x, y}, {/*trans_x=*/true, /*trans_x=*/false});
-  infered_dist_attrs = matmul_spmd_rule.InferForward(ctx);
+  inferred_dist_attrs = matmul_spmd_rule.InferForward(ctx);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {1, -1, -1, 0});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {1, -1, 0, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), false);
+  check_dim_mapping(inferred_dist_attrs.first[0], {1, -1, -1, 0});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {1, -1, 0, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), false);
 
   VLOG(4) << "test7 done." << std::endl << std::endl << std::endl;
 
@@ -161,14 +161,14 @@ TEST(MatmulSPMDRule, Ctor) {
   y = phi::distributed::DistMetaTensor(common::make_ddim(y_shape), y_dist_attr);
   ctx = phi::distributed::InferSpmdContext(
       {x, y}, {/*trans_x=*/false, /*trans_x=*/true});
-  infered_dist_attrs = matmul_spmd_rule.InferForward(ctx);
-  check_dim_mapping(infered_dist_attrs.first[0], {-1, -1, -1, 0});
-  check_dim_mapping(infered_dist_attrs.first[1], {1, 0});
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, -1, -1, 1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), true);
-  check_partial_dims(infered_dist_attrs.second[0], {0});
-  clean_partial_dims(&infered_dist_attrs.second[0], {0});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), false);
+  inferred_dist_attrs = matmul_spmd_rule.InferForward(ctx);
+  check_dim_mapping(inferred_dist_attrs.first[0], {-1, -1, -1, 0});
+  check_dim_mapping(inferred_dist_attrs.first[1], {1, 0});
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, -1, -1, 1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), true);
+  check_partial_dims(inferred_dist_attrs.second[0], {0});
+  clean_partial_dims(&inferred_dist_attrs.second[0], {0});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), false);
   VLOG(4) << "test8 done." << std::endl << std::endl << std::endl;
 
   // abcmk[-1, -1, 0, 1]+trans_x=true, kn[1, 0]+trans_y=true --> abcmk[-1, -1,
@@ -179,17 +179,17 @@ TEST(MatmulSPMDRule, Ctor) {
   y = phi::distributed::DistMetaTensor(common::make_ddim(y_shape), y_dist_attr);
   ctx = phi::distributed::InferSpmdContext(
       {x, y}, {/*trans_x=*/true, /*trans_x=*/true});
-  infered_dist_attrs = matmul_spmd_rule.InferForward(ctx);
+  inferred_dist_attrs = matmul_spmd_rule.InferForward(ctx);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {-1, -1, 0, 1});
-  check_dim_mapping(infered_dist_attrs.first[1],
+  check_dim_mapping(inferred_dist_attrs.first[0], {-1, -1, 0, 1});
+  check_dim_mapping(inferred_dist_attrs.first[1],
                     {-1, 0});  // conflict and should be changed to [-1, 0]
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, -1, 1, -1});
-  check_partial_dims(infered_dist_attrs.second[0], {0});
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, -1, 1, -1});
+  check_partial_dims(inferred_dist_attrs.second[0], {0});
 
-  clean_partial_status(&infered_dist_attrs.second[0]);
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), false);
-  EXPECT_ANY_THROW(set_partial_status(&infered_dist_attrs.second[0], {1}));
+  clean_partial_status(&inferred_dist_attrs.second[0]);
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), false);
+  EXPECT_ANY_THROW(set_partial_status(&inferred_dist_attrs.second[0], {1}));
   VLOG(4) << "test9 done." << std::endl << std::endl << std::endl;
 
   // abcmk[-1, -1, 1, 0], kn[1, 0] --> abcmk[-1, -1, -1, 0],kn[1, 0] =
@@ -200,7 +200,7 @@ TEST(MatmulSPMDRule, Ctor) {
   y = phi::distributed::DistMetaTensor(common::make_ddim(y_shape), y_dist_attr);
   ctx = phi::distributed::InferSpmdContext(
       {x, y}, {/*trans_x=*/true, /*trans_x=*/true});
-  EXPECT_ANY_THROW(infered_dist_attrs = matmul_spmd_rule.InferForward(ctx));
+  EXPECT_ANY_THROW(inferred_dist_attrs = matmul_spmd_rule.InferForward(ctx));
   // Error
   VLOG(4) << "test10 done." << std::endl << std::endl << std::endl;
 
@@ -212,22 +212,22 @@ TEST(MatmulSPMDRule, Ctor) {
   y = phi::distributed::DistMetaTensor(common::make_ddim(y_shape), y_dist_attr);
   ctx = phi::distributed::InferSpmdContext(
       {x, y}, {/*trans_x=*/true, /*trans_x=*/true});
-  infered_dist_attrs = matmul_spmd_rule.InferForward(ctx);
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, -1, 1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), true);
-  check_partial_dims(infered_dist_attrs.second[0], {0});
+  inferred_dist_attrs = matmul_spmd_rule.InferForward(ctx);
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, -1, 1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), true);
+  check_partial_dims(inferred_dist_attrs.second[0], {0});
 
   // try to clean partial on a dim which is not partial
-  EXPECT_ANY_THROW(clean_partial_dims(&infered_dist_attrs.second[0], {1}));
+  EXPECT_ANY_THROW(clean_partial_dims(&inferred_dist_attrs.second[0], {1}));
   // try to clean partial on a dims which is sharded
-  EXPECT_ANY_THROW(set_partial_status(&infered_dist_attrs.second[0], {1}));
+  EXPECT_ANY_THROW(set_partial_status(&inferred_dist_attrs.second[0], {1}));
 
   // clean partial and then re-set again
-  clean_partial_dims(&infered_dist_attrs.second[0], {0});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), false);
-  set_partial_status(&infered_dist_attrs.second[0], {0});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), true);
-  check_partial_dims(infered_dist_attrs.second[0], {0});
+  clean_partial_dims(&inferred_dist_attrs.second[0], {0});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), false);
+  set_partial_status(&inferred_dist_attrs.second[0], {0});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), true);
+  check_partial_dims(inferred_dist_attrs.second[0], {0});
   VLOG(4) << "test11 done." << std::endl << std::endl << std::endl;
 }
 
@@ -276,18 +276,18 @@ TEST(LayerNormSPMDRule, Ctor) {
                                         bias_dist_attr);
   phi::distributed::InferSpmdContext ctx({x, scale, bias},
                                          {epsilon, begin_norm_axis});
-  auto infered_dist_attrs = layer_norm_rule.InferForward(ctx);
+  auto inferred_dist_attrs = layer_norm_rule.InferForward(ctx);
 
   size_t input_size = 3;
   size_t output_size = 3;
-  EXPECT_EQ(infered_dist_attrs.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs.second.size(), output_size);
-  check_dim_mapping(infered_dist_attrs.first[0], {1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1});
-  check_dim_mapping(infered_dist_attrs.first[2], {-1});
-  check_dim_mapping(infered_dist_attrs.second[0], {1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[1], {1, -1});
-  check_dim_mapping(infered_dist_attrs.second[2], {1, -1});
+  EXPECT_EQ(inferred_dist_attrs.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs.second.size(), output_size);
+  check_dim_mapping(inferred_dist_attrs.first[0], {1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1});
+  check_dim_mapping(inferred_dist_attrs.first[2], {-1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[1], {1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[2], {1, -1});
   VLOG(4) << "test1 done.";
 
   // ijk[1, 0, -1],k[0],k[0] --> ijk[1, -1, -1],z[1, 0],z[1, 0],
@@ -303,14 +303,14 @@ TEST(LayerNormSPMDRule, Ctor) {
                                           bias_dist_attr);
   ctx = phi::distributed::InferSpmdContext({x, scale, bias},
                                            {epsilon, begin_norm_axis});
-  infered_dist_attrs = layer_norm_rule.InferForward(ctx);
+  inferred_dist_attrs = layer_norm_rule.InferForward(ctx);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {1, 0, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1});
-  check_dim_mapping(infered_dist_attrs.first[2], {-1});
-  check_dim_mapping(infered_dist_attrs.second[0], {1, 0, -1});
-  check_dim_mapping(infered_dist_attrs.second[1], {1, 0});
-  check_dim_mapping(infered_dist_attrs.second[2], {1, 0});
+  check_dim_mapping(inferred_dist_attrs.first[0], {1, 0, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1});
+  check_dim_mapping(inferred_dist_attrs.first[2], {-1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {1, 0, -1});
+  check_dim_mapping(inferred_dist_attrs.second[1], {1, 0});
+  check_dim_mapping(inferred_dist_attrs.second[2], {1, 0});
   VLOG(4) << "test2 done.";
 
   // ijk[0, -1, -1],y[-1],y[1] --> ijk[0, -1, -1], i[0], i[0], y=jk,
@@ -326,14 +326,14 @@ TEST(LayerNormSPMDRule, Ctor) {
                                           bias_dist_attr);
   ctx = phi::distributed::InferSpmdContext({x, scale, bias},
                                            {epsilon, begin_norm_axis});
-  infered_dist_attrs = layer_norm_rule.InferForward(ctx);
+  inferred_dist_attrs = layer_norm_rule.InferForward(ctx);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {0, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1});
-  check_dim_mapping(infered_dist_attrs.first[2], {-1});
-  check_dim_mapping(infered_dist_attrs.second[0], {0, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[1], {0});
-  check_dim_mapping(infered_dist_attrs.second[2], {0});
+  check_dim_mapping(inferred_dist_attrs.first[0], {0, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1});
+  check_dim_mapping(inferred_dist_attrs.first[2], {-1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {0, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[1], {0});
+  check_dim_mapping(inferred_dist_attrs.second[2], {0});
   VLOG(4) << "test3 done.";
 }
 
@@ -379,19 +379,19 @@ TEST(MatmulSPMDRuleInferBackward, Ctor) {
   // -1]
   phi::distributed::InferSpmdContext ctx(
       {x, y, out}, {/*trans_x=*/false, /*trans_x=*/false});
-  auto infered_dist_attrs = matmul_spmd_rule.InferBackward(ctx);
+  auto inferred_dist_attrs = matmul_spmd_rule.InferBackward(ctx);
 
   size_t input_size = 2;
   size_t output_size = 1;
-  EXPECT_EQ(infered_dist_attrs.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs.second.size(), output_size);
+  EXPECT_EQ(inferred_dist_attrs.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs.second.size(), output_size);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {-1, -1, 1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, -1, 1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.first[0]), false);
-  EXPECT_EQ(is_partial(infered_dist_attrs.first[1]), false);
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), true);
+  check_dim_mapping(inferred_dist_attrs.first[0], {-1, -1, 1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, -1, 1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.first[0]), false);
+  EXPECT_EQ(is_partial(inferred_dist_attrs.first[1]), false);
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), true);
   VLOG(4) << "test1 done." << std::endl << std::endl << std::endl;
 }
 
@@ -436,74 +436,74 @@ TEST(ReplicatedSPMDRule, Ctor) {
 
   // 2 inputs 2 outputs
   // call in vector arguments format
-  auto infered_dist_attrs_st =
+  auto inferred_dist_attrs_st =
       phi::distributed::ReplicatedInferSpmd({&x, &y}, {&out1, &out2});
   // call in variadic arguments format
-  auto infered_dist_attrs_dy =
+  auto inferred_dist_attrs_dy =
       phi::distributed::VariadicReplicatedInferSpmd(x, y, &out1, &out2);
 
   size_t input_size = 2;
   size_t output_size = 2;
-  EXPECT_EQ(infered_dist_attrs_st.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs_st.second.size(), output_size);
-  EXPECT_EQ(infered_dist_attrs_dy.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs_dy.second.size(), output_size);
+  EXPECT_EQ(inferred_dist_attrs_st.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs_st.second.size(), output_size);
+  EXPECT_EQ(inferred_dist_attrs_dy.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs_dy.second.size(), output_size);
 
-  check_dim_mapping(infered_dist_attrs_st.first[0], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs_st.first[1], {-1, -1});
-  check_dim_mapping(infered_dist_attrs_st.second[0], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs_st.second[1], {-1, -1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs_st.first[0]), false);
-  EXPECT_EQ(is_partial(infered_dist_attrs_st.first[1]), false);
-  EXPECT_EQ(is_partial(infered_dist_attrs_st.second[0]), false);
-  EXPECT_EQ(is_partial(infered_dist_attrs_st.second[1]), false);
-  EXPECT_EQ(infered_dist_attrs_st.first, infered_dist_attrs_dy.first);
-  EXPECT_EQ(infered_dist_attrs_st.second, infered_dist_attrs_dy.second);
+  check_dim_mapping(inferred_dist_attrs_st.first[0], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs_st.first[1], {-1, -1});
+  check_dim_mapping(inferred_dist_attrs_st.second[0], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs_st.second[1], {-1, -1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs_st.first[0]), false);
+  EXPECT_EQ(is_partial(inferred_dist_attrs_st.first[1]), false);
+  EXPECT_EQ(is_partial(inferred_dist_attrs_st.second[0]), false);
+  EXPECT_EQ(is_partial(inferred_dist_attrs_st.second[1]), false);
+  EXPECT_EQ(inferred_dist_attrs_st.first, inferred_dist_attrs_dy.first);
+  EXPECT_EQ(inferred_dist_attrs_st.second, inferred_dist_attrs_dy.second);
   VLOG(4) << "test1 done." << std::endl << std::endl << std::endl;
 
   // 3 inputs 1 outputs
   // call in vector arguments format
-  infered_dist_attrs_st =
+  inferred_dist_attrs_st =
       phi::distributed::ReplicatedInferSpmd({&x, &y, &out1}, {&out2});
   // call in variadic arguments format
-  infered_dist_attrs_dy =
+  inferred_dist_attrs_dy =
       phi::distributed::VariadicReplicatedInferSpmd(x, y, out1, &out2);
 
   input_size = 3;
   output_size = 1;
-  EXPECT_EQ(infered_dist_attrs_st.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs_st.second.size(), output_size);
-  EXPECT_EQ(infered_dist_attrs_dy.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs_dy.second.size(), output_size);
-  check_dim_mapping(infered_dist_attrs_dy.first[0], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs_dy.first[1], {-1, -1});
-  check_dim_mapping(infered_dist_attrs_dy.first[2], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs_dy.second[0], {-1, -1, -1});
-  EXPECT_EQ(infered_dist_attrs_st.first, infered_dist_attrs_dy.first);
-  EXPECT_EQ(infered_dist_attrs_st.second, infered_dist_attrs_dy.second);
+  EXPECT_EQ(inferred_dist_attrs_st.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs_st.second.size(), output_size);
+  EXPECT_EQ(inferred_dist_attrs_dy.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs_dy.second.size(), output_size);
+  check_dim_mapping(inferred_dist_attrs_dy.first[0], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs_dy.first[1], {-1, -1});
+  check_dim_mapping(inferred_dist_attrs_dy.first[2], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs_dy.second[0], {-1, -1, -1});
+  EXPECT_EQ(inferred_dist_attrs_st.first, inferred_dist_attrs_dy.first);
+  EXPECT_EQ(inferred_dist_attrs_st.second, inferred_dist_attrs_dy.second);
   VLOG(4) << "test2 done." << std::endl << std::endl << std::endl;
 
   // 1 inputs 3 outputs backward
   // call in vector arguments format
-  infered_dist_attrs_st =
+  inferred_dist_attrs_st =
       phi::distributed::ReplicatedInferSpmdReverse({&x}, {&y, &out1, &out2});
   // call in variadic arguments format
-  infered_dist_attrs_dy =
+  inferred_dist_attrs_dy =
       phi::distributed::VariadicReplicatedInferSpmdReverse(x, &y, &out1, &out2);
 
   input_size = 1;
   output_size = 3;
-  EXPECT_EQ(infered_dist_attrs_st.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs_st.second.size(), output_size);
-  EXPECT_EQ(infered_dist_attrs_dy.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs_dy.second.size(), output_size);
+  EXPECT_EQ(inferred_dist_attrs_st.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs_st.second.size(), output_size);
+  EXPECT_EQ(inferred_dist_attrs_dy.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs_dy.second.size(), output_size);
 
-  check_dim_mapping(infered_dist_attrs_dy.first[0], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs_dy.second[0], {-1, -1});
-  check_dim_mapping(infered_dist_attrs_dy.second[1], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs_dy.second[2], {-1, -1, -1});
-  EXPECT_EQ(infered_dist_attrs_st.first, infered_dist_attrs_dy.first);
-  EXPECT_EQ(infered_dist_attrs_st.second, infered_dist_attrs_dy.second);
+  check_dim_mapping(inferred_dist_attrs_dy.first[0], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs_dy.second[0], {-1, -1});
+  check_dim_mapping(inferred_dist_attrs_dy.second[1], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs_dy.second[2], {-1, -1, -1});
+  EXPECT_EQ(inferred_dist_attrs_st.first, inferred_dist_attrs_dy.first);
+  EXPECT_EQ(inferred_dist_attrs_st.second, inferred_dist_attrs_dy.second);
   VLOG(4) << "test3 done." << std::endl << std::endl << std::endl;
 }
 
@@ -548,55 +548,55 @@ TEST(DefaultDataParallelSPMDRule, Ctor) {
 
   // 2 inputs 2 outputs, batch axis sharding is propagated while other axes are
   // replicated call in vector arguments format
-  auto infered_dist_attrs_st =
+  auto inferred_dist_attrs_st =
       phi::distributed::DefaultDataParallelInferSpmd({&x, &y}, {&out1, &out2});
   // call in variadic arguments format
-  auto infered_dist_attrs_dy =
+  auto inferred_dist_attrs_dy =
       phi::distributed::VariadicDefaultDataParallelInferSpmd(
           x, y, &out1, &out2);
 
   size_t input_size = 2;
   size_t output_size = 2;
-  EXPECT_EQ(infered_dist_attrs_st.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs_st.second.size(), output_size);
-  EXPECT_EQ(infered_dist_attrs_dy.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs_dy.second.size(), output_size);
-  check_dim_mapping(infered_dist_attrs_st.first[0], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs_st.first[1], {0, -1});
-  check_dim_mapping(infered_dist_attrs_st.second[0], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs_st.second[1], {0, -1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs_st.first[0]), false);
-  EXPECT_EQ(is_partial(infered_dist_attrs_st.first[1]), false);
-  EXPECT_EQ(is_partial(infered_dist_attrs_st.second[0]), false);
-  EXPECT_EQ(is_partial(infered_dist_attrs_st.second[1]), false);
+  EXPECT_EQ(inferred_dist_attrs_st.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs_st.second.size(), output_size);
+  EXPECT_EQ(inferred_dist_attrs_dy.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs_dy.second.size(), output_size);
+  check_dim_mapping(inferred_dist_attrs_st.first[0], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs_st.first[1], {0, -1});
+  check_dim_mapping(inferred_dist_attrs_st.second[0], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs_st.second[1], {0, -1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs_st.first[0]), false);
+  EXPECT_EQ(is_partial(inferred_dist_attrs_st.first[1]), false);
+  EXPECT_EQ(is_partial(inferred_dist_attrs_st.second[0]), false);
+  EXPECT_EQ(is_partial(inferred_dist_attrs_st.second[1]), false);
 
-  EXPECT_EQ(infered_dist_attrs_st.first, infered_dist_attrs_dy.first);
-  EXPECT_EQ(infered_dist_attrs_st.second, infered_dist_attrs_dy.second);
+  EXPECT_EQ(inferred_dist_attrs_st.first, inferred_dist_attrs_dy.first);
+  EXPECT_EQ(inferred_dist_attrs_st.second, inferred_dist_attrs_dy.second);
   VLOG(4) << "test1 done." << std::endl << std::endl << std::endl;
 
   // 1 inputs 3 outputs, batch axis is un-sharded
   // call in vector arguments format
-  infered_dist_attrs_st =
+  inferred_dist_attrs_st =
       phi::distributed::DefaultDataParallelInferSpmd({&x}, {&y, &out1, &out2});
   // call in variadic arguments format
-  infered_dist_attrs_dy =
+  inferred_dist_attrs_dy =
       phi::distributed::VariadicDefaultDataParallelInferSpmd(
           x, &y, &out1, &out2);
 
   input_size = 1;
   output_size = 3;
-  EXPECT_EQ(infered_dist_attrs_st.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs_st.second.size(), output_size);
-  EXPECT_EQ(infered_dist_attrs_dy.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs_dy.second.size(), output_size);
+  EXPECT_EQ(inferred_dist_attrs_st.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs_st.second.size(), output_size);
+  EXPECT_EQ(inferred_dist_attrs_dy.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs_dy.second.size(), output_size);
 
-  check_dim_mapping(infered_dist_attrs_dy.first[0], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs_dy.second[0], {-1, -1});
-  check_dim_mapping(infered_dist_attrs_dy.second[1], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs_dy.second[2], {-1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs_dy.first[0], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs_dy.second[0], {-1, -1});
+  check_dim_mapping(inferred_dist_attrs_dy.second[1], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs_dy.second[2], {-1, -1, -1});
 
-  EXPECT_EQ(infered_dist_attrs_st.first, infered_dist_attrs_dy.first);
-  EXPECT_EQ(infered_dist_attrs_st.second, infered_dist_attrs_dy.second);
+  EXPECT_EQ(inferred_dist_attrs_st.first, inferred_dist_attrs_dy.first);
+  EXPECT_EQ(inferred_dist_attrs_st.second, inferred_dist_attrs_dy.second);
   VLOG(4) << "test2 done." << std::endl << std::endl << std::endl;
 
   // conflict on batch axis
@@ -608,11 +608,11 @@ TEST(DefaultDataParallelSPMDRule, Ctor) {
   out1 = phi::distributed::DistMetaTensor(common::make_ddim(out1_shape),
                                           out1_dist_attr);
 
-  EXPECT_ANY_THROW(infered_dist_attrs_st =
+  EXPECT_ANY_THROW(inferred_dist_attrs_st =
                        phi::distributed::DefaultDataParallelInferSpmd(
                            {&x, &y, &out1}, {&out2}));
   // call in variadic arguments format
-  EXPECT_ANY_THROW(infered_dist_attrs_dy =
+  EXPECT_ANY_THROW(inferred_dist_attrs_dy =
                        phi::distributed::VariadicDefaultDataParallelInferSpmd(
                            x, y, out1, &out2));
 
@@ -627,25 +627,26 @@ TEST(DefaultDataParallelSPMDRule, Ctor) {
   out2 = phi::distributed::DistMetaTensor(common::make_ddim(out2_shape),
                                           out2_dist_attr);
 
-  infered_dist_attrs_st = phi::distributed::DefaultDataParallelInferSpmdReverse(
-      {&x, &y}, {&out1, &out2});
+  inferred_dist_attrs_st =
+      phi::distributed::DefaultDataParallelInferSpmdReverse({&x, &y},
+                                                            {&out1, &out2});
   // call in variadic arguments format
-  infered_dist_attrs_dy =
+  inferred_dist_attrs_dy =
       phi::distributed::VariadicDefaultDataParallelInferSpmdReverse(
           x, y, &out1, &out2);
 
   input_size = 2;
   output_size = 2;
-  EXPECT_EQ(infered_dist_attrs_st.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs_st.second.size(), output_size);
-  EXPECT_EQ(infered_dist_attrs_dy.first.size(), input_size);
-  EXPECT_EQ(infered_dist_attrs_dy.second.size(), output_size);
-  check_dim_mapping(infered_dist_attrs_dy.first[0], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs_dy.first[1], {0, -1});
-  check_dim_mapping(infered_dist_attrs_dy.second[0], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs_dy.second[1], {0, -1, -1});
-  EXPECT_EQ(infered_dist_attrs_st.first, infered_dist_attrs_dy.first);
-  EXPECT_EQ(infered_dist_attrs_st.second, infered_dist_attrs_dy.second);
+  EXPECT_EQ(inferred_dist_attrs_st.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs_st.second.size(), output_size);
+  EXPECT_EQ(inferred_dist_attrs_dy.first.size(), input_size);
+  EXPECT_EQ(inferred_dist_attrs_dy.second.size(), output_size);
+  check_dim_mapping(inferred_dist_attrs_dy.first[0], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs_dy.first[1], {0, -1});
+  check_dim_mapping(inferred_dist_attrs_dy.second[0], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs_dy.second[1], {0, -1, -1});
+  EXPECT_EQ(inferred_dist_attrs_st.first, inferred_dist_attrs_dy.first);
+  EXPECT_EQ(inferred_dist_attrs_st.second, inferred_dist_attrs_dy.second);
   VLOG(4) << "test4 done." << std::endl << std::endl << std::endl;
 }
 TEST(ConcatRule, Ctor) {
@@ -676,22 +677,22 @@ TEST(ConcatRule, Ctor) {
 
   // test 1, inputs are aligned according to cost, and partial status is cleared
   auto inputs = build_inputs();
-  auto infered_dist_attrs = phi::distributed::ConcatInferSpmd(inputs, 0);
+  auto inferred_dist_attrs = phi::distributed::ConcatInferSpmd(inputs, 0);
   // list of tensor => single tensor
-  EXPECT_EQ(infered_dist_attrs.first.size(), static_cast<size_t>(1));
-  EXPECT_EQ(infered_dist_attrs.second.size(), static_cast<size_t>(1));
+  EXPECT_EQ(inferred_dist_attrs.first.size(), static_cast<size_t>(1));
+  EXPECT_EQ(inferred_dist_attrs.second.size(), static_cast<size_t>(1));
   EXPECT_TRUE(
       paddle::holds_alternative<std::vector<phi::distributed::TensorDistAttr>>(
-          infered_dist_attrs.first[0]));
+          inferred_dist_attrs.first[0]));
   EXPECT_TRUE(paddle::holds_alternative<phi::distributed::TensorDistAttr>(
-      infered_dist_attrs.second[0]));
-  auto& inputs_infer1 = paddle::get<1>(infered_dist_attrs.first[0]);
+      inferred_dist_attrs.second[0]));
+  auto& inputs_infer1 = paddle::get<1>(inferred_dist_attrs.first[0]);
   for (auto e : inputs_infer1) {
     check_dim_mapping(e, {-1, 1, 0});
     check_partial_dims(e, {});
   }
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, 1, 0});
-  check_partial_dims(infered_dist_attrs.second[0], {});
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, 1, 0});
+  check_partial_dims(inferred_dist_attrs.second[0], {});
 
   auto build_output = [&](const TensorDistAttr& t_dist_attr,
                           const std::vector<int64_t>& shape) {
@@ -700,55 +701,55 @@ TEST(ConcatRule, Ctor) {
   };
 
   auto& output_dist_attr =
-      PADDLE_GET_CONST(TensorDistAttr, infered_dist_attrs.second[0]);
+      PADDLE_GET_CONST(TensorDistAttr, inferred_dist_attrs.second[0]);
   auto output = build_output(output_dist_attr, {22, 16, 16});
   // test reverse
-  auto infered_reverse_attrs =
+  auto inferred_reverse_attrs =
       phi::distributed::ConcatInferSpmdReverse(inputs, output, 0);
   auto& inputs_infer1_reverse = PADDLE_GET_CONST(
-      std::vector<TensorDistAttr>, infered_reverse_attrs.first[0]);
+      std::vector<TensorDistAttr>, inferred_reverse_attrs.first[0]);
   for (auto e : inputs_infer1_reverse) {
     check_dim_mapping(e, {-1, 1, 0});
     check_partial_dims(e, {});
   }
-  check_dim_mapping(infered_reverse_attrs.second[0],
+  check_dim_mapping(inferred_reverse_attrs.second[0],
                     output_dist_attr.dims_mapping());
   // test grad
-  auto infered_grad_attrs =
+  auto inferred_grad_attrs =
       phi::distributed::ConcatGradInferSpmdDynamic(inputs, output, 0);
   auto& inputs_infer1_grad = PADDLE_GET_CONST(std::vector<TensorDistAttr>,
-                                              infered_grad_attrs.first[0]);
+                                              inferred_grad_attrs.first[0]);
   for (auto e : inputs_infer1_grad) {
     check_dim_mapping(e, {-1, 1, 0});
     check_partial_dims(e, {});
   }
-  check_dim_mapping(infered_grad_attrs.first[1],
+  check_dim_mapping(inferred_grad_attrs.first[1],
                     output_dist_attr.dims_mapping());
-  auto& infered_grad = PADDLE_GET_CONST(std::vector<TensorDistAttr>,
-                                        infered_grad_attrs.second[0]);
-  for (auto e : infered_grad) {
+  auto& inferred_grad = PADDLE_GET_CONST(std::vector<TensorDistAttr>,
+                                         inferred_grad_attrs.second[0]);
+  for (auto e : inferred_grad) {
     check_dim_mapping(e, {-1, 1, 0});
     check_partial_dims(e, {});
   }
 
   // test 2，force replicate along concat axis
   inputs = build_inputs();
-  infered_dist_attrs = phi::distributed::ConcatInferSpmd(inputs, 1);
+  inferred_dist_attrs = phi::distributed::ConcatInferSpmd(inputs, 1);
   // list of tensor => single tensor
-  EXPECT_EQ(infered_dist_attrs.first.size(), static_cast<size_t>(1));
-  EXPECT_EQ(infered_dist_attrs.second.size(), static_cast<size_t>(1));
+  EXPECT_EQ(inferred_dist_attrs.first.size(), static_cast<size_t>(1));
+  EXPECT_EQ(inferred_dist_attrs.second.size(), static_cast<size_t>(1));
   EXPECT_TRUE(
       paddle::holds_alternative<std::vector<phi::distributed::TensorDistAttr>>(
-          infered_dist_attrs.first[0]));
+          inferred_dist_attrs.first[0]));
   EXPECT_TRUE(paddle::holds_alternative<phi::distributed::TensorDistAttr>(
-      infered_dist_attrs.second[0]));
-  auto& inputs_infer2 = paddle::get<1>(infered_dist_attrs.first[0]);
+      inferred_dist_attrs.second[0]));
+  auto& inputs_infer2 = paddle::get<1>(inferred_dist_attrs.first[0]);
   for (auto e : inputs_infer2) {
     check_dim_mapping(e, {1, -1, 0});
     check_partial_dims(e, {});
   }
-  check_dim_mapping(infered_dist_attrs.second[0], {1, -1, 0});
-  check_partial_dims(infered_dist_attrs.second[0], {});
+  check_dim_mapping(inferred_dist_attrs.second[0], {1, -1, 0});
+  check_partial_dims(inferred_dist_attrs.second[0], {});
 }
 
 TEST(StackRule, Ctor) {
@@ -794,68 +795,68 @@ TEST(StackRule, Ctor) {
 
   // test 1, inputs are aligned according to cost.
   auto inputs = build_inputs();
-  auto infered_dist_attrs = phi::distributed::StackInferSpmd(inputs, 0);
+  auto inferred_dist_attrs = phi::distributed::StackInferSpmd(inputs, 0);
   // list of tensor => single tensor
-  EXPECT_EQ(infered_dist_attrs.first.size(), static_cast<size_t>(1));
-  EXPECT_EQ(infered_dist_attrs.second.size(), static_cast<size_t>(1));
+  EXPECT_EQ(inferred_dist_attrs.first.size(), static_cast<size_t>(1));
+  EXPECT_EQ(inferred_dist_attrs.second.size(), static_cast<size_t>(1));
   EXPECT_TRUE(
       paddle::holds_alternative<std::vector<phi::distributed::TensorDistAttr>>(
-          infered_dist_attrs.first[0]));
+          inferred_dist_attrs.first[0]));
   EXPECT_TRUE(paddle::holds_alternative<phi::distributed::TensorDistAttr>(
-      infered_dist_attrs.second[0]));
+      inferred_dist_attrs.second[0]));
   auto& inputs_infer1 = PADDLE_GET_CONST(std::vector<TensorDistAttr>,
-                                         infered_dist_attrs.first[0]);
+                                         inferred_dist_attrs.first[0]);
   for (auto e : inputs_infer1) {
     check_dim_mapping(e, {-1, 1, 0});
     check_partial_dims(e, {});
   }
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, -1, 1, 0});
-  check_partial_dims(infered_dist_attrs.second[0], {});
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, -1, 1, 0});
+  check_partial_dims(inferred_dist_attrs.second[0], {});
 
   auto output_dist_attr =
-      PADDLE_GET_CONST(TensorDistAttr, infered_dist_attrs.second[0]);
+      PADDLE_GET_CONST(TensorDistAttr, inferred_dist_attrs.second[0]);
   auto output = build_output(output_dist_attr, 0);
   // test reverse
-  auto infered_reverse_attrs =
+  auto inferred_reverse_attrs =
       phi::distributed::StackInferSpmdReverse(inputs, output, 0);
   auto& inputs_infer1_reverse = PADDLE_GET_CONST(
-      std::vector<TensorDistAttr>, infered_reverse_attrs.first[0]);
+      std::vector<TensorDistAttr>, inferred_reverse_attrs.first[0]);
   for (auto e : inputs_infer1_reverse) {
     check_dim_mapping(e, {-1, 1, 0});
     check_partial_dims(e, {});
   }
-  check_dim_mapping(infered_reverse_attrs.second[0],
+  check_dim_mapping(inferred_reverse_attrs.second[0],
                     output_dist_attr.dims_mapping());
   // test grad
-  auto infered_grad_attrs = phi::distributed::StackGradInferSpmd(output, 0);
-  check_dim_mapping(infered_grad_attrs.first[0],
+  auto inferred_grad_attrs = phi::distributed::StackGradInferSpmd(output, 0);
+  check_dim_mapping(inferred_grad_attrs.first[0],
                     output_dist_attr.dims_mapping());
-  auto& infered_grad = PADDLE_GET_CONST(std::vector<TensorDistAttr>,
-                                        infered_grad_attrs.second[0]);
-  for (auto e : infered_grad) {
+  auto& inferred_grad = PADDLE_GET_CONST(std::vector<TensorDistAttr>,
+                                         inferred_grad_attrs.second[0]);
+  for (auto e : inferred_grad) {
     check_dim_mapping(e, {-1, 1, 0});
     check_partial_dims(e, {});
   }
 
   // test 2，force replicate along concat axis
   inputs = build_inputs();
-  infered_dist_attrs = phi::distributed::StackInferSpmd(inputs, 1);
+  inferred_dist_attrs = phi::distributed::StackInferSpmd(inputs, 1);
   // list of tensor => single tensor
-  EXPECT_EQ(infered_dist_attrs.first.size(), static_cast<size_t>(1));
-  EXPECT_EQ(infered_dist_attrs.second.size(), static_cast<size_t>(1));
+  EXPECT_EQ(inferred_dist_attrs.first.size(), static_cast<size_t>(1));
+  EXPECT_EQ(inferred_dist_attrs.second.size(), static_cast<size_t>(1));
   EXPECT_TRUE(
       paddle::holds_alternative<std::vector<phi::distributed::TensorDistAttr>>(
-          infered_dist_attrs.first[0]));
+          inferred_dist_attrs.first[0]));
   EXPECT_TRUE(paddle::holds_alternative<phi::distributed::TensorDistAttr>(
-      infered_dist_attrs.second[0]));
+      inferred_dist_attrs.second[0]));
   auto& inputs_infer2 = PADDLE_GET_CONST(std::vector<TensorDistAttr>,
-                                         infered_dist_attrs.first[0]);
+                                         inferred_dist_attrs.first[0]);
   for (auto e : inputs_infer2) {
     check_dim_mapping(e, {-1, 1, 0});
     check_partial_dims(e, {});
   }
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, -1, 1, 0});
-  check_partial_dims(infered_dist_attrs.second[0], {});
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, -1, 1, 0});
+  check_partial_dims(inferred_dist_attrs.second[0], {});
 }
 
 TEST(WhereRule, Ctor) {
@@ -882,21 +883,21 @@ TEST(WhereRule, Ctor) {
   };
 
   auto inputs = build_inputs();
-  auto infered_dist_attrs = phi::distributed::WhereGradInferSpmd(
+  auto inferred_dist_attrs = phi::distributed::WhereGradInferSpmd(
       inputs[0], inputs[1], inputs[2], inputs[0]);
 
-  EXPECT_EQ(infered_dist_attrs.first.size(), static_cast<size_t>(4));
-  EXPECT_EQ(infered_dist_attrs.second.size(), static_cast<size_t>(2));
+  EXPECT_EQ(inferred_dist_attrs.first.size(), static_cast<size_t>(4));
+  EXPECT_EQ(inferred_dist_attrs.second.size(), static_cast<size_t>(2));
 
-  check_dim_mapping(infered_dist_attrs.first[0], {-1, 0, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {0, -1});
-  check_dim_mapping(infered_dist_attrs.first[2], {-1});
-  check_dim_mapping(infered_dist_attrs.first[3], {-1, 0, -1});
+  check_dim_mapping(inferred_dist_attrs.first[0], {-1, 0, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {0, -1});
+  check_dim_mapping(inferred_dist_attrs.first[2], {-1});
+  check_dim_mapping(inferred_dist_attrs.first[3], {-1, 0, -1});
 
-  check_dim_mapping(infered_dist_attrs.second[0], {0, -1});
-  check_partial_dims(infered_dist_attrs.second[0], {});
-  check_dim_mapping(infered_dist_attrs.second[1], {-1});
-  check_partial_dims(infered_dist_attrs.second[1], {0});
+  check_dim_mapping(inferred_dist_attrs.second[0], {0, -1});
+  check_partial_dims(inferred_dist_attrs.second[0], {});
+  check_dim_mapping(inferred_dist_attrs.second[1], {-1});
+  check_partial_dims(inferred_dist_attrs.second[1], {0});
 }
 
 TEST(ReduceMaxRule, Ctor) {
@@ -967,12 +968,12 @@ TEST(Numel, Ctor) {
   t_dist_attr.set_dynamic_dims({false, false, false});
   auto input =
       phi::distributed::DistMetaTensor(common::make_ddim(shape), t_dist_attr);
-  auto infered_dist_attrs = phi::distributed::NumelInferSpmd(input);
-  EXPECT_EQ(infered_dist_attrs.first.size(), static_cast<size_t>(1));
-  EXPECT_EQ(infered_dist_attrs.second.size(), static_cast<size_t>(1));
-  check_dim_mapping(infered_dist_attrs.first[0], dims_mapping);
-  check_dim_mapping(infered_dist_attrs.second[0], {});
-  check_partial_dims(infered_dist_attrs.second[0], {0});
+  auto inferred_dist_attrs = phi::distributed::NumelInferSpmd(input);
+  EXPECT_EQ(inferred_dist_attrs.first.size(), static_cast<size_t>(1));
+  EXPECT_EQ(inferred_dist_attrs.second.size(), static_cast<size_t>(1));
+  check_dim_mapping(inferred_dist_attrs.first[0], dims_mapping);
+  check_dim_mapping(inferred_dist_attrs.second[0], {});
+  check_partial_dims(inferred_dist_attrs.second[0], {0});
 }
 
 TEST(Triu, Ctor) {
@@ -990,12 +991,12 @@ TEST(Triu, Ctor) {
   t_dist_attr.set_dynamic_dims({false, false, false});
   auto input =
       phi::distributed::DistMetaTensor(common::make_ddim(shape), t_dist_attr);
-  auto infered_dist_attrs = phi::distributed::TriuGradInferSpmd(input, 0);
-  EXPECT_EQ(infered_dist_attrs.first.size(), static_cast<size_t>(1));
-  EXPECT_EQ(infered_dist_attrs.second.size(), static_cast<size_t>(1));
-  check_dim_mapping(infered_dist_attrs.first[0], {0, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {0, -1, -1});
-  check_partial_dims(infered_dist_attrs.second[0], {});
+  auto inferred_dist_attrs = phi::distributed::TriuGradInferSpmd(input, 0);
+  EXPECT_EQ(inferred_dist_attrs.first.size(), static_cast<size_t>(1));
+  EXPECT_EQ(inferred_dist_attrs.second.size(), static_cast<size_t>(1));
+  check_dim_mapping(inferred_dist_attrs.first[0], {0, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {0, -1, -1});
+  check_partial_dims(inferred_dist_attrs.second[0], {});
 }
 
 TEST(LayerNorm, Ctor) {
@@ -1349,33 +1350,34 @@ TEST(ElementwiseUnaryLike, Ctor) {
   // cast
   auto input =
       phi::distributed::DistMetaTensor(common::make_ddim(shape), t_dist_attr);
-  auto infered_dist_attrs =
+  auto inferred_dist_attrs =
       phi::distributed::CastInferSpmd(input, phi::DataType::FLOAT32);
 
-  check_element_unary_like(infered_dist_attrs);
+  check_element_unary_like(inferred_dist_attrs);
   // full like
   input =
       phi::distributed::DistMetaTensor(common::make_ddim(shape), t_dist_attr);
-  infered_dist_attrs =
+  inferred_dist_attrs =
       phi::distributed::FullLikeInferSpmd(input, 1.0, phi::DataType::FLOAT32);
-  check_element_unary_like(infered_dist_attrs);
+  check_element_unary_like(inferred_dist_attrs);
 
   // pow
   input =
       phi::distributed::DistMetaTensor(common::make_ddim(shape), t_dist_attr);
-  infered_dist_attrs = phi::distributed::PowInferSpmd(input, 2);
-  check_element_unary_like(infered_dist_attrs);
+  inferred_dist_attrs = phi::distributed::PowInferSpmd(input, 2);
+  check_element_unary_like(inferred_dist_attrs);
 
   // pow backward
   input =
       phi::distributed::DistMetaTensor(common::make_ddim(shape), t_dist_attr);
-  infered_dist_attrs = phi::distributed::PowGradInferSpmd(input, input, 2);
+  inferred_dist_attrs = phi::distributed::PowGradInferSpmd(input, input, 2);
 
   // scale
   input =
       phi::distributed::DistMetaTensor(common::make_ddim(shape), t_dist_attr);
-  infered_dist_attrs = phi::distributed::ScaleInferSpmd(input, 1.0, 1.0, false);
-  check_element_unary_like(infered_dist_attrs);
+  inferred_dist_attrs =
+      phi::distributed::ScaleInferSpmd(input, 1.0, 1.0, false);
+  check_element_unary_like(inferred_dist_attrs);
 }
 
 TEST(EmbeddingGradInferSpmd, Ctor) {
@@ -2006,11 +2008,11 @@ TEST(Conv2dSPMDRuleInferForward, Ctor) {
                                            input_dist_attr);
   filter = phi::distributed::DistMetaTensor(common::make_ddim(filter_shape),
                                             filter_dist_attr);
-  auto infered_dist_attrs = phi::distributed::Conv2dInferSpmd(input, filter);
+  auto inferred_dist_attrs = phi::distributed::Conv2dInferSpmd(input, filter);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[0], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {0, -1, -1, -1});
 
   // test 2
   input_dist_attr.set_dims_mapping(std::vector<int64_t>({-1, -1, -1, -1}));
@@ -2020,11 +2022,11 @@ TEST(Conv2dSPMDRuleInferForward, Ctor) {
                                            input_dist_attr);
   filter = phi::distributed::DistMetaTensor(common::make_ddim(filter_shape),
                                             filter_dist_attr);
-  infered_dist_attrs = phi::distributed::Conv2dInferSpmd(input, filter);
+  inferred_dist_attrs = phi::distributed::Conv2dInferSpmd(input, filter);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, 0, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[0], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, 0, -1, -1});
 
   // test 3
   input_dist_attr.set_dims_mapping(std::vector<int64_t>({0, -1, -1, -1}));
@@ -2034,11 +2036,11 @@ TEST(Conv2dSPMDRuleInferForward, Ctor) {
                                            input_dist_attr);
   filter = phi::distributed::DistMetaTensor(common::make_ddim(filter_shape),
                                             filter_dist_attr);
-  infered_dist_attrs = phi::distributed::Conv2dInferSpmd(input, filter);
+  inferred_dist_attrs = phi::distributed::Conv2dInferSpmd(input, filter);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {0, 1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[0], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {0, 1, -1, -1});
 
   // test 4
   input_dist_attr.set_dims_mapping(std::vector<int64_t>({-1, 0, -1, -1}));
@@ -2049,12 +2051,12 @@ TEST(Conv2dSPMDRuleInferForward, Ctor) {
   filter = phi::distributed::DistMetaTensor(common::make_ddim(filter_shape),
                                             filter_dist_attr);
 
-  infered_dist_attrs = phi::distributed::Conv2dInferSpmd(input, filter);
+  inferred_dist_attrs = phi::distributed::Conv2dInferSpmd(input, filter);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {-1, 0, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1, 0, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, -1, -1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), true);
+  check_dim_mapping(inferred_dist_attrs.first[0], {-1, 0, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1, 0, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, -1, -1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), true);
 
   // test 5
   input_dist_attr.set_dims_mapping(std::vector<int64_t>({0, 2, -1, -1}));
@@ -2065,12 +2067,12 @@ TEST(Conv2dSPMDRuleInferForward, Ctor) {
   filter = phi::distributed::DistMetaTensor(common::make_ddim(filter_shape),
                                             filter_dist_attr);
 
-  infered_dist_attrs = phi::distributed::Conv2dInferSpmd(input, filter);
+  inferred_dist_attrs = phi::distributed::Conv2dInferSpmd(input, filter);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {0, 2, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {1, 2, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {0, 1, -1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), true);
+  check_dim_mapping(inferred_dist_attrs.first[0], {0, 2, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {1, 2, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {0, 1, -1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), true);
 }
 
 TEST(Conv2dSPMDRuleInferBackward, Ctor) {
@@ -2109,12 +2111,12 @@ TEST(Conv2dSPMDRuleInferBackward, Ctor) {
   phi::distributed::DistMetaTensor output(common::make_ddim(output_shape),
                                           output_dist_attr);
 
-  auto infered_dist_attrs =
+  auto inferred_dist_attrs =
       phi::distributed::Conv2dInferSpmdReverse(input, filter, output);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {0, 1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[0], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {0, 1, -1, -1});
 }
 
 TEST(Conv2dGradSPMDRule, Ctor) {
@@ -2155,16 +2157,16 @@ TEST(Conv2dGradSPMDRule, Ctor) {
       common::make_ddim(output_grad_shape), output_grad_dist_attr);
 
   // test 1
-  auto infered_dist_attrs =
+  auto inferred_dist_attrs =
       phi::distributed::Conv2dGradInferSpmd(input, filter, output_grad);
-  EXPECT_EQ(infered_dist_attrs.first.size(), (size_t)3);
-  EXPECT_EQ(infered_dist_attrs.second.size(), (size_t)2);
-  check_dim_mapping(infered_dist_attrs.first[0], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[2], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[1], {-1, -1, -1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.first[2]), false);
+  EXPECT_EQ(inferred_dist_attrs.first.size(), (size_t)3);
+  EXPECT_EQ(inferred_dist_attrs.second.size(), (size_t)2);
+  check_dim_mapping(inferred_dist_attrs.first[0], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[2], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[1], {-1, -1, -1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.first[2]), false);
   VLOG(4) << "test 1 done";
 
   // test 2
@@ -2178,16 +2180,16 @@ TEST(Conv2dGradSPMDRule, Ctor) {
                                             filter_dist_attr);
   output_grad = phi::distributed::DistMetaTensor(
       common::make_ddim(output_grad_shape), output_grad_dist_attr);
-  infered_dist_attrs =
+  inferred_dist_attrs =
       phi::distributed::Conv2dGradInferSpmd(input, filter, output_grad);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[2], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[1], {-1, -1, -1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.first[2]), false);
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[1]), true);
+  check_dim_mapping(inferred_dist_attrs.first[0], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[2], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[1], {-1, -1, -1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.first[2]), false);
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[1]), true);
 
   // test 3
   input_dist_attr.set_dims_mapping(std::vector<int64_t>({-1, -1, -1, -1}));
@@ -2200,16 +2202,16 @@ TEST(Conv2dGradSPMDRule, Ctor) {
                                             filter_dist_attr);
   output_grad = phi::distributed::DistMetaTensor(
       common::make_ddim(output_grad_shape), output_grad_dist_attr);
-  infered_dist_attrs =
+  inferred_dist_attrs =
       phi::distributed::Conv2dGradInferSpmd(input, filter, output_grad);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[2], {-1, 0, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {-1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[1], {0, -1, -1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.first[2]), false);
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), true);
+  check_dim_mapping(inferred_dist_attrs.first[0], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[2], {-1, 0, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {-1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[1], {0, -1, -1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.first[2]), false);
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), true);
 
   // test 4
   input_dist_attr.set_dims_mapping(std::vector<int64_t>({0, -1, -1, -1}));
@@ -2222,17 +2224,17 @@ TEST(Conv2dGradSPMDRule, Ctor) {
                                             filter_dist_attr);
   output_grad = phi::distributed::DistMetaTensor(
       common::make_ddim(output_grad_shape), output_grad_dist_attr);
-  infered_dist_attrs =
+  inferred_dist_attrs =
       phi::distributed::Conv2dGradInferSpmd(input, filter, output_grad);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {1, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[2], {0, 1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {0, -1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[1], {1, -1, -1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.first[2]), false);
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), true);
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[1]), true);
+  check_dim_mapping(inferred_dist_attrs.first[0], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {1, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[2], {0, 1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {0, -1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[1], {1, -1, -1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.first[2]), false);
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), true);
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[1]), true);
 
   // test 5
   input_dist_attr.set_dims_mapping(std::vector<int64_t>({0, 2, -1, -1}));
@@ -2247,17 +2249,17 @@ TEST(Conv2dGradSPMDRule, Ctor) {
   output_grad = phi::distributed::DistMetaTensor(
       common::make_ddim(output_grad_shape), output_grad_dist_attr);
 
-  infered_dist_attrs =
+  inferred_dist_attrs =
       phi::distributed::Conv2dGradInferSpmd(input, filter, output_grad);
 
-  check_dim_mapping(infered_dist_attrs.first[0], {0, 2, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[1], {1, 2, -1, -1});
-  check_dim_mapping(infered_dist_attrs.first[2], {0, 1, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[0], {0, 2, -1, -1});
-  check_dim_mapping(infered_dist_attrs.second[1], {1, 2, -1, -1});
-  EXPECT_EQ(is_partial(infered_dist_attrs.first[2]), true);
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[0]), true);
-  EXPECT_EQ(is_partial(infered_dist_attrs.second[1]), true);
+  check_dim_mapping(inferred_dist_attrs.first[0], {0, 2, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[1], {1, 2, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.first[2], {0, 1, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[0], {0, 2, -1, -1});
+  check_dim_mapping(inferred_dist_attrs.second[1], {1, 2, -1, -1});
+  EXPECT_EQ(is_partial(inferred_dist_attrs.first[2]), true);
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[0]), true);
+  EXPECT_EQ(is_partial(inferred_dist_attrs.second[1]), true);
 }
 
 TEST(Dropout, Ctor) {

--- a/test/cpp/auto_parallel/spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/spmd_rule_test.cc
@@ -686,8 +686,8 @@ TEST(ConcatRule, Ctor) {
           inferred_dist_attrs.first[0]));
   EXPECT_TRUE(paddle::holds_alternative<phi::distributed::TensorDistAttr>(
       inferred_dist_attrs.second[0]));
-  auto& inputs_infer1 =
-      PADDLE_GET(std::vector<TensorDistAttr>, inferred_dist_attrs.first[0]);
+  auto& inputs_infer1 = PADDLE_GET_CONST(std::vector<TensorDistAttr>,
+                                         inferred_dist_attrs.first[0]);
   for (auto e : inputs_infer1) {
     check_dim_mapping(e, {-1, 1, 0});
     check_partial_dims(e, {});
@@ -744,8 +744,8 @@ TEST(ConcatRule, Ctor) {
           inferred_dist_attrs.first[0]));
   EXPECT_TRUE(paddle::holds_alternative<phi::distributed::TensorDistAttr>(
       inferred_dist_attrs.second[0]));
-  auto& inputs_infer2 =
-      PADDLE_GET(std::vector<TensorDistAttr>, inferred_dist_attrs.first[0]);
+  auto& inputs_infer2 = PADDLE_GET_CONST(std::vector<TensorDistAttr>,
+                                         inferred_dist_attrs.first[0]);
   for (auto e : inputs_infer2) {
     check_dim_mapping(e, {1, -1, 0});
     check_partial_dims(e, {});

--- a/test/deprecated/mkldnn/test_reshape_mkldnn_op_deprecated.py
+++ b/test/deprecated/mkldnn/test_reshape_mkldnn_op_deprecated.py
@@ -32,7 +32,7 @@ class TestReshape2OneDNNOp(OpTest):
         self.inputs = {"X": np.random.random(self.ori_shape).astype("float32")}
         self.attrs = {"shape": self.new_shape}
         self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
+            "Out": self.inputs["X"].reshape(self.inferred_shape),
             'XShape': np.random.random(self.ori_shape).astype("float32"),
         }
         self.x = self.inputs["X"]
@@ -43,7 +43,7 @@ class TestReshape2OneDNNOp(OpTest):
     def init_data(self):
         self.ori_shape = (2, 60)
         self.new_shape = (12, 10)
-        self.infered_shape = (12, 10)
+        self.inferred_shape = (12, 10)
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -69,35 +69,35 @@ class TestReshape2OneDNNOpZeroDim(TestReshape2OneDNNOp):
     def init_data(self):
         self.ori_shape = ()
         self.new_shape = (1,)
-        self.infered_shape = (1,)
+        self.inferred_shape = (1,)
 
 
 class TestReshape2OneDNNOpZeroDim2(TestReshape2OneDNNOpZeroDim):
     def init_data(self):
         self.ori_shape = (1,)
         self.new_shape = ()
-        self.infered_shape = ()
+        self.inferred_shape = ()
 
 
 class TestReshape2OneDNNOpDimInfer1(TestReshape2OneDNNOp):
     def init_data(self):
         self.ori_shape = (5, 25)
         self.new_shape = (5, -1, 5)
-        self.infered_shape = (5, -1, 5)
+        self.inferred_shape = (5, -1, 5)
 
 
 class TestReshape2OneDNNOpDimInfer2(TestReshape2OneDNNOp):
     def init_data(self):
         self.ori_shape = (6, 20)
         self.new_shape = (0, -1, 20)
-        self.infered_shape = (2, 3, 20)
+        self.inferred_shape = (2, 3, 20)
 
     def set_additional_inputs(self):
-        self.inputs["Shape"] = np.array(self.infered_shape, dtype="int32")
+        self.inputs["Shape"] = np.array(self.inferred_shape, dtype="int32")
 
     def set_outputs(self):
         self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
+            "Out": self.inputs["X"].reshape(self.inferred_shape),
             'XShape': np.random.random(self.ori_shape).astype("float32"),
         }
 
@@ -108,14 +108,14 @@ class TestReshape2OneDNNOp_attr_OnlyShape(TestReshape2OneDNNOp):
 
     def set_outputs(self):
         self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
+            "Out": self.inputs["X"].reshape(self.inferred_shape),
             'XShape': np.random.random(self.ori_shape).astype("float32"),
         }
 
     def init_data(self):
         self.ori_shape = (4, 25)
         self.new_shape = (10, 10)
-        self.infered_shape = (10, 10)
+        self.inferred_shape = (10, 10)
 
 
 class TestReshape2OneDNNOpDimInfer1_attr_OnlyShape(
@@ -124,7 +124,7 @@ class TestReshape2OneDNNOpDimInfer1_attr_OnlyShape(
     def init_data(self):
         self.ori_shape = (5, 20)
         self.new_shape = (5, -1, 10)
-        self.infered_shape = (5, -1, 10)
+        self.inferred_shape = (5, -1, 10)
         self.shape = (5, -1, -1)
 
 
@@ -141,7 +141,7 @@ class TestReshape2OneDNNOpDimInfer1_attr_ShapeTensor(TestReshape2OneDNNOp):
     def init_data(self):
         self.ori_shape = (5, 20)
         self.new_shape = (5, -1, 10)
-        self.infered_shape = (5, -1, 10)
+        self.inferred_shape = (5, -1, 10)
         self.shape = (5, -1, -1)
 
 
@@ -165,7 +165,7 @@ class TestReshapeOneDNNOp(TestReshape2OneDNNOp):
         self.op_type = "reshape"
 
     def set_outputs(self):
-        self.outputs = {"Out": self.inputs["X"].reshape(self.infered_shape)}
+        self.outputs = {"Out": self.inputs["X"].reshape(self.inferred_shape)}
 
     def test_check_output(self):
         self.check_output(check_dygraph=False)
@@ -175,7 +175,7 @@ class TestReshapeOneDNNOpDimInfer1(TestReshapeOneDNNOp):
     def init_data(self):
         self.ori_shape = (5, 25)
         self.new_shape = (5, -1, 5)
-        self.infered_shape = (5, -1, 5)
+        self.inferred_shape = (5, -1, 5)
 
 
 class TestReshapeOneDNNOp_attr_OnlyShape(TestReshape2OneDNNOp_attr_OnlyShape):
@@ -184,7 +184,7 @@ class TestReshapeOneDNNOp_attr_OnlyShape(TestReshape2OneDNNOp_attr_OnlyShape):
         self.op_type = "reshape"
 
     def set_outputs(self):
-        self.outputs = {"Out": self.inputs["X"].reshape(self.infered_shape)}
+        self.outputs = {"Out": self.inputs["X"].reshape(self.inferred_shape)}
 
     def test_check_output(self):
         self.check_output(check_dygraph=False)
@@ -196,7 +196,7 @@ class TestReshapeOneDNNOpDimInfer1_attr_OnlyShape(
     def init_data(self):
         self.ori_shape = (5, 20)
         self.new_shape = (5, -1, 10)
-        self.infered_shape = (5, -1, 10)
+        self.inferred_shape = (5, -1, 10)
         self.shape = (5, -1, -1)
 
 

--- a/test/legacy_test/test_reshape_op.py
+++ b/test/legacy_test/test_reshape_op.py
@@ -34,14 +34,14 @@ class TestReshapeOp(OpTest):
         self.inputs = {"X": np.random.random(self.ori_shape).astype("float32")}
         self.attrs = {"shape": self.new_shape}
         self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
+            "Out": self.inputs["X"].reshape(self.inferred_shape),
             'XShape': np.random.random(self.ori_shape).astype("float32"),
         }
 
     def init_data(self):
         self.ori_shape = (2, 60)
         self.new_shape = (12, 10)
-        self.infered_shape = (12, 10)
+        self.inferred_shape = (12, 10)
 
     def test_check_output(self):
         self.check_output(no_check_set=['XShape'], check_pir=True)
@@ -68,28 +68,28 @@ class TestReshapeOp_ZeroDim1(TestReshapeOp):
         self.inputs = {"X": np.random.random(self.ori_shape).astype("float32")}
         self.attrs = {"shape": self.new_shape}
         self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
+            "Out": self.inputs["X"].reshape(self.inferred_shape),
             'XShape': np.random.random(self.ori_shape).astype("float32"),
         }
 
     def init_data(self):
         self.ori_shape = ()
         self.new_shape = (1,)
-        self.infered_shape = (1,)
+        self.inferred_shape = (1,)
 
 
 class TestReshapeOp_ZeroDim2(TestReshapeOp_ZeroDim1):
     def init_data(self):
         self.ori_shape = ()
         self.new_shape = (-1,)
-        self.infered_shape = (1,)
+        self.inferred_shape = (1,)
 
 
 class TestReshapeOp_ZeroDim3(OpTest):
     def init_data(self):
         self.ori_shape = (1,)
         self.new_shape = ()
-        self.infered_shape = ()
+        self.inferred_shape = ()
 
 
 @unittest.skipIf(
@@ -107,7 +107,7 @@ class TestReshapeBF16Op(OpTest):
         self.python_out_sig = ['Out']
         self.dtype = np.uint16
         x = np.random.random(self.ori_shape).astype("float32")
-        out = x.reshape(self.infered_shape)
+        out = x.reshape(self.inferred_shape)
         self.inputs = {"X": convert_float_to_uint16(x)}
         self.attrs = {"shape": self.new_shape}
         self.outputs = {
@@ -120,7 +120,7 @@ class TestReshapeBF16Op(OpTest):
     def init_data(self):
         self.ori_shape = (2, 60)
         self.new_shape = (12, 10)
-        self.infered_shape = (12, 10)
+        self.inferred_shape = (12, 10)
 
     def test_check_output(self):
         self.check_output(no_check_set=['XShape'], check_pir=True)
@@ -147,14 +147,14 @@ class TestReshapeFP16Op(OpTest):
         self.inputs = {"X": np.random.random(self.ori_shape).astype(self.dtype)}
         self.attrs = {"shape": self.new_shape}
         self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
+            "Out": self.inputs["X"].reshape(self.inferred_shape),
             'XShape': np.random.random(self.ori_shape).astype(self.dtype),
         }
 
     def init_data(self):
         self.ori_shape = (2, 60)
         self.new_shape = (12, 10)
-        self.infered_shape = (12, 10)
+        self.inferred_shape = (12, 10)
 
     def test_check_output(self):
         self.check_output(no_check_set=['XShape'], check_pir=True)
@@ -173,14 +173,14 @@ class TestReshapeOpDimInfer1(TestReshapeOp):
     def init_data(self):
         self.ori_shape = (5, 25)
         self.new_shape = (5, -1, 5)
-        self.infered_shape = (5, -1, 5)
+        self.inferred_shape = (5, -1, 5)
 
 
 class TestReshapeOpDimInfer2(TestReshapeOp):
     def init_data(self):
         self.ori_shape = (10, 2, 6)
         self.new_shape = (10, 0, 3, -1)
-        self.infered_shape = (10, 2, 3, -1)
+        self.inferred_shape = (10, 2, 3, -1)
 
 
 # situation 2: have shape(list, no tensor), have actual shape(Tensor)
@@ -245,14 +245,14 @@ class TestReshapeOp_attr_ShapeTensor(OpTest):
         }
         self.attrs = {'shape': self.shape}
         self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
+            "Out": self.inputs["X"].reshape(self.inferred_shape),
             'XShape': np.random.random(self.ori_shape).astype("float32"),
         }
 
     def init_data(self):
         self.ori_shape = (4, 25)
         self.new_shape = (10, 10)
-        self.infered_shape = (10, 10)
+        self.inferred_shape = (10, 10)
         self.shape = (-1, -1)
 
     def test_check_output(self):
@@ -274,7 +274,7 @@ class TestReshapeOpDimInfer1_attr_ShapeTensor(TestReshapeOp_attr_ShapeTensor):
     def init_data(self):
         self.ori_shape = (5, 20)
         self.new_shape = (5, -1, 20)
-        self.infered_shape = (5, -1, 20)
+        self.inferred_shape = (5, -1, 20)
         self.shape = (5, -1, -1)
 
 
@@ -282,7 +282,7 @@ class TestReshapeOpDimInfer2_attr_ShapeTensor(TestReshapeOp_attr_ShapeTensor):
     def init_data(self):
         self.ori_shape = (10, 2, 6)
         self.new_shape = (10, 0, 3, -1)
-        self.infered_shape = (10, 2, 3, -1)
+        self.inferred_shape = (10, 2, 3, -1)
         self.shape = (10, 0, 3, -1)
 
 
@@ -302,14 +302,14 @@ class TestReshapeOp_attr_OnlyShape(OpTest):
         }
         self.attrs = {}
         self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
+            "Out": self.inputs["X"].reshape(self.inferred_shape),
             'XShape': np.random.random(self.ori_shape).astype("float32"),
         }
 
     def init_data(self):
         self.ori_shape = (4, 25)
         self.new_shape = (10, 10)
-        self.infered_shape = (10, 10)
+        self.inferred_shape = (10, 10)
 
     def test_check_output(self):
         self.check_output(
@@ -330,7 +330,7 @@ class TestReshapeOpDimInfer1_attr_OnlyShape(TestReshapeOp_attr_OnlyShape):
     def init_data(self):
         self.ori_shape = (5, 20)
         self.new_shape = (5, -1, 10)
-        self.infered_shape = (5, -1, 10)
+        self.inferred_shape = (5, -1, 10)
         self.shape = (5, -1, -1)
 
 
@@ -338,7 +338,7 @@ class TestReshapeOpDimInfer2_attr_OnlyShape(TestReshapeOp_attr_OnlyShape):
     def init_data(self):
         self.ori_shape = (10, 2, 6)
         self.new_shape = (10, 0, 3, -1)
-        self.infered_shape = (10, 2, 3, -1)
+        self.inferred_shape = (10, 2, 3, -1)
         self.shape = (10, 0, 3, -1)
 
 
@@ -359,7 +359,7 @@ class TestReshapeInt8Op(OpTest):
             'use_mkldnn': self.use_mkldnn,
         }
         self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
+            "Out": self.inputs["X"].reshape(self.inferred_shape),
             'XShape': np.random.random(self.ori_shape).astype(np.float32),
         }
 
@@ -369,7 +369,7 @@ class TestReshapeInt8Op(OpTest):
     def init_data(self):
         self.ori_shape = (10, 2, 6)
         self.new_shape = (10, 0, 3, -1)
-        self.infered_shape = (10, 2, 3, -1)
+        self.inferred_shape = (10, 2, 3, -1)
 
     def test_check_output(self):
         self.check_output_with_place(
@@ -403,7 +403,7 @@ class TestReshapeOpBool(TestReshapeOp):
         }
         self.attrs = {"shape": self.new_shape}
         self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
+            "Out": self.inputs["X"].reshape(self.inferred_shape),
             'XShape': np.random.random(self.ori_shape).astype("float32"),
         }
 

--- a/test/legacy_test/test_swiglu.py
+++ b/test/legacy_test/test_swiglu.py
@@ -250,12 +250,12 @@ class TestSwigluSpmd(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0])
 
     def test_input_x_unshard_last_dim(self):
         x_shape = [64, 32]
@@ -268,12 +268,12 @@ class TestSwigluSpmd(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, DistTensorSpec()
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/testsuite.py
+++ b/test/legacy_test/testsuite.py
@@ -111,7 +111,7 @@ def append_input_output(
             np_value = np_list[name]
             if isinstance(np_value, tuple):
                 dtype = np_value[0].dtype
-                # output shape, lod should be infered from input.
+                # output shape, lod should be inferred from input.
                 if is_input:
                     shape = list(np_value[0].shape)
                     lod_level = len(np_value[1])

--- a/test/mkldnn/test_reshape_bf16_op.py
+++ b/test/mkldnn/test_reshape_bf16_op.py
@@ -39,14 +39,14 @@ class TestReshapeBf16Op(OpTest):
             'mkldnn_data_type': self.mkldnn_data_type,
         }
         self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
+            "Out": self.inputs["X"].reshape(self.inferred_shape),
             'XShape': np.random.random(self.ori_shape).astype(np.float32),
         }
 
     def init_data(self):
         self.ori_shape = (10, 2, 6)
         self.new_shape = (10, 0, 3, -1)
-        self.infered_shape = (10, 2, 3, -1)
+        self.inferred_shape = (10, 2, 3, -1)
 
     def init_input_data(self):
         self.input_data_fp32 = np.random.random(self.ori_shape).astype(
@@ -70,7 +70,7 @@ class TestReshapeBf16Op(OpTest):
             check_dygraph=False,
             user_defined_grads=[self.input_data_fp32],
             user_defined_grad_outputs=[
-                self.inputs["X"].reshape(self.infered_shape)
+                self.inputs["X"].reshape(self.inferred_shape)
             ],
             check_pir_onednn=(self.op_type == "reshape2"),
         )

--- a/test/xpu/test_reshape2_op_xpu.py
+++ b/test/xpu/test_reshape2_op_xpu.py
@@ -46,7 +46,7 @@ class XPUTestReshapeOp(XPUOpTestWrapper):
         def init_data(self):
             self.ori_shape = (2, 60)
             self.new_shape = (12, 10)
-            self.infered_shape = (12, 10)
+            self.inferred_shape = (12, 10)
 
         def init_test_input(self):
             self.inputs = {
@@ -55,7 +55,7 @@ class XPUTestReshapeOp(XPUOpTestWrapper):
 
         def init_test_output(self):
             self.outputs = {
-                "Out": self.inputs["X"].reshape(self.infered_shape),
+                "Out": self.inputs["X"].reshape(self.inferred_shape),
                 'XShape': np.random.random(self.ori_shape).astype(self.dtype),
             }
 
@@ -76,13 +76,13 @@ class XPUTestReshapeOp(XPUOpTestWrapper):
         def init_data(self):
             self.ori_shape = (5, 25)
             self.new_shape = (5, -1, 5)
-            self.infered_shape = (5, -1, 5)
+            self.inferred_shape = (5, -1, 5)
 
     class TestReshapeOpDimInfer2(TestReshapeOp):
         def init_data(self):
             self.ori_shape = (10, 2, 6)
             self.new_shape = (10, 0, 3, -1)
-            self.infered_shape = (10, 2, 3, -1)
+            self.inferred_shape = (10, 2, 3, -1)
 
     # situation 2: have shape(list, no tensor), have actual shape(Tensor)
     class TestReshapeOpWithInputShape(TestReshapeOp):
@@ -108,7 +108,7 @@ class XPUTestReshapeOp(XPUOpTestWrapper):
         def init_data(self):
             self.ori_shape = (4, 25)
             self.new_shape = (10, 10)
-            self.infered_shape = (10, 10)
+            self.inferred_shape = (10, 10)
             self.shape = (-1, -1)
 
         def init_test_input(self):
@@ -132,7 +132,7 @@ class XPUTestReshapeOp(XPUOpTestWrapper):
         def init_data(self):
             self.ori_shape = (5, 20)
             self.new_shape = (5, -1, 20)
-            self.infered_shape = (5, -1, 20)
+            self.inferred_shape = (5, -1, 20)
             self.shape = (5, -1, -1)
 
     class TestReshapeOpDimInfer2_attr_ShapeTensor(
@@ -141,7 +141,7 @@ class XPUTestReshapeOp(XPUOpTestWrapper):
         def init_data(self):
             self.ori_shape = (10, 2, 6)
             self.new_shape = (10, 0, 3, -1)
-            self.infered_shape = (10, 2, 3, -1)
+            self.inferred_shape = (10, 2, 3, -1)
             self.shape = (10, 0, 3, -1)
 
     # Situation 4: have shape(Tensor), no actual shape(Tensor)
@@ -149,7 +149,7 @@ class XPUTestReshapeOp(XPUOpTestWrapper):
         def init_data(self):
             self.ori_shape = (4, 25)
             self.new_shape = (10, 10)
-            self.infered_shape = (10, 10)
+            self.inferred_shape = (10, 10)
 
         def init_test_input(self):
             self.inputs = {
@@ -164,14 +164,14 @@ class XPUTestReshapeOp(XPUOpTestWrapper):
         def init_data(self):
             self.ori_shape = (5, 20)
             self.new_shape = (5, -1, 10)
-            self.infered_shape = (5, -1, 10)
+            self.inferred_shape = (5, -1, 10)
             self.shape = (5, -1, -1)
 
     class TestReshapeOpDimInfer2_attr_OnlyShape(TestReshapeOp_attr_OnlyShape):
         def init_data(self):
             self.ori_shape = (10, 2, 6)
             self.new_shape = (10, 0, 3, -1)
-            self.infered_shape = (10, 2, 3, -1)
+            self.inferred_shape = (10, 2, 3, -1)
             self.shape = (10, 0, 3, -1)
 
     @check_run_big_shape_test()
@@ -179,35 +179,35 @@ class XPUTestReshapeOp(XPUOpTestWrapper):
         def init_data(self):
             self.ori_shape = (5120, 32)
             self.new_shape = (32, 5120)
-            self.infered_shape = (32, 5120)
+            self.inferred_shape = (32, 5120)
 
     @check_run_big_shape_test()
     class TestReshapeOpLargeShape2(TestReshapeOp):
         def init_data(self):
             self.ori_shape = (1, 8192, 5120)
             self.new_shape = (8192, 5120)
-            self.infered_shape = (8192, 5120)
+            self.inferred_shape = (8192, 5120)
 
     @check_run_big_shape_test()
     class TestReshapeOpLargeShape3(TestReshapeOp):
         def init_data(self):
             self.ori_shape = (1, 8192)
             self.new_shape = (8192,)
-            self.infered_shape = (8192,)
+            self.inferred_shape = (8192,)
 
     @check_run_big_shape_test()
     class TestReshapeOpLargeShape4(TestReshapeOp):
         def init_data(self):
             self.ori_shape = (1, 8192, 5, 64, 2)
             self.new_shape = (1, 8192, 5, 128)
-            self.infered_shape = (1, 8192, 5, 128)
+            self.inferred_shape = (1, 8192, 5, 128)
 
     @check_run_big_shape_test()
     class TestReshapeOpLargeShape5(TestReshapeOp):
         def init_data(self):
             self.ori_shape = (1, 8192, 5, 128)
             self.new_shape = (1, 8192, 640)
-            self.infered_shape = (1, 8192, 640)
+            self.inferred_shape = (1, 8192, 640)
 
 
 support_types = get_xpu_op_support_types("reshape2")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

Fix typo `infered` -> `inferred` part1

```
Before:
~/Projects/Paddle develop*
❯ typos --format brief | wc -l
    2682

After:
~/Projects/Paddle typos/infered-part1*
❯ typos --format brief | wc -l
    2225
```

本 PR 修复约 450 处

### Related links

- #69441

PCard-66972