### PR TITLE
[Paddle TensorRT] delete trt_config.allow_only_specified_trt_ops API

### DIFF
--- a/python/paddle/tensorrt/export.py
+++ b/python/paddle/tensorrt/export.py
@@ -227,7 +227,7 @@ class TensorRTConfig:
             >>> input.input_range=(1,10)
 
             >>> trt_config = TensorRTConfig(inputs=[input])
-            >>> trt_config.disable_ops = "pd_op.dropout"
+            >>> trt_config.disable_ops = ["pd_op.dropout"]
             >>> trt_config.precision_mode = PrecisionMode.FP16
             >>> trt_config.ops_run_float = "pd_op.conv2d"
             >>> trt_config.workspace_size = 2 << 30

--- a/python/paddle/tensorrt/export.py
+++ b/python/paddle/tensorrt/export.py
@@ -36,7 +36,6 @@ from paddle.jit.dy2static.program_translator import (
 from paddle.nn import Layer
 from paddle.tensorrt.converter import PaddleToTensorRTConverter
 from paddle.tensorrt.util import (
-    enforce_op_lower_trt,
     forbid_op_lower_trt,
     mark_builtin_op,
     run_pir_pass,
@@ -176,7 +175,6 @@ class TensorRTConfig:
         optimization_level: int | None = 3,
         disable_passes: list = [],
         workspace_size: int | None = 1 << 30,
-        allow_only_specified_trt_ops: str | list | None = None,
     ) -> None:
         """
         A class for configuring TensorRT optimizations.
@@ -205,8 +203,6 @@ class TensorRTConfig:
                 A list of string representing the names of pass that should not be used for origin program (default is []).
             workspace_size (int, optional):
                 Specifies the maximum GPU memory (in bytes) that TensorRT can use for the optimization process (default is 1 << 30).
-            allow_only_specified_trt_ops(str|list,optional):
-                Allows a specified operation or a list of operations to be passed into TRT, while excluding all others.(default is None).
         Returns:
             None
 
@@ -241,7 +237,6 @@ class TensorRTConfig:
         self.disable_passes = disable_passes
         self.optimization_level = optimization_level
         self.workspace_size = workspace_size
-        self.allow_only_specified_trt_ops = allow_only_specified_trt_ops
         paddle.framework.set_flags(
             {'FLAGS_trt_min_group_size': min_subgraph_size}
         )
@@ -287,14 +282,6 @@ def convert_to_trt(program, trt_config, scope):
             max_shape_feed=max_shape_feed,
             scope=scope,
         )
-        if trt_config.allow_only_specified_trt_ops and trt_config.disable_ops:
-            raise ValueError(
-                "The parameters 'allow_only_specified_trt_ops' and 'disable_ops' are mutually exclusive. Please specify only one."
-            )
-        if trt_config.allow_only_specified_trt_ops:
-            enforce_op_lower_trt(
-                program, trt_config.allow_only_specified_trt_ops
-            )
 
         # specify certain operators to be excluded from entering TensorRT
         if trt_config.disable_ops:

--- a/python/paddle/tensorrt/util.py
+++ b/python/paddle/tensorrt/util.py
@@ -133,12 +133,9 @@ def forbid_op_lower_trt(program, disabled_ops):
             op.set_bool_attr("__l_trt__", False)
 
 
-def enforce_op_lower_trt(program, enable_ops):
-    if isinstance(enable_ops, str):
-        enable_ops = [enable_ops]
+def enforce_op_lower_trt(program, op_name):
     for op in program.global_block().ops:
-        op.set_bool_attr("__l_trt__", False)
-        if op.name() in enable_ops:
+        if op.name() == op_name:
             op.set_bool_attr("__l_trt__", True)
 
 

--- a/python/paddle/tensorrt/util.py
+++ b/python/paddle/tensorrt/util.py
@@ -133,10 +133,12 @@ def forbid_op_lower_trt(program, disabled_ops):
             op.set_bool_attr("__l_trt__", False)
 
 
-def enforce_op_lower_trt(program, op_name):
+def enforce_op_lower_trt(program, enable_ops):
+    if isinstance(enable_ops, str):
+        enable_ops = [enable_ops]
     for op in program.global_block().ops:
         op.set_bool_attr("__l_trt__", False)
-        if op.name() == op.name:
+        if op.name() in enable_ops:
             op.set_bool_attr("__l_trt__", True)
 
 

--- a/test/tensorrt/test_converter_model_dummy.py
+++ b/test/tensorrt/test_converter_model_dummy.py
@@ -47,6 +47,7 @@ class TestConverterDummy(unittest.TestCase):
         trt_config.precision_mode = PrecisionMode.FP16
         trt_config.ops_run_float = "pd_op.add"
         trt_config.optimization_level = 5
+        trt_config.allow_only_specified_trt_ops = "pd_op.add"
 
         output_var = program.list_vars()[-1]
 

--- a/test/tensorrt/test_converter_model_dummy.py
+++ b/test/tensorrt/test_converter_model_dummy.py
@@ -47,7 +47,6 @@ class TestConverterDummy(unittest.TestCase):
         trt_config.precision_mode = PrecisionMode.FP16
         trt_config.ops_run_float = "pd_op.add"
         trt_config.optimization_level = 5
-        trt_config.allow_only_specified_trt_ops = "pd_op.add"
 
         output_var = program.list_vars()[-1]
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
card-71500
删除这个接口