### PR TITLE
[CodeStyle][Typos][I-15] Fix typo `infered` (part3)

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -879,9 +879,9 @@ void ConvTransposeInferMeta(const MetaTensor& x,
             output_size[i],
             infer_shape,
             errors::InvalidArgument(
-                "output_size of Op(ConvTransposeOp) should not be "
-                "less than the infered output size. But received output_size = "
-                "[%s], whose dim %d is less than the infered output size [%s]",
+                "output_size of Op(ConvTransposeOp) should not be less than "
+                "the inferred output size. But received output_size = [%s], "
+                "whose dim %d is less than the inferred output size [%s]",
                 common::make_ddim(output_size).to_str(),
                 i,
                 infer_shape));
@@ -890,8 +890,8 @@ void ConvTransposeInferMeta(const MetaTensor& x,
             infer_shape + strides[i],
             errors::InvalidArgument(
                 "output_size of Op(ConvTransposeOp) should be less "
-                "than infered size + stride. But received output_size = [%s], "
-                "whose dim %d is not less than the infered output size (%d) + "
+                "than inferred size + stride. But received output_size = [%s], "
+                "whose dim %d is not less than the inferred output size (%d) + "
                 "stride (%d) = %d",
                 common::make_ddim(output_size).to_str(),
                 i,

--- a/paddle/phi/infermeta/spmd_rules/cross_entropy_with_softmax.cc
+++ b/paddle/phi/infermeta/spmd_rules/cross_entropy_with_softmax.cc
@@ -313,7 +313,7 @@ SpmdInfo CrossEntropyWithSoftmaxInferSpmdReverse(
           << (numeric_stable_mode ? "true" : "false") << "], use_softmax: ["
           << (use_softmax ? "true" : "false") << "], soft_label: ["
           << (soft_label ? "true" : "false") << "].";
-  VLOG(2) << "x_dims_mapping infered:[" << str_join(x_dims_mapping) << "]";
+  VLOG(2) << "x_dims_mapping inferred:[" << str_join(x_dims_mapping) << "]";
   // in some cases, the softmax_norm axis cannot be sharded
   if (x_dims_mapping[axis] > -1) {
     if (!use_softmax) {

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2151,7 +2151,7 @@ static phi::DDim ValidateShape(const std::vector<int64_t> shape,
 
   for (size_t i = 0; i < shape.size(); ++i) {
     if (shape[i] == -1) {
-      // only one dimension can be set to -1, whose size will be infered.
+      // only one dimension can be set to -1, whose size will be inferred.
       PADDLE_ENFORCE_EQ(
           unk_dim_idx,
           -1,

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -239,8 +239,8 @@ def shard_tensor(
             be Shard, Replicate and Partial.
         dtype(str|np.dtype, optional): The desired data type of returned tensor.
             It Can be 'bool' , 'float16' , 'float32' , 'float64' , 'int8' , 'int16' , 'int32' , 'int64' , 'uint8',
-            'complex64' , 'complex128'. Default: None. If None, the the dtype is infered from ``data``
-            except for python float number, in which case the dtype is infered from ``get_default_type`` .
+            'complex64' , 'complex128'. Default: None. If None, the the dtype is inferred from ``data``
+            except for python float number, in which case the dtype is inferred from ``get_default_type`` .
         place(CPUPlace|CUDAPinnedPlace|CUDAPlace|str, optional): The place to allocate Tensor. Can be
             CPUPlace, CUDAPinnedPlace, CUDAPlace. Default: None, means global place. If ``place`` is
             string, It can be ``cpu``, ``gpu:x`` and ``gpu_pinned``, where ``x`` is the index of the GPUs.

--- a/python/paddle/distributed/passes/auto_parallel_c_embedding.py
+++ b/python/paddle/distributed/passes/auto_parallel_c_embedding.py
@@ -261,15 +261,15 @@ class AutoParallelCEmbeddingPass(PassBase):
                             input_specs.append(inputs)
                             for attr_name in attr_names:
                                 input_specs.append(op.attrs()[attr_name])
-                            infered_dist_attrs = rule.infer_forward(
+                            inferred_dist_attrs = rule.infer_forward(
                                 *input_specs
                             )
-                            dims_mapping_new_out = infered_dist_attrs[1][
+                            dims_mapping_new_out = inferred_dist_attrs[1][
                                 0
                             ].dims_mapping
                             partial_status = {}
-                            if infered_dist_attrs[1][0]._is_partial():
-                                partial_dims = infered_dist_attrs[1][
+                            if inferred_dist_attrs[1][0]._is_partial():
+                                partial_dims = inferred_dist_attrs[1][
                                     0
                                 ]._partial_dims()
                                 for i in partial_dims:

--- a/python/paddle/distributed/passes/auto_parallel_sequence_parallel_optimization.py
+++ b/python/paddle/distributed/passes/auto_parallel_sequence_parallel_optimization.py
@@ -71,7 +71,7 @@ class SequenceParallelOptimizationPass(PassBase):
 
     def _fuse_allreduce_split(self):
         # allreduce is added by dist op and split is added by reshard, so we need this pass to fuse them as reducescatter.
-        # reducescatter should be infered by local reshard in future.
+        # reducescatter should be inferred by local reshard in future.
 
         block = default_main_program().global_block()
 

--- a/test/auto_parallel/spmd_rules/test_flatten_rule.py
+++ b/test/auto_parallel/spmd_rules/test_flatten_rule.py
@@ -47,15 +47,15 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, -1, -1, 1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, 1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1, 1])
 
         # shape: [8, 16, 8, 24] --> [8, 16 * 8, 24]
         # dims_mapping: [-1, 0, -1, 1] --> [-1, 0, -1, 1] ([ -1, 0, 1])
@@ -67,13 +67,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, 0, -1, 1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, 0, -1, 1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0, 1])
 
         # shape: [8, 16, 8, 24] --> [8, 16 * 8, 24]
         # dims_mapping: [-1, -1, 1, 0] --> [-1, -1, -1, 0] ([ -1, -1, 0])
@@ -85,13 +85,15 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1, 0]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, 0]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1, 0])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 0]
+        )
 
         # shape: [8, 16, 8, 24] --> [8 * 16 * 8 * 24]
         # dims_mapping: [-1, 0, 1, -1] --> [-1, -1, -1, -1] ([ -1])
@@ -103,13 +105,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
 
         # shape: [8, 16, 8, 24] --> [8 * 16 * 8 * 24]
         # dims_mapping: [0, -1, -1, 1] --> [0, -1, -1, -1] ([0])
@@ -121,13 +123,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
 
         # shape: [8, 16, 8, 24] --> [8 * 16 * 8 * 24]
         # dims_mapping: [1, 0, -1, -1] --> [1, -1, -1, -1] ([1])
@@ -139,13 +141,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [1, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1])
 
         # shape: [8, 16, 8, 24] --> [8, 16 * 8 * 24]
         # dims_mapping: [-1, -1, 0, 1] --> [-1, -1, -1, -1] ([-1, -1])
@@ -157,13 +159,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
 
         # shape: [8, 16, 8, 24] --> [8, 16 * 8 * 24]
         # dims_mapping: [-1, 0, -1, 1] --> [-1, 0, -1, -1] ([-1, 0])
@@ -175,13 +177,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, 0, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, 0, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0])
 
         # shape: [8, 16, 8, 24] --> [8, 16 * 8 * 24]
         # dims_mapping: [0, 1, -1, -1] --> [0, 1, -1, -1] ([0, 1])
@@ -193,13 +195,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1])
 
     def test_flatten_infer_backward(self):
         process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2, 3], [4, 5, 6, 7]])
@@ -223,15 +225,15 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, -1, -1, 1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, 1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1, 1])
 
         # shape: [8, 16, 8, 24] --> [8, 16 * 8, 24] (input --> output)
         # dims_mapping: [0, 1, -1] --> [0, 1, -1, -1], [0, 1, -1] (output --> input, output)
@@ -245,13 +247,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
 
         # shape: [8, 16, 8, 24] --> [8, 16 * 8, 24] (input --> output)
         # dims_mapping: [-1, 0, 1] --> [-1, 0, -1, 1], [-1, 0, 1] (output --> input, output)
@@ -265,13 +267,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, 0, -1, 1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, 0, -1, 1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0, 1])
 
         # shape: [8, 16, 8, 24] --> [8 * 16 * 8 * 24] (input --> output)
         # dims_mapping: [-1] --> [-1, -1, -1, -1], [-1] (output --> input, output)
@@ -285,13 +287,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
 
         # shape: [8, 16, 8, 24] --> [8 * 16 * 8 * 24] (input --> output)
         # dims_mapping: [0] --> [0, -1, -1, -1], [0] (output --> input, output)
@@ -305,13 +307,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
 
         # shape: [8, 16, 8, 24] --> [8 * 16 * 8 * 24] (input --> output)
         # dims_mapping: [1] --> [1, -1, -1, -1], [1] (output --> input, output)
@@ -325,13 +327,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [1, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1])
 
         # shape: [8, 16, 8, 24] --> [8, 16 * 8 * 24] (input --> output)
         # dims_mapping: [-1, -1] --> [-1, -1, -1, -1], [-1, -1] (output --> input, output)
@@ -345,13 +347,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
 
         # shape: [8, 16, 8, 24] --> [8, 16 * 8 * 24] (input --> output)
         # dims_mapping: [0, -1] --> [0, -1, -1, -1], [0, -1] (output --> input, output)
@@ -365,13 +367,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
         # shape: [8, 16, 8, 24] --> [8, 16 * 8 * 24] (input --> output)
         # dims_mapping: [0, 1] --> [0, 1, -1, -1], [0, 1] (output --> input, output)
@@ -385,13 +387,13 @@ class TestFlattenSPMDRule(unittest.TestCase):
             self.attrs['start_axis'],
             self.attrs['stop_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_fused_dropout_add_rule.py
+++ b/test/auto_parallel/spmd_rules/test_fused_dropout_add_rule.py
@@ -59,39 +59,39 @@ class TestFusedDropoutAddSPMDRule(unittest.TestCase):
     def test_infer_forward(self):
         inputs = self.build_inputs()
         rule = core.get_phi_spmd_rule("fused_dropout_add")
-        infered_dist_attrs = rule.infer_forward(inputs['x'], inputs['y'])
+        inferred_dist_attrs = rule.infer_forward(inputs['x'], inputs['y'])
 
-        self.assertEqual(len(infered_dist_attrs), 2)
+        self.assertEqual(len(inferred_dist_attrs), 2)
 
-        infered_input_dist_attrs = infered_dist_attrs[0]
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
+        inferred_input_dist_attrs = inferred_dist_attrs[0]
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
 
-        infered_output_dist_attrs = infered_dist_attrs[1]
-        self.assertEqual(len(infered_output_dist_attrs), 2)
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [-1])
+        inferred_output_dist_attrs = inferred_dist_attrs[1]
+        self.assertEqual(len(inferred_output_dist_attrs), 2)
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [-1])
 
     def test_infer_backward(self):
         inputs = self.build_inputs()
         outputs = self.build_outputs()
         rule = core.get_phi_spmd_rule("fused_dropout_add")
-        infered_dist_attrs = rule.infer_backward(
+        inferred_dist_attrs = rule.infer_backward(
             inputs['x'], inputs['y'], outputs['out'], outputs['seed_offset']
         )
 
-        self.assertEqual(len(infered_dist_attrs), 2)
+        self.assertEqual(len(inferred_dist_attrs), 2)
 
-        infered_input_dist_attrs = infered_dist_attrs[0]
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
+        inferred_input_dist_attrs = inferred_dist_attrs[0]
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
 
-        infered_output_dist_attrs = infered_dist_attrs[1]
-        self.assertEqual(len(infered_output_dist_attrs), 2)
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [-1])
+        inferred_output_dist_attrs = inferred_dist_attrs[1]
+        self.assertEqual(len(inferred_output_dist_attrs), 2)
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [-1])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_fused_linear_param_grad_add_rule.py
+++ b/test/auto_parallel/spmd_rules/test_fused_linear_param_grad_add_rule.py
@@ -44,22 +44,22 @@ class TestFusedLinearParamGradAddSPMDRule(unittest.TestCase):
         out_grad = self.build_inputs([0, -1, 1], [2, 512, 2048])
         dweight = self.build_inputs([], [])
         dbias = self.build_inputs([], [])
-        infered_dist_attrs = rule.infer_forward(
+        inferred_dist_attrs = rule.infer_forward(
             input, out_grad, dweight, dbias, 0, True
         )
-        self.assertEqual(infered_dist_attrs[1][0].dims_mapping, [-1, 1])
-        self.assertEqual(infered_dist_attrs[1][1].dims_mapping, [1])
+        self.assertEqual(inferred_dist_attrs[1][0].dims_mapping, [-1, 1])
+        self.assertEqual(inferred_dist_attrs[1][1].dims_mapping, [1])
 
         # test mp split by row
         input = self.build_inputs([0, -1, 1], [2, 512, 1024])
         out_grad = self.build_inputs([0, -1, -1], [2, 512, 2048])
         dweight = self.build_inputs([], [])
         dbias = self.build_inputs([], [])
-        infered_dist_attrs = rule.infer_forward(
+        inferred_dist_attrs = rule.infer_forward(
             input, out_grad, dweight, dbias, 0, True
         )
-        self.assertEqual(infered_dist_attrs[1][0].dims_mapping, [1, -1])
-        self.assertEqual(infered_dist_attrs[1][1].dims_mapping, [-1])
+        self.assertEqual(inferred_dist_attrs[1][0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_dist_attrs[1][1].dims_mapping, [-1])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_gather_nd_rule.py
+++ b/test/auto_parallel/spmd_rules/test_gather_nd_rule.py
@@ -52,12 +52,14 @@ class TestGatherNdSPMDRule(unittest.TestCase):
             self.x_spec, self.index_spec
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
 
     def test_forward_mesh_dim_diff_shape(self):
         # dims_mapping: [-1], [0, -1] --> [0]
@@ -75,12 +77,12 @@ class TestGatherNdSPMDRule(unittest.TestCase):
 
         result_dist_attrs = self.rule.infer_forward(x_spec, index_spec)
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
 
     def test_forward_mesh_dim_same_shape(self):
         # dims_mapping: [-1], [0] --> [0]
@@ -98,12 +100,12 @@ class TestGatherNdSPMDRule(unittest.TestCase):
 
         result_dist_attrs = self.rule.infer_forward(x_spec, index_spec)
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
 
     def test_reverse_mesh_dim(self):
         self.x_spec.set_process_mesh(self.process_mesh)
@@ -122,12 +124,14 @@ class TestGatherNdSPMDRule(unittest.TestCase):
             self.index_spec,
             self.out_spec,
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
 
     def test_reverse_mesh_dim_same_shape(self):
         x_shape = [10]
@@ -157,12 +161,12 @@ class TestGatherNdSPMDRule(unittest.TestCase):
             index_spec,
             out_spec,
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
 
     def test_reverse_mesh_dim_diff_shape(self):
         # dims_mapping: [-1], [0, -1] --> [0]
@@ -193,12 +197,12 @@ class TestGatherNdSPMDRule(unittest.TestCase):
             index_spec,
             out_spec,
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_gather_rule.py
+++ b/test/auto_parallel/spmd_rules/test_gather_rule.py
@@ -59,16 +59,18 @@ class TestScatterSPMDRule(unittest.TestCase):
             self.index_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1]
         )
 
         # axis: 0
@@ -82,15 +84,17 @@ class TestScatterSPMDRule(unittest.TestCase):
             self.index_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1]
+        )
 
         # axis: 0
         # dims_mapping: [0, -1, -1], [0] --> [-1, -1, -1], [0], [0, -1, -1]
@@ -102,15 +106,19 @@ class TestScatterSPMDRule(unittest.TestCase):
             self.index_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
 
         # 0-d tensor
         # axis: 1
@@ -125,15 +133,17 @@ class TestScatterSPMDRule(unittest.TestCase):
             self.index_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
         self.index_spec.shape = [16]
 
     def test_multi_mesh_dim(self):
@@ -151,14 +161,14 @@ class TestScatterSPMDRule(unittest.TestCase):
             self.index_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
 
         # [0, 1, -1], [0] --> [0, -1, -1], [0], [0, -1, -1]
         self.attrs['axis'] = 1
@@ -169,14 +179,16 @@ class TestScatterSPMDRule(unittest.TestCase):
             self.index_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
 
     def test_reverse_multi_mesh_dim(self):
         process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
@@ -194,15 +206,15 @@ class TestScatterSPMDRule(unittest.TestCase):
             self.out_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, 0, -1])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_layer_norm_rule.py
+++ b/test/auto_parallel/spmd_rules/test_layer_norm_rule.py
@@ -72,19 +72,21 @@ class TestLayerNormSPMDRule(unittest.TestCase):
             self.attrs['epsilon'],
             self.attrs['begin_norm_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 3)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 3)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [1, -1])
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [1, -1])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [1, -1])
 
         # ijk[1, 0, -1],k[0],k[0] -->
         # [1, 0, -1], [-1], [-1] (inputs)
@@ -101,19 +103,19 @@ class TestLayerNormSPMDRule(unittest.TestCase):
             self.attrs['epsilon'],
             self.attrs['begin_norm_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 3)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 3)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, 0, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [1, 0])
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, 0, -1])
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [1, 0])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [1, 0])
 
         # ijk[0, -1, -1],y[-1],y[1] -->
         # ijk[0, -1, -1],y[-1],y[-1], (inputs)
@@ -136,19 +138,21 @@ class TestLayerNormSPMDRule(unittest.TestCase):
             self.attrs['epsilon'],
             self.attrs['begin_norm_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 3)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 3)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [0])
 
     def test_infer_forward_without_bias(self):
         # ijk[1, -1, -1], k[-1], k[-1] -->
@@ -166,19 +170,21 @@ class TestLayerNormSPMDRule(unittest.TestCase):
             self.attrs['epsilon'],
             self.attrs['begin_norm_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 3)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 3)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [1, -1])
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [1, -1])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [1, -1])
 
         # ijk[1, 0, -1],k[0],k[0] -->
         # [1, 0, -1], [-1], [-1] (inputs)
@@ -194,19 +200,19 @@ class TestLayerNormSPMDRule(unittest.TestCase):
             self.attrs['epsilon'],
             self.attrs['begin_norm_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 3)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 3)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, 0, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [1, 0])
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, 0, -1])
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [1, 0])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [1, 0])
 
     def test_infer_backward(self):
         # [1, -1, -1], [1, -1], [1, -1] (outputs) -->
@@ -235,19 +241,21 @@ class TestLayerNormSPMDRule(unittest.TestCase):
             self.attrs['epsilon'],
             self.attrs['begin_norm_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 3)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 3)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [1, -1])
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [1, -1])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [1, -1])
 
         # [0, -1, -1], [0, -1], [0, -1] (outputs) -->
         # [0, -1, -1], [-1], [-1], (inputs)
@@ -279,19 +287,21 @@ class TestLayerNormSPMDRule(unittest.TestCase):
             self.attrs['epsilon'],
             self.attrs['begin_norm_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 3)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 3)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [0, -1])
 
         # [-1, -1, -1], [0, -1], [-1, 1] (outputs) -->
         # [0, 1, -1], [-1], [-1], (inputs)
@@ -323,19 +333,19 @@ class TestLayerNormSPMDRule(unittest.TestCase):
             self.attrs['epsilon'],
             self.attrs['begin_norm_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 3)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 3)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [0, 1])
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [0, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [0, 1])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [0, 1])
 
         # [-1, 1, -1], [-1, -1], [-1, -1] (outputs) -->
         # [-1, 1, -1], [-1], [-1], (inputs)
@@ -367,19 +377,21 @@ class TestLayerNormSPMDRule(unittest.TestCase):
             self.attrs['epsilon'],
             self.attrs['begin_norm_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 3)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 3)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [-1, 1])
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [-1, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [-1, 1])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [-1, 1])
 
         # [1, -1, -1], [0, -1], [-1, -1] (outputs) --> error
         # begin_norm_axis=2
@@ -441,19 +453,19 @@ class TestLayerNormSPMDRule(unittest.TestCase):
             self.attrs['epsilon'],
             self.attrs['begin_norm_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 3)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 3)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [0, 1])
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [0, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [0, 1])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [0, 1])
 
         # [0, 1, -1], [-1, -1], [-1, -1] (outputs) -->
         # [0, 1, -1], [-1], [-1] (inputs)
@@ -485,19 +497,19 @@ class TestLayerNormSPMDRule(unittest.TestCase):
             self.attrs['epsilon'],
             self.attrs['begin_norm_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 3)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 3)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [0, 1])
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [0, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [0, 1])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [0, 1])
 
         # [0, -1, -1], [-1, 1], [-1, -1] (outputs) -->
         # [0, 1, -1], [-1], [-1], (inputs)
@@ -529,19 +541,19 @@ class TestLayerNormSPMDRule(unittest.TestCase):
             self.attrs['epsilon'],
             self.attrs['begin_norm_axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        self.assertEqual(len(infered_output_dist_attrs), 3)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 3)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [0, 1])
-        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [0, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[1].dims_mapping, [0, 1])
+        self.assertEqual(inferred_output_dist_attrs[2].dims_mapping, [0, 1])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_logsumexp_rule.py
+++ b/test/auto_parallel/spmd_rules/test_logsumexp_rule.py
@@ -62,17 +62,17 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # reduce on dim 0, keep_dim = true, reduce_all = false
         # [0, -1] --> [0, -1], [-1, -1], partial_on_dim:[0]
@@ -86,13 +86,13 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # reduce on dim 1, keep_dim = false, reduce_all = false
         # [0, -1] --> [0, -1], [0], partial_on_dim:[]
@@ -106,12 +106,12 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # reduce on dim 1, keep_dim = true, reduce_all = false
         # [0, -1] --> [0, -1], [0, -1], partial_on_dim:[]
@@ -125,12 +125,12 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # reduce on dim 0 and 1, keep_dim = false, reduce_all = true
         # [0, -1] --> [0, -1], [], partial_on_dim:[0]
@@ -144,13 +144,13 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # reduce on dim 0 and 1, keep_dim = true, reduce_all = true
         # [0, -1] --> [0, -1], [-1, -1], partial_on_dim:[0]
@@ -164,13 +164,13 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
     def test_multi_mesh_dim(self):
         process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
@@ -189,16 +189,16 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # reduce on dim 1, 2, keep_dim = false, reduce_all = false
         # [-1, 0, 1] --> [-1, 0, 1], [-1], partial_on_dim:[0, 1]
@@ -212,16 +212,16 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0, 1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
 
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0, 1})
-        infered_output_dist_attrs[0]._clean_partial_status()
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0, 1})
+        inferred_output_dist_attrs[0]._clean_partial_status()
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # reduction on dim 1, 2, keep_dim = false, reduce_all = false
         # [1, -1, -1] --> [1, -1, -1], [1], partial_on_dim:[]
@@ -235,12 +235,12 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # reduction on dim 1, 2, keep_dim = false, reduce_all = false
         # [0, 1, -1] --> [0, 1, -1], [0], partial_on_dim:[1]
@@ -254,15 +254,15 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {1})
-        infered_output_dist_attrs[0]._clean_partial_status()
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {1})
+        inferred_output_dist_attrs[0]._clean_partial_status()
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # reduction on dim 1, 2, keep_dim = true, reduce_all = false
         # [0, 1, -1] --> [0, 1, -1], [0, -1, -1], partial_on_dim:[1]
@@ -276,13 +276,15 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {1})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {1})
 
         # reduction on dim 0, 1, 2, keep_dim = false, reduce_all = true
         # [0, 1, -1] --> [0, 1, -1], [], partial_on_dim:[0, 1]
@@ -296,13 +298,13 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0, 1})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0, 1})
 
         # reduction on dim 0, 1, 2, keep_dim = true, reduce_all = true
         # [0, 1, -1] --> [0, 1, -1], [-1, -1, -1], partial_on_dim:[0, 1]
@@ -316,15 +318,15 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0, 1})
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0, 1})
 
     def test_backward_single_mesh_dim(self):
         # reduce on dim 0, keep_dim = false, reduce_all = false
@@ -341,15 +343,15 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
 
         # reduce on dim 0, keep_dim = true, reduce_all = false
         # [-1, -1] --> [-1, -1], [-1, -1] (output --> input, output)
@@ -365,11 +367,11 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
 
         # reduce on dim 1, keep_dim = false, reduce_all = false
         # [0] --> [0, -1], [0] (output --> input, output)
@@ -385,11 +387,11 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
 
         # reduce on dim 1, keep_dim = true, reduce_all = false
         # [0, -1] --> [0, -1], [0, -1] (output --> input, output)
@@ -405,11 +407,11 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
         # reduce on dim 0 and 1, keep_dim = false, reduce_all = true
         # [] --> [-1, -1], [] (output --> input, output)
@@ -425,11 +427,11 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [])
 
         # reduce on dim 0 and 1, keep_dim = true, reduce_all = true
         # [-1, -1] --> [-1, -1], [-1, -1] (output --> input, output)
@@ -445,11 +447,11 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
 
     def test_backward_multi_mesh_dim(self):
         process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
@@ -471,15 +473,15 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
 
         # reduce on dim 1, 2, keep_dim = false, reduce_all = false
         # [-1] --> [-1, -1, -1], [-1] (output --> input, output)
@@ -495,11 +497,13 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
 
         # reduction on dim 1, 2, keep_dim = false, reduce_all = false
         # [1] --> [1, -1, -1], [1] (output --> input, output)
@@ -515,11 +519,11 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1])
 
         # reduction on dim 1, 2, keep_dim = true, reduce_all = false
         # [0, -1, -1] --> [0, -1, -1], [0, -1, -1] (output --> input, output)
@@ -535,11 +539,13 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
 
     def test_backward_multi_mesh_dim_partial(self):
         # reduction on dim 1, 2, keep_dim = true, reduce_all = false, partial_dim=[1]
@@ -568,12 +574,14 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(inferred_input_dist_attrs[0]._is_partial(), False)
 
         # reduction on dim 0, 1, 2, keep_dim = true, reduce_all = true, partial_dim=[1]
         # [-1, -1, -1] --> [-1, -1, -1], [-1, -1, -1] (output --> input, output)
@@ -596,14 +604,16 @@ class TestLogSumExpSPMDRule(unittest.TestCase):
             self.attrs['keep_dim'],
             self.attrs['reduce_all'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1]
         )
-        self.assertEqual(infered_input_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(inferred_input_dist_attrs[0]._is_partial(), False)
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_matmul_rule.py
+++ b/test/auto_parallel/spmd_rules/test_matmul_rule.py
@@ -52,34 +52,18 @@ class TestMatmulSPMDRule(unittest.TestCase):
             self.x_dist_tensor_spec, self.y_dist_tensor_spec, False, False
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
-
-        # test row parallel: mk[1, -1],kn[-1, -1] --> mk[1, -1],kn[-1, -1] = nm[1, -1] partial[]
-        self.x_dist_tensor_spec.set_dims_mapping([1, -1])
-        self.y_dist_tensor_spec.set_dims_mapping([-1, -1])
-
-        result_dist_attrs = self.rule.infer_forward(
-            self.x_dist_tensor_spec, self.y_dist_tensor_spec, False, False
-        )
-
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
-
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # test row parallel: mk[1, -1],kn[-1, -1] --> mk[1, -1],kn[-1, -1] = nm[1, -1] partial[]
         self.x_dist_tensor_spec.set_dims_mapping([1, -1])
@@ -88,12 +72,28 @@ class TestMatmulSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec, False, False
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
+
+        # test row parallel: mk[1, -1],kn[-1, -1] --> mk[1, -1],kn[-1, -1] = nm[1, -1] partial[]
+        self.x_dist_tensor_spec.set_dims_mapping([1, -1])
+        self.y_dist_tensor_spec.set_dims_mapping([-1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec, self.y_dist_tensor_spec, False, False
+        )
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # test n parallel: mk[-1, -1],kn[-1, 0] --> mk[-1, -1],kn[-1, 0] = nm[-1, 0] partial[]
         self.x_dist_tensor_spec.set_dims_mapping([-1, -1])
@@ -102,12 +102,12 @@ class TestMatmulSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec, False, False
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # test partial with propagation: mk[1, 0],kn[-1,-1] --> mk[1, 0],kn[0, -1] = nm[1, -1] partial[0]
         self.x_dist_tensor_spec.set_dims_mapping([1, 0])
@@ -116,13 +116,13 @@ class TestMatmulSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec, False, False
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # mk[-1,-1],kn[1,0] --> mk[-1, 1],kn[1, 0] = nm[-1, 0] partial[1]:
         self.x_dist_tensor_spec.set_dims_mapping([-1, -1])
@@ -131,13 +131,13 @@ class TestMatmulSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec, False, False
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {1})
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {1})
 
         # abcmk[1, 0, -1, -1],kn[-1, -1] --> abcmk[1, 0, -1, -1],kn[-1, -1] = abcmn[1, 0, -1, -1] partial[]: done
         self.x_dist_tensor_spec.shape = [512, 48, 64, 32]
@@ -147,16 +147,16 @@ class TestMatmulSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.y_dist_tensor_spec, False, False
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
         )
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # abcmk[1, -1, -1, 0],kn[-1, -1] --> abcmk[1, -1, -1, 0],kn[0, -1] = abcmn[1,-1, -1, -1] partial[0]
         self.x_dist_tensor_spec.set_dims_mapping([1, -1, -1, 0])
@@ -166,17 +166,17 @@ class TestMatmulSPMDRule(unittest.TestCase):
             self.x_dist_tensor_spec, self.y_dist_tensor_spec, False, False
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [1, -1, -1, 0]
+            inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1, 0]
         )
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [1, -1, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, -1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # trans_x = True, abcmk[1, -1, -1, 0], kn[-1, -1] --> abcmk[1, -1, -1, 0],kn[-1, -1] = abcmn[1, -1, 0, -1] partial[]
         self.x_dist_tensor_spec.set_dims_mapping([1, -1, -1, 0])
@@ -186,16 +186,16 @@ class TestMatmulSPMDRule(unittest.TestCase):
             self.x_dist_tensor_spec, self.y_dist_tensor_spec, True, False
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [1, -1, -1, 0]
+            inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1, 0]
         )
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [1, -1, 0, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, 0, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # trans_y = True, abcmk[-1, -1, -1, -1], kn[1, 0] --> abcmk[-1, -1, -1, 0],kn[1, 0] = abcmn[-1, -1, -1, 1] partial[0]: done
         self.x_dist_tensor_spec.set_dims_mapping([-1, -1, -1, -1])
@@ -205,19 +205,19 @@ class TestMatmulSPMDRule(unittest.TestCase):
             self.x_dist_tensor_spec, self.y_dist_tensor_spec, False, True
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1, 0]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, 0]
         )
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, 0])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, -1, 1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1, 1]
         )
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
-        infered_output_dist_attrs[0]._clean_partial_dims([0])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
+        inferred_output_dist_attrs[0]._clean_partial_dims([0])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # trans_y = True, trans_x = True, abcmk[-1, -1, 0, 1], kn[1, 0] --> abcmk[-1, -1, 0, 1]],kn[-1, 0] = abcmn[-1, -1, 1, -1] partial[0]
         # multiple mesh dim shard same tensor axis
@@ -228,19 +228,19 @@ class TestMatmulSPMDRule(unittest.TestCase):
             self.x_dist_tensor_spec, self.y_dist_tensor_spec, True, True
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, -1, 0, 1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, 0, 1]
         )
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, 0])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, 1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 1, -1]
         )
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
-        infered_output_dist_attrs[0]._clean_partial_status()
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
+        inferred_output_dist_attrs[0]._clean_partial_status()
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # trans_y = True, trans_x = True, abcmk[-1, -1, 1, 0], kn[1, 0] --> error:
         # one tensor axis shard multiple mesh dim
@@ -289,19 +289,19 @@ class TestMatmulSPMDRule(unittest.TestCase):
             self.attrs['trans_y'],
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 2)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, 0])
-        self.assertEqual(infered_input_dist_attrs[0]._is_partial(), False)
-        self.assertEqual(infered_input_dist_attrs[1]._is_partial(), False)
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[1]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # test on broadcast axes propagation
         # abmn[1, 0, -1, -1] --> 1mk[-1, -1, -1], abkn[1, 0, -1, -1]
@@ -328,15 +328,17 @@ class TestMatmulSPMDRule(unittest.TestCase):
             self.attrs['trans_y'],
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1])
         self.assertEqual(
-            infered_input_dist_attrs[1].dims_mapping, [1, 0, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1]
         )
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [1, 0, -1, -1]
+            inferred_input_dist_attrs[1].dims_mapping, [1, 0, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [1, 0, -1, -1]
         )
 
         # abmn[-1, 0, -1, 1] --> abmk[-1, 0, -1, -1], a1kn[-1, -1, -1, 1]
@@ -353,17 +355,17 @@ class TestMatmulSPMDRule(unittest.TestCase):
             self.attrs['trans_y'],
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, 0, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, 0, -1, -1]
         )
         self.assertEqual(
-            infered_input_dist_attrs[1].dims_mapping, [-1, -1, -1, 1]
+            inferred_input_dist_attrs[1].dims_mapping, [-1, -1, -1, 1]
         )
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, 0, -1, 1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1, 1]
         )
 
         # trans_x = true, trans_y = true, abmn[-1, -1, 0, 1] --> abmk[-1, -1, -1, 0], a1kn[-1, -1, 1, -1]
@@ -382,17 +384,17 @@ class TestMatmulSPMDRule(unittest.TestCase):
             self.attrs['trans_y'],
         )
 
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(
-            infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1, 0]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, 0]
         )
         self.assertEqual(
-            infered_input_dist_attrs[1].dims_mapping, [-1, -1, 1, -1]
+            inferred_input_dist_attrs[1].dims_mapping, [-1, -1, 1, -1]
         )
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, 0, 1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 0, 1]
         )
 
         # # trans_x = true, trans_y = true, abmn[-1, 1, 0, 1] --> error:

--- a/test/auto_parallel/spmd_rules/test_nonzero_rule.py
+++ b/test/auto_parallel/spmd_rules/test_nonzero_rule.py
@@ -47,33 +47,33 @@ class TestNonZeroSPMDRule(unittest.TestCase):
         # [-1, -1, -1], [-1, -1] (x, output)
         self.x_dist_tensor_spec.set_dims_mapping([1, 1, 1])
 
-        infered_dist_attr = self.rule1.infer_forward(self.x_dist_tensor_spec)
+        inferred_dist_attr = self.rule1.infer_forward(self.x_dist_tensor_spec)
 
-        self.assertEqual(len(infered_dist_attr), 2)
-        infered_input_dist_attr = infered_dist_attr[0]
-        infered_output_dist_attr = infered_dist_attr[1]
+        self.assertEqual(len(inferred_dist_attr), 2)
+        inferred_input_dist_attr = inferred_dist_attr[0]
+        inferred_output_dist_attr = inferred_dist_attr[1]
 
-        self.assertEqual(len(infered_input_dist_attr), 1)
-        self.assertEqual(len(infered_output_dist_attr), 1)
+        self.assertEqual(len(inferred_input_dist_attr), 1)
+        self.assertEqual(len(inferred_output_dist_attr), 1)
 
-        self.assertEqual(infered_input_dist_attr[0].dims_mapping, [-1, -1, -1])
-        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attr[0].dims_mapping, [-1, -1, -1])
+        self.assertEqual(inferred_output_dist_attr[0].dims_mapping, [-1, -1])
 
         # [-1, -1, -1] (x) -->
         # [-1, -1, -1], [-1, -1] (x, output)
         self.x_dist_tensor_spec.set_dims_mapping([-1, -1, -1])
 
-        infered_dist_attr = self.rule1.infer_forward(self.x_dist_tensor_spec)
+        inferred_dist_attr = self.rule1.infer_forward(self.x_dist_tensor_spec)
 
-        self.assertEqual(len(infered_dist_attr), 2)
-        infered_input_dist_attr = infered_dist_attr[0]
-        infered_output_dist_attr = infered_dist_attr[1]
+        self.assertEqual(len(inferred_dist_attr), 2)
+        inferred_input_dist_attr = inferred_dist_attr[0]
+        inferred_output_dist_attr = inferred_dist_attr[1]
 
-        self.assertEqual(len(infered_input_dist_attr), 1)
-        self.assertEqual(len(infered_output_dist_attr), 1)
+        self.assertEqual(len(inferred_input_dist_attr), 1)
+        self.assertEqual(len(inferred_output_dist_attr), 1)
 
-        self.assertEqual(infered_input_dist_attr[0].dims_mapping, [-1, -1, -1])
-        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attr[0].dims_mapping, [-1, -1, -1])
+        self.assertEqual(inferred_output_dist_attr[0].dims_mapping, [-1, -1])
 
     def test_infer_reverse(self):
         # [1, 1, 1], [-1, -1] (x, output) -->
@@ -81,38 +81,38 @@ class TestNonZeroSPMDRule(unittest.TestCase):
         self.x_dist_tensor_spec.set_dims_mapping([1, 1, 1])
         self.output_dist_tensor_spec.set_dims_mapping([1, 1])
 
-        infered_dist_attr = self.rule1.infer_backward(
+        inferred_dist_attr = self.rule1.infer_backward(
             self.x_dist_tensor_spec, self.output_dist_tensor_spec
         )
 
-        self.assertEqual(len(infered_dist_attr), 2)
-        infered_input_dist_attr = infered_dist_attr[0]
-        infered_output_dist_attr = infered_dist_attr[1]
+        self.assertEqual(len(inferred_dist_attr), 2)
+        inferred_input_dist_attr = inferred_dist_attr[0]
+        inferred_output_dist_attr = inferred_dist_attr[1]
 
-        self.assertEqual(len(infered_input_dist_attr), 1)
-        self.assertEqual(len(infered_output_dist_attr), 1)
+        self.assertEqual(len(inferred_input_dist_attr), 1)
+        self.assertEqual(len(inferred_output_dist_attr), 1)
 
-        self.assertEqual(infered_input_dist_attr[0].dims_mapping, [-1, -1, -1])
-        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attr[0].dims_mapping, [-1, -1, -1])
+        self.assertEqual(inferred_output_dist_attr[0].dims_mapping, [-1, -1])
 
         # [-1, -1, -1], [-1, -1] (x, output) -->
         # [-1, -1, -1], [-1, -1] (x, output)
         self.x_dist_tensor_spec.set_dims_mapping([1, 1, 1])
         self.output_dist_tensor_spec.set_dims_mapping([-1, -1])
 
-        infered_dist_attr = self.rule1.infer_backward(
+        inferred_dist_attr = self.rule1.infer_backward(
             self.x_dist_tensor_spec, self.output_dist_tensor_spec
         )
 
-        self.assertEqual(len(infered_dist_attr), 2)
-        infered_input_dist_attr = infered_dist_attr[0]
-        infered_output_dist_attr = infered_dist_attr[1]
+        self.assertEqual(len(inferred_dist_attr), 2)
+        inferred_input_dist_attr = inferred_dist_attr[0]
+        inferred_output_dist_attr = inferred_dist_attr[1]
 
-        self.assertEqual(len(infered_input_dist_attr), 1)
-        self.assertEqual(len(infered_output_dist_attr), 1)
+        self.assertEqual(len(inferred_input_dist_attr), 1)
+        self.assertEqual(len(inferred_output_dist_attr), 1)
 
-        self.assertEqual(infered_input_dist_attr[0].dims_mapping, [-1, -1, -1])
-        self.assertEqual(infered_output_dist_attr[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attr[0].dims_mapping, [-1, -1, -1])
+        self.assertEqual(inferred_output_dist_attr[0].dims_mapping, [-1, -1])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_one_hot_rule.py
+++ b/test/auto_parallel/spmd_rules/test_one_hot_rule.py
@@ -43,15 +43,15 @@ class TestOneHotSPMDRule(unittest.TestCase):
             self.x_spec,
             self.attrs['num_classes'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
 
     def test_one_hot_infer_spmd_reverse(self):
         out_dist_attr = TensorDistAttr()
@@ -66,14 +66,14 @@ class TestOneHotSPMDRule(unittest.TestCase):
             self.out_spec,
             self.attrs['num_classes'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
 
         # [-1, -1], [0, -1, 1] --> [0, -1], [0, -1, -1]
         self.x_spec.set_dims_mapping([-1, -1])
@@ -83,14 +83,16 @@ class TestOneHotSPMDRule(unittest.TestCase):
             self.out_spec,
             self.attrs['num_classes'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_p_norm_rule.py
+++ b/test/auto_parallel/spmd_rules/test_p_norm_rule.py
@@ -70,17 +70,17 @@ class TestPNormSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['asvector'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # reduce on dim 0, keepdims = true, asvector = false
         # [0, -1] --> [0, -1], [-1, -1], partial_on_dim:[0]
@@ -97,13 +97,13 @@ class TestPNormSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['asvector'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # reduce on dim 1, keepdims = false, asvector = false
         # [0, -1] --> [0, -1], [0], partial_on_dim:[]
@@ -119,12 +119,12 @@ class TestPNormSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['asvector'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # reduce on dim 1, keepdims = true, asvector = false
         # [0, -1] --> [0, -1], [0, -1], partial_on_dim:[]
@@ -140,12 +140,12 @@ class TestPNormSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['asvector'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # reduce on dim 0 and 1, keepdims = false, asvector = true
         # [0, -1] --> [0, -1], [], partial_on_dim:[0]
@@ -161,13 +161,13 @@ class TestPNormSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['asvector'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # reduce on dim 0 and 1, keepdims = true, asvector = true
         # [0, -1] --> [0, -1], [-1, -1], partial_on_dim:[0]
@@ -183,13 +183,13 @@ class TestPNormSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['asvector'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
     def test_infer_backward(self):
         # reduce on dim 0, keepdims = false, asvector = false
@@ -208,15 +208,15 @@ class TestPNormSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['asvector'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
 
         # reduce on dim 0, keepdims = true, asvector = false
         # [-1, -1] --> [-1, -1], [-1, -1] (output --> input, output)
@@ -234,11 +234,11 @@ class TestPNormSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['asvector'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
 
         # reduce on dim 1, keepdims = false, asvector = false
         # [0] --> [0, -1], [0] (output --> input, output)
@@ -256,11 +256,11 @@ class TestPNormSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['asvector'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
 
         # reduce on dim 1, keepdims = true, asvector = false
         # [0, -1] --> [0, -1], [0, -1] (output --> input, output)
@@ -278,11 +278,11 @@ class TestPNormSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['asvector'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
         # reduce on dim 0 and 1, keepdims = false, asvector = true
         # [] --> [-1, -1], [] (output --> input, output)
@@ -300,11 +300,11 @@ class TestPNormSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['asvector'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [])
 
         # reduce on dim 0 and 1, keepdims = true, asvector = true
         # [-1, -1] --> [-1, -1], [-1, -1] (output --> input, output)
@@ -322,11 +322,11 @@ class TestPNormSPMDRule(unittest.TestCase):
             self.attrs['keepdims'],
             self.attrs['asvector'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_pad_rule.py
+++ b/test/auto_parallel/spmd_rules/test_pad_rule.py
@@ -41,22 +41,24 @@ class TestPadSPMDRule(unittest.TestCase):
     def test_infer_forward(self):
         inputs = self.build_inputs()
         rule = core.get_phi_spmd_rule("pad")
-        infered_dist_attrs = rule.infer_forward(inputs, self.paddings, 0)
+        inferred_dist_attrs = rule.infer_forward(inputs, self.paddings, 0)
 
-        infered_output_dist_attrs = infered_dist_attrs[1]
-        self.assertEqual(len(infered_output_dist_attrs), 1)
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        inferred_output_dist_attrs = inferred_dist_attrs[1]
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
 
     def test_infer_backward(self):
         inputs = self.build_inputs()
         rule = core.get_phi_spmd_rule("pad")
-        infered_dist_attrs = rule.infer_backward(
+        inferred_dist_attrs = rule.infer_backward(
             inputs, inputs, self.paddings, 0
         )
 
-        infered_input_dist_attrs = infered_dist_attrs[0]
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        inferred_input_dist_attrs = inferred_dist_attrs[0]
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_reduction_rule.py
+++ b/test/auto_parallel/spmd_rules/test_reduction_rule.py
@@ -56,17 +56,17 @@ class TestReductionSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # reduce on dim 0, keep_dim = true
         # [0, -1] --> [0, -1], [-1, -1], partial_on_dim:[0]
@@ -76,13 +76,13 @@ class TestReductionSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # reduce on dim 1, keep_dim = false
         # [0, -1] --> [0, -1], [0], partial_on_dim:[]
@@ -92,12 +92,12 @@ class TestReductionSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # reduce on dim 1, keep_dim = true
         # [0, -1] --> [0, -1], [0, -1], partial_on_dim:[]
@@ -107,12 +107,12 @@ class TestReductionSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # reduce on dim 0 and 1, keep_dim = false
         # [0, -1] --> [0, -1], [], partial_on_dim:[0]
@@ -122,13 +122,13 @@ class TestReductionSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # reduce on dim 0 and 1, keep_dim = true
         # [0, -1] --> [0, -1], [-1, -1], partial_on_dim:[0]
@@ -138,13 +138,13 @@ class TestReductionSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
     def test_multi_mesh_dim(self):
         process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
@@ -159,16 +159,16 @@ class TestReductionSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # reduce on dim 1, 2, keep_dim = false
         # [-1, 0, 1] --> [-1, 0, 1], [-1], partial_on_dim:[0, 1]
@@ -178,16 +178,16 @@ class TestReductionSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0, 1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
 
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0, 1})
-        infered_output_dist_attrs[0]._clean_partial_status()
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0, 1})
+        inferred_output_dist_attrs[0]._clean_partial_status()
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
         # reduction on dim 1, 2, keep_dim = false
         # [1, -1, -1] --> [1, -1, -1], [1], partial_on_dim:[]
         self.attrs['keep_dim'] = False
@@ -196,12 +196,12 @@ class TestReductionSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # reduction on dim 1, 2, keep_dim = false
         # [0, 1, -1] --> [0, 1, -1], [0], partial_on_dim:[1]
@@ -211,15 +211,15 @@ class TestReductionSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {1})
-        infered_output_dist_attrs[0]._clean_partial_status()
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {1})
+        inferred_output_dist_attrs[0]._clean_partial_status()
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
         # reduction on dim 1, 2, keep_dim = true
         # [0, 1, -1] --> [0, 1, -1], [0, -1, -1], partial_on_dim:[1]
@@ -229,13 +229,15 @@ class TestReductionSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
-        self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {1})
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {1})
 
     def test_backward_single_mesh_dim(self):
         # reduce on dim 0, keep_dim = false
@@ -250,15 +252,15 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['axis'],
             self.attrs['keep_dim'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
 
         # reduce on dim 0, keep_dim = true
         # [-1, -1] --> [-1, -1], [-1, -1] (output --> input, output)
@@ -272,11 +274,11 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['axis'],
             self.attrs['keep_dim'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
 
         # reduce on dim 1, keep_dim = false
         # [0] --> [0, -1], [0] (output --> input, output)
@@ -290,11 +292,11 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['axis'],
             self.attrs['keep_dim'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
 
         # reduce on dim 1, keep_dim = true
         # [0, -1] --> [0, -1], [0, -1] (output --> input, output)
@@ -308,11 +310,11 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['axis'],
             self.attrs['keep_dim'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, -1])
 
         # reduce on dim 0 and 1, keep_dim = false
         # [] --> [-1, -1], [] (output --> input, output)
@@ -326,11 +328,11 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['axis'],
             self.attrs['keep_dim'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [])
 
         # reduce on dim 0 and 1, keep_dim = true
         # [-1, -1] --> [-1, -1], [-1, -1] (output --> input, output)
@@ -344,11 +346,11 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['axis'],
             self.attrs['keep_dim'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
 
     def test_backward_multi_mesh_dim(self):
         process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
@@ -368,15 +370,15 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['axis'],
             self.attrs['keep_dim'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(result_dist_attrs), 2)
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0])
 
         # reduce on dim 1, 2, keep_dim = false
         # [-1] --> [-1, -1, -1], [-1] (output --> input, output)
@@ -390,11 +392,13 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['axis'],
             self.attrs['keep_dim'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
 
         # reduction on dim 1, 2, keep_dim = false
         # [1] --> [1, -1, -1], [1] (output --> input, output)
@@ -408,11 +412,11 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['axis'],
             self.attrs['keep_dim'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1])
 
         # reduction on dim 1, 2, keep_dim = true
         # [0, -1, -1] --> [0, -1, -1], [0, -1, -1] (output --> input, output)
@@ -426,11 +430,13 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['axis'],
             self.attrs['keep_dim'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
 
     def test_backward_multi_mesh_dim_partial(self):
         # reduction on dim 1, 2, keep_dim = true, partial_dim=[1]
@@ -457,12 +463,14 @@ class TestReductionSPMDRule(unittest.TestCase):
             self.attrs['axis'],
             self.attrs['keep_dim'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
-        self.assertEqual(infered_input_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1]
+        )
+        self.assertEqual(inferred_input_dist_attrs[0]._is_partial(), False)
 
 
 class TestSquaredL2NormSPMDRule(TestReductionSPMDRule):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

Fix typo `infered` -> `inferred` part3

```
Before:
~/Projects/Paddle develop*
❯ typos --format brief | wc -l
    1610

After:
~/Projects/Paddle typos/infered-part3*
❯ typos --format brief | wc -l
     804
```

本 PR 修复约 800 处

### Related links

- #69441
- #70978
- #70983

PCard-66972