### PR TITLE
【dygraph】backward_api call backward_api_base

### DIFF
--- a/paddle/phi/api/generator/api_gen.py
+++ b/paddle/phi/api/generator/api_gen.py
@@ -37,19 +37,6 @@ optional_out_type_map = {
     "std::vector<Tensor>": "paddle::optional<std::vector<Tensor>>",
 }
 
-manual_impl = '''
-
-PADDLE_API Tensor embedding_grad(const Tensor& x, const Tensor& weight, const Tensor& out_grad, int64_t padding_idx, bool sparse) {
-  Tensor weight_grad;
-  embedding_grad_impl(x, weight, out_grad, padding_idx, sparse, &weight_grad);
-  return weight_grad;
-}
-
-PADDLE_API std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> cudnn_lstm_grad(const Tensor& x, const Tensor& init_h, const Tensor& init_c, const paddle::optional<std::vector<Tensor>>& weight_list, const paddle::optional<Tensor>& sequence_length, const Tensor& out, const Tensor& reserve, const Tensor& state_out, const Tensor& out_grad, const Tensor& last_h_grad, const Tensor& last_c_grad, float dropout_prob, bool is_bidirec, int hidden_size, int num_layers, bool is_test, int seed) {
-  return cudnn_lstm_grad_impl(x, init_h, init_c, weight_list, sequence_length, out, reserve, state_out, out_grad, last_h_grad, last_c_grad, dropout_prob, is_bidirec, hidden_size, num_layers, is_test, seed) ;
-}
-'''
-
 
 class ForwardAPI(BaseAPI):
     def __init__(self, api_item_yaml):
@@ -428,6 +415,72 @@ class ForwardAPI(BaseAPI):
         return remap_code
 
 
+class BackwardAPI(ForwardAPI):
+
+    def gene_base_api_code(self, inplace_flag=False):
+        api_func_name = self.get_api_func_name()
+        if inplace_flag and api_func_name[-1] != '_':
+            inplace_name = api_func_name + '_'
+        else:
+            inplace_name = api_func_name
+        api_code = f"""
+PADDLE_API {self.get_return_type(inplace_flag)} {inplace_name}({self.get_define_args(inplace_flag)}) {{
+{self.get_grad_outputs_define(inplace_flag)}
+    {api_func_name}({self.get_grad_api_call_args(inplace_flag)});
+    return {self.get_grad_output(inplace_flag)};
+}}
+"""
+        return api_code
+
+    def gene_api_code(self):
+        if not self.is_base_api and not self.is_only_composite_api:
+            invoke_func_name = self.invoke.split('(')[0]
+            if (not invoke_func_name.endswith("_grad")) and (
+                not invoke_func_name.endswith('_impl')
+            ):
+                return ""
+
+        if self.is_only_composite_api:
+            return ""
+
+        api_code = self.gene_base_api_code()
+        if self.is_base_api and len(self.inplace_map) > 0:
+            if self.api[-1] == '_':
+                api_code = ""
+            api_code = api_code + self.gene_base_api_code_for_inplace()
+        return api_code
+
+    def gene_api_declaration(self):
+        if not self.is_base_api and not self.is_only_composite_api:
+            invoke_func_name = self.invoke.split('(')[0]
+            if (not invoke_func_name.endswith("_grad")) and (
+                not invoke_func_name.endswith('_impl')
+            ):
+                return ""
+
+        if self.is_only_composite_api:
+            return ""
+
+        api_declaration = ""
+        api_func_name = self.get_api_func_name()
+        if api_func_name[-1] != '_':
+            api_declaration = f"""
+PADDLE_API {self.get_return_type()} {api_func_name}({self.get_declare_args()});
+"""
+
+        if self.is_base_api and len(self.inplace_map) > 0:
+            if api_func_name[-1] != '_':
+                api_func_name += '_'
+            api_declaration = (
+                api_declaration
+                + f"""
+PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_declare_args(inplace_flag=True)});
+"""
+            )
+
+        return api_declaration
+
+
 def header_include():
     return """
 #include <tuple>
@@ -441,12 +494,13 @@ def header_include():
 
 def source_include(header_file_path):
     return f"""
-#include "{header_file_path}"
+
 #include <memory>
 
 #include "glog/logging.h"
 #include "paddle/common/flags.h"
 
+{header_file_path}
 #include "paddle/phi/api/lib/api_custom_impl.h"
 #include "paddle/phi/api/lib/api_gen_utils.h"
 #include "paddle/phi/api/lib/api_registry.h"
@@ -536,11 +590,20 @@ def generate_api(
     header_file.write(header_include())
     header_file.write(namespace[0])
 
-    include_header_file = (
-        "paddle/phi/api/include/fused_api.h"
-        if is_fused_ops_yaml is True
-        else "paddle/phi/api/include/api.h"
-    )
+    if not grad_flag:
+        include_header_file = (
+            '#include "paddle/phi/api/include/fused_api.h"'
+            if is_fused_ops_yaml is True
+            else '#include "paddle/phi/api/include/api.h"'
+        )
+    else:
+        include_header_file = (
+            '#include "paddle/phi/api/backward/fused_backward_api.h" \n'
+            '#include "paddle/phi/api/backward/fused_backward_api_base.h" '
+            if is_fused_ops_yaml is True
+            else '#include "paddle/phi/api/backward/backward_api.h" \n'
+            '#include "paddle/phi/api/backward/backward_api_base.h" '
+        )
     # not all fused ops support dygraph
     if is_fused_ops_yaml is True:
         new_apis = [
@@ -555,8 +618,11 @@ def generate_api(
     source_file.write(namespace[0])
 
     for api in apis:
+        if not grad_flag:
+            forward_api = ForwardAPI(api)
+        else:
+            forward_api = BackwardAPI(api)
 
-        forward_api = ForwardAPI(api)
         if forward_api.api in backward_api_black_list:
             continue
         if forward_api.is_dygraph_api and not is_fused_ops_yaml:
@@ -569,10 +635,7 @@ def generate_api(
             forward_api.is_dygraph_api = True
 
         header_file.write(forward_api.gene_api_declaration())
-        if forward_api.api not in ["embedding_grad", "cudnn_lstm_grad"]:
-            source_file.write(forward_api.gene_api_code())
-    if not is_fused_ops_yaml and grad_flag:
-        source_file.write(manual_impl)
+        source_file.write(forward_api.gene_api_code())
 
     header_file.write(namespace[1])
     source_file.write(namespace[1])

--- a/paddle/phi/api/generator/backward_api_gen.py
+++ b/paddle/phi/api/generator/backward_api_gen.py
@@ -118,6 +118,10 @@ class BackwardAPI(BaseAPI):
                 not invoke_func_name.endswith('_impl')
             ):
                 return ""
+
+        if self.is_only_composite_api:
+            return ""
+
         api_func_name = self.get_api_func_name()
         api_declaration = f"""
 PADDLE_API void {api_func_name}({self.get_declare_args()});

--- a/paddle/phi/api/generator/sparse_bw_api_gen.py
+++ b/paddle/phi/api/generator/sparse_bw_api_gen.py
@@ -204,7 +204,7 @@ def main():
     parser.add_argument(
         '--api_source_path',
         help='output of generated api source code file',
-        default='paddle/phi/api/lib/sparse_bw_api.cc',
+        default='paddle/phi/api/lib/sparse_backward_api_base.cc',
     )
 
     options = parser.parse_args()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164

phi api 目录下的反向api 调用原有反向api 的实现:
PADDLE_API std::tuple<Tensor, Tensor> add_grad(const Tensor& x, const Tensor& y, const Tensor& out_grad, int axis) {
    Tensor x_grad;
    Tensor y_grad;

    add_grad(x, y, out_grad, axis, &x_grad, &y_grad);
    return std::make_tuple(x_grad, y_grad);
}

修复 backward_api_base中头文件生成composite_only api 的接口，但是没有生成实现的问题 （删除头文件内容，composite_only_api 没有kernel)

适配dygraph_grad_function 中关于invoke api的调用路径， 原本invoke api 生成仍调用phi api 中的对应算子，修复后phi 中没有相应算子，需要在dygraph 层直接调用invoke的算子。