### PR TITLE
[Paddle TensorRT] Naming of layers that is complementary to the rest of the converter

### DIFF
--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -336,18 +336,21 @@ def trt_max(network, a, b):
     return layer.get_output(0)
 
 
-def trt_sub(network, a, b):
+def trt_sub(network, a, b, name=None):
     layer = network.add_elementwise(a, b, trt.ElementWiseOperation.SUB)
+    set_layer_name(layer, name)
     return layer.get_output(0)
 
 
-def trt_min(network, a, b):
+def trt_min(network, a, b, name=None):
     layer = network.add_elementwise(a, b, trt.ElementWiseOperation.MIN)
+    set_layer_name(layer, name)
     return layer.get_output(0)
 
 
-def trt_div(network, a, b):
+def trt_div(network, a, b, name=None):
     layer = network.add_elementwise(a, b, trt.ElementWiseOperation.DIV)
+    set_layer_name(layer, name)
     return layer.get_output(0)
 
 

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -310,13 +310,16 @@ def resize_to_1d(network, shape_tensor, name=None):
 
 
 # Get element tensor of 1D shape tensor
-def get_shape_tensor_element(network, x, index, is_scalar=False):
+def get_shape_tensor_element(network, x, index, is_scalar=False, name=None):
     assert (
         index >= 0
     ), f"The index should be greater or equal than 0, but got {index}"
-    index_tensor = add_1D_constant_layer(network, index, is_scalar=is_scalar)
+    index_tensor_name = [name[0], "index_tensor"] if name is not None else None
+    index_tensor = add_1D_constant_layer(network, index, is_scalar=is_scalar, name=index_tensor_name)
     gather_layer = network.add_gather(input=x, indices=index_tensor, axis=0)
-    shape_tensor = resize_to_1d(network, gather_layer.get_output(0))
+    if name is not None:
+        set_layer_name(gather_layer, [name[0], "gather_layer"])
+    shape_tensor = resize_to_1d(network, gather_layer.get_output(0), name=name)
     return shape_tensor
 
 

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -289,7 +289,10 @@ def trt_reshape(network, input, new_shape, name=None, is_shape_tensor=False):
     else:
         reshape_layer.reshape_dims = new_shape
     if name is not None:
-        set_layer_name(reshape_layer, name)
+        if isinstance(name, list):
+            set_layer_name(reshape_layer, name)
+        else:
+            reshape_layer.name = name
     return reshape_layer.get_output(0)
 
 

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -413,8 +413,9 @@ def trt_floor_div(network, a, b, name=None):
     return layer.get_output(0)
 
 
-def trt_equal(network, a, b):
+def trt_equal(network, a, b, name=None):
     layer = network.add_elementwise(a, b, trt.ElementWiseOperation.EQUAL)
+    set_layer_name(layer, name)
     return layer.get_output(0)
 
 

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -865,11 +865,13 @@ def unary_op_converter(network, paddle_op, inputs):
             identity_layer.set_output_type(0, trt.float32)
         else:
             identity_layer.set_output_type(0, trt.float16)
+        set_layer_name(identity_layer, paddle_op)
         input_tensor = identity_layer.get_output(0)
 
     if paddle_op.name() in ops_type_map:
         for trt_op in ops_type_map[paddle_op.name()]:
             layer = network.add_unary(input_tensor, trt_op)
+            set_layer_name(layer, paddle_op)
             input_tensor = layer.get_output(0)
     else:
         raise NotImplementedError(
@@ -878,6 +880,7 @@ def unary_op_converter(network, paddle_op, inputs):
     if need_cast:
         restore_layer = network.add_identity(input_tensor)
         restore_layer.set_output_type(0, trt_type_mapping[org_type])
+        set_layer_name(restore_layer, paddle_op)
         input_tensor = restore_layer.get_output(0)
 
     return input_tensor

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -339,8 +339,9 @@ def trt_sum(network, a, b, name=None):
     return layer.get_output(0)
 
 
-def trt_max(network, a, b):
+def trt_max(network, a, b, name=None):
     layer = network.add_elementwise(a, b, trt.ElementWiseOperation.MAX)
+    set_layer_name(layer, name)
     return layer.get_output(0)
 
 
@@ -362,8 +363,9 @@ def trt_div(network, a, b, name=None):
     return layer.get_output(0)
 
 
-def trt_floor_div(network, a, b):
+def trt_floor_div(network, a, b, name=None):
     layer = network.add_elementwise(a, b, trt.ElementWiseOperation.FLOOR_DIV)
+    set_layer_name(layer, name)
     return layer.get_output(0)
 
 
@@ -477,7 +479,7 @@ def map_trt_dtype(trt_dtype):
 
 
 # Reduce the given tensor in the TensorRT network to a scalar
-def trt_reduce_to_scalar(network, tensor, dtype=trt.int32):
+def trt_reduce_to_scalar(network, tensor, dtype=trt.int32, name=None):
     if len(tensor.shape) == 0:
         return tensor
     axes = 0
@@ -486,7 +488,10 @@ def trt_reduce_to_scalar(network, tensor, dtype=trt.int32):
     reduce_layer = network.add_reduce(
         tensor, trt.ReduceOperation.SUM, axes, keep_dims=False
     )
-    scalar = trt_cast(network, reduce_layer.get_output(0), dtype)
+    if name is not None:
+        set_layer_name(reduce_layer, [name[0], 'reduce_layer'])
+        scalar_name = name
+    scalar = trt_cast(network, reduce_layer.get_output(0), dtype, name=scalar_name)
     return scalar
 
 

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -491,7 +491,9 @@ def trt_reduce_to_scalar(network, tensor, dtype=trt.int32, name=None):
     if name is not None:
         set_layer_name(reduce_layer, [name[0], 'reduce_layer'])
         scalar_name = name
-    scalar = trt_cast(network, reduce_layer.get_output(0), dtype, name=scalar_name)
+    scalar = trt_cast(
+        network, reduce_layer.get_output(0), dtype, name=scalar_name
+    )
     return scalar
 
 

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -671,6 +671,7 @@ def convert_conv3d(network, paddle_op, inputs):
         layer.padding_mode = trt.PaddingMode.SAME_UPPER
 
     layer.dilation_nd = nv_dilations
+    set_layer_name(layer, paddle_op)
 
     return layer.get_output(0)
 

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -394,9 +394,10 @@ def trt_pow(network, a, b, name=None):
     return layer.get_output(0)
 
 
-def cast_tensor(network, input_tensor, dtype):
+def cast_tensor(network, input_tensor, dtype, name=None):
     layer = network.add_identity(input_tensor)
     layer.set_output_type(0, dtype)
+    set_layer_name(layer, name)
     return layer.get_output(0)
 
 

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -282,14 +282,14 @@ def trt_shape(
     return shape_layer.get_output(0)
 
 
-def trt_reshape(network, input, new_shape, name="", is_shape_tensor=False):
+def trt_reshape(network, input, new_shape, name=None, is_shape_tensor=False):
     reshape_layer = network.add_shuffle(input)
     if is_shape_tensor:
         reshape_layer.set_input(1, new_shape)
     else:
         reshape_layer.reshape_dims = new_shape
-    if name != "":
-        reshape_layer.name = name
+    if name is not None:
+        set_layer_name(reshape_layer, name)
     return reshape_layer.get_output(0)
 
 
@@ -315,7 +315,9 @@ def get_shape_tensor_element(network, x, index, is_scalar=False, name=None):
         index >= 0
     ), f"The index should be greater or equal than 0, but got {index}"
     index_tensor_name = [name[0], "index_tensor"] if name is not None else None
-    index_tensor = add_1D_constant_layer(network, index, is_scalar=is_scalar, name=index_tensor_name)
+    index_tensor = add_1D_constant_layer(
+        network, index, is_scalar=is_scalar, name=index_tensor_name
+    )
     gather_layer = network.add_gather(input=x, indices=index_tensor, axis=0)
     if name is not None:
         set_layer_name(gather_layer, [name[0], "gather_layer"])

--- a/python/paddle/tensorrt/impls/activation.py
+++ b/python/paddle/tensorrt/impls/activation.py
@@ -396,7 +396,8 @@ def celu_converter(network, paddle_op, inputs):
         name=[paddle_op.name(), "alpha_data"],
     )
     constant_zero_data = add_constant_layer(
-        network, [0.0],
+        network,
+        [0.0],
         constant_shape,
         dtype="float32",
         name=[paddle_op.name(), "constant_zero_data"],
@@ -522,9 +523,9 @@ def prelu_converter(network, paddle_op, inputs):
             else:
                 shape_tensor = (
                     trt_concat(
-                    network,
-                    [n_tensor, c_tensor],
-                    name=[paddle_op.name(), "shape_tensor"]
+                        network,
+                        [n_tensor, c_tensor],
+                        name=[paddle_op.name(), "shape_tensor"]
                     ),
                 )
         else:

--- a/python/paddle/tensorrt/impls/activation.py
+++ b/python/paddle/tensorrt/impls/activation.py
@@ -490,9 +490,8 @@ def prelu_converter(network, paddle_op, inputs):
     data_format = paddle_op.attrs().get("data_format", "NCHW")
     w_dims = trt.Dims(alpha_data.numpy().shape)
     trt_w_dims = w_dims
-    alpha_tensor = network.add_constant(
-        trt_w_dims,alpha_data, name=[paddle_op.name(), "alpha_tensor"]
-    )
+    alpha_tensor = network.add_constant(trt_w_dims,alpha_data)
+    set_layer_name(alpha_tensor, paddle_op)
     alpha_tensor = alpha_tensor.get_output(0)
     alpha_dims = alpha_tensor.shape
     real_alpha_tensor = alpha_tensor

--- a/python/paddle/tensorrt/impls/activation.py
+++ b/python/paddle/tensorrt/impls/activation.py
@@ -525,7 +525,7 @@ def prelu_converter(network, paddle_op, inputs):
                     trt_concat(
                         network,
                         [n_tensor, c_tensor],
-                        name=[paddle_op.name(), "shape_tensor"]
+                        name=[paddle_op.name(), "shape_tensor"],
                     ),
                 )
         else:

--- a/python/paddle/tensorrt/impls/activation.py
+++ b/python/paddle/tensorrt/impls/activation.py
@@ -490,7 +490,7 @@ def prelu_converter(network, paddle_op, inputs):
     data_format = paddle_op.attrs().get("data_format", "NCHW")
     w_dims = trt.Dims(alpha_data.numpy().shape)
     trt_w_dims = w_dims
-    alpha_tensor = network.add_constant(trt_w_dims,alpha_data)
+    alpha_tensor = network.add_constant(trt_w_dims, alpha_data)
     set_layer_name(alpha_tensor, paddle_op)
     alpha_tensor = alpha_tensor.get_output(0)
     alpha_dims = alpha_tensor.shape
@@ -520,10 +520,13 @@ def prelu_converter(network, paddle_op, inputs):
                     name=[paddle_op.name(), "shape_tensor"],
                 )
             else:
-                shape_tensor = trt_concat(
+                shape_tensor = (
+                    trt_concat(
                     network,
                     [n_tensor, c_tensor],
-                    name=[paddle_op.name(), "shape_tensor"]),
+                    name=[paddle_op.name(), "shape_tensor"]
+                    ),
+                )
         else:
             if hw_tensor:
                 shape_tensor = trt_concat(

--- a/python/paddle/tensorrt/impls/attribute.py
+++ b/python/paddle/tensorrt/impls/attribute.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from paddle.tensorrt.converter_utils import trt_shape, set_layer_name
+from paddle.tensorrt.converter_utils import set_layer_name, trt_shape
 from paddle.tensorrt.register import converter_registry
 
 

--- a/python/paddle/tensorrt/impls/attribute.py
+++ b/python/paddle/tensorrt/impls/attribute.py
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from paddle.tensorrt.converter_utils import trt_shape
+from paddle.tensorrt.converter_utils import trt_shape, set_layer_name
 from paddle.tensorrt.register import converter_registry
 
 
 @converter_registry.register("pd_op.shape", trt_version="trt_version_ge=8.0")
 def shape_converter(network, paddle_op, inputs):
-    return trt_shape(network, inputs[0])
+    return trt_shape(network, inputs[0], name=[paddle_op.name(), 'trt_shape'])
 
 
 @converter_registry.register("pd_op.shape64", trt_version="trt_version_ge=8.0")
 def shape64_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]
     shape_layer = network.add_shape(input_tensor)
+    set_layer_name(shape_layer, paddle_op)
     return shape_layer.get_output(0)

--- a/python/paddle/tensorrt/impls/common.py
+++ b/python/paddle/tensorrt/impls/common.py
@@ -135,7 +135,9 @@ def bilinear_interp_converter(network, paddle_op, inputs):
                     # Extract the first two elements representing height and width
                     outsize_h = size_tensors[0]
                     outsize_w = size_tensors[1]
-                    outsize_tensor = network.add_concatenation([outsize_h, outsize_w])
+                    outsize_tensor = network.add_concatenation(
+                        [outsize_h, outsize_w]
+                    )
                     set_layer_name(outsize_tensor, paddle_op)
                     outsize_tensor = outsize_tensor.get_output(0)
             else:
@@ -151,7 +153,9 @@ def bilinear_interp_converter(network, paddle_op, inputs):
                     )
                     set_layer_name(outsize_w, paddle_op)
                     outsize_w = outsize_w.get_output(0)
-                    outsize_tensor = network.add_concatenation([outsize_h, outsize_w])
+                    outsize_tensor = network.add_concatenation(
+                        [outsize_h, outsize_w]
+                    )
                     set_layer_name(outsize_tensor, paddle_op)
                     outsize_tensor = outsize_tensor.get_output(0)
     use_scales = True
@@ -192,17 +196,28 @@ def bilinear_interp_converter(network, paddle_op, inputs):
     else:
         if outsize_tensor is not None:
             outsize_itensors = []
-            batch_dim = get_shape_tensor_element(network, input_shape_tensor, 0, name=[paddle_op.name(), "batch_dim"])
+            batch_dim = get_shape_tensor_element(
+                network,
+                input_shape_tensor,
+                0,
+                name=[paddle_op.name(), "batch_dim"],
+            )
             outsize_itensors.append(batch_dim)
             if data_format == "NCHW":
                 channel_dim = get_shape_tensor_element(
-                    network, input_shape_tensor, 1, name=[paddle_op.name(), "channel_dim"]
+                    network,
+                    input_shape_tensor,
+                    1,
+                    name=[paddle_op.name(), "channel_dim"],
                 )
                 outsize_itensors.append(channel_dim)
                 outsize_itensors.append(outsize_tensor)
             elif data_format == "NHWC":
                 channel_dim = get_shape_tensor_element(
-                    network, input_shape_tensor, 3, name=[paddle_op.name(), "channel_dim"]
+                    network,
+                    input_shape_tensor,
+                    3,
+                    name=[paddle_op.name(), "channel_dim"],
                 )
                 outsize_itensors.append(outsize_tensor)
                 outsize_itensors.append(channel_dim)
@@ -241,19 +256,37 @@ def unbind_converter(network, paddle_op, inputs):
     new_shape_tensors = []
     for i in range(rank):
         if axis == i:
-            size_tensors.append(add_1D_constant_layer(network, 1, name=[paddle_op.name(), "size_tensor"]))
+            size_tensors.append(
+                add_1D_constant_layer(
+                    network, 1, name=[paddle_op.name(), "size_tensor"]
+                )
+            )
         else:
             size_tensors.append(
-                get_shape_tensor_element(network, trt_shape(network, x, name=[paddle_op.name(), "trt_shape"]), i,
-                                         name=[paddle_op.name(), f"size_tensor_{i}"])
+                get_shape_tensor_element(
+                    network,
+                    trt_shape(network, x, name=[paddle_op.name(), "trt_shape"]),
+                    i,
+                    name=[paddle_op.name(), f"size_tensor_{i}"],
+                )
             )
             new_shape_tensors.append(
-                get_shape_tensor_element(network, trt_shape(network, x, name=[paddle_op.name(), "trt_shape"]), i,
-                                         name=[paddle_op.name(), f"new_shape_tensor_{i}"])
+                get_shape_tensor_element(
+                    network,
+                    trt_shape(network, x, name=[paddle_op.name(), "trt_shape"]),
+                    i,
+                    name=[paddle_op.name(), f"new_shape_tensor_{i}"],
+                )
             )
-        start_tensors.append(add_1D_constant_layer(network, 0, name=[paddle_op.name(), "start_tensor"]))
+        start_tensors.append(
+            add_1D_constant_layer(
+                network, 0, name=[paddle_op.name(), "start_tensor"]
+            )
+        )
 
-    new_shape_tensor = trt_concat(network, new_shape_tensors, name=[paddle_op.name(), "new_shape_tensor"])
+    new_shape_tensor = trt_concat(
+        network, new_shape_tensors, name=[paddle_op.name(), "new_shape_tensor"]
+    )
     stride = trt.Dims([1] * rank)
     outputs = []
     output_size = len(paddle_op.results()[0].type().as_vec_type().as_list())
@@ -358,17 +391,25 @@ def nearest_interp_converter(network, paddle_op, inputs):
         )
     if outsize_tensor is not None:
         outsize_itensors = []
-        batch_dim = get_shape_tensor_element(network, input_shape_tensor, 0, name=[paddle_op.name(), "batch_dim"])
+        batch_dim = get_shape_tensor_element(
+            network, input_shape_tensor, 0, name=[paddle_op.name(), "batch_dim"]
+        )
         outsize_itensors.append(batch_dim)
         if data_format == "NCHW":
             channel_dim = get_shape_tensor_element(
-                network, input_shape_tensor, 1, name=[paddle_op.name(), "channel_dim"]
+                network,
+                input_shape_tensor,
+                1,
+                name=[paddle_op.name(), "channel_dim"],
             )
             outsize_itensors.append(channel_dim)
             outsize_itensors.append(outsize_tensor)
         elif data_format == "NHWC":
             channel_dim = get_shape_tensor_element(
-                network, input_shape_tensor, 3, name=[paddle_op.name(), "channel_dim"]
+                network,
+                input_shape_tensor,
+                3,
+                name=[paddle_op.name(), "channel_dim"],
             )
             outsize_itensors.append(outsize_tensor)
             outsize_itensors.append(channel_dim)
@@ -443,20 +484,35 @@ def linear_interp_converter(network, paddle_op, inputs):
 
     if outsize_tensor is not None:
         outsize_itensors = []
-        input_shape = trt_shape(network, input_tensor, name=[paddle_op.name(), "input_shape"])
-        batch_dim = get_shape_tensor_element(network, input_shape, 0, name=[paddle_op.name(), "batch_dim"])
+        input_shape = trt_shape(
+            network, input_tensor, name=[paddle_op.name(), "input_shape"]
+        )
+        batch_dim = get_shape_tensor_element(
+            network, input_shape, 0, name=[paddle_op.name(), "batch_dim"]
+        )
         outsize_itensors.append(batch_dim)
 
         if data_layout == "NCHW":
-            channel_dim = get_shape_tensor_element(network, input_shape, 1, name=[paddle_op.name(), "channel_dim"])
+            channel_dim = get_shape_tensor_element(
+                network, input_shape, 1, name=[paddle_op.name(), "channel_dim"]
+            )
             outsize_itensors.append(channel_dim)
             outsize_itensors.append(outsize_tensor)
         elif data_layout == "NHWC":
             outsize_itensors.append(outsize_tensor)
-            channel_dim = get_shape_tensor_element(network, input_shape, 2, name=[paddle_op.name(), "channel_dim"])
+            channel_dim = get_shape_tensor_element(
+                network, input_shape, 2, name=[paddle_op.name(), "channel_dim"]
+            )
             outsize_itensors.append(channel_dim)
 
-        layer.set_input(1, trt_concat(network, outsize_itensors, name=[paddle_op.name(), "outsize_itensors"]))
+        layer.set_input(
+            1,
+            trt_concat(
+                network,
+                outsize_itensors,
+                name=[paddle_op.name(), "outsize_itensors"],
+            )
+        )
     else:
         layer.scales = scales
 

--- a/python/paddle/tensorrt/impls/common.py
+++ b/python/paddle/tensorrt/impls/common.py
@@ -291,7 +291,9 @@ def unbind_converter(network, paddle_op, inputs):
     outputs = []
     output_size = len(paddle_op.results()[0].type().as_vec_type().as_list())
     for i in range(output_size):
-        start_tensors[axis] = add_1D_constant_layer(network, i, name=[paddle_op.name(), f"start_{i}_tensor"])
+        start_tensors[axis] = add_1D_constant_layer(
+            network, i, name=[paddle_op.name(), f"start_{i}_tensor"]
+        )
         # Create Slice layer
         slice_layer = network.add_slice(
             x,
@@ -511,7 +513,7 @@ def linear_interp_converter(network, paddle_op, inputs):
                 network,
                 outsize_itensors,
                 name=[paddle_op.name(), "outsize_itensors"],
-            )
+            ),
         )
     else:
         layer.scales = scales

--- a/python/paddle/tensorrt/impls/common.py
+++ b/python/paddle/tensorrt/impls/common.py
@@ -21,6 +21,7 @@ from paddle.tensorrt.converter_utils import (
     add_1D_constant_layer,
     get_input_constant_value,
     get_shape_tensor_element,
+    set_layer_name,
     trt_concat,
     trt_reshape,
     trt_shape,
@@ -37,6 +38,7 @@ def dropout_converter(network, paddle_op, inputs):
 
     if downgrade_in_infer == "upscale_in_train":
         shuffle_layer = network.add_shuffle(input_x)
+        set_layer_name(shuffle_layer, paddle_op)
         return shuffle_layer.get_output(0)
 
     weight_data = np.array([1 - dropout_prob]).astype("float32")
@@ -51,6 +53,7 @@ def dropout_converter(network, paddle_op, inputs):
         scale=scale_weights,
         power=power_weights,
     )
+    set_layer_name(scale_layer, paddle_op)
 
     return scale_layer.get_output(0)
 
@@ -60,7 +63,10 @@ def dropout_converter(network, paddle_op, inputs):
 )
 def bilinear_interp_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]
-    input_shape_tensor = network.add_shape(input_tensor).get_output(0)
+    input_shape_tensor = network.add_shape(input_tensor)
+    set_layer_name(input_shape_tensor, paddle_op)
+    input_shape_tensor = input_shape_tensor.get_output(0)
+
     input_rank = (
         input_shape_tensor.shape
     )  # The reason is unknown that adding this unused code make input_shape_tensor maintain the correct result.
@@ -78,6 +84,7 @@ def bilinear_interp_converter(network, paddle_op, inputs):
     trt_version_float = float(f"{trt_major}.{trt_minor}")
 
     resize_layer = network.add_resize(input_tensor)
+    set_layer_name(resize_layer, paddle_op)
     # Set resize mode to LINEAR unconditionally
     if trt_version_float >= 8.6:
         resize_layer.resize_mode = trt.InterpolationMode.LINEAR
@@ -128,21 +135,25 @@ def bilinear_interp_converter(network, paddle_op, inputs):
                     # Extract the first two elements representing height and width
                     outsize_h = size_tensors[0]
                     outsize_w = size_tensors[1]
-                    outsize_tensor = network.add_concatenation(
-                        [outsize_h, outsize_w]
-                    ).get_output(0)
+                    outsize_tensor = network.add_concatenation([outsize_h, outsize_w])
+                    set_layer_name(outsize_tensor, paddle_op)
+                    outsize_tensor = outsize_tensor.get_output(0)
             else:
                 size_tensor_shape = size_tensor_operand.source().shape
                 if size_tensor_shape.size >= 2:
                     outsize_h = network.add_slice(
                         size_tensor, start=[0], shape=[1], stride=[1]
-                    ).get_output(0)
+                    )
+                    set_layer_name(outsize_h, paddle_op)
+                    outsize_h = outsize_h.get_output(0)
                     outsize_w = network.add_slice(
                         size_tensor, start=[1], shape=[1], stride=[1]
-                    ).get_output(0)
-                    outsize_tensor = network.add_concatenation(
-                        [outsize_h, outsize_w]
-                    ).get_output(0)
+                    )
+                    set_layer_name(outsize_w, paddle_op)
+                    outsize_w = outsize_w.get_output(0)
+                    outsize_tensor = network.add_concatenation([outsize_h, outsize_w])
+                    set_layer_name(outsize_tensor, paddle_op)
+                    outsize_tensor = outsize_tensor.get_output(0)
     use_scales = True
     if outsize_tensor is not None:
         use_scales = False
@@ -181,23 +192,23 @@ def bilinear_interp_converter(network, paddle_op, inputs):
     else:
         if outsize_tensor is not None:
             outsize_itensors = []
-            batch_dim = get_shape_tensor_element(network, input_shape_tensor, 0)
+            batch_dim = get_shape_tensor_element(network, input_shape_tensor, 0, name=[paddle_op.name(), "batch_dim"])
             outsize_itensors.append(batch_dim)
             if data_format == "NCHW":
                 channel_dim = get_shape_tensor_element(
-                    network, input_shape_tensor, 1
+                    network, input_shape_tensor, 1, name=[paddle_op.name(), "channel_dim"]
                 )
                 outsize_itensors.append(channel_dim)
                 outsize_itensors.append(outsize_tensor)
             elif data_format == "NHWC":
                 channel_dim = get_shape_tensor_element(
-                    network, input_shape_tensor, 3
+                    network, input_shape_tensor, 3, name=[paddle_op.name(), "channel_dim"]
                 )
                 outsize_itensors.append(outsize_tensor)
                 outsize_itensors.append(channel_dim)
-            output_size_tensor = network.add_concatenation(
-                outsize_itensors
-            ).get_output(0)
+            output_size_tensor = network.add_concatenation(outsize_itensors)
+            set_layer_name(output_size_tensor, paddle_op)
+            output_size_tensor = output_size_tensor.get_output(0)
             resize_layer.set_input(1, output_size_tensor)
 
     return resize_layer.get_output(0)
@@ -210,6 +221,7 @@ def embedding_converter(network, paddle_op, inputs):
     x = inputs[0]
     weight = inputs[1]
     gather_layer = network.add_gather(weight, x, 0)
+    set_layer_name(gather_layer, paddle_op)
     return gather_layer.get_output(0)
 
 
@@ -229,22 +241,24 @@ def unbind_converter(network, paddle_op, inputs):
     new_shape_tensors = []
     for i in range(rank):
         if axis == i:
-            size_tensors.append(add_1D_constant_layer(network, 1))
+            size_tensors.append(add_1D_constant_layer(network, 1, name=[paddle_op.name(), "size_tensor"]))
         else:
             size_tensors.append(
-                get_shape_tensor_element(network, trt_shape(network, x), i)
+                get_shape_tensor_element(network, trt_shape(network, x, name=[paddle_op.name(), "trt_shape"]), i,
+                                         name=[paddle_op.name(), f"size_tensor_{i}"])
             )
             new_shape_tensors.append(
-                get_shape_tensor_element(network, trt_shape(network, x), i)
+                get_shape_tensor_element(network, trt_shape(network, x, name=[paddle_op.name(), "trt_shape"]), i,
+                                         name=[paddle_op.name(), f"new_shape_tensor_{i}"])
             )
-        start_tensors.append(add_1D_constant_layer(network, 0))
+        start_tensors.append(add_1D_constant_layer(network, 0, name=[paddle_op.name(), "start_tensor"]))
 
-    new_shape_tensor = trt_concat(network, new_shape_tensors)
+    new_shape_tensor = trt_concat(network, new_shape_tensors, name=[paddle_op.name(), "new_shape_tensor"])
     stride = trt.Dims([1] * rank)
     outputs = []
     output_size = len(paddle_op.results()[0].type().as_vec_type().as_list())
     for i in range(output_size):
-        start_tensors[axis] = add_1D_constant_layer(network, i)
+        start_tensors[axis] = add_1D_constant_layer(network, i, name=[paddle_op.name(), f"start_{i}_tensor"])
         # Create Slice layer
         slice_layer = network.add_slice(
             x,
@@ -254,11 +268,13 @@ def unbind_converter(network, paddle_op, inputs):
         )
         slice_layer.set_input(1, trt_concat(network, start_tensors))
         slice_layer.set_input(2, trt_concat(network, size_tensors))
+        set_layer_name(slice_layer, paddle_op)
         shuffle_layer = trt_reshape(
             network,
             slice_layer.get_output(0),
             new_shape_tensor,
             is_shape_tensor=True,
+            name=[paddle_op.name(), f"shuffle_tensor_{i}"],
         )
         outputs.append(shuffle_layer)
     return outputs
@@ -269,7 +285,9 @@ def unbind_converter(network, paddle_op, inputs):
 )
 def nearest_interp_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]
-    input_shape_tensor = network.add_shape(input_tensor).get_output(0)
+    input_shape_tensor = network.add_shape(input_tensor)
+    set_layer_name(input_shape_tensor, paddle_op)
+    input_shape_tensor = input_shape_tensor.get_output(0)
     input_rank = (
         input_shape_tensor.shape
     )  # The reason is unknown that adding this unused code make input_shape_tensor maintain the correct result.
@@ -288,6 +306,7 @@ def nearest_interp_converter(network, paddle_op, inputs):
 
     # Create Resize layer
     resize_layer = network.add_resize(input_tensor)
+    set_layer_name(resize_layer, paddle_op)
 
     if trt_version_float >= 8.6:
         if align_corners:
@@ -320,7 +339,9 @@ def nearest_interp_converter(network, paddle_op, inputs):
 
     outsize_tensor = None
     if inputs[2] is not None:
-        outsize_tensor = network.add_concatenation(inputs[2]).get_output(0)
+        outsize_tensor = network.add_concatenation(inputs[2])
+        set_layer_name(outsize_tensor, paddle_op)
+        outsize_tensor = outsize_tensor.get_output(0)
 
     scales = [1.0] * len(input_tensor.shape)
     if data_format == "NCHW":
@@ -337,17 +358,17 @@ def nearest_interp_converter(network, paddle_op, inputs):
         )
     if outsize_tensor is not None:
         outsize_itensors = []
-        batch_dim = get_shape_tensor_element(network, input_shape_tensor, 0)
+        batch_dim = get_shape_tensor_element(network, input_shape_tensor, 0, name=[paddle_op.name(), "batch_dim"])
         outsize_itensors.append(batch_dim)
         if data_format == "NCHW":
             channel_dim = get_shape_tensor_element(
-                network, input_shape_tensor, 1
+                network, input_shape_tensor, 1, name=[paddle_op.name(), "channel_dim"]
             )
             outsize_itensors.append(channel_dim)
             outsize_itensors.append(outsize_tensor)
         elif data_format == "NHWC":
             channel_dim = get_shape_tensor_element(
-                network, input_shape_tensor, 3
+                network, input_shape_tensor, 3, name=[paddle_op.name(), "channel_dim"]
             )
             outsize_itensors.append(outsize_tensor)
             outsize_itensors.append(channel_dim)
@@ -371,6 +392,7 @@ def linear_interp_converter(network, paddle_op, inputs):
     out_w = paddle_op.attrs().get("out_w")
     scale_attr = paddle_op.attrs().get("scale")
     layer = network.add_resize(input_tensor)
+    set_layer_name(layer, paddle_op)
     trt_major = get_trt_version_list()[0]
     trt_minor = get_trt_version_list()[1]
     trt_version_float = float(f"{trt_major}.{trt_minor}")
@@ -421,20 +443,20 @@ def linear_interp_converter(network, paddle_op, inputs):
 
     if outsize_tensor is not None:
         outsize_itensors = []
-        input_shape = trt_shape(network, input_tensor)
-        batch_dim = get_shape_tensor_element(network, input_shape, 0)
+        input_shape = trt_shape(network, input_tensor, name=[paddle_op.name(), "input_shape"])
+        batch_dim = get_shape_tensor_element(network, input_shape, 0, name=[paddle_op.name(), "batch_dim"])
         outsize_itensors.append(batch_dim)
 
         if data_layout == "NCHW":
-            channel_dim = get_shape_tensor_element(network, input_shape, 1)
+            channel_dim = get_shape_tensor_element(network, input_shape, 1, name=[paddle_op.name(), "channel_dim"])
             outsize_itensors.append(channel_dim)
             outsize_itensors.append(outsize_tensor)
         elif data_layout == "NHWC":
             outsize_itensors.append(outsize_tensor)
-            channel_dim = get_shape_tensor_element(network, input_shape, 2)
+            channel_dim = get_shape_tensor_element(network, input_shape, 2, name=[paddle_op.name(), "channel_dim"])
             outsize_itensors.append(channel_dim)
 
-        layer.set_input(1, trt_concat(network, outsize_itensors))
+        layer.set_input(1, trt_concat(network, outsize_itensors, name=[paddle_op.name(), "outsize_itensors"]))
     else:
         layer.scales = scales
 

--- a/python/paddle/tensorrt/impls/creation.py
+++ b/python/paddle/tensorrt/impls/creation.py
@@ -70,6 +70,7 @@ def full_converter(network, paddle_op, inputs):
 def assign_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]
     identity_layer = network.add_identity(input_tensor)
+    set_layer_name(identity_layer, paddle_op)
     return identity_layer.get_output(0)
 
 
@@ -100,6 +101,7 @@ def assign_value_converter(network, paddle_op, inputs):
     if np_dtype == np.int64:
         arr = arr.astype(np.int32)
     const_layer = network.add_constant(tuple(shape), arr)
+    set_layer_name(const_layer, paddle_op)
     if const_layer is None:
         raise RuntimeError("Failed to create constant layer for assign_value.")
 
@@ -109,30 +111,31 @@ def assign_value_converter(network, paddle_op, inputs):
 @converter_registry.register("pd_op.arange", trt_version="8.x")
 def arange_converter(network, paddle_op, inputs):
     start, end, step = inputs
-    zero_tensor = add_1D_constant_layer(network, 0)
+    zero_tensor = add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'zero_tensor'])
 
-    delta = trt_sub(network, start, end)
+    delta = trt_sub(network, start, end, name=[paddle_op.name(), 'delta'])
 
-    f_quotient_tensor = trt_floor_div(network, delta, step)
+    f_quotient_tensor = trt_floor_div(network, delta, step, name=[paddle_op.name(), 'f_quotient_tensor'])
 
     if start.dtype == trt.DataType.FLOAT:
-        quotient_tensor = trt_cast(network, f_quotient_tensor, trt.int32)
+        quotient_tensor = trt_cast(network, f_quotient_tensor, trt.int32, name=[paddle_op.name(), 'quotient_tensor'])
     else:
         quotient_tensor = f_quotient_tensor
 
-    delta_1 = trt_sub(network, zero_tensor, quotient_tensor)
-    number_tensor = trt_max(network, delta_1, zero_tensor)
+    delta_1 = trt_sub(network, zero_tensor, quotient_tensor, name=[paddle_op.name(), 'delta_1'])
+    number_tensor = trt_max(network, delta_1, zero_tensor, name=[paddle_op.name(), 'number_tensor'])
     start1 = inputs[0]
-    start1 = trt_reshape(network, start1, ())
+    start1 = trt_reshape(network, start1, (), name=[paddle_op.name(), 'start1'])
 
     fill_layer = network.add_fill(shape=(), op=trt.FillOperation.LINSPACE)
     fill_layer.set_input(0, number_tensor)
     fill_layer.set_input(1, start1)
     fill_layer.set_input(2, step)
+    set_layer_name(fill_layer, paddle_op)
 
     output_tensor = fill_layer.get_output(0)
     if start.dtype == trt.DataType.FLOAT:
-        output_tensor = trt_cast(network, output_tensor, trt.int32)
+        output_tensor = trt_cast(network, output_tensor, trt.int32, name=[paddle_op.name(), 'output_tensor'])
     return output_tensor
 
 
@@ -167,41 +170,43 @@ def full_like_converter(network, paddle_op, inputs):
             value = value[0] if value else 0
 
         if target_dtype == trt.int32:
-            value_tensor = add_1D_constant_layer(network, int(value), np.int32)
+            value_tensor = add_1D_constant_layer(network, int(value), np.int32, name=[paddle_op.name(), 'value_tensor'])
         else:
             value_tensor = add_1D_constant_layer(
-                network, float(value), np.float32
+                network, float(value), np.float32, name=[paddle_op.name(), 'value_tensor']
             )
     else:
         value_tensor = inputs[1]
         if value_tensor.dtype != target_dtype:
-            value_tensor = trt_cast(network, value_tensor, target_dtype)
+            value_tensor = trt_cast(network, value_tensor, target_dtype, name=[paddle_op.name(), 'value_tensor'])
 
-    shape_tensor = trt_shape(network, input_tensor)
-    one_rank_tensor = add_1D_constant_layer(network, [1] * ndims)
+    shape_tensor = trt_shape(network, input_tensor, name=[paddle_op.name(), 'shape_tensor'])
+    one_rank_tensor = add_1D_constant_layer(network, [1] * ndims, name=[paddle_op.name(), 'one_rank_tensor'])
     input_shape_tensor = one_rank_tensor
 
     shuffle_layer = network.add_shuffle(value_tensor)
     shuffle_layer.set_input(1, input_shape_tensor)
+    set_layer_name(shuffle_layer, paddle_op)
     start = trt.Dims([0] * ndims)
     size = trt.Dims([1] * ndims)
     stride = trt.Dims([1] * ndims)
 
-    starts_tensor = add_1D_constant_layer(network, [0] * ndims)
-    one_tensor = add_1D_constant_layer(network, 1)
-    sizes_tensor = trt_max(network, input_shape_tensor, shape_tensor)
-    input_sub_tensor = trt_sub(network, input_shape_tensor, one_tensor)
-    strides_tensor = trt_min(network, one_tensor, input_sub_tensor)
+    starts_tensor = add_1D_constant_layer(network, [0] * ndims, name=[paddle_op.name(), 'starts_tensor'])
+    one_tensor = add_1D_constant_layer(network, 1, name=[paddle_op.name(), 'one_tensor'])
+    sizes_tensor = trt_max(network, input_shape_tensor, shape_tensor, name=[paddle_op.name(), 'sizes_tensor'])
+    input_sub_tensor = trt_sub(network, input_shape_tensor, one_tensor, name=[paddle_op.name(), 'input_sub_tensor'])
+    strides_tensor = trt_min(network, one_tensor, input_sub_tensor, name=[paddle_op.name(), 'strides_tensor'])
 
     layer = network.add_slice(shuffle_layer.get_output(0), start, size, stride)
     layer.set_input(1, starts_tensor)
     layer.set_input(2, sizes_tensor)
     layer.set_input(3, strides_tensor)
+    set_layer_name(layer, paddle_op)
 
     output = layer.get_output(0)
 
     if output.dtype != target_dtype:
-        output = trt_cast(network, output, target_dtype)
+        output = trt_cast(network, output, target_dtype, name=[paddle_op.name(), 'output'])
 
     return output
 
@@ -261,27 +266,28 @@ def full_with_tensor_converter(network, paddle_op, inputs):
             shape_tensors = []
             for tensor in shape_tensor_list:
                 if len(tensor.shape) == 0:
-                    tensor = trt_reshape(network, tensor, (1,))
+                    tensor = trt_reshape(network, tensor, (1,), name=[paddle_op.name(), "tensor"])
                 shape_tensors.append(tensor)
 
             concat_layer = network.add_concatenation(shape_tensors)
+            set_layer_name(concat_layer, paddle_op)
             shapes_tensor = concat_layer.get_output(0)
             tensor_rank = len(shape_tensors)
 
-        shapes_tensor = resize_to_1d(network, shapes_tensor)
+        shapes_tensor = resize_to_1d(network, shapes_tensor, name=[paddle_op.name(), "shapes_tensor"])
         fill_layer = network.add_fill(shape=(), op=trt.FillOperation.LINSPACE)
         fill_layer.set_input(0, shapes_tensor)
 
     if dtype == paddle.int32 or dtype == paddle.int64:
         beta_vec = [0] * tensor_rank
-        value_input = trt_reduce_to_scalar(network, value_input)
+        value_input = trt_reduce_to_scalar(network, value_input, name=[paddle_op.name(), 'value_input'])
         fill_layer.set_input(1, value_input)
         fill_layer.set_input(
             2, add_1D_constant_layer(network, beta_vec, np.int32)
         )
     elif dtype == paddle.float32:
         beta_vec = [0.0] * tensor_rank
-        value_input = trt_reduce_to_scalar(network, value_input, trt.float32)
+        value_input = trt_reduce_to_scalar(network, value_input, trt.float32, name=[paddle_op.name(), 'value_input'])
         fill_layer.set_input(1, value_input)
         fill_layer.set_input(
             2, add_1D_constant_layer(network, beta_vec, np.float32)
@@ -289,5 +295,6 @@ def full_with_tensor_converter(network, paddle_op, inputs):
     else:
         raise ValueError(f"Unsupported dtype for full_with_tensor: {dtype}")
 
+    set_layer_name(fill_layer, paddle_op)
     output_tensor = fill_layer.get_output(0)
     return output_tensor

--- a/python/paddle/tensorrt/impls/einsum.py
+++ b/python/paddle/tensorrt/impls/einsum.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from paddle.tensorrt.converter_utils import set_layer_name
 from paddle.tensorrt.register import converter_registry
 
 
@@ -21,5 +22,6 @@ def convert_einsum(network, paddle_op, inputs):
     equation = paddle_op.attrs().get("equation", "")
 
     layer = network.add_einsum(inputs[0], equation)
+    set_layer_name(layer, paddle_op)
     output_tensor = layer.get_output(0)
     return output_tensor

--- a/python/paddle/tensorrt/impls/input.py
+++ b/python/paddle/tensorrt/impls/input.py
@@ -16,7 +16,7 @@
 import numpy as np
 import tensorrt as trt
 
-from paddle.tensorrt.converter_utils import add_1D_constant_layer, cast_tensor
+from paddle.tensorrt.converter_utils import add_1D_constant_layer, cast_tensor, set_layer_name
 from paddle.tensorrt.register import converter_registry
 
 
@@ -45,22 +45,26 @@ def one_hot_converter(network, paddle_op, inputs):
     else:
         raise ValueError(f"Unsupported trt_dtype for one_hot: {trt_dtype}")
 
-    values_tensor = add_1D_constant_layer(network, values_data, dtype=np_dtype)
+    values_tensor = add_1D_constant_layer(network, values_data, dtype=np_dtype, name=[paddle_op.name(), 'values_tensor'])
 
     if isinstance(num_classes_tensor, trt.Weights):
         num_classes_tensor = network.add_constant(
             paddle_op.operands()[1].source().shape, num_classes_tensor
-        ).get_output(0)
+        )
+        set_layer_name(num_classes_tensor, paddle_op)
+        num_classes_tensor = num_classes_tensor.get_output(0)
 
     reshape_layer = network.add_shuffle(num_classes_tensor)
+    set_layer_name(reshape_layer, paddle_op)
     reshape_layer.reshape_dims = ()
     depth_tensor = reshape_layer.get_output(0)
 
-    depth_tensor = cast_tensor(network, depth_tensor, trt.int32)
+    depth_tensor = cast_tensor(network, depth_tensor, trt.int32, name=[paddle_op.name(), 'depth_tensor'])
 
     one_hot_layer = network.add_one_hot(
         input_tensor, values_tensor, depth_tensor, axis=-1
     )
+    set_layer_name(one_hot_layer, paddle_op)
     one_hot_layer.set_output_type(0, trt_dtype)
     output_tensor = one_hot_layer.get_output(0)
 

--- a/python/paddle/tensorrt/impls/input.py
+++ b/python/paddle/tensorrt/impls/input.py
@@ -16,7 +16,11 @@
 import numpy as np
 import tensorrt as trt
 
-from paddle.tensorrt.converter_utils import add_1D_constant_layer, cast_tensor, set_layer_name
+from paddle.tensorrt.converter_utils import (
+    add_1D_constant_layer,
+    cast_tensor,
+    set_layer_name,
+)
 from paddle.tensorrt.register import converter_registry
 
 
@@ -45,7 +49,12 @@ def one_hot_converter(network, paddle_op, inputs):
     else:
         raise ValueError(f"Unsupported trt_dtype for one_hot: {trt_dtype}")
 
-    values_tensor = add_1D_constant_layer(network, values_data, dtype=np_dtype, name=[paddle_op.name(), 'values_tensor'])
+    values_tensor = add_1D_constant_layer(
+        network,
+        values_data,
+        dtype=np_dtype,
+        name=[paddle_op.name(), 'values_tensor'],
+    )
 
     if isinstance(num_classes_tensor, trt.Weights):
         num_classes_tensor = network.add_constant(
@@ -59,7 +68,12 @@ def one_hot_converter(network, paddle_op, inputs):
     reshape_layer.reshape_dims = ()
     depth_tensor = reshape_layer.get_output(0)
 
-    depth_tensor = cast_tensor(network, depth_tensor, trt.int32, name=[paddle_op.name(), 'depth_tensor'])
+    depth_tensor = cast_tensor(
+        network,
+        depth_tensor,
+        trt.int32,
+        name=[paddle_op.name(), 'depth_tensor'],
+    )
 
     one_hot_layer = network.add_one_hot(
         input_tensor, values_tensor, depth_tensor, axis=-1

--- a/python/paddle/tensorrt/impls/linalg.py
+++ b/python/paddle/tensorrt/impls/linalg.py
@@ -85,6 +85,7 @@ def bmm_converter(network, paddle_op, inputs):
     out = network.add_matrix_multiply(
         inputs[0], trt.MatrixOperation.NONE, inputs[1], trt.MatrixOperation.NONE
     )
+    set_layer_name(out, paddle_op)
     return out.get_output(0)
 
 
@@ -95,35 +96,39 @@ def flip_converter(network, paddle_op, inputs):
     rank = len(input_dims)
     axis = paddle_op.attrs()["axis"]
     axis = [a + rank if a < 0 else a for a in axis]
-    shape_tensor = trt_shape(network, input_tensor)
+    shape_tensor = trt_shape(network, input_tensor, name=[paddle_op.name(), 'shape_tensor'])
 
-    def get_axis_length(axis_idx):
+    def get_axis_length(axis_idx, name=None):
         dim_val = input_dims[axis_idx]
         if dim_val >= 0:
-            return add_1D_constant_layer(network, [dim_val], is_scalar=True)
+            return add_1D_constant_layer(network, [dim_val], is_scalar=True, name=[paddle_op.name(), name])
         else:
             return get_shape_tensor_element(
-                network, shape_tensor, axis_idx, is_scalar=True
+                network, shape_tensor, axis_idx, is_scalar=True, name=[paddle_op.name(), name]
             )
 
     for axis_idx in axis:
         loop_layer = network.add_loop()
-        trip_limit = get_axis_length(axis_idx)
+        trip_limit = get_axis_length(axis_idx, f'trip_limit_{axis_idx}')
         loop_layer.add_trip_limit(trip_limit, trt.TripLimit.COUNT)
         iterator = loop_layer.add_iterator(input_tensor, axis_idx, reverse=True)
-        zero_tensor = add_1D_constant_layer(network, [0])
-        one_tensor = add_1D_constant_layer(network, [1])
+        set_layer_name(iterator, paddle_op)
+        zero_tensor = add_1D_constant_layer(network, [0], name=[paddle_op.name(), 'zero_tensor'])
+        one_tensor = add_1D_constant_layer(network, [1], name=[paddle_op.name(), 'one_tensor'])
         iRec_layer = loop_layer.add_recurrence(zero_tensor)
+        set_layer_name(iRec_layer, paddle_op)
         iCur = iRec_layer.get_output(0)
-        iNext_layer = trt_sum(network, iCur, one_tensor)
+        iNext_layer = trt_sum(network, iCur, one_tensor, name=[paddle_op.name(), 'iNext_layer'])
         iRec_layer.set_input(1, iNext_layer)
         loop_out_layer = loop_layer.add_loop_output(
             iterator.get_output(0), trt.LoopOutput.CONCATENATE, axis_idx
         )
         loop_out_layer.set_input(1, trip_limit)
+        set_layer_name(loop_out_layer, paddle_op)
         input_tensor = loop_out_layer.get_output(0)
 
     identity_layer = network.add_identity(input_tensor)
+    set_layer_name(identity_layer, paddle_op)
     return identity_layer.get_output(0)
 
 
@@ -140,14 +145,17 @@ def p_norm_converter(network, paddle_op, inputs):
     prod_layer = network.add_elementwise(
         input_tensor, input_tensor, trt.ElementWiseOperation.PROD
     )
+    set_layer_name(prod_layer, paddle_op)
     prod_tensor = prod_layer.get_output(0)
 
     reduce_layer = network.add_reduce(
         prod_tensor, trt.ReduceOperation.SUM, axis_mask, keepdim
     )
+    set_layer_name(reduce_layer, paddle_op)
     reduced_tensor = reduce_layer.get_output(0)
 
     sqrt_layer = network.add_unary(reduced_tensor, trt.UnaryOperation.SQRT)
+    set_layer_name(sqrt_layer, paddle_op)
     output_tensor = sqrt_layer.get_output(0)
 
     return output_tensor

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -350,16 +350,27 @@ def expand_converter(network, paddle_op, inputs):
 
     shape = get_input_constant_value(paddle_op, inputs, 1)
     if shape is not None:
-        shape_tensor = add_1D_constant_layer(network, shape, name=[paddle_op.name(), 'shape_tensor'])
+        shape_tensor = add_1D_constant_layer(
+            network, shape, name=[paddle_op.name(), 'shape_tensor']
+        )
         shape_rank = len(shape)
     elif paddle_shape_tensor.type().as_vec_type():
         shape_tensors = inputs[1]
         shape_rank = len(shape_tensors)
-        shape_tensor = trt_concat(network, shape_tensors, name=[paddle_op.name(), 'shape_tensor'])
+        shape_tensor = trt_concat(
+            network, shape_tensors, name=[paddle_op.name(), 'shape_tensor']
+        )
     else:
         shape_tensor = inputs[1]
         shape_rank = shape_tensor.shape[0]
-    return trt_expand(network, input, rank, shape_tensor, shape_rank, name=[paddle_op.name(), 'trt_expand'])
+    return trt_expand(
+        network,
+        input,
+        rank,
+        shape_tensor,
+        shape_rank,
+        name=[paddle_op.name(), 'trt_expand'],
+    )
 
 
 @converter_registry.register(
@@ -373,13 +384,24 @@ def expand_as_converter(network, paddle_op, inputs):
 
     if y.initialized():
         y_t = inputs[1]
-        shape_tensor = trt_shape(network, y_t, name=[paddle_op.name(), 'shape_tensor'])
+        shape_tensor = trt_shape(
+            network, y_t, name=[paddle_op.name(), 'shape_tensor']
+        )
         shape_rank = len(y_t.shape)
     else:
         shape = paddle_op.attrs().get("target_shape")
-        shape_tensor = add_1D_constant_layer(network, shape, name=[paddle_op.name(), 'shape_tensor'])
+        shape_tensor = add_1D_constant_layer(
+            network, shape, name=[paddle_op.name(), 'shape_tensor']
+        )
         shape_rank = len(shape)
-    return trt_expand(network, input, rank, shape_tensor, shape_rank, name=[paddle_op.name(), 'trt_expand'])
+    return trt_expand(
+        network,
+        input,
+        rank,
+        shape_tensor,
+        shape_rank,
+        name=[paddle_op.name(), 'trt_expand'],
+    )
 
 
 @converter_registry.register("pd_op.cast", trt_version="8.x")
@@ -417,15 +439,26 @@ def slice_converter(network, paddle_op, inputs):
     axes = paddle_op.attrs()["axes"]
     decrease_axis = paddle_op.attrs().get("decrease_axis")
 
-    input_shape_tensor = trt_shape(network, input_tensor, name=[paddle_op.name(), "input_shape_tensor"])
+    input_shape_tensor = trt_shape(
+        network, input_tensor, name=[paddle_op.name(), "input_shape_tensor"]
+    )
     input_rank = len(input_tensor.shape)
 
     starts_tensor = []
     ends_tensor = []
     for i in range(input_rank):
-        starts_tensor.append(add_1D_constant_layer(network, 0, name=[paddle_op.name(), f'starts_tensor_{i}']))
+        starts_tensor.append(
+            add_1D_constant_layer(
+                network, 0, name=[paddle_op.name(), f'starts_tensor_{i}']
+            )
+        )
         ends_tensor.append(
-            get_shape_tensor_element(network, input_shape_tensor, i, name=[paddle_op.name(), f'end_tensor_{i}'])
+            get_shape_tensor_element(
+                network,
+                input_shape_tensor,
+                i,
+                name=[paddle_op.name(), f'end_tensor_{i}'],
+            )
         )
 
     starts = get_input_constant_value(paddle_op, inputs, 1)
@@ -439,28 +472,50 @@ def slice_converter(network, paddle_op, inputs):
                     network,
                     trt_sum(
                         network,
-                        add_1D_constant_layer(network, starts[idx], name=[paddle_op.name(), f'starts[idx]_{idx}']),
-                        get_shape_tensor_element(
-                            network, input_shape_tensor, axes[idx], name=[paddle_op.name(), f'axes[idx]_{idx}']
+                        add_1D_constant_layer(
+                            network,
+                            starts[idx],
+                            name=[paddle_op.name(), f'starts[idx]_{idx}'],
                         ),
-                        name=[paddle_op.name(), f'trt_sum'],
+                        get_shape_tensor_element(
+                            network,
+                            input_shape_tensor,
+                            axes[idx],
+                            name=[paddle_op.name(), f'axes[idx]_{idx}'],
+                        ),
+                        name=[paddle_op.name(), 'trt_sum'],
                     ),
-                    add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'zero_tensor']),
-                    name=[paddle_op.name(), f'starts_tensor[axes[idx]]_{axes[idx]}'],
+                    add_1D_constant_layer(
+                        network, 0, name=[paddle_op.name(), 'zero_tensor']
+                    ),
+                    name=[
+                        paddle_op.name(),
+                        f'starts_tensor[axes[idx]]_{axes[idx]}',
+                    ],
                 )
             else:
                 starts_tensor[axes[idx]] = trt_min(
                     network,
-                    add_1D_constant_layer(network, starts[idx], name=[paddle_op.name(), f'starts[idx]_{idx}']),
+                    add_1D_constant_layer(
+                        network,
+                        starts[idx],
+                        name=[paddle_op.name(), f'starts[idx]_{idx}'],
+                    ),
                     get_shape_tensor_element(
-                        network, input_shape_tensor, axes[idx], name=[paddle_op.name(), f'axes[idx]_{idx}']
+                        network,
+                        input_shape_tensor,
+                        axes[idx],
+                        name=[paddle_op.name(), f'axes[idx]_{idx}'],
                     ),
                 )
     else:
         starts = inputs[1]
         for idx in range(len(axes)):
             starts_tensor[axes[idx]] = get_shape_tensor_element(
-                network, starts, idx, name=[paddle_op.name(), f'starts_tensor_{idx}']
+                network,
+                starts,
+                idx,
+                name=[paddle_op.name(), f'starts_tensor_{idx}'],
             )
 
     ends = get_input_constant_value(paddle_op, inputs, 2)
@@ -474,28 +529,50 @@ def slice_converter(network, paddle_op, inputs):
                     network,
                     trt_sum(
                         network,
-                        add_1D_constant_layer(network, ends[idx], name=[paddle_op.name(), f'ends[idx]_{idx}']),
-                        get_shape_tensor_element(
-                            network, input_shape_tensor, axes[idx], name=[paddle_op.name(), f'axes[idx]_{idx}']
+                        add_1D_constant_layer(
+                            network,
+                            ends[idx],
+                            name=[paddle_op.name(), f'ends[idx]_{idx}'],
                         ),
-                        name=[paddle_op.name(), f'trt_sum'],
+                        get_shape_tensor_element(
+                            network,
+                            input_shape_tensor,
+                            axes[idx],
+                            name=[paddle_op.name(), f'axes[idx]_{idx}'],
+                        ),
+                        name=[paddle_op.name(), 'trt_sum'],
                     ),
-                    add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'zero_tensor']),
-                    name=[paddle_op.name(), f'ends_tensor[axes[idx]]_{axes[idx]}'],
+                    add_1D_constant_layer(
+                        network, 0, name=[paddle_op.name(), 'zero_tensor']
+                    ),
+                    name=[
+                        paddle_op.name(),
+                        f'ends_tensor[axes[idx]]_{axes[idx]}',
+                    ],
                 )
             else:
                 ends_tensor[axes[idx]] = trt_min(
                     network,
-                    add_1D_constant_layer(network, ends[idx], name=[paddle_op.name(), f'ends[idx]_{idx}']),
+                    add_1D_constant_layer(
+                        network,
+                        ends[idx],
+                        name=[paddle_op.name(), f'ends[idx]_{idx}'],
+                    ),
                     get_shape_tensor_element(
-                        network, input_shape_tensor, axes[idx], name=[paddle_op.name(), f'axes[idx]_{idx}']
+                        network,
+                        input_shape_tensor,
+                        axes[idx],
+                        name=[paddle_op.name(), f'axes[idx]_{idx}'],
                     ),
                 )
     else:
         ends = inputs[2]
         for idx in range(len(axes)):
             ends_tensor[axes[idx]] = get_shape_tensor_element(
-                network, ends, idx, name=[paddle_op.name(), f'ends_tensor_{idx}']
+                network,
+                ends,
+                idx,
+                name=[paddle_op.name(), f'ends_tensor_{idx}'],
             )
 
     start_tensor_layer = network.add_concatenation(starts_tensor)
@@ -506,7 +583,12 @@ def slice_converter(network, paddle_op, inputs):
     end_tensor_layer.axis = 0
     set_layer_name(end_tensor_layer, paddle_op)
     end_tensor = end_tensor_layer.get_output(0)
-    size_tensor = trt_sub(network, end_tensor, start_tensor, name=[paddle_op.name(), 'size_tensor'])
+    size_tensor = trt_sub(
+        network,
+        end_tensor,
+        start_tensor,
+        name=[paddle_op.name(), 'size_tensor'],
+    )
 
     # Create Slice layer
     slice_layer = network.add_slice(
@@ -549,13 +631,22 @@ def split_with_num_converter(network, paddle_op, inputs):
     # Handle the case where axis is of type pir::Value
     axis_value = get_input_constant_value(paddle_op, inputs, 1)
     if axis_value is not None:
-        axis_tensor = add_1D_constant_layer(network, axis_value, name=[paddle_op.name(), 'axis_tensor'])
+        axis_tensor = add_1D_constant_layer(
+            network, axis_value, name=[paddle_op.name(), 'axis_tensor']
+        )
     else:
         axis_tensor = inputs[1]
-        axis_tensor = cast_tensor(network, axis_tensor, trt.int32, name=[paddle_op.name(), 'axis_tensor'])
+        axis_tensor = cast_tensor(
+            network,
+            axis_tensor,
+            trt.int32,
+            name=[paddle_op.name(), 'axis_tensor'],
+        )
 
     num_splits = paddle_op.attrs().get("num")
-    num_splits_tensor = add_1D_constant_layer(network, num_splits, name=[paddle_op.name(), 'num_splits_tensor'])
+    num_splits_tensor = add_1D_constant_layer(
+        network, num_splits, name=[paddle_op.name(), 'num_splits_tensor']
+    )
 
     # Get the dynamic shape of the input tensor
     input_shape_tensor = network.add_shape(input_tensor)
@@ -563,17 +654,41 @@ def split_with_num_converter(network, paddle_op, inputs):
     input_shape_tensor = input_shape_tensor.get_output(0)
 
     # Handle negative axis index
-    input_shape_size_tensor = add_1D_constant_layer(network, input_shape_size, name=[paddle_op.name(), 'input_shape_size_tensor'])
-    zero_tensor = add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'zero_tensor'])
-
-    is_negative_axis = trt_less(network, axis_tensor, zero_tensor, name=[paddle_op.name(), 'is_negative_axis'])
-    is_negative_axis_int = cast_tensor(network, is_negative_axis, trt.int32, name=[paddle_op.name(), 'is_negative_axis_int'])
-
-    axis_adjustment = trt_prod(
-        network, is_negative_axis_int, input_shape_size_tensor, name=[paddle_op.name(), 'axis_adjustment']
+    input_shape_size_tensor = add_1D_constant_layer(
+        network,
+        input_shape_size,
+        name=[paddle_op.name(), 'input_shape_size_tensor'],
+    )
+    zero_tensor = add_1D_constant_layer(
+        network, 0, name=[paddle_op.name(), 'zero_tensor']
     )
 
-    axis_tensor = trt_sum(network, axis_tensor, axis_adjustment, name=[paddle_op.name(), 'axis_tensor'])
+    is_negative_axis = trt_less(
+        network,
+        axis_tensor,
+        zero_tensor,
+        name=[paddle_op.name(), 'is_negative_axis'],
+    )
+    is_negative_axis_int = cast_tensor(
+        network,
+        is_negative_axis,
+        trt.int32,
+        name=[paddle_op.name(), 'is_negative_axis_int'],
+    )
+
+    axis_adjustment = trt_prod(
+        network,
+        is_negative_axis_int,
+        input_shape_size_tensor,
+        name=[paddle_op.name(), 'axis_adjustment'],
+    )
+
+    axis_tensor = trt_sum(
+        network,
+        axis_tensor,
+        axis_adjustment,
+        name=[paddle_op.name(), 'axis_tensor'],
+    )
 
     # Get the size of the dimension specified by axis
     input_axis_size = network.add_gather(
@@ -584,17 +699,28 @@ def split_with_num_converter(network, paddle_op, inputs):
 
     # Compute the size of each split
     split_size = trt_floor_div(
-        network, input_axis_size, num_splits_tensor, name=[paddle_op.name(), 'split_size']
+        network,
+        input_axis_size,
+        num_splits_tensor,
+        name=[paddle_op.name(), 'split_size'],
     )
 
     outputs = []
-    current_offset = add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'current_offset'])
+    current_offset = add_1D_constant_layer(
+        network, 0, name=[paddle_op.name(), 'current_offset']
+    )
 
     for idx in range(num_splits):
-        idx_tensor = add_1D_constant_layer(network, idx, name=[paddle_op.name(), f'idx_tensor_{idx}'])
+        idx_tensor = add_1D_constant_layer(
+            network, idx, name=[paddle_op.name(), f'idx_tensor_{idx}']
+        )
         # Calculate the slice start and size
         start_tensor = build_start_tensor(
-            network, input_shape_size, axis_tensor, current_offset, name=[paddle_op.name(), f'start_tensor_{idx}']
+            network,
+            input_shape_size,
+            axis_tensor,
+            current_offset,
+            name=[paddle_op.name(), f'start_tensor_{idx}'],
         )
         size_tensor = build_size_tensor(
             network,
@@ -619,7 +745,12 @@ def split_with_num_converter(network, paddle_op, inputs):
         outputs.append(slice_layer.get_output(0))
 
         # Update current_offset for the next slice
-        current_offset = trt_sum(network, current_offset, split_size, name=[paddle_op.name(), 'current_offset'])
+        current_offset = trt_sum(
+            network,
+            current_offset,
+            split_size,
+            name=[paddle_op.name(), 'current_offset'],
+        )
 
     return outputs
 
@@ -632,10 +763,17 @@ def split_converter(network, paddle_op, inputs):
 
     axis_value = get_input_constant_value(paddle_op, inputs, 2)
     if axis_value is not None:
-        axis_tensor = add_1D_constant_layer(network, axis_value, name=[paddle_op.name(), 'axis_tensor'])
+        axis_tensor = add_1D_constant_layer(
+            network, axis_value, name=[paddle_op.name(), 'axis_tensor']
+        )
     else:
         axis_tensor = inputs[2]
-        axis_tensor = cast_tensor(network, axis_tensor, trt.int32, name=[paddle_op.name(), 'axis_tensor'])
+        axis_tensor = cast_tensor(
+            network,
+            axis_tensor,
+            trt.int32,
+            name=[paddle_op.name(), 'axis_tensor'],
+        )
 
     # Retrieve and process sections
     sections_value = get_input_constant_value(paddle_op, inputs, 1)
@@ -652,28 +790,62 @@ def split_converter(network, paddle_op, inputs):
     input_shape_tensor = input_shape_tensor.get_output(0)
 
     # Handle negative axis index
-    input_shape_size_tensor = add_1D_constant_layer(network, input_shape_size, name=[paddle_op.name(), 'input_shape_size_tensor'])
-    zero_tensor = add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'zero_tensor'])
+    input_shape_size_tensor = add_1D_constant_layer(
+        network,
+        input_shape_size,
+        name=[paddle_op.name(), 'input_shape_size_tensor'],
+    )
+    zero_tensor = add_1D_constant_layer(
+        network, 0, name=[paddle_op.name(), 'zero_tensor']
+    )
 
-    is_negative_axis = trt_less(network, axis_tensor, zero_tensor, name=[paddle_op.name(), 'is_negative_axis'])
-    is_negative_axis_int = cast_tensor(network, is_negative_axis, trt.int32, name=[paddle_op.name(), 'is_negative_axis_int'])
+    is_negative_axis = trt_less(
+        network,
+        axis_tensor,
+        zero_tensor,
+        name=[paddle_op.name(), 'is_negative_axis'],
+    )
+    is_negative_axis_int = cast_tensor(
+        network,
+        is_negative_axis,
+        trt.int32,
+        name=[paddle_op.name(), 'is_negative_axis_int'],
+    )
 
     axis_adjustment = trt_prod(
-        network, is_negative_axis_int, input_shape_size_tensor, name=[paddle_op.name(), 'axis_adjustment']
+        network,
+        is_negative_axis_int,
+        input_shape_size_tensor,
+        name=[paddle_op.name(), 'axis_adjustment'],
     )
-    axis_tensor = trt_sum(network, axis_tensor, axis_adjustment, name=[paddle_op.name(), 'axis_tensor'])
+    axis_tensor = trt_sum(
+        network,
+        axis_tensor,
+        axis_adjustment,
+        name=[paddle_op.name(), 'axis_tensor'],
+    )
 
     # Initialize output list
     outputs = []
-    offset = add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'offset'])
+    offset = add_1D_constant_layer(
+        network, 0, name=[paddle_op.name(), 'offset']
+    )
 
     if not dynamic_sections:
         for section_size in section_list:
-            section_size_tensor = add_1D_constant_layer(network, section_size, name=[paddle_op.name(), f'section_size_tensor_{section_size}'])
+            section_size_tensor = add_1D_constant_layer(
+                network,
+                section_size,
+                name=[paddle_op.name(), f'section_size_tensor_{section_size}'],
+            )
 
             # Build start_tensor
             start_tensor = build_start_tensor(
-                network, input_shape_size, axis_tensor, offset, name=[paddle_op.name(), f'start_tensor_{section_size}']
+                network,
+                input_shape_size,
+                axis_tensor,
+                offset,
+                name=[paddle_op.name(), f'start_tensor_{section_size}'],
             )
 
             # Build size_tensor
@@ -712,7 +884,9 @@ def split_converter(network, paddle_op, inputs):
         num_sections = int(num_sections)
 
         for idx in range(num_sections):
-            idx_tensor = add_1D_constant_layer(network, idx, name=[paddle_op.name(), f'idx_tensor_{idx}'])
+            idx_tensor = add_1D_constant_layer(
+                network, idx, name=[paddle_op.name(), f'idx_tensor_{idx}']
+            )
 
             # Get section_size_tensor = sections_tensor[idx]
             section_size_tensor = network.add_gather(
@@ -723,7 +897,11 @@ def split_converter(network, paddle_op, inputs):
 
             # Build start_tensor
             start_tensor = build_start_tensor(
-                network, input_shape_size, axis_tensor, offset, name=[paddle_op.name(), f'start_tensor_{idx}']
+                network,
+                input_shape_size,
+                axis_tensor,
+                offset,
+                name=[paddle_op.name(), f'start_tensor_{idx}'],
             )
 
             # Build size_tensor
@@ -782,14 +960,28 @@ def stack_converter(network, paddle_op, inputs):
     for i in range(output_rank):
         if i < axis:
             shape_tensor_vec.append(
-                get_shape_tensor_element(network, shape_tensor, i, name=[paddle_op.name(), f'shape_tensor_vec_{i}'])
+                get_shape_tensor_element(
+                    network,
+                    shape_tensor,
+                    i,
+                    name=[paddle_op.name(), f'shape_tensor_vec_{i}'],
+                )
             )
         elif i > axis:
             shape_tensor_vec.append(
-                get_shape_tensor_element(network, shape_tensor, i - 1, name=[paddle_op.name(), f'shape_tensor_vec_{i}'])
+                get_shape_tensor_element(
+                    network,
+                    shape_tensor,
+                    i - 1,
+                    name=[paddle_op.name(), f'shape_tensor_vec_{i}'],
+                )
             )
         else:
-            shape_tensor_vec.append(add_1D_constant_layer(network, 1, name=[paddle_op.name(), f'shape_tensor_vec_{i}']))
+            shape_tensor_vec.append(
+                add_1D_constant_layer(
+                    network, 1, name=[paddle_op.name(), f'shape_tensor_vec_{i}']
+                )
+            )
 
     after_shape_tensor = network.add_concatenation(shape_tensor_vec)
     set_layer_name(after_shape_tensor, paddle_op)
@@ -813,7 +1005,9 @@ def stack_converter(network, paddle_op, inputs):
         len(paddle_op.results()[0].shape) == 1
         and paddle_op.results()[0].shape[0] != -1
     ):
-        output_tensor = resize_to_1d(network, output_tensor, name=[paddle_op.name(), 'output_tensor'])
+        output_tensor = resize_to_1d(
+            network, output_tensor, name=[paddle_op.name(), 'output_tensor']
+        )
     return output_tensor
 
 
@@ -828,29 +1022,47 @@ def tile_converter(network, paddle_op, inputs):
 
     repeat_times = get_input_constant_value(paddle_op, inputs, 1)
     if repeat_times is not None:
-        repeat_tensor = add_1D_constant_layer(network, repeat_times, name=[paddle_op.name(), 'repeat_tensor'])
+        repeat_tensor = add_1D_constant_layer(
+            network, repeat_times, name=[paddle_op.name(), 'repeat_tensor']
+        )
         repeat_rank = len(repeat_times)
     else:
         repeat_tensor = inputs[1]
-        repeat_tensor = resize_to_1d(network, repeat_tensor, name=[paddle_op.name(), 'repeat_tensor'])
+        repeat_tensor = resize_to_1d(
+            network, repeat_tensor, name=[paddle_op.name(), 'repeat_tensor']
+        )
         repeat_shape = paddle_op.operands()[1].source().shape
         repeat_rank = repeat_shape[0]
 
     if rank > repeat_rank:
         one_rank_tensor = add_1D_constant_layer(
-            network, [1] * (rank - repeat_rank), name=[paddle_op.name(), 'one_rank_tensor']
+            network,
+            [1] * (rank - repeat_rank),
+            name=[paddle_op.name(), 'one_rank_tensor'],
         )
         repeat_expand_tensor = trt_concat(
-            network, [one_rank_tensor, repeat_tensor], name=[paddle_op.name(), 'repeat_expand_tensor']
+            network,
+            [one_rank_tensor, repeat_tensor],
+            name=[paddle_op.name(), 'repeat_expand_tensor'],
         )
     elif rank < repeat_rank:
         one_rank_tensor = add_1D_constant_layer(
-            network, [1] * (repeat_rank - rank), name=[paddle_op.name(), 'one_rank_tensor']
+            network,
+            [1] * (repeat_rank - rank),
+            name=[paddle_op.name(), 'one_rank_tensor'],
         )
         input_shape_tensor = trt_concat(
-            network, [one_rank_tensor, input_shape_tensor], name=[paddle_op.name(), 'input_shape_tensor']
+            network,
+            [one_rank_tensor, input_shape_tensor],
+            name=[paddle_op.name(), 'input_shape_tensor'],
         )
-        input = trt_reshape(network, input, input_shape_tensor, name=[paddle_op.name(), 'input_shape_tensor'], is_shape_tensor=True)
+        input = trt_reshape(
+            network,
+            input,
+            input_shape_tensor,
+            name=[paddle_op.name(), 'input_shape_tensor'],
+            is_shape_tensor=True,
+        )
         repeat_expand_tensor = repeat_tensor
     else:
         repeat_expand_tensor = repeat_tensor
@@ -859,7 +1071,10 @@ def tile_converter(network, paddle_op, inputs):
     stride = [1] * max(rank, repeat_rank)
     output_shape = [0] * max(rank, repeat_rank)
     output_shape_tensor = trt_prod(
-        network, input_shape_tensor, repeat_expand_tensor, name=[paddle_op.name(), 'output_shape_tensor']
+        network,
+        input_shape_tensor,
+        repeat_expand_tensor,
+        name=[paddle_op.name(), 'output_shape_tensor'],
     )
 
     slice_layer = network.add_slice(input, start, output_shape, stride)
@@ -923,38 +1138,77 @@ def strided_slice_converter(network, paddle_op, inputs):
         if starts[i] < 0 or ends[i] < 0:
             has_neg_indices = True
 
-    shape_tensor = trt_shape(network, input_tensor, name=[paddle_op.name(), 'shape_tensor'])
-    start_tensor = add_1D_constant_layer(network, trt_start_dims, name=[paddle_op.name(), 'start_tensor'])
+    shape_tensor = trt_shape(
+        network, input_tensor, name=[paddle_op.name(), 'shape_tensor']
+    )
+    start_tensor = add_1D_constant_layer(
+        network, trt_start_dims, name=[paddle_op.name(), 'start_tensor']
+    )
     if has_neg_indices:
-        start_tensor = fix_negative_indices(network, shape_tensor, start_tensor, name=[paddle_op.name(), 'start_tensor'])
+        start_tensor = fix_negative_indices(
+            network,
+            shape_tensor,
+            start_tensor,
+            name=[paddle_op.name(), 'start_tensor'],
+        )
 
     end_vec_tensor = []
     for i in range(len(trt_end_dims)):
         end_vec_tensor.append(
-            get_shape_tensor_element(network, shape_tensor, i, name=[paddle_op.name(), f'end_vec_tensor{i}'])
+            get_shape_tensor_element(
+                network,
+                shape_tensor,
+                i,
+                name=[paddle_op.name(), f'end_vec_tensor{i}'],
+            )
         )
 
     for i, trt_axis in enumerate(axes):
         if ends[i] >= 0:
-            end_vec_tensor[trt_axis] = add_1D_constant_layer(network, ends[i], name=[paddle_op.name(), f'end_vec_tensor{i}'])
+            end_vec_tensor[trt_axis] = add_1D_constant_layer(
+                network, ends[i], name=[paddle_op.name(), f'end_vec_tensor{i}']
+            )
         else:
             end_vec_tensor[trt_axis] = trt_sum(
                 network,
                 end_vec_tensor[trt_axis],
-                add_1D_constant_layer(network, ends[i], name=[paddle_op.name(), f'end_vec_tensor{i}']),
+                add_1D_constant_layer(
+                    network,
+                    ends[i],
+                    name=[paddle_op.name(), f'end_vec_tensor{i}'],
+                ),
                 name=[paddle_op.name(), f'end_vec_tensor{i}'],
             )
 
     size_tensor = trt_sub(
         network,
         start_tensor,
-        trt_min(network, trt_concat(network, end_vec_tensor, name=[paddle_op.name(), 'trt_concat']), shape_tensor, name=[paddle_op.name(), 'trt_min']),
+        trt_min(
+            network,
+            trt_concat(
+                network, end_vec_tensor, name=[paddle_op.name(), 'trt_concat']
+            ),
+            shape_tensor,
+            name=[paddle_op.name(), 'trt_min'],
+        ),
         name=[paddle_op.name(), 'size_tensor'],
     )
-    zero_t = add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'zero_t'])
-    step_tensor = add_1D_constant_layer(network, trt_step_dims, name=[paddle_op.name(), 'step_tensor'])
+    zero_t = add_1D_constant_layer(
+        network, 0, name=[paddle_op.name(), 'zero_t']
+    )
+    step_tensor = add_1D_constant_layer(
+        network, trt_step_dims, name=[paddle_op.name(), 'step_tensor']
+    )
     size_tensor = trt_sub(
-        network, zero_t, trt_floor_div(network, size_tensor, step_tensor, name=[paddle_op.name(), 'trt_floor_div']), name=[paddle_op.name(), 'size_tensor']
+        network,
+        zero_t,
+        trt_floor_div(
+            network,
+            size_tensor,
+            step_tensor,
+            name=[paddle_op.name(), 'trt_floor_div'],
+        ),
+        name=[paddle_op.name(), 'size_tensor'],
     )
 
     layer = network.add_slice(
@@ -977,34 +1231,96 @@ def roll_converter(network, paddle_op, inputs):
         shifts = inputs[1]
 
     axis_size = len(axis)
-    input_shape_tensor = trt_shape(network, input_tensor, name=[paddle_op.name(), 'input_shape_tensor'])
+    input_shape_tensor = trt_shape(
+        network, input_tensor, name=[paddle_op.name(), 'input_shape_tensor']
+    )
 
     for i in range(axis_size):
         axi = axis[i]
         if isinstance(shifts, trt.ITensor):
-            shift = get_shape_tensor_element(network, shifts, i, name=[paddle_op.name(), f'shift_{i}'])
+            shift = get_shape_tensor_element(
+                network, shifts, i, name=[paddle_op.name(), f'shift_{i}']
+            )
             input_shift = shift
         else:
             shift = shifts[i]
-            input_shift = add_1D_constant_layer(network, shift, name=[paddle_op.name(), f'input_shift_{i}'])
-        input_axis = get_shape_tensor_element(network, input_shape_tensor, axi, name=[paddle_op.name(), f'input_axis_{i}'])
+            input_shift = add_1D_constant_layer(
+                network, shift, name=[paddle_op.name(), f'input_shift_{i}']
+            )
+        input_axis = get_shape_tensor_element(
+            network,
+            input_shape_tensor,
+            axi,
+            name=[paddle_op.name(), f'input_axis_{i}'],
+        )
 
         # 1.sub_value mod input_axis
-        input1 = trt_sub(network, input_axis, input_shift, name=[paddle_op.name(), f'input1_{i}'])
-        tmp_div_res = trt_floor_div(network, input1, input_axis, name=[paddle_op.name(), f'tmp_div_res_{i}'])
-        tmp_prod_res = trt_prod(network, tmp_div_res, input_axis, name=[paddle_op.name(), f'tmp_prod_res_{i}'])
-        start = trt_sub(network, input1, tmp_prod_res, name=[paddle_op.name(), f'start_{i}'])
+        input1 = trt_sub(
+            network,
+            input_axis,
+            input_shift,
+            name=[paddle_op.name(), f'input1_{i}'],
+        )
+        tmp_div_res = trt_floor_div(
+            network,
+            input1,
+            input_axis,
+            name=[paddle_op.name(), f'tmp_div_res_{i}'],
+        )
+        tmp_prod_res = trt_prod(
+            network,
+            tmp_div_res,
+            input_axis,
+            name=[paddle_op.name(), f'tmp_prod_res_{i}'],
+        )
+        start = trt_sub(
+            network, input1, tmp_prod_res, name=[paddle_op.name(), f'start_{i}']
+        )
         # 2.avoid start less than 0,start mod input_axis
-        start = trt_sum(network, start, input_axis, name=[paddle_op.name(), f'start_{i}'])
-        tmp_div_res1 = trt_floor_div(network, start, input_axis, name=[paddle_op.name(), f'tmp_div_res1_{i}'])
-        tmp_prod_res1 = trt_prod(network, tmp_div_res1, input_axis, name=[paddle_op.name(), f'tmp_prod_res1_{i}'])
-        start = trt_sub(network, start, tmp_prod_res1, name=[paddle_op.name(), f'start_{i}'])
-        zero_tensor = add_1D_constant_layer(network, 0, name=[paddle_op.name(), f'zero_tensor_{i}'])
-        step = add_1D_constant_layer(network, 1, name=[paddle_op.name(), f'step_{i}'])
+        start = trt_sum(
+            network, start, input_axis, name=[paddle_op.name(), f'start_{i}']
+        )
+        tmp_div_res1 = trt_floor_div(
+            network,
+            start,
+            input_axis,
+            name=[paddle_op.name(), f'tmp_div_res1_{i}'],
+        )
+        tmp_prod_res1 = trt_prod(
+            network,
+            tmp_div_res1,
+            input_axis,
+            name=[paddle_op.name(), f'tmp_prod_res1_{i}'],
+        )
+        start = trt_sub(
+            network, start, tmp_prod_res1, name=[paddle_op.name(), f'start_{i}']
+        )
+        zero_tensor = add_1D_constant_layer(
+            network, 0, name=[paddle_op.name(), f'zero_tensor_{i}']
+        )
+        step = add_1D_constant_layer(
+            network, 1, name=[paddle_op.name(), f'step_{i}']
+        )
         # 3.make index_tensor0
-        sub_qutient = trt_sub(network, input_axis, start, name=[paddle_op.name(), f'sub_qutient_{i}'])
-        quotient_tensor = trt_floor_div(network, sub_qutient, step, name=[paddle_op.name(), f'quotient_tensor_{i}'])
-        start1 = get_shape_tensor_element(network, start, 0, is_scalar=True, name=[paddle_op.name(), f'start1_{i}'])
+        sub_qutient = trt_sub(
+            network,
+            input_axis,
+            start,
+            name=[paddle_op.name(), f'sub_qutient_{i}'],
+        )
+        quotient_tensor = trt_floor_div(
+            network,
+            sub_qutient,
+            step,
+            name=[paddle_op.name(), f'quotient_tensor_{i}'],
+        )
+        start1 = get_shape_tensor_element(
+            network,
+            start,
+            0,
+            is_scalar=True,
+            name=[paddle_op.name(), f'start1_{i}'],
+        )
         fill_layer0 = network.add_fill(shape=(), op=trt.FillOperation.LINSPACE)
         fill_layer0.set_input(0, quotient_tensor)
         fill_layer0.set_input(1, start1)
@@ -1012,9 +1328,21 @@ def roll_converter(network, paddle_op, inputs):
         set_layer_name(fill_layer0, paddle_op)
         index_tensor0 = fill_layer0.get_output(0)
         # 4.make index_tensor1
-        sub_qutient_tensor = trt_sub(network, start, zero_tensor, name=[paddle_op.name(), f'sub_qutient_tensor_{i}'])
-        quotient_tensor = trt_floor_div(network, sub_qutient_tensor, step, name=[paddle_op.name(), f'quotient_tensor_{i}'])
-        start2 = add_1D_constant_layer(network, 0, is_scalar=True, name=[paddle_op.name(), f'start2_{i}'])
+        sub_qutient_tensor = trt_sub(
+            network,
+            start,
+            zero_tensor,
+            name=[paddle_op.name(), f'sub_qutient_tensor_{i}'],
+        )
+        quotient_tensor = trt_floor_div(
+            network,
+            sub_qutient_tensor,
+            step,
+            name=[paddle_op.name(), f'quotient_tensor_{i}'],
+        )
+        start2 = add_1D_constant_layer(
+            network, 0, is_scalar=True, name=[paddle_op.name(), f'start2_{i}']
+        )
         fill_layer1 = network.add_fill(shape=(), op=trt.FillOperation.LINSPACE)
         fill_layer1.set_input(0, quotient_tensor)
         fill_layer1.set_input(1, start2)
@@ -1022,7 +1350,9 @@ def roll_converter(network, paddle_op, inputs):
         set_layer_name(fill_layer1, paddle_op)
         index_tensor1 = fill_layer1.get_output(0)
         itensors = [index_tensor0, index_tensor1]
-        concat_input_tensor = trt_concat(network, itensors, name=[paddle_op.name(), 'concat_input_tensor'])
+        concat_input_tensor = trt_concat(
+            network, itensors, name=[paddle_op.name(), 'concat_input_tensor']
+        )
         if i == 0:
             layer = network.add_gather(
                 input=input_tensor, indices=concat_input_tensor, axis=axi
@@ -1062,12 +1392,21 @@ def pad3d_converter(network, paddle_op, inputs):
 
     shuffle_index = [4, 2, 0, 5, 3, 1]
     shuffle_inputs = [
-        get_shape_tensor_element(network, paddings, shuffle_index[i], name=[paddle_op.name(), f'shuffle_inputs_{i}'])
+        get_shape_tensor_element(
+            network,
+            paddings,
+            shuffle_index[i],
+            name=[paddle_op.name(), f'shuffle_inputs_{i}'],
+        )
         for i in range(pad_size)
     ]
-    paddings = trt_concat(network, shuffle_inputs, name=[paddle_op.name(), 'paddings'])
+    paddings = trt_concat(
+        network, shuffle_inputs, name=[paddle_op.name(), 'paddings']
+    )
 
-    pre_zeros = add_1D_constant_layer(network, [0, 0], name=[paddle_op.name(), 'pre_zeros'])
+    pre_zeros = add_1D_constant_layer(
+        network, [0, 0], name=[paddle_op.name(), 'pre_zeros']
+    )
     start_slice1 = [0]
     start_slice2 = [3]
     size_slice = [3]
@@ -1077,20 +1416,32 @@ def pad3d_converter(network, paddle_op, inputs):
     )
     set_layer_name(pre_pad, paddle_op)
     pre_pad = pre_pad.get_output(0)
-    pre_pad = trt_concat(network, [pre_zeros, pre_pad], name=[paddle_op.name(), 'pre_pad'])
+    pre_pad = trt_concat(
+        network, [pre_zeros, pre_pad], name=[paddle_op.name(), 'pre_pad']
+    )
     post_pad = network.add_slice(
         paddings, start_slice2, size_slice, stride_slice
     )
     set_layer_name(post_pad, paddle_op)
     post_pad = post_pad.get_output(0)
-    post_pad = trt_concat(network, [pre_zeros, post_pad], name=[paddle_op.name(), 'post_pad'])
+    post_pad = trt_concat(
+        network, [pre_zeros, post_pad], name=[paddle_op.name(), 'post_pad']
+    )
 
-    zeros = add_1D_constant_layer(network, [0] * input_dim, name=[paddle_op.name(), 'zeros'])
+    zeros = add_1D_constant_layer(
+        network, [0] * input_dim, name=[paddle_op.name(), 'zeros']
+    )
 
     start = trt_sub(network, zeros, pre_pad, name=[paddle_op.name(), 'start'])
-    total_padding = trt_sum(network, pre_pad, post_pad, name=[paddle_op.name(), 'total_padding'])
-    input_shape = trt_shape(network, input_tensor, name=[paddle_op.name(), 'input_shape'])
-    size = trt_sum(network, input_shape, total_padding, name=[paddle_op.name(), 'size'])
+    total_padding = trt_sum(
+        network, pre_pad, post_pad, name=[paddle_op.name(), 'total_padding']
+    )
+    input_shape = trt_shape(
+        network, input_tensor, name=[paddle_op.name(), 'input_shape']
+    )
+    size = trt_sum(
+        network, input_shape, total_padding, name=[paddle_op.name(), 'size']
+    )
 
     # Add slice layer
     stride = [1] * input_dim
@@ -1110,12 +1461,18 @@ def pad3d_converter(network, paddle_op, inputs):
                 trt.DataType.INT8,
             ):
                 fill_value = add_1D_constant_layer(
-                    network, value, dtype=np.float32, name=[paddle_op.name(), 'fill_value']
+                    network,
+                    value,
+                    dtype=np.float32,
+                    name=[paddle_op.name(), 'fill_value'],
                 )
             else:
                 value_int = int(value)
                 fill_value = add_1D_constant_layer(
-                    network, value_int, dtype=np.int32, name=[paddle_op.name(), 'fill_value']
+                    network,
+                    value_int,
+                    dtype=np.int32,
+                    name=[paddle_op.name(), 'fill_value'],
                 )
             slice_layer.set_input(4, fill_value)
     elif padding_mode == "reflect":
@@ -1145,7 +1502,9 @@ def numel_converter(network, paddle_op, inputs):
 def index_put_converter(network, paddle_op, inputs):
     input_tensor, indices_list, value_tensor = inputs
     indices_tensor = indices_list[0]
-    input_shape_tensor = trt_shape(network, input_tensor, name=[paddle_op.name(), 'input_shape_tensor'])
+    input_shape_tensor = trt_shape(
+        network, input_tensor, name=[paddle_op.name(), 'input_shape_tensor']
+    )
     input_dims = input_tensor.shape
     indices_dims = indices_tensor.shape
     rank = len(input_dims)
@@ -1153,26 +1512,51 @@ def index_put_converter(network, paddle_op, inputs):
     # indices
     indices_shape_vec = [
         add_1D_constant_layer(
-            network, indices_dims[i] if i < len(indices_dims) else 1, name=[paddle_op.name(), f'indices_shape_vec_{i}']
+            network,
+            indices_dims[i] if i < len(indices_dims) else 1,
+            name=[paddle_op.name(), f'indices_shape_vec_{i}'],
         )
         for i in range(rank)
     ]
-    start_tensor_vec = [add_1D_constant_layer(network, 0, name=[paddle_op.name(), f'start_tensor_vec_{i}']) for i in range(rank)]
-    stride_tensor_vec = [add_1D_constant_layer(network, 1, name=[paddle_op.name(), f'stride_tensor_vec_{i}']) for i in range(rank)]
+    start_tensor_vec = [
+        add_1D_constant_layer(
+            network, 0, name=[paddle_op.name(), f'start_tensor_vec_{i}']
+        )
+        for i in range(rank)
+    ]
+    stride_tensor_vec = [
+        add_1D_constant_layer(
+            network, 1, name=[paddle_op.name(), f'stride_tensor_vec_{i}']
+        )
+        for i in range(rank)
+    ]
     indices_tensor_temp = trt_reshape(
         network,
         indices_tensor,
-        trt_concat(network, indices_shape_vec, name=[paddle_op.name(), 'indices_shape_vec']),
+        trt_concat(
+            network,
+            indices_shape_vec,
+            name=[paddle_op.name(), 'indices_shape_vec'],
+        ),
         name=[paddle_op.name(), 'indices_tensor_temp'],
         is_shape_tensor=True,
     )
-    start_tensor = trt_concat(network, start_tensor_vec, name=[paddle_op.name(), 'start_tensor'])
-    stride_tensor = trt_concat(network, stride_tensor_vec, name=[paddle_op.name(), 'stride_tensor'])
+    start_tensor = trt_concat(
+        network, start_tensor_vec, name=[paddle_op.name(), 'start_tensor']
+    )
+    stride_tensor = trt_concat(
+        network, stride_tensor_vec, name=[paddle_op.name(), 'stride_tensor']
+    )
 
     # slice
     stride = [1] * rank
     indices_slice_layer = network.add_slice(
-        trt_cast(network, indices_tensor_temp, trt.float32, name=[paddle_op.name(), 'indices_tensor_temp']),
+        trt_cast(
+            network,
+            indices_tensor_temp,
+            trt.float32,
+            name=[paddle_op.name(), 'indices_tensor_temp'],
+        ),
         stride,
         stride,
         stride,
@@ -1184,7 +1568,10 @@ def index_put_converter(network, paddle_op, inputs):
     set_layer_name(indices_slice_layer, paddle_op)
 
     bool_indices_tensor = trt_cast(
-        network, indices_slice_layer.get_output(0), trt.bool, name=[paddle_op.name(), 'bool_indices_tensor']
+        network,
+        indices_slice_layer.get_output(0),
+        trt.bool,
+        name=[paddle_op.name(), 'bool_indices_tensor'],
     )
 
     # nonzero
@@ -1196,9 +1583,16 @@ def index_put_converter(network, paddle_op, inputs):
     trans_layer.first_transpose = permutation
     set_layer_name(trans_layer, paddle_op)
     indices_tensor = trans_layer.get_output(0)
-    indices_new_shape_tensor = trt_shape(network, indices_tensor, name=[paddle_op.name(), 'indices_new_shape_tensor'])
+    indices_new_shape_tensor = trt_shape(
+        network,
+        indices_tensor,
+        name=[paddle_op.name(), 'indices_new_shape_tensor'],
+    )
     indices_count_tensor = get_shape_tensor_element(
-        network, indices_new_shape_tensor, 0, name=[paddle_op.name(), 'indices_count_tensor']
+        network,
+        indices_new_shape_tensor,
+        0,
+        name=[paddle_op.name(), 'indices_count_tensor'],
     )
 
     # value
@@ -1206,9 +1600,19 @@ def index_put_converter(network, paddle_op, inputs):
     value_slice_layer = network.add_slice(
         value_tensor, value_stride, value_stride, value_stride
     )
-    value_slice_layer.set_input(1, add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'value_slice_layer_start']))
+    value_slice_layer.set_input(
+        1,
+        add_1D_constant_layer(
+            network, 0, name=[paddle_op.name(), 'value_slice_layer_start']
+        ),
+    )
     value_slice_layer.set_input(2, indices_count_tensor)
-    value_slice_layer.set_input(3, add_1D_constant_layer(network, 1, name=[paddle_op.name(), 'value_slice_layer_stride']))
+    value_slice_layer.set_input(
+        3,
+        add_1D_constant_layer(
+            network, 1, name=[paddle_op.name(), 'value_slice_layer_stride']
+        ),
+    )
     value_slice_layer.mode = trt.SampleMode.CLAMP
     set_layer_name(value_slice_layer, paddle_op)
     value_tensor = value_slice_layer.get_output(0)

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -92,9 +92,11 @@ def gather_converter(network, paddle_op, inputs):
 
     reshape_layer = network.add_shuffle(index_tensor)
     reshape_layer.reshape_dims = (-1,)
+    set_layer_name(reshape_layer, paddle_op)
     gather_layer = network.add_gather(
         input_tensor, reshape_layer.get_output(0), axis_value
     )
+    set_layer_name(gather_layer, paddle_op)
     return gather_layer.get_output(0)
 
 
@@ -348,16 +350,16 @@ def expand_converter(network, paddle_op, inputs):
 
     shape = get_input_constant_value(paddle_op, inputs, 1)
     if shape is not None:
-        shape_tensor = add_1D_constant_layer(network, shape)
+        shape_tensor = add_1D_constant_layer(network, shape, name=[paddle_op.name(), 'shape_tensor'])
         shape_rank = len(shape)
     elif paddle_shape_tensor.type().as_vec_type():
         shape_tensors = inputs[1]
         shape_rank = len(shape_tensors)
-        shape_tensor = trt_concat(network, shape_tensors)
+        shape_tensor = trt_concat(network, shape_tensors, name=[paddle_op.name(), 'shape_tensor'])
     else:
         shape_tensor = inputs[1]
         shape_rank = shape_tensor.shape[0]
-    return trt_expand(network, input, rank, shape_tensor, shape_rank)
+    return trt_expand(network, input, rank, shape_tensor, shape_rank, name=[paddle_op.name(), 'trt_expand'])
 
 
 @converter_registry.register(
@@ -371,13 +373,13 @@ def expand_as_converter(network, paddle_op, inputs):
 
     if y.initialized():
         y_t = inputs[1]
-        shape_tensor = trt_shape(network, y_t)
+        shape_tensor = trt_shape(network, y_t, name=[paddle_op.name(), 'shape_tensor'])
         shape_rank = len(y_t.shape)
     else:
         shape = paddle_op.attrs().get("target_shape")
-        shape_tensor = add_1D_constant_layer(network, shape)
+        shape_tensor = add_1D_constant_layer(network, shape, name=[paddle_op.name(), 'shape_tensor'])
         shape_rank = len(shape)
-    return trt_expand(network, input, rank, shape_tensor, shape_rank)
+    return trt_expand(network, input, rank, shape_tensor, shape_rank, name=[paddle_op.name(), 'trt_expand'])
 
 
 @converter_registry.register("pd_op.cast", trt_version="8.x")
@@ -405,6 +407,7 @@ def cast_converter(network, paddle_op, inputs):
     cast_layer = network.add_identity(input_tensor)
     cast_layer.set_output_type(0, out_dtype)
     cast_layer.get_output(0).dtype = out_dtype
+    set_layer_name(cast_layer, paddle_op)
     return cast_layer.get_output(0)
 
 
@@ -414,15 +417,15 @@ def slice_converter(network, paddle_op, inputs):
     axes = paddle_op.attrs()["axes"]
     decrease_axis = paddle_op.attrs().get("decrease_axis")
 
-    input_shape_tensor = trt_shape(network, input_tensor)
+    input_shape_tensor = trt_shape(network, input_tensor, name=[paddle_op.name(), "input_shape_tensor"])
     input_rank = len(input_tensor.shape)
 
     starts_tensor = []
     ends_tensor = []
     for i in range(input_rank):
-        starts_tensor.append(add_1D_constant_layer(network, 0))
+        starts_tensor.append(add_1D_constant_layer(network, 0, name=[paddle_op.name(), f'starts_tensor_{i}']))
         ends_tensor.append(
-            get_shape_tensor_element(network, input_shape_tensor, i)
+            get_shape_tensor_element(network, input_shape_tensor, i, name=[paddle_op.name(), f'end_tensor_{i}'])
         )
 
     starts = get_input_constant_value(paddle_op, inputs, 1)
@@ -436,26 +439,28 @@ def slice_converter(network, paddle_op, inputs):
                     network,
                     trt_sum(
                         network,
-                        add_1D_constant_layer(network, starts[idx]),
+                        add_1D_constant_layer(network, starts[idx], name=[paddle_op.name(), f'starts[idx]_{idx}']),
                         get_shape_tensor_element(
-                            network, input_shape_tensor, axes[idx]
+                            network, input_shape_tensor, axes[idx], name=[paddle_op.name(), f'axes[idx]_{idx}']
                         ),
+                        name=[paddle_op.name(), f'trt_sum'],
                     ),
-                    add_1D_constant_layer(network, 0),
+                    add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'zero_tensor']),
+                    name=[paddle_op.name(), f'starts_tensor[axes[idx]]_{axes[idx]}'],
                 )
             else:
                 starts_tensor[axes[idx]] = trt_min(
                     network,
-                    add_1D_constant_layer(network, starts[idx]),
+                    add_1D_constant_layer(network, starts[idx], name=[paddle_op.name(), f'starts[idx]_{idx}']),
                     get_shape_tensor_element(
-                        network, input_shape_tensor, axes[idx]
+                        network, input_shape_tensor, axes[idx], name=[paddle_op.name(), f'axes[idx]_{idx}']
                     ),
                 )
     else:
         starts = inputs[1]
         for idx in range(len(axes)):
             starts_tensor[axes[idx]] = get_shape_tensor_element(
-                network, starts, idx
+                network, starts, idx, name=[paddle_op.name(), f'starts_tensor_{idx}']
             )
 
     ends = get_input_constant_value(paddle_op, inputs, 2)
@@ -469,35 +474,39 @@ def slice_converter(network, paddle_op, inputs):
                     network,
                     trt_sum(
                         network,
-                        add_1D_constant_layer(network, ends[idx]),
+                        add_1D_constant_layer(network, ends[idx], name=[paddle_op.name(), f'ends[idx]_{idx}']),
                         get_shape_tensor_element(
-                            network, input_shape_tensor, axes[idx]
+                            network, input_shape_tensor, axes[idx], name=[paddle_op.name(), f'axes[idx]_{idx}']
                         ),
+                        name=[paddle_op.name(), f'trt_sum'],
                     ),
-                    add_1D_constant_layer(network, 0),
+                    add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'zero_tensor']),
+                    name=[paddle_op.name(), f'ends_tensor[axes[idx]]_{axes[idx]}'],
                 )
             else:
                 ends_tensor[axes[idx]] = trt_min(
                     network,
-                    add_1D_constant_layer(network, ends[idx]),
+                    add_1D_constant_layer(network, ends[idx], name=[paddle_op.name(), f'ends[idx]_{idx}']),
                     get_shape_tensor_element(
-                        network, input_shape_tensor, axes[idx]
+                        network, input_shape_tensor, axes[idx], name=[paddle_op.name(), f'axes[idx]_{idx}']
                     ),
                 )
     else:
         ends = inputs[2]
         for idx in range(len(axes)):
             ends_tensor[axes[idx]] = get_shape_tensor_element(
-                network, ends, idx
+                network, ends, idx, name=[paddle_op.name(), f'ends_tensor_{idx}']
             )
 
     start_tensor_layer = network.add_concatenation(starts_tensor)
     start_tensor_layer.axis = 0
+    set_layer_name(start_tensor_layer, paddle_op)
     start_tensor = start_tensor_layer.get_output(0)
     end_tensor_layer = network.add_concatenation(ends_tensor)
     end_tensor_layer.axis = 0
+    set_layer_name(end_tensor_layer, paddle_op)
     end_tensor = end_tensor_layer.get_output(0)
-    size_tensor = trt_sub(network, end_tensor, start_tensor)
+    size_tensor = trt_sub(network, end_tensor, start_tensor, name=[paddle_op.name(), 'size_tensor'])
 
     # Create Slice layer
     slice_layer = network.add_slice(
@@ -505,6 +514,7 @@ def slice_converter(network, paddle_op, inputs):
     )
     slice_layer.set_input(1, start_tensor)
     slice_layer.set_input(2, size_tensor)
+    set_layer_name(slice_layer, paddle_op)
 
     output_tensor = slice_layer.get_output(0)
 
@@ -525,6 +535,7 @@ def slice_converter(network, paddle_op, inputs):
             shuffle_layer = network.add_shuffle(output_tensor)
             shuffle_layer.set_input(1, real_size_tensor)
 
+        set_layer_name(shuffle_layer, paddle_op)
         output_tensor = shuffle_layer.get_output(0)
 
     return output_tensor
@@ -538,46 +549,52 @@ def split_with_num_converter(network, paddle_op, inputs):
     # Handle the case where axis is of type pir::Value
     axis_value = get_input_constant_value(paddle_op, inputs, 1)
     if axis_value is not None:
-        axis_tensor = add_1D_constant_layer(network, axis_value)
+        axis_tensor = add_1D_constant_layer(network, axis_value, name=[paddle_op.name(), 'axis_tensor'])
     else:
         axis_tensor = inputs[1]
-        axis_tensor = cast_tensor(network, axis_tensor, trt.int32)
+        axis_tensor = cast_tensor(network, axis_tensor, trt.int32, name=[paddle_op.name(), 'axis_tensor'])
 
     num_splits = paddle_op.attrs().get("num")
-    num_splits_tensor = add_1D_constant_layer(network, num_splits)
+    num_splits_tensor = add_1D_constant_layer(network, num_splits, name=[paddle_op.name(), 'num_splits_tensor'])
 
     # Get the dynamic shape of the input tensor
-    input_shape_tensor = network.add_shape(input_tensor).get_output(0)
+    input_shape_tensor = network.add_shape(input_tensor)
+    set_layer_name(input_shape_tensor, paddle_op)
+    input_shape_tensor = input_shape_tensor.get_output(0)
 
     # Handle negative axis index
-    input_shape_size_tensor = add_1D_constant_layer(network, input_shape_size)
-    zero_tensor = add_1D_constant_layer(network, 0)
+    input_shape_size_tensor = add_1D_constant_layer(network, input_shape_size, name=[paddle_op.name(), 'input_shape_size_tensor'])
+    zero_tensor = add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'zero_tensor'])
 
-    is_negative_axis = trt_less(network, axis_tensor, zero_tensor)
-    is_negative_axis_int = cast_tensor(network, is_negative_axis, trt.int32)
+    is_negative_axis = trt_less(network, axis_tensor, zero_tensor, name=[paddle_op.name(), 'is_negative_axis'])
+    is_negative_axis_int = cast_tensor(network, is_negative_axis, trt.int32, name=[paddle_op.name(), 'is_negative_axis_int'])
 
     axis_adjustment = trt_prod(
-        network, is_negative_axis_int, input_shape_size_tensor
+        network, is_negative_axis_int, input_shape_size_tensor, name=[paddle_op.name(), 'axis_adjustment']
     )
 
-    axis_tensor = trt_sum(network, axis_tensor, axis_adjustment)
+    axis_tensor = trt_sum(network, axis_tensor, axis_adjustment, name=[paddle_op.name(), 'axis_tensor'])
 
     # Get the size of the dimension specified by axis
     input_axis_size = network.add_gather(
         input_shape_tensor, axis_tensor, axis=0
-    ).get_output(0)
+    )
+    set_layer_name(input_axis_size, paddle_op)
+    input_axis_size = input_axis_size.get_output(0)
 
     # Compute the size of each split
-    split_size = trt_floor_div(network, input_axis_size, num_splits_tensor)
+    split_size = trt_floor_div(
+        network, input_axis_size, num_splits_tensor, name=[paddle_op.name(), 'split_size']
+    )
 
     outputs = []
-    current_offset = add_1D_constant_layer(network, 0)
+    current_offset = add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'current_offset'])
 
     for idx in range(num_splits):
-        idx_tensor = add_1D_constant_layer(network, idx)
+        idx_tensor = add_1D_constant_layer(network, idx, name=[paddle_op.name(), f'idx_tensor_{idx}'])
         # Calculate the slice start and size
         start_tensor = build_start_tensor(
-            network, input_shape_size, axis_tensor, current_offset
+            network, input_shape_size, axis_tensor, current_offset, name=[paddle_op.name(), f'start_tensor_{idx}']
         )
         size_tensor = build_size_tensor(
             network,
@@ -585,6 +602,7 @@ def split_with_num_converter(network, paddle_op, inputs):
             axis_tensor,
             split_size,
             input_shape_tensor,
+            name=[paddle_op.name(), f'size_tensor_{idx}'],
         )
 
         # Create Slice layer
@@ -596,11 +614,12 @@ def split_with_num_converter(network, paddle_op, inputs):
         )
         slice_layer.set_input(1, start_tensor)
         slice_layer.set_input(2, size_tensor)
+        set_layer_name(slice_layer, paddle_op)
 
         outputs.append(slice_layer.get_output(0))
 
         # Update current_offset for the next slice
-        current_offset = trt_sum(network, current_offset, split_size)
+        current_offset = trt_sum(network, current_offset, split_size, name=[paddle_op.name(), 'current_offset'])
 
     return outputs
 
@@ -613,10 +632,10 @@ def split_converter(network, paddle_op, inputs):
 
     axis_value = get_input_constant_value(paddle_op, inputs, 2)
     if axis_value is not None:
-        axis_tensor = add_1D_constant_layer(network, axis_value)
+        axis_tensor = add_1D_constant_layer(network, axis_value, name=[paddle_op.name(), 'axis_tensor'])
     else:
         axis_tensor = inputs[2]
-        axis_tensor = cast_tensor(network, axis_tensor, trt.int32)
+        axis_tensor = cast_tensor(network, axis_tensor, trt.int32, name=[paddle_op.name(), 'axis_tensor'])
 
     # Retrieve and process sections
     sections_value = get_input_constant_value(paddle_op, inputs, 1)
@@ -628,31 +647,33 @@ def split_converter(network, paddle_op, inputs):
         dynamic_sections = True
 
     # Get the dynamic shape of the input tensor
-    input_shape_tensor = network.add_shape(input_tensor).get_output(0)
+    input_shape_tensor = network.add_shape(input_tensor)
+    set_layer_name(input_shape_tensor, paddle_op)
+    input_shape_tensor = input_shape_tensor.get_output(0)
 
     # Handle negative axis index
-    input_shape_size_tensor = add_1D_constant_layer(network, input_shape_size)
-    zero_tensor = add_1D_constant_layer(network, 0)
+    input_shape_size_tensor = add_1D_constant_layer(network, input_shape_size, name=[paddle_op.name(), 'input_shape_size_tensor'])
+    zero_tensor = add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'zero_tensor'])
 
-    is_negative_axis = trt_less(network, axis_tensor, zero_tensor)
-    is_negative_axis_int = cast_tensor(network, is_negative_axis, trt.int32)
+    is_negative_axis = trt_less(network, axis_tensor, zero_tensor, name=[paddle_op.name(), 'is_negative_axis'])
+    is_negative_axis_int = cast_tensor(network, is_negative_axis, trt.int32, name=[paddle_op.name(), 'is_negative_axis_int'])
 
     axis_adjustment = trt_prod(
-        network, is_negative_axis_int, input_shape_size_tensor
+        network, is_negative_axis_int, input_shape_size_tensor, name=[paddle_op.name(), 'axis_adjustment']
     )
-    axis_tensor = trt_sum(network, axis_tensor, axis_adjustment)
+    axis_tensor = trt_sum(network, axis_tensor, axis_adjustment, name=[paddle_op.name(), 'axis_tensor'])
 
     # Initialize output list
     outputs = []
-    offset = add_1D_constant_layer(network, 0)
+    offset = add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'offset'])
 
     if not dynamic_sections:
         for section_size in section_list:
-            section_size_tensor = add_1D_constant_layer(network, section_size)
+            section_size_tensor = add_1D_constant_layer(network, section_size, name=[paddle_op.name(), f'section_size_tensor_{section_size}'])
 
             # Build start_tensor
             start_tensor = build_start_tensor(
-                network, input_shape_size, axis_tensor, offset
+                network, input_shape_size, axis_tensor, offset, name=[paddle_op.name(), f'start_tensor_{section_size}']
             )
 
             # Build size_tensor
@@ -662,6 +683,7 @@ def split_converter(network, paddle_op, inputs):
                 axis_tensor,
                 section_size_tensor,
                 input_shape_tensor,
+                name=[paddle_op.name(), f'size_tensor_{section_size}'],
             )
             # Create Slice layer
             slice_layer = network.add_slice(
@@ -672,13 +694,16 @@ def split_converter(network, paddle_op, inputs):
             )
             slice_layer.set_input(1, start_tensor)
             slice_layer.set_input(2, size_tensor)
+            set_layer_name(slice_layer, paddle_op)
 
             outputs.append(slice_layer.get_output(0))
 
             # Update offset
             offset = network.add_elementwise(
                 offset, section_size_tensor, trt.ElementWiseOperation.SUM
-            ).get_output(0)
+            )
+            set_layer_name(offset, paddle_op)
+            offset = offset.get_output(0)
     else:
         # If sections is a dynamic tensor
         num_sections = sections_tensor.shape[0]
@@ -687,16 +712,18 @@ def split_converter(network, paddle_op, inputs):
         num_sections = int(num_sections)
 
         for idx in range(num_sections):
-            idx_tensor = add_1D_constant_layer(network, idx)
+            idx_tensor = add_1D_constant_layer(network, idx, name=[paddle_op.name(), f'idx_tensor_{idx}'])
 
             # Get section_size_tensor = sections_tensor[idx]
             section_size_tensor = network.add_gather(
                 sections_tensor, idx_tensor, axis=0
-            ).get_output(0)
+            )
+            set_layer_name(section_size_tensor, paddle_op)
+            section_size_tensor = section_size_tensor.get_output(0)
 
             # Build start_tensor
             start_tensor = build_start_tensor(
-                network, input_shape_size, axis_tensor, offset
+                network, input_shape_size, axis_tensor, offset, name=[paddle_op.name(), f'start_tensor_{idx}']
             )
 
             # Build size_tensor
@@ -706,6 +733,7 @@ def split_converter(network, paddle_op, inputs):
                 axis_tensor,
                 section_size_tensor,
                 input_shape_tensor,
+                name=[paddle_op.name(), f'size_tensor_{idx}'],
             )
 
             # Create Slice layer
@@ -717,13 +745,16 @@ def split_converter(network, paddle_op, inputs):
             )
             slice_layer.set_input(1, start_tensor)
             slice_layer.set_input(2, size_tensor)
+            set_layer_name(slice_layer, paddle_op)
 
             outputs.append(slice_layer.get_output(0))
 
             # Update offset
             offset = network.add_elementwise(
                 offset, section_size_tensor, trt.ElementWiseOperation.SUM
-            ).get_output(0)
+            )
+            set_layer_name(offset, paddle_op)
+            offset = offset.get_output(0)
 
     return outputs
 
@@ -744,32 +775,36 @@ def stack_converter(network, paddle_op, inputs):
     if axis < 0:
         axis += output_rank
 
-    shape_tensor = network.add_shape(input_tensors[0]).get_output(0)
+    shape_tensor = network.add_shape(input_tensors[0])
+    set_layer_name(shape_tensor, paddle_op)
+    shape_tensor = shape_tensor.get_output(0)
     shape_tensor_vec = []
     for i in range(output_rank):
         if i < axis:
             shape_tensor_vec.append(
-                get_shape_tensor_element(network, shape_tensor, i)
+                get_shape_tensor_element(network, shape_tensor, i, name=[paddle_op.name(), f'shape_tensor_vec_{i}'])
             )
         elif i > axis:
             shape_tensor_vec.append(
-                get_shape_tensor_element(network, shape_tensor, i - 1)
+                get_shape_tensor_element(network, shape_tensor, i - 1, name=[paddle_op.name(), f'shape_tensor_vec_{i}'])
             )
         else:
-            shape_tensor_vec.append(add_1D_constant_layer(network, 1))
+            shape_tensor_vec.append(add_1D_constant_layer(network, 1, name=[paddle_op.name(), f'shape_tensor_vec_{i}']))
 
-    after_shape_tensor = network.add_concatenation(shape_tensor_vec).get_output(
-        0
-    )
+    after_shape_tensor = network.add_concatenation(shape_tensor_vec)
+    set_layer_name(after_shape_tensor, paddle_op)
+    after_shape_tensor = after_shape_tensor.get_output(0)
 
     for i in range(input_num):
         shuffle_layer = network.add_shuffle(inputs[i])
         shuffle_layer.set_input(1, after_shape_tensor)
+        set_layer_name(shuffle_layer, [paddle_op.name(), f'shuffle_layer_{i}'])
         reshaped_tensor = shuffle_layer.get_output(0)
         inputs[i] = reshaped_tensor
 
     concat_layer = network.add_concatenation(inputs)
     concat_layer.axis = axis
+    set_layer_name(concat_layer, paddle_op)
     output_tensor = concat_layer.get_output(0)
 
     # Because we change tensor to 1-dim in 0-dim tensor situation when use trt,
@@ -778,7 +813,7 @@ def stack_converter(network, paddle_op, inputs):
         len(paddle_op.results()[0].shape) == 1
         and paddle_op.results()[0].shape[0] != -1
     ):
-        output_tensor = resize_to_1d(network, output_tensor)
+        output_tensor = resize_to_1d(network, output_tensor, name=[paddle_op.name(), 'output_tensor'])
     return output_tensor
 
 
@@ -786,34 +821,36 @@ def stack_converter(network, paddle_op, inputs):
 def tile_converter(network, paddle_op, inputs):
     input = inputs[0]
     input_shape = input.shape
-    input_shape_tensor = network.add_shape(input).get_output(0)
+    input_shape_tensor = network.add_shape(input)
+    set_layer_name(input_shape_tensor, paddle_op)
+    input_shape_tensor = input_shape_tensor.get_output(0)
     rank = len(input_shape)
 
     repeat_times = get_input_constant_value(paddle_op, inputs, 1)
     if repeat_times is not None:
-        repeat_tensor = add_1D_constant_layer(network, repeat_times)
+        repeat_tensor = add_1D_constant_layer(network, repeat_times, name=[paddle_op.name(), 'repeat_tensor'])
         repeat_rank = len(repeat_times)
     else:
         repeat_tensor = inputs[1]
-        repeat_tensor = resize_to_1d(network, repeat_tensor)
+        repeat_tensor = resize_to_1d(network, repeat_tensor, name=[paddle_op.name(), 'repeat_tensor'])
         repeat_shape = paddle_op.operands()[1].source().shape
         repeat_rank = repeat_shape[0]
 
     if rank > repeat_rank:
         one_rank_tensor = add_1D_constant_layer(
-            network, [1] * (rank - repeat_rank)
+            network, [1] * (rank - repeat_rank), name=[paddle_op.name(), 'one_rank_tensor']
         )
         repeat_expand_tensor = trt_concat(
-            network, [one_rank_tensor, repeat_tensor]
+            network, [one_rank_tensor, repeat_tensor], name=[paddle_op.name(), 'repeat_expand_tensor']
         )
     elif rank < repeat_rank:
         one_rank_tensor = add_1D_constant_layer(
-            network, [1] * (repeat_rank - rank)
+            network, [1] * (repeat_rank - rank), name=[paddle_op.name(), 'one_rank_tensor']
         )
         input_shape_tensor = trt_concat(
-            network, [one_rank_tensor, input_shape_tensor]
+            network, [one_rank_tensor, input_shape_tensor], name=[paddle_op.name(), 'input_shape_tensor']
         )
-        input = trt_reshape(network, input, input_shape_tensor, "", True)
+        input = trt_reshape(network, input, input_shape_tensor, name=[paddle_op.name(), 'input_shape_tensor'], is_shape_tensor=True)
         repeat_expand_tensor = repeat_tensor
     else:
         repeat_expand_tensor = repeat_tensor
@@ -822,11 +859,12 @@ def tile_converter(network, paddle_op, inputs):
     stride = [1] * max(rank, repeat_rank)
     output_shape = [0] * max(rank, repeat_rank)
     output_shape_tensor = trt_prod(
-        network, input_shape_tensor, repeat_expand_tensor
+        network, input_shape_tensor, repeat_expand_tensor, name=[paddle_op.name(), 'output_shape_tensor']
     )
 
     slice_layer = network.add_slice(input, start, output_shape, stride)
     slice_layer.set_input(2, output_shape_tensor)
+    set_layer_name(slice_layer, paddle_op)
 
     version_list = get_trt_version_list()
     if version_list >= [8, 6, 0]:
@@ -853,6 +891,7 @@ def take_along_axis_converter(network, paddle_op, inputs):
         input_tensor, index_tensor, trt.GatherMode.ELEMENT
     )
     gather_layer.axis = axis
+    set_layer_name(gather_layer, paddle_op)
 
     output_tensor = gather_layer.get_output(0)
 
@@ -884,36 +923,38 @@ def strided_slice_converter(network, paddle_op, inputs):
         if starts[i] < 0 or ends[i] < 0:
             has_neg_indices = True
 
-    shape_tensor = trt_shape(network, input_tensor)
-    start_tensor = add_1D_constant_layer(network, trt_start_dims)
+    shape_tensor = trt_shape(network, input_tensor, name=[paddle_op.name(), 'shape_tensor'])
+    start_tensor = add_1D_constant_layer(network, trt_start_dims, name=[paddle_op.name(), 'start_tensor'])
     if has_neg_indices:
-        start_tensor = fix_negative_indices(network, shape_tensor, start_tensor)
+        start_tensor = fix_negative_indices(network, shape_tensor, start_tensor, name=[paddle_op.name(), 'start_tensor'])
 
     end_vec_tensor = []
     for i in range(len(trt_end_dims)):
         end_vec_tensor.append(
-            get_shape_tensor_element(network, shape_tensor, i)
+            get_shape_tensor_element(network, shape_tensor, i, name=[paddle_op.name(), f'end_vec_tensor{i}'])
         )
 
     for i, trt_axis in enumerate(axes):
         if ends[i] >= 0:
-            end_vec_tensor[trt_axis] = add_1D_constant_layer(network, ends[i])
+            end_vec_tensor[trt_axis] = add_1D_constant_layer(network, ends[i], name=[paddle_op.name(), f'end_vec_tensor{i}'])
         else:
             end_vec_tensor[trt_axis] = trt_sum(
                 network,
                 end_vec_tensor[trt_axis],
-                add_1D_constant_layer(network, ends[i]),
+                add_1D_constant_layer(network, ends[i], name=[paddle_op.name(), f'end_vec_tensor{i}']),
+                name=[paddle_op.name(), f'end_vec_tensor{i}'],
             )
 
     size_tensor = trt_sub(
         network,
         start_tensor,
-        trt_min(network, trt_concat(network, end_vec_tensor), shape_tensor),
+        trt_min(network, trt_concat(network, end_vec_tensor, name=[paddle_op.name(), 'trt_concat']), shape_tensor, name=[paddle_op.name(), 'trt_min']),
+        name=[paddle_op.name(), 'size_tensor'],
     )
-    zero_t = add_1D_constant_layer(network, 0)
-    step_tensor = add_1D_constant_layer(network, trt_step_dims)
+    zero_t = add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'zero_t'])
+    step_tensor = add_1D_constant_layer(network, trt_step_dims, name=[paddle_op.name(), 'step_tensor'])
     size_tensor = trt_sub(
-        network, zero_t, trt_floor_div(network, size_tensor, step_tensor)
+        network, zero_t, trt_floor_div(network, size_tensor, step_tensor, name=[paddle_op.name(), 'trt_floor_div']), name=[paddle_op.name(), 'size_tensor']
     )
 
     layer = network.add_slice(
@@ -922,6 +963,7 @@ def strided_slice_converter(network, paddle_op, inputs):
     layer.set_input(1, start_tensor)
     layer.set_input(2, size_tensor)
     layer.set_input(3, step_tensor)
+    set_layer_name(layer, paddle_op)
     return layer.get_output(0)
 
 
@@ -935,50 +977,52 @@ def roll_converter(network, paddle_op, inputs):
         shifts = inputs[1]
 
     axis_size = len(axis)
-    input_shape_tensor = trt_shape(network, input_tensor)
+    input_shape_tensor = trt_shape(network, input_tensor, name=[paddle_op.name(), 'input_shape_tensor'])
 
     for i in range(axis_size):
         axi = axis[i]
         if isinstance(shifts, trt.ITensor):
-            shift = get_shape_tensor_element(network, shifts, i)
+            shift = get_shape_tensor_element(network, shifts, i, name=[paddle_op.name(), f'shift_{i}'])
             input_shift = shift
         else:
             shift = shifts[i]
-            input_shift = add_1D_constant_layer(network, shift)
-        input_axis = get_shape_tensor_element(network, input_shape_tensor, axi)
+            input_shift = add_1D_constant_layer(network, shift, name=[paddle_op.name(), f'input_shift_{i}'])
+        input_axis = get_shape_tensor_element(network, input_shape_tensor, axi, name=[paddle_op.name(), f'input_axis_{i}'])
 
         # 1.sub_value mod input_axis
-        input1 = trt_sub(network, input_axis, input_shift)
-        tmp_div_res = trt_floor_div(network, input1, input_axis)
-        tmp_prod_res = trt_prod(network, tmp_div_res, input_axis)
-        start = trt_sub(network, input1, tmp_prod_res)
+        input1 = trt_sub(network, input_axis, input_shift, name=[paddle_op.name(), f'input1_{i}'])
+        tmp_div_res = trt_floor_div(network, input1, input_axis, name=[paddle_op.name(), f'tmp_div_res_{i}'])
+        tmp_prod_res = trt_prod(network, tmp_div_res, input_axis, name=[paddle_op.name(), f'tmp_prod_res_{i}'])
+        start = trt_sub(network, input1, tmp_prod_res, name=[paddle_op.name(), f'start_{i}'])
         # 2.avoid start less than 0,start mod input_axis
-        start = trt_sum(network, start, input_axis)
-        tmp_div_res1 = trt_floor_div(network, start, input_axis)
-        tmp_prod_res1 = trt_prod(network, tmp_div_res1, input_axis)
-        start = trt_sub(network, start, tmp_prod_res1)
-        zero_tensor = add_1D_constant_layer(network, 0)
-        step = add_1D_constant_layer(network, 1)
+        start = trt_sum(network, start, input_axis, name=[paddle_op.name(), f'start_{i}'])
+        tmp_div_res1 = trt_floor_div(network, start, input_axis, name=[paddle_op.name(), f'tmp_div_res1_{i}'])
+        tmp_prod_res1 = trt_prod(network, tmp_div_res1, input_axis, name=[paddle_op.name(), f'tmp_prod_res1_{i}'])
+        start = trt_sub(network, start, tmp_prod_res1, name=[paddle_op.name(), f'start_{i}'])
+        zero_tensor = add_1D_constant_layer(network, 0, name=[paddle_op.name(), f'zero_tensor_{i}'])
+        step = add_1D_constant_layer(network, 1, name=[paddle_op.name(), f'step_{i}'])
         # 3.make index_tensor0
-        sub_qutient = trt_sub(network, input_axis, start)
-        quotient_tensor = trt_floor_div(network, sub_qutient, step)
-        start1 = get_shape_tensor_element(network, start, 0, is_scalar=True)
+        sub_qutient = trt_sub(network, input_axis, start, name=[paddle_op.name(), f'sub_qutient_{i}'])
+        quotient_tensor = trt_floor_div(network, sub_qutient, step, name=[paddle_op.name(), f'quotient_tensor_{i}'])
+        start1 = get_shape_tensor_element(network, start, 0, is_scalar=True, name=[paddle_op.name(), f'start1_{i}'])
         fill_layer0 = network.add_fill(shape=(), op=trt.FillOperation.LINSPACE)
         fill_layer0.set_input(0, quotient_tensor)
         fill_layer0.set_input(1, start1)
         fill_layer0.set_input(2, step)
+        set_layer_name(fill_layer0, paddle_op)
         index_tensor0 = fill_layer0.get_output(0)
         # 4.make index_tensor1
-        sub_qutient_tensor = trt_sub(network, start, zero_tensor)
-        quotient_tensor = trt_floor_div(network, sub_qutient_tensor, step)
-        start2 = add_1D_constant_layer(network, 0, is_scalar=True)
+        sub_qutient_tensor = trt_sub(network, start, zero_tensor, name=[paddle_op.name(), f'sub_qutient_tensor_{i}'])
+        quotient_tensor = trt_floor_div(network, sub_qutient_tensor, step, name=[paddle_op.name(), f'quotient_tensor_{i}'])
+        start2 = add_1D_constant_layer(network, 0, is_scalar=True, name=[paddle_op.name(), f'start2_{i}'])
         fill_layer1 = network.add_fill(shape=(), op=trt.FillOperation.LINSPACE)
         fill_layer1.set_input(0, quotient_tensor)
         fill_layer1.set_input(1, start2)
         fill_layer1.set_input(2, step)
+        set_layer_name(fill_layer1, paddle_op)
         index_tensor1 = fill_layer1.get_output(0)
         itensors = [index_tensor0, index_tensor1]
-        concat_input_tensor = trt_concat(network, itensors)
+        concat_input_tensor = trt_concat(network, itensors, name=[paddle_op.name(), 'concat_input_tensor'])
         if i == 0:
             layer = network.add_gather(
                 input=input_tensor, indices=concat_input_tensor, axis=axi
@@ -987,6 +1031,7 @@ def roll_converter(network, paddle_op, inputs):
             layer = network.add_gather(
                 input=layer.get_output(0), indices=concat_input_tensor, axis=axi
             )
+        set_layer_name(layer, paddle_op)
 
     return layer.get_output(0)
 
@@ -999,6 +1044,7 @@ def pad_converter(network, paddle_op, inputs):
     pre_pad = [paddings[pad_size - 4], paddings[pad_size - 2]]
     post_pad = [paddings[pad_size - 3], paddings[pad_size - 1]]
     layer = network.add_padding_nd(input_tensor, pre_pad, post_pad)
+    set_layer_name(layer, paddle_op)
     return layer.get_output(0)
 
 
@@ -1016,31 +1062,35 @@ def pad3d_converter(network, paddle_op, inputs):
 
     shuffle_index = [4, 2, 0, 5, 3, 1]
     shuffle_inputs = [
-        get_shape_tensor_element(network, paddings, shuffle_index[i])
+        get_shape_tensor_element(network, paddings, shuffle_index[i], name=[paddle_op.name(), f'shuffle_inputs_{i}'])
         for i in range(pad_size)
     ]
-    paddings = trt_concat(network, shuffle_inputs)
+    paddings = trt_concat(network, shuffle_inputs, name=[paddle_op.name(), 'paddings'])
 
-    pre_zeros = add_1D_constant_layer(network, [0, 0])
+    pre_zeros = add_1D_constant_layer(network, [0, 0], name=[paddle_op.name(), 'pre_zeros'])
     start_slice1 = [0]
     start_slice2 = [3]
     size_slice = [3]
     stride_slice = [1]
     pre_pad = network.add_slice(
         paddings, start_slice1, size_slice, stride_slice
-    ).get_output(0)
-    pre_pad = trt_concat(network, [pre_zeros, pre_pad])
+    )
+    set_layer_name(pre_pad, paddle_op)
+    pre_pad = pre_pad.get_output(0)
+    pre_pad = trt_concat(network, [pre_zeros, pre_pad], name=[paddle_op.name(), 'pre_pad'])
     post_pad = network.add_slice(
         paddings, start_slice2, size_slice, stride_slice
-    ).get_output(0)
-    post_pad = trt_concat(network, [pre_zeros, post_pad])
+    )
+    set_layer_name(post_pad, paddle_op)
+    post_pad = post_pad.get_output(0)
+    post_pad = trt_concat(network, [pre_zeros, post_pad], name=[paddle_op.name(), 'post_pad'])
 
-    zeros = add_1D_constant_layer(network, [0] * input_dim)
+    zeros = add_1D_constant_layer(network, [0] * input_dim, name=[paddle_op.name(), 'zeros'])
 
-    start = trt_sub(network, zeros, pre_pad)
-    total_padding = trt_sum(network, pre_pad, post_pad)
-    input_shape = trt_shape(network, input_tensor)
-    size = trt_sum(network, input_shape, total_padding)
+    start = trt_sub(network, zeros, pre_pad, name=[paddle_op.name(), 'start'])
+    total_padding = trt_sum(network, pre_pad, post_pad, name=[paddle_op.name(), 'total_padding'])
+    input_shape = trt_shape(network, input_tensor, name=[paddle_op.name(), 'input_shape'])
+    size = trt_sum(network, input_shape, total_padding, name=[paddle_op.name(), 'size'])
 
     # Add slice layer
     stride = [1] * input_dim
@@ -1048,6 +1098,7 @@ def pad3d_converter(network, paddle_op, inputs):
     slice_layer = network.add_slice(input_tensor, dummy, dummy, stride)
     slice_layer.set_input(1, start)
     slice_layer.set_input(2, size)
+    set_layer_name(slice_layer, paddle_op)
 
     # Set padding mode
     if padding_mode == "constant":
@@ -1059,12 +1110,12 @@ def pad3d_converter(network, paddle_op, inputs):
                 trt.DataType.INT8,
             ):
                 fill_value = add_1D_constant_layer(
-                    network, value, dtype=np.float32
+                    network, value, dtype=np.float32, name=[paddle_op.name(), 'fill_value']
                 )
             else:
                 value_int = int(value)
                 fill_value = add_1D_constant_layer(
-                    network, value_int, dtype=np.int32
+                    network, value_int, dtype=np.int32, name=[paddle_op.name(), 'fill_value']
                 )
             slice_layer.set_input(4, fill_value)
     elif padding_mode == "reflect":
@@ -1080,10 +1131,13 @@ def pad3d_converter(network, paddle_op, inputs):
 @converter_registry.register("pd_op.numel", trt_version="8.x")
 def numel_converter(network, paddle_op, inputs):
     input_tensor = inputs[0]
-    shape_tensor = network.add_shape(input_tensor).get_output(0)
+    shape_tensor = network.add_shape(input_tensor)
+    set_layer_name(shape_tensor, paddle_op)
+    shape_tensor = shape_tensor.get_output(0)
     layer = network.add_reduce(
         shape_tensor, trt.ReduceOperation.PROD, axes=1, keep_dims=False
     )
+    set_layer_name(layer, paddle_op)
     return layer.get_output(0)
 
 
@@ -1091,7 +1145,7 @@ def numel_converter(network, paddle_op, inputs):
 def index_put_converter(network, paddle_op, inputs):
     input_tensor, indices_list, value_tensor = inputs
     indices_tensor = indices_list[0]
-    input_shape_tensor = trt_shape(network, input_tensor)
+    input_shape_tensor = trt_shape(network, input_tensor, name=[paddle_op.name(), 'input_shape_tensor'])
     input_dims = input_tensor.shape
     indices_dims = indices_tensor.shape
     rank = len(input_dims)
@@ -1099,25 +1153,26 @@ def index_put_converter(network, paddle_op, inputs):
     # indices
     indices_shape_vec = [
         add_1D_constant_layer(
-            network, indices_dims[i] if i < len(indices_dims) else 1
+            network, indices_dims[i] if i < len(indices_dims) else 1, name=[paddle_op.name(), f'indices_shape_vec_{i}']
         )
         for i in range(rank)
     ]
-    start_tensor_vec = [add_1D_constant_layer(network, 0)] * rank
-    stride_tensor_vec = [add_1D_constant_layer(network, 1)] * rank
+    start_tensor_vec = [add_1D_constant_layer(network, 0, name=[paddle_op.name(), f'start_tensor_vec_{i}']) for i in range(rank)]
+    stride_tensor_vec = [add_1D_constant_layer(network, 1, name=[paddle_op.name(), f'stride_tensor_vec_{i}']) for i in range(rank)]
     indices_tensor_temp = trt_reshape(
         network,
         indices_tensor,
-        trt_concat(network, indices_shape_vec),
+        trt_concat(network, indices_shape_vec, name=[paddle_op.name(), 'indices_shape_vec']),
+        name=[paddle_op.name(), 'indices_tensor_temp'],
         is_shape_tensor=True,
     )
-    start_tensor = trt_concat(network, start_tensor_vec)
-    stride_tensor = trt_concat(network, stride_tensor_vec)
+    start_tensor = trt_concat(network, start_tensor_vec, name=[paddle_op.name(), 'start_tensor'])
+    stride_tensor = trt_concat(network, stride_tensor_vec, name=[paddle_op.name(), 'stride_tensor'])
 
     # slice
     stride = [1] * rank
     indices_slice_layer = network.add_slice(
-        trt_cast(network, indices_tensor_temp, trt.float32),
+        trt_cast(network, indices_tensor_temp, trt.float32, name=[paddle_op.name(), 'indices_tensor_temp']),
         stride,
         stride,
         stride,
@@ -1126,21 +1181,24 @@ def index_put_converter(network, paddle_op, inputs):
     indices_slice_layer.set_input(2, input_shape_tensor)
     indices_slice_layer.set_input(3, stride_tensor)
     indices_slice_layer.mode = trt.SampleMode.CLAMP
+    set_layer_name(indices_slice_layer, paddle_op)
 
     bool_indices_tensor = trt_cast(
-        network, indices_slice_layer.get_output(0), trt.bool
+        network, indices_slice_layer.get_output(0), trt.bool, name=[paddle_op.name(), 'bool_indices_tensor']
     )
 
     # nonzero
     nonzero_layer = network.add_non_zero(bool_indices_tensor)
+    set_layer_name(nonzero_layer, paddle_op)
     indices_tensor = nonzero_layer.get_output(0)
     permutation = trt.Permutation([1, 0])
     trans_layer = network.add_shuffle(indices_tensor)
     trans_layer.first_transpose = permutation
+    set_layer_name(trans_layer, paddle_op)
     indices_tensor = trans_layer.get_output(0)
-    indices_new_shape_tensor = trt_shape(network, indices_tensor)
+    indices_new_shape_tensor = trt_shape(network, indices_tensor, name=[paddle_op.name(), 'indices_new_shape_tensor'])
     indices_count_tensor = get_shape_tensor_element(
-        network, indices_new_shape_tensor, 0
+        network, indices_new_shape_tensor, 0, name=[paddle_op.name(), 'indices_count_tensor']
     )
 
     # value
@@ -1148,13 +1206,15 @@ def index_put_converter(network, paddle_op, inputs):
     value_slice_layer = network.add_slice(
         value_tensor, value_stride, value_stride, value_stride
     )
-    value_slice_layer.set_input(1, add_1D_constant_layer(network, 0))
+    value_slice_layer.set_input(1, add_1D_constant_layer(network, 0, name=[paddle_op.name(), 'value_slice_layer_start']))
     value_slice_layer.set_input(2, indices_count_tensor)
-    value_slice_layer.set_input(3, add_1D_constant_layer(network, 1))
+    value_slice_layer.set_input(3, add_1D_constant_layer(network, 1, name=[paddle_op.name(), 'value_slice_layer_stride']))
     value_slice_layer.mode = trt.SampleMode.CLAMP
+    set_layer_name(value_slice_layer, paddle_op)
     value_tensor = value_slice_layer.get_output(0)
 
     layer = network.add_scatter(
         input_tensor, indices_tensor, value_tensor, trt.ScatterMode.ND
     )
+    set_layer_name(layer, paddle_op)
     return layer.get_output(0)

--- a/python/paddle/tensorrt/impls/norm.py
+++ b/python/paddle/tensorrt/impls/norm.py
@@ -166,6 +166,7 @@ def instance_norm_converter(network, paddle_op, inputs):
         plugin_name, plugin_field_collection, plugin_version
     )
     instance_norm_layer = network.add_plugin_v2(instance_norm_inputs, plugin)
+    set_layer_name(instance_norm_layer, paddle_op)
     return instance_norm_layer.get_output(0)
 
 
@@ -237,6 +238,7 @@ def fused_bias_dropout_residual_layer_norm_converter(
     )
     plugin_inputs = [input1, input2]
     layer = network.add_plugin_v2(plugin_inputs, plugin)
+    set_layer_name(layer, paddle_op)
     return layer.get_output(0)
 
 
@@ -257,20 +259,49 @@ def group_norm_converter(network, paddle_op, inputs):
     for d in range(2, rank_x):
         axes_mask |= 1 << d
 
-    weight_one = add_1D_constant_layer(network, 1.0, np.float32)
-    bias_zero = add_1D_constant_layer(network, 0.0, np.float32)
-    fake_shape = add_1D_constant_layer(network, fake_shape, np.int32)
-    weight_one = trt_expand(network, weight_one, 1, fake_shape, rank_x)
-    bias_zero = trt_expand(network, bias_zero, 1, fake_shape, rank_x)
+    weight_one = add_1D_constant_layer(
+        network, 1.0, np.float32, name=[paddle_op.name(), 'weight_one']
+    )
+    bias_zero = add_1D_constant_layer(
+        network, 0.0, np.float32, name=[paddle_op.name(), 'bias_zero']
+    )
+    fake_shape = add_1D_constant_layer(
+        network, fake_shape, np.int32, name=[paddle_op.name(), 'fake_shape']
+    )
+    weight_one = trt_expand(
+        network,
+        weight_one,
+        1,
+        fake_shape,
+        rank_x,
+        name=[paddle_op.name(), 'weight_one'],
+    )
+    bias_zero = trt_expand(
+        network,
+        bias_zero,
+        1,
+        fake_shape,
+        rank_x,
+        name=[paddle_op.name(), 'bias_zero'],
+    )
     layer = network.add_normalization(x, weight_one, bias_zero, axes_mask)
     layer.num_groups = groups
     layer.epsilon = eps
+    set_layer_name(layer, paddle_op)
     output = layer.get_output(0)
     if scale is not None:
-        scale = trt_reshape(network, scale, broadcast_shape)
-        output = trt_prod(network, output, scale)
+        scale = trt_reshape(
+            network, scale, broadcast_shape, name=[paddle_op.name(), 'scale']
+        )
+        output = trt_prod(
+            network, output, scale, name=[paddle_op.name(), 'output']
+        )
     if bias is not None:
-        bias = trt_reshape(network, bias, broadcast_shape)
-        output = trt_sum(network, output, bias)
+        bias = trt_reshape(
+            network, bias, broadcast_shape, name=[paddle_op.name(), 'bias']
+        )
+        output = trt_sum(
+            network, output, bias, name=[paddle_op.name(), 'output']
+        )
 
     return output

--- a/python/paddle/tensorrt/impls/ops.py
+++ b/python/paddle/tensorrt/impls/ops.py
@@ -18,6 +18,7 @@ import tensorrt as trt
 from paddle.tensorrt.converter_utils import (
     WithFp16,
     get_trt_plugin,
+    set_layer_name,
     unary_op_converter,
 )
 from paddle.tensorrt.register import converter_registry
@@ -103,6 +104,7 @@ def roi_align_converter(network, paddle_op, inputs):
     )
     roi_align_inputs = [x, rois]
     roi_align_layer = network.add_plugin_v2(roi_align_inputs, plugin)
+    set_layer_name(roi_align_layer, paddle_op)
     return roi_align_layer.get_output(0)
 
 
@@ -175,6 +177,7 @@ def YoloBoxOpConverter(network, paddle_op, inputs):
 
     yolo_box_inputs = [x, imgSize]
     yolo_box_layer = network.add_plugin_v2(yolo_box_inputs, plugin)
+    set_layer_name(yolo_box_layer, paddle_op)
     out0 = yolo_box_layer.get_output(0)
     out1 = yolo_box_layer.get_output(1)
     return (out0, out1)
@@ -255,4 +258,5 @@ def deformable_conv_converter(network, paddle_op, inputs):
     deformable_conv_layer = network.add_plugin_v2(
         [inputs[0], inputs[1], inputs[3]], plugin
     )
+    set_layer_name(deformable_conv_layer, paddle_op)
     return deformable_conv_layer.get_output(0)

--- a/python/paddle/tensorrt/impls/others.py
+++ b/python/paddle/tensorrt/impls/others.py
@@ -24,6 +24,7 @@ from paddle.tensorrt.converter_utils import (
     get_input_constant_value,
     get_shape_tensor_element,
     get_trt_plugin,
+    set_layer_name,
     trt_concat,
     trt_div,
     trt_gather,
@@ -57,9 +58,11 @@ def multiclass_nms3_converter(network, paddle_op, inputs):
     bboxes_expand_dims = [bboxes_dims[0], bboxes_dims[1], 1, bboxes_dims[2]]
     bboxes_expand_layer = network.add_shuffle(bboxes)
     bboxes_expand_layer.reshape_dims = trt.Dims(bboxes_expand_dims)
+    set_layer_name(bboxes_expand_layer, paddle_op)
 
     scores_transpose_layer = network.add_shuffle(scores)
     scores_transpose_layer.first_transpose = (0, 2, 1)
+    set_layer_name(scores_transpose_layer, paddle_op)
 
     # create multiclass num3 plugin
     batch_nms_inputs = [
@@ -120,13 +123,16 @@ def multiclass_nms3_converter(network, paddle_op, inputs):
         plugin_name, plugin_field_collection, plugin_version
     )
     batch_nms_layer = network.add_plugin_v2(batch_nms_inputs, plugin)
+    set_layer_name(batch_nms_layer, paddle_op)
 
     # dynamic shape: [bs, keep_topk, 4], [bs, keep_topk], [bs, keep_topk]
     nmsed_boxes = batch_nms_layer.get_output(1)
     nmsed_scores = batch_nms_layer.get_output(2)
     nmsed_classes = batch_nms_layer.get_output(3)
     nmsed_scores_transpose_layer = network.add_shuffle(nmsed_scores)
+    set_layer_name(nmsed_scores_transpose_layer, paddle_op)
     nmsed_classes_reshape_layer = network.add_shuffle(nmsed_classes)
+    set_layer_name(nmsed_classes_reshape_layer, paddle_op)
     nmsed_scores_transpose_layer.reshape_dims = trt.Dims(
         [bboxes_dims[0], keep_top_k, 1]
     )
@@ -141,15 +147,18 @@ def multiclass_nms3_converter(network, paddle_op, inputs):
     ]
     nms_concat_layer = network.add_concatenation(inputs=concat_inputs)
     nms_concat_layer.axis = 2
+    set_layer_name(nms_concat_layer, paddle_op)
     nms_concat_output = nms_concat_layer.get_output(0)
     nms_shuffle_layer = network.add_shuffle(nms_concat_output)
     nms_shuffle_layer.reshape_dims = trt.Dims(
         [bboxes_dims[0], nms_concat_output.shape[-1]]
     )
+    set_layer_name(nms_shuffle_layer, paddle_op)
 
     # add fake index as output to be consistent with the outputs of multiclass_nms3
     shape_weight = trt.Weights(np.array([0], dtype=np.int32))
     constant_layer = network.add_constant([1, 1], shape_weight)
+    set_layer_name(constant_layer, paddle_op)
 
     return (
         nms_shuffle_layer.get_output(0),
@@ -196,18 +205,37 @@ def set_value_converter(network, paddle_op, inputs):
         updates = inputs[1]
     else:
         value = paddle_op.attrs().get("values")
-        input_shape_tensor = trt_shape(network, x)
+        input_shape_tensor = trt_shape(
+            network, x, name=[paddle_op.name(), 'input_shape_tensor']
+        )
         vec_tensor = []
         for i in range(len(input_dims)):
             vec_tensor.append(
-                get_shape_tensor_element(network, input_shape_tensor, i)
+                get_shape_tensor_element(
+                    network,
+                    input_shape_tensor,
+                    i,
+                    name=[paddle_op.name(), f'vec_tensor_{i}'],
+                )
             )
 
         axes_vec = [(ends - 1 - starts) / steps + 1]
-        vec_tensor[axes] = add_1D_constant_layer(network, axes_vec)
-        output_shape_tensor = trt_concat(network, vec_tensor, 0)
+        vec_tensor[axes] = add_1D_constant_layer(
+            network, axes_vec, name=[paddle_op.name(), f'vec_tensor_{axes}']
+        )
+        output_shape_tensor = trt_concat(
+            network,
+            vec_tensor,
+            0,
+            name=[paddle_op.name(), 'output_shape_tensor'],
+        )
         updates = fill_constant_layer(
-            network, output_shape_tensor, len(x.shape), value, x.dtype
+            network,
+            output_shape_tensor,
+            len(x.shape),
+            value,
+            x.dtype,
+            name=[paddle_op.name(), 'updates'],
         )
 
     _logger.info(f"Set_value_op: input's dimension is {input_dims}")
@@ -245,10 +273,15 @@ def set_value_converter(network, paddle_op, inputs):
 
     shape_0 = [1] * len(update_dims)
     shape_weight = trt.Weights(np.array([0], dtype=np.float32))
-    zero_tensor = network.add_constant(shape_0, shape_weight).get_output(0)
+    zero_tensor = network.add_constant(shape_0, shape_weight)
+    set_layer_name(zero_tensor, paddle_op)
+    zero_tensor = zero_tensor.get_output(0)
 
-    indice_tensor = trt_prod(network, zero_tensor, updates)
+    indice_tensor = trt_prod(
+        network, zero_tensor, updates, name=[paddle_op.name(), 'indice_tensor']
+    )
     cast_layer = network.add_identity(indice_tensor)
+    set_layer_name(cast_layer, paddle_op)
     cast_layer.set_output_type(0, trt.int32)
     indice_tensor = cast_layer.get_output(0)
 
@@ -258,12 +291,20 @@ def set_value_converter(network, paddle_op, inputs):
     for i in range(starts, ends, steps):
         tmp_1.append(i)
     shape_weight = trt.Weights(np.array(tmp_1, dtype=np.int32))
-    one_tensor = network.add_constant(shape_1, shape_weight).get_output(0)
+    one_tensor = network.add_constant(shape_1, shape_weight)
+    set_layer_name(one_tensor, paddle_op)
+    one_tensor = one_tensor.get_output(0)
 
-    indice_tensor = trt_sum(network, indice_tensor, one_tensor)
+    indice_tensor = trt_sum(
+        network,
+        indice_tensor,
+        one_tensor,
+        name=[paddle_op.name(), 'indice_tensor'],
+    )
     layer = network.add_scatter(
         x, indice_tensor, updates, trt.ScatterMode.ELEMENT
     )
+    set_layer_name(layer, paddle_op)
     layer.axis = axes
     return layer.get_output(0)
 
@@ -274,6 +315,7 @@ def share_data_converter(network, paddle_op, inputs):
     x = inputs[0]
 
     identity_layer = network.add_identity(x)
+    set_layer_name(identity_layer, paddle_op)
 
     return identity_layer.get_output(0)
 
@@ -289,6 +331,7 @@ def temporal_shift_converter(network, paddle_op, inputs):
         # Transpose input to [N, C, H, W]
         transpose_layer = network.add_shuffle(input_tensor)
         transpose_layer.first_transpose = trt.Permutation([0, 3, 1, 2])
+        set_layer_name(transpose_layer, paddle_op)
         input_tensor = transpose_layer.get_output(0)
 
     input_dims = input_tensor.shape
@@ -297,23 +340,37 @@ def temporal_shift_converter(network, paddle_op, inputs):
     # Reshape input to [N, T, C, H, W]
     reshape_layer = network.add_shuffle(input_tensor)
     reshape_layer.reshape_dims = trt.Dims([-1, T, C, H, W])
+    set_layer_name(reshape_layer, paddle_op)
     input_tensor = reshape_layer.get_output(0)
 
     # Pad input to [N, T + 2, C, H, W]
-    pre_pad = add_1D_constant_layer(network, [0, 1, 0, 0, 0])
-    post_pad = add_1D_constant_layer(network, [0, 1, 0, 0, 0])
+    pre_pad = add_1D_constant_layer(
+        network, [0, 1, 0, 0, 0], name=[paddle_op.name(), 'pre_pad']
+    )
+    post_pad = add_1D_constant_layer(
+        network, [0, 1, 0, 0, 0], name=[paddle_op.name(), 'post_pad']
+    )
     dims = 5
-    zeros = add_1D_constant_layer(network, [0] * dims)
-    start = trt_sub(network, zeros, pre_pad)
-    total_padding = trt_sum(network, pre_pad, post_pad)
-    input_shape = trt_shape(network, input_tensor)
-    size = trt_sum(network, input_shape, total_padding)
+    zeros = add_1D_constant_layer(
+        network, [0] * dims, name=[paddle_op.name(), 'zeros']
+    )
+    start = trt_sub(network, zeros, pre_pad, name=[paddle_op.name(), 'start'])
+    total_padding = trt_sum(
+        network, pre_pad, post_pad, name=[paddle_op.name(), 'total_padding']
+    )
+    input_shape = trt_shape(
+        network, input_tensor, name=[paddle_op.name(), 'input_shape']
+    )
+    size = trt_sum(
+        network, input_shape, total_padding, name=[paddle_op.name(), 'size']
+    )
     stride = [1] * dims
     dummy = stride
 
     slice_layer = network.add_slice(input_tensor, dummy, dummy, stride)
     slice_layer.set_input(1, start)
     slice_layer.set_input(2, size)
+    set_layer_name(slice_layer, paddle_op)
 
     trt_version = trt.__version__.split('.')
     if int(trt_version[0]) > 8 or (
@@ -327,40 +384,71 @@ def temporal_shift_converter(network, paddle_op, inputs):
     slice_c2 = int(C * shift_ratio * 2)
 
     slice_start1 = zeros
-    slice_start2 = add_1D_constant_layer(network, [0, 2, slice_c, 0, 0])
-    slice_start3 = add_1D_constant_layer(network, [0, 1, slice_c2, 0, 0])
-
-    slice_size_base = trt_shape(network, input_tensor)
-    sub_size1 = add_1D_constant_layer(network, [0, 0, C - slice_c, 0, 0])
-    sub_size2 = add_1D_constant_layer(
-        network, [0, 0, C + slice_c - slice_c2, 0, 0]
+    slice_start2 = add_1D_constant_layer(
+        network, [0, 2, slice_c, 0, 0], name=[paddle_op.name(), 'slice_start2']
     )
-    sub_size3 = add_1D_constant_layer(network, [0, 0, slice_c2, 0, 0])
+    slice_start3 = add_1D_constant_layer(
+        network, [0, 1, slice_c2, 0, 0], name=[paddle_op.name(), 'slice_start3']
+    )
 
-    slice_size1 = trt_sub(network, slice_size_base, sub_size1)
-    slice_size2 = trt_sub(network, slice_size_base, sub_size2)
-    slice_size3 = trt_sub(network, slice_size_base, sub_size3)
+    slice_size_base = trt_shape(
+        network, input_tensor, name=[paddle_op.name(), 'slice_size_base']
+    )
+    sub_size1 = add_1D_constant_layer(
+        network, [0, 0, C - slice_c, 0, 0], name=[paddle_op.name(), 'sub_size1']
+    )
+    sub_size2 = add_1D_constant_layer(
+        network,
+        [0, 0, C + slice_c - slice_c2, 0, 0],
+        name=[paddle_op.name(), 'sub_size2'],
+    )
+    sub_size3 = add_1D_constant_layer(
+        network, [0, 0, slice_c2, 0, 0], name=[paddle_op.name(), 'sub_size3']
+    )
+
+    slice_size1 = trt_sub(
+        network,
+        slice_size_base,
+        sub_size1,
+        name=[paddle_op.name(), 'slice_size1'],
+    )
+    slice_size2 = trt_sub(
+        network,
+        slice_size_base,
+        sub_size2,
+        name=[paddle_op.name(), 'slice_size2'],
+    )
+    slice_size3 = trt_sub(
+        network,
+        slice_size_base,
+        sub_size3,
+        name=[paddle_op.name(), 'slice_size3'],
+    )
 
     slice1_layer = network.add_slice(
         slice_layer.get_output(0), start=dummy, shape=dummy, stride=stride
     )
     slice1_layer.set_input(1, slice_start1)
     slice1_layer.set_input(2, slice_size1)
+    set_layer_name(slice1_layer, paddle_op)
     slice2_layer = network.add_slice(
         slice_layer.get_output(0), start=dummy, shape=dummy, stride=stride
     )
     slice2_layer.set_input(1, slice_start2)
     slice2_layer.set_input(2, slice_size2)
+    set_layer_name(slice2_layer, paddle_op)
     slice3_layer = network.add_slice(
         slice_layer.get_output(0), start=dummy, shape=dummy, stride=stride
     )
     slice3_layer.set_input(1, slice_start3)
     slice3_layer.set_input(2, slice_size3)
+    set_layer_name(slice3_layer, paddle_op)
 
     concat_inputs = [slice2_layer.get_output(0), slice3_layer.get_output(0)]
     if slice_c == 0:
         concat_layer = network.add_concatenation(concat_inputs)
         concat_layer.axis = 2
+        set_layer_name(concat_layer, paddle_op)
     else:
         concat_inputs = [
             slice1_layer.get_output(0),
@@ -369,14 +457,17 @@ def temporal_shift_converter(network, paddle_op, inputs):
         ]
         concat_layer = network.add_concatenation(concat_inputs)
         concat_layer.axis = 2
+        set_layer_name(concat_layer, paddle_op)
 
     # Reshape output to [N*T,C,H,W]
     reshape_layer3 = network.add_shuffle(concat_layer.get_output(0))
     reshape_layer3.reshape_dims = trt.Dims([-1, C, H, W])
+    set_layer_name(reshape_layer3, paddle_op)
 
     if data_format == "NHWC":
         transpose_layer2 = network.add_shuffle(reshape_layer3.get_output(0))
         transpose_layer2.first_transpose = trt.Permutation([0, 2, 3, 1])
+        set_layer_name(transpose_layer2, paddle_op)
         output_tensor = transpose_layer2.get_output(0)
     else:
         output_tensor = reshape_layer3.get_output(0)
@@ -439,6 +530,7 @@ def anchor_generator_converter(network, paddle_op, inputs):
         plugin_name, plugin_field_collection, plugin_version
     )
     anchor_generator_layer = network.add_plugin_v2([inputs], plugin)
+    set_layer_name(anchor_generator_layer, paddle_op)
     out0 = anchor_generator_layer.get_output(0)
     out1 = anchor_generator_layer.get_output(1)
     return (out0, out1)
@@ -456,6 +548,7 @@ def affine_channel_converter(network, paddle_op, inputs):
         # Permute NHWC to NCHW
         shuffle_layer1 = network.add_shuffle(x)
         shuffle_layer1.first_transpose = (0, 3, 1, 2)
+        set_layer_name(shuffle_layer1, paddle_op)
         x_input = shuffle_layer1.get_output(0)
         channel_axis = 1
     else:
@@ -482,6 +575,7 @@ def affine_channel_converter(network, paddle_op, inputs):
         power=power_weights,
         channel_axis=channel_axis,
     )
+    set_layer_name(layer, paddle_op)
     if not layer:
         raise RuntimeError("affine_channel: add_scale_nd failed.")
 
@@ -490,6 +584,7 @@ def affine_channel_converter(network, paddle_op, inputs):
     if data_layout == "NHWC":
         shuffle_layer2 = network.add_shuffle(out_tensor)
         shuffle_layer2.first_transpose = (0, 2, 3, 1)
+        set_layer_name(shuffle_layer2, paddle_op)
         out_tensor = shuffle_layer2.get_output(0)
 
     return out_tensor
@@ -499,33 +594,55 @@ def affine_channel_converter(network, paddle_op, inputs):
 def shuffle_channel_converter(network, paddle_op, inputs):
     input = inputs[0]
     group = paddle_op.attrs().get("group")
-    input_shape_tensor = trt_shape(network, input)
+    input_shape_tensor = trt_shape(
+        network, input, name=[paddle_op.name(), 'input_shape_tensor']
+    )
     batch_shape_tensor = get_shape_tensor_element(
-        network, input_shape_tensor, 0
+        network,
+        input_shape_tensor,
+        0,
+        name=[paddle_op.name(), 'batch_shape_tensor'],
     )
     channel_shape_tensor = get_shape_tensor_element(
-        network, input_shape_tensor, 1
+        network,
+        input_shape_tensor,
+        1,
+        name=[paddle_op.name(), 'channel_shape_tensor'],
     )
-    group_tensor = add_1D_constant_layer(network, group)
+    group_tensor = add_1D_constant_layer(
+        network, group, name=[paddle_op.name(), 'group_tensor']
+    )
     new_channel_shape_tensor = trt_div(
-        network, channel_shape_tensor, group_tensor
+        network,
+        channel_shape_tensor,
+        group_tensor,
+        name=[paddle_op.name(), 'new_channel_shape_tensor'],
     )
     shape_dim2 = [2, 3]
-    shape_dim2_tensor = trt_gather(network, input_shape_tensor, shape_dim2)
+    shape_dim2_tensor = trt_gather(
+        network,
+        input_shape_tensor,
+        shape_dim2,
+        name=[paddle_op.name(), 'shape_dim2_tensor'],
+    )
     itensors = [
         batch_shape_tensor,
         group_tensor,
         new_channel_shape_tensor,
         shape_dim2_tensor,
     ]
-    reshape_tensor = trt_concat(network, itensors)
+    reshape_tensor = trt_concat(
+        network, itensors, name=[paddle_op.name(), 'reshape_tensor']
+    )
     layer = network.add_shuffle(input)
     layer.set_input(1, reshape_tensor)
     transpose_embed = trt.Permutation([0, 2, 1, 3, 4])
     layer.second_transpose = transpose_embed
+    set_layer_name(layer, paddle_op)
     output = layer.get_output(0)
     output_layer = network.add_shuffle(output)
     output_layer.set_input(1, input_shape_tensor)
+    set_layer_name(output_layer, paddle_op)
     return output_layer.get_output(0)
 
 
@@ -538,32 +655,56 @@ def full_batch_size_like_converter(network, paddle_op, inputs):
     shape = paddle_op.attrs().get("shape")
     value = float(value)
 
-    input_shape_tensor = trt_shape(network, input)
+    input_shape_tensor = trt_shape(
+        network, input, name=[paddle_op.name(), 'input_shape_tensor']
+    )
     batch_tensor = get_shape_tensor_element(
-        network, input_shape_tensor, input_dim_idx
+        network,
+        input_shape_tensor,
+        input_dim_idx,
+        name=[paddle_op.name(), 'batch_tensor'],
     )
 
-    shape_attr_tensor = add_1D_constant_layer(network, shape)
+    shape_attr_tensor = add_1D_constant_layer(
+        network, shape, name=[paddle_op.name(), 'shape_attr_tensor']
+    )
 
     gather_output_shape_indices = [
         len(shape) if i == output_dim_idx else i for i in range(len(shape))
     ]
 
     concat_inputs = [shape_attr_tensor, batch_tensor]
-    concat_tensor = trt_concat(network, concat_inputs)
+    concat_tensor = trt_concat(
+        network, concat_inputs, name=[paddle_op.name(), 'concat_tensor']
+    )
     out_shape_tensor = trt_gather(
-        network, concat_tensor, gather_output_shape_indices
+        network,
+        concat_tensor,
+        gather_output_shape_indices,
+        name=[paddle_op.name(), 'out_shape_tensor'],
     )
 
     layer = network.add_fill(shape=(), op=trt.FillOperation.LINSPACE)
 
-    value_tensor = add_1D_constant_layer(network, [value], is_scalar=True)
+    value_tensor = add_1D_constant_layer(
+        network,
+        [value],
+        is_scalar=True,
+        name=[paddle_op.name(), 'value_tensor'],
+    )
 
     beta_vec = [0.0] * len(shape)
-    beta_tensor = add_1D_constant_layer(network, beta_vec, is_scalar=False)
+    beta_tensor = add_1D_constant_layer(
+        network,
+        beta_vec,
+        is_scalar=False,
+        name=[paddle_op.name(), 'beta_tensor'],
+    )
 
     layer.set_input(0, out_shape_tensor)
     layer.set_input(1, value_tensor)
     layer.set_input(2, beta_tensor)
+
+    set_layer_name(layer, paddle_op)
 
     return layer.get_output(0)

--- a/python/paddle/tensorrt/impls/pooling.py
+++ b/python/paddle/tensorrt/impls/pooling.py
@@ -339,11 +339,13 @@ def pool3d_converter(network, paddle_op, inputs):
         pool_layer.stride_nd = nv_strides
         pool_layer.padding_nd = nv_paddings
         pool_layer.average_count_excludes_padding = exclusive
+        set_layer_name(pool_layer, paddle_op)
         layer = pool_layer
     elif global_pooling:
         reduce_layer = network.add_reduce(
             input_tensor, reduce_operation, 28, True
         )
+        set_layer_name(reduce_layer, paddle_op)
         layer = reduce_layer
     else:
         plugin_fields = [
@@ -390,4 +392,5 @@ def pool3d_converter(network, paddle_op, inputs):
             plugin_name, plugin_field_collection, plugin_version
         )
         layer = network.add_plugin_v2([input_tensor], plugin)
+        set_layer_name(layer, paddle_op)
     return layer.get_output(0)

--- a/python/paddle/tensorrt/impls/search.py
+++ b/python/paddle/tensorrt/impls/search.py
@@ -53,6 +53,7 @@ def argmax_converter(network, paddle_op, inputs):
     topk_layer = network.add_topk(
         input=x, op=trt.TopKOperation.MAX, k=1, axes=(1 << axis)
     )
+    set_layer_name(topk_layer, paddle_op)
 
     if keepdims:
         return topk_layer.get_output(1)
@@ -70,9 +71,17 @@ def argmax_converter(network, paddle_op, inputs):
 
         # Add Shuffle layer
         layer = network.add_shuffle(topk_out)
-        shape_tensor = trt_shape(network, topk_out)
-        real_shape_tensor = trt_gather(network, shape_tensor, gather_indices)
+        shape_tensor = trt_shape(
+            network, topk_out, name=[paddle_op.name(), 'shape_tensor']
+        )
+        real_shape_tensor = trt_gather(
+            network,
+            shape_tensor,
+            gather_indices,
+            name=[paddle_op.name(), 'real_shape_tensor'],
+        )
         layer.set_input(1, real_shape_tensor)
+        set_layer_name(layer, paddle_op)
         return layer.get_output(0)
 
 
@@ -90,11 +99,13 @@ def argmin_converter(network, paddle_op, inputs):
     topk_layer = network.add_topk(
         input=x, op=trt.TopKOperation.MIN, k=1, axes=(1 << axis)
     )
+    set_layer_name(topk_layer, paddle_op)
 
     if keepdims:
         return topk_layer.get_output(1)
     else:
         squeeze_layer = network.add_shuffle(topk_layer.get_output(1))
+        set_layer_name(squeeze_layer, paddle_op)
         output_dims = []
         for i in range(len(input_dims)):
             if i == axis:
@@ -119,25 +130,54 @@ def argsort_converter(network, paddle_op, inputs):
     if in_rank == 1:
         unsqueeze_shape = trt.Dims([1, -1])
         input_tensor = trt_reshape(
-            network, input_tensor, unsqueeze_shape, is_shape_tensor=False
+            network,
+            input_tensor,
+            unsqueeze_shape,
+            is_shape_tensor=False,
+            name=[paddle_op.name(), 'input_tensor'],
         )
         axis = 1
     if need_cast:
-        input_tensor = trt_cast(network, input_tensor, trt.DataType.FLOAT)
+        input_tensor = trt_cast(
+            network,
+            input_tensor,
+            trt.DataType.FLOAT,
+            name=[paddle_op.name(), 'input_tensor'],
+        )
     topk_layer = network.add_topk(input_tensor, topk_op, 1, 1 << axis)
-    shape = trt_shape(network, input_tensor)
-    k_tensor = get_shape_tensor_element(network, shape, axis, True)
+    shape = trt_shape(network, input_tensor, name=[paddle_op.name(), 'shape'])
+    k_tensor = get_shape_tensor_element(
+        network, shape, axis, True, name=[paddle_op.name(), 'k_tensor']
+    )
     topk_layer.set_input(1, k_tensor)
+    set_layer_name(topk_layer, paddle_op)
     out = topk_layer.get_output(0)
     indices = topk_layer.get_output(1)
     if in_rank == 1:
         squeeze_shape = trt.Dims([-1])
-        out = trt_reshape(network, out, squeeze_shape, is_shape_tensor=False)
-        indices = trt_reshape(
-            network, indices, squeeze_shape, is_shape_tensor=False
+        out = trt_reshape(
+            network,
+            out,
+            squeeze_shape,
+            is_shape_tensor=False,
+            name=[paddle_op.name(), 'out'],
         )
-    out_tensor = trt_cast(network, out, in_type)
-    indices_tensor = trt_cast(network, indices, indices.dtype)
+        indices = trt_reshape(
+            network,
+            indices,
+            squeeze_shape,
+            is_shape_tensor=False,
+            name=[paddle_op.name(), 'indices'],
+        )
+    out_tensor = trt_cast(
+        network, out, in_type, name=[paddle_op.name(), 'out_tensor']
+    )
+    indices_tensor = trt_cast(
+        network,
+        indices,
+        indices.dtype,
+        name=[paddle_op.name(), 'indices_tensor'],
+    )
     return out_tensor, indices_tensor
 
 
@@ -148,6 +188,7 @@ def where_converter(network, paddle_op, inputs):
     y = inputs[2]
 
     select_layer = network.add_select(condition, x, y)
+    set_layer_name(select_layer, paddle_op)
 
     return select_layer.get_output(0)
 
@@ -170,25 +211,42 @@ def topk_converter(network, paddle_op, inputs):
 
     expand_to_2d = input_rank == 1
     if expand_to_2d:
-        input_tensor = trt_unsqueeze(network, input_tensor, [1])
+        input_tensor = trt_unsqueeze(
+            network, input_tensor, [1], name=[paddle_op.name(), 'input_tensor']
+        )
 
     input_type = input_tensor.dtype
     if input_type == trt.DataType.INT32:
-        input_tensor = trt_cast(network, input_tensor, trt.DataType.FLOAT)
+        input_tensor = trt_cast(
+            network,
+            input_tensor,
+            trt.DataType.FLOAT,
+            name=[paddle_op.name(), 'input_tensor'],
+        )
 
     if axis < 0:
         axis += input_rank
 
     layer = network.add_topk(input_tensor, flag, int(k), 1 << axis)
+    set_layer_name(layer, paddle_op)
     values = layer.get_output(0)
     indices = layer.get_output(1)
 
     if expand_to_2d:
-        values = squeeze_trt(network, values, [1])
-        indices = squeeze_trt(network, indices, [1])
+        values = squeeze_trt(
+            network, values, [1], name=[paddle_op.name(), 'values']
+        )
+        indices = squeeze_trt(
+            network, indices, [1], name=[paddle_op.name(), 'indices']
+        )
 
     if input_type == trt.DataType.INT32:
-        values = trt_cast(network, values, trt.DataType.INT32)
+        values = trt_cast(
+            network,
+            values,
+            trt.DataType.INT32,
+            name=[paddle_op.name(), 'values'],
+        )
 
     return values, indices
 
@@ -201,9 +259,11 @@ def index_select_converter(network, paddle_op, inputs):
 
     reshape_layer = network.add_shuffle(index_tensor)
     reshape_layer.reshape_dims = (-1,)
+    set_layer_name(reshape_layer, paddle_op)
 
     gather_layer = network.add_gather(
         input_tensor, reshape_layer.get_output(0), axis
     )
+    set_layer_name(gather_layer, paddle_op)
 
     return gather_layer.get_output(0)

--- a/python/paddle/tensorrt/impls/stat.py
+++ b/python/paddle/tensorrt/impls/stat.py
@@ -14,7 +14,7 @@
 
 # import tensorrt as trt
 
-# from paddle.tensorrt.converter_utils import get_axes_for_reduce_op
+# from paddle.tensorrt.converter_utils import get_axes_for_reduce_op, set_layer_name
 # from paddle.tensorrt.register import converter_registry
 
 
@@ -30,4 +30,5 @@
 #         axes=get_axes_for_reduce_op(dim, network.has_implicit_batch_dimension),
 #         keep_dims=keep_dim,
 #     )
+#     set_layer_name(mean_layer, paddle_op)
 #     return mean_layer.get_output(0)

--- a/python/paddle/tensorrt/impls/vision.py
+++ b/python/paddle/tensorrt/impls/vision.py
@@ -14,6 +14,7 @@
 
 import tensorrt as trt
 
+from paddle.tensorrt.converter_utils import set_layer_name
 from paddle.tensorrt.register import converter_registry
 
 
@@ -43,4 +44,5 @@ def grid_sample_converter(network, paddle_op, inputs):
     grid_sample_layer.interpolation_mode = interpolation_mode
     grid_sample_layer.align_corners = align_corners
     grid_sample_layer.sample_mode = sample_mode
+    set_layer_name(grid_sample_layer, paddle_op)
     return grid_sample_layer.get_output(0)


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
card-71500

给其余层命名，命名规则详见：https://github.com/PaddlePaddle/Paddle/pull/71189

trt_expand需要当name=None时返回None，name不是None是否返回[paddle_op.name(), layer_name]的`process_names`函数