### PR TITLE
[SOT] Fix bug in dispatch for builtin pow function

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -1246,7 +1246,7 @@ def dispatch_pow(
 ):
     graph = base.graph
     result = BuiltinVariable(operator.pow, graph, DanglingTracker())(base, exp)
-    if exp is not None:
+    if mod is not None:
         result = BuiltinVariable(operator.mod, graph, DanglingTracker())(
             result, mod
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
之前在文件`test/sot/test_builtin_dispatch.py`当中，已经存在相关测试。
能通过测试是因为，当mod为空的时候，执行operator.mod会回退到动态图，而Python能正确处理对None取模的情况，所以返回了正确的结果。

PCard-66972