### PR TITLE
[SOT] Refactor sot simulation to avoid hold real frame in graph and codegen

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -35,6 +35,7 @@ from ...utils import (
     log_do,
 )
 from ..custom_code import CustomCode
+from .function_graph import FunctionGraph
 from .guard import Guard
 from .opcode_executor import OpcodeExecutor, OpcodeExecutorBase
 
@@ -235,12 +236,13 @@ def start_translate(
     Returns:
         tuple[CustomCode, Guard | None]: The translated code object and its guard function, or None if translation fails.
     """
-    simulator = OpcodeExecutor(frame, **kwargs)
+    graph = FunctionGraph(frame.f_code, frame.f_globals, **kwargs)
+    simulator = OpcodeExecutor(frame, graph)
     try:
         simulator.check_code_simulatable()
         InfoCollector().attach(CompileCountInfo, frame.f_code)
         with sot_simulation_mode_guard(True):
-            new_custom_code, guard_fn = simulator.transform()
+            new_custom_code, guard_fn = simulator.transform(frame)
         if not simulator._graph.need_cache:
             return (
                 CustomCode(None, True),

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -22,7 +22,7 @@ import inspect
 from collections import namedtuple
 from copy import deepcopy
 from functools import cached_property, reduce
-from typing import Any, Callable, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Tuple, Union
 
 from typing_extensions import TypeAlias, TypeGuard
 
@@ -82,6 +82,10 @@ from .variables import (
     find_traceable_vars,
     map_variables,
 )
+
+if TYPE_CHECKING:
+    import types
+
 
 CompileGraphResult: TypeAlias = Tuple[
     Callable[..., Any],
@@ -211,11 +215,13 @@ class FunctionGraph:
         ],
     )
 
-    def __init__(self, frame, **kwargs):
+    def __init__(
+        self, code: types.CodeType, globals: dict[str, object], **kwargs
+    ):
         self.sir_ctx = SymbolicTraceContext()
         self.inner_out = set()
         self.input_variables = []  # Store variables required within a function
-        self.pycode_gen = PyCodeGen(frame, disable_eval_frame=True)
+        self.pycode_gen = PyCodeGen(code, globals, disable_eval_frame=True)
         self.side_effects = SideEffects()
         self.need_cache = True
         self._global_guarded_variables: OrderedSet[VariableBase] = OrderedSet()

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -66,7 +66,6 @@ from .dispatch_functions import (
     operator_not_in,
 )
 from .dispatcher import Dispatcher
-from .function_graph import FunctionGraph
 from .instr_flag import (
     CALL_FUNCTION_EX_FLAG as CFE,
     CONVERT_VALUE_FLAG as CV,
@@ -111,7 +110,7 @@ from .variables import (
 )
 
 if TYPE_CHECKING:
-    from .function_graph import CompileGraphResult
+    from .function_graph import CompileGraphResult, FunctionGraph
 
 SUPPORT_COMPARE_OP = {
     ">": operator.gt,
@@ -449,16 +448,6 @@ class OpcodeExecutorBase:
         Args:
             result: The execution result.
             instr: The jump instruction.
-
-        Raises:
-            NotImplementedError: If the method is not implemented.
-
-        """
-        raise NotImplementedError
-
-    def transform(self):
-        """
-        Abstract method need to be implemented to symbolic translate each instruction.
 
         Raises:
             NotImplementedError: If the method is not implemented.
@@ -1886,18 +1875,17 @@ class OpcodeExecutor(OpcodeExecutorBase):
 
     """
 
-    def __init__(self, frame: types.FrameType, **kwargs):
-        graph = FunctionGraph(frame, **kwargs)
-        self._frame = frame
+    def __init__(self, frame: types.FrameType, graph: FunctionGraph):
+        self._frame = frame  # TODO: Don't hold frame in executor, just hold vframe instead
         self._name = "Executor"
         self.call_stack[:] = []
         super().__init__(frame.f_code, graph)
         Dispatcher.graph = graph
 
-    def transform(self):
-        static_function = get_static_function(self._frame, "eval_frame")
+    def transform(self, frame: types.FrameType):
+        static_function = get_static_function(frame, "eval_frame")
         if static_function is not None:
-            code = self._frame.f_code
+            code = frame.f_code
             inputs = []
             for i in range(code.co_argcount):
                 arg_name = code.co_varnames[i]
@@ -1932,11 +1920,9 @@ class OpcodeExecutor(OpcodeExecutorBase):
         """
         log(
             3,
-            f"[Executor] code options: co_cellvars={self._frame.f_code.co_cellvars}\n",
+            f"[Executor] code options: co_cellvars={self._code.co_cellvars}\n",
         )
-        free_or_cell_vars = (
-            self._frame.f_code.co_cellvars + self._frame.f_code.co_freevars
-        )
+        free_or_cell_vars = self._code.co_cellvars + self._code.co_freevars
         for name, value in self._frame.f_locals.items():
             tracker = (
                 CellTracker(name)
@@ -2109,7 +2095,10 @@ class OpcodeExecutor(OpcodeExecutorBase):
             ):
                 return None
             cache_key = (ResumeFunctionType.IF_RESUME, self._code, start_idx)
-            resume_fn_creator = ResumeFunctionCreator(self._frame)
+            resume_fn_creator = ResumeFunctionCreator(
+                self._graph.pycode_gen._origin_code,
+                self._graph.pycode_gen._real_globals,
+            )
             if (
                 maybe_resume_fn := resume_fn_creator.lookup(cache_key)
             ) is not None:
@@ -2265,7 +2254,10 @@ class OpcodeExecutor(OpcodeExecutorBase):
             if self._instructions[next_index].opname == "RETURN_VALUE":
                 return None
             cache_key = (ResumeFunctionType.CALL_RESUME, self._code, next_index)
-            resume_fn_creator = ResumeFunctionCreator(self._frame)
+            resume_fn_creator = ResumeFunctionCreator(
+                self._graph.pycode_gen._origin_code,
+                self._graph.pycode_gen._real_globals,
+            )
             if (
                 maybe_resume_fn := resume_fn_creator.lookup(cache_key)
             ) is not None:
@@ -2370,7 +2362,10 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 loop_body_start_idx,
                 loop_body_end_idx,
             )
-            resume_fn_creator = ResumeFunctionCreator(self._frame)
+            resume_fn_creator = ResumeFunctionCreator(
+                self._graph.pycode_gen._origin_code,
+                self._graph.pycode_gen._real_globals,
+            )
             if (
                 maybe_resume_fn := resume_fn_creator.lookup(cache_key)
             ) is not None:
@@ -2441,7 +2436,10 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 self._code,
                 loop_body_end_idx,
             )
-            resume_fn_creator = ResumeFunctionCreator(self._frame)
+            resume_fn_creator = ResumeFunctionCreator(
+                self._graph.pycode_gen._origin_code,
+                self._graph.pycode_gen._real_globals,
+            )
             if (
                 maybe_resume_fn := resume_fn_creator.lookup(cache_key)
             ) is not None:
@@ -2601,7 +2599,10 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 start_idx,
                 end_idx,
             )
-            resume_fn_creator = ResumeFunctionCreator(self._frame)
+            resume_fn_creator = ResumeFunctionCreator(
+                self._graph.pycode_gen._origin_code,
+                self._graph.pycode_gen._real_globals,
+            )
             if (
                 maybe_resume_fn := resume_fn_creator.lookup(cache_key)
             ) is not None:

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -413,7 +413,10 @@ class PyCodeGen:
     """Helper to create new code object"""
 
     def __init__(
-        self, frame: types.FrameType, disable_eval_frame: bool = False
+        self,
+        real_code: types.CodeType,
+        real_globals: dict[str, object],
+        disable_eval_frame: bool = False,
     ):
         """
         Initializes a PyCodeGen object.
@@ -422,11 +425,10 @@ class PyCodeGen:
             frame: The frame to be translated.
             disable_eval_frame (bool): Whether to disable the evaluation frame. Defaults to False.
         """
-        self._frame = frame
-        self._origin_code = frame.f_code
+        self._origin_code = real_code
         self._code_options = gen_code_options(self._origin_code)
         self.update_code_name("", is_resumed_fn=False)
-        self._f_globals = frame.f_globals
+        self._real_globals = real_globals
         self._instructions = []
         self.disable_eval_frame = disable_eval_frame
         self.hooks = []
@@ -666,8 +668,8 @@ class PyCodeGen:
             obj_name (str): The name of the object.
         """
 
-        if obj_name not in self._f_globals:
-            self._f_globals[obj_name] = obj
+        if obj_name not in self._real_globals:
+            self._real_globals[obj_name] = obj
         return self.gen_load_global(obj_name, push_null=push_null)
 
     def gen_load_null_variable(self):
@@ -1007,9 +1009,12 @@ class ResumeFunctionCreator:
     CODE_CACHE = {}
 
     def __init__(
-        self, frame: types.FrameType, disable_eval_frame: bool = False
+        self,
+        code: types.CodeType,
+        globals: dict[str, object],
+        disable_eval_frame: bool = False,
     ):
-        self.codegen = PyCodeGen(frame, disable_eval_frame)
+        self.codegen = PyCodeGen(code, globals, disable_eval_frame)
         self.name = ResumeFnNameFactory().next()
 
     def set_inputs(
@@ -1064,7 +1069,7 @@ class ResumeFunctionCreator:
             cached_code = self.CODE_CACHE[cache_key]
             ResumeFunctionCreator.validate_code(cached_code)
             return types.FunctionType(
-                cached_code, self.codegen._f_globals, cached_code.co_name
+                cached_code, self.codegen._real_globals, cached_code.co_name
             )
         return None
 
@@ -1080,6 +1085,6 @@ class ResumeFunctionCreator:
             self.CODE_CACHE[cache_key] = new_code
         ResumeFunctionCreator.validate_code(new_code)
         fn = types.FunctionType(
-            new_code, self.codegen._f_globals, new_code.co_name
+            new_code, self.codegen._real_globals, new_code.co_name
         )
         return fn

--- a/test/sot/test_sir_rollback.py
+++ b/test/sot/test_sir_rollback.py
@@ -46,7 +46,8 @@ def try_add(x, y):
 class TestRollback(TestCaseBase):
     def test_rollback(self):
         frame = inspect.currentframe()
-        graph = FunctionGraph(frame)
+        assert frame is not None
+        graph = FunctionGraph(frame.f_code, frame.f_globals)
         a = paddle.to_tensor(1.0)
         b = paddle.to_tensor(2.0)
         a = VariableFactory().from_value(a, graph, LocalTracker("a"))


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

重构 SOT pycodegen 和 graph 对 frame 的引用，这些地方都不应该 hold 真实 frame

后续 `OpCodeExecutor` 同样不会 hold 真实 frame，作为替代，会 hold 一个 `VirtualFrame`，这个 vframe 会在 `OpCodeExecutor` 外构造并传入，`OpCodeExecutor` 本身是无状态的，只用来执行（或弱状态，只持有 stack）

后续会进一步改造，https://github.com/PaddleJitLab/deepdive-python-internals/blob/main/examples/generator.py 这种引用关系才是良好的结构，Frame 后续会作为轻量级的可 dump 和 load 的结构，确保实现生成器时能够实现正确的回退

PCard-66972