### PR TITLE
[Dy2St] Restore patch forward after layer call to avoid side effect

### DIFF
--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -22,7 +22,6 @@ import logging
 import os
 import pdb  # noqa: T100
 import re
-from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable
 
 import numpy
@@ -43,7 +42,7 @@ from .program_translator import (
     convert_to_static,
     unwrap_decorators,
 )
-from .utils import is_builtin, is_paddle_func
+from .utils import is_builtin, is_paddle_func, patch_method_guard
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -202,56 +201,6 @@ def is_unsupported(func):
         return True
 
     return False
-
-
-def patch_method(instance: object, name: str, new_method: Callable[..., Any]):
-    def get_original_method(instance: object, name: str):
-        """
-        There are two case we don't need to restore the method:
-        1. If the attribute is not existed
-        2. If the obj.attr.__func__ is obj.__class__.attr
-        If the method need restore, return the original method.
-        Otherwise, return None, indicating that the method can be simply deleted.
-        """
-        if not hasattr(instance, name):
-            return None
-
-        original_method = getattr(instance, name)
-        if not inspect.ismethod(original_method):
-            # obj.attr is a function or other object (not a bound method)
-            return original_method
-
-        if not hasattr(instance.__class__, name):
-            # obj.__class__ has not the same unbound method
-            return original_method
-
-        if original_method.__func__ is not getattr(instance.__class__, name):
-            # obj.attr is a bound method, but it's unbound method is
-            # different from obj.__class__.attr
-            return original_method
-        return None
-
-    original_method = get_original_method(instance, name)
-    object.__setattr__(instance, name, new_method)
-
-    def restorer(instance):
-        if original_method is None:
-            object.__delattr__(instance, name)
-        else:
-            object.__setattr__(instance, name, original_method)
-
-    return restorer
-
-
-@contextmanager
-def patch_method_guard(
-    instance: object, name: str, new_method: Callable[..., Any]
-):
-    restorer = patch_method(instance, name, new_method)
-    try:
-        yield
-    finally:
-        restorer(instance)
 
 
 class StaticLayerWrapper:
@@ -418,18 +367,6 @@ def convert_call(func):
     elif hasattr(func, '__class__') and callable(func.__class__):
         if hasattr(func, 'forward') and isinstance(func, Layer):
             return StaticLayerWrapper(func)
-            # try:
-            #     _, forward_func = unwrap_decorators(func.forward)
-            #     func._original_funcs['forward'] = forward_func.__func__
-            #     forward_func = convert_to_static(forward_func.__func__)
-            #     # Bound method will be convert into plain function after `convert_to_static`.
-            #     # So descriptor mechanism is used to bound `self` instance on function to
-            #     # keep it as bound method.
-            #     func.forward = WeakMethod(forward_func, func)
-            # except (OSError, TypeError):
-            #     # NOTE: func.forward may have been decorated.
-            #     func_self = None if func_self else func_self
-            # converted_call = func
         else:
             try:
                 call_func = func.__class__.__call__

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -662,13 +662,6 @@ class StaticFunction(Generic[_InputT, _RetT]):
                 >>> out = net(x)
         """
 
-        # def rollback_impl(class_instance):
-        #     for name, func in class_instance._original_funcs.items():
-        #         setattr(class_instance, name, func.__get__(class_instance))
-
-        #     for sublayer in class_instance.sublayers(include_self=False):
-        #         rollback_impl(sublayer)
-
         if self.class_instance is None:
             return self._dygraph_function
 
@@ -683,10 +676,6 @@ class StaticFunction(Generic[_InputT, _RetT]):
         ), f"Not Found function '{fn_name}' in class '{self.class_instance.__class__}'."
         func = self.class_instance._original_funcs[fn_name]
         setattr(self.class_instance, fn_name, func.__get__(self.class_instance))
-
-        # for sublayer in self.class_instance.sublayers(include_self=False):
-        #     rollback_impl(sublayer)
-
         return getattr(self.class_instance, fn_name)
 
     def __deepcopy__(self, memo):

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -662,12 +662,12 @@ class StaticFunction(Generic[_InputT, _RetT]):
                 >>> out = net(x)
         """
 
-        def rollback_impl(class_instance):
-            for name, func in class_instance._original_funcs.items():
-                setattr(class_instance, name, func.__get__(class_instance))
+        # def rollback_impl(class_instance):
+        #     for name, func in class_instance._original_funcs.items():
+        #         setattr(class_instance, name, func.__get__(class_instance))
 
-            for sublayer in class_instance.sublayers(include_self=False):
-                rollback_impl(sublayer)
+        #     for sublayer in class_instance.sublayers(include_self=False):
+        #         rollback_impl(sublayer)
 
         if self.class_instance is None:
             return self._dygraph_function
@@ -684,8 +684,8 @@ class StaticFunction(Generic[_InputT, _RetT]):
         func = self.class_instance._original_funcs[fn_name]
         setattr(self.class_instance, fn_name, func.__get__(self.class_instance))
 
-        for sublayer in self.class_instance.sublayers(include_self=False):
-            rollback_impl(sublayer)
+        # for sublayer in self.class_instance.sublayers(include_self=False):
+        #     rollback_impl(sublayer)
 
         return getattr(self.class_instance, fn_name)
 

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -25,9 +25,9 @@ import sys
 import tempfile
 import textwrap
 import types
-import weakref
+from contextlib import contextmanager
 from importlib.machinery import SourceFileLoader
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -41,6 +41,9 @@ from paddle.jit.utils import OrderedSet
 from paddle.utils import flatten, gast
 
 from .ast_utils import ast_to_source_code
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 __all__ = []
 
@@ -141,28 +144,6 @@ class UndefinedVar:
 class Dygraph2StaticException(Exception):
     def __init__(self, message):
         super().__init__(message)
-
-
-class WeakMethod:
-    def __init__(self, fn, instance):
-        self.fn = fn
-        self.instance = weakref.ref(instance)
-
-    @property
-    def __func__(self):
-        return self.fn
-
-    @property
-    def __self__(self):
-        return self.instance()
-
-    def __call__(self, *args, **kwargs):
-        if self.__self__ is None:
-            raise RuntimeError("The object has been destroyed")
-        return self.fn(self.__self__, *args, **kwargs)
-
-    def __deepcopy__(self, memo):
-        return WeakMethod(self.fn, memo[id(self.__self__)])
 
 
 def saw(x):
@@ -521,8 +502,6 @@ def func_to_source_code(function, dedent=True):
     """
     if isinstance(function, functools.partial):
         function = function.func
-    if isinstance(function, WeakMethod):
-        function = function.__func__
     if not (inspect.isfunction(function) or inspect.ismethod(function)):
         raise TypeError(
             f"The type of 'function' should be a function or method, but received {type(function).__name__}."
@@ -786,3 +765,53 @@ def cuda_pinned_tensors_move_to_excepted_place(inputs):
                 var = value._copy_to(expected_place, True)
                 var.stop_gradient = True
                 var._share_buffer_to(value)
+
+
+def patch_method(instance: object, name: str, new_method: Callable[..., Any]):
+    def get_original_method(instance: object, name: str):
+        """
+        There are two case we don't need to restore the method:
+        1. If the attribute is not existed
+        2. If the obj.attr.__func__ is obj.__class__.attr
+        If the method need restore, return the original method.
+        Otherwise, return None, indicating that the method can be simply deleted.
+        """
+        if not hasattr(instance, name):
+            return None
+
+        original_method = getattr(instance, name)
+        if not inspect.ismethod(original_method):
+            # obj.attr is a function or other object (not a bound method)
+            return original_method
+
+        if not hasattr(instance.__class__, name):
+            # obj.__class__ has not the same unbound method
+            return original_method
+
+        if original_method.__func__ is not getattr(instance.__class__, name):
+            # obj.attr is a bound method, but it's unbound method is
+            # different from obj.__class__.attr
+            return original_method
+        return None
+
+    original_method = get_original_method(instance, name)
+    object.__setattr__(instance, name, new_method)
+
+    def restorer(instance):
+        if original_method is None:
+            object.__delattr__(instance, name)
+        else:
+            object.__setattr__(instance, name, original_method)
+
+    return restorer
+
+
+@contextmanager
+def patch_method_guard(
+    instance: object, name: str, new_method: Callable[..., Any]
+):
+    restorer = patch_method(instance, name, new_method)
+    try:
+        yield
+    finally:
+        restorer(instance)

--- a/test/dygraph_to_static/test_convert_operators.py
+++ b/test/dygraph_to_static/test_convert_operators.py
@@ -39,10 +39,6 @@ class ForwardNotExist(paddle.nn.Layer):
         return 0
 
 
-net = ForwardNotExist()
-net.forward = "A string so that convert forward will fail"
-
-
 class TestConvertCall(Dy2StTestBase):
     # fallback mode will raise a InnerError, it's ok.
     @test_ast_only
@@ -54,11 +50,15 @@ class TestConvertCall(Dy2StTestBase):
         with self.assertRaises(AttributeError):
             paddle.jit.to_static(call_not_exist())
 
+        net = ForwardNotExist()
+        net.forward = "A string so that convert forward will fail"
+
         def forward_not_exist():
             return net()
 
-        with self.assertRaises(AttributeError):
-            paddle.jit.to_static(forward_not_exist)()
+        with self.assertRaises(TypeError):
+            forward_not_exist_static = paddle.jit.to_static(forward_not_exist)()
+            forward_not_exist_static()
 
     def test_callable_list(self):
         def callable_list(x, y):

--- a/test/dygraph_to_static/test_deepcopy.py
+++ b/test/dygraph_to_static/test_deepcopy.py
@@ -21,7 +21,6 @@ from test_rollback import Net, foo
 
 import paddle
 from paddle.jit.dy2static.program_translator import StaticFunction
-from paddle.jit.dy2static.utils import WeakMethod
 
 
 class InnerLayer(paddle.nn.Layer):
@@ -90,7 +89,7 @@ class TestDeepCopy(Dy2StTestBase):
         out = model(x)
 
         copied_model = deepcopy(static_model)
-        self.assertIsInstance(copied_model.inner.forward, WeakMethod)
+        # self.assertIsInstance(copied_model.inner.forward, WeakMethod)
         self.assertIsNot(static_model.inner.forward, copied_model.inner.forward)
         self.assertIsNot(
             static_model.inner.forward.__self__,
@@ -102,7 +101,7 @@ class TestDeepCopy(Dy2StTestBase):
         copied_out = copied_model(x)
 
         copied_model.forward.rollback()
-        self.assertFalse(isinstance(copied_model.inner.forward, WeakMethod))
+        # self.assertFalse(isinstance(copied_model.inner.forward, WeakMethod))
         copied_model(x)
         copied_rollback_out = copied_model(x)
         np.testing.assert_array_equal(out.numpy(), copied_out.numpy())

--- a/test/dygraph_to_static/test_deepcopy.py
+++ b/test/dygraph_to_static/test_deepcopy.py
@@ -14,6 +14,7 @@
 
 import unittest
 from copy import deepcopy
+from types import MethodType
 
 import numpy as np
 from dygraph_to_static_utils import Dy2StTestBase, test_ast_only
@@ -89,7 +90,7 @@ class TestDeepCopy(Dy2StTestBase):
         out = model(x)
 
         copied_model = deepcopy(static_model)
-        # self.assertIsInstance(copied_model.inner.forward, WeakMethod)
+        self.assertIsInstance(copied_model.inner.forward, MethodType)
         self.assertIsNot(static_model.inner.forward, copied_model.inner.forward)
         self.assertIsNot(
             static_model.inner.forward.__self__,
@@ -101,7 +102,7 @@ class TestDeepCopy(Dy2StTestBase):
         copied_out = copied_model(x)
 
         copied_model.forward.rollback()
-        # self.assertFalse(isinstance(copied_model.inner.forward, WeakMethod))
+        self.assertIsInstance(copied_model.inner.forward, MethodType)
         copied_model(x)
         copied_rollback_out = copied_model(x)
         np.testing.assert_array_equal(out.numpy(), copied_out.numpy())

--- a/test/dygraph_to_static/test_rollback.py
+++ b/test/dygraph_to_static/test_rollback.py
@@ -96,26 +96,26 @@ class TestRollBackNet(Dy2StTestBase):
 
         # forward function is inplacly converted.
         self.assertTrue(isinstance(net.forward, StaticFunction))
-        self.assertTrue("true_fn" in func_to_source_code(net.sub.forward))
+        # self.assertTrue("true_fn" in func_to_source_code(net.sub.forward))
         # other non-forward function is not inplacly converted.
-        self.assertFalse("true_fn" in func_to_source_code(net.sub.bar))
+        # self.assertFalse("true_fn" in func_to_source_code(net.sub.bar))
 
         net.infer = paddle.jit.to_static(net.infer)
         st_infer_out = net.infer(x)
         self.assertTrue(isinstance(net.infer, StaticFunction))
-        self.assertFalse("true_fn" in func_to_source_code(net.sub.bar))
+        # self.assertFalse("true_fn" in func_to_source_code(net.sub.bar))
 
         # rollback forward into original dygraph method
         net.forward = net.forward.rollback()
         self.assertFalse(isinstance(net.forward, StaticFunction))
-        self.assertFalse("true_fn" in func_to_source_code(net.sub.forward))
+        # self.assertFalse("true_fn" in func_to_source_code(net.sub.forward))
         dy_fwd_out = net(x)
         np.testing.assert_array_equal(st_fwd_out.numpy(), dy_fwd_out.numpy())
 
         # rollback infer into original dygraph method
         net.infer.rollback()
         self.assertFalse(isinstance(net.infer, StaticFunction))
-        self.assertFalse("true_fn" in func_to_source_code(net.sub.forward))
+        # self.assertFalse("true_fn" in func_to_source_code(net.sub.forward))
         dy_infer_out = net.infer(x)
         np.testing.assert_array_equal(
             st_infer_out.numpy(), dy_infer_out.numpy()

--- a/test/dygraph_to_static/test_rollback.py
+++ b/test/dygraph_to_static/test_rollback.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import types
 import unittest
 
 import numpy as np
@@ -96,26 +97,36 @@ class TestRollBackNet(Dy2StTestBase):
 
         # forward function is inplacly converted.
         self.assertTrue(isinstance(net.forward, StaticFunction))
-        # self.assertTrue("true_fn" in func_to_source_code(net.sub.forward))
-        # other non-forward function is not inplacly converted.
-        # self.assertFalse("true_fn" in func_to_source_code(net.sub.bar))
+        # inner forward function is not inplacly converted any more.
+        self.assertIs(net.sub.forward.__func__, SubNet.forward)
+        self.assertIsInstance(net.sub.forward, types.MethodType)
+        self.assertNotIn("true_fn", func_to_source_code(net.sub.forward))
+        self.assertIs(net.sub.bar.__func__, SubNet.bar)
+        self.assertIsInstance(net.sub.bar, types.MethodType)
+        self.assertNotIn("true_fn", func_to_source_code(net.sub.bar))
 
         net.infer = paddle.jit.to_static(net.infer)
         st_infer_out = net.infer(x)
         self.assertTrue(isinstance(net.infer, StaticFunction))
-        # self.assertFalse("true_fn" in func_to_source_code(net.sub.bar))
+        self.assertNotIn("true_fn", func_to_source_code(net.sub.bar))
+        self.assertIsInstance(net.sub.bar, types.MethodType)
+        self.assertIs(net.sub.bar.__func__, SubNet.bar)
 
         # rollback forward into original dygraph method
         net.forward = net.forward.rollback()
         self.assertFalse(isinstance(net.forward, StaticFunction))
-        # self.assertFalse("true_fn" in func_to_source_code(net.sub.forward))
+        self.assertNotIn("true_fn", func_to_source_code(net.sub.bar))
+        self.assertIsInstance(net.sub.forward, types.MethodType)
+        self.assertIs(net.sub.bar.__func__, SubNet.bar)
         dy_fwd_out = net(x)
         np.testing.assert_array_equal(st_fwd_out.numpy(), dy_fwd_out.numpy())
 
         # rollback infer into original dygraph method
         net.infer.rollback()
         self.assertFalse(isinstance(net.infer, StaticFunction))
-        # self.assertFalse("true_fn" in func_to_source_code(net.sub.forward))
+        self.assertNotIn("true_fn", func_to_source_code(net.sub.forward))
+        self.assertIsInstance(net.sub.forward, types.MethodType)
+        self.assertIs(net.sub.forward.__func__, SubNet.forward)
         dy_infer_out = net.infer(x)
         np.testing.assert_array_equal(
             st_infer_out.numpy(), dy_infer_out.numpy()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#71463 后续，发版后再推进，彻底移除组网 convert call 里的 side effect，避免后续 rollback、deepcopy 考虑各种各样奇怪的问题，也避免 convert call 的影响扩散到动态图模型，这是不应该的（理论上顶层也不应该，但改不动）