### PR TITLE
fix paddle.save rng_state error

### DIFF
--- a/paddle/phi/core/generator.h
+++ b/paddle/phi/core/generator.h
@@ -39,10 +39,15 @@ class Generator {
 
     GeneratorState(int64_t device_ = -1,
                    uint64_t seed_ = MAGIC_RANDOM_SEED,
-                   uint64_t offset_ = 0)
+                   uint64_t offset_ = 0,
+                   std::shared_ptr<std::mt19937_64> engine = nullptr)
         : device(device_), seed(seed_), offset(offset_) {
-      std::seed_seq seq({seed});
+      std::seed_seq seq({seed_});
       cpu_engine = std::make_shared<std::mt19937_64>(seq);
+      if (engine != nullptr) {
+        // Clone the engine state
+        *(cpu_engine) = *(engine);
+      }
     }
 
     GeneratorState(const GeneratorState& state)

--- a/test/legacy_test/test_paddle_save_load.py
+++ b/test/legacy_test/test_paddle_save_load.py
@@ -23,7 +23,7 @@ from test_imperative_base import new_program_scope
 import paddle
 import paddle.optimizer as opt
 from paddle import base, nn
-from paddle.base import framework
+from paddle.base import core, framework
 from paddle.framework import in_pir_mode
 from paddle.framework.io_utils import get_value, is_pir_fetch_var, set_value
 from paddle.optimizer import Adam
@@ -1174,6 +1174,27 @@ class TestSaveLoadLayer(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             paddle.save(origin_layer, path)
+        temp_dir.cleanup()
+
+
+class TestSaveLoadRngState(unittest.TestCase):
+    def test_save_load_layer(self):
+        paddle.disable_static()
+        paddle.set_device('cpu')
+        paddle.seed(42)
+        temp_dir = tempfile.TemporaryDirectory()
+        rand_a = paddle.rand([2, 2])
+        checkpoint_rng_state = {
+            "cpu": paddle.framework.core.default_cpu_generator().get_state()
+        }
+        rand_b = paddle.rand([2, 2])
+        path = os.path.join(temp_dir.name, "test_save_load_rng_/rng_state.pth")
+        with self.assertRaises(ValueError):
+            paddle.save(checkpoint_rng_state, path)
+        checkpoint_rng_state = paddle.load(path, return_numpy=True)
+        core.default_cpu_generator().set_state(checkpoint_rng_state["cpu"])
+        rand_c = paddle.rand([2, 2])
+        np.testing.assert_array_equal(rand_b.numpy(), rand_c.numpy())
         temp_dir.cleanup()
 
 

--- a/test/legacy_test/test_paddle_save_load.py
+++ b/test/legacy_test/test_paddle_save_load.py
@@ -1189,8 +1189,7 @@ class TestSaveLoadRngState(unittest.TestCase):
         }
         rand_b = paddle.rand([2, 2])
         path = os.path.join(temp_dir.name, "test_save_load_rng_/rng_state.pth")
-        with self.assertRaises(ValueError):
-            paddle.save(checkpoint_rng_state, path)
+        paddle.save(checkpoint_rng_state, path)
         checkpoint_rng_state = paddle.load(path, return_numpy=True)
         core.default_cpu_generator().set_state(checkpoint_rng_state["cpu"])
         rand_c = paddle.rand([2, 2])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pickle无法序列化mt19937_64，导致paddle.save和load无法恢复paddle cpu rng_state。
本pr将mt19937_64序列化成比特流，再将比特流反序列化成mt19937_64。修复了paddle.save和load无法恢复paddle cpu rng_state的问题。
Pcard-67164