### PR TITLE
[CINN] add easy simplify for min

### DIFF
--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -1211,8 +1211,7 @@ struct SimplifyDiv {
 struct SimplifyMin {
   using dim_expr_type = Min<DimExpr>;
 
-  static const bool IsLhsGreatEqualThanRhs(const DimExpr& lhs,
-                                           const DimExpr& rhs) const {
+  static bool IsLhsGreatEqualThanRhs(const DimExpr& lhs, const DimExpr& rhs) {
     const auto LhsOperandsVisitor =
         common::Overloaded{[&](const Add<DimExpr>& add) {
                              bool lhs_great_equal_than_rhs = false;
@@ -1243,7 +1242,7 @@ struct SimplifyMin {
            symbol::Compare(lhs, rhs) == DimExprCompareResult::GT;
   }
 
-  List<DimExpr> SearchErasable(const List<DimExpr>& operands) {
+  static List<DimExpr> SearchErasable(const List<DimExpr>& operands) {
     List<DimExpr> ret_operands{};
     for (std::size_t i = 0; i < operands->size(); i++) {
       bool is_redundant = false;
@@ -1263,7 +1262,7 @@ struct SimplifyMin {
     return ret_operands;
   }
 
-  DimExpr Rewrite(const DimExpr& expr) const {
+  DimExpr Rewrite(const DimExpr& expr) {
     const auto& [operands] = expr.Get<Min<DimExpr>>();
     List<DimExpr> ret_operands = SearchErasable(operands);
     if (ret_operands->size() == 1) {

--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -1529,22 +1529,31 @@ IR_API PriorityComparisonStatus CompareDimExprPriority(const DimExpr& lhs,
 }
 
 DimExprCompareResult Compare(const DimExpr& lhs, const DimExpr& rhs) {
+  auto CompareExpressions = [](const auto& lhs_val, const auto& rhs_val) {
+    DimExpr simplified_result =
+        SimplifyDimExpr(DimExpr{lhs_val} - DimExpr{rhs_val});
+    if (simplified_result.isa<int64_t>()) {
+      int64_t const_result = simplified_result.dyn_cast<int64_t>();
+      return const_result == 0  ? DimExprCompareResult::EQ
+             : const_result < 0 ? DimExprCompareResult::LT
+                                : DimExprCompareResult::GT;
+    }
+    return DimExprCompareResult::UNKNOWN;
+  };
   auto CompareFunc = common::Overloaded{
       [](const int& lhs, const int& rhs) {
         return lhs == rhs ? DimExprCompareResult::EQ
                           : (lhs < rhs ? DimExprCompareResult::LT
                                        : DimExprCompareResult::GT);
       },
-      [](const Add<DimExpr>& lhs, const Add<DimExpr>& rhs) {
-        DimExpr simplified_result =
-            SimplifyDimExpr(DimExpr{lhs} - DimExpr{rhs});
-        if (simplified_result.isa<int64_t>()) {
-          int64_t const_result = simplified_result.dyn_cast<int64_t>();
-          return const_result == 0  ? DimExprCompareResult::EQ
-                 : const_result < 0 ? DimExprCompareResult::LT
-                                    : DimExprCompareResult::GT;
-        }
-        return DimExprCompareResult::UNKNOWN;
+      [&CompareExpressions](const auto& lhs, const Add<DimExpr>& rhs) {
+        return CompareExpressions(lhs, rhs);
+      },
+      [&CompareExpressions](const Add<DimExpr>& lhs, const auto& rhs) {
+        return CompareExpressions(lhs, rhs);
+      },
+      [&CompareExpressions](const Add<DimExpr>& lhs, const Add<DimExpr>& rhs) {
+        return CompareExpressions(lhs, rhs);
       },
       [](const auto& lhs, const auto& rhs) {
         return DimExprCompareResult::UNKNOWN;

--- a/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
+++ b/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
@@ -225,7 +225,7 @@ TEST(Simplify, SimplifyMin) {
   DimExpr add2{Add<DimExpr>{{S0, neg1}}};
   DimExpr min2{Min<DimExpr>{{S0, add2}}};
   DimExpr simplify_min2 = SimplifyDimExpr(min2);
-  ASSERT_TRUE((simplify_min2 == add2));
+  ASSERT_TRUE((simplify_min2 == Add<DimExpr>{{S0, -1}}));
   // Min(576, Mul(576, S0)) => 576
   DimExpr mul3{Mul<DimExpr>{{DimExpr{576}, S0}}};
   DimExpr min3{Min<DimExpr>{{DimExpr{576}, mul3}}};

--- a/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
+++ b/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
@@ -216,7 +216,7 @@ TEST(Simplify, SimplifyMin) {
   DimExpr S1{"S1"};
   DimExpr S2{"S2"};
   DimExpr add{Add<DimExpr>{{S0, S1}}};
-  DimExpr mul{Mul<DimExpr>{{Add<DimExpr>{{S1, S2}}, S2}}};
+  DimExpr mul{Mul<DimExpr>{{add, S2}}};
   DimExpr min{Min<DimExpr>{{S0, add, mul}}};
   DimExpr simplify_min = SimplifyDimExpr(min);
   ASSERT_TRUE((simplify_min == S0));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164
- add easy simplify for min, Min(576,576*S0) => 576
- test/ir/pir/cinn/symbolic/test_dyshape_slice.py 出现了 Min(S0, Add(S0, -1)) 的表达式，所以改了一下symbol::Compare 支持了一下