### PR TITLE
[Prim][CINN] Use reshape to decompose squeeze grad

### DIFF
--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -1081,10 +1081,17 @@ void squeeze_grad(const Tensor& x,
                   const IntArray& axis,
                   Tensor* x_grad) {
   if (x_grad) {
-    auto x_grad_out = out_grad.dims().size() == x.dims().size()
-                          ? out_grad
-                          : unsqueeze<T>(out_grad, axis);
-    set_output<T>(x_grad_out, x_grad);
+    if (out_grad.dims().size() == x.dims().size()) {
+      set_output<T>(out_grad, x_grad);
+    } else {
+      Tensor grad_x_tmp;
+      if (has_dynamic_shape(x.shape())) {
+        grad_x_tmp = backend::reshape<T>(out_grad, shape64<T>(x));
+      } else {
+        grad_x_tmp = reshape<T>(out_grad, common::vectorize(x.dims()));
+      }
+      set_output<T>(grad_x_tmp, x_grad);
+    }
   }
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

`squeeze` 的 axis 可能是 `[]`，表示将所有为 `1` 的维度移除掉，这里在反向直接 reshape 成原来的 x 的 shape

（@zyfncg 写的）

PCard-66972