### PR TITLE
[XPU] fix xpu comm stream error

### DIFF
--- a/paddle/phi/kernels/xpu/all_gather_kernel.cc
+++ b/paddle/phi/kernels/xpu/all_gather_kernel.cc
@@ -46,7 +46,7 @@ void AllGatherKernel(const Context& dev_ctx,
       errors::InvalidArgument(
           "nranks: %s should equal to %s", nranks, comm_ctx->GetSize()));
 
-  XPUStream stream = comm_ctx->GetStream();
+  XPUStream stream = dev_ctx.stream();
   comm_ctx->AllGather(out, x, stream);
 #else
   PADDLE_THROW(common::errors::PreconditionNotMet(

--- a/paddle/phi/kernels/xpu/all_reduce_kernel.cc
+++ b/paddle/phi/kernels/xpu/all_reduce_kernel.cc
@@ -37,7 +37,8 @@ void AllReduceKernel(const Context& dev_ctx,
                     common::errors::Unavailable(
                         "BKCLCommContext is nullptr, collective op should "
                         "has ring_id attr."));
-  XPUStream stream = comm_ctx->GetStream();
+
+  XPUStream stream = dev_ctx.stream();
 
   BKCLOp bkcl_reduce_type = BKCL_ADD;
   switch (static_cast<ReduceType>(reduce_type)) {

--- a/paddle/phi/kernels/xpu/all_to_all_kernel.cc
+++ b/paddle/phi/kernels/xpu/all_to_all_kernel.cc
@@ -38,7 +38,7 @@ void AllToAllKernel(const Context& dev_ctx,
                         "BKCLCommContext is nullptr, collective op should "
                         "has ring_id attr."));
 
-  XPUStream stream = comm_ctx->GetStream();
+  XPUStream stream = dev_ctx.stream();
   int nranks = comm_ctx->GetSize();
   PADDLE_ENFORCE_EQ(
       x_dims[0] % nranks,

--- a/paddle/phi/kernels/xpu/barrier_kernel.cc
+++ b/paddle/phi/kernels/xpu/barrier_kernel.cc
@@ -42,7 +42,7 @@ void BarrierKernel(const Context &dev_ctx,
                     common::errors::Unavailable(
                         "BKCLCommContext is nullptr, collective op should "
                         "has ring_id attr."));
-  XPUStream stream = comm_ctx->GetStream();
+  XPUStream stream = dev_ctx.stream();
   BKCLOp bkcl_reduce_type = BKCL_ADD;
   comm_ctx->AllReduce(out, *in, bkcl_reduce_type, stream);
   XPUStreamSync(stream);

--- a/paddle/phi/kernels/xpu/reduce_scatter_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_scatter_kernel.cc
@@ -47,7 +47,7 @@ void ReduceScatterKernel(const Context& dev_ctx,
                         "BKCLCommContext is nullptr, collective op should "
                         "has ring_id attr."));
 
-  XPUStream stream = comm_ctx->GetStream();
+  XPUStream stream = dev_ctx.stream();
   comm_ctx->ReduceScatter(out, x, BKCL_ADD, stream);
 #else
   PADDLE_THROW(common::errors::PreconditionNotMet(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

 xpu 上目前有用到多流通信，通信都是在计算流上，就算设置了不在计算流也会被强制使用计算流

之前的通信操作都是默认用通信流会导致调用 dev_ctx.Wait() 的时候 sync 失败

本 PR 将 XPU 场景的通信算子都改为使用计算流，这和 GPU 还有 XPU 动手 的行为都是一致的

Pcard-76459
