### PR TITLE
[Dy2St] Skip constant to variable promotion for all values to avoid warning

### DIFF
--- a/python/paddle/static/nn/control_flow.py
+++ b/python/paddle/static/nn/control_flow.py
@@ -1529,7 +1529,10 @@ class OutputSelector:
                     return out.dtype
             return None
 
-        if all(arg is None for arg in outs):
+        if all(isinstance(out, paddle.pir.Value) for out in outs):
+            return outs
+
+        if all(out is None for out in outs):
             return outs
 
         if all(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

当两个分支结果全是 `Value` 的时候，应该直接 return，无需 constant to variable promotion，之前会命中下面的  `any(isinstance(out, paddle.pir.Value) for out in outs) and all(isinstance(out, (paddle.pir.Value, *promotion_builtin_types)) for out in outs)` 进而导致 warning

```
/workspace/Paddle/build/python/paddle/static/nn/control_flow.py:1557: UserWarning: Return results from different branches in cond are not same type: false_var returned by false_fn is '<class 'paddle.base.libpaddle.pir.Value'>' and true_var of true_fn is '<class 'paddle.base.libpaddle.pir.Value'>'
  warnings.warn(
```

虽然结果没问题，但是 warning 会让用户迷惑

同 #71535