### PR TITLE
[Inference] MoE Use macro to compress code impl

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/moe/fused_moe_op.h
+++ b/paddle/phi/kernels/fusion/cutlass/moe/fused_moe_op.h
@@ -610,6 +610,20 @@ void topk_gating_softmax_launcher_helper(const T* input,
           input, finished, output, num_rows, indices, source_row, k);
 }
 
+#define LAUNCH_TOPK_GATING_SOFTMAX_HELPER(N) \
+    case N: { \
+        topk_gating_softmax_launcher_helper<T, N, WARPS_PER_TB>(input, \
+                                                                finished, \
+                                                                output, \
+                                                                indices, \
+                                                                source_row, \
+                                                                num_rows, \
+                                                                num_experts, \
+                                                                k, \
+                                                                stream); \
+        break; \
+    }
+
 template <typename T>
 void topk_gating_softmax_kernelLauncher(const T* input,
                                         const bool* finished,
@@ -634,102 +648,14 @@ void topk_gating_softmax_kernelLauncher(const T* input,
   static constexpr int WARPS_PER_TB = 4;
 
   switch (num_experts) {
-    case 2: {
-      topk_gating_softmax_launcher_helper<T, 2, WARPS_PER_TB>(input,
-                                                              finished,
-                                                              output,
-                                                              indices,
-                                                              source_row,
-                                                              num_rows,
-                                                              num_experts,
-                                                              k,
-                                                              stream);
-      break;
-    }
-    case 4: {
-      topk_gating_softmax_launcher_helper<T, 4, WARPS_PER_TB>(input,
-                                                              finished,
-                                                              output,
-                                                              indices,
-                                                              source_row,
-                                                              num_rows,
-                                                              num_experts,
-                                                              k,
-                                                              stream);
-      break;
-    }
-    case 8: {
-      topk_gating_softmax_launcher_helper<T, 8, WARPS_PER_TB>(input,
-                                                              finished,
-                                                              output,
-                                                              indices,
-                                                              source_row,
-                                                              num_rows,
-                                                              num_experts,
-                                                              k,
-                                                              stream);
-      break;
-    }
-    case 16: {
-      topk_gating_softmax_launcher_helper<T, 16, WARPS_PER_TB>(input,
-                                                               finished,
-                                                               output,
-                                                               indices,
-                                                               source_row,
-                                                               num_rows,
-                                                               num_experts,
-                                                               k,
-                                                               stream);
-      break;
-    }
-    case 32: {
-      topk_gating_softmax_launcher_helper<T, 32, WARPS_PER_TB>(input,
-                                                               finished,
-                                                               output,
-                                                               indices,
-                                                               source_row,
-                                                               num_rows,
-                                                               num_experts,
-                                                               k,
-                                                               stream);
-      break;
-    }
-    case 64: {
-      topk_gating_softmax_launcher_helper<T, 64, WARPS_PER_TB>(input,
-                                                               finished,
-                                                               output,
-                                                               indices,
-                                                               source_row,
-                                                               num_rows,
-                                                               num_experts,
-                                                               k,
-                                                               stream);
-      break;
-    }
-    case 128: {
-      topk_gating_softmax_launcher_helper<T, 128, WARPS_PER_TB>(input,
-                                                                finished,
-                                                                output,
-                                                                indices,
-                                                                source_row,
-                                                                num_rows,
-                                                                num_experts,
-                                                                k,
-                                                                stream);
-      break;
-    }
-    case 256: {
-      topk_gating_softmax_launcher_helper<T, 256, WARPS_PER_TB>(input,
-                                                                finished,
-                                                                output,
-                                                                indices,
-                                                                source_row,
-                                                                num_rows,
-                                                                num_experts,
-                                                                k,
-                                                                stream);
-      break;
-    }
+    LAUNCH_TOPK_GATING_SOFTMAX_HELPER(2)
+    LAUNCH_TOPK_GATING_SOFTMAX_HELPER(4)
+    LAUNCH_TOPK_GATING_SOFTMAX_HELPER(8)
+    LAUNCH_TOPK_GATING_SOFTMAX_HELPER(16)
+    LAUNCH_TOPK_GATING_SOFTMAX_HELPER(32)
+    LAUNCH_TOPK_GATING_SOFTMAX_HELPER(64)
+    LAUNCH_TOPK_GATING_SOFTMAX_HELPER(128)
+    LAUNCH_TOPK_GATING_SOFTMAX_HELPER(256)
     default: {
       static constexpr int TPB = 256;
       if (group_moe) {

--- a/paddle/phi/kernels/fusion/cutlass/moe/fused_moe_op.h
+++ b/paddle/phi/kernels/fusion/cutlass/moe/fused_moe_op.h
@@ -633,19 +633,19 @@ void topk_gating_softmax_kernelLauncher(const T* input,
   }
   static constexpr int WARPS_PER_TB = 4;
 
-#define LAUNCH_TOPK_GATING_SOFTMAX_HELPER(N) \
-    case N: { \
-        topk_gating_softmax_launcher_helper<T, N, WARPS_PER_TB>(input, \
-                                                                finished, \
-                                                                output, \
-                                                                indices, \
-                                                                source_row, \
-                                                                num_rows, \
-                                                                num_experts, \
-                                                                k, \
-                                                                stream); \
-        break; \
-    }
+#define LAUNCH_TOPK_GATING_SOFTMAX_HELPER(N)                             \
+  case N: {                                                              \
+    topk_gating_softmax_launcher_helper<T, N, WARPS_PER_TB>(input,       \
+                                                            finished,    \
+                                                            output,      \
+                                                            indices,     \
+                                                            source_row,  \
+                                                            num_rows,    \
+                                                            num_experts, \
+                                                            k,           \
+                                                            stream);     \
+    break;                                                               \
+  }
 
   switch (num_experts) {
     LAUNCH_TOPK_GATING_SOFTMAX_HELPER(2)

--- a/paddle/phi/kernels/fusion/cutlass/moe/fused_moe_op.h
+++ b/paddle/phi/kernels/fusion/cutlass/moe/fused_moe_op.h
@@ -610,20 +610,6 @@ void topk_gating_softmax_launcher_helper(const T* input,
           input, finished, output, num_rows, indices, source_row, k);
 }
 
-#define LAUNCH_TOPK_GATING_SOFTMAX_HELPER(N) \
-    case N: { \
-        topk_gating_softmax_launcher_helper<T, N, WARPS_PER_TB>(input, \
-                                                                finished, \
-                                                                output, \
-                                                                indices, \
-                                                                source_row, \
-                                                                num_rows, \
-                                                                num_experts, \
-                                                                k, \
-                                                                stream); \
-        break; \
-    }
-
 template <typename T>
 void topk_gating_softmax_kernelLauncher(const T* input,
                                         const bool* finished,
@@ -646,6 +632,20 @@ void topk_gating_softmax_kernelLauncher(const T* input,
     return;
   }
   static constexpr int WARPS_PER_TB = 4;
+
+#define LAUNCH_TOPK_GATING_SOFTMAX_HELPER(N) \
+    case N: { \
+        topk_gating_softmax_launcher_helper<T, N, WARPS_PER_TB>(input, \
+                                                                finished, \
+                                                                output, \
+                                                                indices, \
+                                                                source_row, \
+                                                                num_rows, \
+                                                                num_experts, \
+                                                                k, \
+                                                                stream); \
+        break; \
+    }
 
   switch (num_experts) {
     LAUNCH_TOPK_GATING_SOFTMAX_HELPER(2)


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation 



### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

Pcard-71500

Use macro to compress the code implementation in `fused_moe_op.h`, save a lot code lines.