### PR TITLE
[CINN] Support printing name of cinn kernel

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
@@ -87,7 +87,7 @@ void OperatorDialect::PrintAttribute(pir::Attribute attr,
   } else if (attr.isa<CINNKernelInfoAttribute>()) {
     auto cinn_kernel_info = attr.dyn_cast<CINNKernelInfoAttribute>();
 
-    os << "(" << cinn_kernel_info.data().fn_ptr;
+    os << "(" << cinn_kernel_info.data().fn_name;
     os << ')';
   } else if (attr.isa<FusionTrackerPtrAttribute>()) {
     auto tracker = attr.dyn_cast<FusionTrackerPtrAttribute>();

--- a/paddle/cinn/hlir/framework/pir/utils.cc
+++ b/paddle/cinn/hlir/framework/pir/utils.cc
@@ -657,8 +657,29 @@ std::string CompatibleInfo::OpName(const ::pir::Operation& op) {
   return OpNameAfterStripDialect(op);
 }
 
+std::string ShortenOpName(const std::string& name) {
+  static const std::unordered_map<std::string, std::string> OP_SHORT_NAMES = {
+      {"fill_constant", "full"},
+      {"reduce_sum", "sum"},
+      {"reduce_max", "r_max"},
+      {"reduce_min", "r_min"},
+      {"reduce_prod", "prod"},
+      {"elementwise_add", "add"},
+      {"elementwise_mul", "mul"},
+      {"subtract", "sub"},
+      {"divide", "div"},
+      {"broadcast_to", "bc"},
+      {"generate_shape", "gs"},
+      {"yield_store", "yield"},
+  };
+  if (OP_SHORT_NAMES.count(name)) {
+    return OP_SHORT_NAMES.at(name);
+  }
+  return name;
+}
+
 std::string CompatibleInfo::OpFuncName(const ::pir::Operation& op) {
-  std::string op_name = OpName(op);
+  std::string op_name = ShortenOpName(OpName(op));
   std::string func_name =
       cinn::common::Context::Global().NewName("fn_" + op_name);
   return func_name;
@@ -668,7 +689,7 @@ std::string CompatibleInfo::GroupOpsName(
     const std::vector<::pir::Operation*>& ops) {
   std::string name = "fn_";
   for (auto* op : ops) {
-    name += OpName(*op);
+    name += ShortenOpName(OpName(*op));
     name += "_";
   }
   return cinn::common::Context::Global().NewName(name);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

1. cinn_jit_kernel 支持打印kernel 原始fn_name, 示例如下：
```
(%10, %11) = "cinn_runtime.jit_kernel" [id:277] (%5, %7, %9, %1, %3) {exec_backend:Place(gpu:0),kernel_info:(fn_reshape_reshape_reshape_gather_nd_reshape_gather_nd_reshape_bc_mul_slice_slice_scale_concat_bc_mul_add_yield_bc_mul_slice_slice_scale_concat_bc_mul_add_yield_),origin_id:265} : (gpu_tensor<1x2048x1x96xf32>, gpu_tensor<1x2048x1x96xf32>, gpu_tensor<1x2048xi64>, gpu_tensor<61x2048x8x96xf32>, gpu_tensor<61x2048x8x96xf32>) -> gpu_tensor<61x2048x8x96xf32>, gpu_tensor<61x2048x8x96xf32>
```
2. 压缩 cinn kernel函数名的字符串长度