### PR TITLE
【CINN】longlong2int for dynamic shape

### DIFF
--- a/paddle/cinn/backends/codegen_device_util.cc
+++ b/paddle/cinn/backends/codegen_device_util.cc
@@ -170,10 +170,18 @@ detail::CollectBucketStrategyHostFunctionVisitor::GenDeviceKernelName(
   std::string cond_str = Predicate2String(predicate);
   // replace '-' with 'NEG'
   size_t pos = cond_str.find("-", 0);
-  const std::string replacement = "NEG";
+  std::string replacement = "NEG";
   while (pos != std::string::npos) {
     cond_str.replace(pos, 1, replacement);
     pos = cond_str.find("-", pos + replacement.length());
+  }
+
+  // replace '!' with 'NOT'
+  pos = cond_str.find("!", 0);
+  replacement = "NOT";
+  while (pos != std::string::npos) {
+    cond_str.replace(pos, 1, replacement);
+    pos = cond_str.find("!", pos + replacement.length());
   }
   VLOG(3) << "predicate string: " << cond_str;
   // NOTE(chenxi67): The kernel name is too long to be supported in cuda12.3 so

--- a/paddle/cinn/backends/codegen_device_util.cc
+++ b/paddle/cinn/backends/codegen_device_util.cc
@@ -335,7 +335,7 @@ void detail::CollectBucketStrategyHostFunctionVisitor::ProcessArgs(
                          ir::CallType::Extern,
                          ir::FunctionRef(),
                          0);
-      ir::Expr let_symbol = ir::Expr(args[i].var_arg());
+      ir::Expr let_symbol = ir::ir_utils::IRCopy(args[i].var_arg());
       let_symbol->set_type(type_of<int64_t>());
       ir::stmt::StmtRef stmt =
           ir::stmt::Let(let_symbol, call_get_value_in_kernel_args);

--- a/paddle/cinn/backends/codegen_device_util.cc
+++ b/paddle/cinn/backends/codegen_device_util.cc
@@ -187,7 +187,7 @@ detail::CollectBucketStrategyHostFunctionVisitor::GenDeviceKernelName(
   // NOTE(chenxi67): The kernel name is too long to be supported in cuda12.3 so
   // we need to curtail it.
   const std::string new_fn_name = CurTailFnName(fn_name);
-  return new_fn_name + "__COND_" + cond_str + "__kernel";
+  return new_fn_name + "_COND_" + cond_str + "__kernel";
 }
 
 void detail::CollectBucketStrategyHostFunctionVisitor::ProcessLoweredFunc(

--- a/paddle/cinn/backends/codegen_device_util.cc
+++ b/paddle/cinn/backends/codegen_device_util.cc
@@ -170,18 +170,18 @@ detail::CollectBucketStrategyHostFunctionVisitor::GenDeviceKernelName(
   std::string cond_str = Predicate2String(predicate);
   // replace '-' with 'NEG'
   size_t pos = cond_str.find("-", 0);
-  std::string replacement = "NEG";
+  const std::string replacement_neg = "NEG";
   while (pos != std::string::npos) {
-    cond_str.replace(pos, 1, replacement);
-    pos = cond_str.find("-", pos + replacement.length());
+    cond_str.replace(pos, 1, replacement_neg);
+    pos = cond_str.find("-", pos + replacement_neg.length());
   }
 
   // replace '!' with 'NOT'
   pos = cond_str.find("!", 0);
-  replacement = "NOT";
+  const std::string replacement_not = "NOT";
   while (pos != std::string::npos) {
-    cond_str.replace(pos, 1, replacement);
-    pos = cond_str.find("!", pos + replacement.length());
+    cond_str.replace(pos, 1, replacement_not);
+    pos = cond_str.find("!", pos + replacement_not.length());
   }
   VLOG(3) << "predicate string: " << cond_str;
   // NOTE(chenxi67): The kernel name is too long to be supported in cuda12.3 so

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -38,6 +38,7 @@
 #include "paddle/cinn/operator_fusion/fusion_interface.h"
 #include "paddle/cinn/optim/check_tensor_buffer_map.h"
 #include "paddle/cinn/optim/eliminate_common_global_memory_read.h"
+#include "paddle/cinn/optim/longlong2int_pass.h"
 #include "paddle/cinn/optim/schedule_block_dce.h"
 #include "paddle/cinn/optim/transform_gpu_forloop.h"
 #include "paddle/common/ddim.h"
@@ -48,6 +49,7 @@
 
 PD_DECLARE_bool(cinn_use_cuda_vectorize);
 PD_DECLARE_bool(cinn_check_tensor_buffer_map);
+PD_DECLARE_bool(cinn_longlong2int);
 const int default_priority = 100;
 
 namespace cinn {
@@ -195,49 +197,48 @@ BucketLoweredFuncsWrapper OpLowererImpl::BucketLower(
   // including preparing function args and temporary variables,
   // applying low-level optimization passes, etc.
   std::vector<ir::Expr> scheduled_func_bodies;
+  std::vector<ir::SymbolicPredicate> predicates;
   for (std::pair<ir::SymbolicPredicate, ir::Expr>& cond2body :
        cond2func_bodies) {
+    predicates.push_back(cond2body.first);
     scheduled_func_bodies.push_back(cond2body.second);
   }
   std::vector<ir::Tensor> group_func_arg_tensors_copy = group_func_arg_tensors;
   std::vector<ir::Argument> group_func_args;
   std::vector<ir::Tensor> infer_shape_tensor_args;
-  std::vector<ir::LoweredFunc> funcs = PostProcess(group,
-                                                   tensor_map,
-                                                   {scheduled_func_bodies},
-                                                   &group_func_arg_tensors_copy,
-                                                   &group_func_args,
-                                                   &infer_shape_tensor_args);
+
+  std::vector<CondFuncPriorWrapper> warps_processed =
+      PostProcess(group,
+                  tensor_map,
+                  fusion_group_info,
+                  {scheduled_func_bodies},
+                  {predicates},
+                  {priorities},
+                  &group_func_arg_tensors_copy,
+                  &group_func_args,
+                  &infer_shape_tensor_args);
   if (FLAGS_cinn_check_tensor_buffer_map) {
-    for (ir::LoweredFunc& func : funcs) {
-      optim::CheckTensorBufferMap(func->body, "BucketLower PostProcess");
+    for (auto& warp : warps_processed) {
+      optim::CheckTensorBufferMap(std::get<1>(warp)->body,
+                                  "BucketLower PostProcess");
     }
     VLOG(3) << "PostProcess tensor-buffer map check succeed";
   }
-  PADDLE_ENFORCE_EQ(funcs.size(),
-                    cond2func_bodies.size(),
-                    ::common::errors::InvalidArgument(
-                        "The size of funcs and cond2func_bodies should be "
-                        "the same."));
-  PADDLE_ENFORCE_EQ(funcs.size(),
-                    priorities.size() + 1,
-                    ::common::errors::InvalidArgument(
-                        "The size of funcs should equals to the "
-                        "size of priorities plus one."));
+
   BucketLoweredFuncsWrapper funcs_wrapper;
-  for (int i = 0; i < funcs.size() - 1; ++i) {
-    funcs_wrapper.predicate2funcs.emplace_back(
-        std::make_tuple(cond2func_bodies[i].first, funcs[i], priorities[i]));
+  for (int i = 0; i < warps_processed.size() - 1; ++i) {
+    funcs_wrapper.predicate2funcs.emplace_back(warps_processed[i]);
   }
+
   // The last func is x86 kernel.
-  for (size_t i = funcs.size() - 1; i < funcs.size(); ++i) {
-    if (funcs[i]->body == ir::Expr(-1)) {
-      continue;
-    }
-    funcs[i]->name = funcs[i]->name + "_CX86";
-    funcs_wrapper.predicate2funcsCX86.emplace_back(cond2func_bodies[i].first,
-                                                   funcs[i]);
+  auto [predicate_postprocessed, func_postprocessed, _] =
+      warps_processed[warps_processed.size() - 1];
+  if (func_postprocessed->body != ir::Expr(-1)) {
+    func_postprocessed->name = func_postprocessed->name + "_CX86";
+    funcs_wrapper.predicate2funcsCX86.emplace_back(predicate_postprocessed,
+                                                   func_postprocessed);
   }
+
   funcs_wrapper.infer_shape_func =
       GenerateInferShapeFunc(group, infer_shape_tensor_args, group_func_args);
 
@@ -258,10 +259,13 @@ std::unordered_set<std::string> CollectStoreBufferNames(
   return buffer_names;
 }
 
-std::vector<ir::LoweredFunc> OpLowererImpl::PostProcess(
+std::vector<CondFuncPriorWrapper> OpLowererImpl::PostProcess(
     const OpLoweringGroupPtr& group,
     const std::unordered_map<::pir::Value, ir::Tensor>& tensor_map,
+    const std::shared_ptr<FusionGroupInfo>& fusion_group_info,
     std::vector<ir::Expr> func_bodies,
+    std::vector<ir::SymbolicPredicate> predicates,
+    std::vector<int> priorities,
     std::vector<ir::Tensor>* group_func_arg_tensors,
     std::vector<ir::Argument>* group_func_args,
     std::vector<ir::Tensor>* infer_shape_arg_tensor) {
@@ -330,6 +334,12 @@ std::vector<ir::LoweredFunc> OpLowererImpl::PostProcess(
   std::map<int, CINNKernelInfo::SymbolArgBindInfo> mps;
   // update args for dynamic dim
   int non_tensor_arg_idx = group_func_args->size();
+
+  std::vector<ir::Argument> group_func_args_int32;
+  for (const auto& arg : *group_func_args) {
+    group_func_args_int32.emplace_back(arg);
+  }
+
   std::unordered_set<std::string> symbol_args_set;
   for (int tensor_arg_idx = 0; tensor_arg_idx < input_tensor_size;
        tensor_arg_idx++) {
@@ -348,6 +358,8 @@ std::vector<ir::LoweredFunc> OpLowererImpl::PostProcess(
           symbol_args_set.insert(symbol_name);
           group_func_args->emplace_back(
               ir::_Var_::Make(symbol_name, cinn::common::Int(64)));
+          group_func_args_int32.emplace_back(
+              ir::_Var_::Make(symbol_name, cinn::common::Int(32)));
           group->mut_symbol_args_map()[non_tensor_arg_idx++] =
               CINNKernelInfo::ArgDimIdx{tensor_arg_idx, tensor_arg_dim_idx};
           VLOG(4) << "device kernel func's " << symbol_name << " is from "
@@ -370,6 +382,8 @@ std::vector<ir::LoweredFunc> OpLowererImpl::PostProcess(
             symbol_args_set.insert(symbol_name);
             group_func_args->emplace_back(
                 ir::_Var_::Make(symbol_name, cinn::common::Int(64)));
+            group_func_args_int32.emplace_back(
+                ir::_Var_::Make(symbol_name, cinn::common::Int(32)));
             group->mut_symbol_args_map()[non_tensor_arg_idx++] =
                 CINNKernelInfo::ArgValueIdx{tensor_arg_idx, value_idx};
             VLOG(4) << "device kernel func's " << symbol_name << " is from "
@@ -381,7 +395,11 @@ std::vector<ir::LoweredFunc> OpLowererImpl::PostProcess(
     AddDimSymbolArgs();
     AddValueSymbolArgs();
   }
-  std::vector<ir::LoweredFunc> lowered_funcs;
+
+  std::vector<ir::LoweredFunc> ret_lowered_funcs;
+  std::vector<ir::SymbolicPredicate> ret_predicates;
+  std::vector<int> ret_priorities;
+
   for (int i = 0; i < func_bodies.size(); ++i) {
     ir::Expr func_body = func_bodies[i];
     optim::EliminateDeadScheduleBlock(&(func_body), group->output_names());
@@ -416,14 +434,87 @@ std::vector<ir::LoweredFunc> OpLowererImpl::PostProcess(
       func = optim::Optimize(func, common::DefaultHostTarget(), false);
     }
     func->num_output_tensors = infer_shape_arg_tensor->size();
-    lowered_funcs.push_back(std::move(func));
+
+    if (FLAGS_cinn_longlong2int && i != func_bodies.size() - 1) {
+      if (fusion_group_info->is_dynamic) {
+        ir::LoweredFunc func_int32 = ir::_LoweredFunc_::Make(
+            group->FuncName(), group_func_args_int32, func_body, temp_buffers);
+        ir::Expr predicates_copied = ir::ir_utils::IRCopy(predicates[i]);
+
+        ir::Expr elems_num(1);
+        for (const auto& loop : fusion_group_info->loop_ranges_expr) {
+          elems_num = ir::Mul::Make(elems_num, loop);
+        }
+        VLOG(10) << "elems_num in dynamic branch: " << elems_num;
+
+        // Deal with predicates, set original predicates to range int64
+        ir::Expr predicate_int32 = ir::And::Make(
+            predicates_copied, ir::LT::Make(elems_num, ir::Expr(INT32_MAX)));
+        predicates[i] = ir::And::Make(
+            predicates[i], ir::GE::Make(elems_num, ir::Expr(INT32_MAX)));
+
+        ir::stmt::BlockRef block =
+            ir::ConvertExprBlockToStmtBlock(func_int32->body);
+        VLOG(10) << "Before CastLonglong2Int: \n" << block;
+
+        optim::TryCastLonglong2Int(block, /*enforce_cast*/ true);
+        VLOG(10) << "After CastLonglong2Int: \n" << block;
+        func_int32->body = ir::ConvertStmtBlockToExprBlock(block);
+
+        ret_predicates.push_back(std::move(predicate_int32));
+        ret_lowered_funcs.push_back(std::move(func_int32));
+        ret_priorities.push_back(priorities[i]);
+      } else {
+        // static branch
+        ir::stmt::BlockRef block = ir::ConvertExprBlockToStmtBlock(func->body);
+
+        int64_t elems_num = 1;
+        for (const auto& loop : fusion_group_info->loop_ranges) {
+          elems_num *= loop;
+        }
+        VLOG(10) << "elems_num in static branch: " << elems_num;
+        VLOG(10) << "Before CastLonglong2Int: \n" << block;
+        optim::TryCastLonglong2Int(block,
+                                   /*enforce_cast*/ elems_num < INT32_MAX);
+        VLOG(10) << "After CastLonglong2Int: \n" << block;
+        func->body = ir::ConvertStmtBlockToExprBlock(block);
+      }
+    }
+
+    ret_predicates.push_back(std::move(predicates[i]));
+    ret_lowered_funcs.push_back(std::move(func));
+    // host func has no priority, since tuples require alignment, set -1 here.
+    if (i != func_bodies.size() - 1) {
+      ret_priorities.push_back(std::move(priorities[i]));
+    } else {
+      ret_priorities.push_back(-1);
+    }
   }
 
   // 5. Unify temp_space args and set temp_space sizes
-  UnifyTempSpaceArgs(&lowered_funcs);
-  group->mut_temp_space_sizes() = CollectTempSpaceSizes(lowered_funcs);
+  UnifyTempSpaceArgs(&ret_lowered_funcs);
+  group->mut_temp_space_sizes() = CollectTempSpaceSizes(ret_lowered_funcs);
 
-  return lowered_funcs;
+  std::vector<CondFuncPriorWrapper> ret_tuples;
+
+  PADDLE_ENFORCE_EQ(
+      ret_lowered_funcs.size(),
+      ret_predicates.size(),
+      ::common::errors::InvalidArgument(
+          "The size of ret_lowered_funcs and ret_predicates should be "
+          "the same."));
+  PADDLE_ENFORCE_EQ(
+      ret_lowered_funcs.size(),
+      ret_priorities.size(),
+      ::common::errors::InvalidArgument(
+          "The size of ret_lowered_funcs and ret_priorities should be "
+          "the same."));
+  for (size_t i = 0; i < ret_lowered_funcs.size(); ++i) {
+    ret_tuples.emplace_back(std::move(ret_predicates[i]),
+                            std::move(ret_lowered_funcs[i]),
+                            std::move(ret_priorities[i]));
+  }
+  return ret_tuples;
 }
 
 std::vector<ir::stmt::BlockRef> OpLowererImpl::LowerOps(

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -434,12 +434,12 @@ std::vector<CondFuncPriorWrapper> OpLowererImpl::PostProcess(
     func->num_output_tensors = infer_shape_arg_tensor->size();
 
     // 5. Apply longlong2int pass
-    LongLong2Int(func,
-                 symbol_args_set,
+    LongLong2Int(symbol_args_set,
                  fusion_group_info->loop_ranges_expr,
                  inputs_element_size,
                  priorities[i],
                  &predicates[i],
+                 &func,
                  &ret_predicates,
                  &ret_lowered_funcs,
                  &ret_priorities);

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -434,16 +434,17 @@ std::vector<CondFuncPriorWrapper> OpLowererImpl::PostProcess(
     func->num_output_tensors = infer_shape_arg_tensor->size();
 
     // 5. Apply longlong2int pass
-    LongLong2Int(symbol_args_set,
-                 fusion_group_info->loop_ranges_expr,
-                 inputs_element_size,
-                 priorities[i],
-                 &predicates[i],
-                 &func,
-                 &ret_predicates,
-                 &ret_lowered_funcs,
-                 &ret_priorities);
-
+    if (i != func_bodies.size() - 1) {
+      LongLong2Int(symbol_args_set,
+                   fusion_group_info->loop_ranges_expr,
+                   inputs_element_size,
+                   priorities[i],
+                   &predicates[i],
+                   &func,
+                   &ret_predicates,
+                   &ret_lowered_funcs,
+                   &ret_priorities);
+    }
     ret_predicates.push_back(std::move(predicates[i]));
     ret_lowered_funcs.push_back(std::move(func));
     // host func has no priority, since tuples require alignment, set -1 here.

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
@@ -68,7 +68,10 @@ class OpLowererImpl : public OpLowererImplBase<OpLoweringGroupPtr> {
    * variables, applying low-level optimization passes, etc.
    * @param group The group to be lowered.
    * @param tensor_map All tensors used for calculating the group.
+   * @param fusion_group_info The info of the fusion group.
    * @param func_bodies The scheduled func bodies of group.
+   * @param predicates The symbolic predicate of each func.
+   * @param priorities The priority of each func.
    * @param group_func_arg_tensors Tensors used as the group function arguments.
    * @param group_func_args Arguments used as the group function arguments.
    * @return The lowered funcs after the post processing.

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
@@ -41,6 +41,8 @@ namespace pir {
 
 class PrettyNamer;
 using OpLoweringGroupPtr = std::shared_ptr<OpLoweringGroup>;
+using CondFuncPriorWrapper =
+    std::tuple<ir::SymbolicPredicate, ir::LoweredFunc, int>;
 
 using cinn::common::Target;
 class OpLowererImpl;
@@ -71,10 +73,13 @@ class OpLowererImpl : public OpLowererImplBase<OpLoweringGroupPtr> {
    * @param group_func_args Arguments used as the group function arguments.
    * @return The lowered funcs after the post processing.
    */
-  std::vector<ir::LoweredFunc> PostProcess(
+  std::vector<CondFuncPriorWrapper> PostProcess(
       const OpLoweringGroupPtr& group,
       const std::unordered_map<::pir::Value, ir::Tensor>& tensor_map,
+      const std::shared_ptr<FusionGroupInfo>& fusion_group_info,
       std::vector<ir::Expr> func_bodies,
+      std::vector<ir::SymbolicPredicate> predicates,
+      std::vector<int> priorities,
       std::vector<ir::Tensor>* group_func_arg_tensors,
       std::vector<ir::Argument>* group_func_args,
       std::vector<ir::Tensor>* infer_shape_arg_tensor);

--- a/paddle/cinn/hlir/framework/pir/op_lowering_util.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_util.cc
@@ -17,15 +17,20 @@
 #include <algorithm>
 #include <unordered_set>
 #include "glog/logging.h"
+#include "paddle/cinn/common/ir_util.h"
 #include "paddle/cinn/hlir/framework/pir/utils.h"
 #include "paddle/cinn/hlir/pe/nn_util.h"
 #include "paddle/cinn/ir/ir.h"
 #include "paddle/cinn/ir/schedule/ir_schedule_util.h"
 #include "paddle/cinn/ir/utils/ir_nodes_collector.h"
+#include "paddle/cinn/optim/longlong2int_pass.h"
 #include "paddle/cinn/utils/string.h"
 #include "paddle/common/enforce.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_attribute.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+
+PD_DECLARE_bool(cinn_longlong2int);
+
 namespace cinn {
 namespace hlir {
 namespace framework {
@@ -1279,6 +1284,97 @@ std::vector<int64_t> CollectTempSpaceSizes(
     }
   }
   return sizes;
+}
+
+void LongLong2Int(const ir::LoweredFunc& func,
+                  const std::unordered_set<std::string> symbol_args_set,
+                  const std::vector<ir::Expr>& loop_ranges_expr,
+                  const std::vector<Expr>& inputs_element_size,
+                  int priorities,
+                  ir::Expr* predicates,
+                  std::vector<ir::Expr>* ret_predicates,
+                  std::vector<ir::LoweredFunc>* ret_lowered_funcs,
+                  std::vector<int>* ret_priorities) {
+  if (!FLAGS_cinn_longlong2int) return;
+  // Helper func for lonnglong2int pass.
+  auto JudgeDynamic = [](const std::vector<cinn::ir::Expr>& loops) {
+    for (const auto& loop : loops) {
+      if (!loop.is_constant()) return true;
+    }
+    return false;
+  };
+
+  auto DealPerdicateCond =
+      [](const ir::Expr& max_output_size,
+         const std::vector<ir::Expr>& inputs_element_size) {
+        ir::Expr pred_longlong2int = ir::Expr(true);
+        std::unordered_set<ir::Expr> perd_set;
+        for (const auto& size : inputs_element_size) {
+          if (!size.is_constant() && perd_set.count(size) == 0) {
+            pred_longlong2int = ir::And::Make(
+                pred_longlong2int, ir::LE::Make(size, ir::Expr(INT32_MAX)));
+            perd_set.insert(size);
+          }
+        }
+        if (!max_output_size.is_constant() &&
+            perd_set.count(max_output_size) == 0) {
+          pred_longlong2int =
+              ir::And::Make(pred_longlong2int,
+                            ir::LE::Make(max_output_size, ir::Expr(INT32_MAX)));
+        }
+        return pred_longlong2int;
+      };
+  // The loop ranges product of Fusion group info is the max elements size
+  // for output, we dont need to calculate every output independently.
+  ir::Expr outputs_element_max_size =
+      cinn::optim::ArithSimplify(common::FoldExpr(
+          [](const Expr& a, const Expr& b) { return ir::Mul::Make(a, b); },
+          loop_ranges_expr));
+  bool is_dynamic = JudgeDynamic(inputs_element_size) ||
+                    !outputs_element_max_size.is_constant();
+  if (is_dynamic) {
+    // Copy lowered_func and predicate for type int32 in dynamic branch.
+    ir::LoweredFunc func_copied = ir::ir_utils::IRCopy(func);
+    ir::Expr predicates_copied = ir::ir_utils::IRCopy(*predicates);
+
+    // Deal longlong2int predicates, calculate all elements size.
+    ir::Expr pred_longlong2int =
+        DealPerdicateCond(outputs_element_max_size, inputs_element_size);
+
+    // New predicate for int32.
+    ir::Expr predicate_int32 =
+        ir::And::Make(predicates_copied, pred_longlong2int);
+
+    // Old predicate for int64.
+    *predicates = ir::And::Make(*predicates, ir::Not::Make(pred_longlong2int));
+
+    // Enforce cast the func copied in dynamic branch.
+    VLOG(6) << "Before CastLonglong2Int In Dynamic Branch: \n" << func_copied;
+    optim::TryCastLonglong2Int(
+        func_copied, symbol_args_set, /*enforce_cast*/ true);
+    VLOG(6) << "After CastLonglong2Int In Dynamic Branch: \n" << func_copied;
+
+    // Add int32 func and predicate. int64 branch is handled by default.
+    ret_predicates->push_back(std::move(predicate_int32));
+    ret_lowered_funcs->push_back(std::move(func_copied));
+    ret_priorities->push_back(priorities);
+  } else {
+    // static branch, Here we have enough information to determine whether
+    // it is safe to transpose, so there is no need to enter the pass to
+    // determine according to the for loop range.
+    auto can_cast = [&]() {
+      for (const auto& size : inputs_element_size) {
+        if (size.as_int64() >= INT32_MAX) return false;
+      }
+      if (outputs_element_max_size.as_int64() >= INT32_MAX) return false;
+      return true;
+    }();
+
+    VLOG(6) << "Before CastLonglong2Int In Static Branch: \n" << func;
+    optim::TryCastLonglong2Int(
+        func, symbol_args_set, /*enforce_cast*/ can_cast);
+    VLOG(6) << "After CastLonglong2Int In Static Branch: \n" << func;
+  }
 }
 
 }  // namespace pir

--- a/paddle/cinn/hlir/framework/pir/op_lowering_util.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_util.cc
@@ -1286,12 +1286,12 @@ std::vector<int64_t> CollectTempSpaceSizes(
   return sizes;
 }
 
-void LongLong2Int(const ir::LoweredFunc& func,
-                  const std::unordered_set<std::string> symbol_args_set,
+void LongLong2Int(const std::unordered_set<std::string> symbol_args_set,
                   const std::vector<ir::Expr>& loop_ranges_expr,
                   const std::vector<Expr>& inputs_element_size,
                   int priorities,
                   ir::Expr* predicates,
+                  ir::LoweredFunc* func,
                   std::vector<ir::Expr>* ret_predicates,
                   std::vector<ir::LoweredFunc>* ret_lowered_funcs,
                   std::vector<int>* ret_priorities) {
@@ -1334,7 +1334,7 @@ void LongLong2Int(const ir::LoweredFunc& func,
                     !outputs_element_max_size.is_constant();
   if (is_dynamic) {
     // Copy lowered_func and predicate for type int32 in dynamic branch.
-    ir::LoweredFunc func_copied = ir::ir_utils::IRCopy(func);
+    ir::LoweredFunc func_copied = ir::ir_utils::IRCopy(*func);
     ir::Expr predicates_copied = ir::ir_utils::IRCopy(*predicates);
 
     // Deal longlong2int predicates, calculate all elements size.
@@ -1372,7 +1372,7 @@ void LongLong2Int(const ir::LoweredFunc& func,
 
     VLOG(6) << "Before CastLonglong2Int In Static Branch: \n" << func;
     optim::TryCastLonglong2Int(
-        func, symbol_args_set, /*enforce_cast*/ can_cast);
+        *func, symbol_args_set, /*enforce_cast*/ can_cast);
     VLOG(6) << "After CastLonglong2Int In Static Branch: \n" << func;
   }
 }

--- a/paddle/cinn/hlir/framework/pir/op_lowering_util.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_util.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <queue>
 
+#include <unordered_set>
 #include "paddle/cinn/hlir/framework/pir/op_lowering_group.h"
 #include "paddle/cinn/ir/schedule/ir_schedule.h"
 #include "paddle/cinn/ir/tensor.h"
@@ -92,6 +93,17 @@ void UnifyTempSpaceArgs(std::vector<ir::LoweredFunc>* funcs);
 std::vector<int64_t> CollectTempSpaceSizes(
     const std::vector<ir::LoweredFunc>& funcs);
 
+/* apply longlong2int pass on func, it will add a int32 branch into buckets, and
+ * the original branch predicates will be changed */
+void LongLong2Int(const ir::LoweredFunc& func,
+                  const std::unordered_set<std::string> symbol_args_set,
+                  const std::vector<ir::Expr>& loop_ranges_expr,
+                  const std::vector<Expr>& inputs_element_size,
+                  int priorities,
+                  ir::Expr* predicates,
+                  std::vector<ir::Expr>* ret_predicates,
+                  std::vector<ir::LoweredFunc>* ret_lowered_funcs,
+                  std::vector<int>* ret_priorities);
 }  // namespace pir
 }  // namespace framework
 }  // namespace hlir

--- a/paddle/cinn/hlir/framework/pir/op_lowering_util.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_util.h
@@ -93,14 +93,14 @@ void UnifyTempSpaceArgs(std::vector<ir::LoweredFunc>* funcs);
 std::vector<int64_t> CollectTempSpaceSizes(
     const std::vector<ir::LoweredFunc>& funcs);
 
-/* apply longlong2int pass on func, it will add a int32 branch into buckets, and
+/* Apply longlong2int pass on func, it will add a int32 branch into buckets, and
  * the original branch predicates will be changed */
-void LongLong2Int(const ir::LoweredFunc& func,
-                  const std::unordered_set<std::string> symbol_args_set,
+void LongLong2Int(const std::unordered_set<std::string> symbol_args_set,
                   const std::vector<ir::Expr>& loop_ranges_expr,
                   const std::vector<Expr>& inputs_element_size,
                   int priorities,
                   ir::Expr* predicates,
+                  ir::LoweredFunc* func,
                   std::vector<ir::Expr>* ret_predicates,
                   std::vector<ir::LoweredFunc>* ret_lowered_funcs,
                   std::vector<int>* ret_priorities);

--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
@@ -557,7 +557,6 @@ std::shared_ptr<FusionGroupInfo> GetFusionGroupInfo(
       if (group_info->reduce_var_name.empty()) {
         std::vector<ir::Var> all_iters =
             AppendBound(GetAllForIters(body), body);
-        bool has_dynamic = false;
         std::transform(all_iters.begin(),
                        all_iters.end(),
                        std::back_inserter(group_info->loop_ranges),
@@ -567,21 +566,18 @@ std::shared_ptr<FusionGroupInfo> GetFusionGroupInfo(
                          if (var->upper_bound.is_constant()) {
                            return var->upper_bound.as_int64();
                          } else {
-                           has_dynamic = true;
                            return (int64_t)-1;
                          }
                        });
-        if (has_dynamic) {
-          std::transform(all_iters.begin(),
-                         all_iters.end(),
-                         std::back_inserter(group_info->loop_ranges_expr),
-                         [](const ir::Var var) {
-                           VLOG(4) << "Var is : : " << var;
-                           VLOG(4)
-                               << "Var->upper_bound_sym: " << var->upper_bound;
-                           return var->upper_bound;
-                         });
-        }
+        std::transform(all_iters.begin(),
+                       all_iters.end(),
+                       std::back_inserter(group_info->loop_ranges_expr),
+                       [](const ir::Var var) {
+                         VLOG(4) << "Var is : : " << var;
+                         VLOG(4)
+                             << "Var->upper_bound_sym: " << var->upper_bound;
+                         return var->upper_bound;
+                       });
         std::vector<ir::Var> reduce_iters = fusion::FilterVector(
             all_iters, [](const ir::Var& var) { return var->is_reduce_axis; });
         for (int64_t i = all_iters.size() - reduce_iters.size();

--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
@@ -566,21 +566,18 @@ std::shared_ptr<FusionGroupInfo> GetFusionGroupInfo(
                          if (var->upper_bound.is_constant()) {
                            return var->upper_bound.as_int64();
                          } else {
-                           group_info->is_dynamic = true;
                            return (int64_t)-1;
                          }
                        });
-        if (group_info->is_dynamic) {
-          std::transform(all_iters.begin(),
-                         all_iters.end(),
-                         std::back_inserter(group_info->loop_ranges_expr),
-                         [&](const ir::Var var) {
-                           VLOG(4) << "Var is : : " << var;
-                           VLOG(4)
-                               << "Var->upper_bound_sym: " << var->upper_bound;
-                           return var->upper_bound;
-                         });
-        }
+        std::transform(all_iters.begin(),
+                       all_iters.end(),
+                       std::back_inserter(group_info->loop_ranges_expr),
+                       [&](const ir::Var var) {
+                         VLOG(4) << "Var is : : " << var;
+                         VLOG(4)
+                             << "Var->upper_bound_sym: " << var->upper_bound;
+                         return var->upper_bound;
+                       });
         std::vector<ir::Var> reduce_iters = fusion::FilterVector(
             all_iters, [](const ir::Var& var) { return var->is_reduce_axis; });
         for (int64_t i = all_iters.size() - reduce_iters.size();

--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
@@ -169,20 +169,24 @@ struct GroupVectorizeInfo {
 
 struct FusionGroupInfo {
   std::vector<int64_t> loop_ranges;
+  std::vector<ir::Expr> loop_ranges_expr;
   std::vector<int64_t> loop_strides;
   std::vector<int64_t> reduce_axis;
   std::vector<std::string> reduce_var_name;
   bool can_apply_grid_reduce;
+  bool is_dynamic{false};
   GroupVectorizeInfo vectorize_info;
 
   std::string DebugPrint() {
     std::stringstream ss;
     ss << "GroupInfo\nloop_ranges: " << cinn::utils::Join(loop_ranges, " ")
+       << "\nloop_ranges_expr: " << cinn::utils::Join(loop_ranges_expr, ", ")
        << "\nloop_strides: " << cinn::utils::Join(loop_strides, ", ")
        << "\nreduce_axis: " << cinn::utils::Join(reduce_axis, " ")
        << "\nreduce_var_name: " << cinn::utils::Join(reduce_var_name, " ")
        << "\ncan_apply_grid_reduce: " << can_apply_grid_reduce
        << "\ncan_apply_vectorize: " << vectorize_info.can_apply_vectorize
+       << "\nis_dynamic: : " << is_dynamic
        << "\nhas_select_op: " << vectorize_info.has_select_op
        << "\ncontinuous_arg_nums: " << vectorize_info.continuous_arg_nums
        << "\nfusion_group_arg_nums: " << vectorize_info.fusion_group_arg_nums;

--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
@@ -174,7 +174,6 @@ struct FusionGroupInfo {
   std::vector<int64_t> reduce_axis;
   std::vector<std::string> reduce_var_name;
   bool can_apply_grid_reduce;
-  bool is_dynamic{false};
   GroupVectorizeInfo vectorize_info;
 
   std::string DebugPrint() {
@@ -186,7 +185,6 @@ struct FusionGroupInfo {
        << "\nreduce_var_name: " << cinn::utils::Join(reduce_var_name, " ")
        << "\ncan_apply_grid_reduce: " << can_apply_grid_reduce
        << "\ncan_apply_vectorize: " << vectorize_info.can_apply_vectorize
-       << "\nis_dynamic: : " << is_dynamic
        << "\nhas_select_op: " << vectorize_info.has_select_op
        << "\ncontinuous_arg_nums: " << vectorize_info.continuous_arg_nums
        << "\nfusion_group_arg_nums: " << vectorize_info.fusion_group_arg_nums;

--- a/paddle/cinn/ir/ir_base.cc
+++ b/paddle/cinn/ir/ir_base.cc
@@ -628,7 +628,11 @@ void IrNode::convert_int64_to_int32() {
   if (type_ == UInt(64)) type_ = UInt(32);
 
   for (Expr &operand : operands) {
-    operand->convert_int64_to_int32();
+    if (operand->node_type() == IrNodeTy::Load) {
+      operand = ir::Cast::Make(Int(32), operand);
+    } else {
+      operand->convert_int64_to_int32();
+    }
   }
 }
 

--- a/paddle/cinn/ir/ir_base.cc
+++ b/paddle/cinn/ir/ir_base.cc
@@ -663,7 +663,6 @@ void TryElevateInt32ToInt64(const std::vector<Expr> &expr_vec) {
 void TryElevateInt64ToInt32(const std::vector<Expr> &expr_vec) {
   for (const Expr &expr : expr_vec) {
     if (!expr.is_index()) return;
-    if (expr.as_index().IsDynamic()) return;
   }
 
   for (const Expr &expr : expr_vec) {

--- a/paddle/cinn/optim/ir_simplify.cc
+++ b/paddle/cinn/optim/ir_simplify.cc
@@ -507,6 +507,7 @@ void SimplifyBlocks(Expr* expr) { SimplifyBlocksMutator()(expr); }
 void SimplifyLogical(Expr* expr) { SimplifyLogicalMutator()(expr); }
 
 Expr ArithSimplify(const Expr& u) {
+  VLOG(3) << "Begin ArithSimplify " << u;
   if (!u.is_index()) return u;
   auto copied = ir_utils::IRCopy(u);
   return copied.as_index().Normalize();

--- a/paddle/cinn/optim/longlong2int_pass.cc
+++ b/paddle/cinn/optim/longlong2int_pass.cc
@@ -249,8 +249,11 @@ bool CanApplyLongLong2Int(ir::stmt::BlockRef block) {
   return !check_overflow(block);
 }
 
-void TryCastLonglong2Int(ir::stmt::BlockRef block) {
-  if (CanApplyLongLong2Int(block)) {
+void TryCastLonglong2Int(ir::stmt::BlockRef block,
+                         std::optional<bool> enforce_cast) {
+  bool can_cast = enforce_cast.has_value() ? enforce_cast.value()
+                                           : CanApplyLongLong2Int(block);
+  if (can_cast) {
     StmtPassManager stmt_pass_manager;
     stmt_pass_manager.AddPass(CreateLongLong2IntStmtPass());
     ExprPassManager expr_pass_manager;

--- a/paddle/cinn/optim/longlong2int_pass.h
+++ b/paddle/cinn/optim/longlong2int_pass.h
@@ -86,7 +86,14 @@ namespace optim {
  *   }
  * }
  */
-void TryCastLonglong2Int(ir::stmt::BlockRef block,
+// if enforce_cast is not null, pass will run only if enforce_cast is true. if
+// enforce_cast is null, pass will run by default.
+bool TryCastLonglong2Int(ir::stmt::BlockRef block,
+                         std::optional<bool> enforce_cast = std::nullopt);
+
+// the lowered_func's args in symbol_args_set will be changed to int32
+bool TryCastLonglong2Int(ir::LoweredFunc& func,  // NOLINT
+                         const std::unordered_set<std::string>& symbol_args_set,
                          std::optional<bool> enforce_cast = std::nullopt);
 
 }  // namespace optim

--- a/paddle/cinn/optim/longlong2int_pass.h
+++ b/paddle/cinn/optim/longlong2int_pass.h
@@ -86,7 +86,8 @@ namespace optim {
  *   }
  * }
  */
-void TryCastLonglong2Int(ir::stmt::BlockRef block);
+void TryCastLonglong2Int(ir::stmt::BlockRef block,
+                         std::optional<bool> enforce_cast = std::nullopt);
 
 }  // namespace optim
 }  // namespace cinn

--- a/paddle/cinn/optim/transform_gpu_forloop.cc
+++ b/paddle/cinn/optim/transform_gpu_forloop.cc
@@ -501,15 +501,6 @@ void OptimizeExprGPU(Expr *expr) {
   VLOG(10) << "After EliminateCommonFactorOfLocalIndex: \n" << *expr;
 
   ResizeBufferToMaxVarRange(expr);
-
-  if (FLAGS_cinn_longlong2int) {
-    ir::stmt::BlockRef block = ir::ConvertExprBlockToStmtBlock(*expr);
-    VLOG(10) << "Before CastLonglong2Int: \n" << block;
-    TryCastLonglong2Int(block);
-    VLOG(10) << "After CastLonglong2Int: \n" << block;
-    *expr = ir::ConvertStmtBlockToExprBlock(block);
-  }
-
   VLOG(4) << "After Optimize Expr: \n" << *expr;
 }
 

--- a/paddle/cinn/optim/transform_gpu_forloop.cc
+++ b/paddle/cinn/optim/transform_gpu_forloop.cc
@@ -31,7 +31,6 @@
 #include "paddle/cinn/ir/utils/stmt_converter.h"
 #include "paddle/cinn/optim/eliminate_common_factor_of_local_index.h"
 #include "paddle/cinn/optim/ir_simplify.h"
-#include "paddle/cinn/optim/longlong2int_pass.h"
 #include "paddle/cinn/optim/replace_var_with_expr.h"
 #include "paddle/cinn/optim/resize_buffer.h"
 #include "paddle/cinn/optim/update_buffer_axis_pass.h"
@@ -42,7 +41,6 @@
 #include "paddle/cinn/utils/string.h"
 #include "paddle/common/enforce.h"
 
-PD_DECLARE_bool(cinn_longlong2int);
 namespace cinn {
 namespace optim {
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
本 PR 为升级动态 shape 下 longlong2int pass
代码结构主要变动如下：
1.  FusionGroupInfo 中加入 loop_ranges_expr 描述 Fusion 中 loop，当存在动态 shape 时，与 loop_ranges 区别如下：
```
loop_ranges: 2,32,16,-1,32
loop_ranges_expr: 2,32,16,S0,32
```
2. PostProcess 返回值由 `std::vector<LoweredFunc>` 变更为 `std::vector<CondFuncPriorWrapper>`，方便在 PostProcess 中添加新的 buckets 分支
3. TryCastLonglong2Int 接受 enforce 参数，输入该参数时强制是否执行类型转换
4. 重载 TryCastLonglong2Int 接受 Lowered_func 参数，支持修改 func args 及 axis_info 类型：
同步修改 axis_info 类型是因为 kernel 中存在类似` __builtin_assume((int)threadIdx.x < min(S0, 32ll))`。32ll 为 int64，S0 为 int32 导致 nvrtc 编译报错


结果输出表现：
1. Host kernel 中对每一个 buckets 对应增加 int32 branch及 int64 branch，但两者只进行一次 `GroupSchedule` 及 `PostProcess` 避免增加编译耗时：
 <img width="920" alt="image" src="https://github.com/user-attachments/assets/db87e5f4-1ed8-48c8-9873-3e3036b63a63" />

2. 因 cinn_get_value_in_cuda_kernel_args 固定返回 int64，所以 Host kernel 中所有符号及表达式均使用 int64 表示，避免 Lower LLVM IR 时类型不匹配编译报错
3. Device kernel 中 int32 branch 函数符号参数（S0,S1...）对应更改为 int32

Pcard-67164