### PR TITLE
[CodeStyle][Typos][I-15] Fix typo `infered` (part5)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -51,8 +51,6 @@ unpacket = "unpacket"
 vaccum = 'vaccum'
 
 # These words need to be fixed
-Infered = 'Infered'
-infered = 'infered'
 Operants = 'Operants'
 operants = 'operants'
 outout = 'outout'

--- a/test/auto_parallel/spmd_rules/test_unsqueeze_rule.py
+++ b/test/auto_parallel/spmd_rules/test_unsqueeze_rule.py
@@ -44,13 +44,13 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, 1])
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0, 1])
 
         # shape: [8, 16] --> [8, 16, 1]
         # dims_mapping: [0, 1] --> [0, 1] [0, 1, -1]
@@ -59,11 +59,11 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
 
         # shape: [8, 16] --> [8, 1, 1, 16]
         # dims_mapping: [0, 1] --> [0, 1] [0, -1, -1, 1]
@@ -72,12 +72,12 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [0, -1, -1, 1]
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1, 1]
         )
 
         # shape: [8, 16] --> [1, 1, 1, 8, 16]
@@ -87,12 +87,12 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, -1, 0, 1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1, 0, 1]
         )
 
         # shape: [8, 16] --> [1, 8, 16]
@@ -102,11 +102,11 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 1, 0])
 
         # shape: [8, 16] --> [8, 16, 1]
         # dims_mapping: [1, 0] --> [1, 0] [1, 0, -1]
@@ -115,11 +115,11 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, 0, -1])
 
         # shape: [8, 16] --> [8, 1, 1, 16]
         # dims_mapping: [1, 0] --> [1, 0] [1, -1, -1, 0]
@@ -128,12 +128,12 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [1, -1, -1, 0]
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, -1, 0]
         )
 
         # shape: [8, 16] --> [1, 1, 1, 8, 16]
@@ -143,12 +143,12 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, -1, 1, 0]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1, 1, 0]
         )
 
         # shape: [1, 8, 16] --> [1, 1, 8, 16]
@@ -159,12 +159,12 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
         result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis']
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 1, -1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, 1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 1, -1]
         )
 
     def test_unsqueeze_infer_backward(self):
@@ -187,13 +187,13 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
             self.output_dist_tensor_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, 1])
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0, 1])
 
         # shape: [8, 16] --> [8, 16, 1] (input --> output)
         # dims_mapping: [0, 1, -1] --> [0, 1], [0, 1, -1] (output --> input, output)
@@ -205,11 +205,11 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
             self.output_dist_tensor_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
 
         # shape: [8, 16] --> [8, 1, 1, 16] (input --> output)
         # dims_mapping: [0, -1, -1, 1] --> [0, 1], [0, -1, -1, 1] (output --> input, output)
@@ -221,12 +221,12 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
             self.output_dist_tensor_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [0, -1, -1, 1]
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1, 1]
         )
 
         # shape: [8, 16] --> [1, 1, 1, 8, 16] (input --> output)
@@ -239,12 +239,12 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
             self.output_dist_tensor_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, -1, 0, 1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1, 0, 1]
         )
 
         # shape: [8, 16] --> [1, 8, 16] (input --> output)
@@ -257,13 +257,13 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
             self.output_dist_tensor_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 1, 0])
+        self.assertEqual(len(inferred_input_dist_attrs), 1)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 1, 0])
 
         # shape: [8, 16] --> [8, 16, 1] (input --> output)
         # dims_mapping: [1, 0, -1] --> [1, 0], [1, 0, -1] (output --> input, output)
@@ -275,11 +275,11 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
             self.output_dist_tensor_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, 0, -1])
 
         # shape: [8, 16] --> [8, 1, 1, 16] (input --> output)
         # dims_mapping: [1, -1, -1, 0] --> [1, 0], [1, -1, -1, 0] (output --> input, output)
@@ -291,12 +291,12 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
             self.output_dist_tensor_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [1, -1, -1, 0]
+            inferred_output_dist_attrs[0].dims_mapping, [1, -1, -1, 0]
         )
 
         # shape: [8, 16] --> [1, 1, 1, 8, 16] (input --> output)
@@ -309,12 +309,12 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
             self.output_dist_tensor_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, -1, 1, 0]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1, 1, 0]
         )
 
         # shape: [1, 8, 16] --> [1, 1, 8, 16] (input --> output)
@@ -328,12 +328,12 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
             self.output_dist_tensor_spec,
             self.attrs['axis'],
         )
-        infered_input_dist_attrs = result_dist_attrs[0]
-        infered_output_dist_attrs = result_dist_attrs[1]
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 1, -1])
         self.assertEqual(
-            infered_output_dist_attrs[0].dims_mapping, [-1, -1, 1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 1, -1]
         )
 
 

--- a/test/auto_parallel/spmd_rules/test_where_rule.py
+++ b/test/auto_parallel/spmd_rules/test_where_rule.py
@@ -44,32 +44,38 @@ class TestWhereSPMDRule(unittest.TestCase):
     def test_infer_forward(self):
         inputs = self.build_inputs()
         rule = core.get_phi_spmd_rule("where")
-        infered_dist_attrs = rule.infer_forward(inputs[0], inputs[1], inputs[2])
-        infered_input_dist_attrs = infered_dist_attrs[0]
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        infered_output_dist_attrs = infered_dist_attrs[1]
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        inferred_dist_attrs = rule.infer_forward(
+            inputs[0], inputs[1], inputs[2]
+        )
+        inferred_input_dist_attrs = inferred_dist_attrs[0]
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        inferred_output_dist_attrs = inferred_dist_attrs[1]
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1]
+        )
 
     def test_infer_reverse(self):
         inputs = self.build_inputs()
         rule = core.get_phi_spmd_rule("where")
-        infered_dist_attrs = rule.infer_backward(
+        inferred_dist_attrs = rule.infer_backward(
             inputs[0], inputs[1], inputs[2], inputs[0]
         )
-        infered_input_dist_attrs = infered_dist_attrs[0]
-        self.assertEqual(len(infered_input_dist_attrs), 3)
-        infered_output_dist_attrs = infered_dist_attrs[1]
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        inferred_input_dist_attrs = inferred_dist_attrs[0]
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        inferred_output_dist_attrs = inferred_dist_attrs[1]
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
 
-        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
-        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [0, -1])
-        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 0, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

Fix typo `infered` -> `inferred` part5 (final part)

### Related links

- #69441
- #70978
- #70983
- #70984
- #70985

PCard-66972