### PR TITLE
[CodeStyle][Typos][I-15] Fix typo `infered` (part2)

### DIFF
--- a/paddle/cinn/adt/schedule_dim.cc
+++ b/paddle/cinn/adt/schedule_dim.cc
@@ -90,16 +90,16 @@ void FilterReducedIterator(
     const List<Iterator>& input_iterators,
     std::unordered_set<Iterator>* unused_input_iterators) {
   std::unordered_set<Iterator> used{};
-  bool is_output_infered = true;
+  bool is_output_inferred = true;
   VisitEachOutputIterator(op_ctx, [&](const Iterator& output_iterator) {
     if (infer_ctx->HasValue(output_iterator)) {
       const auto& iterator_expr = infer_ctx->GetValue(output_iterator);
       CollectTensorIndexIterators(iterator_expr, &used);
     } else {
-      is_output_infered = false;
+      is_output_inferred = false;
     }
   });
-  if (!is_output_infered) {
+  if (!is_output_inferred) {
     return;
   }
   for (const auto& input_iterator : *input_iterators) {

--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -143,7 +143,7 @@ class ReshapeOp : public framework::OperatorWithKernel {
 
     for (size_t i = 0; i < shape.size(); ++i) {
       if (shape[i] == -1) {
-        // only one dimension can be set to -1, whose size will be infered.
+        // only one dimension can be set to -1, whose size will be inferred.
         PADDLE_ENFORCE_EQ(
             unk_dim_idx,
             -1,
@@ -331,7 +331,7 @@ to be copied from the corresponding dimension of Input(X).
 Note:
 
 1. One and only one dimension in Attr(shape) can be set -1. In this case,
-the actual dimension value will be infered from the total element number of
+the actual dimension value will be inferred from the total element number of
 Input(X) and remaining dimensions.
 
 2. More than one dimensions in Attr(shape) can be set to 0, which means the real

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -3028,7 +3028,7 @@ bool ReshapeOpInferSymbolicShape(
       }
     }
 
-    // replace '-1' with infered shape
+    // replace '-1' with inferred shape
 
     const auto &product_exclude_minus_one =
         GetProduct(target_shape, IsPositiveInteger);

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -1336,7 +1336,7 @@ phi::KernelKey GetKernelKey(
   }
 
   if (kernel_backend == phi::Backend::UNDEFINED) {
-    VLOG(8) << "Kernel backend cannot be infered from op operands";
+    VLOG(8) << "Kernel backend cannot be inferred from op operands";
     kernel_backend = paddle::experimental::ParseBackend(place);
   }
 
@@ -1348,7 +1348,7 @@ phi::KernelKey GetKernelKey(
 #endif
   phi::KernelKey res(kernel_backend, kernel_layout, kernel_dtype);
 
-  // kernel backend infered incorrectly from memcpy op operands,
+  // kernel backend inferred incorrectly from memcpy op operands,
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   // case that place from (not GPU) to GPU.
   // We handle this special case by following code to fix up the problem.

--- a/python/paddle/nn/initializer/kaiming.py
+++ b/python/paddle/nn/initializer/kaiming.py
@@ -58,7 +58,7 @@ class MSRAInitializer(Initializer):
 
     Args:
         uniform (bool, optional): whether to use uniform or normal distribution. Default is True.
-        fan_in (float32|None, optional): fan_in (in_features) of trainable Tensor, If None, it will be infered automatically. If you don't want to use in_features of the Tensor, you can set the value of 'fan_in' smartly by yourself. Default is None.
+        fan_in (float32|None, optional): fan_in (in_features) of trainable Tensor, If None, it will be inferred automatically. If you don't want to use in_features of the Tensor, you can set the value of 'fan_in' smartly by yourself. Default is None.
         seed (int32, optional): random seed. Default is 0.
         negative_slope (float, optional): negative_slope (only used with leaky_relu). Default is 0.0.
         nonlinearity(str, optional): the non-linear function. Default is relu.
@@ -270,7 +270,7 @@ class KaimingNormal(MSRAInitializer):
         \frac{gain}{\sqrt{{fan\_in}}}
 
     Args:
-        fan_in (float32|None, optional): fan_in (in_features) of trainable Tensor, If None, it will be infered automatically. If you don't want to use in_features of the Tensor, you can set the value of 'fan_in' smartly by yourself. Default is None.
+        fan_in (float32|None, optional): fan_in (in_features) of trainable Tensor, If None, it will be inferred automatically. If you don't want to use in_features of the Tensor, you can set the value of 'fan_in' smartly by yourself. Default is None.
         negative_slope (float, optional): negative_slope (only used with leaky_relu). Default is 0.0.
         nonlinearity(str, optional): the non-linear function. Default is relu.
 
@@ -321,7 +321,7 @@ class KaimingUniform(MSRAInitializer):
         x = gain \times \sqrt{\frac{3}{fan\_in}}
 
     Args:
-        fan_in (float32|None, optional): fan_in (in_features) of trainable Tensor, If None, it will be infered automatically. If you don't want to use in_features of the Tensor, you can set the value of 'fan_in' smartly by yourself. Default is None.
+        fan_in (float32|None, optional): fan_in (in_features) of trainable Tensor, If None, it will be inferred automatically. If you don't want to use in_features of the Tensor, you can set the value of 'fan_in' smartly by yourself. Default is None.
         negative_slope (float, optional): negative_slope (only used with leaky_relu). Default is 0.0.
         nonlinearity(str, optional): the non-linear function. Default is relu.
 

--- a/test/auto_parallel/spmd_rules/test_add_n_rule.py
+++ b/test/auto_parallel/spmd_rules/test_add_n_rule.py
@@ -55,25 +55,25 @@ class TestAddNSPMDRule(unittest.TestCase):
         )
         self.y_dist_tensor_spec.set_dims_mapping([0, -1, -1])
 
-        infered_dist_attr = self.rule1.infer_forward(
+        inferred_dist_attr = self.rule1.infer_forward(
             [self.x_dist_tensor_spec, self.y_dist_tensor_spec]
         )
 
-        self.assertEqual(len(infered_dist_attr), 2)
-        infered_input_dist_attr = infered_dist_attr[0]
-        infered_output_dist_attr = infered_dist_attr[1]
+        self.assertEqual(len(inferred_dist_attr), 2)
+        inferred_input_dist_attr = inferred_dist_attr[0]
+        inferred_output_dist_attr = inferred_dist_attr[1]
 
-        self.assertEqual(len(infered_input_dist_attr), 1)
-        self.assertEqual(len(infered_input_dist_attr[0]), 2)
-        self.assertEqual(len(infered_output_dist_attr), 1)
+        self.assertEqual(len(inferred_input_dist_attr), 1)
+        self.assertEqual(len(inferred_input_dist_attr[0]), 2)
+        self.assertEqual(len(inferred_output_dist_attr), 1)
 
         self.assertEqual(
-            infered_input_dist_attr[0][0].dims_mapping, [0, -1, -1]
+            inferred_input_dist_attr[0][0].dims_mapping, [0, -1, -1]
         )
         self.assertEqual(
-            infered_input_dist_attr[0][1].dims_mapping, [0, -1, -1]
+            inferred_input_dist_attr[0][1].dims_mapping, [0, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_output_dist_attr[0].dims_mapping, [0, -1, -1])
 
         # [0, -1, -1], [-1, -1, -1] (x, y) partial_dim=[1] -->
         # [0, -1, -1], [0, -1, -1]  (x, y) partial_dim=[1]
@@ -89,33 +89,33 @@ class TestAddNSPMDRule(unittest.TestCase):
         )
         self.y_dist_tensor_spec.set_dims_mapping([-1, -1, -1])
 
-        infered_dist_attr = self.rule1.infer_forward(
+        inferred_dist_attr = self.rule1.infer_forward(
             [self.x_dist_tensor_spec, self.y_dist_tensor_spec]
         )
 
-        self.assertEqual(len(infered_dist_attr), 2)
-        infered_input_dist_attr = infered_dist_attr[0]
-        infered_output_dist_attr = infered_dist_attr[1]
+        self.assertEqual(len(inferred_dist_attr), 2)
+        inferred_input_dist_attr = inferred_dist_attr[0]
+        inferred_output_dist_attr = inferred_dist_attr[1]
 
-        self.assertEqual(len(infered_input_dist_attr), 1)
-        self.assertEqual(len(infered_input_dist_attr[0]), 2)
-        self.assertEqual(len(infered_output_dist_attr), 1)
-
-        self.assertEqual(
-            infered_input_dist_attr[0][0].dims_mapping, [0, -1, -1]
-        )
-        self.assertEqual(infered_input_dist_attr[0][0]._is_partial(), True)
-        self.assertEqual(infered_input_dist_attr[0][0]._partial_dims(), {1})
+        self.assertEqual(len(inferred_input_dist_attr), 1)
+        self.assertEqual(len(inferred_input_dist_attr[0]), 2)
+        self.assertEqual(len(inferred_output_dist_attr), 1)
 
         self.assertEqual(
-            infered_input_dist_attr[0][1].dims_mapping, [0, -1, -1]
+            inferred_input_dist_attr[0][0].dims_mapping, [0, -1, -1]
         )
-        self.assertEqual(infered_input_dist_attr[0][1]._is_partial(), True)
-        self.assertEqual(infered_input_dist_attr[0][1]._partial_dims(), {1})
+        self.assertEqual(inferred_input_dist_attr[0][0]._is_partial(), True)
+        self.assertEqual(inferred_input_dist_attr[0][0]._partial_dims(), {1})
 
-        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attr[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attr[0]._partial_dims(), {1})
+        self.assertEqual(
+            inferred_input_dist_attr[0][1].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(inferred_input_dist_attr[0][1]._is_partial(), True)
+        self.assertEqual(inferred_input_dist_attr[0][1]._partial_dims(), {1})
+
+        self.assertEqual(inferred_output_dist_attr[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_output_dist_attr[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attr[0]._partial_dims(), {1})
 
         # [0, -1, -1] partial_dim=[0], [-1, -1, -1]partial_dim=[1] (x,y)  -->
         # [0, -1, -1], [0, -1, -1] (x, y)
@@ -134,30 +134,30 @@ class TestAddNSPMDRule(unittest.TestCase):
         )
         self.y_dist_tensor_spec.set_dims_mapping([-1, -1, -1])
 
-        infered_dist_attr = self.rule1.infer_forward(
+        inferred_dist_attr = self.rule1.infer_forward(
             [self.x_dist_tensor_spec, self.y_dist_tensor_spec]
         )
 
-        self.assertEqual(len(infered_dist_attr), 2)
-        infered_input_dist_attr = infered_dist_attr[0]
-        infered_output_dist_attr = infered_dist_attr[1]
+        self.assertEqual(len(inferred_dist_attr), 2)
+        inferred_input_dist_attr = inferred_dist_attr[0]
+        inferred_output_dist_attr = inferred_dist_attr[1]
 
-        self.assertEqual(len(infered_input_dist_attr), 1)
-        self.assertEqual(len(infered_input_dist_attr[0]), 2)
-        self.assertEqual(len(infered_output_dist_attr), 1)
-
-        self.assertEqual(
-            infered_input_dist_attr[0][0].dims_mapping, [0, -1, -1]
-        )
-        self.assertEqual(infered_input_dist_attr[0][0]._is_partial(), False)
+        self.assertEqual(len(inferred_input_dist_attr), 1)
+        self.assertEqual(len(inferred_input_dist_attr[0]), 2)
+        self.assertEqual(len(inferred_output_dist_attr), 1)
 
         self.assertEqual(
-            infered_input_dist_attr[0][1].dims_mapping, [0, -1, -1]
+            inferred_input_dist_attr[0][0].dims_mapping, [0, -1, -1]
         )
-        self.assertEqual(infered_input_dist_attr[0][1]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attr[0][0]._is_partial(), False)
 
-        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attr[0]._is_partial(), False)
+        self.assertEqual(
+            inferred_input_dist_attr[0][1].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(inferred_input_dist_attr[0][1]._is_partial(), False)
+
+        self.assertEqual(inferred_output_dist_attr[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_output_dist_attr[0]._is_partial(), False)
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_argmax_rule.py
+++ b/test/auto_parallel/spmd_rules/test_argmax_rule.py
@@ -55,15 +55,15 @@ class TestArgMaxSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['flatten'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
         # axis = -1
         # keepdims = False
@@ -76,15 +76,15 @@ class TestArgMaxSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['flatten'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1])
 
         # axis = -1
         # keepdims = True
@@ -98,15 +98,15 @@ class TestArgMaxSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['flatten'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
         self.attrs['keepdims'] = False
 
         # axis = -1
@@ -121,15 +121,17 @@ class TestArgMaxSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['flatten'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
 
     def test_infer_spmd_reverse(self):
         self.out_spec = DistTensorSpec(self.x_dist_tensor_spec)
@@ -147,14 +149,14 @@ class TestArgMaxSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['flatten'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
         # axis = -1
         # keepdims = False
@@ -170,14 +172,14 @@ class TestArgMaxSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['flatten'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1])
 
         # axis = -1
         # flatten = True
@@ -195,15 +197,17 @@ class TestArgMaxSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['flatten'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1]
         )
 
 

--- a/test/auto_parallel/spmd_rules/test_c_embedding_rule.py
+++ b/test/auto_parallel/spmd_rules/test_c_embedding_rule.py
@@ -51,14 +51,16 @@ class TestEmbeddingSPMDRule(unittest.TestCase):
             self.attrs['start_index'],
             self.attrs['vocab_size'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, -1]
+        )
 
         # table row-wise parallel
         self.table_dist_tensor_spec.set_dims_mapping([1, -1])
@@ -69,15 +71,15 @@ class TestEmbeddingSPMDRule(unittest.TestCase):
             self.attrs['start_index'],
             self.attrs['vocab_size'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1])
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {1})
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {1})
 
     def test_c_embedding_infer_backward(self):
         # backward setup
@@ -111,15 +113,17 @@ class TestEmbeddingSPMDRule(unittest.TestCase):
             self.attrs['start_index'],
             self.attrs['vocab_size'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(
+            inferred_input_dist_attrs[2].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, -1])
 
         # data parallel
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
@@ -131,15 +135,15 @@ class TestEmbeddingSPMDRule(unittest.TestCase):
             self.attrs['start_index'],
             self.attrs['vocab_size'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, -1])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_c_softmax_with_cross_entropy_rule.py
+++ b/test/auto_parallel/spmd_rules/test_c_softmax_with_cross_entropy_rule.py
@@ -76,7 +76,7 @@ class TestCSoftmaxWithCrossEntropySPMDRule(unittest.TestCase):
         self.logit_dist_tensor_spec.set_dims_mapping([-1, -1, 1])
         self.label_dist_tensor_spec.set_dims_mapping([-1, -1, -1])
 
-        infered_dist_attr = self.rule1.infer_forward(
+        inferred_dist_attr = self.rule1.infer_forward(
             self.logit_dist_tensor_spec,
             self.label_dist_tensor_spec,
             self.attrs['ignore_index'],
@@ -85,24 +85,24 @@ class TestCSoftmaxWithCrossEntropySPMDRule(unittest.TestCase):
             self.attrs['nranks'],
         )
 
-        self.assertEqual(len(infered_dist_attr), 2)
-        infered_input_dist_attr = infered_dist_attr[0]
-        infered_output_dist_attr = infered_dist_attr[1]
+        self.assertEqual(len(inferred_dist_attr), 2)
+        inferred_input_dist_attr = inferred_dist_attr[0]
+        inferred_output_dist_attr = inferred_dist_attr[1]
 
-        self.assertEqual(len(infered_input_dist_attr), 2)
-        self.assertEqual(len(infered_output_dist_attr), 2)
+        self.assertEqual(len(inferred_input_dist_attr), 2)
+        self.assertEqual(len(inferred_output_dist_attr), 2)
 
         self.assertEqual(
-            infered_input_dist_attr[0].dims_mapping, [-1, -1, 1]
+            inferred_input_dist_attr[0].dims_mapping, [-1, -1, 1]
         )  # logit
         self.assertEqual(
-            infered_input_dist_attr[1].dims_mapping, [-1, -1, -1]
+            inferred_input_dist_attr[1].dims_mapping, [-1, -1, -1]
         )  # label
         self.assertEqual(
-            infered_output_dist_attr[0].dims_mapping, [-1, -1, 1]
+            inferred_output_dist_attr[0].dims_mapping, [-1, -1, 1]
         )  # softmax
         self.assertEqual(
-            infered_output_dist_attr[1].dims_mapping, [-1, -1, -1]
+            inferred_output_dist_attr[1].dims_mapping, [-1, -1, -1]
         )  # loss
 
         # llama MP-DP case
@@ -112,7 +112,7 @@ class TestCSoftmaxWithCrossEntropySPMDRule(unittest.TestCase):
         self.logit_dist_tensor_spec.set_dims_mapping([0, -1, 1])
         self.label_dist_tensor_spec.set_dims_mapping([0, -1, -1])
 
-        infered_dist_attr = self.rule1.infer_forward(
+        inferred_dist_attr = self.rule1.infer_forward(
             self.logit_dist_tensor_spec,
             self.label_dist_tensor_spec,
             self.attrs['ignore_index'],
@@ -121,24 +121,24 @@ class TestCSoftmaxWithCrossEntropySPMDRule(unittest.TestCase):
             self.attrs['nranks'],
         )
 
-        self.assertEqual(len(infered_dist_attr), 2)
-        infered_input_dist_attr = infered_dist_attr[0]
-        infered_output_dist_attr = infered_dist_attr[1]
+        self.assertEqual(len(inferred_dist_attr), 2)
+        inferred_input_dist_attr = inferred_dist_attr[0]
+        inferred_output_dist_attr = inferred_dist_attr[1]
 
-        self.assertEqual(len(infered_input_dist_attr), 2)
-        self.assertEqual(len(infered_output_dist_attr), 2)
+        self.assertEqual(len(inferred_input_dist_attr), 2)
+        self.assertEqual(len(inferred_output_dist_attr), 2)
 
         self.assertEqual(
-            infered_input_dist_attr[0].dims_mapping, [0, -1, 1]
+            inferred_input_dist_attr[0].dims_mapping, [0, -1, 1]
         )  # logit
         self.assertEqual(
-            infered_input_dist_attr[1].dims_mapping, [0, -1, -1]
+            inferred_input_dist_attr[1].dims_mapping, [0, -1, -1]
         )  # label
         self.assertEqual(
-            infered_output_dist_attr[0].dims_mapping, [0, -1, 1]
+            inferred_output_dist_attr[0].dims_mapping, [0, -1, 1]
         )  # softmax
         self.assertEqual(
-            infered_output_dist_attr[1].dims_mapping, [0, -1, -1]
+            inferred_output_dist_attr[1].dims_mapping, [0, -1, -1]
         )  # loss
 
 

--- a/test/auto_parallel/spmd_rules/test_c_softmax_with_multi_label_cross_entropy_rule.py
+++ b/test/auto_parallel/spmd_rules/test_c_softmax_with_multi_label_cross_entropy_rule.py
@@ -86,7 +86,7 @@ class TestCSoftmaxWithMultiLabelCrossEntropySPMDRule(unittest.TestCase):
         self.label_dist_tensor_spec.set_dims_mapping([-1, -1, -1])
         self.smooth_weight_dist_tensor_spec.set_dims_mapping([-1, -1, -1])
 
-        infered_dist_attr = self.rule1.infer_forward(
+        inferred_dist_attr = self.rule1.infer_forward(
             self.logit_dist_tensor_spec,
             self.label_dist_tensor_spec,
             self.smooth_weight_dist_tensor_spec,
@@ -96,27 +96,27 @@ class TestCSoftmaxWithMultiLabelCrossEntropySPMDRule(unittest.TestCase):
             self.attrs['nranks'],
         )
 
-        self.assertEqual(len(infered_dist_attr), 2)
-        infered_input_dist_attr = infered_dist_attr[0]
-        infered_output_dist_attr = infered_dist_attr[1]
+        self.assertEqual(len(inferred_dist_attr), 2)
+        inferred_input_dist_attr = inferred_dist_attr[0]
+        inferred_output_dist_attr = inferred_dist_attr[1]
 
-        self.assertEqual(len(infered_input_dist_attr), 3)
-        self.assertEqual(len(infered_output_dist_attr), 2)
+        self.assertEqual(len(inferred_input_dist_attr), 3)
+        self.assertEqual(len(inferred_output_dist_attr), 2)
 
         self.assertEqual(
-            infered_input_dist_attr[0].dims_mapping, [-1, -1, 1]
+            inferred_input_dist_attr[0].dims_mapping, [-1, -1, 1]
         )  # logit
         self.assertEqual(
-            infered_input_dist_attr[1].dims_mapping, [-1, -1, -1]
+            inferred_input_dist_attr[1].dims_mapping, [-1, -1, -1]
         )  # label
         self.assertEqual(
-            infered_input_dist_attr[2].dims_mapping, [-1, -1, -1]
+            inferred_input_dist_attr[2].dims_mapping, [-1, -1, -1]
         )  # smooth_weight
         self.assertEqual(
-            infered_output_dist_attr[0].dims_mapping, [-1, -1, 1]
+            inferred_output_dist_attr[0].dims_mapping, [-1, -1, 1]
         )  # softmax
         self.assertEqual(
-            infered_output_dist_attr[1].dims_mapping, [-1, -1, -1]
+            inferred_output_dist_attr[1].dims_mapping, [-1, -1, -1]
         )  # loss
 
         # llama MP-DP case
@@ -127,7 +127,7 @@ class TestCSoftmaxWithMultiLabelCrossEntropySPMDRule(unittest.TestCase):
         self.label_dist_tensor_spec.set_dims_mapping([0, -1, -1])
         self.smooth_weight_dist_tensor_spec.set_dims_mapping([0, -1, -1])
 
-        infered_dist_attr = self.rule1.infer_forward(
+        inferred_dist_attr = self.rule1.infer_forward(
             self.logit_dist_tensor_spec,
             self.label_dist_tensor_spec,
             self.smooth_weight_dist_tensor_spec,
@@ -137,27 +137,27 @@ class TestCSoftmaxWithMultiLabelCrossEntropySPMDRule(unittest.TestCase):
             self.attrs['nranks'],
         )
 
-        self.assertEqual(len(infered_dist_attr), 2)
-        infered_input_dist_attr = infered_dist_attr[0]
-        infered_output_dist_attr = infered_dist_attr[1]
+        self.assertEqual(len(inferred_dist_attr), 2)
+        inferred_input_dist_attr = inferred_dist_attr[0]
+        inferred_output_dist_attr = inferred_dist_attr[1]
 
-        self.assertEqual(len(infered_input_dist_attr), 3)
-        self.assertEqual(len(infered_output_dist_attr), 2)
+        self.assertEqual(len(inferred_input_dist_attr), 3)
+        self.assertEqual(len(inferred_output_dist_attr), 2)
 
         self.assertEqual(
-            infered_input_dist_attr[0].dims_mapping, [0, -1, 1]
+            inferred_input_dist_attr[0].dims_mapping, [0, -1, 1]
         )  # logit
         self.assertEqual(
-            infered_input_dist_attr[1].dims_mapping, [0, -1, -1]
+            inferred_input_dist_attr[1].dims_mapping, [0, -1, -1]
         )  # label
         self.assertEqual(
-            infered_input_dist_attr[2].dims_mapping, [0, -1, -1]
+            inferred_input_dist_attr[2].dims_mapping, [0, -1, -1]
         )  # smooth_weight
         self.assertEqual(
-            infered_output_dist_attr[0].dims_mapping, [0, -1, 1]
+            inferred_output_dist_attr[0].dims_mapping, [0, -1, 1]
         )  # softmax
         self.assertEqual(
-            infered_output_dist_attr[1].dims_mapping, [0, -1, -1]
+            inferred_output_dist_attr[1].dims_mapping, [0, -1, -1]
         )  # loss
 
 

--- a/test/auto_parallel/spmd_rules/test_clip_rule.py
+++ b/test/auto_parallel/spmd_rules/test_clip_rule.py
@@ -45,11 +45,11 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         result_dist_attrs = self.clip_rule.infer_forward(
             self.x_dist_tensor_spec
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0])
 
     def test_backward_single_mesh_dim(self):
         # [-1, 0]--> [-1, 0], [-1, 0] (output --> inputs, output)
@@ -58,11 +58,11 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         result_dist_attrs = self.clip_rule.infer_backward(
             self.x_dist_tensor_spec, self.out_dist_tensor_spec
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_concat_rule.py
+++ b/test/auto_parallel/spmd_rules/test_concat_rule.py
@@ -50,27 +50,27 @@ class TestConcatSPMDRule(unittest.TestCase):
     def test_infer_forward(self):
         inputs = self.build_inputs()
         rule = core.get_phi_spmd_rule("concat")
-        infered_dist_attrs = rule.infer_forward(inputs, 0)
-        infered_input_dist_attrs = infered_dist_attrs[0]
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        infered_output_dist_attrs = infered_dist_attrs[1]
-        self.assertEqual(len(infered_output_dist_attrs), 1)
-        for input_dist_attr in infered_input_dist_attrs[0]:
+        inferred_dist_attrs = rule.infer_forward(inputs, 0)
+        inferred_input_dist_attrs = inferred_dist_attrs[0]
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        inferred_output_dist_attrs = inferred_dist_attrs[1]
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+        for input_dist_attr in inferred_input_dist_attrs[0]:
             self.assertEqual(input_dist_attr.dims_mapping, [-1, 1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 1, 0])
 
     def test_infer_backward(self):
         inputs = self.build_inputs()
         output = self.build_outputs()
         rule = core.get_phi_spmd_rule("concat")
-        infered_dist_attrs = rule.infer_backward(inputs, output, 0)
-        infered_input_dist_attrs = infered_dist_attrs[0]
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        infered_output_dist_attrs = infered_dist_attrs[1]
-        self.assertEqual(len(infered_output_dist_attrs), 1)
-        for input_dist_attr in infered_input_dist_attrs[0]:
+        inferred_dist_attrs = rule.infer_backward(inputs, output, 0)
+        inferred_input_dist_attrs = inferred_dist_attrs[0]
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        inferred_output_dist_attrs = inferred_dist_attrs[1]
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+        for input_dist_attr in inferred_input_dist_attrs[0]:
             self.assertEqual(input_dist_attr.dims_mapping, [-1, 1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 1, 0])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_conv2d_rule.py
+++ b/test/auto_parallel/spmd_rules/test_conv2d_rule.py
@@ -54,23 +54,23 @@ class TestConv2dSPMDRule(unittest.TestCase):
             self.input_dist_tensor_spec, self.filter_dist_tensor_spec
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
         )
         self.assertEqual(
-            infered_input_dist_attrs[1].dims_mapping, [-1, -1, -1, -1]
+            inferred_input_dist_attrs[1].dims_mapping, [-1, -1, -1, -1]
         )
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # case 2
         # input: NCHinWin[-1, -1, -1, -1], filter: MCHkWk[0, -1, -1, -1] ---> output: NMHoutWout[-1, 0, -1, -1]
@@ -81,23 +81,23 @@ class TestConv2dSPMDRule(unittest.TestCase):
             self.input_dist_tensor_spec, self.filter_dist_tensor_spec
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
         )
         self.assertEqual(
-            infered_input_dist_attrs[1].dims_mapping, [0, -1, -1, -1]
+            inferred_input_dist_attrs[1].dims_mapping, [0, -1, -1, -1]
         )
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, 0, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # case 3
         # input: NCHinWin[0, -1, -1, -1], filter: MCHkWk[1, -1, -1, -1] ---> output: NMHoutWout[0, 1, -1, -1]
@@ -108,23 +108,23 @@ class TestConv2dSPMDRule(unittest.TestCase):
             self.input_dist_tensor_spec, self.filter_dist_tensor_spec
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
         )
         self.assertEqual(
-            infered_input_dist_attrs[1].dims_mapping, [1, -1, -1, -1]
+            inferred_input_dist_attrs[1].dims_mapping, [1, -1, -1, -1]
         )
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # case 4
         # input: NCHinWin[-1, 0, -1, -1], filter: MCHkWk[-1, 0, -1, -1] ---> output: NMHoutWout[-1, -1, -1, -1]
@@ -135,24 +135,24 @@ class TestConv2dSPMDRule(unittest.TestCase):
             self.input_dist_tensor_spec, self.filter_dist_tensor_spec
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, 0, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, 0, -1, -1]
         )
         self.assertEqual(
-            infered_input_dist_attrs[1].dims_mapping, [-1, 0, -1, -1]
+            inferred_input_dist_attrs[1].dims_mapping, [-1, 0, -1, -1]
         )
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # case 5
         # input: NCHinWin[0, 2, -1, -1], filter: MCHkWk[1, 2, -1, -1] ---> output: NMHoutWout[0, 1, -1, -1]
@@ -163,24 +163,24 @@ class TestConv2dSPMDRule(unittest.TestCase):
             self.input_dist_tensor_spec, self.filter_dist_tensor_spec
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, 2, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, 2, -1, -1]
         )
         self.assertEqual(
-            infered_input_dist_attrs[1].dims_mapping, [1, 2, -1, -1]
+            inferred_input_dist_attrs[1].dims_mapping, [1, 2, -1, -1]
         )
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {2})
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {2})
 
     def test_conv2d_infer_backward(self):
         # backward setup
@@ -219,25 +219,25 @@ class TestConv2dSPMDRule(unittest.TestCase):
             self.output_dist_tensor_spec,
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
         )
         self.assertEqual(
-            infered_input_dist_attrs[1].dims_mapping, [1, -1, -1, -1]
+            inferred_input_dist_attrs[1].dims_mapping, [1, -1, -1, -1]
         )
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
         )
-        self.assertEqual(infered_input_dist_attrs[0]._is_partial(), False)
-        self.assertEqual(infered_input_dist_attrs[1]._is_partial(), False)
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[1]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_cross_entropy_with_softmax_rule.py
+++ b/test/auto_parallel/spmd_rules/test_cross_entropy_with_softmax_rule.py
@@ -68,20 +68,20 @@ class TestCrossEntropyWithSoftmaxSPMDRule(unittest.TestCase):
             self.attrs['axis'],
         )
         self.assertEqual(len(result_dist_attrs), 2)
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 2)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, 0, -1])
 
         self.assertEqual(
-            infered_output_dist_attrs[1].dims_mapping, [1, 0, -1]
+            inferred_output_dist_attrs[1].dims_mapping, [1, 0, -1]
         )  # loss
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [1, 0, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [1, 0, -1]
         )  # softmax output
 
         # GPT MP case, shard normalized axis
@@ -97,17 +97,19 @@ class TestCrossEntropyWithSoftmaxSPMDRule(unittest.TestCase):
             self.attrs['ignore_index'],
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1, 0])
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [-1, -1, -1]
+        )
 
         self.assertEqual(
-            infered_output_dist_attrs[1].dims_mapping, [-1, -1, -1]
+            inferred_output_dist_attrs[1].dims_mapping, [-1, -1, -1]
         )  # loss
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, 0]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 0]
         )  # softmax output
 
         # GPT MP-DP case
@@ -123,14 +125,16 @@ class TestCrossEntropyWithSoftmaxSPMDRule(unittest.TestCase):
             self.attrs['ignore_index'],
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, -1, -1])
 
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1, 0])
+        self.assertEqual(
+            inferred_output_dist_attrs[1].dims_mapping, [1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, -1, 0])
 
         # Soft Label Error
         self.attrs['soft_label'] = True
@@ -161,14 +165,14 @@ class TestCrossEntropyWithSoftmaxSPMDRule(unittest.TestCase):
             self.attrs['ignore_index'],
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1, -1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, -1, 0])
 
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [1, -1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1, 0])
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [1, -1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, -1, 0])
         self.attrs['axis'] = -1
 
         # Soft Normalized axis Error
@@ -201,17 +205,17 @@ class TestCrossEntropyWithSoftmaxSPMDRule(unittest.TestCase):
             self.attrs['ignore_index'],
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1, -1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, -1, 0])
 
         self.assertEqual(
-            infered_output_dist_attrs[1].dims_mapping, [1, -1, 0]
+            inferred_output_dist_attrs[1].dims_mapping, [1, -1, 0]
         )  # loss
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, []
+            inferred_output_dist_attrs[0].dims_mapping, []
         )  # softmax_out
         self.attrs['axis'] = -1
 
@@ -238,20 +242,20 @@ class TestCrossEntropyWithSoftmaxSPMDRule(unittest.TestCase):
             self.attrs['axis'],
         )
         self.assertEqual(len(result_dist_attrs), 2)
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 2)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, 0, -1])
 
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [1, 0, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [1, 0, -1]
         )  # softmax output
         self.assertEqual(
-            infered_output_dist_attrs[1].dims_mapping, [1, 0, -1]
+            inferred_output_dist_attrs[1].dims_mapping, [1, 0, -1]
         )  # loss
 
         # GPT MP case, shard normalized axis
@@ -275,17 +279,19 @@ class TestCrossEntropyWithSoftmaxSPMDRule(unittest.TestCase):
             self.attrs['ignore_index'],
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1, 0])
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [-1, -1, -1]
+        )
 
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, 0]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 0]
         )  # softmax output
         self.assertEqual(
-            infered_output_dist_attrs[1].dims_mapping, [-1, -1, -1]
+            inferred_output_dist_attrs[1].dims_mapping, [-1, -1, -1]
         )  # loss
 
         # GPT MP-DP case
@@ -309,17 +315,17 @@ class TestCrossEntropyWithSoftmaxSPMDRule(unittest.TestCase):
             self.attrs['ignore_index'],
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, -1, -1])
 
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [1, -1, 0]
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, 0]
         )  # softmax output
         self.assertEqual(
-            infered_output_dist_attrs[1].dims_mapping, [1, -1, -1]
+            inferred_output_dist_attrs[1].dims_mapping, [1, -1, -1]
         )  # loss
 
         # Soft Label, normalized axis = 1
@@ -342,17 +348,17 @@ class TestCrossEntropyWithSoftmaxSPMDRule(unittest.TestCase):
             self.attrs['ignore_index'],
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1, -1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, -1, 0])
 
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [1, -1, 0]
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, 0]
         )  # softmax output
         self.assertEqual(
-            infered_output_dist_attrs[1].dims_mapping, [1, -1, 0]
+            inferred_output_dist_attrs[1].dims_mapping, [1, -1, 0]
         )  # loss
 
         # Soft Label, normalized axis = 1, shard on normalized axis
@@ -375,17 +381,17 @@ class TestCrossEntropyWithSoftmaxSPMDRule(unittest.TestCase):
             self.attrs['ignore_index'],
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, -1, -1])
 
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [1, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, -1]
         )  # softmax output
         self.assertEqual(
-            infered_output_dist_attrs[1].dims_mapping, [1, -1, -1]
+            inferred_output_dist_attrs[1].dims_mapping, [1, -1, -1]
         )  # loss
 
         # Soft Label, normalized axis = -1, shard on normalized axis
@@ -408,17 +414,17 @@ class TestCrossEntropyWithSoftmaxSPMDRule(unittest.TestCase):
             self.attrs['ignore_index'],
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, -1, -1])
 
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [1, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, -1]
         )  # softmax output
         self.assertEqual(
-            infered_output_dist_attrs[1].dims_mapping, [1, -1, -1]
+            inferred_output_dist_attrs[1].dims_mapping, [1, -1, -1]
         )  # loss
 
 

--- a/test/auto_parallel/spmd_rules/test_cumsum_rule.py
+++ b/test/auto_parallel/spmd_rules/test_cumsum_rule.py
@@ -56,15 +56,17 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['exclusive'],
             self.attrs['reverse'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, 1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1, 1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 1]
+        )
 
         # axis = 0
         # [-1, 0, 1] --> [-1, 0, 1], [-1, 0, 1]
@@ -77,15 +79,15 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['exclusive'],
             self.attrs['reverse'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0, 1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0, 1])
 
         # axis=-1, flatten = True
         # [-1, 0, 1] --> [-1, -1, -1], [-1]
@@ -99,15 +101,17 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['exclusive'],
             self.attrs['reverse'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
         self.attrs['flatten'] = False
 
     def test_infer_spmd_reverse(self):
@@ -126,15 +130,17 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['exclusive'],
             self.attrs['reverse'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, 1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1, 1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 1]
+        )
 
         # axis = -1, flatten = True
         # [-1, 0, 1], [-1] --> [-1, -1, -1], [-1]
@@ -151,15 +157,17 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['exclusive'],
             self.attrs['reverse'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
         self.attrs['flatten'] = False
         self.out_spec.shape = [64, 32, 48]
 

--- a/test/auto_parallel/spmd_rules/test_elementwise_rule.py
+++ b/test/auto_parallel/spmd_rules/test_elementwise_rule.py
@@ -52,12 +52,12 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         result_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
         # [0, -1], [-1, 0] --> [0, -1], [0, -1], [0, -1]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
@@ -65,12 +65,12 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         result_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
         # [-1, -1], [-1, -1] --> [-1, -1], [-1, -1], [-1, -1]
         self.x_dist_tensor_spec.set_dims_mapping([-1, -1])
@@ -79,12 +79,12 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         result_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
 
         # [-1, 0]--> [-1, 0], [-1, 0]
         self.x_dist_tensor_spec.set_dims_mapping([-1, 0])
@@ -92,11 +92,11 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         result_dist_attrs = self.unary_rule.infer_forward(
             self.x_dist_tensor_spec
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0])
 
     def test_single_mesh_dim_broadcast(self):
         self.x_dist_tensor_spec.shape = [64, 36, 12]
@@ -109,16 +109,18 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         resulted_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
         self.assertEqual(len(resulted_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
 
         # [-1, 0, -1], [-1] --> [-1, 0, -1], [-1], [-1, 0, -1]
         self.x_dist_tensor_spec.set_dims_mapping([-1, 0, -1])
@@ -127,12 +129,14 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         resulted_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
-        self.assertEqual((infered_input_dist_attrs[1].dims_mapping), [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual((inferred_input_dist_attrs[1].dims_mapping), [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1]
+        )
 
         # [-1, -1, 0], [-1] --> [-1, -1, 0], [0], [-1, -1, 0]
         self.x_dist_tensor_spec.set_dims_mapping([-1, -1, 0])
@@ -141,12 +145,14 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         resulted_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, 0])
-        self.assertEqual((infered_input_dist_attrs[1].dims_mapping), [0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1, 0])
+        self.assertEqual((inferred_input_dist_attrs[1].dims_mapping), [0])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 0]
+        )
 
         # [-1, -1, -1], [0] --> [-1, -1, 0], [0], [-1, -1, 0]
         self.x_dist_tensor_spec.set_dims_mapping([-1, -1, -1])
@@ -154,12 +160,14 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         resulted_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 0]
+        )
 
         self.x_dist_tensor_spec.shape = [64, 36, 12]
         self.y_dist_tensor_spec.shape = [1, 12]
@@ -170,12 +178,14 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         resulted_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1]
+        )
 
         self.x_dist_tensor_spec.shape = [64, 1, 1, 12]
         self.y_dist_tensor_spec.shape = [64, 32, 12]
@@ -186,15 +196,17 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         resulted_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
         )
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1, -1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+            inferred_input_dist_attrs[1].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
         )
 
         # [-1, -1, -1, -1], [0, -1, -1] --> [-1, -1, -1, -1], [0, -1, -1], [-1, 0, -1, -1]
@@ -204,15 +216,15 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         resulted_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
         )
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1, -1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -0, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -0, -1, -1]
         )
 
     def test_multi_mesh_dim(self):
@@ -229,16 +241,16 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         resulted_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
         self.assertEqual(len(resulted_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
 
         # [0, -1, -1], [-1, 1, 0] --> [0, 1, -1], [0, 1, -1], [0, 1, -1]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1, -1])
@@ -246,12 +258,12 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         resulted_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
 
     def test_multi_mesh_dim_broadcast(self):
         process_mesh = auto.ProcessMesh([[0, 1, 2], [3, 4, 5]])
@@ -267,16 +279,16 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         resulted_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
         self.assertEqual(len(resulted_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, 1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, 1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1, 1])
 
         # [0, 1, -1], [0] --> [0, 1, -1], [-1], [0, 1, -1]
         self.x_dist_tensor_spec.set_dims_mapping([0, 1, -1])
@@ -285,12 +297,12 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         resulted_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
 
         self.x_dist_tensor_spec.shape = [96, 1, 1, 48]
         self.y_dist_tensor_spec.shape = [96, 24, 48]
@@ -301,15 +313,15 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         resulted_dist_attrs = self.binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1, 1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, 1]
         )
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1, 1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1, 1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, 0, -1, 1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1, 1]
         )
 
     def test_backward_single_mesh_dim(self):
@@ -320,12 +332,12 @@ class TestElementwiseSPMDRule(unittest.TestCase):
             self.y_dist_tensor_spec,
             self.out_dist_tensor_spec,
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
         # [-1, -1] --> [-1, -1], [-1, -1], [-1, -1] (output --> inputs, output)
         self.out_dist_tensor_spec.set_dims_mapping([-1, -1])
@@ -335,12 +347,12 @@ class TestElementwiseSPMDRule(unittest.TestCase):
             self.y_dist_tensor_spec,
             self.out_dist_tensor_spec,
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
 
         # [-1, 0]--> [-1, 0], [-1, 0] (output --> inputs, output)
         self.out_dist_tensor_spec.set_dims_mapping([-1, 0])
@@ -348,11 +360,11 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         result_dist_attrs = self.unary_rule.infer_backward(
             self.x_dist_tensor_spec, self.out_dist_tensor_spec
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0])
 
     def test_backward_single_mesh_dim_broadcast(self):
         self.x_dist_tensor_spec.shape = [64, 36, 12]
@@ -367,16 +379,18 @@ class TestElementwiseSPMDRule(unittest.TestCase):
             self.y_dist_tensor_spec,
             self.out_dist_tensor_spec,
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
         self.assertEqual(len(resulted_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
 
         # [-1, 0, -1] --> [-1, 0, -1], [-1], [-1, 0, -1] (output --> inputs, output)
         self.out_dist_tensor_spec.set_dims_mapping([-1, 0, -1])
@@ -386,12 +400,14 @@ class TestElementwiseSPMDRule(unittest.TestCase):
             self.y_dist_tensor_spec,
             self.out_dist_tensor_spec,
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
-        self.assertEqual((infered_input_dist_attrs[1].dims_mapping), [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual((inferred_input_dist_attrs[1].dims_mapping), [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1]
+        )
 
         # [-1, -1, 0] --> [-1, -1, 0], [0], [-1, -1, 0] (output --> inputs, output)
         self.out_dist_tensor_spec.set_dims_mapping([-1, -1, 0])
@@ -401,12 +417,14 @@ class TestElementwiseSPMDRule(unittest.TestCase):
             self.y_dist_tensor_spec,
             self.out_dist_tensor_spec,
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, 0])
-        self.assertEqual((infered_input_dist_attrs[1].dims_mapping), [0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1, 0])
+        self.assertEqual((inferred_input_dist_attrs[1].dims_mapping), [0])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 0]
+        )
 
         self.x_dist_tensor_spec.shape = [64, 36, 12]
         self.y_dist_tensor_spec.shape = [1, 12]
@@ -419,12 +437,14 @@ class TestElementwiseSPMDRule(unittest.TestCase):
             self.y_dist_tensor_spec,
             self.out_dist_tensor_spec,
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1]
+        )
 
         self.x_dist_tensor_spec.shape = [64, 1, 1, 12]
         self.y_dist_tensor_spec.shape = [64, 32, 12]
@@ -437,15 +457,17 @@ class TestElementwiseSPMDRule(unittest.TestCase):
             self.y_dist_tensor_spec,
             self.out_dist_tensor_spec,
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
         )
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1, -1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+            inferred_input_dist_attrs[1].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
         )
 
         # [-1, 0, -1, -1] --> [-1, -1, -1, -1], [0, -1, -1], [-1, 0, -1, -1] (output --> inputs, output)
@@ -456,15 +478,15 @@ class TestElementwiseSPMDRule(unittest.TestCase):
             self.y_dist_tensor_spec,
             self.out_dist_tensor_spec,
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
         )
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1, -1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -0, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -0, -1, -1]
         )
 
     def test_backward_multi_mesh_dim(self):
@@ -483,16 +505,16 @@ class TestElementwiseSPMDRule(unittest.TestCase):
             self.y_dist_tensor_spec,
             self.out_dist_tensor_spec,
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
         self.assertEqual(len(resulted_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
 
     def test_backward_multi_mesh_dim_broadcast(self):
         process_mesh = auto.ProcessMesh([[0, 1, 2], [3, 4, 5]])
@@ -510,16 +532,16 @@ class TestElementwiseSPMDRule(unittest.TestCase):
             self.y_dist_tensor_spec,
             self.out_dist_tensor_spec,
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
         self.assertEqual(len(resulted_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, 1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, 1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1, 1])
 
         # [0, 1, -1] --> [0, 1, -1], [-1], [0, 1, -1] (output --> inputs, output)
         self.out_dist_tensor_spec.set_dims_mapping([0, 1, -1])
@@ -529,12 +551,12 @@ class TestElementwiseSPMDRule(unittest.TestCase):
             self.y_dist_tensor_spec,
             self.out_dist_tensor_spec,
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
 
         self.x_dist_tensor_spec.shape = [96, 1, 1, 48]
         self.y_dist_tensor_spec.shape = [96, 24, 48]
@@ -548,15 +570,15 @@ class TestElementwiseSPMDRule(unittest.TestCase):
             self.y_dist_tensor_spec,
             self.out_dist_tensor_spec,
         )
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1, 1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, 1]
         )
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1, 1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1, 1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, 0, -1, 1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1, 1]
         )
 
     def test_single_mesh_dim_greater_than(self):
@@ -569,15 +591,15 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         )
         self.assertEqual(len(result_dist_attrs), 2)
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
         # [0, -1], [-1, 0] --> [0, -1], [0, -1], [0, -1]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
@@ -587,15 +609,15 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         )
         self.assertEqual(len(result_dist_attrs), 2)
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
     def test_single_mesh_dim_broadcast_greater_than(self):
         binary_rule = core.get_phi_spmd_rule("greater_than")
@@ -612,15 +634,15 @@ class TestElementwiseSPMDRule(unittest.TestCase):
 
         self.assertEqual(len(resulted_dist_attrs), 2)
 
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0])
 
     def test_single_mesh_dim_less_than(self):
         binary_rule = core.get_phi_spmd_rule("less_than")
@@ -632,15 +654,15 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         )
         self.assertEqual(len(result_dist_attrs), 2)
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
         # [0, -1], [-1, 0] --> [0, -1], [0, -1], [0, -1]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
@@ -648,12 +670,12 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         result_dist_attrs = binary_rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
     def test_single_mesh_dim_broadcast_less_than(self):
         binary_rule = core.get_phi_spmd_rule("less_than")
@@ -670,15 +692,15 @@ class TestElementwiseSPMDRule(unittest.TestCase):
 
         self.assertEqual(len(resulted_dist_attrs), 2)
 
-        infered_input_dist_attrs = resulted_dist_attrs[0]
-        infered_output_dist_attrs = resulted_dist_attrs[1]
+        inferred_input_dist_attrs = resulted_dist_attrs[0]
+        inferred_output_dist_attrs = resulted_dist_attrs[1]
 
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_embedding_rule.py
+++ b/test/auto_parallel/spmd_rules/test_embedding_rule.py
@@ -54,16 +54,18 @@ class TestEmbeddingSPMDRule(unittest.TestCase):
             self.attrs['padding_idx'],
             self.attrs['sparse'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, -1]
+        )
 
         # table col-wise parallel & dp
         self.x_dist_tensor_spec.set_dims_mapping([1, -1])
@@ -74,12 +76,12 @@ class TestEmbeddingSPMDRule(unittest.TestCase):
             self.attrs['padding_idx'],
             self.attrs['sparse'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, -1, 0])
 
         # table row-wise parallel & dp
         self.x_dist_tensor_spec.set_dims_mapping([1, -1])
@@ -90,14 +92,16 @@ class TestEmbeddingSPMDRule(unittest.TestCase):
             self.attrs['padding_idx'],
             self.attrs['sparse'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # table row-wise parallel & padding_idx
         self.x_dist_tensor_spec.set_dims_mapping([1, -1])
@@ -161,16 +165,18 @@ class TestEmbeddingSPMDRule(unittest.TestCase):
             self.attrs['padding_idx'],
             self.attrs['sparse'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, -1]
+        )
 
         # table col-wise parallel & dp
         self.out_dist_tensor_spec.set_dims_mapping([-1, 0, 1])
@@ -181,12 +187,12 @@ class TestEmbeddingSPMDRule(unittest.TestCase):
             self.attrs['padding_idx'],
             self.attrs['sparse'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, 1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0, 1])
 
         # sharded on multiple broadcast axes
         self.out_dist_tensor_spec.set_dims_mapping([1, 0, -1])
@@ -198,12 +204,12 @@ class TestEmbeddingSPMDRule(unittest.TestCase):
             self.attrs['padding_idx'],
             self.attrs['sparse'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, 0, -1])
 
         # table row-wise parallel
         # skipped

--- a/test/auto_parallel/spmd_rules/test_flash_attention_rule.py
+++ b/test/auto_parallel/spmd_rules/test_flash_attention_rule.py
@@ -88,26 +88,26 @@ class TestFlashAttentionSPMDRule(unittest.TestCase):
             False,
             False,
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 5)
-        self.assertEqual(len(infered_output_dist_attrs), 4)
+        self.assertEqual(len(inferred_input_dist_attrs), 5)
+        self.assertEqual(len(inferred_output_dist_attrs), 4)
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, -1, 1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, 1, -1]
         )
         self.assertEqual(
-            infered_input_dist_attrs[1].dims_mapping, [0, -1, 1, -1]
+            inferred_input_dist_attrs[1].dims_mapping, [0, -1, 1, -1]
         )
         self.assertEqual(
-            infered_input_dist_attrs[2].dims_mapping, [0, -1, 1, -1]
+            inferred_input_dist_attrs[2].dims_mapping, [0, -1, 1, -1]
         )
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [0, -1, 1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, 1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [0, 1, -1])
 
     def test_infer_backward(self):
         result_dist_attrs = self.rule.infer_backward(
@@ -125,26 +125,26 @@ class TestFlashAttentionSPMDRule(unittest.TestCase):
             False,
             False,
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 5)
-        self.assertEqual(len(infered_output_dist_attrs), 4)
+        self.assertEqual(len(inferred_input_dist_attrs), 5)
+        self.assertEqual(len(inferred_output_dist_attrs), 4)
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, -1, 1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, 1, -1]
         )
         self.assertEqual(
-            infered_input_dist_attrs[1].dims_mapping, [0, -1, 1, -1]
+            inferred_input_dist_attrs[1].dims_mapping, [0, -1, 1, -1]
         )
         self.assertEqual(
-            infered_input_dist_attrs[2].dims_mapping, [0, -1, 1, -1]
+            inferred_input_dist_attrs[2].dims_mapping, [0, -1, 1, -1]
         )
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [0, -1, 1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, 1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [0, 1, -1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

Fix typo `infered` -> `inferred` part2

```
Before:
~/Projects/Paddle develop*
❯ typos --format brief | wc -l
    2225

After:
~/Projects/Paddle typos/infered-part2*
❯ typos --format brief | wc -l
    1610
```

本 PR 修复约 600 处

### Related links

- #69441
- #70978

PCard-66972