### PR TITLE
add deformable_conv(api:paddle.vision.ops.deform_conv2d) OP for pir-trt

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/deformable_conv_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/deformable_conv_op_plugin.cu
@@ -1404,6 +1404,472 @@ nvinfer1::IPluginV2Ext* DeformableConvPluginDynamicCreator::createPlugin(
                                   with_fp16);
 }
 
+PIRDeformableConvPluginDynamic::PIRDeformableConvPluginDynamic(
+    const nvinfer1::DataType data_type,
+    const nvinfer1::Weights& weights,
+    const std::vector<int>& kernel_dims,
+    const std::vector<int>& strides,
+    const std::vector<int>& paddings,
+    const std::vector<int>& dilations,
+    const int groups,
+    const int deformable_groups,
+    const int im2col_step,
+    const bool with_fp16)
+    : data_type_(data_type),
+      groups_(groups),
+      deformable_groups_(deformable_groups),
+      im2col_step_(im2col_step),
+      with_fp16_(with_fp16) {
+  weights_ = copyToDevice(weights.values, weights.count);
+  kernel_dims_.insert(
+      kernel_dims_.end(), kernel_dims.cbegin(), kernel_dims.cend());
+
+  strides_.insert(strides_.end(), strides.cbegin(), strides.cend());
+  paddings_.insert(paddings_.end(), paddings.cbegin(), paddings.cend());
+  dilations_.insert(dilations_.end(), dilations.cbegin(), dilations.cend());
+  PADDLE_ENFORCE_EQ(data_type_ == nvinfer1::DataType::kFLOAT ||
+                        data_type_ == nvinfer1::DataType::kHALF,
+                    true,
+                    common::errors::InvalidArgument(
+                        "The DeformableConv TRT Plugin's input type "
+                        "should be float or half."));
+  PADDLE_ENFORCE_EQ(
+      paddings_.size(),
+      strides_.size(),
+      common::errors::InvalidArgument(
+          "The size of paddings (%d) is not equal to the size of strides (%d).",
+          paddings_.size(),
+          strides_.size()));
+}
+PIRDeformableConvPluginDynamic::PIRDeformableConvPluginDynamic(const void* data,
+                                                               size_t length) {
+  DeserializeValue(&data, &length, &data_type_);
+  DeserializeValue(&data, &length, &strides_);
+  DeserializeValue(&data, &length, &paddings_);
+  DeserializeValue(&data, &length, &dilations_);
+  DeserializeValue(&data, &length, &groups_);
+  DeserializeValue(&data, &length, &deformable_groups_);
+  DeserializeValue(&data, &length, &im2col_step_);
+  DeserializeValue(&data, &length, &kernel_dims_);
+  int64_t count;
+  DeserializeValue(&data, &length, &count);
+  weights_ = deserializeToDevice(&data, count);
+  DeserializeValue(&data, &length, &with_fp16_);
+}
+
+PIRDeformableConvPluginDynamic::~PIRDeformableConvPluginDynamic() {
+  if (weights_.values) {
+    cudaFree(const_cast<void*>(weights_.values));
+    weights_.values = nullptr;
+  }
+}
+
+nvinfer1::Weights PIRDeformableConvPluginDynamic::copyToDevice(
+    const void* hostData, size_t count) {
+  int num_bytes = (data_type_ == nvinfer1::DataType::kFLOAT ? 4 : 2);
+  void* deviceData;
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaMalloc(&deviceData, count * num_bytes));
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaMemcpy(
+      deviceData, hostData, count * num_bytes, cudaMemcpyHostToDevice));
+  return nvinfer1::Weights{data_type_, deviceData, int64_t(count)};
+}
+
+void PIRDeformableConvPluginDynamic::serializeFromDevice(
+    void** hostBuffer, const nvinfer1::Weights& deviceWeights) const {
+  int num_bytes = (data_type_ == nvinfer1::DataType::kFLOAT ? 4 : 2);
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaMemcpy(static_cast<char*>(*hostBuffer),
+                                        deviceWeights.values,
+                                        deviceWeights.count * num_bytes,
+                                        cudaMemcpyDeviceToHost));
+  *hostBuffer =
+      reinterpret_cast<char*>(*hostBuffer) + deviceWeights.count * num_bytes;
+}
+
+nvinfer1::Weights PIRDeformableConvPluginDynamic::deserializeToDevice(
+    const void** hostBuffer, size_t count) {
+  int num_bytes = (data_type_ == nvinfer1::DataType::kFLOAT ? 4 : 2);
+  nvinfer1::Weights w =
+      copyToDevice(static_cast<const char*>(*hostBuffer), count);
+  *hostBuffer = reinterpret_cast<const char*>(*hostBuffer) + count * num_bytes;
+  return w;
+}
+
+int PIRDeformableConvPluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
+
+size_t PIRDeformableConvPluginDynamic::getSerializationSize() const
+    TRT_NOEXCEPT {
+  size_t serialize_size = 0;
+  serialize_size += SerializedSize(data_type_);
+  serialize_size += SerializedSize(strides_);
+  serialize_size += SerializedSize(paddings_);
+  serialize_size += SerializedSize(dilations_);
+  serialize_size += SerializedSize(groups_);
+  serialize_size += SerializedSize(deformable_groups_);
+  serialize_size += SerializedSize(im2col_step_);
+  serialize_size += SerializedSize(kernel_dims_);
+  serialize_size += SerializedSize(weights_.count);
+  int num_bytes = (data_type_ == nvinfer1::DataType::kFLOAT ? 4 : 2);
+  serialize_size += weights_.count * num_bytes;
+  serialize_size += SerializedSize(with_fp16_);
+  return serialize_size;
+}
+
+void PIRDeformableConvPluginDynamic::serialize(void* buffer) const
+    TRT_NOEXCEPT {
+  SerializeValue(&buffer, data_type_);
+  SerializeValue(&buffer, strides_);
+  SerializeValue(&buffer, paddings_);
+  SerializeValue(&buffer, dilations_);
+  SerializeValue(&buffer, groups_);
+  SerializeValue(&buffer, deformable_groups_);
+  SerializeValue(&buffer, im2col_step_);
+  SerializeValue(&buffer, kernel_dims_);
+  SerializeValue(&buffer, weights_.count);
+  serializeFromDevice(&buffer, weights_);
+  SerializeValue(&buffer, with_fp16_);
+}
+
+size_t PIRDeformableConvPluginDynamic::getWorkspaceSize(
+    const nvinfer1::PluginTensorDesc* inputs,
+    int nbInputs,
+    const nvinfer1::PluginTensorDesc* outputs,
+    int nbOutputs) const TRT_NOEXCEPT {
+  PADDLE_ENFORCE_EQ(
+      nbInputs,
+      3,
+      common::errors::InvalidArgument(
+          "The number of inputs should be equal to 3, but got %d", nbInputs));
+  PADDLE_ENFORCE_EQ(
+      nbOutputs,
+      1,
+      common::errors::InvalidArgument(
+          "The number of inputs should be equal to 1, but got %d", nbOutputs));
+  int c_i = inputs[0].dims.d[1], h_i = inputs[0].dims.d[2],
+      w_i = inputs[0].dims.d[3];
+  int k_h = kernel_dims_[2], k_w = kernel_dims_[3];
+  int c_o = outputs[0].dims.d[1], h_o = outputs[0].dims.d[2],
+      w_o = outputs[0].dims.d[3];
+  int num_bytes = (data_type_ == nvinfer1::DataType::kFLOAT ? 4 : 2);
+  size_t data_col_size = static_cast<size_t>(c_i * k_h * k_w * im2col_step_ *
+                                             h_o * w_o * num_bytes);
+  return data_col_size;
+}
+
+nvinfer1::DimsExprs PIRDeformableConvPluginDynamic::getOutputDimensions(
+    int output_index,
+    const nvinfer1::DimsExprs* inputDims,
+    int nb_inputs,
+    nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT {
+  PADDLE_ENFORCE_EQ(
+      nb_inputs,
+      3,
+      common::errors::InvalidArgument(
+          "The number of inputs should be equal to 3, but got %d", nb_inputs));
+  nvinfer1::DimsExprs ret;
+  ret.nbDims = inputDims[0].nbDims;
+  ret.d[0] = inputDims[0].d[0];
+  auto ConvOutputSizeDynamic =
+      [&](const nvinfer1::IDimensionExpr* input_size,
+          int filter_size,
+          int dilation,
+          int padding,
+          int stride) -> const nvinfer1::IDimensionExpr* {
+    auto dkernel = dilation * (filter_size - 1) + 1;
+    return expr_builder.operation(
+        nvinfer1::DimensionOperation::kSUM,
+        *expr_builder.operation(
+            nvinfer1::DimensionOperation::kFLOOR_DIV,
+            *expr_builder.operation(
+                nvinfer1::DimensionOperation::kSUM,
+                *input_size,
+                *expr_builder.constant(2 * padding - dkernel)),
+            *expr_builder.constant(stride)),
+        *expr_builder.constant(1));
+  };
+
+  ret.d[1] = expr_builder.constant(kernel_dims_[0]);
+
+  ret.d[2] = ConvOutputSizeDynamic(inputDims[0].d[2],
+                                   kernel_dims_[2],
+                                   dilations_[0],
+                                   paddings_[0],
+                                   strides_[0]);
+  ret.d[3] = ConvOutputSizeDynamic(inputDims[0].d[3],
+                                   kernel_dims_[3],
+                                   dilations_[1],
+                                   paddings_[1],
+                                   strides_[1]);
+  return ret;
+}
+
+bool PIRDeformableConvPluginDynamic::supportsFormatCombination(
+    int pos,
+    const nvinfer1::PluginTensorDesc* in_out,
+    int nb_inputs,
+    int nb_outputs) TRT_NOEXCEPT {
+  PADDLE_ENFORCE_NOT_NULL(
+      in_out,
+      common::errors::InvalidArgument(
+          "The input of groupnorm plugin should not be nullptr."));
+  PADDLE_ENFORCE_LT(
+      pos,
+      nb_inputs + nb_outputs,
+      common::errors::InvalidArgument("The pos(%d) should be less than the "
+                                      "num(%d) of the input and the output.",
+                                      pos,
+                                      nb_inputs + nb_outputs));
+  const nvinfer1::PluginTensorDesc& in = in_out[pos];
+  if (pos == 0) {
+    if (with_fp16_) {
+      return ((in.type == nvinfer1::DataType::kHALF) &&
+              ((in.format == nvinfer1::PluginFormat::kLINEAR) ||
+               in.format == nvinfer1::PluginFormat::kHWC8));
+    } else {
+      return (in.type == nvinfer1::DataType::kFLOAT) &&
+             (in.format == nvinfer1::TensorFormat::kLINEAR);
+    }
+  }
+  const nvinfer1::PluginTensorDesc& prev = in_out[pos - 1];
+  // output
+  return in.type == prev.type && in.format == prev.format;
+}
+
+nvinfer1::DataType PIRDeformableConvPluginDynamic::getOutputDataType(
+    int index,
+    const nvinfer1::DataType* input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
+  PADDLE_ENFORCE_EQ(index,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The Elementwise Plugin only has one input, so the "
+                        "index value should be 0, but get %d.",
+                        index));
+  return input_types[0];
+}
+
+void PIRDeformableConvPluginDynamic::configurePlugin(
+    const nvinfer1::DynamicPluginTensorDesc* in,
+    int nbInputs,
+    const nvinfer1::DynamicPluginTensorDesc* out,
+    int nbOutputs) TRT_NOEXCEPT {
+  PADDLE_ENFORCE_EQ(
+      nbInputs,
+      3,
+      common::errors::InvalidArgument(
+          "The number of inputs should be equal to 3, but got %d", nbInputs));
+  PADDLE_ENFORCE_EQ(
+      nbOutputs,
+      1,
+      common::errors::InvalidArgument(
+          "The number of inputs should be equal to 1, but got %d", nbOutputs));
+}
+
+int PIRDeformableConvPluginDynamic::enqueue(
+    const nvinfer1::PluginTensorDesc* input_desc,
+    const nvinfer1::PluginTensorDesc* output_desc,
+    const void* const* inputs,
+    void* const* outputs,
+    void* workspace,
+    cudaStream_t stream) TRT_NOEXCEPT {
+  if (data_type_ == nvinfer1::DataType::kFLOAT) {
+    enqueue_impl<float>(
+        input_desc, output_desc, inputs, outputs, workspace, stream);
+  } else if (data_type_ == nvinfer1::DataType::kHALF) {
+#if TRT_PLUGIN_FP16_AVAILABLE
+    enqueue_impl<half>(
+        input_desc, output_desc, inputs, outputs, workspace, stream);
+#else
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "Current CUDA arch dose not support fp16. Please use fp32 instead."));
+#endif
+  } else {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "The DeformableConv TRT Plugin's input type should be float or half."));
+  }
+  return cudaGetLastError() != cudaSuccess;
+}
+
+template <typename T>
+int PIRDeformableConvPluginDynamic::enqueue_impl(
+    const nvinfer1::PluginTensorDesc* input_desc,
+    const nvinfer1::PluginTensorDesc* output_desc,
+    const void* const* inputs,
+    void* const* outputs,
+    void* workspace,
+    cudaStream_t stream) {
+  const auto& input_dims = input_desc[0].dims;
+  const auto& offset_dims = input_desc[1].dims;
+  const auto& mask_dims = input_desc[2].dims;
+  const auto& output_dims = output_desc[0].dims;
+
+  int batch_size = input_dims.d[0];
+  const T* input = reinterpret_cast<const T*>(inputs[0]);
+  const T* offset = reinterpret_cast<const T*>(inputs[1]);
+  const T* mask = reinterpret_cast<const T*>(inputs[2]);
+  const T* filter = reinterpret_cast<const T*>(weights_.values);
+  T* output = reinterpret_cast<T*>(outputs[0]);
+
+  int c_i = input_dims.d[1], h_i = input_dims.d[2], w_i = input_dims.d[3];
+  int k_h = kernel_dims_[2], k_w = kernel_dims_[3];
+  int c_o = output_dims.d[1], h_o = output_dims.d[2], w_o = output_dims.d[3];
+
+  int input_stride = c_i * h_i * w_i;
+  int offset_stride = offset_dims.d[1] * offset_dims.d[2] * offset_dims.d[3];
+  int mask_stride = mask_dims.d[1] * mask_dims.d[2] * mask_dims.d[3];
+  int output_stride = c_o * h_o * w_o;
+
+  int M = c_o / groups_;
+  int N = im2col_step_ * h_o * w_o;
+  int K = c_i * k_h * k_w / groups_;
+
+  // c_i / deformable_groups
+  int channel_per_deformable_group = c_i / deformable_groups_;
+  // c_i * im2col_step * h_o * w_o
+  int num_kernels = c_i * im2col_step_ * h_o * w_o;
+
+  int blocks = NumBlocks(num_kernels);
+  int threads = kNumCUDAThreads;
+
+  const T alpha = static_cast<T>(1.0f);
+  const T beta = static_cast<T>(0.0f);
+
+  for (int i = 0; i < batch_size / im2col_step_; ++i) {
+    const T* data_im = input + i * im2col_step_ * input_stride;
+    const T* data_offset = offset + i * im2col_step_ * offset_stride;
+    const T* data_mask = mask + i * im2col_step_ * mask_stride;
+    T* data_col = reinterpret_cast<T*>(workspace);
+
+    ModulatedDeformableIm2colGpuKernel<T>
+        <<<blocks, threads, 0, stream>>>(num_kernels,
+                                         data_im,
+                                         data_offset,
+                                         data_mask,
+                                         h_i,
+                                         w_i,
+                                         k_h,
+                                         k_w,
+                                         paddings_[0],
+                                         paddings_[1],
+                                         strides_[0],
+                                         strides_[1],
+                                         dilations_[0],
+                                         dilations_[1],
+                                         channel_per_deformable_group,
+                                         im2col_step_,
+                                         c_i,
+                                         deformable_groups_,
+                                         h_o,
+                                         w_o,
+                                         data_col);
+
+    for (int g = 0; g < groups_; ++g) {
+      const T* weight = filter + g * M * K;
+      const T* col = data_col + g * K * N;
+      T* out = output + i * im2col_step_ * output_stride + g * M * N;
+
+      gemm_impl_new<T>(N, M, K, &alpha, col, weight, &beta, out);
+    }
+  }
+  return 0;
+}
+
+void PIRDeformableConvPluginDynamicCreator::setPluginNamespace(
+    const char* lib_namespace) TRT_NOEXCEPT {
+  namespace_ = std::string(lib_namespace);
+}
+
+const char* PIRDeformableConvPluginDynamicCreator::getPluginNamespace() const
+    TRT_NOEXCEPT {
+  return namespace_.c_str();
+}
+
+const char* PIRDeformableConvPluginDynamicCreator::getPluginName() const
+    TRT_NOEXCEPT {
+  return "pir_deformable_conv_plugin";
+}
+
+const char* PIRDeformableConvPluginDynamicCreator::getPluginVersion() const
+    TRT_NOEXCEPT {
+  return "1";
+}
+
+const nvinfer1::PluginFieldCollection*
+PIRDeformableConvPluginDynamicCreator::getFieldNames() TRT_NOEXCEPT {
+  return &field_collection_;
+}
+
+nvinfer1::IPluginV2Ext* PIRDeformableConvPluginDynamicCreator::createPlugin(
+    const char* name, const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT {
+  const nvinfer1::PluginField* fields = fc->fields;
+
+  nvinfer1::DataType data_type;
+  std::vector<int> strides, paddings, dilations, kernel_dims;
+  nvinfer1::Weights weights;
+  int groups = -1;
+  int deformable_groups = -1;
+  int im2col_step = -1;
+  bool with_fp16 = false;
+
+  for (int i = 0; i < fc->nbFields; ++i) {
+    const std::string field_name(fc->fields[i].name);
+
+    if (field_name.compare("data_type") == 0) {
+      data_type = *static_cast<const nvinfer1::DataType*>(fc->fields[i].data);
+    } else if (field_name.compare("strides") == 0) {
+      const int length = fc->fields[i].length;
+      const int* data = static_cast<const int*>(fc->fields[i].data);
+      strides.insert(strides.end(), data, data + length);
+    } else if (field_name.compare("paddings") == 0) {
+      const int length = fc->fields[i].length;
+      const int* data = static_cast<const int*>(fc->fields[i].data);
+      paddings.insert(paddings.end(), data, data + length);
+    } else if (field_name.compare("dilations") == 0) {
+      const int length = fc->fields[i].length;
+      const int* data = static_cast<const int*>(fc->fields[i].data);
+      dilations.insert(dilations.end(), data, data + length);
+    } else if (field_name.compare("groups") == 0) {
+      groups = *static_cast<const int*>(fc->fields[i].data);
+    } else if (field_name.compare("deformable_groups") == 0) {
+      deformable_groups = *static_cast<const int*>(fc->fields[i].data);
+    } else if (field_name.compare("im2col_step") == 0) {
+      im2col_step = *static_cast<const int*>(fc->fields[i].data);
+    } else if (field_name.compare("kernel_dims") == 0) {
+      const int length = fc->fields[i].length;
+      const int* data = static_cast<const int*>(fc->fields[i].data);
+      kernel_dims.insert(kernel_dims.end(), data, data + length);
+    } else if (field_name.compare("weights") == 0) {
+      weights.count = fc->fields[i].length;
+      weights.values = fc->fields[i].data;
+    } else if (field_name.compare("with_fp16") == 0) {
+      with_fp16 = *static_cast<const bool*>(fc->fields[i].data);
+    } else {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Unknown plugin field name [%s] in the DeformableConv TRT Plugin.",
+          field_name));
+    }
+  }
+  weights.type = data_type;
+  return new PIRDeformableConvPluginDynamic(data_type,
+                                            weights,
+                                            kernel_dims,
+                                            strides,
+                                            paddings,
+                                            dilations,
+                                            groups,
+                                            deformable_groups,
+                                            im2col_step,
+                                            with_fp16);
+}
+
+nvinfer1::IPluginV2Ext*
+PIRDeformableConvPluginDynamicCreator::deserializePlugin(
+    const char* name,
+    const void* serial_data,
+    size_t serial_length) TRT_NOEXCEPT {
+  auto plugin = new PIRDeformableConvPluginDynamic(serial_data, serial_length);
+  plugin->setPluginNamespace(namespace_.c_str());
+  return plugin;
+}
 #endif
 
 }  // namespace plugin

--- a/paddle/fluid/inference/tensorrt/plugin/deformable_conv_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/deformable_conv_op_plugin.h
@@ -297,6 +297,129 @@ class DeformableConvPluginDynamicCreator : public TensorRTPluginCreator {
   std::string namespace_;
   nvinfer1::PluginFieldCollection field_collection_;
 };
+
+class PIRDeformableConvPluginDynamic : public DynamicPluginTensorRT {
+ public:
+  explicit PIRDeformableConvPluginDynamic(const nvinfer1::DataType data_type,
+                                          const nvinfer1::Weights& weights,
+                                          const std::vector<int>& kernel_dims,
+                                          const std::vector<int>& strides,
+                                          const std::vector<int>& paddings,
+                                          const std::vector<int>& dilations,
+                                          const int groups,
+                                          const int deformable_groups,
+                                          const int im2col_step,
+                                          const bool with_fp16);
+  PIRDeformableConvPluginDynamic(const void* data, size_t length);
+  ~PIRDeformableConvPluginDynamic() override;
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
+    return new PIRDeformableConvPluginDynamic(data_type_,
+                                              weights_,
+                                              kernel_dims_,
+                                              strides_,
+                                              paddings_,
+                                              dilations_,
+                                              groups_,
+                                              deformable_groups_,
+                                              im2col_step_,
+                                              with_fp16_);
+  }
+
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "deformable_conv_plugin_dynamic";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
+
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
+  nvinfer1::DimsExprs getOutputDimensions(
+      int output_index,
+      const nvinfer1::DimsExprs* inputs,
+      int nb_inputs,
+      nvinfer1::IExprBuilder& expr_builder)  // NOLINT
+      TRT_NOEXCEPT override;
+
+  bool supportsFormatCombination(int pos,
+                                 const nvinfer1::PluginTensorDesc* inOut,
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
+
+  void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
+                       int nbInputs,
+                       const nvinfer1::DynamicPluginTensorDesc* out,
+                       int nbOutputs) TRT_NOEXCEPT override;
+  size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
+                          int nbInputs,
+                          const nvinfer1::PluginTensorDesc* outputs,
+                          int nbOutputs) const TRT_NOEXCEPT override;
+
+  int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
+              const nvinfer1::PluginTensorDesc* outputDesc,
+              const void* const* inputs,
+              void* const* outputs,
+              void* workspace,
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  void destroy() TRT_NOEXCEPT override { delete this; }
+
+  nvinfer1::DataType getOutputDataType(int index,
+                                       const nvinfer1::DataType* inputTypes,
+                                       int nbInputs) const
+      TRT_NOEXCEPT override;
+
+ private:
+  nvinfer1::Weights copyToDevice(const void* hostData, size_t count);
+  void serializeFromDevice(void** hostBuffer,
+                           const nvinfer1::Weights& deviceWeights) const;
+  nvinfer1::Weights deserializeToDevice(const void** hostBuffer, size_t count);
+  template <typename T>
+  int enqueue_impl(const nvinfer1::PluginTensorDesc* inputDesc,
+                   const nvinfer1::PluginTensorDesc* outputDesc,
+                   const void* const* inputs,
+                   void* const* outputs,
+                   void* workspace,
+                   cudaStream_t stream);
+  bool with_fp16_;
+  nvinfer1::DataType data_type_;
+  nvinfer1::Weights weights_;
+  std::vector<int> kernel_dims_;
+  std::vector<int> strides_;
+  std::vector<int> paddings_;
+  std::vector<int> dilations_;
+  int groups_;
+  int deformable_groups_;
+  int im2col_step_;
+  std::string namespace_;
+
+  cublasHandle_t cublasHandle_;
+};
+
+class PIRDeformableConvPluginDynamicCreator : public nvinfer1::IPluginCreator {
+ public:
+  PIRDeformableConvPluginDynamicCreator() = default;
+  ~PIRDeformableConvPluginDynamicCreator() override = default;
+
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
+  const char* getPluginName() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
+
+  nvinfer1::IPluginV2Ext* createPlugin(
+      const char* name,
+      const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2Ext* deserializePlugin(const char* name,
+                                            const void* serial_data,
+                                            size_t serial_length)
+      TRT_NOEXCEPT override;
+
+ private:
+  std::string namespace_;
+  nvinfer1::PluginFieldCollection field_collection_;
+};
+
+REGISTER_TRT_PLUGIN_V2(PIRDeformableConvPluginDynamicCreator);
+
 REGISTER_TRT_PLUGIN_V2(DeformableConvPluginDynamicCreator);
 #endif
 }  // namespace plugin

--- a/python/paddle/tensorrt/impls/ops.py
+++ b/python/paddle/tensorrt/impls/ops.py
@@ -125,3 +125,81 @@ def YoloBoxOpConverter(network, paddle_op, inputs):
     out0 = yolo_box_layer.get_output(0)
     out1 = yolo_box_layer.get_output(1)
     return (out0, out1)
+
+
+@converter_registry.register(
+    "pd_op.deformable_conv", trt_version="trt_version_ge=8.5"
+)
+def deformable_conv_converter(network, paddle_op, inputs):
+    input = inputs[0]
+    offset = inputs[1]
+    filter = inputs[2]
+    mask = inputs[3]
+
+    groups = paddle_op.attrs().get("groups")
+    deformable_groups = paddle_op.attrs().get("deformable_groups")
+    im2col_step = paddle_op.attrs().get("im2col_step")
+
+    strides = paddle_op.attrs().get("strides")
+    paddings = paddle_op.attrs().get("paddings")
+    dilations = paddle_op.attrs().get("dilations")
+
+    kernel_dims = paddle_op.operands()[2].source().shape
+
+    plugin_fields = [
+        trt.PluginField(
+            "with_fp16",
+            np.array([False], dtype=np.bool_),
+            trt.PluginFieldType.INT32,
+        ),
+        trt.PluginField(
+            "weights",
+            filter.numpy(),
+            trt.PluginFieldType.FLOAT32,
+        ),
+        trt.PluginField(
+            "kernel_dims",
+            np.array(kernel_dims, dtype=np.int32),
+            trt.PluginFieldType.INT32,
+        ),
+        trt.PluginField(
+            "strides",
+            np.array(strides, dtype=np.int32),
+            trt.PluginFieldType.INT32,
+        ),
+        trt.PluginField(
+            "paddings",
+            np.array(paddings, dtype=np.int32),
+            trt.PluginFieldType.INT32,
+        ),
+        trt.PluginField(
+            "dilations",
+            np.array(dilations, dtype=np.int32),
+            trt.PluginFieldType.INT32,
+        ),
+        trt.PluginField(
+            "groups",
+            np.array(groups, dtype=np.int32),
+            trt.PluginFieldType.INT32,
+        ),
+        trt.PluginField(
+            "deformable_groups",
+            np.array(deformable_groups, dtype=np.int32),
+            trt.PluginFieldType.INT32,
+        ),
+        trt.PluginField(
+            "im2col_step",
+            np.array(im2col_step, dtype=np.int32),
+            trt.PluginFieldType.INT32,
+        ),
+    ]
+    plugin_field_collection = trt.PluginFieldCollection(plugin_fields)
+    plugin_name = "pir_deformable_conv_plugin"
+    plugin_version = "1"
+    plugin = get_trt_plugin(
+        plugin_name, plugin_field_collection, plugin_version
+    )
+    deformable_conv_layer = network.add_plugin_v2(
+        [inputs[0], inputs[1], inputs[3]], plugin
+    )
+    return deformable_conv_layer.get_output(0)

--- a/python/paddle/tensorrt/util.py
+++ b/python/paddle/tensorrt/util.py
@@ -284,6 +284,7 @@ def weight_to_tensor(network, paddle_value, trt_tensor, use_op_name):
         "pd_op.fused_conv2d_add_act",
         "pd_op.affine_channel",
         "pd_op.fused_bias_dropout_residual_layer_norm",
+        "pd_op.deformable_conv",
     ]
     if use_op_name in forbid_cast_op:
         return trt_tensor


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
pcard-71500
add deformable_conv(api:paddle.vision.ops.deform_conv2d) OP for pir-trt