### PR TITLE
【custom】modify custom instruction add pd_op in setup.py

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/custom_engine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/custom_engine_instruction.cc
@@ -16,16 +16,122 @@
 #include "paddle/fluid/custom_engine/custom_engine_ext.h"
 #include "paddle/fluid/custom_engine/custom_engine_manager.h"
 #include "paddle/fluid/framework/new_executor/instruction/instruction_util.h"
+#include "paddle/fluid/framework/new_executor/interpreter/execution_config.h"
+#include "paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_dialect.h"
+#include "paddle/fluid/pir/dialect/operator/utils/op_yaml_info_parser.h"
 
 namespace paddle {
 namespace framework {
+namespace {
+pir::Value GetVarNameToValue(const std::string &var_name,
+                             ValueExecutionInfo *value_exec_info) {
+  for (auto kv : value_exec_info->GetValue2VarName()) {
+    if (kv.second == var_name) {
+      return kv.first;
+    }
+  }
+  PADDLE_THROW(
+      common::errors::NotFound("Not found value for [%s].", var_name.c_str()));
+}
+
+void BuildEngineInputOutputValue(pir::Operation *op,
+                                 ValueExecutionInfo *value_exec_info,
+                                 std::vector<pir::Value> &inputs,     // NOLINT
+                                 std::vector<pir::Value> &outputs) {  // NOLINT
+  auto build = [&](bool is_input) {
+    auto op_value = is_input ? (op->operand_source(0)) : (op->result(0));
+    PADDLE_ENFORCE_EQ(value_exec_info->GetValue2VarName().count(op_value),
+                      true,
+                      common::errors::PreconditionNotMet(
+                          "Input of custom engine op is not in name map"));
+
+    auto op_var = value_exec_info->GetVarByValue(op_value);
+    auto variable_array = op_var->Get<VariableRefArray>();
+
+    for (uint64_t idx = 0; idx < variable_array.size(); ++idx) {
+      PADDLE_ENFORCE_EQ(
+          value_exec_info->GetVar2VarName().count(variable_array[idx]),
+          true,
+          common::errors::PreconditionNotMet(
+              "[%d] the variable in engine op "
+              "%s MUST in variable name map",
+              idx,
+              (is_input ? ("input") : ("output"))));
+      std::string var_name =
+          value_exec_info->GetVar2VarName().at(variable_array[idx]);
+      pir::Value value = GetVarNameToValue(var_name, value_exec_info);
+      if (is_input) {
+        inputs.emplace_back(value);
+      } else {
+        outputs.emplace_back(value);
+      }
+      VLOG(6) << "Build engine " << (is_input ? ("input[") : ("output[")) << idx
+              << "]: " << var_name;
+    }
+  };
+
+  // inputs
+  build(true);
+  // outputs
+  build(false);
+}
+
+void BuildEngineValueMap(
+    pir::Operation *op,
+    ValueExecutionInfo *value_exec_info,
+    std::unordered_map<pir::Value, std::vector<phi::DenseTensor *>>
+        &engine_value_to_tensors,
+    std::unordered_map<pir::Value, std::vector<std::string>>
+        &engine_value_to_var_names) {
+  for (auto kv : value_exec_info->GetValue2VarName()) {
+    pir::Value value = kv.first;
+    std::string var_name = kv.second;
+
+    auto var = value_exec_info->GetVarByValue(value);
+    if (var->IsType<phi::DenseTensor>()) {
+      const phi::DenseTensor *tensor = &(var->Get<phi::DenseTensor>());
+      engine_value_to_tensors[value] = {const_cast<phi::DenseTensor *>(tensor)};
+      engine_value_to_var_names[value] = {var_name};
+      VLOG(6) << "Build engine value map for " << var_name;
+    } else if (var->IsType<VariableRefArray>()) {
+      std::vector<phi::DenseTensor *> tensors;
+      std::vector<std::string> var_names;
+      auto &variable_array = var->Get<VariableRefArray>();
+      for (size_t i = 0; i < variable_array.size(); ++i) {
+        if (variable_array[i]->IsType<phi::DenseTensor>()) {
+          const phi::DenseTensor *tensor =
+              &(variable_array[i]->Get<phi::DenseTensor>());
+          tensors.emplace_back(const_cast<phi::DenseTensor *>(tensor));
+          auto var_name_i = value_exec_info->GetVarName(variable_array[i]);
+          var_names.emplace_back(var_name_i);
+          VLOG(6) << "Build engine value map for Variable[" << i
+                  << "]: " << var_name_i;
+        } else {
+          PADDLE_THROW(common::errors::Unimplemented(
+              "Only support Vector<DenseTensor> now, "
+              "not support vector<%d>.",
+              variable_array[i]->Type()));
+        }
+      }
+      engine_value_to_tensors[value] = tensors;
+      engine_value_to_var_names[value] = var_names;
+    } else {
+      PADDLE_THROW(common::errors::Unimplemented(
+          "Only support DenseTensor and Vector<DenseTensor> now, "
+          "not support .",
+          var->Type()));
+    }
+  }
+}
+}  // namespace
 
 CustomEngineInstruction::CustomEngineInstruction(
     size_t id,
     const phi::Place &place,
     ::pir::Operation *op,
-    const ValueExecutionInfo *value_exec_info)
+    ValueExecutionInfo *value_exec_info,
+    paddle::framework::interpreter::ExecutionConfig execution_config)
     : InstructionBase(id, place), value_exec_info_(value_exec_info) {
   PADDLE_ENFORCE_EQ(paddle::dialect::IsCustomEngineOp(op),
                     true,
@@ -37,24 +143,35 @@ CustomEngineInstruction::CustomEngineInstruction(
 
   auto op_attributes = op->attributes();
   op_ = op;
-  VLOG(6) << "Start Build custom engine";
-  interface_ = paddle::custom_engine::CustomEngineManager::Instance()
-                   ->GetCustomEngineInterface();
-  if (interface_ && interface_->graph_engine_build) {
-    interface_->graph_engine_build(
-        reinterpret_cast<C_CustomEngineInstruction>(this));
-  } else {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "CustomEngineInstruction's C_CustomEngineInterface->graph_engine_build "
-        "not implemented"));
-  }
 
-  PADDLE_ENFORCE_NOT_NULL(
-      custom_engine_,
-      ::common::errors::InvalidArgument(
-          "custom_engine_ should not be nullptr after graph_engine_build"));
+  auto op_name =
+      op_attributes.at("op_name").dyn_cast<pir::StrAttribute>().AsString();
 
-  VLOG(6) << "Finish build engine for: " << op_name_;
+  pir::Region &region = op->region(0);
+  PADDLE_ENFORCE_EQ(
+      region.empty(),
+      false,
+      ::common::errors::Unavailable(
+          "Required CustomEngineOp's region must not be emptpy."));
+  pir::Block *block = &(region.front());
+
+  paddle::framework::Scope *subgraph_scope =
+      &(value_exec_info->GetScope()->NewScope());
+  std::shared_ptr<ValueExecutionInfo> value_exec_info_child =
+      value_exec_info->NewChild(subgraph_scope);
+  std::string subgraph_prefix = op_name + "_subgraph";
+  paddle::framework::BuildScope(
+      *block, subgraph_prefix, execution_config, value_exec_info_child.get());
+  VLOG(6) << "finish build sub scope";
+
+  // must do this after building sub scope
+  BuildEngineInputOutputValue(
+      op, value_exec_info_child.get(), engine_inputs_, engine_outputs_);
+  BuildEngineValueMap(op,
+                      value_exec_info_child.get(),
+                      engine_value_to_tensors_,
+                      engine_value_to_var_names_);
+  VLOG(6) << "finish build data info";
 
   SetDeviceContext(
       ParseDeviceContext(op,
@@ -64,11 +181,58 @@ CustomEngineInstruction::CustomEngineInstruction(
                          GetStreamPriority()));
   VLOG(6) << "finish process device context";
 
+  pir::OpInfo op_info =
+      pir::IrContext::Instance()->GetRegisteredOpInfo(op_name);
+  auto yaml_interface =
+      op_info.GetInterfaceImpl<paddle::dialect::OpYamlInfoInterface>();
+  PADDLE_ENFORCE_NOT_NULL(
+      yaml_interface,
+      common::errors::PreconditionNotMet(
+          "Can not find OpYamlInfoInterface for [%s]", op_name));
+  paddle::dialect::OpYamlInfoParser yaml_info_parser(
+      yaml_interface->get_op_info_(op_name),
+      paddle::dialect::IsLegacyOp(op_name));
+  VLOG(6) << "finish process yaml_info_parser";
+
+  BuildPhiContext<phi::KernelContext,
+                  const phi::TensorBase *,
+                  phi::TensorBase *,
+                  paddle::small_vector<const phi::TensorBase *>,
+                  paddle::small_vector<phi::TensorBase *>,
+                  true>(
+      op, *value_exec_info_, yaml_info_parser, &kernel_context_);
+
+  kernel_context_.SetDeviceContext(dev_ctx_);
+  VLOG(6) << "finish process kernel context";
+
   InitInputsOutputsIds(op, *value_exec_info_);
   VLOG(6) << "finish process inputs outputs index";
 }
 
 void CustomEngineInstruction::Run() {
+  if (!is_builed_) {
+    VLOG(6) << "Start Build custom engine";
+    interface_ = paddle::custom_engine::CustomEngineManager::Instance()
+                     ->GetCustomEngineInterface();
+    if (interface_ && interface_->graph_engine_build) {
+      interface_->graph_engine_build(
+          reinterpret_cast<C_CustomEngineInstruction>(this));
+    } else {
+      PADDLE_THROW(common::errors::Unimplemented(
+          "CustomEngineInstruction's "
+          "C_CustomEngineInterface->graph_engine_build "
+          "not implemented"));
+    }
+
+    PADDLE_ENFORCE_NOT_NULL(
+        custom_engine_,
+        ::common::errors::InvalidArgument(
+            "custom_engine_ should not be nullptr after graph_engine_build"));
+
+    VLOG(6) << "Finish build engine for: " << op_name_;
+    is_builed_ = true;
+  }
+
   if (interface_ && interface_->graph_engine_execute) {
     interface_->graph_engine_execute(
         reinterpret_cast<C_CustomEngineInstruction>(this));

--- a/paddle/fluid/framework/new_executor/instruction/custom_engine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/custom_engine_instruction.cc
@@ -148,11 +148,10 @@ CustomEngineInstruction::CustomEngineInstruction(
       op_attributes.at("op_name").dyn_cast<pir::StrAttribute>().AsString();
 
   pir::Region &region = op->region(0);
-  PADDLE_ENFORCE_EQ(
-      region.empty(),
-      false,
-      ::common::errors::Unavailable(
-          "Required CustomEngineOp's region must not be emptpy."));
+  PADDLE_ENFORCE_EQ(region.empty(),
+                    false,
+                    ::common::errors::Unavailable(
+                        "Required CustomEngineOp's region must not be empty."));
   pir::Block *block = &(region.front());
 
   paddle::framework::Scope *subgraph_scope =

--- a/paddle/fluid/framework/new_executor/instruction/custom_engine_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/custom_engine_instruction.h
@@ -15,8 +15,7 @@
 #pragma once
 #include "paddle/fluid/custom_engine/custom_engine_ext.h"
 #include "paddle/fluid/framework/new_executor/instruction/instruction_base.h"
-#include "paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h"
-#include "paddle/phi/core/platform/device_context.h"
+#include "paddle/phi/core/kernel_context.h"
 namespace pir {
 class Operation;
 }  // namespace pir
@@ -25,14 +24,18 @@ namespace paddle {
 namespace framework {
 class Scope;
 class ValueExecutionInfo;
-
+namespace interpreter {
+class ExecutionConfig;
+}
 class CustomEngineInstruction : public InstructionBase {
  public:
   typedef void (*DeletePtr)(void*);
-  CustomEngineInstruction(size_t id,
-                          const phi::Place& place,
-                          ::pir::Operation* op,
-                          const ValueExecutionInfo* value_exec_info);
+  CustomEngineInstruction(
+      size_t id,
+      const phi::Place& place,
+      ::pir::Operation* op,
+      ValueExecutionInfo* value_exec_info,
+      paddle::framework::interpreter::ExecutionConfig execution_config);
 
   ::pir::Operation* Operation() const override { return op_; }
   const ValueExecutionInfo* GetValueExecutionInfo() const {
@@ -42,7 +45,28 @@ class CustomEngineInstruction : public InstructionBase {
   void Run() override;
 
   void SetName(const std::string& name) { op_name_ = name; }
+
   const std::string& Name() const override { return op_name_; }
+
+  const phi::KernelContext& KernelContext() const { return kernel_context_; }
+
+  const std::vector<pir::Value>& GetEngineInputs() const {
+    return engine_inputs_;
+  }
+
+  const std::vector<pir::Value>& GetEngineOutputs() const {
+    return engine_outputs_;
+  }
+
+  const std::unordered_map<pir::Value, std::vector<phi::DenseTensor*>>&
+  GetEngineValueToTensors() const {
+    return engine_value_to_tensors_;
+  }
+
+  const std::unordered_map<pir::Value, std::vector<std::string>>&
+  GetEngineValueToVarNames() const {
+    return engine_value_to_var_names_;
+  }
 
   void SetCustomEngine(void* custom_engine) { custom_engine_ = custom_engine; }
 
@@ -60,13 +84,23 @@ class CustomEngineInstruction : public InstructionBase {
 
  private:
   phi::Place place_;
-  std::string op_name_ = "custom_engine.base_op";
+  std::string op_name_ = "custom_engine.group_op";
   ::pir::Operation* op_{nullptr};  // not owned
+
+  phi::KernelContext kernel_context_;
+
+  std::vector<pir::Value> engine_inputs_;
+  std::vector<pir::Value> engine_outputs_;
+  std::unordered_map<pir::Value, std::vector<phi::DenseTensor*>>
+      engine_value_to_tensors_;
+  std::unordered_map<pir::Value, std::vector<std::string>>
+      engine_value_to_var_names_;
 
   C_CustomEngineInterface* interface_;
   const ValueExecutionInfo* value_exec_info_;  // not owned
   void* custom_engine_;                        // not owned
   DeletePtr custom_engine_deleter_{nullptr};   // not owned
+  bool is_builed_ = false;
 };
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h
@@ -46,12 +46,13 @@ using ExecutionConfig = interpreter::ExecutionConfig;
 class IfInstruction;
 class WhileInstruction;
 class PyLayerInstruction;
+class CustomEngineInstruction;
 class ValueExecutionInfo {
  public:
   friend class IfInstruction;
   friend class WhileInstruction;
   friend class PyLayerInstruction;
-
+  friend class CustomEngineInstruction;
   explicit ValueExecutionInfo(Scope* scope) : scope_(scope) {}
 
   const ValueExecutionInfo* Parent() const { return parent_; }

--- a/paddle/fluid/framework/new_executor/pir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.cc
@@ -964,7 +964,9 @@ void PirInterpreter::BuildInstruction() {
               op_idx++, place_, &op, *(value_exe_info_.get())));
     } else if (paddle::dialect::IsCustomEngineOp(&op)) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
-      CREATE_INSTR(CustomEngineInstruction);
+      vec_instruction_base_.emplace_back(
+          std::make_unique<CustomEngineInstruction>(
+              op_idx++, place_, &op, value_exe_info_.get(), execution_config_));
 #else
       PADDLE_THROW(common::errors::PreconditionNotMet(
           "Program has CustomEngineOp and must compile Paddle use "

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -72,7 +72,7 @@ COMMON_DECLARE_bool(use_mkldnn);
 
 COMMON_DECLARE_bool(print_ir);
 COMMON_DECLARE_bool(enable_collect_shape);
-
+REGISTER_FILE_SYMBOLS(pd_op_to_kernel_pass);
 namespace paddle::dialect {
 
 pir::Type ConvertOpTypeToKernelType(pir::IrContext* ctx,

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -257,7 +257,7 @@ DECLARE_FILE_SYMBOLS(aligned_allocator);
 DECLARE_FILE_SYMBOLS(pass_timing);
 DECLARE_FILE_SYMBOLS(op_compatible_info);
 DECLARE_FILE_SYMBOLS(sub_graph_detector);
-
+DECLARE_FILE_SYMBOLS(pd_op_to_kernel_pass);
 namespace paddle::pybind {
 
 PyTypeObject *g_framework_scope_pytype = nullptr;

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1172,11 +1172,23 @@ headers = (
     #pir headers
     list(find_files('lexer.h','@PADDLE_SOURCE_DIR@/paddle/pir/src/core/parser/'))+
     list(find_files('token.h','@PADDLE_SOURCE_DIR@/paddle/pir/src/core/parser/'))+
+    #pir ops and dependency
+    list(find_files('pd_op.h','@PADDLE_BINARY_DIR@/paddle/fluid/pir/dialect/operator/ir/'))+
+    list(find_files('utils.h','@PADDLE_SOURCE_DIR@/paddle/fluid/ir_adaptor/translator/'))+
+    list(find_files('*.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/interface/'))+
+    list(find_files('*.hpp','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/interface/'))+
+    list(find_files('*.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/trait/'))+
+    list(find_files('*.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/operator/utils/'))+
+    list(find_files('*.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/dialect/kernel/ir/'))+
+    list(find_files('*.h','@PADDLE_SOURCE_DIR@/paddle/pir/include/core/'))+
+    list(find_files('pd_op_to_kernel_pass.h','@PADDLE_SOURCE_DIR@/paddle/fluid/pir/utils/'))+
     #custom_engine
     list(find_files('custom_engine_ext.h','@PADDLE_SOURCE_DIR@/paddle/fluid/custom_engine/'))+
     #new_executor headers
     list(find_files('pir_adaptor_util.h','@PADDLE_SOURCE_DIR@/paddle/fluid/framework/new_executor/pir_adaptor/'))+
-    list(find_files('custom_engine_instruction.h','@PADDLE_SOURCE_DIR@/paddle/fluid/framework/new_executor/instruction/')))
+    list(find_files('custom_engine_instruction.h','@PADDLE_SOURCE_DIR@/paddle/fluid/framework/new_executor/instruction/'))+
+    list(find_files('new_executor_defs.h','@PADDLE_SOURCE_DIR@/paddle/fluid/framework/new_executor/'))+
+    list(find_files('instruction_base.h','@PADDLE_SOURCE_DIR@/paddle/fluid/framework/new_executor/instruction/')))
 jit_layer_headers = ['layer.h', 'serializer.h', 'serializer_utils.h', 'all.h', 'function.h']
 for f in jit_layer_headers:
     headers += list(find_files(f, '@PADDLE_SOURCE_DIR@/paddle/fluid/jit', recursive=True))

--- a/test/cpp/pir/custom_engine/custom_engine_op.cc
+++ b/test/cpp/pir/custom_engine/custom_engine_op.cc
@@ -42,7 +42,7 @@ OpInfoTuple FakeEngineOp::GetOpInfo() {
                    false)};
 
   paddle::dialect::OpRunTimeInfo run_time_info =
-      OpRunTimeInfo("", {""}, "", {""}, {}, {}, {}, {});
+      OpRunTimeInfo("", {}, "", {}, {}, {}, {}, {});
 
   return std::make_tuple(
       inputs, attributes, outputs, run_time_info, "fake_engine");
@@ -108,6 +108,7 @@ void FakeEngineOp::Build(pir::Builder &builder,             // NOLINT
   argument_outputs.push_back(out_vector_type);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
+  argument.AddRegion(nullptr);
   ::pir::PassStopGradientsDefaultly(argument);
 }
 
@@ -160,6 +161,22 @@ void FakeEngineOp::VerifySig() {
                           "Type validation failed for the 0th output."));
   }
   VLOG(4) << "End Verifying for: FakeEngineOp.";
+}
+
+pir::Block *FakeEngineOp::block() {
+  pir::Region &region = (*this)->region(0);
+  if (region.empty()) region.emplace_back();
+  return &region.front();
+}
+
+pir::Block *FakeEngineOp::block() const {
+  pir::Region &region = (*this)->region(0);
+  PADDLE_ENFORCE_EQ(
+      region.empty(),
+      false,
+      ::common::errors::Unavailable(
+          "Required CustomEngineOp's region must not be emptpy."));
+  return &region.front();
 }
 
 }  // namespace dialect

--- a/test/cpp/pir/custom_engine/custom_engine_op.cc
+++ b/test/cpp/pir/custom_engine/custom_engine_op.cc
@@ -171,11 +171,10 @@ pir::Block *FakeEngineOp::block() {
 
 pir::Block *FakeEngineOp::block() const {
   pir::Region &region = (*this)->region(0);
-  PADDLE_ENFORCE_EQ(
-      region.empty(),
-      false,
-      ::common::errors::Unavailable(
-          "Required CustomEngineOp's region must not be emptpy."));
+  PADDLE_ENFORCE_EQ(region.empty(),
+                    false,
+                    ::common::errors::Unavailable(
+                        "Required CustomEngineOp's region must not be empty."));
   return &region.front();
 }
 

--- a/test/cpp/pir/custom_engine/custom_engine_op.h
+++ b/test/cpp/pir/custom_engine/custom_engine_op.h
@@ -69,7 +69,8 @@ class FakeEngineOp
                     std::vector<phi::DataType> outputs_dtype);
 
   void VerifySig();
-
+  pir::Block *block();
+  pir::Block *block() const;
   pir::Value x() { return operand_source(0); }
   pir::Value out() { return result(0); }
 };

--- a/test/cpp/pir/custom_engine/fake_cpu_engine.h
+++ b/test/cpp/pir/custom_engine/fake_cpu_engine.h
@@ -17,6 +17,7 @@
 
 #include "paddle/fluid/custom_engine/custom_engine_ext.h"
 #include "paddle/fluid/framework/new_executor/instruction/custom_engine_instruction.h"
+#include "paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h"
 #include "test/cpp/pir/custom_engine/custom_engine_op.h"
 #include "test/cpp/pir/custom_engine/fake_cpu_engine_base.h"
 

--- a/test/cpp/pir/custom_engine/fake_cpu_engine.h
+++ b/test/cpp/pir/custom_engine/fake_cpu_engine.h
@@ -18,6 +18,7 @@
 #include "paddle/fluid/custom_engine/custom_engine_ext.h"
 #include "paddle/fluid/framework/new_executor/instruction/custom_engine_instruction.h"
 #include "paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h"
+#include "paddle/fluid/pir/transforms/pd_op_to_kernel_pass.h"
 #include "test/cpp/pir/custom_engine/custom_engine_op.h"
 #include "test/cpp/pir/custom_engine/fake_cpu_engine_base.h"
 
@@ -89,10 +90,42 @@ C_Status CustomEngineOpLower(C_CustomEngineLowerParams* lower_param) {
 
   pir::OpInfo custom_engine_op_info =
       ctx->GetRegisteredOpInfo(paddle::dialect::FakeEngineOp::name());
-  pir::Operation* op = pir::Operation::Create(
-      vec_inputs, op_attribute, op_output_types, custom_engine_op_info);
+  pir::Operation* op = pir::Operation::Create(vec_inputs,
+                                              op_attribute,
+                                              op_output_types,
+                                              custom_engine_op_info,
+                                              1,
+                                              {},
+                                              true);
   op->set_attribute("origin_id", pir::Int64Attribute::get(ctx, op->id()));
   op->set_attribute("op_name", pir::StrAttribute::get(ctx, op->name()));
+
+  VLOG(3) << "CustomEngineOpLower get op_item subgraph block.";
+  pir::Region& op_item_region = op_item->region(0);
+  PADDLE_ENFORCE_EQ(op_item_region.empty(),
+                    false,
+                    ::common::errors::Unavailable(
+                        "Required CustomEngineOp's region must not be empty."));
+  pir::Block* sub_graph_block = &(op_item_region.front());
+
+  VLOG(3) << "CustomEngineOpLower set new op subgraph block.";
+  pir::Region& region = op->region(0);
+  if (region.empty()) {
+    region.emplace_back();
+  }
+  pir::Block* op_block = &(region.front());
+
+  // process subgraph block
+  paddle::dialect::ProcessBlock(
+      *place, sub_graph_block, op_block, ctx, map_op_pair, map_value_pair);
+
+  if (VLOG_IS_ON(3)) {
+    std::stringstream ss;
+    ss << "CustomEngineOpLower new op:";
+    op->Print(ss);
+    VLOG(3) << ss.str();
+  }
+
   (*map_op_pair)[op_item] = op;
   // only deal with single output
   if (op_item->num_results() > 0) {

--- a/test/cpp/pir/custom_engine/test_custom_engine_loadlib.cc
+++ b/test/cpp/pir/custom_engine/test_custom_engine_loadlib.cc
@@ -112,6 +112,7 @@ void CreateProgram(pir::Program *program) {
       std::vector<std::string>{"output_0"},
       std::vector<std::vector<int64_t>>{{2, 2}},
       std::vector<phi::DataType>{phi::DataType::FLOAT32});
+  engine_op->region(0).emplace_back();
 
   auto output = builder.Build<pir::SplitOp>(engine_op.result(0)).outputs()[0];
   builder.Build<pir::ShadowOutputOp>(output, OUT_NAME);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164

修改customEngineInstruction，补充相应成员和方法
暴露pd_op 和相关interface,trait 等数据结构