### PR TITLE
[CINN] Udpate infer_symbol_shape for memcpy_op

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
@@ -121,7 +121,6 @@ OP_SAME_OPERANDS_AND_RESULT(Logit_)
 OP_SAME_OPERANDS_AND_RESULT(Logsigmoid)
 OP_SAME_OPERANDS_AND_RESULT(Logsigmoid_)
 OP_SAME_OPERANDS_AND_RESULT(LogSoftmax)
-OP_SAME_OPERANDS_AND_RESULT(Memcpy)
 OP_SAME_OPERANDS_AND_RESULT(Mish)
 OP_SAME_OPERANDS_AND_RESULT(NumberCount)
 OP_SAME_OPERANDS_AND_RESULT(Pow)
@@ -293,6 +292,14 @@ bool CeilOpInferSymbolicShape(pir::Operation *op,
 bool Ceil_OpInferSymbolicShape(pir::Operation *op,
                                pir::InferSymbolicShapeContext *infer_context) {
   return CeilOpInferSymbolicShape(op, infer_context);
+}
+
+bool MemcpyOpInferSymbolicShape(pir::Operation *op,
+                                pir::InferSymbolicShapeContext *infer_context) {
+  infer_context->SetShapeOrDataForValue(
+      op->result(0),
+      infer_context->GetShapeOrDataForValue(op->operand_source(0)));
+  return true;
 }
 
 }  // namespace paddle::dialect

--- a/paddle/fluid/pybind/eager_legacy_custom_python_api.h
+++ b/paddle/fluid/pybind/eager_legacy_custom_python_api.h
@@ -90,12 +90,12 @@ static PyObject *pir_eager_api_run_program(PyObject *self,
     }
     framework::AttributeMap attrs;
     // TODO(zengjinle): support CUDA Graph on eager mode
-    VLOG(1) << "Start Pir ConstructAttrMapFromPyArgs";
+    VLOG(6) << "Start Pir ConstructAttrMapFromPyArgs";
 
     ConstructAttrMapForRunProgram(
         "run_program", args, 5, PyTuple_GET_SIZE(args), attrs);
 
-    VLOG(1) << "Finish Pir ConstructAttrMapFromPyArgs";
+    VLOG(6) << "Finish Pir ConstructAttrMapFromPyArgs";
     tstate = PyEval_SaveThread();
     pir_run_program_ad_func(X, Params, Out, OutScope, attrs);
     PyEval_RestoreThread(tstate);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修改memcpy算子的符号推导接口实现，支持data区数据的传递。