### PR TITLE
[CINN] Fix part reshape in GetValidLoopTransformRoute

### DIFF
--- a/paddle/cinn/operator_fusion/pir_graph_analyzing/loop_transform_analysis.cc
+++ b/paddle/cinn/operator_fusion/pir_graph_analyzing/loop_transform_analysis.cc
@@ -512,9 +512,9 @@ std::optional<AxisTransformRoute> GetValidLoopTransformRoute(
       }
     }
     new_axis_ids = ConcatVector(
-        new_axis_ids, SliceVector(axis_ids, cur_axis_size, axis_ids.size()));
+        new_axis_ids, SliceVector(axis_ids, in_shape.size(), axis_ids.size()));
     axis_ids = new_axis_ids;
-    cur_axis_size = out_shape.size();
+    cur_axis_size = cur_axis_size - in_shape.size() + out_shape.size();
     result.push_back(transform);
   };
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
- Fix part reshape in GetValidLoopTransformRoute