### PR TITLE
[AutoParallel] remove loss shape assert

### DIFF
--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -23,8 +23,6 @@ import os
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-import numpy as np
-
 import paddle
 import paddle.autograd as imperative_base
 from paddle import _C_ops
@@ -1545,10 +1543,7 @@ class Optimizer:
             else:
                 assert isinstance(callbacks, list)
             program = loss.block.program
-            assert np.prod(loss.shape) == 1, (
-                f"The number of elements of loss should be 1, but the current loss.shape is {loss.shape}, whose number of elements is not 1. "
-                "Maybe that you should call paddle.mean to process the current loss."
-            )
+
             parameter_list = parameters if parameters else self._parameter_list
             with paddle.static.program_guard(program, startup_program):
                 if in_pir_mode():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

移除 backward 时对 loss shape 的判断

使用 local layer 计算 loss 后，loss 的 shape 不是 1

这个判断是很久之前加的了，无从考究为什么加这个判断，xpu 下 loss 的 shape 不是 1，目前本地测下来没有遇到问题

Pcard-76459
