### PR TITLE
[Custom][NPU] fix XCCL communicator

### DIFF
--- a/paddle/fluid/distributed/collective/process_group_custom.cc
+++ b/paddle/fluid/distributed/collective/process_group_custom.cc
@@ -149,8 +149,12 @@ phi::DeviceContext* ProcessGroupCustom::GetDeviceContext(
   }
 }
 
-phi::ccl::CCLComm ProcessGroupCustom::XCCLComm(const Place& place) const {
+phi::ccl::CCLComm ProcessGroupCustom::XCCLComm(const Place& place) {
   const std::string& key = GetKeyFromPlace(place);
+  phi::DeviceGuard guard(place);
+  if (place_to_comm_ctx_.find(key) == place_to_comm_ctx_.end()) {
+    CreateXCCLEnvCache(place, key);
+  }
   const auto& iter = place_to_comm_ctx_.find(key);
   PADDLE_ENFORCE_NE(
       iter,

--- a/paddle/fluid/distributed/collective/process_group_custom.h
+++ b/paddle/fluid/distributed/collective/process_group_custom.h
@@ -172,7 +172,7 @@ class ProcessGroupCustom final : public ProcessGroupWithStream {
 
   static void GroupEnd(const std::string& dev_type);
 
-  phi::ccl::CCLComm XCCLComm(const Place& place) const;
+  phi::ccl::CCLComm XCCLComm(const Place& place);
 
   // TODO(liyurui): This API will be moved later
   std::shared_ptr<ProcessGroup::Task> AllReduce(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
card-85848, NPU算子执行过程中,调用XCCL获取通信组指针，遇到”Cannot find the XCCL communicator in this process group“的问题，PR进行了修复