### PR TITLE
[CINN] Optimize indivisble loops by condition entailment

### DIFF
--- a/paddle/cinn/optim/CMakeLists.txt
+++ b/paddle/cinn/optim/CMakeLists.txt
@@ -11,6 +11,7 @@ gather_srcs(
   transform_polyfor_to_for.cc
   eliminate_broadcast_in_forloop.cc
   eliminate_invariant_loop.cc
+  entail_loop_condition_pass.cc
   fold_cinn_call_arguments.cc
   call_arg_list_to_pod_value.cc
   insert_debug_log_callee.cc

--- a/paddle/cinn/optim/entail_loop_condition_pass.cc
+++ b/paddle/cinn/optim/entail_loop_condition_pass.cc
@@ -1,0 +1,281 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/optim/entail_loop_condition_pass.h"
+#include "paddle/cinn/common/ir_util.h"
+#include "paddle/cinn/ir/ir_mutator.h"
+#include "paddle/cinn/ir/stmt_visitors.h"
+#include "paddle/cinn/ir/utils/ir_copy.h"
+
+namespace cinn {
+namespace optim {
+
+using ir::stmt::BlockRef;
+using ir::stmt::Evaluate;
+using ir::stmt::For;
+using ir::stmt::IfThenElse;
+using ir::stmt::Let;
+using ir::stmt::Schedule;
+using ir::stmt::StmtRef;
+using ir::stmt::Store;
+
+namespace {
+
+struct LoopCondLowerboundMutator : public ir::IRMutator<> {
+  explicit LoopCondLowerboundMutator(const ir::Var& var, const ir::Expr& extent)
+      : var_(var), extent_(extent) {}
+
+  void operator()(ir::Expr* expr) { ir::IRMutator<>::Visit(expr, expr); }
+
+ private:
+  void Visit(const ir::_Var_* op, ir::Expr* expr) {
+    if (!op->is_symbolic_constant) {
+      if (expr->as_var_ref() == var_) {
+        *expr = extent_;
+      } else {
+        *expr = common::make_const(op->type(), 0);
+      }
+    }
+  }
+
+  ir::Var var_;
+  ir::Expr extent_;
+};
+
+bool CanProveEntailment(const ir::Var& loop_var,
+                        const ir::Expr& extent,
+                        const ir::LT* if_cond) {
+  // 1. For static shape, it's easy to prove by setting `loop_var = extent` and
+  //    check whether the if-condition is violated
+  if (extent.is_constant()) {
+    ir::Expr lhs = ir::ir_utils::IRCopy(if_cond->a());
+    ir::Expr rhs = if_cond->b();
+    LoopCondLowerboundMutator(loop_var, extent)(&lhs);
+    if (!lhs.is_index()) return false;
+    lhs = lhs.as_index().Normalize();
+    return lhs.is_constant() && rhs.is_constant() &&
+           lhs.as_int64() >= rhs.as_int64();
+  }
+
+  // 2. For dynamic shape, as CINN is currently unable to prove equality with
+  //    symbols, we just check their forms rather than values. We require that
+  //    the extent be like `(<expr_a> / <expr_b>) + 1`, and the rhs of if_cond
+  //    be `<expr_a>`.
+  auto* add_node = extent.As<ir::Add>();
+  if (!add_node) return false;
+  if (add_node->b() != ir::Expr(1)) return false;
+  auto* div_node = add_node->a().As<ir::Div>();
+  if (!div_node) return false;
+  return div_node->a() == if_cond->b();
+}
+
+bool CanEntailLoopCondition(const For& for_stmt) {
+  // 1. The loop extent must be >32 or be dynamic, otherwise the loop will be
+  //    completely unrolled and we have nothing to do.
+  ir::Expr extent = for_stmt->extent();
+  if (extent.is_constant() && extent.as_int64() <= 32) return false;
+
+  // 2. The loop body must contains exactly one IfThenElse.
+  if (for_stmt->body()->stmts().size() != 1) return false;
+  StmtRef for_body = for_stmt->body()->stmts().front();
+  if (!for_body.isa<IfThenElse>()) return false;
+
+  // 3. The IfThenElse must be a leaf node, i.e., it only contains Schedule
+  //    nodes.
+  IfThenElse if_stmt = for_body.as<IfThenElse>();
+  if (!if_stmt->condition().As<ir::LT>()) return false;
+  if (!if_stmt->false_case()->stmts().empty()) return false;
+  for (auto& inner_stmt : if_stmt->true_case()->stmts()) {
+    if (!inner_stmt.isa<Schedule>()) return false;
+  }
+
+  // 4. Check whether the if-condition actually entails the loop extent.
+  return CanProveEntailment(
+      for_stmt->loop_var(), extent, if_stmt->condition().As<ir::LT>());
+}
+
+struct CommonFactorExtractor : public ir::IRMutator<> {
+  explicit CommonFactorExtractor(const ir::Var& var) : var_(var) {}
+
+  void operator()(ir::Expr* expr) { ir::IRMutator<>::Visit(expr, expr); }
+
+  int64_t GetResult() { return common_factor_ > 0 ? common_factor_ : 1; }
+
+ private:
+  void Visit(const ir::Mul* op, ir::Expr* expr) {
+    if (op->a() != var_ && op->b() != var_) {
+      auto* node = expr->As<ir::Mul>();
+      ir::IRMutator<>::Visit(&node->a(), &node->a());
+      ir::IRMutator<>::Visit(&node->b(), &node->b());
+      return;
+    }
+
+    int64_t factor = 1;
+    if (op->a() == var_ && op->b().is_constant()) {
+      factor = op->b().as_int64();
+    } else if (op->b() == var_ && op->a().is_constant()) {
+      factor = op->a().as_int64();
+    }
+
+    if (common_factor_ == 0) {
+      common_factor_ = factor;
+    } else {
+      common_factor_ = std::gcd(common_factor_, factor);
+    }
+  }
+
+  ir::Expr var_;
+  int64_t common_factor_{0};
+};
+
+int64_t ExtractCommonFactorOfLoopVar(const For& for_stmt) {
+  CommonFactorExtractor extractor(for_stmt->loop_var());
+
+  const auto VisitFn = [&](StmtRef stmt) {
+    if (stmt.isa<IfThenElse>()) {
+      IfThenElse if_stmt = stmt.as<IfThenElse>();
+      ir::Expr condition = if_stmt->condition();
+      extractor(&condition);
+    } else if (stmt.isa<Store>()) {
+      Store store_stmt = stmt.as<Store>();
+      for (ir::Expr index : store_stmt->indices()) {
+        extractor(&index);
+      }
+      ir::Expr value = store_stmt->value();
+      extractor(&value);
+    }
+  };
+
+  ir::stmt::Visit(for_stmt->body(), VisitFn, [](auto) {});
+  return extractor.GetResult();
+}
+
+struct StridedLoopVarReplacer : public ir::IRMutator<> {
+  explicit StridedLoopVarReplacer(const ir::Var& var,
+                                  const ir::Var& new_var,
+                                  int64_t common_factor)
+      : var_(var), new_var_(new_var), common_factor_(common_factor) {}
+
+  void operator()(ir::Expr* expr) { ir::IRMutator<>::Visit(expr, expr); }
+
+ private:
+  void Visit(const ir::Mul* op, ir::Expr* expr) {
+    auto* node = expr->As<ir::Mul>();
+    ir::IRMutator<>::Visit(&node->a(), &node->a());
+    ir::IRMutator<>::Visit(&node->b(), &node->b());
+
+    if (op->a() == var_) {
+      Replace(expr, &node->b());
+    } else if (op->b() == var_) {
+      Replace(expr, &node->a());
+    }
+  }
+
+  void Replace(ir::Expr* expr, ir::Expr* scale) {
+    if (*scale == ir::Expr(common_factor_)) {
+      *expr = new_var_;
+    } else {
+      scale->As<ir::IntImm>()->value /= common_factor_;
+    }
+  }
+
+  ir::Expr var_;
+  ir::Expr new_var_;
+  int64_t common_factor_;
+};
+
+void ReplaceWithStridedLoopVar(For for_stmt,
+                               const ir::Var& strided_loop_var,
+                               int64_t common_factor) {
+  ir::Var loop_var = for_stmt->loop_var();
+  StridedLoopVarReplacer replacer(loop_var, strided_loop_var, common_factor);
+
+  const auto VisitFn = [&](StmtRef stmt) {
+    if (stmt.isa<IfThenElse>()) {
+      IfThenElse if_stmt = stmt.as<IfThenElse>();
+      ir::Expr condition = if_stmt->condition();
+      replacer(&condition);
+    } else if (stmt.isa<Store>()) {
+      Store store_stmt = stmt.as<Store>();
+      for (ir::Expr index : store_stmt->indices()) {
+        replacer(&index);
+      }
+      ir::Expr value = store_stmt->value();
+      replacer(&value);
+    }
+  };
+
+  ir::stmt::Visit(for_stmt->body(), VisitFn, [](auto) {});
+}
+
+void EntailLoopCondition(For for_stmt) {
+  ir::Var loop_var = for_stmt->loop_var();
+  IfThenElse if_stmt = for_stmt->body()->stmts().front().as<IfThenElse>();
+  std::vector<StmtRef> new_body_stmts;
+
+  // Step 1. Try extract common factor of loop_var.
+  // Note: type of common_factor should be strictly the same as loop_var. Don't
+  //   mix int64 value in an int32 expression.
+  int64_t common_factor = ExtractCommonFactorOfLoopVar(for_stmt);
+  ir::Expr common_factor_expr =
+      common::make_const(loop_var->type(), common_factor);
+
+  // Step 2. If loop_var has a non-unit common factor, replace all occurrences
+  //   of loop_var with strided_loop_var = loop_var * common_factor.
+  if (common_factor > 1) {
+    ir::Var strided_loop_var = loop_var->Copy();
+    strided_loop_var->name += "_strided";
+    new_body_stmts.push_back(
+        Let(strided_loop_var, ir::Mul::Make(loop_var, common_factor_expr)));
+
+    ReplaceWithStridedLoopVar(for_stmt, strided_loop_var, common_factor);
+    loop_var = strided_loop_var;
+  }
+
+  // Step 3. Declare the entailment relation on the loop condition.
+  ir::Expr entail_expr =
+      ir::Call::Make(Void(),
+                     "CINN_ENTAIL_LOOP_CONDITION",
+                     {loop_var, if_stmt->condition(), common_factor_expr},
+                     {},
+                     ir::CallType::Intrinsic);
+  new_body_stmts.push_back(Evaluate(entail_expr));
+
+  new_body_stmts.push_back(if_stmt);
+  for_stmt->set_body(BlockRef(new_body_stmts));
+}
+
+}  // namespace
+
+LogicalResult EntailLoopConditionPass::Run(ir::stmt::BlockRef block) {
+  std::vector<StmtRef> new_stmts;
+  for (auto stmt : block->stmts()) {
+    if (stmt.isa<For>()) {
+      For for_stmt = stmt.as<For>();
+      if (CanEntailLoopCondition(for_stmt)) {
+        EntailLoopCondition(for_stmt);
+      }
+    }
+    new_stmts.push_back(stmt);
+  }
+  block->set_stmts(new_stmts);
+  return LogicalResult::success();
+}
+
+std::unique_ptr<BlockPass> CreateEntailLoopConditionPass() {
+  return std::make_unique<EntailLoopConditionPass>();
+}
+
+}  // namespace optim
+}  // namespace cinn

--- a/paddle/cinn/optim/entail_loop_condition_pass.h
+++ b/paddle/cinn/optim/entail_loop_condition_pass.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "paddle/cinn/pass/pass.h"
+
+namespace cinn {
+namespace optim {
+
+/**
+ * Remove the IfThenElse inside indivisible loops by entailing the if-condition
+ * into the loop condition.
+ *
+ * Traditionally, when the element count is not divisble by the block size, an
+ * IfThenElse inside the loop is needed to tell trailing blocks to break early.
+ * However, the IfThenElse introduces an extra comparison in every iteration,
+ * therefore heavily impacting the performance. This pass solves this problem by
+ * observing that most IfThenElses are unnecessary, and can actually entail the
+ * loop condition. By removing one comparison, we reduce the compute intensity
+ * and bring up to 30% speedup.
+ *
+ * For example, in the following loop:
+ *   for (k = 0; k < 8; k += 1) {
+ *     if (((k * 32) + thread.x) < 234) {
+ *       var_1[0] = var_1[0] + var[((block.x * 234) + (k * 32)) + thread.x];
+ *     }
+ *   }
+ * The if-condition actually entails the loop condition, i.e. whenever
+ * `((k * 32) + thread.x) < 234` is true, the `k < 8` is also true. This can
+ * be proved by setting k = 8, then regardless of the value of thread.x, the
+ * `(k * 32) + thread.x` will be at least 256, which violates the premise.
+ *
+ * Therefore, we can override the loop condition with the if-condition,
+ * eliminating one comparison, resulting in a new loop:
+ *   for (k = 0; ((k * 32) + thread.x) < 234; k += 1) {
+ *     var_1[0] = var_1[0] + var[((block.x * 234) + (k * 32)) + thread.x];
+ *   }
+ *
+ * Furthermore, after removing the loop condition, we can see that `k * 32`
+ * becomes a common expression in the whole loop, so we can replace it with
+ * `k_strided = k * 32`. The finally optimized loop is:
+ *   for (k_stride = 0; (k_stride + thread.x) < 234; k_stride += 32) {
+ *     var_1[0] = var_1[0] + var[((block.x * 234) + k_stride) + thread.x];
+ *   }
+ *
+ *
+ * Implementation Notes:
+ *   To put the if-condition into the loop extent, we need the PolyFor node,
+ *   which is currently not available in the new CINN IR. To quickly bring this
+ *   pass online, we temporarily use a macro
+ *     CINN_ENTAIL_LOOP_CONDITION(__loop_var, __cond, __stride)
+ *   that plays some tricks at C level to change the loop structure. This is
+ *   very non-standard and should be replaced by a safer method later.
+ */
+class EntailLoopConditionPass : public BlockPass {
+ public:
+  EntailLoopConditionPass() : BlockPass("entail_loop_condition") {}
+  LogicalResult Run(ir::stmt::BlockRef func) override;
+};
+
+std::unique_ptr<BlockPass> CreateEntailLoopConditionPass();
+
+}  // namespace optim
+}  // namespace cinn

--- a/paddle/cinn/optim/optimize.cc
+++ b/paddle/cinn/optim/optimize.cc
@@ -22,6 +22,7 @@
 #include "paddle/cinn/optim/cast_bool_to_int8.h"
 #include "paddle/cinn/optim/eliminate_broadcast_in_forloop.h"
 #include "paddle/cinn/optim/eliminate_invariant_loop.h"
+#include "paddle/cinn/optim/entail_loop_condition_pass.h"
 #include "paddle/cinn/optim/extern_call_process_pass.h"
 #include "paddle/cinn/optim/fold_cinn_call_arguments.h"
 #include "paddle/cinn/optim/if_fold_pass.h"
@@ -146,7 +147,9 @@ ir::LoweredFunc Optimize(ir::LoweredFunc fn,
 
   BlockPassManager pass_manager;
   pass_manager.AddPass(CreateIfFusionPass());
+  pass_manager.AddPass(CreateEntailLoopConditionPass());
   pass_manager.Run(copied);
+  VLOG(4) << "After Optimize IfFusion and EntailLoopCondition:" << copied;
 
   target.arch.Match(
       [&](common::NVGPUArch) {

--- a/paddle/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
+++ b/paddle/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
@@ -824,6 +824,10 @@ CINN_NVGPU_INDEX_ADD(fp16, float16)
 
 #undef CINN_CUDA_INDEX_ADD
 
+#define CINN_ENTAIL_LOOP_CONDITION(__loop_var, __cond, __stride) \
+  }                                                              \
+  for (decltype(__stride) __loop_var = 0; __cond; __loop_var += __stride) {
+
 __device__ int cinn_cuda_resize_bilinear(const int *buf,
                                          const int c_size,
                                          const int in_h,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Performance


### Description
通过循环条件的蕴含（Entailment）关系对不整除的循环进行优化

这个PR实际上实现了两个优化，第一个优化是消除不整除循环里面的`if`，例如对于下面的循环：
```c
for (k = 0; k < 8; k += 1) {
  if (((k * 32) + thread.x) < 234) {
    var_1[0] = var_1[0] + var[((block.x * 234) + (k * 32)) + thread.x];
  }
}
```

观察到，`if`的条件事实上蕴含（Entail）了循环的条件，即当`((k * 32) + thread.x) < 234`为真时，`k < 8`一定也为真。可以使用反证法证明，假设`k < 8`不为真，例如`k = 8`，则无论`thread.x`等于多少，`((k * 32) + thread.x)`都至少为256，不满足小于234的条件，因此蕴含关系成立。

因此，可以使用`if`的条件替代掉循环的条件，并把`if`消去，得到新的循环：
```c
for (k = 0; ((k * 32) + thread.x) < 234; k += 1) {
  var_1[0] = var_1[0] + var[((block.x * 234) + (k * 32)) + thread.x];
}
```

完成第一个优化后，又注意到第二个优化，即此时`k * 32`是这整个循环中的公共表达式，可以提取出来变成`k_strided = k * 32`，这样进一步省掉一个寄存器，最终优化结果为：
```c
for (k_stride = 0; (k_stride + thread.x) < 234; k_stride += 32) {
  var_1[0] = var_1[0] + var[((block.x * 234) + k_stride) + thread.x];
}
```

关于为什么两个优化实现在一个Pass里，因为这两个优化是息息相关的，都是和循环变量有关，两个优化都要对loop的extent和step进行修改，所以实现在一个Pass里更方便；另外优化二单独做是没有收益的，必须和优化一结合才有收益，因此分开实现可能导致优化一没匹配但优化二自己做了的情况

<b>注：</b>优化一是可以单独做的，在性能收益中占大头；优化二确实有可能匹配不上（尤其在动态shape下），但没关系，收益的大头已经拿到了

#### 关于实现

由于新循环的条件是一个表达式而不是`k < extent`的形式，需要PolyFor才能表示，而当前我们的新IR中把PolyFor移除了，因此为了尽快上线该Pass，我只能先用一个C的宏来进行trick，即：
```c
#define CINN_ENTAIL_LOOP_CONDITION(__loop_var, __cond, __stride) \
  }                                                              \
  for (decltype(__stride) __loop_var = 0; __cond; __loop_var += __stride) {
```
上述循环实际生成的IR为：
```c
for (k = 0; k < 8; k += 1) {
  int k_strided = k * 32;
  CINN_ENTAIL_LOOP_CONDITION(k_strided, ((k * 32) + thread.x) < 234, 32);
  if ((k_strided + thread.x) < 234) {
    var_1[0] = var_1[0] + var[((block.x * 234) + (k * 32)) + thread.x];
  }
}
```
也就是用宏把原有循环打断，然后重新构造一个PolyFor的结构，这样确实不太规范，但至少在现行IR中是安全的，而且字面上没有改变循环的结构，调试的时候直接把`CINN_ENTAIL_LOOP_CONDITION`这行删掉也能正常执行

#### 性能测试
* BatchNorm NHWC [125, 50, 50, 256]

| 用时: us | 前向reduce | 反向reduce
| --- | --: | ---: |
| 原始 | 674 | 891
| 优化一 | 447 | 750
| 优化一+二 | 408 | 748

* BatchNorm NCHW [-256, 256, -56, -56]（负号为动态Shape）

| 用时: us | 前向 | 反向
| --- | --- | --- |
| 原始 | 5592 | 6803
| 优化一 | 4132 | 5570
| 优化一+二 | 4121 | 5506

<br>
Pcard-85711