### PR TITLE
[CINN] Fix shape mismatch in axis transform simulation

### DIFF
--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/loop_axis_mapping.h
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/loop_axis_mapping.h
@@ -156,6 +156,7 @@ class AxisTransformSimulator {
   std::set<std::string> GetRelatedAxisIds(const std::vector<std::string>& ids);
 
   const AxisTransformRoute& route_;
+  std::vector<symbol::DimExpr> out_shape_;
   std::vector<std::string> source_ids_;
   std::vector<std::string> target_ids_;
   std::unordered_map<std::string, symbol::DimExpr> axis_symbols_;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
- Fix shape mismatch in axis transform simulation