### PR TITLE
【AutoParallel】Add dense_tensor_idx in ShardDataloader

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -3280,7 +3280,7 @@ class ShardDataloader:
         input_keys: list[str] | tuple[str] | None = None,
         shard_dims: list | tuple | str | int | None = None,
         is_dataset_splitted: bool = False,
-        dtensor_idx: list | None = None,
+        dense_tensor_idx: list | None = None,
     ):
         # do some check
         if is_dataset_splitted is True and shard_dims is None:
@@ -3351,7 +3351,7 @@ class ShardDataloader:
             )
         # Note(lizhiyu): In dygraph mode, the flag "pin_memory" is default "True", but it decrease the speed of `AutoParallel`
         self._dataloader.pin_memory = False
-        self.dtensor_idx = dtensor_idx
+        self.dense_tensor_idx = dense_tensor_idx
 
     def _process_shard_dims(self, shard_dims):
         if isinstance(shard_dims, (int, str)) or shard_dims is None:
@@ -3449,11 +3449,11 @@ class ShardDataloader:
         return meshes, placements
 
     def _dtensors_from_list_input(
-        self, list_tensors, meshes, placements, dtensor_idx=None
+        self, list_tensors, meshes, placements, dense_tensor_idx=None
     ):
         dist_data = []
         for j in range(len(list_tensors)):
-            if dtensor_idx is not None and j in dtensor_idx:
+            if dense_tensor_idx is not None and j in dense_tensor_idx:
                 dist_data.append(list_tensors[j])
             else:
                 dist_data.append(
@@ -3511,7 +3511,7 @@ class ShardDataloader:
                         i, len(input_data)
                     )
                     dist_batch_data[key] = self._dtensors_from_list_input(
-                        input_data, meshes, placements, self.dtensor_idx
+                        input_data, meshes, placements, self.dense_tensor_idx
                     )
                 elif isinstance(input_data, paddle.Tensor):
                     mesh, placements = self._get_mesh_and_placement(i)
@@ -3541,7 +3541,7 @@ def shard_dataloader(
     input_keys: Sequence[str] | None = None,
     shard_dims: Sequence[str] | Sequence[int] | str | int | None = None,
     is_dataset_splitted: bool = False,
-    dtensor_idx: list | None = None,
+    dense_tensor_idx: list | None = None,
 ) -> ShardDataloader:
     """
     Convert the dataloader to a ShardDataloader which provided two capabilities:
@@ -3730,7 +3730,7 @@ def shard_dataloader(
         input_keys,
         shard_dims,
         is_dataset_splitted,
-        dtensor_idx,
+        dense_tensor_idx,
     )
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Upgrade DataLoader to enable return with both `dist_tensor` and `dtensor` for mixed usage scenarios.
Related PaddleNLP changes: https://github.com/PaddlePaddle/PaddleNLP/pull/10009
Related PaddleMIX changes: https://github.com/jeff41404/PaddleMIX/pull/1
Pcard-70448