### PR TITLE
[Dy2St] Clear `InplaceMap` after program is completed

### DIFF
--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -1304,12 +1304,14 @@ class ConcreteProgram:
 
                 # 3. Gets all ParamBases and buffered VarBases in the function
                 from ..pir_dy2static.parameter_recorder import (
+                    _global_inplace_map,
                     _global_parameter_recorder,
                 )
 
                 all_parameters_and_buffers = _global_parameter_recorder.pop(
                     main_program
                 )
+                _global_inplace_map.pop(main_program)
                 if outputs is not None:
                     need_wrap_into_list = (
                         not isinstance(outputs, (tuple, list))

--- a/python/paddle/jit/pir_dy2static/parameter_recorder.py
+++ b/python/paddle/jit/pir_dy2static/parameter_recorder.py
@@ -98,6 +98,10 @@ class InplaceMap:
             inplace_dict[var] = root_var
         return root_var
 
+    def pop(self, program):
+        key = _program_hash(program)
+        del self.params_dict[key]
+
     def restore_checkpoint(self, checkpoint):
         # InplaceMap is a nested effect.
         # when enter a block, we should save a checkpoint

--- a/python/paddle/jit/pir_dy2static/parameter_recorder.py
+++ b/python/paddle/jit/pir_dy2static/parameter_recorder.py
@@ -100,6 +100,8 @@ class InplaceMap:
 
     def pop(self, program):
         key = _program_hash(program)
+        if key not in self.params_dict:
+            return
         del self.params_dict[key]
 
     def restore_checkpoint(self, checkpoint):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

TL;NR
在动态图转静态图（动转静）模型导出流程中，`paddle.jit.save` 会在组网过程中将部分中间内容缓存于 `_global_inplace_map`，并以 `id(program)` 作为 key。由于该缓存未在组网结束后及时清理，若 program 被复用，则可能出现缓存指向已被释放内存的情况，导致访问非法内存并最终触发段错误（Segmentation fault）。本 PR 针对这一问题，在组网流程结束后增加了对 `_global_inplace_map` 的相应清理，确保缓存与内存状态一致，消除悬垂指针隐患，提升导出流程的稳定性。

-----
在 PaddleSeg 中，即使是以动态图形式运行，但依旧会执行导出过程（会进行动转静）

```python
def export(args, model=None, save_dir=None, use_ema=False):
	......
    model = paddle.jit.to_static(model, input_spec=input_spec)
	......
    paddle.jit.save(model, inference_model_path)
```

在 `jit.save` 过程中，多次执行（>50次）之后会出现段错误
```shell
--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::pybind::static_api_add(_object*, _object*, _object*)
1   paddle::dialect::add(pir::Value const&, pir::Value const&)
2   paddle::dialect::GetValueDataType(pir::Value const&)
3   paddle::dialect::GetValueDataType(pir::Type const&)
4   pir::DenseTensorType::classof(pir::Type)
5   pir::AbstractType::GetInterfaceImpl(pir::TypeId) const

----------------------
Error Message Summary:
----------------------
FatalError: `Segmentation fault` is detected by the operating system.
  [TimeInfo: *** Aborted at 1740228764 (unix time) try "date -d @1740228764" if you are using GNU date ***]
  [SignalInfo: *** SIGSEGV (@0x21) received by PID 19557 (TID 0x7f922eb4e740) from PID 33 ***]
```

在 `paddle.jit.save` 中会进行**组网**，组网过程中会缓存一部分内容，存在 `_global_inplace_map` 与 `_global_parameter_recorder` 中

`_global_parameter_recorder` 在组网结束后会自动释放其中内容，而`_global_inplace_map`不会释放

由于是以 `id(program)` 为 key，所以如果某个 `program` 被复用，则存在访问已被释放变量的风险，导致段错误
本PR添加释放过程

PCard-66972