### PR TITLE
Fix typos SyncCalcuStream SyncCalcStream

### DIFF
--- a/paddle/fluid/distributed/collective/async_load.cc
+++ b/paddle/fluid/distributed/collective/async_load.cc
@@ -48,9 +48,9 @@ std::shared_ptr<AsyncLoad::Task> AsyncLoad::CreateTask(const Place& place) {
   return std::make_shared<AsyncLoad::Task>(place);
 }
 
-void AsyncLoad::SyncCalcuStream(const Place& place,
-                                phi::GPUContext* ctx,
-                                platform::DeviceEvent& calc_event) {  // NOLINT
+void AsyncLoad::SyncCalcStream(const Place& place,
+                               phi::GPUContext* ctx,
+                               platform::DeviceEvent& calc_event) {  // NOLINT
   const auto* calc_ctx = static_cast<phi::GPUContext*>(
       phi::DeviceContextPool::Instance().Get(place));
   calc_event.Record(calc_ctx);
@@ -85,7 +85,7 @@ std::shared_ptr<AsyncLoad::Task> AsyncLoad::Offload(
         key, platform::DeviceEvent(place, platform::GenerateDeviceEventFlag()));
     load_ctx_ = std::make_unique<phi::GPUContext>(place);
   }
-  SyncCalcuStream(gpu_place_, load_ctx_.get(), place_to_calc_event_.at(key));
+  SyncCalcStream(gpu_place_, load_ctx_.get(), place_to_calc_event_.at(key));
 
   // 2. copy data from src to dst
   auto stream = load_ctx_->stream();
@@ -158,7 +158,7 @@ std::shared_ptr<AsyncLoad::Task> AsyncLoad::OffloadWithOffset(
         key, platform::DeviceEvent(place, platform::GenerateDeviceEventFlag()));
     load_ctx_ = std::move(std::make_unique<phi::GPUContext>(place));
   }
-  SyncCalcuStream(gpu_place_, load_ctx_.get(), place_to_calc_event_.at(key));
+  SyncCalcStream(gpu_place_, load_ctx_.get(), place_to_calc_event_.at(key));
 
   // 2. copy data from src to dst
   auto stream = load_ctx_->stream();
@@ -202,7 +202,7 @@ std::shared_ptr<AsyncLoad::Task> AsyncLoad::Reload(
   // 1. wait calc stream to finish
   std::string key = "load";
 
-  SyncCalcuStream(gpu_place_, load_ctx_.get(), place_to_calc_event_.at(key));
+  SyncCalcStream(gpu_place_, load_ctx_.get(), place_to_calc_event_.at(key));
 
   // 2. copy data from src to dst
   auto stream = load_ctx_->stream();

--- a/paddle/fluid/distributed/collective/async_load.h
+++ b/paddle/fluid/distributed/collective/async_load.h
@@ -59,9 +59,9 @@ class AsyncLoad {
       size_t offload_size);
 
   void PrepareLoadEnv(const std::string& key, const Place& place);
-  void SyncCalcuStream(const Place& place,
-                       phi::GPUContext* ctx,
-                       platform::DeviceEvent& calc_event);  // NOLINT
+  void SyncCalcStream(const Place& place,
+                      phi::GPUContext* ctx,
+                      platform::DeviceEvent& calc_event);  // NOLINT
   std::shared_ptr<AsyncLoad::Task> Reload(phi::DenseTensor* dst,
                                           const phi::DenseTensor& src);
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Fix SyncCalcuStream SyncCalcStream
paddle/phi/core/distributed/collective/process_group.h 中使用的是 calc_stream
![image](https://github.com/user-attachments/assets/28fc86c0-6356-46d9-ad65-4ae2cc02defa)
