### PR TITLE
[XPU] enable FLAGS_log_memory_stats in xpu

### DIFF
--- a/paddle/phi/core/memory/stats.cc
+++ b/paddle/phi/core/memory/stats.cc
@@ -121,7 +121,8 @@ void HostMemoryStatResetPeakValue(const std::string& stat_type, int dev_id) {
 }
 
 void LogDeviceMemoryStats(const phi::Place& place, const std::string& op_name) {
-  if (FLAGS_log_memory_stats && (phi::is_gpu_place(place) || phi::is_xpu_place(place))) {
+  if (FLAGS_log_memory_stats &&
+      (phi::is_gpu_place(place) || phi::is_xpu_place(place))) {
     VLOG(0) << "After launching op_name: " << op_name << ", "
             << "memory_allocated: "
             << static_cast<double>(memory::DeviceMemoryStatCurrentValue(

--- a/paddle/phi/core/memory/stats.cc
+++ b/paddle/phi/core/memory/stats.cc
@@ -121,7 +121,7 @@ void HostMemoryStatResetPeakValue(const std::string& stat_type, int dev_id) {
 }
 
 void LogDeviceMemoryStats(const phi::Place& place, const std::string& op_name) {
-  if (FLAGS_log_memory_stats && phi::is_gpu_place(place)) {
+  if (FLAGS_log_memory_stats && (phi::is_gpu_place(place) || phi::is_xpu_place(place))) {
     VLOG(0) << "After launching op_name: " << op_name << ", "
             << "memory_allocated: "
             << static_cast<double>(memory::DeviceMemoryStatCurrentValue(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
在XPU上使能FLAGS_log_memory_stats，在日志中记录显存状态

Pcard-76459