### PR TITLE
[PIR-Auto-Parallel]  fix comm group hang in sync shared param pass

### DIFF
--- a/python/paddle/distributed/passes/auto_parallel_sync_shared_params.py
+++ b/python/paddle/distributed/passes/auto_parallel_sync_shared_params.py
@@ -205,11 +205,12 @@ class AutoParallelSyncSharedParamsPass(PassBase):
             logger.info("No parameter need to share, skip pass.")
             return []
 
-        # # Must initialize the communication group for the allreduce op here.
-        # # Otherwise, it will hang during gradient synchronization.
+        # Must initialize the redundant communication group for the allreduce op here.
+        # Otherwise, it will hang during gradient synchronization.
         for idx in range(len(self.src_ranks)):
             rank_1 = self.src_ranks[idx]
             rank_2 = self.dst_ranks[idx]
+            new_process_group(sorted([rank_1, rank_2]))
             self._get_comm_group([rank_1, rank_2])
 
         return new_shared_params

--- a/python/paddle/distributed/passes/auto_parallel_sync_shared_params.py
+++ b/python/paddle/distributed/passes/auto_parallel_sync_shared_params.py
@@ -63,7 +63,7 @@ class AutoParallelSyncSharedParamsPass(PassBase):
     def _get_comm_group(self, ranks=[]):
         ranks = sorted(ranks)
         if tuple(ranks) in self.comm_group:
-            return self.comm_group[tuple(ranks)].id
+            return self.comm_group[tuple(ranks)]
         # The communication group of this `all_reduce` op satisfies len (ranks)==2.
         # When `force_new_group=False` is set, the `send&recv` group will be returned,
         # At this point, `all_reduce` and `send&recv` share the same group, and
@@ -205,6 +205,13 @@ class AutoParallelSyncSharedParamsPass(PassBase):
             logger.info("No parameter need to share, skip pass.")
             return []
 
+        # Must init comm group for allreduce op here.
+        # Otherwise, it will be hang in sync gradient.
+        for idx in range(len(self.src_ranks)):
+            rank_1 = self.src_ranks[idx]
+            rank_2 = self.dst_ranks[idx]
+            self._get_comm_group([rank_1, rank_2])
+
         return new_shared_params
 
     def sync_shared_parameter_gradient(
@@ -227,6 +234,9 @@ class AutoParallelSyncSharedParamsPass(PassBase):
         ), "Currently, only one shared parameter is supported, and it cannot support more at the moment."
 
         cur_rank = paddle.distributed.get_rank()
+
+        if cur_rank not in self.src_ranks and cur_rank not in self.dst_ranks:
+            return params_grads
 
         pre_name = ""
         if cur_rank in self.dst_ranks:

--- a/python/paddle/distributed/passes/auto_parallel_sync_shared_params.py
+++ b/python/paddle/distributed/passes/auto_parallel_sync_shared_params.py
@@ -205,12 +205,12 @@ class AutoParallelSyncSharedParamsPass(PassBase):
             logger.info("No parameter need to share, skip pass.")
             return []
 
-        # Must initialize the communication group for the allreduce op here.
-        # Otherwise, it will hang during gradient synchronization.
+        # # Must initialize the communication group for the allreduce op here.
+        # # Otherwise, it will hang during gradient synchronization.
         for idx in range(len(self.src_ranks)):
             rank_1 = self.src_ranks[idx]
             rank_2 = self.dst_ranks[idx]
-            new_process_group(sorted([rank_1, rank_2]), force_new_group=True)
+            self._get_comm_group([rank_1, rank_2])
 
         return new_shared_params
 

--- a/python/paddle/distributed/passes/auto_parallel_sync_shared_params.py
+++ b/python/paddle/distributed/passes/auto_parallel_sync_shared_params.py
@@ -205,12 +205,12 @@ class AutoParallelSyncSharedParamsPass(PassBase):
             logger.info("No parameter need to share, skip pass.")
             return []
 
-        # Must init comm group for allreduce op here.
-        # Otherwise, it will be hang in sync gradient.
+        # Must initialize the communication group for the allreduce op here.
+        # Otherwise, it will hang during gradient synchronization.
         for idx in range(len(self.src_ranks)):
             rank_1 = self.src_ranks[idx]
             rank_2 = self.dst_ranks[idx]
-            self._get_comm_group([rank_1, rank_2])
+            new_process_group(sorted([rank_1, rank_2]), force_new_group=True)
 
         return new_shared_params
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes


### Description
<!-- Describe what you’ve done -->
在梯度同步时初始化 allreduce op 通信组，会出现 hang 的问题，需要在 参数同步时提前初始化通信组
Pcard-89509
