### PR TITLE
Support send/recv when mesh is pp_mesh

### DIFF
--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_x_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_x_reshard_function.cc
@@ -71,12 +71,20 @@ void RToXExpandReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   if (root_rank == cur_global_rank) {
     for (const auto& out_process_id : out_process_ids) {
       if (out_process_id != root_rank) {
+        // Should acculate the relative rank in communication.
+        auto relative_rank = out_process_id;
+        for (size_t i = 0; i < all_process_ids.size(); ++i) {
+          if (all_process_ids[i] == out_process_id) {
+            relative_rank = i;
+          }
+        }
+
         RESHARD_FUNCTOR_WITH_COMM(dev_ctx,
                                   PSendKernel,
                                   dtype,
                                   all_process_ids,
                                   in.value(),
-                                  out_process_id,
+                                  /*peer*/ relative_rank,
                                   /*dynamic_shape=*/true);
       }
     }

--- a/python/paddle/distributed/auto_parallel/local_layer.py
+++ b/python/paddle/distributed/auto_parallel/local_layer.py
@@ -134,16 +134,12 @@ class LocalLayer(Layer):
                         self.grad_dist_attrs[idx][0],
                         self.grad_dist_attrs[idx][1],
                     )
-                current_rank = dist.get_rank()
-                if current_rank in mesh.process_ids:
-                    inputs[idx] = dist.auto_parallel.api.dtensor_to_local(
-                        inputs[idx], mesh, placement
-                    )
+
+                inputs[idx] = dist.auto_parallel.api.dtensor_to_local(
+                    inputs[idx], mesh, placement
+                )
 
         outputs = Layer.__call__(self, *inputs, **kwargs)
-        if current_rank not in mesh.process_ids:
-            return outputs
-
         list_outs = paddle.utils.flatten(outputs)
         assert len(list_outs) == len(
             self.out_dist_attrs

--- a/python/paddle/distributed/auto_parallel/local_layer.py
+++ b/python/paddle/distributed/auto_parallel/local_layer.py
@@ -134,12 +134,16 @@ class LocalLayer(Layer):
                         self.grad_dist_attrs[idx][0],
                         self.grad_dist_attrs[idx][1],
                     )
-
-                inputs[idx] = dist.auto_parallel.api.dtensor_to_local(
-                    inputs[idx], mesh, placement
-                )
+                current_rank = dist.get_rank()
+                if current_rank in mesh.process_ids:
+                    inputs[idx] = dist.auto_parallel.api.dtensor_to_local(
+                        inputs[idx], mesh, placement
+                    )
 
         outputs = Layer.__call__(self, *inputs, **kwargs)
+        if current_rank not in mesh.process_ids:
+            return outputs
+
         list_outs = paddle.utils.flatten(outputs)
         assert len(list_outs) == len(
             self.out_dist_attrs

--- a/python/paddle/distributed/utils/moe_utils.py
+++ b/python/paddle/distributed/utils/moe_utils.py
@@ -14,6 +14,7 @@
 
 from paddle import _legacy_C_ops
 from paddle.common_ops_import import check_variable_and_dtype
+from paddle.distributed import fleet
 from paddle.framework import LayerHelper, in_dynamic_mode
 
 
@@ -277,3 +278,30 @@ def global_gather(
             },
         )
         return out
+
+
+def get_complete_pp_mesh(mesh):
+    """
+    Get complete pp mesh with given mesh.
+
+    Args:
+        mesh (Mesh): Mesh object.
+
+    Returns:
+        Mesh: Complete mesh.
+
+    """
+    process_id = mesh.process_ids[0]
+    global_mesh = fleet.auto.get_mesh()
+
+    if "pp" in global_mesh.dim_names:
+        pp_degree = global_mesh.get_dim_size("pp")
+        for i in range(pp_degree):
+            pp_mesh = global_mesh.get_mesh_with_dim("pp", i)
+            if process_id in pp_mesh.process_ids:
+                return pp_mesh
+        AssertionError(
+            f"Current mesh: {mesh} not found in global mesh {global_mesh}"
+        )
+    else:
+        return mesh

--- a/python/paddle/distributed/utils/moe_utils.py
+++ b/python/paddle/distributed/utils/moe_utils.py
@@ -294,7 +294,7 @@ def get_complete_pp_mesh(mesh):
     process_id = mesh.process_ids[0]
     global_mesh = fleet.auto.get_mesh()
 
-    if "pp" in global_mesh.dim_names:
+    if global_mesh and "pp" in global_mesh.dim_names:
         pp_degree = global_mesh.get_dim_size("pp")
         for i in range(pp_degree):
             pp_mesh = global_mesh.get_mesh_with_dim("pp", i)

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -26,6 +26,7 @@ from paddle.base import core, framework, unique_name
 from paddle.base.data_feeder import check_variable_and_dtype
 from paddle.base.libpaddle import DataType
 from paddle.common_ops_import import Variable, check_type, default_main_program
+from paddle.distributed.utils.moe_utils import get_complete_pp_mesh
 from paddle.framework import (
     LayerHelper,
     in_dynamic_mode,
@@ -729,6 +730,12 @@ class ClipGradByGlobalNorm(ClipGradBase):
             # if the gradient mesh is not equal to src mesh
             # do reshard to get the result of squared_l2 from other pp stage mesh
             if src_mesh is not None and g.process_mesh != src_mesh:
+                pp_mesh = get_complete_pp_mesh(g.process_mesh)
+                if set(g.process_mesh.process_ids) < set(pp_mesh.process_ids):
+                    sum_square = dist.reshard(
+                        sum_square, pp_mesh, sum_square.placements
+                    )
+
                 sum_square = dist.reshard(
                     sum_square, src_mesh, sum_square.placements
                 )
@@ -821,6 +828,15 @@ class ClipGradByGlobalNorm(ClipGradBase):
                                 "Reshard a sharded tensor from a local mesh to a global mesh is not supported"
                             )
                     else:
+                        pp_mesh = get_complete_pp_mesh(g.process_mesh)
+
+                        if set(g.process_mesh.process_ids) < set(
+                            pp_mesh.process_ids
+                        ):
+                            clip_input = dist.reshard(
+                                clip_input, pp_mesh, clip_input.placements
+                            )
+
                         clip_input = paddle.distributed.reshard(
                             clip_input, g.process_mesh, clip_input.placements
                         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
Bug fixes


### Description
card-73263
修复PSend, PRecv通信逻辑中 peer 计算逻辑。
eg. 当 mesh1的 process_ids 为 [2]，另有一个mesh2的process_ids 为[2,3]。若此时mesh1向mesh2进行reshard操作时，此时全局process_id为3的device，实际在当前通信组的相对rank为1，传入的peer应换算为相对rank传入。