### PR TITLE
support DeepEP overlap

### DIFF
--- a/paddle/fluid/distributed/collective/deep_ep/CMakeLists.txt
+++ b/paddle/fluid/distributed/collective/deep_ep/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 
 cc_library(
   deep_ep
-  SRCS deep_ep.cpp
+  SRCS deep_ep.cpp src/event_pool.cc src/event.cc src/CUDAStream.cc
   DEPS phi common deepep_kernels)
 
 set_target_properties(deep_ep PROPERTIES CUDA_SEPARABLE_COMPILATION OFF)

--- a/paddle/fluid/distributed/collective/deep_ep/event.hpp
+++ b/paddle/fluid/distributed/collective/deep_ep/event.hpp
@@ -37,6 +37,9 @@ struct EventHandle {
     event->record(deep_ep::detail::getCurrentCUDAStream().raw_stream());
   }
 
+  void CalcStreamWait(int context_ring_id) const;
+  void CommStreamWait(int context_ring_id) const;
+
   explicit EventHandle(const cudaStream_t& stream) {
     event = std::make_shared<deep_ep::detail::Event>();
     event->record(stream);
@@ -51,6 +54,9 @@ struct EventHandle {
         0));
   }
 };
+
+EventHandle GetEventHandleFromCalcStream(int context_ring_id);
+EventHandle GetEventHandleFromCommStream(int context_ring_id);
 
 inline deep_ep::detail::Event create_event(const cudaStream_t& s) {
   auto event = deep_ep::detail::Event();

--- a/paddle/fluid/distributed/collective/deep_ep/include/CUDAStream.h
+++ b/paddle/fluid/distributed/collective/deep_ep/include/CUDAStream.h
@@ -61,4 +61,7 @@ inline void setCurrentCUDAStream(cudaStream_t stream) {
   LOG(FATAL) << "setCurrentCUDAStream is not implemented";
 }
 
+cudaStream_t GetCalcStreamFromGroup(int context_ring_id);
+
+cudaStream_t GetCommStreamFromGroup(int context_ring_id);
 }  // namespace deep_ep::detail

--- a/paddle/fluid/distributed/collective/deep_ep/src/CUDAStream.cc
+++ b/paddle/fluid/distributed/collective/deep_ep/src/CUDAStream.cc
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/distributed/collective/deep_ep/include/CUDAStream.h"
+#include "paddle/fluid/distributed/collective/deep_ep/kernels/exception.cuh"
+#include "paddle/fluid/distributed/collective/process_group_nccl.h"
+#include "paddle/phi/common/place.h"
+
+namespace deep_ep::detail {
+
+cudaStream_t GetCalcStreamFromGroup(int context_ring_id) {
+  int device_id;
+  CUDA_CHECK(cudaGetDevice(&device_id));
+  auto map = paddle::distributed::ProcessGroupMapFromGid::getInstance();
+  paddle::distributed::ProcessGroup* pg = map->get(context_ring_id);
+  const auto& place = phi::GPUPlace(device_id);
+  const auto& calc_ctx = reinterpret_cast<phi::GPUContext*>(
+      reinterpret_cast<paddle::distributed::ProcessGroupNCCL*>(pg)
+          ->GetDeviceContext(place, true));
+  return calc_ctx->stream();
+}
+
+cudaStream_t GetCommStreamFromGroup(int context_ring_id) {
+  int device_id;
+  CUDA_CHECK(cudaGetDevice(&device_id));
+  auto map = paddle::distributed::ProcessGroupMapFromGid::getInstance();
+  paddle::distributed::ProcessGroup* pg = map->get(context_ring_id);
+  const auto& place = phi::GPUPlace(device_id);
+  const auto& comm_ctx =
+      reinterpret_cast<paddle::distributed::ProcessGroupNCCL*>(pg)
+          ->GetOrCreateCommContext(place, phi::distributed::CommType::ALLTOALL);
+  return comm_ctx->GetStream();
+}
+
+}  // namespace deep_ep::detail

--- a/paddle/fluid/distributed/collective/deep_ep/src/event_pool.cc
+++ b/paddle/fluid/distributed/collective/deep_ep/src/event_pool.cc
@@ -1,0 +1,79 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/distributed/collective/deep_ep/include/event_pool.h"
+#include "glog/logging.h"
+
+namespace deep_ep::detail {
+
+EventPool &EventPool::Instance() {
+  static EventPool pool;
+  return pool;
+}
+
+EventPool::~EventPool() {
+  const auto &DestroyEvent = [](cudaEvent_t event) {
+    cudaError_t e = cudaEventDestroy(event);
+    if (e != cudaSuccess) {
+      LOG(ERROR) << "CUDA event destroy failed: ";
+    }
+  };
+  const auto &CheckComplishAndDestroy = [&](cudaEvent_t event) -> bool {
+    if (cudaEventQuery(event) == cudaSuccess) {
+      DestroyEvent(event);
+      return true;
+    }
+    if (cudaEventQuery(event) == cudaErrorNotReady) {
+      LOG(ERROR) << "event is not completed or when destroying event pool.";
+      return false;
+    }
+    LOG(ERROR) << "failed on cudaEventQuery when destroying event pool.";
+    return false;
+  };
+  std::unique_lock<std::mutex> lock(mtx_);
+  while (!incomplished_events_.empty()) {
+    cudaEvent_t event = incomplished_events_.front();
+    if (!CheckComplishAndDestroy(event)) {
+      LOG(ERROR) << "failed on destroying event when destroying event pool.";
+    }
+    incomplished_events_.pop();
+  }
+}
+
+cudaEvent_t EventPool::CreateCudaEventFromPool() {
+  std::unique_lock<std::mutex> lock(mtx_);
+
+  const auto &CreateNewEvent = [&]() -> cudaEvent_t {
+    cudaEvent_t new_event;
+    CUDA_CHECK(cudaEventCreate(&new_event));
+    incomplished_events_.push(new_event);
+    return new_event;
+  };
+
+  const auto &CreateNewOrReuseEvent = [&]() -> cudaEvent_t {
+    cudaEvent_t front_event = incomplished_events_.front();
+    incomplished_events_.pop();
+    incomplished_events_.push(front_event);
+    if (cudaEventQuery(front_event) == cudaSuccess) {
+      return front_event;
+    }
+    return CreateNewEvent();
+  };
+
+  if (incomplished_events_.empty()) {
+    return CreateNewEvent();
+  }
+  return CreateNewOrReuseEvent();
+}
+}  // namespace deep_ep::detail

--- a/paddle/fluid/pybind/deep_ep_api.cc
+++ b/paddle/fluid/pybind/deep_ep_api.cc
@@ -43,7 +43,14 @@ void BindDeepEPApi(pybind11::module *m) {
 
   pybind11::class_<deep_ep::EventHandle>(*m, "EventHandle")
       .def(pybind11::init<>())
-      .def("current_stream_wait", &deep_ep::EventHandle::current_stream_wait);
+      .def("current_stream_wait", &deep_ep::EventHandle::current_stream_wait)
+      .def("calc_stream_wait", &deep_ep::EventHandle::CalcStreamWait)
+      .def("comm_stream_wait", &deep_ep::EventHandle::CommStreamWait);
+
+  m->def("get_event_handle_from_calc_stream",
+         &deep_ep::GetEventHandleFromCalcStream);
+  m->def("get_event_handle_from_comm_stream",
+         &deep_ep::GetEventHandleFromCommStream);
 
   pybind11::class_<deep_ep::Buffer>(*m, "Buffer")
       .def(pybind11::init<int, int, int64_t, int64_t, bool, int>())

--- a/python/paddle/distributed/communication/deep_ep/__init__.py
+++ b/python/paddle/distributed/communication/deep_ep/__init__.py
@@ -12,6 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .buffer import Buffer
+from paddle.base.core import Config
 
-__all__ = ["Buffer"]
+from .buffer import Buffer
+from .utils import (
+    EventOverlap,
+    get_event_from_calc_stream,
+    get_event_from_comm_stream,
+)
+
+__all__ = [
+    "Buffer",
+    "EventOverlap",
+    "Config",
+    "get_event_from_calc_stream",
+    "get_event_from_comm_stream",
+]

--- a/python/paddle/distributed/communication/deep_ep/utils.py
+++ b/python/paddle/distributed/communication/deep_ep/utils.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     import paddle
     from paddle.base.core import EventHandle
 
+import paddle
+
 
 class EventOverlap:
     """
@@ -59,6 +61,12 @@ class EventOverlap:
         assert self.event is not None
         self.event.current_stream_wait()
 
+    def calc_stream_wait(self, group_idx) -> None:
+        self.event.calc_stream_wait(group_idx)
+
+    def comm_stream_wait(self, group_idx) -> None:
+        self.event.comm_stream_wait(group_idx)
+
     def __enter__(self) -> Any:
         """
         Utility for overlapping and Python `with` syntax.
@@ -81,3 +89,15 @@ class EventOverlap:
         """
         if self.event is not None:
             self.event.current_stream_wait()
+
+
+def get_event_from_calc_stream(group_id: int) -> EventOverlap:
+    return EventOverlap(
+        event=paddle.base.core.get_event_handle_from_calc_stream(group_id)
+    )
+
+
+def get_event_from_comm_stream(group_id: int) -> EventOverlap:
+    return EventOverlap(
+        event=paddle.base.core.get_event_handle_from_comm_stream(group_id)
+    )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164
This PR supports DeepEP overlap.事件管理和同步通过DeepEP的EventOverlap类来管理

1.1. 事件获取
事件捕获可以通过两个函数进行：
* deep_ep.get_event_from_calc_stream(group_idx)：事件记录group计算流上的当前任务
* deep_ep.get_event_from_comm_stream(group_idx)：事件记录group通信流上的当前任务
除此之外，DeepEP的两个通信原语在调用后也会直接返回记录其事件
1.2. 事件同步
事件捕获可以通过EventOverlap类的两个成员函数进行：
* event.calc_stream_wait(group_idx)：让group的计算流等待当前event记录的任务
* event.comm_stream_wait(group_idx)：让group的通信流等待当前event记录的任务
除此之外，DeepEP的两个通信原语可以将依赖事件直接作为previous_event参数传入，内部调用进行同步
