### PR TITLE
fix dev_ctx of communication operator if not kDefaultStream

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
@@ -81,7 +81,8 @@ phi::DeviceContext* ParseDeviceContext(pir::Operation* op,
   if (phi::is_gpu_place(place) || phi::is_custom_place(place)) {
     VLOG(6) << "Parse DeviceContext for " << op_name
             << ", execution stream = " << execution_stream;
-    if (execution_stream != kDefaultStream) {
+    if (op_attributes.count("ring_id") == 0 &&
+        execution_stream != kDefaultStream) {
       dev_ctx = ctx_manager
                     .Get(std::string(kCustomStream) + "-" + execution_stream,
                          place,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
fix dev_ctx of communication operator if not kDefaultStream
PCard-86802