### PR TITLE
[CINN][Warning Mitigation] Optimite SetSymbolForValueByStaticShape Warning

### DIFF
--- a/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
+++ b/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
@@ -315,6 +315,9 @@ void InferSymExprForOp(Operation* op,
                      << "[id:" << op->id()
                      << "], op_infer_cache_key is :" << op_infer_cache_key;
         for (uint32_t i = 0; i < op->num_results(); ++i) {
+          if (!op->result(i) || !op->result(i).type()) {
+            continue;
+          }
           infer_context->SetSymbolForValueByStaticShape(op->result(i));
         }
       }

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -146,6 +146,9 @@ void InferSymbolicShapeContext::SetSymbolForValueByStaticShape(Value val) {
     return;
   }
   if (!IsStaticShape(val)) {
+    if (val.isa<pir::BlockArgument>()) {
+      continue;
+    }
     LOG(WARNING)
         << "Risk on SetSymbolForValueByStaticShape for contain_unknown_dim";
   }

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -145,10 +145,7 @@ void InferSymbolicShapeContext::SetSymbolForValueByStaticShape(Value val) {
     LOG(WARNING) << "Risk on SetSymbolForValueByStaticShape for null value";
     return;
   }
-  if (!IsStaticShape(val)) {
-    if (val.isa<pir::BlockArgument>()) {
-      continue;
-    }
+  if (!IsStaticShape(val) && !val.isa<pir::BlockArgument>()) {
     LOG(WARNING)
         << "Risk on SetSymbolForValueByStaticShape for contain_unknown_dim";
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Optimite SetSymbolForValueByStaticShape Warning

1. Skip SetSymbolForValueByStaticShape for null Value in InferSymExprForOp（没有符号推导接口和 cache 的时候
2. BlockArgument 的形状信息使用 SetSymbolForValueByStaticShape 应该没有问题