### PR TITLE
[WIP][CINN] Reset CINN pass related singleton state after apply cinn pass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -261,6 +261,10 @@ int64_t GetOpCount(const ::pir::Operation* op) {
   return count;
 }
 
+void ResetCinnPassRelatedSingletonState() {
+  pir::ShapeAnalysisManager::Instance().Clear();
+}
+
 void ApplyCinnPass(
     ::pir::Program* program,
     const std::function<std::shared_ptr<pir::PassManager>()>& CreatePassManager,
@@ -310,6 +314,8 @@ void ApplyCinnPass(
             << ", after lowering it becomes: " << new_num_ops
             << ". (compression ratio: " << new_num_ops << "/" << origin_num_ops
             << " = " << static_cast<float>(new_num_ops) / origin_num_ops << ")";
+
+  ResetCinnPassRelatedSingletonState();
 }
 
 }  // namespace cinn::dialect::ir

--- a/paddle/pir/include/dialect/shape/utils/shape_analysis.h
+++ b/paddle/pir/include/dialect/shape/utils/shape_analysis.h
@@ -273,6 +273,7 @@ class IR_API ShapeAnalysisManager {
  public:
   static ShapeAnalysisManager& Instance();
   ShapeConstraintIRAnalysis& Get(const pir::Program* program);
+  void Clear() { tables_.clear(); }
 
   ShapeAnalysisManager(const ShapeAnalysisManager&) = delete;
   ShapeAnalysisManager(ShapeAnalysisManager&&) = delete;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

`ApplyCinnPass` 最后清理掉全局单例所持有的对象，以免冗余对象不断增加（本 PR 只清理 shape analysis）

目前在小数据集的 8 卡模型上出现一个问题，在 dataloader iter 时 CINN 会比动转静慢不少

```python
for epoch in range(num_epoch):
    for step, batch in enumerate(dataloader):
        ...
```

注意这里隐式 `iter(dataloader)` 时会触发创建 n 个 workers，即 `multiprocessing.Process`，每个进程在 `p.start()` 时 CINN 约为 0.07s（16 个 worker 平均 1.3s），动转静则为 0.017s 左右（16 个 worker 平均 0.3s），整体编译器会每个 epoch 多 1s

这里 start 时会从主进程 fork 一个子进程，此时会 copy 主进程持有的对象，而 CINN 相比于动转静可能主要多了一些这类的全局单例以及编好的 kernel

目前尝试清理掉 shape analysis 能够降低 0.2s，后续会考虑进一步清理一些其它的单例