### PR TITLE
[CINN] TileBroadcastTactic NHWC layout broadcast

### DIFF
--- a/paddle/cinn/ir/group_schedule/tactic/tile_broadcast_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_broadcast_tactic.cc
@@ -90,22 +90,21 @@ class TileBroadcastTactic final : public ScheduleTactic {
   void InitBroadcastAxisInfo(ir::IRSchedule* sch);
   void InitBroadcastSizeInfo();
   void FuseAxisGroups(ir::IRSchedule* sch, const std::string& block_id);
-  // NHWC layout: calculate number of warps per block
-  static int CalcNumWarps(int64_t preserved_size);
+  std::vector<std::string> TileNCHW(ir::IRSchedule* sch,
+                                    const std::string& block_id,
+                                    int block_size);
+  std::vector<std::string> TileNHWC(ir::IRSchedule* sch,
+                                    const std::string& block_id,
+                                    int block_size);
 
  private:
   ScheduleContext* context_;
 
-  enum class TacticExtension : uint8_t {
-    Invalid = 0x0,
-    NCHWExt,
-    NHWCExt,
-    NumSupportedExt
-  };
+  enum class BroadcastLayout { Invalid = 0x0, NCHWLayout, NHWCLayout };
 
-  TacticExtension applied_ext_;  // applied tactic extension
+  BroadcastLayout applied_layout_;  // applied tactic
 
-  // list of broadcast axis in ascending order, NHWC layout will use this list
+  // list of broadcast axis in ascending order
   std::vector<int> broadcast_axis_;
   // one-hot representation of broadcast_axis
   std::vector<bool> is_broadcast_axis_;
@@ -284,9 +283,43 @@ bool ScheduleBlockEnableVectorize(const ScheduleConfig& config,
   return true;
 }
 
+static int CalcNumWarps(int64_t num_warps) {
+  // NHWC layout: calculate number of warps per block
+  constexpr int MAX_WARP_BLOCK = 32;
+  // the largest preserved size is 1024, for size bigger than 1024
+  // TODO(heqianyue): the code should be revised to be a DP version
+  if (num_warps > 1024) {
+    return -1;
+  }
+  // several rules to decide the thread block size
+  // (1) the preserved size (channel) is too small
+  // we need more threads in a block
+  if (num_warps <= 3) {
+    return std::max(4l, num_warps * 2);
+  }
+  // (2) if the num_warps is power of 2, use thread block size 256
+  if ((num_warps & (num_warps - 1)) == 0) {
+    return 8;
+  }
+  // (3) if num_warps <= 32, use the num_warps * 32 as thread block size
+  if (num_warps <= MAX_WARP_BLOCK) {
+    return num_warps;
+  }
+  // (4) otherwise, find the largest divisor `best` of num_warps that is smaller
+  // than 32 and use `best` * 32 as the block size
+  int best = -1;
+  for (int x = MAX_WARP_BLOCK; x >= 4; x--) {
+    if (num_warps % x == 0) {
+      best = x;
+      break;
+    }
+  }
+  return best;
+}
+
 void TileBroadcastTactic::Init(ScheduleContext* context, ir::IRSchedule* sch) {
   context_ = context;
-  applied_ext_ = TacticExtension::Invalid;
+  applied_layout_ = BroadcastLayout::Invalid;
   if (!FLAGS_cinn_enable_tile_broadcast) {
     return;
   }
@@ -306,8 +339,7 @@ void TileBroadcastTactic::Init(ScheduleContext* context, ir::IRSchedule* sch) {
 
   if (is_broadcast_axis_.back()) {
     // 3. It is an NCHW broadcast. We check this by checking that he last axis
-    // is
-    //    a broadcast axis, and all the 3 groups of axis exist.
+    // is a broadcast axis, and all the 3 groups of axis exist.
     if (high_broadcast_axis_.empty() || low_broadcast_axis_.empty() ||
         preserved_axis_.empty()) {
       return;
@@ -315,15 +347,15 @@ void TileBroadcastTactic::Init(ScheduleContext* context, ir::IRSchedule* sch) {
     InitBroadcastSizeInfo();
     // 4. The low_broadcast_size should be a multiple of 32 (the CUDA warp
     // size).
-    //    Otherwise, memory access will not be fully coalesced, leading to
-    //    performance degradation.
+    // Otherwise, memory access will not be fully coalesced, leading to
+    // performance degradation.
     // TODO(liangshuhao): we may allow aligning to 16 if further optimizations
     //    can compensate for the cost of non-coalesced access.
     if (low_broadcast_size_ % 32 != 0) {
       return;
     }
-    applied_ext_ = TacticExtension::NCHWExt;
-    VLOG(4) << "TileBroadcastTactic::Init: select extension: NCHWExt\n";
+    applied_layout_ = BroadcastLayout::NCHWLayout;
+    VLOG(4) << "TileBroadcastTactic::Init: matched NCHWLayout\n";
   } else {
     // 3. For NHWC layout, we need valid preserved axis and broadcast axis
     // also, to be more stable, we only handles NHW(C) broadcast
@@ -332,17 +364,17 @@ void TileBroadcastTactic::Init(ScheduleContext* context, ir::IRSchedule* sch) {
       return;
     }
     InitBroadcastSizeInfo();
-    // 4. compatible size is the multiple of 32
-    if (broadcast_size_ % 32 != 0 || preserved_size_ % 32 != 0) {
+    // 4. compatible channel size is the multiple of 32
+    if (preserved_size_ % 32 != 0) {
       return;
     }
-    int num_warps = TileBroadcastTactic::CalcNumWarps(preserved_size_ >> 5);
-    // 5. check whether NHWC extension can be successfully applied
+    int num_warps = CalcNumWarps(preserved_size_ >> 5);
+    // 5. check whether NHWC layout can be successfully applied
     if (num_warps < 0) {
       return;
     }
-    applied_ext_ = TacticExtension::NHWCExt;
-    VLOG(4) << "TileBroadcastTactic::Init: select extension: NHWCExt\n";
+    applied_layout_ = BroadcastLayout::NHWCLayout;
+    VLOG(4) << "TileBroadcastTactic::Init: matched NHWCLayout\n";
   }
   // Now we can apply this tactic
   ir::Expr module_root = sch->GetModule().GetExprs().front();
@@ -404,41 +436,75 @@ void TileBroadcastTactic::InitBroadcastSizeInfo() {
   }
 }
 
-int TileBroadcastTactic::CalcNumWarps(int64_t num_warps) {
-  constexpr int MAX_WARP_BLOCK = 32;
-  // the largest preserved size is 1024, for size bigger than 1024
-  // TODO(heqianyue): the code should be revised to be a DP version, see (6)
-  if (num_warps > 1024) {
-    return -1;
+std::vector<std::string> TileBroadcastTactic::TileNCHW(
+    ir::IRSchedule* sch, const std::string& block_id, int block_size) {
+  // To achieve best performance, we apply different tiling templates based on
+  // low_broadcast_size. The key is which axis to allocate inner loop:
+  // 1. For small size:
+  //        [B, P, B<=256]
+  //     => [(blockY, loop), blockX, threadX].
+  // 2. For medium size:
+  //        [B, P, 256<B<=2048],
+  //     => [blockY, blockX, (loop, threadX)].
+  // 3. For large size:
+  //        [B, P, B>2048]
+  //     => [blockX', blockY, (blockX, loop, threadX)].
+  VLOG(4) << "TileBroadcastTactic using original NCHW layout\n";
+  if (low_broadcast_size_ <= 256) {
+    sch->Split(block_id, 0, {-1, 4});
+    return {"blockIdx.y", "", "blockIdx.x", "threadIdx.x"};
+  } else if (low_broadcast_size_ <= 2048) {
+    sch->Split(block_id, 2, {-1, block_size});
+    return {"blockIdx.y", "blockIdx.x", "", "threadIdx.x"};
+  } else {
+    sch->Reorder(block_id, {1, 0});
+    sch->Fuse(block_id, {1, 2});
+    sch->Split(block_id, 1, {-1, 4, block_size});
+    return {"blockIdx.y", "blockIdx.x", "", "threadIdx.x"};
   }
-  // several rules to decide the thread block size
-  // (1) the preserved size (channel) is too small
-  // we need more threads in a block
-  if (num_warps <= 3) {
-    return std::max(4l, num_warps * 2);
-  }
-  // (2) if the num_warps is power of 2, use thread block size 256
-  if ((num_warps & (num_warps - 1)) == 0) {
-    return 8;
-  }
-  // (3) if num_warps is smaller than 32, use the num_warps * 32 as thread block
-  // size
-  if (num_warps <= MAX_WARP_BLOCK) {
-    return num_warps;
-  }
-  // (4) otherwise, find the largest divisor `best` of num_warps that is smaller
-  // than 32 and use `best` * 32 as the block size
-  int best = -1;
-  for (int x = MAX_WARP_BLOCK; x >= 4; x--) {
-    if (num_warps % x == 0) {
-      best = x;
-      break;
+}
+
+std::vector<std::string> TileBroadcastTactic::TileNHWC(
+    ir::IRSchedule* sch, const std::string& block_id, int block_size) {
+  // NHWC layout will have 2 fused loops, so we start with (blockIdx.x,
+  // threadIdx.x)
+  VLOG(4) << "TileBroadcastTactic using NHWC layout, block size: " << block_size
+          << "\n";
+  if (broadcast_size_ <= 64) {
+    /**
+     * if the broadcast size is smaller than 64
+     * this means we need more blocks to increase the occupancy
+     * so no thread coarsening anyway
+     */
+    sch->Split(block_id, 1, {-1, block_size});
+    sch->Fuse(block_id, {0, 1});
+    return {"blockIdx.x", "threadIdx.x"};
+  } else {
+    if (preserved_size_ == block_size) {
+      // block size is enough to cover
+      sch->Split(block_id, 1, {-1, block_size});
+      sch->Fuse(block_id, {0, 1});
+      sch->Split(block_id, 0, {-1, 4});
+      return {"blockIdx.x", "", "threadIdx.x"};
+    } else if (preserved_size_ < block_size) {
+      // block size is larger (deliberately, to have enough threads)
+      // than preserved size
+      sch->Fuse(block_id, {0, 1});  // single fused loop
+      sch->Split(
+          block_id, 0, {-1, 4, block_size / preserved_size_, preserved_size_});
+      return {"blockIdx.x", "", "threadIdx.y", "threadIdx.x"};
+    } else {
+      /**
+       * block size is not enough to cover the preserved size
+       * make the load index invariant to inner loop
+       * (-1, 4, p_size / block_size, block_size)
+       */
+      sch->Split(block_id, 1, {-1, block_size});
+      sch->Fuse(block_id, {0, 1});
+      sch->Split(block_id, 0, {-1, 4, preserved_size_ / block_size});
+      return {"blockIdx.x", "", "blockIdx.y", "threadIdx.x"};
     }
   }
-  // (6) actually, the full problem is a variant to the backpack problem, DP
-  // should be used here But since the problem is not large enough, we can use a
-  // simple greedy algorithm. TODO(heqianyue): use DP to solve bigger psize
-  return best;
 }
 
 void TileBroadcastTactic::Apply(ir::IRSchedule* sch,
@@ -448,91 +514,28 @@ void TileBroadcastTactic::Apply(ir::IRSchedule* sch,
     return;
   }
 
+  if (applied_layout_ == BroadcastLayout::Invalid) return;
   int block_size = 256;
   // check the number of warps here, if not a applicable
   // preserved_size, func will return later
-  if (applied_ext_ == TacticExtension::NHWCExt) {
-    block_size = TileBroadcastTactic::CalcNumWarps(preserved_size_ >> 5);
+  if (applied_layout_ == BroadcastLayout::NHWCLayout) {
+    block_size = CalcNumWarps(preserved_size_ >> 5);
     if (block_size == -1) {
-      applied_ext_ = TacticExtension::Invalid;
+      applied_layout_ = BroadcastLayout::Invalid;
     }
     block_size = std::clamp(block_size << 5, 128, 1024);
   }
-  if (applied_ext_ == TacticExtension::Invalid) return;
 
   // Cluster and fuse axis of the same type to get exactly 3 loops.
   // [B, P, B, P, ..., B, B] => [B, P, B]
   FuseAxisGroups(sch, block_id);
 
+  // Do tiling.
   std::vector<std::string> axis_bind;
-  if (applied_ext_ == TacticExtension::NCHWExt) {
-    // Do tiling.
-    // To achieve best performance, we apply different tiling templates based on
-    // low_broadcast_size. The key is which axis to allocate inner loop:
-    // 1. For small size:
-    //        [B, P, B<=256]
-    //     => [(blockY, loop), blockX, threadX].
-    // 2. For medium size:
-    //        [B, P, 256<B<=2048],
-    //     => [blockY, blockX, (loop, threadX)].
-    // 3. For large size:
-    //        [B, P, B>2048]
-    //     => [blockX', blockY, (blockX, loop, threadX)].
-    if (low_broadcast_size_ <= 256) {
-      sch->Split(block_id, 0, {-1, 4});
-      axis_bind = {"blockIdx.y", "", "blockIdx.x", "threadIdx.x"};
-    } else if (low_broadcast_size_ <= 2048) {
-      sch->Split(block_id, 2, {-1, block_size});
-      axis_bind = {"blockIdx.y", "blockIdx.x", "", "threadIdx.x"};
-    } else {
-      sch->Reorder(block_id, {1, 0});
-      sch->Fuse(block_id, {1, 2});
-      sch->Split(block_id, 1, {-1, 4, block_size});
-      axis_bind = {"blockIdx.y", "blockIdx.x", "", "threadIdx.x"};
-    }
-    VLOG(4) << "TileBroadcastTactic using original NCHW layout extension\n";
-  } else if (applied_ext_ == TacticExtension::NHWCExt) {
-    // NHWC layout will have 2 fused loops, so we start with (blockIdx.x,
-    // threadIdx.x)
-    if (broadcast_size_ <= 64) {
-      /**
-       * if the broadcast size is smaller than 64
-       * this means we need more blocks to increase the occupancy
-       * so no thread coarsening anyway
-       */
-      sch->Split(block_id, 1, {-1, block_size});
-      sch->Fuse(block_id, {0, 1});
-      axis_bind = {"blockIdx.x", "threadIdx.x"};
-    } else {
-      if (preserved_size_ == block_size) {
-        // block size is enough to cover
-        sch->Split(block_id, 1, {-1, block_size});
-        sch->Fuse(block_id, {0, 1});
-        sch->Split(block_id, 0, {-1, 4});
-        axis_bind = {"blockIdx.x", "", "threadIdx.x"};
-      } else if (preserved_size_ < block_size) {
-        // block size is larger (deliberately, to have enough threads)
-        // than preserved size
-        sch->Fuse(block_id, {0, 1});  // single fused loop
-        sch->Split(block_id,
-                   0,
-                   {-1, 4, block_size / preserved_size_, preserved_size_});
-        axis_bind = {"blockIdx.x", "", "threadIdx.y", "threadIdx.x"};
-      } else {
-        /**
-         * block size is not enough to cover the preserved size
-         * make the load index invariant to inner loop
-         * (-1, 4, p_size / block_size, block_size)
-         */
-        sch->Split(block_id, 1, {-1, block_size});
-        sch->Fuse(block_id, {0, 1});
-        sch->Split(block_id, 0, {-1, 4, preserved_size_ / block_size});
-        axis_bind = {"blockIdx.x", "", "blockIdx.y", "threadIdx.x"};
-      }
-    }
-
-    VLOG(4) << "TileBroadcastTactic using NHWC layout extension, block size: "
-            << block_size << "\n";
+  if (applied_layout_ == BroadcastLayout::NCHWLayout) {
+    axis_bind = TileNCHW(sch, block_id, block_size);
+  } else {
+    axis_bind = TileNHWC(sch, block_id, block_size);
   }
 
   // Do binding.
@@ -560,6 +563,7 @@ void TileBroadcastTactic::FuseAxisGroups(ir::IRSchedule* sch,
   // Fuse continuous axis of the same type.
   // [B, B, ..., P, P, ..., B, B] => [B, P, B] (for NCHW layout)
   // [B, B, P, B, ..., P] => [B, P] (for NHWC layout)
+  if (applied_layout_ == BroadcastLayout::Invalid) return;
   const auto FuseRange = [&](int start, int count) {
     if (count > 1) {
       std::vector<int> loops_index(count);
@@ -567,39 +571,30 @@ void TileBroadcastTactic::FuseAxisGroups(ir::IRSchedule* sch,
       sch->Fuse(block_id, loops_index);
     }
   };
-  if (applied_ext_ == TacticExtension::NCHWExt) {
-    std::vector<int> high_axis_perm = high_broadcast_axis_;
-    high_axis_perm.insert(
-        high_axis_perm.end(), preserved_axis_.begin(), preserved_axis_.end());
-    sch->Reorder(block_id, high_axis_perm);
-
-    int high_axis_num = high_broadcast_axis_.size();
-    int mid_axis_num = preserved_axis_.size();
-    int low_axis_num = low_broadcast_axis_.size();
-
-    FuseRange(high_axis_num + mid_axis_num, low_axis_num);
-    FuseRange(high_axis_num, mid_axis_num);
-    FuseRange(0, high_axis_num);
-  } else if (applied_ext_ == TacticExtension::NHWCExt) {
-    std::vector<int> broadcast_axis_perm = broadcast_axis_;
-    broadcast_axis_perm.insert(broadcast_axis_perm.end(),
-                               preserved_axis_.begin(),
-                               preserved_axis_.end());
-    sch->Reorder(block_id, broadcast_axis_perm);
-    int broadcast_num = broadcast_axis_.size();
-    int preserved_num = preserved_axis_.size();
-    FuseRange(broadcast_num, preserved_num);
-    FuseRange(0, broadcast_num);
+  std::vector<int> axis_perm;
+  int high_axis_num = 0;
+  int low_axis_num = 0;
+  int mid_axis_num = preserved_axis_.size();
+  if (applied_layout_ == BroadcastLayout::NCHWLayout) {
+    axis_perm = high_broadcast_axis_;
+    high_axis_num = high_broadcast_axis_.size();
+    low_axis_num = low_broadcast_axis_.size();
   } else {
-    std::cerr << "Unknown tactic extension: " << static_cast<int>(applied_ext_)
-              << std::endl;
-    throw std::runtime_error("Unsupported tactic extension");
+    axis_perm = broadcast_axis_;
+    high_axis_num = broadcast_axis_.size();
   }
+  axis_perm.insert(
+      axis_perm.end(), preserved_axis_.begin(), preserved_axis_.end());
+  sch->Reorder(block_id, axis_perm);
+
+  FuseRange(high_axis_num + mid_axis_num, low_axis_num);
+  FuseRange(high_axis_num, mid_axis_num);
+  FuseRange(0, high_axis_num);
 }
 
 void TileBroadcastTactic::ApplyVectorize(ir::IRSchedule* sch,
                                          const std::string& block_id) {
-  if (applied_ext_ == TacticExtension::Invalid) return;
+  if (applied_layout_ == BroadcastLayout::Invalid) return;
   const auto vectorize_factor =
       static_cast<int>(context_->config.tile_config.vectorize_factor);
 

--- a/paddle/cinn/ir/group_schedule/tactic/tile_broadcast_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_broadcast_tactic.cc
@@ -90,12 +90,22 @@ class TileBroadcastTactic final : public ScheduleTactic {
   void InitBroadcastAxisInfo(ir::IRSchedule* sch);
   void InitBroadcastSizeInfo();
   void FuseAxisGroups(ir::IRSchedule* sch, const std::string& block_id);
+  // NHWC layout: calculate number of warps per block
+  static int CalcNumWarps(int64_t preserved_size);
 
  private:
   ScheduleContext* context_;
-  bool can_apply_;
 
-  // list of broadcast axis in ascending order
+  enum class TacticExtension : uint8_t {
+    Invalid = 0x0,
+    NCHWTested,
+    NHWCAlphaExt,
+    NumSupportedExt
+  };
+
+  TacticExtension applied_ext_;  // applied tactic extension
+
+  // list of broadcast axis in ascending order, NHWC layout will use this list
   std::vector<int> broadcast_axis_;
   // one-hot representation of broadcast_axis
   std::vector<bool> is_broadcast_axis_;
@@ -107,6 +117,7 @@ class TileBroadcastTactic final : public ScheduleTactic {
   //           ^     ^       ^  ^
   //           |     |       low_broadcast_axis
   //        preserved_axis
+
   std::vector<int> high_broadcast_axis_;
   std::vector<int> preserved_axis_;
   std::vector<int> low_broadcast_axis_;
@@ -115,6 +126,8 @@ class TileBroadcastTactic final : public ScheduleTactic {
   int64_t broadcast_size_;
   // product of the low broadcast axis's dim sizes
   int64_t low_broadcast_size_;
+  // product of the preserved axis's dim sizes
+  int64_t preserved_size_;
 };
 
 std::unordered_set<ir::Var> CollectIterVars(
@@ -273,7 +286,7 @@ bool ScheduleBlockEnableVectorize(const ScheduleConfig& config,
 
 void TileBroadcastTactic::Init(ScheduleContext* context, ir::IRSchedule* sch) {
   context_ = context;
-  can_apply_ = false;
+  applied_ext_ = TacticExtension::Invalid;
   if (!FLAGS_cinn_enable_tile_broadcast) {
     return;
   }
@@ -290,27 +303,41 @@ void TileBroadcastTactic::Init(ScheduleContext* context, ir::IRSchedule* sch) {
   if (broadcast_axis_.empty()) {
     return;
   }
-  // 3. It is an NCHW broadcast. We check this by checking that he last axis is
-  //    a broadcast axis, and all the 3 groups of axis exist.
-  if (!is_broadcast_axis_.back()) {
-    return;
-  }
-  if (high_broadcast_axis_.empty() || preserved_axis_.empty() ||
-      low_broadcast_axis_.empty()) {
-    return;
-  }
-  InitBroadcastSizeInfo();
-  // 4. The low_broadcast_size should be a multiple of 32 (the CUDA warp size).
-  //    Otherwise, memory access will not be fully coalesced, leading to
-  //    performance degradation.
-  // TODO(liangshuhao): we may allow aligning to 16 if further optimizations
-  //    can compensate for the cost of non-coalesced access.
-  if (low_broadcast_size_ % 32 != 0) {
-    return;
-  }
 
+  if (is_broadcast_axis_.back()) {
+    // 3. It is an NCHW broadcast. We check this by checking that he last axis
+    // is
+    //    a broadcast axis, and all the 3 groups of axis exist.
+    if (high_broadcast_axis_.empty() || low_broadcast_axis_.empty() ||
+        preserved_axis_.empty()) {
+      return;
+    }
+    InitBroadcastSizeInfo();
+    // 4. The low_broadcast_size should be a multiple of 32 (the CUDA warp
+    // size).
+    //    Otherwise, memory access will not be fully coalesced, leading to
+    //    performance degradation.
+    // TODO(liangshuhao): we may allow aligning to 16 if further optimizations
+    //    can compensate for the cost of non-coalesced access.
+    if (low_broadcast_size_ % 32 != 0) {
+      return;
+    }
+    applied_ext_ = TacticExtension::NCHWTested;
+    VLOG(4) << "TileBroadcastTactic::Init: select extension: NCHWTested\n";
+  } else {
+    // 3. For NHWC layout, we need valid preserved axis and broadcast axis
+    if (preserved_axis_.empty() || broadcast_axis_.empty()) {
+      return;
+    }
+    InitBroadcastSizeInfo();
+    // 4. compatible size is the multiple of 32
+    if (broadcast_size_ % 32 != 0 || preserved_size_ % 32 != 0) {
+      return;
+    }
+    applied_ext_ = TacticExtension::NHWCAlphaExt;
+    VLOG(4) << "TileBroadcastTactic::Init: select extension: NHWCAlphaExt\n";
+  }
   // Now we can apply this tactic
-  can_apply_ = true;
   ir::Expr module_root = sch->GetModule().GetExprs().front();
   ir::Expr root_block = ir::analyzer::GetRootSBlock(module_root);
   auto* root_node = root_block.As<ir::ScheduleBlockRealize>()
@@ -363,6 +390,43 @@ void TileBroadcastTactic::InitBroadcastSizeInfo() {
   for (int axis : low_broadcast_axis_) {
     low_broadcast_size_ = MulDimSize(low_broadcast_size_, loop_ranges[axis]);
   }
+
+  preserved_size_ = 1;
+  for (int axis : preserved_axis_) {
+    preserved_size_ = MulDimSize(preserved_size_, loop_ranges[axis]);
+  }
+}
+
+int TileBroadcastTactic::CalcNumWarps(int64_t num_warps) {
+  constexpr int MAX_WARP_BLOCK = 32;
+  // several rules to decide the thread block size
+  // (1) if the num_warps is power of 2, use thread block size 256
+  if ((num_warps & (num_warps - 1)) == 0) {
+    return 8;
+  }
+  // (2) preserved size is 96, return 192 as block size to have a big enough
+  // block
+  if (num_warps == 3) {
+    return 6;
+  }
+  // (3) if num_warps is smaller than 32, use the num_warps * 32 as thread block
+  // size
+  if (num_warps <= MAX_WARP_BLOCK) {
+    return num_warps;
+  }
+  // (4) otherwise, find the largest divisor `best` of num_warps that is smaller
+  // than 32 and use `best` * 32 as the block size
+  int best = -1;
+  for (int x = MAX_WARP_BLOCK; x >= 4; x--) {
+    if (num_warps % x == 0) {
+      best = x;
+      break;
+    }
+  }
+  // (6) actually, the full problem is a variant to the backpack problem, DP
+  // should be used here But since the problem is not large enough, we can use a
+  // simple greedy algorithm
+  return best;
 }
 
 void TileBroadcastTactic::Apply(ir::IRSchedule* sch,
@@ -372,36 +436,75 @@ void TileBroadcastTactic::Apply(ir::IRSchedule* sch,
     return;
   }
 
-  if (!can_apply_) return;
+  int block_size = 256;
+  // check the number of warps here, if not a applicable
+  // preserved_size, func will return later
+  if (applied_ext_ == TacticExtension::NHWCAlphaExt) {
+    block_size = TileBroadcastTactic::CalcNumWarps(preserved_size_ >> 5);
+    if (block_size == -1) {
+      applied_ext_ = TacticExtension::Invalid;
+    }
+    block_size = block_size << 5;
+  }
+
+  if (applied_ext_ == TacticExtension::Invalid) return;
 
   // Cluster and fuse axis of the same type to get exactly 3 loops.
   // [B, P, B, P, ..., B, B] => [B, P, B]
   FuseAxisGroups(sch, block_id);
 
-  // Do tiling.
-  // To achieve best performance, we apply different tiling templates based on
-  // low_broadcast_size. The key is which axis to allocate inner loop:
-  // 1. For small size:
-  //        [B, P, B<=256]
-  //     => [(blockY, loop), blockX, threadX].
-  // 2. For medium size:
-  //        [B, P, 256<B<=2048],
-  //     => [blockY, blockX, (loop, threadX)].
-  // 3. For large size:
-  //        [B, P, B>2048]
-  //     => [blockX', blockY, (blockX, loop, threadX)].
   std::vector<std::string> axis_bind;
-  if (low_broadcast_size_ <= 256) {
-    sch->Split(block_id, 0, {-1, 4});
-    axis_bind = {"blockIdx.y", "", "blockIdx.x", "threadIdx.x"};
-  } else if (low_broadcast_size_ <= 2048) {
-    sch->Split(block_id, 2, {-1, 256});
-    axis_bind = {"blockIdx.y", "blockIdx.x", "", "threadIdx.x"};
-  } else {
-    sch->Reorder(block_id, {1, 0});
-    sch->Fuse(block_id, {1, 2});
-    sch->Split(block_id, 1, {-1, 4, 256});
-    axis_bind = {"blockIdx.y", "blockIdx.x", "", "threadIdx.x"};
+  if (applied_ext_ == TacticExtension::NCHWTested) {
+    // Do tiling.
+    // To achieve best performance, we apply different tiling templates based on
+    // low_broadcast_size. The key is which axis to allocate inner loop:
+    // 1. For small size:
+    //        [B, P, B<=256]
+    //     => [(blockY, loop), blockX, threadX].
+    // 2. For medium size:
+    //        [B, P, 256<B<=2048],
+    //     => [blockY, blockX, (loop, threadX)].
+    // 3. For large size:
+    //        [B, P, B>2048]
+    //     => [blockX', blockY, (blockX, loop, threadX)].
+    if (low_broadcast_size_ <= 256) {
+      sch->Split(block_id, 0, {-1, 4});
+      axis_bind = {"blockIdx.y", "", "blockIdx.x", "threadIdx.x"};
+    } else if (low_broadcast_size_ <= 2048) {
+      sch->Split(block_id, 2, {-1, block_size});
+      axis_bind = {"blockIdx.y", "blockIdx.x", "", "threadIdx.x"};
+    } else {
+      sch->Reorder(block_id, {1, 0});
+      sch->Fuse(block_id, {1, 2});
+      sch->Split(block_id, 1, {-1, 4, block_size});
+      axis_bind = {"blockIdx.y", "blockIdx.x", "", "threadIdx.x"};
+    }
+    VLOG(4) << "TileBroadcastTactic using original NCHW layout extension\n";
+  } else if (applied_ext_ == TacticExtension::NHWCAlphaExt) {
+    // NHWC layout will have 2 fused loops, so we start with (blockIdx.x,
+    // threadIdx.x)
+    sch->Split(block_id, 1, {-1, block_size});
+    sch->Fuse(block_id, {0, 1});
+    if (broadcast_size_ <= 64 || preserved_size_ > 1024) {
+      /**
+       * when not to use thread coarsening?
+       * 1. when there is not enough blocks (low occupancy, we need more blocks)
+       * 2. when the load/store addressing range for preserved channel is larger
+       * than the block size. In this case, we need to load/store per it in the
+       * for loop anyway, so there is no load/store reuse. In order to have more
+       * eligible warps to hide the latency, we need more blocks.
+       *
+       * TODO: heqianyue: check for4 thread coarsening necessity
+       * it can improve performance by a bit, but it is not the actual problem
+       */
+      axis_bind = {"blockIdx.x", "threadIdx.x"};
+    } else if (broadcast_size_ <= 1024) {
+      sch->Split(block_id, 0, {-1, 4});
+      axis_bind = {"blockIdx.x", "", "threadIdx.x"};
+    }
+
+    VLOG(4) << "TileBroadcastTactic using NHWC layout extension, block size: "
+            << block_size << "\n";
   }
 
   // Do binding.
@@ -426,13 +529,9 @@ void TileBroadcastTactic::FuseAxisGroups(ir::IRSchedule* sch,
                                          const std::string& block_id) {
   // Reorder high-dim axis to cluster axis of the same type.
   // [B, P, B, P, ..., B, B] => [B, B, ..., P, P, ..., B, B]
-  std::vector<int> high_axis_perm = high_broadcast_axis_;
-  high_axis_perm.insert(
-      high_axis_perm.end(), preserved_axis_.begin(), preserved_axis_.end());
-  sch->Reorder(block_id, high_axis_perm);
-
   // Fuse continuous axis of the same type.
-  // [B, B, ..., P, P, ..., B, B] => [B, P, B]
+  // [B, B, ..., P, P, ..., B, B] => [B, P, B] (for NCHW layout)
+  // [B, B, P, B, ..., P] => [B, P] (for NHWC layout)
   const auto FuseRange = [&](int start, int count) {
     if (count > 1) {
       std::vector<int> loops_index(count);
@@ -440,18 +539,39 @@ void TileBroadcastTactic::FuseAxisGroups(ir::IRSchedule* sch,
       sch->Fuse(block_id, loops_index);
     }
   };
-  int high_axis_num = high_broadcast_axis_.size();
-  int mid_axis_num = preserved_axis_.size();
-  int low_axis_num = low_broadcast_axis_.size();
+  if (applied_ext_ == TacticExtension::NCHWTested) {
+    std::vector<int> high_axis_perm = high_broadcast_axis_;
+    high_axis_perm.insert(
+        high_axis_perm.end(), preserved_axis_.begin(), preserved_axis_.end());
+    sch->Reorder(block_id, high_axis_perm);
 
-  FuseRange(high_axis_num + mid_axis_num, low_axis_num);
-  FuseRange(high_axis_num, mid_axis_num);
-  FuseRange(0, high_axis_num);
+    int high_axis_num = high_broadcast_axis_.size();
+    int mid_axis_num = preserved_axis_.size();
+    int low_axis_num = low_broadcast_axis_.size();
+
+    FuseRange(high_axis_num + mid_axis_num, low_axis_num);
+    FuseRange(high_axis_num, mid_axis_num);
+    FuseRange(0, high_axis_num);
+  } else if (applied_ext_ == TacticExtension::NHWCAlphaExt) {
+    std::vector<int> broadcast_axis_perm = broadcast_axis_;
+    broadcast_axis_perm.insert(broadcast_axis_perm.end(),
+                               preserved_axis_.begin(),
+                               preserved_axis_.end());
+    sch->Reorder(block_id, broadcast_axis_perm);
+    int broadcast_num = broadcast_axis_.size();
+    int preserved_num = preserved_axis_.size();
+    FuseRange(broadcast_num, preserved_num);
+    FuseRange(0, broadcast_num);
+  } else {
+    std::cerr << "Unknown tactic extension: " << static_cast<int>(applied_ext_)
+              << std::endl;
+    throw std::runtime_error("Unsupported tactic extension");
+  }
 }
 
 void TileBroadcastTactic::ApplyVectorize(ir::IRSchedule* sch,
                                          const std::string& block_id) {
-  if (!can_apply_) return;
+  if (applied_ext_ == TacticExtension::Invalid) return;
   const auto vectorize_factor =
       static_cast<int>(context_->config.tile_config.vectorize_factor);
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN
### PR Types
Improvements

### Description
Implement the NHWC layout support for `TileBroadcastTactic` introduced in #70092. 

#### Introduction
The original `TileBroadcastTactic` only handles the broadcast of the following form:
```
   [1, C, 1, 1] => [N, C, H, W].
```
For NHWC layout broadcast, CINN will fall back to `TileFirstGeneralTactic` since the last axis is not a broadcast axis. It will have some performance issues, such as using a rather static block size for tensor with different channels, which might produce excessive GMEM load.

The extended `TileBroadcastTactic` also covers the following case:
```
[1, 1, 1, C] => [N, H, W, C]
```
as long as the last axis is a preserved axis (see #70092 for the term definition).

#### Performance Impact
(1) This tactic extension avoids excessive load in the a simple way: find an appropriate block size `K`, which satifies:
- `C % K` is 0
- `K` is a multiple of 32
- `K` should be as close to `C` as possible.
- `K` is within a certain range, for example: [128, 1024].

The first requirement is the most important one: it will eliminate excessive loads by making the load index invariant to the thread coarsening loop index. Here is an example:

Without this extension, for the input tensor with shape (64, 56, 56, 192), the block size is 256, therefore, with thread coarsening, the thread will load one value from GMEM each loop iteration, totaling 4 loads per tensor (that needs to broadcasting). 

```c++
// example 192-> (64, 56, 56, 192) tensor broadcast
  for (int32_t thread_loop_i = 0; thread_loop_i < 4; thread_loop_i += 1) {
    float var_0_local = var_0[((((thread_loop_i * 256) + (int)threadIdx.x) + ((int)blockIdx.x * 1024)) % 192)];
    /* ... */
    to_broad_cast[/* ... */] = some_func(var_0_local, /* ... */);
}
```
With this extension, we only need to load once, since the load index is loop-index invariant. Effectively reducing the number of loads required:
```c++
// example 192-> (64, 56, 56, 192) tensor broadcast
  for (int32_t thread_loop_i = 0; thread_loop_i < 4; thread_loop_i += 1) {
    float var_0_local = var_0[threadIdx.x];
    /* ... */
    to_broad_cast[/* ... */] = some_func(var_0_local, /* ... */);
}
```
(2) Small and Large channel size. 

For small channel size, the tactic first fuses all the dimensions to have a flattened 1D tensor, then we assign a block size (>= 128) to have enough threads in a block. Without fusing into a flattened tensor, the scheduler won't split the last dimension properly, which might cause idle threads in the blocks.

For large channel size, since we will only have 1024 threads at most in a block, channel size greater than 1024 might not have full utilization of bandwidth. We use yet another grid axis, to limit the threads in a block to only part of the input tensor (even with thread coarsening). This makes sure that with thread coarsening, the loaded values can be reused across the inner loop.

#### Limitation

- This extension supports broadcast with any shape, as long as the broadcast form is [B, P]. For example: (1, H, 1, C) -> (N, H, W, C). But this is not locally tested and can be potentially erroneous.

#### Experiment Results

Tested on BatchNorm op (`data_layout="NHWC"`), the forward broadcast kernel (V100):

|shape|max bandwidth %|runtime (us)|bandwidth improvement (%)|runtime decrease (%)|
|---|---|---|---|---|
|256,64,64,192|92.26|1940|35.56|-26.24|
|128,72,72,224|92.33|1430|64.43|-39.14|
|256,48,48,224|92.31|1270|67.29|-40.37|
|400,72,72,384|92.30|7680|62.10|-38.13|

 

    

Pcard-89620
 