### PR TITLE
[CINN][Warning Mitigation] Skip SetShapeOrDataForValue for null Value in InitLocalShapeAnalysis

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/local_infer_symbolic_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/local_infer_symbolic_util.cc
@@ -35,6 +35,9 @@ void InitLocalShapeAnalysis(const pir::Operation& op,
     for (int i = 0; i < op.num_operands(); ++i) {
       pir::Value input = op.operand_source(i);
       const auto& value_dim_exprs = GraphDimExprs4Value(input);
+      if (!input || !input.type()) {
+        continue;
+      }
       Visit(input, value_dim_exprs);
     }
   };


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
缓解为 NULL Value 设置 ShapeOrData 的 Warning

Pcard-67164
- Skip SetShapeOrDataForValue for null Value in InitLocalShapeAnalysis
