### PR TITLE
Support XPU for dygraph auto-parallel

### DIFF
--- a/paddle/phi/core/distributed/auto_parallel/reshard/global_and_sub_mesh_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/global_and_sub_mesh_reshard_function.cc
@@ -80,7 +80,7 @@ void SubMeshToGlobalReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                                           DistTensor* out) {
   VLOG(3) << "Call SubMeshToGlobalReshardFunction Eval";
 #if defined(PADDLE_WITH_XPU)
-    PADDLE_THROW(::common::errors::Unimplemented(
+  PADDLE_THROW(::common::errors::Unimplemented(
       "Not supported PSendKernel/PRecv on xpu yet."));
 #else
   const TensorDistAttr& in_dist_attr = in.dist_attr();

--- a/paddle/phi/core/distributed/auto_parallel/reshard/global_and_sub_mesh_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/global_and_sub_mesh_reshard_function.cc
@@ -79,6 +79,10 @@ void SubMeshToGlobalReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                                           const TensorDistAttr& out_dist_attr,
                                           DistTensor* out) {
   VLOG(3) << "Call SubMeshToGlobalReshardFunction Eval";
+#if defined(PADDLE_WITH_XPU)
+    PADDLE_THROW(::common::errors::Unimplemented(
+      "Not supported PSendKernel/PRecv on xpu yet."));
+#else
   const TensorDistAttr& in_dist_attr = in.dist_attr();
   const ProcessMesh& in_process_mesh = in_dist_attr.process_mesh();
   const ProcessMesh& out_process_mesh = out_dist_attr.process_mesh();
@@ -132,6 +136,7 @@ void SubMeshToGlobalReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                               GetMutableTensor(out));
   }
   SetDistProps(out, in.dims(), out_dist_attr);
+#endif
 }
 
 }  // namespace phi::distributed

--- a/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
@@ -67,6 +67,10 @@ void ReshardPToSWithPadding(DeviceContext* dev_ctx,
   }
 
   DenseTensor out_reduce_scatter;
+#if defined(PADDLE_WITH_XPU)
+    PADDLE_THROW(::common::errors::Unimplemented(
+      "Not supported Reducescatter on xpu yet."));
+#else
   RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                             ReduceScatter,
                             dtype,
@@ -74,7 +78,7 @@ void ReshardPToSWithPadding(DeviceContext* dev_ctx,
                             in_reduce_scatter,
                             static_cast<int64_t>(process_ids.size()),
                             &out_reduce_scatter);
-
+#endif
   DenseTensor out_result;
   if (split_axis != 0) {
     RESHARD_FUNCTOR(

--- a/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
@@ -68,7 +68,7 @@ void ReshardPToSWithPadding(DeviceContext* dev_ctx,
 
   DenseTensor out_reduce_scatter;
 #if defined(PADDLE_WITH_XPU)
-    PADDLE_THROW(::common::errors::Unimplemented(
+  PADDLE_THROW(::common::errors::Unimplemented(
       "Not supported Reducescatter on xpu yet."));
 #else
   RESHARD_FUNCTOR_WITH_COMM(dev_ctx,

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_x_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_x_reshard_function.cc
@@ -60,7 +60,6 @@ void RToXExpandReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   int64_t cur_global_rank = GetCurGlobalRank();
   int64_t root_rank = in_process_ids[0];
   auto all_process_ids = GetUnionProcessIds(in_process_ids, out_process_ids);
-  bool dynamic_shape = true;
   auto dtype = in.dtype();
   const auto& out_partial_status = out_dist_attr.partial_status();
   bool cur_rank_in_out_mesh =
@@ -72,27 +71,37 @@ void RToXExpandReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   if (root_rank == cur_global_rank) {
     for (const auto& out_process_id : out_process_ids) {
       if (out_process_id != root_rank) {
+#if defined(PADDLE_WITH_XPU)
+    PADDLE_THROW(::common::errors::Unimplemented(
+      "Not supported PSendKernel on xpu yet."));
+#else
         RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                                   PSendKernel,
                                   dtype,
                                   all_process_ids,
                                   in.value(),
                                   out_process_id,
-                                  dynamic_shape);
+                                  /*dynamic_shape=*/true);
+#endif
       }
     }
     if (cur_rank_in_out_mesh) {
       result_value = in.value();
     }
   } else {
+#if defined(PADDLE_WITH_XPU)
+    PADDLE_THROW(::common::errors::Unimplemented(
+      "Not supported PRecv on xpu yet."));
+#else
     RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                               PRecv,
                               dtype,
                               all_process_ids,
                               root_rank,
                               {} /*out_shape*/,
-                              dynamic_shape,
+                              /*dynamic_shape=*/true,
                               &result_value);
+#endif
   }
 
   if (cur_rank_in_out_mesh) {

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_x_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_x_reshard_function.cc
@@ -72,8 +72,8 @@ void RToXExpandReshardFunction::Eval(phi::DeviceContext* dev_ctx,
     for (const auto& out_process_id : out_process_ids) {
       if (out_process_id != root_rank) {
 #if defined(PADDLE_WITH_XPU)
-    PADDLE_THROW(::common::errors::Unimplemented(
-      "Not supported PSendKernel on xpu yet."));
+        PADDLE_THROW(::common::errors::Unimplemented(
+            "Not supported PSendKernel on xpu yet."));
 #else
         RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                                   PSendKernel,
@@ -90,8 +90,8 @@ void RToXExpandReshardFunction::Eval(phi::DeviceContext* dev_ctx,
     }
   } else {
 #if defined(PADDLE_WITH_XPU)
-    PADDLE_THROW(::common::errors::Unimplemented(
-      "Not supported PRecv on xpu yet."));
+    PADDLE_THROW(
+        ::common::errors::Unimplemented("Not supported PRecv on xpu yet."));
 #else
     RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                               PRecv,

--- a/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.cc
@@ -111,38 +111,38 @@ CommContext* CreateOrGetCommContext(const DeviceContext& dev_ctx,
 #endif
     }
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_ROCM)
-    else if(phi::GPUContext::classof(&dev_ctx)) { // NOLINT
+    else if (phi::GPUContext::classof(&dev_ctx)) {  // NOLINT
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
-        CommContextManager::CreateNCCLCommContext(store,
-                                                  unique_comm_key,
-                                                  static_cast<int>(rank),
-                                                  static_cast<int>(world_size));
+      CommContextManager::CreateNCCLCommContext(store,
+                                                unique_comm_key,
+                                                static_cast<int>(rank),
+                                                static_cast<int>(world_size));
 #else
       PADDLE_THROW(common::errors::Unimplemented(
           "Cannot use nccl on GPU, please turn WITH_NCCL flag on."));
 #endif
     }
 #elif defined(PADDLE_WITH_XPU)
-    else if(phi::XPUContext::classof(&dev_ctx)) { // NOLINT
+    else if (phi::XPUContext::classof(&dev_ctx)) {  // NOLINT
 #if defined(PADDLE_WITH_XPU_BKCL)
-     CommContextManager::CreateBKCLCommContext(store,
-                                                  unique_comm_key,
-                                                  static_cast<int>(rank),
-                                                  static_cast<int>(world_size));
+      CommContextManager::CreateBKCLCommContext(store,
+                                                unique_comm_key,
+                                                static_cast<int>(rank),
+                                                static_cast<int>(world_size));
 #else
       PADDLE_THROW(common::errors::Unimplemented(
           "Cannot use xpu on GPU, please turn WITH_XPU_BKCL flag on."));
 #endif
     }
 #elif defined(PADDLE_WITH_CUSTOM_DEVICE)
-    else if (phi::CustomContext::classof(&dev_ctx)) { // NOLINT
-        CommContextManager::CreateXCCLCommContext(
-            store, unique_comm_key, dev_ctx.GetPlace(), rank, world_size);
+    else if (phi::CustomContext::classof(&dev_ctx)) {  // NOLINT
+      CommContextManager::CreateXCCLCommContext(
+          store, unique_comm_key, dev_ctx.GetPlace(), rank, world_size);
     }
 #endif
-    else { // NOLINT
-        PADDLE_THROW(common::errors::Unimplemented(
-            "CommContext is only supported CPU, GPU, XPU, and CustomDevice."));
+    else {  // NOLINT
+      PADDLE_THROW(common::errors::Unimplemented(
+          "CommContext is only supported CPU, GPU, XPU, and CustomDevice."));
     }
   }
 

--- a/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.cc
@@ -109,24 +109,40 @@ CommContext* CreateOrGetCommContext(const DeviceContext& dev_ctx,
       PADDLE_THROW(common::errors::Unimplemented(
           "Cannot use gloo on CPU, please turn PADDLE_WITH_GLOO flag on."));
 #endif
-    } else if (phi::CustomContext::classof(&dev_ctx)) {
-#ifdef PADDLE_WITH_CUSTOM_DEVICE
-      CommContextManager::CreateXCCLCommContext(
-          store, unique_comm_key, dev_ctx.GetPlace(), rank, world_size);
-#endif
-    } else {
+    }
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_ROCM)
+    else if(phi::GPUContext::classof(&dev_ctx)) { // NOLINT
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
-      if (phi::GPUContext::classof(&dev_ctx)) {
         CommContextManager::CreateNCCLCommContext(store,
                                                   unique_comm_key,
                                                   static_cast<int>(rank),
                                                   static_cast<int>(world_size));
-      }
 #else
       PADDLE_THROW(common::errors::Unimplemented(
-          "CommContext is only supported on CPU and GPU for now, other devices "
-          "will be supported later."));
+          "Cannot use nccl on GPU, please turn WITH_NCCL flag on."));
 #endif
+    }
+#elif defined(PADDLE_WITH_XPU)
+    else if(phi::XPUContext::classof(&dev_ctx)) { // NOLINT
+#if defined(PADDLE_WITH_XPU_BKCL)
+     CommContextManager::CreateBKCLCommContext(store,
+                                                  unique_comm_key,
+                                                  static_cast<int>(rank),
+                                                  static_cast<int>(world_size));
+#else
+      PADDLE_THROW(common::errors::Unimplemented(
+          "Cannot use xpu on GPU, please turn WITH_XPU_BKCL flag on."));
+#endif
+    }
+#elif defined(PADDLE_WITH_CUSTOM_DEVICE)
+    else if (phi::CustomContext::classof(&dev_ctx)) { // NOLINT
+        CommContextManager::CreateXCCLCommContext(
+            store, unique_comm_key, dev_ctx.GetPlace(), rank, world_size);
+    }
+#endif
+    else { // NOLINT
+        PADDLE_THROW(common::errors::Unimplemented(
+            "CommContext is only supported CPU, GPU, XPU, and CustomDevice."));
     }
   }
 

--- a/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.h
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.h
@@ -79,17 +79,17 @@ phi::DDim InferShapeForReshardFromReplicate(
     const TensorDistAttr& dist_attr);
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-  #define DEVICE_CONTEXT GPUContext
+#define DEVICE_CONTEXT GPUContext
 #elif defined(PADDLE_WITH_XPU)
-  #define DEVICE_CONTEXT XPUContext
+#define DEVICE_CONTEXT XPUContext
 #elif defined(PADDLE_WITH_CUSTOM_DEVICE)
-  #define DEVICE_CONTEXT CustomContext
+#define DEVICE_CONTEXT CustomContext
 #endif
 
 // Some reshard function supports fewer data types on xpu than on gpu. For
 // example, `Transpose`, `Split`, and `Divide` do not support double type.
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-#define PD_VISIT_RESHARD_TYPES  PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES
+#define PD_VISIT_RESHARD_TYPES PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES
 #else
 #define PD_VISIT_RESHARD_TYPES(TYPE, NAME, ...)                               \
   [&] {                                                                       \
@@ -104,35 +104,38 @@ phi::DDim InferShapeForReshardFromReplicate(
           NAME, ::paddle::DataType::FLOAT16, paddle::float16, __VA_ARGS__)    \
       PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, __VA_ARGS__)                        \
       default:                                                                \
-        PD_THROW("Reshard function " #NAME " is not implemented"              \
-                 " for data type `", __dtype__, "`");                         \
+        PD_THROW("Reshard function " #NAME                                    \
+                 " is not implemented"                                        \
+                 " for data type `",                                          \
+                 __dtype__,                                                   \
+                 "`");                                                        \
     }                                                                         \
   }()
 #endif
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
     defined(PADDLE_WITH_XPU)
-#define RESHARD_FUNCTOR_IMPL(dev_ctx, fn_name, dtype, ...)                \
-  do {                                                                    \
-    if (phi::CPUContext::classof(dev_ctx)) {                              \
-      VLOG(4) << "Call `" << #fn_name << "` in Resharding on CPU.";       \
-      PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES_CPU(                  \
-          dtype, #fn_name, ([&] {                                         \
-            fn_name<data_t>(static_cast<const CPUContext&>(*dev_ctx),     \
-                            __VA_ARGS__);                                 \
-          }));                                                            \
-    } else if(DEVICE_CONTEXT::classof(dev_ctx)) {                         \
-      VLOG(4) << "Call `" << #fn_name << "` in Resharding on device.";    \
-      PD_VISIT_RESHARD_TYPES(                                             \
-          dtype, #fn_name, ([&] {                                         \
-            fn_name<data_t>(static_cast<const DEVICE_CONTEXT&>(*dev_ctx), \
-                            __VA_ARGS__);                                 \
-          }));                                                            \
-    } else {                                                              \
-      PADDLE_THROW(common::errors::Unimplemented(                         \
+#define RESHARD_FUNCTOR_IMPL(dev_ctx, fn_name, dtype, ...)                  \
+  do {                                                                      \
+    if (phi::CPUContext::classof(dev_ctx)) {                                \
+      VLOG(4) << "Call `" << #fn_name << "` in Resharding on CPU.";         \
+      PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES_CPU(                    \
+          dtype, #fn_name, ([&] {                                           \
+            fn_name<data_t>(static_cast<const CPUContext&>(*dev_ctx),       \
+                            __VA_ARGS__);                                   \
+          }));                                                              \
+    } else if (DEVICE_CONTEXT::classof(dev_ctx)) {                          \
+      VLOG(4) << "Call `" << #fn_name << "` in Resharding on device.";      \
+      PD_VISIT_RESHARD_TYPES(                                               \
+          dtype, #fn_name, ([&] {                                           \
+            fn_name<data_t>(static_cast<const DEVICE_CONTEXT&>(*dev_ctx),   \
+                            __VA_ARGS__);                                   \
+          }));                                                              \
+    } else {                                                                \
+      PADDLE_THROW(common::errors::Unimplemented(                           \
           "The %s in reshard only supported on CPU, GPU, and XPU for now.", \
-          #fn_name));                                                     \
-    }                                                                     \
+          #fn_name));                                                       \
+    }                                                                       \
   } while (0)
 #else
 #define RESHARD_FUNCTOR_IMPL(dev_ctx, fn_name, dtype, ...)                \
@@ -165,34 +168,34 @@ phi::DDim InferShapeForReshardFromReplicate(
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
     defined(PADDLE_WITH_XPU)
-#define RESHARD_FUNCTOR_WITHOUT_DTYPE(dev_ctx, fn_name, ...)                  \
-  do {                                                                        \
-    if (phi::CPUContext::classof(dev_ctx)) {                                  \
-      VLOG(4) << "Call `" << #fn_name                                         \
-              << "`without DType in  Resharding on CPU.";                     \
-      fn_name(static_cast<const CPUContext&>(*dev_ctx), __VA_ARGS__);         \
-    } else if (DEVICE_CONTEXT::classof(dev_ctx)) {                            \
-            VLOG(4) << "Call `" << #fn_name                                   \
-              << "`without DType in  Resharding on device.";                  \
-      fn_name(static_cast<const DEVICE_CONTEXT&>(*dev_ctx), __VA_ARGS__);     \
-    } else {                                                                  \
-      PADDLE_THROW(common::errors::Unimplemented(                             \
-          "The %s in reshard only supported CPU, GPU, and XPU Device",        \
-          #fn_name));                                                         \
-    }                                                                         \
+#define RESHARD_FUNCTOR_WITHOUT_DTYPE(dev_ctx, fn_name, ...)              \
+  do {                                                                    \
+    if (phi::CPUContext::classof(dev_ctx)) {                              \
+      VLOG(4) << "Call `" << #fn_name                                     \
+              << "`without DType in  Resharding on CPU.";                 \
+      fn_name(static_cast<const CPUContext&>(*dev_ctx), __VA_ARGS__);     \
+    } else if (DEVICE_CONTEXT::classof(dev_ctx)) {                        \
+      VLOG(4) << "Call `" << #fn_name                                     \
+              << "`without DType in  Resharding on device.";              \
+      fn_name(static_cast<const DEVICE_CONTEXT&>(*dev_ctx), __VA_ARGS__); \
+    } else {                                                              \
+      PADDLE_THROW(common::errors::Unimplemented(                         \
+          "The %s in reshard only supported CPU, GPU, and XPU Device",    \
+          #fn_name));                                                     \
+    }                                                                     \
   } while (0)
 #else
-#define RESHARD_FUNCTOR_WITHOUT_DTYPE(dev_ctx, fn_name, ...)                   \
-  do {                                                                         \
-    if (phi::CPUContext::classof(dev_ctx)) {                                   \
-      VLOG(4) << "Call `" << #fn_name                                          \
-              << "`without DType in Resharding on CPU.";                       \
-      fn_name(static_cast<const CPUContext&>(*dev_ctx), __VA_ARGS__);          \
-    } else {                                                                   \
-      PADDLE_THROW(common::errors::Unimplemented(                              \
-          "The %s in reshard only supported CPU, GPU, and XPU Device.",        \
-           #fn_name));                                                         \
-    }                                                                          \
+#define RESHARD_FUNCTOR_WITHOUT_DTYPE(dev_ctx, fn_name, ...)            \
+  do {                                                                  \
+    if (phi::CPUContext::classof(dev_ctx)) {                            \
+      VLOG(4) << "Call `" << #fn_name                                   \
+              << "`without DType in Resharding on CPU.";                \
+      fn_name(static_cast<const CPUContext&>(*dev_ctx), __VA_ARGS__);   \
+    } else {                                                            \
+      PADDLE_THROW(common::errors::Unimplemented(                       \
+          "The %s in reshard only supported CPU, GPU, and XPU Device.", \
+          #fn_name));                                                   \
+    }                                                                   \
   } while (0)
 #endif
 

--- a/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.h
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.h
@@ -146,7 +146,7 @@ phi::DDim InferShapeForReshardFromReplicate(
     RESHARD_FUNCTOR_IMPL(dev_ctx, fn_name, dtype, __VA_ARGS__); \
   } while (0)
 
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) ||
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
     defined(PADDLE_WITH_XPU) || defined(PADDLE_WITH_CUSTOM_DEVICE)
 #define RESHARD_FUNCTOR_WITHOUT_DTYPE(dev_ctx, fn_name, ...)                  \
   do {                                                                        \

--- a/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.h
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.h
@@ -79,29 +79,37 @@ phi::DDim InferShapeForReshardFromReplicate(
     const TensorDistAttr& dist_attr);
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-#define RESHARD_FUNCTOR_IMPL(dev_ctx, fn_name, dtype, ...)            \
-  do {                                                                \
-    if (phi::CPUContext::classof(dev_ctx)) {                          \
-      VLOG(4) << "Call `" << #fn_name << "` in Resharding on CPU.";   \
-      PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES_CPU(              \
-          dtype, #fn_name, ([&] {                                     \
-            fn_name<data_t>(static_cast<const CPUContext&>(*dev_ctx), \
-                            __VA_ARGS__);                             \
-          }));                                                        \
-    } else if (phi::GPUContext::classof(dev_ctx)) {                   \
-      VLOG(4) << "Call `" << #fn_name << "` in Resharding on GPU.";   \
-      PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES_GPU(              \
-          dtype, #fn_name, ([&] {                                     \
-            fn_name<data_t>(static_cast<const GPUContext&>(*dev_ctx), \
-                            __VA_ARGS__);                             \
-          }));                                                        \
-    } else {                                                          \
-      PADDLE_THROW(common::errors::Unimplemented(                     \
-          "The %s in reshard only supported on CPU and GPU for now.", \
-          #fn_name));                                                 \
-    }                                                                 \
-  } while (0)
+  #define DEVICE_CONTEXT GPUContext
+#elif defined(PADDLE_WITH_XPU)
+  #define DEVICE_CONTEXT XPUContext
+#elif defined(PADDLE_WITH_CUSTOM_DEVICE)
+  #define DEVICE_CONTEXT CustomContext
+#endif
+
+// Some reshard function supports fewer data types on xpu than on gpu. For
+// example, `Transpose`, `Split`, and `Divide` do not support double type.
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#define PD_VISIT_RESHARD_TYPES  PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES
 #else
+#define PD_VISIT_RESHARD_TYPES(TYPE, NAME, ...)                               \
+  [&] {                                                                       \
+    const auto& __dtype__ = TYPE;                                             \
+    switch (__dtype__) {                                                      \
+      PD_PRIVATE_CASE_TYPE(NAME, ::paddle::DataType::INT32, int, __VA_ARGS__) \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::INT64, int64_t, __VA_ARGS__)              \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::FLOAT32, float, __VA_ARGS__)              \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::FLOAT16, paddle::float16, __VA_ARGS__)    \
+      PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, __VA_ARGS__)                        \
+      default:                                                                \
+        PD_THROW("Reshard function " #NAME " is not implemented"              \
+                 " for data type `", __dtype__, "`");                         \
+    }                                                                         \
+  }()
+#endif
+
 #define RESHARD_FUNCTOR_IMPL(dev_ctx, fn_name, dtype, ...)                \
   do {                                                                    \
     if (phi::CPUContext::classof(dev_ctx)) {                              \
@@ -111,12 +119,20 @@ phi::DDim InferShapeForReshardFromReplicate(
             fn_name<data_t>(static_cast<const CPUContext&>(*dev_ctx),     \
                             __VA_ARGS__);                                 \
           }));                                                            \
+    } else if(DEVICE_CONTEXT::classof(dev_ctx)) {                         \
+      VLOG(4) << "Call `" << #fn_name << "` in Resharding on device.";    \
+      PD_VISIT_RESHARD_TYPES(                                             \
+          dtype, #fn_name, ([&] {                                         \
+            fn_name<data_t>(static_cast<const DEVICE_CONTEXT&>(*dev_ctx), \
+                            __VA_ARGS__);                                 \
+          }));                                                            \
     } else {                                                              \
       PADDLE_THROW(common::errors::Unimplemented(                         \
-          "The %s in reshard only supported on CPU for now.", #fn_name)); \
+          "The %s in reshard only supported on CPU, GPU, XPU "            \
+          "and Custom Device for now.",                                   \
+          #fn_name));                                                     \
     }                                                                     \
   } while (0)
-#endif
 
 #define RESHARD_FUNCTOR_WITH_COMM(dev_ctx, fn_name, dtype, process_ids, ...) \
   do {                                                                       \
@@ -130,34 +146,36 @@ phi::DDim InferShapeForReshardFromReplicate(
     RESHARD_FUNCTOR_IMPL(dev_ctx, fn_name, dtype, __VA_ARGS__); \
   } while (0)
 
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-#define RESHARD_FUNCTOR_WITHOUT_DTYPE(dev_ctx, fn_name, ...)          \
-  do {                                                                \
-    if (phi::CPUContext::classof(dev_ctx)) {                          \
-      VLOG(4) << "Call `" << #fn_name                                 \
-              << "`without DType in Resharding on CPU.";              \
-      fn_name(static_cast<const CPUContext&>(*dev_ctx), __VA_ARGS__); \
-    } else if (phi::GPUContext::classof(dev_ctx)) {                   \
-      VLOG(4) << "Call `" << #fn_name                                 \
-              << "`without DType in Resharding on GPU.";              \
-      fn_name(static_cast<const GPUContext&>(*dev_ctx), __VA_ARGS__); \
-    } else {                                                          \
-      PADDLE_THROW(common::errors::Unimplemented(                     \
-          "The %s in reshard only supported on CPU and GPU for now.", \
-          #fn_name));                                                 \
-    }                                                                 \
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) ||
+    defined(PADDLE_WITH_XPU) || defined(PADDLE_WITH_CUSTOM_DEVICE)
+#define RESHARD_FUNCTOR_WITHOUT_DTYPE(dev_ctx, fn_name, ...)                  \
+  do {                                                                        \
+    if (phi::CPUContext::classof(dev_ctx)) {                                  \
+      VLOG(4) << "Call `" << #fn_name                                         \
+              << "`without DType in  Resharding on CPU.";                     \
+      fn_name(static_cast<const CPUContext&>(*dev_ctx), __VA_ARGS__);         \
+    } else if (DEVICE_CONTEXT::classof(dev_ctx)) {                            \
+            VLOG(4) << "Call `" << #fn_name                                   \
+              << "`without DType in  Resharding on device.";                  \
+      fn_name(static_cast<const DEVICE_CONTEXT&>(*dev_ctx), __VA_ARGS__);     \
+    } else {                                                                  \
+      PADDLE_THROW(common::errors::Unimplemented(                             \
+          "The %s in reshard only supported CPU, GPU, XPU and Custom Device", \
+          #fn_name));                                                         \
+    }                                                                         \
   } while (0)
 #else
-#define RESHARD_FUNCTOR_WITHOUT_DTYPE(dev_ctx, fn_name, ...)              \
-  do {                                                                    \
-    if (phi::CPUContext::classof(dev_ctx)) {                              \
-      VLOG(4) << "Call `" << #fn_name                                     \
-              << "`without DType in Resharding on CPU.";                  \
-      fn_name(static_cast<const CPUContext&>(*dev_ctx), __VA_ARGS__);     \
-    } else {                                                              \
-      PADDLE_THROW(common::errors::Unimplemented(                         \
-          "The %s in reshard only supported on CPU for now.", #fn_name)); \
-    }                                                                     \
+#define RESHARD_FUNCTOR_WITHOUT_DTYPE(dev_ctx, fn_name, ...)                   \
+  do {                                                                         \
+    if (phi::CPUContext::classof(dev_ctx)) {                                   \
+      VLOG(4) << "Call `" << #fn_name                                          \
+              << "`without DType in Resharding on CPU.";                       \
+      fn_name(static_cast<const CPUContext&>(*dev_ctx), __VA_ARGS__);          \
+    } else {                                                                   \
+      PADDLE_THROW(common::errors::Unimplemented(                              \
+          "The %s in reshard only supported CPU, GPU, XPU and Custom Device.", \
+           #fn_name));                                                         \
+    }                                                                          \
   } while (0)
 #endif
 

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_r_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_r_reshard_function.cc
@@ -42,8 +42,13 @@ void ReshardSToRWithPadding(DeviceContext* dev_ctx,
   // For balanced split to replicate, we need to do all gather first.
   // If the input value doesn't split on axis 0, we need to split
   // and concat on specific axis.
+#if defined(PADDLE_WITH_XPU)
+    PADDLE_THROW(::common::errors::Unimplemented(
+      "Not supported AllGather on xpu yet."));
+#else
   RESHARD_FUNCTOR_WITH_COMM(
       dev_ctx, AllGather, dtype, process_ids, in, num_of_process, out);
+#endif
 
   if (split_axis != 0 || padding_nums != 0) {
     IntArray sections(std::vector<int64_t>(num_of_process, in.dims()[0]));

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_r_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_r_reshard_function.cc
@@ -43,8 +43,8 @@ void ReshardSToRWithPadding(DeviceContext* dev_ctx,
   // If the input value doesn't split on axis 0, we need to split
   // and concat on specific axis.
 #if defined(PADDLE_WITH_XPU)
-    PADDLE_THROW(::common::errors::Unimplemented(
-      "Not supported AllGather on xpu yet."));
+  PADDLE_THROW(
+      ::common::errors::Unimplemented("Not supported AllGather on xpu yet."));
 #else
   RESHARD_FUNCTOR_WITH_COMM(
       dev_ctx, AllGather, dtype, process_ids, in, num_of_process, out);

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
@@ -97,12 +97,17 @@ void SToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   }
 
   // 2. use all to all to switch data to other ranks
+#if defined(PADDLE_WITH_XPU)
+    PADDLE_THROW(::common::errors::Unimplemented(
+      "Not supported AllToAll on xpu yet."));
+#else
   RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                             AllToAll,
                             dtype,
                             in_process_ids,
                             in_all_to_all,
                             GetMutableTensor(out));
+#endif
 
   // 3. postprocess, reshape and transpose the output tensor
   if (in_split_axis != 0) {

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
@@ -98,8 +98,8 @@ void SToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
 
   // 2. use all to all to switch data to other ranks
 #if defined(PADDLE_WITH_XPU)
-    PADDLE_THROW(::common::errors::Unimplemented(
-      "Not supported AllToAll on xpu yet."));
+  PADDLE_THROW(
+      ::common::errors::Unimplemented("Not supported AllToAll on xpu yet."));
 #else
   RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                             AllToAll,

--- a/paddle/phi/core/distributed/auto_parallel/reshard/same_status_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/same_status_reshard_function.cc
@@ -79,8 +79,8 @@ void SameStatusReshardFunction::Eval(phi::DeviceContext* dev_ctx,
     int64_t dst = iter.second;
     if (src == cur_global_rank) {
 #if defined(PADDLE_WITH_XPU)
-    PADDLE_THROW(::common::errors::Unimplemented(
-      "Not supported PSendKernel on xpu yet."));
+      PADDLE_THROW(::common::errors::Unimplemented(
+          "Not supported PSendKernel on xpu yet."));
 #else
       VLOG(3) << "Send from src " << src << " to dst " << dst;
       int64_t dst_local_rank = GetLocalRankInParticipate(all_process_ids, dst);
@@ -102,8 +102,8 @@ void SameStatusReshardFunction::Eval(phi::DeviceContext* dev_ctx,
 #endif
     } else if (dst == cur_global_rank) {
 #if defined(PADDLE_WITH_XPU)
-    PADDLE_THROW(::common::errors::Unimplemented(
-      "Not supported PRecvKernel on xpu yet."));
+      PADDLE_THROW(::common::errors::Unimplemented(
+          "Not supported PRecvKernel on xpu yet."));
 #else
       VLOG(3) << "Recv from src " << src << " to dst " << dst;
       int64_t src_local_rank = GetLocalRankInParticipate(all_process_ids, src);
@@ -113,7 +113,7 @@ void SameStatusReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                                 all_process_ids,
                                 src_local_rank,
                                 {} /*out_shape*/,
-                                 /*dynamic_shape=*/true,
+                                /*dynamic_shape=*/true,
                                 GetMutableTensor(out));
 #endif
     }

--- a/paddle/phi/core/distributed/auto_parallel/reshard/same_status_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/same_status_reshard_function.cc
@@ -55,14 +55,6 @@ void SameStatusReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   const auto& out_process_mesh = out_dist_attr.process_mesh();
   const auto& out_process_ids = out_process_mesh.process_ids();
   auto all_process_ids = GetUnionProcessIds(in_process_ids, out_process_ids);
-  auto dtype = in.dtype();
-  // TODO(liyurui): Use dynamic shape will lead to poor performance, but we
-  // don't have any other good idea now. For the following reasons:
-  // 1. We can not ensure the meta being right deduce by the infermeta.
-  // 2. The meta of some kernels can't decide in compile time.
-  // 3. DenseTensor with empty value only need infermeta and skip the real
-  // kernel execution.
-  bool dynamic_shape = true;
 
   // TODO(GhostScreaming): After cross-mesh reshard, current device may
   // needs to execute next layer. When it construct next layer's backward
@@ -86,28 +78,44 @@ void SameStatusReshardFunction::Eval(phi::DeviceContext* dev_ctx,
     int64_t src = iter.first;
     int64_t dst = iter.second;
     if (src == cur_global_rank) {
+#if defined(PADDLE_WITH_XPU)
+    PADDLE_THROW(::common::errors::Unimplemented(
+      "Not supported PSendKernel on xpu yet."));
+#else
       VLOG(3) << "Send from src " << src << " to dst " << dst;
       int64_t dst_local_rank = GetLocalRankInParticipate(all_process_ids, dst);
       // Since send kernel only has input, so we don't need to infermeta
       // actually. According to this reason, just use the kernel directly.
       RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                                 PSendKernel,
-                                dtype,
+                                in.dtype(),
                                 all_process_ids,
                                 in.value(),
                                 dst_local_rank,
-                                dynamic_shape);
+                                /*dynamic_shape=*/true);
+      // TODO(liyurui): Use dynamic shape will lead to poor performance, but we
+      // don't have any other good idea now. For the following reasons:
+      // 1. We can not ensure the meta being right deduce by the infermeta.
+      // 2. The meta of some kernels can't decide in compile time.
+      // 3. DenseTensor with empty value only need infermeta and skip the real
+      // kernel execution.
+#endif
     } else if (dst == cur_global_rank) {
+#if defined(PADDLE_WITH_XPU)
+    PADDLE_THROW(::common::errors::Unimplemented(
+      "Not supported PRecvKernel on xpu yet."));
+#else
       VLOG(3) << "Recv from src " << src << " to dst " << dst;
       int64_t src_local_rank = GetLocalRankInParticipate(all_process_ids, src);
       RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                                 PRecv,
-                                dtype,
+                                in.dtype(),
                                 all_process_ids,
                                 src_local_rank,
                                 {} /*out_shape*/,
-                                dynamic_shape,
+                                 /*dynamic_shape=*/true,
                                 GetMutableTensor(out));
+#endif
     }
   }
   SetDistProps(out, in.dims(), out_dist_attr);

--- a/paddle/phi/core/distributed/auto_parallel/reshard/x_to_r_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/x_to_r_reshard_function.cc
@@ -67,8 +67,8 @@ void XToRShrinkReshardFunction::Eval(phi::DeviceContext* dev_ctx,
     if (cur_global_rank != root_rank) {
       // send dense tensor to root
 #if defined(PADDLE_WITH_XPU)
-    PADDLE_THROW(::common::errors::Unimplemented(
-      "Not supported PSendKernel  on xpu yet."));
+      PADDLE_THROW(::common::errors::Unimplemented(
+          "Not supported PSendKernel  on xpu yet."));
 #else
       RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                                 PSendKernel,
@@ -83,8 +83,8 @@ void XToRShrinkReshardFunction::Eval(phi::DeviceContext* dev_ctx,
         if (all_process_ids[i] != root_rank) {
           rank_to_result.emplace(all_process_ids[i], DenseTensor());
 #if defined(PADDLE_WITH_XPU)
-    PADDLE_THROW(::common::errors::Unimplemented(
-      "Not supported PRecv on xpu yet."));
+          PADDLE_THROW(::common::errors::Unimplemented(
+              "Not supported PRecv on xpu yet."));
 #else
           RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                                     PRecv,
@@ -92,7 +92,7 @@ void XToRShrinkReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                                     all_process_ids,
                                     all_process_ids[i],
                                     {} /*out_shape*/,
-                                     /*dynamic_shape=*/true,
+                                    /*dynamic_shape=*/true,
                                     &rank_to_result[all_process_ids[i]]);
 #endif
         }

--- a/paddle/phi/core/distributed/auto_parallel/reshard/x_to_r_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/x_to_r_reshard_function.cc
@@ -61,31 +61,40 @@ void XToRShrinkReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   const auto& in_partial_status = in_dist_attr.partial_status();
   auto all_process_ids = GetUnionProcessIds(in_process_ids, out_process_ids);
   std::unordered_map<int64_t, DenseTensor> rank_to_result;
-  bool dynamic_shape = true;
 
   // Step 1: other ranks need to send value to the root
   if (!in_dist_attr.is_replicated()) {
     if (cur_global_rank != root_rank) {
       // send dense tensor to root
+#if defined(PADDLE_WITH_XPU)
+    PADDLE_THROW(::common::errors::Unimplemented(
+      "Not supported PSendKernel  on xpu yet."));
+#else
       RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                                 PSendKernel,
                                 dtype,
                                 all_process_ids,
                                 in.value(),
                                 root_rank,
-                                dynamic_shape);
+                                /*dynamic_shape=*/true);
+#endif
     } else {
       for (size_t i = 0; i < all_process_ids.size(); ++i) {
         if (all_process_ids[i] != root_rank) {
           rank_to_result.emplace(all_process_ids[i], DenseTensor());
+#if defined(PADDLE_WITH_XPU)
+    PADDLE_THROW(::common::errors::Unimplemented(
+      "Not supported PRecv on xpu yet."));
+#else
           RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                                     PRecv,
                                     dtype,
                                     all_process_ids,
                                     all_process_ids[i],
                                     {} /*out_shape*/,
-                                    dynamic_shape,
+                                     /*dynamic_shape=*/true,
                                     &rank_to_result[all_process_ids[i]]);
+#endif
         }
       }
     }

--- a/paddle/phi/core/visit_type.h
+++ b/paddle/phi/core/visit_type.h
@@ -31,8 +31,8 @@ namespace phi {
 #define PD_PRIVATE_CASE_TYPE(NAME, enum_type, type, ...) \
   PD_PRIVATE_CASE_TYPE_USING_HINT(NAME, enum_type, type, data_t, __VA_ARGS__)
 
-#if ((defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)) &&
-     (NCCL_VERSION_CODE >= 21000 && !defined(PADDLE_WITH_RCCL)) ||
+#if ((defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)) &&    \
+     (NCCL_VERSION_CODE >= 21000 && !defined(PADDLE_WITH_RCCL)) || \
     defined(PADDLE_WITH_XPU))
 #define PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, ...)         \
 PD_PRIVATE_CASE_TYPE(NAME, ::paddle::DataType::BFLOAT16, \

--- a/paddle/phi/core/visit_type.h
+++ b/paddle/phi/core/visit_type.h
@@ -31,6 +31,17 @@ namespace phi {
 #define PD_PRIVATE_CASE_TYPE(NAME, enum_type, type, ...) \
   PD_PRIVATE_CASE_TYPE_USING_HINT(NAME, enum_type, type, data_t, __VA_ARGS__)
 
+#if ((defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)) &&
+     (NCCL_VERSION_CODE >= 21000 && !defined(PADDLE_WITH_RCCL)) ||
+    defined(PADDLE_WITH_XPU))
+#define PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, ...)         \
+PD_PRIVATE_CASE_TYPE(NAME, ::paddle::DataType::BFLOAT16, \
+                     phi::bfloat16, __VA_ARGS__)
+#else
+#define PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, ...)
+#endif
+
+
 ///////// Floating Dispatch Marco ///////////
 
 #define PD_VISIT_FLOATING_TYPES(TYPE, NAME, ...)                          \
@@ -58,6 +69,7 @@ namespace phi {
           NAME, ::paddle::DataType::FLOAT64, double, __VA_ARGS__)          \
       PD_PRIVATE_CASE_TYPE(                                                \
           NAME, ::paddle::DataType::FLOAT16, paddle::float16, __VA_ARGS__) \
+      PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, __VA_ARGS__)                  \
       default:                                                             \
         PD_THROW("function " #NAME " is not implemented for data type `",  \
                  __dtype__,                                                \
@@ -149,9 +161,7 @@ namespace phi {
   }()
 
 ///////// BOOL and Floating and Integral Dispatch Marco ///////////
-
-#if (NCCL_VERSION_CODE >= 21000) && !defined(PADDLE_WITH_RCCL)
-#define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES_GPU(TYPE, NAME, ...)    \
+#define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES(TYPE, NAME, ...)    \
   [&] {                                                                       \
     const auto& __dtype__ = TYPE;                                             \
     switch (__dtype__) {                                                      \
@@ -171,42 +181,13 @@ namespace phi {
           NAME, ::paddle::DataType::INT16, int16_t, __VA_ARGS__)              \
       PD_PRIVATE_CASE_TYPE(                                                   \
           NAME, ::paddle::DataType::FLOAT16, float16, __VA_ARGS__)            \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::BFLOAT16, bfloat16, __VA_ARGS__)          \
+      PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, __VA_ARGS__)                        \
       default:                                                                \
         PD_THROW("function " #NAME " is not implemented for data type `",     \
                  __dtype__,                                                   \
                  "`");                                                        \
     }                                                                         \
   }()
-#else
-#define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES_GPU(TYPE, NAME, ...)    \
-  [&] {                                                                       \
-    const auto& __dtype__ = TYPE;                                             \
-    switch (__dtype__) {                                                      \
-      PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::BOOL, bool, __VA_ARGS__)    \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::FLOAT32, float, __VA_ARGS__)              \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::FLOAT64, double, __VA_ARGS__)             \
-      PD_PRIVATE_CASE_TYPE(NAME, ::paddle::DataType::INT32, int, __VA_ARGS__) \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::INT64, int64_t, __VA_ARGS__)              \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::INT8, int8_t, __VA_ARGS__)                \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::UINT8, uint8_t, __VA_ARGS__)              \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::INT16, int16_t, __VA_ARGS__)              \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::FLOAT16, float16, __VA_ARGS__)            \
-      default:                                                                \
-        PD_THROW("function " #NAME " is not implemented for data type `",     \
-                 __dtype__,                                                   \
-                 "`");                                                        \
-    }                                                                         \
-  }()
-#endif
 
 #define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES_CPU(TYPE, NAME, ...)    \
   [&] {                                                                       \

--- a/paddle/phi/core/visit_type.h
+++ b/paddle/phi/core/visit_type.h
@@ -31,16 +31,15 @@ namespace phi {
 #define PD_PRIVATE_CASE_TYPE(NAME, enum_type, type, ...) \
   PD_PRIVATE_CASE_TYPE_USING_HINT(NAME, enum_type, type, data_t, __VA_ARGS__)
 
-#if ((defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)) &&    \
-     (NCCL_VERSION_CODE >= 21000 && !defined(PADDLE_WITH_RCCL)) || \
-    defined(PADDLE_WITH_XPU))
-#define PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, ...)         \
-PD_PRIVATE_CASE_TYPE(NAME, ::paddle::DataType::BFLOAT16, \
-                     phi::bfloat16, __VA_ARGS__)
+#if ((defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)) &&        \
+         (NCCL_VERSION_CODE >= 21000 && !defined(PADDLE_WITH_RCCL)) || \
+     defined(PADDLE_WITH_XPU))
+#define PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, ...) \
+  PD_PRIVATE_CASE_TYPE(                          \
+      NAME, ::paddle::DataType::BFLOAT16, phi::bfloat16, __VA_ARGS__)
 #else
 #define PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, ...)
 #endif
-
 
 ///////// Floating Dispatch Marco ///////////
 
@@ -69,7 +68,7 @@ PD_PRIVATE_CASE_TYPE(NAME, ::paddle::DataType::BFLOAT16, \
           NAME, ::paddle::DataType::FLOAT64, double, __VA_ARGS__)          \
       PD_PRIVATE_CASE_TYPE(                                                \
           NAME, ::paddle::DataType::FLOAT16, paddle::float16, __VA_ARGS__) \
-      PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, __VA_ARGS__)                  \
+      PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, __VA_ARGS__)                     \
       default:                                                             \
         PD_THROW("function " #NAME " is not implemented for data type `",  \
                  __dtype__,                                                \
@@ -161,7 +160,7 @@ PD_PRIVATE_CASE_TYPE(NAME, ::paddle::DataType::BFLOAT16, \
   }()
 
 ///////// BOOL and Floating and Integral Dispatch Marco ///////////
-#define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES(TYPE, NAME, ...)    \
+#define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES(TYPE, NAME, ...)        \
   [&] {                                                                       \
     const auto& __dtype__ = TYPE;                                             \
     switch (__dtype__) {                                                      \

--- a/paddle/phi/kernels/xpu/all_reduce_kernel.cc
+++ b/paddle/phi/kernels/xpu/all_reduce_kernel.cc
@@ -76,6 +76,8 @@ PD_REGISTER_KERNEL(all_reduce,
                    XPU,
                    ALL_LAYOUT,
                    phi::AllReduceKernel,
-                   float,
                    int,
-                   phi::dtype::float16) {}
+                   int64_t,
+                   float,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
New features


### Description
<!-- Describe what you’ve done -->
动态图自动并行支持XPU设备。
因XPU算子限制，目前动态图自动reshard机制仅支持`Allreduce`通信操作，数据类型仅支持`int32`、`int64`、`float`、`float16`和`bfloat16`。

Pcard-76459
