### PR TITLE
[Dy2St] Avoid fallback to dygraph when using deepcopy

### DIFF
--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -495,6 +495,7 @@ class StaticFunction(Generic[_InputT, _RetT]):
             new_static_layer = self._clone()
             if (
                 isinstance(instance, layers.Layer)
+                and hasattr(instance, "_original_funcs")
                 and self._dygraph_function.__name__
                 not in instance._original_funcs.keys()
             ):
@@ -690,11 +691,7 @@ class StaticFunction(Generic[_InputT, _RetT]):
 
     def __deepcopy__(self, memo):
         """
-        Customized behavior for copy.deepcopy, return original decorated function instead
-        of a new StaticFunction Object. StaticFunction itself is not copyable because it's
-        associated with class_instance.
-
-        We add __deepcopy__ here only for the following usage:
+        Customized behavior for copy.deepcopy, return a new StaticFunction instance.
 
         Example::
             .. code-block:: python
@@ -716,19 +713,15 @@ class StaticFunction(Generic[_InputT, _RetT]):
                 >>> x = paddle.randn([10, 1], 'float32')
                 >>> net = paddle.jit.to_static(Net())  # convert into static graph mode
 
-                >>> copy_net = copy.deepcopy(net)      # deepcopy a new net without @to_static
-
-        Please attention that original 'net' will unwrap @to_static and rollback into simple Layer.
+                >>> copy_net = copy.deepcopy(net)      # still in static graph mode
         """
         if self.class_instance is not None:
-            net_name = type(self.class_instance).__name__
-            logging_utils.log(
-                level=-1,
-                msg=f"Not recommend to deepcopy '{net_name}' decorated with @to_static, it has side effect that will"
-                f" rollback into original state before @to_static. Please deepcopy '{net_name}' before applying @to_static.",
+            copied_static_fn = type(self)(
+                self._dygraph_function, self._input_spec, **self._kwargs
             )
-            self.rollback()
-            return self._dygraph_function.__get__(memo[id(self.class_instance)])
+            return copied_static_fn.__get__(
+                memo[id(self.class_instance)], type(self.class_instance)
+            )
         else:
             return self._dygraph_function
 

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -719,6 +719,7 @@ class StaticFunction(Generic[_InputT, _RetT]):
             copied_static_fn = type(self)(
                 self._dygraph_function, self._input_spec, **self._kwargs
             )
+            copied_static_fn._patched_name = self._patched_name
             return copied_static_fn.__get__(
                 memo[id(self.class_instance)], type(self.class_instance)
             )

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -719,6 +719,10 @@ class StaticFunction(Generic[_InputT, _RetT]):
             copied_static_fn = type(self)(
                 self._dygraph_function, self._input_spec, **self._kwargs
             )
+            copied_static_fn._training = self._training
+            copied_static_fn._cuda_graph_pool_id = self._cuda_graph_pool_id
+            copied_static_fn._program_cache = self._program_cache
+            copied_static_fn._descriptor_cache = self._descriptor_cache
             copied_static_fn._patched_name = self._patched_name
             return copied_static_fn.__get__(
                 memo[id(self.class_instance)], type(self.class_instance)

--- a/test/dygraph_to_static/test_deepcopy.py
+++ b/test/dygraph_to_static/test_deepcopy.py
@@ -35,9 +35,16 @@ class TestDeepCopy(Dy2StTestBase):
         copy_net = deepcopy(net)
         copy_out = copy_net(x)
 
-        self.assertFalse(isinstance(net.forward, StaticFunction))
-        self.assertTrue(id(copy_net), id(copy_net.forward.__self__))
+        self.assertIsInstance(copy_net.forward, StaticFunction)
+        self.assertIsNot(net.forward, copy_net.forward)
         np.testing.assert_array_equal(src_out.numpy(), copy_out.numpy())
+
+        copy_net.forward.rollback()
+        self.assertFalse(isinstance(copy_net.forward, StaticFunction))
+        copy_rollback_out = copy_net(x)
+        np.testing.assert_array_equal(
+            src_out.numpy(), copy_rollback_out.numpy()
+        )
 
     def test_func(self):
         st_foo = paddle.jit.to_static(foo)

--- a/test/dygraph_to_static/test_deepcopy.py
+++ b/test/dygraph_to_static/test_deepcopy.py
@@ -37,6 +37,11 @@ class TestDeepCopy(Dy2StTestBase):
 
         self.assertIsInstance(copy_net.forward, StaticFunction)
         self.assertIsNot(net.forward, copy_net.forward)
+        self.assertIsNot(
+            net.forward.class_instance, copy_net.forward.class_instance
+        )
+        self.assertIs(net, net.forward.class_instance)
+        self.assertIs(copy_net, copy_net.forward.class_instance)
         np.testing.assert_array_equal(src_out.numpy(), copy_out.numpy())
 
         copy_net.forward.rollback()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#43317 实现的对 `StaticFunction` deepcopy 时明确会 rollback 回动态图这一 side effect，但这在很多场景下，比如套件中可能造成很多写法限制，这里尝试 deepcopy 时不修改原始 model，copy 后产生一个新的 `StaticFunction`，当然会 bind 新的 `_class_instance`，先看看 CI 会不会有什么问题

PCard-66972