### PR TITLE
[CINN] improve FoldRedundantSymbolicBroadcast

### DIFF
--- a/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
+++ b/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
@@ -182,6 +182,14 @@ TEST(Simplify, FoldBroadcast) {
   ASSERT_TRUE(simplify_broadcast3 == add);
 }
 
+TEST(Simplify, FoldRedundantBroadcast) {
+  DimExpr S0{"S0"};
+  DimExpr S1{"S1"};
+  DimExpr bc{Broadcast<DimExpr>{{S0, S0, S1, S1}}};
+  DimExpr simplify_bc = SimplifyDimExpr(bc);
+  ASSERT_TRUE(simplify_bc == Broadcast<DimExpr>{{S0, S1}});
+}
+
 TEST(Simplify, Case1) {
   // Mul(Broadcast(S11, S8), Broadcast(S10, S13, S4, S7), Broadcast(S12, S3, S6,
   // S9), 1 / (S0), 16, 1 / (49))

--- a/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
+++ b/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
@@ -187,7 +187,7 @@ TEST(Simplify, FoldRedundantBroadcast) {
   DimExpr S1{"S1"};
   DimExpr bc{Broadcast<DimExpr>{{S0, S0, S1, S1}}};
   DimExpr simplify_bc = SimplifyDimExpr(bc);
-  ASSERT_TRUE(simplify_bc == Broadcast<DimExpr>{{S0, S1}});
+  ASSERT_TRUE((simplify_bc == Broadcast<DimExpr>{{S0, S1}}));
 }
 
 TEST(Simplify, Case1) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-67164
improve FoldRedundantSymbolicBroadcast
- 修复注释的示例和代码实现不一致的情况
- 之前只是处理了一组冗余，虽然经过多次的 Pass，也可以完全去除，但是一次去除冗余可能会减少 Pass 次数。

### TODO
- [x] 添加单测