### PR TITLE
[SOT] Fix lost error info

### DIFF
--- a/python/paddle/jit/sot/utils/exceptions.py
+++ b/python/paddle/jit/sot/utils/exceptions.py
@@ -50,7 +50,6 @@ class DataDependencyControlFlowBreak(DataDependencyBreak):
 
     def __init__(self, reason_str=None, file_path="", line_number=-1):
         if reason_str is None:
-
             reason_str = "OpcodeInlineExecutor want break graph when simulate control flow."
 
         super().__init__(
@@ -193,7 +192,7 @@ class FallbackError(SotErrorBase):
 # raise in inline function call strategy.
 class BreakGraphError(SotErrorBase):
     def __init__(self, reason: BreakGraphReasonBase | str = None):
-        super().__init__()
+        super().__init__(str(reason))
 
         if isinstance(reason, str):
             # if reason is a string, then create a UnspecifiedBreakReason object


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

```python
class BreakGraphError(SotErrorBase):
    def __init__(self, reason: BreakGraphReasonBase | str = None):
        super().__init__()   # <------ 

        if isinstance(reason, str):
            # if reason is a string, then create a UnspecifiedBreakReason object
            reason = UnspecifiedBreakReason(reason)
        self.reason = reason
        BreakGraphReasonInfo.collect_break_graph_reason(reason)
```

Due to the inheritance relationship `BreakGraphError <- SotErrorBase <- Exception`, not passing any arguments to `super().__init__()` will result in the raised exception containing no information.😱😱😱

PCard-66972