### PR TITLE
[PIR save/load]Fix bug in deserialize VOID_DATA

### DIFF
--- a/paddle/fluid/pir/serialize_deserialize/include/deserialize_utils.h
+++ b/paddle/fluid/pir/serialize_deserialize/include/deserialize_utils.h
@@ -90,11 +90,11 @@ pir::FloatAttribute deserializeAttrFromJson<pir::FloatAttribute, float>(
   if (attr_json->contains(VOID_DATA)) {
     auto string = attr_json->at(VOID_DATA).template get<std::string>();
     if (string == "NAN") {
-      return pir::FloatAttribute::get(ctx, std::nanf(""));
+      return pir::FloatAttribute::get(ctx, NAN);
     } else if (string == "INF") {
-      return pir::FloatAttribute::get(ctx, FLT_MAX);
+      return pir::FloatAttribute::get(ctx, INFINITY);
     } else if (string == "-INF") {
-      return pir::FloatAttribute::get(ctx, FLT_MIN);
+      return pir::FloatAttribute::get(ctx, -INFINITY);
     }
   }
 
@@ -108,11 +108,11 @@ pir::DoubleAttribute deserializeAttrFromJson<pir::DoubleAttribute, double>(
   if (attr_json->contains(VOID_DATA)) {
     auto string = attr_json->at(VOID_DATA).template get<std::string>();
     if (string == "NAN") {
-      return pir::DoubleAttribute::get(ctx, std::nanf(""));
+      return pir::DoubleAttribute::get(ctx, NAN);
     } else if (string == "INF") {
-      return pir::DoubleAttribute::get(ctx, DBL_MAX);
+      return pir::DoubleAttribute::get(ctx, INFINITY);
     } else if (string == "-INF") {
-      return pir::DoubleAttribute::get(ctx, DBL_MIN);
+      return pir::DoubleAttribute::get(ctx, -INFINITY);
     }
   }
   double data = attr_json->at(DATA).template get<double>();
@@ -640,12 +640,6 @@ pir::Type AttrTypeReader::ReadBuiltInType(const std::string type_name,
   } else if (type_name == pir::IndexType::name()) {
     VLOG(8) << "Parse IndexType ... ";
     return pir::deserializeTypeFromJson<pir::IndexType>(type_json, ctx);
-  } else if (type_name == pir::Float8E4M3FNType::name()) {
-    VLOG(8) << "Parse IndexType ... ";
-    return pir::deserializeTypeFromJson<pir::Float8E4M3FNType>(type_json, ctx);
-  } else if (type_name == pir::Float8E5M2Type::name()) {
-    VLOG(8) << "Parse IndexType ... ";
-    return pir::deserializeTypeFromJson<pir::Float8E5M2Type>(type_json, ctx);
   } else if (type_name == pir::Complex64Type::name()) {
     VLOG(8) << "Parse Complex64Type ... ";
     return pir::deserializeTypeFromJson<pir::Complex64Type>(type_json, ctx);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164

Fix bug in deserialize VOID_DATA:
use builtin macros: NAN INFINITY