### PR TITLE
[CINN] Fix multiple threads conflict and detail ExprSetFinder error message

### DIFF
--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
@@ -325,7 +325,7 @@ ir::Expr CreateExprWithNewComputeBody(const FusibleOp& fusible_op,
 }
 
 int GetTensorCounter() {
-  static int counter = 1;
+  static thread_local std::atomic<int> counter = 1;
   return counter++;
 }
 

--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
@@ -212,10 +212,14 @@ ExprSet ExprSetFinder::operator()(const ir::Expr& x) const { return f_(x); }
 ir::Expr ExprSetFinder::GetSingle(const ir::Expr& x) const {
   ExprSetFinder call = (*this) * ExprSetFinder::GetIdentity();
   const auto& o = call.operator()(x);
-  PADDLE_ENFORCE_EQ(o.size(),
-                    1,
-                    ::common::errors::InvalidArgument(
-                        "Try to get single result, but we get %d.", o.size()));
+  PADDLE_ENFORCE_EQ(
+      o.size(),
+      1,
+      ::common::errors::InvalidArgument(
+          "Try to get single result, but we get %d. \nRoot: %s \nResult: %s\n",
+          o.size(),
+          x,
+          cinn::utils::Join(o, "\n")));
   return *o.begin();
 }
 

--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
@@ -216,7 +216,7 @@ ir::Expr ExprSetFinder::GetSingle(const ir::Expr& x) const {
       o.size(),
       1,
       ::common::errors::InvalidArgument(
-          "Try to get single result, but we get %d. \nRoot: %s \nResult: %s\n",
+          "Try to get single result, but we get %d. \nRoot:\n%s \nResult:\n%s",
           o.size(),
           x,
           cinn::utils::Join(o, "\n")));

--- a/paddle/cinn/operator_fusion/fusion_tracker/expr_utils.cc
+++ b/paddle/cinn/operator_fusion/fusion_tracker/expr_utils.cc
@@ -181,7 +181,7 @@ static std::vector<ir::Var> GetAllForIters(const ir::Expr& expr) {
   return vars;
 }
 
-static int counter = 0;
+static thread_local std::atomic<int> counter = 0;
 ir::Expr UnSqueezeExpr(const ir::Expr& expr,
                        const std::vector<int>& padding_vec) {
   VLOG(4) << "UnSqueezeExpr: " << expr


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- Fix multiple threads conflict and detail ExprSetFinder error message