### PR TITLE
[CINN] Update group substitute_dimexpr_map for broadcast tree

### DIFF
--- a/paddle/cinn/hlir/framework/pir/broadcast_with_cf.cc
+++ b/paddle/cinn/hlir/framework/pir/broadcast_with_cf.cc
@@ -46,9 +46,9 @@ void UpdateGroupShapeExprs(
     const auto& shape_dim_expr =
         value_dim_exprs_list->at(value_to_dim_expr_idx.at(value));
     const auto& origin_shape_or_data = origin_group->GetShapeOrDataExprs(value);
-    UpdateGroupSubstituteDimExprMap(
-        new_group, origin_shape_or_data.shape(), shape_dim_expr);
     if (origin_shape_or_data.data()) {
+      UpdateGroupSubstituteDimExprMap(
+          new_group, origin_shape_or_data.data().value(), shape_dim_expr);
       std::vector<symbol::DimExpr> shape_dim_expr_shape = {
           symbol::DimExpr(static_cast<int64_t>(shape_dim_expr.size()))};
       new_group->SetShapeOrDataExprs(
@@ -56,6 +56,8 @@ void UpdateGroupShapeExprs(
           symbol::ShapeOrDataDimExprs{symbol::TensorShapeOrDataDimExprs(
               shape_dim_expr_shape, shape_dim_expr)});
     } else {
+      UpdateGroupSubstituteDimExprMap(
+          new_group, origin_shape_or_data.shape(), shape_dim_expr);
       new_group->SetShapeOrDataExprs(
           value,
           symbol::ShapeOrDataDimExprs{

--- a/paddle/cinn/hlir/framework/pir/broadcast_with_cf.cc
+++ b/paddle/cinn/hlir/framework/pir/broadcast_with_cf.cc
@@ -24,6 +24,19 @@ using BroadcastCond = std::pair<symbol::Broadcastable<symbol::DimExpr>,
                                 OpLoweringGroup::BranchType>;
 
 namespace {
+
+void UpdateGroupSubstituteDimExprMap(
+    const OpLoweringGroupPtr& group,
+    const std::vector<symbol::DimExpr>& origin_shape,
+    const std::vector<symbol::DimExpr>& new_shape) {
+  auto& dim_expr_map = group->mut_substitute_dimexpr_map();
+  for (size_t i = 0; i < origin_shape.size() && i < new_shape.size(); ++i) {
+    if (origin_shape[i] != new_shape[i]) {
+      dim_expr_map[origin_shape[i]] = new_shape[i];
+    }
+  }
+}
+
 void UpdateGroupShapeExprs(
     const OpLoweringGroupPtr& new_group,
     const OpLoweringGroupPtr& origin_group,
@@ -33,6 +46,8 @@ void UpdateGroupShapeExprs(
     const auto& shape_dim_expr =
         value_dim_exprs_list->at(value_to_dim_expr_idx.at(value));
     const auto& origin_shape_or_data = origin_group->GetShapeOrDataExprs(value);
+    UpdateGroupSubstituteDimExprMap(
+        new_group, origin_shape_or_data.shape(), shape_dim_expr);
     if (origin_shape_or_data.data()) {
       std::vector<symbol::DimExpr> shape_dim_expr_shape = {
           symbol::DimExpr(static_cast<int64_t>(shape_dim_expr.size()))};

--- a/paddle/cinn/hlir/framework/pir/op_lowering_group.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_group.h
@@ -197,6 +197,9 @@ class OpLoweringGroup {
   const DimExprMap& substitute_dimexpr_map() const {
     return this->substitute_dimexpr_map_;
   }
+  DimExprMap& mut_substitute_dimexpr_map() {
+    return this->substitute_dimexpr_map_;
+  }
 
   void set_substitute_dimexpr_map(const DimExprMap& dimexpr_map) {
     this->substitute_dimexpr_map_ = dimexpr_map;

--- a/paddle/cinn/operator_fusion/fusion_tracker/interpreter.cc
+++ b/paddle/cinn/operator_fusion/fusion_tracker/interpreter.cc
@@ -164,8 +164,13 @@ void RunAxisTransformInstr(const std::shared_ptr<AxisTransformInstr>& instr,
   auto substitute_dimexpr_for_shape = [&](std::vector<symbol::DimExpr>& shape) {
     for (auto& dim_expr : shape) {
       if (dim_expr.isa<std::int64_t>()) continue;
-      dim_expr = symbol::SubstituteDimExpr(dim_expr,
-                                           interpreter->substitute_dimexpr_map);
+      symbol::DimExpr origin_dim_expr = dim_expr;
+      while (true) {
+        dim_expr = symbol::SubstituteDimExpr(
+            dim_expr, interpreter->substitute_dimexpr_map);
+        if (dim_expr == origin_dim_expr || dim_expr.isa<std::int64_t>()) break;
+        origin_dim_expr = dim_expr;
+      }
     }
   };
   auto substitute_dimexpr_for_transform =


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996

- Update group substitute_dimexpr_map for broadcast tree