### PR TITLE
[XPU] fix bug in addmm

### DIFF
--- a/tools/xpu/disable_ut_xpu_kl3.local
+++ b/tools/xpu/disable_ut_xpu_kl3.local
@@ -3,7 +3,6 @@ preprocess_local_imagenet
 preprocess_local_pascalvoc
 test_accuracy_op
 test_adaptive_max_pool2d
-test_addmm_op
 test_analyzer
 test_analyzer_bfloat16_googlenet
 test_analyzer_bfloat16_mobilenetv1


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
在`addmm`算子中，如果输入的`input`是一个只有1维的向量，那么计算会报错，原因是形状不匹配。本PR在代码中增加了一个广播操作，并且参考GPU的实现，增加了尺寸的检查。修复之后，可以跑通`test_addmm_op`单测。
