### PR TITLE
[CINN] Fix the condition of CanApplyGridReduce

### DIFF
--- a/paddle/cinn/ir/group_schedule/config/group_tile_util.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_util.cc
@@ -443,10 +443,10 @@ bool GetCanApplyGridReduce(const std::vector<ir::Expr>& op_compute_bodies,
       AddReduceDownstream(expr_block);
     }
 
-    // When a block is downstream of reduce, its output shouldn't contain
-    // reduce axis. Otherwise, it broadcasts the result of reduce. If this
+    // When a block is downstream of reduce, its loop iters shouldn't contain
+    // any reduce axis. Otherwise, it broadcasts the result of reduce. If this
     // is the case, we cannot apply grid reduce.
-    if (is_reduce_downstream && output_has_reduce_axis) {
+    if (is_reduce_downstream && (is_reduce || output_has_reduce_axis)) {
       VLOG(4) << "grid reduce is prohibited by block: " << expr_block;
       return false;
     }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
修复`GetCanApplyGridReduce`的一处判断条件

<b>原因：</b>之前融合不会把broadcast和reduce融到一个循环体里，所以没问题；现在可以融了，所以条件里需要同时判断是否为reduce或broadcast

<br>
Pcard-85711
