### PR TITLE
[PHI] Update depthwise conv kernel

### DIFF
--- a/paddle/phi/kernels/gpu/depthwise_conv.h
+++ b/paddle/phi/kernels/gpu/depthwise_conv.h
@@ -1004,13 +1004,17 @@ __device__ __forceinline__ void NoReturnAtomicAdd(T* tensor,
 
   if (low_byte && index < (numel - 1)) {
     __half2 value2;
-    value2.x = value.to_half();
-    value2.y = __int2half_rz(0);
+    // value2.x = value.to_half();
+    value2.x = *reinterpret_cast<__half *>(&value);
+    // value2.y = __int2half_rz(0);
+    value2.y = 0.0;
     atomicAdd(reinterpret_cast<__half2*>(target_addr), value2);
   } else if (!low_byte && index > 0) {
     __half2 value2;
-    value2.x = __int2half_rz(0);
-    value2.y = value.to_half();
+    // value2.x = __int2half_rz(0);
+    value2.x = 0.0;
+    // value2.y = value.to_half();
+    value2.y = *reinterpret_cast<__half *>(&value);
     atomicAdd(reinterpret_cast<__half2*>(target_addr - 1), value2);
   } else {
     atomicAdd(reinterpret_cast<__half*>(tensor) + index, value.to_half());

--- a/paddle/phi/kernels/gpu/depthwise_conv.h
+++ b/paddle/phi/kernels/gpu/depthwise_conv.h
@@ -1103,11 +1103,12 @@ __device__ __inline__ void KernelDepthwiseConvFilterGradCFilterNHWC(
         }
       }
     }
+    const int numel = output_channels * c_filter * c_filter;
     for (int i = 0; i < c_filter * c_filter; ++i) {
-      T* weight = filter_grad_data + i * output_channels + kernel_id;
+      // T* weight = filter_grad_data + i * output_channels + kernel_id;
       NoReturnAtomicAdd(filter_grad_data,
                         i * output_channels + kernel_id,
-                        output_channels * c_filter * c_filter,
+                        numel,
                         r_weight[i]);
     }
   }

--- a/paddle/phi/kernels/gpu/depthwise_conv.h
+++ b/paddle/phi/kernels/gpu/depthwise_conv.h
@@ -993,7 +993,7 @@ __device__ __forceinline__ void NoReturnAtomicAdd(T* tensor,
                                                   index_t index,
                                                   const index_t numel,
                                                   T value) {
-#if (defined(PADDLE_WITH_ROCM) || \
+#if (defined(PADDLE_WITH_HIP) || \
      (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)))
   phi::CudaAtomicAdd(tensor + index, value);
 #else
@@ -1055,7 +1055,7 @@ __device__ __inline__ void KernelDepthwiseConvFilterGradCFilterNHWC(
   if (image_h >= output_height) {
     return;
   }
-  const int kWeightSize = c_filter * c_filter;
+  constexpr int kWeightSize = c_filter * c_filter;
   T r_weight[kWeightSize];
   const int wi_size = (output_width + dilate_width - 1) / dilate_width;
 

--- a/paddle/phi/kernels/gpu/depthwise_conv.h
+++ b/paddle/phi/kernels/gpu/depthwise_conv.h
@@ -985,6 +985,50 @@ __device__ __inline__ void KernelDepthwiseConvFilterGradNHWC(
   }
 }
 
+template <typename T,
+          typename index_t,
+          typename std::enable_if_t<std::is_same_v<phi::dtype::float16, T>>* =
+              nullptr>
+__device__ __forceinline__ void NoReturnAtomicAdd(T* tensor,
+                                                  index_t index,
+                                                  const index_t numel,
+                                                  T value) {
+#if ((defined(CUDA_VERSION) && (CUDA_VERSION < 10000)) || \
+     (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)))
+  phi::CudaAtomicAdd(tensor + index, value);
+#else
+  // Check if 32 bit aligned
+  __half* target_addr = reinterpret_cast<__half*>(tensor + index);
+  bool low_byte =
+      (reinterpret_cast<std::uintptr_t>(target_addr) % sizeof(__half2) == 0);
+
+  if (low_byte && index < (numel - 1)) {
+    __half2 value2;
+    value2.x = value.to_half();
+    value2.y = __int2half_rz(0);
+    atomicAdd(reinterpret_cast<__half2*>(target_addr), value2);
+  } else if (!low_byte && index > 0) {
+    __half2 value2;
+    value2.x = __int2half_rz(0);
+    value2.y = value.to_half();
+    atomicAdd(reinterpret_cast<__half2*>(target_addr - 1), value2);
+  } else {
+    atomicAdd(reinterpret_cast<__half*>(tensor) + index, value.to_half());
+  }
+#endif
+}
+
+template <typename T,
+          typename index_t,
+          typename std::enable_if_t<!std::is_same_v<phi::dtype::float16, T>>* =
+              nullptr>
+__device__ __forceinline__ void NoReturnAtomicAdd(T* tensor,
+                                                  index_t index,
+                                                  const index_t numel,
+                                                  T value) {
+  phi::CudaAtomicAdd(tensor + index, value);
+}
+
 template <typename T, int c_filter, bool fuse_relu_before_conv>
 __device__ __inline__ void KernelDepthwiseConvFilterGradCFilterNHWC(
     const T* output_grad_data,
@@ -1057,7 +1101,10 @@ __device__ __inline__ void KernelDepthwiseConvFilterGradCFilterNHWC(
     }
     for (int i = 0; i < c_filter * c_filter; ++i) {
       T* weight = filter_grad_data + i * output_channels + kernel_id;
-      phi::CudaAtomicAdd(&weight[0], r_weight[i]);
+      NoReturnAtomicAdd(filter_grad_data,
+                        i * output_channels + kernel_id,
+                        output_channels * c_filter * c_filter,
+                        r_weight[i]);
     }
   }
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

pcard-67164

Optimization speed up __half atomicAdd on V100 (A100, etc.). For those GPUs, using fast vectored __half2 atomicAdd instead of the __half one (up to 5x speedup).

test with depthwise_conv bwd fp16 on V100:

<img width="408" alt="image" src="https://github.com/user-attachments/assets/1ec3237c-75a8-46be-85dc-fff5a16c1c8e" />
