### PR TITLE
[CodeStyle][Typos][O-9] Ignore `operants` check

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -40,6 +40,7 @@ feeded = 'feeded'
 grad = "grad"
 Halfs = 'Halfs'
 kinf = 'kinf'
+operants = 'operants'
 Optin = 'Optin'
 padd = 'padd'
 pash = 'pash'
@@ -52,8 +53,6 @@ unpacket = "unpacket"
 vaccum = 'vaccum'
 
 # These words need to be fixed
-Operants = 'Operants'
-operants = 'operants'
 outout = 'outout'
 ouput = 'ouput'
 outpout = 'outpout'


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

ignore `operants` 检查，因为已经出现在了 API 上

PCard-66972