### PR TITLE
[Paddle TensorRT] Add pd_op.index_put、pd_op.pow converter

### DIFF
--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -2014,7 +2014,8 @@ class IndexPutOpPattern
     int value_num = std::accumulate(
         value_shape.begin(), value_shape.end(), 1, std::multiplies<int>());
     if (value_num != 1) {
-      VLOG(3) << " index_put op only support value_num = 1 in tensorrt." << value_num;
+      VLOG(3) << " index_put op only support value_num = 1 in tensorrt."
+              << value_num;
       return false;
     }
     pir::Value indices = op.operand_source(1);

--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -2005,10 +2005,6 @@ class IndexPutOpPattern
         op->attribute<pir::BoolAttribute>(kCanRunTrtAttr).data()) {
       return false;
     }
-#if IS_TRT_VERSION_LT(8510)
-    VLOG(3) << "index_put is not supported when TensorRT < 8.5.1";
-    return false;
-#endif
     pir::Value value = op.operand_source(2);
     auto value_shape = pir::GetShapeFromValue(value);
     int value_num = std::accumulate(

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -26,6 +26,7 @@ from paddle.tensorrt.converter_utils import (
     get_shape_tensor_element,
     has_dynamic_shape,
     resize_to_1d,
+    trt_cast,
     trt_concat,
     trt_expand,
     trt_floor_div,
@@ -966,5 +967,75 @@ def numel_converter(network, paddle_op, inputs):
     shape_tensor = network.add_shape(input_tensor).get_output(0)
     layer = network.add_reduce(
         shape_tensor, trt.ReduceOperation.PROD, axes=1, keep_dims=False
+    )
+    return layer.get_output(0)
+
+
+@converter_registry.register("pd_op.index_put", trt_version="8.x")
+def index_put_converter(network, paddle_op, inputs):
+    input_tensor, indices_list, value_tensor = inputs
+    indices_tensor = indices_list[0]
+    input_shape_tensor = trt_shape(network, input_tensor)
+    input_dims = input_tensor.shape
+    indices_dims = indices_tensor.shape
+    rank = len(input_dims)
+
+    # indices
+    indices_shape_vec = []
+    start_tensor_vec = []
+    stride_tensor_vec = []
+    for i in range(rank):
+        indices_one = indices_dims[i] if i < len(indices_dims) else 1
+        indices_shape_vec.append(indices_one)
+        start_tensor_vec.append(add_1D_constant_layer(network, 0))
+        stride_tensor_vec.append(add_1D_constant_layer(network, 1))
+    indices_tensor_temp = trt_reshape(
+        network, indices_tensor, indices_shape_vec
+    )
+    start_tensor = trt_concat(network, start_tensor_vec)
+    stride_tensor = trt_concat(network, stride_tensor_vec)
+
+    # slice
+    stride = [1] * rank
+    indices_slice_layer = network.add_slice(
+        trt_cast(network, indices_tensor_temp, trt.float32),
+        stride,
+        stride,
+        stride,
+    )
+    indices_slice_layer.set_input(1, start_tensor)
+    indices_slice_layer.set_input(2, input_shape_tensor)
+    indices_slice_layer.set_input(3, stride_tensor)
+    indices_slice_layer.mode = trt.SampleMode.CLAMP
+
+    bool_indices_tensor = trt_cast(
+        network, indices_slice_layer.get_output(0), trt.bool
+    )
+
+    # nonzero
+    nonzero_layer = network.add_non_zero(bool_indices_tensor)
+    indices_tensor = nonzero_layer.get_output(0)
+    permutation = trt.Permutation([1, 0])
+    trans_layer = network.add_shuffle(indices_tensor)
+    trans_layer.first_transpose = permutation
+    indices_tensor = trans_layer.get_output(0)
+    indices_new_shape_tensor = trt_shape(network, indices_tensor)
+    indices_count_tensor = get_shape_tensor_element(
+        network, indices_new_shape_tensor, 0
+    )
+
+    # value
+    value_stride = [1]
+    value_slice_layer = network.add_slice(
+        value_tensor, value_stride, value_stride, value_stride
+    )
+    value_slice_layer.set_input(1, add_1D_constant_layer(network, 0))
+    value_slice_layer.set_input(2, indices_count_tensor)
+    value_slice_layer.set_input(3, add_1D_constant_layer(network, 1))
+    value_slice_layer.mode = trt.SampleMode.CLAMP
+    value_tensor = value_slice_layer.get_output(0)
+
+    layer = network.add_scatter(
+        input_tensor, indices_tensor, value_tensor, trt.ScatterMode.ND
     )
     return layer.get_output(0)

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -981,12 +981,19 @@ def index_put_converter(network, paddle_op, inputs):
     rank = len(input_dims)
 
     # indices
-    indices_shape_vec = [add_1D_constant_layer(network, indices_dims[i] if i < len(indices_dims) else 1) for i in
-                         range(rank)]
+    indices_shape_vec = [
+        add_1D_constant_layer(
+            network, indices_dims[i] if i < len(indices_dims) else 1
+        )
+        for i in range(rank)
+    ]
     start_tensor_vec = [add_1D_constant_layer(network, 0)] * rank
     stride_tensor_vec = [add_1D_constant_layer(network, 1)] * rank
     indices_tensor_temp = trt_reshape(
-        network, indices_tensor, trt_concat(network, indices_shape_vec), is_shape_tensor=True
+        network,
+        indices_tensor,
+        trt_concat(network, indices_shape_vec),
+        is_shape_tensor=True,
     )
     start_tensor = trt_concat(network, start_tensor_vec)
     stride_tensor = trt_concat(network, stride_tensor_vec)

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -981,16 +981,12 @@ def index_put_converter(network, paddle_op, inputs):
     rank = len(input_dims)
 
     # indices
-    indices_shape_vec = []
-    start_tensor_vec = []
-    stride_tensor_vec = []
-    for i in range(rank):
-        indices_one = indices_dims[i] if i < len(indices_dims) else 1
-        indices_shape_vec.append(indices_one)
-        start_tensor_vec.append(add_1D_constant_layer(network, 0))
-        stride_tensor_vec.append(add_1D_constant_layer(network, 1))
+    indices_shape_vec = [add_1D_constant_layer(network, indices_dims[i] if i < len(indices_dims) else 1) for i in
+                         range(rank)]
+    start_tensor_vec = [add_1D_constant_layer(network, 0)] * rank
+    stride_tensor_vec = [add_1D_constant_layer(network, 1)] * rank
     indices_tensor_temp = trt_reshape(
-        network, indices_tensor, indices_shape_vec
+        network, indices_tensor, trt_concat(network, indices_shape_vec), is_shape_tensor=True
     )
     start_tensor = trt_concat(network, start_tensor_vec)
     stride_tensor = trt_concat(network, stride_tensor_vec)

--- a/python/paddle/tensorrt/impls/math.py
+++ b/python/paddle/tensorrt/impls/math.py
@@ -18,6 +18,7 @@ import tensorrt as trt
 from paddle.tensorrt.converter_utils import (
     add_1D_constant_layer,
     add_cast_reduce_layer,
+    add_constant_layer,
     add_elementwise_layer,
     add_reduce_layer,
     broadcast,
@@ -223,8 +224,8 @@ def pow_converter(network, paddle_op, inputs):
     factor = paddle_op.attrs()["y"]
     dims_x = x.shape
     trt_dims_y = trt.Dims([1] * len(dims_x))
-    w_data = np.array([factor], dtype=np.float32)
-    y = network.add_constant(trt_dims_y, w_data).get_output(0)
+    w_data = [factor]
+    y = add_constant_layer(network, w_data, trt_dims_y, np.float32)
     layer = network.add_elementwise(x, y, trt.ElementWiseOperation.POW)
     support_fp32_mix_precision(paddle_op.name(), layer)
     return layer.get_output(0)

--- a/python/paddle/tensorrt/impls/math.py
+++ b/python/paddle/tensorrt/impls/math.py
@@ -215,6 +215,13 @@ def clip_converter(network, paddle_op, inputs):
     return layer.get_output(0)
 
 
+@converter_registry.register("pd_op.pow", trt_version="8.x")
+def pow_op_converter(network, paddle_op, inputs):
+    return add_elementwise_layer(
+        network, paddle_op, inputs, trt.ElementWiseOperation.POW
+    )
+
+
 @converter_registry.register("pd_op.remainder", trt_version="8.x")
 @converter_registry.register("pd_op.remainder_", trt_version="8.x")
 def remainder_converter(network, paddle_op, inputs):

--- a/test/tensorrt/test_converter_manipulation.py
+++ b/test/tensorrt/test_converter_manipulation.py
@@ -776,5 +776,45 @@ class TestNumelTRTCase2Pattern(TensorRTBaseTest):
         self.check_trt_result()
 
 
+class TestIndexPutTRTCasePattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.index_put
+        self.api_args = {
+            "x": np.zeros([2, 3]).astype("float32"),
+            "indices": [np.array([1, 0]).astype("bool")],
+            "value": np.array([1]).astype("float32"),
+        }
+        self.program_config = {"feed_list": ["x", "indices", "value"]}
+        self.min_shape = {"x": [2, 3]}
+        self.opt_shape = {"x": [2, 3]}
+        self.max_shape = {"x": [4, 3]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+    def test_fp16_result(self):
+        self.check_trt_result(precision_mode="fp16")
+
+
+class TestIndexPutCase2TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.index_put
+        self.api_args = {
+            "x": np.random.random([3, 3]).astype("int64"),
+            "indices": [np.array([0, 1, 1]).astype("bool")],
+            "value": np.array([2]).astype("int64"),
+        }
+        self.program_config = {"feed_list": ["x", "indices", "value"]}
+        self.min_shape = {"x": [1, 3]}
+        self.opt_shape = {"x": [2, 3]}
+        self.max_shape = {"x": [5, 3]}
+
+    def test_trt_result(self):
+        self.check_trt_result()
+
+    def test_fp16_result(self):
+        self.check_trt_result(precision_mode="fp16")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/tensorrt/test_converter_math.py
+++ b/test/tensorrt/test_converter_math.py
@@ -143,7 +143,7 @@ class TestPowCase2TRTPattern(TensorRTBaseTest):
         self.python_api = paddle.pow
         self.api_args = {
             "x": np.random.randn(2, 3).astype("float32"),
-            "y": int(2),
+            "y": 2,
         }
         self.program_config = {"feed_list": ["x"]}
         self.min_shape = {"x": [1, 3]}

--- a/test/tensorrt/test_converter_math.py
+++ b/test/tensorrt/test_converter_math.py
@@ -119,6 +119,63 @@ class TestElementwisePowTRTPattern(TensorRTBaseTest):
         self.check_trt_result()
 
 
+class TestPowCase1TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.pow
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype("float32"),
+            "y": float(np.random.randn()),
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1, 3]}
+        self.opt_shape = {"x": [1, 3]}
+        self.max_shape = {"x": [5, 3]}
+
+    def test_trt_result_fp32(self):
+        self.check_trt_result()
+
+    def test_trt_result_fp16(self):
+        self.check_trt_result(precision_mode="fp16")
+
+
+class TestPowCase2TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.pow
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype("int64"),
+            "y": int(np.random.randn()),
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1, 3]}
+        self.opt_shape = {"x": [1, 3]}
+        self.max_shape = {"x": [5, 3]}
+
+    def test_trt_result_fp32(self):
+        self.check_trt_result()
+
+    def test_trt_result_fp16(self):
+        self.check_trt_result(precision_mode="fp16")
+
+
+class TestPowCase3TRTPattern(TensorRTBaseTest):
+    def setUp(self):
+        self.python_api = paddle.pow
+        self.api_args = {
+            "x": np.random.randn(2, 3).astype("float32"),
+            "y": float(np.random.randn()),
+        }
+        self.program_config = {"feed_list": ["x"]}
+        self.min_shape = {"x": [1, 3]}
+        self.opt_shape = {"x": [1, 3]}
+        self.max_shape = {"x": [5, 3]}
+
+    def test_trt_result_fp32(self):
+        self.check_trt_result()
+
+    def test_trt_result_fp16(self):
+        self.check_trt_result(precision_mode="fp16")
+
+
 class TestRemainderFloatTRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.remainder

--- a/test/tensorrt/test_converter_math.py
+++ b/test/tensorrt/test_converter_math.py
@@ -124,7 +124,7 @@ class TestPowCase1TRTPattern(TensorRTBaseTest):
         self.python_api = paddle.pow
         self.api_args = {
             "x": np.random.randn(2, 3).astype("float32"),
-            "y": float(np.random.randn()),
+            "y": 2.5,
         }
         self.program_config = {"feed_list": ["x"]}
         self.min_shape = {"x": [1, 3]}
@@ -142,27 +142,8 @@ class TestPowCase2TRTPattern(TensorRTBaseTest):
     def setUp(self):
         self.python_api = paddle.pow
         self.api_args = {
-            "x": np.random.randn(2, 3).astype("int64"),
-            "y": int(np.random.randn()),
-        }
-        self.program_config = {"feed_list": ["x"]}
-        self.min_shape = {"x": [1, 3]}
-        self.opt_shape = {"x": [1, 3]}
-        self.max_shape = {"x": [5, 3]}
-
-    def test_trt_result_fp32(self):
-        self.check_trt_result()
-
-    def test_trt_result_fp16(self):
-        self.check_trt_result(precision_mode="fp16")
-
-
-class TestPowCase3TRTPattern(TensorRTBaseTest):
-    def setUp(self):
-        self.python_api = paddle.pow
-        self.api_args = {
             "x": np.random.randn(2, 3).astype("float32"),
-            "y": float(np.random.randn()),
+            "y": int(2),
         }
         self.program_config = {"feed_list": ["x"]}
         self.min_shape = {"x": [1, 3]}


### PR DESCRIPTION
### PR Category
Inference

### PR Types
New features

### Description
pcard-71500
- 新增了pd_op.index_put Marker和Converter（注意：旧ir下indices输入为tensor，但是pir的indices输入为list，这里只支持了输入的list中只有一个tensor的情况，以及测试旧ir单测时indices输入（即generate_input2）应当为`[numpy]`而不是`numpy`）
- 新增了pd_op.pow Marker和Converter