### PR TITLE
[CINN]fix reduce as  to sum pass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/reduce_as_to_sum_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/reduce_as_to_sum_pass.cc
@@ -59,10 +59,7 @@ class ReduceAsOpPattern
 
     size_t x_rank = x_shape.size();
     size_t y_rank = y_shape.size();
-    if (y_rank == 1 && y_shape[0] == 1) {
-      // TODO(phrain): reduce to shape [1] will failed in codegen
-      return false;
-    }
+
     int64_t compare_offset = x_rank - y_rank;
     std::vector<int64_t> reduce_axis;
 


### PR DESCRIPTION
### PR Category
CINN

### PR Types
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-76996

修复 reduce as to sum pass的bug，之前当y.shape = [1]的时候，不会进行转换