### PR TITLE
[Dy2St] Update `no_need_buffer` names if `original_name` no need buffer

### DIFF
--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -418,11 +418,11 @@ class RunnableProgram:
         )
         # Update no_need_buffer_names by rename_mapping
         for original_name, new_name in rename_mapping.items():
-            if (
-                original_name not in no_need_buffer_names
-                and new_name in no_need_buffer_names
-            ):
-                no_need_buffer_names.remove(new_name)
+            if {original_name, new_name} & set(no_need_buffer_names):
+                if original_name in no_need_buffer_names:
+                    no_need_buffer_names.remove(original_name)
+                if new_name in no_need_buffer_names:
+                    no_need_buffer_names.remove(new_name)
 
         value_program_attr = {}
         for k, ns in self.program_name_attr.items():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

同 #71099，之前认为只有 `new_name` 在 `no_need_buffer_names` 里需要删，因为 `original_name` 在 Program 理论上已经找不到了，但 `fwd_map` 和 `bwd_map` 是在 rename 前获取的，因此还是找得到的，这会导致 `original_name` 仍然在 `no_need_buffer_names`，那么这个 var 仍然会被 gc