### PR TITLE
[CINN] fix SimplifyBroadcast bugs

### DIFF
--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -1025,28 +1025,32 @@ struct SimplifyBroadcast {
   }
 
   bool IsLhsGreatThanRhs(const DimExpr& lhs, const DimExpr& rhs) {
-    auto LhsOperandsVisitor = common::Overloaded{
-        [&](const Mul<DimExpr>& mul) {
-          bool lhs_great_than_rhs = false;
-          for (const auto& expr : *mul.operands) {
-            if (expr == rhs)
-              lhs_great_than_rhs = true;
-            else if (!expr.isa<std::int64_t>() && !expr.isa<std::string>())
-              return false;
-          }
-          return lhs_great_than_rhs;
-        },
-        [&](const Add<DimExpr>& add) {
-          bool lhs_great_than_rhs = false;
-          for (const auto& expr : *add.operands) {
-            if (expr == rhs)
-              lhs_great_than_rhs = true;
-            else if (!expr.isa<std::int64_t>() && !expr.isa<std::string>())
-              return false;
-          }
-          return lhs_great_than_rhs;
-        },
-        [&](const auto& lhs) { return false; }};
+    auto LhsOperandsVisitor =
+        common::Overloaded{[&](const Mul<DimExpr>& mul) {
+                             bool lhs_great_than_rhs = false;
+                             for (const auto& expr : *mul.operands) {
+                               if (expr == rhs)
+                                 lhs_great_than_rhs = true;
+                               else if (!(expr.isa<std::int64_t>() &&
+                                          expr.dyn_cast<std::int64_t>() > 0) &&
+                                        !expr.isa<std::string>())
+                                 return false;
+                             }
+                             return lhs_great_than_rhs;
+                           },
+                           [&](const Add<DimExpr>& add) {
+                             bool lhs_great_than_rhs = false;
+                             for (const auto& expr : *add.operands) {
+                               if (expr == rhs)
+                                 lhs_great_than_rhs = true;
+                               else if (!(expr.isa<std::int64_t>() &&
+                                          expr.dyn_cast<std::int64_t>() > 0) &&
+                                        !expr.isa<std::string>())
+                                 return false;
+                             }
+                             return lhs_great_than_rhs;
+                           },
+                           [&](const auto& lhs) { return false; }};
     return std::visit(LhsOperandsVisitor, lhs.variant());
   }
 

--- a/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
+++ b/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
@@ -188,8 +188,10 @@ TEST(Simplify, SimplifyBc) {
   DimExpr bc{Broadcast<DimExpr>{{S0, add}}};
   ASSERT_TRUE((SimplifyDimExpr(bc) != Add<DimExpr>{{S0, -1}}));
   // TODO(ooooo): improve the simplify ability
-  ASSERT_TRUE((SimplifyDimExpr(bc) == bc));
+  DimExpr now_accept{Broadcast<DimExpr>{{S0, Add<DimExpr>{{S0, -1}}}}};
+  ASSERT_TRUE((SimplifyDimExpr(bc) == now_accept));
 }
+
 TEST(Simplify, FoldBroadcast) {
   DimExpr sym0{"S0"};
   DimExpr sym1{"S1"};

--- a/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
+++ b/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
@@ -184,7 +184,7 @@ TEST(Simplify, ConstantMaxMin) {
 TEST(Simplify, SimplifyBc) {
   // Broadcast(S0, Add(S0, -1)) => S0
   DimExpr S0{"S0"};
-  DimExpr add{Add<DimExpr>{{S0, Negative<DimExpr>{S0}}}};
+  DimExpr add{Add<DimExpr>{{S0, Negative<DimExpr>{1}}}};
   DimExpr bc{Broadcast<DimExpr>{{S0, add}}};
   ASSERT_TRUE((SimplifyDimExpr(bc) != Add<DimExpr>{{S0, -1}}));
   // TODO(ooooo): improve the simplify ability

--- a/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
+++ b/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
@@ -181,6 +181,15 @@ TEST(Simplify, ConstantMaxMin) {
   ASSERT_EQ((simplified_dim_expr2.Get<std::int64_t>()), 2);
 }
 
+TEST(Simplify, SimplifyBc) {
+  // Broadcast(S0, Add(S0, -1)) => S0
+  DimExpr S0{"S0"};
+  DimExpr add{Add<DimExpr>{{S0, Negative<DimExpr>{S0}}}};
+  DimExpr bc{Broadcast<DimExpr>{{S0, add}}};
+  ASSERT_TRUE((SimplifyDimExpr(bc) != Add<DimExpr>{{S0, -1}}));
+  // TODO(ooooo): improve the simplify ability
+  ASSERT_TRUE((SimplifyDimExpr(bc) == bc));
+}
 TEST(Simplify, FoldBroadcast) {
   DimExpr sym0{"S0"};
   DimExpr sym1{"S1"};

--- a/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
+++ b/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
@@ -188,7 +188,7 @@ TEST(Simplify, SimplifyBc) {
   DimExpr bc{Broadcast<DimExpr>{{S0, add}}};
   ASSERT_TRUE((SimplifyDimExpr(bc) != Add<DimExpr>{{S0, -1}}));
   // TODO(ooooo): improve the simplify ability
-  DimExpr now_accept{Broadcast<DimExpr>{{S0, Add<DimExpr>{{S0, -1}}}}};
+  DimExpr now_accept{Broadcast<DimExpr>{{Add<DimExpr>{{S0, -1}}, S0}}};
   ASSERT_TRUE((SimplifyDimExpr(bc) == now_accept));
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164
- fix SimplifyBroadcast, becase wrong case: `Broadcast(S0, Add(S0, -1)) => Add(S0, -1) `