### PR TITLE
Support paddle::optional<Tensor> for cpp_extension

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -2546,7 +2546,7 @@ void ApplyCinnPass(Program &program) {  // NOLINT
     ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
     ctx->GetOrRegisterDialect<pir::shape::ShapeDialect>();
     auto pass_manager = std::make_shared<pir::PassManager>(ctx);
-    if (FLAGS_print_ir) {
+    if (FLAGS_print_ir && VLOG_IS_ON(4)) {
       pass_manager->EnableIRPrinting();
     }
     auto &shape_analysis = pir::ShapeAnalysisManager::Instance().Get(&program);

--- a/test/cpp_extension/custom_extension.cc
+++ b/test/cpp_extension/custom_extension.cc
@@ -26,6 +26,14 @@ paddle::Tensor custom_add(const paddle::Tensor& x, const paddle::Tensor& y) {
   return x.exp() + y.exp();
 }
 
+paddle::Tensor custom_optional_add(const paddle::Tensor& x,
+                                   const paddle::optional<paddle::Tensor>& y) {
+  if (y) {
+    return x.exp() + *y;
+  }
+  return x.exp();
+}
+
 std::vector<paddle::Tensor> custom_tensor(
     const std::vector<paddle::Tensor>& inputs) {
   std::vector<paddle::Tensor> out;
@@ -54,6 +62,7 @@ paddle::optional<paddle::Tensor> optional_tensor(bool return_option = false) {
 
 PYBIND11_MODULE(custom_cpp_extension, m) {
   m.def("custom_add", &custom_add, "exp(x) + exp(y)");
+  m.def("custom_optional_add", &custom_optional_add, "exp(x) + optional(y)");
   m.def("custom_sub", &custom_sub, "exp(x) - exp(y)");
   m.def("custom_tensor", &custom_tensor, "x + 1");
   m.def("nullable_tensor", &nullable_tensor, "returned Tensor might be None");

--- a/test/cpp_extension/test_cpp_extension_jit.py
+++ b/test/cpp_extension/test_cpp_extension_jit.py
@@ -88,6 +88,10 @@ class TestCppExtensionJITInstall(unittest.TestCase):
             target_out = np.exp(np_x) + np.exp(np_y)
             np.testing.assert_allclose(out.numpy(), target_out, atol=1e-5)
 
+            out = custom_cpp_extension.custom_optional_add(x, None)
+            target_out = np.exp(np_x)
+            np.testing.assert_allclose(out.numpy(), target_out, atol=1e-5)
+
             # Test we can call a method not defined in the main C++ file.
             out = custom_cpp_extension.custom_sub(x, y)
             target_out = np.exp(np_x) - np.exp(np_y)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-67164

cpp_extension 支持 `paddle::optional<Tensor>` 类型输入参数