### PR TITLE
[CINN] Fix performance issue on gemm fusion in float32 datatype related to fused_gemm_epilogue_pass

### DIFF
--- a/test/cpp/pir/pattern_rewrite/drr_fuse_linear_test.cc
+++ b/test/cpp/pir/pattern_rewrite/drr_fuse_linear_test.cc
@@ -25,16 +25,15 @@
 
 void BuildProgram(pir::Builder &builder) {  // NOLINT
   paddle::dialect::FullOp full_input_op1 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{1, 512, 64},
-                                             1.5,
-                                             phi::DataType::FLOAT16);
+      builder.Build<paddle::dialect::FullOp>(
+          std::vector<int64_t>{1, 512, 64}, 1.5, phi::DataType::FLOAT16);
   // linear 1
   paddle::dialect::FullOp full_weight_op1 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64, 64}, 1.5,
-                                            phi::DataType::FLOAT16);
+      builder.Build<paddle::dialect::FullOp>(
+          std::vector<int64_t>{64, 64}, 1.5, phi::DataType::FLOAT16);
   paddle::dialect::FullOp full_bias_op1 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64}, 1.0,
-                                            phi::DataType::FLOAT16);
+      builder.Build<paddle::dialect::FullOp>(
+          std::vector<int64_t>{64}, 1.0, phi::DataType::FLOAT16);
   paddle::dialect::MatmulOp matmul_op1 =
       builder.Build<paddle::dialect::MatmulOp>(full_input_op1.out(),
                                                full_weight_op1.out());
@@ -42,12 +41,11 @@ void BuildProgram(pir::Builder &builder) {  // NOLINT
       matmul_op1.out(), full_bias_op1.out());
   // linear 2
   paddle::dialect::FullOp full_weight_op2 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64, 128},
-                                             1.5,
-                                             phi::DataType::FLOAT16);
+      builder.Build<paddle::dialect::FullOp>(
+          std::vector<int64_t>{64, 128}, 1.5, phi::DataType::FLOAT16);
   paddle::dialect::FullOp full_bias_op2 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{128}, 1.0,
-                                            phi::DataType::FLOAT16);
+      builder.Build<paddle::dialect::FullOp>(
+          std::vector<int64_t>{128}, 1.0, phi::DataType::FLOAT16);
   paddle::dialect::MatmulOp matmul_op2 =
       builder.Build<paddle::dialect::MatmulOp>(add_op1.out(),
                                                full_weight_op2.out());
@@ -57,12 +55,11 @@ void BuildProgram(pir::Builder &builder) {  // NOLINT
       builder.Build<paddle::dialect::ReluOp>(add_op2.out());
   // linear 3
   paddle::dialect::FullOp full_weight_op3 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{128, 64},
-                                             1.5,
-                                             phi::DataType::FLOAT16);
+      builder.Build<paddle::dialect::FullOp>(
+          std::vector<int64_t>{128, 64}, 1.5, phi::DataType::FLOAT16);
   paddle::dialect::FullOp full_bias_op3 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64}, 1.0,
-                                            phi::DataType::FLOAT16);
+      builder.Build<paddle::dialect::FullOp>(
+          std::vector<int64_t>{64}, 1.0, phi::DataType::FLOAT16);
   paddle::dialect::MatmulOp matmul_op3 =
       builder.Build<paddle::dialect::MatmulOp>(relu_op.out(),
                                                full_weight_op3.out());
@@ -72,11 +69,11 @@ void BuildProgram(pir::Builder &builder) {  // NOLINT
       builder.Build<paddle::dialect::GeluOp>(add_op3.out());
   // linear 4
   paddle::dialect::FullOp full_weight_op4 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64, 64}, 1.5,
-                                            phi::DataType::FLOAT16);
+      builder.Build<paddle::dialect::FullOp>(
+          std::vector<int64_t>{64, 64}, 1.5, phi::DataType::FLOAT16);
   paddle::dialect::FullOp full_bias_op4 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64}, 1.0,
-                                            phi::DataType::FLOAT16);
+      builder.Build<paddle::dialect::FullOp>(
+          std::vector<int64_t>{64}, 1.0, phi::DataType::FLOAT16);
   paddle::dialect::MatmulOp matmul_op4 =
       builder.Build<paddle::dialect::MatmulOp>(gelu_op1.out(),
                                                full_weight_op4.out());

--- a/test/cpp/pir/pattern_rewrite/drr_fuse_linear_test.cc
+++ b/test/cpp/pir/pattern_rewrite/drr_fuse_linear_test.cc
@@ -26,12 +26,15 @@
 void BuildProgram(pir::Builder &builder) {  // NOLINT
   paddle::dialect::FullOp full_input_op1 =
       builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{1, 512, 64},
-                                             1.5);
+                                             1.5,
+                                             phi::DataType::FLOAT16);
   // linear 1
   paddle::dialect::FullOp full_weight_op1 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64, 64}, 1.5);
+      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64, 64}, 1.5,
+                                            phi::DataType::FLOAT16);
   paddle::dialect::FullOp full_bias_op1 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64}, 1.0);
+      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64}, 1.0,
+                                            phi::DataType::FLOAT16);
   paddle::dialect::MatmulOp matmul_op1 =
       builder.Build<paddle::dialect::MatmulOp>(full_input_op1.out(),
                                                full_weight_op1.out());
@@ -40,9 +43,11 @@ void BuildProgram(pir::Builder &builder) {  // NOLINT
   // linear 2
   paddle::dialect::FullOp full_weight_op2 =
       builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64, 128},
-                                             1.5);
+                                             1.5,
+                                             phi::DataType::FLOAT16);
   paddle::dialect::FullOp full_bias_op2 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{128}, 1.0);
+      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{128}, 1.0,
+                                            phi::DataType::FLOAT16);
   paddle::dialect::MatmulOp matmul_op2 =
       builder.Build<paddle::dialect::MatmulOp>(add_op1.out(),
                                                full_weight_op2.out());
@@ -53,9 +58,11 @@ void BuildProgram(pir::Builder &builder) {  // NOLINT
   // linear 3
   paddle::dialect::FullOp full_weight_op3 =
       builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{128, 64},
-                                             1.5);
+                                             1.5,
+                                             phi::DataType::FLOAT16);
   paddle::dialect::FullOp full_bias_op3 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64}, 1.0);
+      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64}, 1.0,
+                                            phi::DataType::FLOAT16);
   paddle::dialect::MatmulOp matmul_op3 =
       builder.Build<paddle::dialect::MatmulOp>(relu_op.out(),
                                                full_weight_op3.out());
@@ -65,9 +72,11 @@ void BuildProgram(pir::Builder &builder) {  // NOLINT
       builder.Build<paddle::dialect::GeluOp>(add_op3.out());
   // linear 4
   paddle::dialect::FullOp full_weight_op4 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64, 64}, 1.5);
+      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64, 64}, 1.5,
+                                            phi::DataType::FLOAT16);
   paddle::dialect::FullOp full_bias_op4 =
-      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64}, 1.0);
+      builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{64}, 1.0,
+                                            phi::DataType::FLOAT16);
   paddle::dialect::MatmulOp matmul_op4 =
       builder.Build<paddle::dialect::MatmulOp>(gelu_op1.out(),
                                                full_weight_op4.out());
@@ -78,7 +87,7 @@ void BuildProgram(pir::Builder &builder) {  // NOLINT
 
   // backward
   paddle::dialect::FullOp full_grad_op = builder.Build<paddle::dialect::FullOp>(
-      std::vector<int64_t>{1, 512, 64}, 1.0);
+      std::vector<int64_t>{1, 512, 64}, 1.0, phi::DataType::FLOAT16);
 
   paddle::dialect::GeluGradOp gelu_op2_grad =
       builder.Build<paddle::dialect::GeluGradOp>(

--- a/test/ir/pir/fused_pass/test_fused_gemm_epilogue_pass.py
+++ b/test/ir/pir/fused_pass/test_fused_gemm_epilogue_pass.py
@@ -52,20 +52,20 @@ class TestFusedGemm_epilogueAdd(unittest.TestCase):
         main_program = paddle.base.Program()
         with paddle.pir_utils.IrGuard():
             x_np = np.random.normal(3, 2.5, size=(1024, 1024)).astype(
-                np.float32
+                np.float16
             )
             y_np = x_np
-            z_np = np.random.normal(3, 2.5, size=(1024)).astype(np.float32)
+            z_np = np.random.normal(3, 2.5, size=(1024)).astype(np.float16)
             with paddle.base.program_guard(main_program):
                 with pir_op_role_guard(0), pir_chunk_id_guard(0):
                     x_ = paddle.static.data(
-                        name="x", shape=[1024, 1024], dtype="float32"
+                        name="x", shape=[1024, 1024], dtype="float16"
                     )
                     y_ = paddle.static.data(
-                        name="y", shape=[1024, 1024], dtype="float32"
+                        name="y", shape=[1024, 1024], dtype="float16"
                     )
                     z_ = paddle.static.data(
-                        name="z", shape=[1024], dtype="float32"
+                        name="z", shape=[1024], dtype="float16"
                     )
                     x_.stop_gradient = False
                     y_.stop_gradient = False


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
 Fix performance issue on gemm fusion in float32 datatype related to fused_gemm_epilogue_pass. 
In **SwinTransformer_base_patch4_window7_224** with **bs=64 and float32 datatype**, ips is improved over **1x** **(138->281)** due to this change.

pcard-76996