### PR TITLE
fix bug of weight_only_linear tune

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm_template.cu
+++ b/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm_template.cu
@@ -617,7 +617,8 @@ void CutlassFpAIntBGemmRunner<T, WeightType>::run_gemm<EpilogueTag,
   } else {
     float best_time = std::numeric_limits<float>::max();
     CutlassGemmConfig best_config;
-    int profile_m = gemmConfigManager.nextPowerOfTwo(m);
+    int profile_m = std::min(gemmConfigManager.nextPowerOfTwo(m),
+                             gemmConfigManager.getMaxProfileM());
     bool found_one = false;
 
     for (size_t ii = 0; ii < candidate_configs.size(); ++ii) {

--- a/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/gemm_config_manager.h
+++ b/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/gemm_config_manager.h
@@ -245,7 +245,7 @@ class GemmConfigManager {
     return ++v;
   }
 
-  int getMaxProfileM() const { return 256; }
+  int getMaxProfileM() const { return 1024; }
 
   bool loadFromJson(const std::string& filename) {
     std::ifstream inFile(filename);

--- a/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/moe_gemm/fused_moe_gemm_kernels_template.h
+++ b/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/moe_gemm/fused_moe_gemm_kernels_template.h
@@ -960,7 +960,9 @@ void MoeGemmRunner<T, WeightType>::run_gemm<EpilogueTag>(
   } else {
     float best_time = std::numeric_limits<float>::max();
     CutlassGemmConfig best_config;
-    int profile_total_rows = gemmConfigManager.nextPowerOfTwo(total_rows);
+    int profile_total_rows =
+        std::min(gemmConfigManager.nextPowerOfTwo(total_rows),
+                 gemmConfigManager.getMaxProfileM());
     bool found_one = false;
 
     for (size_t ii = 0; ii < candidate_configs.size(); ++ii) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-71500

修复weight_only_linear算子bug
