### PR TITLE
Fix dtensor_to_local backward bugs

### DIFF
--- a/paddle/fluid/eager/api/manual/eager_manual/dygraph_forward_api.h
+++ b/paddle/fluid/eager/api/manual/eager_manual/dygraph_forward_api.h
@@ -57,7 +57,10 @@ paddle::Tensor reshard_ad_function(
     const paddle::Tensor& tensor,
     const phi::distributed::TensorDistAttr dist_attr);
 
-paddle::Tensor dtensor_to_local_ad_function(const paddle::Tensor& input);
+paddle::Tensor dtensor_to_local_ad_function(
+    const paddle::Tensor& input,
+    const phi::distributed::ProcessMesh& processmesh,
+    const phi::distributed::Placements& placements);
 
 paddle::Tensor dtensor_from_local_ad_function(
     const paddle::Tensor& input,

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_to_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_to_local_fwd_func.cc
@@ -18,7 +18,10 @@
 #include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
 
-paddle::Tensor dtensor_to_local_ad_function(const paddle::Tensor& input) {
+paddle::Tensor dtensor_to_local_ad_function(
+    const paddle::Tensor& input,
+    const phi::distributed::ProcessMesh& process_mesh,
+    const phi::distributed::Placements& placements) {
 #ifdef PADDLE_WITH_DISTRIBUTE
   VLOG(3) << "Running AD API: "
           << "dtensor_to_local dygraph";
@@ -49,6 +52,11 @@ paddle::Tensor dtensor_to_local_ad_function(const paddle::Tensor& input) {
 
     // Set TensorWrappers for Forward Inputs if needed
     grad_node->SetTensorWrapperNoNeedBuffer_Input(input);
+
+    phi::distributed::TensorDistAttr grad_dist_attr =
+        ToTensorDistAttr(process_mesh, placements, input.dims());
+
+    grad_node->SetGradDistAttr(grad_dist_attr);
   }
 
   // Forward API Call

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/dtensor_to_local_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/dtensor_to_local_node.cc
@@ -47,9 +47,7 @@ DtensorToLocalGradNode::operator()(
 
   // Collect GradIn Tensors, Attrs and Recovered TensorWrappers
   auto input = egr::EagerUtils::RecoverTensorWrapper(&this->input_);
-  const auto& dist_attr =
-      std::static_pointer_cast<phi::distributed::DistTensor>(input.impl())
-          ->dist_attr();
+
   auto& grad_out = hooked_grad[0][0];
   // Prepare Grad function call
 
@@ -82,7 +80,7 @@ DtensorToLocalGradNode::operator()(
 
   // Backward call dtensor_to_local_func function
   auto dist_grad_ptr = std::make_shared<phi::distributed::DistTensor>(
-      grad_out.dims(), dist_attr);
+      grad_out.dims(), grad_dist_attr_);
 
   *(dist_grad_ptr->unsafe_mutable_value()) =
       *(static_cast<phi::DenseTensor*>(grad_out.impl().get()));

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/nodes.h
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/nodes.h
@@ -489,9 +489,15 @@ class DtensorToLocalGradNode : public egr::GradNodeBase {
     input_ = egr::TensorWrapper(input, true);
   }
 
+  void SetGradDistAttr(const phi::distributed::TensorDistAttr& dist_attr) {
+    grad_dist_attr_ = dist_attr;
+  }
+
  private:
   // TensorWrappers
   egr::TensorWrapper input_;
+
+  phi::distributed::TensorDistAttr grad_dist_attr_;
 };
 
 class DtensorFromLocalGradNode : public egr::GradNodeBase {

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_api.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_api.cc
@@ -85,9 +85,23 @@ pir::Value dtensor_from_local(const pir::Value& x,
       .result(0);
 }
 
-pir::Value dtensor_to_local(const pir::Value& x) {
-  return ApiBuilder::Instance().GetBuilder()->Build<DtensorToLocalOp>(x).result(
-      0);
+pir::Value dtensor_to_local(
+    const pir::Value& x,
+    const phi::distributed::ProcessMesh& process_mesh,
+    const std::vector<int64_t>& dims_mapping,
+    const flat_hash_map<int64_t, phi::ReduceType>& partial_status) {
+  pir::IrContext* ctx = pir::IrContext::Instance();
+  TensorDistAttribute grad_dist_attr =
+      TensorDistAttribute::get(ctx, process_mesh, dims_mapping, partial_status);
+  return dtensor_to_local(x, grad_dist_attr);
+}
+
+pir::Value dtensor_to_local(const pir::Value& x,
+                            const TensorDistAttribute& grad_dist_attr) {
+  return ApiBuilder::Instance()
+      .GetBuilder()
+      ->Build<DtensorToLocalOp>(x, grad_dist_attr)
+      .result(0);
 }
 
 std::vector<pir::Value> moe_sub_mesh_tensors(

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_api.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_api.h
@@ -50,7 +50,13 @@ pir::Value dtensor_from_local(
 pir::Value dtensor_from_local(const pir::Value& x,
                               const TensorDistAttribute& tensor_dist_attr);
 
-pir::Value dtensor_to_local(const pir::Value& x);
+pir::Value dtensor_to_local(
+    const pir::Value& x,
+    const phi::distributed::ProcessMesh& process_mesh,
+    const std::vector<int64_t>& dims_mapping,
+    const flat_hash_map<int64_t, phi::ReduceType>& partial_status = {});
+pir::Value dtensor_to_local(const pir::Value& x,
+                            const TensorDistAttribute& grad_dist_attr);
 
 std::vector<pir::Value> moe_sub_mesh_tensors(
     const pir::Value& input,

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_op.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_op.h
@@ -94,7 +94,8 @@ class DtensorToLocalOp
   static constexpr uint32_t attributes_num = 0;
   TEST_API static void Build(pir::Builder& builder,             // NOLINT
                              pir::OperationArgument& argument,  // NOLINT
-                             pir::Value input);
+                             pir::Value input,
+                             TensorDistAttribute grad_dist_attr);
 
   static OpInfoTuple GetOpInfo();
   static std::vector<std::vector<pir::Value>> Vjp(

--- a/paddle/fluid/pybind/auto_parallel_py.cc
+++ b/paddle/fluid/pybind/auto_parallel_py.cc
@@ -803,9 +803,13 @@ void BindAutoParallel(py::module *m) {
 
   m->def(
       "dtensor_to_local",
-      [](py::handle py_tensor) {
+      [](py::handle py_tensor,
+         py::handle py_process_mesh,
+         py::handle py_placements) {
         auto tensor = CastPyArg2Tensor(py_tensor.ptr(), 0);
-        return dtensor_to_local_ad_function(tensor);
+        auto process_mesh = CastPyArg2ProcessMesh(py_process_mesh.ptr(), 1);
+        auto placements = CastPyArg2VectorOfPlacement(py_placements.ptr(), 2);
+        return dtensor_to_local_ad_function(tensor, process_mesh, placements);
       },
       py::return_value_policy::reference);
 

--- a/paddle/fluid/pybind/dist_static_op_function.h
+++ b/paddle/fluid/pybind/dist_static_op_function.h
@@ -182,15 +182,25 @@ static PyObject *static_api_dtensor_to_local(PyObject *self,
                                              PyObject *args,
                                              PyObject *kwargs) {
   try {
-    VLOG(6) << "Add dtensor_from_local op into program";
+    VLOG(6) << "Add dtensor_to_local op into program";
     VLOG(8) << "args count: " << (PyTuple_Size(args) / 2);
 
     // Get Value from args
     PyObject *input_obj = PyTuple_GET_ITEM(args, 0);
-    auto input = CastPyArg2Value(input_obj, "dtensor_from_local", 0);
+    auto input = CastPyArg2Value(input_obj, "dtensor_to_local", 0);
+
+    PyObject *process_mesh_obj = PyTuple_GET_ITEM(args, 1);
+    auto process_mesh = CastPyArg2ProcessMesh(process_mesh_obj, 1);
+
+    PyObject *placements_obj = PyTuple_GET_ITEM(args, 2);
+    auto placements = CastPyArg2VectorOfPlacement(placements_obj, 2);
+
+    int64_t ndim = GetValueDims(input).size();
+    auto res = CvtPlacements(placements, ndim);
 
     // Call ir static api
-    auto static_api_out = paddle::dialect::dtensor_to_local(input);
+    auto static_api_out = paddle::dialect::dtensor_to_local(
+        input, process_mesh, std::get<0>(res), std::get<1>(res));
 
     return ToPyObject(static_api_out);
   } catch (...) {

--- a/paddle/phi/backends/xpu/xpu_info.cc
+++ b/paddle/phi/backends/xpu/xpu_info.cc
@@ -161,6 +161,7 @@ void MemcpySyncD2H(void* dst,
   dev_ctx.Wait();
   PADDLE_ENFORCE_XPU_SUCCESS(
       xpu_memcpy(dst, src, count, XPUMemcpyKind::XPU_DEVICE_TO_HOST));
+  dev_ctx.Wait();
 }
 
 // if src.device == dst.device and you need sync , after call this function,

--- a/paddle/phi/infermeta/spmd_rules/triu.cc
+++ b/paddle/phi/infermeta/spmd_rules/triu.cc
@@ -143,8 +143,8 @@ SpmdInfo TriuGradInferSpmdBase(const DistMetaTensor& out_grad) {
   auto out_grad_dist_attr =
       UnShardTensorDims(out_dist_attr_src, dims_to_unshard);
   out_grad_dist_attr.set_dims_mapping(out_grad_dist_attr.dims_mapping());
-  auto in_grad_dist_attr = CopyTensorDistAttrForOutput(out_grad_dist_attr);
-  in_grad_dist_attr.set_dims_mapping(out_grad_dist_attr.dims_mapping());
+  auto grad_dist_attr = CopyTensorDistAttrForOutput(out_grad_dist_attr);
+  grad_dist_attr.set_dims_mapping(out_grad_dist_attr.dims_mapping());
 
   VLOG(4) << "TriuGradInferSpmdBase:";
 
@@ -155,10 +155,10 @@ SpmdInfo TriuGradInferSpmdBase(const DistMetaTensor& out_grad) {
           << str_join(out_grad_dist_attr.dims_mapping()) << "]";
 
   VLOG(4) << "in grad"
-          << "dst_dims_mapping: [" << str_join(in_grad_dist_attr.dims_mapping())
+          << "dst_dims_mapping: [" << str_join(grad_dist_attr.dims_mapping())
           << "]";
 
-  return SpmdInfo{{out_grad_dist_attr}, {in_grad_dist_attr}};
+  return SpmdInfo{{out_grad_dist_attr}, {grad_dist_attr}};
 }
 
 SpmdInfo TriuGradInferSpmd(const DistMetaTensor& out_grad, int diagonal) {

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -740,14 +740,14 @@ def dtensor_from_local(local_tensor, mesh, placements):
         )
 
 
-def dtensor_to_local(dist_tensor):
+def dtensor_to_local(dist_tensor, mesh, placements):
     if paddle.in_dynamic_mode():
         if dist_tensor.is_dist() is False:
             raise ValueError("The input should be a distributed tensor.")
 
-        return paddle.base.core.dtensor_to_local(dist_tensor)
+        return paddle.base.core.dtensor_to_local(dist_tensor, mesh, placements)
     elif paddle.framework.in_pir_mode():
-        return paddle._C_ops.dtensor_to_local(dist_tensor)
+        return paddle._C_ops.dtensor_to_local(dist_tensor, mesh, placements)
     else:
         raise RuntimeError(
             "dtensor_to_local() are only supported in dynamic or pir mode."

--- a/test/auto_parallel/dtensor_to_local_api.py
+++ b/test/auto_parallel/dtensor_to_local_api.py
@@ -43,7 +43,9 @@ class TestDtensorToLocalAPI:
             )
         )
 
-        tensor1 = dtensor_to_local(input_tensor)
+        tensor1 = dtensor_to_local(
+            input_tensor, input_tensor.process_mesh, input_tensor.placements
+        )
         assert not tensor1.is_dist()
 
         tensor2 = tensor1 + 2

--- a/test/auto_parallel/dy_local_view_compute.py
+++ b/test/auto_parallel/dy_local_view_compute.py
@@ -69,8 +69,12 @@ class TestLocalViewCompute:
         dist_pred = dist.shard_tensor(pred, self._mesh, [dist.Replicate()])
         dist_label = dist.shard_tensor(label, self._mesh, [dist.Replicate()])
 
-        local_pred = dtensor_to_local(dist_pred)
-        local_label = dtensor_to_local(dist_label)
+        local_pred = dtensor_to_local(
+            dist_pred, dist_pred.process_mesh, dist_pred.placements
+        )
+        local_label = dtensor_to_local(
+            dist_label, dist_label.process_mesh, dist_label.placements
+        )
 
         local_pred = local_pred + 1
         local_loss = self.masked_lm_loss_func(

--- a/test/auto_parallel/local_view_compute.py
+++ b/test/auto_parallel/local_view_compute.py
@@ -233,7 +233,7 @@ class TestLocalViewCompute:
             out = model(img)
             loss_func = LocalViewMaskLoss(
                 out_dist_attrs=[(out_process_mesh, out_placements)],
-                grad_dist_attrs=[(out.process_mesh, out.placement)],
+                grad_dist_attrs=[None, None],
             )
             avg_loss = loss_func(out, label)
             avg_loss.backward()
@@ -268,10 +268,8 @@ class TestLocalViewCompute:
         out_placements = [dist.Partial(dist.ReduceType.kRedAvg)]
         in_grad_placements = [dist.Shard(0)]
         loss_func = LocalViewMaskLoss(
-            out_dist_attrs=[
-                (process_mesh, out_placements),
-                (process_mesh, in_grad_placements),
-            ]
+            out_dist_attrs=[(process_mesh, out_placements)],
+            grad_dist_attrs=[(process_mesh, in_grad_placements), None],
         )
         dist_model = dist.to_static(
             model, dist_dataloader, loss_func, optimizer

--- a/test/auto_parallel/pir/test_local_layer.py
+++ b/test/auto_parallel/pir/test_local_layer.py
@@ -30,6 +30,7 @@ class TestLocalLayer(test_base.CommunicationTestDistBase):
         envs_list = test_base.gen_product_envs_list(
             {"dtype": "float32", "seed": "2023"}, {"backend": ["gpu"]}
         )
+        # {"DISTRIBUTED_TRAINER_ENDPOINTS", "10.67.188.11:8544"}
         # self._log_dir.name = "./log"
         for envs in envs_list:
             self.run_test_case(

--- a/test/auto_parallel/pir/vpp_pass_unittest_local_view_pir.py
+++ b/test/auto_parallel/pir/vpp_pass_unittest_local_view_pir.py
@@ -54,8 +54,8 @@ def is_optimize_op(op):
 
 
 class CustomLayer(dist.LocalLayer):
-    def __init__(self, out_dist_attrs):
-        super().__init__(out_dist_attrs)
+    def __init__(self, out_dist_attrs, grad_dist_attrs):
+        super().__init__(out_dist_attrs, grad_dist_attrs)
 
     def forward(self, input):
         input += 0.1
@@ -95,7 +95,9 @@ class MyLinear(nn.Layer):
             [dist.Replicate()],
             stop_gradient=False,
         )
-        self.custom_local_layer = CustomLayer([(mesh, [dist.Replicate()])])
+        self.custom_local_layer = CustomLayer(
+            [(mesh, [dist.Replicate()])], [(mesh, [dist.Replicate()])]
+        )
 
     def forward(self, input):
         out = self.linear0(input)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
Bug fixes


### Description
<!-- Describe what you’ve done -->
修复dtensor_to_local反向切分标记问题。在之前的实现中，dtensor_to_local反向输出梯度的切分状态与前向的对应输入相同，这在很多场景下是不成立的，例如常见的模型并行场景：
```
x: Shard(1)
y: Shard(0)

z = matmul(x, y)

x_grad: Partial(sum)
y_grad: Partial(sum)
```
本PR修改dtensor_to_local实现，允许用户手动标记梯度的切分状态。

Pcard-76459