### PR TITLE
[CINN] Fix fp32 OOM in some models caused by too much unfused gemm epilogues.

### DIFF
--- a/paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.cc
@@ -186,11 +186,16 @@ class FusedLinearGradSinglePattern
                        pir::PatternRewriter &rewriter) const override {
     auto dout = matmul_grad->operand_source(2);
 
+    //TODO(Pan Zhaowu): Figure out exactly why these fused kernel are perform worse in float32
+    // datatype
+    /* ----------------- TEMPORARY DISABLED BECAUSE OOM ------------------
     // The datatype(without auto-promote) of matmul should not be float32 type,
     // which may cause performance issue in some cases.
     if (pir::GetDataTypeFromValue(matmul_grad.x()).isa<pir::Float32Type>()) {
       return false;
     }
+       ----------------- TEMPORARY DISABLED BECAUSE OOM ------------------
+    */
     if (pir::GetShapeFromValue(matmul_grad->operand_source(1)).size() != 2) {
       return false;
     }

--- a/paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_gemm_epilogue_pass.cc
@@ -186,8 +186,8 @@ class FusedLinearGradSinglePattern
                        pir::PatternRewriter &rewriter) const override {
     auto dout = matmul_grad->operand_source(2);
 
-    //TODO(Pan Zhaowu): Figure out exactly why these fused kernel are perform worse in float32
-    // datatype
+    // TODO(Pan Zhaowu): Figure out exactly why these fused kernels are perform
+    // even worse than single kernels in float32 datatype
     /* ----------------- TEMPORARY DISABLED BECAUSE OOM ------------------
     // The datatype(without auto-promote) of matmul should not be float32 type,
     // which may cause performance issue in some cases.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Fix fp32 OOM in some models ( like MobileNetV2_x1_0 ) caused by too much unfused gemm epilogues, while retaining as much performance as possible

pcard-76996