### PR TITLE
[CINN]Softmax optimization based on bucket splitting strategy

### DIFF
--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -717,10 +717,10 @@ TileConfigMap BuildDynamicShapeConfig(
     const std::shared_ptr<ScheduleConfig::BaseInfo>& base_info,
     const common::Target& target) {
   TileConfigCollector collector;
-  collector({1, kMaxNumel, 1, 511}, {4, 128, 1, 1, 1, 4, BlockReduceMethod()});
-  collector({1, kMaxNumel, 512, 2047},
+  collector({1, kMaxNumel, 1, 256}, {8, 32, 1, 1, 1, 8, WarpReduceMethod()});
+  collector({1, kMaxNumel, 257, 2048},
             {8, 256, 1, 1, 1, 8, BlockReduceMethod()});
-  collector({1, kMaxNumel, 2048, kMaxNumel},
+  collector({1, kMaxNumel, 2049, kMaxNumel},
             {32, 1024, 1, 1, 1, -1, BlockReduceMethod()});
   return collector.GetResult();
 }

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -486,6 +486,7 @@ TileConfigMap BuildVectorizeConfig(
                          /* grid_reduce_num = */ 1,
                          /* spatial_inner_num = */ 1,
                          /* vectorize_factor = */ vectorize_factor,
+                         /*reduce_inner_num = */ -1,
                          reduce_method};
   return {{bucket_info, tile_config}};
 }
@@ -573,6 +574,7 @@ TileConfigMap BuildPureStaticShapeConfig(
                          /* grid_reduce_num = */ rd_block_num,
                          /* spatial_inner_num = */ sp_inner_num,
                          /* vectorize_factor = */ 1,
+                         /*reduce_inner_num = */ -1,
                          reduce_method};
   return {{bucket_info, tile_config}};
 }
@@ -597,12 +599,12 @@ TileConfigMap BuildStaticSpatialConfig(
     if (rd_block_num > 1 && base_info->can_apply_grid_reduce) {
       int64_t rd_threshold = rd_block_num * min_loops * 1024;
       collector({1, kMaxNumel, 2049, rd_threshold},
-                {32, 1024, 1, 1, 1, BlockReduceMethod()});
+                {32, 1024, 1, 1, 1,-1, BlockReduceMethod()});
       collector({1, kMaxNumel, rd_threshold + 1, kMaxNumel},
-                {32, 1024, rd_block_num, 1, 1, BlockReduceMethod()});
+                {32, 1024, rd_block_num, 1, 1,-1 BlockReduceMethod()});
     } else {
       collector({1, kMaxNumel, 2049, kMaxNumel},
-                {32, 1024, 1, 1, 1, BlockReduceMethod()});
+                {32, 1024, 1, 1, 1,-1 BlockReduceMethod()});
     }
 
   } else {  // last_dim == "S"
@@ -612,12 +614,12 @@ TileConfigMap BuildStaticSpatialConfig(
     if (rd_block_num > 1 && base_info->can_apply_grid_reduce) {
       int64_t rd_threshold = rd_block_num * min_loops * 16;
       collector({1, kMaxNumel, 1, rd_threshold},
-                {16, 16, 1, 1, 1, BlockReduceMethod()});
+                {16, 16, 1, 1, 1,-1 BlockReduceMethod()});
       collector({1, kMaxNumel, rd_threshold + 1, kMaxNumel},
-                {16, 16, rd_block_num, 1, 1, BlockReduceMethod()});
+                {16, 16, rd_block_num, 1, 1,-1 BlockReduceMethod()});
     } else {
       collector({1, kMaxNumel, 1, kMaxNumel},
-                {16, 16, 1, 1, 1, BlockReduceMethod()});
+                {16, 16, 1, 1, 1,-1 BlockReduceMethod()});
     }
   }
 
@@ -639,6 +641,7 @@ TileConfigMap BuildStaticReduceConfig(
                                    /* grid_reduce_num = */ 1,
                                    /* spatial_inner_num = */ 1,
                                    /* vectorize_factor = */ 1,
+                                   /*reduce_inner_num = */ -1,
                                    NoneReduceMethod()};
     BucketInfo bucket_info__1024_INF{/* sp_lower_bound = */ 1024,
                                      /* sp_upper_bound = */ kMaxNumel,
@@ -651,6 +654,7 @@ TileConfigMap BuildStaticReduceConfig(
                                      /* grid_reduce_num = */ 1,
                                      /* spatial_inner_num = */ 4,
                                      /* vectorize_factor = */ 1,
+                                     /*reduce_inner_num = */ -1,
                                      NoneReduceMethod()};
     return {{bucket_info__1_1023, tile_config__1_1023},
             {bucket_info__1024_INF, tile_config__1024_INF}};
@@ -667,6 +671,7 @@ TileConfigMap BuildStaticReduceConfig(
         /* grid_reduce_num = */ 1,
         /* spatial_inner_num = */ (256 / CeilPow2(base_info->reduce_numel)),
         /* vectorize_factor = */ 1,
+        /*reduce_inner_num = */ -1,
         WarpReduceMethod()};
     return {{bucket_info, tile_config}};
   } else if (base_info->reduce_numel <= 2048) {
@@ -686,6 +691,7 @@ TileConfigMap BuildStaticReduceConfig(
                            /* grid_reduce_num = */ 1,
                            /* spatial_inner_num */ 1,
                            /* vectorize_factor = */ 1,
+                           /*reduce_inner_num = */ -1,
                            BlockReduceMethod()};
     return {{bucket_info, tile_config}};
   } else {
@@ -700,6 +706,7 @@ TileConfigMap BuildStaticReduceConfig(
                            /* grid_reduce_num = */ 1,
                            /* spatial_inner_num = */ 1,
                            /* vectorize_factor = */ 1,
+                           /*reduce_inner_num = */ -1,
                            BlockReduceMethod()};
     return {{bucket_info, tile_config}};
   }
@@ -708,19 +715,62 @@ TileConfigMap BuildStaticReduceConfig(
 TileConfigMap BuildDynamicShapeConfig(
     const std::shared_ptr<ScheduleConfig::BaseInfo>& base_info,
     const common::Target& target) {
-  BucketInfo bucket_info{/* sp_lower_bound = */ 1,
-                         /* sp_upper_bound = */ kMaxNumel,
-                         /* rb_lower_bound = */ 1,
-                         /* rb_upper_bound = */ kMaxNumel,
-                         /* sp_is_dynamic = */ true,
-                         /* rb_is_dynamic = */ true};
-  TileConfig tile_config{/* warp_num = */ 32,
-                         /* tree_reduce_num = */ 1024,
-                         /* grid_reduce_num = */ 1,
-                         /* spatial_inner_num = */ 1,
-                         /* vectorize_factor = */ 1,
-                         BlockReduceMethod()};
-  return {{bucket_info, tile_config}};
+  BucketInfo bucket_info__1_511{/* sp_lower_bound = */ 1,
+                            /* sp_upper_bound = */ kMaxNumel,
+                            /* rb_lower_bound = */ 1,
+                            /* rb_upper_bound = */ 511,
+                            /* sp_is_dynamic = */ true,
+                            /* rb_is_dynamic = */ true};
+  TileConfig tile_config__1_511{/* warp_num = */ 4,
+                            /* tree_reduce_num = */ 128,
+                            /* grid_reduce_num = */ 1,
+                            /* spatial_inner_num = */ 1, 
+                            /* vectorize_factor = */ 1,
+                            /* reduce_inner_num = */ 4,
+                            BlockReduceMethod()};
+  BucketInfo bucket_info__512_1023{/* sp_lower_bound = */ 1,
+                            /* sp_upper_bound = */ kMaxNumel,
+                            /* rb_lower_bound = */ 512,
+                            /* rb_upper_bound = */ 1023,
+                            /* sp_is_dynamic = */ true,
+                            /* rb_is_dynamic = */ true};
+  TileConfig tile_config__512_1023{/* warp_num = */ 8,
+                            /* tree_reduce_num = */ 256,
+                            /* grid_reduce_num = */ 1,
+                            /* spatial_inner_num = */ 1, 
+                            /* vectorize_factor = */ 1,
+                            /* reduce_inner_num = */ 4, 
+                            BlockReduceMethod()};
+  BucketInfo bucket_info__1024_2047{/* sp_lower_bound = */ 1,
+                            /* sp_upper_bound = */ kMaxNumel,
+                            /* rb_lower_bound = */ 1024,
+                            /* rb_upper_bound = */ 2047,
+                            /* sp_is_dynamic = */ true,
+                            /* rb_is_dynamic = */ true};
+  TileConfig tile_config__1024_2047{/* warp_num = */ 16,
+                            /* tree_reduce_num = */ 512,
+                            /* grid_reduce_num = */ 1,
+                            /* spatial_inner_num = */ 1,
+                            /* vectorize_factor = */ 1,
+                            /* reduce_inner_num = */ 4,
+                            BlockReduceMethod()};
+  BucketInfo bucket_info__2048_INF{/* sp_lower_bound = */ 1,
+                            /* sp_upper_bound = */ kMaxNumel,
+                            /* rb_lower_bound = */ 2048,
+                            /* rb_upper_bound = */ kMaxNumel,
+                            /* sp_is_dynamic = */ true,
+                            /* rb_is_dynamic = */ true};
+  TileConfig tile_config__2048_INF{/* warp_num = */ 32,
+                            /* tree_reduce_num = */ 1024,
+                            /* grid_reduce_num = */ 1,
+                            /* spatial_inner_num = */ 1,
+                            /* vectorize_factor = */ 1,
+                            /* reduce_inner_num = */ -1,
+                            BlockReduceMethod()};
+  return {{bucket_info__1_511, tile_config__1_511},
+          {bucket_info__512_1023, tile_config__512_1023},
+          {bucket_info__1024_2047, tile_config__1024_2047},
+          {bucket_info__2048_INF, tile_config__2048_INF}};
 }
 
 std::unordered_map<BucketInfo, ScheduleConfig, BucketInfoHash>

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.h
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.h
@@ -54,6 +54,7 @@ struct ScheduleConfig {
     int64_t grid_reduce_num{1};
     int64_t spatial_inner_num{1};
     int64_t vectorize_factor{1};
+    int64_t reduce_inner_num{1};
     ReduceMethod reduce_method{NoneReduceMethod()};
   };
 

--- a/paddle/cinn/ir/group_schedule/tactic/tile_first_general_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_first_general_tactic.cc
@@ -190,6 +190,7 @@ void TileFirstGeneralTactic::ApplyContinuousDataTile(
   const auto sp_loop = context_->config.tile_config.spatial_inner_num;
   const auto rd_thread = context_->config.tile_config.tree_reduce_num;
   const auto rd_block = context_->config.tile_config.grid_reduce_num;
+  const auto rd_loop = context_->config.tile_config.reduce_inner_num;
   VLOG(4) << "ApplyContinuousDataTile sp_thread=" << sp_thread;
   VLOG(4) << "ApplyContinuousDataTile sp_loop=" << sp_loop;
   VLOG(4) << "ApplyContinuousDataTile rd_thread=" << rd_thread;
@@ -235,7 +236,7 @@ void TileFirstGeneralTactic::ApplyContinuousDataTile(
   std::string global_rf_block;
   if (vec_reduce_axis_.size() > 0) {
     auto loops = sch->GetLoops(block_id);
-    sch->Split(loops[current_reduce_axis], {-1, rd_block * rd_thread});
+    sch->Split(loops[current_reduce_axis], {rd_loop, rd_block * rd_thread});
 
     loops = sch->GetLoops(block_id);
     sch->Reorder({loops[current_reduce_axis + 1], loops[current_reduce_axis]});

--- a/paddle/cinn/ir/schedule/impl/loop_transformation.cc
+++ b/paddle/cinn/ir/schedule/impl/loop_transformation.cc
@@ -159,37 +159,33 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
           << ") at loop:\n"
           << loop;
 
-  bool is_positive = true;
-  int num_minus1 = 0;
+  common::cas_intervals_t var_intervals = {};
+  cinn::common::SymbolicExprAnalyzer analyzer(var_intervals);
+
   std::vector<Expr> process_factors;
-  Expr prod_size(-1);
-  int idx_neg1 = 1;
-  for (auto factor : factors) prod_size = prod_size * Expr(factor);
-  std::for_each(factors.begin(), factors.end(), [&](int factor) {
+  int num_neg1 = 0;
+  Expr explicit_product(1);
+  
+  for (int factor : factors) {
     if (factor == -1) {
-      process_factors.push_back(optim::ArithSimplify(tot_extent / prod_size));
-      idx_neg1 = -idx_neg1;
+      num_neg1++;
+      process_factors.push_back(Expr()); 
     } else {
+      PADDLE_ENFORCE_GE(factor, 1, ::common::errors::InvalidArgument(
+          "[IRScheduleError] An error occurred in the schedule primitive "
+          "<Split>.\n"
+          "[Error info] The params in factors of Split on dynamic shape should "
+          "contains at "
+          "most one '-1' and the rest of them should be positive!\n"
+          "[Expr info] The Expr of current schedule is: %s.",
+          module_expr_.GetExprs()));
+      explicit_product = explicit_product * Expr(factor);
       process_factors.push_back(Expr(factor));
-      if (idx_neg1 > 0) idx_neg1++;
     }
-    if (factor < 1 && factor != -1) is_positive = false;
-    if (factor == -1) ++num_minus1;
-  });
-
-  idx_neg1 = (-idx_neg1) - 1;
-
-  bool exact_split = (tot_extent == optim::ArithSimplify(process_factors[0] *
-                                                         process_factors[1]));
-  if (!exact_split) {
-    process_factors[idx_neg1] =
-        optim::ArithSimplify(process_factors[idx_neg1] + Expr(1));
   }
 
-  PADDLE_ENFORCE_LE(
-      num_minus1,
-      1,
-      ::common::errors::InvalidArgument(
+  if (num_neg1 > 0) {
+    PADDLE_ENFORCE_EQ(num_neg1, 1, ::common::errors::InvalidArgument(
           "[IRScheduleError] An error occurred in the schedule primitive "
           "<Split>.\n"
           "[Error info] The params in factors of Split on dynamic shape should "
@@ -197,17 +193,17 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
           "most one '-1' and the rest of them should be positive!\n"
           "[Expr info] The Expr of current schedule is: %s.",
           module_expr_.GetExprs()));
-  PADDLE_ENFORCE_EQ(
-      is_positive,
-      true,
-      ::common::errors::InvalidArgument(
-          "[IRScheduleError] An error occurred in the schedule primitive "
-          "<Split>.\n"
-          "[Error info] The params in factors of Split on dynamic shape should "
-          "contains at "
-          "most one '-1' and the rest of them should be positive!\n"
-          "[Expr info] The Expr of current schedule is: %s.",
-          module_expr_.GetExprs()));
+    const int neg1_pos = std::find(factors.begin(), factors.end(), -1) - factors.begin();
+    process_factors[neg1_pos] = optim::ArithSimplify((tot_extent + explicit_product - 1) / explicit_product);
+  }
+
+
+  const Expr total_iter = std::accumulate(
+      process_factors.begin(), process_factors.end(), Expr(1), 
+      [](Expr a, Expr b) { return a * b; });
+  
+  bool need_bound_check = !analyzer.ProveLE(total_iter, tot_extent).value_or(false);
+  
 
   std::vector<Var> new_loop_vars;
   Expr substitute_value(0);
@@ -217,16 +213,15 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
     new_loop_vars.push_back(temp_var);
   }
   substitute_value = optim::ArithSimplify(substitute_value);
+
+
   Expr new_node = ir::ir_utils::IRCopy(for_node->body);
   ReplaceExpr(&new_node, {for_node->loop_var}, {substitute_value});
-  std::vector<Expr> splited_loops;
-  splited_loops.resize(process_factors.size());
-
-  if (!exact_split) {
-    new_node =
-        IfThenElse::Make(LT::Make(substitute_value, tot_extent), new_node);
+  if (need_bound_check) {
+    new_node = IfThenElse::Make(LT::Make(substitute_value, tot_extent), new_node);
   }
 
+  std::vector<Expr> splited_loops;
   for (int i = process_factors.size() - 1; i >= 0; i--) {
     if (!new_node.As<ir::Block>()) new_node = Block::Make({new_node});
     new_node = For::Make(new_loop_vars[i],
@@ -235,7 +230,7 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
                          for_node->for_type(),
                          for_node->device_api,
                          new_node);
-    splited_loops[i] = new_node;
+    splited_loops.insert(splited_loops.begin(), new_node);
   }
 
   SimplifyBindingsInStaticShape(this, loop, "split", &new_node);
@@ -245,6 +240,7 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
   return splited_loops;
   CINN_IR_SCHEDULE_END(this->err_msg_level_);
 }
+
 
 // TODO(@LiuYang): now -1 can't exist in factors.
 std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->CINN


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->Improvements


### Description
<!-- Describe what you’ve done -->
softmax算子初始编译后只会产生一个kernel，其中分配1024个线程，这对于小规模输入来说，有大量资源闲置浪费，修改后，细化分桶，为不同规模输入分配不同的线程组合及计算策略。其次，kernel中的for循环的判断条件需要每次重复进行计算，严重拉慢运算速度，修改后为其设置定值，提升速度。

Pcard-85711
