### PR TITLE
【Hackathon 8th No.3】 clean remaining oldIR in AutoParallel -part

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/utils.py
+++ b/python/paddle/distributed/auto_parallel/static/utils.py
@@ -28,7 +28,6 @@ from paddle.base.wrapped_decorator import (
     wrap_decorator,
 )
 from paddle.framework import core
-from paddle.framework.io_utils import is_belong_to_optimizer, is_parameter
 from paddle.static import Variable
 
 from ..process_mesh import ProcessMesh, merge_process_meshes
@@ -874,25 +873,7 @@ def get_dist_attr(program, dist_context=None):
                     "dim_names": process_mesh.dim_names,
                 }
     else:
-        from .dist_context import get_default_distributed_context
-
-        assert isinstance(program, paddle.static.Program)
-        if dist_context is None:
-            dist_context = get_default_distributed_context()
-        for var in program.list_vars():
-            if is_parameter(var) or is_belong_to_optimizer(var):
-                tensor_dist_attr = (
-                    dist_context.get_tensor_dist_attr_for_program(var)
-                )
-                process_mesh = tensor_dist_attr.process_mesh
-                dims_mapping = tensor_dist_attr.dims_mapping
-                dim_names = tensor_dist_attr.process_mesh.dim_names
-                dist_attr[var.name] = {
-                    "process_shape": process_mesh.shape,
-                    "process_group": process_mesh.process_ids,
-                    "dims_mapping": dims_mapping,
-                    "dim_names": dim_names,
-                }
+        raise NotImplementedError("get_dist_attr() only support PIR now.")
     return dist_attr
 
 

--- a/python/paddle/distributed/passes/__init__.py
+++ b/python/paddle/distributed/passes/__init__.py
@@ -43,7 +43,6 @@ from .auto_parallel_grad_clip import (  # noqa: F401
 )
 from .auto_parallel_gradient_merge import (  # noqa: F401
     GradientMergePass,
-    parse_program,
 )
 from .auto_parallel_master_grad import (  # noqa: F401
     MasterGradPass,

--- a/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
+++ b/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
@@ -26,8 +26,6 @@ from paddle.distributed.auto_parallel.static.process_group import (
     get_world_process_group,
 )
 from paddle.distributed.auto_parallel.static.utils import (
-    is_backward_op,
-    is_forward_op,
     is_optimize_op,
     naive_set_dist_op_attr_for_program_by_mesh_and_mapping,
     set_var_dist_attr,
@@ -39,11 +37,9 @@ from paddle.distributed.fleet.meta_optimizers.common import (
 )
 from paddle.framework import (
     _current_expected_place_ as _get_device,
-    core,
 )
 from paddle.static import device_guard
 
-from .auto_parallel_master_grad import _is_master_grad_cast_op
 from .pass_base import PassBase, PassType, register_pass
 
 world_process_group = get_world_process_group()
@@ -156,117 +152,6 @@ def _get_gm_cond_var(main_program, k_steps, dist_context):
         )
 
     return cond_var
-
-
-def _append_gradient_merge_backward_op(
-    main_program,
-    startup_program,
-    params_grads: list[tuple[Any, Any]],
-    dist_context,
-) -> tuple[list[tuple[Any, Any]], dict[str, Any]]:
-    main_block = main_program.global_block()
-    startup_block = startup_program.global_block()
-
-    # step1: remove grad.op's op_role_var
-    grad_to_params_grads = {}
-    for param, grad in params_grads:
-        assert (
-            param.type != core.VarDesc.VarType.SELECTED_ROWS
-        ), "SELECTED_ROWS is not supported in GradientMergeOptimizer for now"
-        grad_to_params_grads[grad.name] = (param, grad)
-
-    # {grad.name: gradient_merge_var.name} to rename opt inputs
-    grad_to_gradient_merge = {}
-    # {param: gradient_merge_var} to insert scale op and fill_constant op
-    new_params_grads = []
-
-    for index, op in reversed(list(enumerate(main_block.ops))):
-        if len(grad_to_params_grads) == 0:
-            break
-        if is_forward_op(op):
-            break
-
-        for out_name in op.desc.output_arg_names():
-            if out_name in grad_to_params_grads:
-                param = grad_to_params_grads[out_name][0]
-                grad = grad_to_params_grads[out_name][1]
-                assert param is not None
-                ref_dist_attr = dist_context.get_tensor_dist_attr_for_program(
-                    param
-                )
-                assert ref_dist_attr is not None
-
-                # step2: create gradient_merge var and init with 0
-                # Add persistable gradient variables in main_program
-                gradient_merge_var = main_block.create_var(
-                    name=param.name + "@GRAD@MERGE",
-                    shape=grad.shape,
-                    dtype=grad.dtype,
-                    persistable=True,
-                )
-                ref_process_mesh = ref_dist_attr.process_mesh
-                ref_dims_mapping = ref_dist_attr.dims_mapping
-                set_var_dist_attr(
-                    dist_context,
-                    gradient_merge_var,
-                    ref_dims_mapping,
-                    ref_process_mesh,
-                    chunk_id=ref_dist_attr.chunk_id,
-                )
-
-                # Add persistable gradient variables in startup_program
-                startup_gradient_merge_var = startup_block.create_var(
-                    name=param.name + "@GRAD@MERGE",
-                    shape=grad.shape,
-                    dtype=grad.dtype,
-                    persistable=True,
-                )
-                # Initial persistable gradient variables in startup_program
-                startup_block.append_op(
-                    type="fill_constant",
-                    outputs={"Out": startup_gradient_merge_var},
-                    attrs={
-                        "shape": grad.shape,
-                        "dtype": startup_gradient_merge_var.dtype,
-                        "value": float(0),
-                    },
-                )
-
-                # step3: Accumulate persistable gradient variables in main_program
-                grad = grad_to_params_grads[out_name][1]
-                assert grad is not None
-                # NOTE(zhaoyingli): inplace operation must be 'a = a + b', cannot be 'a = b + a'
-                new_grad_op = main_block._insert_op_without_sync(
-                    index + 1,
-                    type="elementwise_add",
-                    inputs={'X': gradient_merge_var, 'Y': grad},
-                    outputs={'Out': gradient_merge_var},
-                    attrs={
-                        'axis': -1,
-                        OP_ROLE_KEY: OpRole.Backward,
-                        "op_namescope": "/auto_parallel/gradient_merge",
-                    },
-                )
-
-                # Construct new_params_grads and grad_to_gradient_merge
-                new_params_grads.append([param, gradient_merge_var])
-                grad_to_gradient_merge[grad.name] = gradient_merge_var.name
-                naive_set_dist_op_attr_for_program_by_mesh_and_mapping(
-                    new_grad_op,
-                    ref_process_mesh,
-                    ref_dims_mapping,
-                    dist_context,
-                    chunk_id=ref_dist_attr.chunk_id,
-                )
-
-                del grad_to_params_grads[out_name]
-
-    assert (
-        len(grad_to_params_grads) == 0
-    ), f"grad_to_param_names must be empty right now, but it has {len(grad_to_params_grads)} items"
-    main_block._sync_with_cpp()
-
-    return new_params_grads, grad_to_gradient_merge
 
 
 def _move_used_grad_op(used_grad_op, grad):
@@ -469,46 +354,6 @@ def _pir_move_reduce_to_backward_stage(main_program):
     pass
 
 
-def _remove_cast_for_master_grad(main_program, dist_context):
-    rename_var_map = {}
-    main_block = main_program.global_block()
-    for idx, op in reversed(list(enumerate(main_block.ops))):
-        if _is_master_grad_cast_op(main_block, op):
-            input_var_name = op.input_arg_names[0]
-            output_var_name = op.output_arg_names[0]
-            rename_var_map[input_var_name] = output_var_name
-            in_var = main_block.var(input_var_name)
-            out_var = main_block.var(output_var_name)
-            out_var.desc.set_dtype(in_var.dtype)
-            main_block._remove_op(idx, sync=False)
-            main_block._remove_var(input_var_name)
-
-    # rename "xxx@GRAD@master_grad_fp16" --> "xxx@GRAD"
-    if len(rename_var_map) > 0:
-        for op in reversed(main_block.ops):
-            if is_forward_op(op):
-                break
-            if is_backward_op(op):
-                output_var_names = op.output_arg_names
-                op_dist_attr = dist_context.get_op_dist_attr_for_program(op)
-                for output_var_name in output_var_names:
-                    if output_var_name in rename_var_map:
-                        out_dims_mapping = op_dist_attr.get_output_dims_mapping(
-                            output_var_name
-                        )
-                        op.desc._rename_output(
-                            output_var_name, rename_var_map[output_var_name]
-                        )
-                        op_dist_attr.set_output_dims_mapping(
-                            rename_var_map[output_var_name], out_dims_mapping
-                        )
-                        del rename_var_map[output_var_name]
-        assert (
-            len(rename_var_map) == 0
-        ), f"rename_var_map must be empty, but it is: {rename_var_map}"
-    main_block._sync_with_cpp()
-
-
 def _pir_remove_cast_for_master_grad(main_program, params_grads):
     for op in main_program.global_block().ops:
         if op.has_attr("master_grad_cast"):
@@ -643,54 +488,6 @@ def _create_cond_block_and_update_optimizer(
         ctx=dist_context,
         chunk_id=cond_dist_attr.chunk_id,
     )
-
-
-def parse_program(
-    main_program,
-    startup_program,
-    params_grads,
-    k_steps,
-    avg,
-    dist_context,
-    gradient_sync_after_accumulate,
-):
-    # 1 remove optimizer_op from main_program
-    optimize_ops_block = _remove_and_get_optimizer_op(
-        main_program, dist_context
-    )
-
-    # 2 append gradient merge backward op to main_program
-    (
-        new_params_to_grads,
-        grad_to_gradient_merge,
-    ) = _append_gradient_merge_backward_op(
-        main_program, startup_program, params_grads, dist_context
-    )
-
-    if gradient_sync_after_accumulate:
-        # 3 move reduce op to optimizer_ops_block
-        optimize_ops_block = _move_reduce_to_optimizer_ops_block(
-            main_program, optimize_ops_block, params_grads
-        )
-
-    _remove_cast_for_master_grad(main_program, dist_context)
-
-    # 4 create gradient_merge_cond
-    cond_var = _get_gm_cond_var(main_program, k_steps, dist_context)
-
-    # 5 create ConditionalBlock and append gradient merge optimizer ops
-    _create_cond_block_and_update_optimizer(
-        main_program,
-        cond_var,
-        new_params_to_grads,
-        grad_to_gradient_merge,
-        optimize_ops_block,
-        k_steps,
-        avg,
-        dist_context,
-    )
-
-    return grad_to_gradient_merge
 
 
 def _find_trivial_optimizer_ops(block):
@@ -845,19 +642,6 @@ class GradientMergePass(PassBase):
                     gradient_sync_after_accumulate,
                 )
         else:
-            dist_context = self.get_attr("dist_context")
-            grad_to_global_grad = self.get_attr("grad_to_global_grad", {})
-            with paddle.static.program_guard(main_program, startup_program):
-                grad_to_merge_grad = parse_program(
-                    main_program,
-                    startup_program,
-                    params_grads,
-                    k_steps,
-                    avg,
-                    dist_context,
-                    gradient_sync_after_accumulate,
-                )
-
-            main_program._sync_with_cpp()
-            for k, v in grad_to_merge_grad.items():
-                grad_to_global_grad[k] = v
+            raise NotImplementedError(
+                "auto_parallel_gradient_merge_pass() only support PIR now."
+            )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Deprecations 

### Description
<!-- Describe what you’ve done -->
 clean remaining oldIR in AutoParallel