### PR TITLE
fix error of FlashAttnInferMeta when use flash_attn_unpadded

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/concat.cc
+++ b/paddle/phi/infermeta/spmd_rules/concat.cc
@@ -49,7 +49,7 @@ SpmdInfo ConcatInferSpmd(const std::vector<DistMetaTensor>& x, int axis) {
   /*
 # paddle.concat requires all tensors must either have the same shape (except
 # in the concatenating dimension) or be "empty". "Empty" here strictly means
-# tensor.shape is torch.Size([0]). When tensor.ndim > 1, it will be treated
+# tensor.ndim == 0. When tensor.ndim > 0, it will be treated
 # as a non-empty tensor and the shape must match on non-cat dimensions.
  */
 

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -546,6 +546,19 @@ void FlashAttnInferMeta(const MetaTensor& q,
       softmax_lse->set_dims({batch_size, num_heads, seqlen_q_rounded});
     }
   }
+  if (out_dims.size() == 3) {  // when use flash_attn_unpadded
+    auto round_multiple = [](int x) { return (x + 127) / 128 * 128; };
+    int batch_and_seq_size = q.dims()[0];
+    int num_heads = q.dims()[1];
+    int seqlen_q_rounded = round_multiple(batch_and_seq_size);
+    int seqlen_k_rounded = round_multiple(batch_and_seq_size);
+    if (softmax) {
+      softmax->set_dims({num_heads, seqlen_q_rounded, seqlen_k_rounded});
+    }
+    if (softmax_lse) {
+      softmax_lse->set_dims({num_heads, seqlen_q_rounded});
+    }
+  }
   if (seed_offset) {
     seed_offset->set_dtype(phi::DataType::INT64);
     seed_offset->set_dims({2});


### PR DESCRIPTION
### PR Category
Auto Parallel

### PR Types
Bug fixes

### Description
pcard-89263

When the multimodal model (`Qwen2VL`) calls the `flash_attn_unpadded` operator, `FlashAttnInferMeta` does not set the shape of softmax/softmax_lse when length of shape of q/k/v is 3, resulting error of subsequent function `SetReplicatedDistAttrForOutput`. this PR will fix this issue.
shape of q/k/v:
![image](https://github.com/user-attachments/assets/51dee6d0-2800-44d9-bff4-ef571b0287e7)

call stack:
![image](https://github.com/user-attachments/assets/98f2a130-b7a7-4964-872f-d7ef41f6bcc3)

