### PR TITLE
[XPU] zero size support for gaussian op

### DIFF
--- a/paddle/phi/kernels/xpu/gaussian_kernel.cc
+++ b/paddle/phi/kernels/xpu/gaussian_kernel.cc
@@ -30,6 +30,11 @@ void GaussianKernel(const Context& ctx,
                     DenseTensor* out) {
   out->Resize(common::make_ddim(shape.GetData()));
   T* data = ctx.template Alloc<T>(out);
+
+  if (out->numel() == 0) {
+    return;
+  }
+
   using XPUType = typename XPUTypeTrait<T>::Type;
   int64_t real_seed = seed != 0 ? seed : ctx.GetGenerator()->Random64();
 

--- a/test/xpu/test_gaussian_random_op_xpu.py
+++ b/test/xpu/test_gaussian_random_op_xpu.py
@@ -342,6 +342,13 @@ class TestStandardNormalDtype(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestZeroSizeRandN(unittest.TestCase):
+    def test_zero_size_randn(self):
+        paddle.disable_static()
+        x = paddle.randn((0,))
+        paddle.enable_static()
+
+
 support_types = get_xpu_op_support_types('gaussian_random')
 for stype in support_types:
     create_test_class(globals(), XPUTestGaussianRandomOp, stype)

--- a/tools/xpu/disable_ut_xpu_kl3.local
+++ b/tools/xpu/disable_ut_xpu_kl3.local
@@ -41,7 +41,6 @@ test_auto_checkpoint_dist_basic
 test_auto_checkpoint_multiple
 test_auto_recompute_dy2static
 test_autograd_functional_dynamic
-test_backward_without_params
 test_c_comm_init_op
 test_c_concat
 test_c_split
@@ -156,7 +155,6 @@ test_lstm
 test_masked_select_op
 test_math_op_patch_var_base
 test_matmul_weight_trans_pass
-test_median
 test_meshgrid_op
 test_mnist
 test_mnist_amp

--- a/tools/xpu/disable_ut_xpu_kl3.local
+++ b/tools/xpu/disable_ut_xpu_kl3.local
@@ -155,6 +155,7 @@ test_lstm
 test_masked_select_op
 test_math_op_patch_var_base
 test_matmul_weight_trans_pass
+test_median
 test_meshgrid_op
 test_mnist
 test_mnist_amp


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
当`randn`函数要求生成一个元素个数为0的向量的时候，底层会调用长度为0的`xpu::normal`函数，进而引发报错。本PR修复了此问题，当元素个数为0的时候，直接返回。

修复了之后，`test_backward_without_params`单测可以跑过了。