### PR TITLE
[CINN] Fix the out-of-bounds bug in the vectorize.

### DIFF
--- a/paddle/cinn/optim/vectorize_for_trans.cc
+++ b/paddle/cinn/optim/vectorize_for_trans.cc
@@ -147,6 +147,11 @@ class ForOpWithMultiScheduleBlockSupportVectorize
   void operator()(ir::Expr *expr) { ir::IRMutator<>::Visit(expr, expr); }
 
  private:
+  void Visit(const ir::IfThenElse *op, Expr *expr) override {
+    have_if_then_else_op_ = true;
+    ir::IRMutator<>::Visit(op, expr);
+  }
+
   void Visit(const ir::ScheduleBlockRealize *op, Expr *expr) override {
     auto *node = expr->As<ir::ScheduleBlockRealize>();
     PADDLE_ENFORCE_NOT_NULL(
@@ -154,18 +159,18 @@ class ForOpWithMultiScheduleBlockSupportVectorize
         ::common::errors::InvalidArgument("The input expr should be a Block"));
 
     IRMutator<>::Visit(op, expr);
-    if (in_vectorize_scope) {
+    if (!have_if_then_else_op_ && in_vectorize_scope_) {
       for_op_blocks_.push_back(expr);
     }
   }
 
   void Visit(const ir::For *op, ir::Expr *expr) override {
     auto *forloop = expr->As<ir::For>();
-    if (forloop->is_vectorized()) in_vectorize_scope = true;
+    if (forloop->is_vectorized()) in_vectorize_scope_ = true;
 
     IRMutator<>::Visit(op, expr);
 
-    if (for_op_blocks_.size() > 1 && in_vectorize_scope) {
+    if (for_op_blocks_.size() > 1 && in_vectorize_scope_) {
       std::vector<Expr> stmts;
       for (auto block : for_op_blocks_) {
         Var new_iterator(
@@ -187,11 +192,12 @@ class ForOpWithMultiScheduleBlockSupportVectorize
       Expr block_expr = ir::Block::Make(stmts);
       *expr = block_expr;
     }
-    in_vectorize_scope = false;
+    in_vectorize_scope_ = false;
     for_op_blocks_.clear();
   }
 
-  bool in_vectorize_scope{false};
+  bool in_vectorize_scope_{false};
+  bool have_if_then_else_op_{false};
   std::vector<ir::Expr *> for_op_blocks_;
 };
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes


### Description
<!-- Describe what you’ve done -->
修复开启向量化造成的越界问题，具体为：
开启向量化时，ForOpWithMultiScheduleBlockSupportVectorize丢了一个if语句，造成越界。在if-then-else语句下，不启用向量化。
