### PR TITLE
[CINN] Remove reduce scale constraint for Trivial-Reduce AnchorFusion

### DIFF
--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/loop_transform_analysis.cc
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/loop_transform_analysis.cc
@@ -603,7 +603,7 @@ std::optional<AxisTransformRoute> GetValidLoopTransformRoute(
                            : GetLoopLiftRoute(source, target);
     auto fake_reduce_idx = GetFakeReduceAxisIdx(
         target.loop, reduce_to_trivial_route, target.reduce_axis_num);
-    if (!fake_reduce_idx.empty()) {
+    if (!fake_reduce_idx.empty() && upstream_is_anchor) {
       const auto reduce_dims_product =
           GetShapeProduct(target.loop,
                           target.loop.size() - target.reduce_axis_num,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Pcard-76996

- Remove reduce scale constraint for Trivial-Reduce AnchorFusion