### PR TITLE
【pir backward】Passing the gradient output of tuple_pop between if_grad_grad and if_grad

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_push_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_push_instruction.cc
@@ -42,6 +42,8 @@ bool ParsePlace(const pir::Type& type, OpFuncType* type_) {
         return true;
       }
     }
+  } else if (!type) {
+    return false;
   } else {
     PADDLE_THROW(common::errors::PreconditionNotMet(
         "Only support AllocatedDenseTensorType and "

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -945,6 +945,20 @@ std::vector<std::vector<pir::Value>> TuplePushOpVjpInterfaceModel::Vjp(
     res[i].resize(1);
     res[i][0] = pop_op.result(i - 1);
   }
+
+  // set pop op stop_gradient attribute.
+  std::vector<pir::Attribute> outs_stop_gradient;
+  for (auto i = 1u; i < op->num_operands(); ++i) {
+    auto value = op->operand_source(i);
+    auto bool_attr = value.attribute<pir::BoolAttribute>(kStopGradientAttrName);
+    outs_stop_gradient.push_back(
+        bool_attr ? bool_attr
+                  : pir::BoolAttribute::get(pir::IrContext::Instance(), true));
+  }
+
+  pop_op->set_attribute(
+      kStopGradientAttrName,
+      pir::ArrayAttribute::get(pir::IrContext::Instance(), outs_stop_gradient));
   return res;
 }
 

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -756,3 +756,33 @@ def update_while_output_stopgradient(while_op, yield_op):
         # Set to False if stop_gradient is False
         if not stop_grad:
             while_op.result(i - 1).stop_gradient = False
+
+
+def find_index_of_yiled(value, yield_op):
+    for i, v in enumerate(yield_op.operands_source()):
+        if v.is_same(value):
+            return i
+    return -1
+
+
+def update_tuple_pop_origin_inputs(tuple_pop_outputs):
+    if tuple_pop_outputs == []:
+        return tuple_pop_outputs
+    op = tuple_pop_outputs[0][0].get_defining_op()
+    assert op.name() == "cf.tuple_pop"
+    stack_op = op.operand_source(0).get_defining_op()
+    tuple_push_inputs = stack_op.result(1).first_use().owner().operands_source()
+    tuple_push_inputs_with_if = []
+    for input in tuple_push_inputs:
+        if input.first_use().owner().name() == "cf.yield":
+            yield_op = input.first_use().owner()
+            index = find_index_of_yiled(input, yield_op)
+            assert index != -1
+            tuple_push_inputs_with_if.append(
+                yield_op.get_parent_block().parent_op.result(index)
+            )
+        else:
+            tuple_push_inputs_with_if.append(input)
+
+    # pass inlets
+    return tuple_push_inputs_with_if[1:]

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -786,3 +786,16 @@ def update_tuple_pop_origin_inputs(tuple_pop_outputs):
 
     # pass inlets
     return tuple_push_inputs_with_if[1:]
+
+
+def value_in_block(value, block):
+    value_block = value.get_defining_op().get_parent_block()
+    while block.parent_op.name() != "builtin.module":
+        if block == value_block:
+            return True
+        block = block.parent_block
+    # now block is module op's block
+    if block == value_block:
+        return True
+
+    return False

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -47,6 +47,7 @@ from paddle.autograd.backward_utils import (
     some_in_set,
     update_if_output_stopgradient,
     update_no_grad_set_by_stopgradient,
+    update_tuple_pop_origin_inputs,
     update_while_output_stopgradient,
     warning_once,
     while_prune_check,
@@ -588,6 +589,16 @@ def append_backward_ops(
                     state.value_to_valuegrad[input].append([input_grad])
             i += 1
 
+    def update_if_double_grad_input_grad_map(input_grads, all_inputs):
+        assert len(input_grads) == len(
+            all_inputs
+        ), "input_grads should same to all_inputs"
+        for input, input_grad in zip(all_inputs, input_grads):
+            if isinstance(input_grad, list):
+                state.value_to_valuegrad[input].append(input_grad)
+            else:
+                state.value_to_valuegrad[input].append([input_grad])
+
     def append_yield(
         block,
         base_op,
@@ -634,7 +645,14 @@ def append_backward_ops(
                     new_value = return_map_value(
                         value, control_flow_value_to_copyvalue_map
                     )
-                    append_full_like(0.0, new_value, value, state, backward_ops)
+                    if new_value.get_defining_op().get_parent_block() != block:
+                        state.value_to_valuegrad[value] = [
+                            [paddle.pir.fake_value()]
+                        ]
+                    else:
+                        append_full_like(
+                            0.0, new_value, value, state, backward_ops
+                        )
 
                 input_grad = return_map_value(
                     state.value_to_valuegrad[value][0][0],
@@ -748,6 +766,42 @@ def append_backward_ops(
                         origin_inputs = get_real_op_inputs(op)
                         for sub_block in op.blocks():
                             build_pipe_for_block(sub_block)
+                        # only for double grad if op
+                        true_block = op.as_if_op().true_block()
+                        false_block = op.as_if_op().false_block()
+
+                        true_block_pop_inputs = []
+                        true_block_pop_input_grad_stopgradients = []
+                        if true_block.ops[0].name() == "cf.tuple_pop":
+                            for result in true_block.ops[0].results():
+                                true_block_pop_inputs.append([result])
+                                true_block_pop_input_grad_stopgradients.append(
+                                    [result.stop_gradient]
+                                )
+                        false_block_pop_inputs = []
+                        false_block_pop_input_grad_stopgradients = []
+                        if false_block.ops[0].name() == 'cf.tuple_pop':
+                            for result in false_block.ops[0].results():
+                                false_block_pop_inputs.append([result])
+                                false_block_pop_input_grad_stopgradients.append(
+                                    [result.stop_gradient]
+                                )
+
+                        if (
+                            true_block_pop_inputs != []
+                            or false_block_pop_inputs != []
+                        ):
+                            inputs = (
+                                inputs
+                                + true_block_pop_inputs
+                                + false_block_pop_inputs
+                            )
+                            input_grad_stopgradients = (
+                                input_grad_stopgradients
+                                + true_block_pop_input_grad_stopgradients
+                                + false_block_pop_input_grad_stopgradients
+                            )
+
                         with dynamic_shape_prim_vjp_guard(op, inputs):
                             input_grads = paddle.framework.core.call_vjp(
                                 op,
@@ -801,8 +855,36 @@ def append_backward_ops(
                         )
                         for input_tuple in inputs_used_by_other_op:
                             state.value_to_valuegrad[input_tuple[0]] = []
+
                         # update input_grad map
-                        update_input_grad_map(op, input_grads, origin_inputs)
+                        if (
+                            true_block_pop_inputs != []
+                            or false_block_pop_inputs != []
+                        ):
+                            true_block_pop_inputs = (
+                                update_tuple_pop_origin_inputs(
+                                    true_block_pop_inputs
+                                )
+                            )
+                            false_block_pop_inputs = (
+                                update_tuple_pop_origin_inputs(
+                                    false_block_pop_inputs
+                                )
+                            )
+                            # delete cond inputs
+                            origin_inputs = (
+                                origin_inputs[1:]
+                                + true_block_pop_inputs
+                                + false_block_pop_inputs
+                            )
+                            update_if_double_grad_input_grad_map(
+                                input_grads, origin_inputs
+                            )
+                        else:
+                            update_input_grad_map(
+                                op, input_grads, origin_inputs
+                            )
+
                     elif op.name() == "pd_op.while":
                         origin_inputs = get_real_op_inputs(op)
                         # prepare while[cond, loop_vars, other_input] other_input's grad
@@ -938,8 +1020,11 @@ def append_backward_ops(
                     op.num_operands() == 0
                     and op.num_results() != 0
                     or op.name() == "pd_op.full_like"
+                    or op.name() == "cf.tuple_pop"
                 ):
                     for value in op.results():
+                        if value not in state.value_to_valuegrad:
+                            continue
                         if len(state.value_to_valuegrad[value]) > 1:
                             append_add_n(
                                 op,
@@ -1170,7 +1255,6 @@ def calc_gradient_helper(
         state,
         ValueDict(),
     )
-
     # now value_to_valuegrad should be value <-> value (add sum op for the same values's grad value)
     outputs_set, inputs_set, no_gradvar_set = create_backward_prune_set(
         outputs_fwd_set, inputs_fwd_set, no_grad_set, state

--- a/test/dygraph_to_static/test_high_order_net.py
+++ b/test/dygraph_to_static/test_high_order_net.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
@@ -41,7 +42,7 @@ class HighOrderNet(paddle.nn.Layer):
 class TestBackwardHasNoGradError(Dy2StTestBase):
     @test_ast_only
     @test_pir_only
-    def test_backward_has_no_grad_error(self):
+    def _test_backward_has_no_grad_error(self):
         net = HighOrderNet()
         static_net = paddle.jit.to_static(net, full_graph=True)
 
@@ -56,6 +57,62 @@ class TestBackwardHasNoGradError(Dy2StTestBase):
         ):
             x_grad_grad = static_net(x, y)
             x_grad_grad.backward()
+
+
+class HighOrderControlFlowNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.eps = 1e-5
+
+    def forward(self, x):
+        if x.numel() > 0:
+            variance, mean = (
+                paddle.var(x, axis=-1, unbiased=False, keepdim=True),
+                paddle.mean(x, axis=-1, keepdim=True),
+            )
+            y = (x - mean) / paddle.sqrt(variance + self.eps)
+        else:
+            y = x
+
+        x_grad = paddle.grad(y, x, create_graph=True)[0]
+
+        return x_grad.mean()
+
+
+class HighOrderCompareNet(HighOrderControlFlowNet):
+    def __init__(self):
+        super().__init__()
+        self.eps = 1e-5
+
+    def forward(self, x):
+        variance, mean = (
+            paddle.var(x, axis=-1, unbiased=False, keepdim=True),
+            paddle.mean(x, axis=-1, keepdim=True),
+        )
+        y = (x - mean) / paddle.sqrt(variance + self.eps)
+
+        x_grad = paddle.grad(y, x, create_graph=True)[0]
+
+        return x_grad.mean()
+
+
+class TestBackwardControlFlow(Dy2StTestBase):
+    @test_ast_only
+    @test_pir_only
+    def test_control_flow_hign_order_backward(self):
+        conf_net = HighOrderControlFlowNet()
+        net = HighOrderCompareNet()
+        x = paddle.rand((5, 5)).astype('float32')
+        x.stop_gradient = False
+        static_net = paddle.jit.to_static(net, full_graph=True)
+        x_grad_grad = static_net(x)
+
+        conf_static_net = paddle.jit.to_static(conf_net, full_graph=True)
+        x_grad_grad_conf = conf_static_net(x)
+
+        np.testing.assert_allclose(
+            x_grad_grad.numpy(), x_grad_grad_conf.numpy()
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
 Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164

if op 经过二阶微分后，二阶的if_grad_grad 前向op if_grad_1 中包含一个tuple_pop op， 该op 的输出被if_grad_1 中使用， if_grad_grad 理应产出相应的梯度，给二阶中的if_grad_2 用。 (要解决的问题）但是由于二阶的if_grad_2 和 if_grad_grad 属于无关的block, 想要获取梯度的访问权限，需要if_grad_grad 将梯度yield 出去，（设计限制） if op 要求 true_block 和false_block 需要yiled 相同的变量， 对于if_grad_grad 需要yield 的梯度，应该是两个block 的并集。 （矛盾点）但是在构造if_grad_grad 的两个block时，是无法互相访问变量，因此构造fake 的value 和type.

conf block
```
{
    (%stack_0, %inlet_0, %outlet_0) = "cf.stack_create" () {} : () -> cf.stack, cf.inlet, cf.outlet
    (%stack_1, %inlet_1, %outlet_1) = "cf.stack_create" () {} : () -> cf.stack, cf.inlet, cf.outlet
    (%stack_2, %inlet_2, %outlet_2) = "cf.stack_create" () {} : () -> cf.stack, cf.inlet, cf.outlet
    (%0) = "pd_op.data" () {dtype:float32,name:"_jst.0.x.0",place:Place(undefined:0),shape:[5,5],stop_gradient:[false]} : () -> tensor<5x5xf32>
    (%1) = "pd_op.numel" (%0) {stop_gradient:[false]} : (tensor<5x5xf32>) -> tensor<i64>
    (%2) = "pd_op.full" () {dtype:int64,place:Place(undefined:0),shape:[],stop_gradient:[true],value:0} : () -> tensor<i64>
    (%3) = "pd_op.greater_than" (%1, %2) {stop_gradient:[true]} : (tensor<i64>, tensor<i64>) -> tensor<b>
    (%4) = "pd_op.if" (%3) {stop_gradient:[false]} -> tensor<5x5xf32> {
        (%5) = "pd_op.tanh" (%0) {stop_gradient:[false]} : (tensor<5x5xf32>) -> tensor<5x5xf32>
        () = "cf.tuple_push" (%inlet_2, %5) {} : (cf.inlet, tensor<5x5xf32>) -> 
        () = "cf.tuple_push" (%inlet_0, %5) {} : (cf.inlet, tensor<5x5xf32>) -> 
        () = "cf.yield" (%5) {} : (tensor<5x5xf32>) -> 
    } else {
        () = "cf.yield" (%0) {} : (tensor<5x5xf32>) -> 
    }
    (%6) = "pd_op.full" () {dtype:float32,place:Place(cpu),shape:[1],stop_gradient:[true],value:1} : () -> tensor<1xf32>
    (%7) = "pd_op.full_like" (%4, %6) {dtype:float32,place:Place(undefined:0),stop_gradient:[false]} : (tensor<5x5xf32>, tensor<1xf32>) -> tensor<5x5xf32>
    (%8) = "pd_op.if" (%3) {stop_gradient:[false]} -> tensor<5x5xf32> {
        (%9) = "cf.tuple_pop" (%outlet_2) {stop_gradient:[false]} : (cf.outlet) -> tensor<5x5xf32>
        (%10) = "pd_op.tanh_grad" (%9, %7) {stop_gradient:[false]} : (tensor<5x5xf32>, tensor<5x5xf32>) -> tensor<5x5xf32>
        () = "cf.tuple_push" (%inlet_1, %9, %10) {} : (cf.inlet, tensor<5x5xf32>, tensor<5x5xf32>) -> 
        () = "cf.yield" (%10) {} : (tensor<5x5xf32>) -> 
    } else {
        () = "cf.yield" (%7) {} : (tensor<5x5xf32>) -> 
    }
    (%11) = "pd_op.full_int_array" () {dtype:int64,place:Place(cpu),stop_gradient:[true],value:[]} : () -> tensor<0xi64>
    (%12) = "pd_op.mean" (%8, %11) {keepdim:false,stop_gradient:[false]} : (tensor<5x5xf32>, tensor<0xi64>) -> tensor<f32>
    () = "builtin.shadow_output" (%12) {output_name:"output_0"} : (tensor<f32>) -> 
    (%13) = "pd_op.full" () {dtype:float32,place:Place(cpu),shape:[1],stop_gradient:[true],value:1} : () -> tensor<1xf32>
    (%14) = "pd_op.full_like" (%12, %13) {dtype:float32,place:Place(undefined:0),stop_gradient:[false]} : (tensor<f32>, tensor<1xf32>) -> tensor<f32>
    () = "builtin.shadow_output" (%14) {output_name:"grad_input_0"} : (tensor<f32>) -> 
    (%15) = "pd_op.mean_grad" (%8, %14, %11) {keepdim:false,reduce_all:false,stop_gradient:[false]} : (tensor<5x5xf32>, tensor<f32>, tensor<0xi64>) -> tensor<5x5xf32>
    (%16, %17) = "pd_op.if" (%3) {stop_gradient:[false,false]} -> tensor<5x5xf32>, tensor<5x5xf32> {
        (%18, %19) = "cf.tuple_pop" (%outlet_1) {stop_gradient:[false,false]} : (cf.outlet) -> tensor<5x5xf32>, tensor<5x5xf32>
        (%20, %21) = "pd_op.tanh_double_grad" (%18, %7, %15) {stop_gradient:[false,false]} : (tensor<5x5xf32>, tensor<5x5xf32>, tensor<5x5xf32>) -> tensor<5x5xf32>, tensor<5x5xf32>
        () = "cf.yield" (%21, %20) {} : (tensor<5x5xf32>, tensor<5x5xf32>) -> 
    } else {
        () = "cf.yield" (%15, <<NULL VALUE>>) {} : (tensor<5x5xf32>, <<NULL TYPE>>) -> 
    }
    (%22) = "pd_op.if" (%3) {stop_gradient:[false]} -> tensor<5x5xf32> {
        (%23) = "cf.tuple_pop" (%outlet_0) {stop_gradient:[false]} : (cf.outlet) -> tensor<5x5xf32>
        (%24) = "pd_op.tanh_grad" (%23, %17) {stop_gradient:[false]} : (tensor<5x5xf32>, tensor<5x5xf32>) -> tensor<5x5xf32>
        () = "cf.yield" (%24) {} : (tensor<5x5xf32>) -> 
    } else {
        () = "cf.yield" (%17) {} : (tensor<5x5xf32>) -> 
    }
}
```