### PR TITLE
[Dy2St] Update `no_need_buffer` names after unify value names

### DIFF
--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -406,6 +406,24 @@ class RunnableProgram:
         bwd_map = RunnableProgram._get_name_value_map_from_program(
             self.backward_program
         )
+
+        program_name_attr = self.program_name_attr
+        no_need_buffer_names = program_name_attr["no_need_buffers"]
+        rename_mapping = {}
+        rename_mapping = RunnableProgram.unify_value_names(
+            self.forward_program, rename_mapping
+        )
+        rename_mapping = RunnableProgram.unify_value_names(
+            self.backward_program, rename_mapping
+        )
+        # Update no_need_buffer_names by rename_mapping
+        for original_name, new_name in rename_mapping.items():
+            if (
+                original_name not in no_need_buffer_names
+                and new_name in no_need_buffer_names
+            ):
+                no_need_buffer_names.remove(new_name)
+
         value_program_attr = {}
         for k, ns in self.program_name_attr.items():
             if k.startswith("f"):
@@ -418,13 +436,6 @@ class RunnableProgram:
                 raise ValueError(f"Unknown program attr: {k}")
             value_program_attr[k] = values
 
-        rename_mapping = {}
-        rename_mapping = RunnableProgram.unify_value_names(
-            self.forward_program, rename_mapping
-        )
-        rename_mapping = RunnableProgram.unify_value_names(
-            self.backward_program, rename_mapping
-        )
         return value_program_attr
 
     @staticmethod


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

我们之前动转静在发现最终经过 pass 后的 program 里有一个 Value 同时有多个 name 时（比如同时被多个 `shadow_output` use），会将所有 name 都改成第一个，确保执行器 scope name 管理没有问题。

但是在更新 name 时，没有考虑更新 `no_need_buffers`，比如一个 value 同时有 `middle_15` 和 `middle_127` 两个 name，且 `no_need_buffers` 里包含 `middle_15`，也就是说这个 Tensor 在作为 `middle_15` 时不是 need buffer 的，而作为 `middle_127` 时则是 need buffer 的，那么在 rename 时将两者当成同一个 name 时，就应该将其视为 need buffer 的，也就是将 `middle_15` 从 `no_need_buffers` 里删掉

PCard-66972