### PR TITLE
[Inference]Support INT8 quant in PIR-TRT

### DIFF
--- a/paddle/fluid/pir/transforms/general/delete_quant_dequant_linear_op_pass.cc
+++ b/paddle/fluid/pir/transforms/general/delete_quant_dequant_linear_op_pass.cc
@@ -16,29 +16,143 @@
 
 #include "paddle/fluid/pir/transforms/general/delete_quant_dequant_linear_op_pass.h"
 
+#include "paddle/fluid/pir/dialect/operator/ir/op_attribute.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
 #include "paddle/fluid/pir/utils/analysis_info.h"
 #include "paddle/fluid/pir/utils/general_functions.h"
 
 #include "paddle/fluid/framework/scope.h"
+#include "paddle/fluid/framework/tensor_util.h"
+#include "paddle/phi/common/place.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/pir/include/pass/pass.h"
 #include "paddle/pir/include/pass/pass_registry.h"
 
 namespace {
 
-class DeleteQuantDequantLinearOpPattern : public paddle::drr::DrrPatternBase {
+class DeleteQuantDequantLinearOpBasePattern
+    : public paddle::drr::DrrPatternBase {
  public:
   std::string name() const override {
-    return "DeleteQuantDequantLinearOpPattern";
+    return "DeleteQuantDequantLinearOpBasePattern";
   }
 
-  explicit DeleteQuantDequantLinearOpPattern(
+  explicit DeleteQuantDequantLinearOpBasePattern(
       paddle::framework::Scope* scope,
       std::reference_wrapper<std::optional<pir::detail::PassExecutionState>>
           pass_state)
       : scope_(scope), pass_state_(pass_state) {}
+
+  bool Constraint(const paddle::drr::MatchContext& match_ctx) const {
+    if (!pir::ValueIsPersistable(match_ctx.Tensor("scale"))) {
+      return false;
+    }
+    auto input_scale_dtype =
+        pir::GetDataTypeFromValue(match_ctx.Tensor("scale"));
+    auto input_scale_name =
+        pir::GetParameterNameFromValue(match_ctx.Tensor("scale"));
+    auto* input_scale_var = this->scope_->FindVar(input_scale_name);
+    PADDLE_ENFORCE_NOT_NULL(
+        input_scale_var,
+        common::errors::InvalidArgument("Persistable var [%s] not in scope.",
+                                        input_scale_name));
+    if (!input_scale_dtype.isa<pir::Float16Type>() &&
+        !input_scale_dtype.isa<pir::Float32Type>()) {
+      return false;
+    }
+    return true;
+  }
+
+  void PostProcess(const paddle::drr::MatchContext& match_ctx) const {
+    float input_scale = 0;
+    auto input_scale_dtype =
+        pir::GetDataTypeFromValue(match_ctx.Tensor("scale"));
+    auto input_scale_name =
+        pir::GetParameterNameFromValue(match_ctx.Tensor("scale"));
+    auto* input_scale_var = this->scope_->FindVar(input_scale_name);
+    auto* input_scale_tensor = input_scale_var->GetMutable<phi::DenseTensor>();
+    phi::DenseTensor temp_tensor;
+    temp_tensor.Resize(input_scale_tensor->dims());
+    paddle::framework::TensorCopySync(
+        *input_scale_tensor, phi::CPUPlace{}, &temp_tensor);
+
+    if (input_scale_dtype.isa<pir::Float16Type>()) {
+      const phi::dtype::float16* input_scale_data =
+          temp_tensor.data<phi::dtype::float16>();
+      input_scale = static_cast<float>(input_scale_data[0]);
+    } else {  // (input_scale_dtype.isa<pir::Float32Type>())
+      const float* input_scale_data = temp_tensor.data<float>();
+      input_scale = input_scale_data[0];
+    }
+    PADDLE_ENFORCE_EQ(
+        this->pass_state_.get().has_value(),
+        true,
+        common::errors::InvalidArgument("pass state has no value"));
+
+    auto& quant_analysis =
+        this->pass_state_.get()->am.GetAnalysis<pir::pass::QuantAnalysis>();
+    this->pass_state_.get()
+        ->preserved_analyses.Preserve<pir::pass::QuantAnalysis>();
+    PADDLE_ENFORCE_EQ(
+        this->pass_state_.get()
+            ->preserved_analyses.IsPreserved<pir::pass::QuantAnalysis>(),
+        true,
+        common::errors::InvalidArgument("QuantAnalysis should be Preserved"));
+    quant_analysis.scale_map[match_ctx.Tensor("x")] =
+        std::vector<float>({input_scale});
+
+    // Save scale info into op that connected to dequantize_linear_op
+    pir::Operation* op =
+        match_ctx.Tensor("dequantize_linear_out").defining_op();
+    auto next_op = pir::GetUseOpsForOutput(op, 0)[0].first;
+    pir::IrContext* ctx = pir::IrContext::Instance();
+    auto inputs = next_op->operands_source();
+    std::vector<pir::Attribute> input_index_vec;
+    std::vector<pir::Attribute> input_scale_vec;
+    for (size_t i = 0; i < inputs.size(); i++) {
+      auto input = inputs[i];
+      if (match_ctx.Tensor("dequantize_linear_out") == input) {
+        // non-weight quant-dequant situation
+        pir::Attribute input_index =
+            pir::Int32Attribute::get(ctx, static_cast<int>(i));
+        input_index_vec.push_back(input_index);
+        pir::Attribute input_scale_attr =
+            pir::FloatAttribute::get(pir::IrContext::Instance(), input_scale);
+        input_scale_vec.push_back(input_scale_attr);
+      }
+    }
+    // set the scale info into op
+    if (input_index_vec.size() > 0) {
+      pir::Attribute inputs_index =
+          pir::ArrayAttribute::get(pir::IrContext::Instance(), input_index_vec);
+      next_op->set_attribute("inputs_index", inputs_index);
+      pir::Attribute inputs_scale =
+          pir::ArrayAttribute::get(pir::IrContext::Instance(), input_scale_vec);
+      next_op->set_attribute("inputs_scale", inputs_scale);
+    }
+  }
+
+  void operator()(paddle::drr::DrrPatternContext* ctx) const override {}
+
+ protected:
+  paddle::framework::Scope* scope_{nullptr};
+  std::reference_wrapper<std::optional<pir::detail::PassExecutionState>>
+      pass_state_;
+};
+
+class DeleteQuantDequantLinearOpWithNoneInputPattern
+    : public DeleteQuantDequantLinearOpBasePattern {
+ public:
+  std::string name() const override {
+    return "DeleteQuantDequantLinearOpWithNoneInputPattern";
+  }
+
+  explicit DeleteQuantDequantLinearOpWithNoneInputPattern(
+      paddle::framework::Scope* scope,
+      std::reference_wrapper<std::optional<pir::detail::PassExecutionState>>
+          pass_state)
+      : DeleteQuantDequantLinearOpBasePattern(scope, pass_state) {}
 
   void operator()(paddle::drr::DrrPatternContext* ctx) const override {
     paddle::drr::SourcePattern pat = ctx->SourcePattern();
@@ -66,71 +180,65 @@ class DeleteQuantDequantLinearOpPattern : public paddle::drr::DrrPatternBase {
                           &pat.OutputNoneTensor()});
 
     pat.AddConstraint([this](const paddle::drr::MatchContext& match_ctx) {
-      if (!pir::ValueIsPersistable(match_ctx.Tensor("scale"))) {
-        return false;
-      }
-      auto input_scale_dtype =
-          pir::GetDataTypeFromValue(match_ctx.Tensor("scale"));
-      auto input_scale_name =
-          pir::GetParameterNameFromValue(match_ctx.Tensor("scale"));
-      auto* input_scale_var = this->scope_->FindVar(input_scale_name);
-      PADDLE_ENFORCE_NOT_NULL(
-          input_scale_var,
-          common::errors::InvalidArgument("Persistable var [%s] not in scope.",
-                                          input_scale_name));
-      if (!input_scale_dtype.isa<pir::Float16Type>() &&
-          !input_scale_dtype.isa<pir::Float32Type>()) {
-        return false;
-      }
-      return true;
+      return this->Constraint(match_ctx);
     });
 
     pat.AddPostProcess([this](const paddle::drr::MatchContext& match_ctx) {
-      float input_scale = 0;
-      auto input_scale_dtype =
-          pir::GetDataTypeFromValue(match_ctx.Tensor("scale"));
-      auto input_scale_name =
-          pir::GetParameterNameFromValue(match_ctx.Tensor("scale"));
-      auto* input_scale_var = this->scope_->FindVar(input_scale_name);
-
-      auto* input_scale_tensor =
-          input_scale_var->GetMutable<phi::DenseTensor>();
-      if (input_scale_dtype.isa<pir::Float16Type>()) {
-        const phi::dtype::float16* input_scale_data =
-            input_scale_tensor->data<phi::dtype::float16>();
-        input_scale = static_cast<float>(input_scale_data[0]);
-      } else {  // (input_scale_dtype.isa<pir::Float32Type>())
-        const float* input_scale_data = input_scale_tensor->data<float>();
-        input_scale = input_scale_data[0];
-      }
-
-      PADDLE_ENFORCE_EQ(
-          this->pass_state_.get().has_value(),
-          true,
-          common::errors::InvalidArgument("pass state has no value"));
-
-      auto& quant_analysis =
-          this->pass_state_.get()->am.GetAnalysis<pir::pass::QuantAnalysis>();
-      this->pass_state_.get()
-          ->preserved_analyses.Preserve<pir::pass::QuantAnalysis>();
-      PADDLE_ENFORCE_EQ(
-          this->pass_state_.get()
-              ->preserved_analyses.IsPreserved<pir::pass::QuantAnalysis>(),
-          true,
-          common::errors::InvalidArgument("QuantAnalysis should be Preserved"));
-
-      quant_analysis.scale_map[match_ctx.Tensor("x")] =
-          std::vector<float>({input_scale});
+      this->PostProcess(match_ctx);
     });
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
     res.Tensor("dequantize_linear_out").Assign(res.Tensor("x"));
   }
+};
 
- private:
-  paddle::framework::Scope* scope_{nullptr};
-  std::reference_wrapper<std::optional<pir::detail::PassExecutionState>>
-      pass_state_;
+class DeleteQuantDequantLinearOpPattern
+    : public DeleteQuantDequantLinearOpBasePattern {
+ public:
+  std::string name() const override {
+    return "DeleteQuantDequantLinearOpPattern";
+  }
+
+  explicit DeleteQuantDequantLinearOpPattern(
+      paddle::framework::Scope* scope,
+      std::reference_wrapper<std::optional<pir::detail::PassExecutionState>>
+          pass_state)
+      : DeleteQuantDequantLinearOpBasePattern(scope, pass_state) {}
+
+  void operator()(paddle::drr::DrrPatternContext* ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+    const auto& quantize_linear_op =
+        pat.Op(paddle::dialect::QuantizeLinearOp::name());
+    const auto& dequantize_linear_op =
+        pat.Op(paddle::dialect::DequantizeLinearOp::name());
+    quantize_linear_op({&pat.Tensor("x"),
+                        &pat.Tensor("scale"),
+                        &pat.Tensor("zero_point"),
+                        &pat.Tensor("in_accum"),
+                        &pat.Tensor("in_state")},
+                       {&pat.Tensor("quantize_linear_out"),
+                        &pat.Tensor("state_out"),
+                        &pat.Tensor("accum_out"),
+                        &pat.Tensor("scale_out")});
+    dequantize_linear_op({&pat.Tensor("quantize_linear_out"),
+                          &pat.Tensor("descale"),
+                          &pat.Tensor("dezero_point"),
+                          &pat.Tensor("dein_accum"),
+                          &pat.Tensor("dein_state")},
+                         {&pat.Tensor("dequantize_linear_out"),
+                          &pat.Tensor("destate_out"),
+                          &pat.Tensor("deaccum_out"),
+                          &pat.Tensor("descale_out")});
+
+    pat.AddConstraint([this](const paddle::drr::MatchContext& match_ctx) {
+      return this->Constraint(match_ctx);
+    });
+    pat.AddPostProcess([this](const paddle::drr::MatchContext& match_ctx) {
+      this->PostProcess(match_ctx);
+    });
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+    res.Tensor("dequantize_linear_out").Assign(res.Tensor("x"));
+  }
 };
 
 class DeleteQuantDequantLinearOpPass : public pir::PatternRewritePass {
@@ -151,6 +259,8 @@ class DeleteQuantDequantLinearOpPass : public pir::PatternRewritePass {
         scope_, common::errors::InvalidArgument("scope can not be nullptr"));
     pir::RewritePatternSet ps(context);
     ps.Add(paddle::drr::Create<DeleteQuantDequantLinearOpPattern>(
+        context, scope_, std::ref(pass_state())));
+    ps.Add(paddle::drr::Create<DeleteQuantDequantLinearOpWithNoneInputPattern>(
         context, scope_, std::ref(pass_state())));
 
     return ps;

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -110,5 +110,6 @@ USE_PIR_PASS(convert_MEA_to_FA);
 
 #ifdef PADDLE_WITH_TENSORRT
 USE_PIR_PASS(trt_op_marker_pass);
+USE_PIR_PASS(trt_delete_weight_dequant_linear_op_pass);
 USE_PIR_PASS(trt_sub_graph_extract_pass);
 #endif

--- a/paddle/fluid/pir/transforms/tensorrt/trt_delete_weight_dequant_linear_op_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_delete_weight_dequant_linear_op_pass.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/paddle/fluid/pir/transforms/tensorrt/trt_delete_weight_dequant_linear_op_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_delete_weight_dequant_linear_op_pass.cc
@@ -1,0 +1,361 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/pir/transforms/tensorrt/trt_delete_weight_dequant_linear_op_pass.h"
+
+#include <memory>
+
+#include "paddle/fluid/framework/tensor_util.h"
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
+#include "paddle/fluid/pir/utils/analysis_info.h"
+#include "paddle/fluid/pir/utils/general_functions.h"
+
+#include "paddle/common/ddim.h"
+#include "paddle/fluid/framework/scope.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pass/pass_registry.h"
+
+namespace {
+
+class TrtDeleteWeightDequantLinearOpBasePattern
+    : public paddle::drr::DrrPatternBase {
+ public:
+  std::string name() const override {
+    return "TrtDeleteWeightDequantLinearOpBasePattern";
+  }
+
+  explicit TrtDeleteWeightDequantLinearOpBasePattern(
+      paddle::framework::Scope* scope,
+      std::reference_wrapper<std::optional<pir::detail::PassExecutionState>>
+          pass_state)
+      : scope_(scope), pass_state_(pass_state) {}
+  bool Constraint(const paddle::drr::MatchContext& match_ctx) const {
+    if (!pir::ValueIsPersistable(match_ctx.Tensor("weight"))) {
+      return false;
+    }
+    if (!pir::ValueIsPersistable(match_ctx.Tensor("scale"))) {
+      return false;
+    }
+    pir::Operation* op =
+        match_ctx.Tensor("dequantize_linear_out").defining_op();
+    auto next_op_list = pir::GetUseOpsForOutput(op, 0);
+    for (auto const& [next_op, op_index] : next_op_list) {
+      if (!(next_op->isa<paddle::dialect::Conv2dOp>() ||
+            next_op->isa<paddle::dialect::MatmulOp>() ||
+            next_op->isa<paddle::dialect::DepthwiseConv2dOp>() ||
+            next_op->isa<paddle::dialect::Conv2dTransposeOp>())) {
+        return false;
+      }
+    }
+
+    auto weight_scale_dtype =
+        pir::GetDataTypeFromValue(match_ctx.Tensor("scale"));
+    auto weight_scale_name =
+        pir::GetParameterNameFromValue(match_ctx.Tensor("scale"));
+    auto* weight_scale_var = this->scope_->FindVar(weight_scale_name);
+    PADDLE_ENFORCE_NOT_NULL(
+        weight_scale_var,
+        common::errors::InvalidArgument("Persistable var [%s] not in scope.",
+                                        weight_scale_name));
+    if (!weight_scale_dtype.isa<pir::Float16Type>() &&
+        !weight_scale_dtype.isa<pir::Float32Type>()) {
+      return false;
+    }
+    return true;
+  }
+
+  void PostProcess(const paddle::drr::MatchContext& match_ctx) const {
+    pir::Operation* op =
+        match_ctx.Tensor("dequantize_linear_out").defining_op();
+
+    int bit_length =
+        op->attribute("bit_length").dyn_cast<pir::Int32Attribute>().data();
+    int range = ((1 << (bit_length - 1)) - 1);
+
+    // get weight tensor
+    auto weight_name =
+        pir::GetParameterNameFromValue(match_ctx.Tensor("weight"));
+    auto* weight_tensor =
+        this->scope_->GetVar(weight_name)->GetMutable<phi::DenseTensor>();
+    phi::DenseTensor weight_tensor_cpu;
+    weight_tensor_cpu.Resize(weight_tensor->dims());
+    paddle::framework::TensorCopySync(
+        *weight_tensor, phi::CPUPlace{}, &weight_tensor_cpu);
+    // int8 cast to float for calculation
+    std::vector<float> quantized_weight_data;
+    for (int i = 0; i < weight_tensor_cpu.numel(); i++) {
+      if (weight_tensor_cpu.dtype() == phi::DataType::INT8) {
+        quantized_weight_data.push_back(
+            static_cast<float>(weight_tensor_cpu.data<int8_t>()[i]));
+      } else {
+        quantized_weight_data.push_back(weight_tensor_cpu.data<float>()[i]);
+      }
+    }
+    auto w_dims = weight_tensor_cpu.dims();
+
+    // Get weight scale
+    std::vector<float> weight_scale;
+    auto weight_scale_name =
+        pir::GetParameterNameFromValue(match_ctx.Tensor("scale"));
+    auto* weight_scale_tensor =
+        this->scope_->GetVar(weight_scale_name)->GetMutable<phi::DenseTensor>();
+    phi::DenseTensor weight_scale_tensor_tmp;
+    weight_scale_tensor_tmp.Resize(weight_scale_tensor->dims());
+    paddle::framework::TensorCopySync(
+        *weight_scale_tensor, phi::CPUPlace{}, &weight_scale_tensor_tmp);
+    weight_scale_tensor = &weight_scale_tensor_tmp;
+    float* weight_scale_data = weight_scale_tensor->data<float>();
+    auto weight_scale_nums = weight_scale_tensor->numel();
+    weight_scale.reserve(weight_scale_nums);
+    for (int i = 0; i < weight_scale_nums; i++) {
+      weight_scale.push_back(weight_scale_data[i] / static_cast<float>(range));
+    }
+
+    // dequant weight
+    std::vector<float> weight_data_tmp;
+    weight_data_tmp.reserve(weight_tensor_cpu.numel());
+    int quant_axis =
+        op->attribute("quant_axis").dyn_cast<pir::Int32Attribute>().data();
+
+    if (quant_axis == -1) {  // per_layer quant_dequant: all OP
+      PADDLE_ENFORCE_EQ(weight_scale_nums,
+                        1,
+                        common::errors::InvalidArgument(
+                            "When quant_axis == -1 means use per_layer "
+                            "quant_dequant, weight_scale'number should be 1."));
+
+      //  float(weight) * scale
+      for (int i = 0; i < weight_tensor_cpu.numel(); i++) {
+        weight_data_tmp.push_back(quantized_weight_data[i] * weight_scale[0]);
+      }
+
+    } else if (quant_axis == 0) {  // per_channel quant_dequant: conv2d,
+                                   // depthwise_conv2d, fused_conv2d_add_act
+      PADDLE_ENFORCE_EQ(
+          weight_scale_nums,
+          w_dims[quant_axis],
+          common::errors::InvalidArgument(
+              "When quant_axis == 0 means use per_channel quant_dequant, "
+              "weight_scale'numbers should be equal channels."));
+      PADDLE_ENFORCE_EQ(
+          w_dims.size(),
+          4,
+          common::errors::InvalidArgument(
+              "When quant_axis == 0 means use per_channel "
+              "quant_dequant, (conv2d, depthwise_conv2d, "
+              "fused_conv2d_add_act)'s weight dims should be 4."));
+
+      for (int i = 0; i < weight_tensor_cpu.numel(); i++) {
+        int inner_size = static_cast<int>(w_dims[1] * w_dims[2] * w_dims[3]);
+        weight_data_tmp.push_back(quantized_weight_data[i] *
+                                  weight_scale[i / inner_size]);
+      }
+    } else if (quant_axis == 1) {
+      PADDLE_ENFORCE_EQ(
+          weight_scale_nums,
+          w_dims[quant_axis],
+          common::errors::InvalidArgument(
+              "When quant_axis == 1 means use per_channel quant_dequant, "
+              "weight_scale'numbers should be equal channels."));
+
+      if (w_dims.size() == 4) {  // conv2d_transpose
+        auto next_op_list = pir::GetUseOpsForOutput(op, 0);
+        for (auto const& [next_op, op_index] : next_op_list) {
+          PADDLE_ENFORCE_EQ(
+              next_op->isa<paddle::dialect::Conv2dTransposeOp>(),
+              true,
+              common::errors::InvalidArgument(
+                  "When quant_axis == 1 means use per_channel quant_dequant, "
+                  "only conv2d_transpose weight dims equal 4."));
+        }
+
+        for (int i = 0; i < weight_tensor_cpu.numel(); i++) {
+          int inner_size = static_cast<int>(w_dims[2] * w_dims[3]);
+          weight_data_tmp.push_back(quantized_weight_data[i] *
+                                    weight_scale[(i / inner_size) % w_dims[1]]);
+        }
+      } else if (w_dims.size() == 2) {
+        for (int i = 0; i < weight_tensor_cpu.numel(); i++) {
+          weight_data_tmp.push_back(quantized_weight_data[i] *
+                                    weight_scale[i % w_dims[1]]);
+        }
+      } else {
+        PADDLE_THROW(common::errors::InvalidArgument(
+            "When quant_axis == 1 , weight dims should be 2 or 4, please check "
+            "your model "));
+      }
+    } else {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "quant_axis should be -1 or 0 or 1, please check your model "
+          "OP'attribute "));
+    }
+
+    // set dequant weight data into weight tensor
+    auto weight_tensor_place = weight_tensor->place();
+    weight_tensor->clear();  // clear int weight
+    if (weight_tensor_place == phi::GPUPlace()) {
+      auto* dev_ctx = static_cast<phi::GPUContext*>(
+          phi::DeviceContextPool::Instance().Get(phi::GPUPlace()));
+      paddle::framework::TensorFromVector(
+          weight_data_tmp, *dev_ctx, weight_tensor);
+    } else if (weight_tensor_place == phi::CPUPlace()) {
+      auto* dev_ctx = static_cast<phi::CPUContext*>(
+          phi::DeviceContextPool::Instance().Get(phi::CPUPlace()));
+      paddle::framework::TensorFromVector(
+          weight_data_tmp, *dev_ctx, weight_tensor);
+    } else {
+      PADDLE_THROW(common::errors::Unimplemented(
+          "trt_delete_weight_dequant_linear_op_pass only support cpu and gpu "
+          "place now."));
+    }
+    weight_tensor->Resize(common::make_ddim(common::vectorize(w_dims)));
+  }
+
+  void operator()(paddle::drr::DrrPatternContext* ctx) const override {}
+
+ private:
+  paddle::framework::Scope* scope_{nullptr};
+  std::reference_wrapper<std::optional<pir::detail::PassExecutionState>>
+      pass_state_;
+};
+
+class TrtDeleteWeightDequantLinearOpWithNoneInputPattern
+    : public TrtDeleteWeightDequantLinearOpBasePattern {
+ public:
+  std::string name() const override {
+    return "TrtDeleteWeightDequantLinearOpWithNoneInputPattern";
+  }
+
+  explicit TrtDeleteWeightDequantLinearOpWithNoneInputPattern(
+      paddle::framework::Scope* scope,
+      std::reference_wrapper<std::optional<pir::detail::PassExecutionState>>
+          pass_state)
+      : TrtDeleteWeightDequantLinearOpBasePattern(scope, pass_state) {}
+
+  void operator()(paddle::drr::DrrPatternContext* ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+    const auto& dequantize_linear_op =
+        pat.Op(paddle::dialect::DequantizeLinearOp::name());
+
+    dequantize_linear_op({&pat.Tensor("weight"),
+                          &pat.Tensor("scale"),
+                          &pat.Tensor("dezero_point"),
+                          &pat.InputNoneTensor(),
+                          &pat.InputNoneTensor()},
+                         {&pat.Tensor("dequantize_linear_out"),
+                          &pat.OutputNoneTensor(),
+                          &pat.OutputNoneTensor(),
+                          &pat.OutputNoneTensor()});
+
+    pat.AddConstraint([this](const paddle::drr::MatchContext& match_ctx) {
+      return this->Constraint(match_ctx);
+    });
+
+    pat.AddPostProcess(
+        [this](const paddle::drr::MatchContext& match_ctx) mutable {
+          this->PostProcess(match_ctx);
+        });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+    res.Tensor("dequantize_linear_out").Assign(res.Tensor("weight"));
+  }
+};
+
+class TrtDeleteWeightDequantLinearOpPattern
+    : public TrtDeleteWeightDequantLinearOpBasePattern {
+ public:
+  std::string name() const override {
+    return "TrtDeleteWeightDequantLinearOpPattern";
+  }
+
+  explicit TrtDeleteWeightDequantLinearOpPattern(
+      paddle::framework::Scope* scope,
+      std::reference_wrapper<std::optional<pir::detail::PassExecutionState>>
+          pass_state)
+      : TrtDeleteWeightDequantLinearOpBasePattern(scope, pass_state) {}
+
+  void operator()(paddle::drr::DrrPatternContext* ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+    const auto& dequantize_linear_op =
+        pat.Op(paddle::dialect::DequantizeLinearOp::name());
+
+    dequantize_linear_op({&pat.Tensor("weight"),
+                          &pat.Tensor("scale"),
+                          &pat.Tensor("dezero_point"),
+                          &pat.Tensor("dein_accum"),
+                          &pat.Tensor("dein_state")},
+                         {&pat.Tensor("dequantize_linear_out"),
+                          &pat.Tensor("destate_out"),
+                          &pat.Tensor("deaccum_out"),
+                          &pat.Tensor("descale_out")});
+
+    pat.AddConstraint([this](const paddle::drr::MatchContext& match_ctx) {
+      return this->Constraint(match_ctx);
+    });
+
+    pat.AddPostProcess(
+        [this](const paddle::drr::MatchContext& match_ctx) mutable {
+          this->PostProcess(match_ctx);
+        });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+    res.Tensor("dequantize_linear_out").Assign(res.Tensor("weight"));
+  }
+};
+
+class TrtDeleteWeightDequantLinearOpPatternPass
+    : public pir::PatternRewritePass {
+ public:
+  TrtDeleteWeightDequantLinearOpPatternPass()
+      : pir::PatternRewritePass("trt_delete_weight_dequant_linear_op_pass", 1) {
+  }
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext* context) override {
+    PADDLE_ENFORCE_EQ(
+        Has(pir::Pass::kParamScopeAttr),
+        true,
+        common::errors::InvalidArgument(
+            "Pass initialize failed."
+            "When using TrtDeleteWeightDequantLinearOpPatternPass, scope "
+            "attribute is required!"
+            "Use Set method to set the scope attribute."));
+    scope_ = &Get<paddle::framework::Scope>(pir::Pass::kParamScopeAttr);
+    PADDLE_ENFORCE_NOT_NULL(
+        scope_, common::errors::InvalidArgument("scope can not be nullptr"));
+    pir::RewritePatternSet ps(context);
+    ps.Add(paddle::drr::Create<TrtDeleteWeightDequantLinearOpPattern>(
+        context, scope_, std::ref(pass_state())));
+    ps.Add(
+        paddle::drr::Create<TrtDeleteWeightDequantLinearOpWithNoneInputPattern>(
+            context, scope_, std::ref(pass_state())));
+    return ps;
+  }
+
+ private:
+  paddle::framework::Scope* scope_{nullptr};
+};
+}  // namespace
+
+namespace pir {
+
+std::unique_ptr<Pass> CreateTrtDeleteWeightDequantLinearOpPatternPass() {
+  return std::make_unique<TrtDeleteWeightDequantLinearOpPatternPass>();
+}
+
+}  // namespace pir
+
+REGISTER_IR_PASS(trt_delete_weight_dequant_linear_op_pass,
+                 TrtDeleteWeightDequantLinearOpPatternPass);

--- a/paddle/fluid/pir/transforms/tensorrt/trt_delete_weight_dequant_linear_op_pass.h
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_delete_weight_dequant_linear_op_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <glog/logging.h>
+#include "paddle/pir/include/core/dll_decl.h"
+
+namespace pir {
+
+class Pass;
+
+IR_API std::unique_ptr<Pass> CreateTrtDeleteWeightDequantLinearOpPass();
+
+}  // namespace pir

--- a/paddle/fluid/pir/transforms/tensorrt/trt_delete_weight_dequant_linear_op_pass.h
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_delete_weight_dequant_linear_op_pass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <glog/logging.h>
+#include <memory>
 #include "paddle/pir/include/core/dll_decl.h"
 
 namespace pir {

--- a/python/paddle/tensorrt/converter.py
+++ b/python/paddle/tensorrt/converter.py
@@ -54,6 +54,7 @@ from .util import (
     is_shape_tensor,
     map_dtype,
     remove_duplicate_value,
+    set_dynamic_range,
     weight_to_tensor,
     zero_dims_to_one_dims,
 )
@@ -151,7 +152,9 @@ class PaddleToTensorRTConverter:
         input_names = []
         new_input_values = []
         constant_manager = TensorRTConstantManager()
-
+        precision_mode = PrecisionMode.FP32
+        if self.trt_config is not None:
+            precision_mode = self.trt_config.precision_mode
         # Because one of the inputs to pd_op.concat is builtin.combine,
         # during the conversion process using the converter,
         # it is necessary to obtain the input of builtin.combine.
@@ -254,6 +257,8 @@ class PaddleToTensorRTConverter:
                             f'{source_id} not found in value_to_trt_tensor'
                         )
 
+            if precision_mode == PrecisionMode.INT8:
+                set_dynamic_range(op, operands)
             trt_outs = self.convert(network, op, operands)
 
             results = []
@@ -424,9 +429,7 @@ class PaddleToTensorRTConverter:
             trt.MemoryPoolType.WORKSPACE, self.trt_config.workspace_size
         )
 
-        if self.trt_config is not None:
-            precision_mode = self.trt_config.precision_mode
-        if self.trt_config is not None and precision_mode == PrecisionMode.FP16:
+        if precision_mode == PrecisionMode.FP16:
             if builder.platform_has_fast_fp16:
                 config.set_flag(trt.BuilderFlag.FP16)
                 _logger.info("Run Paddle-TRT FP16 mode")
@@ -434,9 +437,7 @@ class PaddleToTensorRTConverter:
                 _logger.warning(
                     "Hardware does not support FP16. Continuing in FP32 mode."
                 )
-        elif (
-            self.trt_config is not None and precision_mode == PrecisionMode.BF16
-        ):
+        elif precision_mode == PrecisionMode.BF16:
             if version_list[0] >= 9:
                 if builder.platform_has_fast_bfp16 and hasattr(
                     builder, 'plateform_has_fast_bf16'
@@ -457,6 +458,9 @@ class PaddleToTensorRTConverter:
                     _logger.warning(
                         "Hardware does not support FP16. Continuing in FP32 mode."
                     )
+        elif precision_mode == PrecisionMode.INT8:
+            config.set_flag(trt.BuilderFlag.INT8)
+            _logger.info("Run Paddle-TRT INT8 mode")
         elif self.trt_config is not None:
             _logger.info(
                 f"Default precision mode {self.trt_config.precision_mode}"

--- a/python/paddle/tensorrt/export.py
+++ b/python/paddle/tensorrt/export.py
@@ -272,6 +272,7 @@ def convert_to_trt(program, trt_config, scope):
             program,
             disable_passes=trt_config.disable_passes,
             scope=scope,
+            precision_mode=trt_config.precision_mode,
         )
 
         # run warmup for collecting shape

--- a/python/paddle/tensorrt/util.py
+++ b/python/paddle/tensorrt/util.py
@@ -68,7 +68,7 @@ def all_ops_into_trt(program):
     return True
 
 
-def run_pir_pass(program, disable_passes=[], scope=None):
+def run_pir_pass(program, disable_passes=[], scope=None, precision_mode=None):
     def _add_pass_(pm, passes, disable_passes):
         for pass_item in passes:
             for pass_name, pass_attr in pass_item.items():
@@ -87,6 +87,21 @@ def run_pir_pass(program, disable_passes=[], scope=None):
     passes = [
         {'trt_op_marker_pass': {}},
     ]
+    if precision_mode.value == "INT8":
+        passes.append(
+            {
+                'delete_quant_dequant_linear_op_pass': {
+                    "__param_scope__": scope,
+                }
+            }
+        )
+        passes.append(
+            {
+                'trt_delete_weight_dequant_linear_op_pass': {
+                    "__param_scope__": scope,
+                }
+            }
+        )
     _add_pass_(pm, passes, disable_passes)
     pm.run(program)
 
@@ -340,6 +355,15 @@ def remove_duplicate_value(value_list):
             ret_list.append(value)
             ret_list_id.append(value.id)
     return ret_list
+
+
+def set_dynamic_range(paddle_op, trt_inputs):
+    if paddle_op.has_attr("inputs_index"):
+        inputs_index = paddle_op.attrs()["inputs_index"]
+        inputs_scale = paddle_op.attrs()["inputs_scale"]
+        for i, index in enumerate(inputs_index):
+            scale = inputs_scale[i]
+            trt_inputs[index].set_dynamic_range(-scale, scale)
 
 
 def get_trt_version():

--- a/python/paddle/tensorrt/util.py
+++ b/python/paddle/tensorrt/util.py
@@ -87,7 +87,7 @@ def run_pir_pass(program, disable_passes=[], scope=None, precision_mode=None):
     passes = [
         {'trt_op_marker_pass': {}},
     ]
-    if precision_mode.value == "INT8":
+    if precision_mode is not None and precision_mode.value == "INT8":
         passes.append(
             {
                 'delete_quant_dequant_linear_op_pass': {

--- a/test/tensorrt/test_converter_model_resnet50.py
+++ b/test/tensorrt/test_converter_model_resnet50.py
@@ -132,7 +132,7 @@ class TestConverterResNet50(unittest.TestCase):
         predictor = paddle_infer.create_predictor(config)
         output_trt_int8 = predictor.run([image])
 
-        # Check that the results are close to each other within a tolerance of 1e-3
+        # Check that the results are close to each other within a tolerance of 0.9
         np.testing.assert_allclose(
             output_fp32,
             output_trt_int8[0],

--- a/test/tensorrt/test_converter_model_resnet50.py
+++ b/test/tensorrt/test_converter_model_resnet50.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import tempfile
 import unittest
 
 import numpy as np
@@ -19,14 +21,21 @@ from get_program import (
     get_r50_program,
 )
 
+import paddle
+import paddle.inference as paddle_infer
+from paddle.quantization import PTQ, QuantConfig
+from paddle.quantization.observers import AbsmaxObserver
 from paddle.tensorrt.export import (
     Input,
+    PrecisionMode,
     TensorRTConfig,
+    convert,
     convert_to_trt,
 )
 from paddle.tensorrt.util import (
     predict_program,
 )
+from paddle.vision.models import resnet18
 
 
 def standardize(array):
@@ -37,6 +46,10 @@ def standardize(array):
 
 
 class TestConverterResNet50(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.temp_dir.name, 'pir-trt')
+
     def test_paddle_to_tensorrt_conversion_r50(self):
         # Step1: get program and init fake inputs
         program, scope, param_dict = get_r50_program()
@@ -79,6 +92,53 @@ class TestConverterResNet50(unittest.TestCase):
             rtol=1e-3,
             atol=1e-3,
             err_msg="Outputs are not within the 1e-3 tolerance",
+        )
+
+    def test_convert_quant_model(self):
+        paddle.disable_static()
+        image = paddle.ones([1, 3, 224, 224], dtype="float32")
+        model = resnet18()
+        model.eval()
+        output_fp32 = model(image)
+
+        observer = AbsmaxObserver(quant_bits=8)
+        q_config = QuantConfig(activation=observer, weight=observer)
+        ptq = PTQ(q_config)
+        quant_model = ptq.quantize(model)
+        out = quant_model(image)
+        converted_model = ptq.convert(quant_model)
+        save_path = os.path.join(self.temp_dir.name, 'int8_infer')
+        paddle.jit.save(converted_model, save_path, input_spec=[image])
+
+        paddle.enable_static()
+        trt_save_path = os.path.join(self.temp_dir.name, 'int8_trt_infer')
+        # Set input
+        input_config = Input(
+            min_input_shape=(1, 3, 224, 224),
+            optim_input_shape=(1, 3, 224, 224),
+            max_input_shape=(1, 3, 224, 224),
+            input_data_type='float32',
+        )
+        trt_config = TensorRTConfig(inputs=[input_config])
+        trt_config.save_model_dir = trt_save_path
+        trt_config.precision_mode = PrecisionMode.INT8
+        convert(save_path, trt_config)
+
+        config = paddle_infer.Config(
+            trt_config.save_model_dir + '.json',
+            trt_config.save_model_dir + '.pdiparams',
+        )
+        config.enable_use_gpu(100, 0)
+        predictor = paddle_infer.create_predictor(config)
+        output_trt_int8 = predictor.run([image])
+
+        # Check that the results are close to each other within a tolerance of 1e-3
+        np.testing.assert_allclose(
+            output_fp32,
+            output_trt_int8[0],
+            rtol=0.9,
+            atol=0.9,
+            err_msg="Outputs are not within the 0.9 tolerance",
         )
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
card-71500
本PR做了如下工作：
- 用户接口INT8功能设置生效，打通子图Convert过程中INT8量化全流程
- 丰富delete_quant_dequant_linear_op_pass功能，支持将量化信息存入Op，支持可选输入场景量化算子子图的匹配
- 开发trt_delete_weight_dequant_linear_op_pass，支持将量化weight反量化用于TensorRT引擎处理
