### PR TITLE
[XPU] fix error in conv3d_transpose test

### DIFF
--- a/test/xpu/test_conv3d_transpose_op_xpu.py
+++ b/test/xpu/test_conv3d_transpose_op_xpu.py
@@ -237,7 +237,7 @@ class XPUTestConv3DTransposeOp(XPUOpTestWrapper):
 
         def test_check_output(self):
             place = paddle.XPUPlace(0)
-            self.check_output_with_place(place)
+            self.check_output_with_place(place, atol=0.005)
 
         def test_check_grad(self):
             place = core.XPUPlace(0)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
1. fix conv3d_tranpose op test failed due to the change of default quant types. https://github.com/PaddlePaddle/Paddle/pull/70859