### PR TITLE
[SOT] Dont use `get_py_value` from Tensor default in `MAKE_FUNCTION` to avoid breakgraph

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1418,8 +1418,6 @@ class OpcodeExecutorBase:
                 )
             return
 
-        # breakpoint()
-
         flag = instr.arg
         closure, related_list, kw_defaults, default_args = (
             self.attach_new_attribute(flag, related_list)

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1418,6 +1418,8 @@ class OpcodeExecutorBase:
                 )
             return
 
+        # breakpoint()
+
         flag = instr.arg
         closure, related_list, kw_defaults, default_args = (
             self.attach_new_attribute(flag, related_list)
@@ -1509,7 +1511,7 @@ class OpcodeExecutorBase:
             kw_default_args_variable = self.stack.pop()
             assert isinstance(kw_default_args_variable, DictVariable)
             related_list.append(kw_default_args_variable)
-            kw_defaults = kw_default_args_variable.get_py_value()
+            kw_defaults = kw_default_args_variable.get_wrapped_items()
 
         if flag & MF.MF_HAS_DEFAULTS:
             '''

--- a/test/sot/test_13_make_function.py
+++ b/test/sot/test_13_make_function.py
@@ -67,6 +67,24 @@ def make_fn_mix(x: paddle.Tensor):
     return fn(2, 3, c=1, d=2.0) + x
 
 
+def make_fn_tensor_default(x: paddle.Tensor):
+    tensor = paddle.to_tensor(1.0)
+
+    def fn(a, b, c=tensor):
+        return a + b + c
+
+    return fn(1, 2) + x
+
+
+def make_fn_tensor_kwdefault(x: paddle.Tensor):
+    tensor = paddle.to_tensor(1.0)
+
+    def fn(*args, c=tensor):
+        return args[0] + args[1] + c
+
+    return fn(1, 2, c=3) + x
+
+
 class TestMakeFunction(TestCaseBase):
     def test_simple(self):
         self.assert_results(make_fn_simple, paddle.to_tensor(1))
@@ -75,6 +93,10 @@ class TestMakeFunction(TestCaseBase):
         self.assert_results(make_fn_kwdefault, paddle.to_tensor(1))
         self.assert_results(make_fn_closure, paddle.to_tensor(1))
         self.assert_results(make_fn_mix, paddle.to_tensor(1))
+
+    def test_tensor_default(self):
+        self.assert_results(make_fn_tensor_default, paddle.to_tensor(1))
+        self.assert_results(make_fn_tensor_kwdefault, paddle.to_tensor(1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

同 #71040 是在 DiT 上发现的问题

目前在 make function 且有 kwdefault 的情况下，如果默认值包含 tensor，会因为直接 `get_py_value` 触发 `BreakGraphError` 而挂掉，因为 `MAKE_FUNCTION` 并没有捕获 `BreakGraphError`，导致抛到了最外层

但因为 `MAKE_FUNCTION` 自身的特殊性，在 python 3.13 下是 `MAKE_FUNCTION` 后跟随若干 `SET_FUNCTION_ATTRIBUTE` 实现的，如果在 `MAKE_FUNCTION` 处打断，可能会产生一个非法的 Function（在 python 端还不确定），因此此处打断可能不太行

不过这里注意到在之前的实现里，只有 kwdefault 会有问题，普通的 default 没有问题，因为该分支使用了 `get_wrapped_items`，将 Variable 作为生成函数的 defaults，这样做在大多数情况没有问题，因为这个函数会 inline call，后面这些 defaults 也会转成 Variable

因此在 kwdefault 里也用 `get_wrapped_items`，但从长期来看，仍然是将 `FunctionVariable` 表示改为持有多个 Variable 的形式（含 code、closure 等对应的 Variable），使得 `MAKE_FUNCTION` 不可能发生 BreakGraph，因为只是 Variable 的组合，这样才是理想的状态

PCard-66972