### PR TITLE
[XPU] update xhpc lib to 20250306

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -30,7 +30,7 @@ set(XPU_XFA_LIB_NAME "libxpu_flash_attention.so")
 set(XPU_XPUDNN_LIB_NAME "libxpu_dnn.so")
 
 if(NOT DEFINED XPU_XHPC_BASE_DATE)
-  set(XPU_XHPC_BASE_DATE "dev/20250305")
+  set(XPU_XHPC_BASE_DATE "dev/20250306")
 endif()
 set(XPU_XCCL_BASE_VERSION "3.0.2.3") # For XRE5
 if(NOT DEFINED XPU_XFT_BASE_VERSION)

--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -30,7 +30,7 @@ set(XPU_XFA_LIB_NAME "libxpu_flash_attention.so")
 set(XPU_XPUDNN_LIB_NAME "libxpu_dnn.so")
 
 if(NOT DEFINED XPU_XHPC_BASE_DATE)
-  set(XPU_XHPC_BASE_DATE "dev/20250305")
+  set(XPU_XHPC_BASE_DATE "dev/20250309")
 endif()
 set(XPU_XCCL_BASE_VERSION "3.0.2.3") # For XRE5
 if(NOT DEFINED XPU_XFT_BASE_VERSION)


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
接用户反馈，在上一个版本的算子库中，当调用`broadcast_div`函数的时候，会打印出一些冗余信息。底层算子库对此问题进行了修复，本PR对算子库版本进行升级。
