### PR TITLE
[SOT] Support `.tolist()` in SOT Static Mode

### DIFF
--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -1888,6 +1888,34 @@ class Variable(metaclass=VariableMetaClass):
         """
         pass
 
+
+@fake_interface_only
+def tolist(self):
+    """
+    **Notes**:
+        **This API is ONLY available in Dygraph mode**
+
+    Returns a Python list shows the value of current :ref:`api_guide_Variable_en`
+
+    Returns:
+        list: The Python list value of current Variable.
+
+    Returns type:
+        list: dtype is same as current Variable
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+            >>> import paddle.base as base
+
+            >>> with base.dygraph.guard():
+            ...     data_tensor = paddle.randn([2, 3])
+            ...     print(data_tensor.tolist())
+
+    """
+    pass
+
     @non_static_only
     def backward(self, retain_graph=False):
         """

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -1888,34 +1888,6 @@ class Variable(metaclass=VariableMetaClass):
         """
         pass
 
-
-@fake_interface_only
-def tolist(self):
-    """
-    **Notes**:
-        **This API is ONLY available in Dygraph mode**
-
-    Returns a Python list shows the value of current :ref:`api_guide_Variable_en`
-
-    Returns:
-        list: The Python list value of current Variable.
-
-    Returns type:
-        list: dtype is same as current Variable
-
-    Examples:
-        .. code-block:: python
-
-            >>> import paddle
-            >>> import paddle.base as base
-
-            >>> with base.dygraph.guard():
-            ...     data_tensor = paddle.randn([2, 3])
-            ...     print(data_tensor.tolist())
-
-    """
-    pass
-
     @non_static_only
     def backward(self, retain_graph=False):
         """

--- a/python/paddle/jit/sot/utils/paddle_api_config.py
+++ b/python/paddle/jit/sot/utils/paddle_api_config.py
@@ -123,6 +123,7 @@ break_graph_tensor_method = {
     'register_hook',
     'numpy',
     'clear_gradient',
+    'tolist',
     # TODO: Browse all possible functions and make prior judgments.
 }
 

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -1076,6 +1076,7 @@ def monkey_patch_value():
         ('values', values),
         ("_to", _to),
         ("to", to),
+        ("tolist", tolist),
         ("numpy", numpy),
         ("register_hook", register_hook),
         # For basic operators

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -1000,6 +1000,7 @@ def monkey_patch_value():
             ndarray: dtype is same as current Variable
         Examples:
             .. code-block:: python
+
                 >>> import paddle
                 >>> import paddle.base as base
                 >>> from paddle.nn import Linear
@@ -1028,6 +1029,7 @@ def monkey_patch_value():
 
         Examples:
             .. code-block:: python
+
                 >>> import paddle
                 >>> import paddle.base as base
                 >>> import numpy as np

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -1015,6 +1015,27 @@ def monkey_patch_value():
 
     @fake_interface_only
     def tolist(self):
+        """
+        **Notes**:
+            **This API is ONLY available in Dygraph mode**
+        Returns a Python list that contains the elements of current :ref:`api_guide_Variable_en`
+
+        Returns:
+            list: The Python list containing the elements of current Variable.
+
+        Returns type:
+            list: Elements have the same dtype as current Variable
+
+        Examples:
+            .. code-block:: python
+                >>> import paddle
+                >>> import paddle.base as base
+                >>> import numpy as np
+                >>> data = np.random.uniform(-1, 1, [2, 3]).astype('float32')
+                >>> with base.dygraph.guard():
+                ...     x = paddle.to_tensor(data)
+                ...     print(x.tolist())  # Convert tensor to Python list
+        """
         pass
 
     @fake_interface_only

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -1014,6 +1014,10 @@ def monkey_patch_value():
         pass
 
     @fake_interface_only
+    def tolist(self):
+        pass
+
+    @fake_interface_only
     def register_hook(self, hook):
         """
         Value don't have 'register_hook' interface in static graph mode

--- a/test/dygraph_to_static/test_tensor_attr_consistency.py
+++ b/test/dygraph_to_static/test_tensor_attr_consistency.py
@@ -75,7 +75,6 @@ DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(
         'strides',
         'to_sparse_coo',
         'to_sparse_csr',
-        'tolist',
         'value',
         'zero_',
         "__cuda_array_interface__",

--- a/test/sot/test_18_tensor_method.py
+++ b/test/sot/test_18_tensor_method.py
@@ -48,6 +48,8 @@ def tensor_method_property(a: paddle.Tensor, b: paddle.Tensor):
         a.type,
         a.is_tensor(),
         a.clear_gradient(),
+        a.tolist(),
+        a.numpy(),
         a @ b.T.astype(a.dtype)
         + len(a.shape)
         + b.size

--- a/test/sot/test_18_tensor_method.py
+++ b/test/sot/test_18_tensor_method.py
@@ -17,13 +17,16 @@ import unittest
 from test_case_base import TestCaseBase, test_with_faster_guard
 
 import paddle
+from paddle.jit.sot.psdb import check_no_breakgraph
 
 
+@check_no_breakgraph
 def tensor_method_call_1(x: paddle.Tensor):
     y = x + 1
     return y.mean()
 
 
+@check_no_breakgraph
 def tensor_method_call_2(a: paddle.Tensor, b: paddle.Tensor):
     c = a.add(b)
     d = c.multiply(a)
@@ -39,7 +42,7 @@ def tensor_method_passed_by_user(a: paddle.Tensor, func: paddle.Tensor):
     return func(a)
 
 
-def tensor_method_property(a: paddle.Tensor, b: paddle.Tensor):
+def tensor_method_property1(a: paddle.Tensor, b: paddle.Tensor):
     return (
         a.name,
         str(a.place),
@@ -49,6 +52,24 @@ def tensor_method_property(a: paddle.Tensor, b: paddle.Tensor):
         a.is_tensor(),
         a.clear_gradient(),
         a.tolist(),
+        a @ b.T.astype(a.dtype)
+        + len(a.shape)
+        + b.size
+        + a.ndim
+        + a.dim()
+        + a.rank(),
+    )
+
+
+def tensor_method_property2(a: paddle.Tensor, b: paddle.Tensor):
+    return (
+        a.name,
+        str(a.place),
+        a.persistable,
+        a.dtype,
+        a.type,
+        a.is_tensor(),
+        a.clear_gradient(),
         a.numpy(),
         a @ b.T.astype(a.dtype)
         + len(a.shape)
@@ -59,10 +80,12 @@ def tensor_method_property(a: paddle.Tensor, b: paddle.Tensor):
     )
 
 
+@check_no_breakgraph
 def tensor_method_property_mT(a: paddle.Tensor):
     return a.mT
 
 
+@check_no_breakgraph
 def middle_tensor_name(a: paddle.Tensor, b: paddle.Tensor):
     c = a + b
     return c.name
@@ -89,7 +112,8 @@ class TestTensorMethod(TestCaseBase):
     def test_tensor_method_property(self):
         x = paddle.rand([42, 24], dtype='float64')
         y = paddle.rand([42, 24], dtype='float32')
-        self.assert_results(tensor_method_property, x, y)
+        self.assert_results(tensor_method_property1, x, y)
+        self.assert_results(tensor_method_property2, x, y)
 
     @unittest.skip("TODO: dynamic tensor name is different")
     def test_middle_tensor_name(self):

--- a/test/sot/test_18_tensor_method.py
+++ b/test/sot/test_18_tensor_method.py
@@ -42,35 +42,27 @@ def tensor_method_passed_by_user(a: paddle.Tensor, func: paddle.Tensor):
     return func(a)
 
 
-def tensor_method_property1(a: paddle.Tensor, b: paddle.Tensor):
+@check_no_breakgraph
+def tensor_method_property_without_breakgraph(
+    a: paddle.Tensor, b: paddle.Tensor
+):
     return (
         a.name,
-        str(a.place),
         a.persistable,
         a.dtype,
         a.type,
         a.is_tensor(),
-        a.clear_gradient(),
-        a.tolist(),
-        a @ b.T.astype(a.dtype)
-        + len(a.shape)
-        + b.size
-        + a.ndim
-        + a.dim()
-        + a.rank(),
+        len(a.shape) + b.size + a.ndim + a.dim() + a.rank(),
+        a @ b.T.astype(a.dtype),
     )
 
 
-def tensor_method_property2(a: paddle.Tensor, b: paddle.Tensor):
+def tensor_method_property_with_breakgraph(a: paddle.Tensor, b: paddle.Tensor):
     return (
-        a.name,
-        str(a.place),
-        a.persistable,
-        a.dtype,
-        a.type,
-        a.is_tensor(),
-        a.clear_gradient(),
         a.numpy(),
+        a.tolist(),
+        str(a.place),
+        a.clear_gradient(),
         a @ b.T.astype(a.dtype)
         + len(a.shape)
         + b.size
@@ -112,8 +104,8 @@ class TestTensorMethod(TestCaseBase):
     def test_tensor_method_property(self):
         x = paddle.rand([42, 24], dtype='float64')
         y = paddle.rand([42, 24], dtype='float32')
-        self.assert_results(tensor_method_property1, x, y)
-        self.assert_results(tensor_method_property2, x, y)
+        self.assert_results(tensor_method_property_without_breakgraph, x, y)
+        self.assert_results(tensor_method_property_with_breakgraph, x, y)
 
     @unittest.skip("TODO: dynamic tensor name is different")
     def test_middle_tensor_name(self):

--- a/test/sot/test_18_tensor_method.py
+++ b/test/sot/test_18_tensor_method.py
@@ -50,25 +50,23 @@ def tensor_method_property_without_breakgraph(
         a.name,
         a.persistable,
         a.dtype,
-        a.type,
         a.is_tensor(),
-        len(a.shape) + b.size + a.ndim + a.dim() + a.rank(),
-        a @ b.T.astype(a.dtype),
-    )
-
-
-def tensor_method_property_with_breakgraph(a: paddle.Tensor, b: paddle.Tensor):
-    return (
-        a.numpy(),
-        a.tolist(),
-        str(a.place),
-        a.clear_gradient(),
         a @ b.T.astype(a.dtype)
         + len(a.shape)
         + b.size
         + a.ndim
         + a.dim()
         + a.rank(),
+    )
+
+
+def tensor_method_property_with_breakgraph(a: paddle.Tensor, b: paddle.Tensor):
+    return (
+        a.type,
+        a.numpy(),
+        a.tolist(),
+        str(a.place),
+        a.clear_gradient(),
     )
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Currently, `.tolist()` method is not supported in SOT static mode. 

```python
import paddle
import numpy as np


def fn():
    x = paddle.rand([3])
    y = x.tolist()
    return y


static_fn = paddle.jit.to_static(fn, full_graph=False)

out = static_fn()
# out = fn()
print(out)
```
the code will raise:
```shell
paddle.jit.sot.utils.exceptions.HasNoAttributeError: Unknown Tensor attribute: tolist
```

Under @SigureMo ’s guidance, this PR implements `.tolist()` support, following a similar approach to the `.numpy()` implementation.

PCard-66972