### PR TITLE
enhance PD_VISIT_FLOATING_AND_HALF_TYPES

### DIFF
--- a/paddle/phi/core/visit_type.h
+++ b/paddle/phi/core/visit_type.h
@@ -31,6 +31,16 @@ namespace phi {
 #define PD_PRIVATE_CASE_TYPE(NAME, enum_type, type, ...) \
   PD_PRIVATE_CASE_TYPE_USING_HINT(NAME, enum_type, type, data_t, __VA_ARGS__)
 
+#if ((defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)) &&        \
+         (NCCL_VERSION_CODE >= 21000 && !defined(PADDLE_WITH_RCCL)) || \
+     defined(PADDLE_WITH_XPU))
+#define PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, ...) \
+  PD_PRIVATE_CASE_TYPE(                          \
+      NAME, ::paddle::DataType::BFLOAT16, phi::bfloat16, __VA_ARGS__)
+#else
+#define PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, ...)
+#endif
+
 ///////// Floating Dispatch Marco ///////////
 
 #define PD_VISIT_FLOATING_TYPES(TYPE, NAME, ...)                          \

--- a/paddle/phi/core/visit_type.h
+++ b/paddle/phi/core/visit_type.h
@@ -161,33 +161,32 @@ namespace phi {
   }()
 
 ///////// BOOL and Floating and Integral Dispatch Marco ///////////
-#define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES(TYPE, NAME, ...)         \
-  [&] {                                                                        \
-    const auto& __dtype__ = TYPE;                                              \
-    switch (__dtype__) {                                                       \
-      PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::BOOL, bool, __VA_ARGS__)     \
-      PD_PRIVATE_CASE_TYPE(                                                    \
-          NAME, ::paddle::DataType::FLOAT32, float, __VA_ARGS__)               \
-      PD_PRIVATE_CASE_TYPE(                                                    \
-          NAME, ::paddle::DataType::FLOAT64, double, __VA_ARGS__)              \
-      PD_PRIVATE_CASE_TYPE(NAME, ::paddle::DataType::INT32, int, __VA_ARGS__)  \
-      PD_PRIVATE_CASE_TYPE(                                                    \
-          NAME, ::paddle::DataType::INT64, int64_t, __VA_ARGS__)               \
-      PD_PRIVATE_CASE_TYPE(                                                    \
-          NAME, ::paddle::DataType::INT8, int8_t, __VA_ARGS__)                 \
-      PD_PRIVATE_CASE_TYPE(                                                    \
-          NAME, ::paddle::DataType::UINT8, uint8_t, __VA_ARGS__)               \
-      PD_PRIVATE_CASE_TYPE(                                                    \
-          NAME, ::paddle::DataType::INT16, int16_t, __VA_ARGS__)               \
-      PD_PRIVATE_CASE_TYPE(                                                    \
-          NAME, ::paddle::DataType::FLOAT16, ::paddle::float16, __VA_ARGS__)   \
-      PD_PRIVATE_CASE_TYPE(                                                    \
-          NAME, ::paddle::DataType::BFLOAT16, ::paddle::bfloat16, __VA_ARGS__) \
-      default:                                                                 \
-        PD_THROW("function " #NAME " is not implemented for data type `",      \
-                 __dtype__,                                                    \
-                 "`");                                                         \
-    }                                                                          \
+#define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES(TYPE, NAME, ...)        \
+  [&] {                                                                       \
+    const auto& __dtype__ = TYPE;                                             \
+    switch (__dtype__) {                                                      \
+      PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::BOOL, bool, __VA_ARGS__)    \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::FLOAT32, float, __VA_ARGS__)              \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::FLOAT64, double, __VA_ARGS__)             \
+      PD_PRIVATE_CASE_TYPE(NAME, ::paddle::DataType::INT32, int, __VA_ARGS__) \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::INT64, int64_t, __VA_ARGS__)              \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::INT8, int8_t, __VA_ARGS__)                \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::UINT8, uint8_t, __VA_ARGS__)              \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::INT16, int16_t, __VA_ARGS__)              \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::FLOAT16, ::paddle::float16, __VA_ARGS__)  \
+      PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, __VA_ARGS__)                        \
+      default:                                                                \
+        PD_THROW("function " #NAME " is not implemented for data type `",     \
+                 __dtype__,                                                   \
+                 "`");                                                        \
+    }                                                                         \
   }()
 
 #define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES_CPU(TYPE, NAME, ...)    \

--- a/paddle/phi/core/visit_type.h
+++ b/paddle/phi/core/visit_type.h
@@ -31,16 +31,6 @@ namespace phi {
 #define PD_PRIVATE_CASE_TYPE(NAME, enum_type, type, ...) \
   PD_PRIVATE_CASE_TYPE_USING_HINT(NAME, enum_type, type, data_t, __VA_ARGS__)
 
-#if ((defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)) &&        \
-         (NCCL_VERSION_CODE >= 21000 && !defined(PADDLE_WITH_RCCL)) || \
-     defined(PADDLE_WITH_XPU))
-#define PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, ...) \
-  PD_PRIVATE_CASE_TYPE(                          \
-      NAME, ::paddle::DataType::BFLOAT16, phi::bfloat16, __VA_ARGS__)
-#else
-#define PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, ...)
-#endif
-
 ///////// Floating Dispatch Marco ///////////
 
 #define PD_VISIT_FLOATING_TYPES(TYPE, NAME, ...)                          \
@@ -58,22 +48,23 @@ namespace phi {
     }                                                                     \
   }()
 
-#define PD_VISIT_FLOATING_AND_HALF_TYPES(TYPE, NAME, ...)                  \
-  [&] {                                                                    \
-    const auto& __dtype__ = TYPE;                                          \
-    switch (__dtype__) {                                                   \
-      PD_PRIVATE_CASE_TYPE(                                                \
-          NAME, ::paddle::DataType::FLOAT32, float, __VA_ARGS__)           \
-      PD_PRIVATE_CASE_TYPE(                                                \
-          NAME, ::paddle::DataType::FLOAT64, double, __VA_ARGS__)          \
-      PD_PRIVATE_CASE_TYPE(                                                \
-          NAME, ::paddle::DataType::FLOAT16, paddle::float16, __VA_ARGS__) \
-      PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, __VA_ARGS__)                     \
-      default:                                                             \
-        PD_THROW("function " #NAME " is not implemented for data type `",  \
-                 __dtype__,                                                \
-                 "`");                                                     \
-    }                                                                      \
+#define PD_VISIT_FLOATING_AND_HALF_TYPES(TYPE, NAME, ...)                      \
+  [&] {                                                                        \
+    const auto& __dtype__ = TYPE;                                              \
+    switch (__dtype__) {                                                       \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::paddle::DataType::FLOAT32, float, __VA_ARGS__)               \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::paddle::DataType::FLOAT64, double, __VA_ARGS__)              \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::paddle::DataType::FLOAT16, ::paddle::float16, __VA_ARGS__)   \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::paddle::DataType::BFLOAT16, ::paddle::bfloat16, __VA_ARGS__) \
+      default:                                                                 \
+        PD_THROW("function " #NAME " is not implemented for data type `",      \
+                 __dtype__,                                                    \
+                 "`");                                                         \
+    }                                                                          \
   }()
 
 ///////// Integral Dispatch Marco ///////////
@@ -160,32 +151,33 @@ namespace phi {
   }()
 
 ///////// BOOL and Floating and Integral Dispatch Marco ///////////
-#define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES(TYPE, NAME, ...)        \
-  [&] {                                                                       \
-    const auto& __dtype__ = TYPE;                                             \
-    switch (__dtype__) {                                                      \
-      PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::BOOL, bool, __VA_ARGS__)    \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::FLOAT32, float, __VA_ARGS__)              \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::FLOAT64, double, __VA_ARGS__)             \
-      PD_PRIVATE_CASE_TYPE(NAME, ::paddle::DataType::INT32, int, __VA_ARGS__) \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::INT64, int64_t, __VA_ARGS__)              \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::INT8, int8_t, __VA_ARGS__)                \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::UINT8, uint8_t, __VA_ARGS__)              \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::INT16, int16_t, __VA_ARGS__)              \
-      PD_PRIVATE_CASE_TYPE(                                                   \
-          NAME, ::paddle::DataType::FLOAT16, float16, __VA_ARGS__)            \
-      PD_PRIVATE_CASE_TYPE_BFLOAT16(NAME, __VA_ARGS__)                        \
-      default:                                                                \
-        PD_THROW("function " #NAME " is not implemented for data type `",     \
-                 __dtype__,                                                   \
-                 "`");                                                        \
-    }                                                                         \
+#define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES(TYPE, NAME, ...)         \
+  [&] {                                                                        \
+    const auto& __dtype__ = TYPE;                                              \
+    switch (__dtype__) {                                                       \
+      PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::BOOL, bool, __VA_ARGS__)     \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::paddle::DataType::FLOAT32, float, __VA_ARGS__)               \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::paddle::DataType::FLOAT64, double, __VA_ARGS__)              \
+      PD_PRIVATE_CASE_TYPE(NAME, ::paddle::DataType::INT32, int, __VA_ARGS__)  \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::paddle::DataType::INT64, int64_t, __VA_ARGS__)               \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::paddle::DataType::INT8, int8_t, __VA_ARGS__)                 \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::paddle::DataType::UINT8, uint8_t, __VA_ARGS__)               \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::paddle::DataType::INT16, int16_t, __VA_ARGS__)               \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::paddle::DataType::FLOAT16, ::paddle::float16, __VA_ARGS__)   \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::paddle::DataType::BFLOAT16, ::paddle::bfloat16, __VA_ARGS__) \
+      default:                                                                 \
+        PD_THROW("function " #NAME " is not implemented for data type `",      \
+                 __dtype__,                                                    \
+                 "`");                                                         \
+    }                                                                          \
   }()
 
 #define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES_CPU(TYPE, NAME, ...)    \


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-71500

PD_VISIT_FLOATING_AND_HALF_TYPES support bfloat16.