### PR TITLE
[XPU] fix batch_norm_grad when use global status

### DIFF
--- a/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
@@ -191,6 +191,12 @@ void BatchNormGradKernel(const Context &dev_ctx,
 
   const auto *global_mean = mean.get_ptr();
   const auto *global_var = variance.get_ptr();
+  PADDLE_ENFORCE_NOT_NULL(global_mean,
+    errors::InvalidArgument(
+      "global_mean cannot be nullptr when use_global_stats is True")
+  PADDLE_ENFORCE_NOT_NULL(global_var,
+    errors::InvalidArgument(
+      "global_var cannot be nullptr when use_global_stats is True")
 
   float *global_inv_std_data = nullptr;
   int r = 0;

--- a/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
@@ -191,18 +191,18 @@ void BatchNormGradKernel(const Context &dev_ctx,
 
   const auto *global_mean = mean.get_ptr();
   const auto *global_var = variance.get_ptr();
-  PADDLE_ENFORCE_NOT_NULL(
-      global_mean,
-      errors::InvalidArgument(
-          "global_mean cannot be nullptr when use_global_stats is True"));
-  PADDLE_ENFORCE_NOT_NULL(
-      global_var,
-      errors::InvalidArgument(
-          "global_var cannot be nullptr when use_global_stats is True"));
-
   float *global_inv_std_data = nullptr;
   int r = 0;
   if (use_global_stats) {
+    PADDLE_ENFORCE_NOT_NULL(
+        global_mean,
+        errors::InvalidArgument(
+            "global_mean cannot be nullptr when use_global_stats is True"));
+    PADDLE_ENFORCE_NOT_NULL(
+        global_var,
+        errors::InvalidArgument(
+            "global_var cannot be nullptr when use_global_stats is True"));
+
     global_inv_std_data = RAII_GUARD.alloc_l3_or_gm<float>(global_var->numel());
     float *epsilon_data = RAII_GUARD.alloc_l3_or_gm<float>(1);
     r = CalculateInvVar(dev_ctx.x_context(),

--- a/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
@@ -192,34 +192,32 @@ void BatchNormGradKernel(const Context &dev_ctx,
   const auto *global_mean = mean.get_ptr();
   const auto *global_var = variance.get_ptr();
 
-  // TODO(guozibin): handle the situation case of N * H * W = 1
+  float *global_inv_std_data = nullptr;
   int r = 0;
-  if (is_inplace) {
-    float *global_inv_std_data = nullptr;
-    if (use_global_stats) {
-      global_inv_std_data =
-          RAII_GUARD.alloc_l3_or_gm<float>(global_var->numel());
-      float *epsilon_data = RAII_GUARD.alloc_l3_or_gm<float>(1);
-      r = CalculateInvVar(dev_ctx.x_context(),
-                          global_var->data<float>(),
-                          epsilon,
-                          C,
-                          epsilon_data,
-                          global_inv_std_data);
-      PADDLE_ENFORCE_XDNN_SUCCESS(r,
-                                  "batch_norm_grad CalculateInvVar function");
-    }
+  if (use_global_stats) {
+    global_inv_std_data = RAII_GUARD.alloc_l3_or_gm<float>(global_var->numel());
+    float *epsilon_data = RAII_GUARD.alloc_l3_or_gm<float>(1);
+    r = CalculateInvVar(dev_ctx.x_context(),
+                        global_var->data<float>(),
+                        epsilon,
+                        C,
+                        epsilon_data,
+                        global_inv_std_data);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "batch_norm_grad CalculateInvVar function");
+  }
+  auto *inv_std_data =
+      use_global_stats ? global_inv_std_data : saved_variance.data<float>();
+  auto *mean_data =
+      use_global_stats ? global_mean->data<float>() : saved_mean.data<float>();
 
+  // TODO(guozibin): handle the situation case of N * H * W = 1
+  if (is_inplace) {
     // Here is a trick, x is a const input,
     // but trans to a non-const var, is it risky?
     float *x_fp32_data = RAII_GUARD.alloc_l3_or_gm<float>(x.numel());
     r = xpu::cast<XPUType, float>(
         dev_ctx.x_context(), x_data, x_fp32_data, x.numel());
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
-    auto *inv_std_data =
-        use_global_stats ? global_inv_std_data : saved_variance.data<float>();
-    auto *mean_data = use_global_stats ? global_mean->data<float>()
-                                       : saved_mean.data<float>();
     r = CalculateInvBNY(dev_ctx.x_context(),
                         x_fp32_data,
                         new_scale.data<float>(),
@@ -234,49 +232,29 @@ void BatchNormGradKernel(const Context &dev_ctx,
   }
 
   bool is_nchw = data_layout == "NCHW";
-  if (use_global_stats) {
-    r = xpu::batch_norm_grad<XPUType>(dev_ctx.x_context(),
-                                      x_data,
-                                      d_y_data,
-                                      x_grad_data,
-                                      N,
-                                      C,
-                                      H,
-                                      W,
-                                      scale_data,
-                                      nullptr,
-                                      nullptr,
-                                      scale_grad_data,
-                                      bias_grad_data,
-                                      is_nchw,
-                                      global_mean->data<float>(),
-                                      global_var->data<float>(),
-                                      epsilon);
-  } else {
-    if (!x_grad) {
-      x_grad_data = RAII_GUARD.alloc_l3_or_gm<XPUType>(x.numel());
-    }
-    if (!scale_grad) {
-      scale_grad_data = RAII_GUARD.alloc_l3_or_gm<float>(C);
-    }
-    if (!bias_grad_data) {
-      bias_grad_data = RAII_GUARD.alloc_l3_or_gm<float>(C);
-    }
-    r = xpu::batch_norm_grad<XPUType>(dev_ctx.x_context(),
-                                      x_data,
-                                      d_y_data,
-                                      x_grad_data,
-                                      N,
-                                      C,
-                                      H,
-                                      W,
-                                      scale_data,
-                                      saved_mean.data<float>(),
-                                      saved_variance.data<float>(),
-                                      scale_grad_data,
-                                      bias_grad_data,
-                                      is_nchw);
+  if (!x_grad) {
+    x_grad_data = RAII_GUARD.alloc_l3_or_gm<XPUType>(x.numel());
   }
+  if (!scale_grad) {
+    scale_grad_data = RAII_GUARD.alloc_l3_or_gm<float>(C);
+  }
+  if (!bias_grad_data) {
+    bias_grad_data = RAII_GUARD.alloc_l3_or_gm<float>(C);
+  }
+  r = xpu::batch_norm_grad<XPUType>(dev_ctx.x_context(),
+                                    x_data,
+                                    d_y_data,
+                                    x_grad_data,
+                                    N,
+                                    C,
+                                    H,
+                                    W,
+                                    scale_data,
+                                    mean_data,
+                                    inv_std_data,
+                                    scale_grad_data,
+                                    bias_grad_data,
+                                    is_nchw);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "batch_norm_grad");
 }
 

--- a/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
@@ -191,12 +191,14 @@ void BatchNormGradKernel(const Context &dev_ctx,
 
   const auto *global_mean = mean.get_ptr();
   const auto *global_var = variance.get_ptr();
-  PADDLE_ENFORCE_NOT_NULL(global_mean,
-    errors::InvalidArgument(
-      "global_mean cannot be nullptr when use_global_stats is True"));
-  PADDLE_ENFORCE_NOT_NULL(global_var,
-    errors::InvalidArgument(
-      "global_var cannot be nullptr when use_global_stats is True"));
+  PADDLE_ENFORCE_NOT_NULL(
+      global_mean,
+      errors::InvalidArgument(
+          "global_mean cannot be nullptr when use_global_stats is True"));
+  PADDLE_ENFORCE_NOT_NULL(
+      global_var,
+      errors::InvalidArgument(
+          "global_var cannot be nullptr when use_global_stats is True"));
 
   float *global_inv_std_data = nullptr;
   int r = 0;

--- a/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
@@ -193,10 +193,10 @@ void BatchNormGradKernel(const Context &dev_ctx,
   const auto *global_var = variance.get_ptr();
   PADDLE_ENFORCE_NOT_NULL(global_mean,
     errors::InvalidArgument(
-      "global_mean cannot be nullptr when use_global_stats is True")
+      "global_mean cannot be nullptr when use_global_stats is True"));
   PADDLE_ENFORCE_NOT_NULL(global_var,
     errors::InvalidArgument(
-      "global_var cannot be nullptr when use_global_stats is True")
+      "global_var cannot be nullptr when use_global_stats is True"));
 
   float *global_inv_std_data = nullptr;
   int r = 0;

--- a/test/xpu/test_batch_norm_op_xpu.py
+++ b/test/xpu/test_batch_norm_op_xpu.py
@@ -55,9 +55,52 @@ def ref_batch_norm_infer(
     return y
 
 
-def ref_batch_norm_train(
+def ref_batch_norm_grad(x, y_grad, scale, x_mean, x_var, data_layout, epsilon):
+    if data_layout == "NCHW":
+        x = np.transpose(x, (0, 2, 3, 1))
+        y_grad = np.transpose(y_grad, (0, 2, 3, 1))
+    x_grad = (
+        scale
+        * (
+            y_grad
+            - np.mean(y_grad, axis=(0, 1, 2))
+            - (x - x_mean)
+            * np.mean(y_grad * (x - x_mean), axis=(0, 1, 2))
+            / (x_var + epsilon)
+        )
+        / np.sqrt(x_var + epsilon)
+    )
+    scale_grad = np.sum(
+        y_grad * (x - x_mean) / np.sqrt(x_var + epsilon),
+        axis=(0, 1, 2),
+    )
+    bias_grad = np.sum(y_grad, axis=(0, 1, 2))
+    # Transfer back to N, C, H, W
+    if data_layout == "NCHW":
+        x_grad = np.transpose(x_grad, (0, 3, 1, 2))
+        x = np.transpose(x, (0, 3, 1, 2))
+    return x_grad, bias_grad, scale_grad
+
+
+def ref_batch_norm_global(
     x, y_grad, scale, bias, mean, variance, momentum, epsilon, data_layout
 ):
+    y = ref_batch_norm_infer(
+        x, scale, bias, mean, variance, momentum, epsilon, data_layout
+    )
+    x_grad, bias_grad, scale_grad = ref_batch_norm_grad(
+        x, y_grad, scale, mean, variance, data_layout, epsilon
+    )
+    return y, mean, variance, mean, variance, x_grad, scale_grad, bias_grad
+
+
+def ref_batch_norm_train(
+    x, y_grad, scale, bias, mean, variance, momentum, epsilon, data_layout, use_global
+):
+    if use_global:
+        return ref_batch_norm_global(
+            x, y_grad, scale, bias, mean, variance, momentum, epsilon, data_layout
+        )
     # Forward
     if data_layout == "NCHW":
         n, c, h, w = x.shape
@@ -71,9 +114,7 @@ def ref_batch_norm_train(
         saved_mean_tile = np.tile(saved_mean_tile, (n, 1, h, w))
         saved_variance_tile = np.reshape(saved_variance, (1, c, 1, 1))
         saved_variance_tile = np.tile(saved_variance_tile, (n, 1, h, w))
-        normalized_x = (x - saved_mean_tile) / np.sqrt(
-            saved_variance_tile + epsilon
-        )
+        normalized_x = (x - saved_mean_tile) / np.sqrt(saved_variance_tile + epsilon)
         scale_tile = np.reshape(scale, (1, c, 1, 1))
         scale_tile = np.tile(scale_tile, (n, 1, h, w))
         bias_tile = np.reshape(bias, (1, c, 1, 1))
@@ -107,30 +148,9 @@ def ref_batch_norm_train(
     #   1/N * scale * rsqrt(variance + epsilon) * (N * grad_y - sum(grad_y) -
     #   (x - mean) * sum(grad_y * (x - mean)) / (variance + epsilon))
     # Transfer from (N, C, H, W) to (N, H, W, C) to simplify computation
-    if data_layout == "NCHW":
-        x = np.transpose(x, (0, 2, 3, 1))
-        y_grad = np.transpose(y_grad, (0, 2, 3, 1))
-    x_grad = (
-        scale
-        * (
-            y_grad
-            - np.mean(y_grad, axis=(0, 1, 2))
-            - (x - saved_mean)
-            * np.mean(y_grad * (x - saved_mean), axis=(0, 1, 2))
-            / (saved_variance + epsilon)
-        )
-        / np.sqrt(saved_variance + epsilon)
+    x_grad, bias_grad, scale_grad = ref_batch_norm_grad(
+        x, y_grad, scale, saved_mean, saved_variance, data_layout, epsilon
     )
-    scale_grad = np.sum(
-        y_grad * (x - saved_mean) / np.sqrt(saved_variance + epsilon),
-        axis=(0, 1, 2),
-    )
-    bias_grad = np.sum(y_grad, axis=(0, 1, 2))
-    # Transfer back to N, C, H, W
-    if data_layout == "NCHW":
-        x_grad = np.transpose(x_grad, (0, 3, 1, 2))
-        x = np.transpose(x, (0, 3, 1, 2))
-        y_grad = np.transpose(y_grad, (0, 3, 1, 2))
     return (
         y,
         mean_out,
@@ -145,12 +165,10 @@ def ref_batch_norm_train(
 
 class XPUTestBatchNormOp(XPUOpTestWrapper):
     def __init__(self):
-        self.op_name = 'batch_norm'
+        self.op_name = "batch_norm"
         self.use_dynamic_create_class = False
 
-    @unittest.skipIf(
-        not paddle.is_compiled_with_xpu(), "core is not compiled with XPU"
-    )
+    @unittest.skipIf(not paddle.is_compiled_with_xpu(), "core is not compiled with XPU")
     class TestBatchNormOp(unittest.TestCase):
         def setUp(self):
             self.op_type = "batch_norm"
@@ -176,12 +194,8 @@ class XPUTestBatchNormOp(XPUOpTestWrapper):
                 )
             np.random.seed(1024)
             self.x_np = np.random.random_sample(self.shape).astype(self.dtype)
-            self.scale_np = np.random.random_sample([channel_size]).astype(
-                np.float32
-            )
-            self.bias_np = np.random.random_sample([channel_size]).astype(
-                np.float32
-            )
+            self.scale_np = np.random.random_sample([channel_size]).astype(np.float32)
+            self.bias_np = np.random.random_sample([channel_size]).astype(np.float32)
             self.mean_np = np.zeros([channel_size]).astype(np.float32)
             self.variance_np = np.ones([channel_size]).astype(np.float32)
             self.saved_mean_np = np.zeros([channel_size]).astype(np.float32)
@@ -201,18 +215,18 @@ class XPUTestBatchNormOp(XPUOpTestWrapper):
         def test_infer(self):
             paddle.enable_static()
             with paddle.static.program_guard(paddle.static.Program()):
-                x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
+                x = paddle.static.data("X", self.x_np.shape, self.x_np.dtype)
                 scale = paddle.static.data(
-                    'Scale', self.scale_np.shape, self.scale_np.dtype
+                    "Scale", self.scale_np.shape, self.scale_np.dtype
                 )
                 bias = paddle.static.data(
-                    'Bias', self.bias_np.shape, self.bias_np.dtype
+                    "Bias", self.bias_np.shape, self.bias_np.dtype
                 )
                 mean = paddle.static.data(
-                    'Mean', self.mean_np.shape, self.mean_np.dtype
+                    "Mean", self.mean_np.shape, self.mean_np.dtype
                 )
                 variance = paddle.static.data(
-                    'Variance', self.variance_np.shape, self.variance_np.dtype
+                    "Variance", self.variance_np.shape, self.variance_np.dtype
                 )
                 y = F.batch_norm(
                     x,
@@ -228,11 +242,11 @@ class XPUTestBatchNormOp(XPUOpTestWrapper):
                 exe = paddle.static.Executor(self.place)
                 [y_np] = exe.run(
                     feed={
-                        'X': self.x_np,
-                        'Scale': self.scale_np,
-                        'Bias': self.bias_np,
-                        'Mean': self.mean_np,
-                        'Variance': self.variance_np,
+                        "X": self.x_np,
+                        "Scale": self.scale_np,
+                        "Bias": self.bias_np,
+                        "Mean": self.mean_np,
+                        "Variance": self.variance_np,
                     },
                     fetch_list=[y],
                 )
@@ -280,9 +294,7 @@ class XPUTestBatchNormOp(XPUOpTestWrapper):
                         net2.training = False
                     y1 = net1(x)
                     y2 = net2(x)
-                    np.testing.assert_allclose(
-                        y1.numpy(), y2.numpy(), rtol=1e-5
-                    )
+                    np.testing.assert_allclose(y1.numpy(), y2.numpy(), rtol=1e-5)
 
     class TestBatchNormOpUseGlobalStats1(TestBatchNormOpUseGlobalStats):
         # test mode
@@ -297,14 +309,14 @@ class XPUTestBatchNormOp(XPUOpTestWrapper):
             self.trainable_statistics = False
 
 
-support_types = get_xpu_op_support_types('batch_norm')
+support_types = get_xpu_op_support_types("batch_norm")
 for stype in support_types:
     create_test_class(globals(), XPUTestBatchNormOp, stype)
 
 
 class XPUTestBatchNormGradOp(XPUOpTestWrapper):
     def __init__(self):
-        self.op_name = 'batch_norm'
+        self.op_name = "batch_norm"
         self.use_dynamic_create_class = False
 
     class TestBatchNormGradOp(unittest.TestCase):
@@ -334,19 +346,19 @@ class XPUTestBatchNormGradOp(XPUOpTestWrapper):
                 )
             np.random.seed(1024)
             self.x_np = np.random.random_sample(self.shape).astype(self.dtype)
-            self.scale_np = np.random.random_sample([channel_size]).astype(
-                np.float32
-            )
-            self.bias_np = np.random.random_sample([channel_size]).astype(
-                np.float32
-            )
+            self.scale_np = np.random.random_sample([channel_size]).astype(np.float32)
+            self.bias_np = np.random.random_sample([channel_size]).astype(np.float32)
             self.mean_np = np.zeros([channel_size]).astype(np.float32)
             self.variance_np = np.ones([channel_size]).astype(np.float32)
             self.saved_mean_np = np.zeros([channel_size]).astype(np.float32)
             self.saved_variance_np = np.ones([channel_size]).astype(np.float32)
+            self.init_test()
 
         def set_attrs(self):
             pass
+
+        def init_test(self):
+            self.use_global_stats = False
 
         def init_dtype(self):
             self.dtype = self.in_type
@@ -358,9 +370,7 @@ class XPUTestBatchNormGradOp(XPUOpTestWrapper):
 
         def test_train(self):
             with paddle.pir_utils.OldIrGuard():
-                y_grad_np = np.random.random_sample(self.shape).astype(
-                    self.dtype
-                )
+                y_grad_np = np.random.random_sample(self.shape).astype(self.dtype)
                 (
                     y_np,
                     mean_out_np,
@@ -380,33 +390,34 @@ class XPUTestBatchNormGradOp(XPUOpTestWrapper):
                     self.momentum,
                     self.epsilon,
                     self.data_layout,
+                    self.use_global_stats,
                 )
                 inputs = {
-                    'X': self.x_np,
-                    'Scale': self.scale_np,
-                    'Bias': self.bias_np,
-                    'Mean': self.mean_np,
-                    'Variance': self.variance_np,
-                    'Y@GRAD': y_grad_np,
+                    "X": self.x_np,
+                    "Scale": self.scale_np,
+                    "Bias": self.bias_np,
+                    "Mean": self.mean_np,
+                    "Variance": self.variance_np,
+                    "Y@GRAD": y_grad_np,
                 }
                 outputs = {
-                    'Y': y_np,
-                    'Mean': mean_out_np,
-                    'Variance': variance_out_np,
-                    'SavedMean': saved_mean_np,
-                    'SavedVariance': saved_variance_np,
-                    'X@GRAD': x_grad_np,
-                    'Scale@GRAD': scale_grad_np,
-                    'Bias@GRAD': bias_grad_np,
+                    "Y": y_np,
+                    "Mean": mean_out_np,
+                    "Variance": variance_out_np,
+                    "SavedMean": saved_mean_np,
+                    "SavedVariance": saved_variance_np,
+                    "X@GRAD": x_grad_np,
+                    "Scale@GRAD": scale_grad_np,
+                    "Bias@GRAD": bias_grad_np,
                 }
                 attrs = {
-                    'momentum': self.momentum,
-                    'epsilon': self.epsilon,
-                    'is_test': False,
-                    'data_layout': self.data_layout,
-                    'use_mkldnn': False,
-                    'fuse_with_relu': False,
-                    'use_global_stats': False,
+                    "momentum": self.momentum,
+                    "epsilon": self.epsilon,
+                    "is_test": False,
+                    "data_layout": self.data_layout,
+                    "use_mkldnn": False,
+                    "fuse_with_relu": False,
+                    "use_global_stats": self.use_global_stats,
                 }
                 paddle.enable_static()
                 program = paddle.static.Program()
@@ -435,10 +446,10 @@ class XPUTestBatchNormGradOp(XPUOpTestWrapper):
                                 shape=np_value.shape,
                                 dtype=np_value.dtype,
                             )
-                        if var_name == 'Mean':
-                            arg_name = 'MeanOut'  # Share memory
-                        if var_name == 'Variance':
-                            arg_name = 'VarianceOut'  # Share memory
+                        if var_name == "Mean":
+                            arg_name = "MeanOut"  # Share memory
+                        if var_name == "Variance":
+                            arg_name = "VarianceOut"  # Share memory
                         output_vars[arg_name] = block.var(var_name)
                         fetch_list.append(var_name)
                     batch_norm_op = block.append_op(
@@ -457,18 +468,40 @@ class XPUTestBatchNormGradOp(XPUOpTestWrapper):
                     program._sync_with_cpp()
                     exe = paddle.static.Executor(self.place)
                     outs = exe.run(program, feed=inputs, fetch_list=fetch_list)
+                    if self.use_global_stats:
+                        test_name = ["Y", "X@GRAD", "Scale@GRAD", "Bias@GRAD"]
+                    else:
+                        test_name = [
+                            "Y",
+                            "Mean",
+                            "Variance",
+                            "SavedMean",
+                            "SavedVariance",
+                            "X@GRAD",
+                            "Scale@GRAD",
+                            "Bias@GRAD",
+                        ]
                     for id, name in enumerate(fetch_list):
-                        np.testing.assert_allclose(
-                            outputs[name],
-                            outs[id],
-                            rtol=self.rtol,
-                            atol=self.atol,
-                        )
+                        if name in test_name:
+                            np.testing.assert_allclose(
+                                outputs[name],
+                                outs[id],
+                                rtol=self.rtol,
+                                atol=self.atol,
+                            )
+
+    class TestBatchNormGradOpGlobal(TestBatchNormGradOp):
+        def init_test(self):
+            self.use_global_stats = True
+
+    class TestBatchNormGradOpWithoutGlobal(TestBatchNormGradOp):
+        def init_test(self):
+            self.use_global_stats = False
 
 
-support_types_grad = get_xpu_op_support_types('batch_norm_grad')
+support_types_grad = get_xpu_op_support_types("batch_norm_grad")
 for stype_grad in support_types_grad:
     create_test_class(globals(), XPUTestBatchNormGradOp, stype_grad)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/xpu/test_batch_norm_op_xpu.py
+++ b/test/xpu/test_batch_norm_op_xpu.py
@@ -95,11 +95,28 @@ def ref_batch_norm_global(
 
 
 def ref_batch_norm_train(
-    x, y_grad, scale, bias, mean, variance, momentum, epsilon, data_layout, use_global
+    x,
+    y_grad,
+    scale,
+    bias,
+    mean,
+    variance,
+    momentum,
+    epsilon,
+    data_layout,
+    use_global,
 ):
     if use_global:
         return ref_batch_norm_global(
-            x, y_grad, scale, bias, mean, variance, momentum, epsilon, data_layout
+            x,
+            y_grad,
+            scale,
+            bias,
+            mean,
+            variance,
+            momentum,
+            epsilon,
+            data_layout,
         )
     # Forward
     if data_layout == "NCHW":
@@ -114,7 +131,9 @@ def ref_batch_norm_train(
         saved_mean_tile = np.tile(saved_mean_tile, (n, 1, h, w))
         saved_variance_tile = np.reshape(saved_variance, (1, c, 1, 1))
         saved_variance_tile = np.tile(saved_variance_tile, (n, 1, h, w))
-        normalized_x = (x - saved_mean_tile) / np.sqrt(saved_variance_tile + epsilon)
+        normalized_x = (x - saved_mean_tile) / np.sqrt(
+            saved_variance_tile + epsilon
+        )
         scale_tile = np.reshape(scale, (1, c, 1, 1))
         scale_tile = np.tile(scale_tile, (n, 1, h, w))
         bias_tile = np.reshape(bias, (1, c, 1, 1))
@@ -168,7 +187,9 @@ class XPUTestBatchNormOp(XPUOpTestWrapper):
         self.op_name = "batch_norm"
         self.use_dynamic_create_class = False
 
-    @unittest.skipIf(not paddle.is_compiled_with_xpu(), "core is not compiled with XPU")
+    @unittest.skipIf(
+        not paddle.is_compiled_with_xpu(), "core is not compiled with XPU"
+    )
     class TestBatchNormOp(unittest.TestCase):
         def setUp(self):
             self.op_type = "batch_norm"
@@ -194,8 +215,12 @@ class XPUTestBatchNormOp(XPUOpTestWrapper):
                 )
             np.random.seed(1024)
             self.x_np = np.random.random_sample(self.shape).astype(self.dtype)
-            self.scale_np = np.random.random_sample([channel_size]).astype(np.float32)
-            self.bias_np = np.random.random_sample([channel_size]).astype(np.float32)
+            self.scale_np = np.random.random_sample([channel_size]).astype(
+                np.float32
+            )
+            self.bias_np = np.random.random_sample([channel_size]).astype(
+                np.float32
+            )
             self.mean_np = np.zeros([channel_size]).astype(np.float32)
             self.variance_np = np.ones([channel_size]).astype(np.float32)
             self.saved_mean_np = np.zeros([channel_size]).astype(np.float32)
@@ -294,7 +319,9 @@ class XPUTestBatchNormOp(XPUOpTestWrapper):
                         net2.training = False
                     y1 = net1(x)
                     y2 = net2(x)
-                    np.testing.assert_allclose(y1.numpy(), y2.numpy(), rtol=1e-5)
+                    np.testing.assert_allclose(
+                        y1.numpy(), y2.numpy(), rtol=1e-5
+                    )
 
     class TestBatchNormOpUseGlobalStats1(TestBatchNormOpUseGlobalStats):
         # test mode
@@ -346,8 +373,12 @@ class XPUTestBatchNormGradOp(XPUOpTestWrapper):
                 )
             np.random.seed(1024)
             self.x_np = np.random.random_sample(self.shape).astype(self.dtype)
-            self.scale_np = np.random.random_sample([channel_size]).astype(np.float32)
-            self.bias_np = np.random.random_sample([channel_size]).astype(np.float32)
+            self.scale_np = np.random.random_sample([channel_size]).astype(
+                np.float32
+            )
+            self.bias_np = np.random.random_sample([channel_size]).astype(
+                np.float32
+            )
             self.mean_np = np.zeros([channel_size]).astype(np.float32)
             self.variance_np = np.ones([channel_size]).astype(np.float32)
             self.saved_mean_np = np.zeros([channel_size]).astype(np.float32)
@@ -370,7 +401,9 @@ class XPUTestBatchNormGradOp(XPUOpTestWrapper):
 
         def test_train(self):
             with paddle.pir_utils.OldIrGuard():
-                y_grad_np = np.random.random_sample(self.shape).astype(self.dtype)
+                y_grad_np = np.random.random_sample(self.shape).astype(
+                    self.dtype
+                )
                 (
                     y_np,
                     mean_out_np,


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
There is an error in the XPU API related to batch_norm_grad when using global mean and global variance to modify batch normalization. The original implementation may cause unexpected situations, such as the XPU hanging. To address this issue, consider using a combination of alternative APIs to replace the original process.