### PR TITLE
[CINN] Fix strided_slice op infer symbolic interface bug

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
@@ -328,7 +328,7 @@ inline ExprVec GetStridedSliceDims(
 
   for (size_t i = 0; i < axes.size(); ++i) {
     int64_t axis = axes.at(i);
-    if (in_dims.at(i).isa<int64_t>() && starts.at(i).isa<int64_t>() &&
+    if (in_dims.at(axis).isa<int64_t>() && starts.at(i).isa<int64_t>() &&
         ends.at(i).isa<int64_t>() && strides.at(i).isa<int64_t>()) {
       int64_t in_dim = in_dims[axis].Get<int64_t>();
       int64_t start = starts[i].Get<int64_t>();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
fix typo