### PR TITLE
[SOT] Standardize the `from_iterator` method of `MapVariable` and `ZipVariable`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -646,10 +646,10 @@ def create_zip(*var: VariableBase):
 
 # map
 @Dispatcher.register_decorator(map)
-def create_map(func: CallableVariable, *var: VariableBase):
-    tracked_vars = [func, *var]
+def create_map(fn: CallableVariable, *vars: VariableBase):
+    tracked_vars = [fn, *vars]
     return MapVariable.from_iterator(
-        func, var, graph=Dispatcher.graph, tracker=DummyTracker(tracked_vars)
+        fn, vars, graph=Dispatcher.graph, tracker=DummyTracker(tracked_vars)
     )
 
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
@@ -224,11 +224,7 @@ class ZipVariable(SequenceIterVariable):
                 return UserDefinedIterVariable(value, graph, tracker)
             zip_targets.append(iter_variable)
 
-        wrapped_zip_targets = TupleVariable(
-            tuple(zip_targets), graph, DummyTracker(zip_targets)
-        )
-
-        return ZipVariable(wrapped_zip_targets, graph, tracker)
+        return ZipVariable(zip_targets, graph, tracker)
 
 
 class MapVariable(SequenceIterVariable):
@@ -278,11 +274,7 @@ class MapVariable(SequenceIterVariable):
                 return UserDefinedIterVariable(value, graph, tracker)
             map_targets.append(iter_variable)
 
-        wrapped_map_targets = TupleVariable(
-            tuple(map_targets), graph, DummyTracker(map_targets)
-        )
-
-        return MapVariable(fn, wrapped_map_targets, graph, tracker)
+        return MapVariable(fn, map_targets, graph, tracker)
 
 
 # what UserDefinedIterVariable holds doesn't matter, because use user defined iterator will trigger break graph

--- a/python/paddle/jit/sot/utils/exceptions.py
+++ b/python/paddle/jit/sot/utils/exceptions.py
@@ -192,12 +192,9 @@ class FallbackError(SotErrorBase):
 
 # raise in inline function call strategy.
 class BreakGraphError(SotErrorBase):
-    def __init__(self, reason: BreakGraphReasonBase | str = None):
-        super().__init__()
-
-        if isinstance(reason, str):
-            # if reason is a string, then create a UnspecifiedBreakReason object
-            reason = UnspecifiedBreakReason(reason)
+    def __init__(self, reason: BreakGraphReasonBase):
+        assert isinstance(reason, BreakGraphReasonBase)
+        super().__init__(reason.reason_str)
         self.reason = reason
         BreakGraphReasonInfo.collect_break_graph_reason(reason)
 

--- a/python/paddle/jit/sot/utils/exceptions.py
+++ b/python/paddle/jit/sot/utils/exceptions.py
@@ -192,9 +192,12 @@ class FallbackError(SotErrorBase):
 
 # raise in inline function call strategy.
 class BreakGraphError(SotErrorBase):
-    def __init__(self, reason: BreakGraphReasonBase):
-        assert isinstance(reason, BreakGraphReasonBase)
-        super().__init__(reason.reason_str)
+    def __init__(self, reason: BreakGraphReasonBase | str = None):
+        super().__init__()
+
+        if isinstance(reason, str):
+            # if reason is a string, then create a UnspecifiedBreakReason object
+            reason = UnspecifiedBreakReason(reason)
         self.reason = reason
         BreakGraphReasonInfo.collect_break_graph_reason(reason)
 

--- a/test/sot/test_builtin_map.py
+++ b/test/sot/test_builtin_map.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 
 from test_case_base import TestCaseBase, test_with_faster_guard
 
-from paddle import to_tensor
+from paddle import Tensor, to_tensor
 from paddle.jit import sot
 from paddle.jit.sot.psdb import check_no_breakgraph
 from paddle.jit.sot.utils import strict_mode_guard
@@ -100,9 +100,9 @@ def test_map_for_loop(x: list):
 
 
 @check_no_breakgraph
-def test_map_multi_input(func, tensor_, tuple_):
-    x, y, z = map(func, tensor_, tuple_)
-    return x
+def test_map_multi_input(func, a: Tensor, b: tuple[int, ...]):
+    x, y, z = map(func, a, b)
+    return x, y, z
 
 
 @check_no_breakgraph


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
规范了变量名。

在`from_iterator`方法中，把传入的一系列变量封装成`TupleVariable`之后，再传给初始化函数。

PCard-66972