### PR TITLE
[CINN] Fix bug of candidate order in ComputeAtReductionTactic

### DIFF
--- a/paddle/cinn/ir/group_schedule/tactic/compute_at_reduction_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/compute_at_reduction_tactic.cc
@@ -409,6 +409,8 @@ ComputeAtReductionTactic::GetDependencyHarzardFreeBlocks(
     if (dep_graph.HasDependency(*it, *this_it) == analyzer::DepKind::DEP) break;
     results.push_back(other_id);
   }
+  // Note: reverse results here because upstreams were added in reversed order.
+  std::reverse(results.begin(), results.end());
 
   // Search downwards
   for (auto it = this_it + 1; it != stmts.end(); ++it) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
对ComputeAtReductionTactic找到的upstream结果进行排序，使得总是选择最上面的upstream

当图中有多个block时，如果融合关系是 A->B->C，可能A先和B融合，然后B又和C融合，导致AB断开；其实A应该直接和C融合，然后B也和C融合，这样ABC都能融在一起

之前处理的都是两个循环融合，选哪个都一样，但是在某些场景有更多循环，就最好总是选择一个方向进行融合，这样不会导致融了又断开的情况；理论上选最前面和最后面的融合都可以，但实现上由于reduce后面的rfactor块的阻碍，所以这里选了最前面的

<br>
Pcard-85711