### PR TITLE
[cherry-pick]Remove storage when recompute using saved_tensor_hooks (#70455)

### DIFF
--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -430,7 +430,7 @@ def _recompute_without_reentrant(
                             with paddle.autograd.saved_tensors_hooks(
                                 inner_pack, inner_unpack
                             ):
-                                unused_outputs = function(*args, **kwargs)
+                                function(*args, **kwargs)
             else:
                 with paddle.set_grad_enabled(True), paddle.amp.auto_cast(
                     enable=is_fw_autocast,
@@ -441,14 +441,14 @@ def _recompute_without_reentrant(
                 ), paddle.autograd.saved_tensors_hooks(
                     inner_pack, inner_unpack
                 ):
-                    unused_outputs = function(*args, **kwargs)
+                    function(*args, **kwargs)
 
         if x not in storage:
             raise Exception(
                 "Not supported to retrieve a tensor saved by autograd multiple times that is no need to recompute."
             )
 
-        return storage[x]
+        return storage.pop(x)
 
     with paddle.autograd.saved_tensors_hooks(pack, unpack):
         outputs = function(*args, **kwargs)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
cherry-pick #70455 to fix oom on LLM models.