### PR TITLE
[CINN] Remove redundant group output before divide to fusion ops

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -188,8 +188,6 @@ void ApplyGroupOpPass(::pir::Program* program,
   pass_manager->AddPass(cinn::dialect::ir::CreateDynamicReshapeOpPass());
   pass_manager->AddPass(cinn::dialect::ir::CreateFoldManipulationOpsPass());
   pass_manager->AddPass(pir::CreateDeadCodeEliminationPass());
-  // pass_manager->AddPass(
-  //     cinn::dialect::ir::CreateRemoveRedundantGroupOutputPass());
 
   pass_manager->Run(program);
 }
@@ -288,19 +286,7 @@ void ApplyCinnPass(
   PirToPyCodeConverter(program)
       .file_name("group_op_programs.py")
       .SaveIfFlagEnabled();
-  if (VLOG_IS_ON(1)) {
-    auto& shape_analysis = pir::ShapeAnalysisManager::Instance().Get(program);
-    std::cout << "Program before ApplyGroupOpPass: \n"
-              << pir::CustomPrintHelper(*program, shape_analysis.PrintHook())
-              << std::endl;
-  }
   ApplyGroupOpPass(program, CreatePassManager);
-  if (VLOG_IS_ON(1)) {
-    auto& shape_analysis = pir::ShapeAnalysisManager::Instance().Get(program);
-    std::cout << "Program before ApplyDivideGroupOpToFusionOpPass: \n"
-              << pir::CustomPrintHelper(*program, shape_analysis.PrintHook())
-              << std::endl;
-  }
   ApplyDivideGroupOpToFusionOpPass(program, CreatePassManager);
   PirToPyCodeConverter(program)
       .file_name("fusion_op_programs.py")

--- a/paddle/cinn/hlir/dialect/operator/transforms/remove_redundant_group_output_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/remove_redundant_group_output_pass.cc
@@ -1,0 +1,133 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/hlir/dialect/operator/transforms/remove_redundant_group_output_pass.h"
+
+#include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
+#include "paddle/fluid/pir/utils/general_functions.h"
+#include "paddle/pir/include/core/builtin_type_interfaces.h"
+#include "paddle/pir/include/dialect/control_flow/ir/cf_op.h"
+#include "paddle/pir/include/pattern_rewrite/pattern_rewrite_driver.h"
+
+namespace cinn {
+namespace dialect {
+namespace ir {
+
+class RemoveRedundantGroupOutputPattern
+    : public pir::OpRewritePattern<cinn::dialect::GroupOp> {
+ public:
+  explicit RemoveRedundantGroupOutputPattern(::pir::IrContext* context)
+      : pir::OpRewritePattern<cinn::dialect::GroupOp>(context) {}
+
+  bool MatchAndRewrite(cinn::dialect::GroupOp group_op,
+                       pir::PatternRewriter& rewriter) const override {
+    auto module_op = group_op.block()
+                         ->GetParentOp()
+                         ->GetParentOp()
+                         ->dyn_cast<pir::ModuleOp>();
+    if (!module_op) {
+      std::cout << "cannot find module op\n";
+      return false;
+    } else {
+      std::cout << "Before remove redundant output from group op: "
+                << std::endl;
+      module_op->Print(std::cout);
+      std::cout << std::endl;
+    }
+
+    const auto& input_args = pir::GetUsedExternalValue(*group_op.block());
+    const std::unordered_set<pir::Value> inputs_set = {input_args.begin(),
+                                                       input_args.end()};
+    const auto& yield_op = group_op.block()->back();
+    std::vector<pir::Value> new_outputs;
+    std::vector<pir::Type> new_out_types;
+    std::unordered_map<pir::Value, uint32_t> origin_group_out_2_new_out_idx;
+    std::unordered_map<uint32_t, pir::Value>
+        redundant_out_idx_map;  // output index -> input value
+    for (uint32_t i = 0; i < yield_op.num_operands(); ++i) {
+      if (inputs_set.count(yield_op.operand_source(i)) > 0) {
+        redundant_out_idx_map.emplace(i, yield_op.operand_source(i));
+      } else {
+        new_outputs.push_back(yield_op.operand_source(i));
+        new_out_types.push_back(yield_op.operand_source(i).type());
+        origin_group_out_2_new_out_idx[group_op.result(i)] =
+            new_outputs.size() - 1;
+      }
+    }
+    if (redundant_out_idx_map.empty()) {
+      VLOG(1) << "No redundant output in group op, skip.";
+      return false;
+    }
+
+    auto new_group_op = rewriter.Build<cinn::dialect::GroupOp>(new_out_types);
+    const std::vector<pir::Operation*> ops_to_move = [](pir::Block* block) {
+      std::vector<pir::Operation*> ops;
+      for (auto& op : *block) {
+        if (op.isa<pir::YieldOp>()) continue;
+        ops.push_back(&op);
+      }
+      return ops;
+    }(group_op.block());
+    for (auto& op : ops_to_move) {
+      op->MoveTo(new_group_op.block(), new_group_op.block()->end());
+    }
+    rewriter.SetInsertionPointToBlockEnd(new_group_op.block());
+    rewriter.Build<pir::YieldOp>(new_outputs);
+
+    for (uint32_t i = 0; i < group_op.num_results(); ++i) {
+      if (redundant_out_idx_map.count(i) > 0) {
+        rewriter.ReplaceAllUsesWith(group_op.result(i),
+                                    redundant_out_idx_map.at(i));
+      } else {
+        rewriter.ReplaceAllUsesWith(
+            group_op.result(i),
+            new_group_op.result(
+                origin_group_out_2_new_out_idx.at(group_op.result(i))));
+      }
+    }
+    rewriter.EraseOp(group_op);
+    VLOG(1) << "Remove redundant output from group op.";
+    return true;
+  }
+};
+
+class RemoveRedundantGroupOutputPass : public pir::PatternRewritePass {
+ public:
+  RemoveRedundantGroupOutputPass()
+      : pir::PatternRewritePass("remove_redundant_group_output_pass",
+                                /*opt_level=*/1) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext* context) override {
+    pir::RewritePatternSet ps(context);
+
+    ps.Add<RemoveRedundantGroupOutputPattern>(context);
+
+    return ps;
+  }
+
+  bool CanApplyOn(pir::Operation* op) const override {
+    if (op->isa<cinn::dialect::GroupOp>()) {
+      return false;
+    }
+    return op->num_regions() > 0;
+  }
+};
+
+std::unique_ptr<pir::Pass> CreateRemoveRedundantGroupOutputPass() {
+  return std::make_unique<RemoveRedundantGroupOutputPass>();
+}
+
+}  // namespace ir
+}  // namespace dialect
+}  // namespace cinn

--- a/paddle/cinn/hlir/dialect/operator/transforms/remove_redundant_group_output_pass.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/remove_redundant_group_output_pass.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/pass/pass.h"
+
+namespace cinn {
+namespace dialect {
+namespace ir {
+
+std::unique_ptr<pir::Pass> CreateRemoveRedundantGroupOutputPass();
+
+}  // namespace ir
+}  // namespace dialect
+}  // namespace cinn

--- a/paddle/pir/src/pattern_rewrite/pattern_match.cc
+++ b/paddle/pir/src/pattern_rewrite/pattern_match.cc
@@ -135,12 +135,13 @@ void RewriterBase::ReplaceOp(Operation* op,
 }
 
 void RewriterBase::EraseOp(Operation* op) {
-  PADDLE_ENFORCE_EQ(
-      op->use_empty(),
-      true,
-      common::errors::InvalidArgument("Erase op failed. op(%s) is used, the "
-                                      "expectation is that it is not used",
-                                      op->name()));
+  PADDLE_ENFORCE_EQ(op->use_empty(),
+                    true,
+                    common::errors::InvalidArgument(
+                        "Erase op failed. op(%s)[id:%d] is used, the "
+                        "expectation is that it is not used",
+                        op->name(),
+                        op->id()));
   NotifyOperationRemoved(op);
   op->Erase();
 }

--- a/test/ir/pir/cinn/test_remove_redundant_group_output_pass.py
+++ b/test/ir/pir/cinn/test_remove_redundant_group_output_pass.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+import numpy
+
+os.environ['FLAGS_prim_all'] = 'true'
+os.environ['FLAGS_prim_enable_dynamic'] = 'true'
+os.environ['FLAGS_use_cinn'] = '1'
+
+import paddle
+
+build_strategy = paddle.static.BuildStrategy()
+build_strategy.build_cinn_pass = True
+
+
+def init():
+    var_1 = paddle.rand([32, 1])
+    var_1 = paddle.cast(var_1, 'int32')
+    var_0 = paddle.rand([32, 80])
+    return var_1, var_0
+
+
+def func(var_1, var_0):
+    var_15 = paddle.full(shape=[1], dtype='float32', fill_value=1.0)
+    var_16 = var_0 * -1.0 + 0.0
+    var_17 = paddle.exp(var_16)
+    var_18 = var_15 + var_17
+    var_19 = var_15 / var_18
+    var_20 = var_19 * -1.0 + 1.0
+    var_21 = var_20 * 1.0 + 1e-12
+    var_22 = paddle.log(var_21)
+    var_23 = var_22 * -1.0 + 0.0
+    var_24 = var_23 * 0.75 + 0.0
+    var_25 = var_19 * var_19
+    var_26 = var_24 * var_25
+    var_27 = var_19 * 1.0 + 1e-12
+    var_28 = paddle.log(var_27)
+    var_29 = var_28 * -1.0 + 0.0
+    var_30 = var_29 * 0.25 + 0.0
+    var_31 = var_19 * -1.0 + 1.0
+    var_32 = var_31 * var_31
+    var_33 = var_30 * var_32
+    var_34 = paddle.squeeze(var_1, [-1])
+    var_35 = paddle.transpose(var_33, perm=[1, 0])
+    var_36 = paddle.unsqueeze(var_34, [-1])
+    var_37 = paddle.gather_nd(var_35, var_36)
+    var_38 = paddle.transpose(var_37, perm=[1, 0])
+    var_39 = paddle.squeeze(var_1, [-1])
+    var_40 = paddle.transpose(var_26, perm=[1, 0])
+    var_41 = paddle.unsqueeze(var_39, [-1])
+    var_42 = paddle.gather_nd(var_40, var_41)
+    var_43 = paddle.transpose(var_42, perm=[1, 0])
+    var_44 = var_38 - var_43
+    var_45 = var_44 * 2.0 + 0.0
+    return (
+        var_24,
+        var_25,
+        var_30,
+        var_32,
+        var_35,
+        var_36,
+        var_40,
+        var_41,
+        var_45,
+    )
+
+
+def input_spec():
+    return [
+        paddle.static.InputSpec(shape=[None, 1], dtype='int32', name='var_1'),
+        paddle.static.InputSpec(
+            shape=[None, 80], dtype='float32', name='var_0'
+        ),
+    ]
+
+
+class TestCase(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def compare_result(self, dy_compute, data_init):
+        static_compute = paddle.jit.to_static(
+            full_graph=True,
+            build_strategy=build_strategy,
+            input_spec=input_spec(),
+        )(dy_compute)
+        inputs = data_init()
+        dy_out = dy_compute(*inputs)
+        st_out = static_compute(*inputs)
+        if isinstance(dy_out, paddle.Tensor):
+            numpy.testing.assert_allclose(dy_out, st_out, atol=1e-5, rtol=1e-6)
+            return
+        for d, s in zip(dy_out, st_out):
+            numpy.testing.assert_allclose(d, s, atol=1e-5, rtol=1e-6)
+
+    def test_case(self):
+        self.compare_result(func, init)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

```
Before remove redundant output from group op: 
() = "builtin.module" [id:181] () {program:0x55e308966350} : () -> 
{
    (%0) = "pd_op.data" [id:183] () {dtype:int32,name:"var_1",place:Place(undefined:0),shape:[-1,1],stop_gradient:[true]} : () -> tensor<-1x1xi32>
    (%1) = "pd_op.data" [id:184] () {dtype:float32,name:"var_0",place:Place(undefined:0),shape:[-1,80],stop_gradient:[true]} : () -> tensor<-1x80xf32>
    (%2, %3, %4, %5, %6, %7, %8, %9, %10) = "cinn_op.group" [id:279] () -> tensor<-1x80xf32>, tensor<-1x80xf32>, tensor<-1x80xf32>, tensor<-1x80xf32>, tensor<80x-1xf32>, tensor<-1x1xi32>, tensor<80x-1xf32>, tensor<-1x1xi32>, tensor<-1x-1xf32> {
        (%11) = "pd_op.full" [id:185] () {dtype:float32,place:Place(undefined:0),shape:[1],stop_gradient:[true],value:1} : () -> tensor<1xf32>
        (%12) = "cinn_op.scale" [id:259] (%1) {bias:0,bias_after_scale:true,scale:-1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%13) = "cinn_op.scale" [id:260] (%12) {bias:0,bias_after_scale:true,scale:1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%14) = "pd_op.exp" [id:190] (%13) {stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%15) = "cinn_op.generate_shape" [id:293] (%1, %0) {output_dim_exprs:["S1",80],stop_gradient:[true],symbol_bindings:[["ShapeSymbolBinding","S1",0,0]]} : (tensor<-1x80xf32>, tensor<-1x1xi32>) -> tensor<2xi64>
        (%16) = "pd_op.expand" [id:284] (%11, %15) {stop_gradient:[true]} : (tensor<1xf32>, tensor<2xi64>) -> tensor<-1x-1xf32>
        (%17) = "pd_op.add" [id:191] (%16, %14) {stop_gradient:[true]} : (tensor<-1x-1xf32>, tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%18) = "cinn_op.generate_shape" [id:294] (%1, %0) {output_dim_exprs:["S1",80],stop_gradient:[true],symbol_bindings:[["ShapeSymbolBinding","S1",0,0]]} : (tensor<-1x80xf32>, tensor<-1x1xi32>) -> tensor<2xi64>
        (%19) = "pd_op.expand" [id:288] (%11, %18) {stop_gradient:[true]} : (tensor<1xf32>, tensor<2xi64>) -> tensor<-1x-1xf32>
        (%20) = "pd_op.divide" [id:192] (%19, %17) {stop_gradient:[true]} : (tensor<-1x-1xf32>, tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%21) = "cinn_op.scale" [id:261] (%20) {bias:0,bias_after_scale:true,scale:-1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%22) = "cinn_op.scale" [id:262] (%21) {bias:1,bias_after_scale:true,scale:1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%23) = "cinn_op.scale" [id:263] (%22) {bias:0,bias_after_scale:true,scale:1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%24) = "cinn_op.scale" [id:264] (%23) {bias:1e-12,bias_after_scale:true,scale:1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%25) = "pd_op.log" [id:201] (%24) {stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%26) = "cinn_op.scale" [id:265] (%25) {bias:0,bias_after_scale:true,scale:-1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%27) = "cinn_op.scale" [id:266] (%26) {bias:0,bias_after_scale:true,scale:1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%28) = "cinn_op.scale" [id:267] (%27) {bias:0,bias_after_scale:true,scale:0.75,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%29) = "cinn_op.scale" [id:268] (%28) {bias:0,bias_after_scale:true,scale:1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%30) = "pd_op.multiply" [id:210] (%20, %20) {stop_gradient:[true]} : (tensor<-1x80xf32>, tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%31) = "pd_op.multiply" [id:211] (%29, %30) {stop_gradient:[true]} : (tensor<-1x80xf32>, tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%32) = "cinn_op.scale" [id:269] (%20) {bias:0,bias_after_scale:true,scale:1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%33) = "cinn_op.scale" [id:270] (%32) {bias:1e-12,bias_after_scale:true,scale:1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%34) = "pd_op.log" [id:216] (%33) {stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%35) = "cinn_op.scale" [id:271] (%34) {bias:0,bias_after_scale:true,scale:-1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%36) = "cinn_op.scale" [id:272] (%35) {bias:0,bias_after_scale:true,scale:1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%37) = "cinn_op.scale" [id:273] (%36) {bias:0,bias_after_scale:true,scale:0.25,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%38) = "cinn_op.scale" [id:274] (%37) {bias:0,bias_after_scale:true,scale:1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%39) = "cinn_op.scale" [id:275] (%20) {bias:0,bias_after_scale:true,scale:-1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%40) = "cinn_op.scale" [id:276] (%39) {bias:1,bias_after_scale:true,scale:1,stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%41) = "pd_op.multiply" [id:229] (%40, %40) {stop_gradient:[true]} : (tensor<-1x80xf32>, tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%42) = "pd_op.multiply" [id:230] (%38, %41) {stop_gradient:[true]} : (tensor<-1x80xf32>, tensor<-1x80xf32>) -> tensor<-1x80xf32>
        (%43) = "pd_op.transpose" [id:233] (%42) {perm:[1,0],stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<80x-1xf32>
        (%44) = "pd_op.gather_nd" [id:236] (%43, %0) {stop_gradient:[true]} : (tensor<80x-1xf32>, tensor<-1x1xi32>) -> tensor<-1x-1xf32>
        (%45) = "pd_op.transpose" [id:237] (%44) {perm:[1,0],stop_gradient:[true]} : (tensor<-1x-1xf32>) -> tensor<-1x-1xf32>
        (%46) = "pd_op.transpose" [id:240] (%31) {perm:[1,0],stop_gradient:[true]} : (tensor<-1x80xf32>) -> tensor<80x-1xf32>
        (%47) = "pd_op.gather_nd" [id:243] (%46, %0) {stop_gradient:[true]} : (tensor<80x-1xf32>, tensor<-1x1xi32>) -> tensor<-1x-1xf32>
        (%48) = "pd_op.transpose" [id:244] (%47) {perm:[1,0],stop_gradient:[true]} : (tensor<-1x-1xf32>) -> tensor<-1x-1xf32>
        (%49) = "pd_op.subtract" [id:245] (%45, %48) {stop_gradient:[true]} : (tensor<-1x-1xf32>, tensor<-1x-1xf32>) -> tensor<-1x-1xf32>
        (%50) = "cinn_op.scale" [id:277] (%49) {bias:0,bias_after_scale:true,scale:2,stop_gradient:[true]} : (tensor<-1x-1xf32>) -> tensor<-1x-1xf32>
        (%51) = "cinn_op.scale" [id:278] (%50) {bias:0,bias_after_scale:true,scale:1,stop_gradient:[true]} : (tensor<-1x-1xf32>) -> tensor<-1x-1xf32>
        () = "cf.yield" [id:280] (%29, %30, %38, %41, %43, %0, %46, %0, %51) {} : (tensor<-1x80xf32>, tensor<-1x80xf32>, tensor<-1x80xf32>, tensor<-1x80xf32>, tensor<80x-1xf32>, tensor<-1x1xi32>, tensor<80x-1xf32>, tensor<-1x1xi32>, tensor<-1x-1xf32>) -> 
    }
    () = "builtin.shadow_output" [id:250] (%2) {output_name:"output_0"} : (tensor<-1x80xf32>) -> 
    () = "builtin.shadow_output" [id:251] (%3) {output_name:"output_1"} : (tensor<-1x80xf32>) -> 
    () = "builtin.shadow_output" [id:252] (%4) {output_name:"output_2"} : (tensor<-1x80xf32>) -> 
    () = "builtin.shadow_output" [id:253] (%5) {output_name:"output_3"} : (tensor<-1x80xf32>) -> 
    () = "builtin.shadow_output" [id:254] (%6) {output_name:"output_4"} : (tensor<80x-1xf32>) -> 
    () = "builtin.shadow_output" [id:255] (%7) {output_name:"output_5"} : (tensor<-1x1xi32>) -> 
    () = "builtin.shadow_output" [id:256] (%8) {output_name:"output_6"} : (tensor<80x-1xf32>) -> 
    () = "builtin.shadow_output" [id:257] (%9) {output_name:"output_7"} : (tensor<-1x1xi32>) -> 
    () = "builtin.shadow_output" [id:258] (%10) {output_name:"output_8"} : (tensor<-1x-1xf32>) -> 
}
```

注意这里 group op 的输出 `() = "cf.yield" [id:280] (%29, %30, %38, %41, %43, %0, %46, %0, %51) {} : (tensor<-1x80xf32>, tensor<-1x80xf32>, tensor<-1x80xf32>, tensor<-1x80xf32>, tensor<80x-1xf32>, tensor<-1x1xi32>, tensor<80x-1xf32>, tensor<-1x1xi32>, tensor<-1x-1xf32>) -> ` 直接引用了外部变量 `%0`，圈 group 的时候还不是这样，前面的 `FoldManipulationOpsPass` 将中间的 OP 删掉了，变成这样了，后面切分成 FusionOp 时候就挂了

为了避免这一问题，在前面加一个 pass 将 `yield` 里的外部变量删掉，原来使用 group 输出的直接使用外部变量

（基本都是 @zyfncg 写的