### PR TITLE
[CINN] Insert if and inline compute for repeatedly accessed global var

### DIFF
--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.h
@@ -301,6 +301,11 @@ ir::Expr ReshapeLoop(const ir::Expr& root,
 
 void CheckLoopAlignment(const std::vector<ir::Expr>& roots);
 
+ir::Tensor GetOutputTensor(const ir::Expr& root);
+
+void InlineGlobalVarCompute(const std::vector<ir::Expr>& roots,
+                            const std::set<std::string>& global_var_names);
+
 }  // namespace trivial_fusion_detail
 }  // namespace pir
 }  // namespace framework

--- a/paddle/cinn/operator_fusion/fusion_tracker/interpreter.cc
+++ b/paddle/cinn/operator_fusion/fusion_tracker/interpreter.cc
@@ -229,23 +229,27 @@ void RunPaddingInstr(const std::shared_ptr<PaddingInstr>& instr,
 void RunReturnInstr(const std::shared_ptr<ReturnInstr>& instr,
                     FusionInterpreter* interpreter) {
   using namespace cinn::hlir::framework::pir::trivial_fusion_detail;  // NOLINT
+  std::vector<ir::Expr> result;
   for (auto fusion_op : interpreter->scope[instr->target_]->fusion_ops) {
     auto exprs = std::visit(FusibleOp2Expr(), fusion_op);
-    // Insert if for append loops
     for (const auto& expr : exprs) {
-      // interpreter->ret_expr.push_back(expr);
-      std::vector<std::string> load_tensor_names;
-      for (const auto& tensor : GetOutputTensors(expr)) {
-        load_tensor_names.push_back(tensor->name);
-      }
-      if (AnyFirstInSecond(load_tensor_names, interpreter->global_var_names)) {
-        interpreter->ret_expr.push_back(
-            ExprTransformerUtils::InsertIfForAppendVarsTransformer()(expr));
-      } else {
-        interpreter->ret_expr.push_back(expr);
+      result.push_back(expr);
+    }
+  }
+  // Insert if for append loop
+  std::set<std::string> global_vars_need_inline;
+  for (auto& expr : result) {
+    std::string output_var_name = GetOutputTensor(expr)->name;
+    if (interpreter->global_var_names.count(output_var_name)) {
+      expr = ExprTransformerUtils::InsertIfForAppendVarsTransformer()(expr);
+      if (!ExprSetFinderUtils::ChildIfThenElses(expr).empty()) {
+        global_vars_need_inline.insert(output_var_name);
       }
     }
   }
+  // Inline global vars
+  InlineGlobalVarCompute(result, global_vars_need_inline);
+  interpreter->ret_expr = result;
 }
 
 std::vector<ir::Expr> FusionInterpreter::Run() {

--- a/paddle/cinn/operator_fusion/fusion_tracker/interpreter.h
+++ b/paddle/cinn/operator_fusion/fusion_tracker/interpreter.h
@@ -18,7 +18,6 @@
 #include "paddle/cinn/operator_fusion/fusion_tracker/tracker.h"
 #include "paddle/cinn/operator_fusion/pattern.h"
 #include "paddle/cinn/operator_fusion/pattern_fuser.h"
-#include "paddle/fluid/pir/dialect/operator/trait/inplace.h"
 
 namespace cinn::fusion {
 
@@ -45,8 +44,7 @@ struct FusionInterpreter {
         substitute_dimexpr_map(dimexpr_map) {
     auto output_ops = GetGroupOutputOps(ops);
     for (size_t i = 0; i < ops.size(); i++) {
-      if (output_ops.count(ops[i]) ||
-          ops[i]->HasTrait<paddle::dialect::InplaceTrait>()) {
+      if (output_ops.count(ops[i]) || ops[i]->name() == "pd_op.assign_out_") {
         global_var_names.insert(GetOutputTensor(init_fusible_op[i])->name);
       }
     }

--- a/paddle/cinn/operator_fusion/fusion_tracker/interpreter.h
+++ b/paddle/cinn/operator_fusion/fusion_tracker/interpreter.h
@@ -47,15 +47,14 @@ struct FusionInterpreter {
     for (size_t i = 0; i < ops.size(); i++) {
       if (output_ops.count(ops[i]) ||
           ops[i]->HasTrait<paddle::dialect::InplaceTrait>()) {
-        global_var_names.push_back(GetOutputTensor(init_fusible_op[i])->name);
+        global_var_names.insert(GetOutputTensor(init_fusible_op[i])->name);
       }
     }
     VLOG(4) << "Create FusionInterpreter, Tracker is:\n" << tracker->DebugStr();
-    VLOG(4) << "Global var names: " << utils::Join(global_var_names, ", ");
   }
 
   std::vector<FusibleOp> initialized_lowered_op;
-  std::vector<std::string> global_var_names;
+  std::set<std::string> global_var_names;
   std::unordered_map<std::string, ScopeElementPtr> scope;
   DimExprMap substitute_dimexpr_map;
   FusionTrackerPtr tracker;

--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/loop_transform_analysis.cc
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/loop_transform_analysis.cc
@@ -307,6 +307,10 @@ std::optional<AxisTransformRoute> GetValidLoopTransformRoute(
       VLOG(4) << "Cannot transform reduce loop to different reduce axis num.";
       return std::nullopt;
     }
+    if (!ShapeProductEqual(source.loop, target.loop)) {
+      VLOG(4) << "Cannot apply append axis transform between reduce loop.";
+      return std::nullopt;
+    }
     auto get_reduce_loop = [](const LoopAxisMapping& mapping) {
       return SliceVector(mapping.loop,
                          mapping.loop.size() - mapping.reduce_axis_num,

--- a/paddle/cinn/operator_fusion/utils.h
+++ b/paddle/cinn/operator_fusion/utils.h
@@ -96,6 +96,9 @@ static std::string OpsDebugStr(std::vector<pir::Operation*> ops) {
   return ss.str();
 }
 
+std::unordered_set<pir::Operation*> GetGroupOutputOps(
+    const std::vector<pir::Operation*>& ops);
+
 template <typename T>
 void RemoveFromVector(std::vector<T>* vec, T item) {
   auto iter = std::find(vec->begin(), vec->end(), item);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Pcard-76996
- 正确识别 FusionOp 中所有的输出 Value（即 Kernel 里需要写的全局变量），而不是用 yield_store
- 对插入了没用到的轴导致重复读写的全局变量添加 if 限制
- 对同一 Kernel 内所有输出变量的其他用法进行 inline