### PR TITLE
[CINN] Optimize nvrtc compile time

### DIFF
--- a/paddle/cinn/backends/codegen_cuda_dev.cc
+++ b/paddle/cinn/backends/codegen_cuda_dev.cc
@@ -18,11 +18,13 @@ namespace cinn {
 namespace backends {
 
 const std::string CodeGenCudaDev::source_header_ =  // NOLINT
-    R"(#include <cstdint>
+    R"(
+    #pragma once
+#include <cinn_with_cuda_h>
 
-#define CINN_WITH_CUDA
-#include "bfloat16.h"
-#include "float16.h"
+#include <bfloat16_h>
+#include <cstdint>
+#include <float16_h>
 using cinn::common::bfloat16;
 using cinn::common::float16;
 using cinn::common::float8;
@@ -34,8 +36,8 @@ using cinn::common::float162;
 using cinn::common::bfloat168;
 using cinn::common::bfloat164;
 using cinn::common::bfloat162;
+#include <cinn_cuda_runtime_source_h>
 
-#include "cinn_cuda_runtime_source.cuh"
 )";
 
 const std::string &CodeGenCudaDev::GetSourceHeader() { return source_header_; }

--- a/paddle/cinn/backends/codegen_cuda_dev.cc
+++ b/paddle/cinn/backends/codegen_cuda_dev.cc
@@ -16,10 +16,29 @@
 
 namespace cinn {
 namespace backends {
-
+const std::string CodeGenCudaDev::general_source_header_ =  // NOLINT
+    R"(
+#pragma once
+#include <cstdint>
+#define CINN_WITH_CUDA
+#include "bfloat16.h"
+#include "float16.h"
+using cinn::common::bfloat16;
+using cinn::common::float16;
+using cinn::common::float8;
+using cinn::common::half4;
+using cinn::common::half8;
+using cinn::common::float168;
+using cinn::common::float164;
+using cinn::common::float162;
+using cinn::common::bfloat168;
+using cinn::common::bfloat164;
+using cinn::common::bfloat162;
+#include "cinn_cuda_runtime_source.cuh"
+)";
 const std::string CodeGenCudaDev::source_header_ =  // NOLINT
     R"(
-    #pragma once
+#pragma once
 #include <cinn_with_cuda_h>
 
 #include <bfloat16_h>
@@ -41,6 +60,9 @@ using cinn::common::bfloat162;
 )";
 
 const std::string &CodeGenCudaDev::GetSourceHeader() { return source_header_; }
+const std::string &CodeGenCudaDev::GetGeneralSourceHeader() {
+  return general_source_header_;
+}
 
 CodeGenCudaDev::CodeGenCudaDev(Target target) : CodeGenGpuDev(target) {}
 

--- a/paddle/cinn/backends/codegen_cuda_dev.h
+++ b/paddle/cinn/backends/codegen_cuda_dev.h
@@ -31,10 +31,15 @@ class CodeGenCudaDev : public CodeGenGpuDev {
  public:
   explicit CodeGenCudaDev(Target target);
   static const std::string& GetSourceHeader();
+  static const std::string& GetGeneralSourceHeader();
   void PrintIncludes() override;
 
  private:
   static const std::string source_header_;
+  // general_source_header_ is used for the more general situation, which load
+  // some header files while compiling but not set them into header files while
+  // creating the kernel function.
+  static const std::string general_source_header_;
 };
 
 }  // namespace backends

--- a/paddle/cinn/backends/nvrtc/header_generator.cc
+++ b/paddle/cinn/backends/nvrtc/header_generator.cc
@@ -14,9 +14,12 @@
 
 #include "paddle/cinn/backends/nvrtc/header_generator.h"
 
+#include <fstream>
 #include "glog/logging.h"
 #include "jitify.hpp"  // NOLINT
+#include "paddle/cinn/common/common.h"
 #include "paddle/common/enforce.h"
+
 namespace cinn {
 namespace backends {
 namespace nvrtc {
@@ -34,12 +37,57 @@ const size_t JitSafeHeaderGenerator::size() const {
   return include_names_.size();
 }
 
+std::string read_file_as_string(const std::string& file_path) {
+#ifdef RUNTIME_INCLUDE_DIR
+  static constexpr char* defined_runtime_include_dir = RUNTIME_INCLUDE_DIR;
+#else
+  static constexpr char* defined_runtime_include_dir = nullptr;
+#endif
+
+  std::string cinn_path = defined_runtime_include_dir;
+
+  std::ifstream file(cinn_path + '/' + file_path);
+#ifdef CINN_WITH_CUDA
+  PADDLE_ENFORCE_EQ(static_cast<bool>(file),
+                    true,
+                    ::common::errors::InvalidArgument("Failed to open file"));
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  return buffer.str();
+#else
+  return "";
+#endif
+}
+#ifdef CINN_WITH_CUDA
+
+static const std::string cinn_float16_header =  // NOLINT
+    read_file_as_string("float16.h");
+static const std::string cinn_bfloat16_header =  // NOLINT
+    read_file_as_string("bfloat16.h");
+static const std::string cinn_with_cuda_header =  // NOLINT
+    R"(
+#pragma once
+#define CINN_WITH_CUDA
+)";
+static const std::string cinn_cuda_runtime_source_header =  // NOLINT
+    read_file_as_string("cinn_cuda_runtime_source.cuh");
+#endif
 JitSafeHeaderGenerator::JitSafeHeaderGenerator() {
   const auto& headers_map = ::jitify::detail::get_jitsafe_headers_map();
   for (auto& pair : headers_map) {
     include_names_.emplace_back(pair.first.data());
     headers_.emplace_back(pair.second.data());
   }
+#ifdef CINN_WITH_CUDA
+  include_names_.emplace_back("float16_h");
+  headers_.emplace_back(cinn_float16_header.data());
+  include_names_.emplace_back("bfloat16_h");
+  headers_.emplace_back(cinn_bfloat16_header.data());
+  include_names_.emplace_back("cinn_with_cuda_h");
+  headers_.emplace_back(cinn_with_cuda_header.data());
+  include_names_.emplace_back("cinn_cuda_runtime_source_h");
+  headers_.emplace_back(cinn_cuda_runtime_source_header.data());
+#endif
 }
 
 }  // namespace nvrtc

--- a/paddle/cinn/backends/nvrtc/header_generator.cc
+++ b/paddle/cinn/backends/nvrtc/header_generator.cc
@@ -49,9 +49,18 @@ std::string read_file_as_string(const std::string& file_path) {
   std::ifstream file(cinn_path + '/' + file_path);
 #ifdef CINN_WITH_CUDA
   if (!file.is_open()) {
-    LOG_FIRST_N(INFO, 1) << "Unable to open file : " << cinn_path << '/'
-                         << file_path;
-    return "";
+    std::string from = "runtime/cuda";
+    std::string to = "common";
+    size_t pos = cinn_path.rfind(from);
+    if (pos != std::string::npos) {
+      cinn_path.replace(pos, from.length(), to);
+    }
+    std::ifstream file(cinn_path + '/' + file_path);
+    if (!file.is_open()) {
+      LOG_FIRST_N(INFO, 1) << "Unable to open file : " << cinn_path << '/'
+                           << file_path;
+      return "";
+    }
   }
   std::stringstream buffer;
   buffer << file.rdbuf();

--- a/paddle/cinn/backends/nvrtc/header_generator.cc
+++ b/paddle/cinn/backends/nvrtc/header_generator.cc
@@ -48,9 +48,11 @@ std::string read_file_as_string(const std::string& file_path) {
 
   std::ifstream file(cinn_path + '/' + file_path);
 #ifdef CINN_WITH_CUDA
-  PADDLE_ENFORCE_EQ(static_cast<bool>(file),
-                    true,
-                    ::common::errors::InvalidArgument("Failed to open file"));
+  if (!file.is_open()) {
+    LOG_FIRST_N(INFO, 1) << "Unable to open file : " << cinn_path << '/'
+                         << file_path;
+    return "";
+  }
   std::stringstream buffer;
   buffer << file.rdbuf();
   return buffer.str();

--- a/paddle/cinn/backends/nvrtc/header_generator.cc
+++ b/paddle/cinn/backends/nvrtc/header_generator.cc
@@ -44,27 +44,14 @@ std::string read_file_as_string(const std::string& file_path) {
   static constexpr char* defined_runtime_include_dir = nullptr;
 #endif
 
-  std::string cinn_path = defined_runtime_include_dir;
-
-  std::ifstream file(cinn_path + '/' + file_path);
 #ifdef CINN_WITH_CUDA
+  std::string cinn_path = defined_runtime_include_dir;
+  std::ifstream file(cinn_path + '/' + file_path);
+
   if (!file.is_open()) {
-    std::string from = "runtime/cuda";
-    std::string to = "common";
-    size_t pos = cinn_path.rfind(from);
-    if (pos != std::string::npos) {
-      cinn_path.replace(pos, from.length(), to);
-    }
-    std::ifstream file(cinn_path + '/' + file_path);
-    if (!file.is_open()) {
-      LOG_FIRST_N(INFO, 1) << "Unable to open file : " << cinn_path << '/'
-                           << file_path;
-      return "";
-    }
-    std::stringstream buffer;
-    buffer << file.rdbuf();
-    file.close();
-    return buffer.str();
+    LOG_FIRST_N(INFO, 1) << "Unable to open file : " << cinn_path << '/'
+                         << file_path;
+    return "";
   }
   std::stringstream buffer;
   buffer << file.rdbuf();

--- a/paddle/cinn/backends/nvrtc/header_generator.cc
+++ b/paddle/cinn/backends/nvrtc/header_generator.cc
@@ -61,9 +61,14 @@ std::string read_file_as_string(const std::string& file_path) {
                            << file_path;
       return "";
     }
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    file.close();
+    return buffer.str();
   }
   std::stringstream buffer;
   buffer << file.rdbuf();
+  file.close();
   return buffer.str();
 #else
   return "";

--- a/paddle/cinn/backends/nvrtc/nvrtc_util.cc
+++ b/paddle/cinn/backends/nvrtc/nvrtc_util.cc
@@ -24,6 +24,7 @@
 #include <fstream>
 #include <iostream>
 
+#include "paddle/cinn/backends/codegen_cuda_dev.h"
 #include "paddle/cinn/backends/cuda_util.h"
 #include "paddle/cinn/backends/nvrtc/header_generator.h"
 #include "paddle/cinn/common/common.h"
@@ -182,25 +183,7 @@ std::string Compiler::CompileCudaSource(const std::string& code,
       nvrtcCompileProgram(prog, param_cstrings.size(), param_cstrings.data());
 
   if (compile_res != NVRTC_SUCCESS) {
-    std::string source_header_ =  // NOLINT
-        R"(#include <cstdint>
-#define CINN_WITH_CUDA
-#include "bfloat16.h"
-#include "float16.h"
-using cinn::common::bfloat16;
-using cinn::common::float16;
-using cinn::common::float8;
-using cinn::common::half4;
-using cinn::common::half8;
-using cinn::common::float168;
-using cinn::common::float164;
-using cinn::common::float162;
-using cinn::common::bfloat168;
-using cinn::common::bfloat164;
-using cinn::common::bfloat162;
-#include "cinn_cuda_runtime_source.cuh"
-)";
-    std::string new_code = source_header_ + code;
+    std::string new_code = CodeGenCudaDev::GetGeneralSourceHeader() + code;
     NVRTC_CALL(nvrtcCreateProgram(&prog,
                                   new_code.c_str(),
                                   nullptr,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164
Optimize nvrtc compile time
nvrtcCreateProgram中作为参数传入的头文件类似于第三方库，需要在code string中被显式调用才会被编译。所以运行时间慢主要原因是 code string 中默认 include 的头文件大小、多少。以float16.h为例，可以将float16.h中的字符串作为一个header，传递给 nvrtcCreateProgram （类似原来header gen中头文件形式）。这样编译时就不用再次查找、解析，而是直接使用 header 里的字符串。