### PR TITLE
[SOT] Dont get place and type from value in infermeta stage

### DIFF
--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -222,8 +222,8 @@ class MetaInfo:
             value.stop_gradient,
             name,
             value.persistable,
-            value.type,
-            value.place,
+            None,  # type is not a unified attribute in dygraph and static mode.
+            None,  # We can't infer the right place in compile time.
             dist_info=dist_info,
         )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

SOT infermeta 中间变量的 `Value` 不应该获取 `.type` 和 `.place`，特别是对 `Value` 获取 place 时会出现 warning，这会让用户很困惑

```
/workspace/Paddle/build/python/paddle/pir/math_op_patch.py:180: UserWarning: Value do not have 'place' interface for pir graph mode, try not to use it. None will be returned.
  warnings.warn(
```