### PR TITLE
[Dy2St] Custom deepcopy behavior for `WeakMethod` to ensure hold correct instance

### DIFF
--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -161,6 +161,9 @@ class WeakMethod:
             raise RuntimeError("The object has been destroyed")
         return self.fn(self.__self__, *args, **kwargs)
 
+    def __deepcopy__(self, memo):
+        return WeakMethod(self.fn, memo[id(self.__self__)])
+
 
 def saw(x):
     if isinstance(x, UndefinedVar):

--- a/test/dygraph_to_static/test_deepcopy.py
+++ b/test/dygraph_to_static/test_deepcopy.py
@@ -16,11 +16,30 @@ import unittest
 from copy import deepcopy
 
 import numpy as np
-from dygraph_to_static_utils import Dy2StTestBase
+from dygraph_to_static_utils import Dy2StTestBase, test_ast_only
 from test_rollback import Net, foo
 
 import paddle
 from paddle.jit.dy2static.program_translator import StaticFunction
+from paddle.jit.dy2static.utils import WeakMethod
+
+
+class InnerLayer(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.linear = paddle.nn.Linear(32, 32)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class MyLayer(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.inner = InnerLayer()
+
+    def forward(self, x):
+        return self.inner(x)
 
 
 class TestDeepCopy(Dy2StTestBase):
@@ -62,6 +81,32 @@ class TestDeepCopy(Dy2StTestBase):
         self.assertFalse(isinstance(new_foo, StaticFunction))
         new_out = new_foo(x)
         np.testing.assert_array_equal(st_out.numpy(), new_out.numpy())
+
+    @test_ast_only
+    def test_nested_net(self):
+        model = MyLayer()
+        static_model = paddle.jit.to_static(model)
+        x = paddle.randn([1, 256, 32])
+        out = model(x)
+
+        copied_model = deepcopy(static_model)
+        self.assertIsInstance(copied_model.inner.forward, WeakMethod)
+        self.assertIsNot(static_model.inner.forward, copied_model.inner.forward)
+        self.assertIsNot(
+            static_model.inner.forward.__self__,
+            copied_model.inner.forward.__self__,
+        )
+        self.assertIs(static_model.inner, static_model.inner.forward.__self__)
+        self.assertIs(copied_model.inner, copied_model.inner.forward.__self__)
+
+        copied_out = copied_model(x)
+
+        copied_model.forward.rollback()
+        self.assertFalse(isinstance(copied_model.inner.forward, WeakMethod))
+        copied_model(x)
+        copied_rollback_out = copied_model(x)
+        np.testing.assert_array_equal(out.numpy(), copied_out.numpy())
+        np.testing.assert_array_equal(out.numpy(), copied_rollback_out.numpy())
 
 
 if __name__ == "__main__":

--- a/test/dygraph_to_static/test_deepcopy.py
+++ b/test/dygraph_to_static/test_deepcopy.py
@@ -33,7 +33,7 @@ class InnerLayer(paddle.nn.Layer):
         return self.linear(x)
 
 
-class MyLayer(paddle.nn.Layer):
+class NestedLayerForDeepcopy(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.inner = InnerLayer()
@@ -84,7 +84,7 @@ class TestDeepCopy(Dy2StTestBase):
 
     @test_ast_only
     def test_nested_net(self):
-        model = MyLayer()
+        model = NestedLayerForDeepcopy()
         static_model = paddle.jit.to_static(model)
         x = paddle.randn([1, 256, 32])
         out = model(x)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#71336 的后续，确保 `convert_call` 时候对 forward 绑定的 `WeakMethod` 的 instance 是正确的，不应该是之前的，应该也是 deepcopy 之后的

> [!TIP]
>
> 后续发版后有时间可以考虑消除 `convert_call` 产生的 side effect，替换内层 forward 属实有点难看（顶层是 API 层面改不动，内层我觉得完全可以改），可以考虑 `_jst.Call(fn)(args)` 改为 `_jst.Call(fn, args)`，以对 `fn` 调用的全面接管（原来的 `_jst.Call` 和 `_jst.Ld` 有点重复了），调用时可以在 patch guard 下（比如 #69936 里的 patch restorer 机制），调用完就恢复
>
> 或者 `_jst.Call(fn)` 返回一个 ProxyLayer，只用来调用，反正语法层面这里一定是会调用的，不会做别的事情（会有什么问题么？暂时没想到）