### PR TITLE
[CINN] Fix block reduce CUDA template

### DIFF
--- a/paddle/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
+++ b/paddle/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
@@ -572,7 +572,10 @@ EXPAND_REDUCE_FP16_MACRO(CINN_WARP_SHUFFLE_INTERNAL_IMPL)
   }                                                                \
   __syncthreads();                                                 \
   if (threadIdx.x < (blockDim.x + 31) / 32) {                      \
-    shm[0] = cinn_warp_shuffle_internal(shm[threadIdx.x]);         \
+    tmp_val = cinn_warp_shuffle_internal(shm[threadIdx.x]);        \
+    if (threadIdx.x == 0) {                                        \
+      shm[0] = tmp_val;                                            \
+    }                                                              \
   }                                                                \
   __syncthreads();                                                 \
   return shm[0];


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
修复`cinn_block_reduce`模板的一处语义模糊导致的同步错误

之前是整个warp同时写入`shm[0]`，一般来说只有0号线程写成功，这也是我们期望的；但是当数据类型更大时，warp可能分成2段执行，导致写了后半段warp的数据；一般的float、int类型都是正常的，Welford类型因为更大（12bytes）才出现问题

Pcard-85711