### PR TITLE
[AutoParallel] Add auto.Strategy to dist.Strategy in to_static

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -3164,6 +3164,8 @@ def to_static(
                 raise NotImplementedError(
                     "Only sharding stage 1, 2 and 3 can to_static for now. User-defined shard_fn will be supported later."
                 )
+    if isinstance(strategy, fleet.auto.Strategy):
+        strategy = dist.Strategy()._from_legacy_strategy(strategy)
     if strategy is None or strategy.full_graph:
         dist_model = DistModel(
             layer, loader, loss, optimizer, strategy, input_spec=input_spec

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -3165,7 +3165,9 @@ def to_static(
                     "Only sharding stage 1, 2 and 3 can to_static for now. User-defined shard_fn will be supported later."
                 )
     if isinstance(strategy, fleet.auto.Strategy):
-        strategy = dist.Strategy()._from_legacy_strategy(strategy)
+        dist_strategy = dist.Strategy()
+        dist_strategy._from_legacy_strategy(strategy)
+        strategy = dist_strategy
     if strategy is None or strategy.full_graph:
         dist_model = DistModel(
             layer, loader, loss, optimizer, strategy, input_spec=input_spec


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
In to_static, only dist.Strategy is accepted as input. Since optimization strategies are typically set through auto.Strategy, when to_static detects an auto.Strategy, it internally converts it to dist.Strategy using _from_legacy_strategy().
Pcard-70448