### PR TITLE
fix COMPLEX64 or COMPLEX128  is op input for paddle-trt

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -201,9 +201,16 @@ struct SimpleOpTypeSetTeller : public Teller {
         return false;
       }
 #endif
-#if !IS_TRT_VERSION_GE(8600)
       auto x_var_name = desc.Input("X")[0];
       auto* x_var_desc = block->FindVarRecursive(x_var_name);
+      auto x_dtype = x_var_desc->GetDataType();
+      if (x_dtype == framework::proto::VarType::COMPLEX64 ||
+          x_dtype == framework::proto::VarType::COMPLEX128) {
+        VLOG(3) << op_type
+                << " op does not support COMPLEX64 or COMPLEX128 input";
+        return false;
+      }
+#if !IS_TRT_VERSION_GE(8600)
       const auto x_shape = x_var_desc->GetShape();
       if (x_shape.empty() && unary_list.find(op_type) != unary_list.end()) {
         VLOG(3) << op_type


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-71501
Do not support  COMPLEX64 or COMPLEX128  is op input for paddle-trt