### PR TITLE
[CINN]Temporarily handle situations where dim is less than 0 and add check

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -185,6 +185,7 @@ class CinnJitInstruction::FnPtrImpl {
       if (static_cast<size_t>(i) < ir_dim.size() &&
           FLAGS_cinn_check_jit_instruction_shape) {
         CheckDims(ir_dim[i], dim);
+        CheckDimGTZero(dim, this->cinn_kernel_info_.fn_name);
       }
       kernel_tensor_args[input_tensor_size + i]->Resize(dim);
       free(output_tensor_shapes[i]);
@@ -222,6 +223,19 @@ class CinnJitInstruction::FnPtrImpl {
                               i,
                               second[i]));
       }
+    }
+  }
+
+  void CheckDimGTZero(const DDim& dim, const std::string& kernel_name) {
+    VLOG(3) << "Start Check that Dims is greater than zero in jit instruction.";
+    for (int i = 0; i < dim.size(); ++i) {
+      PADDLE_ENFORCE_EQ(dim.at(i) > 0,
+                        true,
+                        phi::errors::PreconditionNotMet(
+                            "The dim of tensor MUST greater than 0. "
+                            "Jit Kernel name: %s. Tensor dim: %s",
+                            kernel_name,
+                            dim.to_str()));
     }
   }
 

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -229,13 +229,13 @@ class CinnJitInstruction::FnPtrImpl {
   void CheckDimGTZero(const DDim& dim, const std::string& kernel_name) {
     VLOG(3) << "Start Check that Dims is greater than zero in jit instruction.";
     for (int i = 0; i < dim.size(); ++i) {
-      PADDLE_ENFORCE_EQ(dim.at(i) > 0,
-                        true,
-                        phi::errors::PreconditionNotMet(
-                            "The dim of tensor MUST greater than 0. "
-                            "Jit Kernel name: %s. Tensor dim: %s",
-                            kernel_name,
-                            dim.to_str()));
+      PADDLE_ENFORCE_EQ(
+          dim.at(i) >= 0,
+          true,
+          phi::errors::PreconditionNotMet("The dim of tensor MUST >= 0. "
+                                          "Jit Kernel name: %s. Tensor dim: %s",
+                                          kernel_name,
+                                          dim.to_str()));
     }
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Have a dim of output from jit_kernel is "S0-2" and "S0-2" is legal. In runtime the symbol S0 is 1，Resulting in tensor with dim less than 0.
+ This PR can only handle 0 size tensors generated by slice & strided_slice op
+ Add  func that check dim GT zero