### PR TITLE
fix issue of expand pir build

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -3380,6 +3380,7 @@ void ExpandOp::Build(pir::Builder &builder,
       ExpandOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
+  argument.AddAttributes(argument_attributes);
   ::pir::PassStopGradientsDefaultly(argument);
 }
 
@@ -3415,6 +3416,7 @@ void ExpandOp::Build(pir::Builder &builder,
       ExpandOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
+  argument.AddAttributes(argument_attributes);
   ::pir::PassStopGradientsDefaultly(argument);
 }
 
@@ -3434,6 +3436,7 @@ void ExpandOp::Build(pir::Builder &builder,
       ExpandOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
+  argument.AddAttributes(argument_attributes);
   ::pir::PassStopGradientsDefaultly(argument);
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
Bug fixes

### Description
pcard-89610

`ExpandOp` in PIR is handwritten, and the result of the spmd has not been updated to `op_dist_attr`, resulting in errors in subsequent kernel execution. 
Specifically, for example, input shape=[32, 10], dims_mapping=[0, -1], target expand shape=[32, 10], expand uses the default segmentation derivation rule, output shape=[32, 10], dims_mapping=[-1, -1]. However, because the result of spmd was not updated to `op_dist_attr`, the input was not reshard, and the local shape remained at [16, 10], resulting in kernel execution errors. this pr will fix this issue.

```python
# -*- coding: UTF-8 -*-
import numpy as np
import paddle
from paddle.distributed import ProcessMesh, shard_tensor, shard_op, Shard, shard_dataloader, to_static
from paddle.io import Dataset, BatchSampler, DataLoader

base_lr = 0.1
momentum_rate = 0.9
l2_decay = 1e-4

epoch = 1
batch_num = 100
batch_size = 32
class_dim = 10

class RandomDataset(Dataset):
    def __init__(self, num_samples):
        self.num_samples = num_samples

    def __getitem__(self, idx):
        image = np.random.random([256]).astype('float32')
        label = np.random.randint(0, class_dim - 1, (1, )).astype('int64')
        return image, label

    def __len__(self):
        return self.num_samples

def optimizer_setting(parameter_list=None):
    optimizer = paddle.optimizer.Momentum(
        learning_rate=base_lr,
        momentum=momentum_rate,
        weight_decay=paddle.regularizer.L2Decay(l2_decay),
        parameters=parameter_list)
    return optimizer

class SimpleNet(paddle.nn.Layer):
    def __init__(self, input_size, inner_size, output_size):
        super().__init__()
        self.output_size = output_size
        self.linear1 = paddle.nn.Linear(input_size, inner_size)
        self.linear2 = paddle.nn.Linear(inner_size, input_size)
        self.linear3 = paddle.nn.Linear(input_size, output_size)
        self.relu = paddle.nn.ReLU()

    def forward(self, x):
        x = self.linear1(x)
        x = self.linear2(x)
        x = self.linear3(x)
        x = paddle.expand(x, [batch_size, self.output_size])  # when use to_static in pir, this will report error
        x = self.relu(x)
        return x

world_process_mesh = ProcessMesh([0, 1], dim_names=["dp"])

def train_model():
    model = SimpleNet(input_size=256, inner_size=1024, output_size=class_dim)
    loss_func = paddle.nn.CrossEntropyLoss()
    optimizer = optimizer_setting(parameter_list=model.parameters())

    dataset = RandomDataset(batch_num * batch_size)
    sampler = BatchSampler(dataset,
                        batch_size=batch_size,shuffle=False, drop_last=True)
    train_loader = DataLoader(dataset,
                            batch_sampler=sampler,
                            num_workers=1)
    dist_dataloader = shard_dataloader(dataloader=train_loader, meshes=world_process_mesh, shard_dims="dp")
    dist_model = to_static(model, dist_dataloader, loss_func, optimizer)

    for eop in range(epoch):
        dist_model.train()

        for batch_id, data in enumerate(dist_dataloader()):
            img, label = data
            label.stop_gradient = True

            loss = dist_model(img, label)

            if batch_id % 5 == 0:
                print("[Epoch %d, batch %d] loss: %.5f" % (eop, batch_id, loss))

if __name__ == '__main__':
    train_model()
```
