### PR TITLE
[PIR] Fix bug of kernel_key selected for memcpy op

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -1200,6 +1200,17 @@ phi::KernelKey GetKernelKey(
     return res;
   }
 
+  if (op->isa<MemcpyOp>()) {
+    auto dst_place = MemcpyOpAttr2Place.at(
+        op->attribute("dst_place_type").dyn_cast<pir::Int32Attribute>().data());
+    auto backend = paddle::experimental::ParseBackend(dst_place, place);
+    return {
+        backend,
+        phi::DataLayout::ANY,
+        TransToPhiDataType(
+            op->operand_source(0).type().dyn_cast<DenseTensorType>().dtype())};
+  }
+
   phi::Backend kernel_backend = phi::Backend::UNDEFINED;
   phi::DataLayout kernel_layout = phi::DataLayout::UNDEFINED;
   phi::DataType kernel_dtype = phi::DataType::UNDEFINED;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复`memcpy`算子的kernel选择逻辑Bug：原先memcpy的输入tensor为cpu，拷贝目标place为gpu时会选择到cpu kernel, 从而导致后续内存地址错误。