### PR TITLE
[XPU] fix bugs when XPU/CUDA_VISIBLE_DEVICES in empty

### DIFF
--- a/paddle/phi/backends/xpu/xpu_info.cc
+++ b/paddle/phi/backends/xpu/xpu_info.cc
@@ -80,6 +80,17 @@ static int GetDeviceCountImpl() {
     }
   }
 
+  const auto* cuda_visible_devices = std::getenv("CUDA_VISIBLE_DEVICES");
+  if (cuda_visible_devices != nullptr) {
+    std::string cuda_visible_devices_str(cuda_visible_devices);
+    if (std::all_of(cuda_visible_devices_str.begin(),
+                    cuda_visible_devices_str.end(),
+                    [](char ch) { return ch == ' '; })) {
+      VLOG(2) << "CUDA_VISIBLE_DEVICES is set to be empty. No XPU detected.";
+      return 0;
+    }
+  }
+
   int count = 0;
   PADDLE_ENFORCE_XPU_SUCCESS(xpu_device_count(&count));
   return count;

--- a/paddle/phi/core/kernel_factory.cc
+++ b/paddle/phi/core/kernel_factory.cc
@@ -350,12 +350,13 @@ KernelResult KernelFactory::SelectKernelOrThrowError(
       (kernel_iter == iter->second.end() || (xpu_unsupported && !has_kp_kernel))
 #elif defined(PADDLE_WITH_XPU) && !defined(PADDLE_WITH_XPU_KP)
   VLOG(6) << "fluid_op_name: " << TransToFluidOpName(kernel_name);
-  bool is_xpu_support1 = phi::backends::xpu::is_xpu_support_op(
-      TransToFluidOpName(kernel_name), kernel_key.dtype());
-  bool is_xpu_support2 =
-      phi::backends::xpu::is_xpu_support_op(kernel_name, kernel_key.dtype());
+  bool is_xpu_unsupported =
+      kernel_key.backend() == Backend::XPU &&
+      !phi::backends::xpu::is_xpu_support_op(TransToFluidOpName(kernel_name),
+                                             kernel_key.dtype()) &&
+      !phi::backends::xpu::is_xpu_support_op(kernel_name, kernel_key.dtype());
   if ((FLAGS_enable_api_kernel_fallback && kernel_iter == iter->second.end()) ||
-      (!is_xpu_support1 && !is_xpu_support2)
+      is_xpu_unsupported
 #elif defined(PADDLE_WITH_CUSTOM_DEVICE)
   if (kernel_iter == iter->second.end() &&
       kernel_key.backend() > phi::Backend::NUM_BACKENDS) {

--- a/test/xpu/test_empty_visible_devices_xpu.py
+++ b/test/xpu/test_empty_visible_devices_xpu.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from multiprocessing import Process
+
+
+def run_test_with_env(env_name):
+    import os
+
+    os.environ[env_name] = ""
+    import paddle
+
+    a = paddle.zeros([2, 2])
+    b = paddle.ones([2, 2])
+    c = a + b
+    assert c.place.is_cpu_place()
+
+
+class TestEmptyVisibleDevices(unittest.TestCase):
+    def test_xpu_env(self):
+        p = Process(target=run_test_with_env, args=("XPU_VISIBLE_DEVICES",))
+        p.start()
+        p.join()
+        self.assertEqual(p.exitcode, 0)
+
+    def test_cuda_env(self):
+        p = Process(target=run_test_with_env, args=("CUDA_VISIBLE_DEVICES",))
+        p.start()
+        p.join()
+        self.assertEqual(p.exitcode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
when `XPU/CUDA_VISIBLE_DEVICES` is set to empty list, there would be errors due to the failures of runtime APIs:

![image](https://github.com/user-attachments/assets/deab4dce-2e3f-4660-ae51-3384ac637272)

The PR fixes this issue.
