### PR TITLE
[XPU] fix xpu pp bug

### DIFF
--- a/paddle/phi/common/place.cc
+++ b/paddle/phi/common/place.cc
@@ -20,6 +20,7 @@ limitations under the License. */
 #include "glog/logging.h"
 #include "paddle/common/exception.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
+#include "paddle/phi/backends/xpu/xpu_info.h"
 
 namespace phi {
 
@@ -269,6 +270,15 @@ GPUPlace DefaultGPUPlace() {
   return GPUPlace(
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
       phi::backends::gpu::GetCurrentDeviceId());
+#else
+      0);
+#endif
+}
+
+phi::XPUPlace DefaultXPUPlace() {
+  return phi::XPUPlace(
+#ifdef PADDLE_WITH_XPU
+      phi::backends::xpu::GetXPUCurrentDeviceId());
 #else
       0);
 #endif

--- a/paddle/phi/common/place.h
+++ b/paddle/phi/common/place.h
@@ -261,4 +261,6 @@ PADDLE_API bool operator==(PlaceType place_type, const Place& place);
 
 PADDLE_API GPUPlace DefaultGPUPlace();
 
+PADDLE_API phi::XPUPlace DefaultXPUPlace();
+
 }  // namespace paddle

--- a/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.cc
@@ -202,6 +202,10 @@ Place GetDefaultPlace() {
   if (phi::backends::gpu::GetGPUDeviceCount() >= 0) {
     return paddle::DefaultGPUPlace();
   }
+#elif defined(PADDLE_WITH_XPU)
+  if (phi::backends::xpu::GetXPUDeviceCount() >= 0) {
+    return paddle::DefaultXPUPlace();
+  }
 #endif
   return paddle::CPUPlace();
 }

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -773,7 +773,7 @@ class ClipGradByGlobalNorm(ClipGradBase):
         global_norm_var = async_add_n(global_norm_var)
         global_norm_var = paddle.sqrt(global_norm_var)
         max_global_norm = paddle.full(
-            shape=[], dtype=sum_dtype, fill_value=self.clip_norm
+            shape=[1], dtype=sum_dtype, fill_value=self.clip_norm
         )
 
         need_clip = False


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

1. pp 场景下没有 init 的 tensor 在计算操作（比如 split，unsqueeze 等）后 device 会变为 cpu，进而导致程序 hang 在后续初始化通信 context 的地方（会错误地初始化 GlooCommContext）
2. xpu send&recv 不支持 0-d tensor，修改 clip 的 value 的 shape 为 1

Pcard-76459