### PR TITLE
[SOT] Extract virtual frame states to a separate class

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -17,11 +17,10 @@
 
 from __future__ import annotations
 
-import builtins
 import inspect
 from collections import namedtuple
 from copy import deepcopy
-from functools import cached_property, reduce
+from functools import reduce
 from typing import TYPE_CHECKING, Any, Callable, Tuple, Union
 
 from typing_extensions import TypeAlias, TypeGuard
@@ -72,7 +71,7 @@ from .side_effects import (
     SideEffectRestorer,
     SideEffects,
 )
-from .tracker import BuiltinTracker, DummyTracker, SymbolicOperationTracker
+from .tracker import DummyTracker, SymbolicOperationTracker
 from .variables import (
     DictVariable,
     GlobalVariable,
@@ -233,16 +232,6 @@ class FunctionGraph:
         self._print_variables = []
         self._inplace_tensors = OrderedSet()
         self._kwargs = kwargs
-
-    @cached_property
-    def _builtins(self):
-        builtins_ = {}
-        # prepare builtins
-        for name, value in builtins.__dict__.items():
-            builtins_[name] = VariableFactory.from_value(
-                value, self, BuiltinTracker(name)
-            )
-        return builtins_
 
     def add_print_variables(self, variable):
         """
@@ -811,9 +800,9 @@ class FunctionGraph:
             return []
         current_executor = OpcodeExecutorBase.call_stack[-1]
         current_line = current_executor._current_line
-        filename = current_executor._code.co_filename
+        filename = current_executor.vframe.code.co_filename
         source_lines, start_line = inspect.getsourcelines(
-            current_executor._code
+            current_executor.vframe.code
         )
         # TODO(SigureMo): In 3.11, lineno maybe changed after multiple breakgraph,
         # We need to find a way to fix this.
@@ -821,7 +810,7 @@ class FunctionGraph:
         code_line = source_lines[line_idx]
         stack = []
         stack.append(
-            f'  File "{filename}", line {current_line}, in {current_executor._code.co_name}'
+            f'  File "{filename}", line {current_line}, in {current_executor.vframe.code.co_name}'
         )
         stack.append(f'    {code_line}')
         return stack

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any, Callable
 import paddle
 from paddle.jit.utils import OrderedSet
 
-from ...profiler import EventGuard, event_register
+from ...profiler import EventGuard
 from ...psdb import NO_BREAKGRAPH_CODES
 from ...utils import (
     ENV_MIN_GRAPH_SIZE,
@@ -81,11 +81,9 @@ from .pycode_generator import (
     ResumeFunctionType,
 )
 from .tracker import (
-    CellTracker,
     ConstTracker,
     DanglingTracker,
     DummyTracker,
-    LocalTracker,
 )
 from .variable_stack import VariableStack
 from .variables import (
@@ -94,7 +92,6 @@ from .variables import (
     ConstantVariable,
     ContainerVariable,
     DictVariable,
-    GlobalVariable,
     IterVariable,
     ListVariable,
     MethodVariable,
@@ -114,6 +111,7 @@ from .variables import (
 
 if TYPE_CHECKING:
     from .function_graph import CompileGraphResult, FunctionGraph
+    from .virtual_frame import VirtualFrame
 
 COMPARE_OP_NAME_TO_FN = {
     ">": operator.gt,
@@ -284,9 +282,9 @@ def call_break_graph_decorator(push_n: int | Callable[[int | None], int]):
             try:
                 return call_fn(self, instr)
             except BreakGraphError as e:
-                if self._code in NO_BREAKGRAPH_CODES:
+                if self.vframe.code in NO_BREAKGRAPH_CODES:
                     raise InnerError(
-                        f"{self._code.co_name} should not break graph, but got '{e}'"
+                        f"{self.vframe.code.co_name} should not break graph, but got '{e}'"
                     )
                 if isinstance(self, OpcodeExecutor):
                     log(
@@ -398,27 +396,21 @@ class OpcodeExecutorBase:
             value, (NullVariable, CellVariable)
         ), f"dangling variable {value} should not be pushed into stack."
 
-    def __init__(self, code: types.CodeType, graph: FunctionGraph):
+    def __init__(self, vframe: VirtualFrame, graph: FunctionGraph):
         OpcodeExecutorBase.call_stack.append(self)
         # fake env for run, new env should be gened by PyCodeGen
         self.stack = VariableStack(validate_value_func=self.validate_value)
-        self._co_consts = []
-        self._locals = {}
-        self._globals: GlobalVariable = None  # type: ignore
-        self._builtins = {}
-        self._cells = {}  # position to put cells
-        self._lasti = 0  # idx of instruction list
-        self._code = code
+        self.vframe = vframe
         self._current_line: int = -1
-        self._instructions = get_instructions(self._code)
+        self._instructions = get_instructions(vframe.code)
         self._graph = graph
-        self.new_code: types.CodeType | None = self.empty_code
+        self.new_code: types.CodeType | None = self.empty_code  # type: ignore
         self.guard_fn = None
         self._name = "Executor"
         self._call_shape: tuple[str, ...] | None = (
             None  # store kwnames for Python 3.11 and 3.12
         )
-        self._prepare_virtual_env()
+        # self._prepare_virtual_env()
         self.stop_state = None
 
     def check_code_simulatable(self):
@@ -474,14 +466,14 @@ class OpcodeExecutorBase:
         space = self.find_space_of_var_name(name)
 
         if space == Space.locals:
-            return name in self._locals
+            return name in self.vframe.locals
         elif space == Space.cells:
-            return name in self._cells
+            return name in self.vframe.cells
         elif space == Space.globals:
             return name in set(
                 chain(
-                    self._globals.keys(),
-                    self._builtins.keys(),
+                    self.vframe.globals.keys(),
+                    self.vframe.builtins.keys(),
                 )
             )
         return False
@@ -500,14 +492,14 @@ class OpcodeExecutorBase:
             InnerError: If the variable cannot be found.
 
         """
-        if name in self._locals.keys():
-            return self._locals[name]
-        elif name in self._cells.keys():  # in closure
-            return self._cells[name].cell_content()
-        elif name in self._globals.keys():
-            return self._globals.get(name)
-        elif name in self._builtins.keys():
-            return self._builtins[name]
+        if name in self.vframe.locals.keys():
+            return self.vframe.locals[name]
+        elif name in self.vframe.cells.keys():  # in closure
+            return self.vframe.cells[name].cell_content()
+        elif name in self.vframe.globals.keys():
+            return self.vframe.globals.get(name)
+        elif name in self.vframe.builtins.keys():
+            return self.vframe.builtins[name]
         elif allow_undefined:
             return SotUndefinedVar()
         else:
@@ -518,11 +510,11 @@ class OpcodeExecutorBase:
 
         # if name is new created, we always place it to locals
         if space in (Space.locals, Space.not_found):
-            self._locals[name] = value
+            self.vframe.locals[name] = value
         elif space == Space.cells:
-            self._cells[name].set_value(value)
+            self.vframe.cells[name].set_value(value)
         elif space == Space.globals:
-            self._globals[name] = value
+            self.vframe.globals[name] = value
 
     def _find_names_in_space(self, names, space):
         target_names = [
@@ -556,7 +548,7 @@ class OpcodeExecutorBase:
         indent = 2 * " "
         message_lines = ["In simulate execution:", ""]
         for current_simulator in OpcodeExecutorBase.call_stack:
-            code = current_simulator._code
+            code = current_simulator.vframe.code
             current_line = current_simulator._current_line
             file = inspect.getfile(code)
             if file.startswith("<") and file.endswith(">"):
@@ -586,19 +578,19 @@ class OpcodeExecutorBase:
         Executes the opcode.
 
         """
-        log(3, f"[EXECUTOR RUN] Start execute opcode: {self._code}\n")
-        self._lasti = 0
+        log(3, f"[EXECUTOR RUN] Start execute opcode: {self.vframe.code}\n")
+        self.vframe.lasti = 0
         while True:
-            if self._lasti >= len(self._instructions):
+            if self.vframe.lasti >= len(self._instructions):
                 raise InnerError("lasti out of range, InnerError.")
-            cur_instr = self._instructions[self._lasti]
-            self._lasti += 1
+            cur_instr = self._instructions[self.vframe.lasti]
+            self.vframe.lasti += 1
             is_stop = self.step(cur_instr)
             if is_stop:
                 self.stop_state = is_stop.state
                 self.pop_call_stack_until_self()
                 break
-        log(3, f"[EXECUTOR RUN] End execute opcode: {self._code}\n")
+        log(3, f"[EXECUTOR RUN] End execute opcode: {self.vframe.code}\n")
 
     def step(self, instr: Instruction):
         """
@@ -620,9 +612,9 @@ class OpcodeExecutorBase:
             raise FallbackError(f"opcode: {instr.opname} is not supported.")
         log_message = f"[Translate {self._name}]: (line {self._current_line:>3}) {instr.opname:<12} {instr.argval}, stack is {self.stack}\n"
         log(3, log_message)
-        code_file = self._code.co_filename
+        code_file = self.vframe.code.co_filename
         code_line = self._current_line
-        code_name = self._code.co_name
+        code_name = self.vframe.code.co_name
         code_offset = instr.offset
         from ..breakpoint import BreakpointManager
 
@@ -661,7 +653,7 @@ class OpcodeExecutorBase:
             instr: The instruction to jump to.
 
         """
-        self._lasti = self.indexof(instr)
+        self.vframe.lasti = self.indexof(instr)
 
     def COPY(self, instr: Instruction):
         assert isinstance(instr.arg, int)
@@ -792,12 +784,12 @@ class OpcodeExecutorBase:
     def LOAD_ATTR(self, instr: Instruction):
         if sys.version_info >= (3, 12):
             assert isinstance(instr.arg, int)
-            attr_name = self._code.co_names[instr.arg >> 1]
+            attr_name = self.vframe.code.co_names[instr.arg >> 1]
             if instr.arg & 1:
                 self.load_method(attr_name)
                 return
         else:
-            attr_name = self._code.co_names[instr.arg]
+            attr_name = self.vframe.code.co_names[instr.arg]
         attr_name_var = ConstantVariable.wrap_literal(attr_name, self._graph)
         obj = self.stack.pop()
         self.stack.push(
@@ -815,43 +807,43 @@ class OpcodeExecutorBase:
         )
 
     def LOAD_CONST(self, instr: Instruction):
-        var = self._co_consts[instr.arg]
+        var = self.vframe.consts[instr.arg]
         self.stack.push(var)
 
     def MAKE_CELL(self, instr: Instruction):
-        self._locals[instr.argval] = self._cells[instr.argval]
+        self.vframe.locals[instr.argval] = self.vframe.cells[instr.argval]
 
     def LOAD_CLOSURE(self, instr: Instruction):
         if sys.version_info >= (3, 11):
             self.LOAD_FAST(instr)
             return
-        namemap = self._code.co_cellvars + self._code.co_freevars
+        namemap = self.vframe.code.co_cellvars + self.vframe.code.co_freevars
         name = namemap[instr.arg]
-        self.stack.push(self._cells[name])
+        self.stack.push(self.vframe.cells[name])
 
     def LOAD_DEREF(self, instr: Instruction):
         if sys.version_info >= (3, 11):
-            self.stack.push(self._locals[instr.argval].cell_content())
+            self.stack.push(self.vframe.locals[instr.argval].cell_content())
             return
-        namemap = self._code.co_cellvars + self._code.co_freevars
+        namemap = self.vframe.code.co_cellvars + self.vframe.code.co_freevars
         name = namemap[instr.arg]
-        self.stack.push(self._cells[name].cell_content())
+        self.stack.push(self.vframe.cells[name].cell_content())
 
     def COPY_FREE_VARS(self, instr: Instruction):
         for i in range(instr.arg):
-            freevar_name = self._code.co_freevars[i]
-            self._locals[freevar_name] = self._cells[freevar_name]
+            freevar_name = self.vframe.code.co_freevars[i]
+            self.vframe.locals[freevar_name] = self.vframe.cells[freevar_name]
 
     def LOAD_FAST(self, instr: Instruction):
-        var = self._locals[instr.argval]
+        var = self.vframe.locals[instr.argval]
         self.stack.push(var)
 
     def LOAD_FAST_CHECK(self, instr: Instruction):
         self.LOAD_FAST(instr)
 
     def DELETE_FAST(self, instr: Instruction):
-        varname = self._code.co_varnames[instr.arg]
-        del self._locals[varname]
+        varname = self.vframe.code.co_varnames[instr.arg]
+        del self.vframe.locals[varname]
 
     def LOAD_GLOBAL(self, instr: Instruction):
         namei: int = instr.arg
@@ -861,11 +853,11 @@ class OpcodeExecutorBase:
             namei >>= 1
         if push_null and not CALL_METHOD_LAYOUT_NULL_AFTER_VALUE:
             self.stack.push(NullVariable())
-        name = self._code.co_names[namei]
-        if name in self._globals.keys():
-            value = self._globals.get(name)
-        elif name in self._builtins.keys():
-            value = self._builtins[name]
+        name = self.vframe.code.co_names[namei]
+        if name in self.vframe.globals.keys():
+            value = self.vframe.globals.get(name)
+        elif name in self.vframe.builtins.keys():
+            value = self.vframe.builtins[name]
         else:
             raise InnerError(f"{name} not in globals and builtins")
         self.stack.push(value)
@@ -900,14 +892,14 @@ class OpcodeExecutorBase:
                 self.stack.push(NullVariable())
 
     def LOAD_METHOD(self, instr: Instruction):
-        method_name = self._code.co_names[instr.arg]
+        method_name = self.vframe.code.co_names[instr.arg]
         self.load_method(method_name)
 
     @call_break_graph_decorator(push_n=0)
     def STORE_ATTR(self, instr: Instruction):
         obj = self.stack.pop()
         val = self.stack.pop()
-        key = self._code.co_names[instr.arg]
+        key = self.vframe.code.co_names[instr.arg]
         key_var = ConstantVariable.wrap_literal(key, self._graph)
         BuiltinVariable(
             setattr, self._graph, DummyTracker([obj, key_var, val])
@@ -923,28 +915,28 @@ class OpcodeExecutorBase:
 
     def STORE_DEREF(self, instr: Instruction):
         if sys.version_info >= (3, 11):
-            self._cells[instr.argval].set_value(self.stack.pop())
-            self._locals[instr.argval] = self._cells[instr.argval]
+            self.vframe.cells[instr.argval].set_value(self.stack.pop())
+            self.vframe.locals[instr.argval] = self.vframe.cells[instr.argval]
             return
-        namemap = self._code.co_cellvars + self._code.co_freevars
+        namemap = self.vframe.code.co_cellvars + self.vframe.code.co_freevars
         name = namemap[instr.arg]
-        self._cells[name].set_value(self.stack.pop())
+        self.vframe.cells[name].set_value(self.stack.pop())
 
     def STORE_FAST(self, instr: Instruction):
         """
         TODO: side effect may happen
         """
         var = self.stack.pop()
-        name = self._code.co_varnames[instr.arg]
-        self._locals[name] = var
+        name = self.vframe.code.co_varnames[instr.arg]
+        self.vframe.locals[name] = var
 
     def STORE_GLOBAL(self, instr: Instruction):
         var = self.stack.pop()
-        name = self._code.co_names[instr.arg]
-        self._globals.set(name, var)
+        name = self.vframe.code.co_names[instr.arg]
+        self.vframe.globals.set(name, var)
 
     def DELETE_GLOBAL(self, instr: Instruction):
-        self._globals.delete(self._code.co_names[instr.arg])
+        self.vframe.globals.delete(self.vframe.code.co_names[instr.arg])
 
     @call_break_graph_decorator(push_n=0)
     def STORE_SUBSCR(self, instr: Instruction):
@@ -1161,8 +1153,8 @@ class OpcodeExecutorBase:
         assert isinstance(instr.arg, int)
         assert instr.opname == "PRECALL"
         self.PRECALL(instr)
-        next_instr = self._instructions[self._lasti]
-        self._lasti += 1
+        next_instr = self._instructions[self.vframe.lasti]
+        self.vframe.lasti += 1
         assert next_instr.opname == "CALL"
         self.CALL(next_instr)
 
@@ -1182,7 +1174,7 @@ class OpcodeExecutorBase:
     def KW_NAMES(self, instr: Instruction):
         assert self._call_shape is None
         assert isinstance(instr.arg, int)
-        self._call_shape = self._co_consts[instr.arg].get_py_value()
+        self._call_shape = self.vframe.consts[instr.arg].get_py_value()
 
     def call_impl_py312_minus(
         self,
@@ -1368,7 +1360,7 @@ class OpcodeExecutorBase:
 
     def TO_BOOL(self, instr: Instruction):
         # we don't do anything in TO_BOOL, we simply check if the bytecode is legal
-        next_instr = self._instructions[self._lasti]
+        next_instr = self._instructions[self.vframe.lasti]
         assert (
             next_instr.opname in NEED_TO_BOOL
         ), f"The bytecode is illegal! The opcode following TO_BOOL must be in ['POP_JUMP_IF_TRUE', 'POP_JUMP_IF_FALSE', 'UNARY_NOT'], the next instruction now is {next_instr.opname}"
@@ -1398,7 +1390,7 @@ class OpcodeExecutorBase:
                 codeobj.value.co_qualname, self._graph, DummyTracker([codeobj])
             )
 
-        global_dict = self._globals.get_value()
+        global_dict = self.vframe.globals.get_value()
 
         related_list = [fn_name, codeobj]
 
@@ -1453,7 +1445,7 @@ class OpcodeExecutorBase:
             )
             self.push_new_fn_on_stack(
                 origin_codeobj.get_py_value(),
-                self._globals.get_value(),
+                self.vframe.globals.get_value(),
                 fn_name.get_py_value(),
                 default_args,
                 closure,
@@ -1890,11 +1882,10 @@ class OpcodeExecutor(OpcodeExecutorBase):
 
     """
 
-    def __init__(self, frame: types.FrameType, graph: FunctionGraph):
-        self._frame = frame  # TODO: Don't hold frame in executor, just hold vframe instead
+    def __init__(self, vframe: VirtualFrame, graph: FunctionGraph):
         self._name = "Executor"
         self.call_stack[:] = []
-        super().__init__(frame.f_code, graph)
+        super().__init__(vframe, graph)
         Dispatcher.graph = graph
 
     def transform(self, frame: types.FrameType):
@@ -1904,7 +1895,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
             inputs = []
             for i in range(code.co_argcount):
                 arg_name = code.co_varnames[i]
-                value = self._locals[arg_name]
+                value = self.vframe.locals[arg_name]
                 inputs.append(value)
             output = self._graph.call_ast(static_function, *inputs)
             if output is not None:
@@ -1926,48 +1917,6 @@ class OpcodeExecutor(OpcodeExecutorBase):
         self._graph.pycode_gen = None
         Dispatcher.graph = None
         self.call_stack[:] = []
-
-    @event_register("OpcodeExecutor: _prepare_virtual_env", event_level=2)
-    def _prepare_virtual_env(self):
-        """
-        Prepare the virtual environment for execution by adding variables from locals, globals, builtins, and constants.
-
-        """
-        log(
-            3,
-            f"[Executor] code options: co_cellvars={self._code.co_cellvars}\n",
-        )
-        free_or_cell_vars = self._code.co_cellvars + self._code.co_freevars
-        for name, value in self._frame.f_locals.items():
-            tracker = (
-                CellTracker(name)
-                if name in free_or_cell_vars
-                else LocalTracker(name)
-            )
-            self._locals[name] = VariableFactory.from_value(
-                value, self._graph, tracker
-            )
-
-        for name in free_or_cell_vars:
-            # create a cell for each variable.
-            self._cells[name] = CellVariable()  # put in cells.
-            if name in self._locals:
-                self._cells[name].set_value(self._locals[name])
-
-        self._globals = GlobalVariable(
-            self._frame.f_globals,
-            self._graph,
-            DanglingTracker(),
-        )
-
-        self._builtins = self._graph._builtins
-
-        for value in self._code.co_consts:
-            self._co_consts.append(
-                VariableFactory.from_value(
-                    value, self._graph, ConstTracker(value)
-                )
-            )
 
     def FOR_ITER(self, instr):
         iterator = self.stack.pop()
@@ -1994,22 +1943,22 @@ class OpcodeExecutor(OpcodeExecutorBase):
             backup_iter_idx = iterator.idx
 
             self._inline_call_for_loop(iterator, instr)
-            self._lasti = self.indexof(instr.jump_to)
+            self.vframe.lasti = self.indexof(instr.jump_to)
             if sys.version_info >= (3, 12):
-                assert self._instructions[self._lasti].opname == "END_FOR"
+                assert self._instructions[self.vframe.lasti].opname == "END_FOR"
                 # NOTE(SigureMo): From Python 3.12, END_FOR indicates the end of the for loop.
                 # But it's never executed, so we need to skip it.
                 # In Python 3.12, it equivalent to POP_TOP + POP_TOP (in one instruction)
                 # In Python 3.13, it equivalent to POP_TOP, and it common with other POP_TOP
                 skip_n_instrs = 2 if sys.version_info >= (3, 13) else 1
-                self._lasti += skip_n_instrs
+                self.vframe.lasti += skip_n_instrs
         except BreakGraphError as e:
             log(3, f"[BreakGraph] FOR_ITER sim for loop failed for: {e}\n")
             if backup_iter_idx:
                 iterator.idx = backup_iter_idx
             self._graph.remove_global_guarded_variable(iterator)
             self.stack.push(iterator)
-            if is_comprehensive_name(self._code.co_name):
+            if is_comprehensive_name(self.vframe.code.co_name):
                 # NOTE(SigureMo): The loop body of comprehensive will access the
                 # value out of the loop, so we simply fallback it now.
                 raise FallbackError(
@@ -2026,7 +1975,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         return self.compile_return(ret_val)
 
     def RETURN_CONST(self, instr: Instruction):
-        ret_const = self._co_consts[instr.arg]
+        ret_const = self.vframe.consts[instr.arg]
         return self.compile_return(ret_const)
 
     def compile_return(self, ret_val):
@@ -2111,7 +2060,11 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 and not is_pop_jump_branch
             ):
                 return None
-            cache_key = (ResumeFunctionType.IF_RESUME, self._code, start_idx)
+            cache_key = (
+                ResumeFunctionType.IF_RESUME,
+                self.vframe.code,
+                start_idx,
+            )
             resume_fn_creator = ResumeFunctionCreator(
                 self._graph.pycode_gen._origin_code,
                 self._graph.pycode_gen._real_globals,
@@ -2165,11 +2118,11 @@ class OpcodeExecutor(OpcodeExecutorBase):
         for name in true_fn_input_var_names[:-1]:
             if not self.has_var(name):
                 self._graph.pycode_gen.gen_load_const(SotUndefinedVar())
-                self._graph.pycode_gen.gen_store(name, self._code)
+                self._graph.pycode_gen.gen_store(name, self.vframe.code)
         for name in false_fn_input_var_names:
             if not self.has_var(name):
                 self._graph.pycode_gen.gen_load_const(SotUndefinedVar())
-                self._graph.pycode_gen.gen_store(name, self._code)
+                self._graph.pycode_gen.gen_store(name, self.vframe.code)
 
         # 4. compile codes before if
         update_var_names = list(true_fn_read_names | false_fn_read_names)
@@ -2270,7 +2223,11 @@ class OpcodeExecutor(OpcodeExecutorBase):
         def create_resume_fn(null_indices):
             if self._instructions[next_index].opname == "RETURN_VALUE":
                 return None
-            cache_key = (ResumeFunctionType.CALL_RESUME, self._code, next_index)
+            cache_key = (
+                ResumeFunctionType.CALL_RESUME,
+                self.vframe.code,
+                next_index,
+            )
             resume_fn_creator = ResumeFunctionCreator(
                 self._graph.pycode_gen._origin_code,
                 self._graph.pycode_gen._real_globals,
@@ -2375,7 +2332,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         def create_loop_body():
             cache_key = (
                 ResumeFunctionType.LOOP_BODY_RESUME,
-                self._code,
+                self.vframe.code,
                 loop_body_start_idx,
                 loop_body_end_idx,
             )
@@ -2450,7 +2407,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 return None
             cache_key = (
                 ResumeFunctionType.AFTER_LOOP_RESUME,
-                self._code,
+                self.vframe.code,
                 loop_body_end_idx,
             )
             resume_fn_creator = ResumeFunctionCreator(
@@ -2486,11 +2443,11 @@ class OpcodeExecutor(OpcodeExecutorBase):
         for name in loop_body_inputs[:-1]:
             if not self.has_var(name):
                 self._graph.pycode_gen.gen_load_const(SotUndefinedVar())
-                self._graph.pycode_gen.gen_store(name, self._code)
+                self._graph.pycode_gen.gen_store(name, self.vframe.code)
         for name in after_loop_fn_inputs:
             if not self.has_var(name):
                 self._graph.pycode_gen.gen_load_const(SotUndefinedVar())
-                self._graph.pycode_gen.gen_store(name, self._code)
+                self._graph.pycode_gen.gen_store(name, self.vframe.code)
 
         # 5. compile sub graph before for-loop
         update_names = list(
@@ -2541,7 +2498,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         self._graph.pycode_gen.gen_unpack_sequence(len(loop_body_outputs))
 
         for name in loop_body_outputs[:-1]:
-            self._graph.pycode_gen.gen_store(name, self._code)
+            self._graph.pycode_gen.gen_store(name, self.vframe.code)
 
         # 8. create the tail of a for loop, jump back to FOR_ITER
         #    and process case if break
@@ -2612,7 +2569,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         def create_inline_call_fn():
             cache_key = (
                 ResumeFunctionType.LOOP_BODY_INLINE_CALL,
-                self._code,
+                self.vframe.code,
                 start_idx,
                 end_idx,
             )

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
@@ -15,33 +15,29 @@
 from __future__ import annotations
 
 import contextlib
-import inspect
-import re
 import sys
 from typing import TYPE_CHECKING
 
-from ...profiler import event_register
 from ...utils import (
     BreakGraphError,
     DataDependencyControlFlowBreak,
     UnsupportedIteratorBreak,
-    log,
 )
 from ..instruction_utils import Instruction
 from .guard import StringifiedExpression, union_free_vars
 from .opcode_executor import OpcodeExecutorBase, Stop
-from .tracker import ConstTracker, DanglingTracker, DummyTracker, Tracker
+from .tracker import Tracker
 from .variables import (
-    CellVariable,
-    FunctionGlobalVariable,
     IterVariable,
     SequenceIterVariable,
     VariableBase,
 )
 
 if TYPE_CHECKING:
+    from .function_graph import FunctionGraph
     from .pycode_generator import PyCodeGen
     from .variables import FunctionVariable
+    from .virtual_frame import VirtualFrame
 
 
 class FunctionGlobalTracker(Tracker):
@@ -161,119 +157,14 @@ class OpcodeInlineExecutor(OpcodeExecutorBase):
 
     def __init__(
         self,
-        fn_variable: FunctionVariable,
-        *args,
-        **kwargs,
+        vframe: VirtualFrame,
+        code_var: VariableBase,
+        graph: FunctionGraph,
     ):
-        self._fn_var = fn_variable
+        super().__init__(vframe, graph)
         self.return_value: VariableBase | None = None
-        self._fn_value = fn_variable.value
-        self._code_var = fn_variable.get_code()
-        super().__init__(self._code_var.value, fn_variable.graph)
+        self._code_var = code_var
         self._name = "Inline"
-        self._prepare_locals(*args, **kwargs)
-        self._prepare_closure()
-
-    def _handle_comps(self):
-        is_comp = any(
-            x in self._fn_value.__name__
-            for x in ['<listcomp>', '<dictcomp>', '<genexpr>']
-        )
-        if not is_comp:
-            return
-        pattern = r'implicit\d+'
-        for name in list(self._locals.keys()):
-            if re.match(pattern, name):
-                self._locals[name.replace('implicit', '.')] = self._locals[name]
-
-    def _prepare_locals(self, *args, **kwargs):
-        """
-        Prepare local variables for execution by adding them to the locals dictionary.
-
-        """
-        from .variables import VariableBase, VariableFactory
-
-        # temparay clear the fn.__signature__ to avoid signature check error
-        with signature_clear_guard(
-            self._fn_value, "__signature__"
-        ), signature_clear_guard(self._fn_value, "__wrapped__"):
-            sig = inspect.signature(self._fn_value)
-            bound_args = sig.bind(*args, **kwargs)
-        bound_args.apply_defaults()
-        for name, value in bound_args.arguments.items():
-            assert name in sig.parameters
-            # Convert varargs and kwargs to Variable
-            if sig.parameters[name].kind == inspect.Parameter.VAR_POSITIONAL:
-                tracker = DummyTracker(value)
-            elif sig.parameters[name].kind == inspect.Parameter.VAR_KEYWORD:
-                tracker = DummyTracker(list(value.values()))
-            # Convert default args to Variable
-            elif not isinstance(value, VariableBase):
-                tracker = ConstTracker(value)
-            else:
-                tracker = value.tracker
-            value = VariableFactory.from_value(value, self._graph, tracker)
-            self._locals[name] = value
-
-        self._handle_comps()
-
-        log(
-            5, f"[INLINE CALL] {self._code.co_name} with locals: ", self._locals
-        )
-
-    def _prepare_closure(self):
-        """
-        Prepare closure variables for execution by adding them to the closure list.
-
-        """
-        from .variables import VariableFactory
-
-        closure = self._fn_var.get_py_value().__closure__
-        for name in self._code.co_cellvars + self._code.co_freevars:
-            # create a cell for each variable.
-            self._cells[name] = CellVariable()  # put in cells.
-            if name in self._locals:
-                self._cells[name].set_value(self._locals[name])
-
-        if closure is None:
-            return
-        assert len(closure) == len(self._code.co_freevars)
-        for idx, (name, cell) in enumerate(
-            zip(self._code.co_freevars, closure)
-        ):
-            value = cell.cell_contents
-            value = VariableFactory.from_value(
-                value, self._graph, FunctionClosureTracker(self._fn_var, idx)
-            )
-            # wrapped by a CellVariable
-            if not isinstance(value, CellVariable):
-                value = CellVariable(value)
-            self._cells[name] = value
-
-    @event_register("OpcodeInlineExecutor: _prepare_virtual_env", event_level=2)
-    def _prepare_virtual_env(self):
-        """
-        Prepare the virtual environment for execution by adding variables from globals, builtins, and constants.
-
-        """
-        from .variables import VariableFactory
-
-        self._globals = FunctionGlobalVariable(
-            self._fn_var,
-            self._fn_value.__globals__,
-            self._graph,
-            DanglingTracker(),
-        )
-
-        self._builtins = self._graph._builtins
-
-        # prepare consts
-        for value in self._code.co_consts:
-            self._co_consts.append(
-                VariableFactory.from_value(
-                    value, self._graph, ConstTracker(value)
-                )
-            )
 
     def inline_call(self) -> VariableBase:
         """
@@ -292,7 +183,7 @@ class OpcodeInlineExecutor(OpcodeExecutorBase):
         return Stop(state="Return")
 
     def RETURN_CONST(self, instr: Instruction):
-        self.return_value = self._co_consts[instr.arg]
+        self.return_value = self.vframe.consts[instr.arg]
         return Stop(state="Return")
 
     def _break_graph_when_if(self, result, instr: Instruction):
@@ -322,11 +213,14 @@ class OpcodeInlineExecutor(OpcodeExecutorBase):
             except StopIteration:
                 self.stack.pop()
                 assert isinstance(instr.jump_to, Instruction)
-                self._lasti = self.indexof(instr.jump_to)
+                self.vframe.lasti = self.indexof(instr.jump_to)
                 if sys.version_info >= (3, 12):
-                    assert self._instructions[self._lasti].opname == "END_FOR"
+                    assert (
+                        self._instructions[self.vframe.lasti].opname
+                        == "END_FOR"
+                    )
                     skip_n_instrs = 2 if sys.version_info >= (3, 13) else 1
-                    self._lasti += skip_n_instrs
+                    self.vframe.lasti += skip_n_instrs
 
         else:
             self._graph.remove_global_guarded_variable(iterator)

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import sys
 from typing import TYPE_CHECKING
 
@@ -133,17 +132,6 @@ class FunctionClosureTracker(Tracker):
 
     def __repr__(self) -> str:
         return f"FunctionClosureTracker(fn={self.fn}, idx={self.idx})"
-
-
-@contextlib.contextmanager
-def signature_clear_guard(fn, name):
-    if not hasattr(fn, name):
-        yield
-    else:
-        saved_attr = getattr(fn, name)
-        delattr(fn, name)
-        yield
-        setattr(fn, name, saved_attr)
 
 
 class OpcodeInlineExecutor(OpcodeExecutorBase):

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -78,6 +78,7 @@ from ..tracker import (
     GetIterTracker,
     Tracker,
 )
+from ..virtual_frame import VirtualFrame
 from .base import VariableFactory
 from .basic import (
     ConstantVariable,
@@ -201,7 +202,7 @@ class UserDefinedFunctionVariable(FunctionVariable):
             from ...breakpoint import BM
 
             BM.locate(BM.executors[-1])
-            BM.add(BM.cur_exe._code.co_filename, BM.cur_exe._current_line)
+            BM.add(BM.cur_exe.vframe.code.co_filename, BM.cur_exe._current_line)
             return ConstantVariable.wrap_literal(None, self.graph)
         elif self.value is psdb.breakgraph:
             raise BreakGraphError(
@@ -229,9 +230,17 @@ class UserDefinedFunctionVariable(FunctionVariable):
                 return output
 
         try:
-            inline_executor = OpcodeInlineExecutor(self, *args, **kwargs)
+            code_var = self.get_code()
+            vframe = VirtualFrame.from_inline_call(
+                code_var.value,
+                self,
+                self.value,
+                self.graph,
+                (args, kwargs),
+            )
+            inline_executor = OpcodeInlineExecutor(vframe, code_var, self.graph)
             with EventGuard(
-                f"Inline Call: {inline_executor._code.co_name.replace('<', '(').replace('>', ')')}, file {inline_executor._code.co_filename}, line {int(inline_executor._code.co_firstlineno)}"
+                f"Inline Call: {inline_executor.vframe.code.co_name.replace('<', '(').replace('>', ')')}, file {inline_executor.vframe.code.co_filename}, line {int(inline_executor.vframe.code.co_firstlineno)}"
             ):
                 output = inline_executor.inline_call()
         except SotErrorBase as error:

--- a/python/paddle/jit/sot/opcode_translator/executor/virtual_frame.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/virtual_frame.py
@@ -258,7 +258,7 @@ class VirtualFrame:
     def handle_comps(self, fn_value):
         is_comp = any(
             x in fn_value.__name__
-            for x in ['<listcomp>', '<dictcomp>', '<genexpr>']
+            for x in ['<listcomp>', '<dictcomp>', '<genexpr>', '<setcomp>']
         )
         if not is_comp:
             return

--- a/python/paddle/jit/sot/opcode_translator/executor/virtual_frame.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/virtual_frame.py
@@ -258,7 +258,7 @@ class VirtualFrame:
     def handle_comps(self, fn_value):
         is_comp = any(
             x in fn_value.__name__
-            for x in ['<listcomp>', '<dictcomp>', '<genexpr>', '<setcomp>']
+            for x in ['<listcomp>', '<dictcomp>', '<setcomp>', '<genexpr>']
         )
         if not is_comp:
             return

--- a/python/paddle/jit/sot/opcode_translator/executor/virtual_frame.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/virtual_frame.py
@@ -1,0 +1,268 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import builtins
+import inspect
+import re
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+from ...utils import log
+from .guard import StringifiedExpression, union_free_vars
+from .tracker import (
+    BuiltinTracker,
+    CellTracker,
+    ConstTracker,
+    DanglingTracker,
+    DummyTracker,
+    LocalTracker,
+    Tracker,
+)
+from .variables.base import VariableBase, VariableFactory
+from .variables.basic import (
+    CellVariable,
+    FunctionGlobalVariable,
+    GlobalVariable,
+)
+
+if TYPE_CHECKING:
+    import types
+
+    from typing_extensions import TypeAlias
+
+    from .function_graph import FunctionGraph
+    from .pycode_generator import PyCodeGen
+    from .variables.callable import FunctionVariable
+
+    # The type to represent the (*args, **kwargs) pack in the call.
+    CallArgsPack: TypeAlias = tuple[tuple[Any, ...], dict[str, Any]]
+
+
+class FunctionClosureTracker(Tracker):
+    """
+    A tracker class that represents a function closure variable.
+
+    Args:
+        fn: The FunctionVariable object.
+        idx: The index of the closure variable.
+
+    """
+
+    def __init__(self, fn: FunctionVariable, idx: int):
+        super().__init__([fn])
+        self.fn = fn
+        self.idx = idx
+
+    def gen_instructions(self, codegen: PyCodeGen):
+        """
+        Generate bytecode instructions to trace the value of the function closure variable.
+
+        Args:
+            codegen: The PyCodeGen object used to generate bytecode.
+
+        """
+        self.fn.tracker.gen_instructions(codegen)
+        codegen.gen_load_attr("__closure__")
+        codegen.gen_load_const(self.idx)
+        codegen.gen_subscribe()
+        codegen.gen_load_attr("cell_contents")
+
+    def trace_value_from_frame(self):
+        """
+        Trace the value of the function closure variable from the frame.
+
+        Returns:
+            The traced value of the function closure variable.
+
+        """
+        fn_tracer = self.fn.tracker.trace_value_from_frame()
+        return StringifiedExpression(
+            f"{{}}.__closure__[{self.idx}].cell_contents",
+            [fn_tracer],
+            union_free_vars(fn_tracer.free_vars),
+        )
+
+    def __repr__(self) -> str:
+        return f"FunctionClosureTracker(fn={self.fn}, idx={self.idx})"
+
+
+@contextmanager
+def signature_clear_guard(fn, name):
+    if not hasattr(fn, name):
+        yield
+    else:
+        saved_attr = getattr(fn, name)
+        delattr(fn, name)
+        yield
+        setattr(fn, name, saved_attr)
+
+
+class VirtualFrame:
+    code: types.CodeType
+    locals: dict[str, Any]  # TODO: should we use DictVariable instead of dict?
+    globals: GlobalVariable
+    builtins: dict[str, Any]
+    consts: list[Any]
+    cells: dict[str, Any]
+    lasti: int
+
+    def __init__(self, code: types.CodeType):
+        self.code = code
+        self.locals = {}
+        self.globals = None  # type: ignore
+        self.builtins = {}
+        self.cells = {}
+        self.lasti = 0
+        self.consts = []
+
+    @staticmethod
+    def from_real_frame(frame: types.FrameType, graph: FunctionGraph):
+        code = frame.f_code
+        locals = frame.f_locals
+        vframe = VirtualFrame(code)
+
+        # convert locals
+        free_or_cell_vars = code.co_cellvars + code.co_freevars
+        for name, value in locals.items():
+            tracker = (
+                CellTracker(name)
+                if name in free_or_cell_vars
+                else LocalTracker(name)
+            )
+            vframe.locals[name] = VariableFactory.from_value(
+                value, graph, tracker
+            )
+
+        for name in free_or_cell_vars:
+            # create a cell for each variable.
+            vframe.cells[name] = CellVariable()  # put in cells.
+            if name in vframe.locals:
+                vframe.cells[name].set_value(vframe.locals[name])
+
+        # convert globals
+        vframe.globals = GlobalVariable(
+            frame.f_globals,
+            graph,
+            DanglingTracker(),
+        )
+
+        # convert builtins
+        for name, value in builtins.__dict__.items():
+            vframe.builtins[name] = VariableFactory.from_value(
+                value, graph, BuiltinTracker(name)
+            )
+        # Temporarily use the builtins from the graph to avoid the conversion overhead.
+        graph.builtins = vframe.builtins
+
+        # prepare consts
+        for value in code.co_consts:
+            vframe.consts.append(
+                VariableFactory.from_value(value, graph, ConstTracker(value))
+            )
+        return vframe
+
+    @staticmethod
+    def from_inline_call(
+        code: types.CodeType,
+        fn_var: FunctionVariable,
+        fn_value: types.FunctionType,
+        graph: FunctionGraph,
+        call_args_pack: CallArgsPack,
+    ):
+        call_args, call_kwargs = call_args_pack
+        vframe = VirtualFrame(code)
+        vframe.globals = FunctionGlobalVariable(
+            fn_var,
+            fn_value.__globals__,
+            graph,
+            DanglingTracker(),
+        )
+
+        # convert builtins
+        # NOTE(SigureMo): inline call should inherit the builtins from the caller to reduce the conversion overhead.
+        vframe.builtins = graph.builtins
+
+        # prepare consts
+        for value in code.co_consts:
+            vframe.consts.append(
+                VariableFactory.from_value(value, graph, ConstTracker(value))
+            )
+
+        # convert locals
+        # temparay clear the fn.__signature__ to avoid signature check error
+        with signature_clear_guard(
+            fn_value, "__signature__"
+        ), signature_clear_guard(fn_value, "__wrapped__"):
+            sig = inspect.signature(fn_value)
+            bound_args = sig.bind(*call_args, **call_kwargs)
+        bound_args.apply_defaults()
+        for name, value in bound_args.arguments.items():
+            assert name in sig.parameters
+            # Convert varargs and kwargs to Variable
+            if sig.parameters[name].kind == inspect.Parameter.VAR_POSITIONAL:
+                tracker = DummyTracker(value)
+            elif sig.parameters[name].kind == inspect.Parameter.VAR_KEYWORD:
+                tracker = DummyTracker(list(value.values()))
+            # Convert default args to Variable
+            elif not isinstance(value, VariableBase):
+                tracker = ConstTracker(value)
+            else:
+                tracker = value.tracker
+            value = VariableFactory.from_value(value, graph, tracker)
+            vframe.locals[name] = value
+
+        log(
+            5,
+            f"[INLINE CALL] {code.co_name} with locals: ",
+            vframe.locals,
+        )
+
+        # handle implicit variables in comprehensions
+        vframe.handle_comps(fn_value)
+
+        # convert closures
+        closure = fn_var.get_py_value().__closure__
+        for name in code.co_cellvars + code.co_freevars:
+            # create a cell for each variable.
+            vframe.cells[name] = CellVariable()  # put in cells.
+            if name in vframe.locals:
+                vframe.cells[name].set_value(vframe.locals[name])
+
+        if closure is None:
+            return vframe
+        assert len(closure) == len(code.co_freevars)
+        for idx, (name, cell) in enumerate(zip(code.co_freevars, closure)):
+            value = cell.cell_contents
+            value = VariableFactory.from_value(
+                value, graph, FunctionClosureTracker(fn_var, idx)
+            )
+            # wrapped by a CellVariable
+            if not isinstance(value, CellVariable):
+                value = CellVariable(value)
+            vframe.cells[name] = value
+        return vframe
+
+    def handle_comps(self, fn_value):
+        is_comp = any(
+            x in fn_value.__name__
+            for x in ['<listcomp>', '<dictcomp>', '<genexpr>']
+        )
+        if not is_comp:
+            return
+        pattern = r'implicit\d+'
+        for name in list(self.locals.keys()):
+            if re.match(pattern, name):
+                self.locals[name.replace('implicit', '.')] = self.locals[name]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

Generator 实现前的重构，step 2

将 `OpcodeExecutor` 中的状态成员提取到 `VirtualFrame` 类中，`OpcodeExecutor` 只承担执行，数据则由 `VirtualFrame` 来承载，以便打断时的恢复回退

- step1 #71275