### PR TITLE
[CINN] Allow elementwise binary op with differenct shape in infer symbolic shape

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/element_wise_binary.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/element_wise_binary.cc
@@ -58,7 +58,8 @@ bool InferSymbolicShapeElementWiseBinary(
     return shapes;
   }();
 
-  if (x_shape.data() && y_shape.data() && DataComputeFunc) {
+  if (x_shape.data() && y_shape.data() &&
+      x_shape.data()->size() == y_shape.data()->size() && DataComputeFunc) {
     PADDLE_ENFORCE_LE(
         x_shape.shape().size(),
         1,
@@ -71,13 +72,6 @@ bool InferSymbolicShapeElementWiseBinary(
         common::errors::InvalidArgument("When compute data, the rank of y "
                                         "should be 0 or 1, but now received %d",
                                         y_shape.shape().size()));
-    PADDLE_ENFORCE_EQ(x_shape.data()->size(),
-                      y_shape.data()->size(),
-                      common::errors::InvalidArgument(
-                          "When compute data, the size of x and y should be "
-                          "equal, but now received %d and %d",
-                          x_shape.data()->size(),
-                          y_shape.data()->size()));
     std::vector<symbol::DimExpr> out_data;
     for (size_t i = 0; i < x_shape.data()->size(); ++i) {
       out_data.emplace_back(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

PaddleMIX 模型 DiT 暴露的问题，lhs 和 rhs 都有 data 时，允许不一致，走 else 分支

PCard-66972