### PR TITLE
【CINN】Add func of parse expr and match pattern

### DIFF
--- a/paddle/cinn/common/simplify_special_pattern.cc
+++ b/paddle/cinn/common/simplify_special_pattern.cc
@@ -23,10 +23,10 @@
 #include "paddle/cinn/optim/simplify_util.h"
 namespace cinn {
 namespace common {
-using cinn::optim::CheckPattern;
 using cinn::optim::GetFlattenExprs;
 using cinn::optim::IsNegatedIndexExpr;
 using cinn::optim::IsSumPartialBySymbol;
+using cinn::optim::MatchPattern;
 using cinn::optim::ProveDivisible;
 using cinn::optim::SimplifySymbolicAdd;
 
@@ -250,13 +250,7 @@ std::optional<ir::IndexExpr> AddMulCornerCase(
 // S0 / (S1 * S2) * S2 + S0 % (S1 * S2) / S1 ===>  S0 / S1
 std::optional<ir::IndexExpr> DivMulAddModDivCase(const ir::IndexExpr& lhs,
                                                  const ir::IndexExpr& rhs) {
-  ir::Var a = ir::Var("a");
-  ir::Var b = ir::Var("b");
-  ir::Var c = ir::Var("c");
-  ir::Var f = ir::Var("f");
-  std::unordered_map<std::string, ir::IndexExpr> map;
-
-  ir::IndexExpr pattern = f / c * a + f % c / b;
+  if (!MatchPattern(rhs, "f % c / b")) return std::nullopt;
 
   auto flatten = GetFlattenExprs<ir::Add>(lhs);
   ir::IndexExpr res;
@@ -264,10 +258,16 @@ std::optional<ir::IndexExpr> DivMulAddModDivCase(const ir::IndexExpr& lhs,
   for (const auto& expr : flatten) {
     if (!find) {
       ir::IndexExpr cand = ir::Add::Make(expr, rhs);
-      map.clear();
+
       // Check if the pattern is matched
-      if (CheckPattern(cand, pattern, &map) &&
-          map.at("c") == map.at("a") * map.at("b")) {
+      auto opt_map = MatchPattern(
+          cand,
+          "f / c * a + f % c / b",
+          [](const std::unordered_map<std::string, ir::IndexExpr>& m) {
+            return m.at("c") == m.at("a") * m.at("b");
+          });
+      if (opt_map) {
+        auto map = opt_map.value();
         ir::IndexExpr simplified = map.at("f") / map.at("b");
         res = res.defined() ? res + simplified : simplified;
         find = true;

--- a/paddle/cinn/ir/ir.cc
+++ b/paddle/cinn/ir/ir.cc
@@ -86,11 +86,13 @@ Expr Cast::Make(Type t, Expr v) {
 #undef __CAST_TO_TYPE
 
   // Cast indexExpr without `cast` and `load`
-  if (optim::VerifyIndex(v) == optim::IndexType::kValid && t == Int(64)) {
+  if (optim::VerifyIndex(v) == ir::IndexExpr::IndexType::kValid &&
+      t == Int(64)) {
     v->convert_int32_to_int64();
     return v;
   }
-  if (optim::VerifyIndex(v) == optim::IndexType::kValid && t == Int(32)) {
+  if (optim::VerifyIndex(v) == ir::IndexExpr::IndexType::kValid &&
+      t == Int(32)) {
     v->convert_int64_to_int32();
     return v;
   }

--- a/paddle/cinn/ir/ir_base.cc
+++ b/paddle/cinn/ir/ir_base.cc
@@ -288,12 +288,12 @@ bool Expr::is_var() const { return As<_Var_>(); }
 bool Expr::is_index() const {
   // Temporarily use `VerifyIndex`. because `get_index` depends on marking
   // `indexExpr` in For::make and sch
-  return optim::VerifyIndex(*this);
+  return optim::VerifyIndex(*this) != ir::IndexExpr::IndexType::kInvalid;
   // return get()->get_index();
 }
 
 Expr &Expr::set_index(bool flag) {
-  if (flag && !optim::VerifyIndex(*this)) {
+  if (flag && optim::VerifyIndex(*this) == ir::IndexExpr::IndexType::kInvalid) {
     PADDLE_THROW(::common::errors::InvalidType(
         "Expr: %s is not IndexExpr! cannot be set as IndexExpr.", *this));
   }
@@ -302,7 +302,7 @@ Expr &Expr::set_index(bool flag) {
 }
 
 const Expr &Expr::set_index(bool flag) const {
-  if (flag && !optim::VerifyIndex(*this)) {
+  if (flag && optim::VerifyIndex(*this) == ir::IndexExpr::IndexType::kInvalid) {
     PADDLE_THROW(::common::errors::InvalidType(
         "Expr: %s is not IndexExpr! cannot be set as IndexExpr.", *this));
   }

--- a/paddle/cinn/ir/ir_base.h
+++ b/paddle/cinn/ir/ir_base.h
@@ -540,6 +540,13 @@ struct IndexExpr : public IrNodeRef {
     Level2 = 2   // Top level, simplify
   };
 
+  enum class IndexType {
+    kInvalid = 0,  // invalid expr
+    kValid = 1,    // valid expr
+    kLoad = 2,     // exist Load
+    kCast = 3      // exist cast
+  };
+
   IndexExpr Normalize(OptLevel level = OptLevel::Level1) const;
 
   bool IsDynamic() const;

--- a/paddle/cinn/optim/simplify_util.cc
+++ b/paddle/cinn/optim/simplify_util.cc
@@ -221,22 +221,23 @@ bool IsNegatedIndexExpr(const ir::IndexExpr &candidate,
   return false;
 }
 
-IndexType VerifyIndex(const ir::Expr &expr) {
+ir::IndexExpr::IndexType VerifyIndex(const ir::Expr &expr) {
   switch (expr.node_type()) {
     case ir::IrNodeTy::_Var_:
     case ir::IrNodeTy::IntImm: {
-      return expr.type().is_index_type() ? IndexType::kValid
-                                         : IndexType::kInvalid;
+      return expr.type().is_index_type() ? ir::IndexExpr::IndexType::kValid
+                                         : ir::IndexExpr::IndexType::kInvalid;
     }
     case ir::IrNodeTy::Load: {
-      return expr.type().is_index_type() ? IndexType::kLoad
-                                         : IndexType::kInvalid;
+      return expr.type().is_index_type() ? ir::IndexExpr::IndexType::kLoad
+                                         : ir::IndexExpr::IndexType::kInvalid;
     }
     case ir::IrNodeTy::Cast: {
-      IndexType result = VerifyIndex(expr->operand(0));
-      return result == IndexType::kValid && expr.type().is_index_type()
-                 ? IndexType::kCast
-                 : IndexType::kInvalid;
+      ir::IndexExpr::IndexType result = VerifyIndex(expr->operand(0));
+      return result == ir::IndexExpr::IndexType::kValid &&
+                     expr.type().is_index_type()
+                 ? ir::IndexExpr::IndexType::kCast
+                 : ir::IndexExpr::IndexType::kInvalid;
     }
     case ir::IrNodeTy::Add:
     case ir::IrNodeTy::Sub:
@@ -245,14 +246,15 @@ IndexType VerifyIndex(const ir::Expr &expr) {
     case ir::IrNodeTy::Mod:
     case ir::IrNodeTy::Max:
     case ir::IrNodeTy::Min: {
-      IndexType left = VerifyIndex(expr->operand(0));
-      IndexType right = VerifyIndex(expr->operand(1));
-      if (left == IndexType::kInvalid || right == IndexType::kInvalid)
-        return IndexType::kInvalid;
+      ir::IndexExpr::IndexType left = VerifyIndex(expr->operand(0));
+      ir::IndexExpr::IndexType right = VerifyIndex(expr->operand(1));
+      if (left == ir::IndexExpr::IndexType::kInvalid ||
+          right == ir::IndexExpr::IndexType::kInvalid)
+        return ir::IndexExpr::IndexType::kInvalid;
       return std::max(left, right);
     }
   }
-  return IndexType::kInvalid;
+  return ir::IndexExpr::IndexType::kInvalid;
 }
 
 ir::IndexExpr ConstructIndexExprByNodeType(const ir::IrNodeTy &ty,
@@ -438,6 +440,167 @@ bool IsPureMath(Expr expr) {
   }
 #endif
   return complex_nodes.empty();
+}
+
+Tokenizer::Tokenizer(const std::string &in) : input(in), pos(0) {}
+
+IndexToken Tokenizer::NextToken() {
+  // skip whitespace
+  while (pos < input.size() && std::isspace(input[pos])) {
+    pos++;
+  }
+  // check if we reached the end of the input
+  if (pos >= input.size()) {
+    return IndexToken(IndexToken::TokenType::kEnd);
+  }
+
+  char c = input[pos++];
+
+  // deal with number (0, 1, 11, 123...) not support float.
+  if (std::isdigit(c)) {
+    std::string num;
+    num += c;
+    while (pos < input.size() && std::isdigit(input[pos])) {
+      num += input[pos++];
+    }
+    return IndexToken(IndexToken::TokenType::kNumber, num);
+  }
+
+  // deal with variable name (a, b, a1, a123, a_1...).
+  if (std::isalpha(c) || input[pos] == '_') {
+    std::string var;
+    var += c;
+    while (pos < input.size() &&
+           (std::isalnum(input[pos]) || input[pos] == '_')) {
+      var += input[pos++];
+    }
+    return IndexToken(IndexToken::TokenType::kVar, var);
+  }
+
+  // deal with operator {+, -, *, /, %, '(', ')'}.
+  switch (c) {
+    case '+':
+      return IndexToken(IndexToken::TokenType::kPlus);
+    case '-':
+      return IndexToken(IndexToken::TokenType::kMinus);
+    case '*':
+      return IndexToken(IndexToken::TokenType::kMultiply);
+    case '/':
+      return IndexToken(IndexToken::TokenType::kDivide);
+    case '%':
+      return IndexToken(IndexToken::TokenType::kModulo);
+    case '(':
+      return IndexToken(IndexToken::TokenType::kLeftParen);
+    case ')':
+      return IndexToken(IndexToken::TokenType::kRightParen);
+    default:
+      PADDLE_THROW(::common::errors::InvalidArgument(
+          "Tokenizer Unexpected character: %s", c));
+  }
+}
+
+Parser::Parser(const std::string &input)
+    : tokenizer(input), currentToken(tokenizer.NextToken()) {}
+
+ir::Expr Parser::Parse() { return ParseExpression(); }
+
+void Parser::Advance() { currentToken = tokenizer.NextToken(); }
+
+ir::Expr Parser::ParseExpression() {
+  auto left = ParseTerm();
+
+  while (currentToken.type == IndexToken::TokenType::kPlus ||
+         currentToken.type == IndexToken::TokenType::kMinus) {
+    auto op = currentToken.type;
+    Advance();
+    auto right = ParseTerm();
+
+    if (op == IndexToken::TokenType::kPlus) {
+      left = ir::Add::Make(left, right);
+    } else {
+      left = ir::Sub::Make(left, right);
+    }
+  }
+
+  return left;
+}
+
+ir::Expr Parser::ParseTerm() {
+  auto left = ParseFactor();
+
+  while (currentToken.type == IndexToken::TokenType::kMultiply ||
+         currentToken.type == IndexToken::TokenType::kDivide ||
+         currentToken.type == IndexToken::TokenType::kModulo) {
+    auto op = currentToken.type;
+    Advance();
+    auto right = ParseFactor();
+
+    if (op == IndexToken::TokenType::kMultiply) {
+      left = ir::Mul::Make(left, right);
+    } else if (op == IndexToken::TokenType::kDivide) {
+      left = ir::Div::Make(left, right);
+    } else {
+      left = ir::Mod::Make(left, right);
+    }
+  }
+
+  return left;
+}
+
+ir::Expr Parser::ParseFactor() {
+  if (currentToken.type == IndexToken::TokenType::kNumber) {
+    int value = std::stoi(currentToken.value);
+    Advance();
+    return ir::Expr(value);
+  } else if (currentToken.type == IndexToken::TokenType::kVar) {
+    auto var_name = currentToken.value;
+    Advance();
+    return GetOrCreateVar(var_name);
+  } else if (currentToken.type == IndexToken::TokenType::kLeftParen) {
+    Advance();
+    auto expr = ParseExpression();
+
+    if (currentToken.type != IndexToken::TokenType::kRightParen) {
+      PADDLE_THROW(::common::errors::InvalidArgument("Parser Expected ')'"));
+    }
+
+    Advance();
+    return expr;
+  } else {
+    PADDLE_THROW(
+        ::common::errors::InvalidArgument("Parser Unexpected IndexToken"));
+  }
+}
+
+ir::Expr Parser::GetOrCreateVar(const std::string &var_name) {
+  if (vars.find(var_name) == vars.end()) {
+    vars[var_name] = ir::Var(var_name);
+  }
+  return vars[var_name];
+}
+
+ir::Expr ParseExpressionFromString(const std::string &expr_str) {
+  Parser parser(expr_str);
+  return parser.Parse();
+}
+
+std::optional<std::unordered_map<std::string, ir::IndexExpr>> MatchPattern(
+    const ir::IndexExpr &expr,
+    const std::string &pattern_str,
+    const std::function<bool(
+        const std::unordered_map<std::string, ir::IndexExpr> &)> &condition) {
+  // Parse the pattern string into an IndexExpr
+  ir::IndexExpr pattern = ParseExpressionFromString(pattern_str);
+
+  std::unordered_map<std::string, ir::IndexExpr> map;
+
+  if (CheckPattern(expr, pattern, &map)) {
+    // Apply the condition if provided
+    if (condition && !condition(map)) return std::nullopt;
+    return map;
+  }
+
+  return std::nullopt;
 }
 }  // namespace optim
 }  // namespace cinn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
1. 移动 enum IndexType 到 IndexExpr 内部，并提升至 enum class IndexType
2. 添加 string 解析工具 IndexToken、Tokenlizer、Parser，并暴露 ParseExpressionFromString 接口，输入 str，输出对应 Expr，输入 str 支持以下类型：
```
  1. Number: 123, 1234...
  2. Variable: a, b, a_1, aa, f1...
  3. Operator: +, -, *, /, %, (, )
  4. Whitespace
```
3. 添加 Expr MatchPattern 方法进行模板匹配，支持传入 lambda 函数进行额外限制：
```
1. Only match structure: 
MatchPattern(expr, "f % c / b")

2. Match structure and optional condition: 
MatchPattern(
          expr,
          "f / c * a + f % c / b",
          [](const std::unordered_map<std::string, ir::IndexExpr>& m) {
            return m.at("c") == m.at("a") * m.at("b");
          });
```
4. 化简模块中添加减枝

注：该工具意义主要有两个：
1. 主要为可以避免对 Expr 结构进行频繁的 As 并判断类型，例如需要判断 expr 是否为 (a + b) / c * (e + f) 类型，原来只能通过：
```
if(auto e = expr.As<Mul>()){
  auto lhs = e->a().As<Div>();
  auto rhs = e->b().As<Add>();
  if(lhs && rhs){
  auto llhs = lhs->a().As<Add>();
  return true;
  }
}
return false;
```
现可使用：
```
MatchPattern(expr, "(a + b) / c * (e + f)");
```
2. 对匹配到的值现在可以直接通过 MatchPattern 返回的 map 进行使用，而不像之前需复杂的命名，并考虑 if 作用域
```
auto map_opt = MatchPattern(expr, "(a + b) / c * (e + f)");
if(map_opt){
  auto map = map_opt.value();
  // do something in map
  auto mul = map["a"] * map["b"];
}
```
