### PR TITLE
Fix cos/sin double_grad functor error when meets null ptr

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -174,10 +174,9 @@ struct SinDoubleGradFunctor : public BaseActivationFunctor<T> {
         GET_DATA_SAFELY(X, "Input", "x", "SinDoubleGrad"));
 
     // calculate d2x first, so d2d1y can inplace d2d1x
-    auto d2x = EigenVector<T>::Flatten(
-        GET_DATA_SAFELY(dX, "Output", "d2x", "SinDoubleGrad"));
-
     if (dX) {
+      auto d2x = EigenVector<T>::Flatten(
+          GET_DATA_SAFELY(dX, "Output", "d2x", "SinDoubleGrad"));
       if (dOut) {
         auto d1y = EigenVector<T>::Flatten(
             GET_DATA_SAFELY(dOut, "Output", "d1y", "SinDoubleGrad"));
@@ -405,9 +404,9 @@ struct CosDoubleGradFunctor : public BaseActivationFunctor<T> {
         GET_DATA_SAFELY(X, "Input", "x", "CosDoubleGrad"));
 
     // calculate d2x first, so d2d1y can inplace d2d1x
-    auto d2x = EigenVector<T>::Flatten(
-        GET_DATA_SAFELY(dX, "Output", "d2x", "CosDoubleGrad"));
     if (dX) {
+      auto d2x = EigenVector<T>::Flatten(
+          GET_DATA_SAFELY(dX, "Output", "d2x", "CosDoubleGrad"));
       auto d1y = EigenVector<T>::Flatten(
           GET_DATA_SAFELY(dOut, "Output", "d1y", "CosDoubleGrad"));
       d2x.device(*device) = -d2d1x * x.unaryExpr(Cosine<T>()) * d1y;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-75624

修复 Sin/Cos Double Grad functor 中为判空直接获取输出指针的行为，将其移动到了判断分支的内部，避免出现类似如下的报错

``` sh
RuntimeError: (NotFound) Unable to get phi::DenseTensor data of Output d2x in operator SinDoubleGrad. Possible reasons are:
  1. The d2x is not the Output of operator SinDoubleGrad;
  2. The d2x has no corresponding variable passed in;
  3. The d2x corresponding variable is not initialized.
  [Hint: pointer dX should not be null.] (at ../paddle/phi/kernels/funcs/activation_functor.h:178)
```