### PR TITLE
[CINN] Correct mistakes in using shape_or_data

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
@@ -932,14 +932,10 @@ bool GatherOpInferSymbolicShape(pir::Operation *op,
   }
 
   const std::vector<symbol::DimExpr> &input_sym_shape =
-      input_shape_or_data.data().has_value()
-          ? input_shape_or_data.data().value()
-          : input_shape_or_data.shape();
+      input_shape_or_data.shape();
 
   const std::vector<symbol::DimExpr> &index_sym_shape =
-      index_shape_or_data.data().has_value()
-          ? index_shape_or_data.data().value()
-          : index_shape_or_data.shape();
+      index_shape_or_data.shape();
 
   if (axis < 0) axis += input_sym_shape.size();
 
@@ -2138,13 +2134,9 @@ bool TakeAlongAxisOpInferSymbolicShape(
   const auto &attributes = op->attributes();
   int axis = attributes.at("axis").dyn_cast<pir::Int32Attribute>().data();
 
-  const std::vector<symbol::DimExpr> &arr_sym_shape =
-      arr_shape_or_data.data().has_value() ? arr_shape_or_data.data().value()
-                                           : arr_shape_or_data.shape();
+  const std::vector<symbol::DimExpr> &arr_sym_shape = arr_shape_or_data.shape();
   const std::vector<symbol::DimExpr> &indices_sym_shape =
-      indices_shape_or_data.data().has_value()
-          ? indices_shape_or_data.data().value()
-          : indices_shape_or_data.shape();
+      indices_shape_or_data.shape();
 
   if (axis < 0) axis += arr_sym_shape.size();
 
@@ -2174,11 +2166,7 @@ bool TopPSamplingOpInferSymbolicShape(
   const auto &x_dims = [op, infer_context] {
     const auto &shape_or_data =
         infer_context->GetShapeOrDataForValue(op->operand_source(0));
-    if (shape_or_data.data().has_value()) {
-      return shape_or_data.data().value();
-    } else {
-      return shape_or_data.shape();
-    }
+    return shape_or_data.shape();
   }();
 
   // all the result have the same shape

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
@@ -396,14 +396,10 @@ bool GatherOpInferSymbolicShape(pir::Operation *op,
   }();
 
   const std::vector<symbol::DimExpr> &input_sym_shape =
-      input_shape_or_data.data().has_value()
-          ? input_shape_or_data.data().value()
-          : input_shape_or_data.shape();
+      input_shape_or_data.shape();
 
   const std::vector<symbol::DimExpr> &index_sym_shape =
-      index_shape_or_data.data().has_value()
-          ? index_shape_or_data.data().value()
-          : index_shape_or_data.shape();
+      index_shape_or_data.shape();
 
   int axis = op->attributes().at("axis").dyn_cast<pir::Int32Attribute>().data();
   if (axis < 0) axis += input_sym_shape.size();

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -2910,15 +2910,13 @@ bool LinspaceOpInferSymbolicShape(
     pir::Operation *op, pir::InferSymbolicShapeContext *infer_context) {
   const auto &num_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(2));
-  const auto step = [&] {
-    symbol::DimExpr expr;
-    if (num_shape_or_data.data().has_value()) {
-      expr = num_shape_or_data.data().value()[0];
-    } else {
-      expr = num_shape_or_data.shape()[0];
-    }
-    return expr;
-  }();
+  PADDLE_ENFORCE_EQ(
+      operand_shape_or_data.data().has_value(),
+      true,
+      common::errors::InvalidArgument("TensorShapeOrDataDimExprs.data() of num "
+                                      "must have value, please check."));
+
+  const auto step = num_shape_or_data.data().value().at(0);
   const symbol::ShapeOrDataDimExprs &shape_data = [&] {
     std::vector<symbol::DimExpr> out_dims{step};
     return symbol::ShapeOrDataDimExprs{

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -2911,7 +2911,7 @@ bool LinspaceOpInferSymbolicShape(
   const auto &num_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(2));
   PADDLE_ENFORCE_EQ(
-      operand_shape_or_data.data().has_value(),
+      num_shape_or_data.data().has_value(),
       true,
       common::errors::InvalidArgument("TensorShapeOrDataDimExprs.data() of num "
                                       "must have value, please check."));

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -2941,26 +2941,16 @@ bool RepeatInterleaveOpInferSymbolicShape(
   // what should I do if axis is null
   int axis = attributes.at("axis").dyn_cast<pir::Int32Attribute>().data();
 
-  const std::vector<symbol::DimExpr> &in_dims_sym = [&] {
-    std::vector<symbol::DimExpr> dims;
-    if (operand_shape_or_data.data().has_value()) {
-      dims = operand_shape_or_data.data().value();
-    } else {
-      dims = operand_shape_or_data.shape();
-    }
-    return dims;
-  }();
-
-  int x_rank = in_dims_sym.size();
+  int x_rank = operand_shape_or_data.shape().size();
   if (axis < 0) axis += x_rank;
 
   const auto &out_sym_shape = [&] {
     std::vector<symbol::DimExpr> out_sym_shape;
     for (int i = 0; i < x_rank; i++) {
       if (i == axis) {
-        out_sym_shape.push_back(in_dims_sym.at(i) * repeats);
+        out_sym_shape.push_back(operand_shape_or_data.shape().at(i) * repeats);
       } else {
-        out_sym_shape.push_back(in_dims_sym.at(i));
+        out_sym_shape.push_back(operand_shape_or_data.shape().at(i));
       }
     }
     return out_sym_shape;
@@ -3771,17 +3761,7 @@ bool TopkOpInferSymbolicShape(pir::Operation *op,
       infer_context->GetShapeOrDataForValue(op->operand_source(1));
   const auto &attributes = op->attributes();
   int axis = attributes.at("axis").dyn_cast<pir::Int32Attribute>().data();
-  const std::vector<symbol::DimExpr> &in_dims_sym = [&] {
-    std::vector<symbol::DimExpr> dims;
-    if (x_shape_or_data.data().has_value()) {
-      dims = x_shape_or_data.data().value();
-    } else {
-      dims = x_shape_or_data.shape();
-    }
-    return dims;
-  }();
-
-  int x_rank = in_dims_sym.size();
+  int x_rank = x_shape_or_data.shape().size();
 
   symbol::DimExpr k = k_shape_or_data.data().value().at(0);
 
@@ -3792,7 +3772,7 @@ bool TopkOpInferSymbolicShape(pir::Operation *op,
       if (i == axis) {
         out_sym_shape.push_back(k);
       } else {
-        out_sym_shape.push_back(in_dims_sym.at(i));
+        out_sym_shape.push_back(x_shape_or_data.shape().at(i));
       }
     }
     return out_sym_shape;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
+ Correct incorrect historical codes in using ShapeOrData
+ This PR can fix the training errors of the Cascade-FasterRCNN-ResNet50-FPN_CINN model in multi card situations that causing by gather op 