### PR TITLE
[Fix] Fix `paddle.where` when meets Tensor and scalar

### DIFF
--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -758,17 +758,27 @@ def where(
             [[2],
              [3]]),)
     """
-    if np.isscalar(x):
-        x = paddle.full([1], x, np.array([x]).dtype.name)
-
-    if np.isscalar(y):
-        y = paddle.full([1], y, np.array([y]).dtype.name)
-
     if x is None and y is None:
         return nonzero(condition, as_tuple=True)
 
     if x is None or y is None:
         raise ValueError("either both or neither of x and y should be given")
+
+    dtype = paddle.get_default_dtype()
+    cdtype = "complex64" if dtype != "float64" else "complex128"
+    if np.isscalar(x):
+        x = paddle.full(
+            [1],
+            x,
+            cdtype if np.iscomplex(x) else dtype,
+        )
+
+    if np.isscalar(y):
+        y = paddle.full(
+            [1],
+            y,
+            cdtype if np.iscomplex(y) else dtype,
+        )
 
     # NOTE: We might need to adapt the broadcast_shape and broadcast_to for dynamic shape
     # so dynamic and pir branch can be merged into one code block

--- a/test/legacy_test/test_where_op.py
+++ b/test/legacy_test/test_where_op.py
@@ -879,7 +879,7 @@ class TestWhereDygraphAPIBroadcast(unittest.TestCase):
 
 
 class TestWhereDygraphAPIDtypePromotion(unittest.TestCase):
-    def test_dtype_auto_promotion_float(self):
+    def test_dtype_auto_promotion_tensor_float32_tensor_float64(self):
         with base.dygraph.guard():
             x_i = np.random.randn(4, 5, 6).astype('float32')
             y_i = np.random.randn(4, 5, 6).astype('float64')
@@ -889,6 +889,34 @@ class TestWhereDygraphAPIDtypePromotion(unittest.TestCase):
             cond = paddle.to_tensor(cond_i)
             out = paddle.where(cond, x, y)
             self.assertEqual(out.dtype, y.dtype)
+            np.testing.assert_array_equal(
+                out.numpy(), np.where(cond_i, x_i, y_i)
+            )
+
+    def test_dtype_auto_promotion_tensor_float32_scalar_float(self):
+        with base.dygraph.guard():
+            x_i = np.random.randn(4, 5, 6).astype('float32')
+            y_i = 1.0
+            cond_i = np.random.randn(4, 5, 6).astype('bool')
+            x = paddle.to_tensor(x_i)
+            y = paddle.to_tensor(y_i)
+            cond = paddle.to_tensor(cond_i)
+            out = paddle.where(cond, x, y)
+            self.assertEqual(out.dtype, x.dtype)
+            np.testing.assert_array_equal(
+                out.numpy(), np.where(cond_i, x_i, y_i)
+            )
+
+    def test_dtype_auto_promotion_tensor_float64_scalar_float(self):
+        with base.dygraph.guard():
+            x_i = np.random.randn(4, 5, 6).astype('float64')
+            y_i = 1.0
+            cond_i = np.random.randn(4, 5, 6).astype('bool')
+            x = paddle.to_tensor(x_i)
+            y = paddle.to_tensor(y_i)
+            cond = paddle.to_tensor(cond_i)
+            out = paddle.where(cond, x, y)
+            self.assertEqual(out.dtype, x.dtype)
             np.testing.assert_array_equal(
                 out.numpy(), np.where(cond_i, x_i, y_i)
             )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

修复`paddle.where`输入参数含有标量时，返回值数据类型是float64的错误情况，正确的返回值数据类型应该与输入中的Tensor类型保持一致