### PR TITLE
[SOT] `GraphLogger`->`SubGraphInfo` to collect graph info

### DIFF
--- a/python/paddle/jit/sot/symbolic/compile_cache.py
+++ b/python/paddle/jit/sot/symbolic/compile_cache.py
@@ -27,11 +27,11 @@ from ..profiler import EventGuard
 from ..utils import (
     ENV_SOT_EXPORT,
     Cache,
-    GraphLogger,
     InfoCollector,
     NewSymbolHitRateInfo,
     Singleton,
     StepInfoManager,
+    SubGraphInfo,
     SubGraphRelationInfo,
     log,
     log_do,
@@ -41,6 +41,7 @@ from .export import export
 from .interpreter import compile_sir
 
 if TYPE_CHECKING:
+    from paddle.framework import Program
     from paddle.static import InputSpec
 
     from .symbolic_context import SymbolicTraceContext
@@ -217,6 +218,18 @@ class FallbackWrapper:
             self.graph_size(),
         )
 
+    def collect_subgraph_info(self, program: Program):
+        if not InfoCollector().need_collect(SubGraphInfo):
+            return
+
+        InfoCollector().attach(
+            SubGraphInfo,
+            program,
+            self.graph_size(),
+            self.SIR.name,
+            self.is_first_call,
+        )
+
     def __call__(self, *args, **kwargs):
         with EventGuard(f"FallbackWrapper: {self.SIR.name}"):
             if StepInfoManager().need_back_trace:
@@ -248,17 +261,12 @@ class FallbackWrapper:
 
             clear_eager_tensor_name(outputs)
             log_do(
-                1,
-                lambda: GraphLogger().add_subgraph(
-                    self.concrete_program.main_program
-                ),
-            )
-            log_do(
                 4,
                 lambda: print("[CompileCache] run sir forward success."),
             )
             self.collect_new_symbol_hit_rate(args, outputs)
             self.collect_subgraph_relation(args, outputs, self.partial_program)
+            self.collect_subgraph_info(self.concrete_program.main_program)
             if ENV_SOT_EXPORT.get() != "" and not self.exported:
                 export(self.SIR, ENV_SOT_EXPORT.get())
                 self.exported = True

--- a/python/paddle/jit/sot/translate.py
+++ b/python/paddle/jit/sot/translate.py
@@ -23,10 +23,8 @@ import paddle
 from .opcode_translator import eval_frame_callback
 from .profiler import SotStepProfilerGuard
 from .utils import (
-    GraphLogger,
     InfoCollector,
     StepInfoManager,
-    log_do,
 )
 
 P = ParamSpec("P")
@@ -100,7 +98,6 @@ def symbolic_translate(fn: Callable[P, R], **kwargs) -> Callable[P, R]:
             assert hasattr(
                 fn, "__code__"
             ), "Target function doesn't have code for simulating."
-            GraphLogger().clear()
             InfoCollector().clear_step_info()
             paddle.framework.core.set_eval_frame(callback)
             try:
@@ -110,7 +107,6 @@ def symbolic_translate(fn: Callable[P, R], **kwargs) -> Callable[P, R]:
             finally:
                 paddle.framework.core.set_eval_frame(None)
 
-            log_do(1, lambda: GraphLogger().print_info())
             InfoCollector().print_step_report()
             return outs
 

--- a/python/paddle/jit/sot/utils/__init__.py
+++ b/python/paddle/jit/sot/utils/__init__.py
@@ -52,6 +52,7 @@ from .info_collector import (  # noqa: F401
     CompileCountInfo,
     InfoCollector,
     NewSymbolHitRateInfo,
+    SubGraphInfo,
     SubGraphRelationInfo,
 )
 from .magic_methods import magic_method_builtin_dispatch  # noqa: F401
@@ -65,7 +66,6 @@ from .paddle_api_config import (  # noqa: F401
 from .utils import (  # noqa: F401
     Cache,
     ConstTypes,
-    GraphLogger,
     NameGenerator,
     ResumeFnNameFactory,
     Singleton,

--- a/python/paddle/jit/sot/utils/info_collector.py
+++ b/python/paddle/jit/sot/utils/info_collector.py
@@ -27,11 +27,9 @@ from .envs import ENV_SOT_COLLECT_INFO
 from .utils import Singleton
 
 if TYPE_CHECKING:
-    from .exceptions import BreakGraphReasonBase
-
-
-if TYPE_CHECKING:
     import types
+
+    from .exceptions import BreakGraphReasonBase
 
 
 def try_import_graphviz():
@@ -220,9 +218,9 @@ class SubGraphRelationInfo(InfoBase):
             dot.node(
                 subgraph_id,
                 f"Subgraph {i} ({info.subgraph_name}, size={info.graph_size})",
-                shape='oval',
-                fillcolor='cyan' if info.is_first_call else None,
-                style='filled' if info.is_first_call else None,
+                shape="oval",
+                fillcolor="cyan" if info.is_first_call else None,
+                style="filled" if info.is_first_call else None,
             )
             for shape_info in info.input_shape_infos:
                 dot.edge(
@@ -281,7 +279,6 @@ class BreakGraphReasonInfo(InfoBase):
 
     @classmethod
     def summary(cls, history: list[Self]) -> str:
-
         reason_dict = {}
 
         for info in history:
@@ -306,3 +303,30 @@ class BreakGraphReasonInfo(InfoBase):
             return
 
         InfoCollector().attach(BreakGraphReasonInfo, reason)
+
+
+class SubGraphInfo(InfoBase):
+    SHORT_NAME = "subgraph_info"
+    TYPE = InfoType.E2E_INFO
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        self.clear()
+
+        self.graph, self.op_num, *_ = args
+
+    def clear(self):
+        self.graph = None
+        self.op_num = 0
+
+    def __str__(self):
+        return f"OpNum: {self.op_num}\n{self.graph}"
+
+    @classmethod
+    def summary(cls, history: list[Self]) -> str:
+        return "\n".join(
+            [
+                f"SubGraphIdx: {idx} {info}"
+                for idx, info in enumerate(map(str, history))
+            ]
+        )

--- a/python/paddle/jit/sot/utils/utils.py
+++ b/python/paddle/jit/sot/utils/utils.py
@@ -42,7 +42,6 @@ from .paddle_api_config import (
 
 if TYPE_CHECKING:
     from paddle._typing import NestedStructure
-    from paddle.framework import Program
 
 T = TypeVar("T")
 T1 = TypeVar("T1")
@@ -327,59 +326,6 @@ def list_contain_by_id(li: list[Any], item: Any) -> int:
 def get_unbound_method(obj, name):
     # TODO(dev): Consider the case of patching methods to instances
     return getattr(obj.__class__, name)
-
-
-class GraphLogger(metaclass=Singleton):
-    graph_num: int
-    graphs: list[Program]
-    num_ops_per_graph: list[int]
-
-    def __init__(self):
-        self.clear()
-
-    def clear(self):
-        self.graph_num = 0
-        self.graphs = []
-        self.num_ops_per_graph = []
-
-    def get_graph_num(self):
-        return self.graph_num
-
-    def get_op_num(self):
-        return sum(self.num_ops_per_graph)
-
-    def add_subgraph(self, program: Program):
-        self.graph_num += 1
-        self.graphs.append(program)
-        sub_graph_op_num = len(program.global_block().ops)
-        self.num_ops_per_graph.append(sub_graph_op_num)
-
-    def add_subgraph_info(self, strs):
-        for i in range(len(self.graphs)):
-            strs.append(
-                "------------------------------------------------------"
-            )
-
-            strs.append(f"subgraph {i}, OpNum: {self.num_ops_per_graph[i]}")
-            strs.append(f"{self.graphs[i]}")
-
-    def __str__(self):
-        strs = []
-        strs.append("---------------- PaddleSOT graph info ----------------")
-        strs.append(f"SubgraphNum: {self.get_graph_num()}")
-        strs.append(f"OpNum: {self.get_op_num()}")
-
-        # We can display every subgraph info
-        log_do(5, lambda: self.add_subgraph_info(strs))
-
-        strs.append("---------------- PaddleSOT graph info ----------------")
-        return "\n".join(strs)
-
-    def __repr__(self):
-        return self.__str__()
-
-    def print_info(self):
-        print(self)
 
 
 class SotUndefinedVar(metaclass=Singleton):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

This PR removes the `GraphLogger` and introduces `SubGraphInfo` to collect subgraph information, including the number of operators (OPs) in each subgraph and the details of the operators. 
Subsequently, the information from `SubGraphInfo` and `BreakGraphReasonInfo` will be integrated.

**Example Code**:

```python
import paddle
import numpy as np


def fn(a):
    # print(a)
    a = a + 1
    b = np.array([2, 1.0], dtype="float32")
    a = a + b
    a = a * 2

    "%s" % a
    # print(a)
    a = a + 1

    f = a + 1
    print(f)
    f += 1
    return f


static_fn = paddle.jit.to_static(fn, full_graph=False)

x = paddle.to_tensor([1.0, 2.0], dtype="float32")
out = static_fn(x)
print(out)
```

**Usage**:

To enable information collection, set the environment variable:

```shell
CUDA_VISIBLE_DEVICES=2 \
PYTHONPATH=/workspace/Paddle/build/python \
MIN_GRAPH_SIZE=0 \
SOT_COLLECT_INFO=subgraph_info,breakgraph_reason \
python test_sot.py
```

This will activate the collection of subgraph information and the reasons for graph breaks.

```

Tensor(shape=[2], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [10., 10.])
Tensor(shape=[2], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [11., 11.])

----------------------------------------
--------- 这部分是子图打断的原因 ---------
----------------------------------------
BreakGraphReasonInfo (breakgraph_reason):
BuiltinFunctionBreak (3):
        Not support builtin function: array with args: Args(ListVariable)
        Not support builtin function: __add__ with args: Args(TensorVariable, NumpyArrayVariable)
        Not support builtin function: print with args: Args(TensorVariable)
UnsupportedOperationBreak (1):
        Unsupported operator '__rmod__' between ConstantVariable and TensorVariable


----------------------------------------
--------- 这部分是子图的信息 ---------
----------------------------------------
SubGraphInfo (subgraph_info):
SubGraphIdx: 0 OpNum: 2
{
    (%0) = "pd_op.data" () {dtype:float32,name:"args_0",place:Place(undefined:0),shape:[2],stop_gradient:[true]} : () -> tensor<2xf32>
    (%1) = "pd_op.full" () {dtype:float32,place:Place(cpu),shape:[1],stop_gradient:[true],value:1} : () -> tensor<1xf32>
    (%2) = "pd_op.scale" (%0, %1) {bias:1,bias_after_scale:true,stop_gradient:[true]} : (tensor<2xf32>, tensor<1xf32>) -> tensor<2xf32>
    () = "builtin.shadow_output" (%2) {output_name:"output_0"} : (tensor<2xf32>) -> 
}

SubGraphIdx: 1 OpNum: 2
{
    (%0) = "pd_op.data" () {dtype:float32,name:"args_0",place:Place(undefined:0),shape:[2],stop_gradient:[true]} : () -> tensor<2xf32>
    (%1) = "pd_op.full" () {dtype:float32,place:Place(cpu),shape:[1],stop_gradient:[true],value:2} : () -> tensor<1xf32>
    (%2) = "pd_op.scale" (%0, %1) {bias:0,bias_after_scale:true,stop_gradient:[true]} : (tensor<2xf32>, tensor<1xf32>) -> tensor<2xf32>
    () = "builtin.shadow_output" (%2) {output_name:"output_0"} : (tensor<2xf32>) -> 
}

SubGraphIdx: 2 OpNum: 4
{
    (%0) = "pd_op.data" () {dtype:float32,name:"args_0",place:Place(undefined:0),shape:[2],stop_gradient:[true]} : () -> tensor<2xf32>
    (%1) = "pd_op.full" () {dtype:float32,place:Place(cpu),shape:[1],stop_gradient:[true],value:1} : () -> tensor<1xf32>
    (%2) = "pd_op.scale" (%0, %1) {bias:1,bias_after_scale:true,stop_gradient:[true]} : (tensor<2xf32>, tensor<1xf32>) -> tensor<2xf32>
    (%3) = "pd_op.full" () {dtype:float32,place:Place(cpu),shape:[1],stop_gradient:[true],value:1} : () -> tensor<1xf32>
    (%4) = "pd_op.scale" (%2, %3) {bias:1,bias_after_scale:true,stop_gradient:[true]} : (tensor<2xf32>, tensor<1xf32>) -> tensor<2xf32>
    () = "builtin.shadow_output" (%4) {output_name:"output_0"} : (tensor<2xf32>) -> 
}

SubGraphIdx: 3 OpNum: 2
{
    (%0) = "pd_op.data" () {dtype:float32,name:"args_0",place:Place(undefined:0),shape:[2],stop_gradient:[true]} : () -> tensor<2xf32>
    (%1) = "pd_op.full" () {dtype:float32,place:Place(cpu),shape:[1],stop_gradient:[true],value:1} : () -> tensor<1xf32>
    (%2) = "pd_op.scale" (%0, %1) {bias:1,bias_after_scale:true,stop_gradient:[true]} : (tensor<2xf32>, tensor<1xf32>) -> tensor<2xf32>
    () = "builtin.shadow_output" (%2) {output_name:"output_0"} : (tensor<2xf32>) -> 
}

```

PCard-66972