### PR TITLE
[View] Change `view_shape_grad` to use invoke `view_shape` 

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -2699,7 +2699,12 @@ class DygraphNodeGenerator(DygraphFunctionGeneratorBase):
             )
 
             grad_api_args[grad_api_position] = name
-            get_grad_in_args_list.append(get_attr_str)
+            if (
+                not is_invoke_forward_api
+                or name in self.grad_api_contents['invoke']
+            ):
+                # NOTE: attr 'dims' is not necessary for 'invoke: view_shape(out_grad, input.shape())'
+                get_grad_in_args_list.append(get_attr_str)
 
         get_grad_in_args_str = "\n".join(get_grad_in_args_list)
 

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -3608,16 +3608,6 @@
     func : view_dtype_grad
     data_type : out_grad
 
-- backward_op : view_shape_grad
-  forward : view_shape (Tensor input, int64_t[] dims = {}) -> Tensor(out)
-  args : (Tensor input, Tensor out_grad, int64_t[] dims = {})
-  output : Tensor(input_grad)
-  infer_meta :
-    func : StridedUnChangedInferMeta
-    param : [input]
-  kernel :
-    func : view_shape_grad
-
 - backward_op : warpctc_grad
   forward : warpctc (Tensor logits, Tensor label, Tensor logits_length, Tensor labels_length, int blank = 0, bool norm_by_times = false) -> Tensor(loss), Tensor(warpctcgrad)
   args : (Tensor logits, Tensor logits_length, Tensor warpctcgrad, Tensor loss_grad, int blank, bool norm_by_times)

--- a/paddle/phi/ops/yaml/inconsistent/dygraph_backward.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/dygraph_backward.yaml
@@ -358,6 +358,12 @@
   composite : tile_grad(x, out_grad, repeat_times, x_grad)
   backward : tile_double_grad
 
+- backward_op : view_shape_grad
+  forward : view_shape (Tensor input, int64_t[] dims = {}) -> Tensor(out)
+  args : (Tensor input, Tensor out_grad, int64_t[] dims = {})
+  output : Tensor(input_grad)
+  invoke: view_shape(out_grad, input.shape())
+
 - backward_op: fused_gemm_epilogue_grad
   forward : fused_gemm_epilogue(Tensor x, Tensor y, Tensor bias, bool trans_x, bool trans_y, str activation) -> Tensor(out), Tensor(reserve_space)
   args : (Tensor x, Tensor y, Tensor reserve_space, Tensor out_grad, bool trans_x, bool trans_y, str activation)

--- a/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
@@ -385,3 +385,13 @@
     data_type : x
   optional : indices, inverse, counts
   traits : paddle::dialect::ForwardOnlyTrait
+
+- op : view_shape
+  args : (Tensor input, int64_t[] dims = {})
+  output : Tensor(out)
+  infer_meta :
+    func : ViewShapeInferMeta
+  kernel :
+    func : view_shape
+  backward : view_shape_grad
+  interfaces : paddle::dialect::InferSymbolicShapeInterface

--- a/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
@@ -394,4 +394,3 @@
   kernel :
     func : view_shape
   backward : view_shape_grad
-  interfaces : paddle::dialect::InferSymbolicShapeInterface

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -5253,16 +5253,6 @@
   no_need_buffer : input
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
-- op : view_shape
-  args : (Tensor input, int64_t[] dims = {})
-  output : Tensor(out)
-  infer_meta :
-    func : ViewShapeInferMeta
-  kernel :
-    func : view_shape
-  backward : view_shape_grad
-  interfaces : paddle::dialect::InferSymbolicShapeInterface
-
 - op : view_slice
   args : (Tensor input, int64_t begin_idx, int64_t end_idx)
   output : Tensor


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-75624

1. 在动态图前向微分中(<https://github.com/PaddlePaddle/Paddle/pull/71075>)，`make_dual`和`unpack_dual`需要使用view算子保持梯度并避免不必要的拷贝，因此将view运算的反向算子改为复用前向算子，从而支持科学计算场景下高阶微分的需求
2. 在invoke情况下，跳过不必要的attr代码生成，否则在CI编译时会因为 unused variable 警告而直接停止编译