### PR TITLE
[SOT] Fix NumPy array guard

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -132,7 +132,7 @@ class OpcodeExecutorCache(metaclass=Singleton):
                 if guard_result:
                     log(
                         2,
-                        f"[Cache]: Cache hit, Guard is \n{getattr(guard_fn, 'expr', 'None')}\n",
+                        f"[Cache] Cache hit, Guard is \n{getattr(guard_fn, 'expr', 'None')}\n",
                     )
                     return custom_code
                 else:
@@ -142,14 +142,18 @@ class OpcodeExecutorCache(metaclass=Singleton):
                     )
                     log(
                         2,
-                        f"[Cache]: Cache miss, Guard is \n{getattr(guard_fn, 'expr', 'None')}\n",
+                        f"[Cache] Cache miss, Guard is \n{getattr(guard_fn, 'expr', 'None')}\n",
                     )
                     log_do(
                         2,
                         self.analyse_guard_error(guard_fn, frame),
                     )
             except Exception as e:
-                log(2, f"[Cache]: Guard function error: {e}\n")
+                log(2, f"[Cache] Guard function error: {e}\n")
+                log(
+                    2,
+                    f"[Cache] Guard is \n{getattr(guard_fn, 'expr', 'None')}\n",
+                )
                 log_do(
                     2,
                     self.analyse_guard_error(guard_fn, frame),
@@ -207,7 +211,7 @@ class OpcodeExecutorCache(metaclass=Singleton):
                     result = guard(frame)
                 except Exception as e:
                     print(
-                        f"[Cache]: Error occurred when checking guard {guard_str}: {e}"
+                        f"[Cache] Error occurred when checking guard {guard_str}: {e}"
                     )
                     return
                 if result is False:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

SOT 对于 NumPy array 之前是使用 `object_equal_stringified_guard`，也就是判等后直接 bool 的，而 NumPy array 是不能直接 bool 的，需要加 `.all()` 才可以，因此修改该 guard

PCard-66972